### PR TITLE
perf(sessions): parallelize fresh conversation tail loads

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1850,9 +1850,20 @@ async function loadSession(sid){
   // resolution out of the first-paint path; old provider-shaped model IDs are
   // repaired by the deferred resolver after S.session is assigned.
   // Guard against network/server failures to prevent a permanently stuck loading state.
+  // Start fresh click-time metadata and tail requests in parallel, while
+  // preserving metadata-first state assignment and same-session reload width.
+  const _freshNavigationRequests = sameSessionForceReload
+    ? null
+    : _startFreshSessionNavigationRequests(sid);
+  const _metadataRequest = _freshNavigationRequests
+    ? _freshNavigationRequests.metadata
+    : api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+  const _freshMessagesRequest = _freshNavigationRequests
+    ? _freshNavigationRequests.messages
+    : null;
   let data;
   try {
-    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+    data = await _metadataRequest;
   } catch(e) {
     const profileMismatch=_sessionProfileMismatchFromError(e);
     if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
@@ -2135,7 +2146,7 @@ async function loadSession(sid){
     // this session's INFLIGHT snapshot, not leave prior-session rows in place.
     if(typeof clearLiveToolCards==='function') clearLiveToolCards();
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration, messageRequest:_freshMessagesRequest});
     } catch(e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
@@ -2241,7 +2252,7 @@ async function loadSession(sid){
     // "messages already populated" early-return inside _ensureMessagesLoaded
     // does NOT skip the swap to the new transcript.
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration, messageRequest:_freshMessagesRequest});
     } catch (e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
@@ -3035,6 +3046,9 @@ let _messagesTruncated = false;
 // server-bounded and do not consume the visible-message budget.
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
+// Ordinary navigation and older-message pagination intentionally share the
+// established 30-renderable-message window.
+const _INITIAL_TAIL_MSG_LIMIT = _INITIAL_MSG_LIMIT;
 // ============================================================================
 // COUPLED CONSTANT — keep in sync with api/routes.py:_MAX_MSG_LIMIT.
 // ============================================================================
@@ -3102,7 +3116,23 @@ function _messageReloadLimitForSession(sid){
       return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
     }
   }
-  return _INITIAL_MSG_LIMIT;
+  // Ordinary first paint keeps the same 30-message contract as older pages.
+  return _INITIAL_TAIL_MSG_LIMIT;
+}
+
+function _startFreshSessionNavigationRequests(sid){
+  const base=`/api/session?session_id=${encodeURIComponent(sid)}`;
+  const metadata=api(`${base}&messages=0&resolve_model=0`);
+  const messages=api(
+    `${base}&messages=1&resolve_model=0&msg_limit=${_INITIAL_TAIL_MSG_LIMIT}&expand_renderable=1`,
+    {timeoutMs:120000}
+  );
+  // Metadata failures can end navigation before the tail is awaited. Attach a
+  // handler immediately so a later tail failure is not reported as an
+  // unhandled rejection; _ensureMessagesLoaded still awaits the original
+  // promise and follows its existing message-load error path when metadata wins.
+  messages.catch(()=>{});
+  return {metadata,messages};
 }
 
 function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
@@ -3172,10 +3202,12 @@ async function _ensureMessagesLoaded(sid, opts) {
   const expandParam = boundedReloadLimit ? '&expand_renderable=1' : '';
   let data;
   try {
-    data = await api(
-      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,
-      {timeoutMs:120000}
-    );
+    data = opts.messageRequest
+      ? await opts.messageRequest
+      : await api(
+        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,
+        {timeoutMs:120000}
+      );
   } finally {
     if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);
   }

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -228,11 +228,22 @@ def test_update_flows_keep_explicit_longer_timeouts():
 def test_session_message_loads_keep_explicit_longer_timeouts():
     """Large state.db installs can take longer than the generic 30s API timeout."""
     src = _source(SESSIONS_JS)
+    # Fresh session navigation starts its tail request in parallel with metadata
+    # but must retain the explicit 120s override on large installs.
     assert (
-        "api(\n"
-        "      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,\n"
-        "      {timeoutMs:120000}\n"
-        "    )"
+        "const messages=api(\n"
+        "    `${base}&messages=1&resolve_model=0&msg_limit=${_INITIAL_TAIL_MSG_LIMIT}&expand_renderable=1`,\n"
+        "    {timeoutMs:120000}\n"
+        "  )"
+    ) in src
+    # Same-session forced reloads do not use the parallel click request because
+    # they preserve the already-visible width; their fallback request keeps the
+    # same timeout contract.
+    assert (
+        ": await api(\n"
+        "        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,\n"
+        "        {timeoutMs:120000}\n"
+        "      )"
     ) in src
     # _loadOlderMessages now picks between two strategies (tail-growth vs
     # msg_before paging) via a useBeforePaging ternary, but both keep the long

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -87,6 +87,9 @@ def _extract_function(source: str, name: str) -> str:
     raise AssertionError(f"Could not extract function {name}")
 
 
+START_FRESH_SESSION_NAVIGATION_REQUESTS_SRC = _extract_function(
+    SESSIONS_SRC, "_startFreshSessionNavigationRequests"
+)
 LOAD_SESSION_SRC = _extract_function(SESSIONS_SRC, "loadSession")
 ENSURE_MESSAGES_LOADED_SRC = _extract_function(SESSIONS_SRC, "_ensureMessagesLoaded")
 INFLIGHT_HAS_VISIBLE_STATE_SRC = _extract_function(SESSIONS_SRC, "_inflightHasVisibleLiveState")
@@ -118,7 +121,10 @@ def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded
         "loadSession() should check ownership in multiple await/catch paths, "
         "including stale _ensureMessagesLoaded catch branches"
     )
-    ensure_call = _normalise_ws("await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});")
+    ensure_call = _normalise_ws(
+        "await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, "
+        "loadGeneration:_loadGeneration, messageRequest:_freshMessagesRequest});"
+    )
     assert ensure_call in norm, (
         "loadSession() must pass generation into _ensureMessagesLoaded() for stale-owner checks"
     )
@@ -347,9 +353,11 @@ let toolSyncCalls = 0;
 let toastCalls = [];
 
 // Source under test
+const _INITIAL_TAIL_MSG_LIMIT = 30;
 __INFLIGHT_HAS_VISIBLE_STATE_SRC__
 __SELECT_LIVE_RECOVERY_INFLIGHT_SRC__
 __MERGE_PENDING_SESSION_MESSAGE_SRC__
+__START_FRESH_SESSION_NAVIGATION_REQUESTS_SRC__
 __LOAD_SESSION_SRC__
 __ENSURE_MESSAGES_LOADED_SRC__
 
@@ -432,10 +440,10 @@ const API_ATLAS_RELOAD_MSGS = {
   },
 };
 
-function buildMessageUrl(sid, mode, suffix='') {
+function buildMessageUrl(sid, mode, suffix='', limit=_INITIAL_TAIL_MSG_LIMIT) {
   const base = `/api/session?session_id=${encodeURIComponent(sid)}&messages=${mode}&resolve_model=0`;
   if (mode === 0) return base;
-  return `${base}&msg_limit=${_messageReloadLimitForSession()}&expand_renderable=1${suffix}`;
+  return `${base}&msg_limit=${limit}&expand_renderable=1${suffix}`;
 }
 
 function makeCrossSessionCalls(apiHost) {
@@ -462,11 +470,14 @@ function runCrossSessionOrderingBase({seedBeaconInflight, resolveBeaconMsgsBefor
   const first = loadSession('sid-beacon', { force: true });
   return (async () => {
     await waitForQueued(apiHost, calls.beaconMeta.url);
+    // A real click must issue both fresh requests before metadata is released.
+    await waitForQueued(apiHost, calls.beaconMsgs.url);
+    const firstRequestsParallel = true;
     calls.beaconMeta._resolve(API_BEACON_META);
 
-    await waitForQueued(apiHost, calls.beaconMsgs.url);
     const second = loadSession('sid-atlas', { force: true });
     await waitForQueued(apiHost, calls.atlasMeta.url);
+    await waitForQueued(apiHost, calls.atlasMsgs.url);
 
     if (resolveBeaconMsgsBeforeAtlasMeta) {
       calls.beaconMsgs._resolve(API_BEACON_MSGS);
@@ -496,6 +507,7 @@ function runCrossSessionOrderingBase({seedBeaconInflight, resolveBeaconMsgsBefor
       loadingSid: snapshotState().loadingSid,
       loadingGeneration: snapshotState().loadingGeneration,
       rearmCalls: snapshotState().rearmCalls,
+      firstRequestsParallel,
     };
   })();
 }
@@ -524,9 +536,9 @@ async function runStaleRejectedIdleCatch() {
 
   const calls = {
     firstMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
-    firstMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
+    firstMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1, '', 2)),
     secondMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
-    secondMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
+    secondMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1, '', 2)),
   };
 
   const first = loadSession('sid-atlas', { force: true });
@@ -608,6 +620,10 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior(tmp_path):
         .replace(
             "__MERGE_PENDING_SESSION_MESSAGE_SRC__", MERGE_PENDING_SESSION_MESSAGE_SRC
         )
+        .replace(
+            "__START_FRESH_SESSION_NAVIGATION_REQUESTS_SRC__",
+            START_FRESH_SESSION_NAVIGATION_REQUESTS_SRC,
+        )
         .replace("__LOAD_SESSION_SRC__", LOAD_SESSION_SRC)
         .replace("__ENSURE_MESSAGES_LOADED_SRC__", ENSURE_MESSAGES_LOADED_SRC)
     )
@@ -633,18 +649,19 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior(tmp_path):
     assert cross["apiCalls"][0] == "/api/session?session_id=sid-beacon&messages=0&resolve_model=0", (
         "first API call should target old session's metadata"
     )
-    assert cross["apiCalls"][1] == "/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1", (
+    assert cross["apiCalls"][1] == "/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1", (
         "beacon transcript request should queue before atlas metadata resolves"
     )
     assert cross["apiCalls"][2] == "/api/session?session_id=sid-atlas&messages=0&resolve_model=0", (
         "second API call should target atlas metadata while stale beacon messages are in flight"
     )
-    assert cross["apiCalls"][3] == "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1", (
+    assert cross["apiCalls"][3] == "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1", (
         "atlas should still fetch a transcript while beacon was stale"
     )
-    assert cross["apiCalls"].count("/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1") == 1, (
+    assert cross["apiCalls"].count("/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1") == 1, (
         "stale overlap should still issue the Beacon transcript call, but it must not win"
     )
+    assert cross["firstRequestsParallel"] is True
     _assert_atlas_wins(cross, label="cross-session-ordering")
 
     # 2) Observed idle-path race with no INFLIGHT: stale Beacon transcript returns
@@ -652,19 +669,19 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior(tmp_path):
     assert observed["apiCalls"][0] == "/api/session?session_id=sid-beacon&messages=0&resolve_model=0", (
         "idle-path race should start from old Beacon metadata"
     )
-    assert observed["apiCalls"][1] == "/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1", (
+    assert observed["apiCalls"][1] == "/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1", (
         "Beacon transcript call should remain queued before Atlas metadata under observed race"
     )
     assert observed["apiCalls"][2] == "/api/session?session_id=sid-atlas&messages=0&resolve_model=0", (
         "Atlas metadata must start while Beacon continuation returns stale"
     )
-    assert observed["apiCalls"][3] == "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1", (
+    assert observed["apiCalls"][3] == "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1", (
         "Atlas transcript request must still issue despite stale Beacon return"
     )
-    assert observed["apiCalls"].count("/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1") == 1, (
+    assert observed["apiCalls"].count("/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1") == 1, (
         "stale Beacon transcript should occur once in observed race"
     )
-    assert observed["apiCalls"].count("/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1") == 1, (
+    assert observed["apiCalls"].count("/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1") == 1, (
         "Atlas transcript must be issued once once stale Beacon is processed first"
     )
     _assert_atlas_wins(observed, label="observed-idle-cross-session-ordering")

--- a/tests/test_gateway_sse_reconnect_dedupe.py
+++ b/tests/test_gateway_sse_reconnect_dedupe.py
@@ -131,7 +131,7 @@ def test_load_session_persists_only_after_metadata_loads():
     # _mergePendingSessionMessage was lifted to a top-level helper for #6419,
     # so use a stable boundary inside loadSession instead.
     load = _block(src, "async function loadSession(sid)", "// Phase 2a:")
-    api_pos = load.index("data = await api(`/api/session")
+    api_pos = load.index("data = await _metadataRequest")
     persist_pos = load.index("localStorage.setItem('hermes-webui-session',S.session.session_id)")
 
     assert "_persistActiveSession" not in src

--- a/tests/test_issue5177_hidden_tab_blank_gap.py
+++ b/tests/test_issue5177_hidden_tab_blank_gap.py
@@ -158,7 +158,7 @@ def test_ensure_messages_loaded_called_with_keep_stale_flag():
     # cannot skip the swap when stale messages are still in place.
     block = _load_session_block(_compact(SESSIONS_JS))
     # Both INFLIGHT and idle paths.
-    assert block.count("await_ensureMessagesLoaded(sid,{force:_keepStaleUntilLoaded,loadGeneration:_loadGeneration})") == 2
+    assert block.count("await_ensureMessagesLoaded(sid,{force:_keepStaleUntilLoaded,loadGeneration:_loadGeneration,messageRequest:_freshMessagesRequest})") == 2
 
 
 def test_ensure_messages_loaded_supports_force_override():

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -971,9 +971,11 @@ def test_load_session_rearms_stream_on_every_early_return():
 
     # The fetch-error catch must restart the stream for the on-screen session,
     # but guarded against the self-healed-current (404'd) case so it never
-    # spins the reconnect loop against a dead session_id.
-    catch_ix = body.index("const _selfHealedCurrent")
-    catch_src = body[catch_ix:catch_ix + 2200]
+    # spins the reconnect loop against a dead session_id. Search from the real
+    # function start instead of the legacy fixed-width `body` window: adding
+    # pre-await setup near the top of loadSession must not truncate this catch.
+    catch_ix = js.index("const _selfHealedCurrent", fn_ix)
+    catch_src = js[catch_ix:catch_ix + 2200]
     assert "!_selfHealedCurrent" in catch_src and "startSessionStream(currentSid)" in catch_src, (
         "fetch-error path must restart the on-screen stream, guarded against "
         "the self-healed-current (deleted/404) session"

--- a/tests/test_session_navigation_prefetch.py
+++ b/tests/test_session_navigation_prefetch.py
@@ -1,0 +1,154 @@
+"""Regression coverage for fresh, bounded session-navigation loads."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+
+def _function_block(source: str, name: str) -> str:
+    markers = (f"async function {name}(", f"function {name}(")
+    starts = [source.find(marker) for marker in markers]
+    start = min(index for index in starts if index >= 0)
+    brace = source.index("{", start)
+    depth = 0
+    in_string = None
+    escaped = False
+    in_line_comment = False
+    in_block_comment = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < len(source) else ""
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            continue
+        if in_block_comment:
+            if char == "*" and next_char == "/":
+                in_block_comment = False
+            continue
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == in_string:
+                in_string = None
+            continue
+        if char == "/" and next_char == "/":
+            in_line_comment = True
+            continue
+        if char == "/" and next_char == "*":
+            in_block_comment = True
+            continue
+        if char in ("'", '"', "`"):
+            in_string = char
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated function {name}")
+
+
+def test_hover_and_focus_do_not_issue_or_cache_session_responses():
+    """A hover burst must remain a pure UI interaction with no response cache."""
+    source = SESSIONS_JS.read_text(encoding="utf-8")
+    render_one = _function_block(source, "_renderOneSession")
+
+    assert "_sessionNavCache" not in source
+    assert "_prefetchSessionForNav" not in source
+    assert "_apiSessionNav" not in source
+    assert "_sessionNavRowIsStreaming" not in source
+    assert "onpointerenter" not in render_one
+    assert "onfocusin" not in render_one
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_session_becoming_streaming_between_hover_and_click_uses_fresh_click_requests():
+    """The real click request path must not consume an earlier idle snapshot."""
+    source = SESSIONS_JS.read_text(encoding="utf-8")
+    start_requests = _function_block(source, "_startFreshSessionNavigationRequests")
+    driver = f"""
+const _INITIAL_MSG_LIMIT = 30;
+const _INITIAL_TAIL_MSG_LIMIT = _INITIAL_MSG_LIMIT;
+const calls = [];
+function api(url, opts) {{
+  calls.push({{url, opts: opts || null}});
+  if(url.includes('messages=0')) {{
+    return Promise.resolve({{session: {{session_id:'target', active_stream_id:'stream-new'}}}});
+  }}
+  return Promise.resolve({{session: {{session_id:'target', messages:[{{role:'assistant', content:'fresh-live-tail'}}]}}}});
+}}
+{start_requests}
+(async () => {{
+  const row = {{}};
+  for(let i=0;i<50;i++) {{
+    if(typeof row.onpointerenter === 'function') row.onpointerenter({{pointerType:'mouse'}});
+    if(typeof row.onfocusin === 'function') row.onfocusin();
+  }}
+  const callsBeforeClick = calls.length;
+  const requests = _startFreshSessionNavigationRequests('target');
+  const metadata = await requests.metadata;
+  const messages = await requests.messages;
+  console.log(JSON.stringify({{callsBeforeClick, calls, metadata, messages}}));
+}})().catch((error) => {{ console.error(error); process.exit(1); }});
+"""
+    proc = subprocess.run(
+        [NODE, "-e", driver],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    observed = json.loads(proc.stdout)
+    assert observed["callsBeforeClick"] == 0
+    assert observed["calls"] == [
+        {
+            "url": "/api/session?session_id=target&messages=0&resolve_model=0",
+            "opts": None,
+        },
+        {
+            "url": "/api/session?session_id=target&messages=1&resolve_model=0&msg_limit=30&expand_renderable=1",
+            "opts": {"timeoutMs": 120000},
+        },
+    ]
+    assert observed["metadata"]["session"]["active_stream_id"] == "stream-new"
+    assert observed["messages"]["session"]["messages"][0]["content"] == "fresh-live-tail"
+
+
+def test_load_session_starts_both_requests_then_assigns_metadata_before_transcript():
+    source = SESSIONS_JS.read_text(encoding="utf-8")
+    load_session = _function_block(source, "loadSession")
+
+    request_start = load_session.index("const _freshNavigationRequests =")
+    metadata_await = load_session.index("data = await _metadataRequest")
+    metadata_assignment = load_session.index("S.session=data.session")
+    transcript_await = load_session.index("messageRequest:_freshMessagesRequest")
+
+    assert request_start < metadata_await < metadata_assignment < transcript_await
+    assert load_session.count("messageRequest:_freshMessagesRequest") == 2
+
+
+def test_initial_tail_and_older_pagination_remain_thirty_messages():
+    source = SESSIONS_JS.read_text(encoding="utf-8")
+    load_older = _function_block(source, "_loadOlderMessages")
+
+    assert "const _INITIAL_MSG_LIMIT = 30;" in source
+    assert "const _INITIAL_TAIL_MSG_LIMIT = _INITIAL_MSG_LIMIT;" in source
+    assert "msg_limit=${_INITIAL_MSG_LIMIT}" in load_older
+
+
+def test_session_visit_model_freshness_default_remains_five_minutes():
+    from api import config
+
+    assert config._SESSION_VISIT_MODELS_FRESHNESS_SECONDS == 300.0


### PR DESCRIPTION
## Thinking Path

- Conversation navigation previously awaited the metadata-only session response before starting the transcript-tail request, multiplying link latency.
- Review rejected hover/focus warming and response caching because they could serve stale content and create speculative request bursts. Review also rejected an 8-row first paint, a 30-minute model-catalog freshness default, and a single combined session response because those shapes changed established behavior or lifecycle invariants.
- The bounded shape is therefore two **fresh click-time** requests started together: metadata remains the first awaited/assigned state, while the existing transcript loader later consumes the already-started 30-row tail request under its existing generation guards.

## What Changed

- Start `messages=0&resolve_model=0` metadata and `messages=1&resolve_model=0&msg_limit=30&expand_renderable=1` transcript requests in parallel for ordinary navigation.
- Preserve metadata-first `S.session` assignment, deferred model resolution, cross-session generation fencing, pending-message carry-forward, hidden-tab stale-row handling, and stream rearm/self-heal behavior.
- Keep same-session forced reloads on their existing width-aware request path.
- Add regression coverage for request timing, cross-session isolation, timeout behavior, and the rejected optimization boundaries.
- Keep hover/focus free of session requests and response caches, retain the 30-renderable-message first paint, and leave session-visit model freshness at 300 seconds.

## Why It Matters

High-latency links now pay one effective network round trip for the two-phase session load without weakening freshness or changing transcript width, model-catalog behavior, persistence, or older-message pagination.

## Verification

On exact rebased head `97104881eb03bcb0dc4f60a247bf57771a27c7e4`:

```text
81 passed, 1 skipped
node --check static/sessions.js
npm run lint:runtime
python3 -m py_compile api/config.py
python scripts/ruff_lint.py --diff origin/master  # no changed Python files
git diff --check origin/master...HEAD
```

The focused run includes the seven lifecycle regressions named in review plus adjacent navigation, isolation, timeout, reconnect, hidden-tab, and stream-rearm coverage. GitHub's supported sharded matrix is green on this exact head: 15 Python 3.11-3.13 test shards, lint, browser smoke, and all three conversation-lifecycle jobs passed.

## Risks / Follow-ups

- Ordinary navigation deliberately starts two fresh server requests. If metadata fails or navigation becomes stale, the independent tail request may finish unused; it is never cached or applied outside the existing load-generation checks.
- A local unsharded all-tests run is not authoritative on this root runner: its first failure is the unchanged root-permission baseline test `test_readonly_parent_with_unwritable_file_still_raises`, followed by order-dependent working-directory fallout. The supported GitHub sharded matrix is the full-suite gate.
- Local Playwright browser smoke was not run because Playwright is absent from this worktree environment; the GitHub Browser smoke workflow owns that proof.

## Contract Routing

Task type: session-navigation performance correction after review.  
Touched areas: browser session loading and regression tests.  
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `docs/rfcs/webui-run-state-consistency-contract.md`, `TESTING.md`.  
State layer: fresh server session responses remain authoritative; browser state and transcript rows remain generation-fenced projections.  
Scope boundaries: no backend API/schema, persistence, model-catalog default, hover behavior, first-paint width, older-message pagination, or same-session forced-reload contract change.  
Evidence: metadata-before-state assignment, fresh click-time tail isolation, stale-load rejection, and the named lifecycle regression suite.

## Model Used

Post-review audit and safe rebase: OpenAI `gpt-5.6-sol` via Hermes Agent, using Git/GitHub CLI and the repository test/lint runners. The original implementation history predates this refresh.
