### PR TITLE
fix(#6672): freeze session-start workspace prompt context

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -486,15 +486,18 @@ def _run_gateway_runs_api_streaming(
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
             headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
-        message_content: Any = str(msg_text or "")
+        from api.streaming import _workspace_context_prefix
+
+        workspace_ctx = _workspace_context_prefix(str(workspace))
+        message_content: Any = workspace_ctx + str(msg_text or "")
         if attachments:
             try:
                 from api.streaming import _build_native_multimodal_message
 
-                message_content = _build_native_multimodal_message("", str(msg_text or ""), attachments, str(workspace), cfg=cfg)
+                message_content = _build_native_multimodal_message(workspace_ctx, str(msg_text or ""), attachments, str(workspace), cfg=cfg)
             except Exception:
                 logger.debug("Failed to build runs-API multimodal attachment payload", exc_info=True)
-                message_content = str(msg_text or "")
+                message_content = workspace_ctx + str(msg_text or "")
         from api.streaming import _strip_oob_blocks
 
         instructions_parts = []
@@ -913,7 +916,8 @@ def _run_gateway_chat_streaming(
                 _prefill_messages_with_webui_context,
                 _normalize_prefill_messages_before_user_turn,
                 _public_prefill_context_status,
-                _webui_ephemeral_system_prompt,
+                _webui_session_workspace_prompts,
+                _workspace_context_prefix,
             )
 
             prefill_context = _load_webui_prefill_context(cfg)
@@ -922,16 +926,11 @@ def _run_gateway_chat_streaming(
             # the ephemeral system prompt rather than a prefill `user` message.
             # The gateway-backed path must build the SAME system prompt so that
             # context is not silently dropped on Gateway-routed WebUI chats.
-            _gateway_system_prompt = _webui_ephemeral_system_prompt(
-                None,
-                surface_context={
-                    "source": "webui",
-                    "session_id": session_id,
-                    "profile": getattr(s, "profile", None),
-                    "workspace": s.workspace if s is not None else str(workspace),
-                },
+            _gateway_system_prompt = _webui_session_workspace_prompts(
+                s,
+                workspace=workspace,
                 config_data=cfg,
-            )
+            )["ephemeral_system_prompt"]
             prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
             prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
             prefill_messages = [
@@ -1008,15 +1007,16 @@ def _run_gateway_chat_streaming(
                 # Scope Gateway long-term continuity to this WebUI conversation
                 # without exposing the browser's auth cookie or CSRF material.
                 headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
-            message_content: Any = str(msg_text or "")
+            workspace_ctx = _workspace_context_prefix(str(workspace))
+            message_content: Any = workspace_ctx + str(msg_text or "")
             if attachments:
                 try:
                     from api.streaming import _build_native_multimodal_message
 
-                    message_content = _build_native_multimodal_message("", str(msg_text or ""), attachments, str(workspace), cfg=cfg)
+                    message_content = _build_native_multimodal_message(workspace_ctx, str(msg_text or ""), attachments, str(workspace), cfg=cfg)
                 except Exception:
                     logger.debug("Failed to build gateway multimodal attachment payload", exc_info=True)
-                    message_content = str(msg_text or "")
+                    message_content = workspace_ctx + str(msg_text or "")
             body = {
                 "model": model or "default",
                 "stream": True,

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -38,6 +38,11 @@ from api.run_journal import RunJournalWriter, bound_run_journal_snapshot_args
 
 logger = logging.getLogger(__name__)
 
+
+def _gateway_workspace_context_fallback(workspace):
+    escaped = str(workspace or "").replace("\\", "\\\\").replace("]", "\\]")
+    return f"[Workspace::v1: {escaped}]\n"
+
 # Maps stream_id -> gateway run_id for approval response relay.
 _STREAM_RUN_IDS: dict[str, str] = {}
 _STREAM_RUN_LIFECYCLE: dict[str, dict[str, Any]] = {}
@@ -488,7 +493,10 @@ def _run_gateway_runs_api_streaming(
             headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
         from api.streaming import _workspace_context_prefix
 
-        workspace_ctx = _workspace_context_prefix(str(workspace))
+        try:
+            workspace_ctx = _workspace_context_prefix(str(workspace))
+        except Exception:
+            workspace_ctx = _gateway_workspace_context_fallback(workspace)
         message_content: Any = workspace_ctx + str(msg_text or "")
         if attachments:
             try:
@@ -499,6 +507,48 @@ def _run_gateway_runs_api_streaming(
                 logger.debug("Failed to build runs-API multimodal attachment payload", exc_info=True)
                 message_content = workspace_ctx + str(msg_text or "")
         from api.streaming import _strip_oob_blocks
+
+        if not any(
+            isinstance(entry, dict) and str(entry.get("role") or "").strip().lower() == "system"
+            for entry in prefill_messages or []
+        ):
+            try:
+                from api.streaming import _webui_session_workspace_prompts
+
+                _workspace_prompts = _webui_session_workspace_prompts(
+                    session,
+                    workspace=workspace,
+                    config_data=cfg,
+                )
+                _gateway_system_prompt = (
+                    _workspace_prompts["system_prompt"]
+                    + "\n\n"
+                    + _workspace_prompts["ephemeral_system_prompt"]
+                )
+            except Exception:
+                from api.streaming import (
+                    _webui_ephemeral_system_prompt,
+                    _webui_workspace_system_prompt,
+                )
+
+                session_start_workspace = str(
+                    getattr(session, "session_start_workspace", None) or workspace or ""
+                )
+                _gateway_system_prompt = (
+                    _webui_workspace_system_prompt(session_start_workspace)
+                    + "\n\n"
+                    + _webui_ephemeral_system_prompt(
+                        None,
+                        surface_context={
+                            "source": "webui",
+                            "session_id": getattr(session, "session_id", None),
+                            "profile": getattr(session, "profile", None),
+                            "workspace": session_start_workspace,
+                        },
+                        config_data=cfg,
+                    )
+                )
+            prefill_messages = [{"role": "system", "content": _gateway_system_prompt}, *prefill_messages]
 
         instructions_parts = []
         conversation_history = []
@@ -917,16 +967,14 @@ def _run_gateway_chat_streaming(
             workspace_ctx = _workspace_context_prefix(str(workspace))
         except Exception:
             logger.debug("Failed to build Gateway workspace prefix", exc_info=True)
+            workspace_ctx = _gateway_workspace_context_fallback(workspace)
+        prefill_messages = []
+        _gateway_system_prompt = ""
         try:
             from api.streaming import (
-                _load_webui_prefill_context,
-                _prefill_messages_with_webui_context,
-                _normalize_prefill_messages_before_user_turn,
-                _public_prefill_context_status,
                 _webui_session_workspace_prompts,
             )
 
-            prefill_context = _load_webui_prefill_context(cfg)
             # #3324: the WebUI session/delivery context (connected platforms,
             # home channels, delivery hints, session framing) is now carried in
             # the ephemeral system prompt rather than a prefill `user` message.
@@ -942,19 +990,62 @@ def _run_gateway_chat_streaming(
                 + "\n\n"
                 + _workspace_prompts["ephemeral_system_prompt"]
             )
+        except Exception:
+            logger.debug("Failed to build WebUI gateway system prompt", exc_info=True)
+            try:
+                from api.streaming import (
+                    _webui_ephemeral_system_prompt,
+                    _webui_workspace_system_prompt,
+                )
+
+                session_start_workspace = str(
+                    getattr(s, "session_start_workspace", None) or workspace or ""
+                )
+                _gateway_system_prompt = (
+                    _webui_workspace_system_prompt(session_start_workspace)
+                    + "\n\n"
+                    + _webui_ephemeral_system_prompt(
+                        None,
+                        surface_context={
+                            "source": "webui",
+                            "session_id": getattr(s, "session_id", None),
+                            "profile": getattr(s, "profile", None),
+                            "workspace": session_start_workspace,
+                        },
+                        config_data=cfg,
+                    )
+                )
+            except Exception:
+                session_start_workspace = str(
+                    getattr(s, "session_start_workspace", None) or workspace or ""
+                )
+                _gateway_system_prompt = (
+                    f"Active workspace at session start: {session_start_workspace}\n"
+                    "Every user message is prefixed with [Workspace::v1: /absolute/path] "
+                    "indicating the workspace selected for that message."
+                )
+        try:
+            from api.streaming import (
+                _load_webui_prefill_context,
+                _prefill_messages_with_webui_context,
+                _normalize_prefill_messages_before_user_turn,
+                _public_prefill_context_status,
+            )
+
+            prefill_context = _load_webui_prefill_context(cfg)
             prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
             prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
-            prefill_messages = [
-                {"role": "system", "content": _gateway_system_prompt},
-                *prefill_messages,
-            ]
             put_gateway_event("context_status", {
                 "session_id": session_id,
                 "prefill": _public_prefill_context_status(prefill_context),
             })
         except Exception:
             logger.debug("Failed to load WebUI gateway prefill context", exc_info=True)
-            prefill_messages = []
+        if _gateway_system_prompt:
+            prefill_messages = [
+                {"role": "system", "content": _gateway_system_prompt},
+                *prefill_messages,
+            ]
         if _use_runs_api:
             body_extras = {}
             if model_provider:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -910,6 +910,13 @@ def _run_gateway_chat_streaming(
         if not _use_runs_api and runs_api_pending_marked:
             _finish_gateway_run_starting(stream_id, result="fallback")
             runs_api_pending_marked = False
+        workspace_ctx = ""
+        try:
+            from api.streaming import _workspace_context_prefix
+
+            workspace_ctx = _workspace_context_prefix(str(workspace))
+        except Exception:
+            logger.debug("Failed to build Gateway workspace prefix", exc_info=True)
         try:
             from api.streaming import (
                 _load_webui_prefill_context,
@@ -917,7 +924,6 @@ def _run_gateway_chat_streaming(
                 _normalize_prefill_messages_before_user_turn,
                 _public_prefill_context_status,
                 _webui_session_workspace_prompts,
-                _workspace_context_prefix,
             )
 
             prefill_context = _load_webui_prefill_context(cfg)
@@ -926,11 +932,16 @@ def _run_gateway_chat_streaming(
             # the ephemeral system prompt rather than a prefill `user` message.
             # The gateway-backed path must build the SAME system prompt so that
             # context is not silently dropped on Gateway-routed WebUI chats.
-            _gateway_system_prompt = _webui_session_workspace_prompts(
+            _workspace_prompts = _webui_session_workspace_prompts(
                 s,
                 workspace=workspace,
                 config_data=cfg,
-            )["ephemeral_system_prompt"]
+            )
+            _gateway_system_prompt = (
+                _workspace_prompts["system_prompt"]
+                + "\n\n"
+                + _workspace_prompts["ephemeral_system_prompt"]
+            )
             prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
             prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
             prefill_messages = [
@@ -1007,7 +1018,6 @@ def _run_gateway_chat_streaming(
                 # Scope Gateway long-term continuity to this WebUI conversation
                 # without exposing the browser's auth cookie or CSRF material.
                 headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
-            workspace_ctx = _workspace_context_prefix(str(workspace))
             message_content: Any = workspace_ctx + str(msg_text or "")
             if attachments:
                 try:

--- a/api/models.py
+++ b/api/models.py
@@ -1117,6 +1117,13 @@ def _load_session_from_path(path: Path) -> "Session | None":
         data = json.loads(path.read_text(encoding='utf-8'))
     except Exception:
         return None
+    if not data.get('session_start_workspace'):
+        _persist_legacy_session_start_workspace(
+            path,
+            data,
+            session_id=data.get('session_id'),
+            expected_sig=_sidecar_stat_signature(path),
+        )
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
     return Session(**data)
 
@@ -1545,11 +1552,19 @@ class Session:
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         _legacy_session_start_workspace = not data.get('session_start_workspace')
         session = cls(**data)
+        _legacy_facts_expected_sig = _pre_read_sig
         if _legacy_session_start_workspace:
-            try:
-                session.save(touch_updated_at=False, skip_index=True)
-            except Exception:
-                logger.debug("Failed to persist session-start workspace for %s", sid, exc_info=True)
+            _legacy_facts_expected_sig = None
+            _migration_lock = _get_session_agent_lock(sid)
+            if _migration_lock.acquire(blocking=False):
+                try:
+                    if _sidecar_stat_signature(p) == _pre_read_sig:
+                        session.save(touch_updated_at=False, skip_index=True)
+                        _legacy_facts_expected_sig = _sidecar_stat_signature(p)
+                except Exception:
+                    logger.debug("Failed to persist session-start workspace for %s", sid, exc_info=True)
+                finally:
+                    _migration_lock.release()
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching
@@ -1575,7 +1590,7 @@ class Session:
                         sid,
                         len(getattr(session, 'messages', None) or []),
                         _anchor_scene_index_from_records(getattr(session, 'anchor_activity_scenes', None)),
-                        expected_sig=_pre_read_sig,
+                        expected_sig=_legacy_facts_expected_sig,
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
@@ -4123,6 +4138,43 @@ def _sidecar_stat_signature(path):
         return None
     return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
             int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+
+
+def _persist_legacy_session_start_workspace(path, data, *, session_id, expected_sig):
+    """Persist the inferred session-start workspace without clobbering a writer."""
+    if not is_safe_session_id(session_id) or expected_sig is None:
+        return None
+    workspace = data.get('workspace')
+    if not workspace:
+        return None
+    lock = _get_session_agent_lock(session_id)
+    if not lock.acquire(blocking=False):
+        return None
+    try:
+        if _sidecar_stat_signature(path) != expected_sig:
+            return None
+        migrated = dict(data)
+        migrated['session_start_workspace'] = str(Path(workspace).expanduser().resolve())
+        tmp = path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+        try:
+            with open(tmp, 'w', encoding='utf-8') as handle:
+                json.dump(migrated, handle, ensure_ascii=False, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            _safe_replace(tmp, path)
+        finally:
+            tmp.unlink(missing_ok=True)
+        return _sidecar_stat_signature(path)
+    except Exception:
+        try:
+            if 'tmp' in locals():
+                tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        logger.debug("Failed to persist explicit-path session-start workspace for %s", session_id, exc_info=True)
+        return None
+    finally:
+        lock.release()
 
 
 def _legacy_sidecar_facts_get(sid):

--- a/api/models.py
+++ b/api/models.py
@@ -1188,6 +1188,7 @@ def model_explicit_pick_signature(model, model_provider) -> str:
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), model=DEFAULT_MODEL,
+                 session_start_workspace=None,
                  model_provider=None,
                  messages=None, created_at=None, updated_at=None,
                  tool_calls=None, pinned: bool=False, archived: bool=False,
@@ -1238,6 +1239,9 @@ class Session:
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
+        self.session_start_workspace = str(
+            Path(session_start_workspace or self.workspace).expanduser().resolve()
+        )
         self.model = model
         self.model_provider = str(model_provider).strip().lower() if model_provider else None
         # #5979: signature of the model the user DELIBERATELY picked this session
@@ -1369,7 +1373,7 @@ class Session:
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
         METADATA_FIELDS = [
-            'session_id', 'title', 'workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
+            'session_id', 'title', 'workspace', 'session_start_workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
             'pinned', 'archived', 'project_id', 'profile',
             'input_tokens', 'output_tokens', 'estimated_cost',
             'cache_read_tokens', 'cache_write_tokens',
@@ -1539,7 +1543,13 @@ class Session:
         _pre_read_sig = _sidecar_stat_signature(p)
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        _legacy_session_start_workspace = not data.get('session_start_workspace')
         session = cls(**data)
+        if _legacy_session_start_workspace:
+            try:
+                session.save(touch_updated_at=False, skip_index=True)
+            except Exception:
+                logger.debug("Failed to persist session-start workspace for %s", sid, exc_info=True)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching
@@ -1594,6 +1604,8 @@ class Session:
             parsed = json.loads(prefix)
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
+                return cls.load(sid)
+            if not parsed.get('session_start_workspace'):
                 return cls.load(sid)
             parsed['messages'] = []
             parsed['tool_calls'] = []
@@ -1713,6 +1725,7 @@ class Session:
             'session_id': self.session_id,
             'title': self.title,
             'workspace': self.workspace,
+            'session_start_workspace': self.session_start_workspace,
             'model': self.model,
             'model_provider': self.model_provider,
             'message_count': message_count,

--- a/api/models.py
+++ b/api/models.py
@@ -7472,14 +7472,15 @@ def _state_projection_sidecar_metadata(sid: str) -> dict:
 
     metadata = dict(default)
     try:
-        webui_meta = Session.load_metadata_only(sid)
+        prefix = _read_metadata_json_prefix(p)
+        webui_meta = json.loads(prefix) if prefix else None
     except Exception:
         webui_meta = None
-    if webui_meta:
-        title = getattr(webui_meta, 'title', None)
+    if isinstance(webui_meta, dict):
+        title = webui_meta.get('title')
         if title:
             metadata["title"] = title
-        metadata["archived"] = bool(getattr(webui_meta, 'archived', False))
+        metadata["archived"] = bool(webui_meta.get('archived', False))
 
     with _SIDECAR_METADATA_CACHE_LOCK:
         # Re-check under lock in case a concurrent build populated it; either

--- a/api/models.py
+++ b/api/models.py
@@ -1621,11 +1621,16 @@ class Session:
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
                 return cls.load(sid)
-            if not parsed.get('session_start_workspace'):
-                return cls.load(sid)
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
+            if not parsed.get('session_start_workspace'):
+                migration_lock = _get_session_agent_lock(sid)
+                if not migration_lock.acquire(blocking=False):
+                    session._metadata_message_count = _parse_nonnegative_int(parsed.get('message_count'))
+                    session._loaded_metadata_only = True
+                    return session
+                migration_lock.release()
             sidecar_message_count = _parse_nonnegative_int(parsed.get('message_count'))
             index_message_count = None
             if sidecar_message_count is None:
@@ -4154,8 +4159,17 @@ def _persist_legacy_session_start_workspace(path, data, *, session_id, expected_
     try:
         if _sidecar_stat_signature(path) != expected_sig:
             return None
-        migrated = dict(data)
-        migrated['session_start_workspace'] = str(Path(workspace).expanduser().resolve())
+        session_start_workspace = str(Path(workspace).expanduser().resolve())
+        migrated = {}
+        inserted = False
+        for key, value in data.items():
+            if not inserted and key in {'messages', 'anchor_activity_scenes'}:
+                migrated['session_start_workspace'] = session_start_workspace
+                inserted = True
+            if key != 'session_start_workspace':
+                migrated[key] = value
+        if not inserted:
+            migrated['session_start_workspace'] = session_start_workspace
         tmp = path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
             with open(tmp, 'w', encoding='utf-8') as handle:

--- a/api/models.py
+++ b/api/models.py
@@ -1114,6 +1114,7 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
 def _load_session_from_path(path: Path) -> "Session | None":
     """Load a session from an explicit JSON path without consulting SESSION_DIR."""
     try:
+        _pre_read_sig = _sidecar_stat_signature(path)
         data = json.loads(path.read_text(encoding='utf-8'))
     except Exception:
         return None
@@ -1122,7 +1123,7 @@ def _load_session_from_path(path: Path) -> "Session | None":
             path,
             data,
             session_id=data.get('session_id'),
-            expected_sig=_sidecar_stat_signature(path),
+            expected_sig=_pre_read_sig,
         )
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
     return Session(**data)

--- a/api/routes.py
+++ b/api/routes.py
@@ -20966,10 +20966,16 @@ def _provisional_title_from_prompt(prompt: str, fallback: str = "Untitled") -> s
 
 
 def _session_start_workspace_for_child(source) -> str:
+    source_workspace = _current_workspace_for_child(source)
     return str(
         getattr(source, "session_start_workspace", None)
-        or getattr(source, "workspace", get_last_workspace())
+        or source_workspace
     )
+
+
+def _current_workspace_for_child(source) -> str:
+    source_workspace = getattr(source, "workspace", None)
+    return str(source_workspace if source_workspace is not None else get_last_workspace())
 
 
 def _prepare_chat_start_session_for_stream(
@@ -21860,7 +21866,7 @@ def _handle_session_compression_recovery_start(handler, body):
             copied_session = Session(
                 session_id=uuid.uuid4().hex[:12],
                 title=title,
-                workspace=getattr(source, "workspace", get_last_workspace()),
+                workspace=_current_workspace_for_child(source),
                 session_start_workspace=_session_start_workspace_for_child(source),
                 model=getattr(source, "model", None),
                 model_provider=getattr(source, "model_provider", None),
@@ -26085,10 +26091,17 @@ def _handle_session_import(handler, body):
     except (TypeError, ValueError) as e:
         return bad(handler, str(e))
     model = body.get("model", DEFAULT_MODEL)
+    session_start_workspace_raw = body.get("session_start_workspace", workspace)
+    if not isinstance(session_start_workspace_raw, (str, Path)):
+        return bad(handler, "session_start_workspace must be a path string")
+    try:
+        session_start_workspace = str(resolve_trusted_workspace(session_start_workspace_raw))
+    except (TypeError, ValueError) as e:
+        return bad(handler, str(e))
     s = Session(
         title=title,
         workspace=workspace,
-        session_start_workspace=body.get("session_start_workspace") or workspace,
+        session_start_workspace=session_start_workspace,
         model=model,
         messages=messages,
         tool_calls=body.get("tool_calls", []),

--- a/api/routes.py
+++ b/api/routes.py
@@ -14390,7 +14390,7 @@ def handle_post(handler, parsed) -> bool:
                 # so `+ " (copy)"` doesn't TypeError.
                 title=(session.title or "Untitled") + " (copy)",
                 workspace=session.workspace,
-                session_start_workspace=getattr(session, "session_start_workspace", session.workspace),
+                session_start_workspace=_session_start_workspace_for_child(session),
                 model=session.model,
                 model_provider=session.model_provider,
                 messages=copy.deepcopy(session.messages),
@@ -15205,7 +15205,7 @@ def handle_post(handler, parsed) -> bool:
         )
         branch = Session(
             workspace=source.workspace,
-            session_start_workspace=getattr(source, "session_start_workspace", source.workspace),
+            session_start_workspace=_session_start_workspace_for_child(source),
             model=source.model,
             model_provider=getattr(source, "model_provider", None),
             profile=getattr(source, "profile", None),
@@ -20965,6 +20965,13 @@ def _provisional_title_from_prompt(prompt: str, fallback: str = "Untitled") -> s
     return title_from([{"role": "user", "content": text}], fallback) or fallback
 
 
+def _session_start_workspace_for_child(source) -> str:
+    return str(
+        getattr(source, "session_start_workspace", None)
+        or getattr(source, "workspace", get_last_workspace())
+    )
+
+
 def _prepare_chat_start_session_for_stream(
     s,
     *,
@@ -21854,11 +21861,7 @@ def _handle_session_compression_recovery_start(handler, body):
                 session_id=uuid.uuid4().hex[:12],
                 title=title,
                 workspace=getattr(source, "workspace", get_last_workspace()),
-                session_start_workspace=getattr(
-                    source,
-                    "session_start_workspace",
-                    getattr(source, "workspace", get_last_workspace()),
-                ),
+                session_start_workspace=_session_start_workspace_for_child(source),
                 model=getattr(source, "model", None),
                 model_provider=getattr(source, "model_provider", None),
                 messages=[],
@@ -22498,12 +22501,12 @@ def _handle_chat_sync(handler, body):
                 _sanitize_messages_for_api,
                 _compact_session_image_parts_for_persistence,
                 _context_messages_for_new_turn,
-                _webui_workspace_system_prompt,
-                _workspace_context_prefix,
+                _webui_session_workspace_prompts,
             )
-            workspace_ctx = _workspace_context_prefix(str(s.workspace))
+            _workspace_prompts = _webui_session_workspace_prompts(s, workspace=workspace)
+            workspace_ctx = _workspace_prompts["workspace_ctx"]
             workspace_system_msg = (
-                _webui_workspace_system_prompt(s.session_start_workspace) + "\n\n"
+                _workspace_prompts["system_prompt"] + "\n\n"
                 f"{_WEBUI_PROGRESS_PROMPT}\n\n"
                 "WebUI external-notes/durable-memory policy: Do not copy or dump this browser transcript "
                 "into external notes or durable memory by default. Write or update durable "

--- a/api/routes.py
+++ b/api/routes.py
@@ -26086,14 +26086,16 @@ def _handle_session_import(handler, body):
     if not isinstance(messages, list):
         return bad(handler, 'JSON must contain a "messages" array')
     title = body.get("title", "Imported session")
+    session_start_workspace_raw = body.get("session_start_workspace")
+    if session_start_workspace_raw is not None and not isinstance(session_start_workspace_raw, (str, Path)):
+        return bad(handler, "session_start_workspace must be a path string")
     try:
         workspace = str(resolve_trusted_workspace(body.get("workspace", str(DEFAULT_WORKSPACE))))
     except (TypeError, ValueError) as e:
         return bad(handler, str(e))
     model = body.get("model", DEFAULT_MODEL)
-    session_start_workspace_raw = body.get("session_start_workspace", workspace)
-    if not isinstance(session_start_workspace_raw, (str, Path)):
-        return bad(handler, "session_start_workspace must be a path string")
+    if session_start_workspace_raw is None:
+        session_start_workspace_raw = workspace
     try:
         session_start_workspace = str(resolve_trusted_workspace(session_start_workspace_raw))
     except (TypeError, ValueError) as e:

--- a/api/routes.py
+++ b/api/routes.py
@@ -14390,6 +14390,7 @@ def handle_post(handler, parsed) -> bool:
                 # so `+ " (copy)"` doesn't TypeError.
                 title=(session.title or "Untitled") + " (copy)",
                 workspace=session.workspace,
+                session_start_workspace=getattr(session, "session_start_workspace", session.workspace),
                 model=session.model,
                 model_provider=session.model_provider,
                 messages=copy.deepcopy(session.messages),
@@ -15204,6 +15205,7 @@ def handle_post(handler, parsed) -> bool:
         )
         branch = Session(
             workspace=source.workspace,
+            session_start_workspace=getattr(source, "session_start_workspace", source.workspace),
             model=source.model,
             model_provider=getattr(source, "model_provider", None),
             profile=getattr(source, "profile", None),
@@ -21852,6 +21854,11 @@ def _handle_session_compression_recovery_start(handler, body):
                 session_id=uuid.uuid4().hex[:12],
                 title=title,
                 workspace=getattr(source, "workspace", get_last_workspace()),
+                session_start_workspace=getattr(
+                    source,
+                    "session_start_workspace",
+                    getattr(source, "workspace", get_last_workspace()),
+                ),
                 model=getattr(source, "model", None),
                 model_provider=getattr(source, "model_provider", None),
                 messages=[],
@@ -22491,19 +22498,12 @@ def _handle_chat_sync(handler, body):
                 _sanitize_messages_for_api,
                 _compact_session_image_parts_for_persistence,
                 _context_messages_for_new_turn,
+                _webui_workspace_system_prompt,
                 _workspace_context_prefix,
             )
             workspace_ctx = _workspace_context_prefix(str(s.workspace))
             workspace_system_msg = (
-                f"Active workspace at session start: {s.workspace}\n"
-                "Every user message is prefixed with [Workspace::v1: /absolute/path] indicating the "
-                "workspace the user has selected in the web UI at the time they sent that message. "
-                "This tag is the single authoritative source of the active workspace and updates "
-                "with every message. It overrides any prior workspace mentioned in this system "
-                "prompt, memory, or conversation history. Always use the value from the most recent "
-                "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
-                "write_file, read_file, search_files, terminal workdir, and patch. "
-                "Never fall back to a hardcoded path when this tag is present.\n\n"
+                _webui_workspace_system_prompt(s.session_start_workspace) + "\n\n"
                 f"{_WEBUI_PROGRESS_PROMPT}\n\n"
                 "WebUI external-notes/durable-memory policy: Do not copy or dump this browser transcript "
                 "into external notes or durable memory by default. Write or update durable "

--- a/api/routes.py
+++ b/api/routes.py
@@ -26088,6 +26088,7 @@ def _handle_session_import(handler, body):
     s = Session(
         title=title,
         workspace=workspace,
+        session_start_workspace=body.get("session_start_workspace") or workspace,
         model=model,
         messages=messages,
         tool_calls=body.get("tool_calls", []),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -737,6 +737,21 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
     return "\n".join(lines)
 
 
+def _webui_workspace_system_prompt(workspace: str) -> str:
+    """Build the stable session-start workspace instructions."""
+    return (
+        f"Active workspace at session start: {workspace}\n"
+        "Every user message is prefixed with [Workspace::v1: /absolute/path] indicating the "
+        "workspace the user has selected in the web UI at the time they sent that message. "
+        "This tag is the single authoritative source of the active workspace and updates "
+        "with every message. It overrides any prior workspace mentioned in this system "
+        "prompt, memory, or conversation history. Always use the value from the most recent "
+        "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
+        "write_file, read_file, search_files, terminal workdir, and patch. "
+        "Never fall back to a hardcoded path when this tag is present."
+    )
+
+
 def _webui_ephemeral_system_prompt(
     personality_prompt: Optional[str],
     surface_context: Optional[dict] = None,
@@ -9414,17 +9429,7 @@ def _run_agent_streaming(
             # Prepend workspace context so the agent always knows which directory
             # to use for file operations, regardless of session age or AGENTS.md defaults.
             workspace_ctx = _workspace_context_prefix(str(s.workspace))
-            workspace_system_msg = (
-                f"Active workspace at session start: {s.workspace}\n"
-                "Every user message is prefixed with [Workspace::v1: /absolute/path] indicating the "
-                "workspace the user has selected in the web UI at the time they sent that message. "
-                "This tag is the single authoritative source of the active workspace and updates "
-                "with every message. It overrides any prior workspace mentioned in this system "
-                "prompt, memory, or conversation history. Always use the value from the most recent "
-                "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
-                "write_file, read_file, search_files, terminal workdir, and patch. "
-                "Never fall back to a hardcoded path when this tag is present."
-            )
+            workspace_system_msg = _webui_workspace_system_prompt(s.session_start_workspace)
             # Resolve personality prompt from config.yaml agent.personalities
             # (matches hermes-agent CLI behavior — passes via ephemeral_system_prompt)
             _personality_prompt = None
@@ -9453,7 +9458,7 @@ def _run_agent_streaming(
                     'source': 'webui',
                     'session_id': session_id,
                     'profile': getattr(s, 'profile', None),
-                    'workspace': s.workspace,
+                    'workspace': s.session_start_workspace,
                 },
                 config_data=_cfg,
             )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -771,6 +771,34 @@ def _webui_ephemeral_system_prompt(
     return "\n\n".join(part for part in parts if part)
 
 
+def _webui_session_workspace_prompts(
+    session,
+    *,
+    workspace: Optional[str] = None,
+    personality_prompt: Optional[str] = None,
+    config_data: Optional[dict] = None,
+) -> dict[str, str]:
+    """Build session-start prompts while retaining the current-turn workspace."""
+    current_workspace = str(workspace or getattr(session, "workspace", "") or "")
+    session_start_workspace = str(
+        getattr(session, "session_start_workspace", None) or current_workspace
+    )
+    return {
+        "workspace_ctx": _workspace_context_prefix(current_workspace),
+        "system_prompt": _webui_workspace_system_prompt(session_start_workspace),
+        "ephemeral_system_prompt": _webui_ephemeral_system_prompt(
+            personality_prompt,
+            surface_context={
+                "source": "webui",
+                "session_id": getattr(session, "session_id", None),
+                "profile": getattr(session, "profile", None),
+                "workspace": session_start_workspace,
+            },
+            config_data=config_data,
+        ),
+    }
+
+
 _SECRET_SHAPED_RE = re.compile(
     r"(?i)(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s]+|"
     r"\b(?:sk-[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b|"
@@ -9428,8 +9456,9 @@ def _run_agent_streaming(
 
             # Prepend workspace context so the agent always knows which directory
             # to use for file operations, regardless of session age or AGENTS.md defaults.
-            workspace_ctx = _workspace_context_prefix(str(s.workspace))
-            workspace_system_msg = _webui_workspace_system_prompt(s.session_start_workspace)
+            _workspace_prompts = _webui_session_workspace_prompts(s, workspace=workspace)
+            workspace_ctx = _workspace_prompts["workspace_ctx"]
+            workspace_system_msg = _workspace_prompts["system_prompt"]
             # Resolve personality prompt from config.yaml agent.personalities
             # (matches hermes-agent CLI behavior — passes via ephemeral_system_prompt)
             _personality_prompt = None
@@ -9452,16 +9481,12 @@ def _run_agent_streaming(
             # (agent's own mechanism). This preserves any selected personality
             # while making long tool runs emit real user-visible interim text
             # through interim_assistant_callback instead of frontend guesses.
-            agent.ephemeral_system_prompt = _webui_ephemeral_system_prompt(
-                _personality_prompt,
-                surface_context={
-                    'source': 'webui',
-                    'session_id': session_id,
-                    'profile': getattr(s, 'profile', None),
-                    'workspace': s.session_start_workspace,
-                },
+            agent.ephemeral_system_prompt = _webui_session_workspace_prompts(
+                s,
+                workspace=workspace,
+                personality_prompt=_personality_prompt,
                 config_data=_cfg,
-            )
+            )["ephemeral_system_prompt"]
             _pending_started_at = getattr(s, 'pending_started_at', None)
             meter().set_pending_started_at(stream_id, _pending_started_at)
             # Normal chat-start sets pending_started_at before spawning this thread;

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -783,8 +783,13 @@ def _webui_session_workspace_prompts(
     session_start_workspace = str(
         getattr(session, "session_start_workspace", None) or current_workspace
     )
+    try:
+        workspace_ctx = _workspace_context_prefix(current_workspace)
+    except Exception:
+        # Keep the current-turn authority available when prefix enrichment degrades.
+        workspace_ctx = f"[Workspace::v1: {_escape_workspace_prefix_path(current_workspace)}]\n"
     return {
-        "workspace_ctx": _workspace_context_prefix(current_workspace),
+        "workspace_ctx": workspace_ctx,
         "system_prompt": _webui_workspace_system_prompt(session_start_workspace),
         "ephemeral_system_prompt": _webui_ephemeral_system_prompt(
             personality_prompt,

--- a/tests/browser_conversation_lifecycle.py
+++ b/tests/browser_conversation_lifecycle.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -1039,7 +1040,13 @@ def main() -> int:
             }
         print("OK  hard reload: transcript-backed Anchor scene preserves settled parity")
 
-        assert gateway.request_body and gateway.request_body.get("input") == PROMPT, gateway.request_body
+        request_input = gateway.request_body.get("input") if gateway.request_body else None
+        assert isinstance(request_input, str) and request_input.endswith(PROMPT), gateway.request_body
+        workspace_prefixes = re.findall(
+            r"\[Workspace::v1:\s*(?:\\.|[^\]\\])+\]\s*",
+            request_input,
+        )
+        assert len(workspace_prefixes) == 1, gateway.request_body
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")
         context.close()

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -468,7 +468,7 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     run_body = json.loads(run_req.data.decode("utf-8"))
     assert run_req.full_url == "http://gw:8642/v1/runs"
     assert run_req.get_header("Authorization") == "Bearer secret"
-    assert run_body["input"] == "hi"
+    assert run_body["input"] == "[Workspace::v1: /tmp]\nhi"
     assert run_body["instructions"] == "system prompt"
     assert run_body["conversation_history"] == [{"role": "assistant", "content": "earlier reply"}]
     assert run_body["provider"] == "anthropic"

--- a/tests/test_issue5139_gateway_approval_offline_notice.py
+++ b/tests/test_issue5139_gateway_approval_offline_notice.py
@@ -42,7 +42,7 @@ def _run_gateway_warning_case(unavailable_reason: str) -> list:
         assert req.full_url == "http://127.0.0.1:8642/v1/chat/completions"
         assert req.get_method() == "POST"
         payload = req.data.decode("utf-8")
-        assert json.loads(payload)["messages"][-1]["content"] == "hi"
+        assert json.loads(payload)["messages"][-1]["content"].endswith("\nhi")
         resp = MagicMock()
         resp.__iter__ = lambda s: iter(
             [

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -567,6 +567,7 @@ def test_run_agent_streaming_composes_frozen_context_through_production_worker(t
 
     class FakeAgent:
         def __init__(self, **kwargs):
+            captured["agent"] = self
             self.context_compressor = None
             self.ephemeral_system_prompt = None
             self.stream_delta_callback = kwargs.get("stream_delta_callback")
@@ -617,6 +618,7 @@ def test_run_agent_streaming_composes_frozen_context_through_production_worker(t
     finally:
         streaming.STREAMS.pop(session.active_stream_id, None)
     assert captured["system_message"] == streaming._webui_workspace_system_prompt(str(initial.resolve()))
+    assert "Final visible assistant replies" in captured["agent"].ephemeral_system_prompt
     assert captured["user_message"] == streaming._workspace_context_prefix(str(changed)) + "hello"
 
 

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -1,6 +1,7 @@
 """Regression coverage for the session-start workspace prompt authority."""
 
 import json
+import queue
 from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
@@ -132,6 +133,50 @@ def test_explicit_path_legacy_load_persists_session_start_workspace(tmp_path, mo
     assert loaded.session_start_workspace == str((tmp_path / "imported-workspace").resolve())
     persisted = json.loads(path.read_text(encoding="utf-8"))
     assert persisted["session_start_workspace"] == loaded.session_start_workspace
+
+    keys = list(persisted)
+    assert keys.index("session_start_workspace") < keys.index("messages")
+
+
+def test_explicit_path_legacy_load_stays_bounded_while_session_lock_is_owned(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    sid = "issue6672explicit-lock"
+    path = session_dir / f"{sid}.json"
+    path.write_text(json.dumps(_legacy_payload(sid, tmp_path / "workspace")), encoding="utf-8")
+    lock = models._get_session_agent_lock(sid)
+    assert lock.acquire(blocking=False)
+    try:
+        loaded = models._load_session_from_path(path)
+    finally:
+        lock.release()
+    assert loaded.session_start_workspace == str((tmp_path / "workspace").resolve())
+    assert "session_start_workspace" not in json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_metadata_only_legacy_load_does_not_full_parse_while_session_lock_is_owned(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    sid = "issue6672metadata-lock"
+    path = session_dir / f"{sid}.json"
+    path.write_text(json.dumps(_legacy_payload(sid, tmp_path / "workspace")), encoding="utf-8")
+    lock = models._get_session_agent_lock(sid)
+    assert lock.acquire(blocking=False)
+    try:
+        loaded = models.Session.load_metadata_only(sid)
+    finally:
+        lock.release()
+    assert loaded._loaded_metadata_only is True
+    assert loaded.messages == []
+    assert loaded.session_start_workspace == loaded.workspace
+    assert "session_start_workspace" not in json.loads(path.read_text(encoding="utf-8"))
 
 
 def test_legacy_migration_skips_a_changed_sidecar(tmp_path, monkeypatch):
@@ -267,6 +312,42 @@ def test_session_import_export_preserves_session_start_workspace(tmp_path, monke
 
     assert imported.session_start_workspace == str(initial.resolve())
     assert Session.load(imported.session_id).session_start_workspace == str(initial.resolve())
+
+
+def test_session_import_rejects_invalid_session_start_workspace_type(tmp_path, monkeypatch):
+    from api import models, routes
+
+    _isolate_session_store(tmp_path, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(routes, "bad", lambda _handler, message: captured.update(message=message) or captured)
+    result = routes._handle_session_import(
+        object(),
+        {
+            "messages": [],
+            "workspace": str(tmp_path),
+            "session_start_workspace": 1234,
+        },
+    )
+    assert result is captured
+    assert "must be a path string" in captured["message"]
+    assert not models.SESSIONS
+
+
+def test_session_import_rejects_untrusted_session_start_workspace(tmp_path, monkeypatch):
+    from api import routes
+
+    _isolate_session_store(tmp_path, monkeypatch)
+    captured = {}
+    monkeypatch.setattr(routes, "bad", lambda _handler, message: captured.update(message=message) or captured)
+    routes._handle_session_import(
+        object(),
+        {
+            "messages": [],
+            "workspace": str(tmp_path),
+            "session_start_workspace": "C:\\Windows",
+        },
+    )
+    assert "outside the user home directory" in captured["message"].lower()
 
 
 def test_session_lineage_variants_inherit_the_session_start_workspace(tmp_path):
@@ -451,6 +532,92 @@ def test_workspace_prompt_helper_keeps_sync_and_gateway_consumers_on_same_author
     assert str(changed.resolve()) not in prompts["system_prompt"]
     assert str(changed.resolve()) not in prompts["ephemeral_system_prompt"]
     assert str(changed.resolve()).replace("\\", "\\\\") in prompts["workspace_ctx"]
+
+
+def test_child_workspace_fallback_is_lazy(tmp_path, monkeypatch):
+    from api import routes
+
+    source = SimpleNamespace(
+        workspace=str(tmp_path / "current"),
+        session_start_workspace=str(tmp_path / "initial"),
+    )
+    monkeypatch.setattr(routes, "get_last_workspace", lambda: (_ for _ in ()).throw(
+        AssertionError("fallback workspace should not be evaluated")
+    ))
+    assert routes._session_start_workspace_for_child(source) == source.session_start_workspace
+
+
+def test_run_agent_streaming_composes_frozen_context_through_production_worker(tmp_path, monkeypatch):
+    from api import streaming
+    from api.models import Session
+
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    session = Session(session_id="issue6672worker", workspace=initial, messages=[])
+    session.workspace = str(changed.resolve())
+    session.active_stream_id = "issue6672worker-stream"
+    session.pending_started_at = None
+    session.pending_user_message = None
+    session.pending_attachments = []
+    session.profile = None
+    session.personality = None
+    session.save = lambda *args, **kwargs: None
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.context_compressor = None
+            self.ephemeral_system_prompt = None
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.tool_progress_callback = kwargs.get("tool_progress_callback")
+            self.reasoning_callback = kwargs.get("reasoning_callback")
+            self.clarify_callback = kwargs.get("clarify_callback")
+
+        def run_conversation(self, **kwargs):
+            captured.update(kwargs)
+            return {"messages": [], "final_response": "done", "completed": True}
+
+    monkeypatch.setattr(streaming, "get_session", lambda _sid: session)
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+    monkeypatch.setattr(streaming, "resolve_model_provider", lambda *_args, **_kwargs: ("test-model", "test-provider", None))
+    monkeypatch.setattr(streaming, "_maybe_schedule_title_refresh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(streaming, "get_state_db_session_messages", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(streaming, "reconciled_state_db_messages_for_session", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(streaming, "_new_turn_context_from_messages", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(streaming, "_deduplicate_context_messages", lambda messages: messages)
+    monkeypatch.setattr(streaming, "_sanitize_messages_for_api", lambda messages, **_kwargs: messages)
+    monkeypatch.setattr(streaming, "_drain_webui_process_notifications", lambda *args, **kwargs: [])
+    monkeypatch.setattr(streaming, "_build_native_multimodal_message", lambda prefix, text, *_args, **_kwargs: prefix + text)
+    monkeypatch.setattr(streaming, "_persistent_state_snapshot", lambda *_args: {})
+    monkeypatch.setattr(streaming, "_accept_pending_async_delegations", lambda *args, **kwargs: [])
+    monkeypatch.setattr(streaming, "_merge_display_messages_after_agent_result", lambda *args, **kwargs: [])
+    monkeypatch.setattr(streaming, "_compact_session_image_parts_for_persistence", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_restore_reasoning_metadata", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_assign_stable_message_ids", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_restore_display_reasoning_metadata", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_dedupe_replayed_context_messages", lambda *_args: [])
+    monkeypatch.setattr(streaming, "_active_turn_identity", None, raising=False)
+    monkeypatch.setattr(streaming, "load_settings", lambda: {})
+    monkeypatch.setattr(streaming, "get_config", lambda: {})
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda *_args: {})
+    monkeypatch.setattr(streaming, "_save_streaming_checkpoint", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_maybe_run_auto_compression", lambda *_args, **_kwargs: None, raising=False)
+    monkeypatch.setattr(streaming, "_finalize_stream_session", lambda *_args, **_kwargs: None, raising=False)
+    streaming.STREAMS[session.active_stream_id] = queue.Queue()
+    try:
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text="hello",
+            model="test-model",
+            model_provider="test-provider",
+            workspace=str(changed),
+            stream_id=session.active_stream_id,
+        )
+    finally:
+        streaming.STREAMS.pop(session.active_stream_id, None)
+    assert captured["system_message"] == streaming._webui_workspace_system_prompt(str(initial.resolve()))
+    assert captured["user_message"] == streaming._workspace_context_prefix(str(changed)) + "hello"
 
 
 def test_sync_chat_consumer_uses_frozen_context_and_current_turn_prefix(tmp_path, monkeypatch):

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -3,6 +3,8 @@
 import json
 from collections import OrderedDict
 from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import urlparse
 
 
 def _legacy_payload(session_id, workspace, *, messages=None):
@@ -89,7 +91,10 @@ def test_session_start_workspace_round_trips_and_legacy_sidecar_freezes_once(tmp
 def test_explicit_path_legacy_load_persists_session_start_workspace(tmp_path, monkeypatch):
     from api import models
 
-    path = tmp_path / "imported-session.json"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    path = session_dir / "issue6672explicit.json"
     path.write_text(
         json.dumps(_legacy_payload("issue6672explicit", tmp_path / "imported-workspace")),
         encoding="utf-8",
@@ -106,7 +111,10 @@ def test_legacy_migration_skips_a_changed_sidecar(tmp_path, monkeypatch):
     from api import models
 
     sid = "issue6672race"
-    path = tmp_path / f"{sid}.json"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    path = session_dir / f"{sid}.json"
     path.write_text(json.dumps(_legacy_payload(sid, tmp_path / "old-workspace")), encoding="utf-8")
     concurrent = _legacy_payload(sid, tmp_path / "concurrent-workspace")
     calls = {"count": 0}
@@ -117,10 +125,10 @@ def test_legacy_migration_skips_a_changed_sidecar(tmp_path, monkeypatch):
             candidate.write_text(json.dumps(concurrent), encoding="utf-8")
         return ("before",) if calls["count"] == 1 else ("after",)
 
-    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "_sidecar_stat_signature", signature_with_concurrent_write)
 
-    loaded = models.Session.load(sid)
+    loaded = models._load_session_from_path(path)
 
     assert loaded.workspace == str((tmp_path / "old-workspace").resolve())
     persisted = json.loads(path.read_text(encoding="utf-8"))
@@ -130,27 +138,108 @@ def test_legacy_migration_skips_a_changed_sidecar(tmp_path, monkeypatch):
 
 def test_current_turn_workspace_remains_authoritative_for_file_ops(tmp_path, monkeypatch):
     from api import models
+    from api import routes
     from api.models import Session
 
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
-    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    sessions = OrderedDict()
+    monkeypatch.setattr(models, "SESSIONS", sessions)
+    monkeypatch.setattr(routes, "SESSIONS", sessions)
     initial = tmp_path / "initial-workspace"
     changed = tmp_path / "changed-workspace"
     changed.mkdir()
     session = Session(session_id="issue6672fileops", workspace=initial)
     session.save(skip_index=True)
+    sessions[session.session_id] = session
     session.workspace = str(changed.resolve())
     session.save(skip_index=True)
 
-    authorized = models.get_session_for_file_ops(session.session_id)
-    marker = Path(authorized.workspace) / "authorized-write.txt"
-    marker.write_text("changed workspace", encoding="utf-8")
+    marker = changed / "authorized-write.txt"
+    marker.write_text("initial", encoding="utf-8")
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload)
+    result = routes._handle_file_save(
+        object(),
+        {
+            "session_id": session.session_id,
+            "path": marker.name,
+            "content": "changed workspace",
+        },
+    )
 
-    assert authorized.workspace == str(changed.resolve())
+    assert result["ok"] is True
     assert marker.read_text(encoding="utf-8") == "changed workspace"
+
+
+def test_session_import_export_preserves_session_start_workspace(tmp_path, monkeypatch):
+    from api import models, routes
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    sessions = OrderedDict()
+    monkeypatch.setattr(models, "SESSIONS", sessions)
+    monkeypatch.setattr(routes, "SESSIONS", sessions)
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda value: Path(value).resolve())
+
+    initial = tmp_path / "initial-workspace"
+    current = tmp_path / "current-workspace"
+    current.mkdir()
+    source = Session(
+        session_id="issue6672export",
+        workspace=current,
+        session_start_workspace=initial,
+        messages=[{"role": "user", "content": "hello"}],
+        profile="default",
+    )
+    source.save(skip_index=True)
+    sessions[source.session_id] = source
+
+    class ExportHandler:
+        def __init__(self):
+            self.headers = {}
+            self.wfile = SimpleNamespace(write=self._write)
+            self.body = b""
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, name, value):
+            self.headers[name] = value
+
+        def end_headers(self):
+            pass
+
+        def _write(self, data):
+            self.body += data
+
+    export_handler = ExportHandler()
+    monkeypatch.setattr(routes, "get_session", lambda _sid: source)
+    routes._handle_session_export(
+        export_handler,
+        urlparse(f"/api/session/export?session_id={source.session_id}"),
+    )
+    exported = json.loads(export_handler.body)
+    assert exported["session_start_workspace"] == str(initial.resolve())
+
+    imported_payload = {}
+
+    def capture_json(_handler, payload, **_kwargs):
+        imported_payload.update(payload)
+        return payload
+
+    monkeypatch.setattr(routes, "j", capture_json)
+    routes._handle_session_import(object(), exported)
+    imported = sessions[imported_payload["session"]["session_id"]]
+
+    assert imported.session_start_workspace == str(initial.resolve())
+    assert Session.load(imported.session_id).session_start_workspace == str(initial.resolve())
 
 
 def test_session_lineage_variants_inherit_the_session_start_workspace(tmp_path):
@@ -235,17 +324,21 @@ def test_sync_chat_consumer_uses_frozen_context_and_current_turn_prefix(tmp_path
     import api.oauth
     from api import routes
     from api import streaming
+    from api import models
     from api.models import Session
 
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
-    monkeypatch.setattr(api.config, "SESSION_DIR", session_dir)
-    monkeypatch.setattr(api.config, "SESSION_INDEX_FILE", session_dir / "_index.json")
-    monkeypatch.setattr(api.config, "SESSIONS", {})
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    sessions = OrderedDict()
+    monkeypatch.setattr(models, "SESSIONS", sessions)
+    monkeypatch.setattr(routes, "SESSIONS", sessions)
     initial = tmp_path / "initial-workspace"
     changed = tmp_path / "changed-workspace"
     session = Session(session_id="issue6672sync", workspace=initial, messages=[])
     session.save(skip_index=True)
+    sessions[session.session_id] = session
     captured = {}
 
     class FakeAgent:

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -1,14 +1,23 @@
 """Regression coverage for the session-start workspace prompt authority."""
 
 import json
+from collections import OrderedDict
 from pathlib import Path
 
 
-def _session_start_workspace(session):
-    return getattr(session, "session_start_workspace", session.workspace)
+def _legacy_payload(session_id, workspace, *, messages=None):
+    return {
+        "session_id": session_id,
+        "title": "Legacy",
+        "workspace": str(workspace),
+        "model": "test-model",
+        "created_at": 1.0,
+        "updated_at": 2.0,
+        "messages": messages or [{"role": "user", "content": "hello"}],
+    }
 
 
-def test_reported_mid_session_switch_keeps_system_prefix(tmp_path):
+def test_reported_mid_session_switch_keeps_streaming_composer_prefix(tmp_path):
     from api import streaming
     from api.models import Session
 
@@ -16,19 +25,21 @@ def test_reported_mid_session_switch_keeps_system_prefix(tmp_path):
     changed = tmp_path / "changed-workspace"
     session = Session(session_id="issue6672prompt", workspace=initial)
 
-    first = streaming._webui_ephemeral_system_prompt(
-        None,
-        surface_context={"source": "webui", "workspace": _session_start_workspace(session)},
+    first = streaming._webui_session_workspace_prompts(
+        session,
+        workspace=session.workspace,
     )
     session.workspace = str(changed.resolve())
-    second = streaming._webui_ephemeral_system_prompt(
-        None,
-        surface_context={"source": "webui", "workspace": _session_start_workspace(session)},
+    second = streaming._webui_session_workspace_prompts(
+        session,
+        workspace=session.workspace,
     )
 
-    assert f"Workspace: {initial.resolve()}" in first
-    assert first == second
-    assert f"Workspace: {changed.resolve()}" not in second
+    assert f"Workspace: {initial.resolve()}" in first["ephemeral_system_prompt"]
+    assert first["ephemeral_system_prompt"] == second["ephemeral_system_prompt"]
+    assert first["system_prompt"] == second["system_prompt"]
+    assert first["workspace_ctx"] != second["workspace_ctx"]
+    assert f"Workspace: {changed.resolve()}" not in second["ephemeral_system_prompt"]
 
 
 def test_session_start_workspace_round_trips_and_legacy_sidecar_freezes_once(tmp_path, monkeypatch):
@@ -39,6 +50,7 @@ def test_session_start_workspace_round_trips_and_legacy_sidecar_freezes_once(tmp
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
 
     initial = tmp_path / "initial-workspace"
     changed = tmp_path / "changed-workspace"
@@ -74,36 +86,222 @@ def test_session_start_workspace_round_trips_and_legacy_sidecar_freezes_once(tmp
     assert Session.load(legacy_id).session_start_workspace == str(initial.resolve())
 
 
-def test_current_turn_tag_and_workspace_io_remain_dynamic(tmp_path):
-    from api import streaming
+def test_explicit_path_legacy_load_persists_session_start_workspace(tmp_path, monkeypatch):
+    from api import models
+
+    path = tmp_path / "imported-session.json"
+    path.write_text(
+        json.dumps(_legacy_payload("issue6672explicit", tmp_path / "imported-workspace")),
+        encoding="utf-8",
+    )
+
+    loaded = models._load_session_from_path(path)
+
+    assert loaded.session_start_workspace == str((tmp_path / "imported-workspace").resolve())
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["session_start_workspace"] == loaded.session_start_workspace
+
+
+def test_legacy_migration_skips_a_changed_sidecar(tmp_path, monkeypatch):
+    from api import models
+
+    sid = "issue6672race"
+    path = tmp_path / f"{sid}.json"
+    path.write_text(json.dumps(_legacy_payload(sid, tmp_path / "old-workspace")), encoding="utf-8")
+    concurrent = _legacy_payload(sid, tmp_path / "concurrent-workspace")
+    calls = {"count": 0}
+
+    def signature_with_concurrent_write(candidate):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            candidate.write_text(json.dumps(concurrent), encoding="utf-8")
+        return ("before",) if calls["count"] == 1 else ("after",)
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "_sidecar_stat_signature", signature_with_concurrent_write)
+
+    loaded = models.Session.load(sid)
+
+    assert loaded.workspace == str((tmp_path / "old-workspace").resolve())
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["workspace"] == str(tmp_path / "concurrent-workspace")
+    assert "session_start_workspace" not in persisted
+
+
+def test_current_turn_workspace_remains_authoritative_for_file_ops(tmp_path, monkeypatch):
+    from api import models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    changed.mkdir()
+    session = Session(session_id="issue6672fileops", workspace=initial)
+    session.save(skip_index=True)
+    session.workspace = str(changed.resolve())
+    session.save(skip_index=True)
+
+    authorized = models.get_session_for_file_ops(session.session_id)
+    marker = Path(authorized.workspace) / "authorized-write.txt"
+    marker.write_text("changed workspace", encoding="utf-8")
+
+    assert authorized.workspace == str(changed.resolve())
+    assert marker.read_text(encoding="utf-8") == "changed workspace"
+
+
+def test_session_lineage_variants_inherit_the_session_start_workspace(tmp_path):
+    from api import routes
     from api.models import Session
 
     initial = tmp_path / "initial-workspace"
     changed = tmp_path / "changed-workspace"
-    changed.mkdir()
-    session = Session(session_id="issue6672dynamic", workspace=initial)
-    session.workspace = str(changed.resolve())
+    variants = [
+        Session(
+            session_id="issue6672-imported-messaging",
+            workspace=changed,
+            session_start_workspace=initial,
+            raw_source="telegram",
+            session_source="messaging",
+        ),
+        Session(
+            session_id="issue6672-duplicate",
+            workspace=changed,
+            session_start_workspace=initial,
+            session_source="webui",
+        ),
+        Session(
+            session_id="issue6672-fork",
+            workspace=changed,
+            session_start_workspace=initial,
+            session_source="fork",
+            parent_session_id="issue6672-parent",
+        ),
+        Session(
+            session_id="issue6672-compressed",
+            workspace=changed,
+            session_start_workspace=initial,
+            session_source="fork",
+            parent_session_id="issue6672-parent",
+            compression_recovery_source_session_id="issue6672-parent",
+        ),
+        Session(
+            session_id="issue6672-cron",
+            workspace=changed,
+            session_start_workspace=initial,
+            raw_source="cron",
+            source_tag="cron",
+            session_source="cron",
+            read_only=True,
+        ),
+        Session(
+            session_id="issue6672-background",
+            workspace=changed,
+            session_start_workspace=initial,
+            raw_source="background",
+            session_source="background",
+            read_only=True,
+        ),
+    ]
 
-    turn_tag = streaming._workspace_context_prefix(session.workspace)
-    assert str(changed.resolve()).replace("\\", "\\\\") in turn_tag
-    assert str(initial.resolve()).replace("\\", "\\\\") not in turn_tag
-
-    marker = Path(session.workspace) / "authorized-write.txt"
-    marker.write_text("changed workspace", encoding="utf-8")
-    assert marker.read_text(encoding="utf-8") == "changed workspace"
+    assert all(
+        routes._session_start_workspace_for_child(variant) == str(initial.resolve())
+        for variant in variants
+    )
 
 
-def test_stream_and_sync_context_use_one_session_authority(tmp_path):
-    from api import routes, streaming
+def test_workspace_prompt_helper_keeps_sync_and_gateway_consumers_on_same_authority(tmp_path):
+    from api import streaming
     from api.models import Session
 
     initial = tmp_path / "initial-workspace"
     changed = tmp_path / "changed-workspace"
     session = Session(session_id="issue6672consumers", workspace=initial)
     session.workspace = str(changed.resolve())
+    prompts = streaming._webui_session_workspace_prompts(session, workspace=session.workspace)
 
-    streaming_context = streaming._webui_workspace_system_prompt(session.session_start_workspace)
-    route_source = Path(routes.__file__).read_text(encoding="utf-8")
-    assert f"Active workspace at session start: {initial.resolve()}" in streaming_context
-    assert str(changed.resolve()) not in streaming_context
-    assert "_webui_workspace_system_prompt(s.session_start_workspace)" in route_source
+    assert f"Active workspace at session start: {initial.resolve()}" in prompts["system_prompt"]
+    assert f"Workspace: {initial.resolve()}" in prompts["ephemeral_system_prompt"]
+    assert str(changed.resolve()) not in prompts["system_prompt"]
+    assert str(changed.resolve()) not in prompts["ephemeral_system_prompt"]
+    assert str(changed.resolve()).replace("\\", "\\\\") in prompts["workspace_ctx"]
+
+
+def test_sync_chat_consumer_uses_frozen_context_and_current_turn_prefix(tmp_path, monkeypatch):
+    import api.config
+    import api.oauth
+    from api import routes
+    from api import streaming
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(api.config, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(api.config, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(api.config, "SESSIONS", {})
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    session = Session(session_id="issue6672sync", workspace=initial, messages=[])
+    session.save(skip_index=True)
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, **kwargs):
+            captured.update(kwargs)
+            result = {
+                "messages": [
+                    {"role": "user", "content": kwargs["user_message"]},
+                    {"role": "assistant", "content": "done"},
+                ],
+                "final_response": "done",
+                "completed": True,
+            }
+            captured["run_result"] = result
+            return result
+
+    monkeypatch.setattr(routes, "get_session", lambda _sid: session)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda value: str(changed.resolve()))
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda *_args: (None, None, {}))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda *_args, **_kwargs: ("test-model", "test-provider"),
+    )
+    monkeypatch.setattr(routes, "require_ai_agent_class", lambda: FakeAgent)
+    monkeypatch.setattr(routes, "_resolve_cli_toolsets", lambda: [])
+    monkeypatch.setattr(streaming, "_context_messages_for_new_turn", lambda *_args: [])
+    monkeypatch.setattr(streaming, "_sanitize_messages_for_api", lambda messages, **_kwargs: messages)
+    monkeypatch.setattr(streaming, "_restore_reasoning_metadata", lambda _old, new: new)
+    monkeypatch.setattr(streaming, "_assign_stable_message_ids", lambda *_args: None)
+    monkeypatch.setattr(streaming, "_dedupe_replayed_context_messages", lambda _old, new, _msg: new)
+    monkeypatch.setattr(streaming, "_restore_display_reasoning_metadata", lambda _old, new: new)
+    monkeypatch.setattr(
+        streaming,
+        "_merge_display_messages_after_agent_result",
+        lambda *_args, **_kwargs: captured["run_result"]["messages"],
+    )
+    monkeypatch.setattr(streaming, "_compact_session_image_parts_for_persistence", lambda _session: None)
+    monkeypatch.setattr(routes, "title_from", lambda messages, fallback: fallback)
+    monkeypatch.setattr(routes, "load_settings", lambda: {})
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload)
+    monkeypatch.setattr(api.config, "resolve_model_provider", lambda *_args: ("test-model", "test-provider", None))
+    monkeypatch.setattr(api.config, "resolve_custom_provider_connection", lambda _provider: (None, None))
+    monkeypatch.setattr(api.oauth, "resolve_runtime_provider_with_anthropic_env_lock", lambda *_args, **_kwargs: {})
+
+    routes._handle_chat_sync(
+        object(),
+        {"session_id": session.session_id, "message": "hello", "workspace": str(changed)},
+    )
+    assert f"Active workspace at session start: {initial.resolve()}" in captured["system_message"]
+    assert str(changed.resolve()) not in captured["system_message"]
+    assert captured["user_message"] == (
+        streaming._webui_session_workspace_prompts(session, workspace=str(changed))["workspace_ctx"]
+        + "hello"
+    )

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -19,6 +19,33 @@ def _legacy_payload(session_id, workspace, *, messages=None):
     }
 
 
+def _isolate_session_store(tmp_path, monkeypatch):
+    from api import models, routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sessions = OrderedDict()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", sessions)
+    monkeypatch.setattr(routes, "SESSIONS", sessions)
+    return session_dir, sessions
+
+
+def _invoke_post_route(monkeypatch, path, body):
+    from api import routes
+
+    captured = {}
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: body)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, **_kwargs: captured.update(
+        payload=payload, status=status
+    ) or payload)
+    routes.handle_post(SimpleNamespace(command="POST"), SimpleNamespace(path=path))
+    return captured
+
+
 def test_reported_mid_session_switch_keeps_streaming_composer_prefix(tmp_path):
     from api import streaming
     from api.models import Session
@@ -300,6 +327,113 @@ def test_session_lineage_variants_inherit_the_session_start_workspace(tmp_path):
         routes._session_start_workspace_for_child(variant) == str(initial.resolve())
         for variant in variants
     )
+
+
+def test_duplicate_route_constructs_child_with_frozen_workspace(tmp_path, monkeypatch):
+    from api import models, routes
+    from api.models import Session
+
+    session_dir, sessions = _isolate_session_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    source = Session(
+        session_id="issue6672-duplicate-route",
+        workspace=changed,
+        session_start_workspace=initial,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    source.save(skip_index=True)
+    sessions[source.session_id] = source
+
+    captured = _invoke_post_route(
+        monkeypatch,
+        "/api/session/duplicate",
+        {"session_id": source.session_id},
+    )
+
+    child_id = captured["payload"]["session"]["session_id"]
+    child = models.Session.load(child_id)
+    assert captured["status"] == 200
+    assert child.session_id != source.session_id
+    assert child.workspace == str(changed)
+    assert child.session_start_workspace == str(initial)
+    assert (session_dir / f"{child_id}.json").exists()
+
+
+def test_fork_route_constructs_child_with_frozen_workspace(tmp_path, monkeypatch):
+    from api import models, routes
+    from api.models import Session
+
+    session_dir, sessions = _isolate_session_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    source = Session(
+        session_id="issue6672-fork-route",
+        workspace=changed,
+        session_start_workspace=initial,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    source.save(skip_index=True)
+    sessions[source.session_id] = source
+
+    captured = _invoke_post_route(
+        monkeypatch,
+        "/api/session/branch",
+        {"session_id": source.session_id, "keep_count": 1},
+    )
+
+    child_id = captured["payload"]["session_id"]
+    child = models.Session.load(child_id)
+    assert captured["status"] == 200
+    assert child.parent_session_id == source.session_id
+    assert child.workspace == str(changed)
+    assert child.session_start_workspace == str(initial)
+    assert (session_dir / f"{child_id}.json").exists()
+
+
+def test_compression_recovery_constructs_child_with_frozen_workspace(tmp_path, monkeypatch):
+    from api import models, routes
+    from api.compression_recovery import stamp_compression_exhausted_recovery
+    from api.models import Session
+
+    session_dir, sessions = _isolate_session_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "_session_visible_to_active_profile", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    source = Session(
+        session_id="issue6672-compression-route",
+        workspace=changed,
+        session_start_workspace=initial,
+        profile="default",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    stamp_compression_exhausted_recovery(source, message="Context length exceeded.")
+    source.save(skip_index=True)
+    sessions[source.session_id] = source
+
+    handler = SimpleNamespace()
+    captured = {}
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, **_kwargs: captured.update(
+            payload=payload, status=status
+        ) or payload,
+    )
+    routes._handle_session_compression_recovery_start(handler, {"session_id": source.session_id})
+
+    child_id = captured["payload"]["session"]["session_id"]
+    child = models.Session.load(child_id)
+    assert captured["status"] == 200
+    assert child.parent_session_id == source.session_id
+    assert child.compression_recovery_source_session_id == source.session_id
+    assert child.workspace == str(changed)
+    assert child.session_start_workspace == str(initial)
+    assert (session_dir / f"{child_id}.json").exists()
 
 
 def test_workspace_prompt_helper_keeps_sync_and_gateway_consumers_on_same_authority(tmp_path):

--- a/tests/test_issue6672_session_start_workspace_context.py
+++ b/tests/test_issue6672_session_start_workspace_context.py
@@ -1,0 +1,109 @@
+"""Regression coverage for the session-start workspace prompt authority."""
+
+import json
+from pathlib import Path
+
+
+def _session_start_workspace(session):
+    return getattr(session, "session_start_workspace", session.workspace)
+
+
+def test_reported_mid_session_switch_keeps_system_prefix(tmp_path):
+    from api import streaming
+    from api.models import Session
+
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    session = Session(session_id="issue6672prompt", workspace=initial)
+
+    first = streaming._webui_ephemeral_system_prompt(
+        None,
+        surface_context={"source": "webui", "workspace": _session_start_workspace(session)},
+    )
+    session.workspace = str(changed.resolve())
+    second = streaming._webui_ephemeral_system_prompt(
+        None,
+        surface_context={"source": "webui", "workspace": _session_start_workspace(session)},
+    )
+
+    assert f"Workspace: {initial.resolve()}" in first
+    assert first == second
+    assert f"Workspace: {changed.resolve()}" not in second
+
+
+def test_session_start_workspace_round_trips_and_legacy_sidecar_freezes_once(tmp_path, monkeypatch):
+    from api import models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    session = Session(
+        session_id="issue6672persist",
+        workspace=initial,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    session.save(skip_index=True)
+    session.workspace = str(changed.resolve())
+    session.save(skip_index=True)
+
+    payload = json.loads(session.path.read_text(encoding="utf-8"))
+    assert payload["session_start_workspace"] == str(initial.resolve())
+    assert Session.load(session.session_id).session_start_workspace == str(initial.resolve())
+    assert Session.load_metadata_only(session.session_id).session_start_workspace == str(initial.resolve())
+
+    legacy_id = "issue6672legacy"
+    legacy_payload = dict(payload)
+    legacy_payload["session_id"] = legacy_id
+    legacy_payload["workspace"] = str(initial.resolve())
+    legacy_payload.pop("session_start_workspace")
+    legacy_path = session_dir / f"{legacy_id}.json"
+    legacy_path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+    legacy = Session.load(legacy_id)
+    assert legacy.session_start_workspace == str(initial.resolve())
+    assert json.loads(legacy_path.read_text(encoding="utf-8"))["session_start_workspace"] == str(initial.resolve())
+    legacy_meta = Session.load_metadata_only(legacy_id)
+    assert legacy_meta.session_start_workspace == str(initial.resolve())
+    legacy.workspace = str(changed.resolve())
+    legacy.save(skip_index=True)
+    assert Session.load(legacy_id).session_start_workspace == str(initial.resolve())
+
+
+def test_current_turn_tag_and_workspace_io_remain_dynamic(tmp_path):
+    from api import streaming
+    from api.models import Session
+
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    changed.mkdir()
+    session = Session(session_id="issue6672dynamic", workspace=initial)
+    session.workspace = str(changed.resolve())
+
+    turn_tag = streaming._workspace_context_prefix(session.workspace)
+    assert str(changed.resolve()).replace("\\", "\\\\") in turn_tag
+    assert str(initial.resolve()).replace("\\", "\\\\") not in turn_tag
+
+    marker = Path(session.workspace) / "authorized-write.txt"
+    marker.write_text("changed workspace", encoding="utf-8")
+    assert marker.read_text(encoding="utf-8") == "changed workspace"
+
+
+def test_stream_and_sync_context_use_one_session_authority(tmp_path):
+    from api import routes, streaming
+    from api.models import Session
+
+    initial = tmp_path / "initial-workspace"
+    changed = tmp_path / "changed-workspace"
+    session = Session(session_id="issue6672consumers", workspace=initial)
+    session.workspace = str(changed.resolve())
+
+    streaming_context = streaming._webui_workspace_system_prompt(session.session_start_workspace)
+    route_source = Path(routes.__file__).read_text(encoding="utf-8")
+    assert f"Active workspace at session start: {initial.resolve()}" in streaming_context
+    assert str(changed.resolve()) not in streaming_context
+    assert "_webui_workspace_system_prompt(s.session_start_workspace)" in route_source

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -1484,6 +1484,7 @@ def test_gateway_runs_api_body_includes_session_id():
                 )
         assert "/v1/runs" in captured["url"]
         assert captured["body"]["session_id"] == "sess-stable-uuid"
+        assert captured["body"]["input"] == "[Workspace::v1: /tmp]\nhi"
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -319,6 +319,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
 
     s = new_session()
+    session_start_workspace = s.session_start_workspace
     stream_id = "stream-gateway-test"
     s.active_stream_id = stream_id
     s.pending_user_message = "Say hello"
@@ -360,6 +361,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     system_msg = payload["messages"][0]
     assert system_msg["role"] == "system"
     assert "Final visible assistant replies" in system_msg["content"]
+    assert f"Workspace: {session_start_workspace}" in system_msg["content"]
+    assert f"Workspace: {str(tmp_path.resolve())}" not in system_msg["content"]
     assert "Need script" in system_msg["content"]
     # The moved session/delivery context must be present in the system prompt.
     assert "Connected Platforms:" in system_msg["content"]
@@ -368,7 +371,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     # terminal user-role prefill before the actual browser user turn.
     assert [m["content"] for m in payload["messages"][1:]] == [
         "prefill summary",
-        "Say hello",
+        f"[Workspace::v1: {str(tmp_path.resolve()).replace(chr(92), chr(92) + chr(92))}]\nSay hello",
     ]
     assert [m["role"] for m in payload["messages"]] == ["system", "assistant", "user"]
     events = []
@@ -999,7 +1002,10 @@ def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_p
     assert captured["normalizer_input"] == prefill_raw
     payload_messages = captured["body"]["messages"]
     assert [m["role"] for m in payload_messages] == ["system", "assistant", "user"]
-    assert [m["content"] for m in payload_messages[1:]] == ["prefill summary", "Say hello"]
+    assert [m["content"] for m in payload_messages[1:]] == [
+        "prefill summary",
+        f"[Workspace::v1: {str(tmp_path.resolve()).replace(chr(92), chr(92) + chr(92))}]\nSay hello",
+    ]
 
 
 def test_gateway_chat_worker_backfills_context_only_turns_into_display(tmp_path, monkeypatch):
@@ -1264,8 +1270,14 @@ def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_
     assert "Final visible assistant replies" in captured["body"]["messages"][0]["content"]
     image_payload = captured["body"]["messages"][1]
     assert image_payload["role"] == "user"
-    assert image_payload["content"][0] == {"type": "text", "text": "What is in this image?"}
-    assert content[0] == {"type": "text", "text": "What is in this image?"}
+    assert image_payload["content"][0] == {
+        "type": "text",
+        "text": streaming._workspace_context_prefix(str(tmp_path)) + "What is in this image?",
+    }
+    assert content[0] == {
+        "type": "text",
+        "text": streaming._workspace_context_prefix(str(tmp_path)) + "What is in this image?",
+    }
     assert content[1]["type"] == "image_url"
     assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
 

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -363,6 +363,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert "Final visible assistant replies" in system_msg["content"]
     assert f"Workspace: {session_start_workspace}" in system_msg["content"]
     assert f"Workspace: {str(tmp_path.resolve())}" not in system_msg["content"]
+    assert "This tag is the single authoritative source of the active workspace" in system_msg["content"]
     assert "Need script" in system_msg["content"]
     # The moved session/delivery context must be present in the system prompt.
     assert "Connected Platforms:" in system_msg["content"]

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -7,6 +7,8 @@ import re
 import time
 import urllib.error
 
+import pytest
+
 import api.gateway_chat as gateway_chat
 import api.models as models
 import api.streaming as streaming
@@ -1489,6 +1491,87 @@ def test_gateway_runs_api_body_includes_session_id():
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
+
+
+@pytest.mark.parametrize("use_runs_api", [False, True], ids=["legacy", "runs"])
+def test_gateway_degraded_prefill_and_prefix_keep_frozen_authority_and_current_tag(
+    tmp_path, monkeypatch, use_runs_api
+):
+    """Gateway fallback work must retain both prompt authorities."""
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_USE_RUNS_API", "1" if use_runs_api else "0")
+    monkeypatch.setattr(gateway_chat, "gateway_supports_approval", lambda *_args: use_runs_api)
+
+    initial = tmp_path / "initial-workspace"
+    current = tmp_path / "current-workspace"
+    s = new_session(workspace=str(initial))
+    s.workspace = str(initial)
+    s.active_stream_id = f"stream-gateway-degraded-{'runs' if use_runs_api else 'legacy'}"
+    s.pending_user_message = "hello"
+    s.pending_started_at = 1
+    monkeypatch.setattr(gateway_chat, "get_session", lambda _session_id: s)
+    channel = MagicMock()
+    channel.put_nowait = lambda _item: None
+    STREAMS[s.active_stream_id] = channel
+
+    def raise_prefill(_cfg):
+        raise RuntimeError("prefill unavailable")
+
+    def raise_prefix(_path):
+        raise RuntimeError("prefix unavailable")
+
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", raise_prefill)
+    monkeypatch.setattr(streaming, "_workspace_context_prefix", raise_prefix)
+    captured = {}
+    calls = 0
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size=65536):
+            return json.dumps({"run_id": "run-degraded"}).encode()
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield b"data: [DONE]\n\n"
+
+    def fake_urlopen(req, timeout=0):
+        nonlocal calls
+        calls += 1
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return Response()
+
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+    try:
+        gateway_chat._run_gateway_chat_streaming(
+            s.session_id, "hello", "test-model", str(current), s.active_stream_id
+        )
+    finally:
+        STREAMS.pop(s.active_stream_id, None)
+
+    body = captured["body"]
+    if use_runs_api:
+        assert "Active workspace at session start:" in body["instructions"]
+        assert "Final visible assistant replies" in body["instructions"]
+        escaped_current = str(current).replace("\\", "\\\\").replace("]", "\\]")
+        assert body["input"] == f"[Workspace::v1: {escaped_current}]\nhello"
+    else:
+        system = body["messages"][0]["content"]
+        assert "Active workspace at session start:" in system
+        assert "Final visible assistant replies" in system
+        escaped_current = str(current).replace("\\", "\\\\").replace("]", "\\]")
+        assert body["messages"][-1]["content"] == f"[Workspace::v1: {escaped_current}]\nhello"
 
 
 def test_gateway_runs_api_classifies_terminal_provider_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Thinking Path

- The streaming path uses the mutable workspace selected for the current turn in both session-start system context and per-turn workspace guidance.
- The prompt already makes the latest `[Workspace::v1]` user-turn tag authoritative, so only the session-start context needs a stable value.
- The change stores that value with the session and leaves current-turn workspace routing unchanged.

## What Changed

- `api/models.py`: persist and reload the session-start workspace value, including signature-guarded legacy migration for regular and explicit-path loads; keep the migrated field in the metadata prefix and bound metadata reads while an active session lock is held.
- `api/streaming.py`, `api/routes.py`, and `api/gateway_chat.py`: use the captured value only for session-start context, while every Gateway transport carries the current-turn tag and its authoritative explanation; validate imported values through the trusted workspace boundary and avoid eager fallback I/O.
- `tests/test_issue6672_session_start_workspace_context.py` and `tests/test_webui_gateway_chat_backend.py`: cover the production streaming worker, prompt stability, JSON import/export and rejection, persistence, metadata-prefix migration, active-lock bounds, migration races, authorized file operations, and Gateway authority behavior.

## Why It Matters

Changing workspaces during a conversation no longer changes the system-prompt prefix. The current turn still receives the selected workspace through the authoritative user-turn tag.

## Verification

 The focused regression exercises the reported two-workspace sequence through `_run_agent_streaming`, then checks Gateway, save/load, synchronous fallback, import trust, migration ordering and active-lock bounds, and current-turn workspace behavior. The base reproduction was run against `320789ae596a3963d726d90f6c7f3bc86f7f2d6d` and failed because the session-start system context changed with the mutable workspace; the head reproduction passes. Provider cache telemetry remains outside the local test environment.

## Risks / Follow-ups

 The provider-owned cache-hit improvement requires a configured long-context provider run. The PR claims prompt-prefix stability and leaves numeric cache metrics to provider validation.

## Contract Routing

Task type: bugfix.
Touched areas: session prompt context and workspace selection.
Relevant public docs: the system prompt's `[Workspace::v1]` authority and workspace session behavior.
Scope boundaries: freeze session-start context only; current-turn tags and workspace I/O remain dynamic.
Evidence needed before claiming done: base/head prompt comparison and lifecycle regression.

## Upstream

Closes #6672.

## Model Used

GPT-5.6 via Codex CLI; focused source inspection and production-composed regression planning.
