### PR TITLE
fix: HTML inline preview shows stale content after file update

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -19163,7 +19163,11 @@ def _handle_media(handler, parsed):
     ) else "attachment"
     # _serve_file_bytes sends Content-Security-Policy when csp is set.
     csp = "sandbox allow-scripts" if html_inline_ok else None
-    return _serve_file_bytes(handler, target, mime, disposition, "private, max-age=3600", csp=csp)
+    # HTML inline previews change frequently (agent edits + re-renders).
+    # Use no-store so the browser always fetches fresh content, avoiding stale
+    # previews that require a manual full-page refresh to update.
+    cache_control = "no-store" if mime == "text/html" else "private, max-age=3600"
+    return _serve_file_bytes(handler, target, mime, disposition, cache_control, csp=csp)
 
 
 def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:

--- a/static/ui.js
+++ b/static/ui.js
@@ -19105,7 +19105,7 @@ function loadHtmlInline(container){
     const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
     const publicMediaUrl='api/media?path='+encodeURIComponent(path);
     const mediaUrl=publicMediaUrl+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
-    fetch(mediaUrl)
+    fetch(mediaUrl, {cache:'no-store'})
       .then(r=>{if(!r.ok) throw new Error(r.status); return r.text();})
       .then(html=>{
         if(html.length>HTML_MAX_SIZE){

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -849,6 +849,12 @@ class TestMediaEndpointIntegration(unittest.TestCase):
                 any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
             )
             self.assertEqual(body, html_bytes)
+            # HTML responses must use no-store to prevent stale preview on
+            # re-send of the same MEDIA: link (attachment branch).
+            self.assertEqual(
+                headers.get("Cache-Control"), "no-store",
+                "HTML attachment must use Cache-Control: no-store"
+            )
 
             body, status, headers = self._get(f"/api/media?path={encoded}&inline=1")
             self.assertEqual(status, 200)
@@ -859,6 +865,11 @@ class TestMediaEndpointIntegration(unittest.TestCase):
                 any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
             )
             self.assertEqual(body, html_bytes)
+            # Inline HTML preview must also use no-store (inline branch).
+            self.assertEqual(
+                headers.get("Cache-Control"), "no-store",
+                "Inline HTML preview must use Cache-Control: no-store"
+            )
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -197,7 +197,10 @@ class TestLoadHtmlInlineFunction:
         body = ui[idx:idx + 1200]
         assert 'const mediaSessionId=' in body
         assert "'&session_id='+encodeURIComponent(mediaSessionId)" in body
-        assert 'fetch(mediaUrl' in body
+        assert "fetch(mediaUrl, {cache:'no-store'})" in body, (
+            "loadHtmlInline must fetch with cache:'no-store' to bypass "
+            "browser cache for stale HTML preview (got body without no-store)"
+        )
         assert "const publicMediaUrl='api/media?path='+encodeURIComponent(path);" in body
         assert "const openUrl=publicMediaUrl+'&inline=1';" in body
 

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -197,7 +197,7 @@ class TestLoadHtmlInlineFunction:
         body = ui[idx:idx + 1200]
         assert 'const mediaSessionId=' in body
         assert "'&session_id='+encodeURIComponent(mediaSessionId)" in body
-        assert 'fetch(mediaUrl)' in body
+        assert 'fetch(mediaUrl' in body
         assert "const publicMediaUrl='api/media?path='+encodeURIComponent(path);" in body
         assert "const openUrl=publicMediaUrl+'&inline=1';" in body
 


### PR DESCRIPTION
## Problem

When an agent edits a local HTML file and re-sends a `MEDIA:` link, the inline preview in the chat shows stale content. The user must open the full page and manually refresh to see the update.

## Root Cause

`/api/media` serves all file types with `Cache-Control: private, max-age=3600`. The `loadHtmlInline()` function fetches the HTML via `fetch(url)` (no cache override), so the browser caches the response for 1 hour. Subsequent renders of the same path hit the cache and return the old content.

Notably, the `/api/file/raw` path already uses `no-store` for HTML — this was simply missed on the `/api/media` path.

## Fix

Two changes:

1. **Backend** (`api/routes.py`): Serve `text/html` with `no-store` instead of `max-age=3600`. Images and other media types keep the existing 1-hour cache.

2. **Frontend** (`static/ui.js`): `loadHtmlInline()` fetches with `{cache: "no-store"}` for belt-and-suspenders defense against intermediate caches.

## Test Plan

- [ ] Edit a local HTML file, send `MEDIA:/path/to/file.html` in chat → preview shows correct content
- [ ] Edit the same file again, send `MEDIA:` again → preview updates without manual refresh
- [ ] Verify image previews still cache normally (no regression)