### PR TITLE
fix(webui): stamp gateway-mode wake rows durably and dedup completion rows at merge

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -44,7 +44,7 @@ from api.agent_sessions import (
     read_importable_agent_session_rows,
     read_session_lineage_metadata,
 )
-from api.process_event_utils import stamp_message_source
+from api.process_event_utils import attach_wakeup_display_meta, stamp_message_source
 
 logger = logging.getLogger(__name__)
 CLI_VISIBLE_SESSION_LIMIT = 20
@@ -8198,7 +8198,13 @@ def _project_state_db_message(row, available, id_col, optional):
         value = row[col]
         if value in (None, ''):
             continue
-        if col in {'tool_calls', 'reasoning_details', 'codex_reasoning_items', 'codex_message_items'}:
+        if col in {
+            'tool_calls',
+            'reasoning_details',
+            'codex_reasoning_items',
+            'codex_message_items',
+            'display_metadata',
+        }:
             value = _json_loads_if_string(value)
         msg[col] = value
     if (
@@ -8319,6 +8325,8 @@ def get_state_db_session_messages(
                 # sidecar in the WebUI's internal history; the provider-safe
                 # projection strips it before any direct API request.
                 'api_content',
+                'display_kind',
+                'display_metadata',
             ]
             id_col = ['id'] if 'id' in available else []
             revision_cols = []
@@ -8710,7 +8718,8 @@ def get_state_db_regeneration_tail_snapshot(
             optional = [
                 'tool_call_id', 'tool_calls', 'tool_name', 'reasoning',
                 'reasoning_details', 'codex_reasoning_items', 'reasoning_content',
-                'codex_message_items', 'api_content',
+                'codex_message_items', 'api_content', 'display_kind',
+                'display_metadata',
             ]
             tail_select = ['id', 'role', 'content', 'timestamp'] if 'id' in available else ['role', 'content', 'timestamp']
             for col in optional + (['active'] if 'active' in available else []):
@@ -8958,6 +8967,20 @@ def _session_messages_have_prefix(messages, prefix) -> bool:
     return True
 
 
+def _trusted_wakeup_delivery_id(message: dict | None) -> str:
+    """Return authoritative Agent wake identity, or fail closed."""
+    if (
+        not isinstance(message, dict)
+        or message.get("role") != "user"
+        or message.get("display_kind") != "process_wakeup"
+    ):
+        return ""
+    metadata = message.get("display_metadata")
+    if not isinstance(metadata, dict):
+        return ""
+    return str(metadata.get("delivery_id") or "").strip()
+
+
 _SESSION_MESSAGE_DISPLAY_METADATA_KEYS = (
     "_turnDuration",
     "_turnTps",
@@ -8995,6 +9018,21 @@ def _merge_session_display_metadata(target: dict | None, source: dict | None) ->
         value = source.get(key)
         if _message_display_metadata_value_present(value):
             target[key] = copy.deepcopy(value)
+
+    # Agent wake provenance is a trusted pair, not two independent display
+    # fields. Copy it atomically from the state.db row; combining one field from
+    # each store could manufacture apparently trusted provenance.
+    target_kind = target.get("display_kind")
+    target_metadata = target.get("display_metadata")
+    if (
+        _message_display_metadata_value_present(target_kind)
+        or _message_display_metadata_value_present(target_metadata)
+    ):
+        return
+    source_metadata = source.get("display_metadata")
+    if _trusted_wakeup_delivery_id(source):
+        target["display_kind"] = "process_wakeup"
+        target["display_metadata"] = copy.deepcopy(source_metadata)
 
 
 def _state_db_row_identity_details(message: dict | None) -> tuple[str | None, bool]:
@@ -9627,7 +9665,7 @@ def _session_message_dedup_key(msg: dict):
     # are never collapsed into one.  (#3346 regression)
     _tc = msg.get("tool_calls")
     _tc_key = json.dumps(_tc, sort_keys=True, default=str) if _tc else ""
-    return _session_message_key_with_sidecar((
+    key = (
         "legacy",
         str(msg.get("role") or ""),
         str(msg.get("content") or ""),
@@ -9635,7 +9673,11 @@ def _session_message_dedup_key(msg: dict):
         str(msg.get("tool_call_id") or ""),
         str(msg.get("tool_name") or msg.get("name") or ""),
         _tc_key,
-    ), msg)
+    )
+    wakeup_delivery_id = _trusted_wakeup_delivery_id(msg)
+    if wakeup_delivery_id:
+        key += ("process_wakeup_delivery", wakeup_delivery_id)
+    return _session_message_key_with_sidecar(key, msg)
 
 
 def _normalized_session_message_content(msg: dict) -> str:
@@ -10085,6 +10127,31 @@ def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
     return True
 
 
+def _normalize_wakeup_rows_for_display(messages):
+    """Project trusted gateway wake provenance and dedupe by delivery id.
+
+    ``display_kind`` and ``display_metadata`` are persisted by the agent at
+    turn start. Unlike message text, they are not user-controlled inference.
+    Rows without that durable provenance are deliberately left byte-identical.
+    """
+    if not isinstance(messages, list) or not messages:
+        return messages
+    seen_delivery_ids = set()
+    normalized = []
+    for msg in messages:
+        delivery_id = _trusted_wakeup_delivery_id(msg)
+        if not delivery_id:
+            normalized.append(msg)
+            continue
+        if delivery_id in seen_delivery_ids:
+            continue
+        seen_delivery_ids.add(delivery_id)
+        msg["_source"] = "process_wakeup"
+        attach_wakeup_display_meta(msg, "process_wakeup")
+        normalized.append(msg)
+    return normalized
+
+
 def merge_session_messages_append_only(
     sidecar_messages: list,
     state_messages: list,
@@ -10214,7 +10281,7 @@ def merge_session_messages_append_only(
 
     watermark_timestamp = _message_timestamp_as_float({"timestamp": truncation_watermark})
     if not state_messages:
-        return sidecar_messages
+        return _normalize_wakeup_rows_for_display(sidecar_messages)
     if not sidecar_messages:
         if watermark_timestamp is None:
             # No watermark — keep everything, just dedup.
@@ -10279,7 +10346,7 @@ def merge_session_messages_append_only(
                 deduped.append(msg)
             else:
                 _merge_session_display_metadata(seen_messages.get(key), msg)
-        return deduped
+        return _normalize_wakeup_rows_for_display(deduped)
 
     merged_messages = []
     seen_message_keys = set()
@@ -10296,8 +10363,14 @@ def merge_session_messages_append_only(
     merged_by_dedup_key = {}
     merged_by_visible_key = {}
     merged_by_row_id = {}
+    merged_by_wakeup_delivery_id = {}
     ambiguous_row_ids = set()
     max_sidecar_timestamp = None
+
+    def _remember_wakeup_delivery(message):
+        delivery_id = _trusted_wakeup_delivery_id(message)
+        if delivery_id:
+            merged_by_wakeup_delivery_id.setdefault(delivery_id, message)
 
     def _remember_merged_message(message, *, source: str):
         if not isinstance(message, dict):
@@ -10313,6 +10386,7 @@ def merge_session_messages_append_only(
                 ambiguous_row_ids.add(row_id)
             else:
                 merged_by_row_id[row_id] = message
+        _remember_wakeup_delivery(message)
 
     for msg in sidecar_messages:
         timestamp = _message_timestamp_as_float(msg)
@@ -10341,7 +10415,7 @@ def merge_session_messages_append_only(
         merged_messages.append(msg)
         _remember_merged_message(msg, source="sidecar")
     if _sidecar_has_terminal_partial_error(sidecar_messages):
-        return merged_messages
+        return _normalize_wakeup_rows_for_display(merged_messages)
     sidecar_visible_lookup = _build_visible_duplicate_lookup(sidecar_visible_keys)
     state_multimodal_mirror_keys = {}
     ambiguous_state_multimodal_mirrors = set()
@@ -10389,6 +10463,7 @@ def merge_session_messages_append_only(
         and boundary_ts < watermark_timestamp
     )
     for msg in state_messages:
+        wakeup_delivery_id = _trusted_wakeup_delivery_id(msg)
         timestamp = _message_timestamp_as_float(msg)
         key = _cached_message_key(msg, "merge")
         dedup_key = _cached_message_key(msg, "dedup")
@@ -10434,6 +10509,7 @@ def merge_session_messages_append_only(
                 state_replay_idx += 1
         if replays_sidecar_prefix:
             _merge_session_display_metadata(replay_target, msg)
+            _remember_wakeup_delivery(replay_target)
             matched_visible_key = _matching_visible_duplicate(
                 visible_key,
                 sidecar_visible_keys,
@@ -10454,12 +10530,18 @@ def merge_session_messages_append_only(
             if row_id_valid and row_id is not None
             else None
         )
+        existing_delivery_id = _trusted_wakeup_delivery_id(existing)
         if (
             row_id_valid
             and row_id is not None
             and existing is not None
             and row_id not in ambiguous_row_ids
             and _row_id_fast_path_allowed(existing, msg)
+            and not (
+                wakeup_delivery_id
+                and existing_delivery_id
+                and existing_delivery_id != wakeup_delivery_id
+            )
         ):
             existing_api_content = _session_message_api_content_key(existing)
             incoming_api_content = _session_message_api_content_key(msg)
@@ -10472,6 +10554,7 @@ def merge_session_messages_append_only(
                 if existing_api_content is None and incoming_api_content is not None:
                     _copy_api_content_sidecar(existing, msg)
                 _merge_session_display_metadata(existing, msg)
+                _remember_wakeup_delivery(existing)
                 continue
         # Skip rows ABOVE the watermark only while the sidecar has NOT advanced
         # past the watermark. Because Session.save() no longer auto-clears the
@@ -10551,6 +10634,22 @@ def merge_session_messages_append_only(
             and content_key not in seen_content_keys
             and str(msg.get("role", "")).lower() == "user"
         ):
+            continue
+        # Trusted Agent delivery identity outranks content/timestamp similarity.
+        # Once truncation guards have admitted the row, collapse only the same
+        # delivery id; a distinct delivery must survive even with identical text
+        # and timestamp.
+        if wakeup_delivery_id:
+            existing_wakeup = merged_by_wakeup_delivery_id.get(wakeup_delivery_id)
+            if existing_wakeup is not None:
+                _merge_session_display_metadata(existing_wakeup, msg)
+                continue
+            if _insert_state_message_chronologically(merged_messages, msg):
+                seen_message_keys.add(key)
+                seen_dedup_keys.add(dedup_key)
+                seen_content_keys.add(content_key)
+                seen_visible_keys.add(visible_key)
+                _remember_merged_message(msg, source="state")
             continue
         # Check for true duplicates using full-precision timestamp (#3346).
         # Must run before the merge-key guards so that legitimately distinct
@@ -10669,7 +10768,7 @@ def merge_session_messages_append_only(
         seen_visible_keys.add(visible_key)
         merged_messages.append(msg)
         _remember_merged_message(msg, source="state")
-    return merged_messages
+    return _normalize_wakeup_rows_for_display(merged_messages)
 
 
 @overload

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11261,6 +11261,8 @@ def _run_agent_streaming(
                                     task_id=session_id,
                                     persist_user_message=msg_text,
                                     persist_user_timestamp=getattr(s, 'pending_started_at', None),
+                                    persist_user_display_kind=_persist_user_display_kind,
+                                    persist_user_display_metadata=_persist_user_display_metadata,
                                 )
                                 if moa_config is not None:
                                     _heal_kwargs["moa_config"] = moa_config
@@ -12559,6 +12561,8 @@ def _run_agent_streaming(
                             task_id=session_id,
                             persist_user_message=msg_text,
                             persist_user_timestamp=getattr(s, 'pending_started_at', None),
+                            persist_user_display_kind=_persist_user_display_kind,
+                            persist_user_display_metadata=_persist_user_display_metadata,
                         )
                         if moa_config is not None:
                             _heal_kwargs2["moa_config"] = moa_config

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8321,6 +8321,8 @@ def _build_run_conversation_kwargs(
     task_id,
     persist_user_message,
     persist_user_timestamp,
+    persist_user_display_kind=None,
+    persist_user_display_metadata=None,
 ):
     """Build one rolling-compatible Agent invocation contract.
 
@@ -8347,7 +8349,35 @@ def _build_run_conversation_kwargs(
         "conversation_history_revision",
         conversation_history_revision,
     )
+    if persist_user_display_kind:
+        _add_supported_run_conversation_kwarg(
+            callable_obj,
+            kwargs,
+            "persist_user_display_kind",
+            persist_user_display_kind,
+        )
+        _add_supported_run_conversation_kwarg(
+            callable_obj,
+            kwargs,
+            "persist_user_display_metadata",
+            persist_user_display_metadata,
+        )
     return kwargs
+
+
+def _trusted_turn_display_persistence(source, delivery_id):
+    """Return durable projection metadata for a server-owned wakeup turn.
+
+    ``source`` comes from the route that admitted the turn, not from prompt
+    content. Browser chat starts always use ``webui``; the background-process
+    drain is the only producer of ``process_wakeup``. The accepted stream id is
+    therefore a unique delivery identity without parsing user-controlled text.
+    """
+    trusted_source = str(source or "").strip()
+    trusted_delivery_id = str(delivery_id or "").strip()
+    if trusted_source != "process_wakeup" or not trusted_delivery_id:
+        return None, None
+    return "process_wakeup", {"delivery_id": trusted_delivery_id}
 
 
 def _attempt_credential_self_heal(
@@ -10683,6 +10713,13 @@ def _run_agent_streaming(
                 _agent_msg_text = "\n\n".join([*_process_notifications, msg_text]).strip()
             user_message = _build_native_multimodal_message(workspace_ctx, _agent_msg_text, attachments, workspace, cfg=_cfg, active_provider=(resolved_provider or ""), active_model=(resolved_model or ""), requested_provider=(_session_requested_provider or ""))
             _persistent_state_before = _persistent_state_snapshot(_profile_home)
+            (
+                _persist_user_display_kind,
+                _persist_user_display_metadata,
+            ) = _trusted_turn_display_persistence(
+                _turn_pending_source,
+                stream_id,
+            )
             _run_conversation_kwargs = _build_run_conversation_kwargs(
                 agent.run_conversation,
                 user_message=user_message,
@@ -10699,6 +10736,8 @@ def _run_agent_streaming(
                 task_id=session_id,
                 persist_user_message=msg_text,
                 persist_user_timestamp=getattr(s, 'pending_started_at', None),
+                persist_user_display_kind=_persist_user_display_kind,
+                persist_user_display_metadata=_persist_user_display_metadata,
             )
             # Only pass moa_config when a /moa override is actually active, so a
             # normal send never trips a TypeError on an older hermes-agent whose

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 
 import api.models as models
+import api.streaming as streaming
 from api.models import (
     _normalize_wakeup_rows_for_display,
     merge_session_messages_append_only,
@@ -138,3 +139,87 @@ def test_non_gateway_rows_are_byte_identical():
 def test_empty_and_non_list_passthrough():
     assert _normalize_wakeup_rows_for_display([]) == []
     assert _normalize_wakeup_rows_for_display(None) is None
+
+
+def test_legacy_process_wakeup_turn_gets_durable_delivery_provenance():
+    kind, metadata = streaming._trusted_turn_display_persistence(
+        "process_wakeup",
+        "stream-123",
+    )
+
+    assert kind == "process_wakeup"
+    assert metadata == {"delivery_id": "stream-123"}
+
+
+def test_browser_turn_cannot_self_classify_as_process_wakeup():
+    assert streaming._trusted_turn_display_persistence(
+        "webui",
+        "stream-123",
+    ) == (None, None)
+
+
+def test_run_conversation_contract_forwards_supported_wakeup_provenance():
+    class ModernAgent:
+        def run_conversation(
+            self,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            persist_user_message,
+            persist_user_timestamp=None,
+            persist_user_display_kind=None,
+            persist_user_display_metadata=None,
+        ):
+            return None
+
+    kind, metadata = streaming._trusted_turn_display_persistence(
+        "process_wakeup",
+        "stream-123",
+    )
+    kwargs = streaming._build_run_conversation_kwargs(
+        ModernAgent().run_conversation,
+        user_message="model-facing prompt",
+        system_message="system",
+        conversation_history=[],
+        conversation_history_revision=None,
+        task_id="session-1",
+        persist_user_message=WAKE_TEXT,
+        persist_user_timestamp=1.0,
+        persist_user_display_kind=kind,
+        persist_user_display_metadata=metadata,
+    )
+
+    assert kwargs["persist_user_display_kind"] == "process_wakeup"
+    assert kwargs["persist_user_display_metadata"] == {
+        "delivery_id": "stream-123"
+    }
+
+
+def test_run_conversation_contract_omits_wakeup_fields_for_older_agent():
+    class LegacyAgent:
+        def run_conversation(
+            self,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            persist_user_message,
+        ):
+            return None
+
+    kwargs = streaming._build_run_conversation_kwargs(
+        LegacyAgent().run_conversation,
+        user_message="model-facing prompt",
+        system_message="system",
+        conversation_history=[],
+        conversation_history_revision=None,
+        task_id="session-1",
+        persist_user_message=WAKE_TEXT,
+        persist_user_timestamp=1.0,
+        persist_user_display_kind="process_wakeup",
+        persist_user_display_metadata={"delivery_id": "stream-123"},
+    )
+
+    assert "persist_user_display_kind" not in kwargs
+    assert "persist_user_display_metadata" not in kwargs

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -1,0 +1,140 @@
+"""Trusted gateway wake provenance projection and delivery-id dedup."""
+
+import json
+import sqlite3
+
+import api.models as models
+from api.models import (
+    _normalize_wakeup_rows_for_display,
+    merge_session_messages_append_only,
+)
+
+
+WAKE_TEXT = (
+    "[IMPORTANT: Background process proc_5b9fcce4cbff completed (exit_code=1).\n"
+    "Command: make test\nOutput:\nfailed]"
+)
+
+
+def _wake(delivery_id, **extra):
+    row = {
+        "role": "user",
+        "content": WAKE_TEXT,
+        "display_kind": "process_wakeup",
+        "display_metadata": {"delivery_id": delivery_id},
+    }
+    row.update(extra)
+    return row
+
+
+def test_state_db_reader_preserves_durable_wakeup_provenance(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE messages ("
+            "session_id TEXT, role TEXT, content TEXT, timestamp REAL, "
+            "display_kind TEXT, display_metadata TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "session-1",
+                "user",
+                WAKE_TEXT,
+                1,
+                "process_wakeup",
+                json.dumps({"delivery_id": "delivery-1"}),
+            ),
+        )
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+
+    assert models.get_state_db_session_messages("session-1") == [
+        _wake("delivery-1", timestamp=1.0)
+    ]
+
+
+def test_trusted_wakeup_is_stamped_and_gets_display_metadata():
+    row = _wake("delivery-1")
+    assert _normalize_wakeup_rows_for_display([row]) == [row]
+    assert row["_source"] == "process_wakeup"
+    assert row["_wakeup_meta"]["task_id"] == "proc_5b9fcce4cbff"
+
+
+def test_merge_deduplicates_only_the_same_delivery_id():
+    first = _wake("delivery-1", timestamp=1)
+    twin = _wake("delivery-1", timestamp=2)
+    assert merge_session_messages_append_only([], [first, twin]) == [first]
+
+
+def test_merge_projects_trusted_state_provenance_onto_sidecar_row():
+    sidecar = {"role": "user", "content": WAKE_TEXT, "timestamp": 1}
+    state = _wake("delivery-1", timestamp=1)
+    distinct = _wake("delivery-2", timestamp=1)
+
+    assert merge_session_messages_append_only([sidecar], [state, distinct]) == [
+        sidecar,
+        distinct,
+    ]
+    assert sidecar["display_kind"] == "process_wakeup"
+    assert sidecar["display_metadata"] == {"delivery_id": "delivery-1"}
+    assert sidecar["_source"] == "process_wakeup"
+    assert distinct["_source"] == "process_wakeup"
+
+
+def test_merge_never_combines_partial_provenance_into_trusted_pair():
+    sidecar = {
+        "role": "user",
+        "content": WAKE_TEXT,
+        "timestamp": 1,
+        "display_kind": "process_wakeup",
+    }
+    before = dict(sidecar)
+    state = _wake("delivery-1", timestamp=1)
+
+    assert merge_session_messages_append_only([sidecar], [state]) == [sidecar]
+    assert sidecar == before
+
+
+def test_distinct_delivery_ids_never_deduplicate_even_with_identical_text():
+    first = _wake("delivery-1", timestamp=1)
+    second = _wake("delivery-2", timestamp=1)
+    assert merge_session_messages_append_only([], [first, second]) == [first, second]
+
+
+def test_user_typed_wakeup_shape_stays_byte_identical():
+    row = {"role": "user", "content": WAKE_TEXT, "timestamp": 1}
+    before = dict(row)
+    assert _normalize_wakeup_rows_for_display([row]) == [row]
+    assert row == before
+
+
+def test_untrusted_or_incomplete_provenance_stays_byte_identical():
+    rows = [
+        _wake("", timestamp=1),
+        {"role": "user", "content": WAKE_TEXT, "display_kind": "process_wakeup"},
+        {
+            "role": "user",
+            "content": WAKE_TEXT,
+            "display_kind": "other",
+            "display_metadata": {"delivery_id": "delivery-1"},
+        },
+    ]
+    before = [dict(row) for row in rows]
+    assert _normalize_wakeup_rows_for_display(rows) == rows
+    assert rows == before
+
+
+def test_non_gateway_rows_are_byte_identical():
+    rows = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "tool", "content": {"not": "coerced"}},
+    ]
+    before = [dict(row) for row in rows]
+    assert _normalize_wakeup_rows_for_display(rows) == rows
+    assert rows == before
+
+
+def test_empty_and_non_list_passthrough():
+    assert _normalize_wakeup_rows_for_display([]) == []
+    assert _normalize_wakeup_rows_for_display(None) is None

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -1,7 +1,10 @@
 """Trusted gateway wake provenance projection and delivery-id dedup."""
 
+import ast
+import inspect
 import json
 import sqlite3
+import textwrap
 
 import api.models as models
 import api.streaming as streaming
@@ -223,3 +226,22 @@ def test_run_conversation_contract_omits_wakeup_fields_for_older_agent():
 
     assert "persist_user_display_kind" not in kwargs
     assert "persist_user_display_metadata" not in kwargs
+
+
+def test_all_run_conversation_retries_forward_wakeup_provenance():
+    """Credential self-heal retries must keep the original turn authority."""
+    source = textwrap.dedent(inspect.getsource(streaming._run_agent_streaming))
+    tree = ast.parse(source)
+    builders = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_build_run_conversation_kwargs"
+    ]
+
+    assert len(builders) == 3
+    for call in builders:
+        keyword_names = {keyword.arg for keyword in call.keywords}
+        assert "persist_user_display_kind" in keyword_names
+        assert "persist_user_display_metadata" in keyword_names

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -57,6 +57,37 @@ def test_state_db_reader_preserves_durable_wakeup_provenance(tmp_path, monkeypat
     ]
 
 
+def test_regeneration_tail_snapshot_preserves_durable_wakeup_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    """The bounded reader must match the canonical state.db projection."""
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE messages ("
+            "session_id TEXT, role TEXT, content TEXT, timestamp REAL, "
+            "display_kind TEXT, display_metadata TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "session-1",
+                "user",
+                WAKE_TEXT,
+                1,
+                "process_wakeup",
+                json.dumps({"delivery_id": "delivery-1"}),
+            ),
+        )
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+
+    snapshot = models.get_state_db_regeneration_tail_snapshot("session-1", 0)
+
+    assert snapshot is not None
+    assert snapshot["tail"] == [_wake("delivery-1", timestamp=1.0)]
+
+
 def test_trusted_wakeup_is_stamped_and_gets_display_metadata():
     row = _wake("delivery-1")
     assert _normalize_wakeup_rows_for_display([row]) == [row]


### PR DESCRIPTION
## Summary

- Preserve agent-owned `display_kind` / `display_metadata` on state-db transcript rows.
- Persist `display_kind="process_wakeup"` plus the accepted WebUI `stream_id` as `delivery_id` for legacy WebUI-owned background wake turns.
- Project only that trusted provenance to `_source="process_wakeup"` and deduplicate by `delivery_id`.
- Keep browser-authored wake-shaped text byte-identical; ordinary `/api/chat/start` requests cannot self-classify as internal events.
- Gate the new Agent kwargs by runtime signature so older Agent builds keep the previous call contract.
- Preserve the same wake provenance across both credential self-heal retry paths.

## Why

Background-process completion turns can be merged back from `state.db` after reload or context compression. The legacy WebUI backend knew those turns were server-owned but did not pass that provenance into Agent persistence, so they could later reappear as messages sent by the user. Text-shape inference is unsafe and also failed for multi-line commands.

This change carries authority at turn start instead: the WebUI already owns the `process_wakeup` source and every accepted turn has a unique stream identity.

## Tests

- `15 passed` in `tests/test_wakeup_source_backstop.py`, including trusted producer kwargs, both credential self-heal retry call sites, legacy-Agent compatibility, durable state-db provenance, delivery-id deduplication, and user-text non-classification.
- `72 passed` across compression-snapshot revision and provider-auth terminal self-heal coverage.
- `178 passed` on the integrated site stack across wakeup rendering, recovery, deferred delivery, cross-session routing, state-row identity/order, sidecarless projection, and compression paths; the mutation-route regression also passes in a standalone clone.
- `scripts/ruff_lint.py --diff origin/master`: no new violations.
