### PR TITLE
fix(routes,gateway): resolve @provider:model through the shared parser

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -24,6 +24,7 @@ from api.config import (
     STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT,
     _get_session_agent_lock,
+    _parse_provider_qualified_model_id,
     coerce_reasoning_effort_for_model,
     gateway_approval_unavailable_reason,
     gateway_supports_approval,
@@ -150,6 +151,28 @@ _WEBUI_GATEWAY_BASE_URL_ENV = "HERMES_WEBUI_GATEWAY_BASE_URL"
 _WEBUI_GATEWAY_API_KEY_ENV = "HERMES_WEBUI_GATEWAY_API_KEY"
 _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
+
+
+def _gateway_model_field(model: str | None) -> str:
+    """Return the bare model name to put in a gateway request body.
+
+    The picker and ``_resolve_compatible_session_model_state`` intentionally
+    keep the full ``@provider:model`` string for internal routing (#1253), but
+    the gateway expects a bare model name and carries the provider separately.
+    Sent verbatim, ``@ollama-cloud:minimax-m2.7`` is forwarded to the upstream
+    provider API, which 404s on the ``@``-prefixed string (#6722).
+
+    Parsing is delegated to ``config._parse_provider_qualified_model_id()`` so
+    a multi-segment custom provider ID (``@custom:backup:model-a``) yields the
+    real model (``model-a``) instead of a positional-split fragment.
+    """
+    if not model:
+        return ""
+    value = str(model).strip()
+    parsed = _parse_provider_qualified_model_id(value)
+    if parsed:
+        return str(parsed[0] or "").strip()
+    return value
 
 
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
@@ -529,7 +552,7 @@ def _run_gateway_runs_api_streaming(
         if isinstance(run_input, list):
             run_input = [{"role": "user", "content": run_input}]
         run_body = {
-            "model": model or "default",
+            "model": _gateway_model_field(model) or "default",
             "input": run_input,
             **body_extras,
             "session_id": session_id,
@@ -1018,7 +1041,7 @@ def _run_gateway_chat_streaming(
                     logger.debug("Failed to build gateway multimodal attachment payload", exc_info=True)
                     message_content = str(msg_text or "")
             body = {
-                "model": model or "default",
+                "model": _gateway_model_field(model) or "default",
                 "stream": True,
                 "messages": [*prefill_messages, {"role": "user", "content": message_content}],
             }

--- a/api/routes.py
+++ b/api/routes.py
@@ -2869,6 +2869,7 @@ from api.config import (
     get_config_for_profile_home,
     _cfg_lock,
     PENDING_BG_TASK_COMPLETIONS,
+    _parse_provider_qualified_model_id,
 )
 from api import config as api_config
 from api.helpers import (
@@ -6394,20 +6395,42 @@ def _repair_foreign_session_model_provider(
 
 
 def _clean_session_model_provider(value: str | None) -> str | None:
+    """Normalize a stored/requested provider value to a bare provider ID.
+
+    An ``@``-prefixed value is a provider-qualified *model* hint, so the
+    provider is resolved with the shared
+    ``config._parse_provider_qualified_model_id()`` grammar rather than a
+    positional colon split — that keeps multi-segment custom provider IDs
+    (``custom:<slug>``, ``custom:<host>:<port>``) whole while still dropping a
+    trailing model segment (#6722). Values without the ``@`` marker are already
+    plain provider IDs, whose colons belong to the ID itself, so they are
+    preserved verbatim.
+    """
     provider = str(value or "").strip().lower()
     if not provider or provider == "default":
         return None
     if provider.startswith("@"):
-        provider = provider[1:]
+        parsed = _parse_provider_qualified_model_id(provider)
+        provider = parsed[1].strip() if parsed else provider[1:]
     return provider or None
 
 
 def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
+    """Split an ``@provider:model`` hint into ``(bare_model, provider)``.
+
+    Delegates the grammar to ``config._parse_provider_qualified_model_id()``,
+    the shared parser that already knows how to keep a multi-segment custom
+    provider ID (``custom:<slug>``, ``custom:<host>:<port>``) intact while
+    still letting the model segment carry its own colons for tags such as
+    ``:free``. Keeping one parser here means every caller in this module and
+    the gateway request path resolve the same provider/model pair (#6722).
+    """
     model = str(model or "").strip()
-    if model.startswith("@") and ":" in model:
-        provider_hint, bare_model = model[1:].rsplit(":", 1)
+    parsed = _parse_provider_qualified_model_id(model)
+    if parsed:
+        bare_model, provider_hint = parsed
         provider = _clean_session_model_provider(provider_hint)
-        bare = bare_model.strip()
+        bare = str(bare_model or "").strip()
         if provider and bare:
             return bare, provider
     return model, None
@@ -7791,6 +7814,10 @@ def _session_model_state_from_request(
         _bare, explicit_provider = _split_provider_qualified_model(model_value)
         if explicit_provider:
             provider = explicit_provider
+            # The provider now travels in its own field, so the model must be
+            # the bare name. Leaving the "@provider:" prefix on model_value is
+            # what reached the gateway verbatim and 404'd upstream (#6722).
+            model_value = _bare
         elif requested_provider is None:
             provider = _clean_session_model_provider(current_provider)
         model_value, provider, _changed = _resolve_compatible_session_model_state(

--- a/api/routes.py
+++ b/api/routes.py
@@ -7814,10 +7814,6 @@ def _session_model_state_from_request(
         _bare, explicit_provider = _split_provider_qualified_model(model_value)
         if explicit_provider:
             provider = explicit_provider
-            # The provider now travels in its own field, so the model must be
-            # the bare name. Leaving the "@provider:" prefix on model_value is
-            # what reached the gateway verbatim and 404'd upstream (#6722).
-            model_value = _bare
         elif requested_provider is None:
             provider = _clean_session_model_provider(current_provider)
         model_value, provider, _changed = _resolve_compatible_session_model_state(

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -1,18 +1,20 @@
 """Regression tests for issue #6722 — @provider:model leaking to the gateway.
 
 The WebUI model picker deliberately carries a provider-qualified model string
-(``@provider:model``) through internal routing (#1253). Three places used to
-mishandle that string:
+(``@provider:model``) through internal routing (#1253). The leak involved
+three parsing/request-boundary failures:
 
-1. ``_clean_session_model_provider`` returned the whole ``provider:model``
-   value as the provider, so the gateway received a provider name like
-   ``ollama-cloud:deepseek-v4-flash`` → "Unknown provider".
-2. ``_session_model_state_from_request`` extracted the provider correctly but
-   kept the full ``@provider:model`` string as the model value.
-3. The gateway request builders sent that string verbatim as ``body["model"]``,
-   which the upstream provider API 404'd on.
+1. ``_clean_session_model_provider`` did not parse qualified values with the
+   shared grammar, so provider selection could retain or truncate the wrong
+   segments.
+2. ``_split_provider_qualified_model`` used a positional split that could not
+   distinguish multi-segment custom provider IDs from colon-tagged model IDs.
+3. The gateway request builders sent the internally qualified model string
+   verbatim as ``body["model"]``, which the upstream provider API 404'd on.
 
-All three now resolve the pair through the single shared grammar in
+Internal session-state resolution deliberately keeps the qualified string for
+routing and provider-switch repair. The gateway boundary alone strips it to the
+bare model. All parsing now uses the single shared grammar in
 ``config._parse_provider_qualified_model_id()``. That parser is the important
 part of the fix: a positional colon split cannot tell
 ``@ollama-cloud:deepseek-v4-flash:0731`` (single-segment provider, tagged

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -1,0 +1,267 @@
+"""Regression tests for issue #6722 — @provider:model leaking to the gateway.
+
+The WebUI model picker deliberately carries a provider-qualified model string
+(``@provider:model``) through internal routing (#1253). Three places used to
+mishandle that string:
+
+1. ``_clean_session_model_provider`` returned the whole ``provider:model``
+   value as the provider, so the gateway received a provider name like
+   ``ollama-cloud:deepseek-v4-flash`` → "Unknown provider".
+2. ``_session_model_state_from_request`` extracted the provider correctly but
+   kept the full ``@provider:model`` string as the model value.
+3. The gateway request builders sent that string verbatim as ``body["model"]``,
+   which the upstream provider API 404'd on.
+
+All three now resolve the pair through the single shared grammar in
+``config._parse_provider_qualified_model_id()``. That parser is the important
+part of the fix: a positional colon split cannot tell
+``@ollama-cloud:deepseek-v4-flash:0731`` (single-segment provider, tagged
+model) from ``@custom:backup:model-a`` (two-segment custom provider ID), and
+guessing either way breaks the other. These tests pin both shapes so a future
+"simplification" back to a split heuristic fails loudly.
+"""
+
+from collections import OrderedDict
+import json
+
+import api.gateway_chat as gateway_chat
+import api.models as models
+import api.streaming as streaming
+from api.config import STREAMS, create_stream_channel
+from api.models import new_session
+
+
+# (qualified value, expected bare model, expected provider)
+#
+# The custom:* rows are the ones a positional split gets wrong. ``custom:backup``
+# and ``custom:<host>:<port>`` are legitimate multi-segment provider IDs, so the
+# provider is NOT just the text before the first colon.
+QUALIFIED_MODEL_CASES = [
+    # Single-segment provider, plain model — the originally reported #6722 case.
+    ("@ollama-cloud:deepseek-v4-flash", "deepseek-v4-flash", "ollama-cloud"),
+    # Single-segment provider, model carrying its own colon tag.
+    ("@ollama-cloud:deepseek-v4-flash:0731", "deepseek-v4-flash:0731", "ollama-cloud"),
+    # Named custom provider — provider keeps both segments.
+    ("@custom:backup:model-a", "model-a", "custom:backup"),
+    # Named custom provider AND a tagged model.
+    ("@custom:backup:model-a:free", "model-a:free", "custom:backup"),
+    # host:port custom provider IDs.
+    ("@custom:192.168.1.5:11434:llama4", "llama4", "custom:192.168.1.5:11434"),
+    ("@custom:localhost:1234:qwen3", "qwen3", "custom:localhost:1234"),
+    # Slash-style model id plus a :free tag (#6221 shape).
+    ("@openrouter:meta/llama-4:free", "meta/llama-4:free", "openrouter"),
+    ("@anthropic:claude-opus-4.8", "claude-opus-4.8", "anthropic"),
+]
+
+
+class TestSharedParserIsTheSingleGrammar:
+    """routes' splitter must agree with the shared config parser, exactly."""
+
+    def test_split_provider_qualified_model_matches_shared_parser(self):
+        from api.config import _parse_provider_qualified_model_id
+        from api.routes import _split_provider_qualified_model
+
+        for value, expected_model, expected_provider in QUALIFIED_MODEL_CASES:
+            assert _parse_provider_qualified_model_id(value) == (
+                expected_model,
+                expected_provider,
+            ), f"shared parser disagrees for {value!r}"
+            assert _split_provider_qualified_model(value) == (
+                expected_model,
+                expected_provider,
+            ), f"routes splitter diverged from the shared parser for {value!r}"
+
+    def test_non_qualified_values_pass_through_unchanged(self):
+        from api.routes import _split_provider_qualified_model
+
+        for value in ("gpt-5.4", "anthropic/claude-opus-4.8", "custom:backup", "@nocolon", ""):
+            assert _split_provider_qualified_model(value) == (value, None)
+
+
+class TestCleanSessionModelProvider:
+    """The provider field must never keep a model segment attached."""
+
+    def test_at_qualified_values_resolve_to_the_provider_only(self):
+        from api.routes import _clean_session_model_provider
+
+        for value, _expected_model, expected_provider in QUALIFIED_MODEL_CASES:
+            assert _clean_session_model_provider(value) == expected_provider, (
+                f"{value!r} must clean to provider {expected_provider!r}"
+            )
+
+    def test_non_at_provider_ids_keep_their_colons(self):
+        """A bare ``custom:backup`` is already a provider ID, not a hint."""
+        from api.routes import _clean_session_model_provider
+
+        assert _clean_session_model_provider("custom:backup") == "custom:backup"
+        assert _clean_session_model_provider("custom:localhost:1234") == "custom:localhost:1234"
+        assert _clean_session_model_provider("ollama-cloud") == "ollama-cloud"
+
+    def test_empty_and_default_values_resolve_to_none(self):
+        from api.routes import _clean_session_model_provider
+
+        for value in (None, "", "   ", "default", "@"):
+            assert _clean_session_model_provider(value) is None
+
+
+class TestSessionModelStateStripsQualifier:
+    """The request path must hand back a bare model plus a separate provider."""
+
+    def test_model_value_is_bare_and_provider_is_split_out(self, monkeypatch):
+        import api.routes as routes
+
+        # Pin the catalog-dependent repair step so this test targets the
+        # qualifier split rather than catalog compatibility behavior.
+        monkeypatch.setattr(
+            routes,
+            "_resolve_compatible_session_model_state",
+            lambda model, provider: (model, provider, False),
+        )
+
+        for value, expected_model, expected_provider in QUALIFIED_MODEL_CASES:
+            model_value, provider = routes._session_model_state_from_request(
+                value, None, None
+            )
+            assert model_value == expected_model, (
+                f"{value!r} must send bare model {expected_model!r}, got {model_value!r}"
+            )
+            assert provider == expected_provider
+
+
+class TestGatewayModelField:
+    """body['model'] must be the bare model for every provider shape."""
+
+    def test_gateway_model_field_strips_qualifier(self):
+        from api.gateway_chat import _gateway_model_field
+
+        for value, expected_model, _expected_provider in QUALIFIED_MODEL_CASES:
+            assert _gateway_model_field(value) == expected_model, (
+                f"gateway body model for {value!r} must be {expected_model!r}"
+            )
+
+    def test_unqualified_models_are_untouched(self):
+        from api.gateway_chat import _gateway_model_field
+
+        assert _gateway_model_field("gpt-5.4") == "gpt-5.4"
+        assert _gateway_model_field("anthropic/claude-opus-4.8") == "anthropic/claude-opus-4.8"
+        assert _gateway_model_field(None) == ""
+        assert _gateway_model_field("") == ""
+
+
+def _stub_prefill(monkeypatch):
+    monkeypatch.setattr(
+        streaming,
+        "_load_webui_prefill_context",
+        lambda cfg: {
+            "status": "not_configured",
+            "source": "none",
+            "label": "",
+            "message_count": 0,
+            "messages": [],
+        },
+    )
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+
+
+class _FakeChatResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        yield b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+        yield b"data: [DONE]\n\n"
+
+
+def _run_legacy_gateway_chat(tmp_path, monkeypatch, model):
+    """Drive the legacy chat-completions path and return the request body."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = req.data.decode("utf-8")
+        return _FakeChatResponse()
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    _stub_prefill(monkeypatch)
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+
+    s = new_session()
+    stream_id = f"stream-6722-legacy-{model}"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "hi"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    channel = create_stream_channel()
+    channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id, "hi", model, str(tmp_path), stream_id, []
+    )
+    return json.loads(captured["body"])
+
+
+class TestGatewayRequestBodiesCarryBareModel:
+    """End-to-end: the bytes actually sent to the gateway."""
+
+    def test_legacy_chat_completions_body_has_bare_model(self, tmp_path, monkeypatch):
+        payload = _run_legacy_gateway_chat(
+            tmp_path, monkeypatch, "@ollama-cloud:deepseek-v4-flash"
+        )
+        assert payload["model"] == "deepseek-v4-flash"
+        assert not payload["model"].startswith("@")
+
+    def test_legacy_body_keeps_named_custom_provider_model_intact(self, tmp_path, monkeypatch):
+        """The multi-segment case a positional split would truncate."""
+        payload = _run_legacy_gateway_chat(
+            tmp_path, monkeypatch, "@custom:backup:model-a:free"
+        )
+        assert payload["model"] == "model-a:free"
+
+    def test_legacy_body_keeps_host_port_custom_provider_model_intact(self, tmp_path, monkeypatch):
+        payload = _run_legacy_gateway_chat(
+            tmp_path, monkeypatch, "@custom:192.168.1.5:11434:llama4"
+        )
+        assert payload["model"] == "llama4"
+
+    def test_runs_api_body_has_bare_model(self, monkeypatch):
+        """The runs API builder is the second gateway request site."""
+        captured = {}
+
+        def fake_urlopen(req, timeout=0):
+            captured["body"] = req.data.decode("utf-8")
+            raise AssertionError("stop after the POST body is captured")
+
+        monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(gateway_chat, "update_active_run", lambda *a, **k: None)
+
+        try:
+            gateway_chat._run_gateway_runs_api_streaming(
+                "sess-6722",
+                "hi",
+                "@custom:backup:model-a:free",
+                "/tmp",
+                "stream-6722-runs",
+                "http://gateway.local",
+                "",
+                [],
+                {},
+                put_gateway_event=lambda *a, **k: None,
+                cancel_event=None,
+            )
+        except Exception:
+            pass
+
+        assert "body" in captured, "runs API POST body was never built"
+        payload = json.loads(captured["body"])
+        assert payload["model"] == "model-a:free"
+        assert not payload["model"].startswith("@")

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -104,28 +104,67 @@ class TestCleanSessionModelProvider:
             assert _clean_session_model_provider(value) is None
 
 
-class TestSessionModelStateStripsQualifier:
-    """The request path must hand back a bare model plus a separate provider."""
+class TestSessionModelStatePreservesQualifierForRepair:
+    """The request path must keep the @provider: qualifier through resolution so
+    the compatibility/repair step (and PR #6718's custom-provider normalizer) can
+    still see the qualified form. The qualifier is stripped to the bare model ONLY
+    at the gateway boundary (see TestGatewayModelField)."""
 
-    def test_model_value_is_bare_and_provider_is_split_out(self, monkeypatch):
+    def test_unavailable_qualified_provider_repairs_to_active_default(self, monkeypatch):
+        """A session pinned to a removed/unconfigured provider must revert to the
+        active default on a non-explicit resolve — the premature strip in the
+        previous revision returned (bare_model, removed) instead."""
         import api.routes as routes
 
-        # Pin the catalog-dependent repair step so this test targets the
-        # qualifier split rather than catalog compatibility behavior.
         monkeypatch.setattr(
             routes,
-            "_resolve_compatible_session_model_state",
-            lambda model, provider: (model, provider, False),
+            "get_available_models",
+            lambda: {
+                "active_provider": "openai-codex",
+                "default_model": "gpt-5.5",
+                "groups": [
+                    {
+                        "provider_id": "openai-codex",
+                        "models": [{"id": "@openai-codex:gpt-5.5"}],
+                    },
+                ],
+            },
         )
+        model_value, provider = routes._session_model_state_from_request(
+            "@removed:mistral-large", None, "removed"
+        )
+        assert model_value == "gpt-5.5", (
+            f"removed/unconfigured qualified provider must repair to the active "
+            f"default, got model_value={model_value!r}"
+        )
+        assert provider == "openai-codex"
 
-        for value, expected_model, expected_provider in QUALIFIED_MODEL_CASES:
-            model_value, provider = routes._session_model_state_from_request(
-                value, None, None
-            )
-            assert model_value == expected_model, (
-                f"{value!r} must send bare model {expected_model!r}, got {model_value!r}"
-            )
-            assert provider == expected_provider
+    def test_active_provider_qualified_model_preserves_qualifier_for_routing(self, monkeypatch):
+        """A qualified model naming the active provider is preserved intact so
+        downstream routing (resolve_model_provider) can use the provider."""
+        import api.routes as routes
+
+        monkeypatch.setattr(
+            routes,
+            "get_available_models",
+            lambda: {
+                "active_provider": "openai-codex",
+                "default_model": "gpt-5.5",
+                "groups": [
+                    {
+                        "provider_id": "openai-codex",
+                        "models": [{"id": "@openai-codex:gpt-5.5"}],
+                    },
+                ],
+            },
+        )
+        model_value, provider = routes._session_model_state_from_request(
+            "@openai-codex:gpt-5.5", "openai-codex"
+        )
+        assert model_value == "@openai-codex:gpt-5.5", (
+            f"qualifier must survive session-state resolution for routing, got {model_value!r}"
+        )
+        assert provider == "openai-codex"
 
 
 class TestGatewayModelField:


### PR DESCRIPTION
## What

`@provider:model` strings were reaching the Hermes gateway API server intact, producing "Unknown provider" and "model not found" 404s for any model not covered by a `model_routes` workaround entry.

The WebUI model picker deliberately keeps the qualified `@provider:model` form for internal routing (#1253). The bug was that nothing converted it back into a `(model, provider)` pair on the way out to the gateway.

## Root cause

Three places on the path to the gateway mishandled the qualified string:

1. **`_clean_session_model_provider`** (`api/routes.py`) returned the whole `provider:model` value as the provider, so the gateway saw a provider named `ollama-cloud:deepseek-v4-flash`.
2. **`_split_provider_qualified_model`** (`api/routes.py`) used a positional split that could not distinguish multi-segment custom provider IDs from colon-tagged model IDs.
3. **Both gateway request builders** (`api/gateway_chat.py`) sent that string verbatim as `body["model"]`, which the upstream provider API 404'd on.

## Fix

All qualified-model parsing goes through the single shared grammar, `config._parse_provider_qualified_model_id()`. No positional colon-split heuristics are introduced anywhere.

- `api/gateway_chat.py` — new `_gateway_model_field()`, a thin wrapper over the shared parser, used at both gateway request sites (runs API + legacy chat completions). This is where the qualifier is stripped to the bare model.
- `api/routes.py` — `_clean_session_model_provider` resolves `@`-prefixed values through the shared parser.
- `api/routes.py` — **`_split_provider_qualified_model()` itself now delegates to the shared parser.** This is the chokepoint: it has 9 call sites in `routes.py`, each of which previously inherited the same truncation for tagged models. Fixing it there means the provider used for the routing *decision* and the model sent in the *request* always come from the same resolved pair.

### Why the shared parser rather than a split

A positional split cannot distinguish a multi-segment custom provider ID from a model segment carrying its own colon tag:

- `@custom:backup:model-a` → provider `custom:backup`, model `model-a`
- `@ollama-cloud:deepseek-v4-flash:0731` → provider `ollama-cloud`, model `deepseek-v4-flash:0731`

Splitting on the first colon breaks the former; splitting on the last breaks the latter. `_parse_provider_qualified_model_id()` already encodes the grammar that gets both right (including `custom:<host>:<port>`), so this PR routes everything through it instead of adding a second set of rules.

### Where the qualifier is stripped

The `@provider:` prefix is stripped to the bare model **only at the gateway request boundary** via `_gateway_model_field()`. It is deliberately **kept** through `_session_model_state_from_request` / `_resolve_compatible_session_model_state()` so that provider-switch repair (a session pinned to a removed provider reverts to the active default) and PR #6718's custom-provider normalizer both still see the qualified form.

Resolution across the layers after the fix:

```
value                                 provider                   gateway body model
@ollama-cloud:deepseek-v4-flash       ollama-cloud               deepseek-v4-flash
@ollama-cloud:deepseek-v4-flash:0731  ollama-cloud               deepseek-v4-flash:0731
@custom:backup:model-a                custom:backup              model-a
@custom:backup:model-a:free           custom:backup              model-a:free
@custom:192.168.1.5:11434:llama4      custom:192.168.1.5:11434   llama4
@custom:localhost:1234:qwen3          custom:localhost:1234      qwen3
@openrouter:meta/llama-4:free         openrouter                 meta/llama-4:free
@anthropic:claude-opus-4.8            anthropic                  claude-opus-4.8
```

## Reproduction

1. Configure `ollama-cloud` as a custom provider in Hermes
2. Select a model like `minimax-m2.7` or `deepseek-v4-flash` from the WebUI picker
3. Send a message
4. Before: HTTP 404 `model @ollama-cloud:minimax-m2.7 not found`, or `Unknown provider 'ollama-cloud:deepseek-v4-flash'`
5. After: model selection works for any provider model

Gateway log evidence:

```
WARNING gateway.platforms.api_server: Provider authentication failed: Unknown provider 'ollama-cloud:deepseek-v4-flash'
```

## Tests

New `tests/test_issue6722_provider_qualified_model_leak.py` — table-driven over every shape above:

- the routes splitter agrees with `_parse_provider_qualified_model_id()` **exactly**, so re-introducing a local split heuristic fails loudly
- provider normalization, including that non-`@` IDs like `custom:backup` keep their colons
- the request-state builder **preserves the qualifier** for repair/routing, and an unavailable qualified provider reverts to the active default
- **both** gateway request bodies carry the bare model, asserted by reading the JSON actually written to the request rather than mocking the helper under test

**Red before green:** the original 12 tests fail on `320789ae` without the fix (including `@custom:backup:model-a:free` reaching the gateway verbatim). The final revision's regression test (`@removed:mistral-large` → active default) failed on the previous head that stripped the qualifier early and passes now.

**Verification:**
- 275 passed across the issue-6722, provider-mismatch, model-resolution-fast-path, gateway-approval (legacy+runs), gateway-routing, custom-provider, session-model-switch and model-not-found suites

## Not covered

Stale sessions with an already-poisoned non-`@` `model_provider` value persisted by an older build (e.g. `"ollama-cloud:deepseek-v4-flash"`) are out of scope. This PR stops the leak at the source rather than migrating existing session state; happy to add a migration separately if wanted.

Fixes #6722
