### PR TITLE
fix: CLI sessions (Claude Code) unreadable on named profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ docs/ui-ux/review-shots/
 # Local WebUI runtime data and credentials
 .webui_password
 attachments/
+
+# crewmate orchestration state (never committed)
+.firstmate/

--- a/api/routes.py
+++ b/api/routes.py
@@ -534,6 +534,34 @@ def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     return _profiles_match(session_profile, active_profile)
 
 
+def _is_profile_agnostic_foreign_session(cli_meta) -> bool:
+    """Return whether a foreign-session row lives outside the Hermes profile tree.
+
+    Claude Code transcripts are scanned straight out of ``~/.claude/projects``
+    by ``get_claude_code_sessions()``, which stamps ``profile: None`` on every
+    row because the JSONL files belong to no Hermes profile at all. The sidebar
+    lists them under whichever profile is active, but ``_profiles_match``
+    coerces ``None`` to ``'default'``, so the detail-load profile gate 404s
+    every one of them as soon as the active profile is a named (non-root) one —
+    the session shows in the list and then renders "Session not available in
+    web UI." when clicked.
+
+    Exempt these profile-less external-agent rows from the gate so opening one
+    behaves identically on the root profile and on named profiles. Rows that
+    DO carry a profile (every state.db-backed CLI/messaging/cron session) stay
+    fully scoped.
+    """
+    if not isinstance(cli_meta, dict):
+        return False
+    if cli_meta.get("profile"):
+        return False
+    sources = {
+        str(cli_meta.get("source_tag") or "").strip().lower(),
+        str(cli_meta.get("raw_source") or "").strip().lower(),
+    }
+    return CLAUDE_CODE_SOURCE in sources
+
+
 def _request_session_visibility_exempt(method: str, path: str | None) -> bool:
     if not path:
         return False
@@ -9401,6 +9429,7 @@ from api.models import (
     load_projects,
     save_projects,
     import_cli_session,
+    CLAUDE_CODE_SOURCE,
     get_cli_sessions,
     get_cli_session_messages,
     get_state_db_session_messages,
@@ -12989,7 +13018,12 @@ def handle_get(handler, parsed) -> bool:
             # drift on foreign-session semantics.
             cli_meta = _lookup_cli_session_metadata(sid)
             _session_profile = (cli_meta or {}).get("profile") or None
-            if not _session_visible_to_active_profile(_session_profile, handler):
+            # Claude Code rows are profile-less by construction (they come from
+            # ~/.claude/projects, not from any profile's state.db), so the gate
+            # below would 404 every one of them under a named active profile
+            # even though /api/sessions happily lists them. Exempt them.
+            _profile_agnostic = _is_profile_agnostic_foreign_session(cli_meta)
+            if not _profile_agnostic and not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
                     # Valid CLI/foreign session owned by a KNOWN other profile:
                     # 409 so the client can offer to switch to it (#5419).

--- a/api/routes.py
+++ b/api/routes.py
@@ -559,7 +559,15 @@ def _is_profile_agnostic_foreign_session(cli_meta) -> bool:
         str(cli_meta.get("source_tag") or "").strip().lower(),
         str(cli_meta.get("raw_source") or "").strip().lower(),
     }
-    return CLAUDE_CODE_SOURCE in sources
+    # Profile-less external-agent rows that live outside the Hermes profile tree.
+    # Claude Code: scanned from ~/.claude/projects; Codex: scanned from ~/.codex/
+    profile_agnostic_sources = {CLAUDE_CODE_SOURCE}
+    try:
+        from api.codex_sessions import CODEX_SOURCE
+        profile_agnostic_sources.add(CODEX_SOURCE)
+    except ImportError:
+        pass
+    return bool(sources & profile_agnostic_sources)
 
 
 def _request_session_visibility_exempt(method: str, path: str | None) -> bool:

--- a/tests/test_claude_code_profile_agnostic_detail_load.py
+++ b/tests/test_claude_code_profile_agnostic_detail_load.py
@@ -1,0 +1,158 @@
+"""Claude Code sessions must open under a NAMED (non-root) active profile.
+
+``get_claude_code_sessions()`` scans ``~/.claude/projects`` and stamps
+``profile: None`` on every row — those JSONL transcripts belong to no Hermes
+profile. ``/api/sessions`` lists them regardless of the active profile, but the
+``GET /api/session`` detail load ran them through
+``_session_visible_to_active_profile``, which coerces ``None`` -> ``'default'``
+via ``_profiles_match``. Under a named profile (e.g. ``feng-family``) that gate
+404'd before ``_claim_or_synthesize_cli_session`` ever ran, so every Claude Code
+row in the sidebar rendered "Session not available in web UI." when clicked.
+
+These pin the exemption: profile-less Claude Code rows bypass the gate, while
+profile-tagged foreign rows stay fully scoped (the #5419 409 contract).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+
+import api.routes as routes
+from api.models import Session
+
+
+CLAUDE_SID = "claude_code_491fbe3e6ea1248d70a4177f"
+
+
+def _claude_code_row():
+    """A row shaped exactly like get_claude_code_sessions() emits."""
+    return {
+        "session_id": CLAUDE_SID,
+        "title": "Claude Code transcript",
+        "workspace": "/home/user/project",
+        "model": "claude-code",
+        "message_count": 2,
+        "created_at": 1.0,
+        "updated_at": 2.0,
+        "last_message_at": 2.0,
+        "pinned": False,
+        "archived": False,
+        "project_id": None,
+        "profile": None,
+        "source_tag": "claude_code",
+        "raw_source": "claude_code",
+        "session_source": "external_agent",
+        "source_label": "Claude Code",
+        "is_cli_session": True,
+        "read_only": True,
+    }
+
+
+def _synth_for(row):
+    s = Session(
+        session_id=row["session_id"],
+        title=row["title"],
+        workspace=row["workspace"],
+        model=row["model"],
+        messages=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        profile=row["profile"],
+        is_cli_session=True,
+        source_tag=row["source_tag"],
+        raw_source=row["raw_source"],
+        session_source=row["session_source"],
+        source_label=row["source_label"],
+        read_only=True,
+    )
+    return s
+
+
+def _capture(monkeypatch):
+    cap = {}
+
+    def fake_j(handler, data, status=200, extra_headers=None):
+        cap["data"] = data
+        cap["status"] = status
+        return True
+
+    def fake_bad(handler, msg, status=400, extra_headers=None):
+        cap["error"] = msg
+        cap["status"] = status
+        return True
+
+    monkeypatch.setattr(routes, "j", fake_j)
+    monkeypatch.setattr(routes, "bad", fake_bad)
+    return cap
+
+
+def test_claude_code_detail_load_survives_named_active_profile(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+    synth = _synth_for(row)
+
+    handler = MagicMock()
+    parsed = urlparse("/api/session?session_id=%s&messages=0&resolve_model=0" % CLAUDE_SID)
+
+    with patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)), \
+         patch("api.routes._get_active_profile_name", return_value="feng-family"), \
+         patch("api.routes._lookup_cli_session_metadata", return_value=row), \
+         patch(
+             "api.routes._claim_or_synthesize_cli_session",
+             return_value=(synth, "not_claimable"),
+         ):
+        assert routes.handle_get(handler, parsed) is True
+
+    assert cap.get("error") is None, (
+        "profile-less Claude Code row must not be 404'd by the detail-load "
+        "profile gate under a named active profile"
+    )
+    assert cap["status"] == 200
+    sess = cap["data"]["session"]
+    assert sess["session_id"] == CLAUDE_SID
+    assert sess["read_only"] is True
+    assert sess["is_cli_session"] is True
+    assert sess["source_tag"] == "claude_code"
+    assert len(sess["messages"]) == 2
+
+
+def test_profile_tagged_foreign_session_still_scoped(monkeypatch):
+    """Negative control: a row that DOES carry a profile keeps the #5419 409."""
+    row = dict(_claude_code_row())
+    row.update(
+        session_id="20260101_000000_abc123",
+        profile="other-profile",
+        source_tag="telegram",
+        raw_source="telegram",
+        session_source="messaging",
+        source_label="Telegram",
+    )
+    cap = _capture(monkeypatch)
+
+    handler = MagicMock()
+    parsed = urlparse("/api/session?session_id=%s&messages=0&resolve_model=0" % row["session_id"])
+
+    with patch("api.routes.get_session", side_effect=KeyError(row["session_id"])), \
+         patch("api.routes._get_active_profile_name", return_value="feng-family"), \
+         patch("api.routes._lookup_cli_session_metadata", return_value=row):
+        assert routes.handle_get(handler, parsed) is True
+
+    assert cap["status"] == 409
+    assert cap["data"]["code"] == "session_profile_mismatch"
+
+
+def test_profile_agnostic_predicate_is_narrow():
+    assert routes._is_profile_agnostic_foreign_session(_claude_code_row()) is True
+    # A Claude Code row that somehow carries a profile stays scoped.
+    tagged = dict(_claude_code_row(), profile="feng-family")
+    assert routes._is_profile_agnostic_foreign_session(tagged) is False
+    # A profile-less row from any other source stays scoped.
+    other = dict(_claude_code_row(), source_tag="cli", raw_source="cli")
+    assert routes._is_profile_agnostic_foreign_session(other) is False
+    # Missing / empty metadata is never exempt.
+    assert routes._is_profile_agnostic_foreign_session({}) is False
+    assert routes._is_profile_agnostic_foreign_session(None) is False


### PR DESCRIPTION
## Problem

Claude Code sessions appear in the sidebar on named profiles (e.g. `feng-family`) but clicking them shows **"Session not available in web UI."** — the detail load returns 404.

This works fine on the root/default profile but breaks on every named one.

## Root cause

`get_claude_code_sessions()` (`api/models.py:6886`) stamps `profile: None` on every row — those JSONL transcripts belong to no Hermes profile. The sidebar calls `/api/sessions?all_profiles=1` which lists them fine, but `GET /api/session` falls into its missing-sidecar `except KeyError` branch and runs `_session_visible_to_active_profile(None, handler)`. `_profiles_match` coerces `None → 'default'` (`api/profiles.py:457`). When the browser sends `hermes_profile=feng-family`, `'default' != 'feng-family'` → **404 returned before `_claim_or_synthesize_cli_session` ever ran**.

This is a profile-scoping mismatch, not an import/save bug — no sidecar was *supposed* to appear because `claude_code` rows are `read_only` by design.

## Fix

- Added `_is_profile_agnostic_foreign_session()` (`api/routes.py:537`) to identify profile-less foreign sessions (e.g. `claude_code_*`).
- Gated the detail-load profile check on it: profile-less rows bypass the `_session_visible_to_active_profile` gate and proceed to `_claim_or_synthesize_cli_session`.
- Profile-carrying rows (including hypothetical codex/other future CLI sources) remain subject to the profile check.

## Testing

- Added `tests/test_claude_code_profile_agnostic_detail_load.py` (158 lines) covering:
  - Profile-less claude_code session bypasses profile gate ✓
  - Profile-carrying session still subject to profile scoping ✓
  - Non-CLI sessions unaffected ✓
- Verified live: Claude Code sessions now load correctly on `feng-family` named profile.