### PR TITLE
feat(mobile): surface server-switch action (#6647)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -12466,6 +12466,33 @@ def _handle_health(handler, parsed):
         "uptime_seconds": round(time.time() - SERVER_START_TIME, 1),
         "accept_loop": _accept_loop_health(handler),
     }
+    # Server identity for companion/mobile clients (#6647): expose the
+    # canonical URL, display name, and version the client is actually talking
+    # to, so a native app (e.g. HerMex on iOS) can surface the active server
+    # at a glance and validate a one-tap server switch without a second
+    # round-trip. All fields derive from the request itself (Host header) or
+    # cheap local reads; any failure degrades to omitting the block rather
+    # than failing the health check.
+    try:
+        from api.updates import WEBUI_VERSION as _health_server_version
+
+        _health_server_url = _request_base_url(handler)
+        _health_server_block = {
+            "url": _health_server_url,
+            "name": _health_server_url.split("://", 1)[-1].split("/", 1)[0],
+            "version": _health_server_version or "",
+        }
+        try:
+            from api.agent_health import get_active_profile_gateway_running_pid
+
+            _health_server_block["gateway_running"] = (
+                get_active_profile_gateway_running_pid() is not None
+            )
+        except Exception:
+            pass
+        payload["server"] = _health_server_block
+    except Exception:
+        pass
     if "oldest_run_age_seconds" in run_check:
         payload["oldest_run_age_seconds"] = run_check["oldest_run_age_seconds"]
     if "idle_seconds_since_last_run" in run_check:

--- a/tests/test_issue6647_server_identity_health.py
+++ b/tests/test_issue6647_server_identity_health.py
@@ -1,0 +1,68 @@
+"""Static contract tests for #6647 — /health server identity block.
+
+HerMex (iOS companion) validates a server by probing GET /health and reading
+`status == "ok"`. To let the app surface the active server at a glance and
+support a one-tap server switch, /health must also report the canonical server
+URL/name/version the client is actually talking to, plus a lightweight
+gateway_running flag — all in the same round-trip the app already performs.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def _health_payload_src() -> str:
+    """Return the /health payload construction block inside `_handle_health`."""
+    health_start = ROUTES_PY.index("def _handle_health")
+    payload_start = ROUTES_PY.index("payload = {", health_start)
+    payload_end = ROUTES_PY.index('if "oldest_run_age_seconds" in run_check:', payload_start)
+    return ROUTES_PY[payload_start:payload_end]
+
+
+def test_health_exposes_server_identity_block():
+    payload = _health_payload_src()
+    assert 'payload["server"] = _health_server_block' in payload, (
+        "/health must expose a server identity block for companion clients (#6647)"
+    )
+
+
+def test_server_identity_url_derived_from_request():
+    payload = _health_payload_src()
+    assert "_health_server_url = _request_base_url(handler)" in payload, (
+        "server.url must be derived from the request Host header so reverse-proxy "
+        "deployments report the URL the client actually used"
+    )
+
+
+def test_server_identity_includes_name_and_version():
+    payload = _health_payload_src()
+    assert '"url": _health_server_url' in payload
+    assert '"name": _health_server_url.split("://", 1)[-1].split("/", 1)[0]' in payload
+    assert '"version": _health_server_version or ""' in payload
+    assert "from api.updates import WEBUI_VERSION as _health_server_version" in payload
+
+
+def test_server_identity_includes_gateway_running_flag():
+    payload = _health_payload_src()
+    assert '_health_server_block["gateway_running"]' in payload, (
+        "server block must include a lightweight gateway_running flag"
+    )
+    assert "get_active_profile_gateway_running_pid() is not None" in payload
+
+
+def test_health_keeps_existing_contract_fields():
+    payload = _health_payload_src()
+    assert '"status": "ok" if stream_check.get("status") == "ok" else "degraded"' in payload
+    assert '"server_started_at": SERVER_START_TIME' in payload
+    assert '"uptime_seconds": round(time.time() - SERVER_START_TIME, 1)' in payload
+    assert '"accept_loop": _accept_loop_health(handler)' in payload
+
+
+def test_server_identity_failure_degrades_gracefully():
+    payload = _health_payload_src()
+    # The block is wrapped so any failure omits the key rather than breaking
+    # the health endpoint (which load balancers and the iOS app rely on).
+    assert "payload[\"server\"] = _health_server_block" in payload
+    assert "except Exception:" in payload


### PR DESCRIPTION
Closes #6647

## Thinking Path

HerMex (iOS) validates a server by probing `GET /health` and reading `status == "ok"` — that is the one round-trip the app already performs when connecting or switching servers. The issue's `upstream-change` label means the WebUI (upstream of the HerMex client) must expose the server identity the app needs to surface the active server at a glance and enable a one-tap switch flow.

Rather than adding a brand-new endpoint (which would require the iOS client to adopt yet another call), this PR enriches the existing `/health` payload with a lightweight `server` block — same request, zero extra round-trips.

## What Changed

- `api/routes.py` — `_handle_health()` now appends a `server` identity block:
  - `server.url` — canonical URL derived from the request Host header (`_request_base_url`), so reverse-proxy/Tailscale deployments report the URL the client actually used
  - `server.name` — host portion of that URL, for at-a-glance display
  - `server.version` — `WEBUI_VERSION`, so the app no longer needs a separate `/api/settings` call to show which server version it's connected to
  - `server.gateway_running` — lightweight flag via `get_active_profile_gateway_running_pid()`
- Wrapped in try/except so any failure omits the block rather than breaking `/health` (which load balancers and the app rely on).
- `tests/test_issue6647_server_identity_health.py` — static contract tests (repo pattern) pinning the new block and guarding the existing `/health` fields.

## Why It Matters

With the server identity in the existing health probe, the HerMex client can render "Connected to <name/url>" at the top of its connection screen and validate a server switch in a single tap — no deep Settings scroll, no extra endpoint to adopt. The core WebUI remains unchanged for browser users.

## Verification

- `python3 -m py_compile api/routes.py` — OK
- `pytest tests/test_issue6647_server_identity_health.py tests/test_update_banner_fixes.py::TestHealthRouteContract tests/test_issue1458_stability_hardening.py::test_health_exposes_accept_loop_heartbeat` — 8 passed
- `pytest tests/test_5455_agent_health_single_flight.py tests/test_agent_health_remote.py tests/test_issue693_system_health_panel.py tests/test_ctl_foreign_server_guard.py` — 50 passed

## Risks / Follow-ups

- `/health` is a public path (no auth); the `server` block exposes only non-sensitive identity (URL/name/version/gateway flag), consistent with what the dashboard probe already surfaces.
- The HerMex client-side UI change (moving the server switcher to a top-level connection control) lives in the native app repo; this PR is the upstream WebUI change that unblocks it.

## Model Used

deepseek-v4-flash