### PR TITLE
fix(streaming): don't persist a failed self-heal retry as success

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1206,6 +1206,15 @@ def _provider_error_probe_text(value) -> tuple[str, int | None]:
     return ' '.join(t for t in _texts if t).strip(), _status_code
 
 
+class _HealRetryTerminalFailure(Exception):
+    """Self-heal retry returned an in-band failure; emit the original error.
+
+    Raised inside the except-path retry block so the existing
+    ``except Exception`` handler routes control to the normal error
+    emission instead of persisting a failed retry as success.
+    """
+
+
 def _classify_provider_error(err_str: str, exc=None, *, silent_failure: bool = False) -> dict:
     """Classify provider/agent failure text for WebUI apperror UX.
 
@@ -10055,6 +10064,33 @@ def _run_agent_streaming(
                                 )
                                 _heal_ok = False
                             if _heal_ok and _heal_result is not None:
+                                # A retry that RETURNED is not yet a retry that
+                                # SUCCEEDED. ``_heal_ok`` only proves an assistant
+                                # row (or streamed token) exists — a retry that
+                                # came back with an explicit error, or with a
+                                # terminal failure and no answer for the current
+                                # turn, would still be persisted as success here
+                                # and the error emission below skipped. Gate on
+                                # the same signals the normal result path uses.
+                                _heal_explicit_error = bool(getattr(agent, '_last_error', None)) or (
+                                    'error' in _heal_result
+                                    and _heal_result.get('error') not in (None, '')
+                                )
+                                _heal_terminal = (
+                                    _agent_result_terminal_failure(_heal_result)
+                                    or _agent_result_tool_limit_reached(_heal_result)
+                                )
+                                _heal_has_answer = _assistant_reply_added_after_current_turn(
+                                    _heal_result.get('messages') or [],
+                                    _previous_context_messages,
+                                    msg_text,
+                                )
+                                if _heal_explicit_error or (_heal_terminal and not _heal_has_answer):
+                                    logger.info(
+                                        '[webui] self-heal: retry returned terminal failure; emitting error'
+                                    )
+                                    _heal_ok = False
+                            if _heal_ok and _heal_result is not None:
                                 # Retry succeeded — replace result and skip error
                                 result = _heal_result
                                 # Fall through past the error-emission block;
@@ -11271,6 +11307,31 @@ def _run_agent_streaming(
                             result=_heal_result,
                             agent=_heal_agent,
                         )
+                        # A retry that returned is not yet a retry that
+                        # succeeded: run_conversation reports many failures
+                        # in-band (result['error'], terminal status) rather
+                        # than by raising. Without this gate such a retry is
+                        # persisted as success and the error emission below
+                        # is skipped — the user sees a silently swallowed
+                        # failure. Same signals as the in-band heal path.
+                        _heal_explicit_error2 = bool(getattr(_heal_agent, '_last_error', None)) or (
+                            'error' in _heal_result
+                            and _heal_result.get('error') not in (None, '')
+                        )
+                        _heal_terminal2 = (
+                            _agent_result_terminal_failure(_heal_result)
+                            or _agent_result_tool_limit_reached(_heal_result)
+                        )
+                        _heal_has_answer2 = _assistant_reply_added_after_current_turn(
+                            _heal_result.get('messages') or [],
+                            _previous_context_messages,
+                            msg_text,
+                        )
+                        if _heal_explicit_error2 or (_heal_terminal2 and not _heal_has_answer2):
+                            logger.info(
+                                '[webui] self-heal (except path): retry returned terminal failure; emitting error'
+                            )
+                            raise _HealRetryTerminalFailure()
                         # Retry succeeded — persist the result normally
                         if s is not None:
                             if _checkpoint_stop is not None:

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -779,3 +779,114 @@ def test_non_auth_seeded_replayed_assistant_does_not_satisfy_current_turn(tmp_pa
     assert apperrors, "expected apperror for seeded replay silent failure"
     assert apperrors[-1]["type"] == "no_response"
     assert not any(event == "done" for event, _ in events)
+
+
+def _build_agent_retry_streams_then_fails(*, second_error: bool):
+    """First run fails silently; the RETRY streams a token, then fails in-band.
+
+    The token streamed DURING the retry is the crux: ``_heal_ok`` includes
+    ``or _token_sent``, so the retry counts as success even though it came
+    back with an explicit ``error`` payload (or a terminal ``failed`` status)
+    and no new assistant message. Neither run raises: run_conversation
+    reports these failures in-band.
+    """
+    class RetryStreamsThenFailsAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            if type(self).runs == 1:
+                return {
+                    "messages": history,
+                    "error": _auth_failure_error_payload(),
+                }
+            if self.stream_delta_callback is not None:
+                self.stream_delta_callback("Visible retry text before failure")
+            if second_error:
+                return {
+                    "status": "ok",
+                    "messages": history,
+                    "error": "provider failed on retry",
+                }
+            return {"status": "failed", "messages": history}
+
+    return RetryStreamsThenFailsAgent
+
+
+def _run_stream_with_heal(monkeypatch, session, stream_id, agent_cls, *, workspace):
+    heal_rt = {
+        "provider": "test-provider",
+        "api_key": "fresh-key",
+        "base_url": None,
+    }
+    fake_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = fake_queue
+    config.STREAM_PARTIAL_TEXT[stream_id] = ""
+
+    with mock.patch.object(streaming, "get_session", return_value=session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
+         mock.patch.object(streaming, "_attempt_credential_self_heal", return_value=heal_rt):
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=workspace,
+            stream_id=stream_id,
+        )
+    return fake_queue
+
+
+def test_auth_retry_streamed_answer_with_explicit_error_still_errors(tmp_path, monkeypatch):
+    """A heal retry that streams a token but returns ``error`` must still error.
+
+    ``_heal_ok`` includes ``or _token_sent``: once the retry streamed a single
+    visible token, it is treated as a success even though it came back with an
+    explicit error payload and no assistant message. The failed result is then
+    settled and persisted and the apperror emission skipped — the user sees a
+    silently swallowed failure (and the streamed fragment as the "answer").
+    """
+    session = _prepare_session(
+        "auth_retry_err", "stream_auth_retry_err",
+        pending_user_message="Please retry then fail explicitly",
+    )
+    agent_cls = _build_agent_retry_streams_then_fails(second_error=True)
+
+    fake_queue = _run_stream_with_heal(
+        monkeypatch, session, "stream_auth_retry_err", agent_cls, workspace=str(tmp_path)
+    )
+
+    saved = Session.load("auth_retry_err")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    apperrors = [payload for event, payload in events if event == "apperror"]
+    assert apperrors, "expected apperror for explicit retry failure"
+    assert not any(event == "done" for event, _ in events)
+    assert saved.messages[-1].get("_error") is True
+    assert saved.messages[-1]["content"] != "Visible retry text before failure"
+
+
+def test_auth_retry_streamed_terminal_failure_without_answer_still_errors(tmp_path, monkeypatch):
+    """Same crux, terminal variant: retry streams a token, ends ``failed``."""
+    session = _prepare_session(
+        "auth_retry_term", "stream_auth_retry_term",
+        pending_user_message="Please retry then fail terminally",
+    )
+    agent_cls = _build_agent_retry_streams_then_fails(second_error=False)
+
+    fake_queue = _run_stream_with_heal(
+        monkeypatch, session, "stream_auth_retry_term", agent_cls, workspace=str(tmp_path)
+    )
+
+    saved = Session.load("auth_retry_term")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    assert any(event == "apperror" for event, _ in events), (
+        "expected apperror for a terminal-failure retry with no answer"
+    )
+    assert not any(event == "done" for event, _ in events)


### PR DESCRIPTION
## Summary

The credential self-heal retry paths treat any retry that *returns* as a
retry that *succeeded*. `run_conversation` reports many failures in-band —
`result["error"]`, a terminal `status="failed"`, a tool-limit stop — rather
than by raising. Both heal paths miss this:

* **In-band path** (`_heal_ok = _has_new_assistant_reply(...) or _token_sent`):
  once the retry streamed a single visible token, it counts as success even
  when it also carries an explicit error payload (or a terminal `failed`
  status) and no assistant message. The failed result is then settled and
  persisted, and the `apperror` emission is skipped — the user sees a
  silently swallowed failure, with the streamed fragment standing in as the
  "answer".
* **Except path**: there is no success check at all. Any non-raising retry is
  persisted via `_settle_result_messages` + `s.save()` and the original
  error emission is skipped.

This PR gates both paths on the same signals the normal result path already
uses: explicit error (`agent._last_error` / `result["error"]`), terminal
failure (`_agent_result_terminal_failure` / `_agent_result_tool_limit_reached`)
without a new assistant reply for the current turn
(`_assistant_reply_added_after_current_turn`). On a failed retry, control
falls through to the existing error emission — no new error surface is
introduced.

## Why

Found while tracking a downstream regression: a heal retry that streamed a
partial token and then returned `{"error": "provider failed on retry"}` was
persisted as a successful turn. No `apperror` reached the client, no error
turn was recorded. Reproduced on pristine `master`: both new tests fail
without the gate (retry persisted as success, no `apperror`) and pass with
it.

## Changes

* `api/streaming.py`: gate in the in-band heal path (sets `_heal_ok = False`
  → existing error emission runs); gate in the except path via a small
  module-level `_HealRetryTerminalFailure` exception routed into the
  existing `except Exception` handler (→ original error emission runs).
  Purely additive, +61 lines, no behavior change for genuinely successful
  retries.

## Validation

* Two new regression tests in
  `tests/test_issue5121_provider_auth_terminal_error.py`, reusing the
  file's existing fixtures/helpers:
  `test_auth_retry_streamed_answer_with_explicit_error_still_errors` and
  `test_auth_retry_streamed_terminal_failure_without_answer_still_errors`.
  Verified both directions: **without** the gate on pristine master the two
  tests fail (2 failed); **with** it the whole file is green (20 passed).
* Full `test_issue5121_provider_auth_terminal_error.py` file green,
  including the existing `test_auth_retry_success_does_not_append_error_turn`
  (genuine successes are unaffected).

## Notes

* The except-path gate deliberately reuses the existing
  `except Exception` handler for control flow instead of restructuring the
  block — keeps the diff reviewable.
* Not addressed here (possible follow-up): the except path emits no
  `done`/`stream_end` after a *successful* retry; clients relying on a
  terminal SSE event may wait until timeout even on success.
