### PR TITLE
feat(ui): add show unread only filter toggle to chat sidebar

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1080,6 +1080,7 @@ const LOCALES = {
     close_menu: 'Close menu',
     new_conversation: 'New conversation',
     filter_conversations: 'Filter conversations...',
+    show_unread_only: 'Show unread only',
     markdown_table_filter: 'Filter table',
     markdown_table_sort_column: 'Sort column',
     session_time_unknown: 'Unknown',

--- a/static/index.html
+++ b/static/index.html
@@ -201,6 +201,7 @@
         </div>
       </div>
       <div class="session-search sidebar-search"><div class="session-search-field"><svg class="sidebar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg><input id="sessionSearch" type="search" placeholder="Filter conversations..." data-i18n-placeholder="filter_conversations" oninput="filterSessions()" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore="true" data-form-type="other"><button type="button" id="sessionSearchClear" class="session-search-clear has-tooltip has-tooltip--bottom-right" aria-label="Clear conversation filter" data-tooltip="Clear conversation filter" onclick="clearSessionSearch()" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button></div></div>
+      <label class="session-unread-toggle"><input id="sessionUnreadToggle" type="checkbox" onchange="_setUnreadOnly(this.checked)"> <span data-i18n="show_unread_only">Show unread only</span></label>
       <div class="session-list" id="sessionList"></div>
     </div>
     <!-- Tasks (cron) panel -->

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3949,6 +3949,25 @@ let _sessionAttentionSoundPrimed = false;
 const _sessionAttentionSoundState = new Map();
 let _renamingSid = null;  // session_id currently being renamed (blocks list re-renders)
 let _showArchived = false;  // toggle to show archived sessions
+const UNREAD_ONLY_STORAGE_KEY = 'hermes-show-unread-only';
+let _showUnreadOnly = false;  // toggle to show only unread sessions
+
+function _restoreUnreadOnly(){
+  try{
+    const raw = localStorage.getItem(UNREAD_ONLY_STORAGE_KEY);
+    _showUnreadOnly = raw === '1' || raw === 'true';
+  }catch(_e){ _showUnreadOnly = false; }
+}
+
+function _setUnreadOnly(enabled){
+  _showUnreadOnly = !!enabled;
+  try{ localStorage.setItem(UNREAD_ONLY_STORAGE_KEY, _showUnreadOnly ? '1' : '0'); }catch(_e){}
+  if(typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+}
+
+_restoreUnreadOnly();
+// Sync checkbox state on load
+(function(){ try{ var cb=document.getElementById('sessionUnreadToggle'); if(cb) cb.checked=_showUnreadOnly; }catch(_){}})();
 let _sessionSelectMode = false;  // batch select mode
 const _selectedSessions = new Set();  // selected session IDs
 let _allProjects = [];  // cached project list
@@ -7925,7 +7944,24 @@ function renderSessionListFromCache(){
     empty.textContent=_activeProject===NO_PROJECT_FILTER?'No unassigned sessions.':'No sessions in this project yet.';
     list.appendChild(empty);
   }
-  const orderedSessions=[...sessions].sort(_sessionSidebarSortCompare);
+  // Unread-only filter: when active, hide sessions that have no unread state.
+  // Always keep the active session visible so the user never loses track of it.
+  let filteredSessions = sessions;
+  if(_showUnreadOnly){
+    const activeSidForFilter = _activeSessionIdForSidebar();
+    filteredSessions = sessions.filter(s => {
+      if(activeSidForFilter && _sessionLineageContainsSession(s, activeSidForFilter)) return true;
+      return _hasUnreadForSession(s) || !!s._child_session_has_unread;
+    });
+  }
+  const orderedSessions=[...filteredSessions].sort(_sessionSidebarSortCompare);
+  // Empty state when unread-only filter hides everything
+  if(_showUnreadOnly && orderedSessions.length === 0 && !(_activeProject && sessions.length === 0)){
+    const empty=document.createElement('div');
+    empty.className='session-empty-note';
+    empty.textContent='No unread conversations.';
+    list.appendChild(empty);
+  }
   // Separate pinned from unpinned
   const pinned=orderedSessions.filter(s=>s.pinned);
   const unpinned=orderedSessions.filter(s=>!s.pinned);

--- a/static/style.css
+++ b/static/style.css
@@ -6750,6 +6750,9 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .kanban-filter-stack{display:flex;flex-direction:column;gap:8px;padding:8px 12px;border-bottom:1px solid var(--border);}
 .kanban-filter-stack select{width:100%;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:5px 8px;font-size:12px;}
 .kanban-check{display:flex;align-items:center;gap:6px;color:var(--muted);font-size:12px;}
+.session-unread-toggle{display:flex;align-items:center;gap:6px;padding:4px 12px 8px;color:var(--muted);font-size:12px;cursor:pointer;flex-shrink:0;}
+.session-unread-toggle input[type=checkbox]{accent-color:var(--accent);cursor:pointer;}
+.session-unread-toggle:hover{color:var(--text);}
 .kanban-summary{padding:8px 12px;color:var(--muted);font-size:12px;border-bottom:1px solid var(--border);}
 .kanban-list{flex:1;overflow-y:auto;padding:8px;display:flex;flex-direction:column;gap:6px;}
 .kanban-list-item{display:flex;flex-direction:column;align-items:flex-start;gap:3px;width:100%;padding:8px;border:1px solid var(--border);border-radius:8px;background:var(--panel);color:var(--text);text-align:left;cursor:pointer;}


### PR DESCRIPTION
Adds a **Show unread only** toggle below the search bar in the chat sidebar. When enabled, the session list filters to only show conversations that have unread state.

Closes #3910

## Changes

- **Session filter toggle**: New checkbox toggle (`.session-unread-toggle`) in the chat panel (static/index.html)
- **Filtering logic**: In `renderSessionListFromCache()`, filters sessions to only those with unread state when the toggle is active (static/sessions.js)
- **Always keeps the active session visible**: The currently viewed session stays in the list even without unread
- **Empty state**: Shows "No unread conversations." when the filter hides everything
- **State persistence**: Toggle state is persisted via localStorage (`hermes-show-unread-only`)
- **CSS**: Styled consistently with existing sidebar toggle patterns like `.kanban-check` (static/style.css)
- **i18n**: Added `show_unread_only` translation key (static/i18n.js)

## Verification

1. Open the chat sidebar
2. Check the "Show unread only" toggle below the search bar
3. Sidebar should only show sessions with unread dots
4. The active session stays visible even without unread
5. Uncheck to restore full list
6. Toggle state persists across page reloads

## Test plan
- [x] Toggle filters correctly (hides read sessions, shows unread ones)
- [x] Active session always visible even when read
- [x] Empty state shows correct message when nothing matches
- [x] State persists across page reloads
- [x] Search + unread filter compose correctly (sessions must match both)
- [x] Narrow sidebar shows toggle without overflow