### PR TITLE
feat(footer): show effective reasoning effort in turn footers and live status

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1534,8 +1534,11 @@ def _run_gateway_chat_streaming(
             s.pending_started_at = None
             s.pending_user_source = None
             s.workspace = str(workspace)
-            s.model = effective_model or model
-            s.model_provider = effective_provider or model_provider
+            # Runtime attribution belongs to the completed assistant row.  Keep
+            # the session's selected route request-owned so a Gateway fallback
+            # does not silently redirect the next turn to the fallback runtime.
+            s.model = model
+            s.model_provider = model_provider
 
             def _restore_cancelled_success_writeback():
                 if pending_source == "process_wakeup":

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -394,6 +394,14 @@ def _auto_approve_gateway_run(
     )
 
 
+def _gateway_reasoning_effort_label(reasoning_effort):
+    """Translate the resolved gateway request value to display metadata."""
+    value = str(reasoning_effort or "").strip().lower()
+    if not value:
+        return None
+    return "off" if value == "none" else value
+
+
 def gateway_chat_config_status(config_data=None, environ: dict[str, str] | None = None) -> dict:
     """Return redacted Gateway-backed chat configuration status."""
     mode = webui_chat_backend_mode(config_data, environ)
@@ -996,6 +1004,13 @@ def _run_gateway_chat_streaming(
             model=model,
             model_provider=model_provider,
         )
+        reasoning_effort_label = _gateway_reasoning_effort_label(reasoning_effort)
+        put_gateway_event("run_meta", {
+            "session_id": session_id,
+            "model": model,
+            "provider": model_provider or "",
+            "reasoning_effort": reasoning_effort_label,
+        })
         base_url = _gateway_base_url(cfg)
         api_key = _gateway_api_key()
         try:
@@ -1293,6 +1308,10 @@ def _run_gateway_chat_streaming(
                 active_turn_identity.get("timestamp") or now
             )
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
+            if model:
+                assistant_msg["_usedModel"] = model
+            if reasoning_effort_label is not None:
+                assistant_msg["_reasoningEffort"] = reasoning_effort_label
             saved_reasoning = STREAM_REASONING_TEXT.get(stream_id, "")
             if saved_reasoning:
                 assistant_msg["reasoning"] = saved_reasoning
@@ -1439,6 +1458,8 @@ def _run_gateway_chat_streaming(
                 goal_exc,
             )
         from api.streaming import _session_payload_with_full_messages
+        if reasoning_effort_label is not None:
+            usage["reasoning_effort"] = reasoning_effort_label
         gateway_session_payload = _session_payload_with_full_messages(s, tool_calls=[])
         put_gateway_event("done", {"session": redact_session_data(gateway_session_payload), "usage": usage})
         put_gateway_event("stream_end", {"session_id": session_id})

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -29,6 +29,7 @@ from api.config import (
     coerce_reasoning_effort_for_model,
     gateway_approval_unavailable_reason,
     gateway_supports_approval,
+    parse_reasoning_effort,
     register_active_run,
     unregister_active_run,
     unregister_stream_owner,
@@ -400,6 +401,30 @@ def _gateway_reasoning_effort_label(reasoning_effort):
     if not value:
         return None
     return "off" if value == "none" else value
+
+
+def _gateway_request_model_options(reasoning_effort, service_tier=None) -> dict[str, Any]:
+    """Build the model-options envelope consumed by the Gateway Agent."""
+    model_options: dict[str, Any] = {}
+    reasoning = parse_reasoning_effort(reasoning_effort)
+    if reasoning is not None:
+        model_options["reasoning"] = reasoning
+    normalized_service_tier = str(service_tier or "").strip().lower()
+    if normalized_service_tier == "priority":
+        model_options["service_tier"] = normalized_service_tier
+    return model_options
+
+
+def _gateway_accepted_reasoning_effort_label(model_options: dict[str, Any]) -> str | None:
+    """Return display metadata from the model options accepted for transport."""
+    reasoning = model_options.get("reasoning")
+    if not isinstance(reasoning, dict):
+        return None
+    if reasoning.get("enabled") is False:
+        return "off"
+    if reasoning.get("enabled") is True:
+        return _gateway_reasoning_effort_label(reasoning.get("effort"))
+    return None
 
 
 def _gateway_effective_runtime_metadata(payload: dict) -> dict:
@@ -1115,13 +1140,6 @@ def _run_gateway_chat_streaming(
             model=model,
             model_provider=model_provider,
         )
-        reasoning_effort_label = _gateway_reasoning_effort_label(reasoning_effort)
-        put_gateway_event("run_meta", {
-            "session_id": session_id,
-            "model": model,
-            "provider": model_provider or "",
-            "reasoning_effort": reasoning_effort_label,
-        })
         base_url = _gateway_base_url(cfg)
         api_key = _gateway_api_key()
         try:
@@ -1133,6 +1151,19 @@ def _run_gateway_chat_streaming(
             )
         except Exception:
             _gw_overrides = {}
+        request_model_options = _gateway_request_model_options(
+            reasoning_effort,
+            _gw_overrides.get("service_tier"),
+        )
+        reasoning_effort_label = _gateway_accepted_reasoning_effort_label(
+            request_model_options
+        )
+        put_gateway_event("run_meta", {
+            "session_id": session_id,
+            "model": model,
+            "provider": model_provider or "",
+            "reasoning_effort": reasoning_effort_label,
+        })
         _runs_api_enabled = _gateway_use_runs_api_enabled(cfg)
         _use_runs_api = _runs_api_enabled and gateway_supports_approval(base_url, api_key)
         if not _use_runs_api and runs_api_pending_marked:
@@ -1180,10 +1211,8 @@ def _run_gateway_chat_streaming(
             body_extras = {}
             if model_provider:
                 body_extras["provider"] = model_provider
-            if reasoning_effort is not None:
-                body_extras["reasoning_effort"] = reasoning_effort
-            if _gw_overrides.get("service_tier"):
-                body_extras["service_tier"] = _gw_overrides["service_tier"]
+            if request_model_options:
+                body_extras["model_options"] = request_model_options
             try:
                 final_text, usage = _run_gateway_runs_api_streaming(
                     session_id, msg_text, model, workspace, stream_id,
@@ -1256,10 +1285,8 @@ def _run_gateway_chat_streaming(
             }
             if model_provider:
                 body["provider"] = model_provider
-            if reasoning_effort is not None:
-                body["reasoning_effort"] = reasoning_effort
-            if _gw_overrides.get("service_tier"):
-                body["service_tier"] = _gw_overrides["service_tier"]
+            if request_model_options:
+                body["model_options"] = request_model_options
             req = urllib.request.Request(
                 url,
                 data=json.dumps(body).encode("utf-8"),

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -402,6 +402,115 @@ def _gateway_reasoning_effort_label(reasoning_effort):
     return "off" if value == "none" else value
 
 
+def _gateway_effective_runtime_metadata(payload: dict) -> dict:
+    """Extract display-safe effective runtime fields from a terminal payload.
+
+    Gateway versions expose the answered identity either in ``runtime`` (the
+    current runs-API contract) or routing metadata using ``used_*`` fields.
+    Requested top-level ``model`` values are deliberately ignored: without an
+    explicit runtime/routing container they are not proof of what answered.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    usage_value = payload.get("usage")
+    usage = usage_value if isinstance(usage_value, dict) else {}
+
+    runtime = {}
+    for container in (payload, usage):
+        for key in ("runtime", "effective_runtime"):
+            value = container.get(key)
+            if isinstance(value, dict):
+                runtime.update(value)
+    effective_value = runtime.get("effective")
+    effective = effective_value if isinstance(effective_value, dict) else {}
+
+    routing = {}
+    for container in (payload, usage):
+        for key in ("routing", "routing_metadata", "gateway_routing", "llm_gateway"):
+            value = container.get(key)
+            if isinstance(value, dict):
+                routing.update(value)
+
+    has_explicit_runtime = bool(runtime or routing)
+    has_explicit_routing_fields = any(
+        key in payload or key in usage
+        for key in ("used_model", "used_provider", "effective_model", "effective_provider")
+    )
+    if not has_explicit_runtime and not has_explicit_routing_fields:
+        return {}
+
+    def _clean(value, limit=240):
+        if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+            return None
+        text = str(value).strip()
+        return text[:limit] if text else None
+
+    runtime_sources = (effective, runtime, routing)
+    direct_sources = (payload, usage)
+
+    def _first(sources, keys, *, limit=240):
+        for source in sources:
+            for key in keys:
+                value = _clean(source.get(key), limit=limit)
+                if value:
+                    return value
+        return None
+
+    result = {}
+    model = _first(runtime_sources, ("effective_model", "used_model", "model"))
+    if model is None:
+        model = _first(direct_sources, ("effective_model", "used_model"))
+    provider = _first(
+        runtime_sources,
+        ("effective_provider", "used_provider", "provider", "provider_id"),
+        limit=80,
+    )
+    if provider is None:
+        provider = _first(
+            direct_sources, ("effective_provider", "used_provider"), limit=80
+        )
+    if model:
+        result["model"] = model
+    if provider:
+        result["provider"] = provider
+
+    sources = (*runtime_sources, *direct_sources)
+    effort_value = _first(
+        sources,
+        ("effective_reasoning_effort", "reasoning_effort", "effort"),
+        limit=32,
+    )
+    reasoning_cfg = None
+    for source in sources:
+        for key in ("reasoning_config", "reasoning"):
+            value = source.get(key)
+            if isinstance(value, dict):
+                reasoning_cfg = value
+                break
+        if reasoning_cfg is not None:
+            break
+    if reasoning_cfg is not None:
+        if reasoning_cfg.get("enabled") is False:
+            effort_value = "off"
+        elif effort_value is None:
+            effort_value = _clean(reasoning_cfg.get("effort"), limit=32)
+    effort_label = _gateway_reasoning_effort_label(effort_value)
+    if effort_label is not None:
+        result["reasoning_effort"] = effort_label
+    return result
+
+
+def _gateway_merge_effective_runtime(usage: dict, payload: dict) -> None:
+    """Accumulate terminal effective metadata under a private transient key."""
+    effective = _gateway_effective_runtime_metadata(payload)
+    if not effective:
+        return
+    current = usage.get("_effective_runtime")
+    merged = dict(current) if isinstance(current, dict) else {}
+    merged.update(effective)
+    usage["_effective_runtime"] = merged
+
+
 def gateway_chat_config_status(config_data=None, environ: dict[str, str] | None = None) -> dict:
     """Return redacted Gateway-backed chat configuration status."""
     mode = webui_chat_backend_mode(config_data, environ)
@@ -755,6 +864,7 @@ def _run_gateway_runs_api_streaming(
                     if stream_id in STREAM_PARTIAL_TEXT:
                         STREAM_PARTIAL_TEXT[stream_id] = output
                 usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
+                _gateway_merge_effective_runtime(usage, payload)
                 sse_event = "message"
                 continue
             if payload_event == "run.failed":
@@ -778,6 +888,7 @@ def _run_gateway_runs_api_streaming(
                     STREAM_PARTIAL_TEXT[stream_id] += delta
                 put_gateway_event("token", {"text": delta})
             usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
+            _gateway_merge_effective_runtime(usage, payload)
     return final_text, usage
 
 
@@ -993,7 +1104,7 @@ def _run_gateway_chat_streaming(
     s = None
     final_text = ""
     terminal_error = ""
-    usage = {"input_tokens": 0, "output_tokens": 0, "estimated_cost": 0}
+    usage: dict[str, Any] = {"input_tokens": 0, "output_tokens": 0, "estimated_cost": 0}
     try:
         s = get_session(session_id)
         from api.config import get_config  # imported lazily to avoid config-cycle churn
@@ -1257,6 +1368,48 @@ def _run_gateway_chat_streaming(
                         put_gateway_event("token", {"text": delta})
                     usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
+            _gateway_merge_effective_runtime(usage, last_payload)
+
+        # Reconcile request-side attribution with the runtime that actually
+        # answered.  The private accumulator is removed before done.usage is
+        # emitted so only the public effective fields leave this worker.
+        effective_runtime_value = usage.pop("_effective_runtime", {})
+        effective_runtime = (
+            effective_runtime_value if isinstance(effective_runtime_value, dict) else {}
+        )
+        effective_model = str(effective_runtime.get("model") or model or "").strip()
+        effective_provider = str(effective_runtime.get("provider") or model_provider or "").strip()
+        effective_reasoning_effort_label = effective_runtime.get(
+            "reasoning_effort", reasoning_effort_label
+        )
+        effective_gateway_routing = None
+        if effective_runtime:
+            from api.streaming import _normalize_gateway_routing_metadata
+
+            effective_gateway_routing = _normalize_gateway_routing_metadata(
+                {
+                    "used_model": effective_model,
+                    "used_provider": effective_provider,
+                    "requested_model": model,
+                    "requested_provider": model_provider,
+                },
+                requested_model=model,
+                requested_provider=model_provider,
+            )
+            replacement_meta = {
+                "session_id": session_id,
+                "model": effective_model,
+                "provider": effective_provider,
+                "reasoning_effort": effective_reasoning_effort_label,
+            }
+            requested_meta = {
+                "session_id": session_id,
+                "model": model,
+                "provider": model_provider or "",
+                "reasoning_effort": reasoning_effort_label,
+            }
+            if replacement_meta != requested_meta:
+                put_gateway_event("run_meta", replacement_meta)
         assistant_text = final_text.strip()
         if terminal_error:
             error_payload = _settle_gateway_terminal_error(
@@ -1308,10 +1461,12 @@ def _run_gateway_chat_streaming(
                 active_turn_identity.get("timestamp") or now
             )
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
-            if model:
-                assistant_msg["_usedModel"] = model
-            if reasoning_effort_label is not None:
-                assistant_msg["_reasoningEffort"] = reasoning_effort_label
+            if effective_model:
+                assistant_msg["_usedModel"] = effective_model
+            if effective_reasoning_effort_label is not None:
+                assistant_msg["_reasoningEffort"] = effective_reasoning_effort_label
+            if effective_gateway_routing is not None:
+                assistant_msg["_gatewayRouting"] = effective_gateway_routing
             saved_reasoning = STREAM_REASONING_TEXT.get(stream_id, "")
             if saved_reasoning:
                 assistant_msg["reasoning"] = saved_reasoning
@@ -1379,8 +1534,8 @@ def _run_gateway_chat_streaming(
             s.pending_started_at = None
             s.pending_user_source = None
             s.workspace = str(workspace)
-            s.model = model
-            s.model_provider = model_provider
+            s.model = effective_model or model
+            s.model_provider = effective_provider or model_provider
 
             def _restore_cancelled_success_writeback():
                 if pending_source == "process_wakeup":
@@ -1458,8 +1613,12 @@ def _run_gateway_chat_streaming(
                 goal_exc,
             )
         from api.streaming import _session_payload_with_full_messages
-        if reasoning_effort_label is not None:
-            usage["reasoning_effort"] = reasoning_effort_label
+        if effective_model:
+            usage["used_model"] = effective_model
+        if effective_provider:
+            usage["used_provider"] = effective_provider
+        if effective_reasoning_effort_label is not None:
+            usage["reasoning_effort"] = effective_reasoning_effort_label
         gateway_session_payload = _session_payload_with_full_messages(s, tool_calls=[])
         put_gateway_event("done", {"session": redact_session_data(gateway_session_payload), "usage": usage})
         put_gateway_event("stream_end", {"session_id": session_id})

--- a/api/models.py
+++ b/api/models.py
@@ -8964,6 +8964,7 @@ _SESSION_MESSAGE_DISPLAY_METADATA_KEYS = (
     "_turnUsage",
     "_firstTokenMs",
     "_usedModel",
+    "_reasoningEffort",
     "_gatewayRouting",
     "_statusCard",
     "_anchor_stream_id",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -672,7 +672,7 @@ def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
             or 'falling back' in m
             or 'fallback activated' in m
             or 'trying fallback' in m
-            or 'switched to fallback model:' in m
+            or 'switched to fallback' in m
         )
     )
 
@@ -682,14 +682,19 @@ def _is_effective_fallback_lifecycle_message(kind: str, message: str) -> bool:
 
     Retry notices such as ``trying fallback`` and ``switching to fallback`` are
     emitted before activation and may still recover on the primary.  Hermes
-    emits the one-shot ``Switched to fallback model: ...`` lifecycle notice
-    after it has replaced ``agent.model``, ``agent.provider`` and
-    ``agent.reasoning_config``.  Only that post-activation notice is safe to use
-    as the trigger for replacing live effective-run metadata.
+    emits one of two post-activation success wordings after it has replaced
+    ``agent.model``, ``agent.provider`` and ``agent.reasoning_config``:
+
+    - ``Switched to fallback model: X via P1 → Y via P2`` (pending notice)
+    - ``↻ Switched to fallback: Y (P2)`` (empty-content path)
+
+    Only those post-activation notices are safe to use as the trigger for
+    replacing live effective-run metadata.  ``switching`` does not contain
+    ``switched``, so pre-activation retry chatter stays excluded.
     """
     k = str(kind or '').strip().lower()
     m = str(message or '').strip().lower()
-    return k == 'lifecycle' and 'switched to fallback model:' in m
+    return k == 'lifecycle' and 'switched to fallback' in m
 
 
 def _is_agent_compression_start_status(kind: str, message: str) -> bool:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9105,6 +9105,23 @@ def _run_agent_streaming(
     # surface the real, actionable cause (model_not_found / auth_mismatch).
     _captured_terminal_error = [None]
 
+    def _emit_effective_run_meta():
+        """Announce the model and reasoning config currently owned by the agent.
+
+        Hermes mutates these values when it activates a fallback, so this must
+        be callable both at run start and from the fallback lifecycle callback.
+        Missing values stay missing; consumers must not infer an effective
+        value from the originally requested session settings.
+        """
+        _effective_model = getattr(agent, 'model', None)
+        _effective_effort = _effective_reasoning_effort_label(agent)
+        put('run_meta', {
+            'session_id': session_id,
+            'model': _effective_model,
+            'provider': getattr(agent, 'provider', None),
+            'reasoning_effort': _effective_effort,
+        })
+
     def _agent_status_callback(kind, message):
         """Bridge Agent lifecycle status into WebUI SSE.
 
@@ -9139,6 +9156,11 @@ def _run_agent_streaming(
         _is_fallback_notice = _is_fallback_lifecycle_message(_kind, _message)
         if _is_fallback_notice:
             put('warning', {'type': 'fallback', 'message': _message})
+            # The agent has already installed the fallback model and its
+            # resolved reasoning config when it emits this lifecycle notice.
+            # Replace the initial run metadata now so live and replayed footers
+            # never keep showing the pre-fallback values.
+            _emit_effective_run_meta()
 
     # xsession wakeup misroute root fix (Option 1): pre-init so the outer
     # finally can always reset even if an exception fires before the bind.
@@ -10506,13 +10528,7 @@ def _run_agent_streaming(
             # the live footer can display them during streaming, not only after
             # the turn settles. The effort label reads the frozen agent config —
             # the value actually used for this run (overrides + clamp applied).
-            _run_meta_effort = _effective_reasoning_effort_label(agent, _reasoning_config)
-            put('run_meta', {
-                'session_id': session_id,
-                'model': getattr(agent, 'model', None) or resolved_model or model,
-                'provider': resolved_provider or '',
-                'reasoning_effort': _run_meta_effort,
-            })
+            _emit_effective_run_meta()
 
             # Prepend workspace context so the agent always knows which directory
             # to use for file operations, regardless of session age or AGENTS.md defaults.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2605,6 +2605,26 @@ def _normalize_gateway_routing_metadata(payload, requested_model=None, requested
     return normalized
 
 
+def _effective_reasoning_effort_label(agent, fallback_config=None):
+    """Effective reasoning effort for footer display: level str, 'off', or None.
+
+    Reads the frozen per-agent reasoning_config (the same dict the run actually
+    used) so the footer reflects the effective effort — after per-model
+    overrides and capability clamping — rather than the raw configured value.
+    Returns None when no explicit reasoning config exists (provider default is
+    unknown; the UI renders no chip instead of guessing).
+    """
+    cfg = getattr(agent, 'reasoning_config', None)
+    if not isinstance(cfg, dict) or 'enabled' not in cfg:
+        cfg = fallback_config
+    if not isinstance(cfg, dict) or 'enabled' not in cfg:
+        return None
+    if cfg.get('enabled') is False:
+        return 'off'
+    effort = str(cfg.get('effort') or '').strip().lower()
+    return effort or None
+
+
 def _extract_gateway_routing_metadata(agent, result, requested_model=None, requested_provider=None):
     candidates = []
     if isinstance(result, dict):
@@ -10482,6 +10502,18 @@ def _run_agent_streaming(
                     put('cancel', _cancel_event_payload('Cancelled by user'))
                     return
 
+            # Announce the run's effective model + reasoning effort up front so
+            # the live footer can display them during streaming, not only after
+            # the turn settles. The effort label reads the frozen agent config —
+            # the value actually used for this run (overrides + clamp applied).
+            _run_meta_effort = _effective_reasoning_effort_label(agent, _reasoning_config)
+            put('run_meta', {
+                'session_id': session_id,
+                'model': getattr(agent, 'model', None) or resolved_model or model,
+                'provider': resolved_provider or '',
+                'reasoning_effort': _run_meta_effort,
+            })
+
             # Prepend workspace context so the agent always knows which directory
             # to use for file operations, regardless of session age or AGENTS.md defaults.
             workspace_ctx = _workspace_context_prefix(str(s.workspace))
@@ -11668,6 +11700,9 @@ def _run_agent_streaming(
                                 _dm['_firstTokenMs'] = _ttft_ms
                             if _used_model:
                                 _dm['_usedModel'] = _used_model
+                            _effort_label = _effective_reasoning_effort_label(agent, _reasoning_config)
+                            if _effort_label:
+                                _dm['_reasoningEffort'] = _effort_label
                             break
                 # Persist context window data on the session so the context-ring
                 # indicator survives a page reload (#1318). Must run BEFORE
@@ -12057,6 +12092,9 @@ def _run_agent_streaming(
                 usage['ttft_ms'] = _ttft_ms
             if _used_model:
                 usage['used_model'] = _used_model
+            _effort_label_done = _effective_reasoning_effort_label(agent, _reasoning_config)
+            if _effort_label_done:
+                usage['reasoning_effort'] = _effort_label_done
             # Include context window data from the agent's compressor for the UI indicator.
             # The session-level persistence happens above (before s.save()) so the values
             # survive a page reload; this block only populates the live SSE usage payload.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -672,8 +672,24 @@ def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
             or 'falling back' in m
             or 'fallback activated' in m
             or 'trying fallback' in m
+            or 'switched to fallback model:' in m
         )
     )
+
+
+def _is_effective_fallback_lifecycle_message(kind: str, message: str) -> bool:
+    """Return True only after Hermes has durably installed a fallback runtime.
+
+    Retry notices such as ``trying fallback`` and ``switching to fallback`` are
+    emitted before activation and may still recover on the primary.  Hermes
+    emits the one-shot ``Switched to fallback model: ...`` lifecycle notice
+    after it has replaced ``agent.model``, ``agent.provider`` and
+    ``agent.reasoning_config``.  Only that post-activation notice is safe to use
+    as the trigger for replacing live effective-run metadata.
+    """
+    k = str(kind or '').strip().lower()
+    m = str(message or '').strip().lower()
+    return k == 'lifecycle' and 'switched to fallback model:' in m
 
 
 def _is_agent_compression_start_status(kind: str, message: str) -> bool:
@@ -2623,6 +2639,43 @@ def _effective_reasoning_effort_label(agent, fallback_config=None):
         return 'off'
     effort = str(cfg.get('effort') or '').strip().lower()
     return effort or None
+
+
+def _effective_run_meta_payload(agent, session_id):
+    """Build the live metadata payload from the runtime currently on *agent*."""
+    return {
+        'session_id': session_id,
+        'model': getattr(agent, 'model', None),
+        'provider': getattr(agent, 'provider', None),
+        'reasoning_effort': _effective_reasoning_effort_label(agent),
+    }
+
+
+def _bridge_fallback_lifecycle_status(
+    kind,
+    message,
+    *,
+    agent,
+    session_id,
+    put,
+    emit_effective_run_meta=None,
+):
+    """Bridge fallback lifecycle status to warning and effective live metadata.
+
+    All recognized retry/fallback lifecycle lines remain user-visible warnings.
+    A replacement ``run_meta`` is emitted only for Hermes' post-activation
+    success notice, never for speculative retry chatter.
+    """
+    text = str(message or '').strip()
+    if not text or not _is_fallback_lifecycle_message(kind, text):
+        return False
+    put('warning', {'type': 'fallback', 'message': text})
+    if _is_effective_fallback_lifecycle_message(kind, text):
+        if emit_effective_run_meta is not None:
+            emit_effective_run_meta()
+        else:
+            put('run_meta', _effective_run_meta_payload(agent, session_id))
+    return True
 
 
 def _extract_gateway_routing_metadata(agent, result, requested_model=None, requested_provider=None):
@@ -9113,14 +9166,7 @@ def _run_agent_streaming(
         Missing values stay missing; consumers must not infer an effective
         value from the originally requested session settings.
         """
-        _effective_model = getattr(agent, 'model', None)
-        _effective_effort = _effective_reasoning_effort_label(agent)
-        put('run_meta', {
-            'session_id': session_id,
-            'model': _effective_model,
-            'provider': getattr(agent, 'provider', None),
-            'reasoning_effort': _effective_effort,
-        })
+        put('run_meta', _effective_run_meta_payload(agent, session_id))
 
     def _agent_status_callback(kind, message):
         """Bridge Agent lifecycle status into WebUI SSE.
@@ -9153,14 +9199,14 @@ def _run_agent_streaming(
             return
         # Pass through rate-limit and fallback messages so the frontend can
         # show them as warnings via the existing messages.js 'warning' listener.
-        _is_fallback_notice = _is_fallback_lifecycle_message(_kind, _message)
-        if _is_fallback_notice:
-            put('warning', {'type': 'fallback', 'message': _message})
-            # The agent has already installed the fallback model and its
-            # resolved reasoning config when it emits this lifecycle notice.
-            # Replace the initial run metadata now so live and replayed footers
-            # never keep showing the pre-fallback values.
-            _emit_effective_run_meta()
+        _bridge_fallback_lifecycle_status(
+            _kind,
+            _message,
+            agent=agent,
+            session_id=session_id,
+            put=put,
+            emit_effective_run_meta=_emit_effective_run_meta,
+        )
 
     # xsession wakeup misroute root fix (Option 1): pre-init so the outer
     # finally can always reset even if an exception fires before the bind.

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -696,6 +696,8 @@ const LOCALES = {
     settings_label_transparent_stream_event_timestamps: 'Show Transparent Stream event timestamps',
     settings_desc_transparent_stream_event_timestamps: 'Keeps the response footer time visible while hiding the per-event timestamp chips.',
     first_token_time: 'Time to first token',
+    reasoning_effort: 'Effective reasoning effort',
+    reasoning_off: 'reasoning off',
     processed_elapsed: _i18nProcessedElapsedEn,
     worklog_thinking: 'Thinking',
     tool_target_skill_suffix: 'skill',
@@ -1782,6 +1784,8 @@ const LOCALES = {
   },
 
   it: {
+    reasoning_effort: 'Sforzo di ragionamento effettivo',
+    reasoning_off: 'ragionamento disattivato',
     offline_title: 'Connessione persa',
     offline_browser_detail: 'Il browser segnala che questo dispositivo è offline.',
     offline_network_detail: 'Hermes non è raggiungibile da questo browser al momento.',
@@ -3541,6 +3545,8 @@ const LOCALES = {
   },
 
   ja: {
+    reasoning_effort: '実際の推論エフォート',
+    reasoning_off: '推論オフ',
     offline_title: '接続が切断されました',
     offline_browser_detail: 'ブラウザはこのデバイスがオフラインだと報告しています。',
     offline_network_detail: '現在、このブラウザからHermesに到達できません。',
@@ -5305,6 +5311,8 @@ const LOCALES = {
   },
 
   ru: {
+    reasoning_effort: 'Фактическое усилие рассуждения',
+    reasoning_off: 'рассуждение выключено',
     offline_title: 'Соединение потеряно',
     offline_browser_detail: 'Браузер сообщает, что это устройство офлайн.',
     offline_network_detail: 'Hermes сейчас недоступен из этого браузера.',
@@ -7043,6 +7051,8 @@ const LOCALES = {
   },
 
   es: {
+    reasoning_effort: 'Esfuerzo de razonamiento efectivo',
+    reasoning_off: 'razonamiento desactivado',
     offline_title: 'Conexión perdida',
     offline_browser_detail: 'Tu navegador indica que este dispositivo está sin conexión.',
     offline_network_detail: 'Hermes no está disponible desde este navegador ahora mismo.',
@@ -8748,6 +8758,8 @@ const LOCALES = {
   },
 
   de: {
+    reasoning_effort: 'Effektiver Reasoning-Aufwand',
+    reasoning_off: 'Reasoning deaktiviert',
     offline_title: 'Verbindung verloren',
     offline_browser_detail: 'Dein Browser meldet, dass dieses Gerät offline ist.',
     offline_network_detail: 'Hermes ist von diesem Browser aus gerade nicht erreichbar.',
@@ -10447,6 +10459,8 @@ const LOCALES = {
   },
 
   zh: {
+    reasoning_effort: '实际推理强度',
+    reasoning_off: '推理已关闭',
     offline_title: '连接已断开',
     offline_browser_detail: '浏览器报告此设备当前离线。',
     offline_network_detail: '此浏览器当前无法连接到 Hermes。',
@@ -12140,6 +12154,8 @@ const LOCALES = {
 
   // Traditional Chinese (zh-Hant)
   'zh-Hant': {
+    reasoning_effort: '實際推理強度',
+    reasoning_off: '推理已關閉',
 
     offline_title: '連線中斷',
     offline_browser_detail: '瀏覽器回報此裝置目前離線。',
@@ -13902,6 +13918,8 @@ const LOCALES = {
   },
 
   pt: {
+    reasoning_effort: 'Esforço de raciocínio efetivo',
+    reasoning_off: 'raciocínio desativado',
     offline_title: 'Conexão perdida',
     offline_browser_detail: 'O navegador informa que este dispositivo está offline.',
     offline_network_detail: 'O Hermes está inacessível neste navegador agora.',
@@ -15480,6 +15498,8 @@ const LOCALES = {
     wiki_not_configured: 'Wiki not configured',
   },
   ko: {
+    reasoning_effort: '실제 추론 강도',
+    reasoning_off: '추론 꺼짐',
     offline_title: '연결이 끊겼습니다',
     offline_browser_detail: '브라우저가 이 장치가 오프라인이라고 보고합니다.',
     offline_network_detail: '현재 이 브라우저에서 Hermes에 연결할 수 없습니다.',
@@ -17906,6 +17926,8 @@ const LOCALES = {
     settings_label_transparent_stream_event_timestamps: 'Show Transparent Stream event timestamps',
     settings_desc_transparent_stream_event_timestamps: 'Keeps the response footer time visible while hiding the per-event timestamp chips.',
     first_token_time: 'Délai jusqu\'au premier jeton',
+    reasoning_effort: 'Effort de raisonnement effectif',
+    reasoning_off: 'raisonnement désactivé',
     processed_elapsed: _i18nProcessedElapsedEn,
     worklog_thinking: 'Réflexion',
     tool_target_skill_suffix: 'compétence',
@@ -18961,6 +18983,8 @@ const LOCALES = {
   },
 
   cs: {
+    reasoning_effort: 'Skutečná úroveň uvažování',
+    reasoning_off: 'uvažování vypnuto',
     _label: 'Čeština',
     _lang: 'cs',
     _speech: 'cs-CZ',
@@ -20679,6 +20703,8 @@ const LOCALES = {
     tool_summary_join: _i18nToolSummaryJoinCs,
   },
   tr: {
+    reasoning_effort: 'Gerçek akıl yürütme çabası',
+    reasoning_off: 'akıl yürütme kapalı',
 
 
 
@@ -22433,6 +22459,8 @@ const LOCALES = {
   
   },
   pl: {
+    reasoning_effort: 'Rzeczywisty poziom rozumowania',
+    reasoning_off: 'rozumowanie wyłączone',
     offline_title: 'Połączenie utracone',
     offline_browser_detail: 'Twoja przeglądarka zgłasza, że to urządzenie jest offline.',
     offline_network_detail: 'Hermes jest obecnie nieosiągalny z tej przeglądarki.',
@@ -24187,6 +24215,8 @@ const LOCALES = {
     checkpoint_diff_files_changed: (n) => n === 1 ? '1 plik zmieniony' : `${n} zmienionych plików`,
   },
   vi: {
+    reasoning_effort: 'Mức suy luận thực tế',
+    reasoning_off: 'đã tắt suy luận',
     offline_title: 'Mất kết nối',
     offline_browser_detail: 'Trình duyệt báo rằng thiết bị này đang ngoại tuyến.',
     offline_network_detail: 'Không thể kết nối tới Hermes từ trình duyệt lúc này.',

--- a/static/messages.js
+++ b/static/messages.js
@@ -6098,6 +6098,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
     });
 
+    // run_meta: backend announces the run's effective model + reasoning effort
+    // up front so the live footer shows them during streaming, not only after
+    // the turn settles. Replayed by the run journal on reconnect.
+    source.addEventListener('run_meta',e=>{
+      try{
+        const d=JSON.parse(e.data||'{}');
+        if(d&&d.session_id&&activeSid&&d.session_id!==activeSid)return;
+        if(typeof updateLiveRunStatus==='function'){
+          updateLiveRunStatus({sessionId:activeSid,meta:{
+            model:String((d&&d.model)||''),
+            effort:String((d&&d.reasoning_effort)||''),
+          }});
+        }
+      }catch(_){}
+    });
+
     source.addEventListener('done',e=>{
       if(_streamFinalized) return;
       _clearStreamEndRecovery();
@@ -6269,6 +6285,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               }
               if(typeof d.usage.duration_seconds==='number'){
                 lastAsst._turnDuration=d.usage.duration_seconds;
+              }
+              if(typeof d.usage.reasoning_effort==='string'&&d.usage.reasoning_effort){
+                lastAsst._reasoningEffort=d.usage.reasoning_effort;
               }
               if(typeof d.usage.tps==='number'&&d.usage.tps>0){
                 lastAsst._turnTps=d.usage.tps;
@@ -6916,7 +6935,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       })();
     });
 
-    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
+    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','run_meta','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
   }

--- a/static/messages.js
+++ b/static/messages.js
@@ -6289,6 +6289,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               if(typeof d.usage.reasoning_effort==='string'&&d.usage.reasoning_effort){
                 lastAsst._reasoningEffort=d.usage.reasoning_effort;
               }
+              if(typeof d.usage.used_model==='string'&&d.usage.used_model){
+                lastAsst._usedModel=d.usage.used_model;
+              }
               if(typeof d.usage.tps==='number'&&d.usage.tps>0){
                 lastAsst._turnTps=d.usage.tps;
               }
@@ -6958,7 +6961,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     return `${m.role}|${ts}|${body.slice(0,160)}`;
   }
-  const _EPHEMERAL_TURN_FIELDS=['_turnUsage','_turnDuration','_turnTps','_gatewayRouting','_statusCard','_anchor_stream_id','_anchor_activity_scene'];
+  const _EPHEMERAL_TURN_FIELDS=['_turnUsage','_turnDuration','_turnTps','_gatewayRouting','_usedModel','_reasoningEffort','_statusCard','_anchor_stream_id','_anchor_activity_scene'];
   function _isHistoricalAnchorActivityScene(scene){
     if(!scene||typeof scene!=='object') return false;
     const identity=scene.identity&&typeof scene.identity==='object'?scene.identity:null;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1925,7 +1925,7 @@ async function send(){
       const _startedAt=typeof startData?.pending_started_at==='number'
         ? startData.pending_started_at
         : (S.session.pending_started_at||Date.now()/1000);
-      showLiveRunStatus(activeSid,{startedAt:_startedAt});
+      showLiveRunStatus(activeSid,{streamId,startedAt:_startedAt});
     }
     if(typeof upsertActiveSessionForLocalTurn==='function'){
       // Third optimistic pass: stream_id is now known, so the row can reconcile
@@ -1985,7 +1985,7 @@ async function startRegeneration(sessionId, regenerationRevision){
     if(!INFLIGHT[sid])INFLIGHT[sid]={messages:S.messages.slice(),uploaded:[],toolCalls:[]};
     markInflight(sid,streamId);
     if(typeof saveInflightState==='function')saveInflightState(sid,{streamId,messages:S.messages.slice(),uploaded:[],toolCalls:[]});
-    if(typeof showLiveRunStatus==='function')showLiveRunStatus(sid,{startedAt:S.session.pending_started_at||Date.now()/1000});
+    if(typeof showLiveRunStatus==='function')showLiveRunStatus(sid,{streamId,startedAt:S.session.pending_started_at||Date.now()/1000});
     if(typeof updateSendBtn==='function')updateSendBtn();
     if(typeof renderSessionList==='function')void renderSessionList();
     attachLiveStream(sid,streamId,[]);
@@ -2061,10 +2061,11 @@ function closeLiveStream(sessionId, streamId, source){
   // thinking/tool content (only the elapsed clock survives). Capturing here
   // guarantees switch-back restores the exact state shown at switch-away. (#3668)
   if(typeof snapshotLiveTurnHtmlForSession==='function') snapshotLiveTurnHtmlForSession(sessionId);
-  // Stop the live footer timer/status for the pane that is being detached; the
-  // reattach path will rebuild it from INFLIGHT/server state if the user returns.
-  if(typeof _clearLiveRunStatusTimer==='function') _clearLiveRunStatusTimer(sessionId);
-  if(typeof hideLiveRunStatus==='function') hideLiveRunStatus(sessionId);
+  // Stop the live footer timer/status only when this stream still owns it. A
+  // successor can already have claimed the same session before the old source
+  // reaches stream_end, and stale teardown must not hide the successor footer.
+  if(typeof hideLiveRunStatus==='function') hideLiveRunStatus(sessionId,live.streamId||streamId);
+  else if(typeof _clearLiveRunStatusTimer==='function') _clearLiveRunStatusTimer(sessionId);
   try{if(live.source&&live.source.readyState!==2)live.source.close();}catch(_){ }
   delete LIVE_STREAMS[sessionId];
   _resumeSessionStreamAfterLiveChat(sessionId);
@@ -2128,6 +2129,7 @@ function _dispatchExtensionTurnLifecycle(type,sessionId,streamId,details={}){
 
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
+  if(typeof _claimLiveRunStatusOwner==='function') _claimLiveRunStatusOwner(activeSid,streamId);
   const reconnecting=!!options.reconnecting;
   const _extensionTurnStartedAt=(S.session&&S.session.session_id===activeSid&&Number.isFinite(S.session.pending_started_at))
     ?S.session.pending_started_at
@@ -2180,7 +2182,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // exists. There is no stale transport teardown in this branch.
     if(reconnecting && S.activeStreamId && typeof showLiveRunStatus==='function'){
       const _startedAt=(S.session&&S.session.pending_started_at)||Date.now()/1000;
-      showLiveRunStatus(activeSid,{startedAt:_startedAt});
+      showLiveRunStatus(activeSid,{streamId,startedAt:_startedAt});
     }
     return;
   }
@@ -2192,7 +2194,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // hides the status while tearing down stale EventSource ownership.
   if(reconnecting && S.activeStreamId && typeof showLiveRunStatus==='function'){
     const _startedAt=(S.session&&S.session.pending_started_at)||Date.now()/1000;
-    showLiveRunStatus(activeSid,{startedAt:_startedAt});
+    showLiveRunStatus(activeSid,{streamId,startedAt:_startedAt});
   }
   _suspendSessionStreamForLiveChat(activeSid);
 
@@ -6106,7 +6108,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const d=JSON.parse(e.data||'{}');
         if(d&&d.session_id&&activeSid&&d.session_id!==activeSid)return;
         if(typeof updateLiveRunStatus==='function'){
-          updateLiveRunStatus({sessionId:activeSid,meta:{
+          updateLiveRunStatus({sessionId:activeSid,streamId,meta:{
             model:String((d&&d.model)||''),
             effort:String((d&&d.reasoning_effort)||''),
           }});

--- a/static/style.css
+++ b/static/style.css
@@ -4479,7 +4479,7 @@ body.resizing .sidebar{transition:none!important;}
   padding:0 24px;
 }
 /* LiveFooter: inline stream spark · elapsed · tokens · status */
-.live-run-status{display:flex;align-items:center;gap:8px;padding-left:0;margin:2px 0 6px;margin-left:var(--msg-rail);max-width:var(--msg-max);font-size:13px;color:var(--muted);font-variant-numeric:tabular-nums;line-height:1;}
+.live-run-status{display:flex;align-items:center;flex-wrap:wrap;gap:8px;row-gap:4px;padding-left:0;margin:2px 0 6px;margin-left:var(--msg-rail);max-width:var(--msg-max);font-size:13px;color:var(--muted);font-variant-numeric:tabular-nums;line-height:1.3;}
 .live-footer{display:flex;align-items:center;gap:8px;padding-left:var(--worklog-rail);margin:2px 0 6px;margin-left:0;max-width:var(--msg-max);font-size:13px;color:var(--muted);}
 .live-run-status[hidden]{display:none;}
 .lf-spark{color:var(--accent);font-size:13px;display:inline-block;animation:lfspin 1.7s linear infinite;line-height:1;}
@@ -4495,7 +4495,7 @@ body.resizing .sidebar{transition:none!important;}
 .lf-status{color:var(--muted);opacity:.85;}
 .live-run-status .lf-model,.live-run-status .lf-effort{color:var(--muted);opacity:.85;}
 @media(max-width:600px){
-  .live-run-status{padding-left:0;font-size:12px;}
+  .live-run-status{padding-left:0;font-size:12px;line-height:1.35;}
   .live-footer{padding-left:var(--worklog-rail);font-size:12px;}
 }
 .compression-block{

--- a/static/style.css
+++ b/static/style.css
@@ -4466,6 +4466,7 @@ body.resizing .sidebar{transition:none!important;}
 .transparent-turn-footer .lf-sep{opacity:.4;}
 .transparent-turn-footer .lf-status{color:var(--muted);opacity:.85;}
 .transparent-turn-footer .lf-model{color:var(--muted);opacity:.85;}
+.transparent-turn-footer .lf-effort{color:var(--muted);opacity:.85;}
 .transparent-turn-footer .lf-ttft{color:var(--accent);opacity:.9;}
 .transparent-turn-footer .lf-tokens{font-variant-numeric:tabular-nums;}
 
@@ -4492,6 +4493,7 @@ body.resizing .sidebar{transition:none!important;}
 .lf-sep{opacity:.4;}
 .lf-tokens{font-variant-numeric:tabular-nums;}
 .lf-status{color:var(--muted);opacity:.85;}
+.live-run-status .lf-model,.live-run-status .lf-effort{color:var(--muted);opacity:.85;}
 @media(max-width:600px){
   .live-run-status{padding-left:0;font-size:12px;}
   .live-footer{padding-left:var(--worklog-rail);font-size:12px;}
@@ -6169,6 +6171,7 @@ body code[class*="language-"],body pre[class*="language-"],body pre code[class*=
 .msg-duration-inline,
 .msg-gateway-inline,
 .msg-used-model-inline,
+.msg-reasoning-inline,
 .gateway-failover-inline,
 .msg-model-warning-inline {
   font-size: 11px;

--- a/static/ui.js
+++ b/static/ui.js
@@ -14606,7 +14606,17 @@ function ensureRunActivityGroup(inner, opts){
 const _liveRunStatusTimers={};  // keyed by sessionId, max 1 active
 let _liveRunStatusTokens=null;
 let _liveRunStatusSessionId=null;
-let _liveRunMeta=null;  // {model, effort} announced by the backend run_meta SSE
+let _liveRunStatusStreamId=null;
+let _liveRunMeta=null;  // {sessionId, streamId, model, effort} from run_meta SSE
+function _claimLiveRunStatusOwner(sid,streamId){
+  const nextSid=String(sid||'');
+  const nextStreamId=String(streamId||'');
+  _liveRunStatusSessionId=nextSid||null;
+  _liveRunStatusStreamId=nextStreamId||null;
+  const metaOwnsNext=!!(_liveRunMeta&&
+    _liveRunMeta.sessionId===nextSid&&_liveRunMeta.streamId===nextStreamId);
+  if(!nextSid||!nextStreamId||!metaOwnsNext)_liveRunMeta=null;
+}
 function _formatRunElapsed(seconds){
   const n=Number(seconds);
   if(!Number.isFinite(n)||n<0)return'00:00';
@@ -14649,6 +14659,7 @@ function placeLiveRunStatusHost(){
   return _moveLiveRunStatusToTurnEnd(el);
 }
 function showLiveRunStatus(sid,opts){
+  _claimLiveRunStatusOwner(sid,opts&&opts.streamId);
   if(typeof isCompactWorklogMode==='function'&&isCompactWorklogMode()){
     _liveRunStatusSessionId=sid;
     _liveRunStatusTokens=opts&&opts.tokens||null;
@@ -14671,7 +14682,9 @@ function _renderLiveRunStatusContent(el,startedAt){
   const elapsed=startedAt?Math.max(0,now-startedAt):0;
   const timeStr=_formatRunElapsed(elapsed);
   const tokens=_liveRunStatusTokens;
-  const meta=_liveRunMeta||{};
+  const meta=(_liveRunMeta&&
+    _liveRunMeta.sessionId===String(_liveRunStatusSessionId||'')&&
+    _liveRunMeta.streamId===String(_liveRunStatusStreamId||''))?_liveRunMeta:{};
   // run_meta is authoritative for the active attempt. Do not fall back to the
   // requested session model: after a runtime fallback that value is stale, and
   // an absent effective model must remain undisplayed rather than guessed.
@@ -14682,9 +14695,16 @@ function _renderLiveRunStatusContent(el,startedAt){
   el.innerHTML=`<span class="live-run-status-dot tool-card-running-dot"></span><span class="live-run-status-text lf-time">${timeStr}</span>${tokens?`<span class="lf-sep">·</span><span class="lf-tokens">${_fmtTokens(tokens)} tokens</span>`:''}${metaModel?`<span class="lf-sep">·</span><span class="lf-model">${esc(metaModel)}</span>`:''}${effortLabel?`<span class="lf-sep">·</span><span class="lf-effort" title="${esc(t('reasoning_effort')||'Effective reasoning effort')}">${esc(effortLabel)}</span>`:''}<span class="lf-sep">·</span><span class="lf-status">Running</span>`;
 }
 function updateLiveRunStatus(opts){
-  if(opts&&opts.sessionId&&_liveRunStatusSessionId&&opts.sessionId!==_liveRunStatusSessionId) return;
+  const sid=String(opts&&opts.sessionId||'');
+  const streamId=String(opts&&opts.streamId||'');
+  if(sid&&_liveRunStatusSessionId&&sid!==_liveRunStatusSessionId) return;
+  if(streamId&&_liveRunStatusStreamId&&streamId!==_liveRunStatusStreamId) return;
   if(opts&&opts.tokens!==undefined)_liveRunStatusTokens=opts.tokens;
-  if(opts&&opts.meta)_liveRunMeta=opts.meta;
+  if(opts&&opts.meta){
+    if(!sid||!streamId)return;
+    _claimLiveRunStatusOwner(sid,streamId);
+    _liveRunMeta={...opts.meta,sessionId:sid,streamId};
+  }
   const el=$('liveRunStatus');
   if(el&&!el.hidden){
     _moveLiveRunStatusToTurnEnd(el);
@@ -14696,6 +14716,7 @@ function updateLiveRunStatus(opts){
 function _syncLiveRunStatusAfterRender(){
   const sid=S.session&&S.session.session_id;
   if(!sid||!S.activeStreamId||!S.busy) return;
+  _claimLiveRunStatusOwner(sid,S.activeStreamId);
   const timer=_liveRunStatusTimers[sid];
   const startedAt=(timer&&timer.startedAt)||((S.session&&S.session.pending_started_at)||Date.now()/1000);
   if(typeof isCompactWorklogMode==='function'&&isCompactWorklogMode()){
@@ -14709,16 +14730,17 @@ function _syncLiveRunStatusAfterRender(){
     _renderLiveRunStatusContent(el,startedAt);
     return;
   }
-  showLiveRunStatus(sid,{startedAt,tokens:_liveRunStatusTokens});
+  showLiveRunStatus(sid,{streamId:S.activeStreamId,startedAt,tokens:_liveRunStatusTokens});
 }
-function hideLiveRunStatus(sid){
+function hideLiveRunStatus(sid,streamId){
   if(sid&&_liveRunStatusSessionId&&sid!==_liveRunStatusSessionId) return;
+  if(streamId&&_liveRunStatusStreamId&&streamId!==_liveRunStatusStreamId) return;
   const el=$('liveRunStatus');
   if(el){el.hidden=true;el.innerHTML='';}
   _clearLiveRunStatusTimer(sid||_liveRunStatusSessionId);
   _liveRunStatusTokens=null;
   _liveRunStatusSessionId=null;
-  _liveRunMeta=null;
+  _liveRunStatusStreamId=null;
 }
 function _startLiveRunStatusTimer(sid,startedAt){
   if(!sid)return;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7456,6 +7456,15 @@ function _usedModelTurnChipLabel(msg){
   if(!usedModel)return'';
   return _compactComposerModelChipLabel(usedModel,getModelLabel(usedModel));
 }
+function _reasoningEffortChipLabel(msg){
+  // Effective reasoning effort stamped on the turn by the backend (post
+  // override + capability clamp). Raw level token ('high', 'max', …) or
+  // 'off' when reasoning is explicitly disabled. Empty = unknown (provider
+  // default) → render nothing rather than guess.
+  const v=String(msg&&msg._reasoningEffort||'').trim().toLowerCase();
+  if(!v)return'';
+  return v==='off'?(t('reasoning_off')||'reasoning off'):v;
+}
 function _gatewayRoutingFailoverText(routing){
   if(!routing||!routing.has_failover)return'';
   const attempts=Array.isArray(routing.routing)?routing.routing:[];
@@ -12479,7 +12488,7 @@ function _transparentTurnMetaMessage(turn){
     const candidate=S.messages[Number(mi)];
     if(!candidate||candidate.role!=='assistant')continue;
     if(!fallback)fallback=candidate;
-    if(candidate._turnDuration!=null||candidate._usedModel||candidate._firstTokenMs!=null||candidate._turnUsage)return candidate;
+    if(candidate._turnDuration!=null||candidate._usedModel||candidate._reasoningEffort||candidate._firstTokenMs!=null||candidate._turnUsage)return candidate;
   }
   return fallback;
 }
@@ -12487,13 +12496,14 @@ function _transparentTurnMetaMessage(turn){
 // Mirrors the live run-status line for settled turns in transparent
 // mode. Shows duration, first-token time, token usage, and final status.
 // Only rendered for turns that have transparent event rows.
-function _transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle){
+function _transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle, effortText){
   const parts=[];
   if(durationText) parts.push(`<span class="lf-time">${esc(durationText)}</span>`);
   if(modelText){
     const titleAttr=(modelTitle&&modelTitle!==modelText)?` title="${esc(modelTitle)}"`:'';
     parts.push(`<span class="lf-model"${titleAttr}>${esc(modelText)}</span>`);
   }
+  if(effortText) parts.push(`<span class="lf-effort" title="${esc(t('reasoning_effort')||'Effective reasoning effort')}">${esc(effortText)}</span>`);
   if(ttftText) parts.push(`<span class="lf-ttft" title="${esc(t('first_token_time')||'Time to first token')}">TTFT ${esc(ttftText)}</span>`);
   if(tokensText) parts.push(`<span class="lf-tokens">${esc(tokensText)}</span>`);
   if(statusText) parts.push(`<span class="lf-status">${esc(statusText)}</span>`);
@@ -12516,8 +12526,9 @@ function _renderTransparentTurnFooter(turn, opts){
   const modelTitle=opts&&opts.modelTitle||'';
   const ttftText=opts&&opts.ttftText||'';
   const tokensText=opts&&opts.tokensText||'';
+  const effortText=opts&&opts.effortText||'';
   const statusText=opts&&opts.statusText||(t('done')||'Done');
-  const html=_transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle);
+  const html=_transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle, effortText);
   let footer=turn.querySelector('.transparent-turn-footer');
   if(!html){
     if(footer) footer.remove();
@@ -14590,6 +14601,7 @@ function ensureRunActivityGroup(inner, opts){
 const _liveRunStatusTimers={};  // keyed by sessionId, max 1 active
 let _liveRunStatusTokens=null;
 let _liveRunStatusSessionId=null;
+let _liveRunMeta=null;  // {model, effort} announced by the backend run_meta SSE
 function _formatRunElapsed(seconds){
   const n=Number(seconds);
   if(!Number.isFinite(n)||n<0)return'00:00';
@@ -14654,11 +14666,17 @@ function _renderLiveRunStatusContent(el,startedAt){
   const elapsed=startedAt?Math.max(0,now-startedAt):0;
   const timeStr=_formatRunElapsed(elapsed);
   const tokens=_liveRunStatusTokens;
-  el.innerHTML=`<span class="live-run-status-dot tool-card-running-dot"></span><span class="live-run-status-text lf-time">${timeStr}</span>${tokens?`<span class="lf-sep">·</span><span class="lf-tokens">${_fmtTokens(tokens)} tokens</span>`:''}<span class="lf-sep">·</span><span class="lf-status">Running</span>`;
+  const meta=_liveRunMeta||{};
+  const metaModelRaw=String(meta.model||((S.session&&S.session.model)||'')).trim();
+  const metaModel=metaModelRaw?_compactComposerModelChipLabel(metaModelRaw,getModelLabel(metaModelRaw)):'';
+  const metaEffort=String(meta.effort||'').trim().toLowerCase();
+  const effortLabel=metaEffort==='off'?(t('reasoning_off')||'reasoning off'):metaEffort;
+  el.innerHTML=`<span class="live-run-status-dot tool-card-running-dot"></span><span class="live-run-status-text lf-time">${timeStr}</span>${tokens?`<span class="lf-sep">·</span><span class="lf-tokens">${_fmtTokens(tokens)} tokens</span>`:''}${metaModel?`<span class="lf-sep">·</span><span class="lf-model">${esc(metaModel)}</span>`:''}${effortLabel?`<span class="lf-sep">·</span><span class="lf-effort" title="${esc(t('reasoning_effort')||'Effective reasoning effort')}">${esc(effortLabel)}</span>`:''}<span class="lf-sep">·</span><span class="lf-status">Running</span>`;
 }
 function updateLiveRunStatus(opts){
   if(opts&&opts.sessionId&&_liveRunStatusSessionId&&opts.sessionId!==_liveRunStatusSessionId) return;
   if(opts&&opts.tokens!==undefined)_liveRunStatusTokens=opts.tokens;
+  if(opts&&opts.meta)_liveRunMeta=opts.meta;
   const el=$('liveRunStatus');
   if(el&&!el.hidden){
     _moveLiveRunStatusToTurnEnd(el);
@@ -14692,6 +14710,7 @@ function hideLiveRunStatus(sid){
   _clearLiveRunStatusTimer(sid||_liveRunStatusSessionId);
   _liveRunStatusTokens=null;
   _liveRunStatusSessionId=null;
+  _liveRunMeta=null;
 }
 function _startLiveRunStatusTimer(sid,startedAt){
   if(!sid)return;
@@ -17862,12 +17881,13 @@ function renderMessages(options){
       const compactWorklogForMessage=isCompactWorklogMode()&&(toolCallAssistantIdxs.has(mi)||assistantThinking.has(mi));
       const durationText=compactWorklogForMessage?'':_formatTurnDuration(msg._turnDuration);
       const usedModelText=_usedModelTurnChipLabel(msg);
-      if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText&&!usedModelText) continue;
+      const effortText=_reasoningEffortChipLabel(msg);
+      if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText&&!usedModelText&&!effortText) continue;
       const seg=assistantSegments.get(mi);
       const row=seg?seg.closest('.assistant-turn'):null;
       const footerRows=row?row.querySelectorAll('.msg-foot'):[];
       const targetFoot=footerRows.length?footerRows[footerRows.length-1]:null;
-      if(!targetFoot||targetFoot.querySelector('.msg-usage-inline,.msg-duration-inline,.msg-gateway-inline,.gateway-failover-inline,.msg-model-warning-inline,.msg-used-model-inline')) continue;
+      if(!targetFoot||targetFoot.querySelector('.msg-usage-inline,.msg-duration-inline,.msg-gateway-inline,.gateway-failover-inline,.msg-model-warning-inline,.msg-used-model-inline,.msg-reasoning-inline')) continue;
       const fragments=[];
       if(modelWarningText){
         const warning=document.createElement('span');
@@ -17909,6 +17929,13 @@ function renderMessages(options){
         const usedModelFull=String(msg._usedModel||'').trim();
         if(usedModelFull&&usedModelFull!==usedModelText) usedModel.title=usedModelFull;
         fragments.push(usedModel);
+      }
+      if(effortText){
+        const effort=document.createElement('span');
+        effort.className='msg-reasoning-inline';
+        effort.textContent=effortText;
+        effort.title=t('reasoning_effort')||'Effective reasoning effort';
+        fragments.push(effort);
       }
       if(window._showTokenUsage&&hasTurnUsage){
         const usage=document.createElement('span');
@@ -17967,10 +17994,12 @@ function renderMessages(options){
         let modelTitle='';
         let ttftText='';
         let tokensText='';
+        let effortText='';
         if(msg){
           if(msg._turnDuration!=null) durationText=_formatTurnDuration(msg._turnDuration);
           modelText=_usedModelTurnChipLabel(msg);
           if(modelText) modelTitle=String(msg._usedModel||'').trim();
+          effortText=_reasoningEffortChipLabel(msg);
           if(msg._firstTokenMs!=null) ttftText=_formatFirstToken(msg._firstTokenMs);
           if(msg._turnUsage){
             const inTok=msg._turnUsage.input_tokens||0;
@@ -17984,6 +18013,7 @@ function renderMessages(options){
           modelTitle,
           ttftText,
           tokensText,
+          effortText,
           statusText: t('done')||'Done',
         });
       }else{

--- a/static/ui.js
+++ b/static/ui.js
@@ -14667,7 +14667,10 @@ function _renderLiveRunStatusContent(el,startedAt){
   const timeStr=_formatRunElapsed(elapsed);
   const tokens=_liveRunStatusTokens;
   const meta=_liveRunMeta||{};
-  const metaModelRaw=String(meta.model||((S.session&&S.session.model)||'')).trim();
+  // run_meta is authoritative for the active attempt. Do not fall back to the
+  // requested session model: after a runtime fallback that value is stale, and
+  // an absent effective model must remain undisplayed rather than guessed.
+  const metaModelRaw=String(meta.model||'').trim();
   const metaModel=metaModelRaw?_compactComposerModelChipLabel(metaModelRaw,getModelLabel(metaModelRaw)):'';
   const metaEffort=String(meta.effort||'').trim().toLowerCase();
   const effortLabel=metaEffort==='off'?(t('reasoning_off')||'reasoning off'):metaEffort;

--- a/static/ui.js
+++ b/static/ui.js
@@ -12492,6 +12492,11 @@ function _transparentTurnMetaMessage(turn){
   }
   return fallback;
 }
+function _transparentTurnFooterOwnsSettledMeta(turn){
+  if(!turn||!isTransparentStream())return false;
+  const blocks=_assistantTurnBlocks(turn);
+  return !!(blocks&&blocks.querySelector(':scope > .transparent-event-row'));
+}
 // ── Transparent turn footer (elapsed · tokens · TTFT · status) ───────────
 // Mirrors the live run-status line for settled turns in transparent
 // mode. Shows duration, first-token time, token usage, and final status.
@@ -17920,10 +17925,10 @@ function renderMessages(options){
       // the turn has transparent event rows — skip the generic chip there so
       // exactly one model label renders per turn. Model sits after duration to
       // match the transparent footer order (elapsed · model · …).
-      const _transparentFooterOwnsModel=usedModelText&&isTransparentStream()&&row&&(()=>{
-        const blocks=_assistantTurnBlocks(row);
-        return !!(blocks&&blocks.querySelector(':scope > .transparent-event-row'));
-      })();
+      const _transparentFooterOwnsSettledMeta=
+        (usedModelText||effortText)&&_transparentTurnFooterOwnsSettledMeta(row);
+      const _transparentFooterOwnsModel=usedModelText&&_transparentFooterOwnsSettledMeta;
+      const _transparentFooterOwnsEffort=effortText&&_transparentFooterOwnsSettledMeta;
       if(usedModelText&&!_transparentFooterOwnsModel){
         const usedModel=document.createElement('span');
         usedModel.className='msg-used-model-inline';
@@ -17933,7 +17938,7 @@ function renderMessages(options){
         if(usedModelFull&&usedModelFull!==usedModelText) usedModel.title=usedModelFull;
         fragments.push(usedModel);
       }
-      if(effortText){
+      if(effortText&&!_transparentFooterOwnsEffort){
         const effort=document.createElement('span');
         effort.className='msg-reasoning-inline';
         effort.textContent=effortText;

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -681,6 +681,7 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
         function _gatewayRoutingFailoverText() {{ return ''; }}
         function _gatewayModelWarningText() {{ return ''; }}
         function _usedModelTurnChipLabel() {{ return ''; }}
+        function _reasoningEffortChipLabel() {{ return ''; }}
         function _formatTurnDuration() {{ return ''; }}
         function _renderSettledAnchorSceneForMessage(message, segment, rawIdx) {{
           const group = new FakeElement('div');

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -4,6 +4,7 @@ from api.compression_anchor import visible_messages_for_anchor
 from api.models import Session
 from api.streaming import (
     _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG,
+    _bridge_fallback_lifecycle_status,
     _compressed_context_tool_result_summary,
     _is_agent_compression_start_status,
     _is_fallback_lifecycle_message,
@@ -456,9 +457,41 @@ def test_agent_status_callback_emits_compressing_and_warning_events():
     assert "or 'compressing' in _lower" not in block
     assert "or 'preflight compression' in _lower" not in block
 
-    # warning events with type:fallback for rate-limit/fallback lifecycle notices
-    assert "put('warning'" in block
-    assert "'type': 'fallback'" in block
+    # warning events with type:fallback for rate-limit/fallback lifecycle
+    # notices. The callback delegates to the module-level bridge helper so the
+    # exact same code path is unit-testable; anchor on the delegation plus the
+    # bridge's real behavior instead of an inline put('warning' source window.
+    assert "_bridge_fallback_lifecycle_status(" in block
+    warning_events = []
+    handled = _bridge_fallback_lifecycle_status(
+        "lifecycle",
+        "⚠️ Rate limited — trying fallback model...",
+        agent=None,
+        session_id="warn-bridge",
+        put=lambda event, data: warning_events.append((event, data)),
+    )
+    assert handled is True
+    assert warning_events == [
+        (
+            "warning",
+            {
+                "type": "fallback",
+                "message": "⚠️ Rate limited — trying fallback model...",
+            },
+        ),
+    ]
+    ignored_events = []
+    assert (
+        _bridge_fallback_lifecycle_status(
+            "lifecycle",
+            "unrelated lifecycle chatter",
+            agent=None,
+            session_id="warn-bridge",
+            put=lambda event, data: ignored_events.append((event, data)),
+        )
+        is False
+    )
+    assert ignored_events == []
     assert "'rate limited'" in src
     assert "'switching to fallback'" in src
     assert "'falling back'" in src

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -330,7 +330,10 @@ def test_gateway_runs_api_submission():
             STREAMS.pop(stream_id, None)
 
     assert runs_called["called"], "The runs-API streaming path should have been invoked"
-    assert captured["body_extras"]["reasoning_effort"] == "high"
+    assert captured["body_extras"]["model_options"]["reasoning"] == {
+        "enabled": True,
+        "effort": "high",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue6068_used_model_footer.py
+++ b/tests/test_issue6068_used_model_footer.py
@@ -207,7 +207,7 @@ def test_settled_footer_orders_model_chip_after_duration():
 
 
 def test_transparent_turn_footer_includes_model_between_duration_and_ttft():
-    assert "function _transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle)" in UI_JS
+    assert "function _transparentTurnFooterHtml(durationText, modelText, ttftText, tokensText, statusText, modelTitle, effortText)" in UI_JS
     assert 'class="lf-model"' in UI_JS
     assert "modelText=_usedModelTurnChipLabel(msg)" in UI_JS
     assert ".transparent-turn-footer .lf-model" in STYLE_CSS

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -1,6 +1,7 @@
 """Visible-order contract for the first anchor-backed Compact Worklog handoff."""
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -767,7 +768,18 @@ def test_live_footer_owner_guard_blocks_stale_session_updates():
     update = _function_body(UI_JS, "updateLiveRunStatus")
     hide = _function_body(UI_JS, "hideLiveRunStatus")
 
-    assert "opts&&opts.sessionId&&_liveRunStatusSessionId&&opts.sessionId!==_liveRunStatusSessionId" in update
+    # The owner guard must reject updates addressed to a session that no longer
+    # owns the live footer. The identity may be read into a local (`sid`) before
+    # the comparison, so anchor on the comparison contract rather than on one
+    # spelling of the expression.
+    assert re.search(
+        r"(opts&&opts\.sessionId|const sid=String\(opts&&opts\.sessionId\|\|''\);)",
+        update,
+    )
+    assert re.search(
+        r"(opts\.sessionId|sid)&&_liveRunStatusSessionId&&(opts\.sessionId|sid)!==_liveRunStatusSessionId",
+        update,
+    )
     assert "sid&&_liveRunStatusSessionId&&sid!==_liveRunStatusSessionId" in hide
 
 

--- a/tests/test_reasoning_effort_effective_runtime.py
+++ b/tests/test_reasoning_effort_effective_runtime.py
@@ -92,7 +92,7 @@ def _event_pairs(subscriber):
 def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
     tmp_path, monkeypatch, runs_api
 ):
-    """Requested A/high must become answered B/C/off on every consumer surface."""
+    """Answer attribution follows B/C/off while the selected route remains A/provider-A."""
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
@@ -131,7 +131,14 @@ def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
         "HERMES_WEBUI_GATEWAY_USE_RUNS_API", "1" if runs_api else "0"
     )
 
+    gateway_requests = []
+
     def fake_urlopen(req, timeout=0):
+        if req.data and (
+            req.full_url.endswith("/v1/runs")
+            or req.full_url.endswith("/v1/chat/completions")
+        ):
+            gateway_requests.append(json.loads(req.data.decode("utf-8")))
         if runs_api and req.full_url.endswith("/v1/runs"):
             return _JsonResponse({"run_id": "run-effective-runtime"})
         return _SseResponse(_runtime_terminal_lines(runs_api=runs_api))
@@ -184,8 +191,8 @@ def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
     assert assistant["_reasoningEffort"] == "off"
     assert assistant["_gatewayRouting"]["used_model"] == "answered-model-b"
     assert assistant["_gatewayRouting"]["used_provider"] == "provider-c"
-    assert saved.model == "answered-model-b"
-    assert saved.model_provider == "provider-c"
+    assert saved.model == "requested-model-a"
+    assert saved.model_provider == "provider-a"
 
     done = [payload for event, payload in events if event == "done"]
     assert len(done) == 1
@@ -194,14 +201,38 @@ def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
     assert done[0]["usage"]["reasoning_effort"] == "off"
     assert "_effective_runtime" not in done[0]["usage"]
 
-    reloaded = models.Session.load(session.session_id)
-    assert reloaded is not None
-    assert reloaded.model == "answered-model-b"
-    assert reloaded.model_provider == "provider-c"
+    models.SESSIONS.clear()
+    reloaded = models.get_session(session.session_id)
+    assert reloaded.model == "requested-model-a"
+    assert reloaded.model_provider == "provider-a"
     reloaded_assistant = reloaded.messages[-1]
     assert reloaded_assistant["_usedModel"] == "answered-model-b"
     assert reloaded_assistant["_reasoningEffort"] == "off"
     assert reloaded_assistant["_gatewayRouting"]["used_provider"] == "provider-c"
+
+    # The next turn is built from the reloaded request-owned selection, not from
+    # the prior turn's effective runtime attribution.
+    next_stream_id = f"next-effective-runtime-{'runs' if runs_api else 'legacy'}"
+    reloaded.active_stream_id = next_stream_id
+    reloaded.pending_user_message = "ask again after fallback"
+    reloaded.pending_attachments = []
+    reloaded.pending_started_at = 456.0
+    reloaded.save()
+    next_channel = create_stream_channel()
+    STREAMS[next_stream_id] = next_channel
+    gateway_chat._run_gateway_chat_streaming(
+        reloaded.session_id,
+        "ask again after fallback",
+        reloaded.model,
+        str(tmp_path),
+        next_stream_id,
+        [],
+        model_provider=reloaded.model_provider,
+    )
+
+    assert len(gateway_requests) == 2
+    assert gateway_requests[1]["model"] == "requested-model-a"
+    assert gateway_requests[1]["provider"] == "provider-a"
 
 
 def test_gateway_does_not_treat_plain_terminal_model_as_effective_runtime():

--- a/tests/test_reasoning_effort_effective_runtime.py
+++ b/tests/test_reasoning_effort_effective_runtime.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
+import subprocess
 from collections import OrderedDict
+from types import SimpleNamespace
 
 import pytest
 
-from api import gateway_chat, models, streaming
+from api import config, gateway_chat, models, streaming
 from api.config import STREAMS, create_stream_channel
 
 
@@ -86,6 +90,214 @@ def _event_pairs(subscriber):
         item = subscriber.get_nowait()
         events.append((item[0], item[1]))
     return events
+
+
+_GATEWAY_PARSE_SCRIPT = """
+import json
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from gateway.platforms.api_server import (
+    _REQUEST_OPTION_MISSING,
+    _request_agent_overrides,
+    _request_reasoning_config,
+    _request_service_tier,
+)
+
+results = []
+for body in json.loads(sys.stdin.read()):
+    overrides = _request_agent_overrides(body, virtual_model="hermes-agent")
+    model_options = overrides.get("model_options")
+    service_tier = _request_service_tier(model_options)
+    results.append({
+        "reasoning": _request_reasoning_config(model_options),
+        "service_tier_missing": service_tier is _REQUEST_OPTION_MISSING,
+        "service_tier": None if service_tier is _REQUEST_OPTION_MISSING else service_tier,
+    })
+print(json.dumps(results))
+"""
+
+
+def _installed_gateway_parser(request_bodies):
+    candidates = []
+    configured = str(os.environ.get("HERMES_WEBUI_AGENT_DIR") or "").strip()
+    if configured:
+        candidates.append(Path(configured))
+    candidates.extend(
+        [
+            Path.home() / ".hermes" / "hermes-agent",
+            Path("/usr/local/lib/hermes-agent"),
+        ]
+    )
+    agent_dir = next(
+        (
+            candidate
+            for candidate in candidates
+            if (candidate / "gateway" / "platforms" / "api_server.py").is_file()
+        ),
+        None,
+    )
+    if agent_dir is None:
+        pytest.skip("installed Hermes Agent Gateway parser is unavailable")
+    python = next(
+        (
+            candidate
+            for candidate in (
+                agent_dir / "venv" / "bin" / "python",
+                agent_dir / "venv" / "Scripts" / "python.exe",
+            )
+            if candidate.is_file()
+        ),
+        None,
+    )
+    if python is None:
+        pytest.skip("installed Hermes Agent Python is unavailable")
+    proc = subprocess.run(
+        [str(python), "-c", _GATEWAY_PARSE_SCRIPT, str(agent_dir)],
+        input=json.dumps(request_bodies),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _capture_gateway_request_body(
+    monkeypatch,
+    tmp_path,
+    *,
+    runs_api,
+    configured_effort,
+    configured_service_tier,
+    suffix,
+):
+    cfg = {
+        "model": {
+            "provider": "openai",
+            "default": "gpt-5.5",
+        },
+    }
+    if configured_effort is not None:
+        cfg["agent"] = {"reasoning_effort": configured_effort}
+    if configured_service_tier is not None:
+        cfg["model"]["service_tier"] = configured_service_tier
+
+    stream_id = f"gateway-options-{suffix}"
+    session_id = f"gateway-options-session-{suffix}"
+    session = SimpleNamespace(
+        active_stream_id=stream_id,
+        workspace=str(tmp_path),
+        profile=None,
+        context_messages=[],
+        _approval_notice_emitted=False,
+        save=lambda: None,
+    )
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+    captured = []
+
+    def fake_urlopen(req, timeout=0):
+        if req.data:
+            captured.append(json.loads(req.data.decode("utf-8")))
+        if runs_api and req.full_url.endswith("/v1/runs"):
+            return _JsonResponse({"run_id": f"run-{suffix}"})
+        return _SseResponse([b"data: [DONE]\n", b"\n"])
+
+    monkeypatch.setattr(gateway_chat, "RunJournalWriter", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(gateway_chat, "get_session", lambda _session_id: session)
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        gateway_chat,
+        "gateway_supports_approval",
+        lambda *_args, **_kwargs: runs_api,
+    )
+    monkeypatch.setattr(
+        gateway_chat,
+        "gateway_approval_unavailable_reason",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda _cfg: {})
+    monkeypatch.setattr(
+        streaming,
+        "_prefill_messages_with_webui_context",
+        lambda _context, _cfg: [],
+    )
+    monkeypatch.setattr(
+        streaming,
+        "_normalize_prefill_messages_before_user_turn",
+        lambda messages: messages,
+    )
+    monkeypatch.setattr(streaming, "_public_prefill_context_status", lambda _context: {})
+    monkeypatch.setattr(
+        streaming,
+        "_webui_ephemeral_system_prompt",
+        lambda *_args, **_kwargs: "system",
+    )
+    monkeypatch.setenv(
+        "HERMES_WEBUI_GATEWAY_USE_RUNS_API",
+        "1" if runs_api else "0",
+    )
+
+    gateway_chat._run_gateway_chat_streaming(
+        session_id,
+        "exercise request options",
+        "gpt-5.5",
+        str(tmp_path),
+        stream_id,
+        [],
+        model_provider="openai",
+    )
+
+    assert len(captured) == 1
+    return captured[0], _event_pairs(subscriber)
+
+
+def test_gateway_request_options_compose_with_installed_parser_for_both_transports(
+    tmp_path, monkeypatch
+):
+    cases = [
+        ("high", "  HIGH  ", "priority", {"enabled": True, "effort": "high"}, "priority"),
+        ("off", "none", "priority", {"enabled": False}, "priority"),
+        ("absent", None, None, None, None),
+        ("invalid", "definitely-invalid", "turbo", None, None),
+    ]
+    bodies = []
+    expected = []
+    expected_run_meta_efforts = []
+
+    for runs_api in (True, False):
+        transport = "runs" if runs_api else "legacy"
+        for case_name, effort, service_tier, reasoning, accepted_tier in cases:
+            with monkeypatch.context() as scoped:
+                body, events = _capture_gateway_request_body(
+                    scoped,
+                    tmp_path,
+                    runs_api=runs_api,
+                    configured_effort=effort,
+                    configured_service_tier=service_tier,
+                    suffix=f"{transport}-{case_name}",
+                )
+            assert "reasoning_effort" not in body
+            assert "service_tier" not in body
+            bodies.append(body)
+            expected.append(
+                {
+                    "reasoning": reasoning,
+                    "service_tier_missing": accepted_tier is None,
+                    "service_tier": accepted_tier,
+                }
+            )
+            initial_meta = [payload for event, payload in events if event == "run_meta"]
+            assert len(initial_meta) == 1
+            expected_run_meta_efforts.append(
+                "off" if reasoning == {"enabled": False} else (reasoning or {}).get("effort")
+            )
+            assert initial_meta[0]["reasoning_effort"] == expected_run_meta_efforts[-1]
+
+    assert _installed_gateway_parser(bodies) == expected
 
 
 @pytest.mark.parametrize("runs_api", [True, False], ids=["runs-api", "legacy-stream"])
@@ -169,6 +381,18 @@ def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
     )
 
     events = _event_pairs(subscriber)
+    assert "reasoning_effort" not in gateway_requests[0]
+    assert gateway_requests[0]["model_options"]["reasoning"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+    assert _installed_gateway_parser([gateway_requests[0]]) == [
+        {
+            "reasoning": {"enabled": True, "effort": "high"},
+            "service_tier_missing": True,
+            "service_tier": None,
+        }
+    ]
     run_meta = [payload for event, payload in events if event == "run_meta"]
     assert run_meta == [
         {

--- a/tests/test_reasoning_effort_effective_runtime.py
+++ b/tests/test_reasoning_effort_effective_runtime.py
@@ -1,0 +1,214 @@
+"""Behavioral regressions for effective reasoning/runtime attribution (#6644)."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+
+import pytest
+
+from api import gateway_chat, models, streaming
+from api.config import STREAMS, create_stream_channel
+
+
+class _JsonResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self, _limit=None):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+class _SseResponse:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+def _terminal_runtime():
+    return {
+        "model": "answered-model-b",
+        "provider": "provider-c",
+        "reasoning": {"enabled": False},
+    }
+
+
+def _runtime_terminal_lines(*, runs_api: bool):
+    runtime = _terminal_runtime()
+    if runs_api:
+        payloads = [
+            {"event": "message.delta", "delta": "answered"},
+            {
+                "event": "run.completed",
+                "output": "answered",
+                "runtime": runtime,
+                "usage": {"input_tokens": 7, "output_tokens": 2},
+            },
+        ]
+    else:
+        payloads = [
+            {"choices": [{"delta": {"content": "answered"}}]},
+            {
+                "choices": [{"delta": {}, "finish_reason": "stop"}],
+                "runtime": runtime,
+                "usage": {"prompt_tokens": 7, "completion_tokens": 2},
+            },
+        ]
+    lines = []
+    for payload in payloads:
+        lines.extend(
+            [
+                f"data: {json.dumps(payload)}\n".encode("utf-8"),
+                b"\n",
+            ]
+        )
+    lines.extend([b"data: [DONE]\n", b"\n"])
+    return lines
+
+
+def _event_pairs(subscriber):
+    events = []
+    while not subscriber.empty():
+        item = subscriber.get_nowait()
+        events.append((item[0], item[1]))
+    return events
+
+
+@pytest.mark.parametrize("runs_api", [True, False], ids=["runs-api", "legacy-stream"])
+def test_gateway_terminal_runtime_reconciles_live_persisted_done_and_reload(
+    tmp_path, monkeypatch, runs_api
+):
+    """Requested A/high must become answered B/C/off on every consumer surface."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(gateway_chat, "RunJournalWriter", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        gateway_chat,
+        "_gateway_reasoning_effort_for_request",
+        lambda *_args, **_kwargs: "high",
+    )
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda _cfg: {
+        "status": "not_configured",
+        "source": "none",
+        "label": "",
+        "message_count": 0,
+        "messages": [],
+    })
+    monkeypatch.setattr(
+        streaming,
+        "_prefill_messages_with_webui_context",
+        lambda _context, _cfg: [],
+    )
+    monkeypatch.setattr(
+        gateway_chat,
+        "gateway_supports_approval",
+        lambda *_args, **_kwargs: runs_api,
+    )
+    monkeypatch.setattr(
+        gateway_chat,
+        "gateway_approval_unavailable_reason",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.test")
+    monkeypatch.setenv(
+        "HERMES_WEBUI_GATEWAY_USE_RUNS_API", "1" if runs_api else "0"
+    )
+
+    def fake_urlopen(req, timeout=0):
+        if runs_api and req.full_url.endswith("/v1/runs"):
+            return _JsonResponse({"run_id": "run-effective-runtime"})
+        return _SseResponse(_runtime_terminal_lines(runs_api=runs_api))
+
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+
+    session = models.new_session()
+    session.model = "requested-model-a"
+    session.model_provider = "provider-a"
+    stream_id = f"effective-runtime-{'runs' if runs_api else 'legacy'}"
+    session.active_stream_id = stream_id
+    session.pending_user_message = "answer using the gateway"
+    session.pending_attachments = []
+    session.pending_started_at = 123.0
+    session.save()
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        session.session_id,
+        "answer using the gateway",
+        "requested-model-a",
+        str(tmp_path),
+        stream_id,
+        [],
+        model_provider="provider-a",
+    )
+
+    events = _event_pairs(subscriber)
+    run_meta = [payload for event, payload in events if event == "run_meta"]
+    assert run_meta == [
+        {
+            "session_id": session.session_id,
+            "model": "requested-model-a",
+            "provider": "provider-a",
+            "reasoning_effort": "high",
+        },
+        {
+            "session_id": session.session_id,
+            "model": "answered-model-b",
+            "provider": "provider-c",
+            "reasoning_effort": "off",
+        },
+    ]
+
+    saved = models.get_session(session.session_id)
+    assistant = saved.messages[-1]
+    assert assistant["_usedModel"] == "answered-model-b"
+    assert assistant["_reasoningEffort"] == "off"
+    assert assistant["_gatewayRouting"]["used_model"] == "answered-model-b"
+    assert assistant["_gatewayRouting"]["used_provider"] == "provider-c"
+    assert saved.model == "answered-model-b"
+    assert saved.model_provider == "provider-c"
+
+    done = [payload for event, payload in events if event == "done"]
+    assert len(done) == 1
+    assert done[0]["usage"]["used_model"] == "answered-model-b"
+    assert done[0]["usage"]["used_provider"] == "provider-c"
+    assert done[0]["usage"]["reasoning_effort"] == "off"
+    assert "_effective_runtime" not in done[0]["usage"]
+
+    reloaded = models.Session.load(session.session_id)
+    assert reloaded is not None
+    assert reloaded.model == "answered-model-b"
+    assert reloaded.model_provider == "provider-c"
+    reloaded_assistant = reloaded.messages[-1]
+    assert reloaded_assistant["_usedModel"] == "answered-model-b"
+    assert reloaded_assistant["_reasoningEffort"] == "off"
+    assert reloaded_assistant["_gatewayRouting"]["used_provider"] == "provider-c"
+
+
+def test_gateway_does_not_treat_plain_terminal_model_as_effective_runtime():
+    """OpenAI-compatible terminal ``model`` is requested-side unless runtime says otherwise."""
+    assert gateway_chat._gateway_effective_runtime_metadata(
+        {
+            "model": "requested-model-a",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    ) == {}

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -66,10 +66,21 @@ class TestEffectiveReasoningEffortLabel:
 class TestBackendEmission:
     def test_run_meta_emitted_upfront_after_agent_registration(self):
         registration = STREAMING_PY.index("AGENT_INSTANCES[stream_id] = agent")
-        emission = STREAMING_PY.index("put('run_meta'")
-        assert registration < emission
-        assert "'reasoning_effort': _run_meta_effort" in STREAMING_PY
-        assert "'model': getattr(agent, 'model', None) or resolved_model or model" in STREAMING_PY
+        initial_emission = STREAMING_PY.index(
+            "_emit_effective_run_meta()", registration
+        )
+        assert registration < initial_emission
+        assert "'reasoning_effort': _effective_effort" in STREAMING_PY
+        assert "'model': _effective_model" in STREAMING_PY
+
+    def test_fallback_reemits_effective_run_meta_after_notice(self):
+        callback = STREAMING_PY.split("def _agent_status_callback", 1)[1].split(
+            "# xsession wakeup", 1
+        )[0]
+        warning = callback.index("put('warning'")
+        refresh = callback.index("_emit_effective_run_meta()")
+        assert warning < refresh
+        assert "_effective_reasoning_effort_label(agent)" in STREAMING_PY
 
     def test_done_payload_carries_reasoning_effort(self):
         assert "usage['reasoning_effort'] = _effort_label_done" in STREAMING_PY
@@ -173,6 +184,8 @@ class TestFrontendWiring:
         assert "'run_meta'" in journal_list
         assert "let _liveRunMeta=null" in UI_JS
         assert "opts.meta)_liveRunMeta=opts.meta" in UI_JS
+        assert "String(meta.model||'').trim()" in UI_JS
+        assert "meta.model||((S.session&&S.session.model)||'')" not in UI_JS
         assert ".live-run-status .lf-effort" in STYLE_CSS
 
     def test_i18n_keys_en_and_fr(self):

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -318,6 +318,123 @@ console.log(JSON.stringify({{
     return json.loads(_run_node(source))
 
 
+def _eval_live_run_meta_ownership() -> dict:
+    """Exercise live metadata across successor, regeneration, and reconnect owners."""
+    ui_js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {ui_js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+const _liveRunStatusTimers = {{}};
+let _liveRunStatusTokens = null;
+let _liveRunStatusSessionId = null;
+let _liveRunStatusStreamId = null;
+let _liveRunMeta = null;
+const el = {{ hidden: true, innerHTML: '', isConnected: true }};
+const S = {{ session: {{ session_id: 'same-session' }}, activeStreamId: null }};
+function $(id) {{ return id === 'liveRunStatus' ? el : null; }}
+function placeLiveRunStatusHost() {{ return el; }}
+function _moveLiveRunStatusToTurnEnd(candidate) {{ return candidate; }}
+function _startLiveRunStatusTimer(sid, startedAt) {{
+  _liveRunStatusTimers[sid] = {{ startedAt }};
+}}
+function _clearLiveRunStatusTimer(sid) {{ delete _liveRunStatusTimers[sid]; }}
+function isCompactWorklogMode() {{ return false; }}
+function _compactComposerModelChipLabel(model) {{ return model; }}
+function getModelLabel(model) {{ return model; }}
+function _fmtTokens(tokens) {{ return String(tokens); }}
+function esc(value) {{ return String(value == null ? '' : value); }}
+function t(key) {{ return key === 'reasoning_off' ? 'reasoning off' : ''; }}
+eval(extractFunc('_formatRunElapsed'));
+if (src.includes('function _claimLiveRunStatusOwner')) {{
+  eval(extractFunc('_claimLiveRunStatusOwner'));
+}}
+eval(extractFunc('_renderLiveRunStatusContent'));
+eval(extractFunc('showLiveRunStatus'));
+eval(extractFunc('updateLiveRunStatus'));
+eval(extractFunc('hideLiveRunStatus'));
+eval(extractFunc('_reasoningEffortChipLabel'));
+eval(extractFunc('_usedModelTurnChipLabel'));
+function hasMeta(model, effort) {{
+  return el.innerHTML.includes(model) && el.innerHTML.includes(effort);
+}}
+
+S.activeStreamId = 'run-a';
+showLiveRunStatus('same-session', {{ streamId: 'run-a', startedAt: 1 }});
+updateLiveRunStatus({{
+  sessionId: 'same-session', streamId: 'run-a',
+  meta: {{ model: 'fallback-a', effort: 'high' }},
+}});
+const firstHasOwnMeta = hasMeta('fallback-a', 'high');
+showLiveRunStatus('same-session', {{ streamId: 'run-a', startedAt: 1 }});
+const rerenderKeepsMeta = hasMeta('fallback-a', 'high');
+
+const settled = {{ _usedModel: 'fallback-a', _reasoningEffort: 'high' }};
+S.activeStreamId = 'run-b';
+showLiveRunStatus('same-session', {{ streamId: 'run-b', startedAt: 2 }});
+const successorStartsClean = !el.innerHTML.includes('fallback-a') && !el.innerHTML.includes('high');
+hideLiveRunStatus('same-session', 'run-a');
+const stalePriorTeardownIgnored = !el.hidden && !el.innerHTML.includes('fallback-a');
+updateLiveRunStatus({{
+  sessionId: 'same-session', streamId: 'run-a',
+  meta: {{ model: 'late-a', effort: 'max' }},
+}});
+const stalePriorEventIgnored = !el.innerHTML.includes('late-a') && !el.innerHTML.includes('max');
+updateLiveRunStatus({{
+  sessionId: 'same-session', streamId: 'run-b',
+  meta: {{ model: 'model-b', effort: 'low' }},
+}});
+const successorHasOwnMeta = hasMeta('model-b', 'low');
+
+S.activeStreamId = 'regen-c';
+showLiveRunStatus('same-session', {{ streamId: 'regen-c', startedAt: 3 }});
+const regenerationStartsClean = !el.innerHTML.includes('model-b') && !el.innerHTML.includes('low');
+updateLiveRunStatus({{
+  sessionId: 'same-session', streamId: 'run-b',
+  meta: {{ model: 'late-b', effort: 'max' }},
+}});
+const staleSuccessorEventIgnored = !el.innerHTML.includes('late-b') && !el.innerHTML.includes('max');
+updateLiveRunStatus({{
+  sessionId: 'same-session', streamId: 'regen-c',
+  meta: {{ model: 'model-c', effort: 'off' }},
+}});
+const regenerationHasOwnMeta = hasMeta('model-c', 'reasoning off');
+showLiveRunStatus('same-session', {{ streamId: 'regen-c', startedAt: 3 }});
+const regenerationRerenderKeepsMeta = hasMeta('model-c', 'reasoning off');
+hideLiveRunStatus('same-session', 'regen-c');
+showLiveRunStatus('same-session', {{ streamId: 'regen-c', startedAt: 3 }});
+const reconnectKeepsMeta = hasMeta('model-c', 'reasoning off');
+
+console.log(JSON.stringify({{
+  firstHasOwnMeta,
+  rerenderKeepsMeta,
+  reconnectKeepsMeta,
+  successorStartsClean,
+  stalePriorTeardownIgnored,
+  stalePriorEventIgnored,
+  successorHasOwnMeta,
+  regenerationStartsClean,
+  staleSuccessorEventIgnored,
+  regenerationHasOwnMeta,
+  regenerationRerenderKeepsMeta,
+  settledModel: _usedModelTurnChipLabel(settled),
+  settledEffort: _reasoningEffortChipLabel(settled),
+}}));
+"""
+    return json.loads(_run_node(source))
+
+
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_reasoning_effort_chip_label_cases():
     cases = _eval_reasoning_effort_chip_cases()
@@ -329,6 +446,26 @@ def test_reasoning_effort_chip_label_cases():
     assert cases["padded"] == "low"
     assert cases["absent"] == ""
     assert cases["nullMsg"] == ""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_live_run_meta_is_owned_by_stream_generation():
+    result = _eval_live_run_meta_ownership()
+    assert result == {
+        "firstHasOwnMeta": True,
+        "rerenderKeepsMeta": True,
+        "reconnectKeepsMeta": True,
+        "successorStartsClean": True,
+        "stalePriorTeardownIgnored": True,
+        "stalePriorEventIgnored": True,
+        "successorHasOwnMeta": True,
+        "regenerationStartsClean": True,
+        "staleSuccessorEventIgnored": True,
+        "regenerationHasOwnMeta": True,
+        "regenerationRerenderKeepsMeta": True,
+        "settledModel": "fallback-a",
+        "settledEffort": "high",
+    }
 
 
 class TestFrontendWiring:
@@ -347,10 +484,31 @@ class TestFrontendWiring:
         journal_list = MESSAGES_JS.split("_runJournalEventName of [", 1)[1].split("]", 1)[0]
         assert "'run_meta'" in journal_list
         assert "let _liveRunMeta=null" in UI_JS
-        assert "opts.meta)_liveRunMeta=opts.meta" in UI_JS
+        assert "_liveRunMeta={...opts.meta,sessionId:sid,streamId}" in UI_JS
+        assert "updateLiveRunStatus({sessionId:activeSid,streamId,meta:" in MESSAGES_JS
         assert "String(meta.model||'').trim()" in UI_JS
         assert "meta.model||((S.session&&S.session.model)||'')" not in UI_JS
         assert ".live-run-status .lf-effort" in STYLE_CSS
+
+    def test_new_run_call_sites_claim_stream_before_first_render(self):
+        send = MESSAGES_JS.split("const startData = postStartData || {};", 1)[1].split(
+            "async function startRegeneration", 1
+        )[0]
+        send_show = "showLiveRunStatus(activeSid,{streamId,startedAt:_startedAt})"
+        assert send_show in send
+        assert send.index(send_show) < send.index(
+            "attachLiveStream(activeSid, streamId, uploadedNames)"
+        )
+
+        regeneration = MESSAGES_JS.split("async function startRegeneration", 1)[1].split(
+            "const LIVE_STREAMS", 1
+        )[0]
+        regeneration_show = "showLiveRunStatus(sid,{streamId,startedAt:"
+        assert regeneration_show in regeneration
+        assert regeneration.index(regeneration_show) < regeneration.index(
+            "attachLiveStream(sid,streamId,[])"
+        )
+        assert "_claimLiveRunStatusOwner(activeSid,streamId)" in MESSAGES_JS
 
     def test_i18n_keys_en_and_fr(self):
         assert "reasoning_effort: 'Effective reasoning effort'" in I18N_JS

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -149,8 +149,41 @@ class TestBackendEmission:
         )
         assert [event for event, _ in events] == ["warning"]
 
+    def test_short_empty_content_success_line_also_refreshes_run_meta(self):
+        # conversation_loop empty-content path uses a shorter wording.
+        agent = _FakeAgent(
+            {"enabled": True, "effort": "high"},
+            model="fallback",
+            provider="p2",
+        )
+        events = []
+        handled = _bridge_fallback_lifecycle_status(
+            "lifecycle",
+            "↻ Switched to fallback: fallback (p2)",
+            agent=agent,
+            session_id="fallback-short",
+            put=lambda event, data: events.append((event, data)),
+        )
+        assert handled is True
+        assert [event for event, _ in events] == ["warning", "run_meta"]
+        assert events[1][1]["model"] == "fallback"
+        assert events[1][1]["provider"] == "p2"
+
     def test_done_payload_carries_reasoning_effort(self):
         assert "usage['reasoning_effort'] = _effort_label_done" in STREAMING_PY
+
+    def test_done_handler_copies_used_model_onto_last_assistant(self):
+        # usage.used_model is stamped from agent.model AFTER the run (so a
+        # fallback is attributed correctly). The live settle path must copy
+        # it onto lastAsst._usedModel or the chip stays empty until reload.
+        assert "lastAsst._usedModel=d.usage.used_model" in MESSAGES_JS
+
+    def test_ephemeral_carry_forward_keeps_used_model_and_effort(self):
+        # A shorter terminal snapshot must not drop the chips the live path
+        # just stamped.
+        ephemeral = MESSAGES_JS.split("const _EPHEMERAL_TURN_FIELDS=")[1].split("];")[0]
+        assert "'_usedModel'" in ephemeral
+        assert "'_reasoningEffort'" in ephemeral
 
     def test_display_metadata_persists_reasoning_effort(self):
         assert "_dm['_reasoningEffort'] = _effort_label" in STREAMING_PY

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -15,7 +15,10 @@ from pathlib import Path
 import pytest
 
 from api.models import Session
-from api.streaming import _effective_reasoning_effort_label
+from api.streaming import (
+    _bridge_fallback_lifecycle_status,
+    _effective_reasoning_effort_label,
+)
 from api.gateway_chat import _gateway_reasoning_effort_label
 
 
@@ -31,9 +34,10 @@ I18N_JS = (REPO / "static" / "i18n.js").read_text(encoding="utf-8")
 
 
 class _FakeAgent:
-    def __init__(self, reasoning_config=None, model="gpt-5-mini"):
+    def __init__(self, reasoning_config=None, model="gpt-5-mini", provider="openai"):
         self.reasoning_config = reasoning_config
         self.model = model
+        self.provider = provider
 
 
 class TestEffectiveReasoningEffortLabel:
@@ -76,17 +80,74 @@ class TestBackendEmission:
             "_emit_effective_run_meta()", registration
         )
         assert registration < initial_emission
-        assert "'reasoning_effort': _effective_effort" in STREAMING_PY
-        assert "'model': _effective_model" in STREAMING_PY
+        assert "put('run_meta', _effective_run_meta_payload(agent, session_id))" in STREAMING_PY
 
     def test_fallback_reemits_effective_run_meta_after_notice(self):
-        callback = STREAMING_PY.split("def _agent_status_callback", 1)[1].split(
-            "# xsession wakeup", 1
+        bridge = STREAMING_PY.split("def _bridge_fallback_lifecycle_status", 1)[1].split(
+            "def _extract_gateway_routing_metadata", 1
         )[0]
-        warning = callback.index("put('warning'")
-        refresh = callback.index("_emit_effective_run_meta()")
+        warning = bridge.index("put('warning'")
+        refresh = bridge.index("emit_effective_run_meta()")
         assert warning < refresh
         assert "_effective_reasoning_effort_label(agent)" in STREAMING_PY
+
+    def test_successful_native_fallback_bridges_exact_runtime_notice(self):
+        """Compose the installed Hermes one-shot notice with the production bridge."""
+        agent = _FakeAgent(
+            {"enabled": True, "effort": "high"},
+            model="primary",
+            provider="p1",
+        )
+        # Hermes installs all three runtime fields before emitting this exact
+        # successful-recovery lifecycle line.
+        agent.model = "fallback"
+        agent.provider = "p2"
+        agent.reasoning_config = {"enabled": False}
+        events = []
+
+        handled = _bridge_fallback_lifecycle_status(
+            "lifecycle",
+            "Switched to fallback model: primary via p1 → fallback via p2",
+            agent=agent,
+            session_id="fallback-live",
+            put=lambda event, data: events.append((event, data)),
+        )
+
+        assert handled is True
+        assert events == [
+            (
+                "warning",
+                {
+                    "type": "fallback",
+                    "message": "Switched to fallback model: primary via p1 → fallback via p2",
+                },
+            ),
+            (
+                "run_meta",
+                {
+                    "session_id": "fallback-live",
+                    "model": "fallback",
+                    "provider": "p2",
+                    "reasoning_effort": "off",
+                },
+            ),
+        ]
+
+    def test_pre_activation_retry_warns_without_replacing_run_meta(self):
+        agent = _FakeAgent(
+            {"enabled": True, "effort": "high"},
+            model="primary",
+            provider="p1",
+        )
+        events = []
+        _bridge_fallback_lifecycle_status(
+            "lifecycle",
+            "Rate limited — switching to fallback provider...",
+            agent=agent,
+            session_id="retry-live",
+            put=lambda event, data: events.append((event, data)),
+        )
+        assert [event for event, _ in events] == ["warning"]
 
     def test_done_payload_carries_reasoning_effort(self):
         assert "usage['reasoning_effort'] = _effort_label_done" in STREAMING_PY
@@ -160,6 +221,70 @@ console.log(JSON.stringify(cases));
     return json.loads(_run_node(source))
 
 
+def _eval_transparent_multi_segment_effort_ownership() -> dict:
+    """Compose final-segment metadata, ownership guard and transparent footer."""
+    ui_js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {ui_js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function esc(value) {{ return String(value == null ? '' : value); }}
+function t() {{ return ''; }}
+function isTransparentStream() {{ return true; }}
+function FakeSeg(idx) {{
+  return {{ getAttribute(name) {{ return name === 'data-msg-idx' ? String(idx) : null; }} }};
+}}
+const S = {{ messages: [
+  {{ role: 'user', content: 'run' }},
+  {{ role: 'assistant', content: '', _toolCalls: [{{ name: 'terminal' }}] }},
+  {{ role: 'assistant', content: 'done', _reasoningEffort: 'high' }},
+] }};
+const blocks = {{
+  querySelector(selector) {{
+    return selector === ':scope > .transparent-event-row' ? {{ className: 'transparent-event-row' }} : null;
+  }},
+}};
+const turn = {{
+  querySelectorAll(selector) {{
+    return selector === '.assistant-segment[data-msg-idx]' ? [FakeSeg(1), FakeSeg(2)] : [];
+  }},
+}};
+function _assistantTurnBlocks(candidate) {{ return candidate === turn ? blocks : null; }}
+eval(extractFunc('_reasoningEffortChipLabel'));
+eval(extractFunc('_transparentTurnMetaMessage'));
+eval(extractFunc('_transparentTurnFooterOwnsSettledMeta'));
+eval(extractFunc('_transparentTurnFooterHtml'));
+const picked = _transparentTurnMetaMessage(turn);
+const effortText = _reasoningEffortChipLabel(picked);
+const ownsEffort = effortText && _transparentTurnFooterOwnsSettledMeta(turn);
+const genericDom = ownsEffort ? '' : `<span class="msg-reasoning-inline">${{effortText}}</span>`;
+const transparentDom = _transparentTurnFooterHtml('', '', '', '', 'Done', '', effortText);
+const composedDom = genericDom + transparentDom;
+const genericCount = (composedDom.match(/class="msg-reasoning-inline"/g) || []).length;
+const transparentCount = (composedDom.match(/class="lf-effort"/g) || []).length;
+console.log(JSON.stringify({{
+  pickedContent: picked && picked.content,
+  effortText,
+  ownsEffort: !!ownsEffort,
+  genericCount,
+  transparentCount,
+  totalEffortLabels: genericCount + transparentCount,
+}}));
+"""
+    return json.loads(_run_node(source))
+
+
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_reasoning_effort_chip_label_cases():
     cases = _eval_reasoning_effort_chip_cases()
@@ -199,3 +324,16 @@ class TestFrontendWiring:
         assert "reasoning_off: 'reasoning off'" in I18N_JS
         assert "reasoning_effort: 'Effort de raisonnement effectif'" in I18N_JS
         assert "reasoning_off: 'raisonnement désactivé'" in I18N_JS
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_transparent_multi_segment_turn_renders_effort_exactly_once():
+    result = _eval_transparent_multi_segment_effort_ownership()
+    assert result == {
+        "pickedContent": "done",
+        "effortText": "high",
+        "ownsEffort": True,
+        "genericCount": 0,
+        "transparentCount": 1,
+        "totalEffortLabels": 1,
+    }

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -490,6 +491,21 @@ class TestFrontendWiring:
         assert "meta.model||((S.session&&S.session.model)||'')" not in UI_JS
         assert ".live-run-status .lf-effort" in STYLE_CSS
 
+    def test_live_status_wraps_with_mobile_readability(self):
+        base = re.search(r"\.live-run-status\s*\{([^{}]+)\}", STYLE_CSS)
+        assert base is not None
+        base_rule = base.group(1)
+        assert re.search(r"flex-wrap\s*:\s*wrap", base_rule)
+        assert re.search(r"row-gap\s*:\s*(?!0(?:[;}]|px))[^;}]+", base_rule)
+
+        mobile = re.search(
+            r"@media\s*\(\s*max-width\s*:\s*600px\s*\)\s*\{\s*"
+            r"\.live-run-status\s*\{([^{}]+)\}",
+            STYLE_CSS,
+        )
+        assert mobile is not None
+        assert re.search(r"line-height\s*:\s*(?:1\.[1-9]\d*|[1-9]\d*px)", mobile.group(1))
+
     def test_new_run_call_sites_claim_stream_before_first_render(self):
         send = MESSAGES_JS.split("const startData = postStartData || {};", 1)[1].split(
             "async function startRegeneration", 1
@@ -528,3 +544,59 @@ def test_transparent_multi_segment_turn_renders_effort_exactly_once():
         "transparentCount": 1,
         "totalEffortLabels": 1,
     }
+
+
+def test_mobile_long_model_keeps_running_status_visible():
+    """Exercise the production CSS at the gate's <=600px long-model viewport."""
+    playwright_api = pytest.importorskip("playwright.sync_api")
+    with playwright_api.sync_playwright() as playwright:
+        browser = playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        page = browser.new_page(viewport={"width": 600, "height": 400})
+        try:
+            page.set_content(
+                """
+                <div class="messages" id="messages" style="width:360px;height:160px">
+                  <div class="live-run-status live-footer" id="status">
+                    <span class="live-run-status-dot tool-card-running-dot"></span>
+                    <span class="live-run-status-text lf-time">00:42</span>
+                    <span class="lf-sep">·</span>
+                    <span class="lf-model">provider/answering-model-with-a-very-long-mobile-label-123456789</span>
+                    <span class="lf-sep">·</span>
+                    <span class="lf-effort">reasoning off</span>
+                    <span class="lf-sep">·</span>
+                    <span class="lf-status">Running</span>
+                  </div>
+                </div>
+                """
+            )
+            page.add_style_tag(path=str(REPO / "static" / "style.css"))
+            layout = page.eval_on_selector(
+                "#status",
+                """el => {
+                  const container = document.querySelector('#messages').getBoundingClientRect();
+                  const dot = el.querySelector('.live-run-status-dot').getBoundingClientRect();
+                  const running = el.querySelector('.lf-status').getBoundingClientRect();
+                  const style = getComputedStyle(el);
+                  return {
+                    flexWrap: style.flexWrap,
+                    rowGap: parseFloat(style.rowGap),
+                    lineHeight: parseFloat(style.lineHeight),
+                    fontSize: parseFloat(style.fontSize),
+                    wrapped: running.top > dot.top + 1,
+                    runningInside: running.left >= container.left - 1 && running.right <= container.right + 1,
+                    runningVisible: running.width > 0 && running.height > 0,
+                  };
+                }""",
+            )
+        finally:
+            browser.close()
+
+    assert layout["flexWrap"] == "wrap"
+    assert layout["rowGap"] > 0
+    assert layout["lineHeight"] > layout["fontSize"]
+    assert layout["wrapped"] is True
+    assert layout["runningInside"] is True
+    assert layout["runningVisible"] is True

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -1,0 +1,182 @@
+"""Effective reasoning effort footer instrumentation (settled + live display).
+
+Covers:
+- backend helper _effective_reasoning_effort_label (frozen agent config first,
+  run-resolved config fallback, honest None when unknown, 'off' when disabled);
+- run_meta SSE emission up front + done payload + display-metadata persistence;
+- frontend chip/footers/live-status wiring and i18n keys.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from api.models import Session
+from api.streaming import _effective_reasoning_effort_label
+
+
+REPO = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+UI_JS_PATH = REPO / "static" / "ui.js"
+STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+MODELS_PY = (REPO / "api" / "models.py").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+I18N_JS = (REPO / "static" / "i18n.js").read_text(encoding="utf-8")
+
+
+class _FakeAgent:
+    def __init__(self, reasoning_config=None, model="gpt-5-mini"):
+        self.reasoning_config = reasoning_config
+        self.model = model
+
+
+class TestEffectiveReasoningEffortLabel:
+    def test_level_passthrough(self):
+        agent = _FakeAgent({"enabled": True, "effort": "high"})
+        assert _effective_reasoning_effort_label(agent) == "high"
+
+    def test_disabled_reasoning_surfaces_off(self):
+        agent = _FakeAgent({"enabled": False})
+        assert _effective_reasoning_effort_label(agent) == "off"
+
+    def test_no_config_means_unknown_not_guess(self):
+        assert _effective_reasoning_effort_label(_FakeAgent(None)) is None
+        assert _effective_reasoning_effort_label(_FakeAgent({})) is None
+
+    def test_falls_back_to_run_resolved_config(self):
+        # If the agent snapshot lost its frozen config (e.g. resumed run), the
+        # run-resolved config still provides the effective value.
+        assert _effective_reasoning_effort_label(
+            _FakeAgent(None), {"enabled": True, "effort": "max"}
+        ) == "max"
+
+    def test_does_not_confuse_session_or_global_shape(self):
+        # {'effort': 'low'} without 'enabled' is the SESSION/GLOBAL settings
+        # shape, not the resolved agent shape — must not be misread.
+        assert _effective_reasoning_effort_label(
+            _FakeAgent(None), {"effort": "low"}
+        ) is None
+
+
+class TestBackendEmission:
+    def test_run_meta_emitted_upfront_after_agent_registration(self):
+        registration = STREAMING_PY.index("AGENT_INSTANCES[stream_id] = agent")
+        emission = STREAMING_PY.index("put('run_meta'")
+        assert registration < emission
+        assert "'reasoning_effort': _run_meta_effort" in STREAMING_PY
+        assert "'model': getattr(agent, 'model', None) or resolved_model or model" in STREAMING_PY
+
+    def test_done_payload_carries_reasoning_effort(self):
+        assert "usage['reasoning_effort'] = _effort_label_done" in STREAMING_PY
+
+    def test_display_metadata_persists_reasoning_effort(self):
+        assert "_dm['_reasoningEffort'] = _effort_label" in STREAMING_PY
+        assert '"_reasoningEffort"' in MODELS_PY.split("_SESSION_MESSAGE_DISPLAY_METADATA_KEYS")[1].split(")")[0]
+
+    def test_models_allowlist_round_trip(self):
+        session = Session(session_id="effortfooter", title="Effort")
+        session.messages = [
+            {
+                "role": "assistant",
+                "content": "done",
+                "_usedModel": "gpt-5-mini",
+                "_reasoningEffort": "high",
+            },
+        ]
+        session.save()
+
+        reloaded = Session.load("effortfooter")
+        assert reloaded.messages[-1]["_reasoningEffort"] == "high"
+        assert reloaded.messages[-1]["_usedModel"] == "gpt-5-mini"
+
+
+def _run_node(source: str) -> str:
+    result = subprocess.run(
+        [NODE],
+        input=source,
+        cwd=str(REPO),
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def _eval_reasoning_effort_chip_cases() -> dict:
+    ui_js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {ui_js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function t() {{ return ''; }}
+eval(extractFunc('_reasoningEffortChipLabel'));
+const cases = {{
+  level: _reasoningEffortChipLabel({{ _reasoningEffort: 'high' }}),
+  maxPreserved: _reasoningEffortChipLabel({{ _reasoningEffort: 'max' }}),
+  off: _reasoningEffortChipLabel({{ _reasoningEffort: 'off' }}),
+  upper: _reasoningEffortChipLabel({{ _reasoningEffort: 'HIGH' }}),
+  padded: _reasoningEffortChipLabel({{ _reasoningEffort: '  low  ' }}),
+  absent: _reasoningEffortChipLabel({{}}),
+  nullMsg: _reasoningEffortChipLabel(null),
+}};
+console.log(JSON.stringify(cases));
+"""
+    return json.loads(_run_node(source))
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_reasoning_effort_chip_label_cases():
+    cases = _eval_reasoning_effort_chip_cases()
+    assert cases["level"] == "high"
+    assert cases["maxPreserved"] == "max"
+    # 'off' is an explicit state, rendered via the i18n fallback label.
+    assert cases["off"] == "reasoning off"
+    assert cases["upper"] == "high"
+    assert cases["padded"] == "low"
+    assert cases["absent"] == ""
+    assert cases["nullMsg"] == ""
+
+
+class TestFrontendWiring:
+    def test_settled_footer_surfaces(self):
+        assert "effortText=_reasoningEffortChipLabel(msg)" in UI_JS
+        assert 'class="lf-effort"' in UI_JS
+        assert "msg-reasoning-inline" in UI_JS
+        assert ".transparent-turn-footer .lf-effort" in STYLE_CSS
+        assert ".msg-reasoning-inline" in STYLE_CSS
+
+    def test_done_handler_stamps_reasoning_effort(self):
+        assert "lastAsst._reasoningEffort=d.usage.reasoning_effort" in MESSAGES_JS
+
+    def test_live_status_consumes_run_meta(self):
+        assert "source.addEventListener('run_meta'" in MESSAGES_JS
+        journal_list = MESSAGES_JS.split("_runJournalEventName of [", 1)[1].split("]", 1)[0]
+        assert "'run_meta'" in journal_list
+        assert "let _liveRunMeta=null" in UI_JS
+        assert "opts.meta)_liveRunMeta=opts.meta" in UI_JS
+        assert ".live-run-status .lf-effort" in STYLE_CSS
+
+    def test_i18n_keys_en_and_fr(self):
+        assert "reasoning_effort: 'Effective reasoning effort'" in I18N_JS
+        assert "reasoning_off: 'reasoning off'" in I18N_JS
+        assert "reasoning_effort: 'Effort de raisonnement effectif'" in I18N_JS
+        assert "reasoning_off: 'raisonnement désactivé'" in I18N_JS

--- a/tests/test_reasoning_effort_footer.py
+++ b/tests/test_reasoning_effort_footer.py
@@ -16,6 +16,7 @@ import pytest
 
 from api.models import Session
 from api.streaming import _effective_reasoning_effort_label
+from api.gateway_chat import _gateway_reasoning_effort_label
 
 
 REPO = Path(__file__).resolve().parents[1]
@@ -64,6 +65,11 @@ class TestEffectiveReasoningEffortLabel:
 
 
 class TestBackendEmission:
+    def test_gateway_reasoning_effort_label(self):
+        assert _gateway_reasoning_effort_label("high") == "high"
+        assert _gateway_reasoning_effort_label("none") == "off"
+        assert _gateway_reasoning_effort_label(None) is None
+
     def test_run_meta_emitted_upfront_after_agent_registration(self):
         registration = STREAMING_PY.index("AGENT_INSTANCES[stream_id] = agent")
         initial_emission = STREAMING_PY.index(

--- a/tests/test_turn_duration_display.py
+++ b/tests/test_turn_duration_display.py
@@ -4,6 +4,7 @@ The WebUI should expose how long an agent turn took, using backend timing so
 reload/reconnect does not lose the measurement.
 """
 from pathlib import Path
+import re
 
 REPO = Path(__file__).resolve().parent.parent
 STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
@@ -78,7 +79,10 @@ def test_active_compact_activity_elapsed_timer_uses_persisted_start_time():
         "send() should copy chat-start pending_started_at into S.session before "
         "attaching the live stream."
     )
-    assert "showLiveRunStatus(activeSid,{startedAt:_startedAt});" in MESSAGES_JS, (
+    assert re.search(
+        r"showLiveRunStatus\(activeSid,\{[^}]*startedAt:_startedAt[^}]*\}\);",
+        MESSAGES_JS,
+    ), (
         "The first chat-start path should show the bottom live footer timer as soon "
         "as stream_id and pending_started_at are known; reconnect should not be the "
         "only path that restores it."
@@ -109,7 +113,10 @@ def test_live_footer_timer_is_re_synced_after_message_rerender():
         "renderMessages() should call the live-status sync helper after it "
         "rebuilds msgInner."
     )
-    assert "showLiveRunStatus(sid,{startedAt,tokens:_liveRunStatusTokens});" in UI_JS, (
+    assert re.search(
+        r"showLiveRunStatus\(sid,\{[^}]*startedAt[^}]*tokens:_liveRunStatusTokens[^}]*\}\);",
+        UI_JS,
+    ), (
         "If the timer node was torn down during a rerender, the helper should "
         "recreate it for the active session."
     )

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -352,7 +352,10 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
     assert '"stream": true' in captured["body"]
     payload = json.loads(captured["body"])
-    assert payload["reasoning_effort"] == "high"
+    assert payload["model_options"]["reasoning"] == {
+        "enabled": True,
+        "effort": "high",
+    }
     # #3324: the gateway path's first system message is now the full WebUI
     # ephemeral system prompt (progress prompt + session/delivery context),
     # NOT the bare _WEBUI_PROGRESS_PROMPT — otherwise the delivery/session


### PR DESCRIPTION
## Problem

The turn footer shows duration, model and status (`25m 6s · gpt-5.6-sol · Done`), but never the **reasoning effort actually applied** to the turn. The configured effort is not always the effective one: per-model overrides (`agent.reasoning_overrides`) and capability clamping (`coerce_reasoning_effort_for_model`) can silently change it, so users cannot tell which effort a response was really produced with — especially while the run is still streaming.

A native or Gateway fallback can also change the **model/provider that actually answered**. The live footer must follow that runtime, not stay pinned on the originally requested model.

## What this does

Surfaces the **effective** reasoning effort next to the existing footer chips, reading the value frozen on the agent at run start (after session > per-model > global resolution and capability clamping — the value actually used for the run):

- **Settled footers** (transparent and non-transparent): an effort chip between the model chip and the rest, e.g. `25m 6s · gpt-5.6-sol · high · Done`. Persisted via a `_reasoningEffort` display-metadata key so it survives reloads (mirrors the existing `_usedModel` pattern).
- **Live during streaming**: a new `run_meta` SSE event emitted right after agent registration announces the run's effective model + effort, rendered in the live run-status line (`0:12 · gpt-5.6-sol · high · Running`). The event is journaled like any other SSE event, so it replays on reconnect.
- **Honest edge cases**: an explicit `reasoning off` chip when reasoning is disabled; **no chip at all** when no explicit config exists (provider default stays unknown — never guessed).
- i18n labels added in English and French; other locales fall back to English.

Review findings from `0672574e` are addressed on this rebased head:

- **A.** Successful native fallback (`Switched to fallback model: …` and the shorter empty-content `Switched to fallback: …`) re-emits `run_meta` with the installed fallback model/provider/effort. Pre-activation retry chatter still warns without replacing live metadata.
- **B.** Gateway runs-API and legacy SSE reconcile requested vs effective runtime from terminal routing payloads; live `run_meta`, persisted assistant metadata, session model/provider, and `done.usage` follow the runtime that answered.
- **C.** Transparent settled footers own the effort chip once; the generic message foot does not duplicate it.

Follow-up on this rebase: copy `usage.used_model` onto `lastAsst._usedModel` at `done`, and carry `_usedModel` / `_reasoningEffort` across a shorter terminal snapshot.

## Risks

- Low. Display-only instrumentation; no change to reasoning resolution, model selection, or streaming control flow.
- `run_meta` is additive: older clients ignore unknown SSE events, and the frontend listener guards on data shape.
- Rebase onto current `master` kept the upstream Gateway YOLO helpers and placed the effort-label helper next to them (insertion-point conflict only).

## Verification

```bash
python -m pytest tests/test_reasoning_effort_footer.py tests/test_reasoning_effort_effective_runtime.py tests/test_issue6068_used_model_footer.py tests/test_anchor_fallback_ownership.py tests/test_auto_compression_card.py -q
python -m pytest tests/test_issue1857_usage_overwrite.py tests/test_issue2419_cache_usage_display.py \
  tests/test_issue4346_vscroll_footer_jitter.py tests/test_issue4539_transparent_tool_settle.py \
  tests/test_issue5367_transparent_live_row_reconcile.py tests/test_issue5966_transparent_stream_lazy_dom.py \
  tests/test_msg_footer_wrap.py tests/test_streaming_live_usage_estimate.py \
  tests/test_issue3397_transparent_stream_prose_segments.py \
  tests/test_issue5749_transparent_stream_prefix_dedupe.py tests/test_issue4658_transparent_collapsed_preview.py -q
```

Local result on this head: 111 targeted + 133 adjacent passed. Diff-scoped ruff is clean.
