### PR TITLE
fix: stop false Compressing-context card on preflight-compression sessions

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -587,8 +587,7 @@ def _is_agent_compression_start_status(kind: str, message: str) -> bool:
     if 'compressed' in m and 'compressing' not in m and 'compression attempt' not in m:
         return False
     return (
-        'preflight compression:' in m
-        or 'pre-api compression:' in m
+        'pre-api compression:' in m
         or 'compacting context' in m
         or 'context too large' in m
         or '— compressing (' in m

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -566,8 +566,11 @@ def _is_agent_compression_start_status(kind: str, message: str) -> bool:
     auto-compression.
 
     Positive markers below match the agent emitters in hermes-agent
-    (``turn_context`` preflight, ``conversation_loop`` pre-API / 413 / too-large,
-    ``conversation_compression`` compaction status). Explicitly reject skip /
+    (``conversation_loop`` pre-API / 413 / too-large,
+    ``conversation_compression`` compaction status). Preflight compression
+    (``turn_context``) is intentionally excluded — the later authoritative
+    ``Compacting context`` marker is the signal that compression actually
+    proceeded. Explicitly reject skip /
     defer notices so "Skipping preflight compression…" never surfaces as a
     running compress divider.
     """

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -473,9 +473,12 @@ def test_agent_status_callback_emits_compressing_and_warning_events():
 
 def test_agent_compression_start_status_matches_real_emitters_only():
     # Real start notices from hermes-agent emitters
-    # Preflight compression is excluded — it fires on every new session
-    # where the system prompt alone exceeds the threshold, producing a
-    # false "Compressing context" card before any model output.
+    # Preflight compression is intentionally excluded — the later
+        # authoritative ``Compacting context`` marker from
+        # conversation_compression is the signal that compression
+        # actually proceeded, and the preflight status can fire even
+        # when compression exits before compaction (e.g. durable
+        # guard refresh, Codex-Hermes mode with no active thread).
     assert not _is_agent_compression_start_status(
         "lifecycle",
         "📦 Preflight compression: ~101,000 tokens >= 96,000 threshold. This may take a moment.",

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -473,7 +473,10 @@ def test_agent_status_callback_emits_compressing_and_warning_events():
 
 def test_agent_compression_start_status_matches_real_emitters_only():
     # Real start notices from hermes-agent emitters
-    assert _is_agent_compression_start_status(
+    # Preflight compression is excluded — it fires on every new session
+    # where the system prompt alone exceeds the threshold, producing a
+    # false "Compressing context" card before any model output.
+    assert not _is_agent_compression_start_status(
         "lifecycle",
         "📦 Preflight compression: ~101,000 tokens >= 96,000 threshold. This may take a moment.",
     )


### PR DESCRIPTION
## Problem

The `_is_agent_compression_start_status` function in `api/streaming.py` matches `'preflight compression:'` in agent lifecycle messages. The Hermes agent emits a preflight check message ("Preflight compression: ~X tokens >= Y threshold") at the start of every session where the system prompt pushes the token estimate over the threshold. This triggers a false "Compressing context" SSE event and frontend card before any model output is generated.

## Root Cause

The `'preflight compression:'` pattern was included in PR #6184 to narrow the agent-status-to-SSE bridge. However, the preflight check is a one-time pre-model-call estimate, not a mid-conversation compression event. When the system prompt (including the large skills catalog) exceeds the compression threshold, this false positive fires on every new session.

## Fix

Remove `'preflight compression:'` from the pattern match list. The remaining patterns still catch real compression events:
- `pre-api compression:`
- `compacting context`
- `context too large`
- `— compressing (`
- `compression attempt`

## Changes

- `api/streaming.py`: Remove `'preflight compression:'` from `_is_agent_compression_start_status`