### PR TITLE
fix(security): isolate terminal backend binding per session to prevent cross-backend tool execution

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -852,6 +852,18 @@ _TERMINAL_ENV_MAPPINGS = {
     'ssh_key': 'TERMINAL_SSH_KEY',
     'ssh_persistent': 'TERMINAL_SSH_PERSISTENT',
     'local_persistent': 'TERMINAL_LOCAL_PERSISTENT',
+    # Canonical fields the agent's TERMINAL_CONFIG_ENV_MAP also supports
+    # (hermes_cli/config.py) — omitted here, a profile configured them in
+    # config.yaml yet the WebUI snapshot fell back to hard-coded defaults.
+    'vercel_runtime': 'TERMINAL_VERCEL_RUNTIME',
+    'docker_network': 'TERMINAL_DOCKER_NETWORK',
+    'docker_extra_args': 'TERMINAL_DOCKER_EXTRA_ARGS',
+    'docker_shm_size': 'TERMINAL_DOCKER_SHM_SIZE',
+    'docker_run_as_host_user': 'TERMINAL_DOCKER_RUN_AS_HOST_USER',
+    'docker_persist_across_processes': 'TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES',
+    'docker_orphan_reaper': 'TERMINAL_DOCKER_ORPHAN_REAPER',
+    'sandbox_dir': 'TERMINAL_SANDBOX_DIR',
+    'degraded_mode': 'TERMINAL_DEGRADED_MODE',
 }
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2806,6 +2806,8 @@ _BACKEND_IDENTITY_KEYS: tuple[str, ...] = (
     'TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES',
     'TERMINAL_DOCKER_ORPHAN_REAPER',
     'TERMINAL_VERCEL_RUNTIME',
+    'TERMINAL_SANDBOX_DIR',
+    'TERMINAL_DEGRADED_MODE',
 )
 
 # Backends whose environment is a container/sandbox (mirrors
@@ -2961,7 +2963,7 @@ def _build_env_config_from_snapshot(
             raise ValueError(
                 f'Invalid value for {name}: {raw!r} (expected {label}). '
                 'Check the profile terminal configuration.'
-            )
+            ) from None
 
     env_type = str(snapshot.get('TERMINAL_ENV', 'local'))
     mount_docker_cwd = str(snapshot.get(
@@ -3235,6 +3237,31 @@ def _wait_for_in_flight_cleanup(
             )
 
 
+def _docker_container_exists(docker_exe: str, container_id: str) -> bool:
+    """True when a container with *container_id* still exists (``docker ps -a``).
+
+    Verifies that forced retirement PHYSICALLY removed the container: the
+    installed Docker worker runs ``docker stop`` / ``docker rm -f`` without
+    checking return codes and publishes no outcome, so ``wait_for_cleanup()``
+    alone cannot distinguish a completed removal from a silently failed one.
+    A failed ``rm -f`` leaves the container and its labels in place, and a
+    replacement would reattach by labels — so existence is checked before any
+    replacement is permitted.
+    """
+    try:
+        result = subprocess.run(
+            [docker_exe, 'ps', '-a', '--no-trunc', '--filter',
+             'id={}'.format(container_id), '--format', '{{.ID}}'],
+            capture_output=True, timeout=15, stdin=subprocess.DEVNULL,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise RuntimeError(
+            f'Could not verify removal of Docker container '
+            f'{container_id[:12]}: {exc} (fail-closed)'
+        ) from exc
+    return bool((result.stdout or b'').strip())
+
+
 def _cleanup_environment_object(env, task_key: str = 'default') -> None:
     """Run the teardown the agent's ``cleanup_vm`` would run on one env.
 
@@ -3257,6 +3284,14 @@ def _cleanup_environment_object(env, task_key: str = 'default') -> None:
     never remove the replacement's live container.
     """
     timeout = float(os.environ.get('HERMES_WEBUI_BACKEND_CLEANUP_TIMEOUT', '90'))
+    # Capture the physical container identity BEFORE teardown: the installed
+    # Docker cleanup nulls ``_container_id`` before its worker thread starts,
+    # so it is only readable here.
+    container_id = (
+        getattr(env, '_container_id', None)
+        or getattr(env, 'container_id', None)
+    )
+    docker_exe = getattr(env, '_docker_exe', None)
     done = threading.Event()
     failed = False
     with _in_flight_env_cleanups_lock:
@@ -3281,6 +3316,21 @@ def _cleanup_environment_object(env, task_key: str = 'default') -> None:
                     f'finish within {timeout:.0f}s; refusing to proceed '
                     '(fail-closed — a replacement must not attach to a '
                     'still-removing container)'
+                )
+        # Physical-removal verification (fail-closed): ``wait_for_cleanup()``
+        # only proves the worker thread ended.  The installed Docker worker
+        # ignores ``docker stop``/``rm -f`` return codes and publishes no
+        # outcome, so a failed ``rm -f`` still reports success while the old
+        # container and its labels remain — and a replacement would reattach
+        # by labels.  Verify the retired container identity is gone before
+        # permitting replacement.
+        if container_id and docker_exe:
+            if _docker_container_exists(docker_exe, container_id):
+                raise RuntimeError(
+                    f'Retired Docker container {container_id[:12]} still '
+                    f'exists after forced teardown; refusing to proceed '
+                    '(fail-closed — a replacement must not reattach to the '
+                    'stale container by labels)'
                 )
     except Exception:
         failed = True
@@ -3318,6 +3368,17 @@ def _retire_generation_env(generation: int | None, task_key: str = 'default') ->
         if env_gen != generation:
             # Replaced by a newer env, or tagged with a different generation —
             # never retire it.
+            return
+        if _env_has_execution_lease(env):
+            # A guarded terminal command is mid-execution against this exact
+            # object.  The installed terminal_tool re-reads the registry by
+            # key before env.execute(), so retiring now would make the
+            # in-flight command run against whatever replaced it.  Defer: the
+            # retirement is re-queued and retried once the last lease releases
+            # (turn-exit drain, or the lease-release drain).
+            if generation is not None:
+                with _backend_generation_lock:
+                    _pending_eviction_generations.add(generation)
             return
         # Compare-and-remove: this whole read/pop is one lock hold, so the
         # registry cannot change underneath us.
@@ -3623,6 +3684,51 @@ def _mark_file_backend_generation(task_key: str, generation: int) -> None:
         _file_backend_generations[task_key] = generation
 
 
+# Execution leases: ``id(env)`` -> number of guarded terminal commands
+# currently executing against that exact object.  The installed
+# ``terminal_tool()`` re-reads ``_active_environments`` by key BEFORE calling
+# ``env.execute()``, so an environment retired/replaced between the WebUI's
+# final ownership check and that lookup would make the command execute
+# against a non-validated object.  A leased environment is therefore never
+# removed by any WebUI retirement path; retirement is deferred until the last
+# lease releases.  Guarded by ``_env_execution_leases_lock``.
+_env_execution_leases: dict[int, int] = {}
+_env_execution_leases_lock = threading.Lock()
+
+
+def _env_has_execution_lease(env) -> bool:
+    """True when a guarded terminal command is executing against *env*."""
+    with _env_execution_leases_lock:
+        return _env_execution_leases.get(id(env), 0) > 0
+
+
+def _acquire_env_execution_lease(env) -> None:
+    """Mark one in-flight guarded terminal execution against *env*."""
+    with _env_execution_leases_lock:
+        _env_execution_leases[id(env)] = _env_execution_leases.get(id(env), 0) + 1
+
+
+def _release_env_execution_lease(env) -> None:
+    """Mark one in-flight guarded terminal execution as finished.
+
+    The lease lock is released BEFORE the deferred-eviction drain runs, so
+    the drain (which takes the registry lock) can never deadlock against a
+    retirement path holding the registry lock while checking a lease.
+    """
+    with _env_execution_leases_lock:
+        remaining = _env_execution_leases.get(id(env), 1) - 1
+        if remaining > 0:
+            _env_execution_leases[id(env)] = remaining
+        else:
+            _env_execution_leases.pop(id(env), None)
+    # A retirement deferred while this lease was held may now proceed.
+    try:
+        _drain_pending_evictions()
+    except Exception:
+        logger.debug('Failed to drain deferred evictions after lease release',
+                     exc_info=True)
+
+
 def _begin_turn_generation(profile_runtime_env: dict | None) -> None:
     """Turn-setup entry: ONE generation-lock transaction, fail-closed.
 
@@ -3833,6 +3939,32 @@ def _install_terminal_env_generation_guard() -> None:
 
         tt._get_env_config = _wrapped_get_env_config
 
+    # 0b) terminal_tool._cleanup_inactive_envs — the agent's idle reaper.
+    #     The installed terminal_tool STARTS the cleanup daemon on every call
+    #     (before the by-key env lookup), and the reaper pops idle envs
+    #     DIRECTLY from _active_environments.  A pop between the WebUI's final
+    #     ownership check and the installed lookup would make the command
+    #     execute against a replacement — or against a freshly created,
+    #     never-validated env.  A leased environment (a guarded terminal
+    #     command executing against that exact object) is kept alive instead:
+    #     its activity stamp is refreshed so the sweep skips it, and it is
+    #     only retired after the last lease releases (via the deferred
+    #     eviction drain).
+    if hasattr(tt, '_cleanup_inactive_envs'):
+        original_cleanup_inactive_envs = tt._cleanup_inactive_envs
+
+        def _wrapped_cleanup_inactive_envs(lifetime_seconds: int = 300):
+            with _env_execution_leases_lock:
+                leased_ids = set(_env_execution_leases.keys())
+            if leased_ids:
+                with tt._env_lock:
+                    for task_id, env in list(tt._active_environments.items()):
+                        if id(env) in leased_ids:
+                            tt._last_activity[task_id] = time.time()
+            return original_cleanup_inactive_envs(lifetime_seconds)
+
+        tt._cleanup_inactive_envs = _wrapped_cleanup_inactive_envs
+
     # 1) terminal_tool.terminal_tool — split into env acquisition (inside the
     #    shared transaction) and command execution (AFTER the transaction):
     #    the installed terminal implementation acquires/reuses the
@@ -3971,13 +4103,27 @@ def _install_terminal_env_generation_guard() -> None:
                 )
             # Lock released — only now does the command execute, against the
             # exact validated environment.
-            return original_terminal_tool(
-                command, background=background, timeout=timeout,
-                task_id=task_id, session_id=session_id, force=force,
-                workdir=workdir, pty=pty,
-                notify_on_complete=notify_on_complete,
-                watch_patterns=watch_patterns,
-            )
+            #
+            # Execution lease: the installed terminal_tool re-reads the
+            # registry by key before env.execute(), so a retirement between
+            # this final check and that lookup would execute the command
+            # against a replacement.  The lease pins the validated object for
+            # the duration of the command: every WebUI retirement path defers
+            # removal while a lease is held, and the registry is re-checked
+            # on release.
+            if env is not None:
+                _acquire_env_execution_lease(env)
+            try:
+                return original_terminal_tool(
+                    command, background=background, timeout=timeout,
+                    task_id=task_id, session_id=session_id, force=force,
+                    workdir=workdir, pty=pty,
+                    notify_on_complete=notify_on_complete,
+                    watch_patterns=watch_patterns,
+                )
+            finally:
+                if env is not None:
+                    _release_env_execution_lease(env)
 
         tt.terminal_tool = _wrapped_terminal_tool
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3259,6 +3259,16 @@ def _docker_container_exists(docker_exe: str, container_id: str) -> bool:
             f'Could not verify removal of Docker container '
             f'{container_id[:12]}: {exc} (fail-closed)'
         ) from exc
+    # Fail closed on ANY nonzero docker ps result: a daemon outage, permission
+    # failure, or bad CLI with empty stdout must never be read as "container
+    # absent" — that would permit a replacement that reattaches by labels.
+    if result.returncode != 0:
+        detail = (result.stderr or b'').decode('utf-8', 'replace').strip()
+        raise RuntimeError(
+            f'Could not verify removal of Docker container '
+            f'{container_id[:12]}: docker ps exited {result.returncode} '
+            f'({detail[:200]}) (fail-closed)'
+        )
     return bool((result.stdout or b'').strip())
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2790,9 +2790,14 @@ def _reset_streaming_hermes_home_override(override_mod, override_token, override
 #  5. ONE shared acquisition boundary (terminal_tool.terminal_tool,
 #     file_tools._get_file_ops, code_execution_tool._get_or_create_env)
 #     compares the live env's tag against the CALLING TURN's captured
-#     (thread-local) generation — never the process-global current
+#     (ContextVar) generation — never the process-global current
 #     generation — and never reuses or tears down an env an active
 #     old-backend turn still owns (retire deferred until drain).
+#     Validation, stale compare-and-remove, reuse/create, object tagging,
+#     owner publication and the final exact-object check are ONE
+#     _backend_acquisition_lock transaction (see _acquire_backend_object),
+#     so no concurrent guarded acquisition can install an env between the
+#     ownership check and the real acquire (empty-slot TOCTOU).
 #  6. Retire is compare-and-remove under the registry lock, cleaning up the
 #     exact removed object OUTSIDE the lock, eliminating the
 #     setup-to-tool os.environ race and the read/retire replacement gap.
@@ -2827,8 +2832,10 @@ _BACKEND_IDENTITY_KEYS: tuple[str, ...] = (
     'TERMINAL_DOCKER_RUN_AS_HOST_USER',
     'TERMINAL_DOCKER_NETWORK',
     'TERMINAL_DOCKER_EXTRA_ARGS',
+    'TERMINAL_DOCKER_SHM_SIZE',
     'TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES',
     'TERMINAL_DOCKER_ORPHAN_REAPER',
+    'TERMINAL_VERCEL_RUNTIME',
 )
 
 # Backend identity and generation tracking
@@ -2976,10 +2983,19 @@ def _cleanup_environment_object(env) -> None:
     Called OUTSIDE the registry lock, on the exact object removed by
     ``_retire_generation_env``, so a replacement installed under the same key
     is never torn down.
+
+    Stale-generation retirement must PHYSICALLY destroy the sandbox: a
+    persistent Docker env cleaned without ``force_remove=True`` survives and
+    can be reattached under stale labels by a later backend.  Backends whose
+    ``cleanup()`` does not accept the kwarg raise TypeError and fall back to
+    the plain call (same signature probe ``cleanup_vm`` uses).
     """
     try:
         if hasattr(env, 'cleanup'):
-            env.cleanup()
+            try:
+                env.cleanup(force_remove=True)
+            except TypeError:
+                env.cleanup()
         elif hasattr(env, 'stop'):
             env.stop()
         elif hasattr(env, 'terminate'):
@@ -3059,29 +3075,45 @@ def _publish_backend_identity(profile_runtime_env: dict | None) -> int | None:
 
 
 def _refresh_env_generation_tag() -> None:
-    """After the agent turn, publish ownership of the live environment.
+    """After the agent turn, publish ownership of the environment THIS TURN
+    actually acquired and used.
 
-    Records the CURRENT TURN's generation as the owner of the cached 'default'
-    env (if one exists) and tags the env object with it.  This is the publish
-    side of the generation protocol: without it the invalidator has no
-    recorded owner to compare against and can never retire a stale env.
+    Operates ONLY on the exact object the calling turn's guarded acquisitions
+    validated: the live 'default' env is published iff its generation tag is
+    ALREADY the calling turn's captured (ContextVar) generation — the only
+    state a registered turn can legitimately leave behind (creation-time
+    tagging via the ``_create_environment`` wrapper, or same-generation
+    reuse).  It NO-OPs when:
 
-    The tag MUST be the calling turn's captured (ContextVar) generation, NOT
-    the process-global current generation: a concurrent profile switch may
-    already have bumped the global generation while this turn was still
-    executing, and tagging this turn's env with that newer generation would
-    make the guard consider a stale-backend env "owned" by the new backend.
+      * begin failed / no generation is bound (the ContextVar is None),
+      * the turn acquired no environment (nothing is tagged with its gen),
+      * the registry object changed (a different object now occupies the
+        slot — detected through its tag, which belongs to another gen),
+      * the object's generation differs.
+
+    In particular it NEVER writes the finishing turn's generation onto an
+    environment created by another turn.  The old global-slot retag admitted
+    this schedule: turn A (gen 0) begins while no env exists, turn B (gen 1)
+    begins after an identity switch and creates a gen-1 env, A finishes
+    without ever acquiring anything, and A's ``finally`` retagged B's live
+    object as gen 0 — so the deferred gen-0 drain then retired B's env while
+    B was still using it.  The tag is the immutable provenance record: only
+    the generation that produced the object may publish it.
     """
+    turn_gen = _get_turn_generation()
+    if turn_gen is None:
+        return
     try:
-        from tools.terminal_tool import get_active_env
-
-        env = get_active_env('default')
-        if env is not None:
-            gen = _get_turn_generation()
-            if gen is None:
-                gen = _get_current_backend_generation()
-            _mark_env_backend_generation('default', gen)
-            env._webui_backend_generation = gen
+        tt = importlib.import_module('tools.terminal_tool')
+        with tt._env_lock:
+            env = tt._active_environments.get('default')
+            if env is None:
+                return
+            if getattr(env, '_webui_backend_generation', None) != turn_gen:
+                # Foreign generation (or untagged): never retag or publish.
+                return
+        # Exact-object + exact-generation match: publish the owner record.
+        _mark_env_backend_generation('default', turn_gen)
     except ImportError:
         pass
     except Exception:
@@ -3122,7 +3154,9 @@ def _wait_for_generation_drain(
             _backend_generation_cond.wait(min(remaining, 1.0))
 
 
-def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None:
+def _validate_backend_ownership(
+    tt, effective_task_id: str, raw_task_id, *, allow_wait: bool = True,
+) -> None:
     """ONE shared acquisition boundary for terminal / file / code-execution.
 
     Guarantees the calling turn never reuses an environment created under a
@@ -3136,14 +3170,24 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
         past the env's tag) and NOT the recorded per-task owner (which a
         concurrent switch may have moved past this turn's capture).
       * An env tagged with a different generation is never reused.
-      * An UNTAGGED env is never reused by a registered WebUI turn: it has no
-        provenance, so it is treated as stale and retired (fail-closed).
-      * If turns still execute under that generation, the retire is deferred:
-        we wait (bounded) for them to drain instead of tearing the env down
-        mid-use.  The retire itself is a compare-and-remove that cleans up the
-        exact removed object OUTSIDE the registry lock, and the loop
-        re-validates afterwards so a replacement installed while we waited is
-        never reused or torn down either.
+      * An UNTAGGED env is never reused by a registered WebUI turn — and it
+        is never DESTROYED speculatively either: it may be in active use by an
+        untracked/non-WebUI caller, so unknown ownership is ISOLATED
+        (compare-and-remove from the registry without running teardown), not
+        accepted and not torn down as if it were inactive.
+      * If turns still execute under a stale env's generation, the retire is
+        deferred: we wait (bounded) for them to drain instead of tearing the
+        env down mid-use.  The retire itself is a compare-and-remove that
+        cleans up the exact removed object OUTSIDE the registry lock, and the
+        loop re-validates afterwards so a replacement installed while we
+        waited is never reused or torn down either.
+
+    ``allow_wait=False`` (the in-transaction re-validation) never blocks: the
+    pre-phase already drained any active foreign generation, and a foreign
+    generation can only become active again through a NEW identity publish,
+    which makes THIS turn the stale owner — refusing is the fail-closed
+    answer, and waiting here would deadlock the active turn, which needs the
+    same acquisition lock to run its own tool calls.
     """
     turn_gen = _get_turn_generation()
     # Untracked callers (non-WebUI flows) fall back to the recorded per-task
@@ -3168,6 +3212,14 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
                 # Non-WebUI caller (no captured turn generation): the agent's
                 # own registry is authoritative — accept untagged envs.
                 return
+            if env_gen is None:
+                # Registered WebUI turn, untagged env: unknown ownership —
+                # isolate (never serve it again) without speculative teardown.
+                tt._active_environments.pop(effective_task_id, None)
+                tt._last_activity.pop(effective_task_id, None)
+                tt._active_environments.pop(raw_task_id, None)
+                tt._last_activity.pop(raw_task_id, None)
+                return
             if turn_gen is not None and env_gen is not None:
                 with _backend_generation_lock:
                     _pending_eviction_generations.add(env_gen)
@@ -3175,6 +3227,16 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
             else:
                 gen_active = False
         if turn_gen is not None and gen_active:
+            if not allow_wait:
+                # A foreign generation became active mid-transaction: this
+                # turn is now the stale owner — refuse (fail-closed) rather
+                # than block the active turn (which needs this lock) or tear
+                # down / reuse its environment.
+                raise RuntimeError(
+                    f'Backend generation {env_gen} is still active; refusing '
+                    'acquisition inside the ownership transaction (would '
+                    'violate the cross-backend boundary)'
+                )
             # An old-backend turn still owns this env — never tear it down.
             # Wait for it to exit, then re-validate (it may have been retired
             # by the drain, or replaced by a concurrent thread).
@@ -3184,10 +3246,15 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
 
 
 def _evict_stale_file_ops_cache_entry(ft, task_key: str, turn_gen: int) -> None:
-    """Drop a cached file_ops object tagged with a stale generation.
+    """Drop a cached file_ops object this turn may not use.
 
     Compare-and-remove under the module's own cache lock so a concurrent
-    replacement installed under the same key is never cleared.
+    replacement installed under the same key is never cleared.  An entry
+    tagged with a DIFFERENT generation OR left UNTAGGED (unknown ownership)
+    is evicted: neither may be served to a registered turn (fail-closed —
+    the old ``cached_gen is None`` early-return accepted unknown ownership).
+    Eviction only drops the wrapper; the underlying env is governed by the
+    registry ownership check.
     """
     try:
         cache = ft._file_ops_cache
@@ -3199,7 +3266,7 @@ def _evict_stale_file_ops_cache_entry(ft, task_key: str, turn_gen: int) -> None:
     if cached is None:
         return
     cached_gen = getattr(cached, '_webui_backend_generation', None)
-    if cached_gen is None or cached_gen == turn_gen:
+    if cached_gen == turn_gen:
         return
     with cache_lock:
         if cache.get(task_key) is cached:
@@ -3274,6 +3341,95 @@ def _end_turn_generation() -> None:
         logger.debug('Turn generation unregister failed', exc_info=True)
 
 
+def _get_registry_env(tt, effective_task_id: str, raw_task_id):
+    """Read the live env for a task key directly under the registry lock.
+
+    Inline lookup only — never a lock-taking accessor like
+    ``get_active_env()`` while the non-reentrant ``_env_lock`` is held.
+    """
+    with tt._env_lock:
+        return (
+            tt._active_environments.get(effective_task_id)
+            or tt._active_environments.get(raw_task_id)
+        )
+
+
+def _final_ownership_check(
+    tt, effective_task_id: str, raw_task_id, turn_gen: int | None,
+):
+    """Final exact-object/exact-generation check inside the transaction.
+
+    After the original acquirer ran, the live env must belong to the calling
+    turn's generation (or be absent — e.g. an execution that produced no
+    sandbox).  A foreign env means the acquirer produced/reused an object
+    this turn may not use: refuse (fail-closed) rather than execute against
+    it or bless a wrapper that wraps it.  Returns the validated env (or
+    None).  The caller must hold ``_backend_acquisition_lock``.
+    """
+    if turn_gen is None:
+        return None
+    env = _get_registry_env(tt, effective_task_id, raw_task_id)
+    if env is None:
+        return None
+    env_gen = getattr(env, '_webui_backend_generation', None)
+    if env_gen != turn_gen:
+        raise RuntimeError(
+            'Backend ownership changed during acquisition: the live '
+            f'environment is tagged generation {env_gen!r} but the calling '
+            f'turn captured {turn_gen!r}; refusing cross-backend reuse'
+        )
+    return env
+
+
+def _acquire_backend_object(
+    tt, effective_task_id: str, raw_task_id, acquire_fn, on_acquired=None,
+):
+    """ONE authoritative acquisition transaction for every guarded path.
+
+    Serializes expected-generation validation, stale compare-and-remove,
+    reuse/create (the original acquirer), object tagging, owner publication
+    and the final exact-object/exact-generation check under
+    ``_backend_acquisition_lock`` — so a concurrent guarded acquisition can
+    never install an env between the ownership check and the real acquire
+    (the empty-slot TOCTOU where generations A and B both validate an empty
+    slot, A creates and registers its env, and B's original fast path then
+    reuses/executes against A's object), and no wrapper can bless an object
+    whose underlying env came from another generation.
+
+    The potentially-blocking stale-generation drain wait runs OUTSIDE the
+    lock (pre-phase): an active old-generation turn still needs the same
+    acquisition lock to run its own tool calls, so waiting under the lock
+    would deadlock it until the drain timeout.  The in-lock re-validation is
+    therefore non-blocking (``allow_wait=False``) and refuses (fail-closed)
+    if a foreign generation somehow became active mid-transaction.
+
+    ``on_acquired(result, turn_gen, validated_env)`` runs inside the
+    transaction, after the final check, and performs object tagging + owner
+    publication for the exact validated object.
+    """
+    turn_gen = _get_turn_generation()
+    # Pre-phase (no global lock): retire/defuse any env this turn may not
+    # use.  Any drain wait happens here — OUTSIDE _backend_acquisition_lock —
+    # so an active old-generation turn can still run its own guarded tool
+    # call (it needs the same lock) and exit, waking this wait.
+    _validate_backend_ownership(tt, effective_task_id, raw_task_id)
+    with _backend_acquisition_lock:
+        # Re-validate: non-blocking here and atomic with the reuse/create
+        # below — no other guarded acquisition can interleave, so the env
+        # this turn validated (or the fresh one the acquirer creates) is the
+        # exact object the turn executes against.
+        _validate_backend_ownership(
+            tt, effective_task_id, raw_task_id, allow_wait=False,
+        )
+        result = acquire_fn()
+        validated_env = _final_ownership_check(
+            tt, effective_task_id, raw_task_id, turn_gen,
+        )
+        if on_acquired is not None:
+            on_acquired(result, turn_gen, validated_env)
+    return result
+
+
 def _install_terminal_env_generation_guard() -> None:
     """Monkey-patch ALL terminal/file/code-execution acquisition paths with a
     single shared backend-ownership boundary.
@@ -3286,12 +3442,14 @@ def _install_terminal_env_generation_guard() -> None:
         env created during a WebUI turn is tagged with the calling turn's
         generation atomically at creation, so no untagged window exists)
 
-    Each wrapped acquisition validates ownership via
-    :func:`_validate_backend_ownership` under the registry lock (inline lookup
-    — never a lock-taking accessor like ``get_active_env()`` while holding the
-    non-reentrant ``_env_lock``) and compares against the calling turn's
-    captured generation, eliminating the setup-to-tool os.environ race for
-    cached environments.
+    Each wrapped acquisition runs the WHOLE validate → reuse/create → tag →
+    publish → final-exact-check sequence through
+    :func:`_acquire_backend_object` — ONE ``_backend_acquisition_lock``
+    transaction — so validation and acquisition cannot be separated by a
+    concurrent guarded acquisition (the empty-slot TOCTOU).  Ownership is
+    compared against the calling turn's captured generation, and the
+    registry is read inline (never a lock-taking accessor like
+    ``get_active_env()`` while holding the non-reentrant ``_env_lock``).
     """
     global _terminal_env_guard_installed
     if _terminal_env_guard_installed:
@@ -3313,19 +3471,37 @@ def _install_terminal_env_generation_guard() -> None:
             notify_on_complete=False, watch_patterns=None,
         ):
             effective_task_id = tt._resolve_container_task_id(task_id)
-            _validate_backend_ownership(tt, effective_task_id, task_id)
-            return original_terminal_tool(
-                command, background=background, timeout=timeout,
-                task_id=task_id, session_id=session_id, force=force,
-                workdir=workdir, pty=pty,
-                notify_on_complete=notify_on_complete,
-                watch_patterns=watch_patterns,
+
+            def _acquire():
+                return original_terminal_tool(
+                    command, background=background, timeout=timeout,
+                    task_id=task_id, session_id=session_id, force=force,
+                    workdir=workdir, pty=pty,
+                    notify_on_complete=notify_on_complete,
+                    watch_patterns=watch_patterns,
+                )
+
+            def _publish(result, gen, validated_env):
+                # Owner publication inside the transaction: the live env was
+                # validated as THIS turn's generation, so the recorded
+                # per-task owner tracks the exact object.
+                if gen is not None and validated_env is not None:
+                    try:
+                        _mark_env_backend_generation(effective_task_id, gen)
+                    except Exception:
+                        pass
+
+            return _acquire_backend_object(
+                tt, effective_task_id, task_id, _acquire,
+                on_acquired=_publish,
             )
 
         tt.terminal_tool = _wrapped_terminal_tool
 
     # 2) file_tools._get_file_ops — previously bypassed the guard entirely:
-    #    it reused _active_environments directly without any ownership check.
+    #    it reused _active_environments directly without any ownership check,
+    #    and its post-hoc tag could bless a wrapper whose underlying env came
+    #    from another generation.  The final exact check now gates the tag.
     try:
         ft = importlib.import_module('tools.file_tools')
     except ImportError:
@@ -3336,17 +3512,32 @@ def _install_terminal_env_generation_guard() -> None:
         def _wrapped_get_file_ops(task_id="default"):
             effective_task_id = tt._resolve_container_task_id(task_id)
             turn_gen = _get_turn_generation()
-            _validate_backend_ownership(tt, effective_task_id, task_id)
-            if turn_gen is not None:
-                _evict_stale_file_ops_cache_entry(ft, effective_task_id, turn_gen)
-            file_ops = original_get_file_ops(task_id)
-            if turn_gen is not None and file_ops is not None:
-                try:
-                    file_ops._webui_backend_generation = turn_gen
-                    _mark_file_backend_generation(effective_task_id, turn_gen)
-                except Exception:
-                    pass
-            return file_ops
+
+            def _acquire():
+                if turn_gen is not None:
+                    _evict_stale_file_ops_cache_entry(
+                        ft, effective_task_id, turn_gen,
+                    )
+                return original_get_file_ops(task_id)
+
+            def _publish(file_ops, gen, validated_env):
+                # Bless the wrapper ONLY for the exact env this transaction
+                # validated as the turn's generation.
+                if (
+                    gen is not None
+                    and file_ops is not None
+                    and validated_env is not None
+                ):
+                    try:
+                        file_ops._webui_backend_generation = gen
+                        _mark_file_backend_generation(effective_task_id, gen)
+                    except Exception:
+                        pass
+
+            return _acquire_backend_object(
+                tt, effective_task_id, task_id, _acquire,
+                on_acquired=_publish,
+            )
 
         ft._get_file_ops = _wrapped_get_file_ops
 
@@ -3362,18 +3553,32 @@ def _install_terminal_env_generation_guard() -> None:
         def _wrapped_get_or_create_env(task_id):
             effective_task_id = tt._resolve_container_task_id(task_id)
             turn_gen = _get_turn_generation()
-            _validate_backend_ownership(tt, effective_task_id, task_id)
-            result = original_get_or_create_env(task_id)
-            if turn_gen is not None and result is not None:
-                try:
-                    env = result[0] if isinstance(result, tuple) else result
-                    if env is not None:
-                        if getattr(env, '_webui_backend_generation', None) is None:
-                            env._webui_backend_generation = turn_gen
-                        _mark_env_backend_generation(effective_task_id, turn_gen)
-                except Exception:
-                    pass
-            return result
+
+            def _acquire():
+                return original_get_or_create_env(task_id)
+
+            def _publish(result, gen, validated_env):
+                if (
+                    gen is not None
+                    and result is not None
+                    and validated_env is not None
+                ):
+                    try:
+                        env = result[0] if isinstance(result, tuple) else result
+                        if (
+                            env is not None
+                            and getattr(env, '_webui_backend_generation', None)
+                            is None
+                        ):
+                            env._webui_backend_generation = gen
+                        _mark_env_backend_generation(effective_task_id, gen)
+                    except Exception:
+                        pass
+
+            return _acquire_backend_object(
+                tt, effective_task_id, task_id, _acquire,
+                on_acquired=_publish,
+            )
 
         cet._get_or_create_env = _wrapped_get_or_create_env
 
@@ -13025,9 +13230,10 @@ def _run_agent_streaming(
                     _unreg_clarify_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister clarify callback")
-            # #5937: tag the live env with this turn's generation so the next
-            # turn's setup can detect staleness.  Run before env var restoration
-            # so get_active_env() still works.
+            # #5937: publish ownership of the env THIS turn acquired and used
+            # (exact-object/exact-generation only — never retag an env
+            # another turn created).  Run before env var restoration so the
+            # registry is still readable.  See _refresh_env_generation_tag.
             _refresh_env_generation_tag()
             # Active-use ownership: this turn has finished; release the
             # registration and drain any stale eviction deferred while it was

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2849,7 +2849,38 @@ _pending_eviction_generations: set[int] = set()
 # Condition notified whenever a turn exits, so an acquisition blocked on an
 # active old generation's drain can proceed the moment it completes.
 _backend_generation_cond = threading.Condition(_backend_generation_lock)
-_turn_state = threading.local()  # thread-local backend generation for the running turn
+# The calling turn's captured backend generation, bound as a ContextVar so the
+# installed Agent's concurrent-tool workers inherit it.  The Agent dispatches
+# parallel-safe tool calls on child threads and propagates ContextVars
+# (contextvars.copy_context() in tools/thread_context.propagate_context_to_thread
+# — agent/tool_executor.py:931-944), NOT arbitrary thread-locals.  A private
+# threading.local() is therefore invisible inside tool workers, and acquisition
+# there fell back to the process-global per-task owner — so a concurrent
+# profile generation change could make file/code-exec validate against the
+# wrong owner and reuse state outside the calling turn's captured generation.
+_TURN_BACKEND_GENERATION: contextvars.ContextVar[int | None] = (
+    contextvars.ContextVar('webui_turn_backend_generation', default=None)
+)
+# Serializes validate/reuse/create into ONE authoritative acquisition
+# transaction for every guarded path (terminal / file / code-execution).  The
+# preflight-then-acquire shape (validate, release the registry lock, then call
+# the original acquirer) left an empty-slot window where a concurrent guarded
+# acquisition could install an env between the ownership check and the real
+# acquire; holding this guard-owned lock across validate + original makes the
+# decision and the reuse/create atomic with respect to all other guarded
+# acquisitions.  The agent's own non-reentrant _env_lock is never held across
+# the original call, so no deadlock is introduced.
+_backend_acquisition_lock = threading.Lock()
+
+
+def _get_turn_generation() -> int | None:
+    """The calling turn's captured backend generation (ContextVar).
+
+    Propagated into the Agent's concurrent tool workers via
+    ``contextvars.copy_context()``; None for non-WebUI callers and outside a
+    turn.
+    """
+    return _TURN_BACKEND_GENERATION.get()
 
 
 def _compute_backend_identity(profile_runtime_env: dict | None) -> str:
@@ -2890,25 +2921,17 @@ def _get_current_backend_generation() -> int:
         return _current_backend_generation
 
 
-def _register_turn_generation() -> None:
-    """Mark the current thread as executing a turn under the current generation.
-
-    Runs at turn startup (after identity invalidation).  The stale-generation
-    retire path consults this counter so it never tears down an environment a
-    concurrent turn is still using.
-    """
-    gen = _get_current_backend_generation()
-    _turn_state.backend_generation = gen
-    with _backend_generation_lock:
-        _active_turn_generations[gen] = _active_turn_generations.get(gen, 0) + 1
-
-
 def _unregister_turn_generation() -> None:
-    """Mark the current turn as finished; drain any deferred stale eviction."""
-    gen = getattr(_turn_state, 'backend_generation', None)
+    """Mark the current turn as finished; drain any deferred stale eviction.
+
+    Resets/decrements the SAME captured generation the turn registered under
+    (read from the ContextVar before it is cleared), so an unregister can
+    never touch another generation's active-use count.
+    """
+    gen = _get_turn_generation()
     if gen is None:
         return
-    _turn_state.backend_generation = None
+    _TURN_BACKEND_GENERATION.set(None)
     with _backend_generation_lock:
         remaining = _active_turn_generations.get(gen, 1) - 1
         if remaining > 0:
@@ -2965,14 +2988,17 @@ def _cleanup_environment_object(env) -> None:
         logger.debug('Failed to clean retired terminal env', exc_info=True)
 
 
-def _retire_generation_env(generation: int, task_key: str = 'default') -> None:
+def _retire_generation_env(generation: int | None, task_key: str = 'default') -> None:
     """Retire the live env tagged with *generation* on *task_key*.
 
     Compare-and-remove is atomic under the registry lock (``tt._env_lock``),
     and the exact removed object is cleaned up OUTSIDE the lock — closing the
     read/retire gap where a replacement installed under the same key could be
     torn down by a later by-key pop.  The env is only retired when its object
-    tag matches *generation*; a newer replacement is never touched.
+    tag matches *generation*; a newer replacement is never touched.  An
+    untagged env (``None`` tag) is retired when *generation* is ``None`` —
+    the fail-closed path a registered WebUI turn takes when it finds an env
+    with no provenance it must not reuse.
     """
     try:
         tt = importlib.import_module('tools.terminal_tool')
@@ -2984,8 +3010,9 @@ def _retire_generation_env(generation: int, task_key: str = 'default') -> None:
         if env is None:
             return
         env_gen = getattr(env, '_webui_backend_generation', None)
-        if env_gen is None or env_gen != generation:
-            # Replaced by a newer env — never retire it.
+        if env_gen != generation:
+            # Replaced by a newer env, or tagged with a different generation —
+            # never retire it.
             return
         # Compare-and-remove: this whole read/pop is one lock hold, so the
         # registry cannot change underneath us.
@@ -3004,68 +3031,31 @@ def _retire_generation_env(generation: int, task_key: str = 'default') -> None:
         )
 
 
-def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None:
-    """Evict the cached terminal/file environment when the backend config changes.
+def _publish_backend_identity(profile_runtime_env: dict | None) -> int | None:
+    """Compare/publish the effective backend identity (generation lock held).
 
-    Called at turn startup, *after* _ENV_LOCK is released.  Uses a full backend
-    identity fingerprint (not just TERMINAL_ENV) and a generation counter so
-    that:
-      - SSH host A -> SSH host B (same TERMINAL_ENV=ssh) is detected
-      - The identity transition and the ownership registration are ATOMIC:
-        the new generation is published as the recorded owner in the same
-        lock hold as the bump, so no interleaved guard read can observe a
-        half-transitioned state (recorded owner still == old generation).
-      - The eviction targets only the exact stale generation, never an env
-        that another concurrent session has already replaced (compare-and-
-        remove, cleanup of the exact removed object outside the lock).
-      - An environment still executing an older turn is never torn down:
-        its retire is deferred until the last turn under that generation exits
-        (recorded in _pending_eviction_generations, drained by
-        _drain_pending_evictions).
+    CALLER MUST HOLD ``_backend_generation_lock``: this is the transition
+    half of the ONE begin transaction.  Returns the stale generation that must
+    be retired once no turn still runs under it, or None when the identity is
+    unchanged.  The identity compare, the generation bump, the owner
+    publication and the pending-eviction record happen in the same lock hold
+    as the turn's generation capture and active-use increment, so no
+    interleaved profile switch can observe a half-transitioned state or
+    retire a generation before the first turn publishes active use.
     """
     global _last_backend_identity, _current_backend_generation
-
     identity = _compute_backend_identity(profile_runtime_env)
-
-    with _backend_generation_lock:
-        if identity == _last_backend_identity:
-            return  # same config, nothing to do
-        _last_backend_identity = identity
-        stale_generation = _current_backend_generation
-        _current_backend_generation += 1
-        # ATOMIC transition + ownership registration: publish the new owner
-        # and record the pending stale generation under the same lock hold as
-        # the bump.  The old code deferred this publish until after the
-        # active-use check, so the guard kept comparing against the old
-        # recorded generation and let the new turn reuse the stale env.
-        _env_backend_generations['default'] = _current_backend_generation
-        _file_backend_generations['default'] = _current_backend_generation
-        _pending_eviction_generations.add(stale_generation)
-
-    logger.info(
-        'Terminal backend identity changed (gen %d -> %d): checking for stale env',
-        stale_generation,
-        stale_generation + 1,
-    )
-
-    if _active_turn_generations.get(stale_generation, 0) > 0:
-        # A turn is still executing under the stale generation — defer the
-        # retire until that turn exits (drained by _drain_pending_evictions).
-        logger.info(
-            'Deferring stale env retire (gen %s) — active turn still using it',
-            stale_generation,
-        )
-        return
-
-    try:
-        _retire_generation_env(stale_generation, 'default')
-        with _backend_generation_lock:
-            _pending_eviction_generations.discard(stale_generation)
-    except Exception:
-        logger.debug(
-            'Failed to invalidate stale terminal env',
-            exc_info=True,
-        )
+    if identity == _last_backend_identity:
+        return None  # same config, nothing to do
+    _last_backend_identity = identity
+    stale_generation = _current_backend_generation
+    _current_backend_generation += 1
+    # Publish the new owner in the SAME lock hold as the bump, and record the
+    # stale generation for deferred retire (compare-and-remove, exact object).
+    _env_backend_generations['default'] = _current_backend_generation
+    _file_backend_generations['default'] = _current_backend_generation
+    _pending_eviction_generations.add(stale_generation)
+    return stale_generation
 
 
 def _refresh_env_generation_tag() -> None:
@@ -3076,7 +3066,7 @@ def _refresh_env_generation_tag() -> None:
     side of the generation protocol: without it the invalidator has no
     recorded owner to compare against and can never retire a stale env.
 
-    The tag MUST be the calling turn's captured (thread-local) generation, NOT
+    The tag MUST be the calling turn's captured (ContextVar) generation, NOT
     the process-global current generation: a concurrent profile switch may
     already have bumped the global generation while this turn was still
     executing, and tagging this turn's env with that newer generation would
@@ -3087,7 +3077,7 @@ def _refresh_env_generation_tag() -> None:
 
         env = get_active_env('default')
         if env is not None:
-            gen = getattr(_turn_state, 'backend_generation', None)
+            gen = _get_turn_generation()
             if gen is None:
                 gen = _get_current_backend_generation()
             _mark_env_backend_generation('default', gen)
@@ -3139,11 +3129,15 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
     different backend generation, and never tears down an environment an
     active old-backend turn still owns:
 
-      * The expected owner is the CALLING TURN's captured (thread-local)
-        generation — carried immutably from turn setup — NOT the
-        process-global current generation (which a concurrent profile switch
-        may already have bumped past the env's tag).
+      * The expected owner is the CALLING TURN's captured (ContextVar)
+        generation — carried immutably from turn setup and propagated into the
+        Agent's concurrent tool workers — NOT the process-global current
+        generation (which a concurrent profile switch may already have bumped
+        past the env's tag) and NOT the recorded per-task owner (which a
+        concurrent switch may have moved past this turn's capture).
       * An env tagged with a different generation is never reused.
+      * An UNTAGGED env is never reused by a registered WebUI turn: it has no
+        provenance, so it is treated as stale and retired (fail-closed).
       * If turns still execute under that generation, the retire is deferred:
         we wait (bounded) for them to drain instead of tearing the env down
         mid-use.  The retire itself is a compare-and-remove that cleans up the
@@ -3151,7 +3145,7 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
         re-validates afterwards so a replacement installed while we waited is
         never reused or torn down either.
     """
-    turn_gen = getattr(_turn_state, 'backend_generation', None)
+    turn_gen = _get_turn_generation()
     # Untracked callers (non-WebUI flows) fall back to the recorded per-task
     # owner; registered WebUI turns always compare against their own captured
     # generation.
@@ -3168,9 +3162,13 @@ def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None
             if env is None:
                 return
             env_gen = getattr(env, '_webui_backend_generation', None)
-            if env_gen is None or env_gen == expected:
+            if env_gen == expected:
                 return
-            if turn_gen is not None:
+            if env_gen is None and turn_gen is None:
+                # Non-WebUI caller (no captured turn generation): the agent's
+                # own registry is authoritative — accept untagged envs.
+                return
+            if turn_gen is not None and env_gen is not None:
                 with _backend_generation_lock:
                     _pending_eviction_generations.add(env_gen)
                     gen_active = _active_turn_generations.get(env_gen, 0) > 0
@@ -3215,22 +3213,57 @@ def _mark_file_backend_generation(task_key: str, generation: int) -> None:
 
 
 def _begin_turn_generation(profile_runtime_env: dict | None) -> None:
-    """Turn-setup entry: identity transition (non-fatal) then registration.
+    """Turn-setup entry: ONE generation-lock transaction, fail-closed.
 
-    Registration is GUARANTEED even when the identity transition fails, and
-    the production call site places this inside the same try whose finally
-    calls :func:`_end_turn_generation` — so a turn can never leak its
-    active-use registration, whatever the agent body does.
+    Under a single ``_backend_generation_lock`` hold the effective backend
+    identity is compared/published (via :func:`_publish_backend_identity`),
+    that exact generation is captured, bound to the calling turn's ContextVar,
+    and its active-use count is incremented — all BEFORE the lock is released.
+    No interleaved profile switch can therefore retire a generation between
+    the identity publish and the first active-use publication (the
+    split-begin race), and every acquisition inside this turn — including the
+    Agent's concurrent tool workers, which inherit the ContextVar — compares
+    against the exact generation captured here.
+
+    A failed identity transition is FAIL-CLOSED: the turn is refused (raises)
+    instead of continuing under an ambiguous owner.  The production call site
+    places this as the first statement of the try whose finally calls
+    :func:`_end_turn_generation`, so a raising body never leaks an active-use
+    registration (nothing was bound, so the finally's unregister no-ops).
     """
     try:
-        _invalidate_stale_terminal_backend(profile_runtime_env)
+        with _backend_generation_lock:
+            stale_generation = _publish_backend_identity(profile_runtime_env)
+            generation = _current_backend_generation
+            _TURN_BACKEND_GENERATION.set(generation)
+            _active_turn_generations[generation] = (
+                _active_turn_generations.get(generation, 0) + 1
+            )
     except Exception:
-        logger.debug(
-            'Terminal backend identity transition failed; continuing with '
-            'current generation',
+        # Fail-closed security boundary: never run a turn under an
+        # ambiguous/unknown backend owner.
+        logger.error(
+            'Terminal backend identity transition failed; refusing turn '
+            '(fail-closed)',
             exc_info=True,
         )
-    _register_turn_generation()
+        raise
+
+    if stale_generation is not None:
+        # Outside the lock: retire the exact stale env if no turn still runs
+        # under it (compare-and-remove; cleanup of the exact removed object).
+        # If an old-backend turn is still active the retire stays deferred in
+        # _pending_eviction_generations and is drained when that turn exits.
+        try:
+            if _active_turn_generations.get(stale_generation, 0) == 0:
+                _retire_generation_env(stale_generation, 'default')
+                with _backend_generation_lock:
+                    _pending_eviction_generations.discard(stale_generation)
+        except Exception:
+            logger.debug(
+                'Failed to retire stale terminal env after identity change',
+                exc_info=True,
+            )
 
 
 def _end_turn_generation() -> None:
@@ -3302,7 +3335,7 @@ def _install_terminal_env_generation_guard() -> None:
 
         def _wrapped_get_file_ops(task_id="default"):
             effective_task_id = tt._resolve_container_task_id(task_id)
-            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            turn_gen = _get_turn_generation()
             _validate_backend_ownership(tt, effective_task_id, task_id)
             if turn_gen is not None:
                 _evict_stale_file_ops_cache_entry(ft, effective_task_id, turn_gen)
@@ -3328,7 +3361,7 @@ def _install_terminal_env_generation_guard() -> None:
 
         def _wrapped_get_or_create_env(task_id):
             effective_task_id = tt._resolve_container_task_id(task_id)
-            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            turn_gen = _get_turn_generation()
             _validate_backend_ownership(tt, effective_task_id, task_id)
             result = original_get_or_create_env(task_id)
             if turn_gen is not None and result is not None:
@@ -3353,7 +3386,7 @@ def _install_terminal_env_generation_guard() -> None:
 
         def _wrapped_create_environment(*args, **kwargs):
             env = original_create_environment(*args, **kwargs)
-            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            turn_gen = _get_turn_generation()
             if turn_gen is not None and env is not None:
                 try:
                     env._webui_backend_generation = turn_gen

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2490,37 +2490,6 @@ from api.workspace import set_last_workspace
 # metadata added by the webui and must be stripped before the API call.
 # `reasoning_content` is provider-facing for reasoning-capable models. Display
 # metadata such as `reasoning`, `thinking`, and `_reasoning` stays omitted here.
-def _copy_api_safe_fields(msg: dict) -> dict:
-    """Return a new dict with only API-safe message fields.
-
-    Uses explicit field-by-field access (always O(|safe_keys|)) instead of a
-    dict comprehension over all msg keys (O(|msg_keys|)), which is faster when
-    messages carry extra WebUI metadata fields like ``timestamp``, ``_ts``,
-    ``_error``, ``_partial``, ``_recovered``, ``attachments``, etc. (#6006 perf).
-    """
-    sanitized = {}
-    role = msg.get('role')
-    if role is not None:
-        sanitized['role'] = role
-    content = msg.get('content')
-    if content is not None:
-        sanitized['content'] = content
-    tool_calls = msg.get('tool_calls')
-    if tool_calls is not None:
-        sanitized['tool_calls'] = tool_calls
-    tool_call_id = msg.get('tool_call_id')
-    if tool_call_id is not None:
-        sanitized['tool_call_id'] = tool_call_id
-    name = msg.get('name')
-    if name is not None:
-        sanitized['name'] = name
-    refusal = msg.get('refusal')
-    if refusal is not None:
-        sanitized['refusal'] = refusal
-    reasoning_content = msg.get('reasoning_content')
-    if reasoning_content is not None:
-        sanitized['reasoning_content'] = reasoning_content
-    return sanitized
 
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
@@ -7311,9 +7280,7 @@ def _restore_reasoning_metadata(previous_messages, updated_messages):
     def _safe_projection(msg):
         if not isinstance(msg, dict):
             return None
-        projected = _copy_api_safe_fields(msg)
-        if not projected.get('role'):
-            return None
+        projected = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS and msg.get('role')}
         # Mirror the empty-tool_calls drop applied by _api_safe_message_positions
         # (#5737) so this projection matches the API-safe positions it's aligned
         # against — otherwise a row stored with tool_calls: [] projects

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3038,6 +3038,7 @@ def _build_env_config_from_snapshot(
     return {
         'env_type': env_type,
         'modal_mode': _modal_mode,
+        'sandbox_dir': str(snapshot.get('TERMINAL_SANDBOX_DIR') or ''),
         'docker_image': str(snapshot.get('TERMINAL_DOCKER_IMAGE', default_image)),
         'docker_forward_env': docker_forward_env,
         'singularity_image': str(snapshot.get(
@@ -4099,30 +4100,29 @@ def _install_terminal_env_generation_guard() -> None:
                 }, ensure_ascii=False)
             # Fail-closed pre-execution gate: the exact validated object must
             # still occupy the registry slot the original tool will reuse —
-            # execution must never begin against a replacement.
+            # execution must never begin against a replacement. The execution
+            # lease is published in the SAME lock transaction as the check, so
+            # a retirement between the check and the lease can never slip in
+            # (#6586 gap 1): once the lock is released, every retirement path
+            # sees the lease and defers removal until the command finishes.
             with tt._env_lock:
                 live = (
                     tt._active_environments.get(effective_task_id)
                     or (tt._active_environments.get(task_id) if task_id else None)
                 )
-            if live is not env:
-                raise RuntimeError(
-                    'Terminal backend environment changed after ownership '
-                    'validation; refusing to execute against a replacement '
-                    '(fail-closed)'
-                )
+                if live is not env:
+                    raise RuntimeError(
+                        'Terminal backend environment changed after ownership '
+                        'validation; refusing to execute against a replacement '
+                        '(fail-closed)'
+                    )
+                if env is not None:
+                    _acquire_env_execution_lease(env)
             # Lock released — only now does the command execute, against the
-            # exact validated environment.
-            #
-            # Execution lease: the installed terminal_tool re-reads the
-            # registry by key before env.execute(), so a retirement between
-            # this final check and that lookup would execute the command
-            # against a replacement.  The lease pins the validated object for
-            # the duration of the command: every WebUI retirement path defers
-            # removal while a lease is held, and the registry is re-checked
-            # on release.
-            if env is not None:
-                _acquire_env_execution_lease(env)
+            # exact validated environment. The lease (published above, under
+            # the same lock) pins the object: every WebUI retirement path
+            # defers removal while a lease is held, and the registry is
+            # re-checked on release.
             try:
                 return original_terminal_tool(
                     command, background=background, timeout=timeout,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -12,6 +12,8 @@ import mimetypes
 import os
 import queue
 import random
+import hashlib
+import importlib
 import re
 import sqlite3
 import shlex
@@ -2764,59 +2766,258 @@ def _reset_streaming_hermes_home_override(override_mod, override_token, override
         logger.debug("Failed to reset streaming Hermes home override", exc_info=True)
 
 
-# ── Stale terminal-env cache invalidation (issue #5937) ─────────────────
+# ── Terminal backend identity and generation tracking (issue #5937) ──────
 # When WebUI switches between profiles with different terminal backends
-# (e.g., local → SSH), the agent's `_active_environments["default"]` cache
-# may still hold an environment created under the *previous* profile's
-# backend vars.  This causes a subsequent local-profile turn to execute
-# terminal/file tool calls against the stale remote SSH environment.
+# (e.g., local ↔ SSH or SSH host A → host B), the agent's
+# `_active_environments["default"]` cache may still hold an environment
+# created under the *previous* profile's backend vars.  This is a
+# security-class issue: a turn using profile B must never reuse an
+# environment created for profile A, even when both use the same
+# TERMINAL_ENV type.
 #
-# A single global tracker is sufficient because the cache is collapsed to
-# the shared key "default" — any profile switch that changes the backend
-# type must invalidate the global cached entry.
-_last_terminal_env: str | None = None
+# Design:
+#  1. Compute a normalized **fingerprint** of ALL terminal-relevant env
+#     vars (the same set consumed by terminal_tool._get_env_config()).
+#  2. Maintain a monotonic **generation counter**; bump it when the
+#     fingerprint changes between turns.
+#  3. Tag the live environment object with the generation that created it
+#     (via a side-attribute set after agent execution).
+#  4. At turn setup, compare fingerprints and bump generation; evict the
+#     cached env only if it matches the *stale* generation (i.e. no other
+#     concurrent turn has already replaced it).
+#  5. After each turn, tag any newly-created env with the current
+#     generation so the next setup can detect staleness.
+#  6. Monkey-patch terminal_tool.terminal_tool for atomic identity
+#     validation in the acquisition critical section, eliminating the
+#     os.environ race between setup and tool execution.
+
+# All env var keys that terminal_tool._get_env_config() reads, sorted.
+# Must be kept in sync with tools/terminal_tool.py:_get_env_config().
+_BACKEND_IDENTITY_KEYS: tuple[str, ...] = (
+    'TERMINAL_ENV',
+    'TERMINAL_CWD',
+    'TERMINAL_TIMEOUT',
+    'TERMINAL_LIFETIME_SECONDS',
+    'TERMINAL_MODAL_MODE',
+    'TERMINAL_DOCKER_IMAGE',
+    'TERMINAL_DOCKER_FORWARD_ENV',
+    'TERMINAL_DOCKER_ENV',
+    'TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE',
+    'TERMINAL_SINGULARITY_IMAGE',
+    'TERMINAL_MODAL_IMAGE',
+    'TERMINAL_DAYTONA_IMAGE',
+    'TERMINAL_CONTAINER_CPU',
+    'TERMINAL_CONTAINER_MEMORY',
+    'TERMINAL_CONTAINER_DISK',
+    'TERMINAL_CONTAINER_PERSISTENT',
+    'TERMINAL_DOCKER_VOLUMES',
+    'TERMINAL_PERSISTENT_SHELL',
+    'TERMINAL_SSH_HOST',
+    'TERMINAL_SSH_USER',
+    'TERMINAL_SSH_PORT',
+    'TERMINAL_SSH_KEY',
+    'TERMINAL_SSH_PERSISTENT',
+    'TERMINAL_LOCAL_PERSISTENT',
+    'TERMINAL_DOCKER_RUN_AS_HOST_USER',
+    'TERMINAL_DOCKER_NETWORK',
+    'TERMINAL_DOCKER_EXTRA_ARGS',
+    'TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES',
+    'TERMINAL_DOCKER_ORPHAN_REAPER',
+)
+
+# Backend identity and generation tracking
+_backend_generation_lock = threading.Lock()
+_current_backend_generation: int = 0  # monotonically increasing, bumps on identity change
+_env_backend_generations: dict[str, int] = {}  # task_key -> generation that created it
+_file_backend_generations: dict[str, int] = {}  # task_key -> generation for file ops cache
+_last_backend_identity: str | None = None  # sha256 fingerprint of the last-seen config
+_terminal_env_guard_installed: bool = False
 
 
-def _invalidate_stale_terminal_env(profile_runtime_env: dict) -> None:
-    """Drop the cached ``\"default\"`` terminal environment when the backend
-    type changes between WebUI turns.
+def _compute_backend_identity(profile_runtime_env: dict | None) -> str:
+    """Return a collision-resistant fingerprint of the terminal backend config.
 
-    Called during streaming turn setup, after the profile's terminal env
-    vars have been written to ``os.environ``, so the next terminal tool
-    call will create a fresh environment with the correct backend config.
+    Includes every env var that terminal_tool._get_env_config() reads, so two
+    profiles with the same TERMINAL_ENV but different SSH hosts, Docker images,
+    resource limits, etc. produce distinct fingerprints.
     """
-    global _last_terminal_env
-    current_env = (profile_runtime_env or {}).get("TERMINAL_ENV", "").strip() or None
+    env = profile_runtime_env or {}
+    parts: list[str] = []
+    for key in _BACKEND_IDENTITY_KEYS:
+        val = env.get(key, '')
+        if isinstance(val, bool):
+            val = 'true' if val else 'false'
+        elif not isinstance(val, str):
+            val = str(val)
+        parts.append(f'{key}={val}')
+    raw = '\n'.join(parts)
+    return hashlib.sha256(raw.encode('utf-8')).hexdigest()
 
-    if current_env == _last_terminal_env:
+
+def _get_expected_backend_generation(task_key: str) -> int | None:
+    """Return the expected generation for *task_key*, or None if untracked."""
+    with _backend_generation_lock:
+        return _env_backend_generations.get(task_key)
+
+
+def _mark_env_backend_generation(task_key: str, generation: int) -> None:
+    """Record the generation under which the env task_key was created."""
+    with _backend_generation_lock:
+        _env_backend_generations[task_key] = generation
+
+
+def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None:
+    """Evict the cached terminal/file environment when the backend config changes.
+
+    Called at turn startup, *after* _ENV_LOCK is released.  Uses a full backend
+    identity fingerprint (not just TERMINAL_ENV) and a generation counter so
+    that:
+      - SSH host A -> SSH host B (same TERMINAL_ENV=ssh) is detected
+      - The eviction targets only the exact stale generation, not an env
+        that another concurrent session has already replaced.
+    """
+    global _last_backend_identity, _current_backend_generation
+
+    identity = _compute_backend_identity(profile_runtime_env)
+
+    stale_generation: int | None = None
+
+    with _backend_generation_lock:
+        if identity == _last_backend_identity:
+            return  # same config, nothing to do
+        # Config changed — bump generation
+        _last_backend_identity = identity
+        stale_generation = _current_backend_generation
+        _current_backend_generation += 1
+        _env_backend_generations.pop('default', None)
+        _file_backend_generations.pop('default', None)
+
+    if stale_generation is None:
         return
 
-    previous = _last_terminal_env
-    _last_terminal_env = current_env
+    logger.info(
+        'Terminal backend identity changed (gen %d -> %d): checking for stale env',
+        stale_generation,
+        stale_generation + 1,
+    )
 
     try:
         from tools.terminal_tool import cleanup_vm, get_active_env
         from tools.file_tools import clear_file_ops_cache
 
-        cached = get_active_env("default")
-        if cached is not None:
-            logger.info(
-                "Terminal backend switched %s -> %s: evicting stale default env",
-                previous or "(none)",
-                current_env or "(none)",
+        # Only evict the env if its recorded generation matches our stale one.
+        # If another concurrent turn already replaced it with a newer generation
+        # (or removed it), we skip the eviction.
+        recorded = _get_expected_backend_generation('default')
+        if recorded != stale_generation:
+            logger.debug(
+                'Skipping eviction — cached env gen %s != stale gen %s',
+                recorded, stale_generation,
             )
-            cleanup_vm("default")
-            clear_file_ops_cache("default")
+            return
+
+        cached = get_active_env('default')
+        if cached is not None:
+            # Double-check the env object's side-attribute also confirms staleness
+            env_gen = getattr(cached, '_webui_backend_generation', None)
+            if env_gen is not None and env_gen != stale_generation:
+                logger.debug(
+                    'Skipping eviction — env object gen %s != stale gen %s',
+                    env_gen, stale_generation,
+                )
+                return
+            logger.info(
+                'Evicting stale terminal environment (gen %s) for new config',
+                stale_generation,
+            )
+            cleanup_vm('default')
+        clear_file_ops_cache('default')
     except ImportError:
         logger.debug(
-            "Terminal or file_tools not available for cache invalidation",
+            'Terminal or file_tools not available for cache invalidation',
             exc_info=True,
         )
     except Exception:
         logger.debug(
-            "Failed to invalidate stale terminal env",
+            'Failed to invalidate stale terminal env',
             exc_info=True,
         )
+
+
+def _refresh_env_generation_tag() -> None:
+    """After the agent turn, tag any newly-created environment with the
+    current generation so the next setup can detect staleness.
+
+    Safe to call multiple times: only tags an untagged or stale-tagged env.
+    """
+    try:
+        from tools.terminal_tool import get_active_env
+
+        env = get_active_env('default')
+        if env is not None:
+            recorded = _get_expected_backend_generation('default')
+            if recorded is not None:
+                env._webui_backend_generation = recorded
+    except ImportError:
+        pass
+    except Exception:
+        logger.debug('Failed to refresh env generation tag', exc_info=True)
+
+
+def _install_terminal_env_generation_guard() -> None:
+    """Monkey-patch terminal_tool.terminal_tool to validate environment
+    generation atomically inside the acquisition critical section.
+
+    This eliminates the os.environ race between turn-setup (which writes
+    env vars) and tool-execution (which reads them): the check happens
+    under _env_lock, in the same code path that acquires the cached env.
+    """
+    global _terminal_env_guard_installed
+    if _terminal_env_guard_installed:
+        return
+
+    try:
+        tt = importlib.import_module('tools.terminal_tool')
+
+        original_terminal_tool = tt.terminal_tool
+
+        def _wrapped_terminal_tool(
+            command, background=False, timeout=None, task_id=None,
+            session_id=None, force=False, workdir=None, pty=False,
+            notify_on_complete=False, watch_patterns=None,
+        ):
+            # Pre-flight: evict stale env under _env_lock, in the same
+            # critical section the acquisition path uses.
+            effective_task_id = tt._resolve_container_task_id(task_id)
+            with tt._env_lock:
+                env = tt.get_active_env(task_id)
+                if env is not None:
+                    env_gen = getattr(env, '_webui_backend_generation', None)
+                    if env_gen is not None:
+                        expected = _get_expected_backend_generation(effective_task_id)
+                        if expected is not None and env_gen != expected:
+                            # This env belongs to a stale generation — evict so
+                            # the acquisition path below creates a fresh one.
+                            logger.info(
+                                'Guard evicting stale env (gen %s, expected %s) on task %s',
+                                env_gen, expected, effective_task_id,
+                            )
+                            tt._active_environments.pop(effective_task_id, None)
+                            tt._last_activity.pop(effective_task_id, None)
+
+            return original_terminal_tool(
+                command, background=background, timeout=timeout,
+                task_id=task_id, session_id=session_id, force=force,
+                workdir=workdir, pty=pty,
+                notify_on_complete=notify_on_complete,
+                watch_patterns=watch_patterns,
+            )
+
+        tt.terminal_tool = _wrapped_terminal_tool
+        _terminal_env_guard_installed = True
+        logger.debug('Installed terminal env generation guard on terminal_tool')
+    except Exception:
+        logger.debug('Could not install terminal env generation guard', exc_info=True)
 
 
 # ── Per-turn session identity (xsession wakeup misroute root fix — Option 1) ─
@@ -9457,11 +9658,12 @@ def _run_agent_streaming(
             pass  # MCP not available or not configured — non-fatal
 
         # #5937: invalidate the cached "default" terminal environment when
-        # the profile's TERMINAL_ENV backend type changes.  Without this,
-        # a local-backend turn reuses a stale SSH/Docker environment created
-        # by an earlier remote-backend profile session in the same process,
-        # causing terminal/file tool calls to execute on the wrong backend.
-        _invalidate_stale_terminal_env(_safe_profile_runtime_env)
+        # the profile's terminal backend identity changes.  Uses a full
+        # config fingerprint (not just TERMINAL_ENV type) and generation
+        # tracking so SSH host A -> host B is detected and only the exact
+        # stale generation is evicted.
+        _invalidate_stale_terminal_backend(_safe_profile_runtime_env)
+        _install_terminal_env_generation_guard()
 
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is
@@ -12434,6 +12636,10 @@ def _run_agent_streaming(
                     _unreg_clarify_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister clarify callback")
+            # #5937: tag the live env with its current generation so the next
+            # turn's setup can detect staleness.  Run before env var restoration
+            # so get_active_env() still works.
+            _refresh_env_generation_tag()
             with _ENV_LOCK:
                 for _key, _old_value in old_profile_env.items():
                     if _old_value is None: os.environ.pop(_key, None)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2780,16 +2780,22 @@ def _reset_streaming_hermes_home_override(override_mod, override_token, override
 #     vars (the same set consumed by terminal_tool._get_env_config()).
 #  2. Maintain a monotonic **generation counter**; bump it when the
 #     fingerprint changes between turns.
-#  3. Tag the live environment object with the generation that created it
-#     (via a side-attribute set after agent execution).
-#  4. At turn setup, compare fingerprints and bump generation; evict the
-#     cached env only if it matches the *stale* generation (i.e. no other
-#     concurrent turn has already replaced it).
-#  5. After each turn, tag any newly-created env with the current
-#     generation so the next setup can detect staleness.
-#  6. Monkey-patch terminal_tool.terminal_tool for atomic identity
-#     validation in the acquisition critical section, eliminating the
-#     os.environ race between setup and tool execution.
+#  3. Tag every live environment object with the generation that created it
+#     (atomically at creation, via a wrapper on _create_environment — the
+#     single creation funnel shared by terminal/file/code-execution paths).
+#  4. At turn setup, compare fingerprints; the identity transition and the
+#     ownership registration (recorded owner = new generation) are ATOMIC
+#     under one lock hold, and the stale generation is recorded in
+#     _pending_eviction_generations.
+#  5. ONE shared acquisition boundary (terminal_tool.terminal_tool,
+#     file_tools._get_file_ops, code_execution_tool._get_or_create_env)
+#     compares the live env's tag against the CALLING TURN's captured
+#     (thread-local) generation — never the process-global current
+#     generation — and never reuses or tears down an env an active
+#     old-backend turn still owns (retire deferred until drain).
+#  6. Retire is compare-and-remove under the registry lock, cleaning up the
+#     exact removed object OUTSIDE the lock, eliminating the
+#     setup-to-tool os.environ race and the read/retire replacement gap.
 
 # All env var keys that terminal_tool._get_env_config() reads, sorted.
 # Must be kept in sync with tools/terminal_tool.py:_get_env_config().
@@ -2836,7 +2842,13 @@ _terminal_env_guard_installed: bool = False
 # it.  A stale generation is only retired once no turn is still using it, so a
 # replacement can never tear down an environment another turn is mid-execution.
 _active_turn_generations: dict[int, int] = {}
-_pending_eviction_generation: int | None = None  # deferred retire, drained on last turn exit
+# Every deferred stale generation (not one lossy scalar): a generation is
+# retired only once no turn still executes under it.  Guarded by
+# _backend_generation_lock; drained by _drain_pending_evictions().
+_pending_eviction_generations: set[int] = set()
+# Condition notified whenever a turn exits, so an acquisition blocked on an
+# active old generation's drain can proceed the moment it completes.
+_backend_generation_cond = threading.Condition(_backend_generation_lock)
 _turn_state = threading.local()  # thread-local backend generation for the running turn
 
 
@@ -2903,45 +2915,93 @@ def _unregister_turn_generation() -> None:
             _active_turn_generations[gen] = remaining
         else:
             _active_turn_generations.pop(gen, None)
-    _drain_pending_eviction()
+        # Wake any acquisition that is blocked waiting for this generation to
+        # drain (see _wait_for_generation_drain) so it can proceed/retire.
+        _backend_generation_cond.notify_all()
+    _drain_pending_evictions()
 
 
-def _drain_pending_eviction() -> None:
-    """Retire a previously-deferred stale environment once no turn uses it.
+def _drain_pending_evictions() -> None:
+    """Retire every deferred stale generation whose turns have all exited.
 
-    Called when the last turn under the deferred generation exits.  Safe to
-    call any time: no-ops when nothing is pending or the generation is still
-    in use.
+    Called when a turn exits.  Safe to call any time: no-ops when nothing is
+    pending or a generation is still in use.  Every pending generation is
+    represented (set, not a lossy scalar), so rapid A→B→C switches each get
+    their stale env retired once their own turns drain.
     """
-    global _pending_eviction_generation
     with _backend_generation_lock:
-        pending = _pending_eviction_generation
-        if pending is None:
+        ready = [
+            g for g in _pending_eviction_generations
+            if _active_turn_generations.get(g, 0) == 0
+        ]
+        if not ready:
             return
-        if _active_turn_generations.get(pending, 0) > 0:
-            return
-        _pending_eviction_generation = None
-    try:
-        from tools.terminal_tool import cleanup_vm, get_active_env
-        from tools.file_tools import clear_file_ops_cache
+        for g in ready:
+            _pending_eviction_generations.discard(g)
+    for g in ready:
+        try:
+            _retire_generation_env(g, 'default')
+        except Exception:
+            logger.debug(
+                'Failed to retire deferred stale generation %s', g, exc_info=True,
+            )
 
-        cached = get_active_env('default')
-        if cached is not None:
-            env_gen = getattr(cached, '_webui_backend_generation', None)
-            if env_gen is None or env_gen == pending:
-                logger.info(
-                    'Retiring deferred stale terminal environment (gen %s)',
-                    pending,
-                )
-                cleanup_vm('default')
-        clear_file_ops_cache('default')
-    except ImportError:
-        logger.debug(
-            'Terminal or file_tools not available for deferred invalidation',
-            exc_info=True,
-        )
+
+def _cleanup_environment_object(env) -> None:
+    """Run the teardown the agent's ``cleanup_vm`` would run on one env.
+
+    Called OUTSIDE the registry lock, on the exact object removed by
+    ``_retire_generation_env``, so a replacement installed under the same key
+    is never torn down.
+    """
+    try:
+        if hasattr(env, 'cleanup'):
+            env.cleanup()
+        elif hasattr(env, 'stop'):
+            env.stop()
+        elif hasattr(env, 'terminate'):
+            env.terminate()
     except Exception:
-        logger.debug('Failed to drain deferred terminal env eviction', exc_info=True)
+        logger.debug('Failed to clean retired terminal env', exc_info=True)
+
+
+def _retire_generation_env(generation: int, task_key: str = 'default') -> None:
+    """Retire the live env tagged with *generation* on *task_key*.
+
+    Compare-and-remove is atomic under the registry lock (``tt._env_lock``),
+    and the exact removed object is cleaned up OUTSIDE the lock — closing the
+    read/retire gap where a replacement installed under the same key could be
+    torn down by a later by-key pop.  The env is only retired when its object
+    tag matches *generation*; a newer replacement is never touched.
+    """
+    try:
+        tt = importlib.import_module('tools.terminal_tool')
+    except ImportError:
+        return
+    stale_env = None
+    with tt._env_lock:
+        env = tt._active_environments.get(task_key)
+        if env is None:
+            return
+        env_gen = getattr(env, '_webui_backend_generation', None)
+        if env_gen is None or env_gen != generation:
+            # Replaced by a newer env — never retire it.
+            return
+        # Compare-and-remove: this whole read/pop is one lock hold, so the
+        # registry cannot change underneath us.
+        tt._active_environments.pop(task_key, None)
+        tt._last_activity.pop(task_key, None)
+        stale_env = env
+    if stale_env is None:
+        return
+    _cleanup_environment_object(stale_env)
+    try:
+        from tools.file_tools import clear_file_ops_cache
+        clear_file_ops_cache(task_key)
+    except Exception:
+        logger.debug(
+            'Failed to clear file ops cache during env retire', exc_info=True,
+        )
 
 
 def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None:
@@ -2951,31 +3011,36 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
     identity fingerprint (not just TERMINAL_ENV) and a generation counter so
     that:
       - SSH host A -> SSH host B (same TERMINAL_ENV=ssh) is detected
-      - The eviction targets only the exact stale generation, not an env
-        that another concurrent session has already replaced.
+      - The identity transition and the ownership registration are ATOMIC:
+        the new generation is published as the recorded owner in the same
+        lock hold as the bump, so no interleaved guard read can observe a
+        half-transitioned state (recorded owner still == old generation).
+      - The eviction targets only the exact stale generation, never an env
+        that another concurrent session has already replaced (compare-and-
+        remove, cleanup of the exact removed object outside the lock).
       - An environment still executing an older turn is never torn down:
-        its retire is deferred until the last turn under that generation exits.
+        its retire is deferred until the last turn under that generation exits
+        (recorded in _pending_eviction_generations, drained by
+        _drain_pending_evictions).
     """
     global _last_backend_identity, _current_backend_generation
 
     identity = _compute_backend_identity(profile_runtime_env)
 
-    stale_generation: int | None = None
-
     with _backend_generation_lock:
         if identity == _last_backend_identity:
             return  # same config, nothing to do
-        # Config changed — bump generation.  NOTE: we do NOT clear the
-        # generation records here; the recorded generation is the evidence
-        # the stale check below compares against.  Popping it first made
-        # `recorded` always None so the eviction never ran.
         _last_backend_identity = identity
         stale_generation = _current_backend_generation
         _current_backend_generation += 1
-        _file_backend_generations.pop('default', None)
-
-    if stale_generation is None:
-        return
+        # ATOMIC transition + ownership registration: publish the new owner
+        # and record the pending stale generation under the same lock hold as
+        # the bump.  The old code deferred this publish until after the
+        # active-use check, so the guard kept comparing against the old
+        # recorded generation and let the new turn reuse the stale env.
+        _env_backend_generations['default'] = _current_backend_generation
+        _file_backend_generations['default'] = _current_backend_generation
+        _pending_eviction_generations.add(stale_generation)
 
     logger.info(
         'Terminal backend identity changed (gen %d -> %d): checking for stale env',
@@ -2983,51 +3048,19 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
         stale_generation + 1,
     )
 
-    try:
-        from tools.terminal_tool import cleanup_vm, get_active_env
-        from tools.file_tools import clear_file_ops_cache
-
-        # Only evict the env if its recorded generation matches our stale one.
-        # If another concurrent turn already replaced it with a newer generation
-        # (or removed it), we skip the eviction.
-        recorded = _get_expected_backend_generation('default')
-        if recorded == stale_generation:
-            if _active_turn_generations.get(stale_generation, 0) > 0:
-                # A turn is still executing under the stale generation —
-                # defer the retire until that turn exits.
-                with _backend_generation_lock:
-                    _pending_eviction_generation = stale_generation
-                logger.info(
-                    'Deferring stale env retire (gen %s) — active turn still using it',
-                    stale_generation,
-                )
-                return
-
-            cached = get_active_env('default')
-            if cached is not None:
-                # Double-check the env object's side-attribute also confirms staleness
-                env_gen = getattr(cached, '_webui_backend_generation', None)
-                if env_gen is not None and env_gen != stale_generation:
-                    logger.debug(
-                        'Skipping eviction — env object gen %s != stale gen %s',
-                        env_gen, stale_generation,
-                    )
-                    return
-                logger.info(
-                    'Evicting stale terminal environment (gen %s) for new config',
-                    stale_generation,
-                )
-                cleanup_vm('default')
-            clear_file_ops_cache('default')
-
-        # Publish ownership: the next environment acquired on this task_key
-        # belongs to the *new* generation.
-        _mark_env_backend_generation('default', _current_backend_generation)
-    except ImportError:
-        logger.debug(
-            'Terminal or file_tools not available for cache invalidation',
-            exc_info=True,
+    if _active_turn_generations.get(stale_generation, 0) > 0:
+        # A turn is still executing under the stale generation — defer the
+        # retire until that turn exits (drained by _drain_pending_evictions).
+        logger.info(
+            'Deferring stale env retire (gen %s) — active turn still using it',
+            stale_generation,
         )
+        return
+
+    try:
+        _retire_generation_env(stale_generation, 'default')
+        with _backend_generation_lock:
+            _pending_eviction_generations.discard(stale_generation)
     except Exception:
         logger.debug(
             'Failed to invalidate stale terminal env',
@@ -3038,17 +3071,25 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
 def _refresh_env_generation_tag() -> None:
     """After the agent turn, publish ownership of the live environment.
 
-    Records the current generation as the owner of the cached 'default' env
-    (if one exists) and tags the env object with it.  This is the publish
+    Records the CURRENT TURN's generation as the owner of the cached 'default'
+    env (if one exists) and tags the env object with it.  This is the publish
     side of the generation protocol: without it the invalidator has no
     recorded owner to compare against and can never retire a stale env.
+
+    The tag MUST be the calling turn's captured (thread-local) generation, NOT
+    the process-global current generation: a concurrent profile switch may
+    already have bumped the global generation while this turn was still
+    executing, and tagging this turn's env with that newer generation would
+    make the guard consider a stale-backend env "owned" by the new backend.
     """
     try:
         from tools.terminal_tool import get_active_env
 
         env = get_active_env('default')
         if env is not None:
-            gen = _get_current_backend_generation()
+            gen = getattr(_turn_state, 'backend_generation', None)
+            if gen is None:
+                gen = _get_current_backend_generation()
             _mark_env_backend_generation('default', gen)
             env._webui_backend_generation = gen
     except ImportError:
@@ -3057,13 +3098,167 @@ def _refresh_env_generation_tag() -> None:
         logger.debug('Failed to refresh env generation tag', exc_info=True)
 
 
-def _install_terminal_env_generation_guard() -> None:
-    """Monkey-patch terminal_tool.terminal_tool to validate environment
-    generation atomically inside the acquisition critical section.
+def _wait_for_generation_drain(
+    generation: int, timeout: float | None = None,
+) -> None:
+    """Block until no turn is active under *generation* (bounded).
 
-    This eliminates the os.environ race between turn-setup (which writes
-    env vars) and tool-execution (which reads them): the check happens
-    under _env_lock, in the same code path that acquires the cached env.
+    Used by the shared acquisition boundary when the live env belongs to a
+    generation that still has executing turns: the new-backend turn must
+    neither reuse nor tear down that env, so it waits for the old turns to
+    exit (their unregister notifies this condition) before retiring the stale
+    env and letting the original acquisition create a fresh one.
+
+    On timeout the acquisition is REFUSED (raises) rather than silently
+    reusing or tearing down an env an active turn may still own.
+    """
+    if timeout is None:
+        timeout = float(os.environ.get('HERMES_WEBUI_BACKEND_DRAIN_TIMEOUT', '300'))
+    deadline = time.monotonic() + timeout
+    with _backend_generation_lock:
+        while _active_turn_generations.get(generation, 0) > 0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    'Timed out waiting for backend generation %s to drain; '
+                    'refusing acquisition rather than reusing or tearing down '
+                    'an environment an active turn may still own',
+                    generation,
+                )
+                raise RuntimeError(
+                    f'Terminal backend generation {generation} did not drain '
+                    f'within {timeout:.0f}s; refusing cross-backend acquisition'
+                )
+            _backend_generation_cond.wait(min(remaining, 1.0))
+
+
+def _validate_backend_ownership(tt, effective_task_id: str, raw_task_id) -> None:
+    """ONE shared acquisition boundary for terminal / file / code-execution.
+
+    Guarantees the calling turn never reuses an environment created under a
+    different backend generation, and never tears down an environment an
+    active old-backend turn still owns:
+
+      * The expected owner is the CALLING TURN's captured (thread-local)
+        generation — carried immutably from turn setup — NOT the
+        process-global current generation (which a concurrent profile switch
+        may already have bumped past the env's tag).
+      * An env tagged with a different generation is never reused.
+      * If turns still execute under that generation, the retire is deferred:
+        we wait (bounded) for them to drain instead of tearing the env down
+        mid-use.  The retire itself is a compare-and-remove that cleans up the
+        exact removed object OUTSIDE the registry lock, and the loop
+        re-validates afterwards so a replacement installed while we waited is
+        never reused or torn down either.
+    """
+    turn_gen = getattr(_turn_state, 'backend_generation', None)
+    # Untracked callers (non-WebUI flows) fall back to the recorded per-task
+    # owner; registered WebUI turns always compare against their own captured
+    # generation.
+    expected = (
+        turn_gen if turn_gen is not None
+        else _get_expected_backend_generation(effective_task_id)
+    )
+    while True:
+        with tt._env_lock:
+            env = (
+                tt._active_environments.get(effective_task_id)
+                or tt._active_environments.get(raw_task_id)
+            )
+            if env is None:
+                return
+            env_gen = getattr(env, '_webui_backend_generation', None)
+            if env_gen is None or env_gen == expected:
+                return
+            if turn_gen is not None:
+                with _backend_generation_lock:
+                    _pending_eviction_generations.add(env_gen)
+                    gen_active = _active_turn_generations.get(env_gen, 0) > 0
+            else:
+                gen_active = False
+        if turn_gen is not None and gen_active:
+            # An old-backend turn still owns this env — never tear it down.
+            # Wait for it to exit, then re-validate (it may have been retired
+            # by the drain, or replaced by a concurrent thread).
+            _wait_for_generation_drain(env_gen)
+        else:
+            _retire_generation_env(env_gen, effective_task_id)
+
+
+def _evict_stale_file_ops_cache_entry(ft, task_key: str, turn_gen: int) -> None:
+    """Drop a cached file_ops object tagged with a stale generation.
+
+    Compare-and-remove under the module's own cache lock so a concurrent
+    replacement installed under the same key is never cleared.
+    """
+    try:
+        cache = ft._file_ops_cache
+        cache_lock = ft._file_ops_lock
+    except AttributeError:
+        return
+    with cache_lock:
+        cached = cache.get(task_key)
+    if cached is None:
+        return
+    cached_gen = getattr(cached, '_webui_backend_generation', None)
+    if cached_gen is None or cached_gen == turn_gen:
+        return
+    with cache_lock:
+        if cache.get(task_key) is cached:
+            cache.pop(task_key, None)
+
+
+def _mark_file_backend_generation(task_key: str, generation: int) -> None:
+    """Record the generation under which the file_ops cache was created."""
+    with _backend_generation_lock:
+        _file_backend_generations[task_key] = generation
+
+
+def _begin_turn_generation(profile_runtime_env: dict | None) -> None:
+    """Turn-setup entry: identity transition (non-fatal) then registration.
+
+    Registration is GUARANTEED even when the identity transition fails, and
+    the production call site places this inside the same try whose finally
+    calls :func:`_end_turn_generation` — so a turn can never leak its
+    active-use registration, whatever the agent body does.
+    """
+    try:
+        _invalidate_stale_terminal_backend(profile_runtime_env)
+    except Exception:
+        logger.debug(
+            'Terminal backend identity transition failed; continuing with '
+            'current generation',
+            exc_info=True,
+        )
+    _register_turn_generation()
+
+
+def _end_turn_generation() -> None:
+    """Turn-teardown entry: guaranteed unregistration + deferred drain."""
+    try:
+        _unregister_turn_generation()
+    except Exception:
+        logger.debug('Turn generation unregister failed', exc_info=True)
+
+
+def _install_terminal_env_generation_guard() -> None:
+    """Monkey-patch ALL terminal/file/code-execution acquisition paths with a
+    single shared backend-ownership boundary.
+
+    The guard wraps:
+      * ``terminal_tool.terminal_tool``
+      * ``file_tools._get_file_ops``            (file tools bypassed the guard)
+      * ``code_execution_tool._get_or_create_env`` (execute_code bypassed it)
+      * ``terminal_tool._create_environment``   (single creation funnel: every
+        env created during a WebUI turn is tagged with the calling turn's
+        generation atomically at creation, so no untagged window exists)
+
+    Each wrapped acquisition validates ownership via
+    :func:`_validate_backend_ownership` under the registry lock (inline lookup
+    — never a lock-taking accessor like ``get_active_env()`` while holding the
+    non-reentrant ``_env_lock``) and compares against the calling turn's
+    captured generation, eliminating the setup-to-tool os.environ race for
+    cached environments.
     """
     global _terminal_env_guard_installed
     if _terminal_env_guard_installed:
@@ -3071,7 +3266,12 @@ def _install_terminal_env_generation_guard() -> None:
 
     try:
         tt = importlib.import_module('tools.terminal_tool')
+    except ImportError:
+        logger.debug('Could not install terminal env generation guard', exc_info=True)
+        return
 
+    # 1) terminal_tool.terminal_tool
+    if hasattr(tt, 'terminal_tool'):
         original_terminal_tool = tt.terminal_tool
 
         def _wrapped_terminal_tool(
@@ -3079,52 +3279,8 @@ def _install_terminal_env_generation_guard() -> None:
             session_id=None, force=False, workdir=None, pty=False,
             notify_on_complete=False, watch_patterns=None,
         ):
-            # Pre-flight: evict stale env under _env_lock, in the same
-            # critical section the acquisition path uses.
-            #
-            # ⚠️ DEADLOCK GUARD: do NOT call tt.get_active_env() while
-            # holding tt._env_lock.  The agent's _env_lock is a plain
-            # non-reentrant threading.Lock and get_active_env() acquires it
-            # again (tools/terminal_tool.py ~1736-1740) — the first guarded
-            # terminal call would block forever.  Replicate the accessor's
-            # lookup inline instead so the read and the compare-and-retire
-            # stay atomic under one acquisition of the lock.
             effective_task_id = tt._resolve_container_task_id(task_id)
-            stale_env = None
-            with tt._env_lock:
-                # Same lookup semantics as tt.get_active_env(task_id):
-                # prefer the collapsed container id, fall back to the raw id.
-                env = (
-                    tt._active_environments.get(effective_task_id)
-                    or tt._active_environments.get(task_id)
-                )
-                if env is not None:
-                    env_gen = getattr(env, '_webui_backend_generation', None)
-                    if env_gen is not None:
-                        expected = _get_expected_backend_generation(effective_task_id)
-                        if expected is not None and env_gen != expected:
-                            # This env belongs to a stale generation — evict so
-                            # the acquisition path below creates a fresh one.
-                            logger.info(
-                                'Guard evicting stale env (gen %s, expected %s) on task %s',
-                                env_gen, expected, effective_task_id,
-                            )
-                            # Compare-and-retire: pop only if the registry still
-                            # points at THIS env object (someone else may have
-                            # replaced it since the read).
-                            if tt._active_environments.get(effective_task_id) is env:
-                                tt._active_environments.pop(effective_task_id, None)
-                                tt._last_activity.pop(effective_task_id, None)
-                                stale_env = env
-
-            if stale_env is not None:
-                # Publish ownership for the replacement BEFORE the original
-                # tool call runs: the next env acquired on this task belongs
-                # to the current generation.
-                _mark_env_backend_generation(
-                    effective_task_id, _get_current_backend_generation()
-                )
-
+            _validate_backend_ownership(tt, effective_task_id, task_id)
             return original_terminal_tool(
                 command, background=background, timeout=timeout,
                 task_id=task_id, session_id=session_id, force=force,
@@ -3134,10 +3290,84 @@ def _install_terminal_env_generation_guard() -> None:
             )
 
         tt.terminal_tool = _wrapped_terminal_tool
-        _terminal_env_guard_installed = True
-        logger.debug('Installed terminal env generation guard on terminal_tool')
-    except Exception:
-        logger.debug('Could not install terminal env generation guard', exc_info=True)
+
+    # 2) file_tools._get_file_ops — previously bypassed the guard entirely:
+    #    it reused _active_environments directly without any ownership check.
+    try:
+        ft = importlib.import_module('tools.file_tools')
+    except ImportError:
+        ft = None
+    if ft is not None and hasattr(ft, '_get_file_ops'):
+        original_get_file_ops = ft._get_file_ops
+
+        def _wrapped_get_file_ops(task_id="default"):
+            effective_task_id = tt._resolve_container_task_id(task_id)
+            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            _validate_backend_ownership(tt, effective_task_id, task_id)
+            if turn_gen is not None:
+                _evict_stale_file_ops_cache_entry(ft, effective_task_id, turn_gen)
+            file_ops = original_get_file_ops(task_id)
+            if turn_gen is not None and file_ops is not None:
+                try:
+                    file_ops._webui_backend_generation = turn_gen
+                    _mark_file_backend_generation(effective_task_id, turn_gen)
+                except Exception:
+                    pass
+            return file_ops
+
+        ft._get_file_ops = _wrapped_get_file_ops
+
+    # 3) code_execution_tool._get_or_create_env — previously bypassed the
+    #    guard entirely: it reused _active_environments directly.
+    try:
+        cet = importlib.import_module('tools.code_execution_tool')
+    except ImportError:
+        cet = None
+    if cet is not None and hasattr(cet, '_get_or_create_env'):
+        original_get_or_create_env = cet._get_or_create_env
+
+        def _wrapped_get_or_create_env(task_id):
+            effective_task_id = tt._resolve_container_task_id(task_id)
+            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            _validate_backend_ownership(tt, effective_task_id, task_id)
+            result = original_get_or_create_env(task_id)
+            if turn_gen is not None and result is not None:
+                try:
+                    env = result[0] if isinstance(result, tuple) else result
+                    if env is not None:
+                        if getattr(env, '_webui_backend_generation', None) is None:
+                            env._webui_backend_generation = turn_gen
+                        _mark_env_backend_generation(effective_task_id, turn_gen)
+                except Exception:
+                    pass
+            return result
+
+        cet._get_or_create_env = _wrapped_get_or_create_env
+
+    # 4) Tag envs at creation — the single creation funnel shared by all three
+    #    paths (terminal_tool, _get_file_ops, _get_or_create_env all call
+    #    _create_environment when no env exists).  Tagging happens before the
+    #    env is stored in the registry, so there is no untagged window.
+    if hasattr(tt, '_create_environment'):
+        original_create_environment = tt._create_environment
+
+        def _wrapped_create_environment(*args, **kwargs):
+            env = original_create_environment(*args, **kwargs)
+            turn_gen = getattr(_turn_state, 'backend_generation', None)
+            if turn_gen is not None and env is not None:
+                try:
+                    env._webui_backend_generation = turn_gen
+                except Exception:
+                    pass
+            return env
+
+        tt._create_environment = _wrapped_create_environment
+
+    _terminal_env_guard_installed = True
+    logger.debug(
+        'Installed terminal env generation guard '
+        '(terminal/file/code-execution paths)'
+    )
 
 
 # ── Per-turn session identity (xsession wakeup misroute root fix — Option 1) ─
@@ -9777,17 +10007,11 @@ def _run_agent_streaming(
         except Exception:
             pass  # MCP not available or not configured — non-fatal
 
-        # #5937: invalidate the cached "default" terminal environment when
-        # the profile's terminal backend identity changes.  Uses a full
-        # config fingerprint (not just TERMINAL_ENV) and generation
-        # tracking so SSH host A -> host B is detected and only the exact
-        # stale generation is evicted.
-        _invalidate_stale_terminal_backend(_safe_profile_runtime_env)
-        _install_terminal_env_generation_guard()
-        # Active-use ownership: this turn now executes under the current
-        # generation, so a concurrent profile switch defers retiring an env
-        # this turn may still be using.
-        _register_turn_generation()
+        # #5937: the terminal backend generation guard + turn registration are
+        # performed INSIDE the guaranteed try/finally below (first statements
+        # of the try), so the finally ALWAYS unregisters this turn — even when
+        # the agent body raises mid-turn.  See _begin_turn_generation /
+        # _end_turn_generation.
 
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is
@@ -9878,6 +10102,14 @@ def _run_agent_streaming(
             )
 
         try:
+            # #5937: install the shared terminal/file/code-execution ownership
+            # guard and register THIS turn's active-use generation FIRST, so
+            # the finally below (which calls _end_turn_generation) is the
+            # guaranteed outer try/finally for the registration — even when the
+            # agent body raises, the registration is released and deferred
+            # stale evictions are drained.
+            _install_terminal_env_generation_guard()
+            _begin_turn_generation(_safe_profile_runtime_env)
             _token_sent = False  # tracks whether any streamed tokens were sent
             _self_healed = False  # (#1401) prevents infinite self-heal retries
             # Per-message reasoning: dict maps assistant-message index → accumulated text
@@ -12760,13 +12992,15 @@ def _run_agent_streaming(
                     _unreg_clarify_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister clarify callback")
-            # #5937: tag the live env with its current generation so the next
+            # #5937: tag the live env with this turn's generation so the next
             # turn's setup can detect staleness.  Run before env var restoration
             # so get_active_env() still works.
             _refresh_env_generation_tag()
-            # Active-use ownership: this turn has finished; drain any stale
-            # eviction deferred while it was still executing.
-            _unregister_turn_generation()
+            # Active-use ownership: this turn has finished; release the
+            # registration and drain any stale eviction deferred while it was
+            # still executing (guaranteed outer try/finally — see
+            # _begin_turn_generation above).
+            _end_turn_generation()
             with _ENV_LOCK:
                 for _key, _old_value in old_profile_env.items():
                     if _old_value is None: os.environ.pop(_key, None)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2832,6 +2832,12 @@ _env_backend_generations: dict[str, int] = {}  # task_key -> generation that cre
 _file_backend_generations: dict[str, int] = {}  # task_key -> generation for file ops cache
 _last_backend_identity: str | None = None  # sha256 fingerprint of the last-seen config
 _terminal_env_guard_installed: bool = False
+# Active-use ownership: generation -> number of turns currently executing under
+# it.  A stale generation is only retired once no turn is still using it, so a
+# replacement can never tear down an environment another turn is mid-execution.
+_active_turn_generations: dict[int, int] = {}
+_pending_eviction_generation: int | None = None  # deferred retire, drained on last turn exit
+_turn_state = threading.local()  # thread-local backend generation for the running turn
 
 
 def _compute_backend_identity(profile_runtime_env: dict | None) -> str:
@@ -2866,6 +2872,78 @@ def _mark_env_backend_generation(task_key: str, generation: int) -> None:
         _env_backend_generations[task_key] = generation
 
 
+def _get_current_backend_generation() -> int:
+    """Return the current generation under the generation lock."""
+    with _backend_generation_lock:
+        return _current_backend_generation
+
+
+def _register_turn_generation() -> None:
+    """Mark the current thread as executing a turn under the current generation.
+
+    Runs at turn startup (after identity invalidation).  The stale-generation
+    retire path consults this counter so it never tears down an environment a
+    concurrent turn is still using.
+    """
+    gen = _get_current_backend_generation()
+    _turn_state.backend_generation = gen
+    with _backend_generation_lock:
+        _active_turn_generations[gen] = _active_turn_generations.get(gen, 0) + 1
+
+
+def _unregister_turn_generation() -> None:
+    """Mark the current turn as finished; drain any deferred stale eviction."""
+    gen = getattr(_turn_state, 'backend_generation', None)
+    if gen is None:
+        return
+    _turn_state.backend_generation = None
+    with _backend_generation_lock:
+        remaining = _active_turn_generations.get(gen, 1) - 1
+        if remaining > 0:
+            _active_turn_generations[gen] = remaining
+        else:
+            _active_turn_generations.pop(gen, None)
+    _drain_pending_eviction()
+
+
+def _drain_pending_eviction() -> None:
+    """Retire a previously-deferred stale environment once no turn uses it.
+
+    Called when the last turn under the deferred generation exits.  Safe to
+    call any time: no-ops when nothing is pending or the generation is still
+    in use.
+    """
+    global _pending_eviction_generation
+    with _backend_generation_lock:
+        pending = _pending_eviction_generation
+        if pending is None:
+            return
+        if _active_turn_generations.get(pending, 0) > 0:
+            return
+        _pending_eviction_generation = None
+    try:
+        from tools.terminal_tool import cleanup_vm, get_active_env
+        from tools.file_tools import clear_file_ops_cache
+
+        cached = get_active_env('default')
+        if cached is not None:
+            env_gen = getattr(cached, '_webui_backend_generation', None)
+            if env_gen is None or env_gen == pending:
+                logger.info(
+                    'Retiring deferred stale terminal environment (gen %s)',
+                    pending,
+                )
+                cleanup_vm('default')
+        clear_file_ops_cache('default')
+    except ImportError:
+        logger.debug(
+            'Terminal or file_tools not available for deferred invalidation',
+            exc_info=True,
+        )
+    except Exception:
+        logger.debug('Failed to drain deferred terminal env eviction', exc_info=True)
+
+
 def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None:
     """Evict the cached terminal/file environment when the backend config changes.
 
@@ -2875,6 +2953,8 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
       - SSH host A -> SSH host B (same TERMINAL_ENV=ssh) is detected
       - The eviction targets only the exact stale generation, not an env
         that another concurrent session has already replaced.
+      - An environment still executing an older turn is never torn down:
+        its retire is deferred until the last turn under that generation exits.
     """
     global _last_backend_identity, _current_backend_generation
 
@@ -2885,11 +2965,13 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
     with _backend_generation_lock:
         if identity == _last_backend_identity:
             return  # same config, nothing to do
-        # Config changed — bump generation
+        # Config changed — bump generation.  NOTE: we do NOT clear the
+        # generation records here; the recorded generation is the evidence
+        # the stale check below compares against.  Popping it first made
+        # `recorded` always None so the eviction never ran.
         _last_backend_identity = identity
         stale_generation = _current_backend_generation
         _current_backend_generation += 1
-        _env_backend_generations.pop('default', None)
         _file_backend_generations.pop('default', None)
 
     if stale_generation is None:
@@ -2909,29 +2991,38 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
         # If another concurrent turn already replaced it with a newer generation
         # (or removed it), we skip the eviction.
         recorded = _get_expected_backend_generation('default')
-        if recorded != stale_generation:
-            logger.debug(
-                'Skipping eviction — cached env gen %s != stale gen %s',
-                recorded, stale_generation,
-            )
-            return
-
-        cached = get_active_env('default')
-        if cached is not None:
-            # Double-check the env object's side-attribute also confirms staleness
-            env_gen = getattr(cached, '_webui_backend_generation', None)
-            if env_gen is not None and env_gen != stale_generation:
-                logger.debug(
-                    'Skipping eviction — env object gen %s != stale gen %s',
-                    env_gen, stale_generation,
+        if recorded == stale_generation:
+            if _active_turn_generations.get(stale_generation, 0) > 0:
+                # A turn is still executing under the stale generation —
+                # defer the retire until that turn exits.
+                with _backend_generation_lock:
+                    _pending_eviction_generation = stale_generation
+                logger.info(
+                    'Deferring stale env retire (gen %s) — active turn still using it',
+                    stale_generation,
                 )
                 return
-            logger.info(
-                'Evicting stale terminal environment (gen %s) for new config',
-                stale_generation,
-            )
-            cleanup_vm('default')
-        clear_file_ops_cache('default')
+
+            cached = get_active_env('default')
+            if cached is not None:
+                # Double-check the env object's side-attribute also confirms staleness
+                env_gen = getattr(cached, '_webui_backend_generation', None)
+                if env_gen is not None and env_gen != stale_generation:
+                    logger.debug(
+                        'Skipping eviction — env object gen %s != stale gen %s',
+                        env_gen, stale_generation,
+                    )
+                    return
+                logger.info(
+                    'Evicting stale terminal environment (gen %s) for new config',
+                    stale_generation,
+                )
+                cleanup_vm('default')
+            clear_file_ops_cache('default')
+
+        # Publish ownership: the next environment acquired on this task_key
+        # belongs to the *new* generation.
+        _mark_env_backend_generation('default', _current_backend_generation)
     except ImportError:
         logger.debug(
             'Terminal or file_tools not available for cache invalidation',
@@ -2945,19 +3036,21 @@ def _invalidate_stale_terminal_backend(profile_runtime_env: dict | None) -> None
 
 
 def _refresh_env_generation_tag() -> None:
-    """After the agent turn, tag any newly-created environment with the
-    current generation so the next setup can detect staleness.
+    """After the agent turn, publish ownership of the live environment.
 
-    Safe to call multiple times: only tags an untagged or stale-tagged env.
+    Records the current generation as the owner of the cached 'default' env
+    (if one exists) and tags the env object with it.  This is the publish
+    side of the generation protocol: without it the invalidator has no
+    recorded owner to compare against and can never retire a stale env.
     """
     try:
         from tools.terminal_tool import get_active_env
 
         env = get_active_env('default')
         if env is not None:
-            recorded = _get_expected_backend_generation('default')
-            if recorded is not None:
-                env._webui_backend_generation = recorded
+            gen = _get_current_backend_generation()
+            _mark_env_backend_generation('default', gen)
+            env._webui_backend_generation = gen
     except ImportError:
         pass
     except Exception:
@@ -2988,9 +3081,23 @@ def _install_terminal_env_generation_guard() -> None:
         ):
             # Pre-flight: evict stale env under _env_lock, in the same
             # critical section the acquisition path uses.
+            #
+            # ⚠️ DEADLOCK GUARD: do NOT call tt.get_active_env() while
+            # holding tt._env_lock.  The agent's _env_lock is a plain
+            # non-reentrant threading.Lock and get_active_env() acquires it
+            # again (tools/terminal_tool.py ~1736-1740) — the first guarded
+            # terminal call would block forever.  Replicate the accessor's
+            # lookup inline instead so the read and the compare-and-retire
+            # stay atomic under one acquisition of the lock.
             effective_task_id = tt._resolve_container_task_id(task_id)
+            stale_env = None
             with tt._env_lock:
-                env = tt.get_active_env(task_id)
+                # Same lookup semantics as tt.get_active_env(task_id):
+                # prefer the collapsed container id, fall back to the raw id.
+                env = (
+                    tt._active_environments.get(effective_task_id)
+                    or tt._active_environments.get(task_id)
+                )
                 if env is not None:
                     env_gen = getattr(env, '_webui_backend_generation', None)
                     if env_gen is not None:
@@ -3002,8 +3109,21 @@ def _install_terminal_env_generation_guard() -> None:
                                 'Guard evicting stale env (gen %s, expected %s) on task %s',
                                 env_gen, expected, effective_task_id,
                             )
-                            tt._active_environments.pop(effective_task_id, None)
-                            tt._last_activity.pop(effective_task_id, None)
+                            # Compare-and-retire: pop only if the registry still
+                            # points at THIS env object (someone else may have
+                            # replaced it since the read).
+                            if tt._active_environments.get(effective_task_id) is env:
+                                tt._active_environments.pop(effective_task_id, None)
+                                tt._last_activity.pop(effective_task_id, None)
+                                stale_env = env
+
+            if stale_env is not None:
+                # Publish ownership for the replacement BEFORE the original
+                # tool call runs: the next env acquired on this task belongs
+                # to the current generation.
+                _mark_env_backend_generation(
+                    effective_task_id, _get_current_backend_generation()
+                )
 
             return original_terminal_tool(
                 command, background=background, timeout=timeout,
@@ -9659,11 +9779,15 @@ def _run_agent_streaming(
 
         # #5937: invalidate the cached "default" terminal environment when
         # the profile's terminal backend identity changes.  Uses a full
-        # config fingerprint (not just TERMINAL_ENV type) and generation
+        # config fingerprint (not just TERMINAL_ENV) and generation
         # tracking so SSH host A -> host B is detected and only the exact
         # stale generation is evicted.
         _invalidate_stale_terminal_backend(_safe_profile_runtime_env)
         _install_terminal_env_generation_guard()
+        # Active-use ownership: this turn now executes under the current
+        # generation, so a concurrent profile switch defers retiring an env
+        # this turn may still be using.
+        _register_turn_generation()
 
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is
@@ -12640,6 +12764,9 @@ def _run_agent_streaming(
             # turn's setup can detect staleness.  Run before env var restoration
             # so get_active_env() still works.
             _refresh_env_generation_tag()
+            # Active-use ownership: this turn has finished; drain any stale
+            # eviction deferred while it was still executing.
+            _unregister_turn_generation()
             with _ENV_LOCK:
                 for _key, _old_value in old_profile_env.items():
                     if _old_value is None: os.environ.pop(_key, None)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2487,7 +2487,37 @@ from api.workspace import set_last_workspace
 # metadata added by the webui and must be stripped before the API call.
 # `reasoning_content` is provider-facing for reasoning-capable models. Display
 # metadata such as `reasoning`, `thinking`, and `_reasoning` stays omitted here.
-_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal', 'reasoning_content'}
+def _copy_api_safe_fields(msg: dict) -> dict:
+    """Return a new dict with only API-safe message fields.
+
+    Uses explicit field-by-field access (always O(|safe_keys|)) instead of a
+    dict comprehension over all msg keys (O(|msg_keys|)), which is faster when
+    messages carry extra WebUI metadata fields like ``timestamp``, ``_ts``,
+    ``_error``, ``_partial``, ``_recovered``, ``attachments``, etc. (#6006 perf).
+    """
+    sanitized = {}
+    role = msg.get('role')
+    if role is not None:
+        sanitized['role'] = role
+    content = msg.get('content')
+    if content is not None:
+        sanitized['content'] = content
+    tool_calls = msg.get('tool_calls')
+    if tool_calls is not None:
+        sanitized['tool_calls'] = tool_calls
+    tool_call_id = msg.get('tool_call_id')
+    if tool_call_id is not None:
+        sanitized['tool_call_id'] = tool_call_id
+    name = msg.get('name')
+    if name is not None:
+        sanitized['name'] = name
+    refusal = msg.get('refusal')
+    if refusal is not None:
+        sanitized['refusal'] = refusal
+    reasoning_content = msg.get('reasoning_content')
+    if reasoning_content is not None:
+        sanitized['reasoning_content'] = reasoning_content
+    return sanitized
 
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
@@ -2732,6 +2762,61 @@ def _reset_streaming_hermes_home_override(override_mod, override_token, override
         override_mod.reset_hermes_home_override(override_token)
     except Exception:
         logger.debug("Failed to reset streaming Hermes home override", exc_info=True)
+
+
+# ── Stale terminal-env cache invalidation (issue #5937) ─────────────────
+# When WebUI switches between profiles with different terminal backends
+# (e.g., local → SSH), the agent's `_active_environments["default"]` cache
+# may still hold an environment created under the *previous* profile's
+# backend vars.  This causes a subsequent local-profile turn to execute
+# terminal/file tool calls against the stale remote SSH environment.
+#
+# A single global tracker is sufficient because the cache is collapsed to
+# the shared key "default" — any profile switch that changes the backend
+# type must invalidate the global cached entry.
+_last_terminal_env: str | None = None
+
+
+def _invalidate_stale_terminal_env(profile_runtime_env: dict) -> None:
+    """Drop the cached ``\"default\"`` terminal environment when the backend
+    type changes between WebUI turns.
+
+    Called during streaming turn setup, after the profile's terminal env
+    vars have been written to ``os.environ``, so the next terminal tool
+    call will create a fresh environment with the correct backend config.
+    """
+    global _last_terminal_env
+    current_env = (profile_runtime_env or {}).get("TERMINAL_ENV", "").strip() or None
+
+    if current_env == _last_terminal_env:
+        return
+
+    previous = _last_terminal_env
+    _last_terminal_env = current_env
+
+    try:
+        from tools.terminal_tool import cleanup_vm, get_active_env
+        from tools.file_tools import clear_file_ops_cache
+
+        cached = get_active_env("default")
+        if cached is not None:
+            logger.info(
+                "Terminal backend switched %s -> %s: evicting stale default env",
+                previous or "(none)",
+                current_env or "(none)",
+            )
+            cleanup_vm("default")
+            clear_file_ops_cache("default")
+    except ImportError:
+        logger.debug(
+            "Terminal or file_tools not available for cache invalidation",
+            exc_info=True,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to invalidate stale terminal env",
+            exc_info=True,
+        )
 
 
 # ── Per-turn session identity (xsession wakeup misroute root fix — Option 1) ─
@@ -5884,7 +5969,9 @@ def _restore_reasoning_metadata(previous_messages, updated_messages):
     def _safe_projection(msg):
         if not isinstance(msg, dict):
             return None
-        projected = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS and msg.get('role')}
+        projected = _copy_api_safe_fields(msg)
+        if not projected.get('role'):
+            return None
         # Mirror the empty-tool_calls drop applied by _api_safe_message_positions
         # (#5737) so this projection matches the API-safe positions it's aligned
         # against — otherwise a row stored with tool_calls: [] projects
@@ -9368,6 +9455,13 @@ def _run_agent_streaming(
             discover_mcp_tools()
         except Exception:
             pass  # MCP not available or not configured — non-fatal
+
+        # #5937: invalidate the cached "default" terminal environment when
+        # the profile's TERMINAL_ENV backend type changes.  Without this,
+        # a local-backend turn reuses a stale SSH/Docker environment created
+        # by an earlier remote-backend profile session in the same process,
+        # causing terminal/file tool calls to execute on the wrong backend.
+        _invalidate_stale_terminal_env(_safe_profile_runtime_env)
 
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -21,6 +21,7 @@ import sys
 import subprocess
 import threading
 import time
+import types
 import traceback
 import copy
 import inspect
@@ -2838,6 +2839,13 @@ _BACKEND_IDENTITY_KEYS: tuple[str, ...] = (
     'TERMINAL_VERCEL_RUNTIME',
 )
 
+# Backends whose environment is a container/sandbox (mirrors
+# tools/terminal_tool.py:_CONTAINER_BACKENDS).  Used by the terminal wrapper
+# when it builds the container_config for the agent's creation funnel.
+_TERMINAL_CONTAINER_BACKENDS: frozenset[str] = frozenset({
+    'docker', 'singularity', 'modal', 'daytona', 'vercel_sandbox',
+})
+
 # Backend identity and generation tracking
 _backend_generation_lock = threading.Lock()
 _current_backend_generation: int = 0  # monotonically increasing, bumps on identity change
@@ -2868,6 +2876,18 @@ _backend_generation_cond = threading.Condition(_backend_generation_lock)
 _TURN_BACKEND_GENERATION: contextvars.ContextVar[int | None] = (
     contextvars.ContextVar('webui_turn_backend_generation', default=None)
 )
+# The calling turn's immutable, normalized terminal backend config, bound at
+# turn setup and inherited by the Agent's concurrent tool workers.  The
+# identity fingerprint, the owner-generation publish AND every real
+# constructor path (the wrapped ``_get_env_config``) consume this SAME
+# object — process-global ``os.environ`` is never the later construction
+# authority.  A concurrent profile turn can replace ``os.environ`` between
+# this turn's identity capture and its actual constructor read; binding one
+# immutable config closes that TOCTOU so a backend built from profile B is
+# never tagged as profile A (or vice versa).
+_TURN_BACKEND_CONFIG: contextvars.ContextVar[types.MappingProxyType | None] = (
+    contextvars.ContextVar('webui_turn_backend_config', default=None)
+)
 # Serializes validate/reuse/create into ONE authoritative acquisition
 # transaction for every guarded path (terminal / file / code-execution).  The
 # preflight-then-acquire shape (validate, release the registry lock, then call
@@ -2888,6 +2908,211 @@ def _get_turn_generation() -> int | None:
     turn.
     """
     return _TURN_BACKEND_GENERATION.get()
+
+
+def _get_turn_backend_config() -> types.MappingProxyType | None:
+    """The calling turn's immutable normalized backend config (ContextVar).
+
+    The SAME object the identity fingerprint, the owner publish and every
+    real constructor path consume.  None outside a registered WebUI turn.
+    """
+    return _TURN_BACKEND_CONFIG.get()
+
+
+def _normalize_backend_config(
+    profile_runtime_env: dict | None,
+) -> types.MappingProxyType:
+    """Freeze ONE immutable selected-profile terminal config for this turn.
+
+    Carries only the env keys the agent's terminal construction actually
+    reads (``_BACKEND_IDENTITY_KEYS``), coerced to str.  The returned
+    mapping is the single authority for this turn's identity fingerprint
+    AND its backend construction (via the wrapped ``_get_env_config``), so
+    the object that is fingerprinted is the object that is built — and
+    neither step can be raced by a concurrent profile turn rewriting
+    process-global ``os.environ`` between them.
+    """
+    src = profile_runtime_env or {}
+    normalized: dict[str, str] = {}
+    for key in _BACKEND_IDENTITY_KEYS:
+        if key not in src:
+            continue
+        val = src[key]
+        if isinstance(val, bool):
+            val = 'true' if val else 'false'
+        elif not isinstance(val, str):
+            val = str(val)
+        normalized[key] = val
+    return types.MappingProxyType(normalized)
+
+
+def _is_unusable_container_cwd(cwd: str) -> bool:
+    """True when *cwd* is a host/relative path invalid as a container workdir.
+
+    Mirrors ``tools/terminal_tool.py:_is_unusable_container_cwd``: a
+    container's cwd must be an absolute path that exists inside the sandbox
+    (e.g. ``/workspace`` or ``/root``); host paths (``/home/user``,
+    ``C:\\Users\\me``) and relative paths (``.``, ``src/``) fail ``docker run
+    -w``.
+    """
+    if not cwd:
+        return False
+    if cwd.startswith(('/Users/', '/home/', 'C:\\', 'C:/')):
+        return True
+    if not os.path.isabs(cwd):
+        return True
+    return False
+
+
+def _build_env_config_from_snapshot(
+    snapshot: types.MappingProxyType,
+) -> dict:
+    """Build the agent's terminal config dict from the turn's immutable
+    snapshot — a faithful port of ``terminal_tool._get_env_config()`` that
+    reads ONLY the bound turn config, never process-global ``os.environ``.
+
+    A concurrent profile turn can replace ``os.environ`` between this turn's
+    identity capture and its real constructor read; binding one immutable
+    config and making every real constructor path (``_get_env_config`` →
+    ``_create_environment``) consume that exact object closes the TOCTOU:
+    the backend is built from — and fingerprinted against — the SAME
+    object.  Defaults and parsing semantics mirror the installed agent so the
+    constructed backend matches the identity that was published.
+    """
+    default_image = 'nikolaik/python-nodejs:python3.11-nodejs20'
+    container_backends = frozenset({
+        'docker', 'singularity', 'modal', 'daytona', 'vercel_sandbox',
+    })
+
+    def _parse(name, default, converter=int, label='integer'):
+        raw = snapshot.get(name, default)
+        try:
+            return converter(raw)
+        except (ValueError, json.JSONDecodeError):
+            raise ValueError(
+                f'Invalid value for {name}: {raw!r} (expected {label}). '
+                'Check the profile terminal configuration.'
+            )
+
+    env_type = str(snapshot.get('TERMINAL_ENV', 'local'))
+    mount_docker_cwd = str(snapshot.get(
+        'TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE', 'false',
+    )).lower() in {'true', '1', 'yes'}
+    container_backend = env_type in container_backends
+    docker_backend = env_type == 'docker'
+
+    if container_backend:
+        container_cpu = _parse('TERMINAL_CONTAINER_CPU', '1', float, 'number')
+        container_memory = _parse('TERMINAL_CONTAINER_MEMORY', '5120')
+        container_disk = _parse('TERMINAL_CONTAINER_DISK', '51200')
+    else:
+        container_cpu = 1.0
+        container_memory = 5120
+        container_disk = 51200
+
+    if docker_backend:
+        docker_forward_env = _parse(
+            'TERMINAL_DOCKER_FORWARD_ENV', '[]', json.loads, 'valid JSON')
+        docker_volumes = _parse(
+            'TERMINAL_DOCKER_VOLUMES', '[]', json.loads, 'valid JSON')
+        docker_env = _parse(
+            'TERMINAL_DOCKER_ENV', '{}', json.loads, 'valid JSON')
+        docker_extra_args = _parse(
+            'TERMINAL_DOCKER_EXTRA_ARGS', '[]', json.loads, 'valid JSON')
+        docker_shm_size = str(snapshot.get('TERMINAL_DOCKER_SHM_SIZE', '1g'))
+    else:
+        docker_forward_env = []
+        docker_volumes = []
+        docker_env = {}
+        docker_extra_args = []
+        docker_shm_size = '1g'
+
+    if env_type == 'local':
+        try:
+            default_cwd = os.getcwd()
+        except OSError:
+            default_cwd = str(snapshot.get('TERMINAL_CWD') or os.path.expanduser('~'))
+    elif env_type == 'ssh':
+        default_cwd = '~'
+    elif env_type == 'vercel_sandbox':
+        default_cwd = '/vercel/sandbox'
+    else:
+        default_cwd = '/root'
+
+    cwd = str(snapshot.get('TERMINAL_CWD', default_cwd))
+    if cwd and not (env_type == 'ssh' and (cwd == '~' or cwd.startswith('~/'))):
+        cwd = os.path.expanduser(cwd)
+    host_cwd = None
+    if env_type == 'docker' and mount_docker_cwd:
+        docker_cwd_source = str(snapshot.get('TERMINAL_CWD') or os.getcwd())
+        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        if (
+            candidate.startswith(('/Users/', '/home/', 'C:\\', 'C:/'))
+            or (
+                os.path.isabs(candidate)
+                and os.path.isdir(candidate)
+                and not candidate.startswith(('/workspace', '/root'))
+            )
+        ):
+            host_cwd = candidate
+            cwd = '/workspace'
+    elif env_type in container_backends and cwd:
+        if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
+            cwd = default_cwd
+
+    _modal_mode = str(snapshot.get('TERMINAL_MODAL_MODE', 'auto')).strip().lower()
+    if _modal_mode not in {'auto', 'direct', 'managed'}:
+        _modal_mode = 'auto'
+
+    return {
+        'env_type': env_type,
+        'modal_mode': _modal_mode,
+        'docker_image': str(snapshot.get('TERMINAL_DOCKER_IMAGE', default_image)),
+        'docker_forward_env': docker_forward_env,
+        'singularity_image': str(snapshot.get(
+            'TERMINAL_SINGULARITY_IMAGE', f'docker://{default_image}')),
+        'modal_image': str(snapshot.get('TERMINAL_MODAL_IMAGE', default_image)),
+        'daytona_image': str(snapshot.get('TERMINAL_DAYTONA_IMAGE', default_image)),
+        'vercel_runtime': str(snapshot.get('TERMINAL_VERCEL_RUNTIME', '')).strip(),
+        'cwd': cwd,
+        'host_cwd': host_cwd,
+        'docker_mount_cwd_to_workspace': mount_docker_cwd,
+        'timeout': _parse('TERMINAL_TIMEOUT', '180'),
+        'lifetime_seconds': _parse('TERMINAL_LIFETIME_SECONDS', '300'),
+        'ssh_host': str(snapshot.get('TERMINAL_SSH_HOST', '')),
+        'ssh_user': str(snapshot.get('TERMINAL_SSH_USER', '')),
+        'ssh_port': _parse('TERMINAL_SSH_PORT', '22'),
+        'ssh_key': str(snapshot.get('TERMINAL_SSH_KEY', '')),
+        'ssh_persistent': str(snapshot.get(
+            'TERMINAL_SSH_PERSISTENT',
+            snapshot.get('TERMINAL_PERSISTENT_SHELL', 'true'),
+        )).lower() in {'true', '1', 'yes'},
+        'local_persistent': str(snapshot.get(
+            'TERMINAL_LOCAL_PERSISTENT', 'false',
+        )).lower() in {'true', '1', 'yes'},
+        'container_cpu': container_cpu,
+        'container_memory': container_memory,
+        'container_disk': container_disk,
+        'container_persistent': str(snapshot.get(
+            'TERMINAL_CONTAINER_PERSISTENT', 'true',
+        )).lower() in {'true', '1', 'yes'},
+        'docker_volumes': docker_volumes,
+        'docker_env': docker_env,
+        'docker_run_as_host_user': str(snapshot.get(
+            'TERMINAL_DOCKER_RUN_AS_HOST_USER', 'false',
+        )).lower() in {'true', '1', 'yes'},
+        'docker_network': str(snapshot.get(
+            'TERMINAL_DOCKER_NETWORK', 'true',
+        )).lower() in {'true', '1', 'yes'},
+        'docker_extra_args': docker_extra_args,
+        'docker_shm_size': docker_shm_size,
+        'docker_persist_across_processes': str(snapshot.get(
+            'TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES', 'true',
+        )).lower() in {'true', '1', 'yes'},
+        'docker_orphan_reaper': str(snapshot.get(
+            'TERMINAL_DOCKER_ORPHAN_REAPER', 'true',
+        )).lower() in {'true', '1', 'yes'},
+    }
 
 
 def _compute_backend_identity(profile_runtime_env: dict | None) -> str:
@@ -2939,6 +3164,7 @@ def _unregister_turn_generation() -> None:
     if gen is None:
         return
     _TURN_BACKEND_GENERATION.set(None)
+    _TURN_BACKEND_CONFIG.set(None)
     with _backend_generation_lock:
         remaining = _active_turn_generations.get(gen, 1) - 1
         if remaining > 0:
@@ -2977,7 +3203,70 @@ def _drain_pending_evictions() -> None:
             )
 
 
-def _cleanup_environment_object(env) -> None:
+# Task-key → ``threading.Event`` fired when the forced teardown of the
+# previous object COMPLETED, plus a set of task keys whose forced teardown
+# FAILED (timed out / raised).  Replacement construction for the same task
+# key blocks until the prior physical removal finishes — a fresh
+# ``DockerEnvironment`` reattaches by labels, so creating it while the stale
+# container is still being ``docker rm -f``'d lets the stale cleanup thread
+# kill the replacement's live container (and vice versa).  Guarded by
+# ``_in_flight_env_cleanups_lock``.
+_in_flight_env_cleanups: dict[str, threading.Event] = {}
+_in_flight_env_cleanup_failures: set[str] = set()
+_in_flight_env_cleanups_lock = threading.Lock()
+
+
+def _wait_for_in_flight_cleanup(
+    task_key: str, *, allow_wait: bool = True, timeout: float | None = None,
+) -> None:
+    """Block until any forced teardown of *task_key*'s previous object ended.
+
+    Called before a fresh environment is created for *task_key*: the fence
+    guarantees replacement construction never overlaps the physical removal
+    of the retired object (Docker label reattachment).  Fails CLOSED (raises)
+    when the prior teardown failed or did not finish in time — a replacement
+    must not attach to a container in an unknown removal state.
+
+    ``allow_wait=False`` (the in-transaction re-validation) never blocks: the
+    pre-phase already drained any in-flight cleanup, and an event appearing
+    mid-transaction is a concurrent retire we must refuse rather than wait
+    under the acquisition lock.
+    """
+    if timeout is None:
+        timeout = float(os.environ.get('HERMES_WEBUI_BACKEND_CLEANUP_TIMEOUT', '90'))
+    with _in_flight_env_cleanups_lock:
+        ev = _in_flight_env_cleanups.get(task_key)
+        failed = task_key in _in_flight_env_cleanup_failures
+    if ev is None:
+        if failed:
+            raise RuntimeError(
+                f'Forced teardown of the previous backend environment for '
+                f'{task_key!r} failed; refusing to create a replacement '
+                '(fail-closed)'
+            )
+        return
+    if not allow_wait:
+        raise RuntimeError(
+            f'Backend environment for {task_key!r} is still being torn down '
+            'inside the ownership transaction; refusing to create a '
+            'replacement (fail-closed)'
+        )
+    if not ev.wait(timeout=timeout):
+        raise RuntimeError(
+            f'Timed out waiting for the forced teardown of the previous '
+            f'backend environment for {task_key!r} to finish; refusing to '
+            'create a replacement (fail-closed)'
+        )
+    with _in_flight_env_cleanups_lock:
+        if task_key in _in_flight_env_cleanup_failures:
+            raise RuntimeError(
+                f'Forced teardown of the previous backend environment for '
+                f'{task_key!r} failed; refusing to create a replacement '
+                '(fail-closed)'
+            )
+
+
+def _cleanup_environment_object(env, task_key: str = 'default') -> None:
     """Run the teardown the agent's ``cleanup_vm`` would run on one env.
 
     Called OUTSIDE the registry lock, on the exact object removed by
@@ -2989,7 +3278,21 @@ def _cleanup_environment_object(env) -> None:
     can be reattached under stale labels by a later backend.  Backends whose
     ``cleanup()`` does not accept the kwarg raise TypeError and fall back to
     the plain call (same signature probe ``cleanup_vm`` uses).
+
+    The teardown is FENCED: the installed Docker ``cleanup()`` starts a
+    daemon stop/remove thread and returns immediately, so this waits for the
+    forced removal to finish (``wait_for_cleanup``) and FAILS CLOSED when it
+    does not.  Replacement construction for *task_key* is gated on this
+    fence, so a fresh ``DockerEnvironment`` can never reattach by labels to a
+    container that is still being removed — and the stale cleanup thread can
+    never remove the replacement's live container.
     """
+    timeout = float(os.environ.get('HERMES_WEBUI_BACKEND_CLEANUP_TIMEOUT', '90'))
+    done = threading.Event()
+    failed = False
+    with _in_flight_env_cleanups_lock:
+        _in_flight_env_cleanups[task_key] = done
+        _in_flight_env_cleanup_failures.discard(task_key)
     try:
         if hasattr(env, 'cleanup'):
             try:
@@ -3000,8 +3303,25 @@ def _cleanup_environment_object(env) -> None:
             env.stop()
         elif hasattr(env, 'terminate'):
             env.terminate()
+        wait_fn = getattr(env, 'wait_for_cleanup', None)
+        if wait_fn is not None:
+            finished = wait_fn(timeout=timeout)
+            if not finished:
+                raise RuntimeError(
+                    f'Forced teardown of retired backend environment did not '
+                    f'finish within {timeout:.0f}s; refusing to proceed '
+                    '(fail-closed — a replacement must not attach to a '
+                    'still-removing container)'
+                )
     except Exception:
-        logger.debug('Failed to clean retired terminal env', exc_info=True)
+        failed = True
+        raise
+    finally:
+        with _in_flight_env_cleanups_lock:
+            if failed:
+                _in_flight_env_cleanup_failures.add(task_key)
+            _in_flight_env_cleanups.pop(task_key, None)
+        done.set()
 
 
 def _retire_generation_env(generation: int | None, task_key: str = 'default') -> None:
@@ -3037,7 +3357,7 @@ def _retire_generation_env(generation: int | None, task_key: str = 'default') ->
         stale_env = env
     if stale_env is None:
         return
-    _cleanup_environment_object(stale_env)
+    _cleanup_environment_object(stale_env, task_key)
     try:
         from tools.file_tools import clear_file_ops_cache
         clear_file_ops_cache(task_key)
@@ -3204,28 +3524,47 @@ def _validate_backend_ownership(
                 or tt._active_environments.get(raw_task_id)
             )
             if env is None:
-                return
-            env_gen = getattr(env, '_webui_backend_generation', None)
-            if env_gen == expected:
-                return
-            if env_gen is None and turn_gen is None:
-                # Non-WebUI caller (no captured turn generation): the agent's
-                # own registry is authoritative — accept untagged envs.
-                return
-            if env_gen is None:
-                # Registered WebUI turn, untagged env: unknown ownership —
-                # isolate (never serve it again) without speculative teardown.
-                tt._active_environments.pop(effective_task_id, None)
-                tt._last_activity.pop(effective_task_id, None)
-                tt._active_environments.pop(raw_task_id, None)
-                tt._last_activity.pop(raw_task_id, None)
-                return
-            if turn_gen is not None and env_gen is not None:
-                with _backend_generation_lock:
-                    _pending_eviction_generations.add(env_gen)
-                    gen_active = _active_turn_generations.get(env_gen, 0) > 0
+                # Empty slot: before allowing the caller to create a fresh
+                # environment, wait out any forced teardown still removing
+                # the PREVIOUS object for this task key (Docker label
+                # reattachment fence).  The wait runs OUTSIDE the registry
+                # lock; allow_wait=False (in-transaction re-validation)
+                # refuses instead of blocking under the acquisition lock.
+                _slot_empty = True
             else:
-                gen_active = False
+                _slot_empty = False
+                env_gen = getattr(env, '_webui_backend_generation', None)
+                if env_gen == expected:
+                    return
+                if env_gen is None and turn_gen is None:
+                    # Non-WebUI caller (no captured turn generation): the
+                    # agent's own registry is authoritative — accept untagged
+                    # envs.
+                    return
+                if env_gen is None:
+                    # Registered WebUI turn, untagged env: unknown ownership
+                    # — isolate (never serve it again) without speculative
+                    # teardown.
+                    tt._active_environments.pop(effective_task_id, None)
+                    tt._last_activity.pop(effective_task_id, None)
+                    tt._active_environments.pop(raw_task_id, None)
+                    tt._last_activity.pop(raw_task_id, None)
+                    return
+                if turn_gen is not None and env_gen is not None:
+                    with _backend_generation_lock:
+                        _pending_eviction_generations.add(env_gen)
+                        gen_active = _active_turn_generations.get(env_gen, 0) > 0
+                else:
+                    gen_active = False
+        if _slot_empty:
+            _wait_for_in_flight_cleanup(
+                effective_task_id, allow_wait=allow_wait,
+            )
+            if raw_task_id and raw_task_id != effective_task_id:
+                _wait_for_in_flight_cleanup(
+                    raw_task_id, allow_wait=allow_wait,
+                )
+            return
         if turn_gen is not None and gen_active:
             if not allow_wait:
                 # A foreign generation became active mid-transaction: this
@@ -3273,6 +3612,42 @@ def _evict_stale_file_ops_cache_entry(ft, task_key: str, turn_gen: int) -> None:
             cache.pop(task_key, None)
 
 
+def _evict_file_ops_wrapping_stale_env(
+    ft, task_key: str, tt, raw_task_id,
+) -> None:
+    """Drop a cached file_ops wrapper whose ``.env`` is NOT the live registry
+    object for *task_key*.
+
+    The installed ``_get_file_ops`` fast path returns a cached wrapper
+    whenever a live env occupies the task slot — it never re-verifies that
+    the wrapper references that env.  A same-key replacement (same
+    generation, e.g. an env retired and recreated without a backend identity
+    change) therefore leaves a cached wrapper around the OLD env X in the
+    cache while the registry holds env Y: a turn could be served X while Y
+    passed the ownership check.  Compare-and-remove under the cache lock,
+    keyed on exact object identity.
+    """
+    try:
+        cache = ft._file_ops_cache
+        cache_lock = ft._file_ops_lock
+    except AttributeError:
+        return
+    with tt._env_lock:
+        live = (
+            tt._active_environments.get(task_key)
+            or (tt._active_environments.get(raw_task_id) if raw_task_id else None)
+        )
+    with cache_lock:
+        cached = cache.get(task_key)
+    if cached is None:
+        return
+    if getattr(cached, 'env', None) is live:
+        return
+    with cache_lock:
+        if cache.get(task_key) is cached:
+            cache.pop(task_key, None)
+
+
 def _mark_file_backend_generation(task_key: str, generation: int) -> None:
     """Record the generation under which the file_ops cache was created."""
     with _backend_generation_lock:
@@ -3292,17 +3667,30 @@ def _begin_turn_generation(profile_runtime_env: dict | None) -> None:
     Agent's concurrent tool workers, which inherit the ContextVar — compares
     against the exact generation captured here.
 
+    The profile env is first frozen into ONE immutable normalized config
+    (:func:`_normalize_backend_config`) which is bound to the turn's
+    ``_TURN_BACKEND_CONFIG`` ContextVar: the identity fingerprint, the owner
+    publish and every real constructor path (the wrapped ``_get_env_config``)
+    all consume that exact object, so construction can never be raced by a
+    concurrent profile turn rewriting process-global ``os.environ`` between
+    this turn's identity capture and its actual constructor read.
+
     A failed identity transition is FAIL-CLOSED: the turn is refused (raises)
     instead of continuing under an ambiguous owner.  The production call site
     places this as the first statement of the try whose finally calls
     :func:`_end_turn_generation`, so a raising body never leaks an active-use
     registration (nothing was bound, so the finally's unregister no-ops).
+    The deferred stale retire is also fail-closed: a forced teardown that
+    does not finish raises, refusing the turn rather than letting a
+    replacement attach to a still-removing container.
     """
+    turn_config = _normalize_backend_config(profile_runtime_env)
     try:
         with _backend_generation_lock:
-            stale_generation = _publish_backend_identity(profile_runtime_env)
+            stale_generation = _publish_backend_identity(turn_config)
             generation = _current_backend_generation
             _TURN_BACKEND_GENERATION.set(generation)
+            _TURN_BACKEND_CONFIG.set(turn_config)
             _active_turn_generations[generation] = (
                 _active_turn_generations.get(generation, 0) + 1
             )
@@ -3321,16 +3709,13 @@ def _begin_turn_generation(profile_runtime_env: dict | None) -> None:
         # under it (compare-and-remove; cleanup of the exact removed object).
         # If an old-backend turn is still active the retire stays deferred in
         # _pending_eviction_generations and is drained when that turn exits.
-        try:
-            if _active_turn_generations.get(stale_generation, 0) == 0:
-                _retire_generation_env(stale_generation, 'default')
-                with _backend_generation_lock:
-                    _pending_eviction_generations.discard(stale_generation)
-        except Exception:
-            logger.debug(
-                'Failed to retire stale terminal env after identity change',
-                exc_info=True,
-            )
+        # A failed forced teardown RAISES (fail-closed): the turn is refused
+        # rather than creating a replacement that could attach to a
+        # still-removing container.
+        if _active_turn_generations.get(stale_generation, 0) == 0:
+            _retire_generation_env(stale_generation, 'default')
+            with _backend_generation_lock:
+                _pending_eviction_generations.discard(stale_generation)
 
 
 def _end_turn_generation() -> None:
@@ -3461,7 +3846,35 @@ def _install_terminal_env_generation_guard() -> None:
         logger.debug('Could not install terminal env generation guard', exc_info=True)
         return
 
-    # 1) terminal_tool.terminal_tool
+    # 0) terminal_tool._get_env_config — the construction authority.  When a
+    #    WebUI turn is bound, the config is built from the turn's immutable
+    #    normalized snapshot (the SAME object that was fingerprinted and
+    #    published as the owner) — never from process-global os.environ,
+    #    which a concurrent profile turn can replace between this turn's
+    #    identity capture and its real constructor read (selected-profile-vs-
+    #    process-global TOCTOU).
+    if hasattr(tt, '_get_env_config'):
+        original_get_env_config = tt._get_env_config
+
+        def _wrapped_get_env_config():
+            turn_config = _TURN_BACKEND_CONFIG.get()
+            if turn_config is None:
+                return original_get_env_config()
+            return _build_env_config_from_snapshot(turn_config)
+
+        tt._get_env_config = _wrapped_get_env_config
+
+    # 1) terminal_tool.terminal_tool — split into env acquisition (inside the
+    #    shared transaction) and command execution (AFTER the transaction):
+    #    the installed terminal implementation acquires/reuses the
+    #    environment AND calls env.execute() in one call, so passing the
+    #    whole original tool as the acquire fn validated ownership only AFTER
+    #    command side effects had happened, and held the acquisition lock
+    #    across approval/execution/retries/result-processing.  Here the
+    #    transaction acquires and validates the exact environment object
+    #    (validate → reuse/create → tag/publish → final exact-object check),
+    #    the lock is released, and only then does the original tool execute
+    #    the command against that validated object.
     if hasattr(tt, 'terminal_tool'):
         original_terminal_tool = tt.terminal_tool
 
@@ -3472,14 +3885,82 @@ def _install_terminal_env_generation_guard() -> None:
         ):
             effective_task_id = tt._resolve_container_task_id(task_id)
 
-            def _acquire():
-                return original_terminal_tool(
-                    command, background=background, timeout=timeout,
-                    task_id=task_id, session_id=session_id, force=force,
-                    workdir=workdir, pty=pty,
-                    notify_on_complete=notify_on_complete,
-                    watch_patterns=watch_patterns,
+            def _acquire_env():
+                # Get-or-create the environment ONLY — never executes the
+                # command.  Registry reuse first, then the agent's single
+                # creation funnel (_create_environment, wrapped to tag) with
+                # the turn-bound config — the exact object the fingerprint
+                # was computed from.
+                with tt._env_lock:
+                    env = (
+                        tt._active_environments.get(effective_task_id)
+                        or (tt._active_environments.get(task_id) if task_id else None)
+                    )
+                    if env is not None:
+                        tt._last_activity[effective_task_id] = time.time()
+                        return env
+                config = tt._get_env_config()
+                env_type = config['env_type']
+                if env_type == 'docker':
+                    image = config.get('docker_image', '')
+                elif env_type == 'singularity':
+                    image = config.get('singularity_image', '')
+                elif env_type == 'modal':
+                    image = config.get('modal_image', '')
+                elif env_type == 'daytona':
+                    image = config.get('daytona_image', '')
+                else:
+                    image = ''
+                cwd = config.get('cwd') or '/root'
+                ssh_config = None
+                if env_type == 'ssh':
+                    ssh_config = {
+                        'host': config.get('ssh_host', ''),
+                        'user': config.get('ssh_user', ''),
+                        'port': config.get('ssh_port', 22),
+                        'key': config.get('ssh_key', ''),
+                        'persistent': config.get('ssh_persistent', False),
+                    }
+                container_config = None
+                if env_type in _TERMINAL_CONTAINER_BACKENDS:
+                    container_config = {
+                        'container_cpu': config.get('container_cpu', 1),
+                        'container_memory': config.get('container_memory', 5120),
+                        'container_disk': config.get('container_disk', 51200),
+                        'container_persistent': config.get('container_persistent', True),
+                        'modal_mode': config.get('modal_mode', 'auto'),
+                        'vercel_runtime': config.get('vercel_runtime', ''),
+                        'docker_volumes': config.get('docker_volumes', []),
+                        'docker_mount_cwd_to_workspace': config.get(
+                            'docker_mount_cwd_to_workspace', False),
+                        'docker_forward_env': config.get('docker_forward_env', []),
+                        'docker_env': config.get('docker_env', {}),
+                        'docker_run_as_host_user': config.get(
+                            'docker_run_as_host_user', False),
+                        'docker_extra_args': config.get('docker_extra_args', []),
+                        'docker_shm_size': config.get('docker_shm_size', '1g'),
+                        'docker_network': config.get('docker_network', True),
+                        'docker_persist_across_processes': config.get(
+                            'docker_persist_across_processes', True),
+                        'docker_orphan_reaper': config.get(
+                            'docker_orphan_reaper', True),
+                    }
+                local_config = None
+                if env_type == 'local':
+                    local_config = {
+                        'persistent': config.get('local_persistent', False),
+                    }
+                new_env = tt._create_environment(
+                    env_type=env_type, image=image, cwd=cwd,
+                    timeout=timeout or config.get('timeout', 180),
+                    ssh_config=ssh_config, container_config=container_config,
+                    local_config=local_config, task_id=effective_task_id,
+                    host_cwd=config.get('host_cwd'),
                 )
+                with tt._env_lock:
+                    tt._active_environments[effective_task_id] = new_env
+                    tt._last_activity[effective_task_id] = time.time()
+                return new_env
 
             def _publish(result, gen, validated_env):
                 # Owner publication inside the transaction: the live env was
@@ -3491,9 +3972,42 @@ def _install_terminal_env_generation_guard() -> None:
                     except Exception:
                         pass
 
-            return _acquire_backend_object(
-                tt, effective_task_id, task_id, _acquire,
-                on_acquired=_publish,
+            try:
+                env = _acquire_backend_object(
+                    tt, effective_task_id, task_id, _acquire_env,
+                    on_acquired=_publish,
+                )
+            except ImportError:
+                # Backend disabled — same graceful contract the installed
+                # terminal tool returns when environment creation fails.
+                return json.dumps({
+                    'output': '',
+                    'exit_code': -1,
+                    'error': 'Terminal tool disabled: environment creation failed',
+                    'status': 'disabled',
+                }, ensure_ascii=False)
+            # Fail-closed pre-execution gate: the exact validated object must
+            # still occupy the registry slot the original tool will reuse —
+            # execution must never begin against a replacement.
+            with tt._env_lock:
+                live = (
+                    tt._active_environments.get(effective_task_id)
+                    or (tt._active_environments.get(task_id) if task_id else None)
+                )
+            if live is not env:
+                raise RuntimeError(
+                    'Terminal backend environment changed after ownership '
+                    'validation; refusing to execute against a replacement '
+                    '(fail-closed)'
+                )
+            # Lock released — only now does the command execute, against the
+            # exact validated environment.
+            return original_terminal_tool(
+                command, background=background, timeout=timeout,
+                task_id=task_id, session_id=session_id, force=force,
+                workdir=workdir, pty=pty,
+                notify_on_complete=notify_on_complete,
+                watch_patterns=watch_patterns,
             )
 
         tt.terminal_tool = _wrapped_terminal_tool
@@ -3501,7 +4015,13 @@ def _install_terminal_env_generation_guard() -> None:
     # 2) file_tools._get_file_ops — previously bypassed the guard entirely:
     #    it reused _active_environments directly without any ownership check,
     #    and its post-hoc tag could bless a wrapper whose underlying env came
-    #    from another generation.  The final exact check now gates the tag.
+    #    from another generation.  The final exact check now gates the tag,
+    #    and the wrapper must PROVE it references the exact validated registry
+    #    object: the installed fast path returns a cached wrapper whenever a
+    #    live env occupies the task slot, so a cached wrapper around a
+    #    replaced env X can be returned while registry env Y is what passed
+    #    the ownership check.  Stale wrappers are evicted before the original
+    #    runs and the returned wrapper is verified by object identity.
     try:
         ft = importlib.import_module('tools.file_tools')
     except ImportError:
@@ -3518,15 +4038,21 @@ def _install_terminal_env_generation_guard() -> None:
                     _evict_stale_file_ops_cache_entry(
                         ft, effective_task_id, turn_gen,
                     )
+                    _evict_file_ops_wrapping_stale_env(
+                        ft, effective_task_id, tt, task_id,
+                    )
                 return original_get_file_ops(task_id)
 
             def _publish(file_ops, gen, validated_env):
-                # Bless the wrapper ONLY for the exact env this transaction
-                # validated as the turn's generation.
+                # Bless the wrapper ONLY when it references the EXACT
+                # validated registry object (object identity, not a tag):
+                # a cached wrapper around a replaced env must never be
+                # blessed just because the registry env passed the check.
                 if (
                     gen is not None
                     and file_ops is not None
                     and validated_env is not None
+                    and getattr(file_ops, 'env', None) is validated_env
                 ):
                     try:
                         file_ops._webui_backend_generation = gen
@@ -3534,10 +4060,21 @@ def _install_terminal_env_generation_guard() -> None:
                     except Exception:
                         pass
 
-            return _acquire_backend_object(
+            result = _acquire_backend_object(
                 tt, effective_task_id, task_id, _acquire,
                 on_acquired=_publish,
             )
+            if turn_gen is not None:
+                # Fail-closed exact-identity gate: never serve a wrapper that
+                # does not reference the exact validated registry object.
+                live_env = _get_registry_env(tt, effective_task_id, task_id)
+                if getattr(result, 'env', None) is not live_env:
+                    raise RuntimeError(
+                        'File ops wrapper does not reference the exact '
+                        'validated backend environment; refusing to serve a '
+                        'stale wrapper (fail-closed)'
+                    )
+            return result
 
         ft._get_file_ops = _wrapped_get_file_ops
 
@@ -3558,6 +4095,9 @@ def _install_terminal_env_generation_guard() -> None:
                 return original_get_or_create_env(task_id)
 
             def _publish(result, gen, validated_env):
+                # Publish ownership ONLY when the returned env IS the exact
+                # validated registry object — a replaced env must never be
+                # blessed or recorded as this turn's owner.
                 if (
                     gen is not None
                     and result is not None
@@ -3565,20 +4105,33 @@ def _install_terminal_env_generation_guard() -> None:
                 ):
                     try:
                         env = result[0] if isinstance(result, tuple) else result
-                        if (
-                            env is not None
-                            and getattr(env, '_webui_backend_generation', None)
-                            is None
-                        ):
-                            env._webui_backend_generation = gen
-                        _mark_env_backend_generation(effective_task_id, gen)
+                        if env is validated_env:
+                            if (
+                                env is not None
+                                and getattr(env, '_webui_backend_generation', None)
+                                is None
+                            ):
+                                env._webui_backend_generation = gen
+                            _mark_env_backend_generation(effective_task_id, gen)
                     except Exception:
                         pass
 
-            return _acquire_backend_object(
+            result = _acquire_backend_object(
                 tt, effective_task_id, task_id, _acquire,
                 on_acquired=_publish,
             )
+            if turn_gen is not None:
+                # Fail-closed exact-identity gate: never hand the caller an
+                # env that is not the exact validated registry object.
+                live_env = _get_registry_env(tt, effective_task_id, task_id)
+                env = result[0] if isinstance(result, tuple) else result
+                if env is not live_env:
+                    raise RuntimeError(
+                        'Execute-code environment does not reference the '
+                        'exact validated backend environment; refusing to '
+                        'use a replaced env (fail-closed)'
+                    )
+            return result
 
         cet._get_or_create_env = _wrapped_get_or_create_env
 
@@ -10347,7 +10900,14 @@ def _run_agent_streaming(
             # agent body raises, the registration is released and deferred
             # stale evictions are drained.
             _install_terminal_env_generation_guard()
-            _begin_turn_generation(_safe_profile_runtime_env)
+            # #5937/#6586: the turn's immutable backend config snapshot folds
+            # in the effective workspace CWD (the same value written to
+            # os.environ['TERMINAL_CWD'] below) so construction and identity
+            # fingerprinting see the identical object.
+            _begin_turn_generation({
+                **_safe_profile_runtime_env,
+                'TERMINAL_CWD': str(s.workspace),
+            })
             _token_sent = False  # tracks whether any streamed tokens were sent
             _self_healed = False  # (#1401) prevents infinite self-heal retries
             # Per-message reasoning: dict maps assistant-message index → accumulated text

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -382,8 +382,32 @@ def test_begin_turn_publishes_ownership_after_identity_change(fake_terminal_tool
 
 
 def test_refresh_tags_env_and_publishes_ownership(fake_terminal_tool):
-    """Blocker 2: _refresh_env_generation_tag must tag the live env AND record
-    the owner generation — the publish side of the protocol."""
+    """_refresh_env_generation_tag publishes ownership ONLY for the env the
+    calling turn actually acquired/used: the live object must already be
+    tagged with the turn's captured generation (creation-time tagging or
+    same-generation reuse).  Untagged/foreign envs are never touched."""
+    streaming = importlib.import_module("api.streaming")
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0 (no bump)
+        env = _FakeEnv(generation=0)          # tagged by this turn's creation
+        fake_terminal_tool._active_environments["default"] = env
+
+        streaming._refresh_env_generation_tag()
+
+        assert env._webui_backend_generation == 0
+        assert streaming._env_backend_generations.get("default") == 0
+    finally:
+        streaming._end_turn_generation()
+
+
+def test_refresh_does_not_tag_env_without_active_turn(fake_terminal_tool):
+    """No turn bound (begin failed / non-WebUI): the refresh must NO-OP —
+    it never tags or publishes an env it has no provenance over."""
     streaming = importlib.import_module("api.streaming")
 
     env = _FakeEnv(generation=None)
@@ -391,8 +415,229 @@ def test_refresh_tags_env_and_publishes_ownership(fake_terminal_tool):
 
     streaming._refresh_env_generation_tag()
 
-    assert env._webui_backend_generation == 0
-    assert streaming._env_backend_generations.get("default") == 0
+    assert env._webui_backend_generation is None
+    assert "default" not in streaming._env_backend_generations
+
+
+def test_finally_does_not_retag_foreign_env(fake_terminal_tool):
+    """Must-fix 2: a finishing turn that acquired nothing must NOT retag an
+    env created by another turn (the A-no-env/B-create/A-finish schedule).
+
+    Turn A (gen 0) begins while no env exists; turn B (gen 1) begins after
+    an identity switch and creates a gen-1 env; A finishes WITHOUT ever
+    acquiring an environment.  A's finally (refresh + unregister) must leave
+    B's live env tagged gen 1 and must NOT let the deferred gen-0 drain
+    retire it while B is still using it.
+
+    Two REAL threads: the ContextVar is per-context, so both turns must live
+    on separate threads (nesting begins on one thread is not a valid
+    schedule)."""
+    streaming = importlib.import_module("api.streaming")
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    host_b_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    a_registered = threading.Event()
+    b_go = threading.Event()
+    b_created = threading.Event()
+    a_may_finish = threading.Event()
+    b_may_finish = threading.Event()
+    a_done = threading.Event()
+    b_done = threading.Event()
+
+    def _turn_a():
+        streaming._begin_turn_generation(host_a_env)          # gen 0 (no bump)
+        a_registered.set()
+        assert a_may_finish.wait(timeout=15)
+        # A's finally: NEVER retag B's env, then release the registration.
+        streaming._refresh_env_generation_tag()
+        streaming._end_turn_generation()
+        a_done.set()
+
+    def _turn_b():
+        assert b_go.wait(timeout=15)
+        streaming._begin_turn_generation(host_b_env)          # gen 1
+        env_b = _FakeEnv(generation=1)
+        fake_terminal_tool._active_environments["default"] = env_b
+        b_created.set()
+        assert b_may_finish.wait(timeout=15)
+        streaming._end_turn_generation()
+        b_done.set()
+
+    ta = threading.Thread(target=_turn_a)
+    tb = threading.Thread(target=_turn_b)
+    ta.start()
+    assert a_registered.wait(timeout=15)
+    tb.start()
+    b_go.set()
+    assert b_created.wait(timeout=15)
+
+    # A finishes WITHOUT acquiring anything.
+    a_may_finish.set()
+    assert a_done.wait(timeout=15)
+
+    # B's live env was NOT retagged as gen 0 and NOT retired by the drain.
+    env_b = fake_terminal_tool._active_environments.get("default")
+    assert env_b is not None
+    assert env_b._webui_backend_generation == 1
+    assert not env_b.cleaned
+    assert streaming._env_backend_generations.get("default") == 1
+    assert streaming._pending_eviction_generations == set()
+
+    b_may_finish.set()
+    assert b_done.wait(timeout=15)
+    ta.join(timeout=15)
+    tb.join(timeout=15)
+    assert not ta.is_alive() and not tb.is_alive()
+
+
+def test_unknown_ownership_is_isolated_not_accepted_or_destroyed(fake_terminal_tool):
+    """Unknown ownership must be isolated or enrolled, not accepted and not
+    destroyed speculatively: a registered turn NEVER reuses an untagged env
+    and NEVER tears it down (it may be in active use by an untracked
+    caller) — the exact object is dropped from the registry untouched."""
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    untagged = _FakeEnv(generation=None)   # unknown provenance, possibly in use
+    fake_terminal_tool._active_environments["default"] = untagged
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0
+        out = fake_terminal_tool.terminal_tool("whoami", session_id="s-u")
+    finally:
+        streaming._end_turn_generation()
+
+    # Isolated: no longer served by the registry, but NOT cleaned up.
+    assert "default" not in fake_terminal_tool._active_environments
+    assert not untagged.cleaned and not untagged.stopped
+    assert out == '{"output": "ok", "exit_code": 0}'
+
+
+def test_untagged_file_cache_entry_is_evicted_for_registered_turn(fake_terminal_tool):
+    """Untagged file-cache entries fail CLOSED for a registered turn: the
+    cached wrapper with no provenance is dropped before the original
+    _get_file_ops runs, so it is never served to the turn."""
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    # Seed an UNTAGGED cached file_ops plus a live env for it to wrap.
+    env = _FakeEnv(generation=0)
+    fake_terminal_tool._active_environments["default"] = env
+    stale_ops = _FakeFileOps(env)
+    fake_terminal_tool.file_tools._file_ops_cache["default"] = stale_ops
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0
+        ops = fake_terminal_tool.file_tools._get_file_ops("default")
+    finally:
+        streaming._end_turn_generation()
+
+    assert ops is not stale_ops, "untagged cached file_ops must not be served"
+    assert ops._webui_backend_generation == 0
+    assert streaming._file_backend_generations.get("default") == 0
+
+
+def test_empty_slot_acquisition_is_one_transaction(fake_terminal_tool):
+    """Must-fix 1: validation and acquisition are ONE transaction.
+
+    Generations A (gen 0) and B (gen 1) both race an EMPTY slot through a
+    gate-controlled original.  On the buggy head (validate, release, then
+    call the original acquirer) both validate the empty slot, A creates its
+    env, and B's original fast path reuses A's object — B executes against
+    A's generation.  With the transaction, B's reuse/create is atomic with
+    its re-validation, so each turn executes only against an env tagged with
+    ITS OWN captured generation."""
+    streaming = importlib.import_module("api.streaming")
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    host_b_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    first_gate = threading.Event()
+    second_gate = threading.Event()
+    used_tags = {}
+    created_envs = []
+
+    def gated_terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        # Two-stage gate: on the buggy head both turns can be mid-acquisition
+        # simultaneously (each validated the empty slot); on the fixed head
+        # only the lock holder ever reaches the original.
+        assert first_gate.wait(timeout=20), "first gate never opened"
+        with fake_terminal_tool._env_lock:
+            env = fake_terminal_tool._active_environments.get("default")
+            if env is None:
+                env = _FakeEnv(generation=_tagged_generation(streaming))
+                fake_terminal_tool._active_environments["default"] = env
+                fake_terminal_tool._last_activity["default"] = time.time()
+                created_envs.append(env)
+            used_tags[command] = getattr(env, "_webui_backend_generation", None)
+        assert second_gate.wait(timeout=20), "second gate never opened"
+        return '{"output": "ok", "exit_code": 0}'
+
+    fake_terminal_tool.terminal_tool = gated_terminal_tool
+    streaming._install_terminal_env_generation_guard()
+
+    a_result, b_result = {}, {}
+
+    def _turn_a():
+        streaming._begin_turn_generation(host_a_env)          # gen 0 (no bump)
+        try:
+            a_result["out"] = fake_terminal_tool.terminal_tool("cmd-a")
+        except Exception as exc:  # pragma: no cover - failure path
+            a_result["error"] = repr(exc)
+        finally:
+            streaming._refresh_env_generation_tag()
+            streaming._end_turn_generation()
+
+    def _turn_b():
+        streaming._begin_turn_generation(host_b_env)          # gen 1
+        try:
+            b_result["out"] = fake_terminal_tool.terminal_tool("cmd-b")
+        except Exception as exc:  # pragma: no cover - failure path
+            b_result["error"] = repr(exc)
+        finally:
+            streaming._refresh_env_generation_tag()
+            streaming._end_turn_generation()
+
+    ta = threading.Thread(target=_turn_a)
+    tb = threading.Thread(target=_turn_b)
+    ta.start()
+    time.sleep(0.2)      # A reaches the first gate inside its transaction
+    tb.start()
+    time.sleep(0.5)      # B: fixed head blocks (lock/drain); buggy head reaches gate
+    first_gate.set()
+    time.sleep(0.2)
+    second_gate.set()
+    ta.join(timeout=25)
+    tb.join(timeout=25)
+    assert not ta.is_alive() and not tb.is_alive()
+
+    # Each turn executed against an env tagged with ITS OWN generation —
+    # never against the other turn's object.
+    assert used_tags.get("cmd-a") == 0, used_tags
+    assert used_tags.get("cmd-b") == 1, used_tags
+    assert "error" not in a_result and "error" not in b_result
+    # B's env is the live one; A's env was retired only after A's turn exited.
+    live = fake_terminal_tool._active_environments.get("default")
+    assert live is not None and live._webui_backend_generation == 1
+    assert len(created_envs) == 2
+    assert created_envs[0].cleaned, "A's stale env must be retired after drain"
 
 
 def test_begin_turn_skips_retire_when_env_replaced_by_newer_generation(fake_terminal_tool):

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -37,6 +37,7 @@ GREEN after the fix.
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 import threading
 import time
@@ -76,15 +77,92 @@ def _build_fake_terminal_tool_module() -> types.ModuleType:
     - ``get_active_env()`` acquires ``_env_lock`` internally (the exact
       accessor shape that deadlocked the buggy guard)
     - registries ``_active_environments`` / ``_last_activity``
+    - ``_get_env_config()`` reads process-global ``os.environ`` (the
+      pre-guard construction authority — the guard's wrapped
+      ``_get_env_config`` overrides it with the turn's immutable snapshot)
+    - ``_create_environment()`` is the SINGLE creation funnel (the guard
+      wraps it to tag every env created during a WebUI turn) and records the
+      config it was called with
+    - ``terminal_tool()`` acquires/reuses the env and executes the command
+      (records it) — the guard splits env acquisition from execution
     """
     mod = types.ModuleType("tools.terminal_tool")
     mod._env_lock = threading.Lock()
     mod._active_environments = {}
     mod._last_activity = {}
     mod.terminal_tool_calls = []
+    mod.created_configs = []
+    mod.executed_envs = []
 
     def _resolve_container_task_id(task_id):
         return task_id or "default"
+
+    def _get_env_config():
+        # Faithful to tools/terminal_tool.py:_get_env_config — reads the
+        # process-global env (the authority the turn snapshot replaces).
+        return {
+            "env_type": os.getenv("TERMINAL_ENV", "local"),
+            "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", "img"),
+            "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", "simg"),
+            "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", "mimg"),
+            "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", "dimg"),
+            "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+            "cwd": os.getenv("TERMINAL_CWD", "/root"),
+            "host_cwd": None,
+            "timeout": int(os.getenv("TERMINAL_TIMEOUT", "180")),
+            "lifetime_seconds": int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300")),
+            "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
+            "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+            "ssh_port": int(os.getenv("TERMINAL_SSH_PORT", "22")),
+            "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+            "ssh_persistent": os.getenv(
+                "TERMINAL_SSH_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+            "local_persistent": os.getenv(
+                "TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+            "modal_mode": "auto",
+            "container_cpu": float(os.getenv("TERMINAL_CONTAINER_CPU", "1")),
+            "container_memory": int(os.getenv("TERMINAL_CONTAINER_MEMORY", "5120")),
+            "container_disk": int(os.getenv("TERMINAL_CONTAINER_DISK", "51200")),
+            "container_persistent": os.getenv(
+                "TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+            "docker_volumes": [],
+            "docker_env": {},
+            "docker_run_as_host_user": False,
+            "docker_network": True,
+            "docker_extra_args": [],
+            "docker_shm_size": "1g",
+            "docker_persist_across_processes": True,
+            "docker_orphan_reaper": True,
+            "docker_forward_env": [],
+            "docker_mount_cwd_to_workspace": False,
+        }
+
+    def _create_environment(
+        env_type="local", image="", cwd="/root", timeout=180,
+        ssh_config=None, container_config=None, local_config=None,
+        task_id="default", host_cwd=None,
+    ):
+        # The SINGLE creation funnel shared by terminal/file/code-execution
+        # (faithful to tools/terminal_tool.py:_create_environment — the
+        # guard's wrapper tags the returned env with the calling turn's
+        # generation).  Records what it was called with so tests can prove
+        # construction consumed the turn's immutable config.
+        streaming = importlib.import_module("api.streaming")
+        env = _FakeEnv(generation=_tagged_generation(streaming))
+        env.backend_env_type = env_type
+        env.backend_cwd = cwd
+        mod.created_configs.append({
+            "env_type": env_type,
+            "image": image,
+            "cwd": cwd,
+            "timeout": timeout,
+            "ssh_config": ssh_config,
+            "container_config": container_config,
+            "local_config": local_config,
+            "task_id": task_id,
+            "host_cwd": host_cwd,
+        })
+        return env
 
     def get_active_env(task_id):
         # Faithful to tools/terminal_tool.py:~1736-1740 — takes the lock.
@@ -110,10 +188,21 @@ def _build_fake_terminal_tool_module() -> types.ModuleType:
         session_id=None, force=False, workdir=None, pty=False,
         notify_on_complete=False, watch_patterns=None,
     ):
+        # Execution half of the installed tool: reuses the env the guarded
+        # acquisition installed and executes the command against it.
         mod.terminal_tool_calls.append(command)
+        eff = _resolve_container_task_id(task_id)
+        with mod._env_lock:
+            env = (
+                mod._active_environments.get(eff)
+                or mod._active_environments.get(task_id)
+            )
+        mod.executed_envs.append((command, env))
         return '{"output": "ok", "exit_code": 0}'
 
     mod._resolve_container_task_id = _resolve_container_task_id
+    mod._get_env_config = _get_env_config
+    mod._create_environment = _create_environment
     mod.get_active_env = get_active_env
     mod.cleanup_vm = cleanup_vm
     mod.terminal_tool = terminal_tool
@@ -128,27 +217,37 @@ def _tagged_generation(streaming) -> int:
     return turn_gen if turn_gen is not None else streaming._get_current_backend_generation()
 
 
-def _install_creating_terminal_tool(fake_terminal_tool, streaming):
-    """Replace the stub terminal_tool with one that creates an env when the
-    registry is empty (mirroring the agent's create-if-missing acquisition),
-    tagging it like the production ``_create_environment`` wrapper.  Must run
-    BEFORE ``_install_terminal_env_generation_guard()`` so the guard wraps it.
+class _FakeDockerEnv:
+    """Faithful stand-in for the agent's ``DockerEnvironment`` teardown
+    contract: ``cleanup(force_remove=True)`` starts a daemon stop/remove
+    thread and returns immediately; ``wait_for_cleanup()`` joins it.
     """
-    def terminal_tool(
-        command, background=False, timeout=None, task_id=None,
-        session_id=None, force=False, workdir=None, pty=False,
-        notify_on_complete=False, watch_patterns=None,
-    ):
-        fake_terminal_tool.terminal_tool_calls.append(command)
-        with fake_terminal_tool._env_lock:
-            env = fake_terminal_tool._active_environments.get("default")
-            if env is None:
-                env = _FakeEnv(generation=_tagged_generation(streaming))
-                fake_terminal_tool._active_environments["default"] = env
-                fake_terminal_tool._last_activity["default"] = time.time()
-        return '{"output": "ok", "exit_code": 0}'
 
-    fake_terminal_tool.terminal_tool = terminal_tool
+    def __init__(self, generation=None, removal_seconds=0.1):
+        self._webui_backend_generation = generation
+        self.cleanup_force_remove = None
+        self.removal_started = threading.Event()
+        self.removal_done = threading.Event()
+        self._cleanup_thread = None
+        self._removal_delay = removal_seconds
+
+    def cleanup(self, *, force_remove=False):
+        self.cleanup_force_remove = force_remove
+        self.removal_started.set()
+
+        def _do_removal():
+            time.sleep(self._removal_delay)
+            self.removal_done.set()
+
+        self._cleanup_thread = threading.Thread(target=_do_removal, daemon=True)
+        self._cleanup_thread.start()
+
+    def wait_for_cleanup(self, timeout=30.0):
+        thread = getattr(self, "_cleanup_thread", None)
+        if thread is None or not thread.is_alive():
+            return True
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
 
 
 @pytest.fixture(autouse=True)
@@ -163,7 +262,11 @@ def _isolate_generation_state(monkeypatch):
         streaming._terminal_env_guard_installed = False
         streaming._active_turn_generations.clear()
         streaming._pending_eviction_generations = set()
+    with streaming._in_flight_env_cleanups_lock:
+        streaming._in_flight_env_cleanups.clear()
+        streaming._in_flight_env_cleanup_failures.clear()
     streaming._TURN_BACKEND_GENERATION.set(None)
+    streaming._TURN_BACKEND_CONFIG.set(None)
     yield
 
 
@@ -188,14 +291,21 @@ def fake_terminal_tool(monkeypatch):
 
     def _get_file_ops(task_id="default"):
         # Faithful to tools/file_tools.py:_get_file_ops: ensure the terminal
-        # env exists (creating + tagging it), then build/cache a file_ops
-        # wrapper around it.
-        streaming = importlib.import_module("api.streaming")
+        # env exists (creating + tagging it via the SINGLE creation funnel),
+        # then build/cache a file_ops wrapper around it.  The fast path
+        # returns a cached wrapper whenever a live env occupies the slot —
+        # it never re-verifies that the wrapper references that env.
         eff = fake._resolve_container_task_id(task_id)
         with fake._env_lock:
             env = fake._active_environments.get(eff)
             if env is None:
-                env = _FakeEnv(generation=_tagged_generation(streaming))
+                config = fake._get_env_config()
+                env = fake._create_environment(
+                    env_type=config["env_type"], image="",
+                    cwd=config.get("cwd", "/root"),
+                    timeout=config.get("timeout", 180),
+                    task_id=eff,
+                )
                 fake._active_environments[eff] = env
                 fake._last_activity[eff] = time.time()
         with fake_file_tools._file_ops_lock:
@@ -214,15 +324,20 @@ def fake_terminal_tool(monkeypatch):
 
     def _get_or_create_env(task_id):
         # Faithful to tools/code_execution_tool.py:_get_or_create_env.
-        streaming = importlib.import_module("api.streaming")
         eff = fake._resolve_container_task_id(task_id)
         with fake._env_lock:
             env = fake._active_environments.get(eff)
             if env is None:
-                env = _FakeEnv(generation=_tagged_generation(streaming))
+                config = fake._get_env_config()
+                env = fake._create_environment(
+                    env_type=config["env_type"], image="",
+                    cwd=config.get("cwd", "/root"),
+                    timeout=config.get("timeout", 180),
+                    task_id=eff,
+                )
                 fake._active_environments[eff] = env
                 fake._last_activity[eff] = time.time()
-            return env, "ssh"
+            return env, fake._get_env_config()["env_type"]
 
     fake_code_exec._get_or_create_env = _get_or_create_env
 
@@ -282,7 +397,8 @@ def test_guard_evicts_stale_generation_env_without_deadlock(fake_terminal_tool):
 
     # Simulate: env was created under generation 0, backend identity changed,
     # generation bumped to 1.  The recorded owner is the NEW generation.
-    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
+    stale_env = _FakeEnv(generation=0)
+    fake_terminal_tool._active_environments["default"] = stale_env
     streaming._mark_env_backend_generation("default", 1)
     streaming._current_backend_generation = 1
 
@@ -303,8 +419,13 @@ def test_guard_evicts_stale_generation_env_without_deadlock(fake_terminal_tool):
     t.join(timeout=5.0)
     assert not t.is_alive(), "guard deadlocked on stale-env eviction path"
 
-    # The stale env was retired from the registry before the original tool ran.
-    assert "default" not in fake_terminal_tool._active_environments
+    # The stale gen-0 env was retired from the registry before the original
+    # tool ran; the shared primitive installed a fresh env for the tool to
+    # reuse (get-or-create in ONE transaction).
+    live = fake_terminal_tool._active_environments.get("default")
+    assert live is not None and live is not stale_env
+    assert live._webui_backend_generation == 1
+    assert stale_env.cleaned
     # Ownership for the replacement was published.
     assert streaming._get_expected_backend_generation("default") == 1
     assert result.get("ok") == '{"output": "ok", "exit_code": 0}'
@@ -347,8 +468,11 @@ def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
     t.start()
     t.join(timeout=10.0)
     assert not t.is_alive()
-    # The gen-0 env was NOT reused by the gen-1 turn and was retired.
-    assert "default" not in fake_terminal_tool._active_environments
+    # The gen-0 env was NOT reused by the gen-1 turn and was retired; the
+    # gen-1 turn executed against a fresh env installed by the transaction.
+    live = fake_terminal_tool._active_environments.get("default")
+    assert live is not None and live is not env_a
+    assert live._webui_backend_generation == 1
     assert env_a.cleaned
     assert result.get("out") == '{"output": "ok", "exit_code": 0}'
 
@@ -514,8 +638,12 @@ def test_unknown_ownership_is_isolated_not_accepted_or_destroyed(fake_terminal_t
     finally:
         streaming._end_turn_generation()
 
-    # Isolated: no longer served by the registry, but NOT cleaned up.
-    assert "default" not in fake_terminal_tool._active_environments
+    # Isolated: the untagged env is no longer served by the registry and is
+    # NOT cleaned up (unknown ownership is never destroyed speculatively);
+    # the turn executes against a fresh env installed by the transaction.
+    live = fake_terminal_tool._active_environments.get("default")
+    assert live is not None and live is not untagged
+    assert live._webui_backend_generation == 0
     assert not untagged.cleaned and not untagged.stopped
     assert out == '{"output": "ok", "exit_code": 0}'
 
@@ -552,12 +680,15 @@ def test_empty_slot_acquisition_is_one_transaction(fake_terminal_tool):
     """Must-fix 1: validation and acquisition are ONE transaction.
 
     Generations A (gen 0) and B (gen 1) both race an EMPTY slot through a
-    gate-controlled original.  On the buggy head (validate, release, then
-    call the original acquirer) both validate the empty slot, A creates its
-    env, and B's original fast path reuses A's object — B executes against
-    A's generation.  With the transaction, B's reuse/create is atomic with
-    its re-validation, so each turn executes only against an env tagged with
-    ITS OWN captured generation."""
+    gate-controlled creation funnel.  On the buggy head (validate, release,
+    then call the original acquirer) both validate the empty slot, A creates
+    its env, and B's original fast path reuses A's object — B executes
+    against A's generation.  With the transaction, B's reuse/create is
+    atomic with its re-validation, so each turn executes only against an env
+    tagged with ITS OWN captured generation.  The gate lives in the SINGLE
+    creation funnel (``_create_environment``) — the real shared acquisition
+    primitive the terminal wrapper drives.
+    """
     streaming = importlib.import_module("api.streaming")
 
     host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
@@ -569,28 +700,41 @@ def test_empty_slot_acquisition_is_one_transaction(fake_terminal_tool):
     second_gate = threading.Event()
     used_tags = {}
     created_envs = []
+    orig_create = fake_terminal_tool._create_environment
 
-    def gated_terminal_tool(
+    def gated_create(
+        env_type="local", image="", cwd="/root", timeout=180,
+        ssh_config=None, container_config=None, local_config=None,
+        task_id="default", host_cwd=None,
+    ):
+        # Two-stage gate in the creation funnel: on the buggy head both turns
+        # can be mid-acquisition simultaneously (each validated the empty
+        # slot); on the fixed head only the lock holder ever reaches creation.
+        assert first_gate.wait(timeout=20), "first gate never opened"
+        env = orig_create(
+            env_type=env_type, image=image, cwd=cwd, timeout=timeout,
+            ssh_config=ssh_config, container_config=container_config,
+            local_config=local_config, task_id=task_id, host_cwd=host_cwd,
+        )
+        created_envs.append(env)
+        assert second_gate.wait(timeout=20), "second gate never opened"
+        return env
+
+    fake_terminal_tool._create_environment = gated_create
+
+    def recording_terminal_tool(
         command, background=False, timeout=None, task_id=None,
         session_id=None, force=False, workdir=None, pty=False,
         notify_on_complete=False, watch_patterns=None,
     ):
-        # Two-stage gate: on the buggy head both turns can be mid-acquisition
-        # simultaneously (each validated the empty slot); on the fixed head
-        # only the lock holder ever reaches the original.
-        assert first_gate.wait(timeout=20), "first gate never opened"
+        # Execution half: records the generation of the env it executed
+        # against (the env the guarded acquisition installed).
         with fake_terminal_tool._env_lock:
             env = fake_terminal_tool._active_environments.get("default")
-            if env is None:
-                env = _FakeEnv(generation=_tagged_generation(streaming))
-                fake_terminal_tool._active_environments["default"] = env
-                fake_terminal_tool._last_activity["default"] = time.time()
-                created_envs.append(env)
-            used_tags[command] = getattr(env, "_webui_backend_generation", None)
-        assert second_gate.wait(timeout=20), "second gate never opened"
+        used_tags[command] = getattr(env, "_webui_backend_generation", None)
         return '{"output": "ok", "exit_code": 0}'
 
-    fake_terminal_tool.terminal_tool = gated_terminal_tool
+    fake_terminal_tool.terminal_tool = recording_terminal_tool
     streaming._install_terminal_env_generation_guard()
 
     a_result, b_result = {}, {}
@@ -620,7 +764,7 @@ def test_empty_slot_acquisition_is_one_transaction(fake_terminal_tool):
     ta.start()
     time.sleep(0.2)      # A reaches the first gate inside its transaction
     tb.start()
-    time.sleep(0.5)      # B: fixed head blocks (lock/drain); buggy head reaches gate
+    time.sleep(0.5)      # B: fixed head blocks (drain/lock); buggy head reaches gate
     first_gate.set()
     time.sleep(0.2)
     second_gate.set()
@@ -874,9 +1018,6 @@ def test_two_thread_backend_switch_no_reuse_or_teardown(
     (terminal, file, execute_code) and BOTH completion orders: the new-backend
     turn must neither reuse nor tear down the old-backend env."""
     streaming = importlib.import_module("api.streaming")
-    if tool == "terminal":
-        # Creating terminal_tool must be in place before the guard wraps it.
-        _install_creating_terminal_tool(fake_terminal_tool, streaming)
     streaming._install_terminal_env_generation_guard()
 
     def acquire(streaming, fake):
@@ -962,3 +1103,266 @@ def test_replacement_between_read_and_retire_not_torn_down(fake_terminal_tool):
         assert e0.cleaned, "the exact stale object must be retired"
     finally:
         streaming._end_turn_generation()
+
+
+def test_terminal_validation_happens_before_execution(fake_terminal_tool):
+    """Fix 1: ownership is validated BEFORE the command executes, and the
+    acquisition lock is released before execution.
+
+    The old wrapper passed the ENTIRE installed ``terminal_tool`` (which
+    acquires the env AND calls ``env.execute()``) as the acquire fn, so the
+    final exact-object check ran only after command side effects, while the
+    acquisition lock was held across approval/execution/retries.  Here the
+    REAL shared primitive and the REAL wrapper record the order: the final
+    ownership check must precede the original tool's execution, and the
+    ``_backend_acquisition_lock`` must NOT be held during execution.
+    """
+    streaming = importlib.import_module("api.streaming")
+    order = []
+    orig_final = streaming._final_ownership_check
+
+    def recorded_final(tt, effective_task_id, raw_task_id, turn_gen):
+        order.append("final_check")
+        return orig_final(tt, effective_task_id, raw_task_id, turn_gen)
+
+    streaming._final_ownership_check = recorded_final
+
+    def recording_terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        order.append(("execution", streaming._backend_acquisition_lock.locked()))
+        return '{"output": "ok", "exit_code": 0}'
+
+    fake_terminal_tool.terminal_tool = recording_terminal_tool
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0
+        out = fake_terminal_tool.terminal_tool("echo hi", session_id="s-v")
+    finally:
+        streaming._end_turn_generation()
+
+    assert order[0] == "final_check", (
+        "the final exact-object ownership check must run BEFORE the command "
+        f"executes (order was {order})")
+    assert order[1][0] == "execution", order
+    assert order[1][1] is False, (
+        "the acquisition lock must be RELEASED before the command executes "
+        "(it serialized terminal/file/execute-code acquisition across "
+        "approval + foreground execution + retries on the buggy head)")
+    assert out == '{"output": "ok", "exit_code": 0}'
+
+
+def test_terminal_executes_only_against_validated_generation(fake_terminal_tool):
+    """Fix 1 (behavioral): a stale foreign env is retired BEFORE the command
+    runs — the command executes only against an env tagged with the calling
+    turn's generation, and never against the foreign object."""
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    host_b_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+    foreign = _FakeEnv(generation=0)
+    fake_terminal_tool._active_environments["default"] = foreign
+
+    try:
+        streaming._begin_turn_generation(host_b_env)          # gen 1
+        out = fake_terminal_tool.terminal_tool("whoami", session_id="s-f")
+    finally:
+        streaming._end_turn_generation()
+
+    # The foreign gen-0 env was retired and NEVER executed against; the
+    # live env is the fresh turn-generation object.
+    live = fake_terminal_tool._active_environments.get("default")
+    assert live is not None and live is not foreign
+    assert live._webui_backend_generation == 1
+    assert foreign.cleaned
+    assert out == '{"output": "ok", "exit_code": 0}'
+    executed = fake_terminal_tool.executed_envs[-1]
+    assert executed[0] == "whoami"
+    assert executed[1] is not foreign
+    assert executed[1]._webui_backend_generation == 1
+
+
+def test_selected_profile_config_wins_over_process_global(fake_terminal_tool, monkeypatch):
+    """Fix 2: construction consumes the turn's immutable normalized config —
+    selected profile A wins even when a concurrent profile turn replaced
+    process-global os.environ with profile B values between A's identity
+    capture and A's real constructor read.
+
+    The fingerprint, the owner publish and every real constructor path
+    (``_get_env_config`` -> ``_create_environment``) consume the SAME
+    normalized object bound to the turn ContextVar; os.environ is never the
+    later construction authority.
+    """
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    profile_a = {
+        "TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a",
+        "TERMINAL_SSH_USER": "user-a", "TERMINAL_CWD": "/workspace-a",
+    }
+    profile_b = {
+        "TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b",
+        "TERMINAL_SSH_USER": "user-b", "TERMINAL_CWD": "/workspace-b",
+    }
+    streaming._last_backend_identity = streaming._compute_backend_identity(profile_a)
+    streaming._current_backend_generation = 0
+
+    # Concurrent profile B rewrote the process-global env AFTER A's setup.
+    for key, value in profile_b.items():
+        monkeypatch.setenv(key, value)
+
+    try:
+        streaming._begin_turn_generation(profile_a)           # turn A bound
+        # The construction authority returns A's values, not B's globals.
+        config = fake_terminal_tool._get_env_config()          # wrapped
+        assert config["ssh_host"] == "host-a", config
+        assert config["ssh_user"] == "user-a", config
+        assert config["cwd"] == "/workspace-a", config
+        # The fingerprint was computed from the SAME normalized object.
+        bound = streaming._get_turn_backend_config()
+        assert bound is not None
+        assert streaming._compute_backend_identity(bound) == streaming._last_backend_identity
+        # The REAL creation funnel consumed the A config (ssh backend).
+        out = fake_terminal_tool.terminal_tool("whoami", session_id="s-c")
+        created = fake_terminal_tool.created_configs[-1]
+        assert created["ssh_config"]["host"] == "host-a", created
+        assert created["ssh_config"]["user"] == "user-a", created
+        assert out == '{"output": "ok", "exit_code": 0}'
+    finally:
+        streaming._end_turn_generation()
+
+    # The turn config ContextVar is cleared on teardown.
+    assert streaming._get_turn_backend_config() is None
+
+
+def test_file_wrapper_requires_exact_validated_env_identity(fake_terminal_tool):
+    """Fix 3: the returned file_ops wrapper must reference the EXACT
+    validated registry object.  The installed fast path returns a cached
+    wrapper whenever a live env occupies the task slot, so a cached wrapper
+    around replaced env X must never be blessed/served while registry env Y
+    is what passed the ownership check (same-key, same-generation
+    replacement — the tag alone cannot distinguish them)."""
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    env_x = _FakeEnv(generation=0)
+    fake_terminal_tool._active_environments["default"] = env_x
+    cached_x = _FakeFileOps(env_x)
+    cached_x._webui_backend_generation = 0     # same-generation tag
+    fake_terminal_tool.file_tools._file_ops_cache["default"] = cached_x
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0
+        # Same-key replacement: env Y replaces X WITHOUT a generation bump.
+        env_y = _FakeEnv(generation=0)
+        fake_terminal_tool._active_environments["default"] = env_y
+        ops = fake_terminal_tool.file_tools._get_file_ops("default")
+    finally:
+        streaming._end_turn_generation()
+
+    assert ops is not cached_x, (
+        "the cached wrapper around replaced env X must never be served")
+    assert getattr(ops, "env", None) is env_y, (
+        "the returned wrapper must reference the exact validated registry env Y")
+    assert ops._webui_backend_generation == 0
+    assert streaming._file_backend_generations.get("default") == 0
+    # The stale cached wrapper was dropped from the cache.
+    cached_now = fake_terminal_tool.file_tools._file_ops_cache.get("default")
+    assert cached_now is None or cached_now is ops
+
+
+def test_execute_code_result_requires_exact_validated_env_identity(fake_terminal_tool):
+    """Fix 3 (execute_code): the result env must be the exact validated
+    registry object before it is tagged or handed to the caller."""
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
+    streaming._current_backend_generation = 0
+
+    try:
+        streaming._begin_turn_generation(host_a_env)          # gen 0
+        result = fake_terminal_tool.code_execution_tool._get_or_create_env("default")
+        env, env_type = result
+        live = fake_terminal_tool._active_environments["default"]
+        assert env is live, "the execute-code env must be the exact registry object"
+        assert env._webui_backend_generation == 0
+        assert env_type == "ssh"
+    finally:
+        streaming._end_turn_generation()
+
+
+def test_forced_docker_teardown_completes_before_replacement(fake_terminal_tool):
+    """Fix 4: physical Docker invalidation is FENCED — the forced teardown
+    (daemon stop/remove thread + ``wait_for_cleanup``) COMPLETES before the
+    retire returns, so replacement construction can never reattach by labels
+    to a still-removing container, and the stale cleanup thread can never
+    remove the replacement's live container."""
+    streaming = importlib.import_module("api.streaming")
+
+    env_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-a"}
+    env_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._env_backend_generations["default"] = 0
+    stale = _FakeDockerEnv(generation=0, removal_seconds=0.4)
+    fake_terminal_tool._active_environments["default"] = stale
+    streaming._install_terminal_env_generation_guard()
+
+    try:
+        streaming._begin_turn_generation(env_b)   # identity change -> retire stale
+        # The forced teardown COMPLETED before begin returned (the old head
+        # returned immediately, leaving the daemon removal in flight):
+        assert stale.removal_done.is_set(), (
+            "forced Docker teardown must finish before the retire returns")
+        assert stale.cleanup_force_remove is True
+        assert "default" not in fake_terminal_tool._active_environments
+        # Replacement construction is gated on the completed removal:
+        out = fake_terminal_tool.terminal_tool("echo fresh", session_id="s-d")
+        fresh = fake_terminal_tool._active_environments["default"]
+        assert fresh is not stale
+        assert fresh._webui_backend_generation == 1
+        assert stale.removal_done.is_set()
+        assert out == '{"output": "ok", "exit_code": 0}'
+    finally:
+        streaming._end_turn_generation()
+
+
+def test_forced_docker_teardown_timeout_fails_closed(fake_terminal_tool, monkeypatch):
+    """Fix 4: a forced teardown that does not finish is FAIL-CLOSED — the
+    turn is refused and no replacement is created; later acquisitions for the
+    same task key are refused too (a replacement must not attach to a
+    container in an unknown removal state)."""
+    streaming = importlib.import_module("api.streaming")
+    monkeypatch.setenv("HERMES_WEBUI_BACKEND_CLEANUP_TIMEOUT", "0.05")
+
+    env_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-a"}
+    env_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._env_backend_generations["default"] = 0
+    stuck = _FakeDockerEnv(generation=0, removal_seconds=5.0)   # >> 0.05s
+    fake_terminal_tool._active_environments["default"] = stuck
+
+    with pytest.raises(RuntimeError, match="did not finish"):
+        streaming._begin_turn_generation(env_b)
+    streaming._end_turn_generation()   # guaranteed outer finally: safe no-op
+    assert streaming._get_turn_generation() is None
+    # Fail-closed: nothing replaced the stale env, and the teardown fence
+    # refuses later creation for the same key.
+    assert "default" not in fake_terminal_tool._active_environments
+    with pytest.raises(RuntimeError, match="fail"):
+        streaming._validate_backend_ownership(fake_terminal_tool, "default", None)

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -1,58 +1,38 @@
 """Regression tests for #5937/#6586 — terminal backend isolation generation protocol.
 
-The re-gate review (nesquena-hermes, PR #6586) found two blockers in the
-first re-push:
+The 2026-08-03 redesign replaced the thread-local ``_turn_state`` (which carried
+the calling turn's backend generation) with an explicit
+``contextvars.ContextVar`` (``_TURN_BACKEND_GENERATION``): the Agent dispatches
+parallel-safe tool calls on child threads and propagates ContextVars
+(``contextvars.copy_context()``), NOT arbitrary thread-locals — so a
+thread-local slot was invisible inside tool workers, and acquisition there fell
+back to the process-global per-task owner, letting a concurrent profile change
+reuse state outside the calling turn's captured generation.
 
-1. **Deterministic deadlock.**  ``api.streaming._wrapped_terminal_tool()``
-   entered ``tt._env_lock`` and then called ``tt.get_active_env()``.  The
-   installed agent defines ``_env_lock = threading.Lock()`` (non-reentrant)
-   and ``get_active_env()`` acquires that same lock, so the first guarded
-   terminal call blocked forever.
+The new protocol, driven by the REAL ``api.streaming`` functions:
 
-2. **Ownership was never published.**  ``_mark_env_backend_generation()``
-   had no caller; ``_invalidate_stale_terminal_backend()`` popped the
-   generation record *before* reading it, so ``recorded`` was always ``None``
-   and the stale check returned early — neither ``cleanup_vm()`` nor
-   ``clear_file_ops_cache()`` was ever reached.  ``_refresh_env_generation_tag()``
-   also could not tag an environment because it depended on that absent record.
+* ``_begin_turn_generation(profile_runtime_env)`` — ONE ``_backend_generation_lock``
+  transaction: identity compare/publish (``_publish_backend_identity``),
+  exact-generation capture, ContextVar bind, active-use increment.  A failed
+  transition RAISES (fail-closed) and binds nothing, so the production
+  try/finally's ``_end_turn_generation()`` no-ops.
+* ``_end_turn_generation()`` / ``_unregister_turn_generation()`` — reads the
+  SAME captured generation from the ContextVar, clears it, decrements active
+  use, and drains deferred stale evictions.
+* ``_validate_backend_ownership`` — ONE shared acquisition boundary for
+  terminal / file / code-execution.  Compares the live env's tag against the
+  CALLING TURN's captured (ContextVar) generation — never the process-global
+  current generation, never the recorded owner.  An untagged env is retired
+  (fail-closed) for registered WebUI turns; an env still owned by an active
+  old-generation turn is waited on (bounded) instead of torn down.
+* ``_retire_generation_env`` — compare-and-remove under the registry lock; the
+  exact removed object is cleaned OUTSIDE the lock, so a replacement installed
+  under the same key is never torn down.
 
-The 2026-08-02 re-gate review found further blockers, all fixed here:
-
-3. **Deferred retire never published.**  ``_invalidate_stale_terminal_backend()``
-   assigned ``_pending_eviction_generation`` without a ``global`` declaration,
-   so the deferral was a local write and the pending retire was lost.  Pending
-   stale generations are now a SET (``_pending_eviction_generations``),
-   drained by ``_drain_pending_evictions()``.
-
-4. **File and execute_code acquisition bypassed the guard.**  Only
-   ``terminal_tool.terminal_tool`` was wrapped; ``file_tools._get_file_ops()``
-   and ``code_execution_tool._get_or_create_env()`` reused/created
-   ``_active_environments`` directly.  All three paths now share ONE
-   acquisition boundary (``_validate_backend_ownership``), and envs are tagged
-   at creation via the shared ``_create_environment`` funnel.
-
-5. **Active-use deferral admitted cross-backend reuse.**  Acquisition compared
-   the live env's tag against the process-global *recorded* owner, which the
-   deferred path never updated.  Acquisition now compares against the CALLING
-   TURN's captured (thread-local) generation — carried immutably from turn
-   setup — and the identity transition + ownership registration are atomic.
-   A new-backend turn neither reuses nor tears down an env an active
-   old-backend turn still owns; it waits (bounded) for that turn to drain.
-
-6. **Read/retire gap.**  ``get_active_env()`` then ``cleanup_vm()`` allowed a
-   replacement installed under the same key to be removed.  Retire is now a
-   compare-and-remove under the registry lock that cleans up the exact removed
-   object OUTSIDE the lock.
-
-7. **Registration was not inside a guaranteed outer try/finally.**  The
-   production call site now registers via ``_begin_turn_generation()`` as the
-   first statements of the try whose finally calls ``_end_turn_generation()``,
-   so a raising agent body can never leak an active-use registration.
-
-These tests drive the REAL ``api.streaming`` functions against a faithful
-fake of the agent's ``tools.terminal_tool`` contract (non-reentrant lock,
-lock-taking accessors, registry dicts), so they are RED on the buggy head
-and GREEN after the fix.
+These tests drive the REAL ``api.streaming`` functions against a faithful fake
+of the agent's ``tools.terminal_tool`` contract (non-reentrant lock,
+lock-taking accessors, registry dicts), so they are RED on the buggy head and
+GREEN after the fix.
 """
 from __future__ import annotations
 
@@ -144,7 +124,7 @@ def _tagged_generation(streaming) -> int:
     """Generation a fake creation path tags a fresh env with: the calling
     turn's captured generation when present, else the current global — the
     same policy the production ``_create_environment`` wrapper applies."""
-    turn_gen = getattr(streaming._turn_state, "backend_generation", None)
+    turn_gen = streaming._get_turn_generation()
     return turn_gen if turn_gen is not None else streaming._get_current_backend_generation()
 
 
@@ -183,7 +163,7 @@ def _isolate_generation_state(monkeypatch):
         streaming._terminal_env_guard_installed = False
         streaming._active_turn_generations.clear()
         streaming._pending_eviction_generations = set()
-    streaming._turn_state.backend_generation = None
+    streaming._TURN_BACKEND_GENERATION.set(None)
     yield
 
 
@@ -331,10 +311,9 @@ def test_guard_evicts_stale_generation_env_without_deadlock(fake_terminal_tool):
 
 
 def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
-    """Blocker 3 (focused): acquisition must compare against the CALLING
-    TURN's captured generation — not the recorded owner (which a deferred
-    transition could leave stale) and not the process-global current
-    generation.
+    """The acquisition boundary must compare against the CALLING TURN's
+    captured generation — not the recorded owner (which a deferred transition
+    could leave stale) and not the process-global current generation.
 
     Here the recorded owner is still 0 (the worst case the old code produced)
     while the env is tagged 0 and the calling turn is registered under gen 1:
@@ -343,6 +322,8 @@ def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
     streaming = importlib.import_module("api.streaming")
     streaming._install_terminal_env_generation_guard()
 
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
     streaming._env_backend_generations["default"] = 0
     streaming._current_backend_generation = 1
     env_a = _FakeEnv(generation=0)
@@ -351,7 +332,8 @@ def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
     result = {}
 
     def _turn_b():
-        streaming._register_turn_generation()          # gen 1
+        # Same identity as _last_backend_identity → no bump → captures gen 1.
+        streaming._begin_turn_generation(host_a_env)          # gen 1
         try:
             result["out"] = fake_terminal_tool.terminal_tool(
                 "whoami", task_id=None, session_id="s3"
@@ -359,7 +341,7 @@ def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
         except Exception as exc:  # pragma: no cover - failure path
             result["error"] = repr(exc)
         finally:
-            streaming._unregister_turn_generation()
+            streaming._end_turn_generation()
 
     t = threading.Thread(target=_turn_b)
     t.start()
@@ -371,28 +353,32 @@ def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
     assert result.get("out") == '{"output": "ok", "exit_code": 0}'
 
 
-def test_invalidate_publishes_ownership_after_identity_change(fake_terminal_tool):
-    """Blocker 2: after a backend identity change the invalidator must (a)
-    retire the stale env, (b) PUBLISH the new generation as owner so the next
-    refresh can tag and future invalidations can compare."""
+def test_begin_turn_publishes_ownership_after_identity_change(fake_terminal_tool):
+    """After a backend identity change the begin transaction must (a) retire
+    the stale env, (b) PUBLISH the new generation as owner so the next refresh
+    can tag and future acquisitions can compare."""
     streaming = importlib.import_module("api.streaming")
 
-    # Turn A: env created under gen 0, ownership published by refresh.
-    streaming._env_backend_generations["default"] = 0
-    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
-
-    # Turn B: profile switches to a different SSH host — same TERMINAL_ENV,
-    # different backend identity (host B).  Full fingerprint must differ.
     env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
     env_b = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
     assert streaming._compute_backend_identity(env_a) != streaming._compute_backend_identity(env_b)
 
-    streaming._invalidate_stale_terminal_backend(env_b)
+    # Turn A: env created under gen 0, ownership published.
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._env_backend_generations["default"] = 0
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
 
-    # Stale env (gen 0) retired; new generation (1) published as owner.
-    assert "default" not in fake_terminal_tool._active_environments
-    assert streaming._env_backend_generations.get("default") == 1
-    assert streaming._current_backend_generation == 1
+    # Turn B: profile switches to a different SSH host — the begin transaction
+    # compares/publishes the identity, bumps to gen 1 and retires the stale env.
+    try:
+        streaming._begin_turn_generation(env_b)
+
+        # Stale env (gen 0) retired; new generation (1) published as owner.
+        assert "default" not in fake_terminal_tool._active_environments
+        assert streaming._env_backend_generations.get("default") == 1
+        assert streaming._current_backend_generation == 1
+    finally:
+        streaming._end_turn_generation()
 
 
 def test_refresh_tags_env_and_publishes_ownership(fake_terminal_tool):
@@ -409,22 +395,27 @@ def test_refresh_tags_env_and_publishes_ownership(fake_terminal_tool):
     assert streaming._env_backend_generations.get("default") == 0
 
 
-def test_invalidate_skips_retire_when_env_replaced_by_newer_generation(fake_terminal_tool):
+def test_begin_turn_skips_retire_when_env_replaced_by_newer_generation(fake_terminal_tool):
     """A concurrent turn already replaced the env with a newer generation:
-    the invalidator must NOT retire that newer env."""
+    the begin transaction must NOT retire that newer env."""
     streaming = importlib.import_module("api.streaming")
 
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    env_b = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+
     # Recorded owner is gen 0 (stale), but the registry already holds a
-    # gen-1 env from a concurrent turn — the invalidator must leave it alone.
+    # gen-1 env from a concurrent turn — the transition must leave it alone.
     streaming._env_backend_generations["default"] = 0
     fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=1)
 
-    streaming._invalidate_stale_terminal_backend(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
-    )
+    try:
+        streaming._begin_turn_generation(env_b)
 
-    assert "default" in fake_terminal_tool._active_environments
-    assert streaming._current_backend_generation == 1
+        assert "default" in fake_terminal_tool._active_environments
+        assert streaming._current_backend_generation == 1
+    finally:
+        streaming._end_turn_generation()
 
 
 def test_active_use_defers_retire_until_turn_exits(fake_terminal_tool):
@@ -432,37 +423,44 @@ def test_active_use_defers_retire_until_turn_exits(fake_terminal_tool):
     not be torn down; the retire is deferred until the turn exits."""
     streaming = importlib.import_module("api.streaming")
 
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    env_b = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
     streaming._env_backend_generations["default"] = 0
     fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
 
     # An older turn is still executing under gen 0.
     streaming._active_turn_generations[0] = 1
 
-    streaming._invalidate_stale_terminal_backend(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
-    )
+    try:
+        streaming._begin_turn_generation(env_b)
 
-    # Not retired yet — deferred (every pending generation, not a scalar).
-    assert "default" in fake_terminal_tool._active_environments
-    assert streaming._pending_eviction_generations == {0}
+        # Not retired yet — deferred (every pending generation, not a scalar).
+        assert "default" in fake_terminal_tool._active_environments
+        assert streaming._pending_eviction_generations == {0}
 
-    # The older turn exits → the deferred retire is drained.
-    streaming._active_turn_generations.pop(0, None)
-    streaming._drain_pending_evictions()
+        # The older turn exits → the deferred retire is drained.
+        streaming._active_turn_generations.pop(0, None)
+        streaming._drain_pending_evictions()
 
-    assert "default" not in fake_terminal_tool._active_environments
-    assert streaming._pending_eviction_generations == set()
+        assert "default" not in fake_terminal_tool._active_environments
+        assert streaming._pending_eviction_generations == set()
+    finally:
+        streaming._end_turn_generation()
 
 
-def test_register_unregister_turn_generation_roundtrip(fake_terminal_tool):
+def test_begin_end_turn_generation_roundtrip(fake_terminal_tool):
     """The turn lifecycle hooks bump/decrement the active-use counter and
     drain deferred evictions on the last exit.
 
-    Uses a faithful TWO-THREAD schedule: ``_turn_state`` is thread-local, so a
+    Uses a faithful TWO-THREAD schedule: the ContextVar is per-context, so a
     single thread can only hold one registration at a time — nesting two
-    registers on one thread is not a valid schedule and left {0: 1} behind.
+    begins on one thread is not a valid schedule and left {0: 1} behind.
     """
     streaming = importlib.import_module("api.streaming")
+
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
 
     a_registered = threading.Event()
     b_go = threading.Event()
@@ -473,18 +471,18 @@ def test_register_unregister_turn_generation_roundtrip(fake_terminal_tool):
     b_done = threading.Event()
 
     def _turn_a():
-        streaming._register_turn_generation()          # gen 0
+        streaming._begin_turn_generation(host_a_env)          # gen 0
         a_registered.set()
         assert a_go.wait(timeout=10)
-        streaming._unregister_turn_generation()
+        streaming._end_turn_generation()
         a_done.set()
 
     def _turn_b():
         assert b_go.wait(timeout=10)
-        streaming._register_turn_generation()          # gen 0
+        streaming._begin_turn_generation(host_a_env)          # gen 0
         b_registered.set()
         assert b_may_finish.wait(timeout=10)
-        streaming._unregister_turn_generation()
+        streaming._end_turn_generation()
         b_done.set()
 
     ta = threading.Thread(target=_turn_a)
@@ -525,18 +523,19 @@ def test_guard_installs_only_once(fake_terminal_tool):
 def _run_two_thread_backend_switch(streaming, fake, acquire, completion_order):
     """Deterministic A-active/B-start backend-switch schedule (REAL threads).
 
-    - Turn A registers under generation 0 (profile host-a) with a live gen-0
+    - Turn A begins under generation 0 (profile host-a) with a live gen-0
       env in the registry.
-    - Turn B starts with profile host-b: identity change bumps to gen 1 and B
-      registers gen 1.
+    - Turn B starts with profile host-b: the begin transaction bumps to gen 1
+      and B captures gen 1.
     - B's acquisition (``acquire(streaming, fake)``) must never reuse env_a
       and never tear it down while A is still active.
     - completion_order=1: B's acquisition blocks (drain wait) until A exits.
     - completion_order=2: A exits first (drain retires env_a) and only then
       does B's acquisition run — it must not block at all.
     """
-    streaming._last_backend_identity = streaming._compute_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"})
+    host_a_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    host_b_env = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(host_a_env)
     streaming._env_backend_generations["default"] = 0
     env_a = _FakeEnv(generation=0)
     fake._active_environments["default"] = env_a
@@ -558,28 +557,28 @@ def _run_two_thread_backend_switch(streaming, fake, acquire, completion_order):
     streaming._wait_for_generation_drain = _hooked_wait
     try:
         def _turn_a():
-            streaming._register_turn_generation()          # gen 0
+            streaming._begin_turn_generation(host_a_env)      # gen 0 (no bump)
             a_registered.set()
             try:
                 assert a_may_finish.wait(timeout=15), "turn A never released"
             finally:
-                streaming._unregister_turn_generation()
+                streaming._end_turn_generation()
                 a_finished.set()
 
         def _turn_b():
-            streaming._invalidate_stale_terminal_backend(
-                {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"})
-            streaming._register_turn_generation()          # gen 1
+            # Identity change + generation capture + active-use increment are
+            # ONE transaction (the invalidate is folded into the begin).
+            streaming._begin_turn_generation(host_b_env)      # gen 1
             b_setup_done.set()
             try:
                 assert b_may_acquire.wait(timeout=15), "turn B never allowed to acquire"
                 b_result["out"] = acquire(streaming, fake)
             finally:
-                streaming._unregister_turn_generation()
+                streaming._end_turn_generation()
 
         ta = threading.Thread(target=_turn_a)
         ta.start()
-        # A must be registered BEFORE B's setup runs, so B's invalidator sees
+        # A must be registered BEFORE B's setup runs, so B's transition sees
         # an active gen-0 turn and defers the retire (deterministic schedule).
         assert a_registered.wait(timeout=15)
 
@@ -658,31 +657,29 @@ def test_two_thread_backend_switch_no_reuse_or_teardown(
         assert isinstance(result["out"], tuple) and result["out"][0] is live
 
 
-def test_setup_exception_still_registers_and_releases_turn(fake_terminal_tool, monkeypatch):
-    """Setup exceptions must not leak a turn registration: the identity
-    transition is non-fatal (registration still happens) and the production
-    try/finally (begin → body → end) always releases it."""
+def test_failed_identity_transition_is_fail_closed(fake_terminal_tool, monkeypatch):
+    """Fail-closed transition: a raising identity publish REFUSES the turn —
+    nothing is bound and no active-use registration leaks — and the guaranteed
+    try/finally's ``_end_turn_generation()`` is a safe no-op afterwards."""
     streaming = importlib.import_module("api.streaming")
 
     def _boom(profile_runtime_env):
         raise RuntimeError("identity transition failed")
 
-    monkeypatch.setattr(streaming, "_invalidate_stale_terminal_backend", _boom)
+    monkeypatch.setattr(streaming, "_publish_backend_identity", _boom)
 
-    # begin must not raise and must still register under the current gen.
-    streaming._begin_turn_generation(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"})
-    assert streaming._active_turn_generations.get(0) == 1
+    with pytest.raises(RuntimeError, match="identity transition failed"):
+        streaming._begin_turn_generation(
+            {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"})
 
-    try:
-        raise RuntimeError("agent body exploded")
-    except RuntimeError:
-        pass
-    finally:
-        streaming._end_turn_generation()
+    # Fail-closed: nothing registered, ContextVar unbound.
+    assert streaming._active_turn_generations == {}
+    assert streaming._get_turn_generation() is None
 
-    assert 0 not in streaming._active_turn_generations
-    assert getattr(streaming._turn_state, "backend_generation", None) is None
+    # The production finally (end_turn_generation) is a safe no-op.
+    streaming._end_turn_generation()
+    assert streaming._active_turn_generations == {}
+    assert streaming._get_turn_generation() is None
 
 
 def test_replacement_between_read_and_retire_not_torn_down(fake_terminal_tool):
@@ -692,6 +689,9 @@ def test_replacement_between_read_and_retire_not_torn_down(fake_terminal_tool):
     now."""
     streaming = importlib.import_module("api.streaming")
 
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    env_b = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
     streaming._env_backend_generations["default"] = 0
     e0 = _FakeEnv(generation=0)
     installed = {}
@@ -707,12 +707,13 @@ def test_replacement_between_read_and_retire_not_torn_down(fake_terminal_tool):
     e0.cleanup = _cleanup_installs_replacement
     fake_terminal_tool._active_environments["default"] = e0
 
-    streaming._invalidate_stale_terminal_backend(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
-    )
+    try:
+        streaming._begin_turn_generation(env_b)
 
-    repl = fake_terminal_tool._active_environments.get("default")
-    assert repl is installed.get("repl"), "the replacement must survive the retire"
-    assert repl._webui_backend_generation == 1
-    assert not repl.cleaned, "the replacement must never be torn down"
-    assert e0.cleaned, "the exact stale object must be retired"
+        repl = fake_terminal_tool._active_environments.get("default")
+        assert repl is installed.get("repl"), "the replacement must survive the retire"
+        assert repl._webui_backend_generation == 1
+        assert not repl.cleaned, "the replacement must never be torn down"
+        assert e0.cleaned, "the exact stale object must be retired"
+    finally:
+        streaming._end_turn_generation()

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -1,0 +1,316 @@
+"""Regression tests for #5937/#6586 — terminal backend isolation generation protocol.
+
+The re-gate review (nesquena-hermes, PR #6586) found two blockers in the
+first re-push:
+
+1. **Deterministic deadlock.**  ``api.streaming._wrapped_terminal_tool()``
+   entered ``tt._env_lock`` and then called ``tt.get_active_env()``.  The
+   installed agent defines ``_env_lock = threading.Lock()`` (non-reentrant)
+   and ``get_active_env()`` acquires that same lock, so the first guarded
+   terminal call blocked forever.
+
+2. **Ownership was never published.**  ``_mark_env_backend_generation()``
+   had no caller; ``_invalidate_stale_terminal_backend()`` popped the
+   generation record *before* reading it, so ``recorded`` was always ``None``
+   and the stale check returned early — neither ``cleanup_vm()`` nor
+   ``clear_file_ops_cache()`` was ever reached.  ``_refresh_env_generation_tag()``
+   also could not tag an environment because it depended on that absent record.
+
+These tests drive the REAL ``api.streaming`` functions against a faithful
+fake of the agent's ``tools.terminal_tool`` contract (non-reentrant lock,
+lock-taking accessors, registry dicts), so they are RED on the buggy head
+and GREEN after the fix.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+import types
+
+import pytest
+
+
+class _FakeEnv:
+    """Minimal stand-in for an agent BaseEnvironment."""
+
+    def __init__(self, generation=None):
+        self.cleaned = False
+        self.stopped = False
+        self._webui_backend_generation = generation
+
+    def cleanup(self):
+        self.cleaned = True
+
+    def stop(self):
+        self.stopped = True
+
+
+def _build_fake_terminal_tool_module() -> types.ModuleType:
+    """Build a fake ``tools.terminal_tool`` faithful to the installed agent:
+
+    - ``_env_lock`` is a plain non-reentrant ``threading.Lock``
+    - ``get_active_env()`` acquires ``_env_lock`` internally (the exact
+      accessor shape that deadlocked the buggy guard)
+    - registries ``_active_environments`` / ``_last_activity``
+    """
+    mod = types.ModuleType("tools.terminal_tool")
+    mod._env_lock = threading.Lock()
+    mod._active_environments = {}
+    mod._last_activity = {}
+    mod.terminal_tool_calls = []
+
+    def _resolve_container_task_id(task_id):
+        return task_id or "default"
+
+    def get_active_env(task_id):
+        # Faithful to tools/terminal_tool.py:~1736-1740 — takes the lock.
+        lookup = _resolve_container_task_id(task_id)
+        with mod._env_lock:
+            return (
+                mod._active_environments.get(lookup)
+                or mod._active_environments.get(task_id)
+            )
+
+    def cleanup_vm(task_id, *, force_remove=False):
+        with mod._env_lock:
+            env = mod._active_environments.pop(task_id, None)
+            mod._last_activity.pop(task_id, None)
+        if env is not None:
+            if hasattr(env, "cleanup"):
+                env.cleanup()
+            elif hasattr(env, "stop"):
+                env.stop()
+
+    def terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        mod.terminal_tool_calls.append(command)
+        return '{"output": "ok", "exit_code": 0}'
+
+    mod._resolve_container_task_id = _resolve_container_task_id
+    mod.get_active_env = get_active_env
+    mod.cleanup_vm = cleanup_vm
+    mod.terminal_tool = terminal_tool
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_generation_state(monkeypatch):
+    """Reset the streaming generation globals around every test."""
+    streaming = importlib.import_module("api.streaming")
+    with streaming._backend_generation_lock:
+        streaming._current_backend_generation = 0
+        streaming._env_backend_generations.clear()
+        streaming._file_backend_generations.clear()
+        streaming._last_backend_identity = None
+        streaming._terminal_env_guard_installed = False
+        streaming._active_turn_generations.clear()
+        streaming._pending_eviction_generation = None
+    yield
+
+
+@pytest.fixture()
+def fake_terminal_tool(monkeypatch):
+    """Install the faithful fake agent terminal module + file_tools."""
+    fake = _build_fake_terminal_tool_module()
+    fake_file_tools = types.ModuleType("tools.file_tools")
+    fake_file_tools.clear_file_ops_cache_calls = []
+
+    def clear_file_ops_cache(task_id):
+        fake_file_tools.clear_file_ops_cache_calls.append(task_id)
+
+    fake_file_tools.clear_file_ops_cache = clear_file_ops_cache
+
+    monkeypatch.setitem(sys.modules, "tools.terminal_tool", fake)
+    monkeypatch.setitem(sys.modules, "tools.file_tools", fake_file_tools)
+    return fake
+
+
+def test_guard_does_not_deadlock_on_first_terminal_call(fake_terminal_tool, monkeypatch):
+    """Blocker 1: the pre-flight guard must not re-acquire the non-reentrant
+    ``_env_lock`` via ``get_active_env()``.
+
+    A real (non-reentrant) lock + a lock-taking accessor deadlock the first
+    guarded call.  The guard must read the registry inline under the lock it
+    already holds (or read first, lock second) — never call
+    ``get_active_env()`` while holding ``_env_lock``.
+    """
+    streaming = importlib.import_module("api.streaming")
+
+    streaming._install_terminal_env_generation_guard()
+
+    # A live env under the CURRENT generation — the normal steady-state path.
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
+    streaming._mark_env_backend_generation("default", 0)
+
+    result = {}
+
+    def _call():
+        try:
+            out = fake_terminal_tool.terminal_tool(
+                "echo hi", task_id=None, session_id="s1"
+            )
+            result["ok"] = out
+        except Exception as exc:  # pragma: no cover - failure path
+            result["error"] = repr(exc)
+
+    t = threading.Thread(target=_call)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive(), (
+        "guard deadlocked: _wrapped_terminal_tool entered tt._env_lock and "
+        "called tt.get_active_env() which re-acquires the same non-reentrant lock"
+    )
+    assert "ok" in result
+    assert result["ok"] == '{"output": "ok", "exit_code": 0}'
+    assert fake_terminal_tool.terminal_tool_calls == ["echo hi"]
+
+
+def test_guard_evicts_stale_generation_env_without_deadlock(fake_terminal_tool):
+    """The guard must evict an env tagged with a stale generation and let the
+    original tool recreate it — without deadlocking on _env_lock."""
+    streaming = importlib.import_module("api.streaming")
+
+    # Simulate: env was created under generation 0, backend identity changed,
+    # generation bumped to 1.  The recorded owner is the NEW generation.
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
+    streaming._mark_env_backend_generation("default", 1)
+    streaming._current_backend_generation = 1
+
+    streaming._install_terminal_env_generation_guard()
+
+    result = {}
+
+    def _call():
+        try:
+            result["ok"] = fake_terminal_tool.terminal_tool(
+                "whoami", task_id=None, session_id="s2"
+            )
+        except Exception as exc:  # pragma: no cover - failure path
+            result["error"] = repr(exc)
+
+    t = threading.Thread(target=_call)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive(), "guard deadlocked on stale-env eviction path"
+
+    # The stale env was retired from the registry before the original tool ran.
+    assert "default" not in fake_terminal_tool._active_environments
+    # Ownership for the replacement was published.
+    assert streaming._get_expected_backend_generation("default") == 1
+    assert result.get("ok") == '{"output": "ok", "exit_code": 0}'
+
+
+def test_invalidate_publishes_ownership_after_identity_change(fake_terminal_tool):
+    """Blocker 2: after a backend identity change the invalidator must (a)
+    retire the stale env, (b) PUBLISH the new generation as owner so the next
+    refresh can tag and future invalidations can compare."""
+    streaming = importlib.import_module("api.streaming")
+
+    # Turn A: env created under gen 0, ownership published by refresh.
+    streaming._env_backend_generations["default"] = 0
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
+
+    # Turn B: profile switches to a different SSH host — same TERMINAL_ENV,
+    # different backend identity (host B).  Full fingerprint must differ.
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    env_b = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    assert streaming._compute_backend_identity(env_a) != streaming._compute_backend_identity(env_b)
+
+    streaming._invalidate_stale_terminal_backend(env_b)
+
+    # Stale env (gen 0) retired; new generation (1) published as owner.
+    assert "default" not in fake_terminal_tool._active_environments
+    assert streaming._env_backend_generations.get("default") == 1
+    assert streaming._current_backend_generation == 1
+
+
+def test_refresh_tags_env_and_publishes_ownership(fake_terminal_tool):
+    """Blocker 2: _refresh_env_generation_tag must tag the live env AND record
+    the owner generation — the publish side of the protocol."""
+    streaming = importlib.import_module("api.streaming")
+
+    env = _FakeEnv(generation=None)
+    fake_terminal_tool._active_environments["default"] = env
+
+    streaming._refresh_env_generation_tag()
+
+    assert env._webui_backend_generation == 0
+    assert streaming._env_backend_generations.get("default") == 0
+
+
+def test_invalidate_skips_retire_when_env_replaced_by_newer_generation(fake_terminal_tool):
+    """A concurrent turn already replaced the env with a newer generation:
+    the invalidator must NOT retire that newer env."""
+    streaming = importlib.import_module("api.streaming")
+
+    # Recorded owner is gen 0 (stale), but the registry already holds a
+    # gen-1 env from a concurrent turn — the invalidator must leave it alone.
+    streaming._env_backend_generations["default"] = 0
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=1)
+
+    streaming._invalidate_stale_terminal_backend(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    )
+
+    assert "default" in fake_terminal_tool._active_environments
+    assert streaming._current_backend_generation == 1
+
+
+def test_active_use_defers_retire_until_turn_exits(fake_terminal_tool):
+    """Active-use ownership: a stale env still executing an older turn must
+    not be torn down; the retire is deferred until the turn exits."""
+    streaming = importlib.import_module("api.streaming")
+
+    streaming._env_backend_generations["default"] = 0
+    fake_terminal_tool._active_environments["default"] = _FakeEnv(generation=0)
+
+    # An older turn is still executing under gen 0.
+    streaming._active_turn_generations[0] = 1
+
+    streaming._invalidate_stale_terminal_backend(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    )
+
+    # Not retired yet — deferred.
+    assert "default" in fake_terminal_tool._active_environments
+    assert streaming._pending_eviction_generation == 0
+
+    # The older turn exits → the deferred retire is drained.
+    streaming._active_turn_generations.pop(0, None)
+    streaming._drain_pending_eviction()
+
+    assert "default" not in fake_terminal_tool._active_environments
+    assert streaming._pending_eviction_generation is None
+
+
+def test_register_unregister_turn_generation_roundtrip(fake_terminal_tool):
+    """The turn lifecycle hooks bump/decrement the active-use counter and
+    drain deferred evictions on the last exit."""
+    streaming = importlib.import_module("api.streaming")
+
+    streaming._register_turn_generation()
+    assert streaming._active_turn_generations.get(0) == 1
+
+    # Second concurrent turn on the same generation.
+    streaming._register_turn_generation()
+    assert streaming._active_turn_generations.get(0) == 2
+
+    streaming._unregister_turn_generation()
+    assert streaming._active_turn_generations.get(0) == 1
+
+    streaming._unregister_turn_generation()
+    assert 0 not in streaming._active_turn_generations
+
+
+def test_guard_installs_only_once(fake_terminal_tool):
+    """Installing the guard is idempotent — no wrapper-on-wrapper stacking."""
+    streaming = importlib.import_module("api.streaming")
+
+    streaming._install_terminal_env_generation_guard()
+    first_wrapper = fake_terminal_tool.terminal_tool
+    streaming._install_terminal_env_generation_guard()
+    assert fake_terminal_tool.terminal_tool is first_wrapper

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -16,6 +16,39 @@ first re-push:
    ``clear_file_ops_cache()`` was ever reached.  ``_refresh_env_generation_tag()``
    also could not tag an environment because it depended on that absent record.
 
+The 2026-08-02 re-gate review found further blockers, all fixed here:
+
+3. **Deferred retire never published.**  ``_invalidate_stale_terminal_backend()``
+   assigned ``_pending_eviction_generation`` without a ``global`` declaration,
+   so the deferral was a local write and the pending retire was lost.  Pending
+   stale generations are now a SET (``_pending_eviction_generations``),
+   drained by ``_drain_pending_evictions()``.
+
+4. **File and execute_code acquisition bypassed the guard.**  Only
+   ``terminal_tool.terminal_tool`` was wrapped; ``file_tools._get_file_ops()``
+   and ``code_execution_tool._get_or_create_env()`` reused/created
+   ``_active_environments`` directly.  All three paths now share ONE
+   acquisition boundary (``_validate_backend_ownership``), and envs are tagged
+   at creation via the shared ``_create_environment`` funnel.
+
+5. **Active-use deferral admitted cross-backend reuse.**  Acquisition compared
+   the live env's tag against the process-global *recorded* owner, which the
+   deferred path never updated.  Acquisition now compares against the CALLING
+   TURN's captured (thread-local) generation — carried immutably from turn
+   setup — and the identity transition + ownership registration are atomic.
+   A new-backend turn neither reuses nor tears down an env an active
+   old-backend turn still owns; it waits (bounded) for that turn to drain.
+
+6. **Read/retire gap.**  ``get_active_env()`` then ``cleanup_vm()`` allowed a
+   replacement installed under the same key to be removed.  Retire is now a
+   compare-and-remove under the registry lock that cleans up the exact removed
+   object OUTSIDE the lock.
+
+7. **Registration was not inside a guaranteed outer try/finally.**  The
+   production call site now registers via ``_begin_turn_generation()`` as the
+   first statements of the try whose finally calls ``_end_turn_generation()``,
+   so a raising agent body can never leak an active-use registration.
+
 These tests drive the REAL ``api.streaming`` functions against a faithful
 fake of the agent's ``tools.terminal_tool`` contract (non-reentrant lock,
 lock-taking accessors, registry dicts), so they are RED on the buggy head
@@ -26,6 +59,7 @@ from __future__ import annotations
 import importlib
 import sys
 import threading
+import time
 import types
 
 import pytest
@@ -44,6 +78,15 @@ class _FakeEnv:
 
     def stop(self):
         self.stopped = True
+
+
+class _FakeFileOps:
+    """Minimal stand-in for ShellFileOperations (the file_ops cache value)."""
+
+    def __init__(self, env):
+        self.env = env
+        self.cwd = getattr(env, "cwd", None)
+        self._webui_backend_generation = None
 
 
 def _build_fake_terminal_tool_module() -> types.ModuleType:
@@ -97,6 +140,37 @@ def _build_fake_terminal_tool_module() -> types.ModuleType:
     return mod
 
 
+def _tagged_generation(streaming) -> int:
+    """Generation a fake creation path tags a fresh env with: the calling
+    turn's captured generation when present, else the current global — the
+    same policy the production ``_create_environment`` wrapper applies."""
+    turn_gen = getattr(streaming._turn_state, "backend_generation", None)
+    return turn_gen if turn_gen is not None else streaming._get_current_backend_generation()
+
+
+def _install_creating_terminal_tool(fake_terminal_tool, streaming):
+    """Replace the stub terminal_tool with one that creates an env when the
+    registry is empty (mirroring the agent's create-if-missing acquisition),
+    tagging it like the production ``_create_environment`` wrapper.  Must run
+    BEFORE ``_install_terminal_env_generation_guard()`` so the guard wraps it.
+    """
+    def terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        fake_terminal_tool.terminal_tool_calls.append(command)
+        with fake_terminal_tool._env_lock:
+            env = fake_terminal_tool._active_environments.get("default")
+            if env is None:
+                env = _FakeEnv(generation=_tagged_generation(streaming))
+                fake_terminal_tool._active_environments["default"] = env
+                fake_terminal_tool._last_activity["default"] = time.time()
+        return '{"output": "ok", "exit_code": 0}'
+
+    fake_terminal_tool.terminal_tool = terminal_tool
+
+
 @pytest.fixture(autouse=True)
 def _isolate_generation_state(monkeypatch):
     """Reset the streaming generation globals around every test."""
@@ -108,24 +182,76 @@ def _isolate_generation_state(monkeypatch):
         streaming._last_backend_identity = None
         streaming._terminal_env_guard_installed = False
         streaming._active_turn_generations.clear()
-        streaming._pending_eviction_generation = None
+        streaming._pending_eviction_generations = set()
+    streaming._turn_state.backend_generation = None
     yield
 
 
 @pytest.fixture()
 def fake_terminal_tool(monkeypatch):
-    """Install the faithful fake agent terminal module + file_tools."""
+    """Install the faithful fake agent terminal module + file_tools +
+    code_execution_tool (all three paths the guard must cover)."""
     fake = _build_fake_terminal_tool_module()
+
     fake_file_tools = types.ModuleType("tools.file_tools")
     fake_file_tools.clear_file_ops_cache_calls = []
+    fake_file_tools._file_ops_lock = threading.Lock()
+    fake_file_tools._file_ops_cache = {}
 
     def clear_file_ops_cache(task_id):
+        with fake_file_tools._file_ops_lock:
+            if task_id:
+                fake_file_tools._file_ops_cache.pop(task_id, None)
+            else:
+                fake_file_tools._file_ops_cache.clear()
         fake_file_tools.clear_file_ops_cache_calls.append(task_id)
 
+    def _get_file_ops(task_id="default"):
+        # Faithful to tools/file_tools.py:_get_file_ops: ensure the terminal
+        # env exists (creating + tagging it), then build/cache a file_ops
+        # wrapper around it.
+        streaming = importlib.import_module("api.streaming")
+        eff = fake._resolve_container_task_id(task_id)
+        with fake._env_lock:
+            env = fake._active_environments.get(eff)
+            if env is None:
+                env = _FakeEnv(generation=_tagged_generation(streaming))
+                fake._active_environments[eff] = env
+                fake._last_activity[eff] = time.time()
+        with fake_file_tools._file_ops_lock:
+            cached = fake_file_tools._file_ops_cache.get(eff)
+        if cached is not None:
+            return cached
+        file_ops = _FakeFileOps(env)
+        with fake_file_tools._file_ops_lock:
+            fake_file_tools._file_ops_cache[eff] = file_ops
+        return file_ops
+
     fake_file_tools.clear_file_ops_cache = clear_file_ops_cache
+    fake_file_tools._get_file_ops = _get_file_ops
+
+    fake_code_exec = types.ModuleType("tools.code_execution_tool")
+
+    def _get_or_create_env(task_id):
+        # Faithful to tools/code_execution_tool.py:_get_or_create_env.
+        streaming = importlib.import_module("api.streaming")
+        eff = fake._resolve_container_task_id(task_id)
+        with fake._env_lock:
+            env = fake._active_environments.get(eff)
+            if env is None:
+                env = _FakeEnv(generation=_tagged_generation(streaming))
+                fake._active_environments[eff] = env
+                fake._last_activity[eff] = time.time()
+            return env, "ssh"
+
+    fake_code_exec._get_or_create_env = _get_or_create_env
+
+    fake.file_tools = fake_file_tools
+    fake.code_execution_tool = fake_code_exec
 
     monkeypatch.setitem(sys.modules, "tools.terminal_tool", fake)
     monkeypatch.setitem(sys.modules, "tools.file_tools", fake_file_tools)
+    monkeypatch.setitem(sys.modules, "tools.code_execution_tool", fake_code_exec)
     return fake
 
 
@@ -204,6 +330,47 @@ def test_guard_evicts_stale_generation_env_without_deadlock(fake_terminal_tool):
     assert result.get("ok") == '{"output": "ok", "exit_code": 0}'
 
 
+def test_guard_compares_against_turn_captured_generation(fake_terminal_tool):
+    """Blocker 3 (focused): acquisition must compare against the CALLING
+    TURN's captured generation — not the recorded owner (which a deferred
+    transition could leave stale) and not the process-global current
+    generation.
+
+    Here the recorded owner is still 0 (the worst case the old code produced)
+    while the env is tagged 0 and the calling turn is registered under gen 1:
+    the guard must still refuse the env and retire it.
+    """
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    streaming._env_backend_generations["default"] = 0
+    streaming._current_backend_generation = 1
+    env_a = _FakeEnv(generation=0)
+    fake_terminal_tool._active_environments["default"] = env_a
+
+    result = {}
+
+    def _turn_b():
+        streaming._register_turn_generation()          # gen 1
+        try:
+            result["out"] = fake_terminal_tool.terminal_tool(
+                "whoami", task_id=None, session_id="s3"
+            )
+        except Exception as exc:  # pragma: no cover - failure path
+            result["error"] = repr(exc)
+        finally:
+            streaming._unregister_turn_generation()
+
+    t = threading.Thread(target=_turn_b)
+    t.start()
+    t.join(timeout=10.0)
+    assert not t.is_alive()
+    # The gen-0 env was NOT reused by the gen-1 turn and was retired.
+    assert "default" not in fake_terminal_tool._active_environments
+    assert env_a.cleaned
+    assert result.get("out") == '{"output": "ok", "exit_code": 0}'
+
+
 def test_invalidate_publishes_ownership_after_identity_change(fake_terminal_tool):
     """Blocker 2: after a backend identity change the invalidator must (a)
     retire the stale env, (b) PUBLISH the new generation as owner so the next
@@ -275,34 +442,73 @@ def test_active_use_defers_retire_until_turn_exits(fake_terminal_tool):
         {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
     )
 
-    # Not retired yet — deferred.
+    # Not retired yet — deferred (every pending generation, not a scalar).
     assert "default" in fake_terminal_tool._active_environments
-    assert streaming._pending_eviction_generation == 0
+    assert streaming._pending_eviction_generations == {0}
 
     # The older turn exits → the deferred retire is drained.
     streaming._active_turn_generations.pop(0, None)
-    streaming._drain_pending_eviction()
+    streaming._drain_pending_evictions()
 
     assert "default" not in fake_terminal_tool._active_environments
-    assert streaming._pending_eviction_generation is None
+    assert streaming._pending_eviction_generations == set()
 
 
 def test_register_unregister_turn_generation_roundtrip(fake_terminal_tool):
     """The turn lifecycle hooks bump/decrement the active-use counter and
-    drain deferred evictions on the last exit."""
+    drain deferred evictions on the last exit.
+
+    Uses a faithful TWO-THREAD schedule: ``_turn_state`` is thread-local, so a
+    single thread can only hold one registration at a time — nesting two
+    registers on one thread is not a valid schedule and left {0: 1} behind.
+    """
     streaming = importlib.import_module("api.streaming")
 
-    streaming._register_turn_generation()
+    a_registered = threading.Event()
+    b_go = threading.Event()
+    b_registered = threading.Event()
+    a_go = threading.Event()
+    b_may_finish = threading.Event()
+    a_done = threading.Event()
+    b_done = threading.Event()
+
+    def _turn_a():
+        streaming._register_turn_generation()          # gen 0
+        a_registered.set()
+        assert a_go.wait(timeout=10)
+        streaming._unregister_turn_generation()
+        a_done.set()
+
+    def _turn_b():
+        assert b_go.wait(timeout=10)
+        streaming._register_turn_generation()          # gen 0
+        b_registered.set()
+        assert b_may_finish.wait(timeout=10)
+        streaming._unregister_turn_generation()
+        b_done.set()
+
+    ta = threading.Thread(target=_turn_a)
+    tb = threading.Thread(target=_turn_b)
+    ta.start()
+    assert a_registered.wait(timeout=10)
     assert streaming._active_turn_generations.get(0) == 1
 
-    # Second concurrent turn on the same generation.
-    streaming._register_turn_generation()
+    tb.start()
+    b_go.set()
+    assert b_registered.wait(timeout=10)
+    # Second concurrent turn on the same generation (separate thread).
     assert streaming._active_turn_generations.get(0) == 2
 
-    streaming._unregister_turn_generation()
+    a_go.set()
+    assert a_done.wait(timeout=10)
+    # B is still registered — only A's registration was released.
     assert streaming._active_turn_generations.get(0) == 1
 
-    streaming._unregister_turn_generation()
+    b_may_finish.set()
+    assert b_done.wait(timeout=10)
+    ta.join(timeout=10)
+    tb.join(timeout=10)
+    assert not ta.is_alive() and not tb.is_alive()
     assert 0 not in streaming._active_turn_generations
 
 
@@ -314,3 +520,199 @@ def test_guard_installs_only_once(fake_terminal_tool):
     first_wrapper = fake_terminal_tool.terminal_tool
     streaming._install_terminal_env_generation_guard()
     assert fake_terminal_tool.terminal_tool is first_wrapper
+
+
+def _run_two_thread_backend_switch(streaming, fake, acquire, completion_order):
+    """Deterministic A-active/B-start backend-switch schedule (REAL threads).
+
+    - Turn A registers under generation 0 (profile host-a) with a live gen-0
+      env in the registry.
+    - Turn B starts with profile host-b: identity change bumps to gen 1 and B
+      registers gen 1.
+    - B's acquisition (``acquire(streaming, fake)``) must never reuse env_a
+      and never tear it down while A is still active.
+    - completion_order=1: B's acquisition blocks (drain wait) until A exits.
+    - completion_order=2: A exits first (drain retires env_a) and only then
+      does B's acquisition run — it must not block at all.
+    """
+    streaming._last_backend_identity = streaming._compute_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"})
+    streaming._env_backend_generations["default"] = 0
+    env_a = _FakeEnv(generation=0)
+    fake._active_environments["default"] = env_a
+
+    a_registered = threading.Event()
+    a_may_finish = threading.Event()
+    a_finished = threading.Event()
+    b_setup_done = threading.Event()
+    b_may_acquire = threading.Event()
+    b_result = {}
+
+    real_wait = streaming._wait_for_generation_drain
+    b_waited = threading.Event()
+
+    def _hooked_wait(generation, timeout=None):
+        b_waited.set()
+        return real_wait(generation, timeout=timeout)
+
+    streaming._wait_for_generation_drain = _hooked_wait
+    try:
+        def _turn_a():
+            streaming._register_turn_generation()          # gen 0
+            a_registered.set()
+            try:
+                assert a_may_finish.wait(timeout=15), "turn A never released"
+            finally:
+                streaming._unregister_turn_generation()
+                a_finished.set()
+
+        def _turn_b():
+            streaming._invalidate_stale_terminal_backend(
+                {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"})
+            streaming._register_turn_generation()          # gen 1
+            b_setup_done.set()
+            try:
+                assert b_may_acquire.wait(timeout=15), "turn B never allowed to acquire"
+                b_result["out"] = acquire(streaming, fake)
+            finally:
+                streaming._unregister_turn_generation()
+
+        ta = threading.Thread(target=_turn_a)
+        ta.start()
+        # A must be registered BEFORE B's setup runs, so B's invalidator sees
+        # an active gen-0 turn and defers the retire (deterministic schedule).
+        assert a_registered.wait(timeout=15)
+
+        tb = threading.Thread(target=_turn_b)
+        tb.start()
+        assert b_setup_done.wait(timeout=15)
+        assert streaming._active_turn_generations.get(0) == 1
+        assert streaming._active_turn_generations.get(1) == 1
+
+        if completion_order == 2:
+            # A finishes before B's acquisition: the deferred retire is drained
+            # on A's exit, so B never blocks and never sees env_a.
+            a_may_finish.set()
+            assert a_finished.wait(timeout=15)
+            assert streaming._pending_eviction_generations == set()
+            b_may_acquire.set()
+            tb.join(timeout=15)
+            ta.join(timeout=15)
+            assert not tb.is_alive() and not ta.is_alive()
+            assert not b_waited.is_set(), "order 2 must not block on drain"
+        else:
+            # B's acquisition starts while A is active: it must block on the
+            # drain (never reuse/tear down env_a), then proceed after A exits.
+            b_may_acquire.set()
+            assert b_waited.wait(timeout=15), "B's acquisition did not defer to A's drain"
+            assert fake._active_environments.get("default") is env_a, (
+                "B must not tear down env_a while turn A is still active")
+            assert streaming._pending_eviction_generations == {0}
+            a_may_finish.set()
+            ta.join(timeout=15)
+            tb.join(timeout=15)
+            assert not tb.is_alive() and not ta.is_alive()
+
+        b_result["env_a"] = env_a
+        b_result["env_a_cleaned"] = env_a.cleaned
+        b_result["live"] = fake._active_environments.get("default")
+        return b_result
+    finally:
+        streaming._wait_for_generation_drain = real_wait
+
+
+@pytest.mark.parametrize("completion_order", [1, 2])
+@pytest.mark.parametrize("tool", ["terminal", "file", "code_exec"])
+def test_two_thread_backend_switch_no_reuse_or_teardown(
+    tool, completion_order, fake_terminal_tool,
+):
+    """REAL two-thread A-active/B-start coverage for EVERY acquisition path
+    (terminal, file, execute_code) and BOTH completion orders: the new-backend
+    turn must neither reuse nor tear down the old-backend env."""
+    streaming = importlib.import_module("api.streaming")
+    if tool == "terminal":
+        # Creating terminal_tool must be in place before the guard wraps it.
+        _install_creating_terminal_tool(fake_terminal_tool, streaming)
+    streaming._install_terminal_env_generation_guard()
+
+    def acquire(streaming, fake):
+        if tool == "terminal":
+            return fake.terminal_tool("echo B", session_id="b")
+        if tool == "file":
+            return fake.file_tools._get_file_ops("default")
+        return fake.code_execution_tool._get_or_create_env("default")
+
+    result = _run_two_thread_backend_switch(
+        streaming, fake_terminal_tool, acquire, completion_order)
+
+    assert result["env_a_cleaned"], f"{tool}: stale gen-0 env must be retired"
+    live = result["live"]
+    assert live is not None, f"{tool}: fresh env must exist after the switch"
+    assert live is not result["env_a"], f"{tool}: B must not reuse A's env"
+    assert live._webui_backend_generation == 1, f"{tool}: B's env must be tagged gen 1"
+    assert streaming._pending_eviction_generations == set()
+    if tool == "file":
+        fops = fake_terminal_tool.file_tools._file_ops_cache.get("default")
+        assert fops is not None and fops._webui_backend_generation == 1
+    if tool == "code_exec":
+        assert isinstance(result["out"], tuple) and result["out"][0] is live
+
+
+def test_setup_exception_still_registers_and_releases_turn(fake_terminal_tool, monkeypatch):
+    """Setup exceptions must not leak a turn registration: the identity
+    transition is non-fatal (registration still happens) and the production
+    try/finally (begin → body → end) always releases it."""
+    streaming = importlib.import_module("api.streaming")
+
+    def _boom(profile_runtime_env):
+        raise RuntimeError("identity transition failed")
+
+    monkeypatch.setattr(streaming, "_invalidate_stale_terminal_backend", _boom)
+
+    # begin must not raise and must still register under the current gen.
+    streaming._begin_turn_generation(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"})
+    assert streaming._active_turn_generations.get(0) == 1
+
+    try:
+        raise RuntimeError("agent body exploded")
+    except RuntimeError:
+        pass
+    finally:
+        streaming._end_turn_generation()
+
+    assert 0 not in streaming._active_turn_generations
+    assert getattr(streaming._turn_state, "backend_generation", None) is None
+
+
+def test_replacement_between_read_and_retire_not_torn_down(fake_terminal_tool):
+    """A replacement installed under the same key between the stale env's
+    removal and its teardown must survive: retire cleans up the EXACT removed
+    object outside the registry lock, never a by-key pop of whatever is there
+    now."""
+    streaming = importlib.import_module("api.streaming")
+
+    streaming._env_backend_generations["default"] = 0
+    e0 = _FakeEnv(generation=0)
+    installed = {}
+
+    def _cleanup_installs_replacement():
+        # Simulates a concurrent thread installing a fresh gen-1 env while the
+        # stale env is being retired (outside the registry lock).
+        e0.cleaned = True
+        repl = _FakeEnv(generation=1)
+        fake_terminal_tool._active_environments["default"] = repl
+        installed["repl"] = repl
+
+    e0.cleanup = _cleanup_installs_replacement
+    fake_terminal_tool._active_environments["default"] = e0
+
+    streaming._invalidate_stale_terminal_backend(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-b"}
+    )
+
+    repl = fake_terminal_tool._active_environments.get("default")
+    assert repl is installed.get("repl"), "the replacement must survive the retire"
+    assert repl._webui_backend_generation == 1
+    assert not repl.cleaned, "the replacement must never be torn down"
+    assert e0.cleaned, "the exact stale object must be retired"

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -1728,3 +1728,56 @@ def test_profile_terminal_mappings_cover_canonical_schema(fake_terminal_tool):
     finally:
         streaming._end_turn_generation()
     assert streaming._get_turn_backend_config() is None
+
+
+def test_docker_container_exists_fails_closed_on_nonzero_ps(monkeypatch):
+    """Blocker 3: a docker ps -a that exits nonzero with empty stdout must
+    raise (fail-closed), never report 'container absent' — a daemon outage or
+    permission failure must not permit a replacement that reattaches by
+    labels."""
+    import subprocess as _subprocess
+    import api.streaming as streaming
+
+    class _FakeCompleted:
+        returncode = 1
+        stdout = b""
+        stderr = b"daemon not running"
+
+    monkeypatch.setattr(
+        streaming.subprocess, "run",
+        lambda *_a, **_k: _FakeCompleted(),
+    )
+    with pytest.raises(RuntimeError, match="fail-closed"):
+        streaming._docker_container_exists("docker", "c0ffee1234567890")
+
+
+def test_docker_container_exists_empty_output_after_success_means_absent(monkeypatch):
+    """Blocker 3 happy path: returncode 0 with empty stdout = container absent."""
+    import api.streaming as streaming
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    monkeypatch.setattr(
+        streaming.subprocess, "run",
+        lambda *_a, **_k: _FakeCompleted(),
+    )
+    assert streaming._docker_container_exists("docker", "c0ffee1234567890") is False
+
+
+def test_docker_container_exists_stdout_id_means_present(monkeypatch):
+    """Blocker 3: returncode 0 with the container id on stdout = still present."""
+    import api.streaming as streaming
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = b"c0ffee1234567890\n"
+        stderr = b""
+
+    monkeypatch.setattr(
+        streaming.subprocess, "run",
+        lambda *_a, **_k: _FakeCompleted(),
+    )
+    assert streaming._docker_container_exists("docker", "c0ffee1234567890") is True

--- a/tests/test_terminal_backend_generation_6586.py
+++ b/tests/test_terminal_backend_generation_6586.py
@@ -36,6 +36,7 @@ GREEN after the fix.
 """
 from __future__ import annotations
 
+import contextvars
 import importlib
 import os
 import sys
@@ -64,9 +65,9 @@ class _FakeEnv:
 class _FakeFileOps:
     """Minimal stand-in for ShellFileOperations (the file_ops cache value)."""
 
-    def __init__(self, env):
-        self.env = env
-        self.cwd = getattr(env, "cwd", None)
+    def __init__(self, env_obj):
+        self.env = env_obj
+        self.cwd = getattr(env_obj, "cwd", None)
         self._webui_backend_generation = None
 
 
@@ -183,6 +184,26 @@ def _build_fake_terminal_tool_module() -> types.ModuleType:
             elif hasattr(env, "stop"):
                 env.stop()
 
+    def _cleanup_inactive_envs(lifetime_seconds=300):
+        # Faithful to tools/terminal_tool.py:_cleanup_inactive_envs — the
+        # idle reaper the installed terminal_tool starts on every call.  It
+        # pops stale envs DIRECTLY from the registry (never through the
+        # WebUI retirement paths) and tears them down outside the lock.
+        current_time = time.time()
+        envs_to_stop = []
+        with mod._env_lock:
+            for task_id, last_time in list(mod._last_activity.items()):
+                if current_time - last_time > lifetime_seconds:
+                    env = mod._active_environments.pop(task_id, None)
+                    mod._last_activity.pop(task_id, None)
+                    if env is not None:
+                        envs_to_stop.append((task_id, env))
+        for _task_id, env in envs_to_stop:
+            if hasattr(env, "cleanup"):
+                env.cleanup()
+            elif hasattr(env, "stop"):
+                env.stop()
+
     def terminal_tool(
         command, background=False, timeout=None, task_id=None,
         session_id=None, force=False, workdir=None, pty=False,
@@ -205,6 +226,7 @@ def _build_fake_terminal_tool_module() -> types.ModuleType:
     mod._create_environment = _create_environment
     mod.get_active_env = get_active_env
     mod.cleanup_vm = cleanup_vm
+    mod._cleanup_inactive_envs = _cleanup_inactive_envs
     mod.terminal_tool = terminal_tool
     return mod
 
@@ -1366,3 +1388,343 @@ def test_forced_docker_teardown_timeout_fails_closed(fake_terminal_tool, monkeyp
     assert "default" not in fake_terminal_tool._active_environments
     with pytest.raises(RuntimeError, match="fail"):
         streaming._validate_backend_ownership(fake_terminal_tool, "default", None)
+
+
+def test_terminal_retirement_deferred_while_command_executes(fake_terminal_tool):
+    """Blocker 1 (2026-08-06 review): acquisition and execution share ONE
+    authority.  A retirement attempted while a guarded terminal command is
+    executing against the validated env must be DEFERRED (execution lease) —
+    the installed ``terminal_tool`` re-reads the registry by key right before
+    ``env.execute()``, so replacing the object mid-command would make the
+    command run against a non-validated replacement.  The command completes
+    against the exact validated object; retirement proceeds afterwards.
+    """
+    streaming = importlib.import_module("api.streaming")
+    started = threading.Event()
+    release = threading.Event()
+    executed_against = []
+
+    def gated_terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        # Execution half of the installed tool: the SECOND by-key lookup,
+        # then env.execute() against whatever it found.
+        eff = fake_terminal_tool._resolve_container_task_id(task_id)
+        with fake_terminal_tool._env_lock:
+            env = (
+                fake_terminal_tool._active_environments.get(eff)
+                or fake_terminal_tool._active_environments.get(task_id)
+            )
+        executed_against.append(env)
+        started.set()
+        assert release.wait(timeout=15), "release gate never opened"
+        return '{"output": "ok", "exit_code": 0}'
+
+    fake_terminal_tool.terminal_tool = gated_terminal_tool
+    streaming._install_terminal_env_generation_guard()
+
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._current_backend_generation = 0
+
+    result = {}
+
+    def _run_command():
+        # The Agent's parallel-tool worker bridge runs the tool on a child
+        # thread and propagates ContextVars — copy_context() is the faithful
+        # shape, so the turn's captured generation reaches the wrapper.
+        result["out"] = fake_terminal_tool.terminal_tool(
+            "long cmd", session_id="s-l")
+
+    try:
+        streaming._begin_turn_generation(env_a)          # gen 0
+        ctx = contextvars.copy_context()
+        thread = threading.Thread(
+            target=lambda: ctx.run(_run_command), daemon=True)
+        thread.start()
+        assert started.wait(timeout=15), "command never started"
+        validated = fake_terminal_tool._active_environments.get("default")
+        assert validated is not None
+        # Mid-command retirement attempt (turn-exit drain / identity switch
+        # would call exactly this path): must be DEFERRED by the lease.
+        streaming._retire_generation_env(0, "default")
+        assert fake_terminal_tool._active_environments.get("default") is validated
+        assert not validated.cleaned
+        release.set()
+        thread.join(timeout=15)
+        assert result["out"] == '{"output": "ok", "exit_code": 0}'
+        # The second lookup found the SAME validated object — no replacement.
+        assert executed_against[0] is validated
+    finally:
+        # Turn exit drains the deferred eviction: the now-idle env is
+        # retired and physically cleaned.
+        streaming._end_turn_generation()
+    assert "default" not in fake_terminal_tool._active_environments
+    assert validated.cleaned
+
+
+def test_reaper_does_not_reap_env_mid_execution(fake_terminal_tool):
+    """Blocker 1: the agent's idle reaper (``_cleanup_inactive_envs``, which
+    the installed terminal_tool STARTS on every call and which pops envs
+    DIRECTLY from the registry) must not remove an environment a guarded
+    terminal command is executing against — the by-key second lookup would
+    then create a fresh, never-validated env and run the command there.  A
+    leased env is kept alive (activity refresh) until the command finishes.
+    """
+    streaming = importlib.import_module("api.streaming")
+    started = threading.Event()
+    release = threading.Event()
+    executed_against = []
+
+    def gated_terminal_tool(
+        command, background=False, timeout=None, task_id=None,
+        session_id=None, force=False, workdir=None, pty=False,
+        notify_on_complete=False, watch_patterns=None,
+    ):
+        eff = fake_terminal_tool._resolve_container_task_id(task_id)
+        with fake_terminal_tool._env_lock:
+            env = (
+                fake_terminal_tool._active_environments.get(eff)
+                or fake_terminal_tool._active_environments.get(task_id)
+            )
+        executed_against.append(env)
+        started.set()
+        assert release.wait(timeout=15), "release gate never opened"
+        return '{"output": "ok", "exit_code": 0}'
+
+    fake_terminal_tool.terminal_tool = gated_terminal_tool
+    streaming._install_terminal_env_generation_guard()
+
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._current_backend_generation = 0
+
+    result = {}
+
+    def _run_command():
+        result["out"] = fake_terminal_tool.terminal_tool(
+            "long cmd", session_id="s-r")
+
+    try:
+        streaming._begin_turn_generation(env_a)          # gen 0
+        ctx = contextvars.copy_context()
+        thread = threading.Thread(
+            target=lambda: ctx.run(_run_command), daemon=True)
+        thread.start()
+        assert started.wait(timeout=15), "command never started"
+        validated = fake_terminal_tool._active_environments.get("default")
+        assert validated is not None
+        # Force the env idle (as a long-running command with no background
+        # process would be), then sweep with a 10s lifetime: at 60s idle the
+        # unfenced reaper would reap it; the fence must keep the env a
+        # guarded command is executing against alive.
+        fake_terminal_tool._last_activity["default"] = time.time() - 60
+        fake_terminal_tool._cleanup_inactive_envs(10)
+        assert fake_terminal_tool._active_environments.get("default") is validated
+        assert not validated.cleaned
+        release.set()
+        thread.join(timeout=15)
+        assert result["out"] == '{"output": "ok", "exit_code": 0}'
+        assert executed_against[0] is validated
+    finally:
+        streaming._end_turn_generation()
+    # Once idle, a later sweep reaps the env normally.
+    fake_terminal_tool._cleanup_inactive_envs(0)
+    assert "default" not in fake_terminal_tool._active_environments
+    assert validated.cleaned
+
+
+def test_fail_closed_gate_refuses_registry_swap_after_validation(
+    fake_terminal_tool, monkeypatch,
+):
+    """Blocker 1: execution never begins against a REPLACEMENT.  If a foreign
+    actor swaps the registry object in the window AFTER the ownership
+    transaction's final check and BEFORE the pre-execution gate, the wrapper
+    refuses (fail-closed) instead of executing on the replacement.
+    """
+    streaming = importlib.import_module("api.streaming")
+    streaming._install_terminal_env_generation_guard()
+
+    env_a = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "host-a"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._current_backend_generation = 0
+
+    real_acquire = streaming._acquire_backend_object
+
+    def swapping_acquire(
+        tt, effective_task_id, raw_task_id, acquire_fn, on_acquired=None,
+    ):
+        result = real_acquire(
+            tt, effective_task_id, raw_task_id, acquire_fn,
+            on_acquired=on_acquired,
+        )
+        # The foreign actor acts between the transaction's final ownership
+        # check and the wrapper's post-lock pre-execution gate: swap the
+        # validated object for another env under the same key.
+        with tt._env_lock:
+            tt._active_environments[effective_task_id] = _FakeEnv(generation=0)
+        return result
+
+    monkeypatch.setattr(streaming, "_acquire_backend_object", swapping_acquire)
+
+    try:
+        streaming._begin_turn_generation(env_a)          # gen 0
+        with pytest.raises(RuntimeError, match="changed after ownership validation"):
+            fake_terminal_tool.terminal_tool("echo hi", session_id="s-g")
+    finally:
+        streaming._end_turn_generation()
+    # No command ran against the replacement.
+    assert fake_terminal_tool.executed_envs == []
+
+
+def test_docker_teardown_verifies_physical_removal_fail_closed(
+    fake_terminal_tool, monkeypatch,
+):
+    """Blocker 3 (2026-08-06 review): ``wait_for_cleanup()`` only proves the
+    worker thread ended — the installed Docker worker ignores ``docker
+    stop``/``rm -f`` return codes, so a failed removal still reports success
+    while the old container and labels remain.  The retired container
+    identity must be verified GONE before replacement is permitted; a
+    still-existing container FAILS CLOSED and blocks later replacement.
+    """
+    streaming = importlib.import_module("api.streaming")
+
+    env_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-a"}
+    env_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._env_backend_generations["default"] = 0
+    stale = _FakeDockerEnv(generation=0, removal_seconds=0.05)
+    stale._container_id = "c0ffee1234567890"
+    stale._docker_exe = "docker"
+    fake_terminal_tool._active_environments["default"] = stale
+    streaming._install_terminal_env_generation_guard()
+
+    monkeypatch.setattr(streaming, "_docker_container_exists", lambda exe, cid: True)
+
+    with pytest.raises(RuntimeError, match="still exists after forced teardown"):
+        streaming._begin_turn_generation(env_b)
+    streaming._end_turn_generation()
+    # Fail-closed: the teardown fence refuses later creation for the key.
+    assert "default" not in fake_terminal_tool._active_environments
+    with pytest.raises(RuntimeError, match="fail"):
+        streaming._validate_backend_ownership(fake_terminal_tool, "default", None)
+
+
+def test_docker_teardown_physical_removal_verified_ok(fake_terminal_tool, monkeypatch):
+    """Blocker 3 happy path: once the retired container identity is confirmed
+    gone, replacement construction proceeds normally.
+    """
+    streaming = importlib.import_module("api.streaming")
+    monkeypatch.setattr(streaming, "_docker_container_exists", lambda exe, cid: False)
+
+    env_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-a"}
+    env_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-b"}
+    streaming._last_backend_identity = streaming._compute_backend_identity(env_a)
+    streaming._env_backend_generations["default"] = 0
+    stale = _FakeDockerEnv(generation=0, removal_seconds=0.05)
+    stale._container_id = "c0ffee1234567890"
+    stale._docker_exe = "docker"
+    fake_terminal_tool._active_environments["default"] = stale
+    streaming._install_terminal_env_generation_guard()
+
+    try:
+        streaming._begin_turn_generation(env_b)   # retire stale + create fresh
+        out = fake_terminal_tool.terminal_tool("echo fresh", session_id="s-d2")
+        fresh = fake_terminal_tool._active_environments["default"]
+        assert fresh is not stale
+        assert fresh._webui_backend_generation == 1
+        assert out == '{"output": "ok", "exit_code": 0}'
+    finally:
+        streaming._end_turn_generation()
+
+
+def test_profile_terminal_mappings_cover_canonical_schema(fake_terminal_tool):
+    """Blocker 2 (2026-08-06 review): the WebUI profile snapshot must cover
+    every field the agent's canonical terminal schema supports
+    (``TERMINAL_CONFIG_ENV_MAP`` in hermes_cli/config.py) — a profile that
+    configures e.g. ``docker_shm_size`` / ``vercel_runtime`` / ``sandbox_dir``
+    in config.yaml must not silently fall back to WebUI hard-coded defaults —
+    and every effective constructor input must stay in the turn's immutable
+    snapshot (the same object the identity fingerprint is computed from).
+    """
+    import api.profiles as profiles
+    streaming = importlib.import_module("api.streaming")
+
+    # Mirror of hermes_cli/config.py:TERMINAL_CONFIG_ENV_MAP (agent side).
+    canonical = {
+        "backend", "modal_mode", "degraded_mode", "cwd", "timeout",
+        "lifetime_seconds", "docker_image", "docker_forward_env",
+        "singularity_image", "modal_image", "daytona_image", "vercel_runtime",
+        "ssh_host", "ssh_user", "ssh_port", "ssh_key", "container_cpu",
+        "container_memory", "container_disk", "container_persistent",
+        "docker_volumes", "docker_env", "docker_mount_cwd_to_workspace",
+        "docker_network", "docker_extra_args", "docker_shm_size",
+        "docker_run_as_host_user", "docker_persist_across_processes",
+        "docker_orphan_reaper", "sandbox_dir", "persistent_shell",
+    }
+    missing = canonical - set(profiles._TERMINAL_ENV_MAPPINGS)
+    assert not missing, (
+        "profile terminal mapping omits canonical fields: %s" % sorted(missing))
+
+    # Every mapped canonical field must also be part of the backend identity
+    # fingerprint, so the immutable turn snapshot cannot diverge from the
+    # identity that was published.
+    mapped_vars = {profiles._TERMINAL_ENV_MAPPINGS[k] for k in canonical}
+    missing_identity = mapped_vars - set(streaming._BACKEND_IDENTITY_KEYS)
+    assert not missing_identity, (
+        "backend identity keys omit mapped fields: %s" % sorted(missing_identity))
+
+    # End-to-end: a profile runtime env configuring the previously-omitted
+    # fields flows through the real constructor input (the wrapped
+    # _get_env_config -> _create_environment) from the SAME immutable
+    # snapshot the fingerprint was computed from.
+    streaming._install_terminal_env_generation_guard()
+    profile_env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_IMAGE": "img-a",
+        "TERMINAL_DOCKER_SHM_SIZE": "2g",
+        "TERMINAL_DOCKER_NETWORK": "false",
+        "TERMINAL_DOCKER_EXTRA_ARGS": '["--cpus=2"]',
+        "TERMINAL_DOCKER_RUN_AS_HOST_USER": "true",
+        "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES": "false",
+        "TERMINAL_DOCKER_ORPHAN_REAPER": "false",
+        "TERMINAL_VERCEL_RUNTIME": "nodejs20",
+        "TERMINAL_SANDBOX_DIR": "/sandbox",
+        "TERMINAL_DEGRADED_MODE": "true",
+    }
+    streaming._last_backend_identity = streaming._compute_backend_identity(
+        {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img-a"})
+    streaming._current_backend_generation = 0
+    try:
+        streaming._begin_turn_generation(profile_env)
+        # The fingerprint was computed from the SAME normalized object.
+        bound = streaming._get_turn_backend_config()
+        assert bound is not None
+        assert streaming._compute_backend_identity(bound) == streaming._last_backend_identity
+        # The construction authority returns the profile values, not
+        # hard-coded defaults.
+        config = fake_terminal_tool._get_env_config()          # wrapped
+        assert config["docker_shm_size"] == "2g", config
+        assert config["docker_network"] is False, config
+        assert config["docker_extra_args"] == ["--cpus=2"], config
+        assert config["docker_run_as_host_user"] is True, config
+        assert config["docker_persist_across_processes"] is False, config
+        assert config["docker_orphan_reaper"] is False, config
+        assert config["vercel_runtime"] == "nodejs20", config
+        # The REAL creation funnel consumed the snapshot values.
+        out = fake_terminal_tool.terminal_tool("echo hi", session_id="s-p")
+        created = fake_terminal_tool.created_configs[-1]
+        cc = created["container_config"]
+        assert cc["docker_shm_size"] == "2g", created
+        assert cc["docker_network"] is False, created
+        assert cc["docker_extra_args"] == ["--cpus=2"], created
+        assert cc["docker_run_as_host_user"] is True, created
+        assert cc["docker_persist_across_processes"] is False, created
+        assert cc["docker_orphan_reaper"] is False, created
+        assert cc["vercel_runtime"] == "nodejs20", created
+        assert out == '{"output": "ok", "exit_code": 0}'
+    finally:
+        streaming._end_turn_generation()
+    assert streaming._get_turn_backend_config() is None


### PR DESCRIPTION
Closes #5937

## Problem

When WebUI switches between profiles with different terminal backends (e.g., local ↔ remote SSH), the agent's `_active_environments["default"]` cache may still hold an environment created under the *previous* profile's backend vars. This causes a subsequent local-profile turn to execute terminal/file tool calls against the stale remote SSH environment.

The root cause is that the terminal environment cache is keyed by a collapsed `"default"` task_id in Hermes Agent (`tools.terminal_tool._resolve_container_task_id`), and WebUI does not invalidate this cache when the profile's `TERMINAL_ENV` backend type changes between turns.

## Fix

Added `_invalidate_stale_terminal_env()` in `api/streaming.py` which:

1. Tracks the last-seen `TERMINAL_ENV` value in a global variable
2. At the start of every streaming agent turn, compares the current profile's `TERMINAL_ENV` against the last-seen value
3. When the backend type changes (e.g., from `"ssh"` to `"local"`), calls `cleanup_vm("default")` and `clear_file_ops_cache("default")` to evict the stale cached environment
4. The next terminal tool call then creates a fresh environment from the (now-correct) profile env vars

## Testing

- **Before fix**: Session A (SSH backend) runs → creates environment under key "default". Session B (local backend) runs → finds cached "default" environment → executes terminal commands on the SSH backend.
- **After fix**: Session A (SSH) runs → `_last_terminal_env` = "ssh". Session B (local) runs → TERMINAL_ENV="local" != "ssh" → stale environment evicted → fresh local environment created.

## Acceptance Criteria

- [ ] Profile A with SSH backend and Profile B with local backend do not share terminal environments in the same WebUI process
- [ ] No regression for single-profile/local-backend users (environment persists across turns when backend type is unchanged)
- [ ] Cleanup failures are non-fatal (logged and swallowed)