### PR TITLE
feat(i18n): apply document direction from locale metadata

### DIFF
--- a/docs/locale-direction.md
+++ b/docs/locale-direction.md
@@ -1,0 +1,15 @@
+# Locale direction metadata
+
+Hermes WebUI locale bundles may declare an optional `_dir` metadata field:
+
+```js
+_dir: 'rtl',
+```
+
+`setLocale()` applies the selected locale to the root document:
+
+- `lang` uses `_speech` when present, preserving the existing behavior.
+- `dir` uses `_dir` when present and otherwise explicitly restores `ltr`.
+- `data-locale` records the resolved locale key for locale-scoped styling and tests.
+
+Technical-content isolation and the Persian locale bundle are intentionally handled in a follow-up change so this infrastructure PR remains small and independently reviewable.

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -26124,6 +26124,8 @@ function setLocale(lang) {
   _locale = LOCALES[resolved];
   try { localStorage.setItem('hermes-lang', resolved); } catch (_) {}
   document.documentElement.lang = _locale._speech || resolved;
+  document.documentElement.dir = _locale._dir || 'ltr';
+  document.documentElement.dataset.locale = resolved;
 }
 
 /**

--- a/tests/test_locale_direction.py
+++ b/tests/test_locale_direction.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+I18N = ROOT / "static" / "i18n.js"
+
+
+def source() -> str:
+    return I18N.read_text(encoding="utf-8")
+
+
+def test_set_locale_applies_direction_metadata():
+    text = source()
+    assert "document.documentElement.dir = _locale._dir || 'ltr';" in text
+    assert "document.documentElement.dataset.locale = resolved;" in text
+
+
+def test_non_rtl_locales_explicitly_restore_ltr():
+    text = source()
+    assert "_locale._dir || 'ltr'" in text
+
+
+def test_direction_update_stays_in_set_locale():
+    text = source()
+    start = text.index("function setLocale(lang)")
+    end = text.index("function loadLocale()", start)
+    block = text[start:end]
+    assert "document.documentElement.dir" in block
+    assert "document.documentElement.dataset.locale" in block


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already centralizes locale switching in `setLocale()`.
- Right-to-left locale support should use locale metadata rather than a language-name allowlist.
- Direction must be restored explicitly when switching from a future RTL locale back to an existing LTR locale.
- This PR keeps the infrastructure independent from the much larger Persian translation review.

## What Changed

- `setLocale()` now applies optional locale `_dir` metadata to `<html dir>`.
- Locales without `_dir` explicitly restore `dir="ltr"`.
- The resolved locale key is exposed as `<html data-locale="…">` for locale-scoped styling and diagnostics.
- Added focused regression tests for direction application, LTR restoration, and placement inside the canonical locale-switch function.
- Added a short maintenance note describing the metadata contract.

## Why It Matters

This provides a small, reusable foundation for Persian and other RTL locales without hardcoding language codes or mixing a large translation bundle into the direction-state change.

## Verification

- `python -m pytest tests/test_locale_direction.py -q`
- `node --check static/i18n.js`
- `git diff --check`

## Scope / Follow-up

- No locale is added in this PR, so current users see no direction change.
- Persian translations, bidi-safe technical-content styling, and desktop/mobile screenshots will follow separately under #6664 after native-language review.

## Upstream

Refs #6664.

## Model Used

OpenAI GPT-5.6 Thinking. AI assisted with repository inspection, implementation drafting, and focused test design; the submitted diff remains small and directly reviewable.
