### PR TITLE
fix: update session.model after gateway failover (#6594)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11655,6 +11655,15 @@ def _run_agent_streaming(
                     _history = list(getattr(s, 'gateway_routing_history', None) or [])
                     _history.append(_gateway_routing)
                     s.gateway_routing_history = _history[-50:]
+                # #6594: after gateway failover, update session.model to the
+                # actual model that processed the turn so downstream consumers
+                # (composer chip, sidebar, export, session recovery) show the
+                # correct model label instead of the stale configured default.
+                if _used_model and _gateway_routing:
+                    _norm_used = str(_used_model).strip().lower()
+                    _norm_current = str(getattr(s, 'model', '') or '').strip().lower()
+                    if _norm_used and _norm_used != _norm_current:
+                        s.model = _used_model
                 if s.messages:
                     for _dm in reversed(s.messages):
                         if isinstance(_dm, dict) and _dm.get('role') == 'assistant':


### PR DESCRIPTION
## Problem

The WebUI model display (composer chip + sidebar session list) shows the **configured default model** from `config.yaml` even when the Hermes gateway has transparently failed over to a different model.

**Example:**
1. config.yaml sets `model.default: custom:LongCat-2.0`
2. Composer shows "LongCat 2.0"
3. Gateway fails to reach LongCat, falls back to `gemini-2.5-flash`
4. Composer **still reads "LongCat 2.0"**

## Root Cause

`s.model` is set once at session creation (`api/routes.py`) and never updated after gateway routing. The `_used_model` is correctly computed in `api/streaming.py` after `agent.run()` (per #6068), and `gateway_routing` is populated on the session — but `s.model` itself is never mutated to reflect the actual model that processed each turn.

## Fix (Option A — source of truth)

In `api/streaming.py`, after computing `_gateway_routing` and `_used_model` (the agent actual model after failover), compare `_used_model` with the current `s.model`. If they differ, update `s.model` to the actual used model.

This is the single-shot fix — every downstream consumer of `session.model` (composer chip, sidebar session list, metadata, export, session recovery) now automatically reflects the real model without individual changes at each display surface.

## Why this works everywhere

- **Composer chip** (`syncModelChip` in ui.js:3823): already calls `_formatGatewayModelLabel(sel.value, compactText, routing)` which uses `routing.used_model` when available. When routing is absent, it falls back to the model dropdown value — which is now also correct since the backend updates `s.model`.
- **Sidebar session list** (`sessions.js:8152`): already uses `_formatSessionModelWithGateway(s)` which calls `_formatGatewayModelLabel`. With `s.model` updated, even the fallback path shows the correct model.
- **Sidebar session meta** — already uses the same gateway-routing-aware formatting.

## Verification

- [x] Existing tests `test_732_gateway_routing_metadata.py` — 5 passed
- [x] Existing tests `test_issue6068_used_model_footer.py` — 8 passed
- [x] Python syntax checked via `py_compile`

Closes #6594