### PR TITLE
fix(test): pin mcp SDK to compatible 1.x range with bootstrap guard (#6602)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7,7 +7,7 @@ Option A rewrite (2026-05-08): imports api.models and api.profiles
 directly from the webui codebase, using canonical helpers for
 locking, profile scoping, index consistency, and validation.
 
-    pip install "mcp<2"   # one-time setup
+    pip install "mcp>=1.28,<2"   # one-time setup
     python3 mcp_server.py # start via stdio
 
 MCP config for Hermes Agent (add to config.yaml):
@@ -446,6 +446,23 @@ async def handle_move_session(arguments: dict) -> list[TextContent]:
         "method": "api",
     }, ensure_ascii=False, indent=2))]
 
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  MCP SDK version guard
+# ═════════════════════════════════════════════════════════════════════════==
+#
+# mcp>=2.0.0 removed the Server.list_tools / Server.call_tool decorator API
+# used by this server. Fail fast instead of producing secondary errors.
+
+if not hasattr(Server, "list_tools"):  # pragma: no cover
+    import sys
+    print(
+        "ERROR: mcp SDK incompatible. This server requires mcp>=1.28,<2 "
+        "(the 1.x Python SDK with the decorator API). "
+        "Run: pip install 'mcp>=1.28,<2'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 # ═══════════════════════════════════════════════════════════════════════════
 #  MCP Server wiring

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-timeout
 pytest-asyncio
 pytest-shard
 ruff
-mcp<2
+mcp>=1.28,<2
 # Optional Office parsers — runtime-optional (commented in requirements.txt), but
 # installed here so the workspace Office-preview tests (tests/test_issue540_*.py)
 # run under the documented ./scripts/test.sh entry point. These files


### PR DESCRIPTION
Closes #6602

## Problem

`requirements-dev.txt` had `mcp<2` (from PR #6564), which prevents installing mcp 2.x but lacks a minimum version floor. An incompatible mcp SDK (2.x) still produces dozens of obscure test failures from `tests/test_mcp_server.py` during collection/setup.

## Changes

1. **requirements-dev.txt**: `mcp<2` → `mcp>=1.28,<2` — explicit compatible range with both lower and upper bounds.
2. **mcp_server.py docstring**: `pip install "mcp<2"` → `pip install "mcp>=1.28,<2"` — keep the setup command consistent.
3. **mcp_server.py bootstrap guard**: Added an import-time `hasattr(Server, "list_tools")` check that fails fast with a clear error message if the installed mcp SDK doesn't expose the decorator API, instead of drowning in secondary errors.

## Verification

- `mcp>=1.28,<2` resolves to `mcp==1.X` (the compatible major range)
- The guard catches incompatible versions at import time and prints:
  `ERROR: mcp SDK incompatible. This server requires mcp>=1.28,<2 (the 1.x Python SDK with the decorator API). Run: pip install 'mcp>=1.28,<2'`

## Rationale

PR #6564 added the upper-bound pin (`mcp<2`) to fix the immediate breakage. This PR completes the mitigation by:
- Adding a minimum version floor (`>=1.28`) so early 1.x releases with potential API gaps are excluded
- Adding a runtime guard that surfaces a clear, actionable message instead of dozens of test failures from an incompatible install