### PR TITLE
fix(workspace): auto-refresh preview after terminal/execute_code mutation (#5747)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4360,6 +4360,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         for(const key of ['activityBurstId','duration','started_at']){
           if((next[key]===undefined||next[key]===null)&&live[key]!==undefined&&live[key]!==null) next[key]=live[key];
         }
+        // #5747 re-gate (F3): the settled snapshot is a REBUILT copy of the live
+        // call, so it must inherit what the live tool_complete handler recorded:
+        // the mutation-consumption flag AND the identity the sink was keyed by.
+        // Without the identity the settled replay's tid net cannot recognize the
+        // event and re-adds a mutation the live path already consumed (a second
+        // reload). Carried for keyed and for ordered-unkeyed matches alike — both
+        // are the same logical event.
+        const liveTid=live.tid||live.id||live.tool_call_id||live.tool_use_id||live.call_id||'';
+        if(liveTid&&!next.tid) next.tid=liveTid;
+        if(live._workspaceMutationConsumed) next._workspaceMutationConsumed=true;
       }
       return next;
     });
@@ -6304,7 +6314,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             return hasTc||hasPartialTc||hasTu;
           });
           if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
-            S.toolCalls=d.session.tool_calls.map(tc=>tc);
+            // #5747 re-gate (F3): do NOT pre-overwrite S.toolCalls here — the
+            // merge below reads it as the LIVE source for burst/duration/consumed
+            // metadata. It replaces S.toolCalls itself.
             S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);
           } else {
             if(hasMessageToolMetadata) S._settledLiveToolMetadata=S.toolCalls.map(tc=>({...tc,done:true}));

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -422,8 +422,14 @@ function _escHtml(s){
 const ARTIFACT_IGNORE_RE = /(^|\/)(?:\.git|\.hg|\.svn|node_modules|\.venv|venv|__pycache__|dist|build|\.next|\.cache)(?:\/|$)/;
 // Canonical Hermes mutators plus MCP filesystem aliases that can create/edit files.
 const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file']);
+// #5747: tools that mutate files through shell/python TEXT (sed -i, shell
+// redirects, open(...,'w')) rather than a structured path arg. Their
+// command/code/result text is scanned for the open preview's path so the
+// preview still refreshes after such edits. Complements #5752 (which scoped
+// these tools as a follow-up).
+const ARTIFACT_TEXT_MUTATION_TOOLS = new Set(['terminal','execute_code']);
 
-function _normalizeArtifactPath(path){
+function _normalizeArtifactPath(path, opts){
   if(!path) return '';
   path = String(path).trim().replace(/[\`"'<>),.;:]+$/g,'').replace(/^[\`"'(<]+/g,'');
   if(!path || path.length > 240 || path.includes('://')) return '';
@@ -434,7 +440,10 @@ function _normalizeArtifactPath(path){
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
   if(!path) return '';
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
-  if(!/[./]/.test(path)) return '';
+  // #5747: allow extension-less root files (Makefile, Dockerfile) when the path
+  // comes from a structured tool arg ({allowBare:true}); text-mined candidates
+  // keep the strict filter so prose like "hello" can't become an artifact.
+  if(!(opts&&opts.allowBare)&&!/[./]/.test(path)) return '';
   return path;
 }
 
@@ -466,14 +475,14 @@ function _artifactCandidatesFromToolCall(tc){
   const args = tc.arguments || tc.args || tc.input || {};
   const result = tc.result || tc.output || tc.snippet || '';
   const out = [];
-  const add = (path, source=name || 'tool') => {
-    path = _normalizeArtifactPath(path);
+  const add = (path, source=name || 'tool', addOpts) => {
+    path = _normalizeArtifactPath(path, addOpts);
     if(path) out.push({path, kind:source});
   };
   if(ARTIFACT_MUTATION_TOOLS.has(name) && args && typeof args === 'object'){
-    for(const key of ['path','file_path','source','destination']) add(args[key]);
-    if(Array.isArray(args.paths)) args.paths.forEach(p=>add(p));
-    if(Array.isArray(args.edits)) args.edits.forEach(e=>add(e&&e.path));
+    for(const key of ['path','file_path','source','destination']) add(args[key], name || 'tool', {allowBare:true});
+    if(Array.isArray(args.paths)) args.paths.forEach(p=>add(p, name || 'tool', {allowBare:true}));
+    if(Array.isArray(args.edits)) args.edits.forEach(e=>add(e&&e.path, name || 'tool', {allowBare:true}));
   }
   const resultText = typeof result === 'string' ? result : (result ? JSON.stringify(result) : '');
   // Tool results may include unified diffs from patch-style tools; scan those
@@ -492,10 +501,64 @@ function resetTurnWorkspaceMutations(){
   _turnMutatedPreviewPaths.clear();
 }
 
+// #5747: terminal/execute_code don't expose a structured path arg — the
+// mutation target lives in the shell command / python code / tool result text.
+// Extract conservative path-like tokens (dotted filenames / slash segments) so
+// sed -i, shell redirects, and open(...,'w') writes still refresh the preview.
+function _textPathTokens(text){
+  if(!text || typeof text !== 'string') return [];
+  const out = [];
+  const re = /(?:^|[\s"'`=(\[,])((?:\.{0,2}\/|~\/)?(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12})(?=[\s"'`)\],;]|$)/g;
+  let m;
+  while((m = re.exec(text))){
+    const p = _normalizeArtifactPath(m[1]);
+    if(p && !out.includes(p)) out.push(p);
+  }
+  return out;
+}
+
+// #5747: direct mention check — if the terminal/execute_code text contains the
+// open preview's relative path (or its basename), the file was very likely
+// touched even when no path-like token regex matched.
+function _toolTextMentionsPreview(tc){
+  if(!_previewCurrentPath) return false;
+  const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
+  const base = rel ? rel.split('/').pop() : '';
+  const args = (tc && (tc.arguments || tc.args || tc.input)) || {};
+  const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
+  const texts = [
+    typeof args === 'string' ? args : JSON.stringify(args || {}),
+    typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
+  ];
+  for(const t of texts){
+    if(!t) continue;
+    if(rel && rel.length > 2 && t.includes(rel)) return true;
+    if(base && base.length > 3 && t.includes(base)) return true;
+  }
+  return false;
+}
+
 function noteWorkspaceMutationsFromToolCall(tc){
   for(const a of _artifactCandidatesFromToolCall(tc)){
     const path=_normalizeArtifactPath(a.path);
     if(path) _turnMutatedPreviewPaths.add(path);
+  }
+  // #5747: text-based mutation tools (terminal/execute_code) — scan command,
+  // code, and result text so preview auto-refresh works for shell/python edits.
+  const name = String(tc && tc.name || '').replace(/^functions\./,'');
+  if(ARTIFACT_TEXT_MUTATION_TOOLS.has(name)){
+    const args = (tc && (tc.arguments || tc.args || tc.input)) || {};
+    const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
+    for(const t of [
+      typeof args === 'string' ? args : JSON.stringify(args || {}),
+      typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
+    ]){
+      for(const p of _textPathTokens(t)) _turnMutatedPreviewPaths.add(p);
+    }
+    if(_toolTextMentionsPreview(tc)){
+      const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
+      if(rel) _turnMutatedPreviewPaths.add(rel);
+    }
   }
 }
 
@@ -506,7 +569,7 @@ function noteWorkspaceMutationsFromToolCalls(toolCalls){
 
 function _isOpenPreviewPathMutated(){
   if(!_previewCurrentPath) return false;
-  const current=_normalizeArtifactPath(_previewCurrentPath);
+  const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
   return !!(current&&_turnMutatedPreviewPaths.has(current));
 }
 

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -1205,8 +1205,6 @@ function _prismLanguageForPath(path){
   return _PRISM_LANG_MAP[ext]!==undefined?_PRISM_LANG_MAP[ext]:'plaintext';
 }
 
-let _previewInFlightGen = 0;
-
 async function openFile(path, opts={}){
   if(!S.session)return;
   

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -495,7 +495,7 @@ function _artifactCandidatesFromToolCall(tc){
   return out;
 }
 
-const _turnMutatedPreviewPaths = new Set();
+const _turnMutatedPreviewPaths = new Map(); // path -> {sessionId, profile, workspace, streamId, path}
 
 function resetTurnWorkspaceMutations(){
   _turnMutatedPreviewPaths.clear();
@@ -505,13 +505,18 @@ function resetTurnWorkspaceMutations(){
 // mutation target lives in the shell command / python code / tool result text.
 // Extract conservative path-like tokens (dotted filenames / slash segments) so
 // sed -i, shell redirects, and open(...,'w') writes still refresh the preview.
-function _textPathTokens(text){
+// IMPORTANT: require a recognized write operation token in the text; do not
+// treat any path mention as a mutation. Resolve against the tool's workdir.
+function _textPathTokens(text, workdir){
   if(!text || typeof text !== 'string') return [];
+  // Only consider it a mutation if text contains a recognized write operation
+  const writeOps = /\b(write_file|sed\s+-i|patch\s+.*-o|>\s*\/|>>\s*\/|open\s*\(\s*['\"][^'\"]*['\"]\s*,\s*['\"]w)/i;
+  if(!writeOps.test(text)) return [];
   const out = [];
-  const re = /(?:^|[\s"'`=(\[,])((?:\.{0,2}\/|~\/)?(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12})(?=[\s"'`)\],;]|$)/g;
+  const re = /(?:^|[\s"'`=(\[,])((?:\.{0,2}\/|~\/)?(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12})(?=[\s"'`\)\],;]|$)/g;
   let m;
   while((m = re.exec(text))){
-    const p = _normalizeArtifactPath(m[1]);
+    const p = _normalizeArtifactPath(m[1], {allowBare:true, workdir: workdir});
     if(p && !out.includes(p)) out.push(p);
   }
   return out;
@@ -520,28 +525,28 @@ function _textPathTokens(text){
 // #5747: direct mention check — if the terminal/execute_code text contains the
 // open preview's relative path (or its basename), the file was very likely
 // touched even when no path-like token regex matched.
+// IMPORTANT: do not equate a path mention with a mutation. Prefer authoritative
+// mutation metadata from noteWorkspaceMutationsFromToolCall(). Only return true
+// if there's an actual mutation recorded for the current preview path.
 function _toolTextMentionsPreview(tc){
   if(!_previewCurrentPath) return false;
   const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-  const base = rel ? rel.split('/').pop() : '';
-  const args = (tc && (tc.arguments || tc.args || tc.input)) || {};
-  const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
-  const texts = [
-    typeof args === 'string' ? args : JSON.stringify(args || {}),
-    typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
-  ];
-  for(const t of texts){
-    if(!t) continue;
-    if(rel && rel.length > 2 && t.includes(rel)) return true;
-    if(base && base.length > 3 && t.includes(base)) return true;
-  }
-  return false;
+  if(!rel) return false;
+  // Only consider it a mention if the tool call actually produced a mutation
+  // that we recorded. Don't infer mutation from mere path mentions in text.
+  return _turnMutatedPreviewPaths.has(rel);
 }
 
 function noteWorkspaceMutationsFromToolCall(tc){
   for(const a of _artifactCandidatesFromToolCall(tc)){
     const path=_normalizeArtifactPath(a.path);
-    if(path) _turnMutatedPreviewPaths.add(path);
+    if(path) _turnMutatedPreviewPaths.set(path, {
+      sessionId: S.session?.id,
+      profile: S.activeProfile?.id || 'default',
+      workspace: S.activeWorkspace?.id,
+      streamId: S.activeStreamId,
+      path: path
+    });
   }
   // #5747: text-based mutation tools (terminal/execute_code) — scan command,
   // code, and result text so preview auto-refresh works for shell/python edits.
@@ -549,15 +554,31 @@ function noteWorkspaceMutationsFromToolCall(tc){
   if(ARTIFACT_TEXT_MUTATION_TOOLS.has(name)){
     const args = (tc && (tc.arguments || tc.args || tc.input)) || {};
     const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
+    // Get workdir for _textPathTokens
+    const workdir = S.activeWorkspace?.path || S.session?.cwd || '.';
     for(const t of [
       typeof args === 'string' ? args : JSON.stringify(args || {}),
       typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
     ]){
-      for(const p of _textPathTokens(t)) _turnMutatedPreviewPaths.add(p);
+      for(const p of _textPathTokens(t, workdir)) {
+        _turnMutatedPreviewPaths.set(p, {
+          sessionId: S.session?.id,
+          profile: S.activeProfile?.id || 'default',
+          workspace: S.activeWorkspace?.id,
+          streamId: S.activeStreamId,
+          path: p
+        });
+      }
     }
     if(_toolTextMentionsPreview(tc)){
       const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-      if(rel) _turnMutatedPreviewPaths.add(rel);
+      if(rel) _turnMutatedPreviewPaths.set(rel, {
+        sessionId: S.session?.id,
+        profile: S.activeProfile?.id || 'default',
+        workspace: S.activeWorkspace?.id,
+        streamId: S.activeStreamId,
+        path: rel
+      });
     }
   }
 }
@@ -570,14 +591,39 @@ function noteWorkspaceMutationsFromToolCalls(toolCalls){
 function _isOpenPreviewPathMutated(){
   if(!_previewCurrentPath) return false;
   const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-  return !!(current&&_turnMutatedPreviewPaths.has(current));
+  const entry = _turnMutatedPreviewPaths.get(current);
+  if(!entry) return false;
+  // Verify ownership: must match current session, profile, workspace, and stream
+  return entry.sessionId === (S.session?.id) &&
+         entry.profile === (S.activeProfile?.id || 'default') &&
+         entry.workspace === (S.activeWorkspace?.id) &&
+         entry.streamId === (S.activeStreamId);
 }
+
+let _previewInFlightGen = 0;
 
 async function refreshOpenPreviewIfMutated(){
   if(typeof _previewDirty!=='undefined'&&_previewDirty) return;
   if(!_isOpenPreviewPathMutated()) return;
   if(!_previewCurrentPath||!S.session) return;
-  await openFile(_previewCurrentPath, { bustCache: true });
+  
+  // Consume/coalesce: remove the mutation entry before starting refresh
+  // so one mutation causes at most one reload
+  const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
+  const mutationEntry = _turnMutatedPreviewPaths.get(current);
+  if(!mutationEntry) return;
+  _turnMutatedPreviewPaths.delete(current);
+  
+  // Track in-flight generation
+  const myGen = ++_previewInFlightGen;
+  try {
+    await openFile(_previewCurrentPath, { bustCache: true });
+  } finally {
+    // If we're still the latest generation, clear in-flight
+    if(_previewInFlightGen === myGen) {
+      _previewInFlightGen = 0;
+    }
+  }
 }
 
 function collectSessionArtifacts(){
@@ -1159,8 +1205,18 @@ function _prismLanguageForPath(path){
   return _PRISM_LANG_MAP[ext]!==undefined?_PRISM_LANG_MAP[ext]:'plaintext';
 }
 
+let _previewInFlightGen = 0;
+
 async function openFile(path, opts={}){
   if(!S.session)return;
+  
+  // Capture identity before await to detect stale calls
+  const callGen = ++_previewInFlightGen;
+  const callSessionId = S.session?.id;
+  const callProfileId = S.activeProfile?.id || 'default';
+  const callWorkspaceId = S.activeWorkspace?.id;
+  const callStreamId = S.activeStreamId;
+  
   const ext=fileExt(path);
   const bustCache=!!(opts&&opts.bustCache);
   const forceRichMarkdown=!!(opts&&opts.forceRichMarkdown);

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -1324,7 +1324,6 @@ async function openFile(path, opts={}){
   // S.session.workspace. A newer openFile() bumps _previewInFlightGen and any
   // owner switch invalidates the captured tuple, so a delayed read bails
   // instead of repainting the current preview.
-  const callGen = ++_previewInFlightGen;
   const callSessionId = S.session && S.session.session_id;
   const callProfileId = S.activeProfile || 'default';
   const callWorkspaceId = S.session && S.session.workspace;
@@ -1341,6 +1340,7 @@ async function openFile(path, opts={}){
     return;
   }
 
+  const callGen = ++_previewInFlightGen;
   _previewServerEditable = null;
   _previewSaveRoute = '/api/file/save';
   _previewOfficeFormat = '';

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -429,9 +429,22 @@ const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','creat
 // these tools as a follow-up).
 const ARTIFACT_TEXT_MUTATION_TOOLS = new Set(['terminal','execute_code']);
 
+// #5747 re-gate (F2): collapse '.'/'..' segments so workdir-relative resolution
+// and workspace containment are exact — no path can escape via '..'.
+function _collapseDotSegments(p){
+  const parts=String(p||'').split('/');
+  const out=[];
+  for(const part of parts){
+    if(part===''||part==='.') continue;
+    if(part==='..'){ if(out.length) out.pop(); }
+    else out.push(part);
+  }
+  return '/'+out.join('/');
+}
+
 function _normalizeArtifactPath(path, opts){
   if(!path) return '';
-  path = String(path).trim().replace(/[\`"'<>),.;:]+$/g,'').replace(/^[\`"'(<]+/g,'');
+  path = String(path).trim().replace(/[`"'<>),.;:]+$/g,'').replace(/^[`"'(<]+/g,'');
   if(!path || path.length > 240 || path.includes('://')) return '';
   // Canonicalize workspace-relative prefixes so a file-tree open ("foo.md") and a
   // tool arg recorded as "./foo.md" or "~/foo.md" compare equal for mutation
@@ -440,6 +453,28 @@ function _normalizeArtifactPath(path, opts){
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
   if(!path) return '';
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
+  // #5747 re-gate (F2): honor the tool's effective workdir when provided.
+  // Resolve relative paths against it, collapse ../ segments, and require
+  // containment inside the active workspace root — foreign/escaping paths are
+  // rejected ('') and the result is normalized to a workspace-relative key so
+  // it compares equal to the open preview's path.
+  if(opts && opts.workdir){
+    const root=(typeof S!=='undefined'&&S&&S.session&&S.session.workspace)
+      ? String(S.session.workspace).replace(/\/+$/,'') : '';
+    const wd=String(opts.workdir).replace(/\/+$/,'');
+    let abs;
+    if(path.startsWith('/')) abs=path;
+    else if(wd) abs=wd+'/'+path;
+    else abs=path;
+    abs=_collapseDotSegments(abs);
+    if(root){
+      if(abs===root) return '';
+      if(!abs.startsWith(root+'/')) return ''; // foreign / escaping path
+      path=abs.slice(root.length+1);
+    } else {
+      path=abs;
+    }
+  }
   // #5747: allow extension-less root files (Makefile, Dockerfile) when the path
   // comes from a structured tool arg ({allowBare:true}); text-mined candidates
   // keep the strict filter so prose like "hello" can't become an artifact.
@@ -495,92 +530,153 @@ function _artifactCandidatesFromToolCall(tc){
   return out;
 }
 
-const _turnMutatedPreviewPaths = new Map(); // path -> {sessionId, profile, workspace, streamId, path}
+// #5747 re-gate (F2): pending mutations are keyed by full visible owner
+// (session/profile/workspace/stream) + normalized workspace-relative path, so a
+// terminal/execute_code write in one session/profile/workspace can never
+// refresh the preview of another. The live authorities are
+// S.session.session_id, the string S.activeProfile, and S.session.workspace —
+// not the phantom S.session?.id / S.activeProfile?.id / S.activeWorkspace?.id
+// fields that were always undefined.
+const _turnMutatedPreviewPaths = new Map(); // mutationKey(owner+path) -> entry{...owner, path}
+
+function _currentMutationOwner(){
+  return {
+    sessionId: (S && S.session && S.session.session_id) ? String(S.session.session_id) : '',
+    profile: (S && S.activeProfile) ? String(S.activeProfile) : 'default',
+    workspace: (S && S.session && S.session.workspace) ? String(S.session.workspace) : '',
+    streamId: (S && S.activeStreamId) ? String(S.activeStreamId) : '',
+  };
+}
+
+function _mutationKey(owner, path){
+  return JSON.stringify([owner.sessionId, owner.profile, owner.workspace, owner.streamId, path]);
+}
+
+// Stable identity of already-consumed tool events (F3): the live tool_complete
+// handler consumes each mutation exactly once, and the stream-settle replay
+// (noteWorkspaceMutationsFromToolCalls) must not re-add those same events
+// (settlement double-add). The object flag travels with the call through
+// _mergeSettledToolCallsWithLiveMetadata; the tid set is a second net for
+// merged copies that lost the flag.
+let _consumedMutationToolIds = new Set();
+const _CONSUMED_MUTATION_TOOL_IDS_MAX = 400;
+
+function _toolMutationIdentity(tc){
+  if(!tc||typeof tc!=='object') return '';
+  const id=tc.tid||tc.tool_call_id||tc.tool_use_id||tc.call_id||tc.id||'';
+  if(id) return 'tid:'+String(id);
+  let argsStr='';
+  try{ argsStr=JSON.stringify(tc.arguments||tc.args||tc.input||{}); }catch(_){}
+  return 'sig:'+String(tc.name||'')+'|'+argsStr+'|'+String(tc.preview||tc.snippet||'').slice(0,80);
+}
 
 function resetTurnWorkspaceMutations(){
   _turnMutatedPreviewPaths.clear();
+  _consumedMutationToolIds.clear();
 }
 
 // #5747: terminal/execute_code don't expose a structured path arg — the
 // mutation target lives in the shell command / python code / tool result text.
-// Extract conservative path-like tokens (dotted filenames / slash segments) so
-// sed -i, shell redirects, and open(...,'w') writes still refresh the preview.
-// IMPORTANT: require a recognized write operation token in the text; do not
-// treat any path mention as a mutation. Resolve against the tool's workdir.
+// Extract only the TARGETS of recognized write operations (sed -i, shell
+// redirects, patch -o, open(...,'w'), write_file(...)) so a mere path mention
+// in prose is never treated as a mutation (F2: mention ≠ change). Each target
+// is resolved against the tool's workdir below.
+function _textWriteOpTargets(text){
+  if(!text || typeof text !== 'string') return [];
+  const out=[];
+  const push=(t)=>{
+    if(!t) return;
+    const s=String(t).trim().replace(/^['"`]+|['"`;,]+$/g,'');
+    if(s) out.push(s);
+  };
+  let m;
+  // 1. shell redirects: `> file` / `>> file` (excludes numeric-fd / stderr dup
+  //    forms like `2> err.log` and `2>&1` — those don't mutate the target).
+  const redirRe=/(^|[\s;|&(])(?:>>?)\s*(?:"([^"]*)"|'([^']*)'|([^\s;|&<>"'`]+))/g;
+  while((m=redirRe.exec(text))){
+    const t=m[2]||m[3]||m[4];
+    if(t && !/^&?\d+$/.test(t)) push(t);
+  }
+  // 2. `sed -i ... <file>` — the last bare token of the sed invocation.
+  const sedRe=/(?:^|[\s;|&])sed\s+-i\b([^;|&\n]*)/g;
+  while((m=sedRe.exec(text))){
+    const toks=(m[1]||'').split(/\s+/).filter(Boolean);
+    if(toks.length) push(toks[toks.length-1]);
+  }
+  // 3. `patch ... -o <file>`.
+  const patchRe=/\bpatch\b([^;|&\n]*?)\s+-o\s+(?:"([^"]+)"|'([^']+)'|([^\s;|&<>"'`]+))/g;
+  while((m=patchRe.exec(text))){
+    push(m[2]||m[3]||m[4]);
+  }
+  // 4. python open('<path>', '<mode>') with a write-capable mode (w/a/+).
+  const openRe=/\bopen\s*\(\s*(?:"([^"]+)"|'([^']+)')\s*,\s*(?:"([^"]*)"|'([^']*)')\s*\)/g;
+  while((m=openRe.exec(text))){
+    const mode=String(m[3]||m[4]||'').toLowerCase();
+    if(/^[rwa]b?\+?$/.test(mode) && (mode[0]==='w'||mode[0]==='a'||mode.includes('+'))) push(m[1]||m[2]);
+  }
+  // 5. write_file('<path>', ...) calls embedded in code text.
+  const wfRe=/\bwrite_file\s*\(\s*(?:"([^"]+)"|'([^']+)')/g;
+  while((m=wfRe.exec(text))) push(m[1]||m[2]);
+  return out;
+}
+
+// Write-op targets resolved to canonical workspace-relative paths (or dropped
+// when they escape the active workspace). `workdir` is the tool's effective
+// working directory (args.workdir, falling back to the session workspace).
 function _textPathTokens(text, workdir){
   if(!text || typeof text !== 'string') return [];
-  // Only consider it a mutation if text contains a recognized write operation
-  const writeOps = /\b(write_file|sed\s+-i|patch\s+.*-o|>\s*\/|>>\s*\/|open\s*\(\s*['\"][^'\"]*['\"]\s*,\s*['\"]w)/i;
-  if(!writeOps.test(text)) return [];
-  const out = [];
-  const re = /(?:^|[\s"'`=(\[,])((?:\.{0,2}\/|~\/)?(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12})(?=[\s"'`\)\],;]|$)/g;
-  let m;
-  while((m = re.exec(text))){
-    const p = _normalizeArtifactPath(m[1], {allowBare:true, workdir: workdir});
+  const out=[];
+  for(const raw of _textWriteOpTargets(text)){
+    const p=_normalizeArtifactPath(raw,{allowBare:true, workdir:workdir});
     if(p && !out.includes(p)) out.push(p);
   }
   return out;
 }
 
-// #5747: direct mention check — if the terminal/execute_code text contains the
-// open preview's relative path (or its basename), the file was very likely
-// touched even when no path-like token regex matched.
-// IMPORTANT: do not equate a path mention with a mutation. Prefer authoritative
-// mutation metadata from noteWorkspaceMutationsFromToolCall(). Only return true
-// if there's an actual mutation recorded for the current preview path.
-function _toolTextMentionsPreview(tc){
-  if(!_previewCurrentPath) return false;
-  const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-  if(!rel) return false;
-  // Only consider it a mention if the tool call actually produced a mutation
-  // that we recorded. Don't infer mutation from mere path mentions in text.
-  return _turnMutatedPreviewPaths.has(rel);
-}
-
 function noteWorkspaceMutationsFromToolCall(tc){
+  // F3: consume each tool event once — the live tool_complete handler records
+  // the mutation; the stream-settle replay (noteWorkspaceMutationsFromToolCalls)
+  // must not re-add the same event (settlement double-add).
+  if(tc && typeof tc==='object' && tc._workspaceMutationConsumed) return;
+  const ident=_toolMutationIdentity(tc);
+  if(ident&&_consumedMutationToolIds.has(ident)) return;
+  if(ident){
+    if(_consumedMutationToolIds.size>=_CONSUMED_MUTATION_TOOL_IDS_MAX) _consumedMutationToolIds=new Set();
+    _consumedMutationToolIds.add(ident);
+  }
+  const owner=_currentMutationOwner();
+  // F1: candidates are already normalized — structured ones with
+  // {allowBare:true}, so extension-less root files (Makefile, Dockerfile)
+  // survive. Insert them directly; do not re-normalize without allowBare
+  // (that would drop `Makefile` before it ever reaches the mutation sink).
   for(const a of _artifactCandidatesFromToolCall(tc)){
-    const path=_normalizeArtifactPath(a.path);
-    if(path) _turnMutatedPreviewPaths.set(path, {
-      sessionId: S.session?.id,
-      profile: S.activeProfile?.id || 'default',
-      workspace: S.activeWorkspace?.id,
-      streamId: S.activeStreamId,
-      path: path
-    });
+    const path=a.path;
+    if(path) _turnMutatedPreviewPaths.set(_mutationKey(owner,path),{...owner,path:path});
   }
   // #5747: text-based mutation tools (terminal/execute_code) — scan command,
   // code, and result text so preview auto-refresh works for shell/python edits.
+  // F2: only explicit write-op TARGETS count (a mere path mention is never a
+  // mutation), and every candidate is resolved against the tool's effective
+  // workdir (args.workdir → S.session.workspace) and rejected when it escapes
+  // the active workspace. Entries are keyed by owner+path, not path alone.
   const name = String(tc && tc.name || '').replace(/^functions\./,'');
   if(ARTIFACT_TEXT_MUTATION_TOOLS.has(name)){
     const args = (tc && (tc.arguments || tc.args || tc.input)) || {};
     const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
-    // Get workdir for _textPathTokens
-    const workdir = S.activeWorkspace?.path || S.session?.cwd || '.';
-    for(const t of [
+    const workdir = (args && typeof args==='object' && args.workdir)
+      || (S && S.session && S.session.workspace) || '.';
+    const texts = [
       typeof args === 'string' ? args : JSON.stringify(args || {}),
       typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
-    ]){
-      for(const p of _textPathTokens(t, workdir)) {
-        _turnMutatedPreviewPaths.set(p, {
-          sessionId: S.session?.id,
-          profile: S.activeProfile?.id || 'default',
-          workspace: S.activeWorkspace?.id,
-          streamId: S.activeStreamId,
-          path: p
-        });
+    ];
+    for(const t of texts){
+      for(const p of _textPathTokens(t, workdir)){
+        const key=_mutationKey(owner,p);
+        if(!_turnMutatedPreviewPaths.has(key)) _turnMutatedPreviewPaths.set(key,{...owner,path:p});
       }
     }
-    if(_toolTextMentionsPreview(tc)){
-      const rel = _normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-      if(rel) _turnMutatedPreviewPaths.set(rel, {
-        sessionId: S.session?.id,
-        profile: S.activeProfile?.id || 'default',
-        workspace: S.activeWorkspace?.id,
-        streamId: S.activeStreamId,
-        path: rel
-      });
-    }
   }
+  if(tc && typeof tc==='object') tc._workspaceMutationConsumed=true;
 }
 
 function noteWorkspaceMutationsFromToolCalls(toolCalls){
@@ -591,39 +687,54 @@ function noteWorkspaceMutationsFromToolCalls(toolCalls){
 function _isOpenPreviewPathMutated(){
   if(!_previewCurrentPath) return false;
   const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-  const entry = _turnMutatedPreviewPaths.get(current);
-  if(!entry) return false;
-  // Verify ownership: must match current session, profile, workspace, and stream
-  return entry.sessionId === (S.session?.id) &&
-         entry.profile === (S.activeProfile?.id || 'default') &&
-         entry.workspace === (S.activeWorkspace?.id) &&
-         entry.streamId === (S.activeStreamId);
+  if(!current) return false;
+  // F2: ownership is encoded in the key (session/profile/workspace/stream + path).
+  return _turnMutatedPreviewPaths.has(_mutationKey(_currentMutationOwner(),current));
 }
 
 let _previewInFlightGen = 0;
+let _previewRefreshPromise = null;
+
+// F3: stale-completion guard — a delayed openFile() read must not repaint the
+// preview if a newer call, file switch, or owner (session/profile/workspace/
+// stream) change happened while the fetch was in flight.
+function _openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId){
+  if(!S || !S.session) return true;
+  if(String(S.session.session_id||'')!==String(callSessionId||'')) return true;
+  if(String(S.activeProfile||'default')!==String(callProfileId||'default')) return true;
+  if(String(S.session.workspace||'')!==String(callWorkspaceId||'')) return true;
+  if(String(S.activeStreamId||'')!==String(callStreamId||'')) return true;
+  if(callGen!==_previewInFlightGen) return true;
+  return false;
+}
+
+// Drain every pending mutation for the currently open preview, reloading via
+// openFile() once per entry. A mutation recorded while a reload is in flight
+// triggers another pass, so no mutation is dropped; concurrent triggers
+// coalesce onto the single in-flight promise (F3: one mutation → at most one
+// reload; N mutations → at most N sequential reloads).
+async function _runPreviewRefreshLoop(){
+  while(true){
+    if(!S || !S.session || !_previewCurrentPath) return;
+    const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
+    if(!current) return;
+    const key=_mutationKey(_currentMutationOwner(),current);
+    if(!_turnMutatedPreviewPaths.has(key)) return;
+    // Consume the entry before reloading so one mutation entry drives at most
+    // one reload — even if further triggers race with the reload.
+    _turnMutatedPreviewPaths.delete(key);
+    await openFile(_previewCurrentPath, { bustCache: true });
+  }
+}
 
 async function refreshOpenPreviewIfMutated(){
   if(typeof _previewDirty!=='undefined'&&_previewDirty) return;
   if(!_isOpenPreviewPathMutated()) return;
   if(!_previewCurrentPath||!S.session) return;
-  
-  // Consume/coalesce: remove the mutation entry before starting refresh
-  // so one mutation causes at most one reload
-  const current=_normalizeArtifactPath(_previewCurrentPath, {allowBare:true});
-  const mutationEntry = _turnMutatedPreviewPaths.get(current);
-  if(!mutationEntry) return;
-  _turnMutatedPreviewPaths.delete(current);
-  
-  // Track in-flight generation
-  const myGen = ++_previewInFlightGen;
-  try {
-    await openFile(_previewCurrentPath, { bustCache: true });
-  } finally {
-    // If we're still the latest generation, clear in-flight
-    if(_previewInFlightGen === myGen) {
-      _previewInFlightGen = 0;
-    }
-  }
+  // Coalesce concurrent triggers onto the single in-flight refresh.
+  if(_previewRefreshPromise) return _previewRefreshPromise;
+  _previewRefreshPromise=_runPreviewRefreshLoop().finally(()=>{_previewRefreshPromise=null;});
+  return _previewRefreshPromise;
 }
 
 function collectSessionArtifacts(){
@@ -1208,11 +1319,15 @@ function _prismLanguageForPath(path){
 async function openFile(path, opts={}){
   if(!S.session)return;
   
-  // Capture identity before await to detect stale calls
+  // Capture identity before await to detect stale calls (F3): the real
+  // authorities are S.session.session_id, the string S.activeProfile, and
+  // S.session.workspace. A newer openFile() bumps _previewInFlightGen and any
+  // owner switch invalidates the captured tuple, so a delayed read bails
+  // instead of repainting the current preview.
   const callGen = ++_previewInFlightGen;
-  const callSessionId = S.session?.id;
-  const callProfileId = S.activeProfile?.id || 'default';
-  const callWorkspaceId = S.activeWorkspace?.id;
+  const callSessionId = S.session && S.session.session_id;
+  const callProfileId = S.activeProfile || 'default';
+  const callWorkspaceId = S.session && S.session.workspace;
   const callStreamId = S.activeStreamId;
   
   const ext=fileExt(path);
@@ -1275,6 +1390,7 @@ async function openFile(path, opts={}){
       const data=forceRichMarkdown&&path===_previewRawContentPath&&_previewRawContent
         ? {content:_previewRawContent}
         : await api(_workspaceRouteForPath(path, 'read'));
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
       _previewRawContent = data.content;
       _previewRawContentPath = path;
       if(!forceRichMarkdown && shouldRenderMarkdownPreviewAsPlainText(data.content)){
@@ -1305,6 +1421,7 @@ async function openFile(path, opts={}){
   } else if(ext==='.csv'){
     try{
       const data=await api(_workspaceRouteForPath(path, 'read'));
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
       if(data.binary){
         downloadFile(path);
         return;
@@ -1318,6 +1435,7 @@ async function openFile(path, opts={}){
     // Plain code / text -- but fall back to download if server signals binary
     try{
       const data=await api(_workspaceRouteForPath(path, 'read'));
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
       if(data.binary){
         // Server flagged this as binary content
         downloadFile(path);

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -549,7 +549,12 @@ function _currentMutationOwner(){
 }
 
 function _mutationKey(owner, path){
-  return JSON.stringify([owner.sessionId, owner.profile, owner.workspace, owner.streamId, path]);
+  // #5747 re-gate (F2): keyed by durable pane ownership only. S.activeStreamId is
+  // transient — the stream-done path clears it before the settled replay runs —
+  // so including it orphaned every entry recorded under that stream and the
+  // pending refresh could never fire. streamId stays on the owner record for
+  // logging; it is not part of the identity.
+  return JSON.stringify([owner.sessionId, owner.profile, owner.workspace, path]);
 }
 
 // Stable identity of already-consumed tool events (F3): the live tool_complete
@@ -665,10 +670,21 @@ function noteWorkspaceMutationsFromToolCall(tc){
     const result = (tc && (tc.result || tc.output || tc.snippet)) || '';
     const workdir = (args && typeof args==='object' && args.workdir)
       || (S && S.session && S.session.workspace) || '.';
-    const texts = [
-      typeof args === 'string' ? args : JSON.stringify(args || {}),
-      typeof result === 'string' ? result : (result ? JSON.stringify(result) : '')
-    ];
+    // #5747 re-gate (F1): the write-op parser expects RAW command/code text — its
+    // shell anchors require whitespace before the operator and JSON framing puts a
+    // quote or colon there, while escaping hides the target. Scan the canonical
+    // payload fields instead of JSON.stringify(args); args.workdir stays the
+    // normalization metadata. Result text is a separate source and still goes
+    // through the same strict write-op extractor, so a mere path mention never
+    // counts as a mutation (F2: mention != change).
+    const texts = [];
+    if(typeof args === 'string') texts.push(args);
+    else if(args && typeof args === 'object'){
+      if(typeof args.command === 'string') texts.push(args.command);
+      if(typeof args.code === 'string') texts.push(args.code);
+    }
+    if(typeof result === 'string') texts.push(result);
+    else if(result) texts.push(JSON.stringify(result));
     for(const t of texts){
       for(const p of _textPathTokens(t, workdir)){
         const key=_mutationKey(owner,p);
@@ -740,15 +756,20 @@ async function refreshOpenPreviewIfMutated(){
 function collectSessionArtifacts(){
   const items = [];
   const seen = new Set();
-  const push = (path, source) => {
-    path = _normalizeArtifactPath(path);
+  const push = (path, source, structured) => {
+    // #5747 re-gate (F5): structured candidates arrive already normalized by
+    // _artifactCandidatesFromToolCall (which runs the allowBare pass for
+    // extension-less root files), so re-normalizing them here silently discards
+    // `Makefile` / `Dockerfile`. Only text-mined candidates need the strict
+    // normalization — provenance decides, not the path shape.
+    if(!structured) path = _normalizeArtifactPath(path);
     if(!path || seen.has(path)) return;
     seen.add(path); items.push({path, source});
   };
   // Source 1: session-level tool call summaries (may be empty when messages
   // carry their own tool metadata — see _syncToolCallsForLoadedMessages).
   for(const tc of (S.toolCalls || [])){
-    for(const a of _artifactCandidatesFromToolCall(tc)) push(a.path, a.kind || tc.name || 'tool');
+    for(const a of _artifactCandidatesFromToolCall(tc)) push(a.path, a.kind || tc.name || 'tool', true);
   }
   // Source 2 & 3: message-level data — both text-mined diffs and structured
   // tool_calls / tool_use content blocks that survive the S.toolCalls clear.
@@ -768,7 +789,7 @@ function collectSessionArtifacts(){
         let args = fn.arguments || tc.arguments || tc.args || tc.input || {};
         if(typeof args === 'string'){ try{ args = JSON.parse(args); }catch(_){} }
         const fakeTc = {name, args, result: tc.result || tc.output || ''};
-        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || name || 'tool');
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || name || 'tool', true);
       }
     }
     // Structured content array with tool_use blocks (Anthropic format).
@@ -778,7 +799,7 @@ function collectSessionArtifacts(){
         let inp = block.input || {};
         if(typeof inp === 'string'){ try{ inp = JSON.parse(inp); }catch(_){} }
         const fakeTc = {name: block.name || '', args: inp, result: block.result || ''};
-        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || block.name || 'tool');
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || block.name || 'tool', true);
       }
     }
   }
@@ -1239,6 +1260,11 @@ async function toggleEditMode(){
         _previewSaveRoute = '/api/file/office-save';
       }
       _previewDirty=false;
+      // #5747 re-gate (F2): clearing the dirty flag makes this pane eligible for
+      // refresh again — a mutation recorded while the user was editing is still
+      // pending (durable key, see _mutationKey) and must drain now, otherwise it
+      // stays orphaned until an unrelated trigger.
+      if(typeof refreshOpenPreviewIfMutated==='function') refreshOpenPreviewIfMutated();
       // Update read-only views AND the cached raw content so a later
       // "Render as markdown anyway" force-render reflects the just-saved text
       // (not the stale pre-edit fetch). #3378 review (Codex).
@@ -1279,6 +1305,9 @@ function cancelEditMode(){
   if(_previewCurrentMode==='code') $('previewCode').style.display='';
   else $('previewMd').style.display='';
   _previewDirty=false;
+  // #5747 re-gate (F2): same drain as the save path — cancel makes the pane
+  // eligible again, so a pending mutation recorded while editing must fire here.
+  if(typeof refreshOpenPreviewIfMutated==='function') refreshOpenPreviewIfMutated();
   updateEditBtn();
 }
 
@@ -1401,7 +1430,12 @@ async function openFile(path, opts={}){
         return;
       }
       renderMarkdownPreviewContent(data);
-    }catch(e){setStatus(t('file_open_failed'));}
+    // #5747 re-gate (F4): a rejection can land after a newer openFile() call, and
+    // its failure status belongs to a preview that is no longer showing.
+    }catch(e){
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
+      setStatus(t('file_open_failed'));
+    }
   } else if(HTML_EXTS.has(ext)){
     // HTML: render in sandboxed iframe via raw endpoint.
     // SECURITY TRADEOFF: We use sandbox="allow-scripts" which lets inline JS run
@@ -1429,6 +1463,9 @@ async function openFile(path, opts={}){
       if(renderCsvPreviewContent(path, data.content)) return;
       renderCodePreviewContent(path, data.content);
     }catch(e){
+      // #5747 re-gate (F4): same stale guard as the markdown catch — a superseded
+      // read must not trigger a download for the pane that moved on.
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
       downloadFile(path);
     }
   } else {
@@ -1451,6 +1488,11 @@ async function openFile(path, opts={}){
       }
       renderCodePreviewContent(path, data.content);
   }catch(e){
+      // #5747 re-gate (F4): clear-grant/toast/download are rejection-side effects
+      // of THIS read. When a newer openFile() superseded it they would clear the
+      // wrong pane's grant and download a file the user already navigated away
+      // from — bail out first.
+      if(_openFileReadStale(callGen, callSessionId, callProfileId, callWorkspaceId, callStreamId)) return;
       const grant = _workspaceEscapeGrantForPath(path);
       if(grant && e && e.status===403){
         _clearWorkspaceEscapeGrant(grant.path);

--- a/tests/test_issue5747_preview_auto_refresh.py
+++ b/tests/test_issue5747_preview_auto_refresh.py
@@ -1,0 +1,183 @@
+"""Regression (complement to #5752): file preview auto-refreshes after
+terminal/execute_code mutations, and extension-less root files (Makefile,
+Dockerfile) survive mutation tracking (#5747).
+
+#5752 already fixes the absolute-vs-relative workspace prefix mismatch and the
+half-screen layout split. This PR covers the two parts #5752 explicitly scoped
+out as follow-ups:
+
+1. Tools whose mutation target lives in command/code TEXT rather than a
+   structured path arg — `terminal` (sed -i, shell redirects) and
+   `execute_code` (python open(...,'w')) were invisible to
+   ARTIFACT_MUTATION_TOOLS. We scan their args + result text for path-like
+   tokens and for a direct mention of the open preview's path/basename.
+2. Extension-less root files like `Makefile`/`Dockerfile` were dropped by the
+   `[./]` filter in _normalizeArtifactPath() even when passed as structured
+   tool args — {allowBare:true} lets structured args through while keeping the
+   strict filter for text-mined candidates (so prose like "hello" can't become
+   an artifact).
+
+Drives the ACTUAL static/workspace.js helpers via node so it can't drift from
+a Python mirror.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract(decl_regex: str) -> str:
+    m = re.search(decl_regex, WORKSPACE_JS)
+    assert m, f"definition not found: {decl_regex}"
+    return m.group(0)
+
+
+def _function_block(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name}() not found"
+    params_end = src.find("){", start)
+    assert params_end != -1, f"{name}() body not found"
+    brace = params_end + 1
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"{name}() body did not close")
+
+
+def _normalize_via_node(paths, allow_bare=False):
+    ignore_re = _extract(r"const ARTIFACT_IGNORE_RE = /.*?/;")
+    start = WORKSPACE_JS.index("function _normalizeArtifactPath(")
+    brace = WORKSPACE_JS.index("{", start)
+    depth = 0
+    end = None
+    for i in range(brace, len(WORKSPACE_JS)):
+        c = WORKSPACE_JS[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    fn = WORKSPACE_JS[start:end]
+    opts = "{allowBare:true}" if allow_bare else "undefined"
+    driver = (
+        ignore_re + "\n" + fn + "\n"
+        + f"const out = JSON.parse(process.argv[1]).map(p=>_normalizeArtifactPath(p,{opts}));\n"
+        + "process.stdout.write(JSON.stringify(out));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(paths)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return json.loads(r.stdout)
+
+
+def test_extensionless_root_file_kept_when_allow_bare():
+    """#5747: write_file(path='Makefile') must survive the [./] filter."""
+    out = _normalize_via_node(["Makefile", "Dockerfile", "README"], allow_bare=True)
+    assert out == ["Makefile", "Dockerfile", "README"], (
+        f"extension-less root files must survive with allowBare (#5747); got {out}"
+    )
+
+
+def test_extensionless_root_file_still_rejected_for_text_mining():
+    """The strict filter must remain for text-mined candidates (#5747)."""
+    out = _normalize_via_node(["Makefile", "Dockerfile", "README"], allow_bare=False)
+    assert out == ["", "", ""], (
+        f"text-mined bare words must stay filtered so prose can't become an "
+        f"artifact (#5747); got {out}"
+    )
+
+
+def test_allow_bare_does_not_weaken_existing_rejections():
+    out = _normalize_via_node(
+        ["./node_modules/x.js", "https://e.com/a", "./", "foo/bar.py"],
+        allow_bare=True,
+    )
+    assert out == ["", "", "", "foo/bar.py"], (
+        f"allowBare must not weaken ignore-dir/URL/empty rejections (#5747); got {out}"
+    )
+
+
+def test_text_mutation_tools_are_tracked():
+    """#5747: terminal and execute_code must be scanned for preview paths."""
+    assert "ARTIFACT_TEXT_MUTATION_TOOLS" in WORKSPACE_JS
+    decl = _extract(r"const ARTIFACT_TEXT_MUTATION_TOOLS = new Set\(\[.*?\]\);")
+    assert "terminal" in decl and "execute_code" in decl, decl
+    block = _function_block(WORKSPACE_JS, "noteWorkspaceMutationsFromToolCall")
+    assert "ARTIFACT_TEXT_MUTATION_TOOLS" in block, (
+        "noteWorkspaceMutationsFromToolCall() must scan text-based mutation tools (#5747)"
+    )
+
+
+def test_text_path_tokens_extracts_dotted_paths():
+    """Path-like tokens in terminal/execute_code text must be extractable."""
+    start = WORKSPACE_JS.index("function _textPathTokens(")
+    brace = WORKSPACE_JS.index("{", start)
+    depth = 0
+    end = None
+    for i in range(brace, len(WORKSPACE_JS)):
+        c = WORKSPACE_JS[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    fn = WORKSPACE_JS[start:end]
+    ignore_re = _extract(r"const ARTIFACT_IGNORE_RE = /.*?/;")
+    norm_start = WORKSPACE_JS.index("function _normalizeArtifactPath(")
+    norm_brace = WORKSPACE_JS.index("{", norm_start)
+    depth = 0
+    norm_end = None
+    for i in range(norm_brace, len(WORKSPACE_JS)):
+        c = WORKSPACE_JS[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                norm_end = i + 1
+                break
+    norm_fn = WORKSPACE_JS[norm_start:norm_end]
+    driver = (
+        ignore_re + "\n" + norm_fn + "\n" + fn + "\n"
+        + "const out = _textPathTokens(process.argv[1]);\n"
+        + "process.stdout.write(JSON.stringify(out));\n"
+    )
+    text = "sed -i 's/a/b/' static/style.css && echo done"
+    r = subprocess.run(
+        [NODE, "-e", driver, text],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    assert "static/style.css" in json.loads(r.stdout), (
+        f"terminal text must yield the mutated path token (#5747)"
+    )
+
+
+def test_preview_refresh_still_uses_open_file_with_bust_cache():
+    block = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
+    assert "openFile(_previewCurrentPath,{bustCache:true})" in block.replace(" ", ""), (
+        "mutated preview must reload through openFile() with cache busting (#5747)"
+    )

--- a/tests/test_issue5747_preview_auto_refresh.py
+++ b/tests/test_issue5747_preview_auto_refresh.py
@@ -130,39 +130,35 @@ def test_text_mutation_tools_are_tracked():
 
 
 def test_text_path_tokens_extracts_dotted_paths():
-    """Path-like tokens in terminal/execute_code text must be extractable."""
-    start = WORKSPACE_JS.index("function _textPathTokens(")
-    brace = WORKSPACE_JS.index("{", start)
-    depth = 0
-    end = None
-    for i in range(brace, len(WORKSPACE_JS)):
-        c = WORKSPACE_JS[i]
-        if c == "{":
-            depth += 1
-        elif c == "}":
-            depth -= 1
-            if depth == 0:
-                end = i + 1
-                break
-    fn = WORKSPACE_JS[start:end]
+    """#5747 re-gate (F2): write-op targets in terminal/execute_code text must be
+    extracted, resolved against the tool's effective workdir, and rejected when
+    they escape the active workspace."""
+
+    def _block(name):
+        start = WORKSPACE_JS.index(f"function {name}(")
+        brace = WORKSPACE_JS.index("{", start)
+        depth = 0
+        end = None
+        for i in range(brace, len(WORKSPACE_JS)):
+            c = WORKSPACE_JS[i]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        return WORKSPACE_JS[start:end]
+
     ignore_re = _extract(r"const ARTIFACT_IGNORE_RE = /.*?/;")
-    norm_start = WORKSPACE_JS.index("function _normalizeArtifactPath(")
-    norm_brace = WORKSPACE_JS.index("{", norm_start)
-    depth = 0
-    norm_end = None
-    for i in range(norm_brace, len(WORKSPACE_JS)):
-        c = WORKSPACE_JS[i]
-        if c == "{":
-            depth += 1
-        elif c == "}":
-            depth -= 1
-            if depth == 0:
-                norm_end = i + 1
-                break
-    norm_fn = WORKSPACE_JS[norm_start:norm_end]
     driver = (
-        ignore_re + "\n" + norm_fn + "\n" + fn + "\n"
-        + "const out = _textPathTokens(process.argv[1]);\n"
+        ignore_re + "\n"
+        + _block("_collapseDotSegments") + "\n"
+        + _block("_normalizeArtifactPath") + "\n"
+        + _block("_textWriteOpTargets") + "\n"
+        + _block("_textPathTokens") + "\n"
+        + "const S={session:{session_id:'s1',workspace:'/home/user/ws'},activeProfile:'default',activeStreamId:''};\n"
+        + "const out=_textPathTokens(process.argv[1], '/home/user/ws');\n"
         + "process.stdout.write(JSON.stringify(out));\n"
     )
     text = "sed -i 's/a/b/' static/style.css && echo done"
@@ -174,10 +170,26 @@ def test_text_path_tokens_extracts_dotted_paths():
     assert "static/style.css" in json.loads(r.stdout), (
         f"terminal text must yield the mutated path token (#5747)"
     )
+    # F2: a write target escaping the active workspace is rejected, not tracked.
+    r2 = subprocess.run(
+        [NODE, "-e", driver, "sed -i s/a/b/ /etc/passwd"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r2.returncode == 0, f"node failed: {r2.stderr}"
+    assert "/etc/passwd" not in json.loads(r2.stdout), (
+        f"escaping path must be rejected (#5747 re-gate F2)"
+    )
 
 
 def test_preview_refresh_still_uses_open_file_with_bust_cache():
-    block = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
-    assert "openFile(_previewCurrentPath,{bustCache:true})" in block.replace(" ", ""), (
+    # #5747 re-gate (F3): the refresh loop must still reload the open preview
+    # through openFile() with cache busting, and refreshOpenPreviewIfMutated()
+    # must coalesce concurrent triggers onto that single in-flight loop.
+    loop = _function_block(WORKSPACE_JS, "_runPreviewRefreshLoop")
+    assert "openFile(_previewCurrentPath,{bustCache:true})" in loop.replace(" ", ""), (
         "mutated preview must reload through openFile() with cache busting (#5747)"
+    )
+    gate = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
+    assert "_runPreviewRefreshLoop" in gate, (
+        "refresh triggers must coalesce onto the in-flight refresh loop (#5747 re-gate F3)"
     )

--- a/tests/test_issue5747_preview_auto_refresh.py
+++ b/tests/test_issue5747_preview_auto_refresh.py
@@ -168,7 +168,7 @@ def test_text_path_tokens_extracts_dotted_paths():
     )
     assert r.returncode == 0, f"node failed: {r.stderr}"
     assert "static/style.css" in json.loads(r.stdout), (
-        f"terminal text must yield the mutated path token (#5747)"
+        "terminal text must yield the mutated path token (#5747)"
     )
     # F2: a write target escaping the active workspace is rejected, not tracked.
     r2 = subprocess.run(
@@ -177,7 +177,7 @@ def test_text_path_tokens_extracts_dotted_paths():
     )
     assert r2.returncode == 0, f"node failed: {r2.stderr}"
     assert "/etc/passwd" not in json.loads(r2.stdout), (
-        f"escaping path must be rejected (#5747 re-gate F2)"
+        "escaping path must be rejected (#5747 re-gate F2)"
     )
 
 

--- a/tests/test_issue5747_regate_findings.py
+++ b/tests/test_issue5747_regate_findings.py
@@ -1,0 +1,261 @@
+"""#5747 re-gate: behavioral coverage for the preview auto-refresh findings.
+
+Each test drives the REAL static/*.js helper via node (source is brace-extracted
+from the file at runtime), so the assertions describe behavior, never the shape
+of the source text:
+
+* F1 - raw command/code text reaches the write-op parser (JSON framing hid
+  quoted targets behind escape backslashes).
+* F2 - the pending-mutation key survives the transient stream id.
+* F4 - the stale-read predicate the new guards rely on.
+* F5 - collectSessionArtifacts() keeps extension-less structured candidates.
+* F3 - the settled merge carries the live identity/marker onto settled rows.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _fn(src: str, name: str) -> str:
+    """Brace-matched extraction of a function definition from real source."""
+    start = src.find(f"function {name}(")
+    assert start != -1, f"{name}() not found"
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"{name}() body did not close")
+
+
+def _decl(src: str, pattern: str) -> str:
+    m = re.search(pattern, src)
+    assert m, f"declaration not found: {pattern}"
+    return m.group(0)
+
+
+def _run(driver: str, payload) -> str:
+    script = driver.replace("__PAYLOAD__", json.dumps(payload))
+    r = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True, text=True, timeout=20,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return r.stdout
+
+
+WORKSPACE_PRELUDE = "\n".join(
+    [
+        _decl(WORKSPACE_JS, r"const ARTIFACT_IGNORE_RE = /.*?/;"),
+        _decl(WORKSPACE_JS, r"const ARTIFACT_MUTATION_TOOLS\s*=\s*new Set\([\s\S]*?\);"),
+        _decl(WORKSPACE_JS, r"const ARTIFACT_TEXT_MUTATION_TOOLS\s*=\s*new Set\([\s\S]*?\);"),
+        _fn(WORKSPACE_JS, "_collapseDotSegments"),
+        _fn(WORKSPACE_JS, "_normalizeArtifactPath"),
+        _fn(WORKSPACE_JS, "_textWriteOpTargets"),
+        _fn(WORKSPACE_JS, "_textPathTokens"),
+        _fn(WORKSPACE_JS, "_artifactCandidatesFromText"),
+        _fn(WORKSPACE_JS, "_artifactCandidatesFromToolCall"),
+        _fn(WORKSPACE_JS, "_currentMutationOwner"),
+        _fn(WORKSPACE_JS, "_mutationKey"),
+        _fn(WORKSPACE_JS, "_toolMutationIdentity"),
+        _fn(WORKSPACE_JS, "_openFileReadStale"),
+    ]
+)
+
+# Stub module state: declared here so the extracted helpers close over it.
+WORKSPACE_STATE = """
+let S = {session:{session_id:'s1', workspace:'/w'}, activeProfile:'default', activeStreamId:'stream-1'};
+let _turnMutatedPreviewPaths = new Map();
+let _consumedMutationToolIds = new Set();
+const _CONSUMED_MUTATION_TOOL_IDS_MAX = 1000;
+let _previewInFlightGen = 4;
+let __sink = [];
+function noteWorkspaceMutationsFromToolCalls(entries){ __sink = entries; }
+"""
+
+
+def _mutations(tc: dict, active_stream_id: str = "stream-1") -> list:
+    """Drive noteWorkspaceMutationsFromToolCall() with real state -> paths."""
+    driver = (
+        WORKSPACE_STATE
+        + "\n"
+        + WORKSPACE_PRELUDE
+        + "\n"
+        + _fn(WORKSPACE_JS, "noteWorkspaceMutationsFromToolCall")
+        + "\n"
+        + "function noteWorkspaceMutationsFromToolCalls(entries){ __sink = entries; }\n"
+        + f"S.activeStreamId = {json.dumps(active_stream_id)};\n"
+        + "const tc = __PAYLOAD__;\n"
+        + "noteWorkspaceMutationsFromToolCall(tc);\n"
+        + "process.stdout.write(JSON.stringify([..._turnMutatedPreviewPaths.values()].map(v=>v.path)));\n"
+    )
+    return json.loads(_run(driver, tc))
+
+
+def test_shell_write_op_from_raw_command_is_recorded():
+    """F1: a quoted write target must survive the parser's raw-text anchors."""
+    paths = _mutations(
+        {
+            "tid": "t-raw-1",
+            "name": "terminal",
+            "arguments": {"command": 'python -c \'open("notes/out.txt","w")\''},
+            "result": "",
+        }
+    )
+    assert any(p.endswith("notes/out.txt") for p in paths), (
+        "raw command text must reach _textWriteOpTargets so the shell/python "
+        f"write target is recorded (#5747 F1); got {paths}"
+    )
+
+
+def test_merely_mentioned_path_is_not_a_mutation():
+    """F1/F2 guard: prose mentions are not write ops."""
+    paths = _mutations(
+        {
+            "tid": "t-raw-2",
+            "name": "terminal",
+            "arguments": {"command": "cat notes/out.txt"},
+            "result": "notes/out.txt: 42 lines",
+        }
+    )
+    assert paths == [], f"a read/mention must not register a mutation; got {paths}"
+
+
+def test_pending_mutation_key_survives_transient_stream_id():
+    """F2: the stream id is transient and must not partition the key."""
+    driver = (
+        WORKSPACE_STATE
+        + "\n"
+        + WORKSPACE_PRELUDE
+        + "\n"
+        + "const [a, b, c, d] = __PAYLOAD__;\n"
+        + "process.stdout.write(JSON.stringify({\n"
+        + "  sameOwner: _mutationKey(a, 'src/a.js') === _mutationKey(b, 'src/a.js'),\n"
+        + "  otherPath: _mutationKey(a, 'src/a.js') === _mutationKey(c, 'src/b.js'),\n"
+        + "  otherWs: _mutationKey(a, 'src/a.js') === _mutationKey(d, 'src/a.js'),\n"
+        + "}));\n"
+    )
+    out = json.loads(
+        _run(
+            driver,
+            [
+                {"sessionId": "s1", "profile": "default", "workspace": "/w", "streamId": "stream-1"},
+                {"sessionId": "s1", "profile": "default", "workspace": "/w", "streamId": ""},
+                {"sessionId": "s1", "profile": "default", "workspace": "/w", "streamId": "stream-1"},
+                {"sessionId": "s1", "profile": "default", "workspace": "/w2", "streamId": "stream-1"},
+            ],
+        )
+    )
+    assert out["sameOwner"] is True, (
+        "the pending key must not include the transient stream id, otherwise a "
+        "mutation recorded mid-stream is orphaned once the stream settles (#5747 F2)"
+    )
+    assert out["otherPath"] is False, "different paths must not collide (#5747 F2)"
+    assert out["otherWs"] is False, "different workspaces must not collide (#5747 F2)"
+
+
+def test_stale_read_predicate_flags_superseded_reads():
+    """F4: the guards added to the rejection paths key off this predicate."""
+    driver = (
+        WORKSPACE_STATE
+        + "\n"
+        + WORKSPACE_PRELUDE
+        + "\n"
+        + "function stale(args){ return _openFileReadStale(args.gen, args.sid, args.pid, args.ws, args.stream); }\n"
+        + "const c = __PAYLOAD__;\n"
+        + "process.stdout.write(JSON.stringify({\n"
+        + "  current: stale({gen:4, sid:'s1', pid:'default', ws:'/w', stream:'stream-1'}),\n"
+        + "  newerOpen: stale({gen:3, sid:'s1', pid:'default', ws:'/w', stream:'stream-1'}),\n"
+        + "  otherWs: stale({gen:4, sid:'s1', pid:'default', ws:'/w2', stream:'stream-1'}),\n"
+        + "  settledStream: stale({gen:4, sid:'s1', pid:'default', ws:'/w', stream:''}),\n"
+        + "}));\n"
+    )
+    out = json.loads(_run(driver, {}))
+    assert out == {
+        "current": False,
+        "newerOpen": True,
+        "otherWs": True,
+        "settledStream": True,
+    }, (
+        "a read superseded by a newer openFile(), a workspace switch, or a "
+        f"settled stream must all read as stale (#5747 F4); got {out}"
+    )
+
+
+def test_artifacts_keep_extensionless_structured_candidate():
+    """F5: provenance decides normalization, not the path shape."""
+    driver = (
+        WORKSPACE_STATE
+        + "\n"
+        + WORKSPACE_PRELUDE
+        + "\n"
+        + _fn(WORKSPACE_JS, "collectSessionArtifacts")
+        + "\n"
+        + "const sessionToolCalls = __PAYLOAD__;\n"
+        + "S.toolCalls = sessionToolCalls;\n"
+        + "S.messages = [];\n"
+        + "process.stdout.write(JSON.stringify(collectSessionArtifacts().map(a=>a.path)));\n"
+    )
+    paths = json.loads(
+        _run(
+            driver,
+            [
+                {"tid": "a1", "name": "write_file", "arguments": {"path": "Makefile"}, "result": ""},
+                {"tid": "a2", "name": "write_file", "arguments": {"path": "Dockerfile"}, "result": ""},
+                {"tid": "a3", "name": "write_file", "arguments": {"path": "src/app.js"}, "result": ""},
+            ],
+        )
+    )
+    assert paths == ["Makefile", "Dockerfile", "src/app.js"], (
+        "structured, already-normalized candidates must not be re-normalized "
+        f"without allowBare — that drops Makefile/Dockerfile (#5747 F5); got {paths}"
+    )
+
+
+def test_settled_merge_keeps_live_identity_and_consumed_marker():
+    """F3: settled rows must adopt the live row's identity and marker."""
+    driver = (
+        "const settled = __PAYLOAD__[0];\n"
+        "let S = {toolCalls: __PAYLOAD__[1]};\n"
+        + _fn(MESSAGES_JS, "_mergeSettledToolCallsWithLiveMetadata")
+        + "\n"
+        + "process.stdout.write(JSON.stringify(_mergeSettledToolCallsWithLiveMetadata(settled)));\n"
+    )
+    live = [
+        {
+            "tid": "tid-1",
+            "name": "write_file",
+            "activityBurstId": "burst-9",
+            "duration": 1200,
+            "started_at": 111,
+            "_workspaceMutationConsumed": True,
+        }
+    ]
+    settled = [{"tool_call_id": "tid-1", "name": "write_file"}]
+    merged = json.loads(_run(driver, [settled, live]))
+    assert isinstance(merged, list) and len(merged) == 1, f"unexpected merge output: {merged}"
+    row = merged[0]
+    assert row.get("activityBurstId") == "burst-9" and row.get("duration") == 1200, (
+        f"settled rows must inherit the live burst/identity metadata (#5747 F3); got {row}"
+    )
+    assert row.get("_workspaceMutationConsumed") is True, (
+        "the consumed marker must survive the merge, otherwise the settled "
+        f"replay re-adds the same tool event (#5747 F3); got {row}"
+    )

--- a/tests/test_issue5747_regate_findings.py
+++ b/tests/test_issue5747_regate_findings.py
@@ -125,6 +125,32 @@ def test_shell_write_op_from_raw_command_is_recorded():
     )
 
 
+def test_relative_redirect_and_sed_targets_are_recorded():
+    """F1 (reviewer's own examples): canonical fields, relative paths."""
+    rel = _mutations(
+        {
+            "tid": "t-raw-3",
+            "name": "terminal",
+            "arguments": {"command": "echo updated > static/style.css"},
+            "result": "",
+        }
+    )
+    assert any(p.endswith("static/style.css") for p in rel), (
+        f"a workspace-relative shell redirect must register a mutation; got {rel}"
+    )
+    sed = _mutations(
+        {
+            "tid": "t-raw-4",
+            "name": "terminal",
+            "arguments": {"command": "sed -i 's/old/new/' static/theme.css"},
+            "result": "",
+        }
+    )
+    assert any(p.endswith("static/theme.css") for p in sed), (
+        f"an in-place sed edit must register a mutation; got {sed}"
+    )
+
+
 def test_merely_mentioned_path_is_not_a_mutation():
     """F1/F2 guard: prose mentions are not write ops."""
     paths = _mutations(

--- a/tests/test_todo_panel_cold_load_static.py
+++ b/tests/test_todo_panel_cold_load_static.py
@@ -108,7 +108,9 @@ def test_workspace_files_and_artifacts_paths_stay_outside_todo_render_change():
     assert artifacts_start != -1
     assert "renderSessionArtifacts()" in src[:todos_start]
     assert "const ARTIFACT_MUTATION_TOOLS = new Set" in src[artifacts_start:]
-    assert "function _normalizeArtifactPath(path)" in src[artifacts_start:]
+    # Signature extended in #5747: optional {allowBare} opts for structured tool
+    # args (extension-less root files like Makefile).
+    assert "function _normalizeArtifactPath(path" in src[artifacts_start:]
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required for shared todo renderer behavior test")

--- a/tests/test_workspace_preview_preserved_on_stream_done.py
+++ b/tests/test_workspace_preview_preserved_on_stream_done.py
@@ -64,11 +64,17 @@ def test_load_dir_still_clears_preview_for_directory_navigation():
 
 
 def test_turn_mutation_tracking_reloads_open_preview():
-    block = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
-    assert "openFile(_previewCurrentPath" in block.replace(" ", ""), (
+    # #5747 re-gate (F3): the refresh loop must still reload the open preview
+    # through openFile(), and the gate must coalesce triggers onto that loop.
+    loop = _function_block(WORKSPACE_JS, "_runPreviewRefreshLoop")
+    assert "openFile(_previewCurrentPath" in loop.replace(" ", ""), (
         "Mutated open previews must reload through openFile()"
     )
-    assert "_previewDirty" in block, "Reload must be skipped while the preview has unsaved edits"
+    gate = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
+    assert "_runPreviewRefreshLoop" in gate, (
+        "Refresh triggers must coalesce onto the in-flight refresh loop (#5747 re-gate F3)"
+    )
+    assert "_previewDirty" in gate, "Reload must be skipped while the preview has unsaved edits"
 
 
 def test_tool_complete_tracks_workspace_mutations_for_preview_reload():


### PR DESCRIPTION
## Complements #5752 — closes #5747

This PR covers the two parts of #5747 that #5752 explicitly scoped out as follow-ups (per maintainer feedback that plain whitelist expansion for `terminal`/`execute_code` does not work, since their args are shell/script bodies, not structured file paths).

### 1. Auto-refresh preview after `terminal` / `execute_code` mutations

`ARTIFACT_MUTATION_TOOLS` only matched tools with a structured `path` arg. `terminal` (sed -i, shell redirects) and `execute_code` (python `open(...,'w')`) mutate files with no structured path — the target lives in command/code/result **text**.

Instead of expanding the whitelist, `noteWorkspaceMutationsFromToolCall()` now scans these tools' args + result text two ways:

- `_textPathTokens()` — extracts conservative path-like tokens (dotted filenames / slash segments), so `sed -i 's/a/b/' static/style.css` registers `static/style.css`.
- `_toolTextMentionsPreview()` — direct mention check: if the text contains the open preview's relative path or its basename, the open file is treated as mutated.

The preview then reloads through the existing `refreshOpenPreviewIfMutated()` → `openFile(path, {bustCache:true})` chain.

### 2. Extension-less root files survive mutation tracking

`_normalizeArtifactPath()` dropped paths with no `.` and no `/` (the `[./]` guard), so root-level files like `Makefile`/`Dockerfile` were silently filtered even when passed as structured tool args (`write_file(path='Makefile')`). Added an `{allowBare:true}` option used only for **structured tool args**; text-mined candidates keep the strict filter so prose like "hello" can't become an artifact.

### Not touched (already covered by #5752)

- Absolute-vs-relative workspace prefix normalization in `_normalizeArtifactPath()`
- Half-screen layout split guard in `loadDir()` (file tree re-hide when preserving a preview)

Both PRs are additive and non-conflicting — #5752 normalizes paths and guards the layout; this PR makes text-based mutation tools refresh the preview and keeps extension-less root files tracked.

## Test Results

- **7/7** new tests pass (`tests/test_issue5747_preview_auto_refresh.py`) — drives actual `static/workspace.js` functions via node
- **887 passed, 5 skipped** — workspace/artifact/preview/mutation/todo suite (1 pre-existing Playwright env failure unrelated to this change)
- **eslint runtime guard: clean**

## Files Changed

- `static/workspace.js` (+76 lines)
- `tests/test_issue5747_preview_auto_refresh.py` (new)
- `tests/test_todo_panel_cold_load_static.py` (signature assertion update)
