### PR TITLE
fix(a11y): clear stale aria-expanded when switching panels

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -529,6 +529,12 @@ function _isSidebarCollapsed(){
 function _syncSidebarAria(){
   // Mirror the open/collapsed state on the active rail button via aria-expanded
   // so screen readers announce the toggle. Open=true, collapsed=false.
+  // Clear the others first: only one panel owns the sidebar, but this used to set
+  // aria-expanded on the newly-active button without unsetting the previous one,
+  // so chat -> kanban -> skills left three buttons claiming aria-expanded=true
+  // and a screen reader announced three open disclosures.
+  document.querySelectorAll('.rail .rail-btn.nav-tab[data-panel][aria-expanded]')
+    .forEach(function(btn){ btn.setAttribute('aria-expanded','false'); });
   const active=document.querySelector('.rail .rail-btn.nav-tab.active[data-panel]');
   if(active)active.setAttribute('aria-expanded',!_isSidebarCollapsed());
 }


### PR DESCRIPTION
`_syncSidebarAria()` sets `aria-expanded` on the newly-active rail button but never unsets it on the previous one, so the attribute accumulates.

**Reproduce** — click Chat, then Kanban, then Skills, and inspect the rail:

```js
[...document.querySelectorAll('.rail [data-panel]')]
  .filter(t => t.getAttribute('aria-expanded') === 'true')
  .map(t => t.dataset.panel)
// => ['chat', 'kanban', 'skills']
```

Three buttons claim `aria-expanded="true"` at once. Only one panel owns the sidebar, so a screen reader announces three open disclosures and the operator has no way to tell which one is actually showing.

**Fix** — clear the attribute across the rail before setting it on the active button. Six lines in `static/boot.js`, no behaviour change for sighted users.

Found while building a panel extension: I first assumed my own code was at fault, then reproduced it with no extension involved — the three clicks above are enough on a stock build.
