### PR TITLE
fix(async): keep legacy busy completions retryable

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -908,8 +908,19 @@ def _requeue_async_delegation_event(
     )
 
 
-def _retry_unclaimed_async_delegation_event(process_registry, evt: dict) -> None:
-    """Retry from durable state, or make one bounded legacy routing pass."""
+def _retry_unclaimed_async_delegation_event(
+    process_registry,
+    evt: dict,
+    *,
+    keep_legacy_retrying: bool = False,
+) -> None:
+    """Retry from durable state, or make a bounded legacy routing pass.
+
+    ``keep_legacy_retrying`` is reserved for a completion whose target session
+    is known but currently busy. That wait state is neither an unroutable event
+    nor a failed delivery attempt, so compatibility-mode delivery must keep
+    backing off until the session becomes idle.
+    """
     completion_queue = getattr(process_registry, "completion_queue", None)
     if schedule_async_delegation_claim_retry(
         evt,
@@ -917,10 +928,11 @@ def _retry_unclaimed_async_delegation_event(process_registry, evt: dict) -> None
         delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
     ):
         return
-    if evt.get("_webui_routing_retry_attempted"):
+    if not keep_legacy_retrying and evt.get("_webui_routing_retry_attempted"):
         return
     retry_evt = dict(evt)
-    retry_evt["_webui_routing_retry_attempted"] = True
+    if not keep_legacy_retrying:
+        retry_evt["_webui_routing_retry_attempted"] = True
     _requeue_async_delegation_event(
         process_registry,
         retry_evt,
@@ -1031,7 +1043,11 @@ def _process_async_delegation_event(
     # not a delivery attempt, so leave the record unclaimed and let the shared
     # restore sweep retry after the session can accept a wakeup.
     if _session_has_active_turn(session_id):
-        _retry_unclaimed_async_delegation_event(process_registry, evt)
+        _retry_unclaimed_async_delegation_event(
+            process_registry,
+            evt,
+            keep_legacy_retrying=True,
+        )
         return
 
     try:

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -126,6 +126,24 @@ def _install_fake_durable_delivery_api(monkeypatch):
     fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
     monkeypatch.setitem(sys.modules, "tools", fake_pkg)
     monkeypatch.setitem(sys.modules, "tools.async_delegation", fake_mod)
+    monkeypatch.setattr(fake_pkg, "async_delegation", fake_mod, raising=False)
+    return calls
+
+
+def _install_fake_legacy_delivery_api(monkeypatch):
+    """Install a pre-durable-core surface with only compatibility markers."""
+    calls = {"mark": [], "legacy": []}
+    fake_mod = types.ModuleType("tools.async_delegation")
+    fake_mod.mark_completion_delivered = (  # type: ignore[reportAttributeAccessIssue]
+        lambda delegation_id: calls["mark"].append(delegation_id) or True
+    )
+    fake_mod.mark_async_delegation_consumed = (  # type: ignore[reportAttributeAccessIssue]
+        lambda delegation_id: calls["legacy"].append(delegation_id)
+    )
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.async_delegation", fake_mod)
+    monkeypatch.setattr(fake_pkg, "async_delegation", fake_mod, raising=False)
     return calls
 
 
@@ -347,6 +365,41 @@ def test_background_active_turn_does_not_consume_durable_delivery_attempts(monke
         assert peu.async_delivery_retry_timer_count() == 1
         assert cfg.DEFERRED_PROCESS_WAKEUPS == {}
         assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+    finally:
+        _reset_wakeup_state()
+
+
+def test_background_busy_legacy_completion_retries_until_session_is_idle(monkeypatch):
+    """A pre-durable core must not discard a completion after one busy retry."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_legacy_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+    busy = {"active": True}
+    accepted: list[tuple[str, str]] = []
+
+    def _accept(session_id, prompt, *, evt, claim, **_kwargs):
+        accepted.append((session_id, prompt))
+        bp._record_async_delegation_accepted(evt, session_id=session_id, claim=claim)
+
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: busy["active"])
+    monkeypatch.setattr(bp, "_start_async_delegation_wakeup_turn", _accept)
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    evt = _async_delegation_event()
+
+    try:
+        bp._process_one(evt)
+        first_retry = registry.completion_queue.get(timeout=1)
+        bp._process_one(first_retry)
+        second_retry = registry.completion_queue.get(timeout=1)
+
+        busy["active"] = False
+        bp._process_one(second_retry)
+
+        assert accepted and accepted[0][0] == "webui-session-1"
+        assert delivery == {"mark": ["deleg_test123"], "legacy": []}
+        assert registry.completion_queue.empty()
     finally:
         _reset_wakeup_state()
 


### PR DESCRIPTION
## Summary

- Keep a legacy async-delegation completion retryable while its already-resolved target session is actively running a turn.
- Preserve the durable-store restore sweep for current Agent cores.
- Preserve the existing one-shot compatibility retry for genuinely unresolvable or unmapped legacy events.
- Add a regression covering two busy backoff cycles followed by successful delivery when the session becomes idle.

## Why

#6632 correctly prevents a busy foreground turn from consuming the Agent core's finite durable-delivery claim budget. On a pre-durable Agent core, however, the shared retry helper falls back to one direct requeue marked as already attempted. If the target remains busy for longer than that one retry, the second busy pass consumes no claim but returns without requeueing, silently losing the completion.

A known busy target is a normal wait state, not a routing failure. The compatibility path must keep backing off until that known session can accept the completion.

## Validation

- RED on #6632 head: the second legacy busy pass left the completion queue empty.
- `tests/test_async_delegation_webui_bridge.py -q`: **37 passed** in 13.03s, using isolated state and Python 3.11.
- Targeted regression set: **3 passed**.
- `ruff check api/background_process.py tests/test_async_delegation_webui_bridge.py`: passed.
- `py_compile` and `git diff --check`: passed.
- Independent review: **ACCEPT**.

## Notes

This is a stacked follow-up to #6632 and intentionally targets its branch. Once #6632 merges, GitHub can retarget this small compatibility fix to `master` without reintroducing the root-fix diff.

## What this deliberately does NOT change

- It does **not** alter durable claim/ACK/release semantics or the finite attempt cap for genuine durable delivery attempts.
- It does **not** make unknown, unmapped, or malformed legacy events retry forever; their existing one-shot fallback remains bounded.
- It does **not** change Agent core code, persistence schema, or normal accepted-wakeup behavior.
- It does **not** replay historical dropped completions.

## Refs

- Depends on #6632 (`fix(async): preserve durable delivery attempts while sessions are busy`).
- Addresses the legacy-core busy-retry review finding on that PR.
