### PR TITLE
fix(streaming): preserve interrupted tool context

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1783,6 +1783,154 @@ def _settle_result_messages(
     return result_messages
 
 
+def _extract_current_turn_completed_tool_rows(
+    result_messages,
+    msg_text,
+    *,
+    active_turn_identity=None,
+    previous_context_messages=None,
+):
+    """Return user + complete tool-call/result rows for the current turn."""
+    if isinstance(result_messages, dict):
+        result_messages = result_messages.get('messages')
+    cleaned = _drop_synthetic_control_messages(result_messages)
+    cleaned = _drop_synthetic_max_iteration_summary_requests(cleaned)
+    if not cleaned:
+        return []
+
+    previous_context_messages = list(previous_context_messages or [])
+    if _active_turn_boundary_is_valid(active_turn_identity):
+        current_user_idx = _find_active_turn_checkpoint_index(
+            cleaned,
+            previous_context_messages,
+            active_turn_identity,
+            msg_text,
+        )
+        if current_user_idx is None:
+            return []
+    else:
+        current_user_idx = _find_current_user_turn(cleaned, msg_text)
+    if current_user_idx is None:
+        return []
+
+    turn_messages = cleaned[current_user_idx:]
+    if len(turn_messages) < 2:
+        return []
+
+    for idx in range(1, len(turn_messages)):
+        if (
+            isinstance(turn_messages[idx], dict)
+            and turn_messages[idx].get('role') == 'user'
+        ):
+            turn_messages = turn_messages[:idx]
+            break
+
+    turn_messages = _sanitize_messages_for_api(turn_messages)
+    if not turn_messages:
+        return []
+    current_user = turn_messages[0]
+    if not isinstance(current_user, dict) or current_user.get('role') != 'user':
+        return []
+
+    completed_tool_result_ids = {
+        str(msg.get('tool_call_id') or '')
+        for msg in turn_messages
+        if isinstance(msg, dict)
+        and msg.get('role') == 'tool'
+        and str(msg.get('tool_call_id') or '')
+    }
+    if not completed_tool_result_ids:
+        return []
+
+    last_tool_result_idx = max(
+        idx
+        for idx, msg in enumerate(turn_messages)
+        if isinstance(msg, dict)
+        and msg.get('role') == 'tool'
+        and str(msg.get('tool_call_id') or '') in completed_tool_result_ids
+    )
+
+    rows = [copy.deepcopy(current_user)]
+    for msg in turn_messages[1:last_tool_result_idx + 1]:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get('role')
+        if role == 'assistant' and msg.get('tool_calls'):
+            cleaned_calls = []
+            for tc in msg.get('tool_calls') or []:
+                if not isinstance(tc, dict):
+                    continue
+                tc_id = str(tc.get('id') or tc.get('call_id') or '')
+                if tc_id in completed_tool_result_ids:
+                    cleaned_calls.append(copy.deepcopy(tc))
+            if not cleaned_calls:
+                continue
+            tool_row = copy.deepcopy(msg)
+            tool_row['tool_calls'] = cleaned_calls
+            rows.append(tool_row)
+            continue
+        if role == 'tool' and str(msg.get('tool_call_id') or '') in completed_tool_result_ids:
+            rows.append(copy.deepcopy(msg))
+    return rows
+
+
+def _preserve_cancelled_turn_tool_context(
+    session,
+    stream_id,
+    result_messages,
+    previous_context_messages,
+    msg_text,
+    source,
+    active_turn_identity,
+    ephemeral=False,
+):
+    """Persist completed current-turn tool context for a cancelled turn."""
+    if ephemeral:
+        return True
+    if not _can_settle_cancelled_turn_result(session, stream_id, msg_text):
+        return False
+
+    context_rows = _extract_current_turn_completed_tool_rows(
+        result_messages,
+        msg_text,
+        active_turn_identity=active_turn_identity,
+        previous_context_messages=previous_context_messages,
+    )
+    if not context_rows:
+        return True
+
+    context_rows = list(context_rows)
+    if previous_context_messages is None:
+        previous_context = list(session.context_messages or [])
+    else:
+        previous_context = list(previous_context_messages)
+    if [
+        _message_text(msg.get('content')) for msg in (session.context_messages or [])
+        if _is_context_compression_marker(msg)
+    ] != [
+        _message_text(msg.get('content')) for msg in previous_context
+        if _is_context_compression_marker(msg)
+    ]:
+        return True
+    merge_base = previous_context + list(context_rows)
+    next_context = _dedupe_replayed_context_messages(
+        previous_context,
+        merge_base,
+        msg_text,
+    )
+    next_context = _settle_current_turn_boundary(
+        previous_context,
+        next_context,
+        active_turn_identity,
+        msg_text,
+        source,
+    )
+    session.context_messages = _deduplicate_context_messages(
+        next_context if next_context else previous_context
+    )
+    return True
+
+
 def _current_turn_already_has_visible_assistant_answer(messages, *, active_turn_identity=None):
     """Return True only when the token-owned current turn already has visible assistant prose."""
     if not isinstance(active_turn_identity, dict) or not active_turn_identity.get('token'):
@@ -6065,6 +6213,59 @@ def _stream_writeback_can_supersede_recovery_marker(session, msg_text):
     return False
 
 
+def _stream_writeback_can_supersede_cancelled_turn_marker(session, msg_text):
+    """Allow a finishing worker to replace a persisted cancel marker row.
+
+    cancel_stream() may clear ``active_stream_id`` before the stream worker
+    finishes; in that case this helper permits that worker to retain completed
+    tool context as long as this turn is the visible latest cancellation turn.
+    """
+    if getattr(session, 'active_stream_id', None):
+        return False
+    if getattr(session, 'pending_user_message', None):
+        return False
+    if getattr(session, 'pending_attachments', None):
+        return False
+
+    messages = list(getattr(session, 'messages', None) or [])
+    if not messages:
+        return False
+
+    marker = messages[-1]
+    if not isinstance(marker, dict):
+        return False
+    if marker.get('role') != 'assistant' or not marker.get('_error'):
+        return False
+    content = str(marker.get('content') or '')
+    norm = content.strip().lower()
+    if not any(pattern in norm for pattern in _CANCEL_MARKER_PATTERNS):
+        return False
+
+    expected = ' '.join(str(msg_text or '').split())
+    if not expected:
+        return False
+    for idx in range(len(messages) - 2, -1, -1):
+        msg = messages[idx]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get('_error'):
+            continue
+        if msg.get('role') != 'user':
+            continue
+        actual = ' '.join(str(msg.get('content') or '').split())
+        return actual == expected
+    return False
+
+
+def _can_settle_cancelled_turn_result(session, stream_id, msg_text):
+    """Return True when interrupted-result settlement for this turn is still valid."""
+    if _stream_writeback_is_current(session, stream_id):
+        return True
+    if _stream_writeback_can_supersede_cancelled_turn_marker(session, msg_text):
+        return True
+    return False
+
+
 def _advance_truncation_watermark_after_commit(session) -> None:
     """Advance a positive truncation watermark once a new user turn is committed
     to ``session.messages`` (#3831).
@@ -9594,6 +9795,21 @@ def _run_agent_streaming(
                 result=result,
                 agent=agent,
             )
+
+            def _settle_cancelled_turn_tool_context():
+                try:
+                    _preserve_cancelled_turn_tool_context(
+                        s,
+                        stream_id,
+                        result,
+                        _previous_owner_context_messages,
+                        msg_text,
+                        _turn_pending_source,
+                        _active_turn_identity,
+                        ephemeral,
+                    )
+                except Exception:
+                    logger.debug("Failed to preserve tool context during cancellation", exc_info=True)
             # #4729: the run is done — flush any reasoning tail still in the coalescing
             # buffer (the agent never calls reasoning_callback(None), and a turn can end on
             # reasoning with no trailing token/tool boundary to trigger a flush) so the last
@@ -9608,6 +9824,7 @@ def _run_agent_streaming(
                     _cleanup_ephemeral_cancelled_turn(s)
                 else:
                     with _agent_lock:
+                        _settle_cancelled_turn_tool_context()
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:
                             append_turn_journal_event_for_stream(
@@ -9650,6 +9867,7 @@ def _run_agent_streaming(
                 _ckpt_thread.join(timeout=15)
             if cancel_event.is_set():
                 with _agent_lock:
+                    _settle_cancelled_turn_tool_context()
                     _finalize_cancelled_turn(s, ephemeral=False)
                     try:
                         append_turn_journal_event_for_stream(
@@ -9711,6 +9929,7 @@ def _run_agent_streaming(
                         if isinstance(result, dict):
                             result = {**result, 'messages': _result_messages}
                     if cancel_event.is_set():
+                        _settle_cancelled_turn_tool_context()
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:
                             append_turn_journal_event_for_stream(
@@ -9963,6 +10182,7 @@ def _run_agent_streaming(
                 # _token_sent tracks whether on_token() was called (any streamed text)
                 if _terminal_failure or (not _assistant_added and not _token_sent):
                     if cancel_event.is_set():
+                        _settle_cancelled_turn_tool_context()
                         _finalize_cancelled_turn(s, ephemeral=ephemeral)
                         if not ephemeral:
                             try:
@@ -10624,6 +10844,7 @@ def _run_agent_streaming(
                         except Exception:
                             logger.debug("Failed to append assistant_started turn journal event", exc_info=True)
                 if cancel_event.is_set():
+                    _settle_cancelled_turn_tool_context()
                     _finalize_cancelled_turn(s, ephemeral=False)
                     try:
                         append_turn_journal_event_for_stream(
@@ -10642,6 +10863,7 @@ def _run_agent_streaming(
                 with _stream_writeback_stage(_writeback_timings, "session_save"):
                     s.save()
                 if cancel_event.is_set():
+                    _settle_cancelled_turn_tool_context()
                     _finalize_cancelled_turn(s, ephemeral=False)
                     try:
                         append_turn_journal_event_for_stream(
@@ -10746,6 +10968,7 @@ def _run_agent_streaming(
             _lock_ctx = _agent_lock if _agent_lock is not None else contextlib.nullcontext()
             with _lock_ctx:
                 if cancel_event.is_set():
+                    _settle_cancelled_turn_tool_context()
                     _finalize_cancelled_turn(s, ephemeral=False)
                     try:
                         append_turn_journal_event_for_stream(
@@ -10778,6 +11001,7 @@ def _run_agent_streaming(
                             s.save(touch_updated_at=False)
                         except Exception:
                             logger.debug("Failed to persist restored process wakeup pause", exc_info=True)
+                        _settle_cancelled_turn_tool_context()
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:
                             append_turn_journal_event_for_stream(
@@ -10801,6 +11025,7 @@ def _run_agent_streaming(
                             s.save(touch_updated_at=False)
                         except Exception:
                             logger.debug("Failed to persist restored process wakeup pause", exc_info=True)
+                        _settle_cancelled_turn_tool_context()
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:
                             append_turn_journal_event_for_stream(

--- a/tests/test_cancelled_turn_result_settlement.py
+++ b/tests/test_cancelled_turn_result_settlement.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from api.streaming import _preserve_cancelled_turn_tool_context, _sanitize_messages_for_api
+
+
+class _DummySession:
+    def __init__(
+        self,
+        *,
+        context_messages=None,
+        messages=None,
+        active_stream_id="stream-active",
+        pending_user_message=None,
+        pending_attachments=None,
+    ):
+        self.session_id = "cancelled-context-session"
+        self.path = ""
+        self.active_stream_id = active_stream_id
+        self.pending_user_message = pending_user_message
+        self.pending_attachments = [] if pending_attachments is None else list(pending_attachments)
+        self.pending_started_at = 1_700_000_000
+        self.pending_user_source = "webui"
+        self.messages = list(messages or [])
+        self.context_messages = deepcopy(context_messages or [])
+
+    def save(self, *args, **kwargs):
+        return None
+
+
+def _turn_identity(msg_text, current_turn_user_idx, *, token="tok"):
+    return {"token": token, "source": "webui", "text": msg_text, "timestamp": 1_700_000_000, "attachments": [], "current_turn_user_idx": current_turn_user_idx, "turn_id": "turn"}
+
+
+def _interrupted_user(msg_text):
+    return {"role": "user", "content": msg_text, "_recovered": True}
+
+
+def _cancelled_marker():
+    return {"role": "assistant", "content": "**Task cancelled:** Task cancelled.", "_error": True}
+
+
+def _compression_marker(content="[context compaction — summary]"):
+    return {"role": "assistant", "content": content, "_compressed_summary": True}
+
+
+def _settle(
+    *, session, msg_text, result_messages, result_identity, ephemeral=False, previous_context_messages=None
+):
+    if previous_context_messages is None:
+        previous_context_messages = list(session.context_messages or [])
+    return _preserve_cancelled_turn_tool_context(session, "stream-active", result_messages, list(previous_context_messages), msg_text, "webui", result_identity, ephemeral=ephemeral)
+
+
+def _tool_result_messages(msg_text):
+    return [
+        {"role": "user", "content": msg_text},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc-commit", "type": "function", "function": {"name": "git_commit", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "commit abc1234", "tool_call_id": "tc-commit"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc-status", "type": "function", "function": {"name": "git_status", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "clean", "tool_call_id": "tc-status"},
+        {"role": "assistant", "tool_calls": [{"id": "tc-unused", "type": "function", "function": {"name": "noop", "arguments": "{}"}}]},
+        {"role": "assistant", "content": "trailing prose"},
+    ]
+
+
+def _repeated_prompt_with_stale_index_messages(prompt):
+    return [
+        {"role": "user", "content": prompt},
+        {"role": "assistant", "content": "old"},
+        {"role": "assistant", "tool_calls": [{"id": "tc-old", "type": "function", "function": {"name": "noop", "arguments": "{}"}}]},
+        {"role": "tool", "content": "old ok", "tool_call_id": "tc-old"},
+        {
+            "role": "user",
+            "content": prompt,
+            "_active_turn_token": "turn-current",
+        },
+        {"role": "assistant", "tool_calls": [{"id": "tc-new", "type": "function", "function": {"name": "noop", "arguments": "{}"}}]},
+        {"role": "tool", "content": "new ok", "tool_call_id": "tc-new"},
+        {"role": "assistant", "content": "tail"},
+    ]
+
+
+def test_preserve_completed_tool_rows_and_block_newer_turn():
+    msg_text = "remove last commit"
+    base_context = [{"role": "user", "content": "seed"}, {"role": "assistant", "content": "ok"}]
+    result_payload = {"messages": _tool_result_messages(msg_text), "final_response": "ok"}
+    identity = _turn_identity(msg_text, current_turn_user_idx=0)
+
+    session = _DummySession(
+        context_messages=deepcopy(base_context),
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(session=session, msg_text=msg_text, result_messages=result_payload, result_identity=identity) is True
+    settled = _sanitize_messages_for_api(session.context_messages)
+    assert [m.get("role") for m in settled] == ["user", "assistant", "user", "assistant", "tool", "assistant", "tool"]
+    assert not any(m.get("content") == "trailing prose" for m in settled)
+    assert not any(m.get("role") == "assistant" and any(tc.get("id") == "tc-unused" for tc in (m.get("tool_calls") or [])) for m in settled)
+
+    session_with_tail = _DummySession(
+        context_messages=base_context
+        + _tool_result_messages(msg_text)
+        + [{"role": "assistant", "content": "late trailing prose"}],
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(
+        session=session_with_tail,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=deepcopy(base_context),
+    ) is True
+    late_settled = _sanitize_messages_for_api(session_with_tail.context_messages)
+    assert late_settled == [
+        {"role": "user", "content": "seed"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": msg_text},
+        {"role": "assistant", "tool_calls": [{"id": "tc-commit", "type": "function", "function": {"name": "git_commit", "arguments": "{}"}}]},
+        {"role": "tool", "content": "commit abc1234", "tool_call_id": "tc-commit"},
+        {"role": "assistant", "tool_calls": [{"id": "tc-status", "type": "function", "function": {"name": "git_status", "arguments": "{}"}}]},
+        {"role": "tool", "content": "clean", "tool_call_id": "tc-status"},
+    ]
+
+    assert _settle(
+        session=session,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=deepcopy(base_context),
+    ) is True
+    assert settled == _sanitize_messages_for_api(session.context_messages)
+
+    session_empty_snapshot = _DummySession(
+        context_messages=base_context
+        + _tool_result_messages(msg_text)
+        + [{"role": "assistant", "content": "late trailing prose"}],
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(
+        session=session_empty_snapshot,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=[],
+    ) is True
+    empty_snapshot_settled = _sanitize_messages_for_api(session_empty_snapshot.context_messages)
+    assert empty_snapshot_settled == [
+        {"role": "user", "content": msg_text},
+        {"role": "assistant", "tool_calls": [{"id": "tc-commit", "type": "function", "function": {"name": "git_commit", "arguments": "{}"}}]},
+        {"role": "tool", "content": "commit abc1234", "tool_call_id": "tc-commit"},
+        {"role": "assistant", "tool_calls": [{"id": "tc-status", "type": "function", "function": {"name": "git_status", "arguments": "{}"}}]},
+        {"role": "tool", "content": "clean", "tool_call_id": "tc-status"},
+    ]
+
+    stale = _DummySession(
+        context_messages=deepcopy(base_context),
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id="other",
+    )
+    assert not _settle(session=stale, msg_text=msg_text, result_messages=result_payload, result_identity=identity)
+    assert stale.context_messages == base_context
+
+    newer = _DummySession(
+        context_messages=deepcopy(base_context),
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker(), {"role": "assistant", "content": "later"}, {"role": "user", "content": "next"}],
+        active_stream_id=None,
+    )
+    assert not _settle(session=newer, msg_text=msg_text, result_messages=result_payload, result_identity=identity)
+    assert newer.context_messages == base_context
+
+    pending_tail = _DummySession(
+        context_messages=deepcopy(base_context),
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+        pending_user_message="next",
+    )
+    assert not _settle(session=pending_tail, msg_text=msg_text, result_messages=result_payload, result_identity=identity)
+    assert pending_tail.context_messages == base_context
+
+
+def test_preserve_short_circuit_for_compressed_live_context():
+    msg_text = "remove last commit"
+    identity = _turn_identity(msg_text, current_turn_user_idx=0)
+    result_payload = {"messages": _tool_result_messages(msg_text), "final_response": "ok"}
+    base_context = [{"role": "user", "content": "seed"}, {"role": "assistant", "content": "ok"}]
+    first_compression_session = _DummySession(
+        context_messages=base_context + [_compression_marker("[context compaction — replacement marker]")],
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(
+        session=first_compression_session,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=base_context,
+    ) is True
+    assert first_compression_session.context_messages == base_context + [_compression_marker("[context compaction — replacement marker]")]
+
+    pre_turn_context = base_context + [_compression_marker("[context compaction — old marker]")]
+    session = _DummySession(
+        context_messages=base_context + [_compression_marker("[context compaction — replacement marker]")],
+        messages=pre_turn_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(
+        session=session,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=pre_turn_context,
+    ) is True
+    assert session.context_messages == base_context + [_compression_marker("[context compaction — replacement marker]")]
+
+    unchanged_marker_session = _DummySession(
+        context_messages=base_context + [_compression_marker("[context compaction — replacement marker]")],
+        messages=base_context + [_interrupted_user(msg_text), _cancelled_marker()],
+        active_stream_id=None,
+    )
+    assert _settle(
+        session=unchanged_marker_session,
+        msg_text=msg_text,
+        result_messages=result_payload,
+        result_identity=identity,
+        previous_context_messages=base_context + [_compression_marker("[context compaction — replacement marker]")],
+    ) is True
+    assert _sanitize_messages_for_api(unchanged_marker_session.context_messages) == [
+        {"role": "user", "content": "seed"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "assistant", "content": "[context compaction — replacement marker]"},
+        {"role": "user", "content": msg_text},
+        {"role": "assistant", "tool_calls": [{"id": "tc-commit", "type": "function", "function": {"name": "git_commit", "arguments": "{}"}}]},
+        {"role": "tool", "content": "commit abc1234", "tool_call_id": "tc-commit"},
+        {"role": "assistant", "tool_calls": [{"id": "tc-status", "type": "function", "function": {"name": "git_status", "arguments": "{}"}}]},
+        {"role": "tool", "content": "clean", "tool_call_id": "tc-status"},
+    ]
+
+
+def test_repeated_prompt_uses_active_turn_identity():
+    msg_text = "remove last commit"
+    result_messages = _repeated_prompt_with_stale_index_messages(msg_text)
+    identity = _turn_identity(msg_text, current_turn_user_idx=0, token="turn-current")
+    session = _DummySession(
+        context_messages=[{"role": "user", "content": "seed"}, {"role": "assistant", "content": "ok"}],
+        messages=[
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "ok"},
+            _interrupted_user(msg_text),
+            _cancelled_marker(),
+        ],
+    )
+
+    assert _settle(
+        session=session,
+        msg_text=msg_text,
+        result_messages=result_messages,
+        result_identity=identity,
+    ) is True
+
+    settled = _sanitize_messages_for_api(session.context_messages)
+    assert [m.get("role") for m in settled] == ["user", "assistant", "user", "assistant", "tool"]
+    assert not any(m.get("content") == "old ok" for m in settled)
+    assert not any(m.get("content") == "tail" for m in settled)
+
+
+def test_ephemeral_settlement_is_noop():
+    session = _DummySession(context_messages=[{"role": "user", "content": "seed"}, {"role": "assistant", "content": "ok"}])
+    msg_text = "remove last commit"
+    assert _settle(
+        session=session,
+        msg_text=msg_text,
+        result_messages=_tool_result_messages(msg_text),
+        result_identity=_turn_identity(msg_text, current_turn_user_idx=0),
+        ephemeral=True,
+    ) is True
+    assert session.context_messages == [{"role": "user", "content": "seed"}, {"role": "assistant", "content": "ok"}]


### PR DESCRIPTION
## Thinking Path

- Cancelling a running turn can leave completed tool side effects in place while the replacement turn receives history that omits the tool calls and results that caused them.
- The WebUI owns the cancellation-to-next-turn context handoff, so the fix belongs in streaming session settlement rather than the frontend or Hermes Agent.
- The narrow fix preserves only complete current-turn tool-call/result exchanges in model-facing context. It does not retain unfinished assistant prose or change the visible cancellation transcript.
- Stale workers may write only when they still own the stream or when the exact cancelled turn remains the visible tail with no active or pending successor.
- If context compression changed during the turn, preservation fails closed instead of rebuilding from stale pre-compression history.

## What Changed

- Extract complete tool-call/result exchanges from a cancelled agent result using the authoritative current-turn identity.
- Preserve those exchanges in `context_messages` at existing post-result cancellation checkpoints while leaving finalization, journaling, SSE, and ephemeral behavior unchanged.
- Reject stale ownership, incomplete tool calls, interrupted prose, cancellation markers, and compression-state mismatches.
- Add regression coverage for production-shaped results, repeated prompts, late cancellation, stale/pending successors, empty context, compression replacement, idempotence, and ephemeral turns.

## Why It Matters

- Replacement turns can reason from the actions that actually completed before interruption.
- The model no longer targets stale state after an interrupted tool changes an external system.
- Partial assistant output remains excluded, and newer turns remain protected from stale-worker writeback.

## Screenshots

Not applicable. This change affects backend session context only and does not change rendered UI.

## Verification

Targeted regression:

`./scripts/test.sh tests/test_cancelled_turn_result_settlement.py -q`

Result: `4 passed`

Adjacent cancellation and recovery coverage:

`./scripts/test.sh tests/test_issue4283_recovered_context_replay.py tests/test_issue1298_cancel_and_activity.py tests/test_stale_stream_cleanup.py tests/test_cancelled_turn_result_settlement.py -q`

Result: `43 passed`

Diff-aware lint and hygiene:

- `python3 scripts/ruff_lint.py --diff origin/master` — no new violations on added or modified lines
- `git diff --check origin/master...HEAD` — passed
- `python3 -m py_compile api/streaming.py tests/test_cancelled_turn_result_settlement.py` — passed

## Related Work

- #6047 also changes cancellation settlement, but proposes rolling an interrupted turn out of both display history and model context. That PR targets a cleaner Stop experience, but its current approach conflicts with the existing Live-to-Final cancellation contract and has an outstanding changes-requested review over data-loss and stale-replay risks.
- This PR takes the narrower complementary direction: it leaves the visible cancellation transcript unchanged and preserves only completed tool-call/result exchanges in model-facing context. The two implementations therefore compete for the same cancellation paths and should not be merged independently without reconciling their behavior.

## Risks / Follow-ups

- Preservation intentionally no-ops when context compression markers changed during the turn. This avoids restoring pre-compression history while retaining newer compression metadata.
- No frontend, API schema, or Hermes Agent behavior changed.

## Model Used

- OpenAI / `gpt-5.6-sol` via Hermes Agent for diagnosis, implementation specification, and verification.
- OpenAI / `gpt-5.3-codex-spark` via Codex for implementation and regression tests.
- Anthropic / `claude-opus-5` via Claude Code for independent review.
