### PR TITLE
fix: preserve compressed fork lineage

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -51,6 +51,7 @@ MESSAGING_SOURCES = {
 
 CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
 CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
+CONTINUATION_BOUNDARY_TOLERANCE_SECONDS = 1.0
 
 SOURCE_LABELS = {
     'acp': 'ACP',
@@ -331,7 +332,11 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         # continuations when no boundary timestamp is available.
         return True
     try:
-        return float(child.get('started_at') or 0) >= float(ended_at)
+        return (
+            float(child.get('started_at') or 0)
+            + CONTINUATION_BOUNDARY_TOLERANCE_SECONDS
+            >= float(ended_at)
+        )
     except (TypeError, ValueError):
         return False
 

--- a/api/models.py
+++ b/api/models.py
@@ -5748,7 +5748,9 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
         if state_db_source == 'webui':
             session['source_tag'] = state_db_source_tag
             session['raw_source'] = state_db_raw_source
-            session['session_source'] = state_db_session_source
+            # ``state.db`` has no fork provenance on older Agent schemas.
+            if str(session.get('session_source') or '').strip().lower() != 'fork':
+                session['session_source'] = state_db_session_source
             session['source_label'] = state_db_source_label
             session['is_cli_session'] = False
         # Overlay the real state.db message count for WebUI-owned rows AND for
@@ -5833,6 +5835,11 @@ def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
         candidates = sessions[:_cap]
     else:
         candidates = sessions
+    originals = {
+        str(session.get('session_id')): dict(session)
+        for session in sessions
+        if session.get('session_id')
+    }
     try:
         metadata = read_session_lineage_metadata(
             _active_state_db_path(),
@@ -5854,7 +5861,62 @@ def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
                 '_state_db_source_label',
             ):
                 entry.pop(key, None)
+
+            root_id = str(entry.get('_lineage_root_id') or '')
+            root = originals.get(root_id)
+            if root_id and root is None:
+                try:
+                    root_session = Session.load_metadata_only(root_id)
+                except Exception:
+                    root_session = None
+                root = root_session.compact() if root_session else None
+
+            if root_id:
+                for key in (
+                    'relationship_type',
+                    'parent_title',
+                    'parent_source',
+                    '_parent_lineage_root_id',
+                    '_parent_lineage_tip_id',
+                    '_cross_surface_child_session',
+                ):
+                    session.pop(key, None)
+
+            original = originals.get(str(sid), {})
+            fork_root = root if root and root.get('session_source') == 'fork' else None
+            if not root_id and original.get('session_source') == 'fork':
+                fork_root = original
+
+            if fork_root:
+                parent_id = str(fork_root.get('parent_session_id') or '')
+                session['session_source'] = 'fork'
+                entry['parent_session_id'] = parent_id or None
+                entry['relationship_type'] = 'child_session'
+                if parent_id:
+                    parent_meta = metadata.get(parent_id)
+                    if parent_meta is None:
+                        parent_meta = read_session_lineage_metadata(
+                            _active_state_db_path(), {parent_id}
+                        ).get(parent_id, {})
+                    entry['_parent_lineage_root_id'] = (
+                        parent_meta.get('_lineage_root_id') or parent_id
+                    )
+                    entry['_parent_lineage_tip_id'] = (
+                        parent_meta.get('_lineage_tip_id') or parent_id
+                    )
+            elif root_id and originals.get(str(sid), {}).get('session_source') == 'fork':
+                session['session_source'] = 'webui'
             session.update(entry)
+
+
+def _enrich_sidebar_visibility_metadata(sessions: list[dict]) -> None:
+    sensitive = [
+        session for session in sessions
+        if session.get('pre_compression_snapshot')
+        or session.get('session_source') == 'fork'
+    ]
+    if sensitive:
+        _enrich_sidebar_lineage_metadata(sensitive)
 
 
 def _diag_stage(diag, name: str) -> None:
@@ -6004,6 +6066,7 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
             else:
                 _diag_stage(diag, "all_sessions.state_db_overrides")
                 _apply_sidebar_state_db_overrides(result)
+                _enrich_sidebar_visibility_metadata(result)
                 _diag_stage(diag, "all_sessions.lineage_metadata_skipped")
             result = _prefer_fuller_snapshots_for_sidebar(result)
             sidebar_candidates = result
@@ -6059,6 +6122,7 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
     else:
         _diag_stage(diag, "all_sessions.state_db_overrides")
         _apply_sidebar_state_db_overrides(result)
+        _enrich_sidebar_visibility_metadata(result)
         _diag_stage(diag, "all_sessions.lineage_metadata_skipped")
     result = _prefer_fuller_snapshots_for_sidebar(result)
     sidebar_candidates = result

--- a/api/routes.py
+++ b/api/routes.py
@@ -2356,6 +2356,10 @@ def _build_session_list_cache_payload(
         # Apply the same CLI visibility semantics to imported local copies so
         # low-value imported artifacts do not leak into the sidebar.
         webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]
+        # Resolve lineage before checking which state.db rows are represented.
+        _enrich_sidebar_lineage_metadata([
+            s for s in webui_sessions if not _is_cli_session_for_settings(s)
+        ])
         represented_webui_ids = set()
         for s in webui_sessions:
             represented_webui_ids.update(_session_lineage_ids(s))
@@ -9128,6 +9132,7 @@ def _reconcile_session_detail_source_flags(session: dict, state_meta: dict) -> d
     if not _session_source_is_webui(state_meta):
         return dict(session)
 
+    was_fork = session.get("session_source") == "fork"
     reconciled = dict(session)
     reconciled["is_cli_session"] = False
     reconciled["read_only"] = False
@@ -9151,6 +9156,9 @@ def _reconcile_session_detail_source_flags(session: dict, state_meta: dict) -> d
                 reconciled[key] = max(float(current or 0), float(state_meta.get(key) or 0))
             except (TypeError, ValueError):
                 reconciled[key] = state_meta[key]
+    if was_fork:
+        reconciled["session_source"] = "fork"
+        _enrich_sidebar_lineage_metadata([reconciled])
     return reconciled
 
 

--- a/tests/test_session_import_cli_fallback_model.py
+++ b/tests/test_session_import_cli_fallback_model.py
@@ -344,8 +344,6 @@ def test_sessions_endpoint_suppresses_duplicate_webui_state_projection(monkeypat
         "source_tag": "webui",
         "raw_source": "webui",
         "session_source": "webui",
-        "_lineage_root_id": "root_sid",
-        "_lineage_tip_id": "visible_tip",
     }
     duplicate_webui_projection = {
         "session_id": "state_projection_tip",
@@ -375,6 +373,14 @@ def test_sessions_endpoint_suppresses_duplicate_webui_state_projection(monkeypat
 
     monkeypatch.setattr(routes, "all_sessions", lambda diag=None: [webui_row])
     monkeypatch.setattr(routes, "get_cli_sessions", lambda source_filter=None, all_profiles=False: [duplicate_webui_projection, external_projection])
+    monkeypatch.setattr(
+        routes,
+        "_enrich_sidebar_lineage_metadata",
+        lambda rows: rows[0].update(
+            _lineage_root_id="root_sid",
+            _lineage_tip_id="visible_tip",
+        ),
+    )
 
     handler = _FakeHandler()
     routes.handle_get(handler, urlparse("http://example.com/api/sessions"))

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -91,12 +91,13 @@ def _insert_state_row(conn, sid, *, title=None, parent=None, ended_at=None, end_
     conn.commit()
 
 
-def _save_webui_session(sid, *, title, updated_at):
+def _save_webui_session(sid, *, title, updated_at, **metadata):
     session = Session(
         session_id=sid,
         title=title,
         messages=[{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}],
         updated_at=updated_at,
+        **metadata,
     )
     session.save(touch_updated_at=False)
     return session
@@ -129,6 +130,57 @@ def test_all_sessions_exposes_state_db_lineage_metadata_for_webui_json_sessions(
         assert rows["lineage_api_tip"].get("_lineage_root_id") == "lineage_api_root"
         assert rows["lineage_api_tip"].get("_compression_segment_count") == 2
         assert "_lineage_root_id" not in rows["lineage_api_root"]
+    finally:
+        conn.close()
+
+
+def test_state_db_webui_override_preserves_compressed_fork(_isolate):
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    try:
+        _save_webui_session("fork_parent", title="Parent", updated_at=t0)
+        _save_webui_session(
+            "fork_root", title="Fork", updated_at=t0 + 10,
+            parent_session_id="fork_parent", session_source="fork",
+            pre_compression_snapshot=True,
+        )
+        _save_webui_session(
+            "fork_tip", title="Fork", updated_at=t0 + 30,
+            parent_session_id="fork_root", session_source="fork",
+        )
+        _insert_state_row(conn, "fork_parent", started_at=t0)
+        _insert_state_row(
+            conn, "fork_root", started_at=t0 + 10,
+            ended_at=t0 + 15, end_reason="compression",
+        )
+        _insert_state_row(
+            conn, "fork_mid", parent="fork_root", started_at=t0 + 16,
+            ended_at=t0 + 25, end_reason="compression",
+        )
+        _insert_state_row(conn, "fork_tip", parent="fork_mid", started_at=t0 + 26)
+
+        visible = [
+            row for row in all_sessions(include_lineage_metadata=False)
+            if row["session_id"] in {"fork_root", "fork_tip"}
+        ]
+        assert [row["session_id"] for row in visible] == ["fork_tip"]
+        tip = visible[0]
+        assert tip["session_source"] == "fork"
+        assert tip["relationship_type"] == "child_session"
+        assert tip["parent_session_id"] == "fork_parent"
+        assert tip["_lineage_root_id"] == "fork_root"
+        assert tip["_lineage_tip_id"] == "fork_tip"
+
+        state_tip = models.read_session_lineage_metadata(
+            _isolate, ["fork_tip"]
+        )["fork_tip"]
+        state_tip["source_tag"] = state_tip["session_source"] = "webui"
+        detail = routes._reconcile_session_detail_source_flags(
+            Session.load_metadata_only("fork_tip").compact(), state_tip
+        )
+        assert detail["session_source"] == "fork"
+        assert detail["parent_session_id"] == "fork_parent"
+        assert detail["_lineage_root_id"] == "fork_root"
     finally:
         conn.close()
 

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from urllib.parse import urlparse
 from unittest.mock import patch
 
+import pytest
+
 import api.agent_sessions as agent_sessions
 import api.routes as routes
 
@@ -57,6 +59,24 @@ def _insert_message(conn, sid, *, timestamp=None, role="user"):
         (f"msg_{sid}_{role}", sid, role, timestamp or time.time()),
     )
     conn.commit()
+
+
+@pytest.mark.parametrize("started_at, expected", [(104.95, True), (103.0, False)])
+def test_continuation_boundary_tolerance(started_at, expected):
+    parent = {
+        "id": "parent",
+        "source": "webui",
+        "ended_at": 105.0,
+        "end_reason": "compression",
+    }
+    child = {
+        "id": "child",
+        "source": "webui",
+        "parent_session_id": "parent",
+        "started_at": started_at,
+    }
+
+    assert agent_sessions._is_continuation_session(parent, child) is expected
 
 
 def test_lineage_report_returns_bounded_read_only_tip_and_hidden_segments(tmp_path):


### PR DESCRIPTION
## Summary
- tolerate sub-second write ordering at compression boundaries
- preserve sidecar-only fork provenance while using state.db for compression lineage
- enrich lineage before state-projection deduplication so list and detail APIs agree

## Test plan
- `159 passed in 6.12s` across lineage, sidebar merge, source filtering, and performance regressions
- verified the production-shaped fork projects as one child conversation with no duplicate state row