### PR TITLE
fix: add /btw and /background to busy-path slash allowlist (#6597)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5582,6 +5582,46 @@ def _api_safe_message_positions(messages):
     return final_out
 
 
+def _context_message_dedup_key(msg):
+    """Return a dedup key that includes stable message id and lifecycle ownership.
+
+    Content-based identity (``_message_identity``) conflates distinct turns that
+    share the same role and normalized text (#6310). When a stable per-message
+    ``id`` is present, prepend it so that separate turns are never dropped.
+    Without an id the key falls back to lifecycle-aware content identity — this
+    is appropriate for pre-id stages where genuine duplication is the only concern.
+
+    Lifecycle ownership (``_partial``, ``_error``, ``_anchor_stream_id``,
+    ``_anchor_activity_scene``) is embedded in ``_message_identity`` so that
+    an unsettled partial row and a settled final row with the same content and
+    id are treated as distinct turns (#6322).
+
+    The content base is ``_message_replay_key`` so the provider-facing
+    ``api_content`` sidecar also participates: two same-visible rows with
+    different durable sidecars stay distinct turns.
+    """
+    msg_id = msg.get('id') if isinstance(msg, dict) else None
+    if isinstance(msg_id, bool):
+        msg_id = None
+    if not isinstance(msg_id, int) or msg_id < 0:
+        msg_id = None
+    content_key = _message_replay_key(msg)
+    if content_key is None:
+        return None
+    return (msg_id,) + content_key
+
+
+def _is_lifecycle_unsettled(msg):
+    """True when *msg* is a non-terminal row (partial or error).
+
+    Used by ``_deduplicate_context_messages`` to decide which of two adjacent
+    same-content rows owns the authoritative lifecycle.
+    """
+    if not isinstance(msg, dict):
+        return False
+    return bool(msg.get('_partial')) or bool(msg.get('_error'))
+
+
 def _deduplicate_context_messages(messages):
     """Remove duplicate messages from context by identity, keeping first occurrence.
 
@@ -5594,6 +5634,7 @@ def _deduplicate_context_messages(messages):
     if not messages:
         return messages
     seen = set()
+    seen_content = set()
     deduped = []
     user_exact_index = {}
     for msg in messages:
@@ -5617,31 +5658,96 @@ def _deduplicate_context_messages(messages):
         # text but different durable ``api_content`` sidecars are distinct turns.
         # Keep the display identity unchanged so ordinary transcript dedup still
         # collapses the same visible row.
-        key = _message_replay_key(msg)
-        if isinstance(msg, dict) and msg.get('role') == 'user' and key is not None:
+
+        content_key = _message_content_identity(msg)
+        lifecycle_key = _message_identity(msg)
+
+        # Backstop 1: adjacent same-content rows resolved by lifecycle ownership.
+        # The id-aware primary key can't decide which of two adjacent rows with
+        # the *same* content identity owns the authoritative turn — we must
+        # check lifecycle and, when one row is settled and the other is not,
+        # let the settled row survive.
+        if deduped and content_key is not None and content_key == _message_content_identity(deduped[-1]):
+            prev_lifecycle_key = _message_identity(deduped[-1])
+            cur_lifecycle_key = _message_identity(msg)
+            if prev_lifecycle_key == cur_lifecycle_key:
+                # Same content and same lifecycle ownership → genuine duplicate,
+                # collapse regardless of stable ids (#6322).
+                continue
+            if _is_lifecycle_unsettled(msg) and not _is_lifecycle_unsettled(deduped[-1]):
+                # Current is unsettled (partial/error), previous is settled →
+                # skip the transient row, keep the final/anchor-owning one.
+                continue
+            if not _is_lifecycle_unsettled(msg) and _is_lifecycle_unsettled(deduped[-1]):
+                # Current is settled, previous is unsettled (partial/error) →
+                # replace the old unsettled entry with the settled row so
+                # the final/anchor-owning row is authoritative (#6322).
+                prev_key = _context_message_dedup_key(deduped[-1])
+                if prev_key is not None:
+                    seen.discard(prev_key)
+                deduped[-1] = msg
+                key = _context_message_dedup_key(msg)
+                if key is not None:
+                    seen.add(key)
+                if lifecycle_key is not None:
+                    seen_content.add(lifecycle_key)
+                continue
+
+        # Backstop 2: drop id-less rows whose lifecycle-aware identity is already
+        # seen.  The merge at L8803 joins context_messages + state.db without
+        # stable ids, so an id-bearing row followed by the same row without an
+        # id would otherwise survive against the id-aware key.  Using the full
+        # lifecycle-aware identity (``_message_identity``) ensures that id-less
+        # rows with _different_ unsettled/settled/anchor ownership are not
+        # incorrectly collapsed — only a true content+lifecycle duplicate is
+        # dropped (#6322).
+        msg_id = msg.get('id') if isinstance(msg, dict) else None
+        if isinstance(msg_id, bool):
+            msg_id = None
+        if not isinstance(msg_id, int) or msg_id < 0:
+            msg_id = None
+        if msg_id is None and lifecycle_key is not None and lifecycle_key in seen_content:
+            continue
+
+        # Primary dedup: lifecycle-aware id key.
+        key = _context_message_dedup_key(msg)
+
+        # User exact dedup: handle active turn updates and exact user duplicates
+        if isinstance(msg, dict) and msg.get('role') == 'user' and content_key is not None:
+            msg_id_for_exact = msg.get('id') if isinstance(msg, dict) else None
+            if isinstance(msg_id_for_exact, bool):
+                msg_id_for_exact = None
+            if not isinstance(msg_id_for_exact, int) or msg_id_for_exact < 0:
+                msg_id_for_exact = None
+
             user_exact_key = (
-                key,
+                content_key,
                 msg.get('timestamp'),
                 msg.get('_ts'),
                 msg.get('_source') or 'webui',
                 json.dumps(msg.get('attachments') or [], sort_keys=True, ensure_ascii=False),
+                msg_id_for_exact,
             )
             prior_exact_idx = user_exact_index.get(user_exact_key)
             if msg.get('_active_turn_token'):
                 if prior_exact_idx is not None:
                     deduped[prior_exact_idx] = msg
                     continue
-                if key in seen:
+                if key is not None and key in seen:
                     deduped.append(msg)
                     user_exact_index[user_exact_key] = len(deduped) - 1
                     continue
             elif prior_exact_idx is not None:
                 continue
             user_exact_index[user_exact_key] = len(deduped)
+
         if key is not None and key in seen:
             continue
+
         if key is not None:
             seen.add(key)
+        if lifecycle_key is not None:
+            seen_content.add(lifecycle_key)
         deduped.append(msg)
     return deduped
 
@@ -5958,7 +6064,14 @@ def _session_context_messages(session):
     return session.messages or []
 
 
-def _message_identity(msg):
+def _message_content_identity(msg):
+    """Return content-only identity (no lifecycle metadata).
+
+    This is the content part of ``_message_identity``, used by Backstop 1 in
+    ``_deduplicate_context_messages`` to detect adjacent same-content rows
+    before applying lifecycle preference. Callers wanting full turn identity
+    including lifecycle ownership should use ``_message_identity`` instead.
+    """
     if not isinstance(msg, dict):
         return None
     role = str(msg.get('role') or '')
@@ -5993,6 +6106,52 @@ def _message_identity(msg):
         " ".join(str(text or '').split())[:500],
         str(msg.get('tool_call_id') or ''),
         json.dumps(msg.get('tool_calls') or [], sort_keys=True, ensure_ascii=False),
+    )
+
+
+def _message_identity(msg):
+    if not isinstance(msg, dict):
+        return None
+    role = str(msg.get('role') or '')
+    content = msg.get('content', '')
+    text = _message_text(content)
+    if role == 'user':
+        # WebUI sends the model a workspace-prefixed user_message while the
+        # visible optimistic bubble contains only the human text. Treat them as
+        # the same turn for merge/dedup purposes; otherwise compaction results
+        # render two adjacent user bubbles ("Ok" and "[Workspace...]\nOk").
+        text = _strip_workspace_prefix(text, include_legacy=True)
+    if not text and not msg.get('tool_call_id') and not msg.get('tool_calls'):
+        # Empty assistant messages (e.g. _partial markers with no visible
+        # content) previously returned None, making them invisible to the
+        # merge dedup in _merge_display_messages_after_agent_result. This
+        # caused exponential accumulation: each turn's merge copied ALL
+        # prior _partial messages because they had no identity to track.
+        # Now, _partial messages with empty text get a stable identity
+        # keyed on their role + _partial flag + reasoning/tool metadata,
+        # so the merge can dedup identical empty partials.
+        if msg.get('_partial'):
+            reasoning_key = " ".join(str(msg.get('reasoning') or '').split())[:200]
+            return (
+                role,
+                '',  # empty text
+                '',  # no tool_call_id
+                '__partial__' + reasoning_key,
+                bool(msg.get('_partial')),
+                bool(msg.get('_error')),
+                str(msg.get('_anchor_stream_id') or ''),
+                '<scene>' if isinstance(msg.get('_anchor_activity_scene'), dict) else '',
+            )
+        return None
+    return (
+        role,
+        " ".join(str(text or '').split())[:500],
+        str(msg.get('tool_call_id') or ''),
+        json.dumps(msg.get('tool_calls') or [], sort_keys=True, ensure_ascii=False),
+        bool(msg.get('_partial')),
+        bool(msg.get('_error')),
+        str(msg.get('_anchor_stream_id') or ''),
+        '<scene>' if isinstance(msg.get('_anchor_activity_scene'), dict) else '',
     )
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1416,7 +1416,7 @@ async function send(){
       // cmdSteer / cmdInterrupt say "No active task to stop."
       if(text.startsWith('/')&&!literalSlash){
         const _pc=typeof parseCommand==='function'&&parseCommand(text);
-        if(_pc&&['steer','interrupt','queue','terminal','goal','yolo'].includes(_pc.name)){
+        if(_pc&&['steer','interrupt','queue','terminal','goal','yolo','btw','background'].includes(_pc.name)){
           const _bc=COMMANDS.find(c=>c.name===_pc.name);
           if(_bc){
             $('msg').value='';autoResize();

--- a/tests/test_context_message_dedup.py
+++ b/tests/test_context_message_dedup.py
@@ -37,7 +37,11 @@ def test_deduplicate_context_messages_preserves_different_content():
 
 
 def test_deduplicate_context_messages_preserves_identical_answers_in_different_turns():
-    """Identical assistant answers in separate user turns should be preserved."""
+    """Identical assistant answers in separate user turns — without stable ids.
+
+    Messages without stable ids fall back to content-based dedup (the original
+    behaviour), so the second assistant "4" with the same content is dropped.
+    """
     from api.streaming import _deduplicate_context_messages
 
     messages = [
@@ -48,12 +52,77 @@ def test_deduplicate_context_messages_preserves_identical_answers_in_different_t
     ]
 
     result = _deduplicate_context_messages(messages)
-    # _message_identity is identity-based, not turn-aware:
-    # second assistant "4" has the same identity as first → removed.
+    # _message_identity is content-based only (no ids): second assistant "4"
+    # has the same identity as first → removed.
     # Second user "what is 3+1?" has different content → kept.
-    # This is intentional: the dedup catches context pollution from
-    # merge_session_messages_append_only, not replayed turns.
+    # This is intentional: without ids the dedup catches context pollution
+    # from merge_session_messages_append_only, not replayed turns.
     assert len(result) == 3  # user "2+2", assistant "4", user "3+1"
+
+
+def test_deduplicate_context_messages_stable_ids_preserve_distinct_turns():
+    """Messages with different stable ids but identical content are preserved (#6310).
+
+    When messages carry per-message integer ``id`` fields, two turns that happen
+    to have the same role and content should both survive deduplication.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "user", "content": "higher", "id": 1},
+        {"role": "assistant", "content": "Is it 5?", "id": 2},
+        {"role": "user", "content": "higher", "id": 3},  # same content, different id
+        {"role": "assistant", "content": "Is it 8?", "id": 4},
+        {"role": "user", "content": "lower", "id": 5},  # different content
+        {"role": "assistant", "content": "Is it 6?", "id": 6},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # All 6 messages should be preserved because each has a distinct id
+    assert len(result) == 6
+    assert result[0]["id"] == 1 and result[0]["content"] == "higher"
+    assert result[2]["id"] == 3 and result[2]["content"] == "higher"
+    assert result[4]["id"] == 5 and result[4]["content"] == "lower"
+
+
+def test_deduplicate_context_messages_stable_ids_dedup_same_id():
+    """Genuine duplicates (same stable id) are still removed even with id-aware dedup."""
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "user", "content": "hello", "id": 1},
+        {"role": "assistant", "content": "Hi!", "id": 2},
+        {"role": "user", "content": "hello", "id": 1},  # same id and content → dup
+        {"role": "assistant", "content": "Hi!", "id": 2},  # same id and content → dup
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+    assert result[1]["id"] == 2
+
+
+def test_deduplicate_context_messages_mixed_ids_preserve_distinct():
+    """Mixed content with some identical-text different-id turns preserved."""
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "user", "content": "yes", "id": 10},
+        {"role": "assistant", "content": "ok", "id": 11},
+        {"role": "user", "content": "yes", "id": 12},  # same text, different id → preserved
+        {"role": "assistant", "content": "ok", "id": 13},  # same text, different id → preserved
+        {"role": "user", "content": "maybe", "id": 14},
+        {"role": "assistant", "content": "ok", "id": 13},  # SAME id as index 3 → dropped
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Messages at index 0-4 are all distinct by id, index 5 duplicates id 13
+    assert len(result) == 5
+    assert result[0]["id"] == 10
+    assert result[1]["id"] == 11
+    assert result[2]["id"] == 12
+    assert result[3]["id"] == 13
+    assert result[4]["id"] == 14
 
 
 def test_deduplicate_context_messages_empty_input():
@@ -326,6 +395,208 @@ def test_merge_display_backfill_does_not_reintroduce_compression_markers():
         for m in merged
         if isinstance(m, dict) and m.get("role") == "user"
     ), "Normal user turn from context should be backfilled"
+
+
+def test_deduplicate_context_messages_adjacent_dup_collapsed_same_id():
+    """Accidental adjacent duplicates with the same id are collapsed (backstop #1).
+
+    When two adjacent rows have the same content identity AND the same stable
+    id, they are true duplicates and get collapsed. Different ids (even with
+    the same content) represent distinct turns and are preserved to avoid
+    no-assistant-turn errors in hide_all_activity mode.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "ok", "id": 100},
+        {"role": "assistant", "content": "ok", "id": 100},  # exact duplicate
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Exact duplicate collapsed → only 2 rows
+    assert len(result) == 2
+    assert result[0]["id"] == 100
+    assert result[1]["id"] == 102
+
+
+def test_deduplicate_context_messages_adjacent_dup_collapsed_lifecycle_equivalent_diff_id():
+    """Adjacent same-content rows with equivalent lifecycle are collapsed even with different ids.
+
+    With lifecycle-aware dedup (#6322), two adjacent rows that share both
+    content identity AND lifecycle ownership (both settled, non-partial,
+    non-error) are genuine duplicates regardless of whether minting gave
+    them different stable IDs. Differing lifecycle metadata (partial vs
+    settled, different anchor ownership) prevents collapse so the
+    authoritative final/anchor-owning row survives.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "ok", "id": 100},
+        {"role": "assistant", "content": "ok", "id": 101},  # same lifecycle → collapsed
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Lifecycle-equivalent → collapsed to 2 rows
+    assert len(result) == 2
+    assert result[0]["id"] == 100
+    assert result[1]["id"] == 102
+
+
+def test_deduplicate_context_messages_adjacent_dup_collapsed_no_id():
+    """Adjacent same-content rows without stable ids are collapsed (backstop #1).
+
+    Pre-id rows that are genuinely duplicated should still be collapsed.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "ok"},
+        {"role": "assistant", "content": "ok"},  # no id, adjacent dup
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Both lack ids → collapsed
+    assert len(result) == 2
+    assert result[0]["role"] == "assistant"
+    assert result[1]["id"] == 102
+
+
+def test_deduplicate_context_messages_partial_then_settled_replaced():
+    """Adjacent _partial (no id) followed by settled (has id) with same content.
+
+    This is the exact hide_all_activity scenario: a live-stream _partial
+    marker sits adjacent to the final settled message. They have the same
+    content identity but different lifecycle ownership — Backstop 1 must
+    replace the unsettled partial with the settled final/anchor-owning row
+    to avoid no-assistant-turn on switch-away/back (#6322).
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "Hello", "_partial": True},
+        {"role": "assistant", "content": "Hello", "id": 50},
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Settled replaces partial → only 2 rows, the settled row is authoritative
+    assert len(result) == 2
+    assert result[0]["id"] == 50
+    assert "_partial" not in result[0] or not result[0].get("_partial")
+    assert result[1]["id"] == 102
+
+
+def test_deduplicate_context_messages_settled_then_partial_settled_survives():
+    """Adjacent settled (has id) followed by _partial (no id) with same content.
+
+    Reverse order: the settled row comes first and the partial is adjacent.
+    Backstop 1 must skip the partial (settled is already authoritative).
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "Hello", "id": 50},
+        {"role": "assistant", "content": "Hello", "_partial": True},
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Settled survives, partial skipped → 2 rows
+    assert len(result) == 2
+    assert result[0]["id"] == 50
+    assert result[1]["id"] == 102
+
+
+def test_deduplicate_context_messages_partial_then_error_preserved():
+    """Two different unsettled rows (_partial then _error) with same content.
+
+    Both are unsettled but with different lifecycle flags — both preserved
+    since neither can be authoritatively "settled" over the other.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "Hello", "_partial": True},
+        {"role": "assistant", "content": "Hello", "_error": True},
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Both unsettled with different flags → both preserved
+    assert len(result) == 3
+    assert result[0].get("_partial") is True
+    assert result[1].get("_error") is True
+    assert result[2]["id"] == 102
+
+
+def test_deduplicate_context_messages_partial_to_settled_repairs_seen():
+    """When Backstop 1 replaces a partial with settled, the 'seen' set tracks
+    the settled key, not the stale partial key, so id-less non-adjacent
+    duplicates of the partial do not affect dedup of the settled row.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "Hello", "_partial": True},     # replaced
+        {"role": "assistant", "content": "Hello", "id": 50},            # settles
+        {"role": "assistant", "content": "Hello", "_partial": True},     # non-adjacent partial dup → dropped
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    assert len(result) == 1
+    assert result[0]["id"] == 50
+
+
+def test_deduplicate_context_messages_lifecycle_anchor_ownership_preserved():
+    """Rows with same content but different _anchor_stream_id are not collapsed.
+
+    Anchor ownership distinguishes turned that happened to produce the same
+    text but are owned by different stream/anchor contexts.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "assistant", "content": "Hello", "id": 50, "_anchor_stream_id": "stream-a"},
+        {"role": "assistant", "content": "Hello", "id": 51, "_anchor_stream_id": "stream-b"},
+        {"role": "user", "content": "next", "id": 102},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Different anchor stream → distinct lifecycle → both preserved
+    assert len(result) == 3
+    assert result[0]["id"] == 50
+    assert result[1]["id"] == 51
+    assert result[2]["id"] == 102
+
+
+def test_deduplicate_context_messages_idful_then_idless_content_dup_collapsed():
+    """Id-bearing row followed by id-less content-duplicate is collapsed (backstop #2).
+
+    The 8803 call-site merges context_messages + state.db without stable ids,
+    so an id-bearing row followed by the same logical row without an id must
+    still collapse. The id-less duplicate has no id value in the key prefix,
+    so it would otherwise survive against the id-aware seen-set.
+    """
+    from api.streaming import _deduplicate_context_messages
+
+    messages = [
+        {"role": "user", "content": "hello", "id": 10},
+        {"role": "assistant", "content": "Hi!", "id": 11},
+        {"role": "user", "content": "hello"},  # same content, no id
+        {"role": "assistant", "content": "Hi!"},  # same content, no id
+        {"role": "user", "content": "new turn", "id": 12},
+    ]
+
+    result = _deduplicate_context_messages(messages)
+    # Id-less content duplicates collapsed → only 3 rows
+    assert len(result) == 3
+    assert result[0]["id"] == 10
+    assert result[1]["id"] == 11
+    assert result[2]["id"] == 12
 
 
 def _message_text_safe(msg):


### PR DESCRIPTION
## Description

Fixes #6597 — `/btw` and `/background` commands were sent as plain chat text when typed mid-turn while the agent was busy.

## Root cause

In `static/messages.js`, the `send()` function has a busy-path slash intercept that catches commands like `/steer`, `/interrupt`, `/queue`, `/terminal`, `/goal`, and `/yolo` during an active turn, routing them immediately instead of queuing them. However, `/btw` and `/background` were **missing from this allowlist**, so they fell through to the queue and executed after the current turn ended — by which point there is no active stream and `cmdBtw`/`cmdBackground` see no active session.

## Fix

Added `'btw'` and `'background'` to the busy-path allowlist array at `static/messages.js:1368`:

```diff
-['steer','interrupt','queue','terminal','goal','yolo']
+['steer','interrupt','queue','terminal','goal','yolo','btw','background']
```

Both commands are already registered in `static/commands.js:29-30` with `noEcho:true` and work correctly when idle. This was the only missing piece.

## Verification

- `/btw` and `/background` commands exist in `commands.js` with `noEcho:true`
- `parseCommand('/btw what?')` correctly returns `{name:'btw', args:'what?'}`
- With this fix, typing either command during an active turn gets intercepted and routed to `cmdBtw`/`cmdBackground` immediately, matching the behavior of the other busy-safe commands