### PR TITLE
test(streaming): pin identical-prompt retry settlement (#6571)

### DIFF
--- a/tests/test_issue6571_identical_retry_settlement.py
+++ b/tests/test_issue6571_identical_retry_settlement.py
@@ -1,0 +1,79 @@
+"""Regression coverage for #6571 identical-prompt retry settlement."""
+
+from __future__ import annotations
+
+from api import streaming
+
+
+PROMPT = "Apply the two requested configuration updates."
+
+
+def _previous_turns():
+    previous_display = [
+        {"role": "user", "content": "Earlier task", "id": 1},
+        {"role": "assistant", "content": "Earlier answer", "id": 2},
+        {"role": "user", "content": PROMPT, "id": 10},
+    ]
+    return previous_display, previous_display[:2]
+
+
+def _active_turn_identity():
+    return {
+        "token": "direct-stream:2",
+        "text": PROMPT,
+        "timestamp": 2.0,
+        "source": "webui",
+        "attachments": [],
+        "current_turn_user_idx": 2,
+        "turn_id": "turn-2",
+    }
+
+
+def _lacks_final_answer(result_messages):
+    previous_display, previous_context = _previous_turns()
+    return streaming._merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        previous_context,
+        result_messages,
+        PROMPT,
+        source="webui",
+        drop_replayed_assistant=False,
+        active_turn_identity=_active_turn_identity(),
+    )
+
+
+def test_successful_identical_prompt_retry_keeps_terminal_answer():
+    _previous_display, previous_context = _previous_turns()
+    result_messages = previous_context + [
+        {"role": "user", "content": PROMPT, "id": 11},
+        {"role": "assistant", "content": "Working on it.", "id": 12},
+        {
+            "role": "tool",
+            "content": "update succeeded",
+            "tool_call_id": "tool-1",
+            "id": 13,
+        },
+        {
+            "role": "assistant",
+            "content": "Both changes were applied and verified.",
+            "id": 14,
+        },
+    ]
+
+    assert _lacks_final_answer(result_messages) is False
+
+
+def test_failed_identical_prompt_retry_still_lacks_terminal_answer():
+    _previous_display, previous_context = _previous_turns()
+    result_messages = previous_context + [
+        {"role": "user", "content": PROMPT, "id": 11},
+        {"role": "assistant", "content": "Working on it.", "id": 12},
+        {
+            "role": "tool",
+            "content": "update failed",
+            "tool_call_id": "tool-1",
+            "id": 13,
+        },
+    ]
+
+    assert _lacks_final_answer(result_messages) is True


### PR DESCRIPTION
## Summary

Current master already carries the active-turn ownership repair that resolves #6571: settlement materializes the exact pending turn before evaluating whether the result has a terminal assistant answer. The issue's original helper-only reproduction omitted that runtime identity, so the shipped repair was not covered by an issue-specific two-direction regression.

This PR adds that missing coverage:

- a successful retry of identical prompt text keeps its terminal assistant answer and does not qualify for `no_response`;
- an otherwise identical retry with no terminal answer still qualifies as a genuine failure.

No production code changes are needed.

Closes #6571

## Verification

- `20 passed` across the new regression plus the neighboring #5141 and #6481 settlement suites.
- Ruff forward gate: clean.
- Mutation bite: replacing the merge's `active_turn_identity` provenance with `None` makes the successful-retry case fail (`lacks_final=True`); restoring the production ownership path returns both tests to green.
