### PR TITLE
fix(api): normalize API path case sensitivity

### DIFF
--- a/api/kanban_bridge.py
+++ b/api/kanban_bridge.py
@@ -1173,6 +1173,7 @@ def handle_kanban_get(handler, parsed) -> bool | None:
     to distinguish unmatched paths from already-responded paths (#1843).
     """
     path = parsed.path
+    raw_path = getattr(handler, "_raw_api_path", None) or parsed.path
     try:
         # Multi-board management endpoints — these do NOT take a board arg
         # because they operate on the on-disk board collection itself, not
@@ -1192,7 +1193,7 @@ def handle_kanban_get(handler, parsed) -> bool | None:
         if path == "/api/kanban/events/stream":
             return _handle_events_sse_stream(handler, parsed)
         if path.startswith(_TASK_PREFIX) and path.endswith("/log"):
-            task_id = unquote(path[len(_TASK_PREFIX):-len("/log")]).strip("/")
+            task_id = unquote(raw_path[len(_TASK_PREFIX):-len("/log")]).strip("/")
             if not task_id or "/" in task_id:
                 return False
             payload = _task_log_payload(parsed, task_id)
@@ -1200,7 +1201,7 @@ def handle_kanban_get(handler, parsed) -> bool | None:
                 return bad(handler, "task not found", status=404)
             return j(handler, payload) or True
         if path.startswith(_TASK_PREFIX):
-            task_id = unquote(path[len(_TASK_PREFIX):]).strip("/")
+            task_id = unquote(raw_path[len(_TASK_PREFIX):]).strip("/")
             if not task_id or "/" in task_id:
                 return False
             payload = _task_detail_payload(task_id, board=_resolve_board(parsed))
@@ -1225,6 +1226,7 @@ def handle_kanban_post(handler, parsed, body) -> bool | None:
     """Dispatch a Kanban POST. See ``handle_kanban_get`` for the
     three-valued ``True | None | False`` contract (#1843)."""
     path = parsed.path
+    raw_path = getattr(handler, "_raw_api_path", None) or parsed.path
     try:
         # Multi-board management endpoints — `_create_board_payload` and
         # `_switch_board_payload` operate on the on-disk board collection,
@@ -1234,7 +1236,7 @@ def handle_kanban_post(handler, parsed, body) -> bool | None:
         # POST /api/kanban/boards/<slug>/switch — set active board
         _BOARDS_PREFIX = "/api/kanban/boards/"
         if path.startswith(_BOARDS_PREFIX) and path.endswith("/switch"):
-            slug = unquote(path[len(_BOARDS_PREFIX):-len("/switch")]).strip("/")
+            slug = unquote(raw_path[len(_BOARDS_PREFIX):-len("/switch")]).strip("/")
             if not slug or "/" in slug:
                 return False
             return j(handler, _switch_board_payload(slug)) or True
@@ -1254,14 +1256,14 @@ def handle_kanban_post(handler, parsed, body) -> bool | None:
         if path == "/api/kanban/links/delete":
             return j(handler, _link_tasks_payload(body, unlink=True, board=board)) or True
         if path.startswith(_TASK_PREFIX) and path.endswith("/comments"):
-            task_id = path[len(_TASK_PREFIX):-len("/comments")].strip("/")
+            task_id = raw_path[len(_TASK_PREFIX):-len("/comments")].strip("/")
             return j(handler, _comment_payload(task_id, body, board=board)) or True
         for suffix, action in (("/block", "block"), ("/unblock", "unblock")):
             if path.startswith(_TASK_PREFIX) and path.endswith(suffix):
-                task_id = path[len(_TASK_PREFIX):-len(suffix)].strip("/")
+                task_id = raw_path[len(_TASK_PREFIX):-len(suffix)].strip("/")
                 return j(handler, _task_action_payload(task_id, body, action, board=board)) or True
         if path.startswith(_TASK_PREFIX) and path.endswith("/patch"):
-            task_id = path[len(_TASK_PREFIX):-len("/patch")].strip("/")
+            task_id = raw_path[len(_TASK_PREFIX):-len("/patch")].strip("/")
             return j(handler, _patch_task_payload(task_id, body, board=board)) or True
     except ImportError as exc:
         return bad(handler, f"kanban unavailable: {exc}", status=503)
@@ -1278,6 +1280,7 @@ def handle_kanban_patch(handler, parsed, body) -> bool | None:
     """Dispatch a Kanban PATCH. See ``handle_kanban_get`` for the
     three-valued ``True | None | False`` contract (#1843)."""
     path = parsed.path
+    raw_path = getattr(handler, "_raw_api_path", None) or parsed.path
     try:
         if path == "/api/kanban/config":
             return j(handler, _update_config_payload(body)) or True
@@ -1289,7 +1292,7 @@ def handle_kanban_patch(handler, parsed, body) -> bool | None:
         # by Opus advisor.)
         _BOARDS_PREFIX = "/api/kanban/boards/"
         if path.startswith(_BOARDS_PREFIX):
-            slug = unquote(path[len(_BOARDS_PREFIX):]).strip("/")
+            slug = unquote(raw_path[len(_BOARDS_PREFIX):]).strip("/")
             if not slug or "/" in slug:
                 return False
             return j(handler, _update_board_payload(slug, body)) or True
@@ -1299,7 +1302,7 @@ def handle_kanban_patch(handler, parsed, body) -> bool | None:
         board_b = _resolve_board_from_body(body)
         board = board_q if board_q is not None else board_b
         if path.startswith(_TASK_PREFIX):
-            task_id = unquote(path[len(_TASK_PREFIX):]).strip("/")
+            task_id = unquote(raw_path[len(_TASK_PREFIX):]).strip("/")
             if not task_id or "/" in task_id:
                 return False
             return j(handler, _patch_task_payload(task_id, body, board=board)) or True
@@ -1318,12 +1321,13 @@ def handle_kanban_delete(handler, parsed, body) -> bool | None:
     """Dispatch a Kanban DELETE. See ``handle_kanban_get`` for the
     three-valued ``True | None | False`` contract (#1843)."""
     path = parsed.path
+    raw_path = getattr(handler, "_raw_api_path", None) or parsed.path
     try:
         # Same routing reorder as PATCH: /boards/<slug> path-routed first,
         # so a stray ?board=ghost can't 404 a legitimate board archive.
         _BOARDS_PREFIX = "/api/kanban/boards/"
         if path.startswith(_BOARDS_PREFIX):
-            slug = unquote(path[len(_BOARDS_PREFIX):]).strip("/")
+            slug = unquote(raw_path[len(_BOARDS_PREFIX):]).strip("/")
             if not slug or "/" in slug:
                 return False
             return j(handler, _delete_board_payload(slug, parsed)) or True

--- a/api/routes.py
+++ b/api/routes.py
@@ -5694,6 +5694,27 @@ def _check_csrf(handler) -> bool:
 _EXTENSION_SIDECAR_PROXY_RE = _re.compile(
     r"^/api/extensions/(?P<extension_id>[^/]+)/sidecar(?:/(?P<proxy_path>.*))?$"
 )
+_EXTENSION_SIDECAR_PROXY_RE_IC = _re.compile(
+    r"^/api/extensions/(?P<extension_id>[^/]+)/sidecar(?:/(?P<proxy_path>.*))?$",
+    _re.IGNORECASE,
+)
+
+
+def _original_api_path(handler, parsed):
+    """Return the request path exactly as received by the server.
+
+    server.py case-folds ``/api/*`` paths for case-insensitive route matching
+    and retains the original-case path on the handler (``_raw_api_path``).
+    Dynamic path captures — share tokens, MCP server names, sidecar proxy
+    paths, opaque IDs — are case-sensitive and must be extracted from the
+    original path, never from the folded matching path. Falls back to
+    ``parsed.path`` when the request did not pass through server.py's
+    normalization (e.g. direct unit-test calls).
+    """
+    raw = getattr(handler, "_raw_api_path", None)
+    return raw if isinstance(raw, str) else parsed.path
+
+
 _HOP_BY_HOP_HEADERS = {
     "connection",
     "keep-alive",
@@ -5860,6 +5881,12 @@ def _handle_extension_sidecar_proxy(
     matched = _match_extension_sidecar_proxy_path(parsed.path)
     if matched is None:
         return False
+    # The sidecar extension id and proxy path are case-sensitive dynamic
+    # values: re-extract them from the original-case request path (see
+    # _original_api_path) instead of the case-folded matching path.
+    raw_matched = _EXTENSION_SIDECAR_PROXY_RE_IC.match(_original_api_path(handler, parsed) or "")
+    if raw_matched:
+        matched = (raw_matched.group("extension_id"), raw_matched.group("proxy_path") or "")
     # Require same-origin browser provenance on EVERY proxied method, not just
     # GET. Browser extensions (the only legitimate caller) always send Origin/
     # Referer/Sec-Fetch-Site, so this costs nothing on the real path while
@@ -13053,7 +13080,10 @@ def handle_get(handler, parsed) -> bool:
         return j(handler, payload)
 
     if parsed.path.startswith("/api/share/"):
-        token = parsed.path[len("/api/share/"):].strip()
+        # Share tokens are case-sensitive (secrets.token_urlsafe), so the
+        # capture must come from the original-case path, not the folded
+        # matching path (server.py normalizes /api/ paths for matching).
+        token = _original_api_path(handler, parsed)[len("/api/share/"):].strip()
         share = load_share(token)
         if not share:
             return bad(handler, "Shared conversation not found", 404)
@@ -17631,7 +17661,9 @@ def handle_patch(handler, parsed) -> bool:
     if not _guard_request_session_visibility(handler, parsed, body=body, method="PATCH"):
         return True
     if parsed.path.startswith("/api/mcp/servers/"):
-        name = parsed.path[len("/api/mcp/servers/"):]
+        # MCP server names are case-sensitive config keys: capture from the
+        # original-case path, not the folded matching path.
+        name = _original_api_path(handler, parsed)[len("/api/mcp/servers/"):]
         return _handle_mcp_server_toggle(handler, name, body)
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_patch
@@ -17659,7 +17691,9 @@ def handle_delete(handler, parsed) -> bool:
     if not _guard_request_session_visibility(handler, parsed, body=body, method="DELETE"):
         return True
     if parsed.path.startswith("/api/mcp/servers/"):
-        name = parsed.path[len("/api/mcp/servers/"):]
+        # MCP server names are case-sensitive config keys: capture from the
+        # original-case path, not the folded matching path.
+        name = _original_api_path(handler, parsed)[len("/api/mcp/servers/"):]
         return _handle_mcp_server_delete(handler, name)
     if parsed.path == "/api/prompts":
         pid = str(body.get("id") or "").strip()
@@ -17695,7 +17729,9 @@ def handle_put(handler, parsed) -> bool:
     if not _guard_request_session_visibility(handler, parsed, body=body, method="PUT"):
         return True
     if parsed.path.startswith("/api/mcp/servers/"):
-        name = parsed.path[len("/api/mcp/servers/"):]
+        # MCP server names are case-sensitive config keys: capture from the
+        # original-case path, not the folded matching path.
+        name = _original_api_path(handler, parsed)[len("/api/mcp/servers/"):]
         return _handle_mcp_server_update(handler, name, body)
     return False
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5715,6 +5715,31 @@ def _original_api_path(handler, parsed):
     return raw if isinstance(raw, str) else parsed.path
 
 
+def _match_api_segments(handler, parsed, template):
+    """Match a fixed-shape /api/ route case-insensitively and return the
+    dynamic capture sliced from the ORIGINAL-case path (#6589 re-gate).
+
+    ``template`` lists every server-owned segment, with ``None`` marking the
+    single dynamic slot that is a case-sensitive capture (session id, board
+    id, …): e.g. ``("api", "sessions", None, "events")``. Static segments are
+    compared case-insensitively, so ``/API/Sessions/AbC/events`` matches the
+    template while still returning ``AbC`` (never the case-folded ``abc``).
+    Returns None when the path shape does not match.
+    """
+    raw = _original_api_path(handler, parsed) or ""
+    parts = raw.strip("/").split("/")
+    if len(parts) != len(template):
+        return None
+    capture = None
+    for i, expected in enumerate(template):
+        if expected is None:
+            capture = parts[i]
+            continue
+        if parts[i].casefold() != str(expected).casefold():
+            return None
+    return capture or None
+
+
 _HOP_BY_HOP_HEADERS = {
     "connection",
     "keep-alive",
@@ -14424,7 +14449,9 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == '/api/sessions/events':
         return _handle_session_events_stream(handler)
 
-    session_events_session_id = _session_events_path_session_id(parsed.path)
+    session_events_session_id = _match_api_segments(
+        handler, parsed, ("api", "sessions", None, "events")
+    )
     if session_events_session_id is not None:
         return _handle_session_sse_stream_for_session(handler, parsed, session_events_session_id)
 
@@ -14770,7 +14797,11 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Plugin static assets ──
     if parsed.path.startswith("/dashboard-plugins/"):
-        parts = parsed.path.split("/", 3)
+        # Plugin names and asset paths are case-sensitive (config keys + disk
+        # paths) — split the ORIGINAL-case path, not the folded matching path
+        # (#6589 re-gate).
+        raw_plugins = _original_api_path(handler, parsed) or parsed.path
+        parts = raw_plugins.split("/", 3)
         if len(parts) >= 3:
             plugin_name = parts[2]
             rel_path = parts[3] if len(parts) > 3 else ""
@@ -17773,8 +17804,14 @@ _STATIC_CACHE_LOCK = threading.Lock()
 
 def _serve_static(handler, parsed):
     static_root = api_config.get_static_root().resolve()
-    # Strip the leading '/static/' prefix, then resolve and sandbox
-    rel = parsed.path[len("/static/") :]
+    # Strip the leading '/static/' prefix, then resolve and sandbox. The
+    # server-owned prefix is matched case-insensitively but the file path is
+    # case-sensitive on disk — slice from the ORIGINAL-case path (#6589).
+    raw = _original_api_path(handler, parsed) or ""
+    if "/api/static/" in raw.casefold():
+        rel = raw[raw.casefold().index("/api/static/") + len("/api/static/"):]
+    else:
+        rel = parsed.path[len("/static/"):]
     static_file = (static_root / rel).resolve()
     try:
         static_file.relative_to(static_root)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14798,10 +14798,12 @@ def handle_get(handler, parsed) -> bool:
     # ── Plugin static assets ──
     if parsed.path.startswith("/dashboard-plugins/"):
         # Plugin names and asset paths are case-sensitive (config keys + disk
-        # paths) — split the ORIGINAL-case path, not the folded matching path
-        # (#6589 re-gate).
-        raw_plugins = _original_api_path(handler, parsed) or parsed.path
-        parts = raw_plugins.split("/", 3)
+        # paths). This route is NOT API-folded (server.py folds only /api/*),
+        # so parsed.path already carries the original case — and it must come
+        # from the CURRENT request: the handler is reused across keep-alive
+        # requests, so an API-only retained path (_raw_api_path) from an
+        # earlier request would be stale here (#6589 re-gate).
+        parts = parsed.path.split("/", 3)
         if len(parts) >= 3:
             plugin_name = parts[2]
             rel_path = parts[3] if len(parts) > 3 else ""
@@ -17805,13 +17807,12 @@ _STATIC_CACHE_LOCK = threading.Lock()
 def _serve_static(handler, parsed):
     static_root = api_config.get_static_root().resolve()
     # Strip the leading '/static/' prefix, then resolve and sandbox. The
-    # server-owned prefix is matched case-insensitively but the file path is
-    # case-sensitive on disk — slice from the ORIGINAL-case path (#6589).
-    raw = _original_api_path(handler, parsed) or ""
-    if "/api/static/" in raw.casefold():
-        rel = raw[raw.casefold().index("/api/static/") + len("/api/static/"):]
-    else:
-        rel = parsed.path[len("/static/"):]
+    # server-owned prefix is matched case-insensitively upstream, but the file
+    # path is case-sensitive on disk. This route is NOT API-folded (server.py
+    # folds only /api/*), so parsed.path is the CURRENT request's original-case
+    # path — never an API-only retained path left behind by an earlier
+    # keep-alive request (#6589 re-gate).
+    rel = parsed.path[len("/static/"):]
     static_file = (static_root / rel).resolve()
     try:
         static_file.relative_to(static_root)

--- a/server.py
+++ b/server.py
@@ -290,6 +290,24 @@ class QuietHTTPServer(ThreadingHTTPServer):
         super().handle_error(request, client_address)
 
 
+def _fold_api_path(handler, parsed):
+    """Case-insensitive /api/ route matching that preserves dynamic values.
+
+    API routes are matched case-insensitively (e.g. ``/API/Settings`` and
+    ``/api/settings`` dispatch identically, and an uppercase ``/API/`` prefix
+    is normalized too), but only the *matching* path is case-folded. The
+    original-case path is retained on the handler (``_raw_api_path``) so route
+    handlers can extract case-sensitive dynamic values — share tokens, MCP
+    server names, opaque IDs — from the unmodified tail instead of from the
+    folded path (see api/routes._original_api_path).
+    """
+    raw_path = parsed.path
+    if raw_path.casefold().startswith("/api/"):
+        handler._raw_api_path = raw_path
+        return parsed._replace(path=raw_path.casefold())
+    return parsed
+
+
 class Handler(BaseHTTPRequestHandler):
     # HTTP/1.1 keep-alive stays on, so every response must declare framing.
     protocol_version = "HTTP/1.1"
@@ -378,6 +396,9 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
+            # Case-insensitive /api/ routing: fold only the matching path,
+            # keep the original-case path for dynamic captures (#3943).
+            parsed = _fold_api_path(self, parsed)
             if not check_auth(self, parsed): return
             result = handle_get(self, parsed)
             if result is False:
@@ -403,6 +424,9 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
+            # Case-insensitive /api/ routing: fold only the matching path,
+            # keep the original-case path for dynamic captures (#3943).
+            parsed = _fold_api_path(self, parsed)
             _is_csp_report_post = (
                 parsed.path == "/api/csp-report" and self.command == "POST"
             )

--- a/server.py
+++ b/server.py
@@ -300,7 +300,16 @@ def _fold_api_path(handler, parsed):
     handlers can extract case-sensitive dynamic values — share tokens, MCP
     server names, opaque IDs — from the unmodified tail instead of from the
     folded path (see api/routes._original_api_path).
+
+    The handler instance is reused across HTTP/1.1 keep-alive requests, so the
+    retained path is reset for EVERY request: a non-API request must never see
+    an ``_raw_api_path`` left behind by an earlier /api/ request on the same
+    connection (#6589 re-gate).
     """
+    # Per-request state: clear the previous request's retained path up front.
+    # Only /api/* requests below retain a path; without this reset, a later
+    # non-API request on the same connection would read stale API state.
+    handler._raw_api_path = None
     raw_path = parsed.path
     if raw_path.casefold().startswith("/api/"):
         handler._raw_api_path = raw_path

--- a/tests/test_api_path_case_normalization.py
+++ b/tests/test_api_path_case_normalization.py
@@ -1,0 +1,224 @@
+"""
+Regression tests for case-insensitive /api/ route matching (#6589).
+
+The server case-folds ``/api/*`` paths ONLY for route matching
+(``server._fold_api_path``) and retains the original-case path on the handler,
+so case-sensitive dynamic values carried as path segments -- share tokens, MCP
+server names -- survive normalization instead of being corrupted.
+
+Covers the review's four cases:
+  1. mixed-case fixed route dispatch (``/api/Auth/Status`` -> ``/api/auth/status``)
+  2. uppercase ``/API/`` prefix dispatch (``/API/Auth/Status`` -> ``/api/auth/status``)
+  3. a share token containing uppercase characters is preserved (no 404)
+  4. an MCP server name containing uppercase characters is preserved
+     (PATCH / DELETE / PUT)
+Plus explicit guards that existing lowercase routes are unchanged.
+
+Note on the ``is not False`` assertions: handlers that respond via ``j()``
+return ``None`` (``j`` has no return value), and server.py treats anything
+``is not False`` as handled (``False`` is reserved for "no route matched").
+"""
+
+import io
+import json
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from api.routes import handle_delete, handle_get, handle_patch, handle_put
+from server import _fold_api_path
+
+
+class _Headers(dict):
+    """Minimal dict mirroring BaseHTTPRequestHandler.headers (``.get`` default)."""
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class _FakeHandler:
+    """Minimal stand-in for the server Handler (tests/test_compress_status_404_fix.py)."""
+
+    def __init__(self, body=b"{}"):
+        self.wfile = io.BytesIO()
+        self.rfile = io.BytesIO(body)
+        self.status = None
+        self.sent_headers = {}
+        self.headers = _Headers({"Content-Length": str(len(body))})
+        self.close_connection = False
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _dispatch(path, body=b"{}"):
+    """Fold the request path exactly like server.do_GET / server._handle_write."""
+    handler = _FakeHandler(body=body)
+    parsed = _fold_api_path(handler, urlparse("http://example.com" + path))
+    return handler, parsed
+
+
+# -- 1/2. mixed-case fixed-route + uppercase /API/ prefix dispatch -----------
+
+
+def test_mixed_case_fixed_route_dispatches_to_lowercase_route():
+    handler, parsed = _dispatch("/api/Auth/Status")
+    assert handle_get(handler, parsed) is not False
+    assert handler.status == 200
+    assert "auth_enabled" in handler.payload()
+
+
+def test_uppercase_api_prefix_dispatches():
+    handler, parsed = _dispatch("/API/Auth/Status")
+    assert handle_get(handler, parsed) is not False
+    assert handler.status == 200
+    assert "auth_enabled" in handler.payload()
+
+
+def test_lowercase_route_is_unchanged():
+    handler, parsed = _dispatch("/api/auth/status")
+    assert handle_get(handler, parsed) is not False
+    assert handler.status == 200
+    assert "auth_enabled" in handler.payload()
+
+
+# -- 3. share token with uppercase characters survives ------------------------
+
+
+def test_share_token_with_uppercase_characters_is_preserved():
+    handler, parsed = _dispatch("/api/Share/AbC123XyZ")
+    calls = []
+
+    def fake_load_share(token):
+        calls.append(token)
+        return {"token": token, "title": "case-sensitive-token"}
+
+    with patch("api.routes.load_share", fake_load_share):
+        result = handle_get(handler, parsed)
+
+    assert result is not False
+    assert handler.status == 200
+    assert calls == ["AbC123XyZ"], f"share token corrupted: {calls!r}"
+    assert handler.payload()["share"]["token"] == "AbC123XyZ"
+
+
+def test_share_token_lowercase_route_still_works():
+    handler, parsed = _dispatch("/api/share/plain-token-abc")
+    calls = []
+
+    def fake_load_share(token):
+        calls.append(token)
+        return {"token": token, "title": "lowercase"}
+
+    with patch("api.routes.load_share", fake_load_share):
+        result = handle_get(handler, parsed)
+
+    assert result is not False
+    assert calls == ["plain-token-abc"]
+
+
+# -- 4. MCP server name with uppercase characters survives (PATCH/DELETE/PUT) -
+
+
+def test_mcp_server_name_preserved_on_patch():
+    handler, parsed = _dispatch("/api/Mcp/Servers/MyServer")
+    captured = {}
+
+    def fake_toggle(h, name, body):
+        captured["name"] = name
+        return True
+
+    with patch("api.routes._handle_mcp_server_toggle", fake_toggle):
+        result = handle_patch(handler, parsed)
+
+    assert result is True
+    assert captured.get("name") == "MyServer", f"name corrupted: {captured!r}"
+
+
+def test_mcp_server_name_preserved_on_delete():
+    handler, parsed = _dispatch("/api/Mcp/Servers/MyServer")
+    captured = {}
+
+    def fake_delete(h, name):
+        captured["name"] = name
+        return True
+
+    with patch("api.routes._handle_mcp_server_delete", fake_delete):
+        result = handle_delete(handler, parsed)
+
+    assert result is True
+    assert captured.get("name") == "MyServer", f"name corrupted: {captured!r}"
+
+
+def test_mcp_server_name_preserved_on_put():
+    handler, parsed = _dispatch("/api/Mcp/Servers/MyServer")
+    captured = {}
+
+    def fake_update(h, name, body):
+        captured["name"] = name
+        return True
+
+    with patch("api.routes._handle_mcp_server_update", fake_update):
+        result = handle_put(handler, parsed)
+
+    assert result is True
+    assert captured.get("name") == "MyServer", f"name corrupted: {captured!r}"
+
+
+# -- sidecar proxy captures (case-sensitive proxy path) -----------------------
+
+
+def test_sidecar_proxy_path_capture_preserved():
+    """/api/extensions/*/sidecar/* carries a case-sensitive proxy path."""
+    from api.routes import _handle_extension_sidecar_proxy
+
+    handler, parsed = _dispatch("/api/Extensions/Ext_A/sidecar/Path/With/Case")
+
+    # Fake same-origin provenance so the proxy handler proceeds past CSRF.
+    handler.headers["Origin"] = "http://example.com"
+    handler.headers["Host"] = "example.com"
+
+    class _FakeResponse:
+        status = 200
+        headers = {}
+
+        def read(self, n=-1):
+            return b'{"ok": true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _FakeOpener:
+        def open(self, request, timeout=None):
+            return _FakeResponse()
+
+    with patch("api.extensions.resolve_extension_sidecar_proxy_target") as resolve:
+        resolve.return_value = {
+            "upstream_url": "http://127.0.0.1:9999",
+            "origin": "http://example.com",
+            "auth_token": None,
+        }
+        with patch("api.routes.Request") as fake_request, patch(
+            "api.routes._extension_sidecar_proxy_same_origin_opener",
+            return_value=_FakeOpener(),
+        ):
+            result = _handle_extension_sidecar_proxy(handler, parsed, "GET")
+
+    assert result is True
+    assert resolve.call_count == 1
+    args = resolve.call_args.args
+    kwargs = resolve.call_args.kwargs
+    assert args and args[0] == "Ext_A", f"extension id corrupted: {args!r}"
+    assert args and args[1] == "Path/With/Case", f"proxy path corrupted: {args!r}"
+    assert kwargs.get("query") == ""

--- a/tests/test_api_path_case_normalization.py
+++ b/tests/test_api_path_case_normalization.py
@@ -222,3 +222,120 @@ def test_sidecar_proxy_path_capture_preserved():
     assert args and args[0] == "Ext_A", f"extension id corrupted: {args!r}"
     assert args and args[1] == "Path/With/Case", f"proxy path corrupted: {args!r}"
     assert kwargs.get("query") == ""
+
+
+class TestDynamicCapturesPreserveCase:
+    """#6589 re-gate: every case-sensitive dynamic capture must come from the
+    ORIGINAL-case path, never the case-folded matching path."""
+
+    def _handler(self, raw_path):
+        h = _FakeHandler()
+        h._raw_api_path = raw_path
+        return h
+
+    def test_match_api_segments_session_id_preserves_case(self):
+        from api.routes import _match_api_segments
+        from urllib.parse import urlsplit
+
+        parsed = urlparse("/api/sessions/abc/events")
+        h = self._handler("/API/Sessions/AbC/events")
+        sid = _match_api_segments(h, parsed, ("api", "sessions", None, "events"))
+        assert sid == "AbC", f"session id corrupted: {sid!r}"
+
+    def test_match_api_segments_rejects_wrong_shape(self):
+        from api.routes import _match_api_segments
+        from urllib.parse import urlsplit
+
+        parsed = urlparse("/api/sessions/abc")
+        h = self._handler("/API/Sessions/AbC")
+        assert _match_api_segments(h, parsed, ("api", "sessions", None, "events")) is None
+
+    def test_session_events_dispatch_uses_original_case_sid(self):
+        import api.routes as routes
+        from urllib.parse import urlsplit
+
+        captured = {}
+        orig = routes._handle_session_sse_stream_for_session
+
+        def spy(handler, parsed, sid):
+            captured["sid"] = sid
+            return True
+
+        routes._handle_session_sse_stream_for_session = spy
+        try:
+            parsed = urlparse("/api/sessions/abc/events")
+            h = self._handler("/API/Sessions/AbC/events")
+            routes.handle_get(h, parsed)
+        finally:
+            routes._handle_session_sse_stream_for_session = orig
+        assert captured.get("sid") == "AbC", f"sid corrupted: {captured.get('sid')!r}"
+
+    def test_static_serves_case_sensitive_file_path(self):
+        from api.routes import _serve_static
+        from urllib.parse import urlsplit
+        from unittest.mock import patch
+
+        served = {}
+        orig = None
+        with patch("api.routes.api_config.get_static_root") as root:
+            root.return_value = root.return_value  # noqa: B018  (patched below)
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            static_root = pathlib.Path(tmpd)
+            (static_root / "MyFile.PNG").write_bytes(b"PNGDATA")
+            parsed = urlparse("/api/static/myfile.png")
+            h = self._handler("/API/static/MyFile.PNG")
+            with patch("api.routes.api_config.get_static_root", return_value=static_root):
+                sent = {}
+                orig_wfile = h.wfile
+
+                class _W:
+                    def write(self, b):
+                        sent["body"] = b
+
+                h.wfile = _W()
+                result = _serve_static(h, parsed)
+            assert result is True, "case-sensitive static file must be served"
+            assert sent.get("body") == b"PNGDATA", f"wrong file served: {sent.get('body')!r}"
+
+    def test_kanban_task_id_preserves_case(self):
+        import api.kanban_bridge as kb
+        from urllib.parse import urlsplit
+
+        captured = {}
+        orig = kb._task_log_payload
+
+        def spy(parsed, task_id):
+            captured["task_id"] = task_id
+            return {"ok": True}
+
+        kb._task_log_payload = spy
+        try:
+            parsed = urlparse("/api/kanban/tasks/abcdef/log")
+            h = self._handler("/api/kanban/tasks/AbCdEf/log")
+            kb.handle_kanban_get(h, parsed)
+        finally:
+            kb._task_log_payload = orig
+        assert captured.get("task_id") == "AbCdEf", f"task id corrupted: {captured.get('task_id')!r}"
+
+    def test_kanban_board_slug_preserves_case(self):
+        import api.kanban_bridge as kb
+        from urllib.parse import urlsplit
+
+        captured = {}
+        orig = kb._update_board_payload
+
+        def spy(slug, body):
+            captured["slug"] = slug
+            return {"ok": True}
+
+        kb._update_board_payload = spy
+        try:
+            parsed = urlparse("/api/kanban/boards/myboard")
+            h = self._handler("/api/kanban/boards/MyBoard")
+            kb.handle_kanban_patch(h, parsed, {})
+        finally:
+            kb._update_board_payload = orig
+        assert captured.get("slug") == "MyBoard", f"slug corrupted: {captured.get('slug')!r}"

--- a/tests/test_api_path_case_normalization.py
+++ b/tests/test_api_path_case_normalization.py
@@ -271,32 +271,29 @@ class TestDynamicCapturesPreserveCase:
         assert captured.get("sid") == "AbC", f"sid corrupted: {captured.get('sid')!r}"
 
     def test_static_serves_case_sensitive_file_path(self):
-        from api.routes import _serve_static
-        from urllib.parse import urlsplit
-        from unittest.mock import patch
-
-        served = {}
-        orig = None
-        with patch("api.routes.api_config.get_static_root") as root:
-            root.return_value = root.return_value  # noqa: B018  (patched below)
+        """Production boundary: /static/* is NOT API-folded, so the original
+        case reaches _serve_static and the case-sensitive file is served
+        (the fabricated /api/static/* branch was removed as dead code)."""
         import pathlib
         import tempfile
 
         with tempfile.TemporaryDirectory() as tmpd:
             static_root = pathlib.Path(tmpd)
             (static_root / "MyFile.PNG").write_bytes(b"PNGDATA")
-            parsed = urlparse("/api/static/myfile.png")
-            h = self._handler("/API/static/MyFile.PNG")
+            h = _FakeHandler()
+            # Non-API path: _fold_api_path leaves it untouched (and resets any
+            # prior _raw_api_path), so parsed.path carries the original case.
+            parsed = _fold_api_path(h, urlparse("/static/MyFile.PNG"))
+            assert getattr(h, "_raw_api_path", None) is None
             with patch("api.routes.api_config.get_static_root", return_value=static_root):
                 sent = {}
-                orig_wfile = h.wfile
 
                 class _W:
                     def write(self, b):
                         sent["body"] = b
 
                 h.wfile = _W()
-                result = _serve_static(h, parsed)
+                result = handle_get(h, parsed)
             assert result is True, "case-sensitive static file must be served"
             assert sent.get("body") == b"PNGDATA", f"wrong file served: {sent.get('body')!r}"
 
@@ -339,3 +336,92 @@ class TestDynamicCapturesPreserveCase:
         finally:
             kb._update_board_payload = orig
         assert captured.get("slug") == "MyBoard", f"slug corrupted: {captured.get('slug')!r}"
+
+
+class TestHandlerReuseAcrossKeepAliveRequests:
+    """#6589 re-gate: the handler instance is reused across HTTP/1.1 keep-alive
+    requests. API-only retained state (``_raw_api_path``) from an earlier
+    request must never leak into a later non-API request (dashboard-plugins
+    assets, static files). Regression for the review's stale raw-path bug.
+    """
+
+    @staticmethod
+    def _static_through_handle_get(handler, static_root, path, out):
+        parsed = _fold_api_path(handler, urlparse(path))
+        with patch("api.routes.api_config.get_static_root", return_value=static_root):
+            class _W:
+                def write(self, b):
+                    out["body"] = b
+
+            handler.wfile = _W()
+            return handle_get(handler, parsed)
+
+    def test_dashboard_plugins_after_api_request_uses_current_path(self):
+        """API request then dashboard-plugin asset on one connection: the asset
+        must be parsed from the CURRENT path, not a stale API path."""
+        import api.plugins as plugins_mod
+
+        handler = _FakeHandler()
+        # Request 1: /api/ request on this connection (leaves _raw_api_path set).
+        parsed1 = _fold_api_path(handler, urlparse("/API/Auth/Status"))
+        assert handler._raw_api_path == "/API/Auth/Status"
+        handle_get(handler, parsed1)  # dispatched normally
+        # Request 2: dashboard-plugin asset on the SAME connection.
+        parsed2 = _fold_api_path(
+            handler, urlparse("/dashboard-plugins/MyPlugin/dist/index.js")
+        )
+        assert getattr(handler, "_raw_api_path", None) is None, (
+            "non-API request must clear API-only retained state"
+        )
+        with patch("api.routes._dashboard_plugin_enabled", return_value=True), patch.object(
+            plugins_mod, "serve_plugin_static"
+        ) as serve:
+            serve.return_value = (b"// plugin", "application/javascript")
+            result = handle_get(handler, parsed2)
+        assert result is True
+        assert serve.call_count == 1
+        args = serve.call_args.args
+        assert args == ("MyPlugin", "dist/index.js"), (
+            f"stale API path leaked into dashboard-plugins routing: {args!r}"
+        )
+
+    def test_static_after_api_request_uses_current_path(self):
+        """API request then static file on one connection: only the second
+        request's path may drive the response."""
+        import pathlib
+        import tempfile
+
+        handler = _FakeHandler()
+        _fold_api_path(handler, urlparse("/API/Sessions/AbC/events"))  # API first
+        assert handler._raw_api_path == "/API/Sessions/AbC/events"
+        with tempfile.TemporaryDirectory() as tmpd:
+            static_root = pathlib.Path(tmpd)
+            (static_root / "MyFile.PNG").write_bytes(b"PNGDATA")
+            out = {}
+            result = self._static_through_handle_get(
+                handler, static_root, "/static/MyFile.PNG", out
+            )
+        assert result is True
+        assert out.get("body") == b"PNGDATA", f"wrong file served: {out.get('body')!r}"
+
+    def test_stale_api_static_path_cannot_affect_next_static_response(self):
+        """Negative case: a prior /api/static/<other> request must NOT change
+        what the next /static/<Y> request serves."""
+        import pathlib
+        import tempfile
+
+        handler = _FakeHandler()
+        _fold_api_path(handler, urlparse("/api/static/Other.png"))  # API first
+        assert handler._raw_api_path == "/api/static/Other.png"
+        with tempfile.TemporaryDirectory() as tmpd:
+            static_root = pathlib.Path(tmpd)
+            (static_root / "MyFile.PNG").write_bytes(b"PNGDATA")
+            (static_root / "Other.png").write_bytes(b"EVIL")
+            out = {}
+            result = self._static_through_handle_get(
+                handler, static_root, "/static/MyFile.PNG", out
+            )
+        assert result is True
+        assert out.get("body") == b"PNGDATA", (
+            f"stale /api/static path changed the static response: {out.get('body')!r}"
+        )


### PR DESCRIPTION
Closes #3943

## Problem

API paths were case-sensitive, causing inconsistencies where /api/Session and /api/session would resolve differently. This is against RESTful conventions and could cause routing issues in certain HTTP clients or proxies.

## Fix

Normalize all API paths to lowercase at the entry point in server.py for both GET and mutating HTTP methods (POST, PUT, PATCH, DELETE). The normalization happens right after urlparse(), before auth checking and route dispatch, so all downstream path comparisons work with lowercase paths.

## Verification

- All existing API route paths in api/routes.py are already lowercase — the normalization is a safety layer for incoming requests with mixed case.
- server.py parses correctly with ast.parse.
- Auth path checks in api/auth.py also benefit from the normalization since they receive the lowered path.

### Changes
- server.py: Added .lower() normalization for paths starting with /api/ in do_GET() and _handle_write() (covers POST, PUT, PATCH, DELETE).