### PR TITLE
fix(sessions): prevent incomplete-message amplification

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -438,7 +438,15 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
                 raise ValueError("session index must be a list")
             with LOCK:
                 in_memory_ids = set(SESSIONS.keys())
-                updated_map = {s.session_id: s.compact() for s in updates}
+            # Callers may pass already-owned compact entries.  In particular,
+            # Session.save() does so to prevent the index writer from rereading
+            # mutable Session state after the matching sidecar was published.
+            updated_map = {}
+            for update in updates:
+                entry = update if isinstance(update, dict) else update.compact()
+                sid = entry.get('session_id') if isinstance(entry, dict) else None
+                if sid:
+                    updated_map[sid] = entry
 
             existing = [
                 e for e in existing
@@ -1395,6 +1403,23 @@ class Session:
         # Own the complete snapshot BEFORE duplicate selection.  Otherwise a
         # nested mutation after selection but before deepcopy can invalidate the
         # equality decision and leak into this save's payload (#6600).
+        # One Session may be saved by a stream worker and a request worker at
+        # the same time.  Serialize the complete sidecar + index publication so
+        # the two files always describe one owned save generation.  RLock keeps
+        # nested same-thread save paths safe without involving the global
+        # sessions lock during filesystem I/O.
+        persistence_lock = getattr(self, '_persistence_lock', None)
+        if persistence_lock is None:
+            with LOCK:
+                persistence_lock = getattr(self, '_persistence_lock', None)
+                if persistence_lock is None:
+                    persistence_lock = threading.RLock()
+                    self._persistence_lock = persistence_lock
+        with persistence_lock:
+            return self._save_owned(touch_updated_at=touch_updated_at, skip_index=skip_index)
+
+    def _save_owned(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        """Publish one deep-owned sidecar/index generation under the save lock."""
         owned_messages = copy.deepcopy(self.messages)
         messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(owned_messages)
         if touch_updated_at:
@@ -1536,11 +1561,8 @@ class Session:
             # just serialized — never from the live list — so _index.json can
             # neither record the uncollapsed message_count nor adopt a dropped
             # duplicate row's later timestamp.
-            self._index_projection_messages = messages_to_persist
-            try:
-                _write_session_index(updates=[self])
-            finally:
-                self._index_projection_messages = None
+            index_entry = self.compact(projection_messages=messages_to_persist)
+            _write_session_index(updates=[index_entry])
 
         # #4985 belt-and-suspenders self-heal: a successful save with at
         # least one real message on the sidecar is unconditional proof the
@@ -1740,14 +1762,13 @@ class Session:
                     n += 1
         return n
 
-    def compact(self, include_runtime=False, active_stream_ids=None) -> dict:
+    def compact(self, include_runtime=False, active_stream_ids=None, projection_messages=None) -> dict:
         active_stream_ids = active_stream_ids if active_stream_ids is not None else set()
         has_pending_user_message = bool(self.pending_user_message)
         # #6600: during save()'s index update this is the detached, collapsed
         # snapshot just written to the sidecar, keeping the index projection
         # identical to the persisted payload.  Outside save() it is None and
         # the live list is used as before.
-        projection_messages = getattr(self, '_index_projection_messages', None)
         has_index_projection = projection_messages is not None
         if not has_index_projection:
             projection_messages = self.messages

--- a/api/models.py
+++ b/api/models.py
@@ -186,21 +186,33 @@ def _safe_replace(src: Path, dst: Path) -> None:
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
-_SESSION_SAVE_AUTHORITIES_LOCK = threading.Lock()
-_SESSION_SAVE_AUTHORITIES: "weakref.WeakValueDictionary[str, threading.RLock]" = weakref.WeakValueDictionary()
+_SESSION_SIDECAR_AUTHORITIES_LOCK = threading.Lock()
+_SESSION_SIDECAR_AUTHORITIES: "weakref.WeakValueDictionary[str, threading.RLock]" = weakref.WeakValueDictionary()
 _SESSION_INDEX_REBUILD_LOCK = threading.Lock()
 _SESSION_INDEX_REBUILD_THREAD = None
 _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
 
 
-def _session_save_authority(session_id: str) -> threading.RLock:
-    """Return the process-wide reentrant save authority for one session ID."""
-    with _SESSION_SAVE_AUTHORITIES_LOCK:
-        authority = _SESSION_SAVE_AUTHORITIES.get(session_id)
+def _session_sidecar_authority(session_id: str) -> threading.RLock:
+    """Return the process-wide sidecar mutation authority for one session ID.
+
+    This authority covers load reconciliation, save, backup recovery, workspace
+    binding and lifecycle retirement.  When a caller also needs
+    ``_get_session_agent_lock(sid)``, the global order is agent lock first,
+    sidecar authority second; this authority must never acquire an agent lock.
+    """
+    sid = str(session_id or "")
+    with _SESSION_SIDECAR_AUTHORITIES_LOCK:
+        authority = _SESSION_SIDECAR_AUTHORITIES.get(sid)
         if authority is None:
             authority = threading.RLock()
-            _SESSION_SAVE_AUTHORITIES[session_id] = authority
+            _SESSION_SIDECAR_AUTHORITIES[sid] = authority
         return authority
+
+
+# Compatibility alias for downstream private imports. New sidecar mutation
+# paths use the broader name above so their shared coordination is explicit.
+_session_save_authority = _session_sidecar_authority
 
 # Serializes ``_record_webui_zero_message_orphan_tombstone`` /
 # ``_clear_webui_zero_message_orphan_tombstone`` so two concurrent sidebar
@@ -833,6 +845,37 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
             logger.debug("Failed to remove empty webui deleted-session tombstone", exc_info=True)
 
 
+def retire_session_sidecar(
+    session_id: str,
+    *,
+    remove_backup: bool = True,
+    record_deleted_tombstone: bool = False,
+) -> bool:
+    """Retire one sidecar generation under the shared per-SID authority.
+
+    Callers holding the agent lock must acquire it before this helper.  Keeping
+    unlink and the durable deletion marker in one critical section prevents a
+    delayed repair load from republishing an old generation and clearing the
+    marker after retirement committed.
+    """
+    sid = str(session_id or "").strip()
+    if not is_safe_session_id(sid):
+        return False
+    path = SESSION_DIR / f"{sid}.json"
+    with _session_sidecar_authority(sid):
+        # Publish and verify the durable retirement authority before removing
+        # the live generation. If marker persistence fails, leave the sidecar
+        # intact rather than creating a recoverable-but-unmarked delete window.
+        if record_deleted_tombstone:
+            _record_webui_deleted_session_tombstone(sid)
+            if sid not in _load_webui_deleted_session_tombstone():
+                raise OSError(f"Failed to persist deletion marker for {sid}")
+        path.unlink(missing_ok=True)
+        if remove_backup:
+            path.with_suffix(".json.bak").unlink(missing_ok=True)
+        return not path.exists()
+
+
 def _content_has_reasoning_only_parts(content) -> bool:
     if not isinstance(content, list) or not content:
         return False
@@ -1250,6 +1293,9 @@ class Session:
                  truncation_boundary=None,
                  clear_generation=None,
                  intentional_shrink_generation=None,
+                 squash_projection_generation=None,
+                 squash_projection_cutoff=None,
+                 squash_projection_superseded_by=None,
                  gateway_routing=None, gateway_routing_history=None,
                  llm_title_generated: bool=False,
                  manual_title: bool=False,
@@ -1347,6 +1393,9 @@ class Session:
         self.truncation_boundary = truncation_boundary
         self.clear_generation = clear_generation
         self.intentional_shrink_generation = intentional_shrink_generation
+        self.squash_projection_generation = squash_projection_generation
+        self.squash_projection_cutoff = squash_projection_cutoff
+        self.squash_projection_superseded_by = squash_projection_superseded_by
         self.gateway_routing = gateway_routing if isinstance(gateway_routing, dict) else None
         self.gateway_routing_history = gateway_routing_history if isinstance(gateway_routing_history, list) else []
         self.llm_title_generated = bool(llm_title_generated)
@@ -1393,6 +1442,9 @@ class Session:
         # Distinct Session objects can represent the same durable sidecar.  One
         # stable SID authority therefore spans snapshot creation, sidecar
         # replacement, and publication of the matching compact index row.
+        # Keep the compatibility alias at this call boundary so focused tests
+        # and downstream private monkeypatches still observe save entry. The
+        # alias resolves to the same shared sidecar authority in production.
         authority = _session_save_authority(self.session_id)
         with authority:
             self._save_owned_generation(touch_updated_at=touch_updated_at, skip_index=skip_index)
@@ -1426,6 +1478,26 @@ class Session:
         # equality decision and leak into this save's payload (#6600).
         if touch_updated_at:
             self.updated_at = time.time()
+        if (
+            self.messages
+            and isinstance(self.messages[0], dict)
+            and self.messages[0].get('_squash_summary') is True
+            and self.squash_projection_superseded_by is None
+        ):
+            # Claim explicit persisted generation+cutoff authority for
+            # legacy/manual squash producers. A later intentional shrink
+            # supersedes this exact projection authority.
+            if self.squash_projection_generation is None:
+                self.squash_projection_generation = str(uuid.uuid4())
+            if self.squash_projection_cutoff is None:
+                raw_cutoff = self.truncation_watermark
+                if raw_cutoff is None:
+                    self.squash_projection_cutoff = _last_message_timestamp(self.messages)
+                else:
+                    try:
+                        self.squash_projection_cutoff = float(raw_cutoff)
+                    except (TypeError, ValueError):
+                        self.squash_projection_cutoff = _last_message_timestamp(self.messages)
         # Freeze every persisted/indexed field, not only messages.  The sidecar
         # and compact row below are projections of this one immutable generation.
         generation = copy.copy(self)
@@ -1457,6 +1529,8 @@ class Session:
             'truncation_boundary',
             'clear_generation',
             'intentional_shrink_generation',
+            'squash_projection_generation', 'squash_projection_cutoff',
+            'squash_projection_superseded_by',
             'gateway_routing', 'gateway_routing_history', 'llm_title_generated', 'manual_title',
             'parent_session_id',
             'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
@@ -1612,7 +1686,7 @@ class Session:
         # Loading may self-heal duplicate partial rows. Keep the sidecar read,
         # collapse, and write-back in the same per-session save generation so a
         # stale loader cannot overwrite a newer durable save.
-        with _session_save_authority(sid):
+        with _session_sidecar_authority(sid):
             return cls._load_under_save_authority(sid)
 
     @classmethod
@@ -1624,12 +1698,26 @@ class Session:
         # cache write is only committed if the file didn't change under us
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
+        source_payload = p.read_bytes()
+        data = json.loads(source_payload)
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         data['messages'], _collapsed_incomplete_ids = _collapse_duplicate_incomplete_message_ids(data.get('messages'))
         session = cls(**data)
         if _collapsed_partials or _collapsed_incomplete_ids:
             try:
+                # Revalidate the exact source generation immediately before
+                # repair. Cooperative mutators are serialized by the sidecar
+                # authority; this check also prevents a non-cooperating atomic
+                # replace observed during parsing from being overwritten by a
+                # stale self-heal generation.
+                if not p.exists():
+                    return cls._load_under_save_authority(sid)
+                try:
+                    current_payload = p.read_bytes()
+                except OSError:
+                    return cls._load_under_save_authority(sid)
+                if current_payload != source_payload:
+                    return cls._load_under_save_authority(sid)
                 # Self-heal bloated sessions on first full load without touching
                 # recency/index ordering; save() creates a .bak because this
                 # intentionally shrinks the transcript (#2592).
@@ -5841,7 +5929,8 @@ def persist_recovered_workspace_binding(
     expected = str(expected_value or "")
     path = SESSION_DIR / f"{sid}.json"
     lock = _get_session_agent_lock(sid)
-    with lock:
+    # Global order: agent lock first, then the per-SID sidecar authority.
+    with lock, _session_sidecar_authority(sid):
         if not path.exists():
             # Recovery only repairs an existing WebUI sidecar. Creating a new
             # sidecar here can resurrect a session that was deleted after the

--- a/api/models.py
+++ b/api/models.py
@@ -1124,6 +1124,7 @@ def _load_session_from_path(path: Path) -> "Session | None":
     except Exception:
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+    data['messages'], _collapsed_incomplete_ids = _collapse_duplicate_incomplete_message_ids(data.get('messages'))
     return Session(**data)
 
 
@@ -1564,15 +1565,16 @@ class Session:
         _pre_read_sig = _sidecar_stat_signature(p)
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        data['messages'], _collapsed_incomplete_ids = _collapse_duplicate_incomplete_message_ids(data.get('messages'))
         session = cls(**data)
-        if _collapsed_partials:
+        if _collapsed_partials or _collapsed_incomplete_ids:
             try:
                 # Self-heal bloated sessions on first full load without touching
                 # recency/index ordering; save() creates a .bak because this
                 # intentionally shrinks the transcript (#2592).
                 session.save(touch_updated_at=False, skip_index=True)
             except Exception:
-                logger.debug("Failed to persist collapsed duplicate partials for %s", sid, exc_info=True)
+                logger.debug("Failed to persist collapsed duplicate assistant rows for %s", sid, exc_info=True)
         else:
             # #5854: for a LEGACY sidecar (no modern anchor_scene_index key), the
             # cheap metadata-prefix read cannot recover message_count/scenes when
@@ -1582,8 +1584,8 @@ class Session:
             # Keyed by stat signature, so any edit invalidates it; the next
             # save() rewrites the modern layout and the fallback stops firing.
             # expected_sig guards against an atomic replace during the read.
-            # (When _collapsed_partials fired, save() above already rewrote the
-            # modern layout, so no legacy caching is needed.)
+            # (When either duplicate-row repair fired, save() above already
+            # rewrote the modern layout, so no legacy caching is needed.)
             if 'anchor_scene_index' not in data:
                 try:
                     _legacy_sidecar_facts_put(
@@ -2392,6 +2394,58 @@ def _collapse_adjacent_duplicate_partials(messages) -> tuple[list, bool]:
         else:
             previous_partial_sig = None
         collapsed.append(message)
+    return collapsed, changed
+
+
+def _incomplete_reasoning_message_id(message):
+    """Return the stable id of an empty incomplete assistant result, if any."""
+    if not isinstance(message, dict) or message.get('role') != 'assistant':
+        return None
+    if str(message.get('finish_reason') or '').lower() != 'incomplete':
+        return None
+    if str(message.get('content') or '').strip():
+        return None
+    if message.get('tool_call_id') or message.get('tool_calls'):
+        return None
+    message_id = message.get('id')
+    if message_id is None or str(message_id) == '':
+        return None
+    return str(message_id)
+
+
+def _message_information_score(message) -> int:
+    """Prefer the richest replay when one stable incomplete id occurs repeatedly."""
+    if not isinstance(message, dict):
+        return 0
+    try:
+        return len(json.dumps(message, sort_keys=True, ensure_ascii=False, default=str))
+    except (TypeError, ValueError):
+        return len(str(message))
+
+
+def _collapse_duplicate_incomplete_message_ids(messages) -> tuple[list, bool]:
+    """Collapse non-adjacent replays of empty incomplete assistant message ids."""
+    if not isinstance(messages, list):
+        return messages, False
+    collapsed = []
+    seen_indexes = {}
+    changed = False
+    for message in messages:
+        message_id = _incomplete_reasoning_message_id(message)
+        if message_id is None:
+            collapsed.append(message)
+            continue
+        existing_index = seen_indexes.get(message_id)
+        if existing_index is None:
+            seen_indexes[message_id] = len(collapsed)
+            collapsed.append(message)
+            continue
+        changed = True
+        existing = collapsed[existing_index]
+        if message == existing:
+            continue
+        if _message_information_score(message) > _message_information_score(existing):
+            collapsed[existing_index] = message
     return collapsed, changed
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -1403,23 +1403,6 @@ class Session:
         # Own the complete snapshot BEFORE duplicate selection.  Otherwise a
         # nested mutation after selection but before deepcopy can invalidate the
         # equality decision and leak into this save's payload (#6600).
-        # One Session may be saved by a stream worker and a request worker at
-        # the same time.  Serialize the complete sidecar + index publication so
-        # the two files always describe one owned save generation.  RLock keeps
-        # nested same-thread save paths safe without involving the global
-        # sessions lock during filesystem I/O.
-        persistence_lock = getattr(self, '_persistence_lock', None)
-        if persistence_lock is None:
-            with LOCK:
-                persistence_lock = getattr(self, '_persistence_lock', None)
-                if persistence_lock is None:
-                    persistence_lock = threading.RLock()
-                    self._persistence_lock = persistence_lock
-        with persistence_lock:
-            return self._save_owned(touch_updated_at=touch_updated_at, skip_index=skip_index)
-
-    def _save_owned(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
-        """Publish one deep-owned sidecar/index generation under the save lock."""
         owned_messages = copy.deepcopy(self.messages)
         messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(owned_messages)
         if touch_updated_at:

--- a/api/models.py
+++ b/api/models.py
@@ -1578,7 +1578,10 @@ class Session:
         # #4985 belt-and-suspenders self-heal: a successful save with at
         # least one real message on the sidecar is unconditional proof the
         # row is alive (the #4985 "zero-message orphan" only ever exists
-        # when ``len(self.messages) == 0``). Clear the tombstone so the
+        # when the OWNED, persisted generation has no messages). Never
+        # re-read mutable ``self.messages`` here: a worker can append through a
+        # live alias after generation capture, and that later append is not proof
+        # that this save published a non-empty sidecar. Clear the tombstone so the
         # next ``/api/sessions`` poll does not need the prune helper to
         # run before the row re-appears — useful when the message-commit
         # happens on a poll that does not yet see state.db.messages rows
@@ -1588,7 +1591,7 @@ class Session:
         # save. The helper's self-healing branch in
         # ``_prune_orphaned_webui_zero_message_sessions`` is the primary
         # fix; this is the belt.
-        if self.messages:
+        if messages_to_persist:
             try:
                 _clear_webui_zero_message_orphan_tombstone(self.session_id)
                 _clear_webui_deleted_session_tombstone(self.session_id)

--- a/api/models.py
+++ b/api/models.py
@@ -1388,6 +1388,7 @@ class Session:
                 f"Reload with metadata_only=False before mutating state. "
                 f"See #1558."
             )
+        self.messages, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
         if touch_updated_at:
             self.updated_at = time.time()
         # Write metadata fields first so load_metadata_only() can read them

--- a/api/models.py
+++ b/api/models.py
@@ -1392,11 +1392,11 @@ class Session:
         # list.  Active workers can hold an alias to ``self.messages``; replacing
         # it here would detach an append that lands while save() is preparing
         # the payload.  A later save will include any concurrent append.
-        # Deep-copy the retained rows so a worker mutating a nested dict (e.g.
-        # codex_reasoning_items[0].encrypted_content) between the collapse scan
-        # and json.dumps cannot leak into this save's immutable payload (#6600).
-        collapsed_messages, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
-        messages_to_persist = copy.deepcopy(collapsed_messages)
+        # Own the complete snapshot BEFORE duplicate selection.  Otherwise a
+        # nested mutation after selection but before deepcopy can invalidate the
+        # equality decision and leak into this save's payload (#6600).
+        owned_messages = copy.deepcopy(self.messages)
+        messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(owned_messages)
         if touch_updated_at:
             self.updated_at = time.time()
         # Write metadata fields first so load_metadata_only() can read them
@@ -1748,17 +1748,21 @@ class Session:
         # identical to the persisted payload.  Outside save() it is None and
         # the live list is used as before.
         projection_messages = getattr(self, '_index_projection_messages', None)
-        if projection_messages is None:
+        has_index_projection = projection_messages is not None
+        if not has_index_projection:
             projection_messages = self.messages
-        message_count = (
-            self._metadata_message_count
-            if self._metadata_message_count is not None
-            else len(projection_messages)
-        )
-        if has_pending_user_message:
+        if has_index_projection:
+            message_count = len(projection_messages)
+        else:
+            message_count = (
+                self._metadata_message_count
+                if self._metadata_message_count is not None
+                else len(projection_messages)
+            )
+        if has_pending_user_message and not has_index_projection:
             message_count = max(message_count, 1)
         last_message_at = _last_message_timestamp(projection_messages) or self.updated_at
-        if has_pending_user_message and self.pending_started_at:
+        if has_pending_user_message and self.pending_started_at and not has_index_projection:
             last_message_at = self.pending_started_at
         return {
             'session_id': self.session_id,
@@ -1816,7 +1820,7 @@ class Session:
                 'worktree_repo_root': self.worktree_repo_root,
                 'worktree_created_at': self.worktree_created_at,
             } if self.worktree_path else {}),
-            'user_message_count': Session._compute_user_message_count(self.messages),
+            'user_message_count': Session._compute_user_message_count(projection_messages),
             'active_stream_id': self.active_stream_id,
             'pending_user_message': self.pending_user_message,
             'has_pending_user_message': has_pending_user_message,

--- a/api/models.py
+++ b/api/models.py
@@ -848,6 +848,7 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
 def retire_session_sidecar(
     session_id: str,
     *,
+    sidecar_path: Path | str | None = None,
     remove_backup: bool = True,
     record_deleted_tombstone: bool = False,
 ) -> bool:
@@ -861,7 +862,9 @@ def retire_session_sidecar(
     sid = str(session_id or "").strip()
     if not is_safe_session_id(sid):
         return False
-    path = SESSION_DIR / f"{sid}.json"
+    path = Path(sidecar_path) if sidecar_path is not None else SESSION_DIR / f"{sid}.json"
+    if path.name != f"{sid}.json":
+        raise ValueError(f"Sidecar path does not match session ID {sid!r}")
     with _session_sidecar_authority(sid):
         # Publish and verify the durable retirement authority before removing
         # the live generation. If marker persistence fails, leave the sidecar

--- a/api/models.py
+++ b/api/models.py
@@ -1609,6 +1609,14 @@ class Session:
         # ``reachy-voice-*``); allow those but still reject dots/slashes.
         if not is_safe_session_id(sid):
             return None
+        # Loading may self-heal duplicate partial rows. Keep the sidecar read,
+        # collapse, and write-back in the same per-session save generation so a
+        # stale loader cannot overwrite a newer durable save.
+        with _session_save_authority(sid):
+            return cls._load_under_save_authority(sid)
+
+    @classmethod
+    def _load_under_save_authority(cls, sid):
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
             return None
@@ -10285,6 +10293,7 @@ def merge_session_messages_append_only(
     *,
     truncation_watermark=None,
     truncation_boundary=None,
+    preserve_state_rows_after_watermark: bool = False,
 ) -> list:
     """Merge sidecar/context and state.db messages without deleting local rows.
 
@@ -10293,6 +10302,10 @@ def merge_session_messages_append_only(
     watermark is later advanced (new turn committed), this boundary is preserved
     so the empty-sidecar recovery can distinguish a legitimate prefix from a
     deleted suffix instead of guessing by dropping one turn pair.
+
+    ``preserve_state_rows_after_watermark`` is reserved for a caller that has
+    proved the sidecar is a squash projection.  Such rows are projected tail,
+    not a deleted edit suffix, and remain ordered even within the sidecar range.
     """
     sidecar_messages = list(sidecar_messages or [])
     state_messages = list(state_messages or [])
@@ -10707,6 +10720,7 @@ def merge_session_messages_append_only(
             and timestamp is not None
             and timestamp > watermark_timestamp
             and key not in seen_message_keys
+            and not preserve_state_rows_after_watermark
             and (
                 not sidecar_advanced_past_watermark
                 or (max_sidecar_timestamp is not None and timestamp <= max_sidecar_timestamp)
@@ -10786,6 +10800,26 @@ def merge_session_messages_append_only(
                 skipped_state_visible_counts[matched_visible_key] = skipped_count + 1
                 _merge_session_display_metadata(merged_by_visible_key.get(matched_visible_key), msg)
                 continue
+        # A squash summary is an authoritative replacement for rows at/before
+        # its watermark, but distinct state.db rows after that watermark are
+        # part of the projected tail even when their timestamp falls inside the
+        # sidecar's range. The squash caller opts into this only after proving
+        # the first sidecar row is a squash summary.
+        if (
+            preserve_state_rows_after_watermark
+            and watermark_timestamp is not None
+            and timestamp is not None
+            and timestamp > watermark_timestamp
+            and max_sidecar_timestamp is not None
+            and timestamp <= max_sidecar_timestamp
+        ):
+            if _insert_state_message_chronologically(merged_messages, msg):
+                seen_message_keys.add(key)
+                seen_dedup_keys.add(dedup_key)
+                seen_content_keys.add(content_key)
+                seen_visible_keys.add(visible_key)
+                _remember_merged_message(msg, source="state")
+            continue
         # State rows at or before the newest sidecar timestamp are normally
         # assumed to have already been observed by the sidecar. The <= gate
         # preserves sidecar-only ordering/metadata for equal timestamps and

--- a/api/models.py
+++ b/api/models.py
@@ -1388,7 +1388,11 @@ class Session:
                 f"Reload with metadata_only=False before mutating state. "
                 f"See #1558."
             )
-        self.messages, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
+        # Persist a collapsed snapshot without rebinding or mutating the live
+        # list.  Active workers can hold an alias to ``self.messages``; replacing
+        # it here would detach an append that lands while save() is preparing
+        # the payload.  A later save will include any concurrent append.
+        messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
         if touch_updated_at:
             self.updated_at = time.time()
         # Write metadata fields first so load_metadata_only() can read them
@@ -1428,7 +1432,7 @@ class Session:
         # scene bodies. message_count is placed BEFORE anchor_scene_index so a
         # legacy-format reader that stops at a scene key still finds the count.
         # The full anchor_activity_scenes bodies serialize AFTER messages.
-        meta['message_count'] = len(self.messages or [])
+        meta['message_count'] = len(messages_to_persist or [])
         meta['anchor_scene_index'] = _anchor_scene_index_from_records(self.anchor_activity_scenes)
         # Keep the in-memory fingerprint aligned with what we just persisted, so a
         # later metadata-only reload of THIS object (or any fingerprint reader)
@@ -1436,7 +1440,7 @@ class Session:
         # defense-in-depth; the cached-side freshness check reads real records,
         # not this, so this is belt-and-suspenders).
         self._anchor_scene_index = dict(meta['anchor_scene_index'])
-        meta['messages'] = self.messages
+        meta['messages'] = messages_to_persist
         meta['tool_calls'] = self.tool_calls
         meta['anchor_activity_scenes'] = self.anchor_activity_scenes if isinstance(self.anchor_activity_scenes, dict) else {}
         # Fields not in METADATA_FIELDS (e.g. last_usage) go at the end. Exclude
@@ -1467,7 +1471,7 @@ class Session:
                     existing_msg_count = len(existing.get('messages') or [])
                 except (json.JSONDecodeError, ValueError):
                     existing_msg_count = -1  # corrupt → always back up
-                incoming_msg_count = len(self.messages or [])
+                incoming_msg_count = len(messages_to_persist or [])
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0

--- a/api/models.py
+++ b/api/models.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 import uuid
+import weakref
 from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -185,9 +186,21 @@ def _safe_replace(src: Path, dst: Path) -> None:
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
+_SESSION_SAVE_AUTHORITIES_LOCK = threading.Lock()
+_SESSION_SAVE_AUTHORITIES: "weakref.WeakValueDictionary[str, threading.RLock]" = weakref.WeakValueDictionary()
 _SESSION_INDEX_REBUILD_LOCK = threading.Lock()
 _SESSION_INDEX_REBUILD_THREAD = None
 _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
+
+
+def _session_save_authority(session_id: str) -> threading.RLock:
+    """Return the process-wide reentrant save authority for one session ID."""
+    with _SESSION_SAVE_AUTHORITIES_LOCK:
+        authority = _SESSION_SAVE_AUTHORITIES.get(session_id)
+        if authority is None:
+            authority = threading.RLock()
+            _SESSION_SAVE_AUTHORITIES[session_id] = authority
+        return authority
 
 # Serializes ``_record_webui_zero_message_orphan_tombstone`` /
 # ``_clear_webui_zero_message_orphan_tombstone`` so two concurrent sidebar
@@ -1377,6 +1390,14 @@ class Session:
         return SESSION_DIR / f'{self.session_id}.json'
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        # Distinct Session objects can represent the same durable sidecar.  One
+        # stable SID authority therefore spans snapshot creation, sidecar
+        # replacement, and publication of the matching compact index row.
+        authority = _session_save_authority(self.session_id)
+        with authority:
+            self._save_owned_generation(touch_updated_at=touch_updated_at, skip_index=skip_index)
+
+    def _save_owned_generation(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1403,10 +1424,17 @@ class Session:
         # Own the complete snapshot BEFORE duplicate selection.  Otherwise a
         # nested mutation after selection but before deepcopy can invalidate the
         # equality decision and leak into this save's payload (#6600).
-        owned_messages = copy.deepcopy(self.messages)
-        messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(owned_messages)
         if touch_updated_at:
             self.updated_at = time.time()
+        # Freeze every persisted/indexed field, not only messages.  The sidecar
+        # and compact row below are projections of this one immutable generation.
+        generation = copy.copy(self)
+        generation.__dict__ = {
+            key: copy.deepcopy(value)
+            for key, value in self.__dict__.items()
+        }
+        owned_messages = generation.messages
+        messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(owned_messages)
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -1437,7 +1465,7 @@ class Session:
             'process_wakeup_pause',
             'share_token', 'share_created_at',
         ]
-        meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
+        meta = {k: getattr(generation, k, None) for k in METADATA_FIELDS}
         # #5854: message_count and a compact anchor-scene fingerprint go in the
         # metadata prefix (BEFORE messages) so load_metadata_only() and the
         # sidebar-poll freshness check never have to parse the full (250-480KB)
@@ -1445,7 +1473,7 @@ class Session:
         # legacy-format reader that stops at a scene key still finds the count.
         # The full anchor_activity_scenes bodies serialize AFTER messages.
         meta['message_count'] = len(messages_to_persist or [])
-        meta['anchor_scene_index'] = _anchor_scene_index_from_records(self.anchor_activity_scenes)
+        meta['anchor_scene_index'] = _anchor_scene_index_from_records(generation.anchor_activity_scenes)
         # Keep the in-memory fingerprint aligned with what we just persisted, so a
         # later metadata-only reload of THIS object (or any fingerprint reader)
         # sees the current value rather than a stale load-time snapshot (#5854
@@ -1453,12 +1481,12 @@ class Session:
         # not this, so this is belt-and-suspenders).
         self._anchor_scene_index = dict(meta['anchor_scene_index'])
         meta['messages'] = messages_to_persist
-        meta['tool_calls'] = self.tool_calls
-        meta['anchor_activity_scenes'] = self.anchor_activity_scenes if isinstance(self.anchor_activity_scenes, dict) else {}
+        meta['tool_calls'] = generation.tool_calls
+        meta['anchor_activity_scenes'] = generation.anchor_activity_scenes if isinstance(generation.anchor_activity_scenes, dict) else {}
         # Fields not in METADATA_FIELDS (e.g. last_usage) go at the end. Exclude
         # the keys we placed explicitly above so they aren't emitted twice.
         _placed = {'message_count', 'anchor_scene_index', 'messages', 'tool_calls', 'anchor_activity_scenes'}
-        extra = {k: v for k, v in self.__dict__.items()
+        extra = {k: v for k, v in generation.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
         payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
@@ -1487,7 +1515,7 @@ class Session:
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0
-                    and (self.active_stream_id or self.pending_user_message)
+                    and (generation.active_stream_id or generation.pending_user_message)
                 ):
                     logger.warning(
                         "refusing to overwrite session %s messages with empty active/pending snapshot "
@@ -1495,7 +1523,7 @@ class Session:
                         self.session_id,
                         existing_msg_count,
                         incoming_msg_count,
-                        self.active_stream_id,
+                        generation.active_stream_id,
                     )
                     return
                 if existing_msg_count > incoming_msg_count:
@@ -1544,7 +1572,7 @@ class Session:
             # just serialized — never from the live list — so _index.json can
             # neither record the uncollapsed message_count nor adopt a dropped
             # duplicate row's later timestamp.
-            index_entry = self.compact(projection_messages=messages_to_persist)
+            index_entry = generation.compact(projection_messages=messages_to_persist)
             _write_session_index(updates=[index_entry])
 
         # #4985 belt-and-suspenders self-heal: a successful save with at

--- a/api/models.py
+++ b/api/models.py
@@ -1392,7 +1392,11 @@ class Session:
         # list.  Active workers can hold an alias to ``self.messages``; replacing
         # it here would detach an append that lands while save() is preparing
         # the payload.  A later save will include any concurrent append.
-        messages_to_persist, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
+        # Deep-copy the retained rows so a worker mutating a nested dict (e.g.
+        # codex_reasoning_items[0].encrypted_content) between the collapse scan
+        # and json.dumps cannot leak into this save's immutable payload (#6600).
+        collapsed_messages, _ = _collapse_duplicate_incomplete_message_ids(self.messages)
+        messages_to_persist = copy.deepcopy(collapsed_messages)
         if touch_updated_at:
             self.updated_at = time.time()
         # Write metadata fields first so load_metadata_only() can read them
@@ -1528,7 +1532,15 @@ class Session:
                 pass
             raise
         if not skip_index:
-            _write_session_index(updates=[self])
+            # #6600: project the sidebar index from the SAME detached snapshot
+            # just serialized — never from the live list — so _index.json can
+            # neither record the uncollapsed message_count nor adopt a dropped
+            # duplicate row's later timestamp.
+            self._index_projection_messages = messages_to_persist
+            try:
+                _write_session_index(updates=[self])
+            finally:
+                self._index_projection_messages = None
 
         # #4985 belt-and-suspenders self-heal: a successful save with at
         # least one real message on the sidecar is unconditional proof the
@@ -1731,14 +1743,21 @@ class Session:
     def compact(self, include_runtime=False, active_stream_ids=None) -> dict:
         active_stream_ids = active_stream_ids if active_stream_ids is not None else set()
         has_pending_user_message = bool(self.pending_user_message)
+        # #6600: during save()'s index update this is the detached, collapsed
+        # snapshot just written to the sidecar, keeping the index projection
+        # identical to the persisted payload.  Outside save() it is None and
+        # the live list is used as before.
+        projection_messages = getattr(self, '_index_projection_messages', None)
+        if projection_messages is None:
+            projection_messages = self.messages
         message_count = (
             self._metadata_message_count
             if self._metadata_message_count is not None
-            else len(self.messages)
+            else len(projection_messages)
         )
         if has_pending_user_message:
             message_count = max(message_count, 1)
-        last_message_at = _last_message_timestamp(self.messages) or self.updated_at
+        last_message_at = _last_message_timestamp(projection_messages) or self.updated_at
         if has_pending_user_message and self.pending_started_at:
             last_message_at = self.pending_started_at
         return {
@@ -2402,20 +2421,97 @@ def _collapse_adjacent_duplicate_partials(messages) -> tuple[list, bool]:
     return collapsed, changed
 
 
+def _strict_incomplete_message_id_key(message_id):
+    """Return a type-tagged deletion key for a persisted message id, or None.
+
+    Only exact ``str``/``int``/finite-``float`` scalars carry deletion
+    authority.  Booleans, containers, subclass instances (e.g. enum-like
+    ids), and non-finite floats are rejected so distinct typed ids such as
+    ``1`` vs ``"1"`` or ``True`` vs ``"True"`` can never collapse into the
+    same bucket — a genuinely distinct backup row must never be classified
+    as a duplicate-only replay (#6600 review).
+    """
+    if isinstance(message_id, bool):
+        return None
+    if type(message_id) is str:
+        return ('str', message_id) if message_id != '' else None
+    if type(message_id) is int:
+        return ('int', message_id)
+    if type(message_id) is float:
+        return ('float', message_id) if math.isfinite(message_id) else None
+    return None
+
+
+def _strip_thinking_markup_for_incomplete(text: str) -> str:
+    """Emptiness-equivalent mirror of api.streaming._strip_thinking_markup.
+
+    Keep the regexes in sync with api.streaming._strip_thinking_markup; the
+    durable incomplete-row predicate must consider exactly the same content
+    "blank" as the reconciliation layer.  Duplicated (rather than imported)
+    because api.streaming already imports api.models at module load, and the
+    .bak recovery path must not depend on the streaming import chain.
+    Parity is pinned by tests/test_issue2592_partial_dedupe.py.
+    """
+    if not text:
+        return ''
+    s = str(text)
+    s = re.sub(r'^\s*<think>.*?</think>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)
+    s = re.sub(r'^\s*<\|channel\|?>thought\n?.*?<channel\|>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)
+    s = re.sub(r'^\s*<\|turn\|>thinking\n.*?<turn\|>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)  # Gemma 4
+    s = re.sub(r'^\s*(the|ther)\s+user\s+is\s+asking[^\n]*(?:\n|$)', ' ', s, flags=re.IGNORECASE)
+    s = re.sub(
+        r"^\s*(?:here(?:'s| is) (?:a |my )?(?:thinking|thought) (?:process|trace|through)\b[^\n]*\n?"
+        r"|let me (?:think|work|reason|analyze|walk) (?:through|about|this|step)\b[^\n]*\n?"
+        r"|i(?:'ll| will) (?:think|work|reason|analyze|break this down)\b[^\n]*\n?"
+        r"|(?:okay|alright|sure|of course),?\s+let me\b[^\n]*\n?)",
+        ' ', s, flags=re.IGNORECASE
+    )
+    s = re.sub(r'\s+', ' ', s).strip()
+    return s
+
+
+def _incomplete_message_content_text(content) -> str:
+    """Extract visible text for the incomplete-row eligibility predicate.
+
+    Mirrors api.streaming._message_text (structured content parts +
+    thinking-markup stripping) so the persistence boundary empties exactly
+    the rows the reconciliation layer empties (#6600 review: one shared
+    eligibility semantics for both layers).
+    """
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            part_type = str(part.get('type') or '').lower()
+            if part_type in ('', 'text', 'input_text', 'output_text'):
+                parts.append(str(
+                    part.get('text') or part.get('content') or part.get('input_text') or part.get('output_text') or ''
+                ))
+        return _strip_thinking_markup_for_incomplete('\n'.join(parts).strip())
+    return _strip_thinking_markup_for_incomplete(str(content or '').strip())
+
+
 def _incomplete_reasoning_message_id(message):
-    """Return the stable id of an empty incomplete assistant result, if any."""
+    """Return the strict typed identity key of an empty incomplete assistant result.
+
+    This is the SINGLE eligibility predicate shared by the persistence
+    boundary (Session.save/load and .bak recovery) and the in-memory
+    reconciliation layer (api.streaming._message_identity): a row one layer
+    collapses is exactly a row the other layer collapses, so neither can
+    drop a row the other considers distinct.  Returns a hashable
+    type-tagged tuple, or None when the row is not an eligible empty
+    incomplete assistant result.
+    """
     if not isinstance(message, dict) or message.get('role') != 'assistant':
         return None
     if str(message.get('finish_reason') or '').lower() != 'incomplete':
         return None
-    if str(message.get('content') or '').strip():
+    if _incomplete_message_content_text(message.get('content')):
         return None
     if message.get('tool_call_id') or message.get('tool_calls'):
         return None
-    message_id = message.get('id')
-    if message_id is None or str(message_id) == '':
-        return None
-    return str(message_id)
+    return _strict_incomplete_message_id_key(message.get('id'))
 
 
 def _message_information_score(message) -> int:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9741,7 +9741,7 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     cli_messages = list(cli_messages or [])
     sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
     is_squashed_transcript = (
-        len(sidecar_messages) == 1
+        bool(sidecar_messages)
         and isinstance(sidecar_messages[0], dict)
         and sidecar_messages[0].get("_squash_summary") is True
         and getattr(session, "truncation_watermark", None) is not None

--- a/api/routes.py
+++ b/api/routes.py
@@ -9740,7 +9740,20 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """
     cli_messages = list(cli_messages or [])
     sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    is_squashed_transcript = (
+        len(sidecar_messages) == 1
+        and isinstance(sidecar_messages[0], dict)
+        and sidecar_messages[0].get("_squash_summary") is True
+        and getattr(session, "truncation_watermark", None) is not None
+    )
     if cli_messages:
+        if is_squashed_transcript:
+            return merge_session_messages_append_only(
+                sidecar_messages,
+                cli_messages,
+                truncation_watermark=getattr(session, "truncation_watermark", None),
+                truncation_boundary=getattr(session, "truncation_boundary", None),
+            )
         if sidecar_messages and sidecar_messages != cli_messages:
             if len(sidecar_messages) >= len(cli_messages):
                 return merge_session_messages_append_only(

--- a/api/routes.py
+++ b/api/routes.py
@@ -9753,6 +9753,7 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                 cli_messages,
                 truncation_watermark=getattr(session, "truncation_watermark", None),
                 truncation_boundary=getattr(session, "truncation_boundary", None),
+                preserve_state_rows_after_watermark=True,
             )
         if sidecar_messages and sidecar_messages != cli_messages:
             if len(sidecar_messages) >= len(cli_messages):

--- a/api/routes.py
+++ b/api/routes.py
@@ -9729,6 +9729,39 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     return merged
 
 
+def _manual_squash_projection_is_active(session, sidecar_messages: list) -> bool:
+    """Return whether this persisted squash generation still owns its state tail."""
+    is_squashed_transcript = (
+        bool(sidecar_messages)
+        and isinstance(sidecar_messages[0], dict)
+        and sidecar_messages[0].get("_squash_summary") is True
+        and getattr(session, "truncation_watermark", None) is not None
+    )
+    if not is_squashed_transcript:
+        return False
+    if getattr(session, "squash_projection_superseded_by", None) is not None:
+        return False
+    projection_generation = getattr(session, "squash_projection_generation", None)
+    projection_cutoff = getattr(session, "squash_projection_cutoff", None)
+    if projection_generation is None and projection_cutoff is None:
+        # Compatibility for manual squash sidecars created before generation
+        # authority was persisted. Their next save claims an explicit UUID.
+        return True
+    if projection_generation is None or projection_cutoff is None:
+        return False
+    try:
+        parsed_generation = uuid.UUID(str(projection_generation))
+        cutoff = float(projection_cutoff)
+        watermark = float(getattr(session, "truncation_watermark", None))
+    except (TypeError, ValueError, AttributeError):
+        return False
+    return (
+        parsed_generation.version == 4
+        and -float("inf") < cutoff < float("inf")
+        and cutoff == watermark
+    )
+
+
 def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """Return the message coordinate space exposed by ``GET /api/session``.
 
@@ -9753,7 +9786,9 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                 cli_messages,
                 truncation_watermark=getattr(session, "truncation_watermark", None),
                 truncation_boundary=getattr(session, "truncation_boundary", None),
-                preserve_state_rows_after_watermark=True,
+                preserve_state_rows_after_watermark=_manual_squash_projection_is_active(
+                    session, sidecar_messages
+                ),
             )
         if sidecar_messages and sidecar_messages != cli_messages:
             if len(sidecar_messages) >= len(cli_messages):
@@ -10316,6 +10351,7 @@ from api.models import (
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
     _record_webui_deleted_session_tombstone,
+    retire_session_sidecar,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -15933,25 +15969,20 @@ def handle_post(handler, parsed) -> bool:
                 p.relative_to(SESSION_DIR.resolve())
             except Exception:
                 return bad(handler, "Invalid session_id", 400)
-            sidecar_deleted = False
             try:
-                p.unlink(missing_ok=True)
+                # Agent lock is already held: acquire the shared sidecar
+                # authority second and commit unlink + durable marker together.
+                retire_session_sidecar(
+                    sid,
+                    remove_backup=True,
+                    record_deleted_tombstone=not is_messaging_session,
+                )
             except Exception:
-                logger.debug("Failed to unlink session file %s", p)
-            sidecar_deleted = not p.exists()
+                logger.debug("Failed to retire session sidecar %s", p, exc_info=True)
             try:
                 prune_session_from_index(sid)
             except Exception:
                 logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-            try:
-                p.with_suffix('.json.bak').unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
-            if sidecar_deleted and not is_messaging_session:
-                try:
-                    _record_webui_deleted_session_tombstone(sid)
-                except Exception:
-                    logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
         # Evict outside the mutation lock: lifecycle commit may perform provider
@@ -22465,7 +22496,7 @@ def _handle_background(handler, body):
             # clutter the sidebar or SESSION_DIR. The index is pruned on the
             # next rebuild via _index_entry_exists().
             try:
-                (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                retire_session_sidecar(bg_sid, record_deleted_tombstone=False)
             except Exception:
                 pass
         except Exception:

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -607,7 +607,21 @@ def _stamp_intentional_shrink_generation(session, old_message_count: int, new_me
     """Stamp a new generation only when the visible message list shrinks."""
     if new_message_count >= old_message_count:
         return False
-    session.intentional_shrink_generation = uuid.uuid4().hex
+    generation = uuid.uuid4().hex
+    session.intentional_shrink_generation = generation
+    messages = getattr(session, 'messages', None) or []
+    if (
+        messages
+        and isinstance(messages[0], dict)
+        and messages[0].get('_squash_summary') is True
+    ):
+        # A manual squash owns a forward state.db projection only until the
+        # next explicit retry/undo/truncate generation. Persist both the
+        # superseding generation and its cutoff so reload/GET/branch paths do
+        # not resurrect projected rows that the user intentionally removed.
+        session.squash_projection_superseded_by = generation
+        if getattr(session, 'squash_projection_cutoff', None) is None:
+            session.squash_projection_cutoff = _truncation_watermark_for(messages)
     return True
 
 

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import sqlite3
 import threading
+from collections import Counter
 from contextlib import closing
 from pathlib import Path
 
@@ -64,10 +65,10 @@ def _is_valid_intentional_shrink_generation(value) -> bool:
     )
 
 
-def _msg_count(p: Path) -> int:
-    """Return the effective message count, or -1 on read/parse error.
+def _effective_messages(p: Path) -> list | None:
+    """Return the duplicate-normalized messages, or ``None`` on invalid input.
 
-    Returns -1 for any non-session-shape file:
+    Returns ``None`` for any non-session-shape file:
     - File can't be read (OSError)
     - Top-level isn't valid JSON or is invalid (JSONDecodeError, ValueError)
     - Top-level isn't a dict (AttributeError on .get) — e.g. ``_index.json``
@@ -78,12 +79,12 @@ def _msg_count(p: Path) -> int:
     try:
         data = json.loads(p.read_text(encoding='utf-8'))
     except (OSError, json.JSONDecodeError, ValueError):
-        return -1
+        return None
     if not isinstance(data, dict):
-        return -1
+        return None
     msgs = data.get('messages')
     if not isinstance(msgs, list):
-        return -1
+        return None
     # A shrink caused only by collapsing replayed empty ``incomplete`` rows is
     # an intentional repair, not data loss.  Compare live and backup using the
     # same narrow identity rule as Session.save() so startup recovery does not
@@ -94,9 +95,33 @@ def _msg_count(p: Path) -> int:
 
         msgs, _ = _collapse_duplicate_incomplete_message_ids(msgs)
     except Exception:
-        logger.debug("Failed to compute effective recovery message count for %s", p, exc_info=True)
-        return -1
-    return len(msgs)
+        logger.debug("Failed to compute effective recovery messages for %s", p, exc_info=True)
+        return None
+    return msgs
+
+
+def _msg_count(p: Path) -> int:
+    """Return the effective message count, or -1 on read/parse error."""
+    messages = _effective_messages(p)
+    return len(messages) if messages is not None else -1
+
+
+def _message_membership(messages: list) -> Counter[str]:
+    """Return a content-complete multiset for conservative recovery decisions."""
+    return Counter(
+        json.dumps(message, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+        for message in messages
+    )
+
+
+def _membership_delta(live_messages: list, backup_messages: list) -> tuple[int, int]:
+    """Return effective ``(live_only, backup_only)`` message multiplicities."""
+    live_membership = _message_membership(live_messages)
+    backup_membership = _message_membership(backup_messages)
+    return (
+        sum((live_membership - backup_membership).values()),
+        sum((backup_membership - live_membership).values()),
+    )
 
 
 def _rebuild_recovery_session_index(session_dir: Path) -> None:
@@ -354,10 +379,17 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
       "session_id": "...",
       "live_messages": int,    # -1 if live file unreadable
       "bak_messages": int,     # -1 if no .bak or unreadable
-      "recommend": "restore" | "no_action" | "no_backup",
+      "recommend": "restore" | "manual_review" | "no_action" | "no_backup",
     }
+
+    A strictly larger normalized backup retains the established restore
+    authority. When normalized counts are equal but both files own unique rows,
+    neither count is authoritative; recovery fails closed for manual review and
+    leaves both files untouched.
     """
     bak_path = session_path.with_suffix('.json.bak')
+    # Keep count reads on the established helper: startup recovery deliberately
+    # uses this boundary to avoid reading clean live files without a backup.
     live_count = _msg_count(session_path)
     if not bak_path.exists():
         return {
@@ -367,6 +399,17 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
             "recommend": "no_backup",
         }
     bak_count = _msg_count(bak_path)
+    live_only = 0
+    backup_only = 0
+    membership_conflict = False
+    if live_count >= 0 and bak_count == live_count:
+        # Membership is needed only for the ambiguous equal-count case. Avoid
+        # the extra parse on the established strict-excess restore path.
+        live_messages = _effective_messages(session_path)
+        backup_messages = _effective_messages(bak_path)
+        if live_messages is not None and backup_messages is not None:
+            live_only, backup_only = _membership_delta(live_messages, backup_messages)
+            membership_conflict = live_only > 0 and backup_only > 0
     if bak_count > live_count:
         if (
             _session_records_clear_sentinel(session_path, bak_path)
@@ -403,6 +446,16 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
             "live_messages": live_count,
             "bak_messages": bak_count,
             "recommend": "restore",
+        }
+    if bak_count == live_count and membership_conflict:
+        return {
+            "session_id": session_path.stem,
+            "live_messages": live_count,
+            "bak_messages": bak_count,
+            "recommend": "manual_review",
+            "membership_conflict": True,
+            "live_only_messages": live_only,
+            "backup_only_messages": backup_only,
         }
     return {
         "session_id": session_path.stem,
@@ -881,6 +934,17 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
                 status.get('live_messages', -1),
                 status.get('bak_messages', -1),
             ))
+        elif status.get('recommend') == 'manual_review':
+            items.append(_new_audit_item(
+                status['session_id'],
+                "divergent_live_backup_membership",
+                "unsafe_to_repair",
+                "manual_review",
+                status.get('live_messages', -1),
+                status.get('bak_messages', -1),
+                live_only_messages=status.get('live_only_messages', 0),
+                backup_only_messages=status.get('backup_only_messages', 0),
+            ))
 
     # Track sids already classified as deleted-webui-tombstone from the orphan
     # .bak branch below, so the later state_db_missing_rows loop doesn't emit a
@@ -1098,6 +1162,15 @@ def recover_all_sessions_on_startup(
         if result.get("restored"):
             restored += 1
             details.append(result)
+        elif result.get("recommend") == "manual_review":
+            # Preserve both files and surface the conflict instead of silently
+            # treating equal normalized counts as a healthy backup pair.
+            details.append(result)
+            logger.warning(
+                "recover_all_sessions_on_startup: left %s untouched because live and backup "
+                "both contain unique messages; manual review required",
+                path.name,
+            )
     if restored:
         logger.warning(
             "recover_all_sessions_on_startup: restored %d/%d sessions from .bak. "

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -65,7 +65,7 @@ def _is_valid_intentional_shrink_generation(value) -> bool:
 
 
 def _msg_count(p: Path) -> int:
-    """Return the number of messages in a session JSON file, or -1 on read/parse error.
+    """Return the effective message count, or -1 on read/parse error.
 
     Returns -1 for any non-session-shape file:
     - File can't be read (OSError)
@@ -82,7 +82,21 @@ def _msg_count(p: Path) -> int:
     if not isinstance(data, dict):
         return -1
     msgs = data.get('messages')
-    return len(msgs) if isinstance(msgs, list) else -1
+    if not isinstance(msgs, list):
+        return -1
+    # A shrink caused only by collapsing replayed empty ``incomplete`` rows is
+    # an intentional repair, not data loss.  Compare live and backup using the
+    # same narrow identity rule as Session.save() so startup recovery does not
+    # resurrect the amplification.  Unique backup messages still increase the
+    # effective count and remain recoverable.
+    try:
+        from api.models import _collapse_duplicate_incomplete_message_ids
+
+        msgs, _ = _collapse_duplicate_incomplete_message_ids(msgs)
+    except Exception:
+        logger.debug("Failed to compute effective recovery message count for %s", p, exc_info=True)
+        return -1
+    return len(msgs)
 
 
 def _rebuild_recovery_session_index(session_dir: Path) -> None:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -466,7 +466,16 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
 
 
 def recover_session(session_path: Path) -> dict:
-    """Restore session_path from its .bak when the bak has more messages.
+    """Inspect and restore one backup under the shared sidecar authority."""
+    from api.models import _session_sidecar_authority
+
+    sid = Path(session_path).stem
+    with _session_sidecar_authority(sid):
+        return _recover_session_under_sidecar_authority(session_path)
+
+
+def _recover_session_under_sidecar_authority(session_path: Path) -> dict:
+    """Owned implementation; caller holds the per-SID sidecar authority.
 
     Returns a status dict identical to ``inspect_session_recovery_status``
     plus a "restored" boolean.
@@ -732,6 +741,8 @@ def _state_db_row_to_sidecar(row: dict) -> dict:
 
 def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Path | None) -> dict:
     """Materialize missing WebUI JSON sidecars from canonical state.db rows."""
+    from api.models import _session_sidecar_authority
+
     rows = _read_state_db_missing_sidecar_rows(session_dir, state_db_path)
     materialized = 0
     details: list[dict] = []
@@ -765,7 +776,16 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         # will win and we silently skip rather than overwrite a live sidecar.
         materialized_now = False
         try:
-            os.link(str(tmp), str(target))
+            with _session_sidecar_authority(sid):
+                # Revalidate lifecycle authority after the earlier state.db
+                # scan. A delete may have committed its durable tombstone while
+                # this reconciliation generation was being staged.
+                if (
+                    target.exists()
+                    or _durable_tombstone_marks_deleted_webui_session(session_dir, sid)
+                ):
+                    raise FileExistsError(str(target))
+                os.link(str(tmp), str(target))
             materialized_now = True
         except FileExistsError:
             # Live sidecar appeared between the check and the link — keep it.

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -422,13 +422,29 @@ def recover_session(session_path: Path) -> dict:
     if status["recommend"] != "restore":
         return {**status, "restored": False}
     bak_path = session_path.with_suffix('.json.bak')
-    # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
-    # cannot leave a half-written session.json.
+    # Stage the recovery via a tmp write + atomic replace so a crash
+    # mid-restore cannot leave a half-written session.json.
     tmp_path = session_path.with_suffix('.json.recover.tmp')
     try:
-        shutil.copyfile(bak_path, tmp_path)
+        # #6600: restore the SAME effective payload that _msg_count()
+        # evaluated — collapse replayed empty ``incomplete`` rows and
+        # recompute message_count from the collapsed list — so recovery never
+        # resurrects the duplicate amplification it just decided to repair.
+        bak_data = json.loads(bak_path.read_text(encoding='utf-8'))
+        if not isinstance(bak_data, dict):
+            raise ValueError("backup payload is not a session object")
+        from api.models import _collapse_duplicate_incomplete_message_ids
+
+        bak_messages = bak_data.get('messages')
+        if isinstance(bak_messages, list):
+            collapsed_messages, _ = _collapse_duplicate_incomplete_message_ids(bak_messages)
+            bak_data['messages'] = collapsed_messages
+            bak_data['message_count'] = len(collapsed_messages)
+        tmp_path.write_text(
+            json.dumps(bak_data, ensure_ascii=False, indent=2), encoding='utf-8'
+        )
         tmp_path.replace(session_path)
-    except OSError as exc:
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
         logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
         try:
             tmp_path.unlink(missing_ok=True)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2275,8 +2275,8 @@ def _cleanup_ephemeral_cancelled_turn(session) -> None:
     session.pending_started_at = None
     session.pending_user_source = None
     try:
-        import pathlib
-        pathlib.Path(session.path).unlink(missing_ok=True)
+        from api.models import retire_session_sidecar
+        retire_session_sidecar(session.session_id, record_deleted_tombstone=False)
     except Exception:
         logger.debug("Failed to clean up ephemeral cancelled session", exc_info=True)
 
@@ -10825,8 +10825,8 @@ def _run_agent_streaming(
                 if _checkpoint_stop is not None:
                     _checkpoint_stop.set()
                 try:
-                    import pathlib
-                    pathlib.Path(s.path).unlink(missing_ok=True)
+                    from api.models import retire_session_sidecar
+                    retire_session_sidecar(s.session_id, record_deleted_tombstone=False)
                 except Exception:
                     pass
                 return  # skip all normal persistence for ephemeral sessions

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5981,14 +5981,6 @@ def _message_identity(msg):
         # Now, _partial messages with empty text get a stable identity
         # keyed on their role + _partial flag + reasoning/tool metadata,
         # so the merge can dedup identical empty partials.
-        if msg.get('_partial'):
-            reasoning_key = " ".join(str(msg.get('reasoning') or '').split())[:200]
-            return (
-                role,
-                '',  # empty text
-                '',  # no tool_call_id
-                '__partial__' + reasoning_key,
-            )
         # Codex can persist a reasoning-only assistant result with an empty
         # visible body and finish_reason=incomplete without the legacy
         # ``_partial`` flag. Those rows still carry the stable core message id.
@@ -6011,6 +6003,16 @@ def _message_identity(msg):
                     '',
                     '__incomplete_message_id__' + repr(typed_id_key),
                 )
+        # Canonical incomplete identity must win over the legacy partial arm:
+        # persistence keys `_partial + incomplete` rows by typed message id too.
+        if msg.get('_partial'):
+            reasoning_key = " ".join(str(msg.get('reasoning') or '').split())[:200]
+            return (
+                role,
+                '',  # empty text
+                '',  # no tool_call_id
+                '__partial__' + reasoning_key,
+            )
         return None
     return (
         role,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -68,6 +68,7 @@ from api.models import (
     StateDBSessionMessagesSnapshot,
     _collapse_duplicate_incomplete_message_ids,
     _is_empty_partial_activity_message,
+    _strict_incomplete_message_id_key,
     _evict_sessions_over_cap,
     clear_process_wakeup_pause,
     get_state_db_session_messages,
@@ -5994,19 +5995,22 @@ def _message_identity(msg):
         # Returning None here made every reconcile treat the same result as a
         # fresh context-only row, which amplified alternating replays such as
         # FD05 message ids 1701/1702 on every subsequent turn.
-        message_id = msg.get('id')
+        # #6600: share the persistence boundary's strict typed scalar identity
+        # (api.models._strict_incomplete_message_id_key) so str/int/float ids
+        # never collapse across types and bools/containers/subclasses/non-finite
+        # floats are rejected in BOTH layers.
         if (
             role == 'assistant'
             and str(msg.get('finish_reason') or '').lower() == 'incomplete'
-            and message_id is not None
-            and str(message_id) != ''
         ):
-            return (
-                role,
-                '',
-                '',
-                '__incomplete_message_id__' + str(message_id),
-            )
+            typed_id_key = _strict_incomplete_message_id_key(msg.get('id'))
+            if typed_id_key is not None:
+                return (
+                    role,
+                    '',
+                    '',
+                    '__incomplete_message_id__' + repr(typed_id_key),
+                )
         return None
     return (
         role,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5987,6 +5987,25 @@ def _message_identity(msg):
                 '',  # no tool_call_id
                 '__partial__' + reasoning_key,
             )
+        # Codex can persist a reasoning-only assistant result with an empty
+        # visible body and finish_reason=incomplete without the legacy
+        # ``_partial`` flag. Those rows still carry the stable core message id.
+        # Returning None here made every reconcile treat the same result as a
+        # fresh context-only row, which amplified alternating replays such as
+        # FD05 message ids 1701/1702 on every subsequent turn.
+        message_id = msg.get('id')
+        if (
+            role == 'assistant'
+            and str(msg.get('finish_reason') or '').lower() == 'incomplete'
+            and message_id is not None
+            and str(message_id) != ''
+        ):
+            return (
+                role,
+                '',
+                '',
+                '__incomplete_message_id__' + str(message_id),
+            )
         return None
     return (
         role,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2276,7 +2276,12 @@ def _cleanup_ephemeral_cancelled_turn(session) -> None:
     session.pending_user_source = None
     try:
         from api.models import retire_session_sidecar
-        retire_session_sidecar(session.session_id, record_deleted_tombstone=False)
+        sidecar_path = Path(session.path)
+        retire_session_sidecar(
+            getattr(session, "session_id", None) or sidecar_path.stem,
+            sidecar_path=sidecar_path,
+            record_deleted_tombstone=False,
+        )
     except Exception:
         logger.debug("Failed to clean up ephemeral cancelled session", exc_info=True)
 
@@ -10826,7 +10831,12 @@ def _run_agent_streaming(
                     _checkpoint_stop.set()
                 try:
                     from api.models import retire_session_sidecar
-                    retire_session_sidecar(s.session_id, record_deleted_tombstone=False)
+                    sidecar_path = Path(s.path)
+                    retire_session_sidecar(
+                        s.session_id,
+                        sidecar_path=sidecar_path,
+                        record_deleted_tombstone=False,
+                    )
                 except Exception:
                     pass
                 return  # skip all normal persistence for ephemeral sessions

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -66,6 +66,7 @@ from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
     StateDBSessionMessagesSnapshot,
+    _collapse_duplicate_incomplete_message_ids,
     _is_empty_partial_activity_message,
     _evict_sessions_over_cap,
     clear_process_wakeup_pause,
@@ -6801,6 +6802,7 @@ def _merge_display_messages_after_agent_result(
     # three inputs consistently so prefix/delta detection below stays aligned.
     # (#5334; same internal-control-message class as #3320/#3821/#4373/#4875)
     previous_display = _drop_synthetic_control_messages(previous_display)
+    previous_display, _ = _collapse_duplicate_incomplete_message_ids(previous_display)
     # Deduplicate stale _partial messages that accumulated in previous_display.
     # A bug in cancel_stream() could insert multiple identical _partial messages
     # when _stripped was empty but _has_reasoning/_has_tools was True. The
@@ -6851,6 +6853,8 @@ def _merge_display_messages_after_agent_result(
     # would otherwise slip into the merged transcript as a real delta. (#5334)
     previous_context = _drop_synthetic_control_messages(previous_context)
     result_messages = _drop_synthetic_control_messages(result_messages)
+    previous_context, _ = _collapse_duplicate_incomplete_message_ids(previous_context)
+    result_messages, _ = _collapse_duplicate_incomplete_message_ids(result_messages)
     if not result_messages:
         return previous_display
     previous_user_tail = _stale_user_tail_candidate(_last_user_row(previous_context))

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -601,15 +601,14 @@ def test_session_model_parent_session_id():
 def test_session_compact_includes_parent():
     """Verify compact() includes parent_session_id."""
     src = _read('api/models.py')
-    # Find the compact method and scan its full body for parent_session_id.
-    # PR #1591 (May 2026) added a has_pending_user_message recompute block at
-    # the top of compact() which pushed the parent_session_id field beyond a
-    # 1500-char window — widen the scan to 3000 chars to cover the full
-    # return-dict body without re-tightening every time compact() grows.
-    compact_def_match = re.search(r"def compact\(self", src)
-    assert compact_def_match, "Could not find compact() method"
-    snippet = src[compact_def_match.start():compact_def_match.start() + 3000]
-    assert "'parent_session_id'" in snippet, \
+    # Bound the assertion to the semantic method body instead of a fixed byte
+    # window, which becomes stale whenever compact() gains legitimate logic.
+    compact_match = re.search(
+        r"(?ms)^    def compact\(self.*?(?=^    (?:def|@classmethod|@staticmethod)\b)",
+        src,
+    )
+    assert compact_match, "Could not find compact() method"
+    assert "'parent_session_id'" in compact_match.group(0), \
         "compact() should include parent_session_id"
 
 

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -2,6 +2,8 @@ import copy
 import json
 import threading
 
+import pytest
+
 
 def _incomplete_reasoning_only(message_id, *, reasoning="encrypted reasoning", timestamp=123):
     return {
@@ -465,6 +467,80 @@ def test_save_writes_index_from_same_collapsed_snapshot(tmp_path, monkeypatch):
     # 2, and no adoption of the dropped duplicate's later timestamp.
     assert entry["message_count"] == sidecar["message_count"] == 1
     assert entry["last_message_at"] == 100
+
+
+@pytest.mark.parametrize("first_generation", ["one", "two"])
+def test_same_sid_saves_publish_one_complete_generation_in_both_orders(
+    tmp_path, monkeypatch, first_generation
+):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    one = models.Session(
+        session_id="shared-save-authority",
+        title="generation-one",
+        model="model-one",
+        messages=[{"role": "user", "content": "one", "timestamp": 100}],
+    )
+    two = models.Session(
+        session_id="shared-save-authority",
+        title="generation-two",
+        model="model-two",
+        messages=[
+            {"role": "user", "content": "one", "timestamp": 100},
+            {"role": "assistant", "content": "two", "timestamp": 200},
+        ],
+    )
+    generations = {"one": one, "two": two}
+    second_generation = "two" if first_generation == "one" else "one"
+    first_reached_index = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    real_write_index = models._write_session_index
+    first_thread_id = {"value": None}
+
+    def gated_write_index(*args, **kwargs):
+        if threading.get_ident() == first_thread_id["value"]:
+            first_reached_index.set()
+            assert release_first.wait(timeout=2)
+        return real_write_index(*args, **kwargs)
+
+    monkeypatch.setattr(models, "_write_session_index", gated_write_index)
+
+    def save_first():
+        first_thread_id["value"] = threading.get_ident()
+        generations[first_generation].save(touch_updated_at=False)
+
+    def save_second():
+        second_started.set()
+        generations[second_generation].save(touch_updated_at=False)
+
+    first = threading.Thread(target=save_first)
+    second = threading.Thread(target=save_second)
+    first.start()
+    assert first_reached_index.wait(timeout=2)
+    second.start()
+    assert second_started.wait(timeout=2)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+    assert not first.is_alive()
+    assert not second.is_alive()
+
+    sidecar = json.loads((session_dir / "shared-save-authority.json").read_text(encoding="utf-8"))
+    index = json.loads(index_file.read_text(encoding="utf-8"))
+    row = next(entry for entry in index if entry["session_id"] == "shared-save-authority")
+    expected = generations[second_generation]
+    assert sidecar["title"] == row["title"] == expected.title
+    assert sidecar["model"] == row["model"] == expected.model
+    assert sidecar["message_count"] == row["message_count"] == len(expected.messages)
+    assert row["user_message_count"] == expected._compute_user_message_count(expected.messages)
+    assert row["last_message_at"] == expected.messages[-1]["timestamp"]
 
 
 def test_recovery_restores_the_collapsed_backup_payload(tmp_path):

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -157,6 +157,88 @@ def test_session_load_collapses_non_adjacent_duplicate_incomplete_ids(tmp_path, 
     assert (session_dir / f"{sid}.json.bak").exists()
 
 
+def test_load_self_heal_cannot_overwrite_a_newer_save(tmp_path, monkeypatch):
+    """The read, repair, and write-back must share one save generation."""
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_write_session_index", lambda *_args, **_kwargs: None)
+
+    sid = "load-self-heal-generation"
+    session_path = session_dir / f"{sid}.json"
+    duplicate = _incomplete_reasoning_only(1701)
+    session_path.write_text(
+        json.dumps({"session_id": sid, "messages": [duplicate, dict(duplicate)]}),
+        encoding="utf-8",
+    )
+
+    stale_read = threading.Event()
+    release_stale_reader = threading.Event()
+    writer_started = threading.Event()
+    writer_committed = threading.Event()
+    paused = False
+    real_read_text = Path.read_text
+
+    def _pause_loader_after_sidecar_read(path, *args, **kwargs):
+        nonlocal paused
+        text = real_read_text(path, *args, **kwargs)
+        if (
+            path == session_path
+            and threading.current_thread().name == "stale-loader"
+            and not paused
+        ):
+            paused = True
+            stale_read.set()
+            assert release_stale_reader.wait(timeout=5)
+        return text
+
+    monkeypatch.setattr(Path, "read_text", _pause_loader_after_sidecar_read)
+    errors = []
+
+    def _load_and_repair():
+        try:
+            assert models.Session.load(sid) is not None
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    newer = _incomplete_reasoning_only(1702)
+
+    def _write_newer_generation():
+        try:
+            writer_started.set()
+            models.Session(session_id=sid, messages=[duplicate, newer]).save(skip_index=True)
+            writer_committed.set()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    loader = threading.Thread(target=_load_and_repair, name="stale-loader")
+    writer = threading.Thread(target=_write_newer_generation, name="newer-writer")
+    loader.start()
+    assert stale_read.wait(timeout=5)
+    writer.start()
+    assert writer_started.wait(timeout=5)
+
+    # On the unfenced implementation the writer commits here and the stale
+    # loader subsequently overwrites it. With generation fencing it waits for
+    # the repair, then publishes the newest durable sidecar.
+    writer_committed.wait(timeout=1)
+    release_stale_reader.set()
+    loader.join(timeout=5)
+    writer.join(timeout=5)
+
+    assert not loader.is_alive()
+    assert not writer.is_alive()
+    assert errors == []
+    assert writer_committed.is_set()
+    assert [
+        message["id"]
+        for message in json.loads(session_path.read_text(encoding="utf-8"))["messages"]
+    ] == [1701, 1702]
+
+
 def test_context_dedupe_is_idempotent_for_alternating_incomplete_ids():
     from api.streaming import _deduplicate_context_messages
 

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -1,6 +1,18 @@
 import json
 
 
+def _incomplete_reasoning_only(message_id, *, reasoning="encrypted reasoning", timestamp=123):
+    return {
+        "id": message_id,
+        "role": "assistant",
+        "content": "",
+        "timestamp": timestamp,
+        "finish_reason": "incomplete",
+        "reasoning": reasoning,
+        "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "opaque"}],
+    }
+
+
 def _tool_partial(reasoning="same reasoning", args=None, *, timestamp=123):
     return {
         "role": "assistant",
@@ -85,3 +97,70 @@ def test_session_load_collapses_adjacent_duplicate_partials(tmp_path, monkeypatc
     assert sum(1 for message in persisted["messages"] if message.get("_partial")) == 1
     assert persisted["updated_at"] == 200.0
     assert (session_dir / f"{sid}.json.bak").exists()
+
+
+def test_reasoning_only_incomplete_identity_uses_stable_message_id():
+    from api.streaming import _message_identity
+
+    first = _incomplete_reasoning_only(1701)
+    replay = _incomplete_reasoning_only(1701, timestamp=999)
+    distinct = _incomplete_reasoning_only(1702)
+
+    assert _message_identity(first) == _message_identity(replay)
+    assert _message_identity(first) != _message_identity(distinct)
+    assert _message_identity({"role": "assistant", "content": "", "finish_reason": "incomplete"}) is None
+
+
+def test_session_load_collapses_non_adjacent_duplicate_incomplete_ids(tmp_path, monkeypatch):
+    import api.models as models
+
+    sid = "fd05-copy"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    second = _incomplete_reasoning_only(1702, reasoning="second")
+    payload = {
+        "session_id": sid,
+        "title": "FD05 duplicated incomplete responses",
+        "workspace": str(tmp_path),
+        "model": "gpt-5.6",
+        "created_at": 100.0,
+        "updated_at": 200.0,
+        "messages": [
+            {"role": "user", "content": "run this"},
+            first,
+            second,
+            dict(first),
+            dict(second),
+            dict(first),
+            dict(second),
+            {"role": "assistant", "content": "final visible answer"},
+        ],
+        "tool_calls": [],
+    }
+    (session_dir / f"{sid}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = models.Session.load(sid)
+
+    assert loaded is not None
+    assert [message.get("id") for message in loaded.messages if message.get("id")] == [1701, 1702]
+    persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    assert [message.get("id") for message in persisted["messages"] if message.get("id")] == [1701, 1702]
+    assert persisted["updated_at"] == 200.0
+    assert (session_dir / f"{sid}.json.bak").exists()
+
+
+def test_context_dedupe_is_idempotent_for_alternating_incomplete_ids():
+    from api.streaming import _deduplicate_context_messages
+
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    second = _incomplete_reasoning_only(1702, reasoning="second")
+    messages = [first, second, dict(first), dict(second)] * 10
+
+    once = _deduplicate_context_messages(messages)
+    twice = _deduplicate_context_messages(once)
+
+    assert [message["id"] for message in once] == [1701, 1702]
+    assert twice == once

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -2,6 +2,7 @@ import copy
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -180,11 +181,11 @@ def test_load_self_heal_cannot_overwrite_a_newer_save(tmp_path, monkeypatch):
     writer_started = threading.Event()
     writer_committed = threading.Event()
     paused = False
-    real_read_text = Path.read_text
+    real_read_bytes = Path.read_bytes
 
     def _pause_loader_after_sidecar_read(path, *args, **kwargs):
         nonlocal paused
-        text = real_read_text(path, *args, **kwargs)
+        payload = real_read_bytes(path, *args, **kwargs)
         if (
             path == session_path
             and threading.current_thread().name == "stale-loader"
@@ -193,9 +194,9 @@ def test_load_self_heal_cannot_overwrite_a_newer_save(tmp_path, monkeypatch):
             paused = True
             stale_read.set()
             assert release_stale_reader.wait(timeout=5)
-        return text
+        return payload
 
-    monkeypatch.setattr(Path, "read_text", _pause_loader_after_sidecar_read)
+    monkeypatch.setattr(Path, "read_bytes", _pause_loader_after_sidecar_read)
     errors = []
 
     def _load_and_repair():
@@ -237,6 +238,206 @@ def test_load_self_heal_cannot_overwrite_a_newer_save(tmp_path, monkeypatch):
         message["id"]
         for message in json.loads(session_path.read_text(encoding="utf-8"))["messages"]
     ] == [1701, 1702]
+
+
+def test_load_self_heal_revalidates_exact_source_generation(tmp_path, monkeypatch):
+    """A non-cooperating replace observed after read restarts reconciliation."""
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_write_session_index", lambda *_args, **_kwargs: None)
+
+    sid = "load-self-heal-exact-source"
+    session_path = session_dir / f"{sid}.json"
+    first = _incomplete_reasoning_only(1701)
+    newer = _incomplete_reasoning_only(1702)
+    stale_payload = {"session_id": sid, "messages": [first, dict(first)]}
+    newer_payload = {"session_id": sid, "messages": [first, newer]}
+    session_path.write_text(json.dumps(stale_payload), encoding="utf-8")
+
+    real_read_bytes = Path.read_bytes
+    swapped = False
+
+    def _replace_after_first_generation_read(path, *args, **kwargs):
+        nonlocal swapped
+        payload = real_read_bytes(path, *args, **kwargs)
+        if path == session_path and not swapped:
+            swapped = True
+            path.write_text(json.dumps(newer_payload), encoding="utf-8")
+        return payload
+
+    monkeypatch.setattr(Path, "read_bytes", _replace_after_first_generation_read)
+
+    loaded = models.Session.load(sid)
+
+    assert swapped is True
+    assert loaded is not None
+    assert [message["id"] for message in loaded.messages] == [1701, 1702]
+    assert [
+        message["id"]
+        for message in json.loads(session_path.read_text(encoding="utf-8"))["messages"]
+    ] == [1701, 1702]
+
+
+def test_workspace_binding_cannot_be_reverted_by_delayed_load_repair(tmp_path, monkeypatch):
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_write_session_index", lambda *_args, **_kwargs: None)
+
+    sid = "load-repair-workspace-binding"
+    old_workspace = tmp_path / "old-workspace"
+    new_workspace = tmp_path / "new-workspace"
+    new_workspace.mkdir()
+    first = _incomplete_reasoning_only(1701)
+    session_path = session_dir / f"{sid}.json"
+    session_path.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "workspace": str(old_workspace),
+                "messages": [first, dict(first)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loader_read = threading.Event()
+    release_loader = threading.Event()
+    binding_started = threading.Event()
+    binding_committed = threading.Event()
+    paused = False
+    real_read_bytes = Path.read_bytes
+
+    def _pause_delayed_loader(path, *args, **kwargs):
+        nonlocal paused
+        payload = real_read_bytes(path, *args, **kwargs)
+        if path == session_path and threading.current_thread().name == "workspace-loader" and not paused:
+            paused = True
+            loader_read.set()
+            assert release_loader.wait(timeout=5)
+        return payload
+
+    monkeypatch.setattr(Path, "read_bytes", _pause_delayed_loader)
+    errors = []
+
+    def _load_and_repair():
+        try:
+            models.Session.load(sid)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    def _bind_workspace():
+        try:
+            binding_started.set()
+            models.persist_recovered_workspace_binding(
+                SimpleNamespace(session_id=sid, workspace=str(old_workspace)),
+                new_workspace,
+                expected_workspace=str(old_workspace),
+            )
+            binding_committed.set()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    loader = threading.Thread(target=_load_and_repair, name="workspace-loader")
+    binder = threading.Thread(target=_bind_workspace, name="workspace-binder")
+    loader.start()
+    assert loader_read.wait(timeout=5)
+    binder.start()
+    assert binding_started.wait(timeout=5)
+    assert not binding_committed.wait(timeout=0.2)
+
+    release_loader.set()
+    loader.join(timeout=5)
+    binder.join(timeout=5)
+
+    assert not loader.is_alive()
+    assert not binder.is_alive()
+    assert errors == []
+    assert binding_committed.is_set()
+    persisted = json.loads(session_path.read_text(encoding="utf-8"))
+    assert persisted["workspace"] == str(new_workspace.resolve())
+    assert [message["id"] for message in persisted["messages"]] == [1701]
+
+
+def test_lifecycle_retirement_cannot_be_republished_by_delayed_load_repair(
+    tmp_path, monkeypatch
+):
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_write_session_index", lambda *_args, **_kwargs: None)
+
+    sid = "load-repair-lifecycle-retirement"
+    first = _incomplete_reasoning_only(1701)
+    session_path = session_dir / f"{sid}.json"
+    session_path.write_text(
+        json.dumps({"session_id": sid, "messages": [first, dict(first)]}),
+        encoding="utf-8",
+    )
+
+    loader_read = threading.Event()
+    release_loader = threading.Event()
+    retirement_started = threading.Event()
+    retirement_committed = threading.Event()
+    paused = False
+    real_read_bytes = Path.read_bytes
+
+    def _pause_delayed_loader(path, *args, **kwargs):
+        nonlocal paused
+        payload = real_read_bytes(path, *args, **kwargs)
+        if path == session_path and threading.current_thread().name == "retirement-loader" and not paused:
+            paused = True
+            loader_read.set()
+            assert release_loader.wait(timeout=5)
+        return payload
+
+    monkeypatch.setattr(Path, "read_bytes", _pause_delayed_loader)
+    errors = []
+
+    def _load_and_repair():
+        try:
+            models.Session.load(sid)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    def _retire():
+        try:
+            retirement_started.set()
+            assert models.retire_session_sidecar(
+                sid, record_deleted_tombstone=True
+            )
+            retirement_committed.set()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    loader = threading.Thread(target=_load_and_repair, name="retirement-loader")
+    retire = threading.Thread(target=_retire, name="session-retirement")
+    loader.start()
+    assert loader_read.wait(timeout=5)
+    retire.start()
+    assert retirement_started.wait(timeout=5)
+    assert not retirement_committed.wait(timeout=0.2)
+
+    release_loader.set()
+    loader.join(timeout=5)
+    retire.join(timeout=5)
+
+    assert not loader.is_alive()
+    assert not retire.is_alive()
+    assert errors == []
+    assert retirement_committed.is_set()
+    assert not session_path.exists()
+    assert sid in models._load_webui_deleted_session_tombstone()
 
 
 def test_context_dedupe_is_idempotent_for_alternating_incomplete_ids():

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 
@@ -279,3 +280,223 @@ def test_recovery_still_restores_unique_backup_excess(tmp_path):
     assert status["live_messages"] == 1
     assert status["bak_messages"] == 2
     assert status["recommend"] == "restore"
+
+
+def test_typed_incomplete_ids_round_trip_without_cross_type_collision():
+    from api.models import (
+        _collapse_duplicate_incomplete_message_ids,
+        _strict_incomplete_message_id_key,
+    )
+
+    # Each admissible scalar type carries its own deletion authority.
+    assert _strict_incomplete_message_id_key("abc") == ("str", "abc")
+    assert _strict_incomplete_message_id_key(1701) == ("int", 1701)
+    assert _strict_incomplete_message_id_key(1.5) == ("float", 1.5)
+
+    # 1 vs "1" vs 1.0 vs True vs "True" vs b"1" are DISTINCT rows: none may
+    # collapse into another's bucket, and the bytes id must round-trip intact.
+    typed_ids = [1, "1", 1.0, True, "True", b"1"]
+    rows = [_incomplete_reasoning_only(message_id) for message_id in typed_ids]
+    collapsed, _ = _collapse_duplicate_incomplete_message_ids(rows)
+    assert len(collapsed) == len(rows)
+    kept = [message["id"] for message in collapsed]
+    assert sum(1 for k in kept if type(k) is int and k == 1) == 1
+    assert sum(1 for k in kept if type(k) is str and k == "1") == 1
+    assert sum(1 for k in kept if type(k) is float and k == 1.0) == 1
+    assert sum(1 for k in kept if type(k) is str and k == "True") == 1
+    assert sum(1 for k in kept if type(k) is bool and k is True) == 1
+    assert sum(1 for k in kept if type(k) is bytes and k == b"1") == 1
+
+    # Same-type replays of an admissible id still collapse exactly as before.
+    for message_id in (1, "1", 1.5):
+        pair = [_incomplete_reasoning_only(message_id), _incomplete_reasoning_only(message_id)]
+        deduped, changed = _collapse_duplicate_incomplete_message_ids(pair)
+        assert changed is True
+        assert len(deduped) == 1
+        assert deduped[0]["id"] == message_id
+        assert type(deduped[0]["id"]) is type(message_id)
+
+
+def test_incomplete_id_rejects_bool_container_subclass_and_non_finite():
+    from api.models import _strict_incomplete_message_id_key as key
+
+    class StrId(str):
+        pass
+
+    class IntId(int):
+        pass
+
+    assert key(True) is None
+    assert key(False) is None
+    assert key(None) is None
+    assert key("") is None
+    assert key(["1"]) is None
+    assert key({"id": 1}) is None
+    assert key(("1",)) is None
+    assert key(b"1") is None
+    assert key(StrId("1")) is None
+    assert key(IntId(1)) is None
+    assert key(float("nan")) is None
+    assert key(float("inf")) is None
+    assert key(float("-inf")) is None
+
+
+def test_mixed_type_backup_rows_remain_independently_recoverable(tmp_path):
+    from api.session_recovery import inspect_session_recovery_status
+
+    session_path = tmp_path / "mixed.json"
+    backup_path = tmp_path / "mixed.json.bak"
+    int_row = _incomplete_reasoning_only(1)
+    str_row = _incomplete_reasoning_only("1")
+    session_path.write_text(json.dumps({"messages": [int_row]}), encoding="utf-8")
+    backup_path.write_text(
+        json.dumps({"messages": [int_row, str_row]}), encoding="utf-8"
+    )
+
+    status = inspect_session_recovery_status(session_path)
+    assert status["live_messages"] == 1
+    # "1" is NOT a duplicate-only replay of 1: the distinct backup row keeps
+    # its recovery authority instead of being classified as a replay of 1.
+    assert status["bak_messages"] == 2
+    assert status["recommend"] == "restore"
+
+
+def test_save_deep_isolates_retained_rows_from_concurrent_mutation(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "index.json")
+
+    session = models.Session(
+        session_id="deep-isolation",
+        messages=[_incomplete_reasoning_only(1701)],
+    )
+    live_row = session.messages[0]
+    real_deepcopy = copy.deepcopy
+
+    def deepcopy_then_mutate(obj, *args, **kwargs):
+        snapshot = real_deepcopy(obj, *args, **kwargs)
+        if isinstance(obj, list) and obj and obj[0] is live_row:
+            # A worker mutates the LIVE nested dict in the window between the
+            # collapse scan and json.dumps; the persisted payload must not
+            # observe it.
+            live_row["codex_reasoning_items"][0]["encrypted_content"] = "MUTATED"
+        return snapshot
+
+    monkeypatch.setattr(models.copy, "deepcopy", deepcopy_then_mutate)
+    session.save(skip_index=True)
+
+    persisted = json.loads((session_dir / "deep-isolation.json").read_text(encoding="utf-8"))
+    assert persisted["messages"][0]["codex_reasoning_items"][0]["encrypted_content"] == "opaque"
+    assert session.messages[0]["codex_reasoning_items"][0]["encrypted_content"] == "MUTATED"
+
+
+def test_save_writes_index_from_same_collapsed_snapshot(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = tmp_path / "index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    session = models.Session(
+        session_id="index-parity",
+        messages=[_incomplete_reasoning_only(1701, timestamp=100)],
+    )
+    session.save()  # full-rebuild path creates the index
+
+    # A replayed duplicate carrying a LATER timestamp lands in the live list.
+    session.messages.append(_incomplete_reasoning_only(1701, timestamp=999))
+    session.save()  # fast path: _write_session_index(updates=[self])
+
+    sidecar = json.loads((session_dir / "index-parity.json").read_text(encoding="utf-8"))
+    assert sidecar["message_count"] == 1
+    assert len(sidecar["messages"]) == 1
+
+    index_entries = json.loads(index_file.read_text(encoding="utf-8"))
+    entry = next(e for e in index_entries if e["session_id"] == "index-parity")
+    # The sidebar index must reflect the SAME collapsed snapshot: no count of
+    # 2, and no adoption of the dropped duplicate's later timestamp.
+    assert entry["message_count"] == sidecar["message_count"] == 1
+    assert entry["last_message_at"] == 100
+
+
+def test_recovery_restores_the_collapsed_backup_payload(tmp_path):
+    from api.session_recovery import inspect_session_recovery_status, recover_session
+
+    session_path = tmp_path / "restored.json"
+    backup_path = tmp_path / "restored.json.bak"
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    unique = {"role": "user", "content": "must survive", "id": 1702}
+    session_path.write_text(json.dumps({"messages": [first]}), encoding="utf-8")
+    backup_path.write_text(
+        json.dumps({"messages": [first, dict(first), unique], "message_count": 3}),
+        encoding="utf-8",
+    )
+
+    status = inspect_session_recovery_status(session_path)
+    assert status["recommend"] == "restore"
+    result = recover_session(session_path)
+    assert result["restored"] is True
+
+    # The restore writes the SAME effective payload _msg_count() evaluated:
+    # the duplicate-only replay is NOT resurrected, the unique row survives,
+    # and message_count is recomputed from the collapsed payload.
+    restored = json.loads(session_path.read_text(encoding="utf-8"))
+    assert restored["messages"] == [first, unique]
+    assert restored["message_count"] == 2
+
+
+def test_reconciliation_and_persistence_share_incomplete_eligibility():
+    from api.models import _incomplete_reasoning_message_id
+    from api.streaming import _message_identity
+
+    def reconciliation_incomplete_key(message):
+        identity = _message_identity(message)
+        if (
+            isinstance(identity, tuple)
+            and len(identity) == 4
+            and str(identity[3]).startswith("__incomplete_message_id__")
+        ):
+            return identity[3]
+        return None
+
+    base = _incomplete_reasoning_only(1701)
+    structured_blank = {
+        **base,
+        "content": [{"type": "output_text", "text": "  <think>hidden</think>  "}],
+    }
+    structured_visible = {
+        **base,
+        "content": [{"type": "output_text", "text": "visible answer"}],
+    }
+    cases_eligible = [
+        base,
+        structured_blank,
+        {**base, "id": 1},
+        {**base, "id": "1"},
+        {**base, "id": 1.5},
+    ]
+    cases_ineligible = [
+        structured_visible,
+        {**base, "tool_call_id": "call_1"},
+        {**base, "tool_calls": [{"id": "call_1"}]},
+        {**base, "id": True},
+        {**base, "id": ""},
+        {**base, "id": None},
+        {**base, "id": ["1"]},
+        {**base, "id": float("nan")},
+    ]
+
+    # Blank content (plain or structured), tool-call identity, and malformed
+    # ids are classified identically by both layers: neither may drop a row
+    # the other considers distinct.
+    for message in cases_eligible:
+        assert _incomplete_reasoning_message_id(message) is not None
+        assert reconciliation_incomplete_key(message) is not None
+    for message in cases_ineligible:
+        assert _incomplete_reasoning_message_id(message) is None
+        assert reconciliation_incomplete_key(message) is None

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -498,11 +499,68 @@ def test_same_sid_saves_publish_one_complete_generation_in_both_orders(
     )
     generations = {"one": one, "two": two}
     second_generation = "two" if first_generation == "one" else "one"
+    sidecar_path = session_dir / "shared-save-authority.json"
     first_reached_index = threading.Event()
     release_first = threading.Event()
-    second_started = threading.Event()
+    second_attempted_entry = threading.Event()
+    second_observed_contention = threading.Event()
+    first_generation_completed = threading.Event()
+    publication_reached = {
+        ("first", "sidecar"): threading.Event(),
+        ("first", "index"): threading.Event(),
+        ("second", "sidecar"): threading.Event(),
+        ("second", "index"): threading.Event(),
+    }
+    publication_before_first_completion = []
+    errors = []
+    real_authority = models._session_save_authority(one.session_id)
+    real_safe_replace = models._safe_replace
     real_write_index = models._write_session_index
-    first_thread_id = {"value": None}
+    first_thread_id: dict[str, int | None] = {"value": None}
+    second_thread_id: dict[str, int | None] = {"value": None}
+
+    class ObservedAuthority:
+        """Expose a real failed try-acquire before the second writer blocks."""
+
+        def __enter__(self):
+            current = threading.get_ident()
+            if current == second_thread_id["value"]:
+                second_attempted_entry.set()
+                if real_authority.acquire(blocking=False):
+                    return self
+                second_observed_contention.set()
+            real_authority.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            if threading.get_ident() == first_thread_id["value"]:
+                # The complete first generation (sidecar plus index) is still
+                # protected here; publish this observation before unlocking it.
+                first_generation_completed.set()
+            real_authority.release()
+
+    def observed_authority(session_id):
+        assert session_id == one.session_id
+        return ObservedAuthority()
+
+    def tracked_safe_replace(src, dst):
+        current = threading.get_ident()
+        writer = None
+        if current == first_thread_id["value"]:
+            writer = "first"
+        elif current == second_thread_id["value"]:
+            writer = "second"
+        destination = Path(dst)
+        sink = None
+        if destination == sidecar_path:
+            sink = "sidecar"
+        elif destination == index_file:
+            sink = "index"
+        if writer is not None and sink is not None:
+            publication_reached[(writer, sink)].set()
+            if writer == "second" and not first_generation_completed.is_set():
+                publication_before_first_completion.append(sink)
+        return real_safe_replace(src, dst)
 
     def gated_write_index(*args, **kwargs):
         if threading.get_ident() == first_thread_id["value"]:
@@ -510,29 +568,59 @@ def test_same_sid_saves_publish_one_complete_generation_in_both_orders(
             assert release_first.wait(timeout=2)
         return real_write_index(*args, **kwargs)
 
+    monkeypatch.setattr(models, "_session_save_authority", observed_authority)
+    monkeypatch.setattr(models, "_safe_replace", tracked_safe_replace)
     monkeypatch.setattr(models, "_write_session_index", gated_write_index)
 
     def save_first():
         first_thread_id["value"] = threading.get_ident()
-        generations[first_generation].save(touch_updated_at=False)
+        try:
+            generations[first_generation].save(touch_updated_at=False)
+        except BaseException as exc:
+            errors.append(("first", exc))
 
     def save_second():
-        second_started.set()
-        generations[second_generation].save(touch_updated_at=False)
+        second_thread_id["value"] = threading.get_ident()
+        try:
+            generations[second_generation].save(touch_updated_at=False)
+        except BaseException as exc:
+            errors.append(("second", exc))
 
     first = threading.Thread(target=save_first)
     second = threading.Thread(target=save_second)
     first.start()
-    assert first_reached_index.wait(timeout=2)
-    second.start()
-    assert second_started.wait(timeout=2)
-    release_first.set()
-    first.join(timeout=2)
-    second.join(timeout=2)
+    try:
+        assert first_reached_index.wait(timeout=2)
+        # The first generation is paused after reaching sidecar publication but
+        # before reaching index publication, while still owning the SID fence.
+        assert publication_reached[("first", "sidecar")].is_set()
+        assert not publication_reached[("first", "index")].is_set()
+
+        second.start()
+        assert second_attempted_entry.wait(timeout=2)
+        assert second_observed_contention.wait(timeout=2)
+        assert second.is_alive()
+        # This is the remaining concurrency oracle: the second writer has made
+        # a real failed try-acquire on the SID authority, yet cannot reach
+        # EITHER publication sink while the first generation is paused.
+        assert not publication_reached[("second", "sidecar")].is_set()
+        assert not publication_reached[("second", "index")].is_set()
+    finally:
+        release_first.set()
+        first.join(timeout=2)
+        if second.ident is not None:
+            second.join(timeout=2)
+
     assert not first.is_alive()
     assert not second.is_alive()
+    assert not errors
+    assert first_generation_completed.is_set()
+    for sink in ("sidecar", "index"):
+        assert publication_reached[("first", sink)].is_set()
+        assert publication_reached[("second", sink)].is_set()
+    assert publication_before_first_completion == []
 
-    sidecar = json.loads((session_dir / "shared-save-authority.json").read_text(encoding="utf-8"))
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
     index = json.loads(index_file.read_text(encoding="utf-8"))
     row = next(entry for entry in index if entry["session_id"] == "shared-save-authority")
     expected = generations[second_generation]

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -205,6 +205,77 @@ def test_save_is_a_final_idempotent_barrier_for_incomplete_message_ids(tmp_path,
     session.save(skip_index=True)
     session.save(skip_index=True)
 
-    assert [message["id"] for message in session.messages] == [1701, 1702]
-    persisted = json.loads(session.path.read_text(encoding="utf-8"))
+    # save() never rebinds or mutates the list visible to active workers.
+    assert [message["id"] for message in session.messages] == [1701, 1702, 1701, 1702]
+    persisted = json.loads((session_dir / "save-barrier.json").read_text(encoding="utf-8"))
     assert [message["id"] for message in persisted["messages"]] == [1701, 1702]
+    assert persisted["message_count"] == 2
+
+
+def test_save_snapshot_does_not_lose_concurrent_alias_append(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "index.json")
+
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    session = models.Session(session_id="concurrent-alias", messages=[first, dict(first)])
+    live_alias = session.messages
+    concurrent = {"role": "user", "content": "arrived during save", "id": 1702}
+    real_collapse = models._collapse_duplicate_incomplete_message_ids
+
+    def collapse_then_append(messages):
+        collapsed = real_collapse(messages)
+        live_alias.append(concurrent)
+        return collapsed
+
+    monkeypatch.setattr(models, "_collapse_duplicate_incomplete_message_ids", collapse_then_append)
+    session.save(skip_index=True)
+
+    assert session.messages is live_alias
+    assert session.messages[-1] == concurrent
+    first_payload = json.loads((session_dir / "concurrent-alias.json").read_text(encoding="utf-8"))
+    assert [message["id"] for message in first_payload["messages"]] == [1701]
+
+    monkeypatch.setattr(models, "_collapse_duplicate_incomplete_message_ids", real_collapse)
+    session.save(skip_index=True)
+    second_payload = json.loads((session_dir / "concurrent-alias.json").read_text(encoding="utf-8"))
+    assert [message["id"] for message in second_payload["messages"]] == [1701, 1702]
+
+
+def test_recovery_does_not_resurrect_duplicate_incomplete_backup(tmp_path):
+    from api.session_recovery import inspect_session_recovery_status, recover_session
+
+    session_path = tmp_path / "repaired.json"
+    backup_path = tmp_path / "repaired.json.bak"
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    second = _incomplete_reasoning_only(1702, reasoning="second")
+    session_path.write_text(json.dumps({"messages": [first, second]}), encoding="utf-8")
+    backup_path.write_text(
+        json.dumps({"messages": [first, second, dict(first), dict(second)]}),
+        encoding="utf-8",
+    )
+
+    status = inspect_session_recovery_status(session_path)
+    assert status["live_messages"] == 2
+    assert status["bak_messages"] == 2
+    assert status["recommend"] == "no_action"
+    assert recover_session(session_path)["restored"] is False
+
+
+def test_recovery_still_restores_unique_backup_excess(tmp_path):
+    from api.session_recovery import inspect_session_recovery_status
+
+    session_path = tmp_path / "repaired.json"
+    backup_path = tmp_path / "repaired.json.bak"
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    unique = {"role": "user", "content": "must survive", "id": 1702}
+    session_path.write_text(json.dumps({"messages": [first]}), encoding="utf-8")
+    backup_path.write_text(json.dumps({"messages": [first, unique]}), encoding="utf-8")
+
+    status = inspect_session_recovery_status(session_path)
+    assert status["live_messages"] == 1
+    assert status["bak_messages"] == 2
+    assert status["recommend"] == "restore"

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -164,3 +164,47 @@ def test_context_dedupe_is_idempotent_for_alternating_incomplete_ids():
 
     assert [message["id"] for message in once] == [1701, 1702]
     assert twice == once
+
+
+def test_display_merge_dedupes_incomplete_ids_after_state_db_reconciliation():
+    from api.streaming import _merge_display_messages_after_agent_result
+
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    second = _incomplete_reasoning_only(1702, reasoning="second")
+    user = {"role": "user", "content": "next", "id": 1703}
+    answer = {"role": "assistant", "content": "done", "id": 1704, "finish_reason": "stop"}
+
+    merged = _merge_display_messages_after_agent_result(
+        [first, second, dict(first), dict(second)],
+        [first, second],
+        [first, second, dict(first), dict(second), user, answer],
+        "next",
+    )
+
+    ids = [message.get("id") for message in merged]
+    assert ids.count(1701) == 1
+    assert ids.count(1702) == 1
+    assert ids[-2:] == [1703, 1704]
+
+
+def test_save_is_a_final_idempotent_barrier_for_incomplete_message_ids(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "index.json")
+
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    second = _incomplete_reasoning_only(1702, reasoning="second")
+    session = models.Session(
+        session_id="save-barrier",
+        messages=[first, second, dict(first), dict(second)],
+    )
+
+    session.save(skip_index=True)
+    session.save(skip_index=True)
+
+    assert [message["id"] for message in session.messages] == [1701, 1702]
+    persisted = json.loads(session.path.read_text(encoding="utf-8"))
+    assert [message["id"] for message in persisted["messages"]] == [1701, 1702]

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -286,6 +286,124 @@ def test_recovery_still_restores_unique_backup_excess(tmp_path):
     assert status["recommend"] == "restore"
 
 
+def test_recovery_equal_normalized_counts_with_divergent_membership_requires_review(tmp_path):
+    from api.session_recovery import (
+        audit_session_recovery,
+        inspect_session_recovery_status,
+        recover_all_sessions_on_startup,
+        recover_session,
+    )
+
+    session_path = tmp_path / "membership-diverged.json"
+    backup_path = tmp_path / "membership-diverged.json.bak"
+    shared = _incomplete_reasoning_only(1701, reasoning="shared")
+    live_only = {"role": "user", "content": "new live row", "id": 1702}
+    backup_only = {"role": "assistant", "content": "backup-only information", "id": 1703}
+    live_payload = {"messages": [shared, live_only], "message_count": 2}
+    backup_payload = {
+        "messages": [shared, backup_only, dict(shared)],
+        "message_count": 3,
+    }
+    session_path.write_text(json.dumps(live_payload), encoding="utf-8")
+    backup_path.write_text(json.dumps(backup_payload), encoding="utf-8")
+
+    status = inspect_session_recovery_status(session_path)
+
+    assert status["live_messages"] == status["bak_messages"] == 2
+    assert status["recommend"] == "manual_review"
+    assert status["membership_conflict"] is True
+    assert status["live_only_messages"] == 1
+    assert status["backup_only_messages"] == 1
+    result = recover_session(session_path)
+    assert result["restored"] is False
+    # Fail closed: neither side is overwritten, so both the new live row and
+    # the otherwise-unrepresented backup row remain available for review.
+    assert json.loads(session_path.read_text(encoding="utf-8")) == live_payload
+    assert json.loads(backup_path.read_text(encoding="utf-8")) == backup_payload
+    startup = recover_all_sessions_on_startup(tmp_path)
+    assert startup["restored"] == 0
+    assert len(startup["details"]) == 1
+    assert startup["details"][0]["recommend"] == "manual_review"
+    assert startup["details"][0]["restored"] is False
+    audit = audit_session_recovery(tmp_path)
+    assert audit["status"] == "needs_manual_review"
+    assert audit["items"] == [
+        {
+            "session_id": "membership-diverged",
+            "kind": "divergent_live_backup_membership",
+            "category": "unsafe_to_repair",
+            "recommendation": "manual_review",
+            "live_messages": 2,
+            "bak_messages": 2,
+            "live_only_messages": 1,
+            "backup_only_messages": 1,
+        }
+    ]
+
+
+def test_owned_empty_generation_does_not_clear_tombstones_for_later_alias_append(
+    tmp_path, monkeypatch
+):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+
+    session = models.Session(session_id="owned-empty-generation", messages=[])
+    live_alias = session.messages
+    appended = {"role": "user", "content": "arrived after capture", "id": 1801}
+    snapshot_captured = threading.Event()
+    append_finished = threading.Event()
+    real_collapse = models._collapse_duplicate_incomplete_message_ids
+    cleared = []
+
+    def collapse_after_capture(messages):
+        assert messages == []
+        snapshot_captured.set()
+        assert append_finished.wait(timeout=2)
+        return real_collapse(messages)
+
+    def append_after_capture():
+        assert snapshot_captured.wait(timeout=2)
+        live_alias.append(appended)
+        append_finished.set()
+
+    monkeypatch.setattr(models, "_collapse_duplicate_incomplete_message_ids", collapse_after_capture)
+    monkeypatch.setattr(
+        models,
+        "_clear_webui_zero_message_orphan_tombstone",
+        lambda sid: cleared.append(("zero", sid)),
+    )
+    monkeypatch.setattr(
+        models,
+        "_clear_webui_deleted_session_tombstone",
+        lambda sid: cleared.append(("deleted", sid)),
+    )
+    worker = threading.Thread(target=append_after_capture)
+    worker.start()
+    session.save(skip_index=True, touch_updated_at=False)
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+
+    first_payload = json.loads(session.path.read_text(encoding="utf-8"))
+    assert first_payload["messages"] == []
+    assert session.messages is live_alias
+    assert session.messages == [appended]
+    assert cleared == []
+
+    monkeypatch.setattr(models, "_collapse_duplicate_incomplete_message_ids", real_collapse)
+    session.save(skip_index=True, touch_updated_at=False)
+
+    second_payload = json.loads(session.path.read_text(encoding="utf-8"))
+    assert second_payload["messages"] == [appended]
+    assert cleared == [
+        ("zero", session.session_id),
+        ("deleted", session.session_id),
+    ]
+
+
 def test_typed_incomplete_ids_round_trip_without_cross_type_collision():
     from api.models import (
         _collapse_duplicate_incomplete_message_ids,

--- a/tests/test_issue2592_partial_dedupe.py
+++ b/tests/test_issue2592_partial_dedupe.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import threading
 
 
 def _incomplete_reasoning_only(message_id, *, reasoning="encrypted reasoning", timestamp=123):
@@ -393,6 +394,47 @@ def test_save_deep_isolates_retained_rows_from_concurrent_mutation(tmp_path, mon
     assert session.messages[0]["codex_reasoning_items"][0]["encrypted_content"] == "MUTATED"
 
 
+def test_save_owns_snapshot_before_duplicate_selection(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "index.json")
+
+    first = _incomplete_reasoning_only(1701, reasoning="first")
+    duplicate = copy.deepcopy(first)
+    session = models.Session(session_id="selection-isolation", messages=[first, duplicate])
+    real_collapse = models._collapse_duplicate_incomplete_message_ids
+    selection_done = threading.Event()
+    mutation_done = threading.Event()
+
+    def mutate_after_selection():
+        assert selection_done.wait(timeout=2)
+        first["codex_reasoning_items"][0]["encrypted_content"] = "MUTATED"
+        mutation_done.set()
+
+    worker = threading.Thread(target=mutate_after_selection)
+    worker.start()
+
+    def collapse_then_mutate(messages):
+        selected = real_collapse(messages)
+        # Pause save after selection while a scheduled writer mutates the live
+        # row.  This is exactly before the old post-selection deepcopy.
+        selection_done.set()
+        assert mutation_done.wait(timeout=2)
+        return selected
+
+    monkeypatch.setattr(models, "_collapse_duplicate_incomplete_message_ids", collapse_then_mutate)
+    session.save(skip_index=True)
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+
+    persisted = json.loads((session_dir / "selection-isolation.json").read_text(encoding="utf-8"))
+    assert len(persisted["messages"]) == 1
+    assert persisted["messages"][0]["codex_reasoning_items"][0]["encrypted_content"] == "opaque"
+
+
 def test_save_writes_index_from_same_collapsed_snapshot(tmp_path, monkeypatch):
     from api import models
 
@@ -410,6 +452,7 @@ def test_save_writes_index_from_same_collapsed_snapshot(tmp_path, monkeypatch):
 
     # A replayed duplicate carrying a LATER timestamp lands in the live list.
     session.messages.append(_incomplete_reasoning_only(1701, timestamp=999))
+    session._metadata_message_count = 2
     session.save()  # fast path: _write_session_index(updates=[self])
 
     sidecar = json.loads((session_dir / "index-parity.json").read_text(encoding="utf-8"))
@@ -491,6 +534,15 @@ def test_reconciliation_and_persistence_share_incomplete_eligibility():
         {**base, "id": float("nan")},
     ]
 
+    partial_same_id_different_reasoning = [
+        {**base, "_partial": True, "reasoning": "first"},
+        {**base, "_partial": True, "reasoning": "second"},
+    ]
+    partial_different_ids_same_reasoning = [
+        {**base, "_partial": True, "id": 1701, "reasoning": "same"},
+        {**base, "_partial": True, "id": 1702, "reasoning": "same"},
+    ]
+
     # Blank content (plain or structured), tool-call identity, and malformed
     # ids are classified identically by both layers: neither may drop a row
     # the other considers distinct.
@@ -500,3 +552,11 @@ def test_reconciliation_and_persistence_share_incomplete_eligibility():
     for message in cases_ineligible:
         assert _incomplete_reasoning_message_id(message) is None
         assert reconciliation_incomplete_key(message) is None
+    assert (
+        reconciliation_incomplete_key(partial_same_id_different_reasoning[0])
+        == reconciliation_incomplete_key(partial_same_id_different_reasoning[1])
+    )
+    assert (
+        reconciliation_incomplete_key(partial_different_ids_same_reasoning[0])
+        != reconciliation_incomplete_key(partial_different_ids_same_reasoning[1])
+    )

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -284,6 +284,11 @@ class TestIssue765FollowupHardening:
         with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
         threads would target the same path and the second replace would deterministically
         fail once the first consume/remove happened.
+
+        The workers rendezvous immediately BEFORE `save()` rather than inside
+        os.replace(): the per-session save authority admits one same-SID save at a
+        time, so a barrier held inside the protected transaction could never be
+        satisfied. Contending on entry still exercises the same temp-path scheme.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
@@ -291,17 +296,19 @@ class TestIssue765FollowupHardening:
         original_replace = models.os.replace
         barrier = threading.Barrier(2)
         replace_sources = []
+        replace_sources_lock = threading.Lock()
         errors = []
 
-        def _replace_with_barrier(src, dst):
-            replace_sources.append(str(src))
-            barrier.wait(timeout=5)
+        def _recording_replace(src, dst):
+            with replace_sources_lock:
+                replace_sources.append(str(src))
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models.os, "replace", _recording_replace)
 
         def _save_worker():
             try:
+                barrier.wait(timeout=5)
                 s.save(skip_index=True)
             except Exception as e:
                 errors.append(e)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -354,7 +354,10 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+2400]
+            delete_end = text.find("\n    if parsed.path == ", delete_idx + 1)
+            delete_block = text[delete_idx:delete_end if delete_end >= 0 else None]
+            assert "retire_session_sidecar(" in delete_block, \
+                f"{label} session/delete must retire its sidecar generation"
             assert "prune_session_from_index(sid)" in delete_block, \
                 f"{label} session/delete must prune SESSION_INDEX_FILE"
             return
@@ -364,14 +367,24 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
 def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
     """session/delete must remove sidecar backups so deleted sessions stay deleted."""
     routes_src = (REPO_ROOT / "api" / "routes.py").read_text()
+    models_src = (REPO_ROOT / "api" / "models.py").read_text()
     delete_idx = max(
         routes_src.find("if parsed.path == '/api/session/delete':"),
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+2400]
-    assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
-        "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
+    delete_end = routes_src.find("\n    if parsed.path == ", delete_idx + 1)
+    delete_block = routes_src[delete_idx:delete_end if delete_end >= 0 else None]
+    helper_idx = models_src.index("def retire_session_sidecar(")
+    helper_end = models_src.find("\ndef ", helper_idx + 1)
+    helper_block = models_src[helper_idx:helper_end if helper_end >= 0 else None]
+    assert "retire_session_sidecar(" in delete_block
+    assert "remove_backup=True" in delete_block
+    assert "if remove_backup:" in helper_block
+    assert (
+        "with_suffix('.json.bak').unlink" in helper_block
+        or 'with_suffix(".json.bak").unlink' in helper_block
+    ), "retire_session_sidecar must unlink <sid>.json.bak when requested"
 
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
 

--- a/tests/test_squash_session_projection.py
+++ b/tests/test_squash_session_projection.py
@@ -166,3 +166,34 @@ def test_branch_keep_count_uses_squash_authoritative_display_coordinates(monkeyp
         "# Session compactée\n\nRésumé opérationnel vérifié.",
         "nouvelle demande",
     ]
+
+
+def test_squash_projection_preserves_distinct_state_only_rows_after_watermark():
+    sidecar_messages, cli_messages = _production_squash_projection()
+    cli_messages.insert(
+        2,
+        _message(
+            "assistant",
+            "réponse disponible uniquement dans state.db",
+            250.0,
+            message_id="state-only-250",
+        ),
+    )
+    session = SimpleNamespace(
+        session_id="production-squash-state-only-tail",
+        messages=sidecar_messages,
+        session_source="webui",
+        parent_session_id=None,
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+    )
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [message["content"] for message in merged] == [
+        "# Session compactée\n\nRésumé opérationnel vérifié.",
+        "réponse disponible uniquement dans state.db",
+        "nouvelle demande",
+        "nouvelle réponse",
+    ]

--- a/tests/test_squash_session_projection.py
+++ b/tests/test_squash_session_projection.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+
+def _message(role, content, timestamp, message_id=None, **extra):
+    message = {
+        "role": role,
+        "content": content,
+        "timestamp": timestamp,
+    }
+    if message_id is not None:
+        message["id"] = message_id
+    message.update(extra)
+    return message
+
+
+def test_squash_summary_watermark_blocks_older_state_db_replay():
+    from api.routes import _merged_session_messages_for_display
+
+    summary = _message(
+        "assistant",
+        "# Session compactée\n\nRésumé opérationnel vérifié.",
+        200.0,
+        message_id="squash-200",
+        _squash_summary=True,
+    )
+    session = SimpleNamespace(
+        session_id="fd05-copy",
+        messages=[summary],
+        session_source="webui",
+        parent_session_id=None,
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+    )
+    state_db_messages = [
+        _message("user", "ancien prompt", 100.0, message_id=1),
+        _message("assistant", "ancienne réponse", 110.0, message_id=2),
+    ]
+
+    merged = _merged_session_messages_for_display(session, state_db_messages)
+
+    assert merged == [summary]
+
+
+def test_non_squash_short_sidecar_keeps_existing_merge_behavior():
+    from api.routes import _merged_session_messages_for_display
+
+    sidecar = _message("assistant", "nouvelle réponse", 200.0, message_id=3)
+    session = SimpleNamespace(
+        session_id="ordinary-session",
+        messages=[sidecar],
+        session_source="webui",
+        parent_session_id=None,
+        truncation_watermark=None,
+        truncation_boundary=None,
+        compression_anchor_mode=None,
+    )
+    state_db_messages = [
+        _message("user", "ancien prompt", 100.0, message_id=1),
+        _message("assistant", "ancienne réponse", 110.0, message_id=2),
+    ]
+
+    merged = _merged_session_messages_for_display(session, state_db_messages)
+
+    assert [message["id"] for message in merged] == [1, 2, 3]

--- a/tests/test_squash_session_projection.py
+++ b/tests/test_squash_session_projection.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 from types import SimpleNamespace
 
+import pytest
+
 from api import routes
 from api.models import Session
 
@@ -196,4 +198,156 @@ def test_squash_projection_preserves_distinct_state_only_rows_after_watermark():
         "réponse disponible uniquement dans state.db",
         "nouvelle demande",
         "nouvelle réponse",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("generation", "cutoff"),
+    [("", 200.0), ("not-a-uuid", 200.0), ("0123456789ab4cde8f0123456789abcd", 199.0)],
+)
+def test_malformed_squash_projection_authority_fails_closed(generation, cutoff):
+    sidecar_messages, cli_messages = _production_squash_projection()
+    cli_messages.insert(
+        2,
+        _message("assistant", "state-only row", 250.0, message_id="state-only-invalid"),
+    )
+    session = SimpleNamespace(
+        session_id="invalid-squash-authority",
+        messages=[sidecar_messages[0]],
+        session_source="webui",
+        parent_session_id=None,
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        squash_projection_generation=generation,
+        squash_projection_cutoff=cutoff,
+        squash_projection_superseded_by=None,
+    )
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert merged == [sidecar_messages[0]]
+
+
+@pytest.mark.parametrize("operation", ["truncate", "retry", "undo"])
+def test_post_squash_intentional_shrink_supersedes_state_projection(
+    operation, monkeypatch, tmp_path
+):
+    from api import models, session_ops
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_write_session_index", lambda *_args, **_kwargs: None)
+
+    sidecar_messages, cli_messages = _production_squash_projection()
+    cli_messages.insert(
+        2,
+        _message(
+            "assistant",
+            "state-only row removed by later shrink",
+            250.0,
+            message_id="state-only-250",
+        ),
+    )
+    session = Session(
+        session_id=f"squash-{operation}",
+        workspace=str(tmp_path),
+        messages=sidecar_messages,
+        context_messages=list(sidecar_messages),
+        session_source="webui",
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+    )
+    session.save(skip_index=True, touch_updated_at=False)
+    active_projection_generation = session.squash_projection_generation
+    assert active_projection_generation
+
+    if operation == "truncate":
+        session_ops.truncate_session_at_keep(session, 1)
+        session.save(skip_index=True, touch_updated_at=False)
+    else:
+        store = OrderedDict([(session.session_id, session)])
+        monkeypatch.setattr(session_ops, "SESSIONS", store)
+        monkeypatch.setattr(session_ops, "get_session", lambda _sid: session)
+        getattr(session_ops, f"{operation}_last")(session.session_id)
+
+    reloaded = Session.load(session.session_id)
+    assert reloaded is not None
+    assert reloaded.squash_projection_generation == active_projection_generation
+    assert reloaded.squash_projection_superseded_by == reloaded.intentional_shrink_generation
+    assert reloaded.squash_projection_cutoff == 200.0
+
+    merged = routes._merged_session_messages_for_display(reloaded, cli_messages)
+
+    assert [message["content"] for message in merged] == [
+        "# Session compactée\n\nRésumé opérationnel vérifié."
+    ]
+
+
+def test_branch_after_post_squash_truncate_uses_superseded_coordinates(
+    monkeypatch, tmp_path
+):
+    from api.session_ops import truncate_session_at_keep
+
+    sidecar_messages, cli_messages = _production_squash_projection()
+    cli_messages.insert(
+        2,
+        _message(
+            "assistant",
+            "state-only row removed before branch",
+            250.0,
+            message_id="state-only-branch-250",
+        ),
+    )
+    source = Session(
+        session_id="post-squash-truncate-branch",
+        title="Squashed then truncated source",
+        workspace=str(tmp_path),
+        messages=sidecar_messages,
+        context_messages=list(sidecar_messages),
+        session_source="webui",
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+        squash_projection_generation="0123456789ab4cde8f0123456789abcd",
+    )
+    truncate_session_at_keep(source, 1)
+    branch_store = OrderedDict()
+    response = {}
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_handle_extension_sidecar_proxy", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"session_id": source.session_id, "keep_count": 1},
+    )
+    monkeypatch.setattr(routes, "_load_branch_source_or_refuse", lambda *_args: source)
+    monkeypatch.setattr(routes, "_session_requires_cli_metadata_lookup", lambda _source: True)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_record", lambda _record: True)
+    monkeypatch.setattr(routes, "get_cli_session_messages", lambda _sid: cli_messages)
+    monkeypatch.setattr(Session, "save", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(routes, "SESSIONS", branch_store)
+    monkeypatch.setattr(routes, "_evict_sessions_over_cap", lambda: None)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+
+    def capture_json(_handler, payload, status=200, **_kwargs):
+        response.update({"payload": payload, "status": status})
+        return True
+
+    monkeypatch.setattr(routes, "j", capture_json)
+
+    handled = routes.handle_post(
+        SimpleNamespace(),
+        SimpleNamespace(path="/api/session/branch", query=""),
+    )
+
+    assert handled is True
+    assert response["status"] == 200
+    branch = branch_store[response["payload"]["session_id"]]
+    assert [message["content"] for message in branch.messages] == [
+        "# Session compactée\n\nRésumé opérationnel vérifié."
     ]

--- a/tests/test_squash_session_projection.py
+++ b/tests/test_squash_session_projection.py
@@ -1,4 +1,8 @@
+from collections import OrderedDict
 from types import SimpleNamespace
+
+from api import routes
+from api.models import Session
 
 
 def _message(role, content, timestamp, message_id=None, **extra):
@@ -63,3 +67,102 @@ def test_non_squash_short_sidecar_keeps_existing_merge_behavior():
     merged = _merged_session_messages_for_display(session, state_db_messages)
 
     assert [message["id"] for message in merged] == [1, 2, 3]
+
+
+def _production_squash_projection():
+    summary = _message(
+        "assistant",
+        "# Session compactée\n\nRésumé opérationnel vérifié.",
+        200.0,
+        message_id="squash-200",
+        _squash_summary=True,
+    )
+    post_user = _message("user", "nouvelle demande", 300.0, message_id=3)
+    post_assistant = _message("assistant", "nouvelle réponse", 310.0, message_id=4)
+    sidecar_messages = [summary, post_user, post_assistant]
+    cli_messages = [
+        _message("user", "ancien prompt", 100.0, message_id=1),
+        _message("assistant", "ancienne réponse", 110.0, message_id=2),
+        dict(post_user),
+        dict(post_assistant),
+    ]
+    return sidecar_messages, cli_messages
+
+
+def test_squash_summary_with_tail_keeps_projection_authoritative_over_longer_cli_state():
+    sidecar_messages, cli_messages = _production_squash_projection()
+    session = SimpleNamespace(
+        session_id="production-squash-tail",
+        messages=sidecar_messages,
+        session_source="webui",
+        parent_session_id=None,
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+    )
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    contents = [message["content"] for message in merged]
+    assert contents == [
+        "# Session compactée\n\nRésumé opérationnel vérifié.",
+        "nouvelle demande",
+        "nouvelle réponse",
+    ]
+    assert "ancien prompt" not in contents
+    assert "ancienne réponse" not in contents
+    assert contents.count("nouvelle demande") == 1
+    assert contents.count("nouvelle réponse") == 1
+
+
+def test_branch_keep_count_uses_squash_authoritative_display_coordinates(monkeypatch, tmp_path):
+    sidecar_messages, cli_messages = _production_squash_projection()
+    source = Session(
+        session_id="production-squash-branch",
+        title="Squashed source",
+        workspace=str(tmp_path),
+        messages=sidecar_messages,
+        context_messages=list(sidecar_messages),
+        session_source="webui",
+        truncation_watermark=200.0,
+        truncation_boundary=200.0,
+        compression_anchor_mode="manual",
+    )
+    branch_store = OrderedDict()
+    response = {}
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_handle_extension_sidecar_proxy", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"session_id": source.session_id, "keep_count": 2},
+    )
+    monkeypatch.setattr(routes, "_load_branch_source_or_refuse", lambda *_args: source)
+    monkeypatch.setattr(routes, "_session_requires_cli_metadata_lookup", lambda _source: True)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_record", lambda _record: True)
+    monkeypatch.setattr(routes, "get_cli_session_messages", lambda _sid: cli_messages)
+    monkeypatch.setattr(Session, "save", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(routes, "SESSIONS", branch_store)
+    monkeypatch.setattr(routes, "_evict_sessions_over_cap", lambda: None)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+
+    def capture_json(_handler, payload, status=200, **_kwargs):
+        response.update({"payload": payload, "status": status})
+        return True
+
+    monkeypatch.setattr(routes, "j", capture_json)
+
+    handled = routes.handle_post(
+        SimpleNamespace(),
+        SimpleNamespace(path="/api/session/branch", query=""),
+    )
+
+    assert handled is True
+    assert response["status"] == 200
+    branch = branch_store[response["payload"]["session_id"]]
+    assert [message["content"] for message in branch.messages] == [
+        "# Session compactée\n\nRésumé opérationnel vérifié.",
+        "nouvelle demande",
+    ]


### PR DESCRIPTION
## Summary

- give empty `assistant` rows with `finish_reason=incomplete` a stable reconciliation identity based on their core message id
- collapse non-adjacent replays at load, reconciliation, display merge, and the final persistence boundary
- preserve squash truncation watermarks so pre-squash StateDB rows cannot be projected back into the sidecar
- persist from a detached collapsed snapshot so active workers keep their live `Session.messages` alias and concurrent appends are not lost
- compare live and `.bak` recovery counts after the same narrow collapse, preventing startup recovery from resurrecting duplicate-only amplification while still restoring genuinely unique backup messages

## Root cause

Reasoning-only Codex results can be stored as empty assistant rows with `finish_reason=incomplete` and a stable message id, but without the legacy `_partial` marker or a stable timestamp. The reconciliation identity treated those rows as anonymous, so alternating replays of the same ids were appended again on each turn. A squash projection could also reintroduce older StateDB rows when its truncation watermark was not forwarded.

The final save barrier alone is not sufficient: it must be non-destructive to the live list, and startup recovery must compare the effective transcript rather than raw duplicate counts.

## Behavior and safety

The collapse is deliberately narrow. A row is eligible only when it is:

- an `assistant` message;
- visibly empty;
- `finish_reason=incomplete`;
- free of tool calls/tool-call identity;
- carrying a non-empty stable message id.

For repeated variants of one id, the richest payload is retained. Normal user/assistant messages, completed answers, tool messages, and messages without stable ids are unchanged.

`Session.save()` serializes a collapsed snapshot without rebinding or mutating `self.messages`. A deterministic regression test appends through an existing alias while the snapshot is prepared and proves that the append remains live and is persisted by the next save.

Recovery still recommends restore when a backup has a genuinely unique extra row. It returns `no_action` only when the apparent excess collapses to the same effective incomplete-message set.

## Relation to #6569

This is complementary to #6569 rather than a duplicate. #6569 guards byte-equivalent replay rows that carry both stable `id` and timestamp identity. These reasoning-only `incomplete` rows can lack that timestamp and may have enriched variants.

The two behavioral test files from this branch were transplanted onto exact #6569 head `6d20e1ff660d8c51158a1d0f7a63433c5137375a`: **6 tests remained RED / 4 passed**, covering incomplete-id identity, load repair, post-reconciliation dedupe, save idempotence, and squash watermark projection.

## Validation

```text
126 passed in 13.07s
```

Covered suites:

- `tests/test_issue2592_partial_dedupe.py`
- `tests/test_squash_session_projection.py`
- `tests/test_issue3468_duplicate_after_compression.py`
- `tests/test_issue6481_verification_evidence_phantom.py`
- `tests/test_gateway_sync.py`
- `tests/test_metadata_save_wipe_1558.py`
- `tests/test_session_recovery_audit.py`
- `tests/test_session_recovery_api.py`

Additional gates:

- `python -m py_compile api/models.py api/routes.py api/streaming.py api/session_recovery.py`
- `git diff --check origin/master..HEAD`
- diff scan: no credentials, private paths, local patch refs, or deployment artifacts
