### PR TITLE
fix(session): resolve custom-provider model format to canonical slug

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -526,6 +526,28 @@ def _resolve_profile_home_for_name(name: str) -> Path:
     return _resolve_named_profile_home(name)
 
 
+def is_valid_profile_identity(name: str) -> bool:
+    """Return True when *name* is a resolvable profile identity.
+
+    ``_resolve_profile_home_for_name`` deliberately maps invalid names (path
+    traversal, anything not matching the profile-id shape) to the ROOT home —
+    a safe default for path resolution, but a cross-profile leak for callers
+    that must load a *session's* config: an invalid stored ``session.profile``
+    would load the ROOT config. Fail-closed callers (e.g. the #6648 custom
+    provider slug normalizer config load) validate with this helper BEFORE
+    resolving and treat ``False`` as "no identity" (return None).
+
+    ``None``/empty (root convention), root aliases ('default', a renamed root
+    display name), and syntactically valid named profiles return True;
+    everything else False.
+    """
+    if not name:
+        return True
+    if _is_root_profile(name):
+        return True
+    return bool(_PROFILE_ID_RE.fullmatch(str(name)))
+
+
 def get_active_hermes_home() -> Path:
     """Return the HERMES_HOME path for the currently active profile.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -6677,20 +6677,35 @@ def _normalize_custom_qualified_session_model(
         # session stays broken. Walk back colon-by-colon, re-attaching the
         # eaten segments to the model, until the qualifier resolves to a
         # configured named slug. Fail closed: only a REAL configured match
-        # triggers, and endpoint-derived host:port slugs (custom:<host>:<port>)
-        # are preserved (#1776 form, verified unchanged).
-        if not _custom_slug_rest_looks_like_host_port(qualifier.removeprefix("custom:")):
-            parts = qualifier.split(":")
-            for i in range(len(parts) - 1, 1, -1):
-                candidate = ":".join(parts[:i])
-                candidate_slug = _named_custom_provider_slug_for_provider(
-                    candidate,
-                    config_obj=profile_config,
-                )
-                if candidate_slug:
-                    slug = candidate_slug
-                    bare = ":".join(parts[i:] + [bare])
-                    break
+        # triggers.
+        #
+        # The CONFIGURED shorter prefix is authoritative and is checked BEFORE
+        # the endpoint classification (greptile P1 re-gate): a named provider
+        # 'custom:localhost' receiving a colon-bearing model like '8080:Qwen3'
+        # produces qualifier 'custom:localhost:8080', which the host:port
+        # heuristic would otherwise classify as an endpoint before the
+        # configured prefix is ever consulted. Genuine endpoint-derived slugs
+        # (custom:<host>:<port>, #1776 form) stay unchanged because the
+        # walk-back only fires on a REAL configured match, and an
+        # endpoint-shaped qualifier with no configured prefix falls through to
+        # the host:port check below and returns None.
+        parts = qualifier.split(":")
+        for i in range(len(parts) - 1, 1, -1):
+            candidate = ":".join(parts[:i])
+            candidate_slug = _named_custom_provider_slug_for_provider(
+                candidate,
+                config_obj=profile_config,
+            )
+            if candidate_slug:
+                slug = candidate_slug
+                bare = ":".join(parts[i:] + [bare])
+                break
+        if not slug and _custom_slug_rest_looks_like_host_port(
+            qualifier.removeprefix("custom:")
+        ):
+            # Endpoint-derived custom:<host>:<port> slug with no configured
+            # prefix to walk back to: keep the #1776 form untouched.
+            return None
     if not slug:
         return None
     canonical = slug.removeprefix("custom:")

--- a/api/routes.py
+++ b/api/routes.py
@@ -6661,12 +6661,36 @@ def _normalize_custom_qualified_session_model(
 
     try:
         from api.config import _named_custom_provider_slug_for_provider
+        from api.config import _custom_slug_rest_looks_like_host_port
     except Exception:
         return None
     slug = _named_custom_provider_slug_for_provider(
         qualifier,
         config_obj=profile_config,
     )
+    if not slug and model.startswith("@") and ":" in qualifier:
+        # #6718 (greptile-apps[bot]): a model id that itself contains ':' (e.g.
+        # "@custom:sensenova-primary:model:free" where the model is
+        # "model:free") makes _split_provider_qualified_model's rsplit fold the
+        # model's tail into the qualifier ("custom:sensenova-primary:model"),
+        # which matches no configured slug, so normalization is skipped and the
+        # session stays broken. Walk back colon-by-colon, re-attaching the
+        # eaten segments to the model, until the qualifier resolves to a
+        # configured named slug. Fail closed: only a REAL configured match
+        # triggers, and endpoint-derived host:port slugs (custom:<host>:<port>)
+        # are preserved (#1776 form, verified unchanged).
+        if not _custom_slug_rest_looks_like_host_port(qualifier.removeprefix("custom:")):
+            parts = qualifier.split(":")
+            for i in range(len(parts) - 1, 1, -1):
+                candidate = ":".join(parts[:i])
+                candidate_slug = _named_custom_provider_slug_for_provider(
+                    candidate,
+                    config_obj=profile_config,
+                )
+                if candidate_slug:
+                    slug = candidate_slug
+                    bare = ":".join(parts[i:] + [bare])
+                    break
     if not slug:
         return None
     canonical = slug.removeprefix("custom:")

--- a/api/routes.py
+++ b/api/routes.py
@@ -7145,8 +7145,20 @@ def _read_profile_model_config(
 
     try:
         from api.profiles import get_hermes_home_for_profile
+        from api.profiles import is_valid_profile_identity
 
         _profile_name = str(session.profile or "")
+        # #6718 review 3 (SILENT): fail closed on an INVALID persisted
+        # session.profile. ``get_hermes_home_for_profile`` maps names that do
+        # not match the profile-id shape to the ROOT home, so an invalid
+        # stored name would load the ROOT config here — and this function's
+        # ``profile_config`` result feeds the custom-provider slug normalizer
+        # (GET /api/session display, chat/start wakeup, goal paths), letting a
+        # root-only provider slug remap inside that session. Validate BEFORE
+        # resolution; anything that is neither a root alias nor a valid named
+        # profile yields None (no config), never the root fallback.
+        if not is_valid_profile_identity(_profile_name):
+            return None, None, None
         _profile_home = get_hermes_home_for_profile(_profile_name)
         _profile_cfg_path = os.path.join(str(_profile_home), "config.yaml")
         if not os.path.isfile(_profile_cfg_path):

--- a/api/routes.py
+++ b/api/routes.py
@@ -7357,6 +7357,8 @@ def _repair_bare_custom_provider_model(
     only that object's ``custom_providers`` are scanned. Otherwise uses
     ``get_config()`` for the active global config (not the raw ``cfg`` alias).
     """
+    if not isinstance(config_obj, dict):
+        return None
     try:
         model = str(bare_model or "").strip()
         prov = _clean_session_model_provider(provider)

--- a/api/routes.py
+++ b/api/routes.py
@@ -6606,6 +6606,51 @@ def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
     return model, None
 
 
+def _normalize_custom_qualified_session_model(
+    model: str,
+    provider: str | None,
+) -> tuple[str, str] | None:
+    """#6648: map session-persisted custom-provider formats to canonical slugs.
+
+    Sessions created with a named custom OpenAI-compatible provider persist the
+    model in forms the Hermes runtime cannot resolve:
+
+      - ``@custom:<slug>:<model>`` (qualifier ``custom:<slug>``)
+      - ``custom/<model>``        (slash form with a bare ``custom`` qualifier)
+
+    The runtime only knows the canonical provider slug (e.g. ``sensenova-primary``),
+    so the ``custom:`` prefix must be stripped. Returns ``(model, provider)``
+    normalized to ``<slug>/<bare>`` / ``<slug>`` when the qualifier matches a
+    NAMED ``custom_providers`` entry, else ``None`` (caller keeps current
+    behavior — e.g. endpoint-derived ``custom:<host>:<port>`` slugs stay as-is).
+    """
+    bare: str | None = None
+    qualifier: str | None = None
+    if model.startswith("@"):
+        bare, qualifier = _split_provider_qualified_model(model)
+        if not qualifier:
+            return None
+    elif model.lower().startswith("custom/"):
+        bare = model.split("/", 1)[1].strip()
+        qualifier = provider or "custom"
+    else:
+        return None
+    if not bare:
+        return None
+
+    try:
+        from api.config import _named_custom_provider_slug_for_provider
+    except Exception:
+        return None
+    slug = _named_custom_provider_slug_for_provider(qualifier)
+    if not slug:
+        return None
+    canonical = slug.removeprefix("custom:")
+    if not canonical:
+        return None
+    return f"{canonical}/{bare}", canonical
+
+
 def _model_matches_configured_default(
     session_model: str | None,
     cfg_default: str | None,
@@ -7328,6 +7373,16 @@ def _resolve_compatible_session_model_state(
     """
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    # #6648: session-persisted custom-provider qualifiers ("@custom:<slug>:<model>"
+    # or "custom/<model>") carry the "custom:" prefix the Hermes runtime does not
+    # recognize — it only knows the canonical provider slug. Normalize to
+    # "<slug>/<bare_model>" (when the qualifier matches a named custom_providers
+    # entry) so chat/start routes in a single API call instead of exhausting the
+    # full fallback chain (10-30x slower). Runs before every fast path below so
+    # no branch can return the broken "@custom:..." form verbatim.
+    _custom_norm = _normalize_custom_qualified_session_model(model, requested_provider)
+    if _custom_norm is not None:
+        return _custom_norm[0], _custom_norm[1], True
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -15441,10 +15441,8 @@ def handle_post(handler, parsed) -> bool:
         _profile_name = str(body.get("profile") or "").strip() or None
         if _profile_name is None:
             try:
-                from api.profiles import get_active_profile_name
-
-                _profile_name = str(get_active_profile_name() or "").strip() or None
-            except ImportError:
+                _profile_name = str(_get_active_profile_name() or "").strip() or None
+            except Exception:
                 _profile_name = None
         _session_profile_config = None
         try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7245,14 +7245,27 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
 
 
 def _load_profile_config_dict(session) -> dict | None:
-    """Load the session profile's config.yaml as a dict, or None."""
-    if not getattr(session, "profile", None):
+    """Load the session profile's config.yaml as a dict, or None.
+
+    #6718 review 3 (SILENT): fail closed on an INVALID persisted profile name.
+    ``get_hermes_home_for_profile`` resolves names that do not match the
+    profile-id shape to the ROOT home, so an invalid stored ``session.profile``
+    used to load the root config — letting a root-only custom-provider slug
+    remap inside that session. The identity is validated BEFORE resolution;
+    anything that is neither a root alias nor a syntactically valid named
+    profile yields None (no config), never the root fallback.
+    """
+    _profile = getattr(session, "profile", None)
+    if not _profile:
         return None
     try:
         from api.profiles import get_hermes_home_for_profile
+        from api.profiles import is_valid_profile_identity
 
+        if not is_valid_profile_identity(str(_profile)):
+            return None
         _profile_cfg_path = os.path.join(
-            str(get_hermes_home_for_profile(session.profile)),
+            str(get_hermes_home_for_profile(_profile)),
             "config.yaml",
         )
         if not os.path.isfile(_profile_cfg_path):
@@ -15387,20 +15400,42 @@ def handle_post(handler, parsed) -> bool:
         # #6718 re-gate: the custom-provider slug normalizer must resolve under
         # the session's OWN profile config (fail-closed when unreadable) —
         # never the process-global config, which may belong to another profile.
+        # #6718 review 3 (CORE): resolve ONE authoritative session profile
+        # identity — the explicit body.profile, else the active profile that
+        # new_session() would otherwise stamp the session with — and use that
+        # SAME identity for both the profile-config load below and
+        # new_session(profile=...) below. Previously an omitted body.profile
+        # loaded the DEFAULT (root) config while the session was stamped with
+        # the active NAMED profile: two different identities in one request,
+        # letting a root-only custom-provider slug remap inside another
+        # profile's session. An explicit body.profile that is not a valid
+        # profile identity also fails closed (no config) instead of resolving
+        # to the root home.
         _profile_name = str(body.get("profile") or "").strip() or None
+        if _profile_name is None:
+            try:
+                from api.profiles import get_active_profile_name
+
+                _profile_name = str(get_active_profile_name() or "").strip() or None
+            except ImportError:
+                _profile_name = None
         _session_profile_config = None
         try:
             from api.profiles import get_hermes_home_for_profile
+            from api.profiles import is_valid_profile_identity
 
-            _p_cfg_path = os.path.join(
-                str(get_hermes_home_for_profile(_profile_name)),
-                "config.yaml",
-            )
-            if os.path.isfile(_p_cfg_path):
-                _session_profile_config = _read_profile_config_cached(
-                    str(_profile_name or ""),
-                    _p_cfg_path,
+            if _profile_name is not None and not is_valid_profile_identity(_profile_name):
+                _session_profile_config = None
+            else:
+                _p_cfg_path = os.path.join(
+                    str(get_hermes_home_for_profile(_profile_name)),
+                    "config.yaml",
                 )
+                if os.path.isfile(_p_cfg_path):
+                    _session_profile_config = _read_profile_config_cached(
+                        str(_profile_name or ""),
+                        _p_cfg_path,
+                    )
         except Exception:
             _session_profile_config = None
         model, model_provider = _session_model_state_from_request(
@@ -15472,7 +15507,9 @@ def handle_post(handler, parsed) -> bool:
             workspace=workspace,
             model=model,
             model_provider=model_provider,
-            profile=body.get("profile") or None,
+            # Same authoritative identity resolved above (body.profile, else the
+            # active profile): the config load and the session stamp must agree.
+            profile=_profile_name,
             project_id=body.get("project_id") or None,
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,

--- a/api/routes.py
+++ b/api/routes.py
@@ -6609,6 +6609,8 @@ def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
 def _normalize_custom_qualified_session_model(
     model: str,
     provider: str | None,
+    *,
+    profile_config: dict | None = None,
 ) -> tuple[str, str] | None:
     """#6648: map session-persisted custom-provider formats to canonical slugs.
 
@@ -6616,33 +6618,46 @@ def _normalize_custom_qualified_session_model(
     model in forms the Hermes runtime cannot resolve:
 
       - ``@custom:<slug>:<model>`` (qualifier ``custom:<slug>``)
-      - ``custom/<model>``        (slash form with a bare ``custom`` qualifier)
+      - ``custom/<model>``        (slash form persisted under a ``custom:<slug>`` provider)
 
     The runtime only knows the canonical provider slug (e.g. ``sensenova-primary``),
     so the ``custom:`` prefix must be stripped. Returns ``(model, provider)``
     normalized to ``<slug>/<bare>`` / ``<slug>`` when the qualifier matches a
     NAMED ``custom_providers`` entry, else ``None`` (caller keeps current
     behavior — e.g. endpoint-derived ``custom:<host>:<port>`` slugs stay as-is).
+
+    Only qualifiers that THEMSELVES start with ``custom:`` are eligible — never a
+    bare ``custom/`` model-prefix match or an arbitrary provider name (``moa``,
+    ``openai``, ...), which would hijack unrelated routes (#6718 re-gate). The
+    canonical slug always comes from the CONFIGURED entry (the profile's
+    ``custom_providers`` qualified value), not from the raw stored string.
+
+    The lookup runs against ``profile_config`` when supplied (the session's own
+    profile config.yaml), with NO fallback to the module-global config — a slug
+    removed from the session's own profile must not be remapped from another
+    profile's ``custom_providers``.
     """
     bare: str | None = None
     qualifier: str | None = None
     if model.startswith("@"):
         bare, qualifier = _split_provider_qualified_model(model)
-        if not qualifier:
-            return None
-    elif model.lower().startswith("custom/"):
+    elif model.lower().startswith("custom/") and provider:
         bare = model.split("/", 1)[1].strip()
-        qualifier = provider or "custom"
+        qualifier = provider
     else:
         return None
-    if not bare:
+    qualifier = _clean_session_model_provider(qualifier)
+    if not bare or not qualifier or not qualifier.startswith("custom:"):
         return None
 
     try:
         from api.config import _named_custom_provider_slug_for_provider
     except Exception:
         return None
-    slug = _named_custom_provider_slug_for_provider(qualifier)
+    slug = _named_custom_provider_slug_for_provider(
+        qualifier,
+        config_obj=profile_config,
+    )
     if not slug:
         return None
     canonical = slug.removeprefix("custom:")
@@ -7376,11 +7391,17 @@ def _resolve_compatible_session_model_state(
     # #6648: session-persisted custom-provider qualifiers ("@custom:<slug>:<model>"
     # or "custom/<model>") carry the "custom:" prefix the Hermes runtime does not
     # recognize — it only knows the canonical provider slug. Normalize to
-    # "<slug>/<bare_model>" (when the qualifier matches a named custom_providers
-    # entry) so chat/start routes in a single API call instead of exhausting the
-    # full fallback chain (10-30x slower). Runs before every fast path below so
-    # no branch can return the broken "@custom:..." form verbatim.
-    _custom_norm = _normalize_custom_qualified_session_model(model, requested_provider)
+    # "<slug>/<bare_model>" when the qualifier matches a named custom_providers
+    # entry in the SESSION's own profile config (profile_config) so chat/start
+    # routes in a single API call instead of exhausting the full fallback chain
+    # (10-30x slower). Runs before every fast path below so no branch can return
+    # the broken "@custom:..." form verbatim; non-custom qualifiers (moa, openai,
+    # ...) and unknown custom slugs fall through unchanged (#6718 re-gate).
+    _custom_norm = _normalize_custom_qualified_session_model(
+        model,
+        requested_provider,
+        profile_config=profile_config,
+    )
     if _custom_norm is not None:
         return _custom_norm[0], _custom_norm[1], True
     if model and requested_provider == "moa":

--- a/api/routes.py
+++ b/api/routes.py
@@ -6637,6 +6637,15 @@ def _normalize_custom_qualified_session_model(
     removed from the session's own profile must not be remapped from another
     profile's ``custom_providers``.
     """
+    # #6718 re-gate (CORE 2 follow-up): fail closed. A ``None`` profile config
+    # must NEVER fall through to the module-global ``api.config.cfg``
+    # (``_custom_provider_entries`` defaults to it when handed a non-dict) —
+    # otherwise a slug removed from the session's own profile gets remapped
+    # from another profile's (or the process-global) ``custom_providers``.
+    # Callers that need normalization (chat/start, /api/session/new,
+    # /api/session/update) thread the session's own profile config here.
+    if not isinstance(profile_config, dict):
+        return None
     bare: str | None = None
     qualifier: str | None = None
     if model.startswith("@"):
@@ -8049,6 +8058,8 @@ def _session_model_state_from_request(
     model: str | None,
     requested_provider: str | None,
     current_provider: str | None = None,
+    *,
+    profile_config: dict | None = None,
 ) -> tuple[str | None, str | None]:
     model_value = str(model).strip() if model is not None else None
     provider = (
@@ -8065,6 +8076,7 @@ def _session_model_state_from_request(
         model_value, provider, _changed = _resolve_compatible_session_model_state(
             model_value,
             provider,
+            profile_config=profile_config,
         )
     return model_value, provider
 
@@ -15348,9 +15360,29 @@ def handle_post(handler, parsed) -> bool:
             except Exception as e:
                 logger.exception("failed to create worktree-backed session")
                 return bad(handler, f"Failed to create worktree: {e}", status=500)
+        # #6718 re-gate: the custom-provider slug normalizer must resolve under
+        # the session's OWN profile config (fail-closed when unreadable) —
+        # never the process-global config, which may belong to another profile.
+        _profile_name = str(body.get("profile") or "").strip() or None
+        _session_profile_config = None
+        try:
+            from api.profiles import get_hermes_home_for_profile
+
+            _p_cfg_path = os.path.join(
+                str(get_hermes_home_for_profile(_profile_name)),
+                "config.yaml",
+            )
+            if os.path.isfile(_p_cfg_path):
+                _session_profile_config = _read_profile_config_cached(
+                    str(_profile_name or ""),
+                    _p_cfg_path,
+                )
+        except Exception:
+            _session_profile_config = None
         model, model_provider = _session_model_state_from_request(
             body.get("model"),
             body.get("model_provider"),
+            profile_config=_session_profile_config,
         )
         try:
             enabled_toolsets = _validate_session_toolsets_shape(body.get("enabled_toolsets"))
@@ -15903,10 +15935,13 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(body["session_id"]):
             s.workspace = new_ws
             if "model" in body or "model_provider" in body:
+                # #6718 re-gate: normalize under the session's OWN profile
+                # config (fail-closed when unreadable), never process-global.
                 model, provider = _session_model_state_from_request(
                     body.get("model", s.model),
                     body.get("model_provider") if "model_provider" in body else None,
                     getattr(s, "model_provider", None),
+                    profile_config=_load_profile_config_dict(s),
                 )
                 if model is not None:
                     s.model = model

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -296,6 +296,47 @@ def test_endpoint_derived_host_port_slug_not_walked_back():
     )
 
 
+def test_configured_prefix_recovered_before_host_port_classification():
+    """#6718 (greptile P1 re-gate): a configured named provider whose slug is a
+    shorter prefix of the qualifier must be matched BEFORE the endpoint
+    host:port classification.
+
+    ``@custom:localhost:8080:Qwen3`` under a configured provider 'localhost'
+    (slug ``custom:localhost``) rsplit's into qualifier ``custom:localhost:8080``
+    and model ``Qwen3`` — the qualifier looks host:port-shaped, but the
+    CONFIGURED prefix ``custom:localhost`` wins: the colon-bearing model
+    ``8080:Qwen3`` is recovered and the session normalizes instead of staying
+    on the unknown-provider fallback path. Genuine endpoint-derived slugs
+    (``custom:<host>:<port>`` with NO configured prefix) stay unchanged
+    (see test_endpoint_derived_host_port_slug_not_walked_back)."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "localhost", "model": "Qwen3"},
+        ]
+    }
+
+    assert (
+        routes._normalize_custom_qualified_session_model(
+            "@custom:localhost:8080:Qwen3",
+            None,
+            profile_config=session_cfg,
+        )
+        == ("localhost/8080:Qwen3", "localhost")
+    )
+
+    # The resolver entry point agrees and returns before any catalog call.
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:localhost:8080:Qwen3",
+        None,
+        profile_config=session_cfg,
+    )
+    assert changed is True
+    assert effective == "localhost/8080:Qwen3", effective
+    assert provider == "localhost", provider
+
+
 def test_profile_config_none_fails_closed_against_global(monkeypatch):
     """A slug configured only in the module-global config must NOT normalize
     when ``profile_config=None`` — the ``None`` state is reachable from

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -627,3 +627,56 @@ def test_load_profile_config_dict_fails_closed_on_invalid_persisted_profile(monk
     assert routes_mod._load_profile_config_dict(_RootAliasSession()) == {
         "custom_providers": [{"name": "Root Only", "model": "gpt-5.5"}]
     }
+
+
+def test_read_profile_model_config_fails_closed_on_invalid_persisted_profile(monkeypatch, tmp_path):
+    """#6718 review 3 (SILENT): the display/start config loader must ALSO fail
+    closed on an invalid persisted ``session.profile``.
+
+    ``_read_profile_model_config`` feeds its ``profile_config`` result into the
+    custom-provider slug normalizer on the GET /api/session display path,
+    chat/start wakeup and goal paths. ``get_hermes_home_for_profile`` maps
+    invalid names to the ROOT home, so pre-fix an invalid stored profile name
+    loaded the ROOT config — letting a root-only custom-provider slug remap
+    inside that session. The identity is validated before resolution;
+    anything that is neither a root alias nor a valid named profile yields
+    (None, None, None) (fail closed), never the root fallback.
+    """
+    import api.profiles as profiles_mod
+    import api.routes as routes_mod
+
+    root_home = tmp_path / "root"
+    root_home.mkdir(parents=True)
+    (root_home / "config.yaml").write_text(
+        "custom_providers:\n  - name: Root Only\n    model: gpt-5.5\n"
+    )
+
+    # ANY name resolves to the root home — the resolver fallback the guard
+    # must defeat: pre-fix this made the root config load for the invalid
+    # stored profile name.
+    monkeypatch.setattr(profiles_mod, "get_hermes_home_for_profile", lambda name: root_home)
+
+    class _InvalidProfileSession:
+        profile = "../../evil"
+
+    assert routes_mod._read_profile_model_config(_InvalidProfileSession(), None) == (None, None, None)
+
+    class _TraversalProfileSession:
+        profile = "..%2f..%2fetc"
+
+    assert routes_mod._read_profile_model_config(_TraversalProfileSession(), None) == (None, None, None)
+
+    # A valid named profile still loads its own config (positive control)...
+    class _NamedProfileSession:
+        profile = "work"
+
+    _pp, _pd, _pcfg = routes_mod._read_profile_model_config(_NamedProfileSession(), None)
+    assert _pcfg == {"custom_providers": [{"name": "Root Only", "model": "gpt-5.5"}]}
+
+    # ...and a root alias is still the root profile's OWN config (legitimate,
+    # not a cross-profile leak).
+    class _RootAliasSession:
+        profile = "default"
+
+    _pp, _pd, _pcfg = routes_mod._read_profile_model_config(_RootAliasSession(), None)
+    assert _pcfg == {"custom_providers": [{"name": "Root Only", "model": "gpt-5.5"}]}

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -227,6 +227,72 @@ def test_configured_qualified_value_drives_normalization():
     assert provider == "sensenova-primary", provider
 
 
+def test_colon_suffixed_model_id_normalized(monkeypatch):
+    """#6718 (greptile-apps[bot]): a model id that itself contains ':' (e.g.
+    ``@custom:sensenova-primary:model:free`` where the model is ``model:free``)
+    must still normalize. ``_split_provider_qualified_model`` rsplit's on the
+    LAST ':', so the naive qualifier ``custom:sensenova-primary:model`` matches
+    no configured slug; the normalizer must walk back to the configured prefix
+    and re-attach the eaten segments to the model."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:model:free",
+        None,
+        profile_config=session_cfg,
+    )
+    assert changed is True
+    assert effective == "sensenova-primary/model:free", effective
+    assert provider == "sensenova-primary", provider
+
+
+def test_colon_suffixed_model_id_multi_segment(monkeypatch):
+    """Multi-colon model id: ``@custom:sensenova-primary:a:b:c`` -> model ``a:b:c``."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:a:b:c",
+        None,
+        profile_config=session_cfg,
+    )
+    assert changed is True
+    assert effective == "sensenova-primary/a:b:c", effective
+    assert provider == "sensenova-primary", provider
+
+
+def test_endpoint_derived_host_port_slug_not_walked_back():
+    """Endpoint-derived ``custom:<host>:<port>`` slugs must stay unchanged —
+    the colon walk-back must NOT eat ``8080:Qwen3`` into the model (#1776 form)."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+
+    assert (
+        routes._normalize_custom_qualified_session_model(
+            "@custom:10.8.71.41:8080:Qwen3",
+            None,
+            profile_config=session_cfg,
+        )
+        is None
+    )
+
+
 def test_profile_config_none_fails_closed_against_global(monkeypatch):
     """A slug configured only in the module-global config must NOT normalize
     when ``profile_config=None`` — the ``None`` state is reachable from

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -112,3 +112,112 @@ def test_non_custom_model_untouched(monkeypatch):
 
     assert routes._normalize_custom_qualified_session_model("@deepseek:deepseek-v4-pro", None) is None
     assert routes._normalize_custom_qualified_session_model("gpt-5.4", None) is None
+
+
+def test_provider_name_collisions_never_normalized(monkeypatch):
+    """Non-custom qualifiers are never normalized, even when the lookup would
+    resolve them to a custom slug (#6718 re-gate, CORE finding 1).
+
+    Regression cases from the review:
+      - ``@openai:gpt-5.5`` with a named ``openai`` provider must reach OpenAI
+        as the bare ``gpt-5.5``, never ``openai/gpt-5.5``;
+      - ``custom/x`` under an ``moa`` provider must not be rerouted to moa.
+    """
+    import api.config as config
+    import api.routes as routes
+
+    # The lookup resolves ANY qualifier to a custom slug — the gate must reject
+    # non-``custom:`` qualifiers before the lookup is even consulted.
+    monkeypatch.setattr(
+        config,
+        "_named_custom_provider_slug_for_provider",
+        lambda provider, config_obj=None: "custom:" + str(provider).removeprefix("custom:"),
+    )
+
+    assert routes._normalize_custom_qualified_session_model("@openai:gpt-5.5", "openai") is None
+    assert routes._normalize_custom_qualified_session_model("@moa:ensemble", "moa") is None
+    assert routes._normalize_custom_qualified_session_model("custom/x", "moa") is None
+    assert routes._normalize_custom_qualified_session_model("custom/x", None) is None
+
+
+def test_session_profile_config_is_source_of_truth(monkeypatch):
+    """The lookup must run against the session's OWN profile config — the
+    ``config_obj`` threaded into the helper must be the session profile dict
+    (#6718 re-gate, CORE finding 2)."""
+    import api.config as config
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+    captured = {}
+
+    def _fake_named_slug(provider, config_obj=None):
+        captured["config_obj"] = config_obj
+        if config_obj is session_cfg and provider == "custom:sensenova-primary":
+            return "custom:sensenova-primary"
+        return ""
+
+    monkeypatch.setattr(config, "_named_custom_provider_slug_for_provider", _fake_named_slug)
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+        profile_config=session_cfg,
+    )
+
+    assert changed is True
+    assert captured["config_obj"] is session_cfg
+    assert effective == "sensenova-primary/deepseek-v4-flash", effective
+    assert provider == "sensenova-primary", provider
+
+
+def test_slug_missing_from_session_profile_not_leaked(monkeypatch):
+    """A slug defined only in another profile (global cfg) must NOT remap a
+    session whose own profile no longer defines it (#6718 re-gate, CORE
+    finding 2: no global fallback when a profile config was supplied)."""
+    import api.config as config
+    import api.routes as routes
+
+    # Global config still defines the slug...
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {"custom_providers": [{"name": "Sensenova Primary"}]},
+    )
+
+    # ...but the session's own profile does not. The REAL helper must not fall
+    # back to the global cfg once a profile config dict was supplied.
+    session_cfg = {"custom_providers": []}
+
+    result = routes._normalize_custom_qualified_session_model(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+        profile_config=session_cfg,
+    )
+    assert result is None
+
+
+def test_configured_qualified_value_drives_normalization():
+    """End-to-end through the REAL helper: the canonical slug comes from the
+    profile config entry's qualified value (custom_providers), resolved under
+    the session's own profile config."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        "custom:sensenova-primary",
+        profile_config=session_cfg,
+    )
+
+    assert changed is True
+    assert effective == "sensenova-primary/deepseek-v4-flash", effective
+    assert provider == "sensenova-primary", provider

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -12,6 +12,9 @@ the qualifier matches a NAMED ``custom_providers`` entry, and preserves the
 current behavior otherwise.
 """
 
+import io
+import json
+
 
 def test_custom_qualified_model_normalized_to_canonical_slug(monkeypatch):
     """@custom:sensenova-primary:deepseek-v4-flash -> sensenova-primary/deepseek-v4-flash."""
@@ -393,3 +396,193 @@ def test_session_new_request_e2e_profile_config():
 
     assert model == "sensenova-primary/deepseek-v4-flash", model
     assert provider == "sensenova-primary", provider
+
+
+# ── #6718 review 3 regressions ────────────────────────────────────────────
+# (CORE) /api/session/new must resolve ONE authoritative session profile
+# identity and use it for BOTH the profile-config load and new_session().
+# (SILENT) invalid persisted session.profile names must fail closed instead
+# of loading the root config.
+
+
+class _RoutePostHandler:
+    """Minimal fake handler for driving ``routes.handle_post`` in-process."""
+
+    def __init__(self, body: dict):
+        raw = json.dumps(body).encode("utf-8")
+        self.headers = {"Content-Length": str(len(raw))}
+        self.rfile = io.BytesIO(raw)
+        self.wfile = io.BytesIO()
+        self.client_address = ("127.0.0.1", 12345)
+        self.status = None
+        self.response_headers = {}
+
+    def send_response(self, code: int):
+        self.status = code
+
+    def send_header(self, key: str, value: str):
+        self.response_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def log_message(self, *_args, **_kwargs):
+        pass
+
+    def payload(self) -> dict:
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def test_session_new_omitted_profile_uses_active_profile_config(monkeypatch, tmp_path):
+    """#6718 review 3 (CORE): POST /api/session/new with ``body.profile``
+    omitted must resolve the session model against the ACTIVE profile's config
+    — not the default/root config.
+
+    Previously the config lookup loaded the root config (profile=None →
+    default home) while ``new_session()`` stamped the session with the active
+    NAMED profile: two different identities in one request, so a root-only
+    ``@custom:other-profile-only:...`` slug remapped inside another profile's
+    session.
+    """
+    from urllib.parse import urlparse
+
+    import api.profiles as profiles_mod
+    import api.routes as routes_mod
+
+    root_home = tmp_path / "root"
+    work_home = tmp_path / "profiles" / "work"
+    root_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    (root_home / "config.yaml").write_text(
+        "custom_providers:\n  - name: Other Profile Only\n    model: gpt-5.5\n"
+    )
+    (work_home / "config.yaml").write_text(
+        "custom_providers:\n  - name: Sensenova Primary\n    model: deepseek-v4-flash\n"
+    )
+
+    # The named profile home resolves for 'work', the root home for anything
+    # else (None/empty/root aliases → root) — exactly the resolver behavior
+    # the review reproduced the leak through.
+    monkeypatch.setattr(
+        profiles_mod,
+        "get_hermes_home_for_profile",
+        lambda name: root_home if not name or str(name).strip().lower() in ("default", "root") else work_home,
+    )
+    # The handler resolves the omitted-profile identity through
+    # api.profiles.get_active_profile_name — the SAME function new_session()
+    # falls back to (one authoritative identity).
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(routes_mod, "_get_active_profile_name", lambda: "work")
+    # Keep the post-normalization catalog resolution off the network.
+    monkeypatch.setattr(
+        routes_mod,
+        "get_available_models",
+        lambda *a, **k: {"default_model": "gpt-5.4"},
+    )
+
+    handler = _RoutePostHandler({"model": "@custom:other-profile-only:gpt-5.5"})
+    routes_mod.handle_post(handler, urlparse("/api/session/new"))
+
+    assert handler.status == 200, handler.payload()
+    session = handler.payload()["session"]
+    assert session["profile"] == "work", session["profile"]
+    # The root-only slug must NOT be applied inside the 'work' profile's
+    # session: 'work' config has no matching named entry, so the persisted
+    # form is kept (fail closed) instead of being remapped to the root slug.
+    assert session["model"] == "@custom:other-profile-only:gpt-5.5", session["model"]
+    assert session["model"] != "other-profile-only/gpt-5.5", session["model"]
+
+
+def test_session_new_omitted_profile_matches_active_profile_slug(monkeypatch, tmp_path):
+    """#6718 review 3 (CORE) positive control: with body.profile omitted, a
+    model whose qualifier IS configured in the active named profile's config
+    still normalizes — proving the active identity drives the config load."""
+    from urllib.parse import urlparse
+
+    import api.profiles as profiles_mod
+    import api.routes as routes_mod
+
+    root_home = tmp_path / "root"
+    work_home = tmp_path / "profiles" / "work"
+    root_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    # The slug lives ONLY in the active profile's config, not the root config.
+    (root_home / "config.yaml").write_text("custom_providers: []\n")
+    (work_home / "config.yaml").write_text(
+        "custom_providers:\n  - name: Sensenova Primary\n    model: deepseek-v4-flash\n"
+    )
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "get_hermes_home_for_profile",
+        lambda name: root_home if not name or str(name).strip().lower() in ("default", "root") else work_home,
+    )
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(routes_mod, "_get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(
+        routes_mod,
+        "get_available_models",
+        lambda *a, **k: {"default_model": "gpt-5.4"},
+    )
+
+    handler = _RoutePostHandler({"model": "@custom:sensenova-primary:deepseek-v4-flash"})
+    routes_mod.handle_post(handler, urlparse("/api/session/new"))
+
+    assert handler.status == 200, handler.payload()
+    session = handler.payload()["session"]
+    assert session["profile"] == "work", session["profile"]
+    assert session["model"] == "sensenova-primary/deepseek-v4-flash", session["model"]
+
+
+def test_load_profile_config_dict_fails_closed_on_invalid_persisted_profile(monkeypatch, tmp_path):
+    """#6718 review 3 (SILENT): a session whose PERSISTED profile name is
+    invalid must NOT load the root config.
+
+    ``get_hermes_home_for_profile`` resolves names that do not match the
+    profile-id shape to the ROOT home, so pre-fix an invalid stored
+    ``session.profile`` loaded the root config — letting a root-only
+    custom-provider slug remap inside that session. The identity is validated
+    before resolution; anything that is neither a root alias nor a valid named
+    profile yields None (fail closed), never the root fallback.
+    """
+    import api.profiles as profiles_mod
+    import api.routes as routes_mod
+
+    root_home = tmp_path / "root"
+    root_home.mkdir(parents=True)
+    root_cfg_text = (
+        "custom_providers:\n  - name: Root Only\n    model: gpt-5.5\n"
+    )
+    (root_home / "config.yaml").write_text(root_cfg_text)
+
+    # ANY name resolves to the root home — the resolver fallback the guard
+    # must defeat: pre-fix this made the root config load for the invalid
+    # stored profile name.
+    monkeypatch.setattr(profiles_mod, "get_hermes_home_for_profile", lambda name: root_home)
+
+    class _InvalidProfileSession:
+        profile = "../../evil"
+
+    assert routes_mod._load_profile_config_dict(_InvalidProfileSession()) is None
+
+    class _TraversalProfileSession:
+        profile = "..%2f..%2fetc"
+
+    assert routes_mod._load_profile_config_dict(_TraversalProfileSession()) is None
+
+    # A valid named profile still loads its own config (positive control)...
+    class _NamedProfileSession:
+        profile = "work"
+
+    assert routes_mod._load_profile_config_dict(_NamedProfileSession()) == {
+        "custom_providers": [{"name": "Root Only", "model": "gpt-5.5"}]
+    }
+
+    # ...and a root alias is still the root profile's OWN config (legitimate,
+    # not a cross-profile leak).
+    class _RootAliasSession:
+        profile = "default"
+
+    assert routes_mod._load_profile_config_dict(_RootAliasSession()) == {
+        "custom_providers": [{"name": "Root Only", "model": "gpt-5.5"}]
+    }

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -23,9 +23,11 @@ def test_custom_qualified_model_normalized_to_canonical_slug(monkeypatch):
 
     monkeypatch.setattr(config, "_named_custom_provider_slug_for_provider", _fake_named_slug)
 
+    profile_cfg = {"custom_providers": [{"name": "Sensenova Primary"}]}
     effective, provider, changed = routes._resolve_compatible_session_model_state(
         "@custom:sensenova-primary:deepseek-v4-flash",
         None,
+        profile_config=profile_cfg,
     )
 
     assert changed is True
@@ -49,6 +51,7 @@ def test_custom_qualified_model_routes_in_single_path(monkeypatch):
     effective, provider, changed = routes._resolve_compatible_session_model_state(
         "@custom:sensenova-primary:deepseek-v4-flash",
         "custom:sensenova-primary",
+        profile_config={"custom_providers": [{"name": "Sensenova Primary"}]},
     )
 
     assert changed is True
@@ -74,6 +77,7 @@ def test_slash_custom_form_normalized(monkeypatch):
     effective, provider, changed = routes._resolve_compatible_session_model_state(
         "custom/deepseek-v4-flash",
         "custom:sensenova-primary",
+        profile_config={"custom_providers": [{"name": "Sensenova Primary"}]},
     )
 
     assert changed is True
@@ -220,4 +224,106 @@ def test_configured_qualified_value_drives_normalization():
 
     assert changed is True
     assert effective == "sensenova-primary/deepseek-v4-flash", effective
+    assert provider == "sensenova-primary", provider
+
+
+def test_profile_config_none_fails_closed_against_global(monkeypatch):
+    """A slug configured only in the module-global config must NOT normalize
+    when ``profile_config=None`` — the ``None`` state is reachable from
+    /api/session/new and chat/start when the profile YAML is absent/unreadable,
+    and the helper chain must fail closed instead of falling back to
+    ``api.config.cfg`` (#6718 re-gate, CORE 2 follow-up).
+
+    The REAL helper is used end-to-end (no slug-lookup monkeypatch): the global
+    config defines the slug, so any global fallback would resolve it.
+    """
+    import api.config as config
+    import api.routes as routes
+
+    # Only the module-global config defines the slug.
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {"custom_providers": [{"name": "Sensenova Primary"}]},
+    )
+    # Keep the resolver out of the real (network-backed) catalog — the
+    # assertion here is about fail-closed normalization, not catalog resolution.
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda *a, **k: {"default_model": "gpt-5.4"},
+    )
+
+    # Direct helper call with profile_config=None → fail closed.
+    assert (
+        routes._normalize_custom_qualified_session_model(
+            "@custom:sensenova-primary:deepseek-v4-flash",
+            None,
+            profile_config=None,
+        )
+        is None
+    )
+
+    # The resolver entry point without a profile config also fails closed.
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+        profile_config=None,
+    )
+    assert changed is False
+    assert effective == "@custom:sensenova-primary:deepseek-v4-flash", effective
+
+
+def test_session_new_request_threads_profile_config(monkeypatch):
+    """``_session_model_state_from_request`` (the /api/session/new and
+    /api/session/update entry point) must thread the session profile config
+    into the normalizer — the lookup sees the session's own config dict
+    (#6718 re-gate, CORE 2 follow-up)."""
+    import api.config as config
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+    captured = {}
+
+    def _fake_named_slug(provider, config_obj=None):
+        captured["config_obj"] = config_obj
+        if config_obj is session_cfg and provider == "custom:sensenova-primary":
+            return "custom:sensenova-primary"
+        return ""
+
+    monkeypatch.setattr(config, "_named_custom_provider_slug_for_provider", _fake_named_slug)
+
+    model, provider = routes._session_model_state_from_request(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+        profile_config=session_cfg,
+    )
+
+    assert captured.get("config_obj") is session_cfg
+    assert model == "sensenova-primary/deepseek-v4-flash", model
+    assert provider == "sensenova-primary", provider
+
+
+def test_session_new_request_e2e_profile_config():
+    """End-to-end through the REAL helper: a named-custom model on /api/session/new
+    normalizes to the canonical slug under the session's own profile config."""
+    import api.routes as routes
+
+    session_cfg = {
+        "custom_providers": [
+            {"name": "Sensenova Primary", "model": "deepseek-v4-flash"},
+        ]
+    }
+
+    model, provider = routes._session_model_state_from_request(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+        profile_config=session_cfg,
+    )
+
+    assert model == "sensenova-primary/deepseek-v4-flash", model
     assert provider == "sensenova-primary", provider

--- a/tests/test_issue6648_custom_provider_session_model.py
+++ b/tests/test_issue6648_custom_provider_session_model.py
@@ -1,0 +1,114 @@
+"""Regression tests for issue #6648.
+
+Sessions created with a custom OpenAI-compatible provider persist the model as
+``@custom:<slug>:<model>`` (or ``custom/<model>``). The Hermes runtime does not
+recognize a provider named ``custom:<something>`` — it only knows the canonical
+provider slug (e.g. ``sensenova-primary``). Without normalization every request
+fails with "Unknown provider 'custom:...'" and exhausts the full fallback chain,
+making WebUI responses 10-30x slower than Hermes Desktop.
+
+The fix normalizes to ``<canonical-slug>/<bare_model>`` (single API call) when
+the qualifier matches a NAMED ``custom_providers`` entry, and preserves the
+current behavior otherwise.
+"""
+
+
+def test_custom_qualified_model_normalized_to_canonical_slug(monkeypatch):
+    """@custom:sensenova-primary:deepseek-v4-flash -> sensenova-primary/deepseek-v4-flash."""
+    import api.config as config
+    import api.routes as routes
+
+    def _fake_named_slug(provider, config_obj=None):
+        return "custom:sensenova-primary" if provider == "custom:sensenova-primary" else ""
+
+    monkeypatch.setattr(config, "_named_custom_provider_slug_for_provider", _fake_named_slug)
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        None,
+    )
+
+    assert changed is True
+    assert effective == "sensenova-primary/deepseek-v4-flash", effective
+    assert provider == "sensenova-primary", provider
+
+
+def test_custom_qualified_model_routes_in_single_path(monkeypatch):
+    """Provider must come back canonical (no 'custom:' prefix) so the runtime resolves it."""
+    import api.config as config
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        config,
+        "_named_custom_provider_slug_for_provider",
+        lambda provider, config_obj=None: "custom:sensenova-primary"
+        if provider == "custom:sensenova-primary"
+        else "",
+    )
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "@custom:sensenova-primary:deepseek-v4-flash",
+        "custom:sensenova-primary",
+    )
+
+    assert changed is True
+    assert provider == "sensenova-primary"
+    assert effective == "sensenova-primary/deepseek-v4-flash"
+    assert "custom:" not in provider
+    assert "custom:" not in effective.split("/", 1)[0]
+
+
+def test_slash_custom_form_normalized(monkeypatch):
+    """Persisted 'custom/<model>' form with a custom:<slug> provider is also normalized."""
+    import api.config as config
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        config,
+        "_named_custom_provider_slug_for_provider",
+        lambda provider, config_obj=None: "custom:sensenova-primary"
+        if provider == "custom:sensenova-primary"
+        else "",
+    )
+
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "custom/deepseek-v4-flash",
+        "custom:sensenova-primary",
+    )
+
+    assert changed is True
+    assert effective == "sensenova-primary/deepseek-v4-flash", effective
+    assert provider == "sensenova-primary"
+
+
+def test_unmatched_qualifier_preserved(monkeypatch):
+    """A custom: qualifier that matches NO named entry stays untouched (no rerouting)."""
+    import api.config as config
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        config,
+        "_named_custom_provider_slug_for_provider",
+        lambda provider, config_obj=None: "",
+    )
+
+    result = routes._normalize_custom_qualified_session_model(
+        "@custom:unknown-slug:gpt-5.4-mini",
+        None,
+    )
+    assert result is None
+
+
+def test_non_custom_model_untouched(monkeypatch):
+    """Regular @provider:model and bare models never hit the custom normalizer path."""
+    import api.config as config
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        config,
+        "_named_custom_provider_slug_for_provider",
+        lambda provider, config_obj=None: "",
+    )
+
+    assert routes._normalize_custom_qualified_session_model("@deepseek:deepseek-v4-pro", None) is None
+    assert routes._normalize_custom_qualified_session_model("gpt-5.4", None) is None


### PR DESCRIPTION
## Summary
Sessions created with a custom OpenAI-compatible provider persist the model as `@custom:<slug>:<model>` (or `custom/<model>`). The Hermes runtime does not recognize a provider named `custom:<something>` — it only knows the canonical slug (e.g. `sensenova-primary`). Every request failed with `Unknown provider 'custom:...'` and exhausted the full fallback chain, making WebUI responses 10-30x slower than Hermes Desktop for the same model. This fix normalizes the persisted format to `<canonical-slug>/<bare_model>` so chat/start routes in a single API call.

## Root Cause
`_resolve_compatible_session_model_state()` in `api/routes.py` returned the `@provider:model` hint verbatim (with the `custom:` prefix) whenever the custom provider matched. `resolve_model_provider()` in `api/config.py` then carried `custom:<slug>` through to `resolve_runtime_provider()`, which only resolves `custom:<slug>` when a provider block literally declares that name — the WebUI-derived slug never matched, triggering the fallback chain on every turn.

## Change
- `api/routes.py`: new `_normalize_custom_qualified_session_model()` helper + early guard in `_resolve_compatible_session_model_state()`. When the qualifier matches a NAMED `custom_providers` entry (via `_named_custom_provider_slug_for_provider`), the model is normalized to `<canonical-slug>/<bare_model>` and the provider to the canonical slug (prefix stripped). Conservative: endpoint-derived slugs (`custom:<host>:<port>`) and unmatched qualifiers are left untouched.
- New tests: `tests/test_issue6648_custom_provider_session_model.py` — canonical normalization, single-path routing (no `custom:` prefix in provider or model), `custom/<model>` slash form, unmatched qualifier preserved, non-custom models untouched.

## Verification
- New suite: 5 passed
- `tests/test_provider_mismatch.py` (incl. pinned `test_named_custom_provider_hint_with_colon_is_preserved`) + `tests/test_issue1855_resolve_model_provider_fast_path.py` → 95 passed, 0 failed

Closes #6648
