### PR TITLE
feat(worktrees): add fail-closed audit-only cleanup analysis

### DIFF
--- a/api/worktree_gc_git.py
+++ b/api/worktree_gc_git.py
@@ -1,0 +1,647 @@
+"""Fail-closed Git primitives for auditing linked worktrees.
+
+This module deliberately has no dependency on WebUI sessions or models.  Its
+inputs are the Git identities needed to prove whether a linked worktree can be
+considered inactive without inspecting file contents.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+KEEP_DIRTY = "KEEP_DIRTY"
+KEEP_IGNORED_FILES = "KEEP_IGNORED_FILES"
+KEEP_STALE_METADATA = "KEEP_STALE_METADATA"
+KEEP_UNIQUE_COMMITS = "KEEP_UNIQUE_COMMITS"
+KEEP_UNCERTAIN = "KEEP_UNCERTAIN"
+REMOVE_ANCESTOR = "REMOVE_ANCESTOR"
+REMOVE_PATCH_EQUIVALENT_KEEP_BRANCH = "REMOVE_PATCH_EQUIVALENT_KEEP_BRANCH"
+
+GIT_TIMEOUT = 10
+IGNORED_OUTPUT_LIMIT = 1024 * 1024
+IGNORED_ENTRY_LIMIT = 10_000
+_IGNORED_FILES_ARGS = (
+    "ls-files",
+    "--others",
+    "--ignored",
+    "--exclude-standard",
+    "-z",
+)
+
+_GIT_ENV_KEYS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_SHALLOW_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_ASKPASS",
+    "SSH_ASKPASS",
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+)
+_GIT_ENV_PREFIXES = ("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")
+_GIT_CONFIG = (
+    ("core.fsmonitor", "false"),
+    ("core.sshCommand", "ssh"),
+    ("core.askPass", ""),
+    ("credential.helper", ""),
+    ("protocol.ext.allow", "never"),
+    ("core.gitProxy", ""),
+    ("submodule.recurse", "false"),
+    ("fetch.recurseSubmodules", "false"),
+)
+
+
+@dataclass(frozen=True)
+class GitWorktreeDecision:
+    path: str
+    branch: str | None
+    repo_root: str
+    target_ref: str
+    verdict: str
+    eligible: bool
+    exists: bool | None
+    listed: bool | None
+    dirty: bool | None
+    untracked_count: int | None
+    ignored_count: int | None
+    ancestor_of_target: bool | None
+    cherry_unique_count: int | None
+    reasons: tuple[str, ...]
+
+
+class _GitInvocationError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _clean_git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in _GIT_ENV_KEYS:
+        env.pop(key, None)
+    for key in tuple(env):
+        if key.startswith(_GIT_ENV_PREFIXES):
+            env.pop(key, None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    return env
+
+
+def _git_argv(args: list[str], hooks_path: str) -> list[str]:
+    argv = ["git", "--no-replace-objects"]
+    for key, value in _GIT_CONFIG:
+        argv.extend(["-c", f"{key}={value}"])
+    argv.extend(["-c", f"core.hooksPath={hooks_path}"])
+    argv.extend(args)
+    return argv
+
+
+def _read_only_git_args(args: list[str]) -> bool:
+    command = tuple(args)
+    if command in {
+        ("rev-parse", "--show-toplevel"),
+        ("worktree", "list", "--porcelain"),
+        ("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        _IGNORED_FILES_ARGS,
+    }:
+        return True
+    if (
+        len(command) == 5
+        and command[:4]
+        == (
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+        )
+    ):
+        return True
+    if len(command) == 3 and command[:2] == ("check-ref-format", "--branch"):
+        return True
+    if len(command) == 4 and command[:2] == ("merge-base", "--is-ancestor"):
+        return True
+    if (
+        len(command) == 4
+        and command[:3] == ("show-ref", "--verify", "--quiet")
+    ):
+        return True
+    return len(command) == 3 and command[0] == "cherry"
+
+
+def _run_git(
+    args: list[str],
+    cwd: str | Path,
+    *,
+    timeout: float = GIT_TIMEOUT,
+) -> subprocess.CompletedProcess[bytes]:
+    if not _read_only_git_args(args):
+        raise _GitInvocationError("git_command_not_allowed")
+    hooks_path: str | None = None
+    try:
+        hooks_path = tempfile.mkdtemp(prefix="hermes-webui-worktree-git-hooks-")
+        argv = _git_argv(args, hooks_path)
+        if tuple(args) == _IGNORED_FILES_ARGS:
+            with tempfile.TemporaryFile() as stdout:
+                result = subprocess.run(
+                    argv,
+                    cwd=str(cwd),
+                    shell=False,
+                    stdout=stdout,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=timeout,
+                    env=_clean_git_env(),
+                )
+                stdout.seek(0)
+                bounded_stdout = stdout.read(IGNORED_OUTPUT_LIMIT + 1)
+            return subprocess.CompletedProcess(
+                result.args,
+                result.returncode,
+                bounded_stdout,
+                b"",
+            )
+        return subprocess.run(
+            argv,
+            cwd=str(cwd),
+            shell=False,
+            capture_output=True,
+            text=False,
+            check=False,
+            timeout=timeout,
+            env=_clean_git_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _GitInvocationError("git_timeout") from exc
+    except FileNotFoundError as exc:
+        raise _GitInvocationError("git_missing") from exc
+    except OSError as exc:
+        raise _GitInvocationError("git_invocation_failed") from exc
+    finally:
+        if hooks_path:
+            try:
+                os.rmdir(hooks_path)
+            except OSError:
+                pass
+
+
+def _input_text(value: object) -> str:
+    try:
+        return os.fsdecode(os.fspath(value))  # type: ignore[arg-type]
+    except TypeError:
+        return "" if value is None else str(value)
+
+
+def _resolved_path(value: object) -> Path:
+    return Path(_input_text(value)).expanduser().resolve(strict=False)
+
+
+def _decode_path(value: bytes) -> Path:
+    return Path(os.fsdecode(value)).expanduser().resolve(strict=False)
+
+
+def _valid_ref_input(value: str) -> bool:
+    return bool(value) and not value.startswith("-") and "\0" not in value and "\n" not in value
+
+
+def _verify_repo_root(repo_root: Path) -> str | None:
+    if not repo_root.is_dir():
+        return "repo_root_missing"
+    try:
+        result = _run_git(["rev-parse", "--show-toplevel"], repo_root)
+    except _GitInvocationError as exc:
+        return exc.code
+    if result.returncode != 0 or not result.stdout:
+        return "repo_root_invalid"
+    try:
+        discovered = _decode_path(result.stdout.rstrip(b"\r\n"))
+    except (OSError, RuntimeError, ValueError):
+        return "repo_root_unparseable"
+    if discovered != repo_root:
+        return "repo_root_mismatch"
+    return None
+
+
+def _verify_target(repo_root: Path, target_ref: str) -> str | None:
+    if not _valid_ref_input(target_ref):
+        return "target_ref_invalid"
+    try:
+        result = _run_git(
+            [
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "--end-of-options",
+                f"{target_ref}^{{commit}}",
+            ],
+            repo_root,
+        )
+    except _GitInvocationError as exc:
+        return exc.code
+    if result.returncode != 0 or not result.stdout.strip():
+        return "target_ref_missing"
+    return None
+
+
+def _local_branch_ref(branch: str | None) -> tuple[str | None, str | None]:
+    if branch is None or not _valid_ref_input(branch):
+        return None, "branch_invalid"
+    return f"refs/heads/{branch}", None
+
+
+def _verify_branch(repo_root: Path, branch: str | None) -> tuple[str | None, str | None]:
+    branch_ref, error = _local_branch_ref(branch)
+    if error:
+        return None, error
+    assert branch_ref is not None
+    try:
+        valid_name = _run_git(["check-ref-format", "--branch", branch], repo_root)
+        if valid_name.returncode != 0:
+            return None, "branch_invalid"
+        exists = _run_git(
+            ["show-ref", "--verify", "--quiet", branch_ref],
+            repo_root,
+        )
+    except _GitInvocationError as exc:
+        return None, exc.code
+    if exists.returncode != 0:
+        return None, "branch_missing"
+    return branch_ref, None
+
+
+def _parse_worktree_list(output: bytes) -> list[tuple[Path, str | None]]:
+    records: list[tuple[Path, str | None]] = []
+    path: Path | None = None
+    branch_ref: str | None = None
+    branch_kind_seen = False
+
+    def finish_record() -> None:
+        nonlocal path, branch_ref, branch_kind_seen
+        if path is None or not branch_kind_seen:
+            raise ValueError("incomplete worktree record")
+        records.append((path, branch_ref))
+        path = None
+        branch_ref = None
+        branch_kind_seen = False
+
+    if not output:
+        raise ValueError("empty worktree list")
+    for raw_line in output.splitlines():
+        if not raw_line:
+            if path is not None:
+                finish_record()
+            continue
+        if raw_line.startswith(b"worktree "):
+            if path is not None:
+                raise ValueError("unterminated worktree record")
+            raw_path = raw_line[len(b"worktree ") :]
+            if not raw_path:
+                raise ValueError("empty worktree path")
+            path = _decode_path(raw_path)
+            continue
+        if path is None:
+            raise ValueError("field outside worktree record")
+        if raw_line.startswith(b"HEAD "):
+            head = raw_line[len(b"HEAD ") :]
+            if not head or any(char not in b"0123456789abcdefABCDEF" for char in head):
+                raise ValueError("invalid worktree head")
+        elif raw_line.startswith(b"branch "):
+            if branch_kind_seen:
+                raise ValueError("duplicate worktree branch kind")
+            raw_branch = raw_line[len(b"branch ") :]
+            if not raw_branch:
+                raise ValueError("empty worktree branch")
+            branch_ref = os.fsdecode(raw_branch)
+            branch_kind_seen = True
+        elif raw_line in {b"detached", b"bare"}:
+            if branch_kind_seen:
+                raise ValueError("duplicate worktree branch kind")
+            branch_kind_seen = True
+        elif raw_line == b"locked" or raw_line.startswith(b"locked "):
+            continue
+        elif raw_line == b"prunable" or raw_line.startswith(b"prunable "):
+            continue
+        else:
+            raise ValueError("unknown worktree field")
+    if path is not None:
+        finish_record()
+    if not records:
+        raise ValueError("no worktree records")
+    return records
+
+
+def _worktree_record(
+    repo_root: Path,
+    worktree_path: Path,
+) -> tuple[bool | None, str | None, str | None]:
+    try:
+        result = _run_git(["worktree", "list", "--porcelain"], repo_root)
+    except _GitInvocationError as exc:
+        return None, None, exc.code
+    if result.returncode != 0:
+        return None, None, "worktree_list_failed"
+    try:
+        matches = [
+            branch_ref
+            for listed_path, branch_ref in _parse_worktree_list(result.stdout)
+            if listed_path == worktree_path
+        ]
+    except (OSError, RuntimeError, UnicodeError, ValueError):
+        return None, None, "worktree_list_unparseable"
+    if len(matches) > 1:
+        return None, None, "worktree_list_ambiguous"
+    if not matches:
+        return False, None, None
+    return True, matches[0], None
+
+
+def _parse_status_porcelain(output: bytes) -> tuple[bool, int]:
+    if not output:
+        return False, 0
+    if not output.endswith(b"\0"):
+        raise ValueError("status output is not NUL terminated")
+    fields = output.split(b"\0")[:-1]
+    untracked_count = 0
+    index = 0
+    allowed = b" MADRCUT?!"
+    while index < len(fields):
+        entry = fields[index]
+        if len(entry) < 4 or entry[2:3] != b" " or not entry[3:]:
+            raise ValueError("invalid status entry")
+        status = entry[:2]
+        if status[0] not in allowed or status[1] not in allowed:
+            raise ValueError("invalid status code")
+        if status in {b"??", b"!!"}:
+            if status == b"??":
+                untracked_count += 1
+        elif status == b"  " or b"?" in status or b"!" in status:
+            raise ValueError("invalid ordinary status code")
+        if status[0:1] in {b"R", b"C"} or status[1:2] in {b"R", b"C"}:
+            index += 1
+            if index >= len(fields) or not fields[index]:
+                raise ValueError("rename/copy source missing")
+        index += 1
+    return True, untracked_count
+
+
+def _status(repo_path: Path) -> tuple[bool | None, int | None, str | None]:
+    try:
+        result = _run_git(
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            repo_path,
+        )
+    except _GitInvocationError as exc:
+        return None, None, exc.code
+    if result.returncode != 0:
+        return None, None, "status_failed"
+    try:
+        dirty, untracked_count = _parse_status_porcelain(result.stdout)
+    except ValueError:
+        return None, None, "status_unparseable"
+    return dirty, untracked_count, None
+
+
+def _parse_ignored_paths(output: bytes) -> int:
+    if not output:
+        return 0
+    if len(output) > IGNORED_OUTPUT_LIMIT or not output.endswith(b"\0"):
+        raise ValueError("ignored-file output is invalid")
+    fields = output[:-1].split(b"\0")
+    if (
+        not fields
+        or any(not field for field in fields)
+        or len(fields) > IGNORED_ENTRY_LIMIT
+    ):
+        raise ValueError("ignored-file output is invalid")
+    return len(fields)
+
+
+def _ignored_files(repo_path: Path) -> tuple[int | None, str | None]:
+    try:
+        result = _run_git(list(_IGNORED_FILES_ARGS), repo_path)
+    except _GitInvocationError as exc:
+        return None, exc.code
+    if result.returncode != 0:
+        return None, "ignored_files_failed"
+    try:
+        return _parse_ignored_paths(result.stdout), None
+    except ValueError:
+        return None, "ignored_files_unparseable"
+
+
+def _decision(
+    *,
+    path: str,
+    branch: str | None,
+    repo_root: str,
+    target_ref: str,
+    verdict: str,
+    eligible: bool = False,
+    exists: bool | None = None,
+    listed: bool | None = None,
+    dirty: bool | None = None,
+    untracked_count: int | None = None,
+    ignored_count: int | None = None,
+    ancestor_of_target: bool | None = None,
+    cherry_unique_count: int | None = None,
+    reasons: tuple[str, ...],
+) -> GitWorktreeDecision:
+    return GitWorktreeDecision(
+        path=path,
+        branch=branch,
+        repo_root=repo_root,
+        target_ref=target_ref,
+        verdict=verdict,
+        eligible=eligible,
+        exists=exists,
+        listed=listed,
+        dirty=dirty,
+        untracked_count=untracked_count,
+        ignored_count=ignored_count,
+        ancestor_of_target=ancestor_of_target,
+        cherry_unique_count=cherry_unique_count,
+        reasons=reasons,
+    )
+
+
+def classify_git_worktree(
+    path,
+    branch,
+    repo_root,
+    *,
+    target_ref: str = "origin/master",
+) -> GitWorktreeDecision:
+    """Return a conservative decision based only on current Git evidence."""
+    raw_path = _input_text(path)
+    raw_repo_root = _input_text(repo_root)
+    branch_name = None if branch is None else str(branch)
+    target_name = str(target_ref or "")
+    if not raw_path:
+        return _decision(
+            path=raw_path,
+            branch=branch_name,
+            repo_root=raw_repo_root,
+            target_ref=target_name,
+            verdict=KEEP_UNCERTAIN,
+            reasons=("path_input_invalid",),
+        )
+    if not raw_repo_root:
+        return _decision(
+            path=raw_path,
+            branch=branch_name,
+            repo_root=raw_repo_root,
+            target_ref=target_name,
+            verdict=KEEP_UNCERTAIN,
+            reasons=("repo_root_input_invalid",),
+        )
+    try:
+        worktree_path = _resolved_path(raw_path)
+        repo_path = _resolved_path(raw_repo_root)
+    except (OSError, RuntimeError, ValueError):
+        return _decision(
+            path=raw_path,
+            branch=branch_name,
+            repo_root=raw_repo_root,
+            target_ref=target_name,
+            verdict=KEEP_UNCERTAIN,
+            reasons=("path_input_invalid",),
+        )
+
+    audit = {
+        "path": str(worktree_path),
+        "branch": branch_name,
+        "repo_root": str(repo_path),
+        "target_ref": target_name,
+        "exists": worktree_path.exists(),
+        "listed": None,
+        "dirty": None,
+        "untracked_count": None,
+        "ignored_count": None,
+        "ancestor_of_target": None,
+        "cherry_unique_count": None,
+    }
+
+    def result(verdict: str, *reasons: str, eligible: bool = False) -> GitWorktreeDecision:
+        return _decision(
+            **audit,
+            verdict=verdict,
+            eligible=eligible,
+            reasons=tuple(reasons),
+        )
+
+    repo_error = _verify_repo_root(repo_path)
+    if repo_error:
+        return result(KEEP_UNCERTAIN, repo_error)
+
+    listed, listed_branch, list_error = _worktree_record(repo_path, worktree_path)
+    audit["listed"] = listed
+    if list_error:
+        return result(KEEP_UNCERTAIN, list_error)
+
+    target_error = _verify_target(repo_path, target_name)
+    if target_error:
+        return result(KEEP_UNCERTAIN, target_error)
+
+    branch_ref, branch_error = _verify_branch(repo_path, branch_name)
+    if branch_error:
+        return result(KEEP_UNCERTAIN, branch_error)
+    assert branch_ref is not None
+
+    if listed and listed_branch != branch_ref:
+        return result(KEEP_UNCERTAIN, "worktree_branch_mismatch")
+    if audit["exists"] is False:
+        if listed:
+            return result(KEEP_STALE_METADATA, "worktree_metadata_stale")
+        return result(KEEP_UNCERTAIN, "worktree_path_absent")
+    if not worktree_path.is_dir():
+        return result(KEEP_UNCERTAIN, "worktree_path_not_directory")
+    if not listed:
+        return result(KEEP_UNCERTAIN, "worktree_not_listed")
+
+    dirty, untracked_count, status_error = _status(worktree_path)
+    audit["dirty"] = dirty
+    audit["untracked_count"] = untracked_count
+    if status_error:
+        return result(KEEP_UNCERTAIN, status_error)
+
+    ignored_count, ignored_error = _ignored_files(worktree_path)
+    audit["ignored_count"] = ignored_count
+    if ignored_error:
+        return result(KEEP_UNCERTAIN, ignored_error)
+    if dirty:
+        reasons = ["dirty_worktree"]
+        if untracked_count:
+            reasons.append("untracked_files_present")
+        if ignored_count:
+            reasons.append("ignored_files_present")
+        return result(KEEP_DIRTY, *reasons)
+    if ignored_count:
+        return result(KEEP_IGNORED_FILES, "ignored_files_present")
+
+    try:
+        ancestor = _run_git(
+            ["merge-base", "--is-ancestor", branch_ref, target_name],
+            repo_path,
+        )
+    except _GitInvocationError as exc:
+        return result(KEEP_UNCERTAIN, exc.code)
+    if ancestor.returncode == 0:
+        audit["ancestor_of_target"] = True
+        return result(
+            REMOVE_ANCESTOR,
+            "branch_is_ancestor_of_target",
+            eligible=True,
+        )
+    if ancestor.returncode != 1:
+        return result(KEEP_UNCERTAIN, "ancestor_check_failed")
+    audit["ancestor_of_target"] = False
+
+    try:
+        cherry = _run_git(
+            ["cherry", target_name, branch_ref],
+            repo_path,
+        )
+    except _GitInvocationError as exc:
+        return result(KEEP_UNCERTAIN, exc.code)
+    if cherry.returncode != 0:
+        return result(KEEP_UNCERTAIN, "cherry_failed")
+    lines = [line for line in cherry.stdout.splitlines() if line]
+    if not lines:
+        return result(KEEP_UNCERTAIN, "cherry_empty")
+    signs: list[bytes] = []
+    for line in lines:
+        parts = line.split()
+        if (
+            len(parts) != 2
+            or parts[0] not in {b"+", b"-"}
+            or not parts[1]
+            or any(char not in b"0123456789abcdefABCDEF" for char in parts[1])
+        ):
+            return result(KEEP_UNCERTAIN, "cherry_unparseable")
+        signs.append(parts[0])
+    unique_count = signs.count(b"+")
+    audit["cherry_unique_count"] = unique_count
+    if unique_count:
+        return result(KEEP_UNIQUE_COMMITS, "unique_commits_present")
+    if all(sign == b"-" for sign in signs):
+        return result(
+            REMOVE_PATCH_EQUIVALENT_KEEP_BRANCH,
+            "all_branch_commits_patch_equivalent",
+            eligible=True,
+        )
+    return result(KEEP_UNCERTAIN, "cherry_unparseable")

--- a/api/worktree_gc_inventory.py
+++ b/api/worktree_gc_inventory.py
@@ -574,7 +574,12 @@ def _scan_managed_worktree_sessions(
     try:
         paths = sorted(sessions_dir.iterdir(), key=lambda path: path.name)
     except FileNotFoundError:
-        return _SessionScan((), (), 0, ())
+        return _SessionScan(
+            (),
+            (),
+            0,
+            ("session_directory_missing",),
+        )
     except OSError as exc:
         return _SessionScan(
             (),

--- a/api/worktree_gc_inventory.py
+++ b/api/worktree_gc_inventory.py
@@ -1,0 +1,1038 @@
+"""Fail-closed inventory for WebUI-managed Git worktrees."""
+
+from __future__ import annotations
+
+import errno
+import json
+import math
+import os
+import tempfile
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib import request
+
+
+_DAY_SECONDS = 24 * 60 * 60
+_GIT_REPORT_FIELDS = (
+    "path",
+    "branch",
+    "repo_root",
+    "target_ref",
+    "verdict",
+    "eligible",
+    "exists",
+    "listed",
+    "dirty",
+    "untracked_count",
+    "ignored_count",
+    "ancestor_of_target",
+    "cherry_unique_count",
+    "reasons",
+)
+
+
+@dataclass(frozen=True)
+class ProcessCwd:
+    pid: int
+    cwd: str
+
+
+@dataclass(frozen=True)
+class ProcessScan:
+    available: bool
+    complete: bool
+    process_cwds: tuple[ProcessCwd, ...]
+    unreadable_count: int = 0
+    disappeared_count: int = 0
+    error: str | None = None
+
+    @property
+    def process_count(self) -> int:
+        return len(self.process_cwds)
+
+    @property
+    def cwds(self) -> tuple[str, ...]:
+        return tuple(item.cwd for item in self.process_cwds)
+
+    def blocking_process_count(self, worktree_path: str | Path) -> int:
+        worktree = _canonical_path(worktree_path)
+        if worktree is None:
+            return 0
+        return sum(
+            1
+            for process in self.process_cwds
+            if _path_is_within(Path(process.cwd), worktree)
+        )
+
+    def blocking_process_counts(
+        self, worktree_paths: tuple[str | Path, ...]
+    ) -> dict[str, int]:
+        """Count blocking CWDs for many worktrees without a paths × CWDs scan."""
+        counts: dict[str, int] = {}
+        for raw_path in worktree_paths:
+            worktree = _canonical_path(raw_path)
+            if worktree is not None:
+                counts[str(worktree)] = 0
+        for process in self.process_cwds:
+            cwd = _canonical_path(process.cwd)
+            if cwd is None:
+                continue
+            for ancestor in (cwd, *cwd.parents):
+                key = str(ancestor)
+                if key in counts:
+                    counts[key] += 1
+        return counts
+
+
+@dataclass(frozen=True)
+class HealthProbe:
+    reachable: bool
+    active_runs: int | None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ManagedWorktreeCandidate:
+    session_id: str
+    session_ids: tuple[str, ...]
+    profile: str
+    worktree_path: str | None
+    worktree_branch: str | None
+    worktree_repo_root: str | None
+    worktree_created_at: Any
+    updated_at: Any
+    archived: bool
+    has_active_stream: bool
+    has_pending_user_message: bool
+    has_pending_attachments: bool
+    has_pending_started_at: bool
+    linked_session_latest_updated_at: float | None = None
+    linked_session_age_uncertain: bool = False
+    uncertainty_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorktreeGcDecision:
+    session_id: str
+    session_ids: tuple[str, ...]
+    profile: str
+    worktree_path: str | None
+    worktree_branch: str | None
+    worktree_repo_root: str | None
+    worktree_created_at: float | None
+    age_days: float | None
+    age_source: str | None
+    verdict: str
+    eligible: bool
+    reasons: tuple[str, ...]
+    git: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class _SessionScan:
+    candidates: tuple[ManagedWorktreeCandidate, ...]
+    workspace_sessions: tuple[_WorkspaceSession, ...]
+    sidecars_scanned: int
+    errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _WorkspaceSession:
+    session_id: str
+    workspace: str
+    updated_at: float | None
+    archived: bool
+    has_active_stream: bool
+    has_pending_user_message: bool
+    has_pending_attachments: bool
+    has_pending_started_at: bool
+
+
+def _canonical_path(value: str | os.PathLike[str] | None) -> Path | None:
+    if value is None:
+        return None
+    try:
+        path = Path(value).expanduser()
+    except (TypeError, ValueError, OSError):
+        return None
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+
+
+def _canonical_absolute_path(value: Any) -> Path | None:
+    if not isinstance(value, (str, os.PathLike)):
+        return None
+    try:
+        path = Path(value).expanduser()
+    except (TypeError, ValueError, OSError):
+        return None
+    if not path.is_absolute() or "\x00" in str(path):
+        return None
+    resolved = _canonical_path(path)
+    if resolved is None or resolved == Path(resolved.anchor):
+        return None
+    return resolved
+
+
+def _canonical_repo_filter(value: Any) -> Path | None:
+    if not isinstance(value, (str, os.PathLike)):
+        return None
+    try:
+        raw = os.fspath(value)
+    except TypeError:
+        return None
+    if not raw or "\x00" in str(raw):
+        return None
+    resolved = _canonical_path(value)
+    if resolved is None or resolved == Path(resolved.anchor):
+        return None
+    return resolved
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    canonical_path = _canonical_path(path)
+    canonical_parent = _canonical_path(parent)
+    if canonical_path is None or canonical_parent is None:
+        return False
+    try:
+        canonical_path.relative_to(canonical_parent)
+    except ValueError:
+        return False
+    return True
+
+
+def scan_process_cwds(proc_root: Path = Path("/proc")) -> ProcessScan:
+    """Snapshot readable ``/proc/<pid>/cwd`` links without treating PID exit as failure."""
+    root = Path(proc_root)
+    try:
+        with os.scandir(root) as iterator:
+            entries = sorted(
+                (entry for entry in iterator if entry.name.isdecimal()),
+                key=lambda entry: int(entry.name),
+            )
+    except OSError as exc:
+        return ProcessScan(
+            available=False,
+            complete=False,
+            process_cwds=(),
+            error=type(exc).__name__,
+        )
+
+    processes: list[ProcessCwd] = []
+    unreadable = 0
+    disappeared = 0
+    for entry in entries:
+        cwd_link = root / entry.name / "cwd"
+        try:
+            raw_cwd = os.readlink(cwd_link)
+        except OSError as exc:
+            if isinstance(exc, (FileNotFoundError, ProcessLookupError)) or exc.errno in {
+                errno.ENOENT,
+                errno.ESRCH,
+            }:
+                disappeared += 1
+                continue
+            unreadable += 1
+            continue
+        cwd_path = Path(raw_cwd)
+        if not cwd_path.is_absolute():
+            cwd_path = cwd_link.parent / cwd_path
+        canonical = _canonical_path(cwd_path)
+        if canonical is None:
+            unreadable += 1
+            continue
+        processes.append(ProcessCwd(pid=int(entry.name), cwd=str(canonical)))
+
+    return ProcessScan(
+        available=True,
+        complete=unreadable == 0,
+        process_cwds=tuple(processes),
+        unreadable_count=unreadable,
+        disappeared_count=disappeared,
+    )
+
+
+def probe_webui_health(health_url: str, *, timeout: float = 3.0) -> HealthProbe:
+    """Read the non-sensitive active-run count from the WebUI health endpoint."""
+    try:
+        with request.urlopen(health_url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        return HealthProbe(
+            reachable=False,
+            active_runs=None,
+            reason=type(exc).__name__,
+        )
+    if not isinstance(payload, dict):
+        return HealthProbe(False, None, "invalid_payload")
+    active_runs = payload.get("active_runs")
+    if (
+        isinstance(active_runs, bool)
+        or not isinstance(active_runs, int)
+        or active_runs < 0
+    ):
+        return HealthProbe(False, None, "invalid_active_runs")
+    if payload.get("status") != "ok":
+        return HealthProbe(False, active_runs, "unhealthy_status")
+    return HealthProbe(True, active_runs)
+
+
+def _safe_session_id(payload: dict[str, Any], path: Path) -> str:
+    value = payload.get("session_id")
+    if not isinstance(value, str) or not value:
+        value = path.stem
+    if value and all(character.isalnum() or character in "_-" for character in value):
+        return value[:160]
+    fallback = path.stem
+    if fallback and all(
+        character.isalnum() or character in "_-" for character in fallback
+    ):
+        return fallback[:160]
+    return "unknown"
+
+
+def _valid_branch(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    branch = value.strip()
+    if (
+        not branch
+        or branch == "@"
+        or branch.startswith("-")
+        or branch.startswith("/")
+        or branch.endswith(("/", "."))
+        or "//" in branch
+        or ".." in branch
+        or "@{" in branch
+        or any(
+            ord(character) <= 32
+            or ord(character) == 127
+            or character in "~^:?*[\\"
+            for character in branch
+        )
+    ):
+        return None
+    components = branch.split("/")
+    if any(
+        component.startswith(".") or component.endswith(".lock")
+        for component in components
+    ):
+        return None
+    return branch
+
+
+def _candidate_from_payload(
+    payload: dict[str, Any],
+    path: Path,
+    *,
+    profile: str,
+) -> ManagedWorktreeCandidate | None:
+    stored_profile = payload["profile"] if "profile" in payload else "default"
+    if stored_profile != profile:
+        return None
+
+    worktree_keys = (
+        "worktree_path",
+        "worktree_branch",
+        "worktree_repo_root",
+        "worktree_created_at",
+    )
+    if not any(payload.get(key) is not None for key in worktree_keys):
+        return None
+
+    uncertainty: list[str] = []
+    worktree_path = _canonical_absolute_path(payload.get("worktree_path"))
+    if worktree_path is None:
+        uncertainty.append("invalid_worktree_path")
+    repo_root = _canonical_absolute_path(payload.get("worktree_repo_root"))
+    if repo_root is None:
+        uncertainty.append("invalid_repo_root")
+    branch = _valid_branch(payload.get("worktree_branch"))
+    if branch is None:
+        uncertainty.append("invalid_worktree_branch")
+    session_id = _safe_session_id(payload, path)
+    return ManagedWorktreeCandidate(
+        session_id=session_id,
+        session_ids=(session_id,),
+        profile=profile,
+        worktree_path=str(worktree_path) if worktree_path else None,
+        worktree_branch=branch,
+        worktree_repo_root=str(repo_root) if repo_root else None,
+        worktree_created_at=payload.get("worktree_created_at"),
+        updated_at=payload.get("updated_at"),
+        archived=payload.get("archived") is True,
+        has_active_stream=bool(payload.get("active_stream_id")),
+        has_pending_user_message=bool(payload.get("pending_user_message")),
+        has_pending_attachments=bool(payload.get("pending_attachments")),
+        has_pending_started_at=payload.get("pending_started_at") is not None,
+        uncertainty_reasons=tuple(uncertainty),
+    )
+
+
+def _workspace_session_from_payload(
+    payload: dict[str, Any],
+    path: Path,
+    *,
+    profile: str,
+) -> tuple[_WorkspaceSession | None, str | None]:
+    stored_profile = payload["profile"] if "profile" in payload else "default"
+    if stored_profile != profile:
+        return None, None
+    raw_workspace = payload.get("workspace")
+    if raw_workspace is None or raw_workspace == "":
+        return None, None
+    workspace = _canonical_absolute_path(raw_workspace)
+    if workspace is None:
+        return None, "session_workspace_invalid"
+    return (
+        _WorkspaceSession(
+            session_id=_safe_session_id(payload, path),
+            workspace=str(workspace),
+            updated_at=_timestamp(payload.get("updated_at")),
+            archived=payload.get("archived") is True,
+            has_active_stream=bool(payload.get("active_stream_id")),
+            has_pending_user_message=bool(payload.get("pending_user_message")),
+            has_pending_attachments=bool(payload.get("pending_attachments")),
+            has_pending_started_at=payload.get("pending_started_at") is not None,
+        ),
+        None,
+    )
+
+
+def _candidate_conflict_key(candidate: ManagedWorktreeCandidate) -> tuple[Any, ...]:
+    return (
+        candidate.profile,
+        candidate.worktree_path,
+        candidate.worktree_branch,
+        candidate.worktree_repo_root,
+        candidate.worktree_created_at,
+        candidate.uncertainty_reasons,
+    )
+
+
+def _deduplicate_candidates(
+    candidates: list[ManagedWorktreeCandidate],
+    *,
+    preferred_repo: Path | None = None,
+) -> tuple[ManagedWorktreeCandidate, ...]:
+    by_path: dict[str, list[ManagedWorktreeCandidate]] = {}
+    for candidate in candidates:
+        key = candidate.worktree_path or f"invalid:{candidate.session_id}"
+        by_path.setdefault(key, []).append(candidate)
+
+    deduplicated: list[ManagedWorktreeCandidate] = []
+    for group in by_path.values():
+        def preference(candidate: ManagedWorktreeCandidate) -> tuple[int, str]:
+            if (
+                preferred_repo is not None
+                and candidate.worktree_repo_root == str(preferred_repo)
+            ):
+                rank = 0
+            elif candidate.worktree_repo_root is None:
+                rank = 1
+            else:
+                rank = 2
+            return rank, candidate.session_id
+
+        group.sort(key=preference)
+        first = group[0]
+        session_ids = tuple(
+            sorted(
+                {
+                    session_id
+                    for candidate in group
+                    for session_id in candidate.session_ids
+                }
+            )
+        )
+        reasons = list(first.uncertainty_reasons)
+        if any(
+            _candidate_conflict_key(candidate)
+            != _candidate_conflict_key(first)
+            for candidate in group[1:]
+        ):
+            reasons.append("duplicate_conflict")
+        updated_at = first.updated_at
+        if first.worktree_created_at is None:
+            parsed_updates = [
+                (_timestamp(candidate.updated_at), candidate.updated_at)
+                for candidate in group
+            ]
+            if any(timestamp is None for timestamp, _value in parsed_updates):
+                reasons.append("duplicate_conflict")
+            else:
+                updated_at = max(parsed_updates, key=lambda item: item[0])[1]
+        deduplicated.append(
+            replace(
+                first,
+                session_id=session_ids[0],
+                session_ids=session_ids,
+                updated_at=updated_at,
+                archived=all(candidate.archived for candidate in group),
+                has_active_stream=any(
+                    candidate.has_active_stream for candidate in group
+                ),
+                has_pending_user_message=any(
+                    candidate.has_pending_user_message for candidate in group
+                ),
+                has_pending_attachments=any(
+                    candidate.has_pending_attachments for candidate in group
+                ),
+                has_pending_started_at=any(
+                    candidate.has_pending_started_at for candidate in group
+                ),
+                uncertainty_reasons=tuple(dict.fromkeys(reasons)),
+            )
+        )
+    deduplicated.sort(key=lambda candidate: candidate.session_id)
+    return tuple(deduplicated)
+
+
+def _attach_workspace_sessions(
+    candidates: tuple[ManagedWorktreeCandidate, ...],
+    workspace_sessions: list[_WorkspaceSession],
+) -> tuple[ManagedWorktreeCandidate, ...]:
+    linked_by_path: dict[str, list[_WorkspaceSession]] = {}
+    for candidate in candidates:
+        candidate_path = _canonical_absolute_path(candidate.worktree_path)
+        if candidate_path is not None:
+            linked_by_path.setdefault(str(candidate_path), [])
+    for session in workspace_sessions:
+        workspace = Path(session.workspace)
+        for ancestor in (workspace, *workspace.parents):
+            linked = linked_by_path.get(str(ancestor))
+            if linked is not None:
+                linked.append(session)
+
+    result: list[ManagedWorktreeCandidate] = []
+    for candidate in candidates:
+        candidate_path = _canonical_absolute_path(candidate.worktree_path)
+        if candidate_path is None:
+            result.append(candidate)
+            continue
+        linked = linked_by_path[str(candidate_path)]
+        if not linked:
+            result.append(candidate)
+            continue
+        valid_updates = [
+            session.updated_at
+            for session in linked
+            if session.updated_at is not None
+        ]
+        result.append(
+            replace(
+                candidate,
+                session_ids=tuple(
+                    sorted(
+                        set(candidate.session_ids)
+                        | {session.session_id for session in linked}
+                    )
+                ),
+                archived=candidate.archived
+                and all(session.archived for session in linked),
+                has_active_stream=candidate.has_active_stream
+                or any(session.has_active_stream for session in linked),
+                has_pending_user_message=candidate.has_pending_user_message
+                or any(
+                    session.has_pending_user_message for session in linked
+                ),
+                has_pending_attachments=candidate.has_pending_attachments
+                or any(
+                    session.has_pending_attachments for session in linked
+                ),
+                has_pending_started_at=candidate.has_pending_started_at
+                or any(
+                    session.has_pending_started_at for session in linked
+                ),
+                linked_session_latest_updated_at=(
+                    max(valid_updates) if valid_updates else None
+                ),
+                linked_session_age_uncertain=any(
+                    session.updated_at is None for session in linked
+                ),
+            )
+        )
+    return tuple(result)
+
+
+def _scan_managed_worktree_sessions(
+    state_dir: str | Path,
+    *,
+    profile: str,
+    repo_filter: str | Path | None,
+) -> _SessionScan:
+    sessions_dir = Path(state_dir).expanduser() / "sessions"
+    canonical_filter = (
+        _canonical_repo_filter(repo_filter) if repo_filter is not None else None
+    )
+    if repo_filter is not None and canonical_filter is None:
+        raise ValueError("repo_filter must be a valid, non-root path")
+    try:
+        paths = sorted(sessions_dir.iterdir(), key=lambda path: path.name)
+    except FileNotFoundError:
+        return _SessionScan((), (), 0, ())
+    except OSError as exc:
+        return _SessionScan(
+            (),
+            (),
+            0,
+            (f"session_directory_{type(exc).__name__}",),
+        )
+
+    candidates: list[ManagedWorktreeCandidate] = []
+    workspace_sessions: list[_WorkspaceSession] = []
+    errors: list[str] = []
+    scanned = 0
+    for path in paths:
+        name = path.name
+        if (
+            name == "_index.json"
+            or path.suffix != ".json"
+            or ".tmp." in name
+            or name.startswith(".")
+        ):
+            continue
+        scanned += 1
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            errors.append(f"session_sidecar_{type(exc).__name__}")
+            continue
+        if not isinstance(payload, dict):
+            errors.append("session_sidecar_invalid_payload")
+            continue
+        workspace_session, workspace_error = _workspace_session_from_payload(
+            payload,
+            path,
+            profile=profile,
+        )
+        if workspace_error:
+            errors.append(workspace_error)
+        if workspace_session is not None:
+            workspace_sessions.append(workspace_session)
+        candidate = _candidate_from_payload(payload, path, profile=profile)
+        if candidate is None:
+            continue
+        candidates.append(candidate)
+    deduplicated = _deduplicate_candidates(
+        candidates,
+        preferred_repo=canonical_filter,
+    )
+    if canonical_filter is not None:
+        deduplicated = tuple(
+            candidate
+            for candidate in deduplicated
+            if candidate.worktree_repo_root is None
+            or Path(candidate.worktree_repo_root) == canonical_filter
+        )
+    deduplicated = _attach_workspace_sessions(
+        deduplicated,
+        workspace_sessions,
+    )
+    return _SessionScan(
+        deduplicated,
+        tuple(workspace_sessions),
+        scanned,
+        tuple(errors),
+    )
+
+
+def load_managed_worktree_sessions(
+    state_dir: str | Path,
+    *,
+    profile: str,
+    repo_filter: str | Path | None = None,
+) -> list[ManagedWorktreeCandidate]:
+    """Load profile-scoped sidecars without importing or mutating WebUI runtime state."""
+    return list(
+        _scan_managed_worktree_sessions(
+            state_dir,
+            profile=profile,
+            repo_filter=repo_filter,
+        ).candidates
+    )
+
+
+def _timestamp(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        timestamp = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            timestamp = float(text)
+        except ValueError:
+            try:
+                parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                return None
+            timestamp = parsed.timestamp()
+    else:
+        return None
+    if not math.isfinite(timestamp) or timestamp <= 0:
+        return None
+    return timestamp
+
+
+def _now_timestamp(now: datetime | float | int | None) -> float:
+    if now is None:
+        return datetime.now(timezone.utc).timestamp()
+    if isinstance(now, datetime):
+        if now.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        return now.timestamp()
+    parsed = _timestamp(now)
+    if parsed is None:
+        raise ValueError("now must be a valid timestamp")
+    return parsed
+
+
+def _git_decision_report(decision: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field in _GIT_REPORT_FIELDS:
+        if isinstance(decision, dict):
+            value = decision.get(field)
+        else:
+            value = getattr(decision, field, None)
+        if field == "reasons":
+            value = list(value or ())
+        if value is not None:
+            result[field] = value
+    return result
+
+
+def _decision_report(decision: WorktreeGcDecision) -> dict[str, Any]:
+    return {
+        "session_id": decision.session_id,
+        "session_ids": list(decision.session_ids),
+        "profile": decision.profile,
+        "worktree_path": decision.worktree_path,
+        "worktree_branch": decision.worktree_branch,
+        "worktree_repo_root": decision.worktree_repo_root,
+        "worktree_created_at": decision.worktree_created_at,
+        "age_days": decision.age_days,
+        "age_source": decision.age_source,
+        "verdict": decision.verdict,
+        "eligible": decision.eligible,
+        "reasons": list(decision.reasons),
+        **({"git": decision.git} if decision.git is not None else {}),
+    }
+
+
+def audit_managed_worktrees(
+    *,
+    state_dir: str | Path,
+    profile: str,
+    repo_filter: str | Path,
+    min_age_days: int,
+    target_ref: str,
+    git_backend: Any,
+    health_url: str,
+    now: datetime | float | int | None = None,
+    health_probe: Callable[[str], HealthProbe] = probe_webui_health,
+    process_scan: ProcessScan | None = None,
+) -> dict[str, Any]:
+    """Audit managed worktrees and call Git classification only after all guards."""
+    if (
+        isinstance(min_age_days, bool)
+        or not isinstance(min_age_days, int)
+        or min_age_days < 1
+    ):
+        raise ValueError("min_age_days must be at least 1")
+    canonical_repo = _canonical_repo_filter(repo_filter)
+    if canonical_repo is None:
+        raise ValueError("repo_filter must be a valid, non-root path")
+    if not isinstance(target_ref, str) or not target_ref.strip():
+        raise ValueError("target_ref is required")
+
+    now_timestamp = _now_timestamp(now)
+    session_scan = _scan_managed_worktree_sessions(
+        state_dir,
+        profile=profile,
+        repo_filter=canonical_repo,
+    )
+    process_snapshot = process_scan or scan_process_cwds()
+    health = health_probe(health_url)
+    process_counts = process_snapshot.blocking_process_counts(
+        tuple(
+            candidate.worktree_path
+            for candidate in session_scan.candidates
+            if candidate.worktree_path is not None
+        )
+    )
+
+    global_reasons: list[str] = []
+    if session_scan.errors:
+        global_reasons.append("session_scan_incomplete")
+    if not process_snapshot.available or not process_snapshot.complete:
+        global_reasons.append("process_scan_incomplete")
+    if not health.reachable or health.active_runs is None:
+        global_reasons.append("health_unavailable")
+    elif health.active_runs > 0:
+        global_reasons.append("active_runs")
+
+    decisions: list[WorktreeGcDecision] = []
+    for candidate in session_scan.candidates:
+        uncertain_reasons = list(candidate.uncertainty_reasons)
+        active_reasons: list[str] = []
+        keep_reasons: list[str] = []
+
+        if not candidate.archived:
+            keep_reasons.append("session_not_archived")
+        if (
+            candidate.worktree_path is None
+            or candidate.worktree_branch is None
+            or candidate.worktree_repo_root is None
+        ):
+            uncertain_reasons.append("incomplete_worktree_metadata")
+
+        created_at = _timestamp(candidate.worktree_created_at)
+        age_source: str | None = "worktree_created_at"
+        if candidate.worktree_created_at is None:
+            created_at = _timestamp(candidate.updated_at)
+            age_source = "updated_at"
+        if created_at is None:
+            uncertain_reasons.append("invalid_or_missing_age")
+            age_source = None
+            age_days = None
+        else:
+            age_days = max(0.0, (now_timestamp - created_at) / _DAY_SECONDS)
+            if age_days < min_age_days:
+                keep_reasons.append("younger_than_min_age")
+
+        if candidate.has_active_stream:
+            active_reasons.append("active_stream")
+        if candidate.has_pending_user_message:
+            active_reasons.append("pending_user_message")
+        if candidate.has_pending_attachments:
+            active_reasons.append("pending_attachments")
+        if candidate.has_pending_started_at:
+            active_reasons.append("pending_started_at")
+        if candidate.worktree_path is not None:
+            blocked_processes = process_counts.get(candidate.worktree_path, 0)
+            if blocked_processes:
+                active_reasons.append("process_cwd_in_worktree")
+
+        if "session_scan_incomplete" in global_reasons:
+            uncertain_reasons.append("session_scan_incomplete")
+        if "process_scan_incomplete" in global_reasons:
+            uncertain_reasons.append("process_scan_incomplete")
+        if "health_unavailable" in global_reasons:
+            uncertain_reasons.append("health_unavailable")
+        if "active_runs" in global_reasons:
+            active_reasons.append("active_runs")
+
+        if candidate.linked_session_age_uncertain:
+            uncertain_reasons.append(
+                "linked_session_invalid_or_missing_age"
+            )
+        elif candidate.linked_session_latest_updated_at is not None:
+            linked_age_days = max(
+                0.0,
+                (
+                    now_timestamp
+                    - candidate.linked_session_latest_updated_at
+                )
+                / _DAY_SECONDS,
+            )
+            if linked_age_days < min_age_days:
+                keep_reasons.append(
+                    "linked_session_younger_than_min_age"
+                )
+
+        reasons = tuple(
+            dict.fromkeys(uncertain_reasons + active_reasons + keep_reasons)
+        )
+        common = {
+            "session_id": candidate.session_id,
+            "session_ids": candidate.session_ids,
+            "profile": candidate.profile,
+            "worktree_path": candidate.worktree_path,
+            "worktree_branch": candidate.worktree_branch,
+            "worktree_repo_root": candidate.worktree_repo_root,
+            "worktree_created_at": created_at,
+            "age_days": round(age_days, 3) if age_days is not None else None,
+            "age_source": age_source,
+        }
+        if uncertain_reasons:
+            decisions.append(
+                WorktreeGcDecision(
+                    **common,
+                    verdict="KEEP_UNCERTAIN",
+                    eligible=False,
+                    reasons=reasons,
+                )
+            )
+            continue
+        if active_reasons:
+            decisions.append(
+                WorktreeGcDecision(
+                    **common,
+                    verdict="KEEP_ACTIVE",
+                    eligible=False,
+                    reasons=reasons,
+                )
+            )
+            continue
+        if "session_not_archived" in keep_reasons:
+            decisions.append(
+                WorktreeGcDecision(
+                    **common,
+                    verdict="KEEP_NOT_ARCHIVED",
+                    eligible=False,
+                    reasons=reasons,
+                )
+            )
+            continue
+        if "younger_than_min_age" in keep_reasons:
+            decisions.append(
+                WorktreeGcDecision(
+                    **common,
+                    verdict="KEEP_RECENT",
+                    eligible=False,
+                    reasons=reasons,
+                )
+            )
+            continue
+        if "linked_session_younger_than_min_age" in keep_reasons:
+            decisions.append(
+                WorktreeGcDecision(
+                    **common,
+                    verdict="KEEP_RECENT",
+                    eligible=False,
+                    reasons=reasons,
+                )
+            )
+            continue
+
+        try:
+            git_decision = git_backend.classify_git_worktree(
+                candidate.worktree_path,
+                candidate.worktree_branch,
+                candidate.worktree_repo_root,
+                target_ref=target_ref,
+            )
+            git_report = _git_decision_report(git_decision)
+            verdict = str(git_report.get("verdict") or "KEEP_UNCERTAIN")
+            eligible = bool(git_report.get("eligible"))
+            git_reasons = tuple(str(reason) for reason in git_report.get("reasons", ()))
+            if not git_report.get("verdict"):
+                verdict = "KEEP_UNCERTAIN"
+                eligible = False
+                git_reasons = ("invalid_git_decision",)
+        except Exception:
+            git_decision = None
+            git_report = None
+            verdict = "KEEP_UNCERTAIN"
+            eligible = False
+            git_reasons = ("git_classification_failed",)
+        decisions.append(
+            WorktreeGcDecision(
+                **common,
+                verdict=verdict,
+                eligible=eligible,
+                reasons=git_reasons,
+                git=git_report,
+            )
+        )
+    report_candidates = [_decision_report(decision) for decision in decisions]
+    blocking_count = sum(1 for decision in decisions if not decision.eligible)
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.fromtimestamp(
+            now_timestamp,
+            tz=timezone.utc,
+        ).isoformat(),
+        "profile": profile,
+        "repo": str(canonical_repo),
+        "target_ref": target_ref,
+        "min_age_days": min_age_days,
+        "mode": "dry-run",
+        "collection_requested": False,
+        "global_reasons": global_reasons,
+        "health": {
+            "reachable": health.reachable,
+            "active_runs": health.active_runs,
+            **({"reason": health.reason} if health.reason else {}),
+        },
+        "process_scan": {
+            "available": process_snapshot.available,
+            "complete": process_snapshot.complete,
+            "process_count": process_snapshot.process_count,
+            "unreadable_count": process_snapshot.unreadable_count,
+            "disappeared_count": process_snapshot.disappeared_count,
+        },
+        "session_scan": {
+            "sidecars_scanned": session_scan.sidecars_scanned,
+            "errors": len(session_scan.errors),
+            "error_kinds": sorted(set(session_scan.errors)),
+        },
+        "candidates": report_candidates,
+        "counts": {
+            "candidates": len(decisions),
+            "eligible": sum(1 for decision in decisions if decision.eligible),
+            "blocking": blocking_count,
+            "uncertain": sum(
+                1 for decision in decisions if decision.verdict == "KEEP_UNCERTAIN"
+            ),
+            "active": sum(
+                1 for decision in decisions if decision.verdict == "KEEP_ACTIVE"
+            ),
+        },
+        "has_blocking_anomalies": bool(global_reasons or blocking_count),
+    }
+
+
+def write_report_atomic(report: dict[str, Any], path: str | Path) -> None:
+    """Durably replace a JSON report using a temporary file beside its target."""
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        try:
+            os.chmod(temporary_path, 0o600)
+        except OSError:
+            pass
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+            json.dump(
+                report,
+                handle,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, destination)
+        if os.name != "nt":
+            directory_descriptor = os.open(
+                destination.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+    except Exception:
+        try:
+            os.close(file_descriptor)
+        except OSError:
+            pass
+        temporary_path.unlink(missing_ok=True)
+        raise

--- a/docs/worktree-gc.md
+++ b/docs/worktree-gc.md
@@ -1,0 +1,136 @@
+# Managed worktree audit (V1)
+
+Hermes WebUI V1 provides an observation-only command for Git worktrees created
+for WebUI sessions. It reads session sidecars, checks process and WebUI
+activity, and classifies current Git state. It never removes a worktree,
+deletes a branch, edits a sidecar, refreshes a remote reference, or otherwise
+changes repository state.
+
+V1 is approved for a seven-day observation period only. There is no mutation
+mode.
+
+## Run an audit
+
+One repository filter is required:
+
+```bash
+python scripts/worktree_gc.py --repo /path/to/repository
+```
+
+Useful options include:
+
+```bash
+python scripts/worktree_gc.py \
+  --repo /path/to/repository \
+  --profile default \
+  --min-age-days 14 \
+  --target-ref origin/master \
+  --json
+```
+
+`--dry-run` may be supplied explicitly, but observation-only behavior is always
+used.
+
+Defaults:
+
+- `--profile`: `default`
+- `--min-age-days`: `7` (values below `1` are rejected)
+- `--target-ref`: `origin/master`
+- `--state-dir`: `HERMES_WEBUI_STATE_DIR`, otherwise
+  `${HERMES_HOME:-~/.hermes}/webui`
+- `--health-url`: `http://127.0.0.1:${HERMES_WEBUI_PORT:-8787}/health`
+- `--report-path`:
+  `${XDG_STATE_HOME:-~/.local/state}/hermes-webui/worktree-gc/report.json`;
+  another user-state path is preferred if needed, and the operating system's
+  temporary directory is the last fallback. Defaults stay outside the source
+  checkout.
+
+For a scheduled audit, pass explicit `--repo`, `--state-dir`, `--health-url`,
+and `--report-path` values when the scheduler environment may differ from an
+interactive shell. Prevent overlapping invocations at the scheduler level.
+
+## Fail-closed workflow
+
+The audit discovers `<state-dir>/sessions/*.json` without importing the WebUI
+runtime or changing the active profile. It ignores `_index.json`, backup names,
+and in-progress temporary names. A session without a `profile` field is treated
+as `default` for compatibility; an explicit null or different profile is not.
+Repository and workspace comparisons use canonical path containment, never
+string prefixes.
+
+For each managed worktree, the audit also indexes every session in the selected
+profile that has a canonical `workspace`. A session is linked when its
+workspace equals the worktree path or is a descendant of it. This catches
+ordinary, duplicate, and forked sessions that share a worktree without copying
+the `worktree_*` metadata. The report aggregates only their session IDs; titles,
+messages, attachment names, and content are never emitted.
+
+A worktree reaches Git classification only when all of these facts are
+confirmed:
+
+1. Every linked session is explicitly archived.
+2. The managed worktree path, branch, and repository root are valid.
+3. The canonical repository root equals `--repo`.
+4. The managed worktree is old enough. `worktree_created_at` is authoritative;
+   when absent, `updated_at` is the conservative fallback.
+5. Every linked session has a valid `updated_at` that reaches the age threshold.
+6. No linked session records an active stream.
+7. No linked session records pending text, attachments, or a pending-start
+   timestamp.
+8. A complete `/proc` scan finds no process whose canonical cwd equals or is
+   below the worktree path.
+9. The health endpoint responds successfully with `active_runs == 0`.
+
+The creation-time Hermes worktree lock PID is bookkeeping, not independent
+proof of activity. Activity is established by the stream, pending, health, and
+cwd checks above.
+
+The Git classifier uses only local, read-only evidence. It validates the
+configured target ref, lists registered worktrees, checks tracked and untracked
+status, and separately enumerates ignored paths with NUL-delimited output. It
+never reads ignored file contents. A present ignored path produces
+`KEEP_IGNORED_FILES` and an `ignored_count`.
+
+Missing or invalid dates, unreadable or malformed sidecars, contradictory
+duplicate records, invalid workspace paths, an incomplete process scan, a
+failed health probe, a failed Git command, a timeout, oversized output, or
+non-parseable NUL output are uncertainties. Uncertainty keeps the worktree and
+makes the audit blocking. A local target ref is not refreshed by this command;
+operators who need a newer comparison point must update it outside the audit
+under their normal repository controls, then rerun the audit.
+
+## Report
+
+Every report has `mode="dry-run"` and `collection_requested=false`. It has no
+per-candidate mutation result and makes no claim that a worktree or branch was
+changed.
+
+The JSON report is written through a mode-`0600` temporary file in the
+destination directory. The file is flushed and synced, atomically replaced,
+then the parent directory is synced on supported POSIX systems. `--json` prints
+the same report to stdout; otherwise stdout contains a one-line summary and the
+report path.
+
+Reports contain only operational metadata: session IDs, profile, worktree
+identity, normalized timestamps and age, verdicts, reasons, health/process
+counters, and Git classification counts. They do not include conversation
+titles, messages, attachment names or contents, credentials, Git stderr, or
+ignored file names and contents.
+
+## Exit codes
+
+- `0`: the audit completed with no blocking item or global uncertainty.
+- `2`: activity, work in progress, ignored/untracked/dirty data, unique work,
+  or uncertainty kept at least one item.
+
+Argument errors use the command-line parser's standard exit `2`. Unhandled
+execution failures remain standard non-zero process failures. V1 has no partial
+mutation status or dedicated partial-mutation exit code.
+
+## After the observation period
+
+Enabling automated removal after the seven-day observation period requires a
+new design and a separate review. That future design must provide an atomic or
+compare-and-swap authority boundary across session identity, workspace
+references, runtime activity, Git branch identity, and the final filesystem
+action. V1 audit evidence is not authorization to add mutation to this command.

--- a/scripts/worktree_gc.py
+++ b/scripts/worktree_gc.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Audit WebUI-managed Git worktrees without mutating repository state."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, TextIO
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from api.worktree_gc_inventory import (  # noqa: E402
+    audit_managed_worktrees,
+    write_report_atomic,
+)
+
+
+def default_state_dir(environ: dict[str, str] | os._Environ[str] | None = None) -> Path:
+    env = environ if environ is not None else os.environ
+    explicit = env.get("HERMES_WEBUI_STATE_DIR")
+    if explicit:
+        return Path(explicit).expanduser()
+    hermes_home = env.get("HERMES_HOME")
+    base = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    return base / "webui"
+
+
+def default_health_url(
+    environ: dict[str, str] | os._Environ[str] | None = None,
+) -> str:
+    env = environ if environ is not None else os.environ
+    port = str(env.get("HERMES_WEBUI_PORT") or "8787").strip()
+    return f"http://127.0.0.1:{port}/health"
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def default_report_path(
+    environ: dict[str, str] | os._Environ[str] | None = None,
+) -> Path:
+    """Prefer durable user state, with temporary storage as the last fallback."""
+    env = environ if environ is not None else os.environ
+    candidates: list[Path] = []
+    xdg_state_home = str(env.get("XDG_STATE_HOME") or "").strip()
+    if xdg_state_home:
+        xdg_path = Path(xdg_state_home).expanduser()
+        if xdg_path.is_absolute():
+            candidates.append(
+                xdg_path / "hermes-webui" / "worktree-gc" / "report.json"
+            )
+    candidates.extend(
+        (
+            Path.home()
+            / ".local"
+            / "state"
+            / "hermes-webui"
+            / "worktree-gc"
+            / "report.json",
+            Path(tempfile.gettempdir())
+            / "hermes-webui-worktree-gc"
+            / "report.json",
+        )
+    )
+    for candidate in candidates:
+        if not _is_within(candidate, REPO_ROOT):
+            return candidate
+    raise RuntimeError("could not choose a report path outside the repository")
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit WebUI-managed worktrees in observation-only mode.",
+    )
+    parser.add_argument("--profile", default="default")
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--min-age-days", type=_positive_int, default=7)
+    parser.add_argument("--target-ref", default="origin/master")
+    parser.add_argument("--state-dir", type=Path, default=default_state_dir())
+    parser.add_argument("--health-url", default=default_health_url())
+    parser.add_argument("--report-path", type=Path)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="audit only (the only supported mode)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="write the complete report as JSON to stdout",
+    )
+    return parser
+
+
+def load_git_backend() -> Any:
+    """Import the read-only Git classifier only when the CLI actually runs."""
+    return importlib.import_module("api.worktree_gc_git")
+
+
+def _emit_summary(
+    report: dict[str, Any],
+    report_path: Path,
+    *,
+    as_json: bool,
+    stdout: TextIO,
+) -> None:
+    if as_json:
+        json.dump(
+            report,
+            stdout,
+            ensure_ascii=False,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        stdout.write("\n")
+        return
+    counts = report.get("counts") or {}
+    stdout.write(
+        f"mode={report.get('mode')} "
+        f"candidates={int(counts.get('candidates') or 0)} "
+        f"eligible={int(counts.get('eligible') or 0)} "
+        f"blocking={int(counts.get('blocking') or 0)} "
+        f"report={report_path}\n"
+    )
+
+
+def _audit_exit_code(report: dict[str, Any]) -> int:
+    return 2 if report.get("has_blocking_anomalies", False) else 0
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    git_backend: Any = None,
+    audit_fn: Callable[..., dict[str, Any]] = audit_managed_worktrees,
+    stdout: TextIO | None = None,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output = stdout if stdout is not None else sys.stdout
+    backend = git_backend if git_backend is not None else load_git_backend()
+    report_path = (
+        args.report_path.expanduser()
+        if args.report_path is not None
+        else default_report_path()
+    )
+    report = audit_fn(
+        state_dir=args.state_dir,
+        profile=args.profile,
+        repo_filter=args.repo,
+        min_age_days=args.min_age_days,
+        target_ref=args.target_ref,
+        git_backend=backend,
+        health_url=args.health_url,
+    )
+    report["mode"] = "dry-run"
+    report["collection_requested"] = False
+    write_report_atomic(report, report_path)
+    _emit_summary(
+        report,
+        report_path,
+        as_json=args.json,
+        stdout=output,
+    )
+    return _audit_exit_code(report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_worktree_gc_cli.py
+++ b/tests/test_worktree_gc_cli.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from api.worktree_gc_inventory import write_report_atomic
+from scripts import worktree_gc
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_server():
+    """These CLI tests do not need the repository's HTTP server fixture."""
+
+
+def _report(repo: Path, *, blocking: bool) -> dict:
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-07-23T12:00:00+00:00",
+        "mode": "dry-run",
+        "collection_requested": False,
+        "profile": "default",
+        "repo": str(repo),
+        "target_ref": "origin/master",
+        "min_age_days": 7,
+        "global_reasons": ["health_unavailable"] if blocking else [],
+        "health": {
+            "reachable": not blocking,
+            "active_runs": None if blocking else 0,
+        },
+        "process_scan": {
+            "available": True,
+            "complete": True,
+            "process_count": 0,
+            "unreadable_count": 0,
+            "disappeared_count": 0,
+        },
+        "session_scan": {
+            "sidecars_scanned": 0,
+            "errors": 0,
+            "error_kinds": [],
+        },
+        "candidates": [],
+        "counts": {
+            "candidates": 0,
+            "eligible": 0,
+            "blocking": int(blocking),
+            "uncertain": int(blocking),
+            "active": 0,
+        },
+        "has_blocking_anomalies": blocking,
+    }
+
+
+def test_help_describes_observation_only_and_has_no_collect_flag():
+    help_text = worktree_gc.build_parser().format_help()
+
+    assert "--dry-run" in help_text
+    assert "--collect" not in help_text
+    assert "collect" not in help_text.lower()
+    assert "audit" in help_text.lower()
+
+
+def test_help_exits_before_loading_git_backend(monkeypatch):
+    monkeypatch.setattr(
+        worktree_gc,
+        "load_git_backend",
+        lambda: pytest.fail("help must not load the backend"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        worktree_gc.main(["--help"])
+
+    assert exc.value.code == 0
+
+
+def test_removed_collect_flag_is_argparse_error_before_any_action(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        worktree_gc,
+        "load_git_backend",
+        lambda: pytest.fail("unknown arguments must fail before backend load"),
+    )
+    monkeypatch.setattr(
+        worktree_gc,
+        "write_report_atomic",
+        lambda *_args, **_kwargs: pytest.fail(
+            "unknown arguments must fail before report mutation"
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        worktree_gc.main(
+            ["--repo", str(repo), "--collect"],
+            audit_fn=lambda **_kwargs: pytest.fail(
+                "unknown arguments must fail before audit"
+            ),
+        )
+
+    assert exc.value.code == 2
+
+
+def test_audit_writes_identical_non_collection_report_and_returns_zero(tmp_path):
+    repo = tmp_path / "repo"
+    state_dir = tmp_path / "state"
+    report_path = tmp_path / "reports" / "worktree-gc.json"
+    repo.mkdir()
+    stdout = io.StringIO()
+    calls = []
+    backend = object()
+
+    def fake_audit(**kwargs):
+        calls.append(kwargs)
+        return _report(repo.resolve(), blocking=False)
+
+    return_code = worktree_gc.main(
+        [
+            "--repo",
+            str(repo),
+            "--state-dir",
+            str(state_dir),
+            "--health-url",
+            "http://127.0.0.1:9898/health",
+            "--report-path",
+            str(report_path),
+            "--json",
+        ],
+        git_backend=backend,
+        audit_fn=fake_audit,
+        stdout=stdout,
+    )
+    emitted = json.loads(stdout.getvalue())
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert return_code == 0
+    assert emitted == persisted
+    assert emitted["mode"] == "dry-run"
+    assert emitted["collection_requested"] is False
+    assert "collection" not in emitted
+    assert "collection_allowed" not in emitted
+    assert len(calls) == 1
+    assert calls[0] == {
+        "state_dir": state_dir,
+        "profile": "default",
+        "repo_filter": repo,
+        "min_age_days": 7,
+        "target_ref": "origin/master",
+        "git_backend": backend,
+        "health_url": "http://127.0.0.1:9898/health",
+    }
+
+
+def test_blocking_audit_returns_two_and_still_persists_report(tmp_path):
+    repo = tmp_path / "repo"
+    report_path = tmp_path / "report.json"
+    repo.mkdir()
+
+    return_code = worktree_gc.main(
+        [
+            "--repo",
+            str(repo),
+            "--report-path",
+            str(report_path),
+        ],
+        git_backend=object(),
+        audit_fn=lambda **_kwargs: _report(repo.resolve(), blocking=True),
+        stdout=io.StringIO(),
+    )
+
+    assert return_code == 2
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["mode"] == "dry-run"
+    assert persisted["collection_requested"] is False
+    assert persisted["has_blocking_anomalies"] is True
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-an-integer"])
+def test_invalid_minimum_age_uses_argparse_exit_two(tmp_path, value):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(SystemExit) as exc:
+        worktree_gc.main(
+            ["--repo", str(repo), "--min-age-days", value],
+            audit_fn=lambda **_kwargs: pytest.fail("invalid args must not audit"),
+        )
+
+    assert exc.value.code == 2
+
+
+def test_default_paths_stay_outside_checkout(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    env = {
+        "HERMES_HOME": str(tmp_path / "hermes"),
+        "XDG_STATE_HOME": str(tmp_path / "xdg"),
+    }
+
+    state_dir = worktree_gc.default_state_dir(env)
+    report_path = worktree_gc.default_report_path(env)
+
+    assert state_dir == tmp_path / "hermes" / "webui"
+    assert report_path == (
+        tmp_path / "xdg" / "hermes-webui" / "worktree-gc" / "report.json"
+    )
+    assert not worktree_gc._is_within(state_dir, worktree_gc.REPO_ROOT)
+    assert not worktree_gc._is_within(report_path, worktree_gc.REPO_ROOT)
+
+
+def test_atomic_report_replaces_only_after_complete_fsync(tmp_path, monkeypatch):
+    report_path = tmp_path / "nested" / "report.json"
+    report_path.parent.mkdir()
+    report_path.write_text('{"old": true}\n', encoding="utf-8")
+    real_replace = os.replace
+    real_fsync = os.fsync
+    events = []
+
+    def observing_fsync(fd):
+        events.append(("fsync", fd))
+        return real_fsync(fd)
+
+    def observing_replace(source, destination):
+        events.append(("replace", Path(source), Path(destination)))
+        assert json.loads(Path(source).read_text(encoding="utf-8")) == {"new": True}
+        assert json.loads(report_path.read_text(encoding="utf-8")) == {"old": True}
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "fsync", observing_fsync)
+    monkeypatch.setattr(os, "replace", observing_replace)
+
+    write_report_atomic({"new": True}, report_path)
+
+    replace_index = next(
+        index for index, event in enumerate(events) if event[0] == "replace"
+    )
+    assert any(event[0] == "fsync" for event in events[:replace_index])
+    assert any(event[0] == "fsync" for event in events[replace_index + 1 :])
+    assert json.loads(report_path.read_text(encoding="utf-8")) == {"new": True}
+    assert list(report_path.parent.glob(f".{report_path.name}.*")) == []

--- a/tests/test_worktree_gc_collect.py
+++ b/tests/test_worktree_gc_collect.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import api.worktree_gc_git as git_backend
+from scripts import worktree_gc
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_server():
+    """These static safety tests do not need the HTTP server fixture."""
+
+
+def _source_path(module) -> Path:
+    return Path(module.__file__).resolve()
+
+
+def test_git_backend_does_not_export_a_collector():
+    assert not hasattr(git_backend, "collect_git_worktree")
+
+
+def test_application_modules_have_no_destructive_filesystem_calls():
+    forbidden_attributes = {
+        ("shutil", "rmtree"),
+    }
+    for module in (git_backend, worktree_gc):
+        tree = ast.parse(_source_path(module).read_text(encoding="utf-8"))
+        calls = {
+            (node.func.value.id, node.func.attr)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+        }
+        assert calls.isdisjoint(forbidden_attributes)
+
+
+def test_git_backend_contains_no_destructive_git_command():
+    source = _source_path(git_backend).read_text(encoding="utf-8")
+    forbidden_fragments = (
+        '"worktree", "unlock"',
+        '"worktree", "remove"',
+        '"branch", "-d"',
+        '"branch", "-D"',
+        '"update-ref", "-d"',
+        '"worktree", "prune"',
+    )
+    assert all(fragment not in source for fragment in forbidden_fragments)
+
+
+def test_git_runner_rejects_commands_outside_read_only_allowlist(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        git_backend.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail(
+            "rejected commands must not reach Git"
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        git_backend._run_git(
+            ["worktree", "remove", str(tmp_path / "candidate")],
+            tmp_path,
+        )
+
+    assert getattr(exc.value, "code", None) == "git_command_not_allowed"
+
+
+def test_cli_contains_no_collection_path_or_recursive_delete():
+    source = _source_path(worktree_gc).read_text(encoding="utf-8")
+    assert "collect_git_worktree" not in source
+    assert "rmtree" not in source
+    assert "def _collect" not in source
+    assert "args.collect" not in source
+    assert '"collection"' not in source

--- a/tests/test_worktree_gc_git_classification.py
+++ b/tests/test_worktree_gc_git_classification.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from api.worktree_gc_git import (
+    KEEP_DIRTY,
+    KEEP_IGNORED_FILES,
+    KEEP_STALE_METADATA,
+    KEEP_UNCERTAIN,
+    KEEP_UNIQUE_COMMITS,
+    REMOVE_ANCESTOR,
+    REMOVE_PATCH_EQUIVALENT_KEEP_BRANCH,
+    GitWorktreeDecision,
+    classify_git_worktree,
+)
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _commit(repo: Path, filename: str, content: str, message: str) -> str:
+    (repo / filename).write_text(content, encoding="utf-8")
+    _git(repo, "add", "--", filename)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def make_remote_repo(tmp_path: Path) -> dict[str, Path | str]:
+    remote = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    remote.mkdir()
+    repo.mkdir()
+    _git(remote, "init", "--bare", "--initial-branch=master")
+    _git(repo, "init", "--initial-branch=master")
+    _git(repo, "config", "user.email", "gc-tests@example.invalid")
+    _git(repo, "config", "user.name", "Worktree GC Tests")
+    base_sha = _commit(repo, "base.txt", "base\n", "base")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "master")
+    target_sha = _commit(repo, "shared.txt", "same patch\n", "target patch")
+    _git(repo, "push", "origin", "master")
+    return {
+        "repo": repo,
+        "remote": remote,
+        "base_sha": base_sha,
+        "target_sha": target_sha,
+    }
+
+
+def add_worktree(
+    case: dict[str, Path | str],
+    tmp_path: Path,
+    branch: str,
+    *,
+    start: str | None = None,
+) -> Path:
+    repo = case["repo"]
+    assert isinstance(repo, Path)
+    worktree = tmp_path / branch.replace("/", "-")
+    _git(
+        repo,
+        "worktree",
+        "add",
+        "-b",
+        branch,
+        str(worktree),
+        start or str(case["base_sha"]),
+    )
+    _git(worktree, "config", "user.email", "gc-tests@example.invalid")
+    _git(worktree, "config", "user.name", "Worktree GC Tests")
+    return worktree
+
+
+def test_decision_is_frozen_and_exposes_audit_fields(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/ancestor")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/ancestor",
+        case["repo"],
+    )
+
+    assert isinstance(decision, GitWorktreeDecision)
+    assert decision.path == str(worktree.resolve())
+    assert decision.branch == "gc/ancestor"
+    assert decision.repo_root == str(Path(case["repo"]).resolve())
+    assert decision.target_ref == "origin/master"
+    assert decision.verdict == REMOVE_ANCESTOR
+    assert decision.eligible is True
+    assert decision.exists is True
+    assert decision.listed is True
+    assert decision.dirty is False
+    assert decision.untracked_count == 0
+    assert decision.ancestor_of_target is True
+    assert decision.cherry_unique_count is None
+    assert decision.reasons
+    with pytest.raises(FrozenInstanceError):
+        decision.verdict = KEEP_UNCERTAIN  # type: ignore[misc]
+
+
+def test_patch_equivalent_commit_removes_only_worktree(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/patch-equivalent")
+    patch_sha = _commit(
+        worktree,
+        "shared.txt",
+        "same patch\n",
+        "equivalent patch under another sha",
+    )
+    assert patch_sha != case["target_sha"]
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/patch-equivalent",
+        case["repo"],
+    )
+
+    assert decision.verdict == REMOVE_PATCH_EQUIVALENT_KEEP_BRANCH
+    assert decision.eligible is True
+    assert decision.ancestor_of_target is False
+    assert decision.cherry_unique_count == 0
+
+
+def test_one_unique_cherry_commit_keeps_worktree_and_branch(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/unique")
+    _commit(worktree, "unique.txt", "must survive\n", "unique work")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/unique",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNIQUE_COMMITS
+    assert decision.eligible is False
+    assert decision.ancestor_of_target is False
+    assert decision.cherry_unique_count == 1
+
+
+def test_equivalent_and_unique_cherry_commits_still_keep_worktree(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/mixed-cherry")
+    _commit(
+        worktree,
+        "shared.txt",
+        "same patch\n",
+        "equivalent patch under another sha",
+    )
+    _commit(worktree, "unique.txt", "must survive\n", "unique work")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/mixed-cherry",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNIQUE_COMMITS
+    assert decision.eligible is False
+    assert decision.cherry_unique_count == 1
+
+
+@pytest.mark.parametrize("untracked", [False, True], ids=["tracked", "untracked"])
+def test_dirty_or_untracked_content_is_kept(tmp_path, untracked):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, f"gc/dirty-{untracked}")
+    if untracked:
+        (worktree / "untracked.txt").write_text("local\n", encoding="utf-8")
+    else:
+        (worktree / "base.txt").write_text("edited\n", encoding="utf-8")
+
+    decision = classify_git_worktree(
+        worktree,
+        f"gc/dirty-{untracked}",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_DIRTY
+    assert decision.eligible is False
+    assert decision.dirty is True
+    assert decision.untracked_count == (1 if untracked else 0)
+    assert decision.ignored_count == 0
+    assert decision.ancestor_of_target is None
+
+
+@pytest.mark.parametrize(
+    "ignored_name",
+    [
+        ".env",
+        "ignored directory/private.txt",
+        "ignored name with spaces.txt",
+        "ignored-newline-directory/ignored-name-with-\n-newline.txt",
+    ],
+)
+def test_ignored_files_are_kept_without_reading_contents(tmp_path, ignored_name):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/ignored")
+    ignored = worktree / ignored_name
+    ignored.parent.mkdir(parents=True, exist_ok=True)
+    ignored.write_text("must remain private\n", encoding="utf-8")
+    (worktree / ".gitignore").write_text(
+        f"/{ignored_name.split('/', 1)[0]}\n",
+        encoding="utf-8",
+    )
+    _git(worktree, "add", ".gitignore")
+    _git(worktree, "commit", "-m", "ignore private file")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/ignored",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_IGNORED_FILES
+    assert decision.eligible is False
+    assert decision.dirty is False
+    assert decision.untracked_count == 0
+    assert decision.ignored_count == 1
+    assert decision.reasons == ("ignored_files_present",)
+    assert "must remain private" not in repr(decision)
+
+
+def test_no_ignored_files_reports_zero_and_remains_eligible(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/no-ignored")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/no-ignored",
+        case["repo"],
+    )
+
+    assert decision.verdict == REMOVE_ANCESTOR
+    assert decision.eligible is True
+    assert decision.ignored_count == 0
+
+
+@pytest.mark.parametrize(
+    ("stdout", "returncode", "expected_reason"),
+    [
+        (b"unterminated", 0, "ignored_files_unparseable"),
+        (b"", 1, "ignored_files_failed"),
+    ],
+)
+def test_unverifiable_ignored_file_probe_fails_closed(
+    tmp_path,
+    monkeypatch,
+    stdout,
+    returncode,
+    expected_reason,
+):
+    import api.worktree_gc_git as gc_git
+
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/ignored-uncertain")
+    real_run_git = gc_git._run_git
+
+    def corrupt_ignored_probe(args, cwd, *, timeout=gc_git.GIT_TIMEOUT):
+        if args == [
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ]:
+            return subprocess.CompletedProcess(
+                ["git", *args],
+                returncode,
+                stdout=stdout,
+                stderr=b"private detail",
+            )
+        return real_run_git(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(gc_git, "_run_git", corrupt_ignored_probe)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/ignored-uncertain",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.ignored_count is None
+    assert decision.reasons == (expected_reason,)
+    assert "private detail" not in repr(decision)
+
+
+def test_ignored_file_probe_timeout_fails_closed(tmp_path, monkeypatch):
+    import api.worktree_gc_git as gc_git
+
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/ignored-timeout")
+    real_run_git = gc_git._run_git
+
+    def timeout_ignored_probe(args, cwd, *, timeout=gc_git.GIT_TIMEOUT):
+        if args == [
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ]:
+            raise gc_git._GitInvocationError("git_timeout")
+        return real_run_git(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(gc_git, "_run_git", timeout_ignored_probe)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/ignored-timeout",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.ignored_count is None
+    assert decision.reasons == ("git_timeout",)
+
+
+def test_ignored_file_probe_output_limit_fails_closed(tmp_path, monkeypatch):
+    import api.worktree_gc_git as gc_git
+
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/ignored-output-limit")
+    real_run_git = gc_git._run_git
+
+    def oversized_ignored_probe(args, cwd, *, timeout=gc_git.GIT_TIMEOUT):
+        if args == list(gc_git._IGNORED_FILES_ARGS):
+            return subprocess.CompletedProcess(
+                ["git", *args],
+                0,
+                stdout=b"x" * (gc_git.IGNORED_OUTPUT_LIMIT + 1),
+                stderr=b"",
+            )
+        return real_run_git(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(gc_git, "_run_git", oversized_ignored_probe)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/ignored-output-limit",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.ignored_count is None
+    assert decision.reasons == ("ignored_files_unparseable",)
+
+
+def test_path_branch_mismatch_fails_closed(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/actual")
+    repo = case["repo"]
+    assert isinstance(repo, Path)
+    _git(repo, "branch", "gc/claimed", str(case["base_sha"]))
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/claimed",
+        repo,
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.exists is True
+    assert decision.listed is True
+    assert "worktree_branch_mismatch" in decision.reasons
+
+
+def test_missing_local_branch_fails_closed(tmp_path):
+    case = make_remote_repo(tmp_path)
+    absent = tmp_path / "missing-branch-worktree"
+
+    decision = classify_git_worktree(
+        absent,
+        "gc/not-created",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert "branch_missing" in decision.reasons
+
+
+def test_missing_target_fails_closed(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/missing-target")
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/missing-target",
+        case["repo"],
+        target_ref="origin/not-there",
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.ancestor_of_target is None
+    assert "target_ref_missing" in decision.reasons
+
+
+def test_missing_path_still_listed_is_stale_metadata_audit_only(tmp_path):
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/stale")
+    holding = tmp_path / "moved-aside"
+    worktree.rename(holding)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/stale",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_STALE_METADATA
+    assert decision.eligible is False
+    assert decision.exists is False
+    assert decision.listed is True
+    assert decision.dirty is None
+    assert decision.untracked_count is None
+
+
+def test_empty_path_inputs_are_rejected_before_running_git(tmp_path, monkeypatch):
+    import api.worktree_gc_git as gc_git
+
+    monkeypatch.setattr(
+        gc_git,
+        "_run_git",
+        lambda *args, **kwargs: pytest.fail("invalid empty paths must not run git"),
+    )
+
+    missing_path = classify_git_worktree("", "gc/branch", tmp_path)
+    missing_repo = classify_git_worktree(tmp_path / "worktree", "gc/branch", "")
+
+    assert missing_path.verdict == KEEP_UNCERTAIN
+    assert missing_path.path == ""
+    assert missing_path.exists is None
+    assert missing_path.reasons == ("path_input_invalid",)
+    assert missing_repo.verdict == KEEP_UNCERTAIN
+    assert missing_repo.repo_root == ""
+    assert missing_repo.exists is None
+    assert missing_repo.reasons == ("repo_root_input_invalid",)
+
+
+def test_absent_unlisted_path_is_uncertain_not_a_prune_instruction(tmp_path):
+    case = make_remote_repo(tmp_path)
+    repo = case["repo"]
+    assert isinstance(repo, Path)
+    _git(repo, "branch", "gc/absent", str(case["base_sha"]))
+    absent = tmp_path / "never-listed"
+
+    decision = classify_git_worktree(
+        absent,
+        "gc/absent",
+        repo,
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.exists is False
+    assert decision.listed is False
+
+
+def test_non_interpretable_porcelain_status_fails_closed(tmp_path, monkeypatch):
+    import api.worktree_gc_git as gc_git
+
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/bad-status")
+    real_run_git = gc_git._run_git
+
+    def corrupt_status(args, cwd, *, timeout=gc_git.GIT_TIMEOUT):
+        if args == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
+            return subprocess.CompletedProcess(
+                ["git", *args],
+                0,
+                stdout=b"?? unterminated",
+                stderr=b"",
+            )
+        return real_run_git(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(gc_git, "_run_git", corrupt_status)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/bad-status",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.dirty is None
+    assert decision.untracked_count is None
+    assert "status_unparseable" in decision.reasons
+
+
+def test_status_timeout_fails_closed(tmp_path, monkeypatch):
+    import api.worktree_gc_git as gc_git
+
+    case = make_remote_repo(tmp_path)
+    worktree = add_worktree(case, tmp_path, "gc/status-timeout")
+    real_run_git = gc_git._run_git
+
+    def timeout_status(args, cwd, *, timeout=gc_git.GIT_TIMEOUT):
+        if args == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
+            raise gc_git._GitInvocationError("git_timeout")
+        return real_run_git(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(gc_git, "_run_git", timeout_status)
+
+    decision = classify_git_worktree(
+        worktree,
+        "gc/status-timeout",
+        case["repo"],
+    )
+
+    assert decision.verdict == KEEP_UNCERTAIN
+    assert decision.eligible is False
+    assert decision.dirty is None
+    assert "git_timeout" in decision.reasons

--- a/tests/test_worktree_gc_integration.py
+++ b/tests/test_worktree_gc_integration.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import io
+import json
+import time
+from pathlib import Path
+
+import api.worktree_gc_git as git_backend
+from api.worktree_gc_inventory import (
+    HealthProbe,
+    ProcessScan,
+    audit_managed_worktrees,
+)
+from scripts import worktree_gc as cli
+from tests.test_worktree_gc_git_classification import (
+    _git,
+    add_worktree,
+    make_remote_repo,
+)
+
+
+def _audit_without_host_activity(**kwargs):
+    return audit_managed_worktrees(
+        **kwargs,
+        health_probe=lambda _url: HealthProbe(True, 0),
+        process_scan=ProcessScan(True, True, ()),
+    )
+
+
+def _write_archived_sidecar(
+    state_dir: Path,
+    *,
+    session_id: str,
+    worktree: Path,
+    branch: str,
+    repo: Path,
+) -> None:
+    sessions = state_dir / "sessions"
+    sessions.mkdir(parents=True)
+    old_timestamp = time.time() - (8 * 24 * 60 * 60)
+    (sessions / f"{session_id}.json").write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "profile": "default",
+                "archived": True,
+                "workspace": str(worktree),
+                "worktree_path": str(worktree),
+                "worktree_branch": branch,
+                "worktree_repo_root": str(repo),
+                "worktree_created_at": old_timestamp,
+                "updated_at": old_timestamp,
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "pending_attachments": None,
+                "pending_started_at": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    return (
+        _git(
+            repo,
+            "show-ref",
+            "--verify",
+            "--quiet",
+            f"refs/heads/{branch}",
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def test_real_git_audit_never_mutates_eligible_or_ignored_worktree(tmp_path):
+    case = make_remote_repo(tmp_path)
+    repo = case["repo"]
+    assert isinstance(repo, Path)
+    (repo / ".gitignore").write_text("/.env\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "ignore local environment")
+    _git(repo, "push", "origin", "master")
+
+    branch = "gc/integration-ancestor"
+    worktree = add_worktree(case, tmp_path, branch, start="origin/master")
+    state_dir = tmp_path / "state"
+    report_path = tmp_path / "reports" / "worktree-gc.json"
+    _write_archived_sidecar(
+        state_dir,
+        session_id="integration-session",
+        worktree=worktree,
+        branch=branch,
+        repo=repo,
+    )
+    common_args = [
+        "--repo",
+        str(repo),
+        "--state-dir",
+        str(state_dir),
+        "--health-url",
+        "http://unused.invalid/health",
+        "--report-path",
+        str(report_path),
+        "--min-age-days",
+        "7",
+        "--json",
+    ]
+
+    eligible_stdout = io.StringIO()
+    eligible_rc = cli.main(
+        common_args,
+        git_backend=git_backend,
+        audit_fn=_audit_without_host_activity,
+        stdout=eligible_stdout,
+    )
+    eligible_report = json.loads(eligible_stdout.getvalue())
+
+    assert eligible_rc == 0
+    assert eligible_report["mode"] == "dry-run"
+    assert eligible_report["collection_requested"] is False
+    assert "collection" not in eligible_report
+    assert eligible_report["counts"]["eligible"] == 1
+    assert eligible_report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+    assert worktree.is_dir()
+    assert _branch_exists(repo, branch)
+
+    (worktree / ".env").write_text("PRIVATE=must-not-be-read\n", encoding="utf-8")
+    ignored_stdout = io.StringIO()
+    ignored_rc = cli.main(
+        common_args,
+        git_backend=git_backend,
+        audit_fn=_audit_without_host_activity,
+        stdout=ignored_stdout,
+    )
+    ignored_report = json.loads(ignored_stdout.getvalue())
+    persisted_report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert ignored_rc == 2
+    assert ignored_report == persisted_report
+    assert ignored_report["mode"] == "dry-run"
+    assert ignored_report["collection_requested"] is False
+    assert ignored_report["candidates"][0]["verdict"] == "KEEP_IGNORED_FILES"
+    assert ignored_report["candidates"][0]["git"]["ignored_count"] == 1
+    assert "must-not-be-read" not in json.dumps(ignored_report)
+    assert worktree.is_dir()
+    assert _branch_exists(repo, branch)

--- a/tests/test_worktree_gc_performance.py
+++ b/tests/test_worktree_gc_performance.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import api.worktree_gc_inventory as inventory
+from api.worktree_gc_inventory import ManagedWorktreeCandidate, ProcessCwd, ProcessScan
+
+
+def _candidate(path: Path, index: int) -> ManagedWorktreeCandidate:
+    return ManagedWorktreeCandidate(
+        session_id=f"managed-{index}",
+        session_ids=(f"managed-{index}",),
+        profile="default",
+        worktree_path=str(path),
+        worktree_branch=f"hermes/{index}",
+        worktree_repo_root=str(path.parent),
+        worktree_created_at=1.0,
+        updated_at=1.0,
+        archived=True,
+        has_active_stream=False,
+        has_pending_user_message=False,
+        has_pending_attachments=False,
+        has_pending_started_at=False,
+    )
+
+
+def _workspace(path: Path, index: int) -> inventory._WorkspaceSession:
+    return inventory._WorkspaceSession(
+        session_id=f"fork-{index}",
+        workspace=str(path),
+        updated_at=1.0,
+        archived=True,
+        has_active_stream=False,
+        has_pending_user_message=False,
+        has_pending_attachments=False,
+        has_pending_started_at=False,
+    )
+
+
+def test_workspace_linking_is_indexed_instead_of_candidate_times_session(
+    tmp_path, monkeypatch
+):
+    candidates = tuple(
+        _candidate(tmp_path / "worktrees" / f"feature-{index}", index)
+        for index in range(100)
+    )
+    sessions = [
+        _workspace(Path(candidate.worktree_path) / "nested", index)
+        for index, candidate in enumerate(candidates)
+    ]
+    original = inventory._path_is_within
+    calls = 0
+
+    def counted(child, parent):
+        nonlocal calls
+        calls += 1
+        return original(child, parent)
+
+    monkeypatch.setattr(inventory, "_path_is_within", counted)
+
+    linked = inventory._attach_workspace_sessions(candidates, sessions)
+
+    assert all(len(candidate.session_ids) == 2 for candidate in linked)
+    assert calls < 2_000
+
+
+def test_batch_process_counts_cover_nested_candidates_without_lookalikes(tmp_path):
+    parent = tmp_path / "worktrees" / "feature"
+    nested = parent / "nested"
+    lookalike = tmp_path / "worktrees" / "feature-copy"
+    scan = ProcessScan(
+        available=True,
+        complete=True,
+        process_cwds=(
+            ProcessCwd(1, str(parent)),
+            ProcessCwd(2, str(nested / "child")),
+            ProcessCwd(3, str(lookalike)),
+        ),
+    )
+
+    counts = scan.blocking_process_counts((parent, nested, lookalike))
+
+    assert counts == {
+        str(parent.resolve()): 2,
+        str(nested.resolve()): 1,
+        str(lookalike.resolve()): 1,
+    }

--- a/tests/test_worktree_gc_process_guards.py
+++ b/tests/test_worktree_gc_process_guards.py
@@ -1,0 +1,92 @@
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from api.worktree_gc_inventory import scan_process_cwds
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_server():
+    """These unit tests do not need the repository's HTTP server fixture."""
+
+
+def _proc_cwd(proc_root: Path, pid: int, cwd: Path) -> None:
+    pid_dir = proc_root / str(pid)
+    pid_dir.mkdir(parents=True)
+    os.symlink(cwd, pid_dir / "cwd")
+
+
+def test_process_scan_blocks_exact_and_descendant_cwds_but_not_prefix_lookalike(
+    tmp_path,
+):
+    proc_root = tmp_path / "proc"
+    worktree = tmp_path / "worktrees" / "feature"
+    child = worktree / "nested"
+    lookalike = tmp_path / "worktrees" / "feature-copy"
+    child.mkdir(parents=True)
+    lookalike.mkdir(parents=True)
+    _proc_cwd(proc_root, 101, worktree)
+    _proc_cwd(proc_root, 102, child)
+    _proc_cwd(proc_root, 103, lookalike)
+
+    scan = scan_process_cwds(proc_root)
+
+    assert scan.available is True
+    assert scan.complete is True
+    assert scan.process_count == 3
+    assert scan.blocking_process_count(worktree) == 2
+    assert scan.blocking_process_count(child) == 1
+    assert scan.blocking_process_count(lookalike) == 1
+
+
+def test_process_that_disappears_during_scan_is_not_an_error(tmp_path, monkeypatch):
+    proc_root = tmp_path / "proc"
+    cwd = tmp_path / "worktree"
+    cwd.mkdir()
+    _proc_cwd(proc_root, 201, cwd)
+    (proc_root / "202").mkdir()
+    real_readlink = os.readlink
+
+    def disappearing_readlink(path):
+        if Path(path).parent.name == "202":
+            raise FileNotFoundError(errno.ENOENT, "gone", str(path))
+        return real_readlink(path)
+
+    monkeypatch.setattr(os, "readlink", disappearing_readlink)
+
+    scan = scan_process_cwds(proc_root)
+
+    assert scan.available is True
+    assert scan.complete is True
+    assert scan.process_count == 1
+    assert scan.unreadable_count == 0
+
+
+def test_globally_inaccessible_proc_scan_is_uncertain(tmp_path):
+    proc_root = tmp_path / "not-a-directory"
+    proc_root.write_text("not proc", encoding="utf-8")
+
+    scan = scan_process_cwds(proc_root)
+
+    assert scan.available is False
+    assert scan.complete is False
+    assert scan.process_count == 0
+    assert scan.blocking_process_count(tmp_path) == 0
+
+
+def test_unreadable_pid_cwd_makes_scan_incomplete(tmp_path, monkeypatch):
+    proc_root = tmp_path / "proc"
+    (proc_root / "301").mkdir(parents=True)
+
+    def denied_readlink(path):
+        raise PermissionError(errno.EACCES, "denied", str(path))
+
+    monkeypatch.setattr(os, "readlink", denied_readlink)
+
+    scan = scan_process_cwds(proc_root)
+
+    assert scan.available is True
+    assert scan.complete is False
+    assert scan.unreadable_count == 1

--- a/tests/test_worktree_gc_session_guards.py
+++ b/tests/test_worktree_gc_session_guards.py
@@ -1,0 +1,682 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from api.worktree_gc_inventory import (
+    HealthProbe,
+    ProcessScan,
+    audit_managed_worktrees,
+    load_managed_worktree_sessions,
+)
+
+
+NOW = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_server():
+    """These unit tests do not need the repository's HTTP server fixture."""
+
+
+@dataclass(frozen=True)
+class FakeGitDecision:
+    path: str
+    branch: str
+    repo_root: str
+    target_ref: str
+    verdict: str = "REMOVE_ANCESTOR"
+    eligible: bool = True
+    reasons: tuple[str, ...] = ("branch_is_ancestor",)
+
+
+class FakeGitBackend:
+    def __init__(self):
+        self.classify_calls = []
+
+    def classify_git_worktree(self, path, branch, repo_root, *, target_ref):
+        self.classify_calls.append((path, branch, repo_root, target_ref))
+        return FakeGitDecision(path, branch, repo_root, target_ref)
+
+
+def _write_session(
+    state_dir: Path,
+    session_id: str,
+    worktree: Path,
+    repo: Path,
+    **overrides,
+) -> Path:
+    sessions = state_dir / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "profile": "default",
+        "archived": True,
+        "workspace": str(worktree),
+        "updated_at": NOW.timestamp() - 30 * 86400,
+        "worktree_path": str(worktree),
+        "worktree_branch": f"hermes/{session_id}",
+        "worktree_repo_root": str(repo),
+        "worktree_created_at": NOW.timestamp() - 30 * 86400,
+        "active_stream_id": None,
+        "pending_user_message": None,
+        "pending_attachments": [],
+        "pending_started_at": None,
+        "messages": [{"role": "user", "content": "must never reach reports"}],
+        "title": "must never reach reports",
+    }
+    payload.update(overrides)
+    path = sessions / f"{session_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _safe_health(_url):
+    return HealthProbe(reachable=True, active_runs=0)
+
+
+def _empty_process_scan():
+    return ProcessScan(available=True, complete=True, process_cwds=())
+
+
+def _write_workspace_session(
+    state_dir: Path,
+    session_id: str,
+    workspace: Path,
+    **overrides,
+) -> Path:
+    sessions = state_dir / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "profile": "default",
+        "archived": True,
+        "workspace": str(workspace),
+        "updated_at": NOW.timestamp() - 30 * 86400,
+        "active_stream_id": None,
+        "pending_user_message": None,
+        "pending_attachments": [],
+        "pending_started_at": None,
+        "messages": [{"role": "user", "content": "private derived content"}],
+        "title": "private derived title",
+    }
+    payload.update(overrides)
+    path = sessions / f"{session_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _audit(state_dir, repo, backend, **kwargs):
+    process_scan = kwargs.pop("process_scan", _empty_process_scan())
+    return audit_managed_worktrees(
+        state_dir=state_dir,
+        profile="default",
+        repo_filter=repo,
+        min_age_days=7,
+        target_ref="origin/master",
+        git_backend=backend,
+        health_url="http://127.0.0.1:8787/health",
+        health_probe=_safe_health,
+        process_scan=process_scan,
+        now=NOW,
+        **kwargs,
+    )
+
+
+def test_session_loader_filters_profile_and_repo_by_canonical_equality(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    other_repo = tmp_path / "repo-copy"
+    worktrees = tmp_path / "worktrees"
+    repo.mkdir()
+    other_repo.mkdir()
+    worktrees.mkdir()
+    _write_session(state_dir, "included", worktrees / "included", repo)
+    _write_session(
+        state_dir,
+        "legacy-default",
+        worktrees / "legacy",
+        repo,
+        profile_key_is_absent=True,
+    )
+    legacy_path = state_dir / "sessions" / "legacy-default.json"
+    legacy = json.loads(legacy_path.read_text(encoding="utf-8"))
+    legacy.pop("profile")
+    legacy.pop("profile_key_is_absent")
+    legacy_path.write_text(json.dumps(legacy), encoding="utf-8")
+    _write_session(
+        state_dir,
+        "wrong-profile",
+        worktrees / "wrong-profile",
+        repo,
+        profile="other",
+    )
+    _write_session(
+        state_dir,
+        "explicit-null-profile",
+        worktrees / "null-profile",
+        repo,
+        profile=None,
+    )
+    _write_session(
+        state_dir,
+        "wrong-repo",
+        worktrees / "wrong-repo",
+        other_repo,
+    )
+    (state_dir / "sessions" / "_index.json").write_text("{}", encoding="utf-8")
+    (state_dir / "sessions" / "ignored.json.tmp.1").write_text(
+        "{not json", encoding="utf-8"
+    )
+
+    candidates = load_managed_worktree_sessions(
+        state_dir,
+        profile="default",
+        repo_filter=repo,
+    )
+
+    assert [candidate.session_id for candidate in candidates] == [
+        "included",
+        "legacy-default",
+    ]
+
+
+def test_repo_filter_is_canonicalized_from_a_relative_cli_path(
+    tmp_path,
+    monkeypatch,
+):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "relative-repo", worktree, repo)
+    monkeypatch.chdir(tmp_path)
+
+    candidates = load_managed_worktree_sessions(
+        state_dir,
+        profile="default",
+        repo_filter=Path("repo"),
+    )
+
+    assert [candidate.session_id for candidate in candidates] == [
+        "relative-repo"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_verdict"),
+    [
+        ({"archived": False}, "KEEP_NOT_ARCHIVED"),
+        (
+            {"worktree_created_at": NOW.timestamp() - 2 * 86400},
+            "KEEP_RECENT",
+        ),
+        (
+            {"worktree_created_at": None, "updated_at": None},
+            "KEEP_UNCERTAIN",
+        ),
+        ({"worktree_created_at": "not-a-date"}, "KEEP_UNCERTAIN"),
+        ({"worktree_branch": "not a valid branch"}, "KEEP_UNCERTAIN"),
+        ({"active_stream_id": "stream-1"}, "KEEP_ACTIVE"),
+        ({"pending_user_message": "queued"}, "KEEP_ACTIVE"),
+        ({"pending_attachments": [{"name": "secret.txt"}]}, "KEEP_ACTIVE"),
+        ({"pending_started_at": NOW.timestamp()}, "KEEP_ACTIVE"),
+    ],
+)
+def test_session_guards_stop_candidates_before_git(
+    tmp_path,
+    overrides,
+    expected_verdict,
+):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "guarded", worktree, repo, **overrides)
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == expected_verdict
+    serialized = json.dumps(report)
+    assert "must never reach reports" not in serialized
+    assert "secret.txt" not in serialized
+
+
+def test_missing_creation_date_falls_back_to_old_updated_at(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(
+        state_dir,
+        "fallback-date",
+        worktree,
+        repo,
+        worktree_created_at=None,
+        updated_at=NOW.timestamp() - 30 * 86400,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert len(backend.classify_calls) == 1
+    assert report["candidates"][0]["age_source"] == "updated_at"
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        HealthProbe(reachable=True, active_runs=1),
+        HealthProbe(reachable=False, active_runs=None, reason="unreachable"),
+    ],
+)
+def test_health_activity_or_failure_blocks_all_git_classification(
+    tmp_path,
+    probe,
+):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "health-guarded", worktree, repo)
+    backend = FakeGitBackend()
+
+    report = audit_managed_worktrees(
+        state_dir=state_dir,
+        profile="default",
+        repo_filter=repo,
+        min_age_days=7,
+        target_ref="origin/master",
+        git_backend=backend,
+        health_url="http://127.0.0.1:8787/health",
+        health_probe=lambda _url: probe,
+        process_scan=_empty_process_scan(),
+        now=NOW,
+    )
+
+    assert backend.classify_calls == []
+    assert report["mode"] == "dry-run"
+    assert report["collection_requested"] is False
+    assert report["has_blocking_anomalies"] is True
+    assert report["candidates"][0]["verdict"] in {"KEEP_ACTIVE", "KEEP_UNCERTAIN"}
+
+
+def test_incomplete_process_scan_blocks_git_classification(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "proc-uncertain", worktree, repo)
+    backend = FakeGitBackend()
+
+    report = _audit(
+        state_dir,
+        repo,
+        backend,
+        process_scan=ProcessScan(
+            available=False,
+            complete=False,
+            process_cwds=(),
+            error="PermissionError",
+        ),
+    )
+
+    assert backend.classify_calls == []
+    assert report["has_blocking_anomalies"] is True
+    assert report["candidates"][0]["verdict"] == "KEEP_UNCERTAIN"
+    assert "process_scan_incomplete" in report["candidates"][0]["reasons"]
+
+
+def test_unreadable_sidecar_blocks_collection_without_exposing_contents(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "valid", worktree, repo)
+    (state_dir / "sessions" / "broken.json").write_text(
+        '{"secret": "must-not-leak"',
+        encoding="utf-8",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["has_blocking_anomalies"] is True
+    assert report["session_scan"]["errors"] == 1
+    assert "must-not-leak" not in json.dumps(report)
+
+
+def test_contradictory_duplicate_path_is_uncertain(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "duplicate-a", worktree, repo)
+    _write_session(
+        state_dir,
+        "duplicate-b",
+        worktree,
+        repo,
+        worktree_branch="hermes/different",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert len(report["candidates"]) == 1
+    assert report["candidates"][0]["verdict"] == "KEEP_UNCERTAIN"
+    assert "duplicate_conflict" in report["candidates"][0]["reasons"]
+    assert report["candidates"][0]["session_ids"] == [
+        "duplicate-a",
+        "duplicate-b",
+    ]
+
+
+def test_duplicate_repo_conflict_is_not_hidden_by_repo_filter(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    other_repo = tmp_path / "other-repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    other_repo.mkdir()
+    worktree.mkdir()
+    _write_session(
+        state_dir,
+        "duplicate-a",
+        worktree,
+        other_repo,
+        worktree_branch="hermes/shared",
+    )
+    _write_session(
+        state_dir,
+        "duplicate-b",
+        worktree,
+        repo,
+        worktree_branch="hermes/shared",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert len(report["candidates"]) == 1
+    assert report["candidates"][0]["worktree_repo_root"] == str(repo.resolve())
+    assert report["candidates"][0]["verdict"] == "KEEP_UNCERTAIN"
+    assert "duplicate_conflict" in report["candidates"][0]["reasons"]
+
+
+def test_equivalent_duplicate_path_with_different_session_recency_is_deduplicated(
+    tmp_path,
+):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(
+        state_dir,
+        "duplicate-a",
+        worktree,
+        repo,
+        worktree_branch="hermes/shared",
+        updated_at=NOW.timestamp() - 20 * 86400,
+    )
+    _write_session(
+        state_dir,
+        "duplicate-b",
+        worktree,
+        repo,
+        worktree_branch="hermes/shared",
+        updated_at=NOW.timestamp() - 10 * 86400,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert len(backend.classify_calls) == 1
+    assert len(report["candidates"]) == 1
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+    assert report["candidates"][0]["session_ids"] == [
+        "duplicate-a",
+        "duplicate-b",
+    ]
+
+
+def test_complete_old_inactive_session_reaches_git_backend(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "eligible", worktree, repo)
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == [
+        (
+            str(worktree.resolve()),
+            "hermes/eligible",
+            str(repo.resolve()),
+            "origin/master",
+        )
+    ]
+    assert report["mode"] == "dry-run"
+    assert report["collection_requested"] is False
+    assert "collection_allowed" not in report
+    assert report["candidates"][0]["eligible"] is True
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+
+
+def test_non_archived_fork_without_worktree_fields_blocks_shared_workspace(
+    tmp_path,
+):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "fork",
+        worktree,
+        archived=False,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == "KEEP_NOT_ARCHIVED"
+    assert report["candidates"][0]["session_ids"] == ["fork", "managed"]
+    serialized = json.dumps(report)
+    assert "private derived content" not in serialized
+    assert "private derived title" not in serialized
+
+
+def test_recent_archived_duplicate_without_worktree_fields_blocks(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "duplicate",
+        worktree,
+        updated_at=NOW.timestamp() - 2 * 86400,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == "KEEP_RECENT"
+    assert report["candidates"][0]["session_ids"] == ["duplicate", "managed"]
+    assert "linked_session_younger_than_min_age" in report["candidates"][0]["reasons"]
+
+
+def test_workspace_prefix_lookalike_does_not_block(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    lookalike = tmp_path / "worktree-copy"
+    repo.mkdir()
+    worktree.mkdir()
+    lookalike.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "lookalike",
+        lookalike,
+        archived=False,
+        active_stream_id="active",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert len(backend.classify_calls) == 1
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+    assert report["candidates"][0]["session_ids"] == ["managed"]
+
+
+def test_descendant_workspace_blocks(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    descendant = worktree / "nested" / "project"
+    repo.mkdir()
+    descendant.mkdir(parents=True)
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "descendant",
+        descendant,
+        archived=False,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == "KEEP_NOT_ARCHIVED"
+    assert report["candidates"][0]["session_ids"] == ["descendant", "managed"]
+
+
+def test_different_profile_shared_workspace_does_not_block(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "other-profile",
+        worktree,
+        profile="other",
+        archived=False,
+        active_stream_id="active",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert len(backend.classify_calls) == 1
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"
+    assert report["candidates"][0]["session_ids"] == ["managed"]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"active_stream_id": "stream"},
+        {"pending_user_message": "queued"},
+        {"pending_attachments": [{"name": "private.txt"}]},
+        {"pending_started_at": NOW.timestamp()},
+    ],
+)
+def test_linked_workspace_activity_blocks(tmp_path, overrides):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "active-derived",
+        worktree,
+        **overrides,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == "KEEP_ACTIVE"
+    assert report["candidates"][0]["session_ids"] == [
+        "active-derived",
+        "managed",
+    ]
+    assert "private.txt" not in json.dumps(report)
+
+
+def test_linked_workspace_invalid_date_is_uncertain(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(state_dir, "managed", worktree, repo)
+    _write_workspace_session(
+        state_dir,
+        "invalid-date",
+        worktree,
+        updated_at="not-a-date",
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"][0]["verdict"] == "KEEP_UNCERTAIN"
+    assert "linked_session_invalid_or_missing_age" in report["candidates"][0]["reasons"]
+
+
+def test_creation_lock_pid_alone_does_not_count_as_activity(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    _write_session(
+        state_dir,
+        "bookkeeping-lock",
+        worktree,
+        repo,
+        worktree_lock_pid=99999,
+    )
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert len(backend.classify_calls) == 1
+    assert report["candidates"][0]["verdict"] == "REMOVE_ANCESTOR"

--- a/tests/test_worktree_gc_session_guards.py
+++ b/tests/test_worktree_gc_session_guards.py
@@ -358,6 +358,26 @@ def test_unreadable_sidecar_blocks_collection_without_exposing_contents(tmp_path
     assert "must-not-leak" not in json.dumps(report)
 
 
+def test_missing_sessions_directory_is_a_blocking_inventory_failure(tmp_path):
+    state_dir = tmp_path / "state"
+    repo = tmp_path / "repo"
+    state_dir.mkdir()
+    repo.mkdir()
+    backend = FakeGitBackend()
+
+    report = _audit(state_dir, repo, backend)
+
+    assert backend.classify_calls == []
+    assert report["candidates"] == []
+    assert report["has_blocking_anomalies"] is True
+    assert report["global_reasons"] == ["session_scan_incomplete"]
+    assert report["session_scan"] == {
+        "sidecars_scanned": 0,
+        "errors": 1,
+        "error_kinds": ["session_directory_missing"],
+    }
+
+
 def test_contradictory_duplicate_path_is_uncertain(tmp_path):
     state_dir = tmp_path / "state"
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Thinking Path

1. WebUI-created conversation worktrees need lifecycle visibility before any cleanup can be automated safely.
2. Git cleanliness alone is insufficient: ignored files, linked/forked sessions, active streams, pending input, process working directories, stale refs, and patch-equivalent commits all affect safety.
3. The initial collector design was rejected during independent review because filesystem and runtime races could still destroy local state.
4. This PR therefore ships the first phase only: a fail-closed, observation-only audit. It contains no worktree or branch deletion path.

## What Changed

- Add a read-only Git classifier for linked worktrees.
  - tracked and untracked status
  - ignored-file detection without reading file contents
  - ancestor, unique-commit, and patch-equivalence classification
  - hook-neutralized, allowlisted Git subprocesses
- Add a profile-scoped WebUI session inventory.
  - archived/age/pending/stream guards
  - linked duplicate/fork sessions discovered through their inherited workspace
  - `/proc/<pid>/cwd` and WebUI health checks, fail-closed when unavailable
  - duplicate/conflicting metadata detection
- Add an observation-only CLI with atomic JSON reports and exit codes suitable for a scheduler.
- Document the audit contract and the explicit absence of a collector.
- Add 74 focused tests plus neighboring worktree regression coverage.

## Safety Contract

- No `--collect` option.
- No `git worktree remove`, branch deletion, ref deletion, prune, reset, clean, or filesystem removal.
- Ignored files block eligibility.
- Corrupt sidecars, incomplete process visibility, unhealthy WebUI health, active runs, pending messages, or ambiguous metadata block eligibility.
- A future collector requires a separate atomic/CAS design and review after operators have observed audit reports.

## Verification

- Focused GC and neighboring worktree tests: 100 passed on the final SHA.
- Python compile: passed.
- Ruff diff gate: no findings.
- `git diff --check`: passed.
- Five-shard comparison against the exact upstream base showed no HEAD-only failures; the feature adds 93 passing tests to the shard matrix.
- 700-candidate/700-session inventory benchmark improved from about 99.2 s to 0.405 s after path indexing.
- Real local dry-run against a large session inventory produced a report with `collection_requested=false` and made no worktree mutation.
- Independent security review confirmed no Git/filesystem collection primitive is exposed by the runtime CLI.

## Operational Notes

The CLI intentionally classifies the target ref present in the repository. Schedulers that require fresh remote evidence should refresh the target ref before launching the audit, under their own maintenance lock.

## Model Used

GPT-5.6 Sol with xhigh reasoning, with independent safety and quality review passes.

## Contract Routing

This is a standalone operational audit surface. It does not change the WebUI API, session persistence schema, chat runtime, UI, or deployment contracts.
