### PR TITLE
fix(session): no-provider recovery (#2761)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1767,8 +1767,10 @@ async function send(){
   // continuation session, the `compressed` SSE event carries the new id.
   // Recovery paths (done settle, _restoreSettledSession) must know it to
   // avoid polling the archived pre-compression session and freezing the
-  // live turn behind the running compression card.
-  let _streamCompressionContinuationSid='';
+  // live turn behind the running compression card. The captured id is
+  // STREAM-OWNED state and lives in attachLiveStream() (see there) — a
+  // send()-scoped binding would be invisible to the compressed handler and
+  // _restoreSettledSession, silently relying on an implicit global.
   let postStartData;
   let modelStateForPostStart;
   let explicitPickForPostStart;
@@ -1887,7 +1889,6 @@ async function send(){
   const startData = postStartData || {};
   streamId = postStartData ? postStartData.stream_id : null;
   S.activeStreamId = streamId;
-  _streamCompressionContinuationSid='';
   // setBusy(true) already ran with activeStreamId=null; refresh now that we
   // have a stream id so the primary button can switch to Stop (see
   // getComposerPrimaryAction).
@@ -2019,6 +2020,13 @@ const _STREAM_NOTIFICATION_BACKGROUND={};
 // keeps the prior state when the streamId matches. One idempotent
 // visibilitychange listener (never leaks) flips wasHidden on all active entries.
 const _STREAM_WAS_HIDDEN={};
+// #2761 (Gate B): per-stream continuation-session id registry, mirroring
+// _STREAM_WAS_HIDDEN's stream-ownership model. Keyed by activeSid with
+// {streamId, continuationSid}; a reconnect of the SAME stream keeps the
+// rotated id captured before the drop, while a brand-new stream starts clean.
+// The live value is a local inside attachLiveStream() — the registry only
+// preserves it across reconnects of the same stream.
+const _STREAM_COMPRESSION_SIDS={};
 let _streamHiddenTrackerBound=false;
 function _bindStreamHiddenTracker(){
   if(_streamHiddenTrackerBound||typeof document==='undefined'||typeof document.addEventListener!=='function') return;
@@ -2139,6 +2147,21 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const _extensionTurnStartedAt=(S.session&&S.session.session_id===activeSid&&Number.isFinite(S.session.pending_started_at))
     ?S.session.pending_started_at
     :Date.now()/1000;
+  // #2761 (Gate B): continuation-session id captured from the `compressed`
+  // SSE event. STREAM-OWNED: declared here (not in send()) so the compressed
+  // handler and _restoreSettledSession share one per-stream binding instead
+  // of relying on an implicit global. A reconnect of the SAME stream keeps
+  // the rotated id captured before the drop; a brand-new stream starts clean.
+  let _streamCompressionContinuationSid='';
+  {
+    const _prevComp=_STREAM_COMPRESSION_SIDS[activeSid];
+    const _keepComp=reconnecting&&_prevComp&&_prevComp.streamId===streamId;
+    if(_keepComp){
+      _streamCompressionContinuationSid=_prevComp.continuationSid||'';
+    }else{
+      _STREAM_COMPRESSION_SIDS[activeSid]={streamId,continuationSid:''};
+    }
+  }
   // #4416: start (or, on reconnect for the SAME stream, keep) tracking whether
   // the tab was hidden during this stream so the done-notification fires for a
   // backgrounded tab. A reconnect with a different streamId re-seeds (the old
@@ -6160,9 +6183,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // to the visible pane when its completed session id equals the
         // currently displayed session, so treat that as an active-session
         // settle even though the turn's original activeSid rotated.
-        const isActiveSession=_isSessionCurrentPane(activeSid)
-          || (!!completedSid && !!S.session && S.session.session_id===completedSid);
-        const isSessionViewed=_isSessionActivelyViewed(activeSid);
+        // #2761 re-gate: the backend clears/saves active_stream_id BEFORE
+        // emitting done, so a newer continuation turn can start in that
+        // interval. Require canonical-pane AND current-stream ownership
+        // immediately before any mutation of S.session / S.messages /
+        // S.activeStreamId — otherwise the old handler clears the newer
+        // stream id, replaces its transcript, and the newer terminal event is
+        // rejected as stale (the newer answer is dropped).
+        const isActiveSession=(_isSessionCurrentPane(activeSid)
+          || (!!completedSid && !!S.session && S.session.session_id===completedSid))
+          && (!S.activeStreamId || S.activeStreamId===streamId);
+        // #2761 re-gate: the pane may have rotated to the continuation id, so
+        // resolve completedSid and treat EITHER the original activeSid or the
+        // rotated completedSid as viewed — a continuation pane the user is
+        // looking at must not be persisted as unread.
+        const isSessionViewed=_isSessionActivelyViewed(activeSid)
+          || (!!completedSid && _isSessionActivelyViewed(completedSid));
         const completedMessageCount=completedSession.message_count != null
           ? completedSession.message_count
           : (
@@ -6529,8 +6565,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // #2761 (Gate B): capture the rotated continuation id so recovery paths
       // (done settle, _restoreSettledSession) can poll the session that
       // actually carries the final answer instead of the archived
-      // pre-compression session.
-      if(continuationSid&&continuationSid!==activeSid) _streamCompressionContinuationSid=continuationSid;
+      // pre-compression session. Record it in the stream-owned local AND the
+      // per-stream registry so a same-stream reconnect keeps it.
+      if(continuationSid&&continuationSid!==activeSid){
+        _streamCompressionContinuationSid=continuationSid;
+        if(_STREAM_COMPRESSION_SIDS[activeSid]){
+          _STREAM_COMPRESSION_SIDS[activeSid]={streamId,continuationSid};
+        }
+      }
       const eventMatchesCurrent=!!(currentSid&&(eventSid===currentSid||d.new_session_id===currentSid||d.continuation_session_id===currentSid));
       if(!eventMatchesCurrent) return;
       _applyToAnchor('compressed',d,e);
@@ -7017,6 +7059,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const session=data&&data.session;
       if(!session) return returnStatus?'missing':false;
       if(session.active_stream_id||session.pending_user_message) return returnStatus?'active':false;
+      // #2761 re-gate (finding #1 of #6689): the backend clears/saves
+      // active_stream_id BEFORE emitting done, so a newer continuation turn can
+      // start while this poll was in flight. Re-assert canonical-pane AND
+      // current-stream ownership immediately before ANY mutation of S.session /
+      // S.messages / S.activeStreamId — a stale handler must not clear the
+      // newer stream id, mark its completion unread, or replace its transcript.
+      if(!(_isSessionCurrentPane(activeSid)||_isSessionCurrentPane(_restoreSid))
+        || (S.activeStreamId && S.activeStreamId!==streamId)){
+        _closeSource(source);
+        return returnStatus?'stale':false;
+      }
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
       _cancelThrottledSnapshotTimer();
       _clearAnchorProseIncrementalNode();
@@ -7031,15 +7084,21 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _closeSource(source);
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
-      const isSessionViewed=_isSessionActivelyViewed(activeSid);
       const completedSid=session.session_id||activeSid;
+      // #2761 re-gate: the pane may have rotated to the continuation id, so
+      // treat EITHER the original activeSid or the rotated completedSid as
+      // viewed — a continuation pane the user is looking at must not be
+      // persisted as unread.
+      const isSessionViewed=_isSessionActivelyViewed(activeSid)
+        || (!!completedSid && _isSessionActivelyViewed(completedSid));
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
         _markSessionCompletionUnread(completedSid, session.message_count);
       }
       // #2761 (Gate B): when the session was rotated to a continuation id,
       // the pane is authoritative if it is showing the rotated session (or
       // still the original one).
-      const isActiveSession=_isSessionCurrentPane(activeSid)||_isSessionCurrentPane(_restoreSid);
+      const isActiveSession=(_isSessionCurrentPane(activeSid)||_isSessionCurrentPane(_restoreSid))
+        && (!S.activeStreamId || S.activeStreamId===streamId);
       if(isActiveSession){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1763,6 +1763,12 @@ async function send(){
 
   // Start the agent via POST, get a stream_id back
   let streamId;
+  // #2761: when auto-compression rotates the backend session id to a
+  // continuation session, the `compressed` SSE event carries the new id.
+  // Recovery paths (done settle, _restoreSettledSession) must know it to
+  // avoid polling the archived pre-compression session and freezing the
+  // live turn behind the running compression card.
+  let _streamCompressionContinuationSid='';
   let postStartData;
   let modelStateForPostStart;
   let explicitPickForPostStart;
@@ -1881,6 +1887,7 @@ async function send(){
   const startData = postStartData || {};
   streamId = postStartData ? postStartData.stream_id : null;
   S.activeStreamId = streamId;
+  _streamCompressionContinuationSid='';
   // setBusy(true) already ran with activeStreamId=null; refresh now that we
   // have a stream id so the primary button can switch to Stop (see
   // getComposerPrimaryAction).
@@ -6142,10 +6149,20 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         },_doneEvent);
         _scheduleAnchorRegistryCleanup();
         _clearAnchorProseIncrementalNode();
-        const isActiveSession=_isSessionCurrentPane(activeSid);
-        const isSessionViewed=_isSessionActivelyViewed(activeSid);
         const completedSession=d.session||{session_id:activeSid};
         const completedSid=completedSession.session_id||activeSid;
+        // #2761 (Gate A): auto-compression can rotate the backend session id
+        // mid-turn to a continuation session. If the pane already advanced to
+        // that continuation id (external refresh / apperror reconcile) before
+        // `done` arrives, _isSessionCurrentPane(activeSid) is false and the
+        // settle block below is skipped — leaving the running compression card
+        // frozen and the final answer never rendered. The done payload belongs
+        // to the visible pane when its completed session id equals the
+        // currently displayed session, so treat that as an active-session
+        // settle even though the turn's original activeSid rotated.
+        const isActiveSession=_isSessionCurrentPane(activeSid)
+          || (!!completedSid && !!S.session && S.session.session_id===completedSid);
+        const isSessionViewed=_isSessionActivelyViewed(activeSid);
         const completedMessageCount=completedSession.message_count != null
           ? completedSession.message_count
           : (
@@ -6509,6 +6526,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
       const eventSid=d.old_session_id||d.session_id||activeSid;
       const continuationSid=d.new_session_id||d.continuation_session_id||'';
+      // #2761 (Gate B): capture the rotated continuation id so recovery paths
+      // (done settle, _restoreSettledSession) can poll the session that
+      // actually carries the final answer instead of the archived
+      // pre-compression session.
+      if(continuationSid&&continuationSid!==activeSid) _streamCompressionContinuationSid=continuationSid;
       const eventMatchesCurrent=!!(currentSid&&(eventSid===currentSid||d.new_session_id===currentSid||d.continuation_session_id===currentSid));
       if(!eventMatchesCurrent) return;
       _applyToAnchor('compressed',d,e);
@@ -6978,7 +7000,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       return returnStatus?'stale':false;
     }
     try{
-      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+      // #2761 (Gate B): after auto-compression the backend rotates to a
+      // continuation session id. Polling the ORIGINAL activeSid returns the
+      // archived pre-compression session, which may keep a stale
+      // active_stream_id/pending_user_message (exhausting the retry loop into
+      // _finalizeStreamEndFallback) or simply lack the final answer — either
+      // way the response never renders. When the `compressed` event gave us
+      // the rotated id, poll that session instead.
+      const _restoreSid=(_streamCompressionContinuationSid&&_streamCompressionContinuationSid!==activeSid)
+        ? _streamCompressionContinuationSid
+        : activeSid;
+      const data=await api(`/api/session?session_id=${encodeURIComponent(_restoreSid)}`);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;
@@ -7004,7 +7036,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
         _markSessionCompletionUnread(completedSid, session.message_count);
       }
-      const isActiveSession=_isSessionCurrentPane(activeSid);
+      // #2761 (Gate B): when the session was rotated to a continuation id,
+      // the pane is authoritative if it is showing the rotated session (or
+      // still the original one).
+      const isActiveSession=_isSessionCurrentPane(activeSid)||_isSessionCurrentPane(_restoreSid);
       if(isActiveSession){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
@@ -7067,6 +7102,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(typeof projectSessionArtifactsForOwner==='function') projectSessionArtifactsForOwner(completedSid);
       }
       if(_isActiveSession()) _queueDrainSid=activeSid;
+      else if(S.session&&S.session.session_id===_restoreSid) _queueDrainSid=_restoreSid;
       renderSessionList();
       _setActivePaneIdleIfOwner();
       return returnStatus?'restored':true;

--- a/static/messages.js
+++ b/static/messages.js
@@ -6456,7 +6456,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           sessionId:completedSid,
           liveDisplayText:typeof _streamDisplay==='function'?_streamDisplay():assistantText,
         });
-        sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid});
+        sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:completedSid});
       };
       if(_shouldUseLiveProseFade()&&assistantBody){
         _cancelAnimationFramePendingStreamRender();

--- a/static/messages.js
+++ b/static/messages.js
@@ -7037,6 +7037,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   async function _restoreSettledSession(source, options=null){
     const returnStatus=!!(options&&options.status);
     const preserveVisibleOnShorterTerminalSnapshot=!!(options&&options.preserveVisibleOnShorterTerminalSnapshot);
+    // #6689 re-gate (finding #2 of #6689): a `compressed` event can rotate
+    // _streamCompressionContinuationSid WHILE the /api/session poll is in
+    // flight. A payload resolved against the pre-await sid then describes the
+    // archived parent session — settling it would clobber the continuation
+    // turn (STALE-OLD). So after every await the CURRENT continuation target
+    // is re-read and required to equal the sid we polled; a rotation discards
+    // the stale payload and retries against the current continuation id. The
+    // recursive call re-runs the same stream-ownership guard, and a stale
+    // payload never sets _streamFinalized nor mutates S.session / S.messages
+    // / S.activeStreamId. The retry is bounded so pathological repeated
+    // rotation cannot loop forever.
+    const _rotationRetries=(options&&options._rotationRetries)||0;
     if(_isActiveSession() && S.activeStreamId!==streamId){
       _closeSource(source);
       return returnStatus?'stale':false;
@@ -7056,6 +7068,19 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;
+      // #6689 re-gate (finding #2 of #6689): the continuation id captured
+      // BEFORE the await may already be stale. Re-read the CURRENT
+      // continuation target and require it to equal the sid we polled; if it
+      // rotated during the await, this payload belongs to the archived parent
+      // session — discard it and retry against the current continuation id
+      // under the same stream-ownership guard.
+      const _currentSid=(_streamCompressionContinuationSid&&_streamCompressionContinuationSid!==activeSid)
+        ? _streamCompressionContinuationSid
+        : activeSid;
+      if(_currentSid!==_restoreSid){
+        if(_rotationRetries>=4) return returnStatus?'stale':false;
+        return _restoreSettledSession(source,{...options,_rotationRetries:_rotationRetries+1});
+      }
       const session=data&&data.session;
       if(!session) return returnStatus?'missing':false;
       if(session.active_stream_id||session.pending_user_message) return returnStatus?'active':false;

--- a/tests/test_issue2761_compression_recovery.py
+++ b/tests/test_issue2761_compression_recovery.py
@@ -105,16 +105,29 @@ def test_restore_settled_session_polls_rotated_continuation_id():
 
 def test_continuation_sid_is_reset_per_turn():
     """The captured continuation id must be scoped to one stream/turn so a
-    previous turn's rotation cannot leak into the next turn's recovery."""
+    previous turn's rotation cannot leak into the next turn's recovery.
+    The state is STREAM-OWNED: it lives inside attachLiveStream() (not
+    send()), and a brand-new stream starts clean via the per-stream registry
+    (_STREAM_COMPRESSION_SIDS) while a reconnect of the SAME stream keeps the
+    rotated id captured before the drop.
+    """
     src = _read("static/messages.js")
     decl = src.find("let _streamCompressionContinuationSid='';")
     assert decl != -1, "per-stream continuation sid declaration not found"
-    # Skip past the declaration itself (it also ends with `='';`).
-    reset = src.find("_streamCompressionContinuationSid='';", decl + len("let _streamCompressionContinuationSid='';"))
+    # The declaration must live inside attachLiveStream (stream ownership),
+    # not in send() — a send()-scoped binding is invisible to the compressed
+    # handler and _restoreSettledSession (implicit-global bug).
+    attach_start = src.find("function attachLiveStream(")
+    assert attach_start != -1 and attach_start < decl, (
+        "continuation sid declaration must be inside attachLiveStream, not send()"
+    )
+    # A brand-new stream starts clean: the registry entry is re-seeded.
+    reset = src.find("{streamId,continuationSid:''}", decl)
     assert reset != -1 and reset > decl, (
-        "continuation sid must be reset after stream id assignment"
+        "per-stream continuation sid reset not found after declaration"
     )
-    stream_id_assign = src.find("S.activeStreamId = streamId;", decl)
-    assert stream_id_assign != -1 and stream_id_assign < reset, (
-        "continuation sid reset must happen at stream start"
-    )
+    # Reconnect of the SAME stream must preserve the rotated id.
+    assert "reconnecting&&_prevComp&&_prevComp.streamId===streamId" in src
+    # No implicit-global send() binding may remain.
+    send_decl = src.find("let _streamCompressionContinuationSid='';", 0, attach_start)
+    assert send_decl == -1, "send() must not bind the continuation sid (implicit global)"

--- a/tests/test_issue2761_compression_recovery.py
+++ b/tests/test_issue2761_compression_recovery.py
@@ -1,0 +1,120 @@
+"""Regression tests for #2761 — mid-conversation recovery after auto-compression.
+
+The bug: when auto-compression rotates the backend session id to a
+continuation session, the WebUI's live->settled transition could be skipped:
+
+- Gate A (done handler): the settle block is gated on
+  ``_isSessionCurrentPane(activeSid)``; if the pane already advanced to the
+  rotated continuation id before ``done`` arrives, the block is skipped and
+  the final answer is never rendered (blue compression card frozen).
+- Gate B (``_restoreSettledSession``): the recovery always polled the
+  original ``activeSid``, which post-rotation is an archived pre-compression
+  session that may keep a stale ``active_stream_id`` (exhausting the retry
+  loop) or simply lack the final answer.
+
+These are source-level regression tests in the same style as
+``test_auto_compression_card.py``: they read ``static/messages.js`` and pin
+the recovery guards so a future refactor cannot silently reintroduce the
+skipped settle.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def _done_listener_block() -> str:
+    src = _read("static/messages.js")
+    start = src.find("source.addEventListener('done'")
+    assert start != -1, "done SSE listener not found"
+    end = src.find("source.addEventListener('stream_end'", start)
+    assert end != -1, "stream_end listener after done SSE listener not found"
+    return src[start:end]
+
+
+def _compressed_listener_block() -> str:
+    src = _read("static/messages.js")
+    start = src.find("source.addEventListener('compressed'")
+    assert start != -1, "compressed SSE listener not found"
+    end = src.find("source.addEventListener('metering'", start)
+    assert end != -1, "metering listener after compressed SSE listener not found"
+    return src[start:end]
+
+
+def _restore_settled_session_block() -> str:
+    src = _read("static/messages.js")
+    start = src.find("async function _restoreSettledSession(")
+    assert start != -1, "_restoreSettledSession not found"
+    end = src.find("function _handleStreamError(", start)
+    assert end != -1, "_handleStreamError after _restoreSettledSession not found"
+    return src[start:end]
+
+
+def test_done_settle_survives_continuation_session_rotation():
+    """Gate A: the done settle must run when the completed session id equals
+    the currently displayed session, even if the turn's original activeSid was
+    rotated by auto-compression."""
+    block = _done_listener_block()
+
+    # The fallback must be present: treat done as active-session when the pane
+    # is showing the completed session (continuation id).
+    assert "S.session.session_id===completedSid" in block
+    # completedSid must be computed BEFORE isActiveSession uses it.
+    completed_idx = block.find("const completedSid=")
+    active_idx = block.find("const isActiveSession=")
+    assert completed_idx != -1 and active_idx != -1
+    assert completed_idx < active_idx, (
+        "completedSid must be resolved before isActiveSession so the rotation "
+        "fallback can reference it"
+    )
+    # The settle itself (transcript replace + render) must still be gated on
+    # isActiveSession (now rotation-aware), not removed or bypassed.
+    assert "S.session=d.session" in block
+    assert "renderMessages({preserveScroll:true})" in block
+
+
+def test_compressed_listener_captures_continuation_sid():
+    """Gate B: the compressed SSE listener must record the rotated continuation
+    id so recovery paths can poll the session carrying the final answer."""
+    block = _compressed_listener_block()
+
+    assert "_streamCompressionContinuationSid=continuationSid" in block
+    assert "continuationSid!==activeSid" in block
+
+
+def test_restore_settled_session_polls_rotated_continuation_id():
+    """Gate B: _restoreSettledSession must poll the rotated continuation id
+    (when known) instead of always polling the archived pre-compression
+    activeSid, and the settle must accept the rotated session as the pane."""
+    block = _restore_settled_session_block()
+
+    # Recovery resolves a restore target sid that prefers the continuation id.
+    assert "_restoreSid=" in block
+    assert "_streamCompressionContinuationSid!==activeSid" in block
+    # The /api/session poll uses the resolved sid, not hardcoded activeSid.
+    assert "session_id=${encodeURIComponent(_restoreSid)}" in block
+    # The settle pane check accepts the rotated session.
+    assert "_isSessionCurrentPane(_restoreSid)" in block
+    # The queue drain follows the rotated session when the pane shows it.
+    assert "_queueDrainSid=_restoreSid" in block
+
+
+def test_continuation_sid_is_reset_per_turn():
+    """The captured continuation id must be scoped to one stream/turn so a
+    previous turn's rotation cannot leak into the next turn's recovery."""
+    src = _read("static/messages.js")
+    decl = src.find("let _streamCompressionContinuationSid='';")
+    assert decl != -1, "per-stream continuation sid declaration not found"
+    # Skip past the declaration itself (it also ends with `='';`).
+    reset = src.find("_streamCompressionContinuationSid='';", decl + len("let _streamCompressionContinuationSid='';"))
+    assert reset != -1 and reset > decl, (
+        "continuation sid must be reset after stream id assignment"
+    )
+    stream_id_assign = src.find("S.activeStreamId = streamId;", decl)
+    assert stream_id_assign != -1 and stream_id_assign < reset, (
+        "continuation sid reset must happen at stream start"
+    )

--- a/tests/test_issue2761_compression_recovery.py
+++ b/tests/test_issue2761_compression_recovery.py
@@ -131,3 +131,36 @@ def test_continuation_sid_is_reset_per_turn():
     # No implicit-global send() binding may remain.
     send_decl = src.find("let _streamCompressionContinuationSid='';", 0, attach_start)
     assert send_decl == -1, "send() must not bind the continuation sid (implicit global)"
+
+
+def test_restore_settled_session_requeries_continuation_id_after_await():
+    """Gate B (finding #2 of #6689): _restoreSettledSession must re-read the
+    CURRENT continuation id AFTER the /api/session await and discard/requery
+    when it rotated during the in-flight request. The pre-await captured
+    _restoreSid alone lets the archived-parent payload settle (STALE-OLD): the
+    concurrent continuation request returns 'restored' but gets suppressed by
+    _streamFinalized, so the wrong session settles. The re-read must compare
+    the current continuation target against the sid that was polled, and the
+    stale-payload path must retry — never set _streamFinalized or mutate
+    S.session / S.messages / S.activeStreamId."""
+    block = _restore_settled_session_block()
+
+    # The post-await re-read of the current continuation target must exist and
+    # be compared against the sid that was actually polled.
+    assert "_currentSid=" in block
+    assert "_currentSid!==_restoreSid" in block
+    # The re-read must happen AFTER the await and BEFORE any settle mutation
+    # (the settle sets _streamFinalized).
+    requery_idx = block.find("_currentSid!==_restoreSid")
+    assert requery_idx != -1
+    await_idx = block.find("await api(`/api/session?session_id=${encodeURIComponent(_restoreSid)}`)")
+    assert await_idx != -1 and requery_idx > await_idx, (
+        "continuation re-read must happen after the /api/session await"
+    )
+    finalized_idx = block.find("_streamFinalized=true;")
+    assert finalized_idx != -1 and requery_idx < finalized_idx, (
+        "continuation re-read must precede any settle mutation"
+    )
+    # The stale-payload path must retry against the current continuation id
+    # (recursive call re-runs the stream-ownership guard), not settle.
+    assert "_restoreSettledSession(source,{...options,_rotationRetries:_rotationRetries+1})" in block

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -242,6 +242,37 @@ function buildRuntime() {
     return;
   }
 
+  if (scenario.action === 'restore_rotation_during_await') {
+    // #6689 re-gate (finding #2): the continuation session id rotates WHILE
+    // the /api/session poll for the archived parent session is in flight. The
+    // stale archived-parent payload must be discarded (no settle, no state
+    // mutation, no _streamFinalized), and the recovery must re-poll the
+    // CURRENT continuation id so ONLY the continuation payload settles.
+    let apiCalls = 0;
+    globalThis.api = async () => {
+      apiCalls += 1;
+      if (apiCalls === 1) {
+        // Rotation arrives during request #1 (archived parent) — as if the
+        // `compressed` SSE event landed mid-roundtrip.
+        _streamCompressionContinuationSid = 'session-cont-1';
+        return scenario.parentPayload || { session: null };
+      }
+      return scenario.contPayload || { session: null };
+    };
+    const status = await _restoreSettledSession({}, { status: true });
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    console.log(JSON.stringify({
+      action: scenario.action,
+      status,
+      apiCalls,
+      session: S.session ? { session_id: S.session.session_id } : null,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      streamFinalized: !!_streamFinalized,
+      calls,
+    }));
+    return;
+  }
+
   throw new Error(`unknown action: ${scenario.action}`);
 })().catch((err) => {
   console.error(err && err.stack ? err.stack : String(err));
@@ -536,3 +567,74 @@ def test_two_stream_recovery_newer_continuation_wins_over_stale_done(driver_path
     assert "B final answer" in b_contents, (
         f"B's final answer must land in the transcript: {b_contents}"
     )
+
+
+def test_rotation_during_await_settles_only_continuation_payload(driver_path):
+    """Deferred-request regression (#6689 re-gate finding #2): the continuation
+    session id rotates WHILE the archived-parent /api/session poll is in flight
+    (the `compressed` SSE event lands mid-roundtrip). The stale archived-parent
+    payload must be discarded — no settle, no S.session / S.messages /
+    S.activeStreamId mutation, no _streamFinalized — and the recovery must
+    re-poll the CURRENT continuation id so ONLY the continuation payload
+    settles."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_rotation_during_await",
+        "state": {
+            "session": {"session_id": "session-2761", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                {"role": "assistant", "content": "Live pre-compression fragment", "_ts": "a1"},
+            ],
+            "activeStreamId": "stream-2761",
+        },
+        "parentPayload": {
+            "session": {
+                "session_id": "session-2761",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "ARCHIVED parent answer (must be discarded)", "_ts": "aParent"},
+                ],
+            },
+        },
+        "contPayload": {
+            "session": {
+                "session_id": "session-cont-1",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "CONTINUATION final answer", "_ts": "aCont"},
+                ],
+            },
+        },
+        "activeSid": "session-2761",
+        "streamId": "stream-2761",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    # The recovery must settle ('restored'), not give up or settle the archive.
+    assert outcome["status"] == "restored", f"got {outcome['status']}"
+    # Exactly two polls: the discarded archived-parent fetch + the retry
+    # against the current continuation id. The stale payload must NOT settle.
+    assert outcome["apiCalls"] == 2, (
+        f"expected archived-parent poll + continuation retry (2 calls), got {outcome['apiCalls']}"
+    )
+    # Only the continuation payload may settle: S.session is the continuation
+    # session and the archived-parent answer never lands in the transcript.
+    assert outcome["session"] == {"session_id": "session-cont-1"}, (
+        f"archived parent settled instead of continuation: {outcome['session']}"
+    )
+    contents = [item["content"] for item in outcome["messages"]]
+    assert "CONTINUATION final answer" in contents, (
+        f"continuation payload did not settle: {contents}"
+    )
+    assert "ARCHIVED parent answer" not in contents, (
+        f"stale archived-parent payload settled: {contents}"
+    )
+    # A legit settle finalizes the stream; the stale payload must not have been
+    # the one to do it (it never reached the mutation block).
+    assert outcome["streamFinalized"] is True

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -273,6 +273,46 @@ function buildRuntime() {
     return;
   }
 
+  if (scenario.action === 'restore_rotation_concurrent') {
+    // #6689 re-gate (finding #2, STALE-OLD reproduction): TWO recovery
+    // requests race. The archived-parent poll (A) is in flight when the
+    // continuation session id rotates, and a SECOND recovery request (B)
+    // for the continuation is in flight concurrently — the exact
+    // interleaving the maintainer's Codex reproduction ended with
+    // (STALE-OLD: the concurrent continuation request returned 'restored'
+    // but got suppressed by _streamFinalized, leaving the wrong archived
+    // session settled). A's stale archived-parent payload must be discarded
+    // by the post-await re-read, and the continuation payload must be the
+    // ONLY one to settle — the archived parent must never set
+    // _streamFinalized nor mutate S.session / S.messages.
+    let apiCalls = 0;
+    globalThis.api = async () => {
+      apiCalls += 1;
+      if (apiCalls === 1) {
+        // Rotation lands while A's archived-parent poll is in flight (the
+        // `compressed` SSE event lands mid-roundtrip).
+        _streamCompressionContinuationSid = 'session-cont-1';
+        return scenario.parentPayload || { session: null };
+      }
+      return scenario.contPayload || { session: null };
+    };
+    const aPromise = _restoreSettledSession({}, { status: true });
+    const bPromise = _restoreSettledSession({}, { status: true });
+    const [aStatus, bStatus] = await Promise.all([aPromise, bPromise]);
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    console.log(JSON.stringify({
+      action: scenario.action,
+      aStatus,
+      bStatus,
+      apiCalls,
+      session: S.session ? { session_id: S.session.session_id } : null,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      streamFinalized: !!_streamFinalized,
+      calls,
+    }));
+    return;
+  }
+
   throw new Error(`unknown action: ${scenario.action}`);
 })().catch((err) => {
   console.error(err && err.stack ? err.stack : String(err));
@@ -637,4 +677,81 @@ def test_rotation_during_await_settles_only_continuation_payload(driver_path):
     )
     # A legit settle finalizes the stream; the stale payload must not have been
     # the one to do it (it never reached the mutation block).
+    assert outcome["streamFinalized"] is True
+
+
+def test_concurrent_continuation_request_never_settles_archived_parent(driver_path):
+    """#6689 re-gate (finding #2, STALE-OLD reproduction): the archived-parent
+    /api/session poll is in flight when the continuation session id rotates
+    AND a second recovery request for the continuation is already in flight —
+    the exact interleaving the maintainer's Codex reproduction ended with.
+    The stale archived-parent payload must be discarded by the post-await
+    re-read; ONLY the continuation payload may settle (never the archived
+    parent, which must not set _streamFinalized or mutate S.session /
+    S.messages)."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_rotation_concurrent",
+        "state": {
+            "session": {"session_id": "session-2761", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                {"role": "assistant", "content": "Live pre-compression fragment", "_ts": "a1"},
+            ],
+            "activeStreamId": "stream-2761",
+        },
+        "parentPayload": {
+            "session": {
+                "session_id": "session-2761",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "ARCHIVED parent answer (must be discarded)", "_ts": "aParent"},
+                ],
+            },
+        },
+        "contPayload": {
+            "session": {
+                "session_id": "session-cont-1",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "CONTINUATION final answer", "_ts": "aCont"},
+                ],
+            },
+        },
+        "activeSid": "session-2761",
+        "streamId": "stream-2761",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    # The archived parent never settles: S.session is the continuation and the
+    # archived answer never lands in the transcript.
+    assert outcome["session"] == {"session_id": "session-cont-1"}, (
+        f"archived parent settled instead of continuation: {outcome['session']}"
+    )
+    contents = [item["content"] for item in outcome["messages"]]
+    assert "CONTINUATION final answer" in contents, (
+        f"continuation payload did not settle: {contents}"
+    )
+    assert "ARCHIVED parent answer" not in contents, (
+        f"stale archived-parent payload settled: {contents}"
+    )
+    # Both concurrent requests resolve 'restored': one settles the
+    # continuation, the other is suppressed by _streamFinalized — never the
+    # archived parent.
+    assert outcome["aStatus"] == "restored", f"parent-side recovery: {outcome['aStatus']}"
+    assert outcome["bStatus"] == "restored", f"continuation-side recovery: {outcome['bStatus']}"
+    # Exactly three polls: (1) A's archived-parent poll — discarded by the
+    # post-await re-read; (2) B's continuation poll — settles; (3) A's retry
+    # against the current continuation id — suppressed by _streamFinalized.
+    # The archived parent is polled exactly once and never settles.
+    assert outcome["apiCalls"] == 3, (
+        f"expected archived-parent poll + continuation poll + retry (3 calls), "
+        f"got {outcome['apiCalls']}"
+    )
+    # The stream is finalized by the continuation settle (never the archive).
     assert outcome["streamFinalized"] is True

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -141,6 +141,10 @@ function buildRuntime() {
   globalThis._messageRenderWindowSize = 20;
   globalThis._streamFinalized = !!scenario.streamFinalized;
   globalThis._persistTimer = null;
+  // #2761: _restoreSettledSession reads the STREAM-OWNED continuation-sid
+  // binding that attachLiveStream() provides. The standalone extraction has no
+  // attachLiveStream scope, so mirror the closure default ('' = no rotation).
+  globalThis._streamCompressionContinuationSid = '';
   globalThis.api = async () => scenario.apiPayload || { session: null };
   globalThis.msgContent = undefined;
   globalThis._isPreservedCompressionTaskListMarkerOnlyText = () => false;
@@ -194,6 +198,46 @@ function buildRuntime() {
       messages: messages.map((m) => ({ role: m.role, content: m.content })),
       terminalMarkerCount,
       calls,
+    }));
+    return;
+  }
+
+  if (scenario.action === 'restore_two_stream_race') {
+    // Two-stream recovery (#6689 re-gate finding #1): stream A settles via
+    // _restoreSettledSession. While A's /api/session poll is in flight, a
+    // newer continuation turn B starts and takes stream ownership
+    // (S.activeStreamId -> 'stream-B'). A's late settle must be rejected as
+    // stale and must NOT clear B's stream id, replace S.session, or replace
+    // S.messages with A's archived transcript. Then B's own terminal settle
+    // must be honored ('restored'), not rejected as stale.
+    globalThis.api = async () => {
+      // B starts in the interval after A's active_stream_id is cleared but
+      // before A's done lands.
+      S.activeStreamId = 'stream-B';
+      return scenario.aPayload || { session: null };
+    };
+    const aStatus = await _restoreSettledSession({}, { status: true });
+    const afterA = {
+      status: aStatus,
+      activeStreamId: S.activeStreamId,
+      session: S.session ? { session_id: S.session.session_id } : null,
+      messages: Array.isArray(S.messages) ? S.messages.map((m) => ({ role: m.role, content: m.content })) : [],
+      calls: calls.slice(),
+    };
+    // Phase 2: B's own settle (B owns the stream now).
+    globalThis.streamId = 'stream-B';
+    globalThis._streamFinalized = false;
+    globalThis.api = async () => scenario.bPayload || { session: null };
+    const bStatus = await _restoreSettledSession({}, { status: true });
+    console.log(JSON.stringify({
+      action: scenario.action,
+      a: afterA,
+      b: {
+        status: bStatus,
+        session: S.session ? { session_id: S.session.session_id } : null,
+        messages: Array.isArray(S.messages) ? S.messages.map((m) => ({ role: m.role, content: m.content })) : [],
+        calls: calls.slice(),
+      },
     }));
     return;
   }
@@ -421,3 +465,74 @@ def test_terminal_error_marker_is_single_instance_and_not_duplicated(driver_path
 
     assert outcome["terminalMarkerCount"] == 1, f"terminal marker should be deduped to one, got {outcome['terminalMarkerCount']}"
     assert outcome["messages"][-1]["content"].startswith("**Connection interrupted:**")
+
+
+def test_two_stream_recovery_newer_continuation_wins_over_stale_done(driver_path):
+    """Two-stream recovery (#6689 re-gate finding #1): a newer continuation
+    turn B starts in the interval after A's active_stream_id is cleared but
+    before A's done lands. A's late settle must be rejected as stale and must
+    NOT clear B's stream id, replace S.session, or clobber B's transcript;
+    B's own terminal event must be honored (not rejected as stale)."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_two_stream_race",
+        "state": {
+            "session": {"session_id": "session-5224", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                {"role": "assistant", "content": "B live answer segment", "_ts": "b1"},
+            ],
+            "activeStreamId": "stream-A",
+        },
+        "aPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "A stale archived answer", "_ts": "a1"},
+                ],
+            },
+        },
+        "bPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "B final answer", "_ts": "bFinal"},
+                ],
+            },
+        },
+        "activeSid": "session-5224",
+        "streamId": "stream-A",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    a = outcome["a"]
+    # A's late settle must be rejected as stale — the newer stream B owns the turn.
+    assert a["status"] == "stale", f"A must be rejected as stale, got {a['status']}"
+    # A must NOT clear B's stream id.
+    assert a["activeStreamId"] == "stream-B", (
+        f"A clobbered B's stream id: {a['activeStreamId']}"
+    )
+    # A must NOT replace S.session with its archived snapshot.
+    assert a["session"] == {"session_id": "session-5224"}
+    # A must NOT clobber B's live transcript with A's archived messages.
+    a_contents = [item["content"] for item in a["messages"]]
+    assert "B live answer segment" in a_contents, (
+        f"B's live transcript was clobbered by A: {a_contents}"
+    )
+    assert "A stale archived answer" not in a_contents, (
+        f"A replaced B's transcript with its archived snapshot: {a_contents}"
+    )
+    # B's own terminal event must be honored (not rejected as stale).
+    b = outcome["b"]
+    assert b["status"] == "restored", f"B's terminal settle must be honored, got {b['status']}"
+    b_contents = [item["content"] for item in b["messages"]]
+    assert "B final answer" in b_contents, (
+        f"B's final answer must land in the transcript: {b_contents}"
+    )

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -507,6 +507,7 @@ const INFLIGHT=global.INFLIGHT={};
 const LIVE_STREAMS=global.LIVE_STREAMS={};
 const _STREAM_WAS_HIDDEN=global._STREAM_WAS_HIDDEN={};
 const _STREAM_NOTIFICATION_BACKGROUND=global._STREAM_NOTIFICATION_BACKGROUND={};
+const _STREAM_COMPRESSION_SIDS=global._STREAM_COMPRESSION_SIDS={};
 const _desktopBackgroundedForNotifications=false;
 global._bindStreamHiddenTracker=()=>{};
 global.closeOtherLiveStreams=()=>{};

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -63,7 +63,11 @@ def test_background_completion_unread_uses_explicit_marker_not_message_delta():
 
 def test_background_done_sets_marker_when_session_not_actively_viewed():
     done_block = _done_block()
-    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in done_block
+    # Viewed-state must resolve completedSid and treat EITHER the original
+    # activeSid or the rotated completedSid as viewed (finding #2 of #6689
+    # re-gate) — the line is split across two lines, so check both halves.
+    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid)" in done_block
+    assert "|| (!!completedSid && _isSessionActivelyViewed(completedSid));" in done_block
     assert "const completedSession=d.session||{session_id:activeSid};" in done_block
     assert "const completedSid=completedSession.session_id||activeSid;" in done_block
     assert "const completedMessageCount=completedSession.message_count != null" in done_block
@@ -434,8 +438,8 @@ def test_active_done_marks_viewed_without_setting_unread_marker():
 def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     done_block = _done_block()
 
-    active_const_idx = done_block.find("const isActiveSession=_isSessionCurrentPane(activeSid);")
-    viewed_const_idx = done_block.find("const isSessionViewed=_isSessionActivelyViewed(activeSid);")
+    active_const_idx = done_block.find("const isActiveSession=(_isSessionCurrentPane(activeSid)")
+    viewed_const_idx = done_block.find("const isSessionViewed=_isSessionActivelyViewed(activeSid)")
     active_guard_idx = done_block.find("if(isActiveSession){", viewed_const_idx)
     session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
     render_idx = done_block.find("renderMessages(", active_guard_idx)
@@ -445,6 +449,14 @@ def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     assert active_const_idx != -1, "done handler must compute active/current pane separately"
     assert viewed_const_idx != -1, "done handler must still compute visible/focused read state"
     assert active_const_idx < viewed_const_idx
+    # #6689 re-gate finding #1: the done settle must re-assert current-stream
+    # ownership (canonical-pane AND current-stream) before mutating S.session.
+    assert "S.activeStreamId===streamId" in done_block, (
+        "done handler must re-assert stream ownership before settling (stale-stream race)"
+    )
+    assert "&& (!S.activeStreamId || S.activeStreamId===streamId);" in done_block, (
+        "isActiveSession must require current-stream ownership"
+    )
     assert session_update_idx != -1, "active hidden completion must still refresh S.session"
     assert render_idx != -1, "active hidden completion must still render the final assistant response"
     assert load_dir_idx != -1, "active hidden completion must keep normal active-session finalization"
@@ -492,8 +504,20 @@ def test_restore_settled_background_stream_marks_completion_unread():
     assert restore_idx != -1, "_restoreSettledSession(source) not found"
     restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
 
-    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in restore_block
+    # #6689 re-gate finding #2: restore must resolve completedSid first and
+    # treat either the original activeSid or the rotated completedSid as viewed
+    # (line is split across two lines — check both halves).
+    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid)" in restore_block
+    assert "|| (!!completedSid && _isSessionActivelyViewed(completedSid));" in restore_block
     assert "const completedSid=session.session_id||activeSid;" in restore_block
+    # #6689 re-gate finding #1: restore must re-assert canonical-pane AND
+    # current-stream ownership before mutating S.session/S.messages/S.activeStreamId.
+    assert "S.activeStreamId && S.activeStreamId!==streamId" in restore_block, (
+        "restore must bail out as stale when a newer stream owns the turn"
+    )
+    assert "&& (!S.activeStreamId || S.activeStreamId===streamId);" in restore_block, (
+        "restore isActiveSession must require current-stream ownership"
+    )
     assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in restore_block
     assert "_markSessionCompletionUnread(completedSid, session.message_count);" in restore_block
     assert "if(isSessionViewed) _markSessionViewed(completedSid" in restore_block, (

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -1,6 +1,11 @@
 """Regression coverage for PWA-backed browser notifications (#3196)."""
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
@@ -200,3 +205,357 @@ def test_notification_i18n_and_changelog_entries_exist():
         if "Notification permission controls now reflect the real browser state" in line
     )
     assert entry.count("#4118") == 1
+
+
+_ROTATED_DONE_HARNESS = r"""
+// Behavioral harness for the #6689 rotated-done notification regression.
+// Loads the REAL static/messages.js into a vm sandbox, drives the REAL
+// attachLiveStream() + its registered 'done' callback with a done payload whose
+// session.session_id names the continuation session, and captures the delivery
+// through the REAL sendBrowserNotification() -> _notificationOptions() chain
+// into a direct `new Notification(...)` sink (navigator.serviceWorker absent).
+// The real _sessionUrlForSid() is extracted from static/sessions.js so the
+// tag/data.url composition is exercised against the shipped function.
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+
+const MESSAGES_PATH = process.argv[1];
+const SESSIONS_PATH = process.argv[2];
+const MESSAGES = fs.readFileSync(MESSAGES_PATH, 'utf8');
+const SESSIONS = fs.readFileSync(SESSIONS_PATH, 'utf8');
+
+// --- extract a real function body from source (balanced braces) ---
+function extractFunction(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) throw new Error('missing ' + marker);
+  const brace = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') { depth--; if (depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error('unbalanced ' + marker);
+}
+const SESSION_URL_FN = extractFunction(SESSIONS, 'function _sessionUrlForSid');
+
+// --- minimal DOM/browser element stub ---
+function makeElement() {
+  const el = {
+    nodeType: 1, tagName: 'DIV', className: '', dataset: {}, style: {},
+    children: [], _children: [],
+    appendChild(c) { this._children.push(c); this.children = this._children; return c; },
+    append(...cs) { cs.forEach((c) => this.appendChild(c)); },
+    remove() {}, addEventListener() {}, removeEventListener() {},
+    setAttribute() {}, removeAttribute() {}, getAttribute() { return null; },
+    hasAttribute() { return false; }, getAttributeNames() { return []; }, toggleAttribute() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    closest() { return null; }, replaceWith() {}, before() {}, after() {},
+    insertBefore() {}, removeChild() {}, contains() { return false; },
+    isConnected: false, focus() {}, blur() {}, click() {}, scrollIntoView() {},
+    parentElement: null, parentNode: null, firstChild: null, lastChild: null,
+    nextSibling: null, previousSibling: null, classList: { add() {}, remove() {}, contains() { return false; } },
+  };
+  Object.defineProperty(el, 'innerHTML', { get() { return this._inner || ''; }, set(v) { this._inner = String(v); } });
+  Object.defineProperty(el, 'textContent', { get() { return this._text || ''; }, set(v) { this._text = String(v); } });
+  return el;
+}
+
+function buildSandbox(scenario) {
+  const captured = [];
+  const sources = [];
+  const sandbox = {
+    console,
+    setTimeout, clearTimeout, setInterval, clearInterval,
+    Date, Math, JSON, URL, URLSearchParams, encodeURIComponent, decodeURIComponent,
+    Map, Set, WeakMap, Promise, Number, String, Boolean, Object, Array, RegExp, Error, TypeError, parseInt, parseFloat, isNaN,
+  };
+  sandbox.window = sandbox;
+  sandbox.addEventListener = () => {};
+  sandbox.removeEventListener = () => {};
+  sandbox.dispatchEvent = () => {};
+  sandbox.__captured = captured;
+  sandbox.__sources = sources;
+
+  const documentStub = {
+    hidden: !!scenario.hiddenAtAttach,
+    visibilityState: scenario.hiddenAtAttach ? 'hidden' : 'visible',
+    baseURI: 'http://localhost:8787/',
+    addEventListener() {}, removeEventListener() {},
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    createElement() { return makeElement(); },
+    createTextNode(t) { return { nodeType: 3, data: String(t), textContent: String(t) }; },
+    createDocumentFragment() { return makeElement(); },
+    hasFocus() { return true; },
+    body: makeElement(),
+    documentElement: makeElement(),
+  };
+  sandbox.document = documentStub;
+
+  sandbox.location = {
+    origin: 'http://localhost:8787',
+    href: 'http://localhost:8787/session/parent',
+    pathname: '/session/parent',
+    search: '', hash: '',
+  };
+  sandbox.history = { replaceState() {}, pushState() {} };
+  sandbox.navigator = {};
+  sandbox.localStorage = {
+    getItem() { return null; }, setItem() {}, removeItem() {},
+  };
+  sandbox.requestAnimationFrame = () => {};
+  sandbox.cancelAnimationFrame = () => {};
+  sandbox.matchMedia = () => ({ matches: false, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {} });
+  sandbox.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+
+  sandbox.EventSource = class {
+    static CONNECTING = 0; static OPEN = 1; static CLOSED = 2;
+    constructor(url, opts) {
+      this.url = url; this.opts = opts; this.readyState = sandbox.EventSource.CONNECTING;
+      this._listeners = {};
+      sources.push(this);
+    }
+    addEventListener(ev, fn) {
+      (this._listeners[ev] = this._listeners[ev] || []).push(fn);
+    }
+    removeEventListener(ev, fn) {
+      const arr = this._listeners[ev];
+      if (!arr) return;
+      const idx = arr.indexOf(fn);
+      if (idx >= 0) arr.splice(idx, 1);
+    }
+    close() { this.readyState = sandbox.EventSource.CLOSED; }
+    dispatch(ev, data) {
+      const arr = this._listeners[ev] || [];
+      const event = { data, type: ev, lastEventId: '', target: this };
+      for (const fn of arr.slice()) fn(event);
+    }
+  };
+
+  sandbox.Notification = class {
+    static permission = 'granted';
+    constructor(title, options) {
+      captured.push({ title, options });
+    }
+  };
+
+  // Helpers that live in OTHER static files (ui.js / workspace.js / sessions.js
+  // / i18n.js) and are referenced by the real messages.js code paths we drive.
+  const noop = () => {};
+  const ext = {
+    $: () => null,
+    t: (k) => k,
+    api: async () => null,
+    showToast: noop, setBusy: noop, setComposerStatus: noop, setStatus: noop,
+    renderMessages: noop, syncTopbar: noop, renderSessionList: noop, loadDir: noop,
+    showLiveRunStatus: noop, hideLiveRunStatus: noop,
+    clearInflight: noop, clearInflightState: noop, markInflight: noop, saveInflightState: noop,
+    _suspendSessionStreamForLiveChat: noop, _resumeSessionStreamAfterLiveChat: noop,
+    _clearApprovalPendingForSession: noop, _clearClarifyPendingForSession: noop,
+    stopApprovalPolling: noop, stopClarifyPolling: noop,
+    hideApprovalCard: noop, hideClarifyCard: noop,
+    ensureLiveWorklogShell: noop, appendThinking: noop, removeThinking: noop,
+    finalizeThinkingCard: noop, clearLiveToolCards: noop,
+    highlightCode: noop, addCopyButtons: noop, renderKatexBlocks: noop,
+    _hydrateTodosFromSession: noop, clearVisibleMessageRowCache: noop,
+    _mergeUsageForCtxIndicator: noop, _syncCtxIndicator: noop,
+    _shouldFollowMessagesOnDomReplace: noop, _isMessagePaneNearBottom: () => false,
+    _captureMessageScrollSnapshot: () => null,
+    _armKeepSettledWorklogOpen: noop, _disarmKeepSettledWorklogOpen: noop,
+    _renderMessagesWithScrollSnapshot: noop, scrollToBottom: noop,
+    noteWorkspaceMutationsFromToolCalls: noop, autoReadLastAssistant: noop,
+    queueSessionMessage: noop, updateQueueBadge: noop,
+    _markSessionCompletionUnread: noop, _markSessionCompletedInList: noop,
+    _setActiveSessionUrl: noop, _setSessionViewedCount: noop,
+    _clearSessionCompletionUnread: noop, renderSessionListFromCache: noop,
+    resetTurnWorkspaceMutations: noop, _resetStreamScrollFollow: noop,
+    renderSessionArtifacts: noop, trackBackgroundError: noop,
+    recordClientSSEError: noop, _deferStreamErrorIfOffline: () => false,
+    msgContent: (m) => {
+      if (!m || typeof m !== 'object') return '';
+      if (Array.isArray(m.content)) {
+        return m.content.filter((p) => p && p.type === 'text').map((p) => p.text || '').join('');
+      }
+      return typeof m.content === 'string' ? m.content : '';
+    },
+    _assistantTurnAnchorSettledFinalAnswer: () => undefined,
+    _isPreservedCompressionTaskListMarkerOnlyText: () => false,
+    _smdMediaTailFlush: noop, _smdMediaTailClear: noop, _smdClearParserIdentity: noop,
+    _isSafeDataImageUri: () => false,
+    assistantDisplayName: () => 'Hermes',
+    setComposerStatus: noop,
+    _isMessageReaderUnpinned: () => false,
+  };
+  Object.assign(sandbox, ext);
+  return sandbox;
+}
+
+function runScenario(scenario) {
+  const sandbox = buildSandbox(scenario);
+  vm.createContext(sandbox);
+  vm.runInContext(SESSION_URL_FN, sandbox);
+  vm.runInContext(MESSAGES, sandbox);
+  const driver = `
+    const S={session:{session_id:'parent',message_count:2},messages:[],toolCalls:[],busy:false,activeStreamId:'stream-1',todos:[],todoStateMeta:null};
+    const INFLIGHT={};
+    window._notificationsEnabled=${scenario.enabled};
+    document.hidden=${scenario.hiddenAtAttach};
+    _desktopBackgroundedForNotifications=${scenario.desktopBackgrounded};
+    attachLiveStream('parent','stream-1');
+    // The page returns to the foreground before 'done' arrives (throttled SSE).
+    document.hidden=false;
+    const __src=LIVE_STREAMS['parent'].source;
+    if(!__src) throw new Error('no source wired');
+    __src.dispatch('done', ${JSON.stringify(scenario.donePayload)});
+    __out={
+      captured: __captured.map(function(c){return {title:c.title, tag:c.options.tag, url:c.options.data.url, body:c.options.body};}),
+      count: __captured.length,
+      sessionAfterDone: (S.session&&S.session.session_id)||null,
+      expectedUrl: location.origin + _sessionUrlForSid('${scenario.expectedSid}'),
+    };
+  `;
+  vm.runInContext(driver, sandbox);
+  return sandbox.__out;
+}
+
+const scenarios = {
+  rotated: {
+    hiddenAtAttach: true,
+    desktopBackgrounded: true,
+    enabled: true,
+    expectedSid: 'continuation',
+    donePayload: JSON.stringify({
+      status: 'completed',
+      session: { session_id: 'continuation', messages: [{ role: 'assistant', content: 'Hello world' }] },
+    }),
+  },
+  nonRotated: {
+    hiddenAtAttach: true,
+    desktopBackgrounded: true,
+    enabled: true,
+    expectedSid: 'parent',
+    // No rotation: the done payload still names the parent session id, so the
+    // notification must fall back to the activeSid tag/url.
+    donePayload: JSON.stringify({
+      status: 'completed',
+      session: { session_id: 'parent', messages: [{ role: 'assistant', content: 'Hello world' }] },
+    }),
+  },
+  disabled: {
+    hiddenAtAttach: true,
+    desktopBackgrounded: true,
+    enabled: false,
+    expectedSid: 'continuation',
+    donePayload: JSON.stringify({
+      status: 'completed',
+      session: { session_id: 'continuation', messages: [{ role: 'assistant', content: 'Hello world' }] },
+    }),
+  },
+  neverBackgrounded: {
+    hiddenAtAttach: false,
+    desktopBackgrounded: false,
+    enabled: true,
+    expectedSid: 'continuation',
+    donePayload: JSON.stringify({
+      status: 'completed',
+      session: { session_id: 'continuation', messages: [{ role: 'assistant', content: 'Hello world' }] },
+    }),
+  },
+};
+
+const out = {};
+for (const name of Object.keys(scenarios)) {
+  try {
+    out[name] = runScenario(scenarios[name]);
+  } catch (err) {
+    out[name] = { error: String(err && err.stack || err) };
+  }
+}
+console.log(JSON.stringify(out, null, 2));
+"""
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node required for behavioral test")
+def test_rotated_done_notification_delivers_continuation_tag_and_url():
+    """#6689 re-gate: BEHAVIORAL regression for the rotated-done notification.
+
+    The previous round's
+    `test_rotated_done_notification_uses_continuation_session_for_tag_and_url`
+    only slices messages.js source; this test replaces that oracle as the
+    primary proof by EXECUTING the shipped code:
+
+      - the real `attachLiveStream('parent', 'stream-1')` runs in a node vm and
+        wires the real EventSource `done` listener;
+      - the page is hidden + desktop-backgrounded at attach time and returns to
+        the foreground before `done` arrives, so the #4416 forceHidden delivery
+        gate is exercised (a late, throttled SSE must still notify);
+      - the done payload carries `session.session_id='continuation'`, so the
+        handler resolves completedSid to the continuation id;
+      - the delivery flows through the REAL sendBrowserNotification ->
+        _notificationOptions -> _sessionUrlForSid chain into a captured
+        `new Notification` sink (direct path: no service worker in the sandbox).
+
+    Assertions:
+      - exactly ONE delivery with tag == 'hermes-continuation' and
+        data.url == location.origin + _sessionUrlForSid('continuation')
+        (computed inside the harness against the shipped _sessionUrlForSid);
+      - non-rotated control (payload still names the parent sid) must fall back
+        to tag == 'hermes-parent' / the parent url;
+      - notifications-disabled control delivers nothing;
+      - never-backgrounded control (watched stream) delivers nothing.
+
+    Mutation sensitivity (verified manually): reverting the done-path call to
+    `sid:activeSid` makes the rotated scenario deliver tag 'hermes-parent'
+    instead of 'hermes-continuation', failing this test.
+    """
+    res = subprocess.run(
+        [
+            "node",
+            "-e",
+            _ROTATED_DONE_HARNESS,
+            str(ROOT / "static" / "messages.js"),
+            str(ROOT / "static" / "sessions.js"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert res.returncode == 0, res.stderr
+    out = json.loads(res.stdout.strip())
+
+    rotated = out["rotated"]
+    assert "error" not in rotated, rotated.get("error")
+    assert rotated["count"] == 1, "rotated done must deliver exactly one notification"
+    assert rotated["sessionAfterDone"] == "continuation", (
+        "done handler must settle onto the continuation session"
+    )
+    delivery = rotated["captured"][0]
+    assert delivery["title"] == "Response complete"
+    assert delivery["tag"] == "hermes-continuation", (
+        "notification tag must point at the CONTINUATION session, not the "
+        "archived parent (got " + repr(delivery["tag"]) + ")"
+    )
+    assert delivery["url"] == rotated["expectedUrl"], (
+        "notification click URL must equal location.origin + "
+        "_sessionUrlForSid('continuation')"
+    )
+    assert rotated["expectedUrl"] == "http://localhost:8787/session/continuation"
+
+    non_rotated = out["nonRotated"]
+    assert "error" not in non_rotated, non_rotated.get("error")
+    assert non_rotated["count"] == 1
+    assert non_rotated["captured"][0]["tag"] == "hermes-parent"
+    assert non_rotated["captured"][0]["url"] == non_rotated["expectedUrl"]
+    assert non_rotated["expectedUrl"] == "http://localhost:8787/session/parent"
+
+    disabled = out["disabled"]
+    assert "error" not in disabled, disabled.get("error")
+    assert disabled["count"] == 0, "notifications-disabled must not deliver"
+
+    watched = out["neverBackgrounded"]
+    assert "error" not in watched, watched.get("error")
+    assert watched["count"] == 0, (
+        "a stream the user watched (never hidden/backgrounded) must not deliver"
+    )

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -39,7 +39,7 @@ def test_notification_payload_uses_completion_session_when_provided():
     assert "tag:sid?`hermes-${sid}`" in MESSAGES_JS
     assert "function _completionNotificationPreviewText" in MESSAGES_JS
     assert "_completionNotificationPreviewText(lastAsst," in MESSAGES_JS
-    assert "sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid})" in MESSAGES_JS
+    assert "sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:completedSid})" in MESSAGES_JS
     assert "assistantText?assistantText.slice(0,100)" not in MESSAGES_JS
     assert "sendBrowserNotification('Approval required',d.description||'Tool approval needed',{sid:activeSid})" in MESSAGES_JS
     assert "sendBrowserNotification('Clarification needed',d.question||'Tool clarification needed',{sid:activeSid})" in MESSAGES_JS
@@ -100,6 +100,38 @@ def test_desktop_background_notification_signal_stays_out_of_stream_visibility()
     for name in DESKTOP_BACKGROUND_NOTIFICATION_NAMES:
         assert name not in stream_tracker
         assert name not in deferred_recovery
+
+
+def test_rotated_done_notification_uses_continuation_session_for_tag_and_url():
+    """
+    #6689 re-gate: after auto-compression rotates the session id to a continuation,
+    the completion notification's tag and click URL must point to the CONTINUATION
+    session (completedSid), not the archived parent (activeSid).
+
+    The done handler computes completedSid from the done payload and passes it to
+    sendBrowserNotification. _notificationOptions derives the tag and data.url from
+    options.sid, so the notification must carry completedSid. The hidden/background
+    delivery gate (forceHidden) must still be respected — only the sid changes.
+    """
+    done_block = _source_between(
+        "source.addEventListener('done'", "source.addEventListener('stream_end'"
+    )
+    # The notification call in the done block must use completedSid
+    assert "sendBrowserNotification('Response complete'" in done_block
+    assert "sid:completedSid" in done_block
+    # The legacy activeSid must NOT appear in the response-complete call
+    # (it may appear in approval/clarification calls — those are pre-rotation)
+    response_complete_call = done_block[
+        done_block.index("sendBrowserNotification('Response complete'")
+        : done_block.index("sendBrowserNotification('Response complete'") + 200
+    ]
+    assert "sid:activeSid" not in response_complete_call, (
+        "response-complete notification must not use activeSid (archived parent)"
+    )
+    # The preview helper must receive the completed session id
+    assert "sessionId:completedSid" in done_block
+    # forceHidden gate must still be present (hidden/background delivery preserved)
+    assert "forceHidden:_wasEverBackgrounded" in done_block
 
 
 def test_service_worker_handles_notification_clicks_without_hijacking_other_sessions():


### PR DESCRIPTION
Closes #2761

## Problem

Mid-conversation, when auto-compression rotates the backend session id to a **continuation session**, the WebUI's live→settled transition can be skipped, leaving the blue *"Auto-compressing context..."* running card frozen and the final assistant answer never rendered (Symptom 3 of #2761). The session looks bricked until the user forks/retries.

Two gates on the WebUI side (both identified in the maintainer's analysis on #2761):

- **Gate A — `done` settle gated on the pre-rotation session id.** In the `done` SSE handler, the whole settle block (`S.session=d.session; S.messages=…; renderMessages`) runs only when `_isSessionCurrentPane(activeSid)`. If the pane already advanced to the rotated continuation id (external refresh / apperror reconcile) before `done` arrives, the block is skipped and the final answer is never applied to the DOM.
- **Gate B — recovery polls the archived pre-compression session.** `_restoreSettledSession` always polled `/api/session?session_id=<original activeSid>`. After rotation that session is archived read-only: it can keep a stale `active_stream_id`/`pending_user_message` (exhausting the 10-retry loop into `_finalizeStreamEndFallback`) or simply lack the final answer, which lives on the continuation session.

## Fix

All changes are in `static/messages.js`, scoped to the stream turn:

1. **Capture the rotated continuation id.** The `compressed` SSE listener now records `d.new_session_id`/`d.continuation_session_id` in a per-turn `_streamCompressionContinuationSid` (reset at stream start).
2. **Gate A:** the `done` handler resolves `completedSid` *before* computing `isActiveSession`, and treats the turn as active when the completed session id equals the currently displayed session — so a rotated continuation session still settles and renders the answer.
3. **Gate B:** `_restoreSettledSession` polls the captured continuation id instead of the archived original when one exists, accepts the rotated session as the active pane, and routes the queue drain to it.

No behavior change on the happy path: when no rotation occurred, `_streamCompressionContinuationSid` is empty and `_restoreSid === activeSid`, so all existing guards behave exactly as before.

## Tests

New `tests/test_issue2761_compression_recovery.py` (source-level regressions, same style as `test_auto_compression_card.py`) pins:

- done settle survives continuation-session rotation (completedSid resolved before isActiveSession; rotation fallback present; settle not removed),
- `compressed` listener captures the continuation id,
- `_restoreSettledSession` polls the rotated id and accepts it as the pane,
- the continuation id is reset per turn.

```
tests/test_issue2761_compression_recovery.py       4 passed
tests/test_auto_compression_card.py (and related) 157 passed
```
