### PR TITLE
fix(renderer): preserve nested mixed ul/ol list hierarchy (#6700)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -7801,48 +7801,72 @@ function renderMd(raw){
   s=s.replace(/^---+$/gm,'<hr>');
   // (Blockquotes are handled by the pre-pass at the top of renderMd, before
   // fence_stash. The per-line passes below never see > prefixes.)
-  function _renderListBlock(lines, ordered){
-    const marker=ordered?'\\d+\\. ':'[-*+] ';
-    let html=ordered?'<ol>':'<ul>';
-    let item=null;
-    const flush=()=>{
-      if(!item) return;
-      const body=item.parts.join('\n').trim();
-      const text=body;
-      let inner;
-      if(!ordered && /^\[x\] /i.test(text)) inner='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
-      else if(!ordered && /^\[ \] /.test(text)) inner='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
-      else inner=inlineMd(text);
-      const valueAttr=item.value!==null?` value="${item.value}"`:'';
-      const styleAttr=item.indent?` style="margin-left:16px"`:'';
-      html+=`<li${valueAttr}${styleAttr}>${inner}</li>`;
-      item=null;
+  function _renderListBlock(lines){
+    // Single-pass mixed-marker list renderer (#6700). Builds a real nested
+    // <ul>/<ol> tree with a stack keyed by indentation depth + marker kind
+    // instead of rendering one marker family and re-parsing the generated
+    // HTML with the other. Only item text goes through inlineMd(); tags
+    // emitted here are never parsed as Markdown again.
+    const root={ordered:false,items:[]};   // container for top-level lists
+    const listStack=[];                    // listStack[k]: list open at depth k
+    const itemStack=[];                    // itemStack[k]: last item at depth k
+    const openList=(depth,ordered)=>{
+      const ln={ordered,items:[]};
+      // Attach to the nearest open ancestor item when indentation jumps by
+      // more than one level (e.g. 4-space indent straight from the top), so
+      // the new list nests under the right parent instead of detaching.
+      let parentItem=null;
+      for(let k=depth-1;k>=0;k--){
+        if(itemStack[k]){ parentItem=itemStack[k]; break; }
+      }
+      (parentItem?parentItem.sublists:root.items).push(ln);
+      listStack[depth]=ln;
+      return ln;
+    };
+    const openItem=(depth,ordered,value,content)=>{
+      for(let k=listStack.length-1;k>depth;k--) listStack.pop();
+      if(!listStack[depth]||listStack[depth].ordered!==ordered){
+        if(listStack[depth]) listStack.pop();
+        listStack[depth]=openList(depth,ordered);
+      }
+      const item={value,content:[content],sublists:[]};
+      listStack[depth].items.push(item);
+      itemStack[depth]=item;
+      for(let k=itemStack.length-1;k>depth;k--) itemStack.pop();
+      return item;
     };
     for(const raw of lines){
       const line=String(raw||'');
-      const nested=line.match(new RegExp(`^ {2,}(${marker})(.*)$`));
-      if(nested){
-        flush();
-        item={indent:true,value:ordered?parseInt(nested[1],10):null,parts:[nested[2]]};
-        continue;
+      const om=line.match(/^(\s*)(\d+)\.\s+(.*)$/);
+      const um=line.match(/^(\s*)([-*+])\s+(.*)$/);
+      const m=om||um;
+      if(m){
+        const depth=m[1].length<2?0:Math.floor(m[1].length/2);
+        openItem(depth,!!om,om?parseInt(om[2],10):null,m[3]);
+      } else if(itemStack.length){
+        itemStack[itemStack.length-1].content.push(line.replace(/^ {2,}/,'').trim());
       }
-      const top=line.match(new RegExp(`^(?:  )?(${marker})(.*)$`));
-      if(top){
-        flush();
-        item={indent:false,value:ordered?parseInt(top[1],10):null,parts:[top[2]]};
-        continue;
-      }
-      if(!item) continue;
-      item.parts.push(line.replace(/^ {2,}/,'').trim());
     }
-    flush();
-    return html+(ordered?'</ol>':'</ul>');
+    const renderList=ln=>'<'+(ln.ordered?'ol':'ul')+'>'+ln.items.map(renderItem).join('')+'</'+(ln.ordered?'ol':'ul')+'>';
+    const renderItem=it=>{
+      const text=it.content.join('\n').trim();
+      let inner;
+      if(!it.ordered && /^\[x\] /i.test(text)) inner='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
+      else if(!it.ordered && /^\[ \] /.test(text)) inner='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
+      else inner=inlineMd(text);
+      const valueAttr=it.value!==null?` value="${it.value}"`:'';
+      return `<li${valueAttr}>${inner}${it.sublists.map(renderList).join('')}</li>`;
+    };
+    return root.items.map(renderList).join('');
   }
-  function _renderLists(src, ordered){
+  function _renderLists(src){
+    // Single pass over source lines: collect a contiguous list region (any
+    // marker family, top-level or nested, plus continuation lines) and hand
+    // it to _renderListBlock, which builds the structural <ul>/<ol> tree.
     const lines=src.split('\n');
     const out=[];
-    const topRe=ordered?/^(?:  )?\d+\. /:/^(?:  )?[-*+] /;
-    const nestedRe=ordered?/^ {2,}\d+\. /:/^ {2,}[-*+] /;
+    const topRe=/^(?:  )?(?:\d+\.|[-*+]) /;
+    const nestedRe=/^ {2,}(?:\d+\.|[-*+]) /;
     const contRe=/^ {2,}\S/;
     let i=0;
     while(i<lines.length){
@@ -7869,18 +7893,16 @@ function renderMd(raw){
         }
         break;
       }
-      out.push(_renderListBlock(block,ordered));
+      out.push(_renderListBlock(block));
     }
     return out.join('\n');
   }
-  // Preserve continuation lines, nested indentation, and LaTeX placeholder lines
-  // inside list items without changing the wider markdown pipeline.
-  s=_renderLists(s,false);
-  // Ordered-list parsing intentionally runs on the post-unordered string; the
-  // unordered pass emits <ul> HTML that cannot satisfy the ordered-item regex.
-  // Keep continuation lines attached to their item and preserve explicit
-  // numbering via value= even when blank lines split the markdown.
-  s=_renderLists(s,true);
+  // Single-pass list stage (#6700): one parser handles both marker families
+  // with a stack keyed by indentation + marker kind, so mixed nested lists
+  // (ul→ol→ul) build valid <ul>/<ol> structure instead of re-parsing
+  // renderer-generated HTML as Markdown. value="N" is still emitted on every
+  // ordered <li> so explicit numbering survives blank-line splits (#886).
+  s=_renderLists(s);
   // Tables: | col | col | header row followed by | --- | --- | separator then data rows
   // NOTE: table pass runs BEFORE outer link pass so [label](url) in table cells
   // is handled by inlineMd() only — prevents double-linking.
@@ -8043,8 +8065,7 @@ function renderMd(raw){
     const a=_attrs(rawAttrs);
     if(name==='li'){
       const value=/^\d+$/.test(a.value||'')?` value="${esc(a.value)}"`:'';
-      const style=(a.style||'').replace(/\s+/g,'').toLowerCase()==='margin-left:16px'?` style="margin-left:16px"`:'';
-      return `<li${value}${style}>`;
+      return `<li${value}>`;
     }
     if(name==='span'){
       return `<span${_cls(a.class,['task-done','task-todo','katex-inline'])}${a['data-katex']==='inline'?' data-katex="inline"':''}>`;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7829,7 +7829,7 @@ function renderMd(raw){
         if(listStack[depth]) listStack.pop();
         listStack[depth]=openList(depth,ordered);
       }
-      const item={value,content:[content],sublists:[]};
+      const item={ordered,value,content:[content],sublists:[]};
       listStack[depth].items.push(item);
       itemStack[depth]=item;
       for(let k=itemStack.length-1;k>depth;k--) itemStack.pop();

--- a/static/ui.js
+++ b/static/ui.js
@@ -7847,17 +7847,42 @@ function renderMd(raw){
         itemStack[itemStack.length-1].content.push(line.replace(/^ {2,}/,'').trim());
       }
     }
-    const renderList=ln=>'<'+(ln.ordered?'ol':'ul')+'>'+ln.items.map(renderItem).join('')+'</'+(ln.ordered?'ol':'ul')+'>';
-    const renderItem=it=>{
-      const text=it.content.join('\n').trim();
-      let inner;
-      if(!it.ordered && /^\[x\] /i.test(text)) inner='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
-      else if(!it.ordered && /^\[ \] /.test(text)) inner='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
-      else inner=inlineMd(text);
-      const valueAttr=it.value!==null?` value="${it.value}"`:'';
-      return `<li${valueAttr}>${inner}${it.sublists.map(renderList).join('')}</li>`;
-    };
-    return root.items.map(renderList).join('');
+    // Iterative depth-first emit (#6700 re-gate). The recursive
+    // renderList/renderItem pair recursed once per nesting level, so a
+    // pathologically deep list (an agent dumping deeply nested structured
+    // data) threw RangeError at ~2,000 levels; renderMd() runs after the
+    // transcript container is cleared, so the uncaught throw blanked the
+    // whole session. Emit order is identical — list open, items, nested
+    // sublists, item close, list close — but sublists are pushed onto an
+    // explicit work stack instead of the call stack.
+    const html=[];
+    const work=[];                                  // {open:list} | {item} | {close:list} | {closeItem:true}
+    for(let i=root.items.length-1;i>=0;i--) work.push({open:root.items[i]});
+    while(work.length){
+      const f=work.pop();
+      if(f.item){
+        const it=f.item;
+        const text=it.content.join('\n').trim();
+        let inner;
+        if(!it.ordered && /^\[x\] /i.test(text)) inner='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
+        else if(!it.ordered && /^\[ \] /.test(text)) inner='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
+        else inner=inlineMd(text);
+        const valueAttr=it.value!==null?` value="${it.value}"`:'';
+        html.push(`<li${valueAttr}>`,inner);
+        work.push({closeItem:true});                // </li> after any nested sublists
+        for(let i=it.sublists.length-1;i>=0;i--) work.push({open:it.sublists[i]});
+      } else if(f.closeItem){
+        html.push('</li>');
+      } else if(f.open){
+        const ln=f.open;
+        html.push('<',ln.ordered?'ol':'ul','>');
+        work.push({close:ln});                      // </ul>/</ol> after all items
+        for(let i=ln.items.length-1;i>=0;i--) work.push({item:ln.items[i]});
+      } else {
+        html.push('</',f.close.ordered?'ol':'ul','>');
+      }
+    }
+    return html.join('');
   }
   function _renderLists(src){
     // Single pass over source lines: collect a contiguous list region (any

--- a/tests/test_886_ordered_list_numbering.py
+++ b/tests/test_886_ordered_list_numbering.py
@@ -8,6 +8,11 @@ at 1, producing "1. 1. 1." instead of "1. 2. 3.".
 
 Fix: emit value="N" on every <li> so the correct ordinal is preserved even when
 items end up in separate <ol> containers after the paragraph split.
+
+The list stage was rewritten for #6700 into a single-pass, mixed-marker parser
+(a stack keyed by indentation + marker kind). These static assertions pin the
+parts of that implementation that keep #886 working: the ordered-marker digit
+capture and the value="N" emission on <li>.
 """
 import os
 import re
@@ -21,15 +26,15 @@ def get_ui_js():
 
 class TestOrderedListNumbering:
     def _ordered_list_block(self, src: str) -> str:
-        start = src.find("function _renderListBlock(lines, ordered){")
+        start = src.find("function _renderListBlock(lines){")
         assert start != -1, "_renderListBlock helper not found in ui.js"
-        end = src.find("function _renderLists(src, ordered){", start)
+        end = src.find("function _renderLists(src){", start)
         assert end != -1, "_renderLists helper not found after _renderListBlock"
         return src[start:end]
 
     def _ordered_list_dispatch_block(self, src: str) -> str:
-        start = src.find("s=_renderLists(s,true);")
-        assert start != -1, "ordered-list dispatch not found in ui.js"
+        start = src.find("s=_renderLists(s);")
+        assert start != -1, "list dispatch not found in ui.js"
         return src[max(0, start - 260):start + 80]
 
     def test_li_value_attr_present_in_ordered_list_block(self):
@@ -42,18 +47,18 @@ class TestOrderedListNumbering:
         )
 
     def test_li_value_uses_parsed_number(self):
-        """The value= must be derived from parseInt of the captured digit, not hardcoded."""
+        """The value= must be derived from parseInt of the captured digits, not hardcoded."""
         src = get_ui_js()
         ol_block = self._ordered_list_block(src)
         assert 'parseInt' in ol_block, (
             "Ordered-list block should use parseInt() to parse the list number (#886)"
         )
 
-    def test_numMatch_variable_present(self):
-        """The ordered-list branch must still capture digits from the markdown marker."""
+    def test_marker_digit_capture_present(self):
+        """The ordered branch must still capture digits from the markdown marker."""
         src = get_ui_js()
         ol_block = self._ordered_list_block(src)
-        assert "const marker=ordered?'\\\\d+\\\\. ':'[-*+] ';" in ol_block, (
+        assert "\\d+\\." in ol_block or re.search(r"\(\\d\+\)\\\.", ol_block), (
             "Ordered-list block should keep a digit marker pattern for numbered items (#886)"
         )
 
@@ -68,18 +73,18 @@ class TestOrderedListNumbering:
         )
 
     def test_ordered_list_comment_references_issue(self):
-        """A comment near the OL fix should reference the issue (#886) or the symptom."""
+        """A comment near the list dispatch should reference #886 or the symptom."""
         src = get_ui_js()
         context = self._ordered_list_dispatch_block(src)
         has_comment = '#886' in context or '1. 1. 1.' in context or 'blank lines' in context.lower()
         assert has_comment, (
-            "Expected a comment near the OL fix explaining the blank-line issue (#886)"
+            "Expected a comment near the list dispatch explaining the blank-line issue (#886)"
         )
 
-    def test_list_without_blank_lines_unaffected(self):
-        """A compact list should still flow through the ordered-list helper."""
+    def test_lists_route_through_single_shared_helper(self):
+        """All list rendering must flow through the single-pass shared helper."""
         src = get_ui_js()
-        ol_block = self._ordered_list_dispatch_block(src)
-        assert "s=_renderLists(s,true);" in ol_block, (
-            "Ordered-list rendering should still route through the shared helper"
+        dispatch = self._ordered_list_dispatch_block(src)
+        assert "s=_renderLists(s);" in dispatch, (
+            "List rendering should route through the single-pass _renderLists helper"
         )

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -338,10 +338,13 @@ class TestMarkdownListsWithLatex:
         assert "<li>next item</li>" in out
 
     def test_nested_indentation_stays_in_list(self, driver_path):
+        """Same-marker nesting builds a structural nested <ul> instead of a
+        styled sibling <li> — the margin-left convention was removed by the
+        single-pass mixed-marker parser (#6700)."""
         out = _render(driver_path, "- parent\n  - child")
         assert "<ul>" in out
-        assert "<li>parent</li>" in out
-        assert '<li style="margin-left:16px">child</li>' in out
+        assert "<li>parent<ul><li>child</li></ul></li>" in out
+        assert "margin-left:16px" not in out
 
     def test_display_math_line_stays_inside_list_item(self, driver_path):
         src = "- intro\n\n  $$x^2$$\n\n  continuation"
@@ -359,6 +362,63 @@ class TestMarkdownListsWithLatex:
         assert "<span class=\"katex-inline\" data-katex=\"inline\">x</span>" in out
         assert "<div class=\"katex-block\" data-katex=\"display\">y</div>" in out
         assert '<li value="3">tail</li>' in out
+
+
+class TestMixedNestedLists:
+    """#6700: mixed ul/ol nesting must build a valid structural hierarchy.
+
+    Regression for the old two-pass list renderer, where the ordered pass
+    re-parsed the <ul> HTML emitted by the unordered pass as Markdown. That
+    leaked escaped fragments like `&lt;/li&gt;&lt;li style=&quot;margin-left:
+    16px&quot;&gt;` into the chat and flattened the inverse (ol→ul) shape.
+    """
+
+    def test_ul_ol_ul_nested_then_top_level_return(self, driver_path):
+        src = (
+            "- normal item\n"
+            "  1. numbered child\n"
+            "  2. second numbered child\n"
+            "  - unordered child again\n"
+            "- next normal item"
+        )
+        out = _render(driver_path, src)
+        # No escaped renderer-generated fragments may leak into the output
+        assert "&lt;/li&gt;" not in out, out
+        assert "&lt;ul" not in out, out
+        assert "&lt;ol" not in out, out
+        assert "margin-left:16px" not in out, out
+        # Balanced containers
+        assert out.count("<ul>") == out.count("</ul>"), out
+        assert out.count("<ol>") == out.count("</ol>"), out
+        # Exact structural hierarchy: ul > li > (ol, ul) > li
+        assert (
+            '<ul><li>normal item'
+            '<ol><li value="1">numbered child</li>'
+            '<li value="2">second numbered child</li></ol>'
+            '<ul><li>unordered child again</li></ul></li>'
+            '<li>next normal item</li></ul>'
+        ) in out, out
+
+    def test_ol_ul_nested_keeps_bullets(self, driver_path):
+        src = "1. first step\n   - detail A\n   - detail B\n2. second step"
+        out = _render(driver_path, src)
+        assert "&lt;/li&gt;" not in out, out
+        assert "&lt;ul" not in out, out
+        assert "&lt;ol" not in out, out
+        assert out.count("<ol>") == out.count("</ol>"), out
+        assert out.count("<ul>") == out.count("</ul>"), out
+        assert (
+            '<ol><li value="1">first step'
+            '<ul><li>detail A</li><li>detail B</li></ul></li>'
+            '<li value="2">second step</li></ol>'
+        ) in out, out
+
+    def test_top_level_marker_switch_starts_sibling_list(self, driver_path):
+        out = _render(driver_path, "- bullet\n1. numbered")
+        assert (
+            '<ul><li>bullet</li></ul><ol><li value="1">numbered</li></ol>'
+        ) in out, out
+        assert "&lt;/li&gt;" not in out, out
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -420,6 +420,20 @@ class TestMixedNestedLists:
         ) in out, out
         assert "&lt;/li&gt;" not in out, out
 
+    def test_ordered_item_with_task_marker_keeps_literal_prefix(self, driver_path):
+        """Task-list rendering applies only to unordered items: an ordered
+        item whose text starts with [x]/[ ] must keep its literal prefix
+        (e.g. '1. [x] shipped') instead of being silently converted to a
+        ✅/☐ task icon (review fix for #6700: openItem() dropped `ordered`
+        from the item constructor, so every item looked unordered)."""
+        out = _render(driver_path, "1. [x] shipped\n2. [ ] pending")
+        assert 'class="task-done"' not in out, out
+        assert 'class="task-todo"' not in out, out
+        assert "✅" not in out, out
+        assert "☐" not in out, out
+        assert '<ol><li value="1">[x] shipped</li>' in out, out
+        assert '<li value="2">[ ] pending</li>' in out, out
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Block-level constructs INSIDE blockquotes — the six bugs documented in

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -434,6 +434,27 @@ class TestMixedNestedLists:
         assert '<ol><li value="1">[x] shipped</li>' in out, out
         assert '<li value="2">[ ] pending</li>' in out, out
 
+    def test_deeply_nested_list_does_not_overflow_the_stack(self, driver_path):
+        """The single-pass tree serializer must not recurse per nesting level.
+
+        The first serializer for the #6700 tree was mutually recursive
+        (renderList -> renderItem -> renderList ...), so a pathologically
+        deep list threw ``RangeError: Maximum call stack size exceeded`` at
+        ~2,000 nested items. renderMd() runs after the transcript container
+        is cleared and the throw is uncaught, so one hostile/degenerate
+        message blanked the whole session. The emit step is iterative, so a
+        deep chain must render balanced HTML without throwing.
+        """
+        depth = 2000
+        src = "".join(" " * (2 * k) + "- item %d\n" % k for k in range(depth))
+        out = _render(driver_path, src)
+        assert out.count("<ul>") == depth, out[-400:]
+        assert out.count("</ul>") == depth, out[-400:]
+        assert out.count("<li>") == depth, out[-400:]
+        assert out.count("</li>") == depth, out[-400:]
+        # First and last items survive at the extremes of the chain.
+        assert "item 0" in out and "item %d" % (depth - 1) in out, out[-400:]
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Block-level constructs INSIDE blockquotes — the six bugs documented in

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -101,18 +101,27 @@ def render_md(raw):
         lines = block.strip().split("\n")
         out = "<ul>"
         prev = 0
+        first = True
         for l in lines:
             m = re.match(r"^( *)([-*+]) (.*)$", l)
             if not m:
                 continue
             depth = 0 if len(m.group(1)) < 2 else len(m.group(1)) // 2
             if depth > prev:
-                out += "<ul>"
+                # Deeper: the previous <li> stays OPEN so the nested <ul>
+                # renders INSIDE it (matches renderMd(): parent<li>child<ul>).
+                out += "<ul>" * (depth - prev)
             elif depth < prev:
-                out += "</ul>" * (prev - depth)
+                # Shallower: close the deepest <li>, each nested <ul> and the
+                # <li> it hung from, then the current item's parent <li>.
+                out += "</li></ul>" * (prev - depth) + "</li>"
+            elif not first:
+                # Same depth: close the previous sibling <li> only.
+                out += "</li>"
             prev = depth
-            out += f"<li>{inline_md(m.group(3))}</li>"
-        out += "</ul>" * (prev + 1)
+            first = False
+            out += f"<li>{inline_md(m.group(3))}"
+        out += "</li></ul>" * (prev + 1)
         return out
 
     s = re.sub(r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m: handle_ul(m.group()), s, flags=re.M)
@@ -121,18 +130,27 @@ def render_md(raw):
         lines = block.strip().split("\n")
         out = "<ol>"
         prev = 0
+        first = True
         for l in lines:
             m = re.match(r"^( *)(\d+)\. (.*)$", l)
             if not m:
                 continue
             depth = 0 if len(m.group(1)) < 2 else len(m.group(1)) // 2
             if depth > prev:
-                out += "<ol>"
+                # Deeper: the previous <li> stays OPEN so the nested <ol>
+                # renders INSIDE it (matches renderMd(): parent<li>child<ol>).
+                out += "<ol>" * (depth - prev)
             elif depth < prev:
-                out += "</ol>" * (prev - depth)
+                # Shallower: close the deepest <li>, each nested <ol> and the
+                # <li> it hung from, then the current item's parent <li>.
+                out += "</li></ol>" * (prev - depth) + "</li>"
+            elif not first:
+                # Same depth: close the previous sibling <li> only.
+                out += "</li>"
             prev = depth
-            out += f"<li>{inline_md(m.group(3))}</li>"
-        out += "</ol>" * (prev + 1)
+            first = False
+            out += f"<li>{inline_md(m.group(3))}"
+        out += "</li></ol>" * (prev + 1)
         return out
 
     s = re.sub(r"((?:^(?:  )?\d+\. .+\n?)+)", lambda m: handle_ol(m.group()), s, flags=re.M)
@@ -583,6 +601,19 @@ def test_indented_list_item_bold(cleanup_test_sessions):
     assert "<strong>nested bold</strong>" in out
     assert "<ul><li><strong>nested bold</strong></li></ul>" in out
     assert "margin-left:16px" not in out
+
+def test_mirror_nests_same_marker_child_list_inside_parent_li(cleanup_test_sessions):
+    """greptile P2 (#6700): the mirror's handle_ul/handle_ol must nest a
+    same-marker child list INSIDE the parent <li>, exactly like renderMd()
+    in ui.js — not close the parent <li> before opening the child <ul>/<ol>.
+    The old shape (<li>parent</li><ul>…) let structural assertions pass
+    without validating the production renderer's parent-child hierarchy."""
+    assert render_md("- parent\n  - child") == (
+        "<ul><li>parent<ul><li>child</li></ul></li></ul>"
+    )
+    assert render_md("1. parent\n  1. child") == (
+        "<ol><li>parent<ol><li>child</li></ol></li></ol>"
+    )
 
 # --- Blockquote variants ---
 

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -100,22 +100,40 @@ def render_md(raw):
     def handle_ul(block):
         lines = block.strip().split("\n")
         out = "<ul>"
+        prev = 0
         for l in lines:
-            indent = bool(re.match(r"^ {2,}", l))
-            text = re.sub(r"^ {0,4}[-*+] ", "", l)
-            style = ' style="margin-left:16px"' if indent else ""
-            out += f"<li{style}>{inline_md(text)}</li>"
-        return out + "</ul>"
+            m = re.match(r"^( *)([-*+]) (.*)$", l)
+            if not m:
+                continue
+            depth = 0 if len(m.group(1)) < 2 else len(m.group(1)) // 2
+            if depth > prev:
+                out += "<ul>"
+            elif depth < prev:
+                out += "</ul>" * (prev - depth)
+            prev = depth
+            out += f"<li>{inline_md(m.group(3))}</li>"
+        out += "</ul>" * (prev + 1)
+        return out
 
     s = re.sub(r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m: handle_ul(m.group()), s, flags=re.M)
 
     def handle_ol(block):
         lines = block.strip().split("\n")
         out = "<ol>"
+        prev = 0
         for l in lines:
-            text = re.sub(r"^ {0,4}\d+\. ", "", l)
-            out += f"<li>{inline_md(text)}</li>"
-        return out + "</ol>"
+            m = re.match(r"^( *)(\d+)\. (.*)$", l)
+            if not m:
+                continue
+            depth = 0 if len(m.group(1)) < 2 else len(m.group(1)) // 2
+            if depth > prev:
+                out += "<ol>"
+            elif depth < prev:
+                out += "</ol>" * (prev - depth)
+            prev = depth
+            out += f"<li>{inline_md(m.group(3))}</li>"
+        out += "</ol>" * (prev + 1)
+        return out
 
     s = re.sub(r"((?:^(?:  )?\d+\. .+\n?)+)", lambda m: handle_ol(m.group()), s, flags=re.M)
 
@@ -559,10 +577,12 @@ def test_ordered_list_code_spans(cleanup_test_sessions):
     assert "<code>npm start</code>" in out
 
 def test_indented_list_item_bold(cleanup_test_sessions):
-    """Bold inside indented (nested) list item."""
+    """Bold inside indented (nested) list item — nested items now build a
+    structural nested <ul> instead of a margin-left sibling (#6700)."""
     out = render_md("- top level\n  - **nested bold**")
     assert "<strong>nested bold</strong>" in out
-    assert "margin-left:16px" in out
+    assert "<ul><li><strong>nested bold</strong></li></ul>" in out
+    assert "margin-left:16px" not in out
 
 # --- Blockquote variants ---
 


### PR DESCRIPTION
## Summary

Fixes mixed nested unordered/ordered Markdown lists leaking escaped renderer-generated HTML into chat. When the list marker type changes inside a nested list and then changes back (e.g. `-` → `1.` → `-`), `renderMd()` in `static/ui.js` re-processed the `<ul>` HTML emitted by the unordered pass as Markdown in the ordered pass, making escaped fragments like `</li><li style="margin-left:16px">` visible in the message. The inverse shape (`1.` → `-`) silently lost the nested bullets instead of constructing a nested list.

## Root Cause

List rendering was split into two homogeneous passes: `_renderLists(s, false)` converted unordered lists to HTML first, then `_renderLists(s, true)` parsed ordered lists from the **already-mutated string**. Generated HTML from pass one was therefore eligible input to pass two:

- `- normal item` → `<ul><li>normal item`, then `1. numbered child` / `2. second numbered child` (continuation lines absorbed by the unordered pass) matched the ordered-item regex in pass two and were wrapped in a fresh `<ol>`, with the surrounding `<ul>`/`<li>` HTML ending up as literal text inside the `<li>` body — where `inlineMd()`'s tag allowlist (which only admits `strong|em|del|code|a|img`) escaped it as `&lt;/li&gt;&lt;li style=&quot;margin-left:16px&quot;&gt;...`.
- `1. first step` → `<ol><li value="1">first step`, then `- detail A` / `- detail B` no longer matched any regex, so they stayed as literal text inside the item instead of becoming a nested list.

Escaping around `<li>` or swapping pass order would only move the failure to the opposite marker order — the wrong abstraction boundary was the two-pass design itself.

## Change

Rewrote the list stage in `static/ui.js` as a **single pass** over source lines:

- `_renderLists(src)` now collects a contiguous list region across **both** marker families (top-level or nested) plus continuation lines, and hands it to `_renderListBlock(lines)`.
- `_renderListBlock(lines)` builds a real nested `<ul>/<ol>` tree with a stack keyed by **indentation depth + marker kind**: it closes containers until the target depth is reached, opens `ul` or `ol` when the marker kind changes, and attaches a nested container to the preceding `<li>` (nearest open ancestor, so indentation jumps of more than one level still nest correctly).
- Only item text goes through `inlineMd()`; tags emitted by the builder are never parsed as Markdown again.
- Nested lists are now structural (`<ul><li>parent<ul><li>child</li></ul></li></ul>`) instead of flat `margin-left:16px` siblings; the `margin-left:16px` allowance was also dropped from the `<li>` sanitizer since nothing generates that style anymore.
- `value="N"` is still emitted on every ordered `<li>`, preserving explicit numbering when blank lines split a list (#886).

## Verification

- New regression cases in `tests/test_renderer_js_behaviour.py` (`TestMixedNestedLists`), driving the **real** `renderMd()` via Node with both marker transitions and a top-level return. They assert balanced `<ul>`/`<ol>` counts, parent→child ordering, and absence of `&lt;/li&gt;`, `&lt;ul`, `&lt;ol`, and `margin-left` style text:
  - `- normal item` / `1. numbered child` / `2. second numbered child` / `- unordered child again` / `- next normal item` → `ul > li > (ol, ul) > li` hierarchy, no escaped fragments.
  - `1. first step` / `- detail A` / `- detail B` / `2. second step` → nested `<ul>` preserved inside the ordered item.
  - `- bullet` / `1. numbered` → sibling lists at the top level.
- The same-marker nested case (`- parent` / `- child`) was updated to expect structural nesting (maintainer-recommended).
- `tests/test_886_ordered_list_numbering.py` static assertions updated for the single-pass implementation (digit capture + `value="N"` preserved).
- `tests/test_sprint16.py` Python mirror updated to structural nesting so it cannot drift from the JS on the `margin-left` convention.

Test results (Node-driven real renderer + mirrors):

```
tests/test_renderer_js_behaviour.py ... 61 passed
tests/test_886_ordered_list_numbering.py ... 6 passed
tests/test_sprint16.py ... passed
tests/test_renderer_comprehensive.py, test_blockquote_rendering.py ... passed
386 passed (renderer + adjacent markdown/static suites)
```

Also verified: `node --check static/ui.js` passes; blank-line split lists keep `value="1/2/3"`; mixed lists inside blockquotes (recursive `renderMd`) render correctly; task lists, math placeholders, and continuation lines are unchanged.

## Risks / Follow-ups

- Nested items now render as real nested `<ul>/<ol>` (indented via the existing `.msg-body ul,.msg-body ol{margin:…20px}` CSS) instead of `margin-left:16px` siblings — a visual improvement, but a deliberate rendering change for nested lists.
- Indentation depth follows the renderer's existing 2-space convention (`floor(indent/2)`); 4+ space indents now nest one level deeper than the old flat margin-left behavior, which is closer to CommonMark.

Closes #6700
