### PR TITLE
perf: bound session cache by serialized bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,16 @@ Full list of environment variables:
 | `HERMES_CONFIG_PATH` | `$HERMES_HOME/config.yaml` | Path to Hermes config file |
 | `HERMES_WEBUI_SERVER_CWD` | *(unset)* | Working directory for the server process. Defaults to the agent dir; point it at a writable workspace when the agent dir is read-only so fallback relative writes land somewhere writable |
 | `HERMES_WEBUI_AGENT_CACHE_MAX` | `25` | Max live agent instances kept warm in the in-memory LRU. Each pins a full conversation transcript, so this is the dominant lever on resident memory — lower it on installs with many long sessions to cap RAM (at the cost of more cold reloads) |
-| `HERMES_WEBUI_SESSIONS_MAX` | `100` | Legacy operator override for the max compact `Session` objects held in the in-memory LRU. Prefer the `webui.sessions_cache_max` key in `config.yaml` (which takes precedence); this env var remains a fallback. Bounds resident memory so long-running installs cannot accumulate every session ever touched and eventually crash (#4765/#2233/#4633). Eviction only ever drops clean, persisted, non-active sessions; an evicted session lazily reloads from its JSON sidecar on next access |
+| `HERMES_WEBUI_SESSIONS_MAX` | `100` | Legacy operator override for the max compact `Session` objects held in the in-memory LRU. Prefer the `webui.sessions_cache_max` key in `config.yaml` (which takes precedence); this env var remains a fallback. Bounds resident memory so long-running installs cannot accumulate every session ever touched and eventually crash (#4765/#2233/#4633). Eviction protects active sessions and unsaved data; stale empty draftless shells may expire after their grace period. Persisted victims lazily reload from their JSON sidecars on next access |
+
+The resident-session LRU also has an independent serialized-size budget so a few very large transcripts cannot bypass the entry limit. It defaults to 128 MiB and can be tuned in `config.yaml` without adding another environment variable:
+
+```yaml
+webui:
+  sessions_cache_max_mb: 128
+```
+
+The size is a stable floor for resident Python memory rather than an exact RSS ceiling. Active sessions and sessions with unsaved data are protected; a stale empty draftless shell may be evicted after its grace period. Under byte-only pressure, one oversized most-recent transcript stays warm to avoid a cold-reload loop; the entry-count cap remains authoritative when both limits are exceeded.
 
 Extension deployments can inspect sanitized, authenticated diagnostics at `GET /api/extensions/status`; see [WebUI Extensions](docs/EXTENSIONS.md#diagnostics).
 

--- a/api/config.py
+++ b/api/config.py
@@ -8705,6 +8705,33 @@ def get_sessions_cache_max(config_data: dict | None = None) -> int:
 # dict mode, which reads no file and takes no lock, so the value is right before
 # the first eviction pass instead of after it.
 _LAST_APPLIED_SESSIONS_CACHE_MAX: int = get_sessions_cache_max(cfg)
+
+# Entry count alone cannot bound resident memory when a handful of transcripts
+# are tens of MiB each (#6351). Use serialized sidecar bytes as a stable,
+# allocation-free weight; Python object overhead makes this a conservative floor,
+# not an exact RSS measurement. No env fallback is added for this non-secret knob.
+DEFAULT_SESSIONS_CACHE_MAX_BYTES = 128 * 1024 * 1024
+
+
+def get_sessions_cache_max_bytes(config_data: dict | None = None) -> int:
+    """Return the serialized-byte budget for resident full Session objects.
+
+    ``webui.sessions_cache_max_mb`` uses MiB despite the familiar ``mb`` config
+    spelling. Missing, invalid, or below-1 values fall back to the bounded
+    default so a typo cannot silently disable the memory backstop.
+    """
+    active_cfg = config_data if isinstance(config_data, dict) else get_config()
+    webui_cfg = active_cfg.get("webui", {}) if isinstance(active_cfg, dict) else {}
+    raw = webui_cfg.get("sessions_cache_max_mb") if isinstance(webui_cfg, dict) else None
+    try:
+        value_mib = int(raw) if raw is not None else None
+    except (TypeError, ValueError, OverflowError):
+        value_mib = None
+    if value_mib is not None and value_mib >= 1:
+        return value_mib * 1024 * 1024
+    return DEFAULT_SESSIONS_CACHE_MAX_BYTES
+
+
 CHAT_LOCK = threading.Lock()
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -1437,14 +1437,14 @@ class Session:
         # scene bodies. message_count is placed BEFORE anchor_scene_index so a
         # legacy-format reader that stops at a scene key still finds the count.
         # The full anchor_activity_scenes bodies serialize AFTER messages.
-        meta['message_count'] = len(self.messages or [])
-        meta['anchor_scene_index'] = _anchor_scene_index_from_records(self.anchor_activity_scenes)
-        # Keep the in-memory fingerprint aligned with what we just persisted, so a
-        # later metadata-only reload of THIS object (or any fingerprint reader)
-        # sees the current value rather than a stale load-time snapshot (#5854
-        # defense-in-depth; the cached-side freshness check reads real records,
-        # not this, so this is belt-and-suspenders).
-        self._anchor_scene_index = dict(meta['anchor_scene_index'])
+        # Placeholders only — reserves their position ahead of 'messages' in
+        # dict/JSON key order. The real values are derived from ``snapshot``
+        # below (after the deep copy), not from live ``self``, so a concurrent
+        # mutation of self.messages/self.anchor_activity_scenes during the
+        # deep copy can't leave stale counts describing a payload that no
+        # longer matches what was actually captured.
+        meta['message_count'] = None
+        meta['anchor_scene_index'] = None
         meta['messages'] = self.messages
         meta['tool_calls'] = self.tool_calls
         meta['anchor_activity_scenes'] = self.anchor_activity_scenes if isinstance(self.anchor_activity_scenes, dict) else {}
@@ -1469,6 +1469,22 @@ class Session:
         # (during or after this point) can change what gets hashed or written.
         payload_data = {**meta, **extra}
         snapshot = copy.deepcopy(payload_data)
+        # Derive the prefix metadata from the snapshot itself (not live self)
+        # now that the copy is complete, so message_count/anchor_scene_index
+        # always describe the exact messages/anchor_activity_scenes that got
+        # captured into ``snapshot`` — even if ``self`` was mutated during the
+        # deepcopy above. Assigning into the existing keys does not change
+        # their position, so they still precede 'messages' in JSON output.
+        snapshot['message_count'] = len(snapshot.get('messages') or [])
+        snapshot['anchor_scene_index'] = _anchor_scene_index_from_records(
+            snapshot.get('anchor_activity_scenes')
+        )
+        # Keep the in-memory fingerprint aligned with what we just persisted, so a
+        # later metadata-only reload of THIS object (or any fingerprint reader)
+        # sees the current value rather than a stale load-time snapshot (#5854
+        # defense-in-depth; the cached-side freshness check reads real records,
+        # not this, so this is belt-and-suspenders).
+        self._anchor_scene_index = dict(snapshot['anchor_scene_index'])
         persisted_fingerprint = _session_public_state_fingerprint({
             key: value
             for key, value in snapshot.items()
@@ -1496,11 +1512,11 @@ class Session:
                     existing_msg_count = len(existing.get('messages') or [])
                 except (json.JSONDecodeError, ValueError):
                     existing_msg_count = -1  # corrupt → always back up
-                incoming_msg_count = len(self.messages or [])
+                incoming_msg_count = len(snapshot.get('messages') or [])
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0
-                    and (self.active_stream_id or self.pending_user_message)
+                    and (snapshot.get('active_stream_id') or snapshot.get('pending_user_message'))
                 ):
                     logger.warning(
                         "refusing to overwrite session %s messages with empty active/pending snapshot "

--- a/api/models.py
+++ b/api/models.py
@@ -1368,6 +1368,14 @@ class Session:
         # eviction compares this allocation-bounded digest before dropping a full
         # session, because message-count parity cannot detect same-count edits.
         self._cache_persisted_fingerprint = None
+        # One authority token couples the public-state fingerprint with the
+        # durable sidecar generation it describes.  The two legacy projections
+        # above/below remain for compatibility with existing callers, but every
+        # eviction/publication decision reads this tuple so a partial transfer
+        # fails closed rather than pairing one writer's fingerprint with another
+        # writer's sidecar generation.
+        self._cache_persisted_authority = None
+        self._sidecar_stat_sig = None
 
     @property
     def path(self):
@@ -1557,6 +1565,8 @@ class Session:
 
         tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         written_size = None
+        written_identity = None
+        installed_sig = None
         try:
             with open(tmp, 'w', encoding='utf-8') as f:
                 f.write(payload)
@@ -1566,10 +1576,29 @@ class Session:
                     # Measure the exact temp-file inode whose bytes will be
                     # atomically installed. A later path stat can race cleanup
                     # or replacement and must not preserve a stale old weight.
-                    written_size = max(0, int(os.fstat(f.fileno()).st_size))
+                    written_stat = os.fstat(f.fileno())
+                    written_size = max(0, int(written_stat.st_size))
+                    # Keep the exact temp inode identity while it still names
+                    # the bytes that were just fsync'd.  ``os.replace`` moves
+                    # that inode into place; a post-replace path stat can then
+                    # prove the final path still names *this* payload instead
+                    # of a concurrent writer's replacement.
+                    written_identity = _sidecar_file_identity_from_stat(written_stat)
                 except (OSError, TypeError, ValueError, OverflowError):
                     written_size = None
             _safe_replace(tmp, self.path)
+            # Do not blindly stat the path and call it this save's generation:
+            # another writer may replace it immediately after our install.  A
+            # matching inode/dev/size/mtime identity binds the captured final
+            # signature to the exact fsync'd temp bytes; otherwise both the
+            # fingerprint and generation become unknown and byte eviction fails
+            # closed.
+            observed_sig = _sidecar_stat_signature(self.path)
+            if (
+                written_identity is not None
+                and _sidecar_signature_has_file_identity(observed_sig, written_identity)
+            ):
+                installed_sig = observed_sig
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)
@@ -1578,14 +1607,19 @@ class Session:
             raise
         # ``None`` is an explicit unknown-weight sentinel. Cache accounting
         # treats it as over-budget rather than retaining a stale pre-save size.
-        self._cache_resident_bytes = written_size
+        # A replacement detected between install and generation capture is also
+        # unknown: the temp-file byte count belongs to another path generation.
+        self._cache_resident_bytes = written_size if installed_sig is not None else None
         if (
             persisted_fingerprint is not None
             and _session_state_fingerprint(self) != persisted_fingerprint
         ):
             persisted_fingerprint = None
-        self._cache_persisted_fingerprint = persisted_fingerprint
-        self._sidecar_stat_sig = _sidecar_stat_signature(self.path)
+        _set_session_persisted_authority(
+            self,
+            persisted_fingerprint,
+            installed_sig,
+        )
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1622,12 +1656,33 @@ class Session:
             try:
                 with LOCK:
                     cached = SESSIONS.get(self.session_id)
+                    self_authority = _session_persisted_authority(self)
                     if cached is not None:
+                        cached_authority = _session_persisted_authority(cached)
+                        # A detached writer may replace only a clean older
+                        # generation. Do not snapshot arbitrary live state here:
+                        # another writer can already hold the per-session lock,
+                        # mutate this object, and be waiting for LOCK. Its
+                        # persisted fingerprint is the only safe CAS baseline.
+                        cached_state_fingerprint = (
+                            cached_authority[0] if cached_authority is not None else None
+                        )
                         if cached is self:
                             _evict_sessions_over_cap()
-                        elif _session_is_evictable(cached) and _session_matches_persisted_state(cached):
-                            # cached in SESSIONS is an unmodified reload of an older generation;
-                            # replace it with the newly saved self
+                        elif (
+                            _session_is_evictable(cached)
+                            and _session_has_current_persisted_generation(self, self_authority)
+                            and _cache_entry_matches_observed_authority(
+                                cached,
+                                cached,
+                                cached_authority,
+                                cached_state_fingerprint,
+                            )
+                        ):
+                            # CAS-publish this newly saved generation only over
+                            # a still-clean observed cache entry. A concurrent
+                            # writer/cache publisher changes either identity or
+                            # authority and wins instead of being overwritten.
                             SESSIONS[self.session_id] = self
                             _evict_sessions_over_cap()
             except Exception:
@@ -1645,14 +1700,30 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
-        if not p.exists():
+        # Read one descriptor-stable sidecar generation.  A plain ``stat`` then
+        # ``read_bytes`` can describe different atomic-replace generations; the
+        # helper binds the parsed bytes to a descriptor-derived token and
+        # revalidates the pathname before we construct a cacheable Session.
+        # Parsing a very large sidecar is itself a window, so retry the complete
+        # read → parse → path-validation sequence boundedly rather than returning
+        # an object whose exact input generation has already gone stale.
+        sidecar_bytes = None
+        _pre_read_sig = None
+        data = None
+        for _attempt in range(_SIDECAR_GENERATION_READ_RETRIES):
+            snapshot = _read_sidecar_snapshot(p)
+            if snapshot is None:
+                continue
+            candidate_bytes, candidate_sig = snapshot
+            candidate_data = json.loads(candidate_bytes)
+            if not _sidecar_signature_matches_path(p, candidate_sig):
+                continue
+            sidecar_bytes = candidate_bytes
+            _pre_read_sig = candidate_sig
+            data = candidate_data
+            break
+        if sidecar_bytes is None or _pre_read_sig is None or data is None:
             return None
-        # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
-        # cache write is only committed if the file didn't change under us
-        # during the parse (TOCTOU guard against an atomic replace mid-read).
-        _pre_read_sig = _sidecar_stat_signature(p)
-        sidecar_bytes = p.read_bytes()
-        data = json.loads(sidecar_bytes)
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
         # Weight the exact buffer parsed above. The path can be atomically
@@ -1696,8 +1767,11 @@ class Session:
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
-            session._cache_persisted_fingerprint = _session_state_fingerprint(session)
-        session._sidecar_stat_sig = _pre_read_sig
+            _set_session_persisted_authority(
+                session,
+                _session_state_fingerprint(session),
+                _pre_read_sig,
+            )
         return session
 
     @classmethod
@@ -4060,25 +4134,54 @@ def _sync_sidecar_from_state_db_if_newer(
         # accounting only when this cached projection exactly matches what was
         # persisted; otherwise leave it fingerprint-unknown so byte eviction is
         # conservative about any concurrent unsaved metadata.
-        locked_fingerprint = getattr(locked, '_cache_persisted_fingerprint', None)
+        locked_authority = _session_persisted_authority(locked)
         try:
             if (
-                isinstance(locked_fingerprint, bytes)
-                and _session_state_fingerprint(session) == locked_fingerprint
+                locked_authority is not None
+                and _session_has_current_persisted_generation(locked, locked_authority)
+                and _session_state_fingerprint(session) == locked_authority[0]
             ):
-                session._cache_persisted_fingerprint = locked_fingerprint
+                _set_session_persisted_authority(
+                    session,
+                    locked_authority[0],
+                    locked_authority[1],
+                )
             else:
-                session._cache_persisted_fingerprint = None
+                # Keep fingerprint and sidecar generation inseparable. A newer
+                # path replacement, or any caller-local metadata divergence,
+                # makes both unknown so byte eviction cannot misclassify it.
+                _set_session_persisted_authority(session, None, None)
         except Exception:
-            session._cache_persisted_fingerprint = None
+            _set_session_persisted_authority(session, None, None)
         if enforce_cache_bounds:
             try:
                 with LOCK:
                     cached = SESSIONS.get(sid)
+                    session_authority = _session_persisted_authority(session)
                     if cached is not None:
+                        cached_authority = _session_persisted_authority(cached)
+                        # This reconciliation holds the session mutation lock;
+                        # nevertheless a cached object may have unsaved state
+                        # from a prior owner. Replace only an exact clean older
+                        # authority, never a freshly observed mutable graph.
+                        cached_state_fingerprint = (
+                            cached_authority[0] if cached_authority is not None else None
+                        )
                         if cached is session:
                             _evict_sessions_over_cap()
-                        elif _session_is_evictable(cached) and _session_matches_persisted_state(cached):
+                        elif (
+                            _session_is_evictable(cached)
+                            and _session_has_current_persisted_generation(session, session_authority)
+                            and _cache_entry_matches_observed_authority(
+                                cached,
+                                cached,
+                                cached_authority,
+                                cached_state_fingerprint,
+                            )
+                        ):
+                            # Publish the reconciled projection only if the
+                            # resident entry still represents the clean state we
+                            # observed; a competing writer/publication wins CAS.
                             SESSIONS[sid] = session
                             _evict_sessions_over_cap()
             except Exception:
@@ -4276,18 +4379,100 @@ def _disk_scene_fingerprint(disk_meta_prefix: dict):
     return None
 
 
+_SIDECAR_GENERATION_READ_RETRIES = 3
+
+
+def _sidecar_file_identity_from_stat(st):
+    """Return the immutable-on-replace part of one sidecar ``stat`` result.
+
+    ``ctime`` changes when a temporary inode is renamed into its final path on
+    common Linux filesystems, so it cannot prove that a post-rename path still
+    names the inode we fsync'd.  Device/inode/size/mtime can: a competing atomic
+    replace necessarily changes the inode (and an in-place edit changes size or
+    mtime).  The full signature below still retains ctime for ordinary freshness
+    checks.
+    """
+    try:
+        return (
+            int(st.st_dev),
+            int(st.st_ino),
+            int(st.st_size),
+            int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
+        )
+    except (AttributeError, OSError, TypeError, ValueError, OverflowError):
+        return None
+
+
+def _sidecar_stat_signature_from_stat(path, st):
+    """Build a durable sidecar generation token from one descriptor/path stat."""
+    identity = _sidecar_file_identity_from_stat(st)
+    if identity is None:
+        return None
+    try:
+        return (
+            str(path),
+            identity[3],
+            identity[2],
+            int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))),
+            identity[0],
+            identity[1],
+        )
+    except (AttributeError, OSError, TypeError, ValueError, OverflowError):
+        return None
+
+
+def _sidecar_signature_has_file_identity(signature, identity) -> bool:
+    """Whether a path signature still names an expected fsync'd file identity."""
+    if not isinstance(signature, tuple) or len(signature) < 6 or identity is None:
+        return False
+    try:
+        return (signature[4], signature[5], signature[2], signature[1]) == tuple(identity)
+    except (TypeError, ValueError, IndexError):
+        return False
+
+
 def _sidecar_stat_signature(path):
     """Stat signature for a sidecar path, or None if it can't be stat'd.
 
-    Any edit (atomic-rename or in-place) changes at least one component, so a
-    cached entry keyed by this signature is auto-invalidated on the next write.
+    Device and inode distinguish an atomic replacement from an equal-size,
+    same-timestamp sibling write.  Callers that parse a sidecar use
+    ``_read_sidecar_snapshot`` below, which derives this token from the opened
+    descriptor and revalidates the path before it is published.
     """
     try:
         st = path.stat()
     except OSError:
         return None
-    return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
-            int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+    return _sidecar_stat_signature_from_stat(path, st)
+
+
+def _sidecar_signature_matches_path(path, signature) -> bool:
+    """Return whether ``path`` still names the exact captured generation."""
+    return signature is not None and _sidecar_stat_signature(path) == signature
+
+
+def _read_sidecar_snapshot(path):
+    """Read one stable sidecar generation as ``(bytes, signature)`` or ``None``.
+
+    The descriptor is fstat'd before and after the read, then the path is
+    revalidated against that descriptor-derived token.  Therefore the returned
+    bytes, generation, and current pathname all describe one coherent sidecar
+    generation.  A rename or in-place edit at any observed boundary retries;
+    bounded exhaustion fails closed rather than publishing an unverifiable load.
+    """
+    for _attempt in range(_SIDECAR_GENERATION_READ_RETRIES):
+        try:
+            with open(path, 'rb') as sidecar:
+                before = _sidecar_stat_signature_from_stat(path, os.fstat(sidecar.fileno()))
+                sidecar_bytes = sidecar.read()
+                after = _sidecar_stat_signature_from_stat(path, os.fstat(sidecar.fileno()))
+        except OSError:
+            continue
+        if before is None or before != after:
+            continue
+        if _sidecar_signature_matches_path(path, after):
+            return sidecar_bytes, after
+    return None
 
 
 def _legacy_sidecar_facts_get(sid):
@@ -4509,12 +4694,23 @@ def _cached_session_lags_disk(cached) -> bool:
             # Inactive session, count matches, scene records match.
             # Check if disk was modified (e.g. metadata or same-count edit)
             # while cached has remained clean and unmodified.
-            cached_sig = getattr(cached, '_sidecar_stat_sig', None)
-            if cached_sig is not None:
+            authority = _session_persisted_authority(cached)
+            if authority is not None:
                 disk_sig = _sidecar_stat_signature(cached.path)
-                if disk_sig is not None and disk_sig != cached_sig:
-                    if _session_matches_persisted_state(cached):
-                        return True
+                if disk_sig is not None and disk_sig != authority[1]:
+                    # The cache may legitimately hold a clean older generation
+                    # while a detached writer has installed a newer sidecar. Do
+                    # not require path parity here: that is exactly the stale
+                    # condition we are detecting. The public fingerprint still
+                    # proves this object itself has not accrued unsaved edits.
+                    try:
+                        if (
+                            _session_persisted_authority(cached) == authority
+                            and _session_state_fingerprint(cached) == authority[0]
+                        ):
+                            return True
+                    except Exception:
+                        pass
             return False
     try:
         disk_meta = Session.load_metadata_only(sid)
@@ -4864,12 +5060,89 @@ def _session_state_fingerprint(session) -> bytes:
     })
 
 
-def _session_matches_persisted_state(session) -> bool:
-    expected = getattr(session, '_cache_persisted_fingerprint', None)
-    if not isinstance(expected, bytes):
+def _session_persisted_authority(session):
+    """Return ``(public_fingerprint, exact_sidecar_generation)`` or ``None``.
+
+    The tuple is the authoritative cache proof.  The legacy attributes remain
+    observable for existing call sites/tests, but must never be independently
+    mixed: a fingerprint without its descriptor/path generation is deliberately
+    untrusted.
+    """
+    if hasattr(session, '_cache_persisted_authority'):
+        authority = getattr(session, '_cache_persisted_authority', None)
+        if (
+            isinstance(authority, tuple)
+            and len(authority) == 2
+            and isinstance(authority[0], bytes)
+            and authority[1] is not None
+        ):
+            return authority
+        return None
+    # Compatibility for a resident object created before this module revision
+    # was loaded.  New Session objects always carry the atomic tuple above.
+    fingerprint = getattr(session, '_cache_persisted_fingerprint', None)
+    signature = getattr(session, '_sidecar_stat_sig', None)
+    if isinstance(fingerprint, bytes) and signature is not None:
+        return fingerprint, signature
+    return None
+
+
+def _set_session_persisted_authority(session, fingerprint, signature) -> None:
+    """Publish or clear fingerprint and durable generation as one authority unit."""
+    if not isinstance(fingerprint, bytes) or signature is None:
+        fingerprint = None
+        signature = None
+        authority = None
+    else:
+        authority = (fingerprint, signature)
+    # Clear the tuple before changing compatibility projections, then make the
+    # complete pair visible in one assignment.  Readers use the tuple, so any
+    # concurrent observation during this small window fails closed.
+    session._cache_persisted_authority = None
+    session._cache_persisted_fingerprint = fingerprint
+    session._sidecar_stat_sig = signature
+    session._cache_persisted_authority = authority
+
+
+def _session_has_current_persisted_generation(session, authority=None) -> bool:
+    """Return whether a session's authority still names the current sidecar."""
+    if authority is None:
+        authority = _session_persisted_authority(session)
+    if authority is None:
         return False
     try:
-        return _session_state_fingerprint(session) == expected
+        return _sidecar_signature_matches_path(session.path, authority[1])
+    except Exception:
+        return False
+
+
+def _session_matches_persisted_state(
+    session,
+    *,
+    authority=None,
+    require_current_generation=True,
+) -> bool:
+    """Return whether public state matches its paired durable authority.
+
+    ``require_current_generation=False`` is reserved for a CAS that is about to
+    replace a clean *older* cache generation with a newer, independently
+    verified writer/load candidate.  Eviction and ordinary freshness decisions
+    retain the default, which requires both equal public state and a path that
+    still names the exact descriptor generation.
+    """
+    if authority is None:
+        authority = _session_persisted_authority(session)
+    if authority is None:
+        return False
+    try:
+        if _session_persisted_authority(session) != authority:
+            return False
+        if _session_state_fingerprint(session) != authority[0]:
+            return False
+        return (
+            not require_current_generation
+            or _session_has_current_persisted_generation(session, authority)
+        )
     except Exception:
         return False
 
@@ -5071,6 +5344,127 @@ def _finish_full_session_resolve(session_id: str, event: threading.Event) -> Non
     event.set()
 
 
+_SESSION_CACHE_PUBLICATION_RETRIES = 3
+
+
+def _cache_entry_matches_observed_authority(
+    session,
+    expected_session,
+    expected_authority,
+    expected_state_fingerprint,
+) -> bool:
+    """CAS predicate for a cache entry observed before a disk load.
+
+    Object identity alone is not enough: another writer may have mutated and
+    saved the same resident object while a loader was parsing disk. The observed
+    public-state fingerprint catches mutations even for intentionally unpersisted
+    optimistic projections; the paired authority (including ``None``) catches a
+    competing durable publication without taking a blocking session lock while
+    ``LOCK`` is held.
+    """
+    if session is not expected_session or not isinstance(expected_state_fingerprint, bytes):
+        return False
+    try:
+        return (
+            _session_persisted_authority(session) == expected_authority
+            and _session_state_fingerprint(session) == expected_state_fingerprint
+        )
+    except Exception:
+        return False
+
+
+def _publish_verified_session_cas(
+    sid,
+    candidate,
+    *,
+    expected_cached,
+    expected_authority,
+    expected_state_fingerprint,
+    promote_cache,
+    enforce_cache_bounds,
+):
+    """Publish a loaded full session only if cache and disk generations still match.
+
+    Returns ``("published", candidate)`` when this caller won publication,
+    ``("current", current)`` when another cache writer won, and ``("retry",
+    None)`` when the loaded candidate no longer names the durable sidecar.
+    Callers perform bounded reloads for the latter case; they never install an
+    unverifiable snapshot.
+    """
+    if (
+        candidate is None
+        or str(getattr(candidate, 'session_id', '') or '') != str(sid)
+        or not _session_has_current_persisted_generation(candidate)
+    ):
+        return "retry", None
+    with LOCK:
+        current = SESSIONS.get(sid)
+        if expected_cached is None:
+            if current is not None:
+                return "current", current
+        else:
+            if current is not expected_cached:
+                return "current", current
+            if not _cache_entry_matches_observed_authority(
+                current,
+                expected_cached,
+                expected_authority,
+                expected_state_fingerprint,
+            ):
+                return "current", current
+
+        # Revalidate after taking the cache lock. A sidecar replacement while
+        # the JSON parser ran must not become a stale cache publication merely
+        # because the cache entry itself was unchanged.
+        if not _session_has_current_persisted_generation(candidate):
+            return "retry", None
+        SESSIONS[sid] = candidate
+        if promote_cache:
+            SESSIONS.move_to_end(sid)
+        if enforce_cache_bounds:
+            _evict_sessions_over_cap()
+        return "published", candidate
+
+
+def _reload_and_publish_session_cas(
+    sid,
+    *,
+    expected_cached,
+    expected_authority,
+    expected_state_fingerprint,
+    promote_cache,
+    enforce_cache_bounds,
+):
+    """Boundedly reload and CAS-publish one current full sidecar generation."""
+    observed_cached = expected_cached
+    observed_authority = expected_authority
+    observed_state_fingerprint = expected_state_fingerprint
+    for _attempt in range(_SESSION_CACHE_PUBLICATION_RETRIES):
+        candidate = Session.load(sid)
+        if candidate is None:
+            continue
+        status, result = _publish_verified_session_cas(
+            sid,
+            candidate,
+            expected_cached=observed_cached,
+            expected_authority=observed_authority,
+            expected_state_fingerprint=observed_state_fingerprint,
+            promote_cache=promote_cache,
+            enforce_cache_bounds=enforce_cache_bounds,
+        )
+        if status == "published":
+            return result
+        if status == "current":
+            # Another publisher won. Its object is authoritative for this cache
+            # generation; importantly, do not overwrite it with our old parse.
+            if result is not None:
+                return result
+            observed_cached = None
+            observed_authority = None
+            observed_state_fingerprint = None
+    return None
+
+
 def _resolve_session_once(
     sid,
     metadata_only=False,
@@ -5112,14 +5506,20 @@ def _resolve_session_once(
             if not allow_full_load:
                 raise _FullSessionResolveRequired
             try:
-                disk_session = Session.load(sid)
-                with LOCK:
-                    SESSIONS[sid] = disk_session
-                    if promote_cache:
-                        SESSIONS.move_to_end(sid)
-                    if cache_on_miss:
-                        _evict_sessions_over_cap()
-                cached = disk_session
+                try:
+                    observed_state_fingerprint = _session_state_fingerprint(cached)
+                except Exception:
+                    observed_state_fingerprint = None
+                refreshed = _reload_and_publish_session_cas(
+                    sid,
+                    expected_cached=cached,
+                    expected_authority=_session_persisted_authority(cached),
+                    expected_state_fingerprint=observed_state_fingerprint,
+                    promote_cache=promote_cache,
+                    enforce_cache_bounds=cache_on_miss,
+                )
+                if refreshed is not None:
+                    cached = refreshed
             except Exception:
                 logger.debug(
                     "cached session disk-freshness check failed for session %s", sid, exc_info=True,
@@ -5128,15 +5528,40 @@ def _resolve_session_once(
             if not allow_full_load:
                 raise _FullSessionResolveRequired
             try:
-                disk_session = Session.load(sid)
-                if _cache_has_stale_unsaved_user_tail(cached, disk_session):
-                    with LOCK:
-                        SESSIONS[sid] = disk_session
-                        if promote_cache:
-                            SESSIONS.move_to_end(sid)
-                        if cache_on_miss:
-                            _evict_sessions_over_cap()
-                    cached = disk_session
+                observed_cached = cached
+                observed_authority = _session_persisted_authority(cached)
+                try:
+                    observed_state_fingerprint = _session_state_fingerprint(cached)
+                except Exception:
+                    observed_state_fingerprint = None
+                for _attempt in range(_SESSION_CACHE_PUBLICATION_RETRIES):
+                    disk_session = Session.load(sid)
+                    if disk_session is None:
+                        continue
+                    if not _cache_has_stale_unsaved_user_tail(cached, disk_session):
+                        break
+                    status, result = _publish_verified_session_cas(
+                        sid,
+                        disk_session,
+                        expected_cached=observed_cached,
+                        expected_authority=observed_authority,
+                        expected_state_fingerprint=observed_state_fingerprint,
+                        promote_cache=promote_cache,
+                        enforce_cache_bounds=cache_on_miss,
+                    )
+                    if status == "published":
+                        cached = result
+                        break
+                    if status == "current":
+                        if result is not None:
+                            cached = result
+                            break
+                        # The observed entry was evicted while we parsed disk.
+                        # Retry as a cache miss rather than pinning the detached
+                        # stale object or overwriting a future publisher.
+                        observed_cached = None
+                        observed_authority = None
+                        observed_state_fingerprint = None
             except Exception:
                 logger.debug(
                     "stale cached user-tail check failed for session %s", sid, exc_info=True,
@@ -5169,28 +5594,34 @@ def _resolve_session_once(
         s = Session.load(sid)
     if s:
         if cache_on_miss:
-            with LOCK:
-                current_cached = SESSIONS.get(sid)
-                if current_cached is not None:
-                    s = current_cached
-                    if promote_cache:
-                        SESSIONS.move_to_end(sid)
-                else:
-                    disk_sig = _sidecar_stat_signature(s.path)
-                    s_sig = getattr(s, '_sidecar_stat_sig', None)
-                    if disk_sig is not None and s_sig is not None and disk_sig != s_sig:
-                        fresh = Session.load(sid)
-                        if fresh is not None:
-                            s = fresh
-                            SESSIONS[sid] = s
-                            if promote_cache:
-                                SESSIONS.move_to_end(sid)
-                            _evict_sessions_over_cap()
-                    else:
-                        SESSIONS[sid] = s
-                        if promote_cache:
-                            SESSIONS.move_to_end(sid)
-                        _evict_sessions_over_cap()
+            candidate = s
+            published = None
+            for _attempt in range(_SESSION_CACHE_PUBLICATION_RETRIES):
+                status, result = _publish_verified_session_cas(
+                    sid,
+                    candidate,
+                    expected_cached=None,
+                    expected_authority=None,
+                    expected_state_fingerprint=None,
+                    promote_cache=promote_cache,
+                    enforce_cache_bounds=True,
+                )
+                if status in {"published", "current"} and result is not None:
+                    published = result
+                    break
+                # The candidate's descriptor/path generation changed before
+                # publication (or couldn't be proven). Read a new coherent
+                # generation for the next bounded attempt; after exhaustion we
+                # fail closed below instead of putting an unverifiable object in
+                # SESSIONS.
+                if _attempt + 1 < _SESSION_CACHE_PUBLICATION_RETRIES:
+                    candidate = Session.load(sid)
+            if published is None:
+                with LOCK:
+                    published = SESSIONS.get(sid)
+            if published is None:
+                raise KeyError(sid)
+            s = published
         if not metadata_only:
             try:
                 synced_from_state = _sync_sidecar_from_state_db_if_newer(

--- a/api/models.py
+++ b/api/models.py
@@ -1454,19 +1454,27 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        # Capture the public state before serialization. The assigned persisted
-        # fingerprint may describe this snapshot only if the resident object is
-        # still identical after the payload has been serialized and installed.
-        # If another request mutates the object anywhere across that window, keep
-        # the fingerprint unknown so byte-only eviction fails closed instead of
-        # mistaking the later in-memory state for the bytes written below.
+        # Capture ONE immutable snapshot of the public state and use it for both
+        # the fingerprint and the serialized bytes. ``payload_data`` itself only
+        # holds top-level references to ``self``'s attributes (e.g.
+        # ``meta['messages'] is self.messages``), so hashing it and then calling
+        # ``json.dumps`` on it in a separate traversal previously left a window
+        # where a nested field could change A->B->A between the two passes
+        # (e.g. across a slow/yielding serialization of a huge transcript): the
+        # fingerprint would describe A, the disk bytes would describe B, and a
+        # revert back to A before the post-write comparison below would make
+        # the mismatch invisible, letting byte-only eviction treat a corrupted
+        # sidecar as clean. Deep-copying breaks that aliasing: the copy is a
+        # fully independent object graph, so no concurrent mutation of ``self``
+        # (during or after this point) can change what gets hashed or written.
         payload_data = {**meta, **extra}
+        snapshot = copy.deepcopy(payload_data)
         persisted_fingerprint = _session_public_state_fingerprint({
             key: value
-            for key, value in payload_data.items()
+            for key, value in snapshot.items()
             if key not in {'message_count', 'anchor_scene_index'}
         })
-        payload = json.dumps(payload_data, ensure_ascii=False, indent=2)
+        payload = json.dumps(snapshot, ensure_ascii=False, indent=2)
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -4847,16 +4855,35 @@ def _evict_sessions_over_cap(cap: int | None = None, max_bytes: int | None = Non
     does not cold-reload on every access.
 
     CALLER CONTRACT: the global ``LOCK`` MUST already be held (every call site
-    mutates ``SESSIONS`` under ``LOCK``). This function never acquires ``LOCK``
-    or any stream lock itself, so it cannot introduce a lock-ordering deadlock.
-    Under that same held ``LOCK`` it publishes the cap it enforced into
-    ``api.config._LAST_APPLIED_SESSIONS_CACHE_MAX`` for nonblocking diagnostics
-    (#6351); any future edit that can change ``cap`` after that point must move
-    the publish down with it.
+    mutates ``SESSIONS`` under ``LOCK``). Byte-only removal additionally makes a
+    *nonblocking* attempt at the candidate's per-session agent lock (see below);
+    it never blocks on ``LOCK`` or any other lock itself, so it cannot introduce
+    a lock-ordering deadlock. Under that same held ``LOCK`` it publishes the cap
+    it enforced into ``api.config._LAST_APPLIED_SESSIONS_CACHE_MAX`` for
+    nonblocking diagnostics (#6351); any future edit that can change ``cap``
+    after that point must move the publish down with it.
+
+    Byte-only eviction validates ``_session_matches_persisted_state()`` and then
+    removes the entry. Validating and removing are not atomic with respect to a
+    writer: without ownership, a writer could establish mutation ownership (the
+    per-session agent lock every normal mutation path takes) in the window
+    between validation and removal, and its update would be silently discarded
+    once the stale in-memory copy is dropped. To close that window, the
+    byte-only path takes the candidate's per-session agent lock around the
+    (re-)validate-then-pop pair, so a writer using the standard lock-then-mutate
+    discipline either finishes and releases before we validate, or blocks until
+    we finish and release — either way it cannot observe removal mid-mutation.
+    The acquire is nonblocking: normal code takes session-lock then ``LOCK``, so
+    a *blocking* acquire here (``LOCK`` already held) would invert that order
+    and could deadlock against a writer holding the session lock and waiting on
+    ``LOCK``. A contended lock (including this same thread already holding it
+    via a self-heal path, e.g. ``_sync_sidecar_from_state_db_if_newer``) just
+    leaves the candidate resident this pass — the same fail-safe posture used
+    elsewhere in this function for weight/parity uncertainty.
 
     Returns the number of sessions evicted. If every over-budget candidate is
-    active/unsaved, the cache may temporarily exceed a bound — that is the
-    intended safe behavior (never lose an active/unsaved session).
+    active/unsaved/lock-contended, the cache may temporarily exceed a bound —
+    that is the intended safe behavior (never lose an active/unsaved session).
     """
     config_data = None
     if cap is None or max_bytes is None:
@@ -4922,14 +4949,27 @@ def _evict_sessions_over_cap(cap: int | None = None, max_bytes: int | None = Non
             # is more frequent for large full sessions and must not widen that
             # policy to same-count edits or unsaved metadata. Metadata-only stubs
             # are immutable disk projections and need no full-state digest.
-            if (
+            byte_only_pressure = (
                 over_bytes
                 and not over_count
                 and not getattr(candidate, '_loaded_metadata_only', False)
-                and not _session_matches_persisted_state(candidate)
-            ):
-                continue
-            removed = SESSIONS.pop(sid, None)
+            )
+            if byte_only_pressure:
+                # Tie validation to removal via mutation ownership (see the
+                # CALLER CONTRACT note above): a writer cannot establish
+                # ownership of *candidate* while we hold its lock, so a clean
+                # verdict here cannot be invalidated before the pop below.
+                session_lock = _get_session_agent_lock(sid)
+                if not session_lock.acquire(blocking=False):
+                    continue
+                try:
+                    if not _session_matches_persisted_state(candidate):
+                        continue
+                    removed = SESSIONS.pop(sid, None)
+                finally:
+                    session_lock.release()
+            else:
+                removed = SESSIONS.pop(sid, None)
             if removed is not None:
                 resident_bytes = max(
                     0,

--- a/api/models.py
+++ b/api/models.py
@@ -1360,12 +1360,25 @@ class Session:
             except (TypeError, ValueError):
                 parsed_message_count = None
         self._metadata_message_count = parsed_message_count if parsed_message_count is not None and parsed_message_count >= 0 else None
+        # Serialized bytes represented by this resident object. Full loads and
+        # successful saves refresh this scalar without walking the Python object
+        # graph; metadata-only stubs replace it with their small prefix size.
+        self._cache_resident_bytes = 0
+        # Fingerprint of the last successfully persisted public state. Byte-only
+        # eviction compares this allocation-bounded digest before dropping a full
+        # session, because message-count parity cannot detect same-count edits.
+        self._cache_persisted_fingerprint = None
 
     @property
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+    def save(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+        enforce_cache_bounds: bool = True,
+    ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1441,7 +1454,19 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        # Capture the public state before serialization. The assigned persisted
+        # fingerprint may describe this snapshot only if the resident object is
+        # still identical after the payload has been serialized and installed.
+        # If another request mutates the object anywhere across that window, keep
+        # the fingerprint unknown so byte-only eviction fails closed instead of
+        # mistaking the later in-memory state for the bytes written below.
+        payload_data = {**meta, **extra}
+        persisted_fingerprint = _session_public_state_fingerprint({
+            key: value
+            for key, value in payload_data.items()
+            if key not in {'message_count', 'anchor_scene_index'}
+        })
+        payload = json.dumps(payload_data, ensure_ascii=False, indent=2)
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -1507,11 +1532,19 @@ class Session:
             pass
 
         tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+        written_size = None
         try:
             with open(tmp, 'w', encoding='utf-8') as f:
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())
+                try:
+                    # Measure the exact temp-file inode whose bytes will be
+                    # atomically installed. A later path stat can race cleanup
+                    # or replacement and must not preserve a stale old weight.
+                    written_size = max(0, int(os.fstat(f.fileno()).st_size))
+                except (OSError, TypeError, ValueError, OverflowError):
+                    written_size = None
             _safe_replace(tmp, self.path)
         except Exception:
             try:
@@ -1519,6 +1552,15 @@ class Session:
             except Exception:
                 pass
             raise
+        # ``None`` is an explicit unknown-weight sentinel. Cache accounting
+        # treats it as over-budget rather than retaining a stale pre-save size.
+        self._cache_resident_bytes = written_size
+        if (
+            persisted_fingerprint is not None
+            and _session_state_fingerprint(self) != persisted_fingerprint
+        ):
+            persisted_fingerprint = None
+        self._cache_persisted_fingerprint = persisted_fingerprint
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1546,6 +1588,23 @@ class Session:
                     exc_info=True,
                 )
 
+        # A resident session can grow far past the aggregate byte budget without
+        # causing another cache insertion. Re-run the shared bound after durable
+        # persistence so old clean entries are reclaimed immediately. Cache
+        # maintenance is best-effort: a completed sidecar save must not be
+        # reported as failed if eviction diagnostics encounter an error.
+        if enforce_cache_bounds:
+            try:
+                with LOCK:
+                    if SESSIONS.get(self.session_id) is self:
+                        _evict_sessions_over_cap()
+            except Exception:
+                logger.debug(
+                    "Post-save session cache enforcement failed for %s",
+                    self.session_id,
+                    exc_info=True,
+                )
+
     @classmethod
     def load(cls, sid):
         # Validate session ID format to prevent path traversal.  API/gateway
@@ -1560,15 +1619,28 @@ class Session:
         # cache write is only committed if the file didn't change under us
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
+        sidecar_bytes = p.read_bytes()
+        data = json.loads(sidecar_bytes)
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
+        # Weight the exact buffer parsed above. The path can be atomically
+        # replaced between the pre-read signature and open/read; using that old
+        # signature's size would permanently undercount a larger replacement.
+        session._cache_resident_bytes = len(sidecar_bytes)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching
                 # recency/index ordering; save() creates a .bak because this
                 # intentionally shrinks the transcript (#2592).
-                session.save(touch_updated_at=False, skip_index=True)
+                # A full load can occur inside the global cache lock while an
+                # eviction pass resolves authoritative legacy facts. That outer
+                # pass already enforces the bound; reacquiring the non-reentrant
+                # LOCK here would deadlock. Normal saves retain enforcement.
+                session.save(
+                    touch_updated_at=False,
+                    skip_index=True,
+                    enforce_cache_bounds=False,
+                )
             except Exception:
                 logger.debug("Failed to persist collapsed duplicate partials for %s", sid, exc_info=True)
         else:
@@ -1592,6 +1664,7 @@ class Session:
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
+            session._cache_persisted_fingerprint = _session_state_fingerprint(session)
         return session
 
     @classmethod
@@ -1620,7 +1693,9 @@ class Session:
                 return cls.load(sid)
             parsed['messages'] = []
             parsed['tool_calls'] = []
+            metadata_resident_bytes = len(prefix.encode('utf-8'))
             session = cls(**parsed)
+            session._cache_resident_bytes = metadata_resident_bytes
             sidecar_message_count = _parse_nonnegative_int(parsed.get('message_count'))
             index_message_count = None
             if sidecar_message_count is None:
@@ -1652,6 +1727,7 @@ class Session:
                 if _facts is not None:
                     parsed['anchor_scene_index'] = _facts.get('scene_index') or {}
                     session = cls(**parsed)
+                    session._cache_resident_bytes = metadata_resident_bytes
                     session._metadata_message_count = _parse_nonnegative_int(_facts.get('message_count'))
                     session._loaded_metadata_only = True
                     return session
@@ -3760,7 +3836,11 @@ def _repair_stale_pending(session) -> bool:
         return False
 
 
-def _sync_sidecar_from_state_db_if_newer(session) -> bool:
+def _sync_sidecar_from_state_db_if_newer(
+    session,
+    *,
+    enforce_cache_bounds: bool = True,
+) -> bool:
     """Read-side self-heal when WebUI sidecar lags Hermes state.db.
 
     A WebUI stream can lose its terminal ``done``/``stream_end`` path while the
@@ -3773,6 +3853,10 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     This deliberately reuses the existing append-only reconciler so workspace
     prefixes, timestamp drift, compaction watermarks, and tool metadata keep the
     same semantics as normal WebUI/state.db display merging.
+
+    ``enforce_cache_bounds=False`` preserves the scan accessor's no-LRU-churn
+    contract. The durable repair and cached projection still update, but a
+    content scan must not evict or promote the user's working set.
     """
     if session is None or getattr(session, '_loaded_metadata_only', False):
         return False
@@ -3936,6 +4020,35 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
         session.pending_attachments = []
         session.pending_started_at = None
         session.pending_user_source = None
+        session.updated_at = locked.updated_at
+        session._cache_resident_bytes = locked._cache_resident_bytes
+        # The durable save happened through a freshly loaded lock-owned object,
+        # not necessarily the object held in SESSIONS. Transfer the derived
+        # accounting only when this cached projection exactly matches what was
+        # persisted; otherwise leave it fingerprint-unknown so byte eviction is
+        # conservative about any concurrent unsaved metadata.
+        locked_fingerprint = getattr(locked, '_cache_persisted_fingerprint', None)
+        try:
+            if (
+                isinstance(locked_fingerprint, bytes)
+                and _session_state_fingerprint(session) == locked_fingerprint
+            ):
+                session._cache_persisted_fingerprint = locked_fingerprint
+            else:
+                session._cache_persisted_fingerprint = None
+        except Exception:
+            session._cache_persisted_fingerprint = None
+        if enforce_cache_bounds:
+            try:
+                with LOCK:
+                    if SESSIONS.get(sid) is session:
+                        _evict_sessions_over_cap()
+            except Exception:
+                logger.debug(
+                    "Post-reconciliation session cache enforcement failed for %s",
+                    sid,
+                    exc_info=True,
+                )
         logger.info(
             "Session %s: synced sidecar from newer state.db transcript (%d -> %d messages)",
             sid,
@@ -4614,8 +4727,110 @@ def _session_is_evictable(s) -> bool:
     return disk_count >= in_memory_count
 
 
-def _evict_sessions_over_cap(cap: int | None = None) -> int:
-    """Evict clean, persisted, non-active sessions until len(SESSIONS) <= cap.
+_UNKNOWN_SESSION_CACHE_RESIDENT_BYTES = (1 << 63) - 1
+
+
+def _session_cache_resident_bytes(session) -> int:
+    """Return recorded weight, failing closed when a full-session size is unknown."""
+    raw_value = getattr(session, '_cache_resident_bytes', 0)
+    if raw_value is None:
+        return _UNKNOWN_SESSION_CACHE_RESIDENT_BYTES
+    try:
+        value = int(raw_value or 0)
+    except (TypeError, ValueError, OverflowError):
+        return _UNKNOWN_SESSION_CACHE_RESIDENT_BYTES
+    return max(0, value)
+
+
+def _session_public_state_fingerprint(public_state: dict) -> bytes:
+    """Hash a public-state mapping without materializing another JSON payload.
+
+    Walking the object graph catches same-count message edits and metadata
+    changes while keeping temporary allocation bounded for transcripts with
+    giant strings.
+    """
+    digest = hashlib.blake2b(digest_size=16)
+    seen = set()
+
+    def update(value):
+        if value is None:
+            digest.update(b'n;')
+        elif value is True:
+            digest.update(b'b1;')
+        elif value is False:
+            digest.update(b'b0;')
+        elif isinstance(value, int):
+            digest.update(b'i')
+            digest.update(str(value).encode('ascii'))
+            digest.update(b';')
+        elif isinstance(value, float):
+            digest.update(b'f')
+            digest.update(repr(value).encode('ascii'))
+            digest.update(b';')
+        elif isinstance(value, str):
+            digest.update(b's')
+            digest.update(str(len(value)).encode('ascii'))
+            digest.update(b':')
+            for offset in range(0, len(value), 256 * 1024):
+                digest.update(value[offset:offset + 256 * 1024].encode('utf-8'))
+            digest.update(b';')
+        elif isinstance(value, (list, tuple)):
+            obj_id = id(value)
+            if obj_id in seen:
+                digest.update(b'cycle;')
+                return
+            seen.add(obj_id)
+            digest.update(b'l[')
+            for item in value:
+                update(item)
+            digest.update(b'];')
+            seen.remove(obj_id)
+        elif isinstance(value, dict):
+            obj_id = id(value)
+            if obj_id in seen:
+                digest.update(b'cycle;')
+                return
+            seen.add(obj_id)
+            digest.update(b'd{')
+            for key in sorted(value, key=lambda item: (type(item).__name__, repr(item))):
+                update(key)
+                update(value[key])
+            digest.update(b'};')
+            seen.remove(obj_id)
+        else:
+            # Session.save() would reject non-JSON state. Keep this conservative:
+            # a changed fallback representation blocks byte-only eviction.
+            digest.update(b'x')
+            digest.update(type(value).__qualname__.encode('utf-8', errors='replace'))
+            digest.update(b':')
+            digest.update(repr(value).encode('utf-8', errors='replace'))
+            digest.update(b';')
+
+    update(public_state)
+    return digest.digest()
+
+
+def _session_state_fingerprint(session) -> bytes:
+    """Hash the resident session state represented by its persisted public fields."""
+    return _session_public_state_fingerprint({
+        key: value
+        for key, value in getattr(session, '__dict__', {}).items()
+        if not key.startswith('_')
+    })
+
+
+def _session_matches_persisted_state(session) -> bool:
+    expected = getattr(session, '_cache_persisted_fingerprint', None)
+    if not isinstance(expected, bytes):
+        return False
+    try:
+        return _session_state_fingerprint(session) == expected
+    except Exception:
+        return False
+
+
+def _evict_sessions_over_cap(cap: int | None = None, max_bytes: int | None = None) -> int:
+    """Evict safe LRU entries until count and serialized-byte bounds are met.
 
     Replaces the previous blind ``SESSIONS.popitem(last=False)`` loops (#4765).
     The blind loops could evict the least-recently-used entry even if it was
@@ -4623,6 +4838,13 @@ def _evict_sessions_over_cap(cap: int | None = None) -> int:
     conversation. This walks the LRU from oldest to newest and removes only
     entries that ``_session_is_evictable()`` proves are safe. An evicted session
     transparently lazily reloads from its sidecar on the next ``get_session()``.
+
+    The byte budget uses each resident object's serialized sidecar size, captured
+    on full load/save. It is a stable, allocation-free floor for Python memory,
+    not an exact RSS measurement. Unknown weights fail closed as over-budget;
+    metadata-only stubs contribute only their small parsed prefix. One most-recent
+    entry may remain above the byte budget by itself so an oversized transcript
+    does not cold-reload on every access.
 
     CALLER CONTRACT: the global ``LOCK`` MUST already be held (every call site
     mutates ``SESSIONS`` under ``LOCK``). This function never acquires ``LOCK``
@@ -4632,13 +4854,26 @@ def _evict_sessions_over_cap(cap: int | None = None) -> int:
     (#6351); any future edit that can change ``cap`` after that point must move
     the publish down with it.
 
-    Returns the number of sessions evicted. If every over-cap candidate is
-    active/unsaved, the cache may temporarily exceed ``cap`` — that is the
+    Returns the number of sessions evicted. If every over-budget candidate is
+    active/unsaved, the cache may temporarily exceed a bound — that is the
     intended safe behavior (never lose an active/unsaved session).
     """
+    config_data = None
+    if cap is None or max_bytes is None:
+        try:
+            loaded_config = _cfg.get_config()
+            if isinstance(loaded_config, dict):
+                config_data = loaded_config
+        except Exception:
+            pass
+
     if cap is None:
         try:
-            cap = _cfg.get_sessions_cache_max()
+            cap = (
+                _cfg.get_sessions_cache_max(config_data)
+                if config_data is not None
+                else SESSIONS_MAX
+            )
         except Exception:
             cap = SESSIONS_MAX
     if not isinstance(cap, int) or cap < 1:
@@ -4648,23 +4883,66 @@ def _evict_sessions_over_cap(cap: int | None = None) -> int:
     # payload report a cap eviction actually applied — including the getter-failure
     # fallback and explicit/normalized calls, which never reach the resolver (#6351).
     _cfg._LAST_APPLIED_SESSIONS_CACHE_MAX = cap
+
+    if max_bytes is None:
+        try:
+            max_bytes = (
+                _cfg.get_sessions_cache_max_bytes(config_data)
+                if config_data is not None
+                else _cfg.DEFAULT_SESSIONS_CACHE_MAX_BYTES
+            )
+        except Exception:
+            max_bytes = _cfg.DEFAULT_SESSIONS_CACHE_MAX_BYTES
+    if not isinstance(max_bytes, int) or max_bytes < 1:
+        max_bytes = _cfg.DEFAULT_SESSIONS_CACHE_MAX_BYTES
+
+    resident_bytes = sum(_session_cache_resident_bytes(s) for s in SESSIONS.values())
     evicted = 0
-    # Iterate over a snapshot of ids in LRU order (oldest first). We stop as
-    # soon as we are at/below the cap. Skipping a non-evictable oldest entry and
-    # moving on lets us reclaim a slightly-newer clean entry instead of blocking
-    # eviction entirely behind one pinned active session.
+    mru_sid = next(reversed(SESSIONS), None) if SESSIONS else None
+    # Iterate over a snapshot of ids in LRU order (oldest first). Skipping a
+    # non-evictable oldest entry lets us reclaim a slightly-newer clean entry
+    # instead of blocking behind one pinned active session.
     for sid in list(SESSIONS.keys()):
-        if len(SESSIONS) <= cap:
+        over_count = len(SESSIONS) > cap
+        over_bytes = resident_bytes > max_bytes
+        if not over_count and not over_bytes:
+            break
+        # Byte pressure never evicts the currently warm MRU. Count pressure keeps
+        # its existing semantics and may still reclaim it when all older entries
+        # are pinned, because the public entry cap remains authoritative.
+        if over_bytes and not over_count and sid == mru_sid:
+            continue
+        # Keep one warm entry even when it alone exceeds the byte budget. This is
+        # not needed for count pressure because cap is always at least one.
+        if len(SESSIONS) <= 1 and not over_count:
             break
         candidate = SESSIONS.get(sid)
         if _session_is_evictable(candidate):
-            SESSIONS.pop(sid, None)
-            evicted += 1
-    if len(SESSIONS) > cap:
+            # The historical count cap used message-count parity. Byte pressure
+            # is more frequent for large full sessions and must not widen that
+            # policy to same-count edits or unsaved metadata. Metadata-only stubs
+            # are immutable disk projections and need no full-state digest.
+            if (
+                over_bytes
+                and not over_count
+                and not getattr(candidate, '_loaded_metadata_only', False)
+                and not _session_matches_persisted_state(candidate)
+            ):
+                continue
+            removed = SESSIONS.pop(sid, None)
+            if removed is not None:
+                resident_bytes = max(
+                    0,
+                    resident_bytes - _session_cache_resident_bytes(removed),
+                )
+                evicted += 1
+
+    if len(SESSIONS) > cap or resident_bytes > max_bytes:
         logger.debug(
-            "SESSIONS cache above cap (%d > %d) after eviction pass: remaining "
-            "entries are active or unsaved and were preserved (#4765)",
-            len(SESSIONS), cap,
+            "SESSIONS cache remains above a safe bound after eviction: "
+            "entries=%d/%d serialized_bytes=%d/%d; remaining entries are "
+            "active, unsaved, or the sole warm transcript (#4765/#6351)",
+            len(SESSIONS), cap, resident_bytes, max_bytes,
         )
     return evicted
 
@@ -4762,6 +5040,8 @@ def _resolve_session_once(
                     SESSIONS[sid] = disk_session
                     if promote_cache:
                         SESSIONS.move_to_end(sid)
+                    if cache_on_miss:
+                        _evict_sessions_over_cap()
                 cached = disk_session
             except Exception:
                 logger.debug(
@@ -4777,6 +5057,8 @@ def _resolve_session_once(
                         SESSIONS[sid] = disk_session
                         if promote_cache:
                             SESSIONS.move_to_end(sid)
+                        if cache_on_miss:
+                            _evict_sessions_over_cap()
                     cached = disk_session
             except Exception:
                 logger.debug(
@@ -4791,7 +5073,10 @@ def _resolve_session_once(
                 )
         if not metadata_only:
             try:
-                _sync_sidecar_from_state_db_if_newer(cached)
+                _sync_sidecar_from_state_db_if_newer(
+                    cached,
+                    enforce_cache_bounds=cache_on_miss,
+                )
             except Exception:
                 logger.debug(
                     "state.db newer-sidecar sync failed on cache hit for session %s", sid, exc_info=True,
@@ -4814,7 +5099,10 @@ def _resolve_session_once(
                 _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
         if not metadata_only:
             try:
-                synced_from_state = _sync_sidecar_from_state_db_if_newer(s)
+                synced_from_state = _sync_sidecar_from_state_db_if_newer(
+                    s,
+                    enforce_cache_bounds=cache_on_miss,
+                )
                 repaired = False if synced_from_state else _repair_stale_pending(s)
                 # If the stale-pending repair did not fire but the session
                 # already carries a pending-journal-retry marker (e.g. set on

--- a/api/models.py
+++ b/api/models.py
@@ -1585,6 +1585,7 @@ class Session:
         ):
             persisted_fingerprint = None
         self._cache_persisted_fingerprint = persisted_fingerprint
+        self._sidecar_stat_sig = _sidecar_stat_signature(self.path)
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1620,8 +1621,15 @@ class Session:
         if enforce_cache_bounds:
             try:
                 with LOCK:
-                    if SESSIONS.get(self.session_id) is self:
-                        _evict_sessions_over_cap()
+                    cached = SESSIONS.get(self.session_id)
+                    if cached is not None:
+                        if cached is self:
+                            _evict_sessions_over_cap()
+                        elif _session_is_evictable(cached) and _session_matches_persisted_state(cached):
+                            # cached in SESSIONS is an unmodified reload of an older generation;
+                            # replace it with the newly saved self
+                            SESSIONS[self.session_id] = self
+                            _evict_sessions_over_cap()
             except Exception:
                 logger.debug(
                     "Post-save session cache enforcement failed for %s",
@@ -1689,6 +1697,7 @@ class Session:
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
             session._cache_persisted_fingerprint = _session_state_fingerprint(session)
+        session._sidecar_stat_sig = _pre_read_sig
         return session
 
     @classmethod
@@ -4065,8 +4074,13 @@ def _sync_sidecar_from_state_db_if_newer(
         if enforce_cache_bounds:
             try:
                 with LOCK:
-                    if SESSIONS.get(sid) is session:
-                        _evict_sessions_over_cap()
+                    cached = SESSIONS.get(sid)
+                    if cached is not None:
+                        if cached is session:
+                            _evict_sessions_over_cap()
+                        elif _session_is_evictable(cached) and _session_matches_persisted_state(cached):
+                            SESSIONS[sid] = session
+                            _evict_sessions_over_cap()
             except Exception:
                 logger.debug(
                     "Post-reconciliation session cache enforcement failed for %s",
@@ -4492,8 +4506,15 @@ def _cached_session_lags_disk(cached) -> bool:
             # (which would serve a potentially stale cache). Greptile P1.
             pass
         else:
-            # Inactive session, count matches, scene records match — cache is
-            # at parity with disk.
+            # Inactive session, count matches, scene records match.
+            # Check if disk was modified (e.g. metadata or same-count edit)
+            # while cached has remained clean and unmodified.
+            cached_sig = getattr(cached, '_sidecar_stat_sig', None)
+            if cached_sig is not None:
+                disk_sig = _sidecar_stat_signature(cached.path)
+                if disk_sig is not None and disk_sig != cached_sig:
+                    if _session_matches_persisted_state(cached):
+                        return True
             return False
     try:
         disk_meta = Session.load_metadata_only(sid)
@@ -5149,10 +5170,27 @@ def _resolve_session_once(
     if s:
         if cache_on_miss:
             with LOCK:
-                SESSIONS[sid] = s
-                if promote_cache:
-                    SESSIONS.move_to_end(sid)
-                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                current_cached = SESSIONS.get(sid)
+                if current_cached is not None:
+                    s = current_cached
+                    if promote_cache:
+                        SESSIONS.move_to_end(sid)
+                else:
+                    disk_sig = _sidecar_stat_signature(s.path)
+                    s_sig = getattr(s, '_sidecar_stat_sig', None)
+                    if disk_sig is not None and s_sig is not None and disk_sig != s_sig:
+                        fresh = Session.load(sid)
+                        if fresh is not None:
+                            s = fresh
+                            SESSIONS[sid] = s
+                            if promote_cache:
+                                SESSIONS.move_to_end(sid)
+                            _evict_sessions_over_cap()
+                    else:
+                        SESSIONS[sid] = s
+                        if promote_cache:
+                            SESSIONS.move_to_end(sid)
+                        _evict_sessions_over_cap()
         if not metadata_only:
             try:
                 synced_from_state = _sync_sidecar_from_state_db_if_newer(

--- a/tests/test_full_session_resolve_gate.py
+++ b/tests/test_full_session_resolve_gate.py
@@ -14,6 +14,15 @@ def _install_lightweight_resolve_stubs(monkeypatch, models) -> None:
     monkeypatch.setattr(models, "_sync_sidecar_from_state_db_if_newer", lambda _session: False)
     monkeypatch.setattr(models, "_repair_stale_pending", lambda _session: False)
     monkeypatch.setattr(models, "_session_has_pending_journal_retry", lambda _session: False)
+    # These gate tests replace Session.load with tiny in-memory stubs rather
+    # than opening a real sidecar descriptor. Generation validation belongs to
+    # the sidecar/CAS regressions; declare these synthetic loads trusted so this
+    # module continues to exercise only single-flight slot behavior.
+    monkeypatch.setattr(
+        models,
+        "_session_has_current_persisted_generation",
+        lambda _session, authority=None: True,
+    )
 
 
 def _empty_session(models, sid: str):

--- a/tests/test_issue4765_sessions_lru_eviction.py
+++ b/tests/test_issue4765_sessions_lru_eviction.py
@@ -627,6 +627,11 @@ def test_state_db_reconcile_refreshes_cached_weight_and_enforces_budget(
     assert sibling.session_id not in SESSIONS
     assert cached._cache_resident_bytes == cached.path.stat().st_size
     assert models._session_matches_persisted_state(cached) is True
+    authority = models._session_persisted_authority(cached)
+    assert authority is not None
+    assert cached._cache_persisted_fingerprint == authority[0]
+    assert cached._sidecar_stat_sig == authority[1]
+    assert models._sidecar_signature_matches_path(cached.path, authority[1]) is True
 
 
 def test_state_db_reconcile_preserves_unsaved_metadata_and_skips_byte_eviction(
@@ -1625,3 +1630,266 @@ def test_cached_session_lags_disk_detects_clean_cache_stat_signature_mismatch(
     resolved = models.get_session(sid)
     assert resolved.title == "Modified on disk directly"
     assert resolved.composer_draft == {"text": "external draft"}
+
+
+def test_save_clears_authority_when_replaced_before_generation_capture(
+    isolated_session_env, monkeypatch,
+):
+    """A save must not pair its snapshot fingerprint with another writer's path stat."""
+    from api import models
+
+    original = _make_persisted_session(810)
+    writer = models.Session(
+        session_id=original.session_id,
+        title="writer payload",
+        composer_draft={"text": "writer draft"},
+        messages=list(original.messages),
+    )
+    replacement_data = json.loads(original.path.read_text(encoding="utf-8"))
+    replacement_data["title"] = "interposed replacement"
+    replacement_data["composer_draft"] = {"text": "interposed draft"}
+    replacement = original.path.with_suffix(".generation-race")
+    replacement.write_text(
+        json.dumps(replacement_data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    real_replace = models._safe_replace
+    interposed = False
+
+    def install_then_replace(src, dst):
+        nonlocal interposed
+        real_replace(src, dst)
+        if Path(dst) == writer.path and not interposed:
+            interposed = True
+            os.replace(replacement, dst)
+
+    monkeypatch.setattr(models, "_safe_replace", install_then_replace)
+
+    writer.save(touch_updated_at=False, skip_index=True, enforce_cache_bounds=False)
+
+    assert interposed is True
+    assert writer._cache_persisted_authority is None
+    assert writer._cache_persisted_fingerprint is None
+    assert writer._sidecar_stat_sig is None
+    assert writer._cache_resident_bytes is None
+    persisted = json.loads(writer.path.read_text(encoding="utf-8"))
+    assert persisted["title"] == "interposed replacement"
+    assert persisted["composer_draft"] == {"text": "interposed draft"}
+
+
+def test_cold_load_retries_each_replacement_and_publishes_only_final_generation(
+    isolated_session_env, monkeypatch,
+):
+    """Cold cache insertion retries every stale candidate, including retry #2."""
+    from api import models
+    from api.config import SESSIONS
+
+    sid = "sess-cold-two-replacements"
+    v1 = models.Session(
+        session_id=sid,
+        title="generation one",
+        composer_draft={"text": "one"},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    v2 = models.Session(
+        session_id=sid,
+        title="generation two",
+        composer_draft={"text": "two"},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    v3 = models.Session(
+        session_id=sid,
+        title="generation three",
+        composer_draft={"text": "three"},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    v1.save(touch_updated_at=False, enforce_cache_bounds=False)
+
+    real_publish = models._publish_verified_session_cas
+    replacements = [v2, v3]
+    publish_calls = 0
+
+    def replace_before_publish(*args, **kwargs):
+        nonlocal publish_calls
+        if publish_calls < len(replacements):
+            replacements[publish_calls].save(
+                touch_updated_at=False,
+                skip_index=True,
+                enforce_cache_bounds=False,
+            )
+        publish_calls += 1
+        return real_publish(*args, **kwargs)
+
+    monkeypatch.setattr(models, "_publish_verified_session_cas", replace_before_publish)
+
+    resolved = models.get_session(sid)
+
+    assert publish_calls == 3
+    assert resolved.title == "generation three"
+    assert resolved.composer_draft == {"text": "three"}
+    assert SESSIONS[sid] is resolved
+    assert models._session_matches_persisted_state(resolved) is True
+
+
+def test_cold_load_never_caches_missing_generation_after_bounded_exhaustion(
+    isolated_session_env, monkeypatch,
+):
+    """Missing generation tokens fail closed rather than entering SESSIONS."""
+    from api import models
+    from api.config import SESSIONS
+
+    sid = "sess-cold-missing-generation"
+    source = models.Session(
+        session_id=sid,
+        title="stable disk payload",
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    source.save(touch_updated_at=False, enforce_cache_bounds=False)
+
+    real_load = models.Session.load
+    loads = 0
+
+    def load_without_generation(cls, session_id):
+        nonlocal loads
+        loaded = real_load(session_id)
+        if session_id == sid and loaded is not None:
+            loads += 1
+            models._set_session_persisted_authority(loaded, None, None)
+        return loaded
+
+    monkeypatch.setattr(models.Session, "load", classmethod(load_without_generation))
+
+    with pytest.raises(KeyError):
+        models.get_session(sid)
+
+    assert loads == models._SESSION_CACHE_PUBLICATION_RETRIES
+    assert sid not in SESSIONS
+
+
+def test_cache_hit_refresh_cas_preserves_newer_cache_publication(
+    isolated_session_env, monkeypatch,
+):
+    """A stale disk load cannot overwrite a cache entry published while it parsed."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    sid = "sess-cache-hit-cas"
+    old = models.Session(
+        session_id=sid,
+        title="old cache generation",
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    old.save(touch_updated_at=False, enforce_cache_bounds=False)
+    disk = models.Session(
+        session_id=sid,
+        title="disk refresh generation",
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    disk.save(touch_updated_at=False, enforce_cache_bounds=False)
+    # Deliberately retain the older clean generation in cache so the normal
+    # freshness path starts a full disk load.
+    with LOCK:
+        SESSIONS[sid] = old
+
+    winner = models.Session.load(sid)
+    assert winner is not None
+    winner.composer_draft = {"text": "newer cache publication"}
+    real_load = models.Session.load
+    interposed = False
+
+    def load_then_publish_winner(cls, session_id):
+        nonlocal interposed
+        loaded = real_load(session_id)
+        if session_id == sid and not interposed:
+            interposed = True
+            with LOCK:
+                SESSIONS[sid] = winner
+        return loaded
+
+    monkeypatch.setattr(models.Session, "load", classmethod(load_then_publish_winner))
+
+    resolved = models.get_session(sid)
+
+    assert interposed is True
+    assert resolved is winner
+    assert SESSIONS[sid] is winner
+    assert resolved.composer_draft == {"text": "newer cache publication"}
+
+
+def test_detached_save_cas_never_replaces_dirty_cached_generation(
+    isolated_session_env,
+):
+    """A detached writer cannot discard a cache object's unsaved metadata."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    sid = "sess-save-cas-dirty-cache"
+    v1 = models.Session(
+        session_id=sid,
+        title="generation one",
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    v1.save(touch_updated_at=False, enforce_cache_bounds=False)
+    dirty_cached = models.Session.load(sid)
+    assert dirty_cached is not None
+    dirty_cached.composer_draft = {"text": "unsaved cache draft"}
+    with LOCK:
+        SESSIONS[sid] = dirty_cached
+
+    detached_writer = models.Session(
+        session_id=sid,
+        title="generation two",
+        composer_draft={"text": "durable writer draft"},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 1.0}],
+    )
+    detached_writer.save(touch_updated_at=False)
+
+    assert SESSIONS[sid] is dirty_cached
+    assert dirty_cached.composer_draft == {"text": "unsaved cache draft"}
+    persisted = json.loads(detached_writer.path.read_text(encoding="utf-8"))
+    assert persisted["composer_draft"] == {"text": "durable writer draft"}
+
+
+def test_stale_tail_cas_retries_after_observed_cache_entry_is_removed(
+    isolated_session_env, monkeypatch,
+):
+    """A stale-tail refresh retries as a cold publication if its cache CAS loses to removal."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    sid = "sess-stale-tail-cas-removal"
+    disk = models.Session(
+        session_id=sid,
+        title="durable assistant tail",
+        messages=[
+            {"role": "user", "content": "prompt", "timestamp": 1.0},
+            {"role": "assistant", "content": "durable answer", "timestamp": 2.0},
+        ],
+    )
+    disk.save(touch_updated_at=False, enforce_cache_bounds=False)
+    stale = models.Session.load(sid)
+    assert stale is not None
+    stale.messages[-1] = {"role": "user", "content": "prompt", "timestamp": 2.0}
+    with LOCK:
+        SESSIONS[sid] = stale
+
+    real_publish = models._publish_verified_session_cas
+    publish_calls = 0
+
+    def remove_observed_entry_once(*args, **kwargs):
+        nonlocal publish_calls
+        if publish_calls == 0:
+            with LOCK:
+                SESSIONS.pop(sid, None)
+        publish_calls += 1
+        return real_publish(*args, **kwargs)
+
+    monkeypatch.setattr(models, "_publish_verified_session_cas", remove_observed_entry_once)
+
+    resolved = models.get_session(sid)
+
+    assert publish_calls == 2
+    assert resolved.messages[-1]["role"] == "assistant"
+    assert resolved.messages[-1]["content"] == "durable answer"
+    assert SESSIONS[sid] is resolved

--- a/tests/test_issue4765_sessions_lru_eviction.py
+++ b/tests/test_issue4765_sessions_lru_eviction.py
@@ -374,6 +374,138 @@ def test_save_fingerprint_describes_serialized_snapshot_not_later_mutation(
     assert SESSIONS[session.session_id] is session
 
 
+def test_save_snapshot_is_not_fooled_by_nested_aba_during_serialization(
+    isolated_session_env, monkeypatch,
+):
+    """The payload and durable fingerprint must describe one immutable snapshot."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    session = _make_persisted_session(
+        87,
+        messages=[{"role": "assistant", "content": "A"}],
+    )
+    _insert(session)
+    real_dumps = models.json.dumps
+    mutated = False
+
+    def dumps_with_nested_aba(value, *args, **kwargs):
+        nonlocal mutated
+        if (
+            not mutated
+            and isinstance(value, dict)
+            and value.get("session_id") == session.session_id
+            and isinstance(value.get("messages"), list)
+        ):
+            mutated = True
+            session.messages[0]["content"] = "B"
+            try:
+                return real_dumps(value, *args, **kwargs)
+            finally:
+                session.messages[0]["content"] = "A"
+        return real_dumps(value, *args, **kwargs)
+
+    monkeypatch.setattr(models.json, "dumps", dumps_with_nested_aba)
+    session.save(touch_updated_at=False)
+
+    assert mutated is True
+    persisted = json.loads(session.path.read_text(encoding="utf-8"))
+    assert persisted["messages"][0]["content"] == "A"
+    assert session.messages[0]["content"] == "A"
+    assert models._session_matches_persisted_state(session) is True
+
+    sibling = _make_persisted_session(86)
+    _insert(sibling)  # make the sibling MRU before reclaiming the clean LRU
+    with LOCK:
+        evicted = models._evict_sessions_over_cap(cap=10, max_bytes=1)
+
+    assert evicted == 1
+    assert session.session_id not in SESSIONS
+    assert models.get_session(session.session_id).messages[0]["content"] == "A"
+
+
+class _ObservedSessions(collections.OrderedDict):
+    """Ordered cache double that exposes the candidate-removal instant."""
+
+    def __init__(self, *args, observed_session_id, removal_started, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._observed_session_id = observed_session_id
+        self._removal_started = removal_started
+
+    def pop(self, key, default=None):
+        if key == self._observed_session_id:
+            self._removal_started.set()
+        return super().pop(key, default)
+
+
+def test_byte_eviction_coordinates_validation_and_removal_with_session_writer(
+    isolated_session_env, monkeypatch,
+):
+    """A writer that begins after validation cannot lose an unsaved mutation."""
+    from api import config as _cfg
+    from api import models
+    from api.config import LOCK
+
+    candidate = _make_persisted_session(85)
+    sibling = _make_persisted_session(84)
+    removal_started = threading.Event()
+    cache = _ObservedSessions(
+        [(candidate.session_id, candidate), (sibling.session_id, sibling)],
+        observed_session_id=candidate.session_id,
+        removal_started=removal_started,
+    )
+    monkeypatch.setattr(_cfg, "SESSIONS", cache)
+    monkeypatch.setattr(models, "SESSIONS", cache)
+
+    real_matches = models._session_matches_persisted_state
+    validation_finished = threading.Event()
+    mutation_attempted = threading.Event()
+    mutation_finished = threading.Event()
+    mutation_before_removal = threading.Event()
+    failures = []
+
+    def matches_then_offer_writer(session):
+        matches = real_matches(session)
+        if session is candidate:
+            validation_finished.set()
+            assert mutation_attempted.wait(timeout=1.0)
+            # The unsafe implementation lets the writer mutate here. A safe
+            # implementation either blocks it until removal, or revalidates and
+            # retains the changed cache entry.
+            mutation_finished.wait(timeout=0.1)
+        return matches
+
+    monkeypatch.setattr(models, "_session_matches_persisted_state", matches_then_offer_writer)
+
+    def mutate_and_save():
+        try:
+            assert validation_finished.wait(timeout=1.0)
+            mutation_attempted.set()
+            with _cfg._get_session_agent_lock(candidate.session_id):
+                if not removal_started.is_set():
+                    mutation_before_removal.set()
+                candidate.title = "Unsaved concurrent title"
+                mutation_finished.set()
+                candidate.save(touch_updated_at=False)
+        except BaseException as exc:
+            failures.append(exc)
+
+    writer = threading.Thread(target=mutate_and_save, daemon=True)
+    writer.start()
+    with LOCK:
+        models._evict_sessions_over_cap(cap=10, max_bytes=1)
+    writer.join(timeout=2.0)
+
+    assert writer.is_alive() is False
+    assert failures == []
+    # If mutation won the race, validation must have been repeated and cache
+    # removal skipped. If removal won under the writer lock, the subsequent save
+    # is durable and it is safe for the old clean object to have been reclaimed.
+    assert not (
+        mutation_before_removal.is_set() and candidate.session_id not in cache
+    ), "byte eviction removed state changed after its durability check"
+
+
 def test_state_db_reconcile_refreshes_cached_weight_and_enforces_budget(
     isolated_session_env, monkeypatch,
 ):

--- a/tests/test_issue4765_sessions_lru_eviction.py
+++ b/tests/test_issue4765_sessions_lru_eviction.py
@@ -13,13 +13,17 @@ unsaved session and lose data) with ``_evict_sessions_over_cap()``: it only ever
 removes clean, persisted, non-active sessions, and ``get_session()`` lazily
 reloads an evicted session from its JSON sidecar on next access.
 
-These tests prove the four required invariants:
-  1. Eviction happens once the cache grows past the cap.
+These tests prove the required invariants:
+  1. Eviction happens once the cache grows past the entry or byte cap.
   2. An active / streaming session is NEVER evicted, even when oldest.
   3. An evicted session lazily reloads from disk with identical content.
   4. No data loss: eviction removes only the in-memory copy, never the file.
+  5. Full loads/saves record serialized weight; metadata stubs stay lightweight.
+  6. One oversized most-recent transcript remains warm instead of reload-looping.
 """
 import collections
+import json
+import os
 import shutil
 import tempfile
 import threading
@@ -150,6 +154,81 @@ def test_cache_cap_preserves_environment_fallback():
         _cfg.SESSIONS_MAX = old_sessions_max
 
 
+def test_default_sessions_cache_byte_cap_is_128_mib():
+    """The entry cap also has a serialized-byte backstop for large transcripts."""
+    from api import config as _cfg
+
+    assert _cfg.DEFAULT_SESSIONS_CACHE_MAX_BYTES == 128 * 1024 * 1024
+
+
+def test_cache_byte_cap_reads_config_yaml_key_and_fails_safe():
+    """Operators can tune the byte budget without disabling it accidentally."""
+    from api import config as _cfg
+
+    mib = 1024 * 1024
+    assert _cfg.get_sessions_cache_max_bytes(
+        {"webui": {"sessions_cache_max_mb": 64}}
+    ) == 64 * mib
+    assert _cfg.get_sessions_cache_max_bytes(
+        {"webui": {"sessions_cache_max_mb": "32"}}
+    ) == 32 * mib
+    for invalid in (0, -1, "nope", None):
+        assert _cfg.get_sessions_cache_max_bytes(
+            {"webui": {"sessions_cache_max_mb": invalid}}
+        ) == _cfg.DEFAULT_SESSIONS_CACHE_MAX_BYTES
+
+
+def test_eviction_resolves_both_limits_from_one_config_snapshot(
+    isolated_session_env, monkeypatch,
+):
+    """Each pass uses one snapshot whose count and byte limits drive eviction."""
+    from api import config as _cfg
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    calls = 0
+
+    def fake_get_config():
+        nonlocal calls
+        calls += 1
+        return {
+            "webui": {
+                "sessions_cache_max": 2,
+                "sessions_cache_max_mb": 1,
+            }
+        }
+
+    monkeypatch.setattr(_cfg, "get_config", fake_get_config)
+
+    # Count dominates: three tiny sessions are below 1 MiB but exceed cap=2.
+    count_sessions = [_make_persisted_session(700 + i) for i in range(3)]
+    with LOCK:
+        for session in count_sessions:
+            SESSIONS[session.session_id] = session
+        count_evicted = _evict_sessions_over_cap()
+    assert count_evicted == 1
+    assert list(SESSIONS) == [s.session_id for s in count_sessions[-2:]]
+
+    SESSIONS.clear()
+
+    # Bytes dominate: two ~700 KiB sessions meet cap=2 but exceed 1 MiB.
+    byte_sessions = [
+        _make_persisted_session(
+            710 + i,
+            messages=[{"role": "assistant", "content": "x" * (700 * 1024)}],
+        )
+        for i in range(2)
+    ]
+    with LOCK:
+        for session in byte_sessions:
+            SESSIONS[session.session_id] = session
+        byte_evicted = _evict_sessions_over_cap()
+
+    assert byte_evicted == 1
+    assert list(SESSIONS) == [byte_sessions[-1].session_id]
+    assert calls == 2  # exactly one configuration read per enforcement pass
+
+
 # ─────────────────────────── invariant 1: eviction ──────────────────────────
 
 def test_eviction_happens_past_the_cap(isolated_session_env):
@@ -175,6 +254,613 @@ def test_eviction_happens_past_the_cap(isolated_session_env):
     kept = set(SESSIONS.keys())
     assert created[-1].session_id in kept
     assert created[0].session_id not in kept
+
+
+def test_eviction_happens_past_the_byte_cap_below_entry_cap(isolated_session_env):
+    """A few large transcripts must not bypass the count-only LRU bound."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    created = [
+        _make_persisted_session(
+            i,
+            messages=[{"role": "assistant", "content": "x" * (700 * 1024)}],
+        )
+        for i in range(3)
+    ]
+    for session in created:
+        _insert(session)
+
+    assert len(SESSIONS) == 3  # comfortably below the entry cap used below
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1024 * 1024)
+
+    assert evicted == 2
+    assert list(SESSIONS) == [created[-1].session_id]
+    assert sum(s._cache_resident_bytes for s in SESSIONS.values()) <= 1024 * 1024
+
+
+def test_byte_eviction_preserves_same_count_unsaved_edit(isolated_session_env):
+    """Byte pressure must not discard edits that do not change message count."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap, get_session
+
+    edited = _make_persisted_session(
+        90,
+        messages=[{"role": "assistant", "content": "old"}],
+    )
+    sibling = _make_persisted_session(
+        91,
+        messages=[{"role": "assistant", "content": "sibling"}],
+    )
+    _insert(edited)
+    _insert(sibling)
+
+    edited.messages[0]["content"] = "new"
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1)
+
+    assert evicted == 0
+    assert edited.session_id in SESSIONS
+    assert SESSIONS[edited.session_id] is edited
+    assert get_session(edited.session_id).messages[0]["content"] == "new"
+
+    # A successful save refreshes the persisted-state fingerprint, so the now
+    # clean LRU can be reclaimed and lazy reload returns the edited content.
+    edited.save()
+    get_session(sibling.session_id)  # make the sibling MRU; edited is evictable LRU
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1)
+    assert evicted == 1
+    assert edited.session_id not in SESSIONS
+    assert get_session(edited.session_id).messages[0]["content"] == "new"
+
+
+def test_byte_eviction_preserves_unsaved_metadata_edit(isolated_session_env):
+    """Persisted message parity cannot justify dropping changed metadata."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    edited = _make_persisted_session(92)
+    sibling = _make_persisted_session(93)
+    _insert(edited)
+    _insert(sibling)
+
+    edited.title = "Unsaved title"
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1)
+
+    assert evicted == 0
+    assert SESSIONS[edited.session_id] is edited
+    assert SESSIONS[edited.session_id].title == "Unsaved title"
+
+
+def test_save_fingerprint_describes_serialized_snapshot_not_later_mutation(
+    isolated_session_env, monkeypatch,
+):
+    """A mutation after payload capture must remain visibly unsaved."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    session = _make_persisted_session(
+        89,
+        messages=[{"role": "assistant", "content": "persisted"}],
+    )
+    _insert(session)
+    real_replace = models._safe_replace
+    mutated = False
+
+    def replace_then_mutate(src, dst):
+        nonlocal mutated
+        real_replace(src, dst)
+        if Path(dst) == session.path:
+            session.title = "unsaved after payload"
+            mutated = True
+
+    monkeypatch.setattr(models, "_safe_replace", replace_then_mutate)
+    session.save(touch_updated_at=False)
+
+    persisted = json.loads(session.path.read_text(encoding="utf-8"))
+    assert mutated is True
+    assert persisted["title"] != session.title
+    assert models._session_matches_persisted_state(session) is False
+
+    sibling = _make_persisted_session(88)
+    _insert(sibling)  # make the sibling MRU so the edited session is considered
+    with LOCK:
+        evicted = models._evict_sessions_over_cap(cap=10, max_bytes=1)
+
+    assert evicted == 0
+    assert SESSIONS[session.session_id] is session
+
+
+def test_state_db_reconcile_refreshes_cached_weight_and_enforces_budget(
+    isolated_session_env, monkeypatch,
+):
+    """Reconciliation through a locked copy must update the cached projection."""
+    from api import config as _cfg
+    from api import models
+    from api.config import SESSIONS
+
+    sibling = _make_persisted_session(
+        94,
+        messages=[{"role": "assistant", "content": "s" * (400 * 1024), "timestamp": 1.0}],
+    )
+    cached = _make_persisted_session(
+        95,
+        messages=[{"role": "user", "content": "u" * (400 * 1024), "timestamp": 1.0}],
+    )
+    cached.active_stream_id = "dead-stream"
+    cached.save(touch_updated_at=False)
+    _insert(sibling)
+    _insert(cached)  # the get_session reconciliation path promotes this to MRU
+
+    state_messages = list(cached.messages) + [
+        {"role": "assistant", "content": "a" * (700 * 1024), "timestamp": 2.0}
+    ]
+    monkeypatch.setattr(models, "_active_stream_ids", lambda: set())
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda *_args, **_kwargs: {"message_count": 2, "last_message_at": 2.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda *_args, **_kwargs: state_messages,
+    )
+    monkeypatch.setattr(
+        models,
+        "reconciled_state_db_messages_for_session",
+        lambda *_args, **kwargs: list(state_messages),
+    )
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+
+    assert models._sync_sidecar_from_state_db_if_newer(cached) is True
+
+    assert SESSIONS[cached.session_id] is cached
+    assert sibling.session_id not in SESSIONS
+    assert cached._cache_resident_bytes == cached.path.stat().st_size
+    assert models._session_matches_persisted_state(cached) is True
+
+
+def test_state_db_reconcile_preserves_unsaved_metadata_and_skips_byte_eviction(
+    isolated_session_env, monkeypatch,
+):
+    """A lock-owned repair cannot make unrelated cached metadata look durable."""
+    from api import config as _cfg
+    from api import models
+    from api.config import SESSIONS
+
+    cached = _make_persisted_session(
+        96,
+        messages=[{"role": "user", "content": "u" * (400 * 1024), "timestamp": 1.0}],
+    )
+    cached.active_stream_id = "dead-metadata-stream"
+    cached.save(touch_updated_at=False)
+    sibling = _make_persisted_session(
+        97,
+        messages=[{"role": "assistant", "content": "s" * (400 * 1024), "timestamp": 1.0}],
+    )
+    _insert(cached)
+    _insert(sibling)
+    cached.title = "Unsaved title"
+
+    recovered = list(cached.messages) + [
+        {"role": "assistant", "content": "a" * (700 * 1024), "timestamp": 2.0}
+    ]
+    monkeypatch.setattr(models, "_active_stream_ids", lambda: set())
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda *_args, **_kwargs: {"message_count": 2, "last_message_at": 2.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda *_args, **_kwargs: list(recovered),
+    )
+    monkeypatch.setattr(
+        models,
+        "reconciled_state_db_messages_for_session",
+        lambda *_args, **_kwargs: list(recovered),
+    )
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+
+    assert models._sync_sidecar_from_state_db_if_newer(cached) is True
+
+    assert SESSIONS[cached.session_id] is cached
+    assert cached.title == "Unsaved title"
+    assert cached._cache_persisted_fingerprint is None
+    assert sibling.session_id in SESSIONS
+
+
+def test_save_enforces_byte_budget_after_resident_session_grows(
+    isolated_session_env, monkeypatch,
+):
+    """A hot session growing in place reclaims old cache entries immediately."""
+    from api import config as _cfg
+    from api.config import SESSIONS
+
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+
+    sessions = [
+        _make_persisted_session(
+            400 + i,
+            messages=[{"role": "assistant", "content": "s" * (250 * 1024)}],
+        )
+        for i in range(3)
+    ]
+    for session in sessions:
+        _insert(session)
+
+    assert list(SESSIONS) == [session.session_id for session in sessions]
+
+    current = sessions[-1]
+    current.messages = [
+        {"role": "assistant", "content": "g" * (700 * 1024)}
+    ]
+    current.save()
+
+    assert current._cache_resident_bytes == current.path.stat().st_size
+    assert sessions[0].session_id not in SESSIONS
+    assert sessions[1].session_id in SESSIONS
+    assert current.session_id in SESSIONS
+    assert sum(s._cache_resident_bytes for s in SESSIONS.values()) <= 1024 * 1024
+
+
+def test_cache_hit_full_reload_enforces_grown_sidecar_weight(
+    isolated_session_env, monkeypatch,
+):
+    """Replacing a stale cache hit must immediately reapply the byte budget."""
+    from api import config as _cfg
+    from api import models
+    from api.config import SESSIONS
+
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+    siblings = [
+        _make_persisted_session(
+            410 + i,
+            messages=[{"role": "assistant", "content": "s" * (400 * 1024)}],
+        )
+        for i in range(2)
+    ]
+    stale = _make_persisted_session(
+        412,
+        messages=[{"role": "assistant", "content": "old" * 1024}],
+    )
+    for session in [*siblings, stale]:
+        _insert(session)
+
+    external = models.Session(
+        session_id=stale.session_id,
+        title=stale.title,
+        messages=[
+            {"role": "user", "content": "new prompt"},
+            {"role": "assistant", "content": "grown" + "g" * (700 * 1024)},
+        ],
+        created_at=stale.created_at,
+        updated_at=stale.updated_at + 1,
+    )
+    external.save(touch_updated_at=False)
+
+    refreshed = models.get_session(stale.session_id)
+
+    assert refreshed is SESSIONS[stale.session_id]
+    assert refreshed is not stale
+    assert refreshed.messages[-1]["content"].startswith("grown")
+    assert refreshed._cache_resident_bytes == refreshed.path.stat().st_size
+    assert all(session.session_id not in SESSIONS for session in siblings)
+    assert sum(models._session_cache_resident_bytes(s) for s in SESSIONS.values()) <= 1024 * 1024
+
+
+def test_eviction_legacy_partial_self_heal_does_not_reacquire_cache_lock(
+    isolated_session_env,
+):
+    """Eviction can full-load and repair legacy partials without deadlocking LOCK."""
+    from api import models
+    from api.config import LOCK, SESSIONS
+
+    sid = "legacy-partial-eviction"
+    partial = {
+        "role": "assistant",
+        "content": "working",
+        "_partial": True,
+        "timestamp": 123.0,
+    }
+    # Pre-#5854 ordering: scenes precede message_count, so the cheap prefix has
+    # no authoritative count and eviction must full-load. Duplicate partials
+    # make that load invoke its self-healing save path.
+    legacy_payload = {
+        "session_id": sid,
+        "title": "Legacy partials",
+        "workspace": str(isolated_session_env.parent),
+        "model": "test",
+        "created_at": 100.0,
+        "updated_at": 200.0,
+        "anchor_activity_scenes": {},
+        "message_count": 3,
+        "messages": [
+            {"role": "user", "content": "run it"},
+            partial,
+            dict(partial),
+        ],
+        "tool_calls": [],
+    }
+    path = isolated_session_env / f"{sid}.json"
+    path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+    cached = models.Session(
+        session_id=sid,
+        title="Legacy partials",
+        messages=[legacy_payload["messages"][0], partial],
+        created_at=100.0,
+        updated_at=200.0,
+    )
+    cached._cache_resident_bytes = path.stat().st_size
+    sibling = _make_persisted_session(419)
+    SESSIONS[sid] = cached
+    SESSIONS[sibling.session_id] = sibling
+
+    failures = []
+
+    def enforce():
+        try:
+            with LOCK:
+                models._evict_sessions_over_cap(cap=1, max_bytes=1 << 30)
+        except BaseException as exc:  # surface cleanup errors after breaking a RED deadlock
+            failures.append(exc)
+
+    worker = threading.Thread(target=enforce, daemon=True)
+    worker.start()
+    worker.join(timeout=1.0)
+    deadlocked = worker.is_alive()
+    if deadlocked:
+        # A plain threading.Lock has no ownership, so release the outer hold to
+        # let the daemon unwind instead of leaking a stuck thread into pytest.
+        LOCK.release()
+        worker.join(timeout=1.0)
+
+    assert deadlocked is False, "legacy self-heal recursively acquired the cache LOCK"
+    assert failures == []
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert sum(1 for message in persisted["messages"] if message.get("_partial")) == 1
+
+
+def test_byte_eviction_preserves_active_session_and_reclaims_clean_entries(isolated_session_env):
+    """Byte pressure keeps active and MRU state while reclaiming older clean data."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    clean = _make_persisted_session(
+        100,
+        messages=[{"role": "assistant", "content": "b" * (700 * 1024)}],
+    )
+    active = _make_persisted_session(
+        101,
+        messages=[{"role": "assistant", "content": "a" * (700 * 1024)}],
+    )
+    active.active_stream_id = "live-stream"
+    current = _make_persisted_session(
+        102,
+        messages=[{"role": "assistant", "content": "c" * (100 * 1024)}],
+    )
+    _insert(clean)
+    _insert(active)
+    _insert(current)
+
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1024 * 1024)
+
+    assert evicted == 1
+    assert clean.session_id not in SESSIONS
+    assert active.session_id in SESSIONS
+    assert current.session_id in SESSIONS
+
+
+def test_byte_eviction_keeps_mru_warm_behind_pinned_active_session(isolated_session_env):
+    """Pinned work must not force the visible MRU into a cold-load loop."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    active = _make_persisted_session(
+        190,
+        messages=[{"role": "assistant", "content": "a" * (700 * 1024)}],
+    )
+    active.active_stream_id = "live-stream"
+    current = _make_persisted_session(
+        191,
+        messages=[{"role": "assistant", "content": "c" * (700 * 1024)}],
+    )
+    _insert(active)
+    _insert(current)  # MRU / currently viewed transcript
+
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1024 * 1024)
+
+    assert evicted == 0
+    assert list(SESSIONS) == [active.session_id, current.session_id]
+
+
+def test_byte_eviction_keeps_one_oversized_mru_to_avoid_reload_loop(isolated_session_env):
+    """One transcript may exceed the budget; retaining it avoids cold-loading every access."""
+    from api.config import LOCK, SESSIONS
+    from api.models import _evict_sessions_over_cap
+
+    oversized = _make_persisted_session(
+        200,
+        messages=[{"role": "assistant", "content": "z" * (2 * 1024 * 1024)}],
+    )
+    _insert(oversized)
+
+    with LOCK:
+        evicted = _evict_sessions_over_cap(cap=10, max_bytes=1024 * 1024)
+
+    assert evicted == 0
+    assert list(SESSIONS) == [oversized.session_id]
+    assert oversized._cache_resident_bytes > 1024 * 1024
+
+
+def test_resident_weight_tracks_save_full_load_and_metadata_stub(isolated_session_env):
+    """Weights follow retained data without deep-walking the Python object graph."""
+    from api.models import Session
+
+    session = _make_persisted_session(
+        300,
+        messages=[{"role": "assistant", "content": "w" * (256 * 1024)}],
+    )
+    sidecar_bytes = session.path.stat().st_size
+    assert session._cache_resident_bytes == sidecar_bytes
+
+    loaded = Session.load(session.session_id)
+    assert loaded is not None
+    assert loaded._cache_resident_bytes == sidecar_bytes
+    assert loaded._cache_persisted_fingerprint is not None
+
+    metadata_stub = Session.load_metadata_only(session.session_id)
+    assert metadata_stub is not None
+    assert 0 < metadata_stub._cache_resident_bytes < sidecar_bytes
+
+
+def test_full_load_weights_the_exact_bytes_read_across_atomic_replace(
+    isolated_session_env, monkeypatch,
+):
+    """A pre-read stat from the old inode cannot weight replacement JSON."""
+    from api import models
+    from api.models import Session
+
+    original = _make_persisted_session(
+        301,
+        messages=[{"role": "assistant", "content": "old"}],
+    )
+    target = original.path
+    old_sig = models._sidecar_stat_signature(target)
+    replacement_data = json.loads(target.read_text(encoding="utf-8"))
+    replacement_data["messages"] = [
+        {"role": "assistant", "content": "new" + "x" * (700 * 1024)}
+    ]
+    replacement_data["message_count"] = 1
+    replacement = target.with_suffix(".replacement")
+    replacement.write_text(
+        json.dumps(replacement_data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    replacement_size = replacement.stat().st_size
+    real_signature = models._sidecar_stat_signature
+    swapped = False
+
+    def replace_after_signature(path):
+        nonlocal swapped
+        if Path(path) == target and not swapped:
+            swapped = True
+            os.replace(replacement, target)
+            return old_sig
+        return real_signature(path)
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", replace_after_signature)
+
+    loaded = Session.load(original.session_id)
+
+    assert swapped is True
+    assert loaded.messages[0]["content"].startswith("new")
+    assert loaded._cache_resident_bytes == replacement_size
+    assert replacement_size > old_sig[2]
+
+
+def test_save_measurement_failure_marks_weight_unknown_and_enforces_conservatively(
+    isolated_session_env, monkeypatch,
+):
+    """A successful save never keeps a stale pre-growth weight after size failure."""
+    from api import config as _cfg
+    from api import models
+    from api.config import SESSIONS
+
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+    sessions = [
+        _make_persisted_session(
+            310 + i,
+            messages=[{"role": "assistant", "content": "s" * (250 * 1024)}],
+        )
+        for i in range(3)
+    ]
+    for session in sessions:
+        _insert(session)
+
+    current = sessions[-1]
+    replaced = False
+    real_replace = models._safe_replace
+    real_path_stat = Path.stat
+
+    def marked_replace(src, dst):
+        nonlocal replaced
+        real_replace(src, dst)
+        if Path(dst) == current.path:
+            replaced = True
+
+    def fail_target_stat(path, *args, **kwargs):
+        if replaced and Path(path) == current.path:
+            raise OSError("post-replace stat unavailable")
+        return real_path_stat(path, *args, **kwargs)
+
+    def fail_open_file_stat(_fd):
+        raise OSError("open-file size unavailable")
+
+    monkeypatch.setattr(models, "_safe_replace", marked_replace)
+    monkeypatch.setattr(Path, "stat", fail_target_stat)
+    monkeypatch.setattr(models.os, "fstat", fail_open_file_stat)
+    current.messages = [
+        {"role": "assistant", "content": "grown" + "g" * (700 * 1024)}
+    ]
+
+    current.save()
+
+    assert current._cache_resident_bytes is None
+    assert sessions[0].session_id not in SESSIONS
+    assert current.session_id in SESSIONS
 
 
 # ────────────────────── invariant 2: never evict active ──────────────────────
@@ -489,6 +1175,74 @@ def test_scan_accessor_reuses_resident_sessions_without_promoting(isolated_sessi
 
     assert scanned is SESSIONS[first.session_id], "scan should reuse the resident object"
     assert list(SESSIONS.keys()) == order_before, "scan must not promote in the LRU"
+
+
+def test_scan_reconciliation_does_not_enforce_cache_bounds(
+    isolated_session_env, monkeypatch,
+):
+    """A scan self-heal may update disk/cache state but must not churn the LRU."""
+    from api import config as _cfg
+    from api import models
+    from api.config import SESSIONS
+
+    stale = _make_persisted_session(
+        940,
+        messages=[
+            {"role": "user", "content": "u" * (400 * 1024), "timestamp": 100.0}
+        ],
+    )
+    stale.active_stream_id = "dead-scan-stream"
+    stale.pending_user_message = "recover scan"
+    stale.pending_started_at = 102.0
+    stale.save(touch_updated_at=False)
+    siblings = [
+        _make_persisted_session(
+            941 + i,
+            messages=[
+                {"role": "assistant", "content": "s" * (400 * 1024), "timestamp": 100.0}
+            ],
+        )
+        for i in range(2)
+    ]
+    _insert(stale)
+    for sibling in siblings:
+        _insert(sibling)
+    order_before = list(SESSIONS)
+
+    recovered = list(stale.messages) + [
+        {
+            "role": "assistant",
+            "content": "recovered" + "a" * (700 * 1024),
+            "timestamp": 103.0,
+        }
+    ]
+    monkeypatch.setattr(models, "_active_stream_ids", lambda: set())
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda *_args, **_kwargs: {"message_count": 2, "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda *_args, **_kwargs: list(recovered),
+    )
+    monkeypatch.setattr(
+        _cfg,
+        "get_config",
+        lambda: {
+            "webui": {
+                "sessions_cache_max": 10,
+                "sessions_cache_max_mb": 1,
+            }
+        },
+    )
+
+    scanned = models.get_session_for_scan(stale.session_id)
+
+    assert scanned is stale
+    assert scanned.messages[-1]["content"].startswith("recovered")
+    assert list(SESSIONS) == order_before, "scan reconciliation must not evict or promote"
 
 
 def test_content_search_scan_recovers_newer_state_db_without_lru_churn(

--- a/tests/test_issue4765_sessions_lru_eviction.py
+++ b/tests/test_issue4765_sessions_lru_eviction.py
@@ -424,6 +424,54 @@ def test_save_snapshot_is_not_fooled_by_nested_aba_during_serialization(
     assert models.get_session(session.session_id).messages[0]["content"] == "A"
 
 
+def test_save_snapshot_drives_prefix_metadata_and_backup_decisions(
+    isolated_session_env, monkeypatch,
+):
+    """Derived prefix fields and shrink recovery must use the copied snapshot."""
+    from api import models
+
+    previous_messages = [
+        {"role": "user", "content": f"previous {i}"}
+        for i in range(5)
+    ]
+    session = _make_persisted_session(83, messages=previous_messages)
+    current_messages = [
+        {"role": "user", "content": f"current {i}"}
+        for i in range(10)
+    ]
+    session.messages = list(current_messages)
+    real_deepcopy = models.copy.deepcopy
+    mutated = False
+
+    def deepcopy_with_nested_mutation(value, *args, **kwargs):
+        nonlocal mutated
+        if (
+            not mutated
+            and isinstance(value, dict)
+            and value.get("session_id") == session.session_id
+            and value.get("messages") is session.messages
+        ):
+            mutated = True
+            session.messages.clear()
+            try:
+                return real_deepcopy(value, *args, **kwargs)
+            finally:
+                session.messages.extend(current_messages)
+        return real_deepcopy(value, *args, **kwargs)
+
+    monkeypatch.setattr(models.copy, "deepcopy", deepcopy_with_nested_mutation)
+    session.save(touch_updated_at=False)
+
+    assert mutated is True
+    persisted = json.loads(session.path.read_text(encoding="utf-8"))
+    backup = json.loads(session.path.with_suffix(".json.bak").read_text(encoding="utf-8"))
+    assert persisted["message_count"] == 0
+    assert persisted["messages"] == []
+    assert len(backup["messages"]) == len(previous_messages)
+    assert len(session.messages) == len(current_messages)
+    assert session._cache_persisted_fingerprint is None
+
+
 class _ObservedSessions(collections.OrderedDict):
     """Ordered cache double that exposes the candidate-removal instant."""
 

--- a/tests/test_issue4765_sessions_lru_eviction.py
+++ b/tests/test_issue4765_sessions_lru_eviction.py
@@ -532,6 +532,15 @@ def test_byte_eviction_coordinates_validation_and_removal_with_session_writer(
             with _cfg._get_session_agent_lock(candidate.session_id):
                 if not removal_started.is_set():
                     mutation_before_removal.set()
+                else:
+                    # Eviction removed candidate from cache under lock. Interpose
+                    # a reader that cold-loads the old sidecar into cache before
+                    # this detached save finishes.
+                    reader_session = models.get_session(candidate.session_id)
+                    assert reader_session is not candidate
+                    assert reader_session.composer_draft == {}
+                    assert cache.get(candidate.session_id) is reader_session
+                candidate.composer_draft = {"text": "new composer draft"}
                 candidate.title = "Unsaved concurrent title"
                 mutation_finished.set()
                 candidate.save(touch_updated_at=False)
@@ -552,6 +561,13 @@ def test_byte_eviction_coordinates_validation_and_removal_with_session_writer(
     assert not (
         mutation_before_removal.is_set() and candidate.session_id not in cache
     ), "byte eviction removed state changed after its durability check"
+    # Both disk and cache must return the new draft rather than leaving an
+    # interposed reader's stale-generation reload resident in cache.
+    persisted_disk = json.loads(candidate.path.read_text(encoding="utf-8"))
+    assert persisted_disk.get("composer_draft") == {"text": "new composer draft"}
+    cached_resolved = models.get_session(candidate.session_id)
+    assert cached_resolved.composer_draft == {"text": "new composer draft"}
+    assert cache.get(candidate.session_id).composer_draft == {"text": "new composer draft"}
 
 
 def test_state_db_reconcile_refreshes_cached_weight_and_enforces_budget(
@@ -1490,3 +1506,122 @@ def test_content_search_scan_recovers_newer_state_db_without_lru_churn(
     assert captured["payload"]["sessions"][0]["session_id"] == stale.session_id
     assert list(SESSIONS.keys()) == order_before, "scan recovery must not promote the LRU"
     assert len(SESSIONS) == size_before, "scan recovery must not insert or evict cache entries"
+
+
+def test_cold_load_rejects_stale_sidecar_generation_on_concurrent_disk_change(
+    isolated_session_env, monkeypatch,
+):
+    """Cold-load insertion must detect concurrent sidecar replacement and reload fresh disk."""
+    from api import models
+    from api.config import SESSIONS
+
+    sid = "sess-cas-cold-load"
+    original = models.Session(
+        session_id=sid,
+        title="Original title",
+        messages=[{"role": "user", "content": "hello", "timestamp": 100.0}],
+    )
+    original.save()
+
+    real_load = models.Session.load
+    interposed = False
+
+    def load_and_interpose(cls, session_id):
+        nonlocal interposed
+        loaded = real_load(session_id)
+        if session_id == sid and not interposed:
+            interposed = True
+            # Replace the file on disk concurrently before _resolve_session inserts
+            updated = models.Session(
+                session_id=sid,
+                title="Updated title on disk",
+                composer_draft={"text": "concurrent draft"},
+                messages=[{"role": "user", "content": "hello", "timestamp": 100.0}],
+            )
+            updated.save()
+        return loaded
+
+    monkeypatch.setattr(models.Session, "load", classmethod(load_and_interpose))
+
+    resolved = models.get_session(sid)
+    assert resolved is not None
+    assert resolved.title == "Updated title on disk"
+    assert resolved.composer_draft == {"text": "concurrent draft"}
+    cached = SESSIONS.get(sid)
+    assert cached is not None
+    assert cached.title == "Updated title on disk"
+    assert cached.composer_draft == {"text": "concurrent draft"}
+
+
+def test_detached_save_reconciles_clean_reloaded_cache_across_same_count_metadata_edit(
+    isolated_session_env,
+):
+    """A detached save replacing a sidecar with same count must overwrite a clean old cache entry."""
+    from api import models
+    from api.config import SESSIONS
+
+    sid = "sess-detached-metadata-cas"
+    v1 = models.Session(
+        session_id=sid,
+        title="Version 1",
+        composer_draft={},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 100.0}],
+    )
+    v1.save()
+
+    # Reader cold-loads v1 into SESSIONS
+    loaded_v1 = models.get_session(sid)
+    assert loaded_v1 is not None
+    assert SESSIONS.get(sid) is loaded_v1
+
+    # Detached writer had resolved v1 earlier, mutates metadata, and saves
+    v2 = models.Session(
+        session_id=sid,
+        title="Version 2 Updated",
+        composer_draft={"text": "draft v2"},
+        messages=[{"role": "user", "content": "prompt", "timestamp": 100.0}],
+    )
+    v2.save()
+
+    # Cache must now serve v2, not stale loaded_v1
+    cached = SESSIONS.get(sid)
+    assert cached is not None
+    assert cached.title == "Version 2 Updated"
+    assert cached.composer_draft == {"text": "draft v2"}
+    resolved = models.get_session(sid)
+    assert resolved.title == "Version 2 Updated"
+    assert resolved.composer_draft == {"text": "draft v2"}
+
+
+def test_cached_session_lags_disk_detects_clean_cache_stat_signature_mismatch(
+    isolated_session_env,
+):
+    """An inactive clean cached session detects same-count disk modification via stat signature."""
+    from api import models
+    from api.config import SESSIONS
+
+    sid = "sess-lags-stat-sig"
+    v1 = models.Session(
+        session_id=sid,
+        title="Original",
+        composer_draft={},
+        messages=[{"role": "user", "content": "msg", "timestamp": 100.0}],
+    )
+    v1.save()
+
+    cached = models.get_session(sid)
+    assert cached is not None
+    assert SESSIONS.get(sid) is cached
+    assert models._cached_session_lags_disk(cached) is False
+
+    # An external writer updates disk directly (e.g. outside process or via raw file write)
+    payload = json.loads(v1.path.read_text(encoding="utf-8"))
+    payload["title"] = "Modified on disk directly"
+    payload["composer_draft"] = {"text": "external draft"}
+    v1.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # Because cached is clean and its _sidecar_stat_sig != disk stat signature, lags_disk returns True
+    assert models._cached_session_lags_disk(cached) is True
+    resolved = models.get_session(sid)
+    assert resolved.title == "Modified on disk directly"
+    assert resolved.composer_draft == {"text": "external draft"}


### PR DESCRIPTION
## Summary

This supplements the existing 100-entry `SESSIONS` LRU with a conservative serialized-byte budget (`webui.sessions_cache_max_mb`, default `128`). Byte pressure is deliberately best-effort: active, dirty, uncertain, lock-contended, or most-recent sessions remain protected even if that temporarily exceeds the byte target.

## Latest review follow-up: coherent sidecar generations and CAS cache publication

This revision addresses the maintainer’s latest blocking generation/publication review:

- `Session.save()` records a durable generation only when the post-replace path still names the exact fsync’d temporary inode (device, inode, size, and mtime identity). If another writer replaces the sidecar between install and generation capture, both its resident weight and persisted fingerprint/generation authority are invalidated.
- Full loads read through one descriptor, `fstat()` before and after the read, and revalidate the pathname against that descriptor-derived token before constructing a cacheable session. Device/inode were added to the stat token so equal-size/timestamp atomic replacements remain distinguishable.
- A single authority tuple couples the public-state fingerprint and sidecar generation. Byte eviction requires both state equality and a still-current durable generation; reconciliation transfers the pair only when its copied public state matches, otherwise clears both.
- Cache-hit refresh, stale-tail repair, cold-load insertion, detached-save republish, and state.db reconciliation now use identity + observed-state CAS and revalidate the candidate generation immediately before cache publication. Cold loads retry boundedly and fail closed rather than caching a missing/unverifiable token.
- Existing per-session lock ordering is preserved: cache publication never takes a blocking session lock while holding the non-reentrant cache `LOCK`; byte eviction retains its existing nonblocking candidate-lock discipline.

## Deterministic regressions

The test coverage now includes deterministic interleavings for:

- replacement after `Session.save()` installs its payload but before generation capture;
- two successive replacements during cold-load retry, plus missing-token exhaustion;
- a newer cache publication between cache-hit disk load and assignment;
- stale-tail cache deletion during CAS, which must retry as a cold publication rather than return stale data;
- detached save attempting to replace an unsaved dirty cached generation;
- state.db reconciliation preserving a matching fingerprint/generation pair.

`tests/test_full_session_resolve_gate.py` also explicitly marks its synthetic no-filesystem `Session.load` stubs as trusted so it continues to test only single-flight slot behavior; real generation validation remains covered by the sidecar/CAS regressions.

## Configuration

```yaml
webui:
  sessions_cache_max: 100
  sessions_cache_max_mb: 128
```

Missing, invalid, or below-1 values fall back to the 128 MiB default. The budget measures serialized sidecar size, not transient JSON-decoding peak RSS.

## Verification

Exact candidate: `0de1a03b881486c5ea981409ce0602b0acd42cc6` (rebased onto `origin/master` `6bc16a68bc17f18740c7feab101f98d9605d680c`).

- Maintainer-focused session/cache/recovery/single-flight/approval matrix: **349 passed**.
- Exact-head read-only generation/CAS review: **PASS**.
- `git diff --check origin/master...HEAD`: passed.
- Diff-aware Ruff: no new violations on added or modified lines.
- Broad suite excluding the optional Playwright collection test: **14,797 passed, 176 skipped, 1 xfailed, 2 xpassed, 34 subtests passed**.
- The only 15 broad-suite failures are unchanged baseline/environment failures: 13 in `tests/test_5774b_atomic_config_writes.py` and 2 in `tests/test_tls_aware_probe.py`. The same two files were run directly against clean current `origin/master` (`6bc16a68`): **15 failed, 33 passed**.
- `tests/test_compression_phantom_barrier.py` is excluded locally because its optional `playwright` dependency is not installed.

## Contract Routing

Task type: session cache durability, eviction safety, and stale-generation reconciliation.

Touched areas: `api/models.py`; targeted cache-generation and full-session-resolve regression tests.

Relevant docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, and `docs/rfcs/webui-run-state-consistency-contract.md`.

Scope boundaries: no live service changes, no sidecar format break, and no change to count-cap eviction semantics.

## Risks / follow-up

The byte target remains intentionally conservative: when every candidate is protected, resident bytes can remain above target. The deliberate detached `deepcopy` snapshot also has transient CPU/memory cost for exceptionally large saves; it is retained because it is the durable-state proof that closes the ABA/data-loss class, while a streaming serializer redesign is outside this focused concurrency fix. The optional Playwright test needs a provisioned dependency to collect locally.
