### PR TITLE
fix(insights): restore dropdown chevron lost to inline background shorthand

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -279,7 +279,7 @@
         </div>
       </div>
       <div class="panel-head-sub" style="padding:0 12px 8px">
-        <select id="insightsPeriod" onchange="loadInsights()" style="width:100%;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px">
+        <select id="insightsPeriod" class="insights-period-select" onchange="loadInsights()">
           <option value="7">7 days</option>
           <option value="30" selected>30 days</option>
           <option value="90">90 days</option>
@@ -1101,7 +1101,7 @@
             </div>
             <div class="settings-field" style="margin-top:8px">
               <label for="settingsStructuredCodeMode" data-i18n="settings_label_structured_code">JSON/YAML code blocks</label>
-              <select id="settingsStructuredCodeMode" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
+              <select id="settingsStructuredCodeMode" style="width:100%;padding:8px;background-color:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
                 <option value="auto" data-i18n="settings_option_structured_code_auto">Auto: Tree for long blocks</option>
                 <option value="on" data-i18n="settings_option_structured_code_on">Tree by default</option>
                 <option value="off" data-i18n="settings_option_structured_code_off">Raw by default</option>
@@ -1154,7 +1154,7 @@
               <label for="settingsModelChip" data-i18n="settings_label_model">Default Model</label>
               <div class="model-advanced-row">
                 <button type="button" id="settingsModelChip" class="settings-model-chip" aria-haspopup="listbox" aria-expanded="false">Default Model</button>
-                <select id="settingsModel" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
+                <select id="settingsModel" style="width:100%;padding:8px;background-color:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
                 <button type="button" id="mainAdvancedBtn" class="model-advanced-btn" title="Advanced options" aria-label="Advanced options for main model"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
                 <div class="model-dropdown settings-model-dropdown" id="settingsModelDropdown"></div>
               </div>
@@ -1192,7 +1192,7 @@
             </div>
             <div class="settings-field">
               <label for="settingsSendKey" data-i18n="settings_label_send_key">Send Key</label>
-              <select id="settingsSendKey" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
+              <select id="settingsSendKey" style="width:100%;padding:8px;background-color:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
                 <option value="enter">Enter (Shift+Enter for newline)</option>
                 <option value="ctrl+enter">Ctrl+Enter (Enter for newline)</option>
                 <option value="shift+enter">Shift+Enter (Enter for newline)</option>
@@ -1200,7 +1200,7 @@
             </div>
             <div class="settings-field">
               <label for="settingsLanguage" data-i18n="settings_label_language">Language</label>
-              <select id="settingsLanguage" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
+              <select id="settingsLanguage" style="width:100%;padding:8px;background-color:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">

--- a/static/style.css
+++ b/static/style.css
@@ -2231,6 +2231,7 @@
 .field-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:5px;opacity:.8;}
   select{width:100%;background:var(--input-bg);border:1px solid var(--border2);border-radius:8px;color:var(--text);padding:8px 28px 8px 10px;font-size:12px;outline:none;appearance:none;margin-bottom:6px;cursor:pointer;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238888aa' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 10px center;}
   select:focus{border-color:var(--accent);box-shadow:0 0 0 2px var(--accent-bg);}
+.insights-period-select{border-radius:6px;padding:6px 28px 6px 10px;font-size:12px;margin-bottom:0;}
   optgroup{color:var(--muted);font-size:11px;font-weight:700;}
   option{background:var(--bg);color:var(--text);padding:6px;}
   .sidebar-actions{display:flex;gap:6px;}


### PR DESCRIPTION
## Problem

The Insights period filter (`#insightsPeriod`) renders as a flat full-width bar with no dropdown indicator — it looks like a static label rather than a control. The filter has been functional the whole time, but visually invisible.

## Root cause

The base `select` rule in `static/style.css` provides a custom SVG chevron via `background-image` with `appearance:none`. However, the inline `style` attribute on `#insightsPeriod` uses the `background` **shorthand**, which resets `background-image` to `none`, erasing the chevron. The inline `padding:4px 8px` also drops the 28px right padding that reserved space for the chevron.

## Fix

1. **Removed the inline style from `#insightsPeriod`** and added a class `.insights-period-select` with only the delta styles (tighter border-radius, adjusted padding, no bottom margin).

2. **Fixed 4 settings-panel selects** that had the same `background:` shorthand trap: `#settingsStructuredCodeMode`, `#settingsModel`, `#settingsSendKey`, `#settingsLanguage`. Changed `background:var(--code-bg)` to `background-color:var(--code-bg)` so the base chevron survives.

## Verification

- The base `select` rule's `background-image` (chevron SVG) now renders on `#insightsPeriod`
- The `appearance:none` from the base rule still applies (not overridden)
- Settings selects retain their `--code-bg` background color while also showing the chevron

Closes #6725