### PR TITLE
test(#6630): isolate auxiliary client fixtures

### DIFF
--- a/tests/_aux_client_helpers.py
+++ b/tests/_aux_client_helpers.py
@@ -12,6 +12,13 @@ restore: it snapshots the mapping and puts it back on exit, so a key that was
 absent is deleted, a key that was present is restored by identity, and a key
 holding ``None`` stays ``None``. ``tests/test_4413_seed_provider_models.py``
 already stubs ``sys.modules`` this way, including the ``None`` case.
+
+One constraint that comes with it: ``patch.dict`` restores by clearing the
+mapping and replacing it wholesale, so any module first imported inside the
+scope is evicted on exit and re-imported later as a new object. That is
+harmless for these suites, which import everything they touch at collection
+time, but it is the thing to check before reusing this helper around code
+that imports lazily.
 """
 from __future__ import annotations
 

--- a/tests/_aux_client_helpers.py
+++ b/tests/_aux_client_helpers.py
@@ -1,0 +1,45 @@
+"""Shared scaffolding for the auxiliary title-generation test suites.
+
+``test_title_aux_routing.py`` and ``test_2235_initial_aux_title.py`` both need
+``agent.auxiliary_client`` importable so ``api.streaming`` can be patched
+against it. Both used to install synthetic modules at import time with
+``sys.modules.setdefault`` and never remove them, so whichever ran first left
+the stub in place for the rest of the process and the next file to import
+``agent.context_compressor`` got the stub instead of the real module (#6630).
+
+Scope the install to the test that needs it and let ``mock.patch.dict`` own the
+restore: it snapshots the mapping and puts it back on exit, so a key that was
+absent is deleted, a key that was present is restored by identity, and a key
+holding ``None`` stays ``None``. ``tests/test_4413_seed_provider_models.py``
+already stubs ``sys.modules`` this way, including the ``None`` case.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest import mock
+
+
+def auxiliary_client_modules():
+    """Context manager installing stub ``agent`` / ``agent.auxiliary_client``.
+
+    The stubs are fresh objects owned by this helper, so the ``auxiliary_client``
+    attribute is set on our own module and no pre-existing ``agent`` module is
+    mutated. Restoration is therefore entirely ``patch.dict``'s job.
+    """
+    agent_stub = types.ModuleType("agent")
+    auxiliary_client_stub = types.ModuleType("agent.auxiliary_client")
+    agent_stub.auxiliary_client = auxiliary_client_stub
+    return mock.patch.dict(
+        sys.modules,
+        {"agent": agent_stub, "agent.auxiliary_client": auxiliary_client_stub},
+    )
+
+
+def patch_tg_config(config_dict):
+    """Make ``_get_auxiliary_task_config`` return ``config_dict``."""
+    return mock.patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=config_dict,
+        create=True,
+    )

--- a/tests/test_2235_initial_aux_title.py
+++ b/tests/test_2235_initial_aux_title.py
@@ -12,22 +12,28 @@ Covers:
 """
 import sys
 import threading
-import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Stub agent.auxiliary_client so it is importable in the test environment
-# (the real package lives in hermes-agent, which is not installed here).
-_agent_stub = types.ModuleType('agent')
-_aux_stub = types.ModuleType('agent.auxiliary_client')
-sys.modules.setdefault('agent', _agent_stub)
-sys.modules.setdefault('agent.auxiliary_client', _aux_stub)
-_agent_stub.auxiliary_client = _aux_stub
+import pytest
+
+from tests._aux_client_helpers import auxiliary_client_modules, patch_tg_config
+
+
+@pytest.fixture(autouse=True)
+def _install_auxiliary_client_modules():
+    """Scope the synthetic hermes-agent modules to each test (#6630).
+
+    This file carried the same unscoped sys.modules.setdefault install as
+    test_title_aux_routing.py, so it leaked the stub the same way.
+    """
+    with auxiliary_client_modules():
+        yield
 
 
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
-    return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
+    return patch_tg_config(config_dict)
 
 
 def _make_provisional_session(user_text, assistant_text='Here is the answer.'):

--- a/tests/test_2235_initial_aux_title.py
+++ b/tests/test_2235_initial_aux_title.py
@@ -10,7 +10,6 @@ Covers:
   3. Refresh path parity — configured aux routing still applies to the
      adaptive title refresh path.
 """
-import sys
 import threading
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -7,7 +7,6 @@ Covers:
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
 import os
-from contextlib import contextmanager
 from pathlib import Path
 import sys
 import types
@@ -16,100 +15,71 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-_MISSING = object()
-
-
-@contextmanager
-def _auxiliary_client_modules():
-    """Temporarily provide the hermes-agent modules needed by these tests."""
-    previous_agent = sys.modules.get('agent', _MISSING)
-    previous_auxiliary_client = sys.modules.get('agent.auxiliary_client', _MISSING)
-    previous_attribute = (
-        getattr(previous_agent, 'auxiliary_client', _MISSING)
-        if previous_agent is not _MISSING
-        else _MISSING
-    )
-
-    agent_stub = types.ModuleType('agent')
-    auxiliary_client_stub = types.ModuleType('agent.auxiliary_client')
-    agent_stub.auxiliary_client = auxiliary_client_stub
-    sys.modules['agent'] = agent_stub
-    sys.modules['agent.auxiliary_client'] = auxiliary_client_stub
-
-    try:
-        yield
-    finally:
-        if previous_agent is _MISSING:
-            sys.modules.pop('agent', None)
-        else:
-            sys.modules['agent'] = previous_agent
-
-        if previous_auxiliary_client is _MISSING:
-            sys.modules.pop('agent.auxiliary_client', None)
-        else:
-            sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
-
-        if previous_agent is not _MISSING:
-            if previous_attribute is _MISSING:
-                vars(previous_agent).pop('auxiliary_client', None)
-            else:
-                previous_agent.auxiliary_client = previous_attribute
+from tests._aux_client_helpers import auxiliary_client_modules, patch_tg_config
 
 
 @pytest.fixture(autouse=True)
 def _install_auxiliary_client_modules():
-    # The real package lives in hermes-agent, which is not installed here.
-    with _auxiliary_client_modules():
+    """Scope the synthetic hermes-agent modules to each test (#6630)."""
+    with auxiliary_client_modules():
         yield
 
 
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
-    return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
+    return patch_tg_config(config_dict)
 
 
-class TestAuxiliaryClientModuleIsolation(unittest.TestCase):
-    def test_existing_modules_are_restored_exactly(self):
-        previous_agent = types.ModuleType('agent')
-        previous_auxiliary_client = types.ModuleType('agent.auxiliary_client')
-        previous_agent.auxiliary_client = previous_auxiliary_client
-        sys.modules['agent'] = previous_agent
-        sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
+class TestAuxiliaryClientModuleRestore(unittest.TestCase):
+    """Restoration properties the #6630 fix depends on.
 
-        with _auxiliary_client_modules():
-            self.assertIsNot(sys.modules['agent'], previous_agent)
-            self.assertIsNot(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
+    These drive the helper directly. The fixture boundary itself is proved by
+    the cross-file run in the PR description: running this file before
+    tests/test_issue4685_post_compression_context_metering.py used to fail that
+    file's agent.context_compressor import and no longer does.
+    """
 
-        self.assertIs(sys.modules['agent'], previous_agent)
-        self.assertIs(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
-        self.assertIs(previous_agent.auxiliary_client, previous_auxiliary_client)
+    def test_prior_modules_restored_by_identity(self):
+        prior_agent = types.ModuleType("agent")
+        prior_aux = types.ModuleType("agent.auxiliary_client")
+        prior_agent.auxiliary_client = prior_aux
+        with patch.dict(sys.modules, {"agent": prior_agent, "agent.auxiliary_client": prior_aux}):
+            with auxiliary_client_modules():
+                self.assertIsNot(sys.modules["agent"], prior_agent)
+                self.assertIsNot(sys.modules["agent.auxiliary_client"], prior_aux)
+            self.assertIs(sys.modules["agent"], prior_agent)
+            self.assertIs(sys.modules["agent.auxiliary_client"], prior_aux)
+            self.assertIs(prior_agent.auxiliary_client, prior_aux)
 
-    def test_absent_modules_are_removed_after_context(self):
-        sys.modules.pop('agent', None)
-        sys.modules.pop('agent.auxiliary_client', None)
+    def test_absent_keys_removed(self):
+        with patch.dict(sys.modules):
+            sys.modules.pop("agent", None)
+            sys.modules.pop("agent.auxiliary_client", None)
+            with auxiliary_client_modules():
+                self.assertIn("agent", sys.modules)
+                self.assertIn("agent.auxiliary_client", sys.modules)
+            self.assertNotIn("agent", sys.modules)
+            self.assertNotIn("agent.auxiliary_client", sys.modules)
 
-        with _auxiliary_client_modules():
-            self.assertIn('agent', sys.modules)
-            self.assertIn('agent.auxiliary_client', sys.modules)
+    def test_prior_none_value_preserved(self):
+        """A present-but-None entry is not an absent entry."""
+        with patch.dict(sys.modules, {"agent": None, "agent.auxiliary_client": None}):
+            with auxiliary_client_modules():
+                self.assertIsNotNone(sys.modules["agent"])
+            self.assertIn("agent", sys.modules)
+            self.assertIsNone(sys.modules["agent"])
+            self.assertIsNone(sys.modules["agent.auxiliary_client"])
 
-        self.assertNotIn('agent', sys.modules)
-        self.assertNotIn('agent.auxiliary_client', sys.modules)
-
-    def test_existing_modules_are_restored_after_exception(self):
-        previous_agent = types.ModuleType('agent')
-        previous_auxiliary_client = types.ModuleType('agent.auxiliary_client')
-        previous_agent.auxiliary_client = previous_auxiliary_client
-        sys.modules['agent'] = previous_agent
-        sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
-
-        with self.assertRaisesRegex(RuntimeError, 'fixture failure'):
-            with _auxiliary_client_modules():
-                raise RuntimeError('fixture failure')
-
-        self.assertIs(sys.modules['agent'], previous_agent)
-        self.assertIs(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
-        self.assertIs(previous_agent.auxiliary_client, previous_auxiliary_client)
+    def test_restored_after_exception(self):
+        prior_agent = types.ModuleType("agent")
+        prior_aux = types.ModuleType("agent.auxiliary_client")
+        prior_agent.auxiliary_client = prior_aux
+        with patch.dict(sys.modules, {"agent": prior_agent, "agent.auxiliary_client": prior_aux}):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                with auxiliary_client_modules():
+                    raise RuntimeError("boom")
+            self.assertIs(sys.modules["agent"], prior_agent)
+            self.assertIs(sys.modules["agent.auxiliary_client"], prior_aux)
 
 
 class TestAuxTitleConfigured(unittest.TestCase):

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -7,24 +7,109 @@ Covers:
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
 import os
+from contextlib import contextmanager
 from pathlib import Path
 import sys
 import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Stub agent.auxiliary_client so it is importable in the test environment
-# (the real package lives in hermes-agent, which is not installed here).
-_agent_stub = types.ModuleType('agent')
-_aux_stub = types.ModuleType('agent.auxiliary_client')
-sys.modules.setdefault('agent', _agent_stub)
-sys.modules.setdefault('agent.auxiliary_client', _aux_stub)
-_agent_stub.auxiliary_client = _aux_stub
+import pytest
+
+
+_MISSING = object()
+
+
+@contextmanager
+def _auxiliary_client_modules():
+    """Temporarily provide the hermes-agent modules needed by these tests."""
+    previous_agent = sys.modules.get('agent', _MISSING)
+    previous_auxiliary_client = sys.modules.get('agent.auxiliary_client', _MISSING)
+    previous_attribute = (
+        getattr(previous_agent, 'auxiliary_client', _MISSING)
+        if previous_agent is not _MISSING
+        else _MISSING
+    )
+
+    agent_stub = types.ModuleType('agent')
+    auxiliary_client_stub = types.ModuleType('agent.auxiliary_client')
+    agent_stub.auxiliary_client = auxiliary_client_stub
+    sys.modules['agent'] = agent_stub
+    sys.modules['agent.auxiliary_client'] = auxiliary_client_stub
+
+    try:
+        yield
+    finally:
+        if previous_agent is _MISSING:
+            sys.modules.pop('agent', None)
+        else:
+            sys.modules['agent'] = previous_agent
+
+        if previous_auxiliary_client is _MISSING:
+            sys.modules.pop('agent.auxiliary_client', None)
+        else:
+            sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
+
+        if previous_agent is not _MISSING:
+            if previous_attribute is _MISSING:
+                vars(previous_agent).pop('auxiliary_client', None)
+            else:
+                previous_agent.auxiliary_client = previous_attribute
+
+
+@pytest.fixture(autouse=True)
+def _install_auxiliary_client_modules():
+    # The real package lives in hermes-agent, which is not installed here.
+    with _auxiliary_client_modules():
+        yield
 
 
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
     return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
+
+
+class TestAuxiliaryClientModuleIsolation(unittest.TestCase):
+    def test_existing_modules_are_restored_exactly(self):
+        previous_agent = types.ModuleType('agent')
+        previous_auxiliary_client = types.ModuleType('agent.auxiliary_client')
+        previous_agent.auxiliary_client = previous_auxiliary_client
+        sys.modules['agent'] = previous_agent
+        sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
+
+        with _auxiliary_client_modules():
+            self.assertIsNot(sys.modules['agent'], previous_agent)
+            self.assertIsNot(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
+
+        self.assertIs(sys.modules['agent'], previous_agent)
+        self.assertIs(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
+        self.assertIs(previous_agent.auxiliary_client, previous_auxiliary_client)
+
+    def test_absent_modules_are_removed_after_context(self):
+        sys.modules.pop('agent', None)
+        sys.modules.pop('agent.auxiliary_client', None)
+
+        with _auxiliary_client_modules():
+            self.assertIn('agent', sys.modules)
+            self.assertIn('agent.auxiliary_client', sys.modules)
+
+        self.assertNotIn('agent', sys.modules)
+        self.assertNotIn('agent.auxiliary_client', sys.modules)
+
+    def test_existing_modules_are_restored_after_exception(self):
+        previous_agent = types.ModuleType('agent')
+        previous_auxiliary_client = types.ModuleType('agent.auxiliary_client')
+        previous_agent.auxiliary_client = previous_auxiliary_client
+        sys.modules['agent'] = previous_agent
+        sys.modules['agent.auxiliary_client'] = previous_auxiliary_client
+
+        with self.assertRaisesRegex(RuntimeError, 'fixture failure'):
+            with _auxiliary_client_modules():
+                raise RuntimeError('fixture failure')
+
+        self.assertIs(sys.modules['agent'], previous_agent)
+        self.assertIs(sys.modules['agent.auxiliary_client'], previous_auxiliary_client)
+        self.assertIs(previous_agent.auxiliary_client, previous_auxiliary_client)
 
 
 class TestAuxTitleConfigured(unittest.TestCase):


### PR DESCRIPTION
## Thinking Path

- `tests/test_title_aux_routing.py` needs `agent.auxiliary_client` importable so `api.streaming`'s title routing can be patched against it, and it got that by installing synthetic `agent` and `agent.auxiliary_client` modules at import time with `sys.modules.setdefault`.
- Nothing ever removed them, so the stub outlived the file. Anything that later imported `agent.context_compressor` in the same process got the stub instead of the real module, which is what breaks `tests/test_issue4685_post_compression_context_metering.py`.
- `tests/test_2235_initial_aux_title.py` carried the identical install and leaked the same way, so the fix belongs at a shared chokepoint rather than in one file: both now go through `tests/_aux_client_helpers.py`, which scopes the install to a single test and lets `unittest.mock.patch.dict` own the restore.
- Four other suites carry the same class and are left out of scope, each stubbing unrelated module sets for its own import-time reasons: `tests/test_issue4783_profile_skills_mtime_cache.py` and `tests/test_sprint48.py` never restore; `tests/test_custom_provider_prefix_collisions.py` additionally grafts an attribute onto a pre-existing `agent` module, which no `sys.modules`-level restore would undo; and `tests/test_issue4360_generic_pool_quota.py` cleans up after its `yield` with no `try`/`finally`, so an exception skips it. The last two need a different mechanism than this change provides.

## What Changed

- `tests/_aux_client_helpers.py` (new): one owner for the synthetic `agent` / `agent.auxiliary_client` install and the `_get_auxiliary_task_config` patch, scoped through `mock.patch.dict`.
- `tests/test_title_aux_routing.py`: import-time install replaced by an autouse fixture around that helper; adds four tests covering restoration by identity, absent-key cleanup, present-but-`None` preservation, and restoration when the body raises.
- `tests/test_2235_initial_aux_title.py`: same import-time install, same replacement.

## Why It Matters

Running either auxiliary-title suite before `tests/test_issue4685_post_compression_context_metering.py` in one process no longer breaks that file's `agent.context_compressor` import, so those suites stop depending on run order.

## Verification

Both pairings fail on master for the right reason and pass here: `test_title_aux_routing.py` followed by the metering file, and `test_2235_initial_aux_title.py` followed by it, each raising `ImportError: cannot import name 'call_llm' from 'agent.auxiliary_client'` on the unfixed code. All three files together pass in a single process, as do the four new restoration tests and every pre-existing assertion in both suites. CI runs the full matrix.

## Risks / Follow-ups

`patch.dict` restores by clearing the mapping and replacing it wholesale, so a module first imported inside the scoped window is evicted at exit and re-imported later as a new object. Both suites import everything they touch at collection time, so nothing is evicted in practice, but it is recorded in the helper's docstring as a constraint on reuse.

The four same-class sites named above are left alone; each needs a different fix than this one, and the attribute-mutation and missing-`finally` cases in particular are not solvable at the `sys.modules` level.

## Upstream

Closes #6630.

## Model Used

Claude Opus 5 via Claude Code
