### PR TITLE
fix(async): preserve durable delivery attempts while sessions are busy (#6601)

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -908,8 +908,8 @@ def _requeue_async_delegation_event(
     )
 
 
-def _retry_unmapped_async_delegation_event(process_registry, evt: dict) -> None:
-    """Retry durable routing, or one bounded best-effort legacy routing pass."""
+def _retry_unclaimed_async_delegation_event(process_registry, evt: dict) -> None:
+    """Retry from durable state, or make one bounded legacy routing pass."""
     completion_queue = getattr(process_registry, "completion_queue", None)
     if schedule_async_delegation_claim_retry(
         evt,
@@ -988,7 +988,7 @@ def _start_async_delegation_wakeup_turn(
                 return
 
             release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt, claim=claim)
+            _retry_unclaimed_async_delegation_event(process_registry, evt)
             if status == 409 and (resp or {}).get("error") == "process_wakeup_paused":
                 logger.info(
                     "async delegation wakeup paused for session %s; delivery remains retryable",
@@ -997,16 +997,16 @@ def _start_async_delegation_wakeup_turn(
             else:
                 logger.debug(
                     "async delegation wakeup not accepted for session %s: "
-                    "status=%s err=%r; requeued",
+                    "status=%s err=%r; durable retry scheduled",
                     session_id,
                     status,
                     (resp or {}).get("error"),
                 )
         except Exception:
             release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt, claim=claim)
+            _retry_unclaimed_async_delegation_event(process_registry, evt)
             logger.warning(
-                "async delegation wakeup turn failed for session %s; requeued",
+                "async delegation wakeup turn failed for session %s; durable retry scheduled",
                 session_id,
                 exc_info=True,
             )
@@ -1027,6 +1027,13 @@ def _process_async_delegation_event(
 ) -> None:
     """Claim and route one async completion without private registry markers."""
 
+    # A durable claim has a finite attempt budget. A busy foreground turn is
+    # not a delivery attempt, so leave the record unclaimed and let the shared
+    # restore sweep retry after the session can accept a wakeup.
+    if _session_has_active_turn(session_id):
+        _retry_unclaimed_async_delegation_event(process_registry, evt)
+        return
+
     try:
         claim = claim_async_delegation_delivery(evt, "webui-background")
     except Exception:
@@ -1043,14 +1050,6 @@ def _process_async_delegation_event(
         if not wakeup_prompt:
             raise RuntimeError("async delegation completion could not be formatted")
 
-        # Do not persist async results in the process-local deferred list. If a
-        # foreground turn owns the session, release the durable claim and retry
-        # from the shared queue; the core record therefore remains restart-safe.
-        if _session_has_active_turn(session_id):
-            release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt, claim=claim)
-            return
-
         _start_async_delegation_wakeup_turn(
             session_id,
             wakeup_prompt,
@@ -1061,7 +1060,7 @@ def _process_async_delegation_event(
         )
     except Exception:
         release_async_delegation_delivery(evt, claim)
-        _requeue_async_delegation_event(process_registry, evt, claim=claim)
+        _retry_unclaimed_async_delegation_event(process_registry, evt)
         logger.warning(
             "server-side async delegation dispatch failed for session %s",
             session_id,
@@ -1144,7 +1143,7 @@ def _process_one(evt: dict) -> None:
             process_id,
         )
         if evt.get("type") == "async_delegation":
-            _retry_unmapped_async_delegation_event(_process_registry, evt)
+            _retry_unclaimed_async_delegation_event(_process_registry, evt)
         return
     session_id = ""
     if session_key:
@@ -1157,7 +1156,7 @@ def _process_one(evt: dict) -> None:
         # registered shortly after process restore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
         if evt.get("type") == "async_delegation":
-            _retry_unmapped_async_delegation_event(_process_registry, evt)
+            _retry_unclaimed_async_delegation_event(_process_registry, evt)
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
     # First retain the process-registry spawn-owner cross-check for legacy
@@ -1186,7 +1185,7 @@ def _process_one(evt: dict) -> None:
         # the bounded retry instead (arms a durable retry / one best-effort
         # legacy requeue), so it stays retryable without a spurious ACK.
         if evt.get("type") == "async_delegation":
-            _retry_unmapped_async_delegation_event(_process_registry, evt)
+            _retry_unclaimed_async_delegation_event(_process_registry, evt)
         return
     # ── THE SEAM: async delegations take the durable-claim delivery path,
     # routed to the origin-resolved session. The claim/complete/release

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -69,6 +69,7 @@ def _install_fake_durable_delivery_api(monkeypatch):
         "mark": [],
         "legacy": [],
         "delivery_state": "pending",
+        "delivery_attempts": 0,
         "pending_ids": set(),
         "restore_failures": 0,
     }
@@ -76,6 +77,9 @@ def _install_fake_durable_delivery_api(monkeypatch):
 
     def _claim(evt, consumer):
         calls["claim"].append((dict(evt), consumer))
+        if calls["delivery_state"] != "pending":
+            return None
+        calls["delivery_attempts"] += 1
         return f"claim:{consumer}"
 
     def _complete(evt, claim_id):
@@ -84,7 +88,9 @@ def _install_fake_durable_delivery_api(monkeypatch):
 
     def _release(evt, claim_id):
         calls["release"].append((dict(evt), claim_id))
-        calls["delivery_state"] = "pending"
+        calls["delivery_state"] = (
+            "dropped" if calls["delivery_attempts"] >= 8 else "pending"
+        )
 
     def _get_durable(delegation_id):
         if calls["delivery_state"] == "pending":
@@ -315,30 +321,38 @@ def test_background_wakeup_releases_claim_when_dispatch_fails(monkeypatch):
     assert "deleg_test123" not in cfg.BG_TASK_COMPLETE_EVENTS_SEEN.get("webui-session-1", set())
 
 
-def test_background_active_turn_releases_and_requeues_without_in_memory_defer(monkeypatch):
+def test_background_active_turn_does_not_consume_durable_delivery_attempts(monkeypatch):
     _reset_wakeup_state()
     registry = _install_fake_process_registry(monkeypatch)
     delivery = _install_fake_durable_delivery_api(monkeypatch)
     cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
     monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: True)
+    monkeypatch.setattr(peu, "ASYNC_DELIVERY_CLAIM_RETRY_SECONDS", 0.2)
     monkeypatch.setattr(
         bp,
         "_start_async_delegation_wakeup_turn",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must stay deferred")),
     )
 
-    bp._process_one(_async_delegation_event())
+    try:
+        for _ in range(10):
+            bp._process_one(_async_delegation_event())
 
-    assert len(delivery["claim"]) == 1
-    assert delivery["complete"] == []
-    assert len(delivery["release"]) == 1
-    assert registry.completion_queue.qsize() == 1
-    assert cfg.DEFERRED_PROCESS_WAKEUPS == {}
-    assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+        assert delivery["claim"] == []
+        assert delivery["delivery_attempts"] == 0
+        assert delivery["complete"] == []
+        assert delivery["release"] == []
+        assert delivery["delivery_state"] == "pending"
+        assert registry.completion_queue.empty()
+        assert peu.async_delivery_retry_timer_count() == 1
+        assert cfg.DEFERRED_PROCESS_WAKEUPS == {}
+        assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+    finally:
+        _reset_wakeup_state()
 
 
 @pytest.mark.parametrize("status", [None, 302, 409, 500])
-def test_autonomous_wakeup_only_acks_after_turn_acceptance(monkeypatch, status):
+def test_autonomous_wakeup_rejection_uses_bounded_durable_retry(monkeypatch, status):
     _reset_wakeup_state()
     registry = _install_fake_process_registry(monkeypatch)
     delivery = _install_fake_durable_delivery_api(monkeypatch)
@@ -349,26 +363,31 @@ def test_autonomous_wakeup_only_acks_after_turn_acceptance(monkeypatch, status):
         "start_session_turn",
         lambda *_args, **_kwargs: {"_status": status, "error": "busy"},
     )
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 10.0)
     evt = _async_delegation_event()
     claim = peu.claim_async_delegation_delivery(evt, "webui-background")
     assert claim is not None
 
-    bp._start_async_delegation_wakeup_turn(
-        "webui-session-1",
-        "delegation result",
-        delegation_id="deleg_test123",
-        evt=evt,
-        claim=claim,
-        process_registry=registry,
-    )
+    try:
+        bp._start_async_delegation_wakeup_turn(
+            "webui-session-1",
+            "delegation result",
+            delegation_id="deleg_test123",
+            evt=evt,
+            claim=claim,
+            process_registry=registry,
+        )
 
-    assert _wait_until(lambda: len(delivery["release"]) == 1)
-    assert delivery["complete"] == []
-    assert _wait_until(lambda: registry.completion_queue.qsize() == 1)
-    assert "deleg_test123" not in cfg.BG_TASK_COMPLETE_EVENTS_SEEN.get("webui-session-1", set())
+        assert _wait_until(lambda: len(delivery["release"]) == 1)
+        assert delivery["complete"] == []
+        assert registry.completion_queue.empty()
+        assert peu.async_delivery_retry_timer_count() == 1
+        assert "deleg_test123" not in cfg.BG_TASK_COMPLETE_EVENTS_SEEN.get("webui-session-1", set())
+    finally:
+        _reset_wakeup_state()
 
 
-def test_autonomous_wakeup_exception_releases_and_requeues(monkeypatch):
+def test_autonomous_wakeup_exception_uses_bounded_durable_retry(monkeypatch):
     _reset_wakeup_state()
     registry = _install_fake_process_registry(monkeypatch)
     delivery = _install_fake_durable_delivery_api(monkeypatch)
@@ -379,22 +398,27 @@ def test_autonomous_wakeup_exception_releases_and_requeues(monkeypatch):
         "start_session_turn",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("start failed")),
     )
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 10.0)
     evt = _async_delegation_event()
     claim = peu.claim_async_delegation_delivery(evt, "webui-background")
     assert claim is not None
 
-    bp._start_async_delegation_wakeup_turn(
-        "webui-session-1",
-        "delegation result",
-        delegation_id="deleg_test123",
-        evt=evt,
-        claim=claim,
-        process_registry=registry,
-    )
+    try:
+        bp._start_async_delegation_wakeup_turn(
+            "webui-session-1",
+            "delegation result",
+            delegation_id="deleg_test123",
+            evt=evt,
+            claim=claim,
+            process_registry=registry,
+        )
 
-    assert _wait_until(lambda: len(delivery["release"]) == 1)
-    assert delivery["complete"] == []
-    assert _wait_until(lambda: registry.completion_queue.qsize() == 1)
+        assert _wait_until(lambda: len(delivery["release"]) == 1)
+        assert delivery["complete"] == []
+        assert registry.completion_queue.empty()
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
 
 
 def test_autonomous_wakeup_acks_after_successful_turn_acceptance(monkeypatch):
@@ -1062,7 +1086,7 @@ def test_async_completion_with_unresolvable_target_retries_not_silent_drop(monke
     retried: list[dict] = []
     monkeypatch.setattr(
         bp,
-        "_retry_unmapped_async_delegation_event",
+        "_retry_unclaimed_async_delegation_event",
         lambda process_registry, evt: retried.append(dict(evt)),
     )
 


### PR DESCRIPTION
## Summary

- Check whether the origin session has an active turn before taking the Agent core's finite durable-delivery claim.
- Leave busy-session completions pending in the durable store and retry them through the existing shared restore sweep.
- Route rejected/failed wakeup starts through that same bounded durable retry instead of a 0.5-second claim/release hot loop.
- Make the bridge fake model the real eight-attempt terminal-drop contract.

Closes #6601

## Why

The current path claims first, then releases and hot-requeues while the origin session is busy. Agent core increments `delivery_attempts` on every claim and terminally drops the eighth release, so a normal completion can disappear after about four seconds of overlap with an active foreground turn.

A busy session is not a delivery attempt. This keeps the durable row authoritative and unclaimed until WebUI can actually attempt wakeup acceptance.

## Verification

- RED before the implementation: ten active-turn passes made ten claim calls and exhausted the modeled attempt budget.
- Focused bridge/background suites: `52 passed`.
- Ruff forward gate: clean.
- Real installed-core differential in isolated state:
  - master: `delivery_state=dropped`, `delivery_attempts=8`;
  - this branch: `delivery_state=pending`, `delivery_attempts=0`.
- Full suite: `13,868 passed, 14 skipped, 1 xfailed, 2 xpassed, 34 subtests passed` in 10m34s.

## Risk

Backend-only. Accepted wakeups keep the existing claim/ACK path. Busy or rejected wakeups use the existing single restore timer; legacy cores without durable rows retain one bounded best-effort queue retry.
