### PR TITLE
Make agent self-update safe against local commits and dirty trees

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,7 +66,9 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       startup.py           Startup helpers: auto_install_agent_deps()
       state_sync.py        /insights sync — message_count to the agent's state.db
       streaming.py         SSE engine, run_agent, cancel, compression, HERMES_HOME save/restore
-      updates.py           Self-update check and release notes
+      updates.py           Self-update check/apply with dirty+divergence preflight,
+                           timestamped backup branches/stashes, agent safe-reset,
+                           diagnose_checkout(), and release notes
       upload.py            Multipart parser, file upload handler
       workspace.py         File ops: list_dir, read_file_content, git detection, workspace helpers
     static/

--- a/api/routes.py
+++ b/api/routes.py
@@ -13355,6 +13355,15 @@ def handle_get(handler, parsed) -> bool:
 
         return j(handler, cached_update_status(include_agent=include_agent_updates))
 
+    if parsed.path == "/api/updates/diagnose":
+        qs = parse_qs(parsed.query)
+        target = (qs.get("target", ["agent"])[0] or "agent").strip()
+        if target not in ("webui", "agent"):
+            return bad(handler, 'target must be "webui" or "agent"')
+        from api.updates import diagnose_checkout
+
+        return j(handler, diagnose_checkout(target))
+
     if parsed.path == "/api/chat/stream/status":
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
         if not _stream_id_visible_to_request_profile(handler, stream_id):

--- a/api/updates.py
+++ b/api/updates.py
@@ -21,6 +21,7 @@ import time
 import urllib.error
 import urllib.request
 from collections import OrderedDict
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -1995,6 +1996,28 @@ def apply_force_update(target: str, channel=None) -> dict:
                 'channel': channel,
                 'refused_rewind': True,
             }
+
+        # Preserve local commits before destructive reset. Force-update still
+        # discards the working tree tip, but never silently deletes commits.
+        sync = _describe_checkout_sync(path, compare_ref)
+        backup_branch = None
+        if sync.get('relationship') in {'ahead', 'diverged'} or (
+            isinstance(sync.get('ahead'), int) and sync['ahead'] > 0
+        ) or sync.get('dirty_tracked'):
+            backup = _create_update_backup_branch(path)
+            if backup.get('ok'):
+                backup_branch = backup['branch']
+            else:
+                return {
+                    'ok': False,
+                    'message': (
+                        'Force update aborted: could not create a backup branch '
+                        f'before reset ({backup.get("error") or "unknown error"}). '
+                        'Local commits/modifications were left untouched.'
+                    ),
+                    'target': target,
+                }
+
         # Discard local modifications and untracked colliders before resetting.
         # Do not use -x: ignored build/cache artifacts should survive force update.
         _run_git(['checkout', '.'], path)
@@ -2036,9 +2059,13 @@ def apply_force_update(target: str, channel=None) -> dict:
 
         response = {
             'ok': True,
-            'message': f'{target} force-updated to {compare_ref}',
+            'message': (
+                f'{target} force-updated to {compare_ref}'
+                + (f' (local tip preserved on {backup_branch})' if backup_branch else '')
+            ),
             'target': target,
             'restart_scheduled': True,
+            'backup_branch': backup_branch,
         }
         if target == 'agent':
             response['gateway_restart'] = gateway_result.get('status')
@@ -2062,6 +2089,183 @@ def apply_update(target, channel=None):
         return _apply_update_inner(target, channel)
     finally:
         _apply_lock.release()
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')
+
+
+def _count_commits(path: Path, a: str, b: str) -> int | None:
+    """Return how many commits are reachable from ``b`` but not ``a``."""
+    out, ok = _run_git(['rev-list', '--count', f'{a}..{b}'], path)
+    if not ok or not out.isdigit():
+        return None
+    return int(out)
+
+
+def _list_checkout_processes(path: Path, *, limit: int = 25) -> list[dict]:
+    """Best-effort list of processes whose argv references ``path``."""
+    needle = str(path)
+    try:
+        proc = subprocess.run(
+            ['ps', '-ax', '-o', 'pid=,command='],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            encoding='utf-8',
+            errors='replace',
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    hits: list[dict] = []
+    for line in (proc.stdout or '').splitlines():
+        text = line.strip()
+        if not text or needle not in text:
+            continue
+        parts = text.split(None, 1)
+        if not parts:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        hits.append({'pid': pid, 'command': parts[1] if len(parts) > 1 else ''})
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def _describe_checkout_sync(path: Path, compare_ref: str | None) -> dict:
+    """Return ahead/behind/diverged/dirty state for an update target checkout.
+
+    Relationship meanings (relative to ``compare_ref``):
+      identical — HEAD and compare_ref resolve to the same commit
+      behind    — HEAD is a strict ancestor of compare_ref (ff-only safe)
+      ahead     — compare_ref is a strict ancestor of HEAD (local-only commits)
+      diverged  — histories share no fast-forward path
+      unknown   — git could not classify the relationship
+    """
+    head_sha, head_ok = _run_git(['rev-parse', 'HEAD'], path)
+    branch_out, branch_ok = _run_git(['rev-parse', '--abbrev-ref', 'HEAD'], path)
+    remote_url, _ = _run_git(['remote', 'get-url', 'origin'], path)
+    status_out, status_ok = _run_git(['status', '--porcelain'], path)
+    dirty_tracked_out, dirty_tracked_ok = _run_git(
+        ['status', '--porcelain', '--untracked-files=no'], path
+    )
+    modified: list[str] = []
+    untracked: list[str] = []
+    if status_ok:
+        for line in status_out.splitlines():
+            if len(line) < 4:
+                continue
+            code, name = line[:2], line[3:]
+            if code == '??':
+                untracked.append(name)
+            else:
+                modified.append(name)
+
+    result = {
+        'path': str(path),
+        'branch': branch_out if branch_ok else None,
+        'head_sha': head_sha if head_ok else None,
+        'remote_url': _normalize_remote_url(remote_url) if remote_url else None,
+        'compare_ref': compare_ref,
+        'ahead': None,
+        'behind': None,
+        'relationship': 'unknown',
+        'dirty': bool(status_ok and status_out),
+        'dirty_tracked': bool(dirty_tracked_ok and dirty_tracked_out),
+        'modified_files': modified[:100],
+        'untracked_files': untracked[:100],
+        'modified_count': len(modified),
+        'untracked_count': len(untracked),
+        'processes': _list_checkout_processes(path),
+    }
+    if not compare_ref or not head_ok:
+        return result
+
+    tip_sha, tip_ok = _run_git(['rev-parse', compare_ref], path)
+    if not tip_ok:
+        result['compare_error'] = tip_sha
+        return result
+    result['compare_sha'] = tip_sha
+    if tip_sha == head_sha:
+        result['relationship'] = 'identical'
+        result['ahead'] = 0
+        result['behind'] = 0
+        return result
+
+    ahead = _count_commits(path, tip_sha, head_sha)
+    behind = _count_commits(path, head_sha, tip_sha)
+    result['ahead'] = ahead
+    result['behind'] = behind
+    can_ff = _can_fast_forward_to(path, compare_ref)
+    head_has = _head_contains_ref(path, compare_ref)
+    if can_ff and not head_has:
+        result['relationship'] = 'behind'
+    elif head_has and not can_ff:
+        result['relationship'] = 'ahead'
+    elif can_ff and head_has:
+        # Same commit already handled; treat as identical if counts are zero.
+        result['relationship'] = 'identical' if ahead == 0 and behind == 0 else 'unknown'
+    else:
+        result['relationship'] = 'diverged'
+    return result
+
+
+def _create_update_backup_branch(path: Path, *, prefix: str = 'hermes-update-backup') -> dict:
+    """Create a timestamped branch at HEAD. Never moves/deletes existing refs."""
+    stamp = _utc_stamp()
+    branch = f'{prefix}/{stamp}'
+    out, ok = _run_git(['branch', branch, 'HEAD'], path)
+    if not ok:
+        # Collision within the same second — add a suffix and retry once.
+        branch = f'{prefix}/{stamp}-{os.getpid()}'
+        out, ok = _run_git(['branch', branch, 'HEAD'], path)
+    if not ok:
+        return {'ok': False, 'branch': None, 'error': out}
+    head_sha, _ = _run_git(['rev-parse', 'HEAD'], path)
+    return {'ok': True, 'branch': branch, 'head_sha': head_sha, 'error': None}
+
+
+def _stash_message() -> str:
+    return f'hermes-update-autostash-{_utc_stamp()}'
+
+
+def diagnose_checkout(target: str = 'agent', channel=None) -> dict:
+    """Return a non-mutating diagnostic snapshot for an update target checkout."""
+    if channel is None:
+        channel = _read_update_channel()
+    channel = _normalize_channel(channel)
+    if target == 'webui':
+        path = REPO_ROOT
+    elif target == 'agent':
+        path = _AGENT_DIR
+        channel = DEFAULT_UPDATE_CHANNEL
+    else:
+        return {'ok': False, 'message': f'Unknown target: {target}'}
+    if path is None or not (Path(path) / '.git').exists():
+        return {
+            'ok': False,
+            'target': target,
+            'message': 'Not a git repository',
+            'path': str(path) if path else None,
+        }
+
+    path = Path(path)
+    # Fetch is intentionally skipped: diagnose must be safe to run while the
+    # gateway/WebUI are live and must not mutate refs or the working tree.
+    compare_ref = _select_apply_compare_ref(path, channel, target)
+    sync = _describe_checkout_sync(path, compare_ref)
+    return {
+        'ok': True,
+        'target': target,
+        'channel': channel,
+        'compare_ref': compare_ref,
+        **sync,
+    }
 
 
 def _restore_stash_after_pull_failure(
@@ -2147,8 +2351,20 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             'channel': channel,
         }
 
-    # Check for dirty working tree (ignore untracked files — git stash
-    # doesn't include them, so stashing on '??' alone leaves nothing to pop)
+    # Preflight: classify ahead/behind/diverged/dirty before mutating.
+    sync = _describe_checkout_sync(path, compare_ref)
+    if sync.get('relationship') == 'identical':
+        return {
+            'ok': True,
+            'message': f'{target} is already up to date.',
+            'target': target,
+            'up_to_date': True,
+            'channel': channel,
+            'relationship': 'identical',
+            'ahead': 0,
+            'behind': 0,
+        }
+
     status_out, status_ok = _run_git(
         ['status', '--porcelain', '--untracked-files=no'], path
     )
@@ -2167,29 +2383,139 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             'ok': False,
             'message': (
                 f'The local {target} repo has unresolved merge conflicts. '
-                'To reset to the latest remote version run: '
-                'git -C ' + str(path) + ' checkout . && '
-                'git -C ' + str(path) + ' pull --ff-only'
+                'Resolve them, or create a backup branch and reset with the '
+                'force-update path after confirming local work is preserved.'
             ),
             'conflict': True,
+            'relationship': sync.get('relationship'),
+            'ahead': sync.get('ahead'),
+            'behind': sync.get('behind'),
         }
+
+    backup_branch = None
+    local_commits = sync.get('relationship') in {'ahead', 'diverged'} or (
+        isinstance(sync.get('ahead'), int) and sync['ahead'] > 0
+    )
+    if local_commits:
+        backup = _create_update_backup_branch(path)
+        if not backup.get('ok'):
+            return {
+                'ok': False,
+                'message': (
+                    f'The local {target} checkout has commits not on '
+                    f'{compare_ref}, and creating a backup branch failed '
+                    f'({backup.get("error") or "unknown error"}). '
+                    'Update aborted without discarding local commits. '
+                    f'Inspect with: git -C {path} status && '
+                    f'git -C {path} log --oneline {compare_ref}..HEAD'
+                ),
+                'diverged': True,
+                'relationship': sync.get('relationship'),
+                'ahead': sync.get('ahead'),
+                'behind': sync.get('behind'),
+            }
+        backup_branch = backup['branch']
+        logger.info(
+            'update preflight: preserved %s HEAD %s on backup branch %s '
+            '(relationship=%s ahead=%s behind=%s)',
+            target,
+            backup.get('head_sha'),
+            backup_branch,
+            sync.get('relationship'),
+            sync.get('ahead'),
+            sync.get('behind'),
+        )
+
     stashed = False
+    stash_label = None
     if status_out:
-        _, ok = _run_git(['stash', 'push', '-m', 'hermes-update-autostash'], path)
+        stash_label = _stash_message()
+        _, ok = _run_git(['stash', 'push', '-m', stash_label], path)
         if not ok:
-            return {'ok': False, 'message': 'Failed to stash local changes'}
+            return {
+                'ok': False,
+                'message': (
+                    'Failed to stash local changes before update; '
+                    'working tree left unchanged.'
+                    + (f' Local commits remain on {backup_branch}.' if backup_branch else '')
+                ),
+                'backup_branch': backup_branch,
+                'relationship': sync.get('relationship'),
+            }
         stashed = True
 
-    # Pull with ff-only (no merge commits).
-    # Split tracking refs like 'origin/main' into separate remote + branch
-    # arguments — git treats 'origin/main' as a repository name otherwise.
-    remote, branch = _split_remote_ref(compare_ref)
-    pull_args = ['pull', '--ff-only']
-    if remote:
-        pull_args.extend([remote, branch])
+    # Agent production checkouts should track upstream. When local commits make
+    # ff-only impossible, reset to compare_ref AFTER the backup branch exists.
+    # WebUI keeps fail-closed so intentional local WebUI work is never silently
+    # discarded; the force-update button remains the explicit recovery path.
+    used_safe_reset = False
+    if local_commits and target == 'agent':
+        _, reset_ok = _run_git(['reset', '--hard', compare_ref], path)
+        if not reset_ok:
+            stash_recovery_note = ''
+            if stashed:
+                stash_recovery_note = _restore_stash_after_pull_failure(
+                    target, path, f'reset --hard {compare_ref} failed'
+                )
+            return {
+                'ok': False,
+                'message': (
+                    f'Failed to reset {target} to {compare_ref} after creating '
+                    f'backup branch {backup_branch}. Local commits are still on '
+                    f'that branch.'
+                    + (f' {stash_recovery_note}' if stash_recovery_note else '')
+                ),
+                'diverged': True,
+                'backup_branch': backup_branch,
+                'relationship': sync.get('relationship'),
+                'ahead': sync.get('ahead'),
+                'behind': sync.get('behind'),
+            }
+        used_safe_reset = True
+        pull_out, pull_ok = f'Reset to {compare_ref}', True
+    elif local_commits and target == 'webui':
+        stash_recovery_note = ''
+        if stashed:
+            stash_recovery_note = _restore_stash_after_pull_failure(
+                target, path, 'local commits block fast-forward'
+            )
+        message_parts = [
+            f'The local {target} repo has commits that are not on the remote '
+            f'ref ({compare_ref}), so a fast-forward update is not possible.',
+            f'Local commits were preserved on backup branch {backup_branch}.',
+        ]
+        if stash_recovery_note:
+            message_parts.append(stash_recovery_note)
+        elif stashed:
+            message_parts.append(
+                f'Local modifications remain in git stash ({stash_label}).'
+            )
+        message_parts.append(
+            'Use Force Update to discard the local branch tip after confirming '
+            f'the backup, or recover with: git -C {path} checkout {backup_branch}'
+        )
+        return {
+            'ok': False,
+            'message': ' '.join(message_parts),
+            'diverged': True,
+            'backup_branch': backup_branch,
+            'stash_ref_message': stash_label,
+            'relationship': sync.get('relationship'),
+            'ahead': sync.get('ahead'),
+            'behind': sync.get('behind'),
+        }
     else:
-        pull_args.extend(['origin', compare_ref])
-    pull_out, pull_ok = _run_git(pull_args, path, timeout=30)
+        # Pull with ff-only (no merge commits).
+        # Split tracking refs like 'origin/main' into separate remote + branch
+        # arguments — git treats 'origin/main' as a repository name otherwise.
+        remote, branch = _split_remote_ref(compare_ref)
+        pull_args = ['pull', '--ff-only']
+        if remote:
+            pull_args.extend([remote, branch])
+        else:
+            pull_args.extend(['origin', compare_ref])
+        pull_out, pull_ok = _run_git(pull_args, path, timeout=30)
+
     if not pull_ok:
         if _is_git_lock_error(pull_out):
             # Lock conflict during pull. If a stash was pushed for the local
@@ -2204,10 +2530,13 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             message = f'Pull failed due to a repository lock: {pull_out.strip()}'
             if stash_recovery_note:
                 message = f'{message} {stash_recovery_note}'
+            if backup_branch:
+                message = f'{message} Local commits remain on {backup_branch}.'
             return {
                 'ok': False,
                 'message': message,
                 'lock_conflict': True,
+                'backup_branch': backup_branch,
             }
         pull_lower = pull_out.lower()
         detail = pull_out.strip()[:300] if pull_out.strip() else '(no output from git)'
@@ -2237,8 +2566,10 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                             'reset --hard HEAD to remove conflict markers. Your '
                             'changes remain in the git stash. Pull error: '
                             + detail
+                            + (f' Backup branch: {backup_branch}.' if backup_branch else '')
                         ),
                         'stash_conflict': True,
+                        'backup_branch': backup_branch,
                     }
                     if diverged_failure:
                         response['diverged'] = True
@@ -2252,8 +2583,10 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                         'remain in the git stash. To inspect: git -C ' + str(path) + ' stash show -p. '
                         'To re-apply: git -C ' + str(path) + ' stash apply, then '
                         'resolve conflicts. Pull error: ' + detail
+                        + (f' Backup branch: {backup_branch}.' if backup_branch else '')
                     ),
                     'stash_conflict': True,
+                    'backup_branch': backup_branch,
                 }
                 if diverged_failure:
                     response['diverged'] = True
@@ -2271,6 +2604,17 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                     'The temporary stash entry may still be present because '
                     'git stash drop failed.'
                 )
+        elif stashed:
+            restored_note_parts.append(
+                f'Local {target} modifications were not restored to the working '
+                'tree; they remain safely in `git stash list`'
+                + (f' ({stash_label})' if stash_label else '')
+                + '.'
+            )
+        if backup_branch:
+            restored_note_parts.append(
+                f'Local commits were preserved on backup branch {backup_branch}.'
+            )
         restored_note = ' '.join(restored_note_parts)
 
         # Diagnose the most common failure modes and surface actionable messages.
@@ -2281,14 +2625,23 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             ]
             if restored_note:
                 message_parts.append(restored_note)
-            message_parts.append(
-                'Run: git -C ' + str(path) + ' fetch origin && '
-                'git -C ' + str(path) + ' reset --hard ' + compare_ref
-            )
+            if backup_branch:
+                message_parts.append(
+                    f'Recover local commits with: git -C {path} checkout {backup_branch}'
+                )
+            else:
+                message_parts.append(
+                    'Run: git -C ' + str(path) + ' fetch origin && '
+                    'git -C ' + str(path) + ' reset --hard ' + compare_ref
+                )
             return {
                 'ok': False,
                 'message': ' '.join(message_parts),
                 'diverged': True,
+                'backup_branch': backup_branch,
+                'relationship': sync.get('relationship'),
+                'ahead': sync.get('ahead'),
+                'behind': sync.get('behind'),
             }
         if 'does not track' in pull_lower or 'no tracking information' in pull_lower:
             message_parts = [
@@ -2302,12 +2655,17 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             return {
                 'ok': False,
                 'message': ' '.join(message_parts),
+                'backup_branch': backup_branch,
             }
         # Generic fallback — include the raw git output for debugging.
         message_parts = [f'Pull failed: {detail}']
         if restored_note:
             message_parts.append(restored_note)
-        response = {'ok': False, 'message': ' '.join(message_parts)}
+        response = {
+            'ok': False,
+            'message': ' '.join(message_parts),
+            'backup_branch': backup_branch,
+        }
         if untracked_collision:
             response['conflict'] = True
         return response
@@ -2391,6 +2749,11 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     # and the restart land at roughly the same time.
     _schedule_restart()
     message = f'{target} updated successfully'
+    if used_safe_reset and backup_branch:
+        message = (
+            f'{target} updated to {compare_ref} after preserving local commits '
+            f'on backup branch {backup_branch}'
+        )
     if stash_drop_failed:
         message += (
             '. Local modifications were restored, but the temporary stash '
@@ -2402,6 +2765,9 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         'message': message,
         'target': target,
         'restart_scheduled': True,
+        'backup_branch': backup_branch,
+        'relationship': sync.get('relationship'),
+        'safe_reset': used_safe_reset,
     }
     if target == 'agent':
         response['gateway_restart'] = gateway_result.get('status')

--- a/api/updates.py
+++ b/api/updates.py
@@ -47,6 +47,10 @@ _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same re
 CACHE_TTL = 1800  # 30 minutes
 _AGENT_GATEWAY_RESTART_RETRY_DELAY_S = 1.0
 _GIT_DIAGNOSTIC_MAX_CHARS = 300
+# Native Windows runs the WebUI as a windowed process: every git child spawned
+# without this flag flashes a console host on the user's desktop. Zero on POSIX,
+# where subprocess only rejects a NON-zero creationflags value.
+_NO_CONSOLE_WINDOW = getattr(subprocess, 'CREATE_NO_WINDOW', 0) if sys.platform == 'win32' else 0
 _CREDENTIAL_IN_URL_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s'\"]+)@")
 _GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")
 _QUERY_SECRET_RE = re.compile(r"([?&](?:access_token|oauth_token|private_token|client_secret|app_secret|api[_-]?key|token|password|secret|auth|key)=)[^&\s'\"]+", re.IGNORECASE)
@@ -218,6 +222,7 @@ def _run_git(args, cwd, timeout=10):
             [git_executable] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
             encoding='utf-8', errors='replace',
+            creationflags=_NO_CONSOLE_WINDOW,
         )
         # On non-UTF-8 locales (e.g. Chinese Windows GBK), a binary git
         # output that fails to decode used to leave r.stdout = None and crash
@@ -2114,6 +2119,7 @@ def _list_checkout_processes(path: Path, *, limit: int = 25) -> list[dict]:
             timeout=5,
             encoding='utf-8',
             errors='replace',
+            creationflags=_NO_CONSOLE_WINDOW,
         )
     except (OSError, subprocess.TimeoutExpired):
         return []

--- a/api/updates.py
+++ b/api/updates.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -214,14 +215,28 @@ def _run_git(args, cwd, timeout=10):
     On failure, returns stderr (or stdout as fallback) so callers can
     surface actionable git error messages instead of empty strings.
     """
+    return _run_git_env(args, cwd, timeout=timeout)
+
+
+def _run_git_env(args, cwd, timeout=10, env=None):
+    """Run git, optionally with extra environment (used for temp-index snapshots).
+
+    Intentionally separate from ``_run_git`` so mocked apply tests that replace
+    ``_run_git`` do not intercept the lossless snapshot object-db writes.
+    """
     git_executable = _resolve_git_executable()
     if not git_executable:
         return 'git executable not found', False
+    run_env = None
+    if env:
+        run_env = os.environ.copy()
+        run_env.update(env)
     try:
         r = subprocess.run(
             [git_executable] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
             encoding='utf-8', errors='replace',
+            env=run_env,
             creationflags=_NO_CONSOLE_WINDOW,
         )
         # On non-UTF-8 locales (e.g. Chinese Windows GBK), a binary git
@@ -2002,26 +2017,26 @@ def apply_force_update(target: str, channel=None) -> dict:
                 'refused_rewind': True,
             }
 
-        # Preserve local commits before destructive reset. Force-update still
-        # discards the working tree tip, but never silently deletes commits.
+        # Preserve local commits AND working-tree bytes before destructive reset.
+        # Force-update still moves HEAD, but recovery must reload exact dirty
+        # tracked / untracked bytes when we claim a backup/recovery artifact.
         sync = _describe_checkout_sync(path, compare_ref)
+        snapshot = None
         backup_branch = None
-        if sync.get('relationship') in {'ahead', 'diverged'} or (
-            isinstance(sync.get('ahead'), int) and sync['ahead'] > 0
-        ) or sync.get('dirty_tracked'):
-            backup = _create_update_backup_branch(path)
-            if backup.get('ok'):
-                backup_branch = backup['branch']
-            else:
+        if _needs_update_snapshot(sync):
+            snapshot = _create_update_recovery_snapshot(path, sync)
+            if not snapshot.get('ok'):
                 return {
                     'ok': False,
                     'message': (
-                        'Force update aborted: could not create a backup branch '
-                        f'before reset ({backup.get("error") or "unknown error"}). '
+                        'Force update aborted: could not create a verified '
+                        'recovery snapshot before reset '
+                        f'({snapshot.get("error") or "unknown error"}). '
                         'Local commits/modifications were left untouched.'
                     ),
                     'target': target,
                 }
+            backup_branch = snapshot['branch']
 
         # Discard local modifications and untracked colliders before resetting.
         # Do not use -x: ignored build/cache artifacts should survive force update.
@@ -2045,7 +2060,12 @@ def apply_force_update(target: str, channel=None) -> dict:
             )
         _, ok = _run_git(['reset', '--hard', compare_ref], path)
         if not ok:
-            return {'ok': False, 'message': f'Force reset to {compare_ref} failed'}
+            response = {
+                'ok': False,
+                'message': f'Force reset to {compare_ref} failed',
+                'target': target,
+            }
+            return _attach_recovery(response, path, snapshot)
 
         with _cache_lock:
             _update_cache['checked_at'] = 0
@@ -2053,12 +2073,13 @@ def apply_force_update(target: str, channel=None) -> dict:
         if target == 'agent':
             gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
             if not gateway_ok:
-                return {
+                response = {
                     'ok': False,
                     'message': _agent_gateway_restart_failure_message(target, gateway_result),
                     'target': target,
                     'gateway_restart': gateway_result.get('status'),
                 }
+                return _attach_recovery(response, path, snapshot)
 
         _schedule_restart()
 
@@ -2066,12 +2087,14 @@ def apply_force_update(target: str, channel=None) -> dict:
             'ok': True,
             'message': (
                 f'{target} force-updated to {compare_ref}'
-                + (f' (local tip preserved on {backup_branch})' if backup_branch else '')
+                + (f' (local state preserved on {backup_branch})' if backup_branch else '')
             ),
             'target': target,
             'restart_scheduled': True,
             'backup_branch': backup_branch,
         }
+        if backup_branch:
+            response['recovery_ref'] = backup_branch
         if target == 'agent':
             response['gateway_restart'] = gateway_result.get('status')
         return response
@@ -2221,7 +2244,125 @@ def _describe_checkout_sync(path: Path, compare_ref: str | None) -> dict:
     return result
 
 
-def _create_update_backup_branch(path: Path, *, prefix: str = 'hermes-update-backup') -> dict:
+_UPDATE_RECOVERY_PREFIX = 'hermes-update-backup'
+_SHA_RE = re.compile(r'^[0-9a-f]{40,64}$')
+
+
+def _is_real_git_checkout(path: Path) -> bool:
+    """Return True when ``path`` has a usable git HEAD (not a tests-only ``.git`` stub)."""
+    git_dir = path / '.git'
+    if git_dir.is_file():
+        return True
+    return git_dir.is_dir() and (git_dir / 'HEAD').exists()
+
+
+def _needs_update_snapshot(sync: dict) -> bool:
+    """True when local commits, dirty tracked files, or untracked files exist."""
+    if sync.get('relationship') in {'ahead', 'diverged'}:
+        return True
+    ahead = sync.get('ahead')
+    if isinstance(ahead, int) and ahead > 0:
+        return True
+    if sync.get('dirty_tracked') or sync.get('dirty'):
+        return True
+    if sync.get('untracked_count') or sync.get('untracked_files'):
+        return True
+    return False
+
+
+def _posix_relpath(path: Path, rel: str) -> str:
+    return Path(rel).as_posix().lstrip('./')
+
+
+def _iter_worktree_files(root: Path, rel: str) -> list[str]:
+    """Expand a porcelain path to concrete files (handles untracked directories)."""
+    rel = _posix_relpath(root, rel)
+    target = root / rel
+    if target.is_dir():
+        return [
+            f.relative_to(root).as_posix()
+            for f in target.rglob('*')
+            if f.is_file()
+        ]
+    if target.is_file() or target.is_symlink():
+        return [rel]
+    return []
+
+
+def _list_snapshot_paths(path: Path) -> list[str]:
+    """Dirty tracked paths plus untracked, non-ignored files."""
+    dirty, dirty_ok = _run_git_env(['diff', '--name-only', 'HEAD'], path)
+    staged, staged_ok = _run_git_env(['diff', '--name-only', '--cached'], path)
+    untracked, untracked_ok = _run_git_env(
+        ['ls-files', '-z', '--others', '--exclude-standard'], path,
+    )
+    names: list[str] = []
+    if dirty_ok and dirty:
+        names.extend(dirty.splitlines())
+    if staged_ok and staged:
+        names.extend(staged.splitlines())
+    if untracked_ok and untracked:
+        names.extend(p for p in untracked.split('\0') if p)
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        for rel in _iter_worktree_files(path, name):
+            if rel not in seen:
+                seen.add(rel)
+                expanded.append(rel)
+    return expanded
+
+
+def _list_untracked_files(path: Path) -> tuple[list[str], bool]:
+    """Untracked, non-ignored files only. Never includes dirty tracked paths."""
+    out, ok = _run_git_env(
+        ['ls-files', '-z', '--others', '--exclude-standard'], path,
+    )
+    if not ok:
+        return [], False
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for name in (p for p in out.split('\0') if p):
+        for rel in _iter_worktree_files(path, name):
+            if rel not in seen:
+                seen.add(rel)
+                expanded.append(rel)
+    return expanded, True
+
+
+def _recovery_ref_instructions(path: Path, branch: str | None) -> str:
+    if not branch:
+        return (
+            f'No recovery snapshot is available. Inspect with: git -C {path} status'
+        )
+    return (
+        f'Recovery snapshot is {branch} and must be retained. '
+        f'Inspect: git -C {path} log -1 --stat {branch}. '
+        f'Restore exact bytes for a path: git -C {path} show {branch}:PATH. '
+        f'Restore the snapshotted tree: git -C {path} checkout {branch} -- .'
+    )
+
+
+def _attach_recovery(response: dict, path: Path, snapshot: dict | None) -> dict:
+    """Stamp recovery fields onto an update response. Never drops the recovery ref."""
+    if not snapshot or not snapshot.get('branch'):
+        return response
+    branch = snapshot['branch']
+    response['backup_branch'] = branch
+    response['recovery_ref'] = branch
+    if snapshot.get('commit'):
+        response['recovery_commit'] = snapshot['commit']
+    captured = snapshot.get('captured_paths') or []
+    if captured:
+        response['recovery_paths'] = captured
+    message = (response.get('message') or '').rstrip()
+    instructions = _recovery_ref_instructions(path, branch)
+    if instructions not in message:
+        response['message'] = f'{message} {instructions}'.strip()
+    return response
+
+
+def _create_update_backup_branch(path: Path, *, prefix: str = _UPDATE_RECOVERY_PREFIX) -> dict:
     """Create a timestamped branch at HEAD. Never moves/deletes existing refs."""
     stamp = _utc_stamp()
     branch = f'{prefix}/{stamp}'
@@ -2231,9 +2372,160 @@ def _create_update_backup_branch(path: Path, *, prefix: str = 'hermes-update-bac
         branch = f'{prefix}/{stamp}-{os.getpid()}'
         out, ok = _run_git(['branch', branch, 'HEAD'], path)
     if not ok:
-        return {'ok': False, 'branch': None, 'error': out}
+        return {'ok': False, 'branch': None, 'commit': None, 'error': out}
     head_sha, _ = _run_git(['rev-parse', 'HEAD'], path)
-    return {'ok': True, 'branch': branch, 'head_sha': head_sha, 'error': None}
+    return {
+        'ok': True,
+        'branch': branch,
+        'head_sha': head_sha,
+        'commit': head_sha,
+        'captured_paths': [],
+        'error': None,
+    }
+
+
+def _verify_snapshot_bytes(path: Path, commit: str, captured_paths: list[str]) -> tuple[bool, str]:
+    """Confirm every captured working-tree path hashes identically in ``commit``."""
+    for rel in captured_paths:
+        wt_hash, wt_ok = _run_git_env(['hash-object', '--', rel], path)
+        blob, blob_ok = _run_git_env(['rev-parse', f'{commit}:{rel}'], path)
+        if not wt_ok or not blob_ok or not wt_hash or wt_hash != blob:
+            return False, (
+                f'snapshot verification failed for {rel}: '
+                f'working-tree {wt_hash or "(missing)"} vs snapshot {blob or "(missing)"}'
+            )
+    return True, ''
+
+
+def _create_worktree_snapshot_commit(path: Path, captured_paths: list[str]) -> dict:
+    """Commit HEAD + dirty tracked + untracked bytes without mutating the checkout.
+
+    Uses a temporary index (GIT_INDEX_FILE) so the real index and working tree
+    stay untouched. Verifies blob hashes before the recovery ref is created.
+    """
+    head_sha, head_ok = _run_git_env(['rev-parse', 'HEAD'], path)
+    if not head_ok or not _SHA_RE.match(head_sha or ''):
+        return {'ok': False, 'error': f'cannot resolve HEAD: {head_sha}'}
+
+    stamp = _utc_stamp()
+    pid = os.getpid()
+    index_path = Path(tempfile.gettempdir()) / f'hermes-update-tmp-index-{stamp}-{pid}'
+    env = {
+        'GIT_INDEX_FILE': str(index_path),
+        'GIT_AUTHOR_NAME': 'hermes-webui',
+        'GIT_AUTHOR_EMAIL': 'hermes-webui@localhost',
+        'GIT_COMMITTER_NAME': 'hermes-webui',
+        'GIT_COMMITTER_EMAIL': 'hermes-webui@localhost',
+    }
+    try:
+        out, ok = _run_git_env(['read-tree', 'HEAD'], path, env=env)
+        if not ok:
+            return {'ok': False, 'error': f'read-tree failed: {out}'}
+        out, ok = _run_git_env(['add', '-A', '--'], path, env=env)
+        if not ok:
+            return {'ok': False, 'error': f'git add -A failed: {out}'}
+        tree, ok = _run_git_env(['write-tree'], path, env=env)
+        if not ok or not _SHA_RE.match(tree or ''):
+            return {'ok': False, 'error': f'write-tree failed: {tree}'}
+        message = f'hermes-update-recovery {stamp}'
+        commit, ok = _run_git_env(
+            ['commit-tree', tree, '-p', head_sha, '-m', message],
+            path,
+            env=env,
+        )
+        if not ok or not _SHA_RE.match(commit or ''):
+            return {'ok': False, 'error': f'commit-tree failed: {commit}'}
+        verified, verify_error = _verify_snapshot_bytes(path, commit, captured_paths)
+        if not verified:
+            return {'ok': False, 'error': verify_error, 'commit': commit}
+        branch = f'{_UPDATE_RECOVERY_PREFIX}/{stamp}'
+        out, ok = _run_git_env(['branch', branch, commit], path)
+        if not ok:
+            branch = f'{_UPDATE_RECOVERY_PREFIX}/{stamp}-{pid}'
+            out, ok = _run_git_env(['branch', branch, commit], path)
+        if not ok:
+            return {
+                'ok': False,
+                'error': f'failed to create recovery branch: {out}',
+                'commit': commit,
+            }
+        return {
+            'ok': True,
+            'branch': branch,
+            'commit': commit,
+            'head_sha': head_sha,
+            'captured_paths': list(captured_paths),
+            'error': None,
+        }
+    finally:
+        try:
+            index_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        try:
+            Path(str(index_path) + '.lock').unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _create_update_recovery_snapshot(path: Path, sync: dict | None = None) -> dict:
+    """Create a verified recovery ref capturing local commits and working-tree bytes.
+
+    Abort contract: callers must not reset/checkout/clean/pull if this returns
+    ``ok: False``. Ignored files are omitted because the updater never uses
+    ``git clean -x``; they survive force update.
+    """
+    sync = sync or {}
+    captured: list[str] = []
+    if _is_real_git_checkout(path) and (
+        sync.get('dirty_tracked') or sync.get('dirty') or sync.get('untracked_count')
+        or sync.get('untracked_files') or sync.get('modified_files')
+    ):
+        captured = _list_snapshot_paths(path)
+
+    if captured:
+        snapshot = _create_worktree_snapshot_commit(path, captured)
+        if snapshot.get('ok'):
+            return snapshot
+        return snapshot
+
+    # HEAD-only ref: local commits with a clean tree, or mocked .git stubs.
+    backup = _create_update_backup_branch(path)
+    if backup.get('ok'):
+        backup['captured_paths'] = []
+    return backup
+
+
+def _untracked_colliders(path: Path, compare_ref: str, untracked_files: list[str]) -> list[str]:
+    """Untracked working-tree files that ``compare_ref`` already tracks."""
+    if not compare_ref or not untracked_files:
+        return []
+    tree_out, tree_ok = _run_git(['ls-tree', '-r', '--name-only', compare_ref], path)
+    if not tree_ok:
+        return []
+    tracked = {line.strip() for line in tree_out.splitlines() if line.strip()}
+    colliders: list[str] = []
+    seen: set[str] = set()
+    for name in untracked_files:
+        for rel in _iter_worktree_files(path, name):
+            if rel in tracked and rel not in seen:
+                seen.add(rel)
+                colliders.append(rel)
+    return colliders
+
+
+def _remove_untracked_colliders(path: Path, colliders: list[str]) -> tuple[bool, str]:
+    """Delete colliding untracked files after a verified snapshot exists."""
+    for rel in colliders:
+        target = path / rel
+        try:
+            if target.is_file() or target.is_symlink():
+                target.unlink()
+            elif target.is_dir():
+                shutil.rmtree(target)
+        except OSError as exc:
+            return False, f'failed to move colliding untracked path {rel} aside: {exc}'
+    return True, ''
 
 
 def _stash_message() -> str:
@@ -2398,39 +2690,81 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             'behind': sync.get('behind'),
         }
 
+    snapshot = None
     backup_branch = None
     local_commits = sync.get('relationship') in {'ahead', 'diverged'} or (
         isinstance(sync.get('ahead'), int) and sync['ahead'] > 0
     )
-    if local_commits:
-        backup = _create_update_backup_branch(path)
-        if not backup.get('ok'):
+    collider_paths: list[str] = []
+    if _needs_update_snapshot(sync):
+        snapshot = _create_update_recovery_snapshot(path, sync)
+        if not snapshot.get('ok'):
             return {
                 'ok': False,
                 'message': (
-                    f'The local {target} checkout has commits not on '
-                    f'{compare_ref}, and creating a backup branch failed '
-                    f'({backup.get("error") or "unknown error"}). '
-                    'Update aborted without discarding local commits. '
+                    f'Update aborted before mutating {target}: could not create '
+                    'a verified recovery snapshot '
+                    f'({snapshot.get("error") or "unknown error"}). '
+                    'Local commits, dirty tracked files, and untracked files '
+                    'were left untouched. '
                     f'Inspect with: git -C {path} status && '
                     f'git -C {path} log --oneline {compare_ref}..HEAD'
                 ),
-                'diverged': True,
+                'diverged': bool(local_commits),
                 'relationship': sync.get('relationship'),
                 'ahead': sync.get('ahead'),
                 'behind': sync.get('behind'),
             }
-        backup_branch = backup['branch']
+        backup_branch = snapshot['branch']
         logger.info(
-            'update preflight: preserved %s HEAD %s on backup branch %s '
-            '(relationship=%s ahead=%s behind=%s)',
+            'update preflight: preserved %s HEAD %s on recovery ref %s '
+            '(relationship=%s ahead=%s behind=%s captured=%s)',
             target,
-            backup.get('head_sha'),
+            snapshot.get('head_sha'),
             backup_branch,
             sync.get('relationship'),
             sync.get('ahead'),
             sync.get('behind'),
+            snapshot.get('captured_paths'),
         )
+
+    if _is_real_git_checkout(path) and (sync.get('untracked_count') or sync.get('untracked_files')):
+        # Must come from git, not from the snapshot's captured_paths: those also
+        # contain dirty TRACKED files, and treating one as a collider would
+        # unlink it from the working tree before the stash push.
+        untracked, listed = _list_untracked_files(path)
+        if not listed:
+            untracked = list(sync.get('untracked_files') or [])
+        collider_paths = _untracked_colliders(path, compare_ref, untracked)
+        if collider_paths and not backup_branch:
+            return {
+                'ok': False,
+                'message': (
+                    f'Update aborted before mutating {target}: untracked path(s) '
+                    f'{", ".join(collider_paths)} collide with {compare_ref} and '
+                    'no verified recovery snapshot exists. Local bytes were left '
+                    f'untouched. Inspect with: git -C {path} status'
+                ),
+                'conflict': True,
+                'relationship': sync.get('relationship'),
+                'ahead': sync.get('ahead'),
+                'behind': sync.get('behind'),
+            }
+        if collider_paths:
+            cleared, clear_error = _remove_untracked_colliders(path, collider_paths)
+            if not cleared:
+                response = {
+                    'ok': False,
+                    'message': (
+                        f'Update aborted before reset/checkout/clean: {clear_error} '
+                        'Colliding untracked files were left in the working tree.'
+                    ),
+                    'conflict': True,
+                    'relationship': sync.get('relationship'),
+                    'ahead': sync.get('ahead'),
+                    'behind': sync.get('behind'),
+                }
+                return _attach_recovery(response, path, snapshot)
 
     stashed = False
     stash_label = None
@@ -2438,7 +2772,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         stash_label = _stash_message()
         _, ok = _run_git(['stash', 'push', '-m', stash_label], path)
         if not ok:
-            return {
+            response = {
                 'ok': False,
                 'message': (
                     'Failed to stash local changes before update; '
@@ -2448,6 +2782,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 'backup_branch': backup_branch,
                 'relationship': sync.get('relationship'),
             }
+            return _attach_recovery(response, path, snapshot)
         stashed = True
 
     # Agent production checkouts should track upstream. When local commits make
@@ -2463,12 +2798,12 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 stash_recovery_note = _restore_stash_after_pull_failure(
                     target, path, f'reset --hard {compare_ref} failed'
                 )
-            return {
+            return _attach_recovery({
                 'ok': False,
                 'message': (
                     f'Failed to reset {target} to {compare_ref} after creating '
-                    f'backup branch {backup_branch}. Local commits are still on '
-                    f'that branch.'
+                    f'recovery snapshot {backup_branch}. Local commits and '
+                    'working-tree bytes remain on that ref.'
                     + (f' {stash_recovery_note}' if stash_recovery_note else '')
                 ),
                 'diverged': True,
@@ -2476,7 +2811,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 'relationship': sync.get('relationship'),
                 'ahead': sync.get('ahead'),
                 'behind': sync.get('behind'),
-            }
+            }, path, snapshot)
         used_safe_reset = True
         pull_out, pull_ok = f'Reset to {compare_ref}', True
     elif local_commits and target == 'webui':
@@ -2500,7 +2835,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             'Use Force Update to discard the local branch tip after confirming '
             f'the backup, or recover with: git -C {path} checkout {backup_branch}'
         )
-        return {
+        return _attach_recovery({
             'ok': False,
             'message': ' '.join(message_parts),
             'diverged': True,
@@ -2509,7 +2844,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             'relationship': sync.get('relationship'),
             'ahead': sync.get('ahead'),
             'behind': sync.get('behind'),
-        }
+        }, path, snapshot)
     else:
         # Pull with ff-only (no merge commits).
         # Split tracking refs like 'origin/main' into separate remote + branch
@@ -2538,12 +2873,12 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 message = f'{message} {stash_recovery_note}'
             if backup_branch:
                 message = f'{message} Local commits remain on {backup_branch}.'
-            return {
+            return _attach_recovery({
                 'ok': False,
                 'message': message,
                 'lock_conflict': True,
                 'backup_branch': backup_branch,
-            }
+            }, path, snapshot)
         pull_lower = pull_out.lower()
         detail = pull_out.strip()[:300] if pull_out.strip() else '(no output from git)'
         untracked_collision = (
@@ -2579,7 +2914,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                     }
                     if diverged_failure:
                         response['diverged'] = True
-                    return response
+                    return _attach_recovery(response, path, snapshot)
                 response = {
                     'ok': False,
                     'message': (
@@ -2596,7 +2931,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 }
                 if diverged_failure:
                     response['diverged'] = True
-                return response
+                return _attach_recovery(response, path, snapshot)
 
         restored_note_parts = []
         if restored_stash:
@@ -2640,7 +2975,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                     'Run: git -C ' + str(path) + ' fetch origin && '
                     'git -C ' + str(path) + ' reset --hard ' + compare_ref
                 )
-            return {
+            return _attach_recovery({
                 'ok': False,
                 'message': ' '.join(message_parts),
                 'diverged': True,
@@ -2648,7 +2983,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 'relationship': sync.get('relationship'),
                 'ahead': sync.get('ahead'),
                 'behind': sync.get('behind'),
-            }
+            }, path, snapshot)
         if 'does not track' in pull_lower or 'no tracking information' in pull_lower:
             message_parts = [
                 f'The local {target} branch has no upstream tracking branch configured.'
@@ -2658,11 +2993,11 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
             message_parts.append(
                 'Run: git -C ' + str(path) + ' branch --set-upstream-to=' + compare_ref
             )
-            return {
+            return _attach_recovery({
                 'ok': False,
                 'message': ' '.join(message_parts),
                 'backup_branch': backup_branch,
-            }
+            }, path, snapshot)
         # Generic fallback — include the raw git output for debugging.
         message_parts = [f'Pull failed: {detail}']
         if restored_note:
@@ -2674,7 +3009,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         }
         if untracked_collision:
             response['conflict'] = True
-        return response
+        return _attach_recovery(response, path, snapshot)
 
     # Re-apply stash if we stashed.
     stash_drop_failed = False
@@ -2686,47 +3021,58 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         else:
             _, reset_ok = _run_git(['reset', '--hard', 'HEAD'], path)
             if not reset_ok:
-                return {
+                return _attach_recovery({
                     'ok': False,
                     'message': (
                         'Updated successfully, but failed to clean up a '
                         'stash-apply conflict. Manual intervention needed: '
                         'run git -C ' + str(path) + ' reset --hard HEAD to '
                         'remove conflict markers. Your changes remain in the '
-                        'git stash.'
+                        'git stash and on the recovery snapshot.'
                     ),
                     'stash_conflict': True,
-                }
+                }, path, snapshot)
             with _cache_lock:
                 _update_cache['checked_at'] = 0
 
             if target == 'agent':
                 gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
                 if not gateway_ok:
-                    return {
+                    return _attach_recovery({
                         'ok': False,
                         'message': _agent_gateway_restart_failure_message(target, gateway_result),
                         'target': target,
                         'gateway_restart': gateway_result.get('status'),
-                    }
+                        'stash_conflict': True,
+                    }, path, snapshot)
             _schedule_restart()
+            conflict_message = (
+                f'{target} updated to the latest version. Your local '
+                'modifications conflicted with upstream changes and were '
+                'set aside in a git stash. To inspect: '
+                'git -C ' + str(path) + ' stash show -p. To re-apply: '
+                'git -C ' + str(path) + ' stash apply, then resolve '
+                'conflicts. Drop the stash after you are satisfied.'
+            )
+            if collider_paths:
+                conflict_message += (
+                    f' Untracked path(s) {", ".join(collider_paths)} collided with '
+                    f'{compare_ref} and were replaced by upstream content; recover '
+                    f'exact local bytes with: git -C {path} show '
+                    f'{backup_branch or "<recovery-ref>"}:PATH'
+                )
             response = {
                 'ok': True,
-                'message': (
-                    f'{target} updated to the latest version. Your local '
-                    'modifications conflicted with upstream changes and were '
-                    'set aside in a git stash. To inspect: '
-                    'git -C ' + str(path) + ' stash show -p. To re-apply: '
-                    'git -C ' + str(path) + ' stash apply, then resolve '
-                    'conflicts. Drop the stash after you are satisfied.'
-                ),
+                'message': conflict_message,
                 'target': target,
                 'restart_scheduled': True,
                 'stash_conflict': True,
             }
+            if collider_paths:
+                response['untracked_colliders'] = collider_paths
             if target == 'agent':
                 response['gateway_restart'] = gateway_result.get('status')
-            return response
+            return _attach_recovery(response, path, snapshot)
 
     # Invalidate cache
     with _cache_lock:
@@ -2735,12 +3081,12 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     if target == 'agent':
         gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
         if not gateway_ok:
-            return {
+            return _attach_recovery({
                 'ok': False,
                 'message': _agent_gateway_restart_failure_message(target, gateway_result),
                 'target': target,
                 'gateway_restart': gateway_result.get('status'),
-            }
+            }, path, snapshot)
 
     # Schedule a self-restart so the updated code is loaded fresh.  A plain
     # git pull leaves stale Python modules in sys.modules — agent imports that
@@ -2757,8 +3103,14 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     message = f'{target} updated successfully'
     if used_safe_reset and backup_branch:
         message = (
-            f'{target} updated to {compare_ref} after preserving local commits '
-            f'on backup branch {backup_branch}'
+            f'{target} updated to {compare_ref} after preserving local state '
+            f'on recovery snapshot {backup_branch}'
+        )
+    if collider_paths and backup_branch:
+        message += (
+            f'. Untracked path(s) {", ".join(collider_paths)} collided with '
+            f'{compare_ref} and were preserved on {backup_branch}; recover exact '
+            f'bytes with: git -C {path} show {backup_branch}:PATH'
         )
     if stash_drop_failed:
         message += (
@@ -2775,6 +3127,10 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         'relationship': sync.get('relationship'),
         'safe_reset': used_safe_reset,
     }
+    if backup_branch:
+        response['recovery_ref'] = backup_branch
+    if collider_paths:
+        response['untracked_colliders'] = collider_paths
     if target == 'agent':
         response['gateway_restart'] = gateway_result.get('status')
     return response

--- a/scripts/diagnose_agent_checkout.py
+++ b/scripts/diagnose_agent_checkout.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Report Hermes agent/webui checkout sync state for update troubleshooting.
+
+Non-mutating: does not fetch, stash, reset, or modify the working tree.
+Prints branch, commit, remote, ahead/behind/diverged, dirty files, and
+processes referencing the checkout.
+
+Can run with system Python (no WebUI deps required). When --via-api is set,
+uses hermes-webui's diagnose_checkout() for the same fields the HTTP API
+returns.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[str, bool]:
+    try:
+        proc = subprocess.run(
+            ['git', *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            encoding='utf-8',
+            errors='replace',
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return str(exc), False
+    out = ((proc.stdout or '') + (proc.stderr or '')).strip() if proc.returncode else (proc.stdout or '').strip()
+    if proc.returncode == 0:
+        return (proc.stdout or '').strip(), True
+    return out or f'git exited {proc.returncode}', False
+
+
+def _default_agent_dir() -> Path:
+    env = os.environ.get('HERMES_WEBUI_AGENT_DIR') or os.environ.get('HERMES_AGENT_DIR')
+    if env:
+        return Path(env).expanduser()
+    home = Path(os.environ.get('HERMES_HOME', Path.home() / '.hermes')).expanduser()
+    return home / 'hermes-agent'
+
+
+def _list_processes(path: Path, *, limit: int = 25) -> list[dict]:
+    needle = str(path)
+    try:
+        proc = subprocess.run(
+            ['ps', '-ax', '-o', 'pid=,command='],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            encoding='utf-8',
+            errors='replace',
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    hits: list[dict] = []
+    for line in (proc.stdout or '').splitlines():
+        text = line.strip()
+        if not text or needle not in text:
+            continue
+        parts = text.split(None, 1)
+        try:
+            pid = int(parts[0])
+        except (ValueError, IndexError):
+            continue
+        hits.append({'pid': pid, 'command': parts[1] if len(parts) > 1 else ''})
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def _standalone_diagnose(path: Path) -> dict:
+    if not (path / '.git').exists():
+        return {'ok': False, 'path': str(path), 'message': 'Not a git repository'}
+
+    branch, _ = _run_git(['rev-parse', '--abbrev-ref', 'HEAD'], path)
+    head, head_ok = _run_git(['rev-parse', 'HEAD'], path)
+    remote, _ = _run_git(['remote', 'get-url', 'origin'], path)
+    upstream, up_ok = _run_git(['rev-parse', '--abbrev-ref', '@{upstream}'], path)
+    if not up_ok:
+        # Prefer origin/main then origin/master for agent/webui defaults.
+        for candidate in ('origin/main', 'origin/master'):
+            _, ok = _run_git(['rev-parse', '--verify', candidate], path)
+            if ok:
+                upstream = candidate
+                up_ok = True
+                break
+    compare_ref = upstream if up_ok else None
+    compare_sha = None
+    ahead = behind = None
+    relationship = 'unknown'
+    if compare_ref and head_ok:
+        compare_sha, tip_ok = _run_git(['rev-parse', compare_ref], path)
+        if tip_ok and compare_sha == head:
+            relationship = 'identical'
+            ahead = behind = 0
+        elif tip_ok:
+            ahead_out, ahead_ok = _run_git(['rev-list', '--count', f'{compare_sha}..{head}'], path)
+            behind_out, behind_ok = _run_git(['rev-list', '--count', f'{head}..{compare_sha}'], path)
+            ahead = int(ahead_out) if ahead_ok and ahead_out.isdigit() else None
+            behind = int(behind_out) if behind_ok and behind_out.isdigit() else None
+            _, can_ff = _run_git(['merge-base', '--is-ancestor', 'HEAD', compare_ref], path)
+            _, head_has = _run_git(['merge-base', '--is-ancestor', compare_ref, 'HEAD'], path)
+            if can_ff and not head_has:
+                relationship = 'behind'
+            elif head_has and not can_ff:
+                relationship = 'ahead'
+            else:
+                relationship = 'diverged'
+
+    status, status_ok = _run_git(['status', '--porcelain'], path)
+    modified: list[str] = []
+    untracked: list[str] = []
+    if status_ok:
+        for line in status.splitlines():
+            if len(line) < 4:
+                continue
+            code, name = line[:2], line[3:]
+            if code == '??':
+                untracked.append(name)
+            else:
+                modified.append(name)
+
+    return {
+        'ok': True,
+        'path': str(path),
+        'branch': branch or None,
+        'head_sha': head if head_ok else None,
+        'remote_url': remote or None,
+        'compare_ref': compare_ref,
+        'compare_sha': compare_sha,
+        'relationship': relationship,
+        'ahead': ahead,
+        'behind': behind,
+        'dirty': bool(status_ok and status),
+        'dirty_tracked': bool(modified),
+        'modified_files': modified[:100],
+        'untracked_files': untracked[:100],
+        'modified_count': len(modified),
+        'untracked_count': len(untracked),
+        'processes': _list_processes(path),
+    }
+
+
+def _print_report(report: dict) -> None:
+    if not report.get('ok'):
+        print(f"ERROR: {report.get('message') or 'diagnose failed'}")
+        if report.get('path'):
+            print(f"path: {report['path']}")
+        return
+    print(f"target:      {report.get('target', '-')}")
+    print(f"path:        {report.get('path')}")
+    print(f"branch:      {report.get('branch')}")
+    print(f"HEAD:        {report.get('head_sha')}")
+    print(f"remote:      {report.get('remote_url')}")
+    print(f"compare_ref: {report.get('compare_ref')}")
+    if report.get('compare_sha'):
+        print(f"compare_sha: {report.get('compare_sha')}")
+    print(f"relationship:{report.get('relationship')}")
+    print(f"ahead:       {report.get('ahead')}")
+    print(f"behind:      {report.get('behind')}")
+    print(f"dirty:       {report.get('dirty')} (tracked={report.get('dirty_tracked')})")
+    print(f"modified:    {report.get('modified_count')} file(s)")
+    for name in report.get('modified_files') or []:
+        print(f"  M {name}")
+    print(f"untracked:   {report.get('untracked_count')} file(s)")
+    for name in report.get('untracked_files') or []:
+        print(f"  ? {name}")
+    procs = report.get('processes') or []
+    print(f"processes:   {len(procs)}")
+    for proc in procs:
+        cmd = (proc.get('command') or '')[:160]
+        print(f"  pid {proc.get('pid')}: {cmd}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--target', choices=('agent', 'webui'), default='agent')
+    parser.add_argument('--json', action='store_true')
+    parser.add_argument(
+        '--via-api',
+        action='store_true',
+        help='Use api.updates.diagnose_checkout (requires WebUI Python deps)',
+    )
+    parser.add_argument(
+        '--path',
+        help='Override checkout path (defaults: agent ~/.hermes/hermes-agent, webui repo root)',
+    )
+    args = parser.parse_args(argv)
+
+    if args.via_api:
+        if str(REPO_ROOT) not in sys.path:
+            sys.path.insert(0, str(REPO_ROOT))
+        from api.updates import diagnose_checkout
+
+        report = diagnose_checkout(args.target)
+    else:
+        if args.path:
+            path = Path(args.path).expanduser()
+        elif args.target == 'webui':
+            path = REPO_ROOT
+        else:
+            path = _default_agent_dir()
+        report = _standalone_diagnose(path)
+        report['target'] = args.target
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_report(report)
+    return 0 if report.get('ok') else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -469,6 +469,28 @@ def _pytest_session_safe_execv(_exe, _args):  # pragma: no cover — never calle
 
 os.execv = _pytest_session_safe_execv
 
+# ── Windows counterpart of the execv guard ─────────────────────────────────
+# The guard above only covers the POSIX branch of _schedule_restart(). On
+# Windows os.execv() does not replace the process, so _schedule_restart()
+# instead spawns a DETACHED copy of the current command line and then calls
+# os._exit(0). Inside pytest that command line is the pytest invocation
+# itself: a late-firing daemon thread kills the runner mid-session AND
+# relaunches the whole suite detached, which then schedules its own restarts
+# — a self-multiplying storm of background pytest sessions.
+#
+# os.execv can be neutered in place because it is a leaf call; the Windows
+# branch cannot, because the damage is done by the Popen() before os._exit().
+# So the whole scheduler is made inert for the session instead. Tests that
+# assert restart behaviour monkeypatch _schedule_restart themselves and are
+# unaffected; production never imports this conftest.
+if sys.platform == 'win32':  # pragma: no cover — POSIX CI never takes this path
+    try:
+        import api.updates as _hermes_updates
+
+        _hermes_updates._schedule_restart = lambda delay=2.0: None
+    except Exception:
+        pass
+
 # ── Hermetic network isolation ─────────────────────────────────────────────
 # Tests must not reach the public internet. Outbound to Anthropic / OpenAI /
 # Amazon / OpenRouter / etc. is forbidden by default. The test suite already

--- a/tests/test_update_stash_recovery.py
+++ b/tests/test_update_stash_recovery.py
@@ -4,6 +4,39 @@ from unittest.mock import patch
 import api.updates as updates
 
 
+def _behind_sync(**overrides):
+    base = {
+        'path': '/tmp/repo',
+        'branch': 'master',
+        'head_sha': 'abc',
+        'remote_url': 'https://example.test/repo.git',
+        'compare_ref': 'origin/master',
+        'compare_sha': 'def',
+        'ahead': 0,
+        'behind': 1,
+        'relationship': 'behind',
+        'dirty': False,
+        'dirty_tracked': False,
+        'modified_files': [],
+        'untracked_files': [],
+        'modified_count': 0,
+        'untracked_count': 0,
+        'processes': [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _is_autostash_push(args) -> bool:
+    return (
+        len(args) >= 4
+        and args[0] == 'stash'
+        and args[1] == 'push'
+        and args[2] == '-m'
+        and str(args[3]).startswith('hermes-update-autostash')
+    )
+
+
 def test_pull_failure_untracked_overwrite_flags_conflict(tmp_path):
     """Untracked overwrite pull failures must surface the existing force-update path."""
     (tmp_path / '.git').mkdir()
@@ -31,6 +64,7 @@ def test_pull_failure_untracked_overwrite_flags_conflict(tmp_path):
         patch.object(updates, 'REPO_ROOT', tmp_path),
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -39,7 +73,7 @@ def test_pull_failure_untracked_overwrite_flags_conflict(tmp_path):
     assert result['conflict'] is True
     assert result['message'].startswith('Pull failed:')
     assert 'untracked working tree files would be overwritten' in result['message']
-    assert ['stash', 'push', '-m', 'hermes-update-autostash'] not in call_log
+    assert not any(_is_autostash_push(args) for args in call_log)
     assert len(restart_calls) == 0
 
 
@@ -70,6 +104,7 @@ def test_apply_force_update_removes_untracked_files_before_reset(tmp_path):
         patch.object(updates, 'REPO_ROOT', tmp_path),
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates.apply_force_update('webui')
@@ -113,6 +148,7 @@ def test_apply_force_update_proceeds_when_clean_fails(tmp_path):
         patch.object(updates, 'REPO_ROOT', tmp_path),
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates.apply_force_update('webui')
@@ -136,7 +172,7 @@ def test_stash_apply_conflict_preserves_stash(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Already up to date.', True
@@ -151,6 +187,7 @@ def test_stash_apply_conflict_preserves_stash(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -174,7 +211,7 @@ def test_stash_apply_reset_failure_returns_error(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Already up to date.', True
@@ -189,6 +226,7 @@ def test_stash_apply_reset_failure_returns_error(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -213,7 +251,7 @@ def test_stash_apply_success_drops_and_restarts(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Already up to date.', True
@@ -228,6 +266,7 @@ def test_stash_apply_success_drops_and_restarts(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -249,7 +288,7 @@ def test_stash_apply_success_discloses_drop_failure(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Already up to date.', True
@@ -264,6 +303,7 @@ def test_stash_apply_success_discloses_drop_failure(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -284,7 +324,7 @@ def test_pull_failure_stash_apply_recovery(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Some unrecognized git error', False
@@ -299,6 +339,7 @@ def test_pull_failure_stash_apply_recovery(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -322,7 +363,7 @@ def test_pull_failure_stash_apply_recovery_discloses_drop_failure(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Some unrecognized git error', False
@@ -335,6 +376,7 @@ def test_pull_failure_stash_apply_recovery_discloses_drop_failure(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart'),
     ):
         result = updates._apply_update_inner('webui')
@@ -355,7 +397,7 @@ def test_pull_failure_stash_apply_recovery_warns_before_diverged_reset(tmp_path)
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Not possible to fast-forward, aborting.', False
@@ -368,6 +410,7 @@ def test_pull_failure_stash_apply_recovery_warns_before_diverged_reset(tmp_path)
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart'),
     ):
         result = updates._apply_update_inner('webui')
@@ -390,7 +433,7 @@ def test_pull_failure_stash_apply_conflict_cleans_worktree(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Some unrecognized git error', False
@@ -405,6 +448,7 @@ def test_pull_failure_stash_apply_conflict_cleans_worktree(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -430,7 +474,7 @@ def test_pull_failure_stash_apply_conflict_preserves_diverged_flag(tmp_path):
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Not possible to fast-forward, aborting.', False
@@ -443,6 +487,7 @@ def test_pull_failure_stash_apply_conflict_preserves_diverged_flag(tmp_path):
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart'),
     ):
         result = updates._apply_update_inner('webui')
@@ -463,7 +508,7 @@ def test_pull_failure_stash_apply_conflict_reset_failure_returns_error(tmp_path)
             return '', True
         if args == ['status', '--porcelain', '--untracked-files=no']:
             return 'M modified_file.py', True
-        if args == ['stash', 'push', '-m', 'hermes-update-autostash']:
+        if _is_autostash_push(args):
             return '', True
         if args[:2] == ['pull', '--ff-only']:
             return 'Some unrecognized git error', False
@@ -478,6 +523,7 @@ def test_pull_failure_stash_apply_conflict_reset_failure_returns_error(tmp_path)
     with (
         patch.object(updates, '_run_git', side_effect=fake_git),
         patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(updates, '_describe_checkout_sync', return_value=_behind_sync()),
         patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
     ):
         result = updates._apply_update_inner('webui')
@@ -491,3 +537,160 @@ def test_pull_failure_stash_apply_conflict_reset_failure_returns_error(tmp_path)
     assert ['reset', '--hard', 'HEAD'] in call_log
     assert ['stash', 'drop'] not in call_log
     assert len(restart_calls) == 0
+
+
+def test_agent_ahead_creates_backup_and_safe_resets(tmp_path):
+    """Agent updates with local-only commits backup HEAD then reset to origin."""
+    (tmp_path / '.git').mkdir()
+    call_log = []
+
+    def fake_git(args, path, timeout=10):
+        call_log.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            return '', True
+        if args == ['status', '--porcelain', '--untracked-files=no']:
+            return '', True
+        if args[:2] == ['branch', 'hermes-update-backup'] or (
+            len(args) >= 2 and args[0] == 'branch' and str(args[1]).startswith('hermes-update-backup/')
+        ):
+            return '', True
+        if args[:2] == ['rev-parse', 'HEAD']:
+            return 'localdeadbeef', True
+        if args == ['reset', '--hard', 'origin/main']:
+            return '', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    restart_calls = []
+    gateway_calls = []
+
+    with (
+        patch.object(updates, '_AGENT_DIR', tmp_path),
+        patch.object(updates, '_run_git', side_effect=fake_git),
+        patch.object(updates, '_select_apply_compare_ref', return_value='origin/main'),
+        patch.object(
+            updates,
+            '_describe_checkout_sync',
+            return_value=_behind_sync(
+                relationship='ahead',
+                ahead=1,
+                behind=3,
+                compare_ref='origin/main',
+            ),
+        ),
+        patch.object(updates, '_schedule_restart', side_effect=lambda: restart_calls.append(1)),
+        patch.object(
+            updates,
+            '_ensure_gateway_restart_for_agent_update',
+            side_effect=lambda: gateway_calls.append(1) or (True, {'status': 'restarted'}),
+        ),
+    ):
+        result = updates._apply_update_inner('agent')
+
+    assert result['ok'] is True
+    assert result['safe_reset'] is True
+    assert result['backup_branch']
+    assert result['backup_branch'].startswith('hermes-update-backup/')
+    assert ['reset', '--hard', 'origin/main'] in call_log
+    assert any(args[0] == 'branch' for args in call_log)
+    assert len(restart_calls) == 1
+    assert len(gateway_calls) == 1
+
+
+def test_webui_ahead_fails_closed_after_backup(tmp_path):
+    """WebUI keeps intentional local commits; backup then fail with recovery path."""
+    (tmp_path / '.git').mkdir()
+    call_log = []
+
+    def fake_git(args, path, timeout=10):
+        call_log.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            return '', True
+        if args == ['status', '--porcelain', '--untracked-files=no']:
+            return '', True
+        if args[0] == 'branch' and str(args[1]).startswith('hermes-update-backup/'):
+            return '', True
+        if args[:2] == ['rev-parse', 'HEAD']:
+            return 'localdeadbeef', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with (
+        patch.object(updates, 'REPO_ROOT', tmp_path),
+        patch.object(updates, '_run_git', side_effect=fake_git),
+        patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(
+            updates,
+            '_describe_checkout_sync',
+            return_value=_behind_sync(relationship='ahead', ahead=2, behind=5),
+        ),
+        patch.object(updates, '_schedule_restart'),
+    ):
+        result = updates._apply_update_inner('webui')
+
+    assert result['ok'] is False
+    assert result['diverged'] is True
+    assert result['backup_branch']
+    assert 'preserved on backup branch' in result['message']
+    assert ['reset', '--hard', 'origin/master'] not in call_log
+
+
+def test_identical_sync_is_idempotent_noop(tmp_path):
+    (tmp_path / '.git').mkdir()
+    call_log = []
+
+    def fake_git(args, path, timeout=10):
+        call_log.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            return '', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with (
+        patch.object(updates, 'REPO_ROOT', tmp_path),
+        patch.object(updates, '_run_git', side_effect=fake_git),
+        patch.object(updates, '_select_apply_compare_ref', return_value='origin/master'),
+        patch.object(
+            updates,
+            '_describe_checkout_sync',
+            return_value=_behind_sync(relationship='identical', ahead=0, behind=0),
+        ),
+        patch.object(updates, '_schedule_restart'),
+    ):
+        result = updates._apply_update_inner('webui')
+
+    assert result['ok'] is True
+    assert result['up_to_date'] is True
+    assert result['relationship'] == 'identical'
+    assert not any(args[:2] == ['pull', '--ff-only'] for args in call_log)
+
+
+def test_diagnose_checkout_reports_sync_fields(tmp_path):
+    (tmp_path / '.git').mkdir()
+
+    with (
+        patch.object(updates, '_AGENT_DIR', tmp_path),
+        patch.object(
+            updates,
+            '_select_apply_compare_ref',
+            return_value='origin/main',
+        ),
+        patch.object(
+            updates,
+            '_describe_checkout_sync',
+            return_value=_behind_sync(
+                path=str(tmp_path),
+                branch='main',
+                relationship='behind',
+                ahead=0,
+                behind=2,
+                compare_ref='origin/main',
+                modified_files=['foo.py'],
+                modified_count=1,
+            ),
+        ),
+    ):
+        report = updates.diagnose_checkout('agent')
+
+    assert report['ok'] is True
+    assert report['target'] == 'agent'
+    assert report['relationship'] == 'behind'
+    assert report['behind'] == 2
+    assert report['modified_files'] == ['foo.py']

--- a/tests/test_update_stash_recovery.py
+++ b/tests/test_update_stash_recovery.py
@@ -1,5 +1,9 @@
 """Tests for graceful stash-apply recovery in _apply_update_inner."""
+import subprocess
+import sys
 from unittest.mock import patch
+
+import pytest
 
 import api.updates as updates
 
@@ -694,3 +698,347 @@ def test_diagnose_checkout_reports_sync_fields(tmp_path):
     assert report['relationship'] == 'behind'
     assert report['behind'] == 2
     assert report['modified_files'] == ['foo.py']
+
+
+# ── Real-git lossless snapshot regressions (reviewer exact-head blockers) ─────
+
+
+_DIRTY_BYTES = b'dirty-tracked-UNIQUE-\x00-bytes\n'
+_UNTRACKED_LOCAL = b'untracked-local-UNIQUE-\x00-bytes\n'
+_UNTRACKED_UPSTREAM = b'untracked-upstream-OVERWRITE\n'
+_TRACKED_UPSTREAM = b'tracked-upstream-changed\n'
+_MUTATING_GIT = {'reset', 'checkout', 'clean', 'pull', 'merge', 'rebase'}
+
+
+# Windows spawns a console host for every git child unless this flag is set.
+# These tests run hundreds of git commands, so without it a local run carpets
+# the desktop with popup windows. Zero on POSIX, where subprocess only rejects
+# a NON-zero creationflags value.
+_NO_CONSOLE_WINDOW = (
+    getattr(subprocess, 'CREATE_NO_WINDOW', 0) if sys.platform == 'win32' else 0
+)
+
+
+def _git_raw(repo, args, check=True):
+    proc = subprocess.run(
+        ['git', *args],
+        cwd=str(repo),
+        capture_output=True,
+        check=False,
+        creationflags=_NO_CONSOLE_WINDOW,
+    )
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            f'git {args} failed: {proc.stderr.decode("utf-8", "replace")}'
+        )
+    return proc
+
+
+def _git(repo, *args):
+    return _git_raw(repo, args).stdout.decode('utf-8', 'replace').strip()
+
+
+def _git_bytes(repo, *args):
+    return _git_raw(repo, args).stdout
+
+
+def _configure_git(repo):
+    # One process instead of four: config --local accepts repeated pairs via
+    # separate invocations only, so write the file directly.
+    config = repo / ('config' if (repo / 'HEAD').exists() else '.git/config')
+    with open(config, 'a', encoding='utf-8') as fh:
+        fh.write(
+            '[user]\n\temail = t@t.co\n\tname = Test\n'
+            '[commit]\n\tgpgsign = false\n'
+            '[core]\n\tautocrlf = false\n'
+        )
+
+
+def _make_agent_pair(tmp_path):
+    """Bare origin + one working clone, built without intermediate seed clones."""
+    origin = tmp_path / 'origin.git'
+    _git(tmp_path, 'init', '--bare', '-q', '-b', 'main', str(origin))
+    agent = tmp_path / 'agent'
+    agent.mkdir()
+    _git(agent, 'init', '-q', '-b', 'main')
+    _configure_git(agent)
+    (agent / 'README').write_bytes(b'base-readme\n')
+    (agent / 'tracked.txt').write_bytes(b'tracked-clean\n')
+    _git(agent, 'add', 'README', 'tracked.txt')
+    _git(agent, 'commit', '-q', '-m', 'base')
+    _git(agent, 'remote', 'add', 'origin', str(origin))
+    _git(agent, 'push', '-q', '-u', 'origin', 'main')
+    return origin, agent
+
+
+def _origin_work_clone(tmp_path, origin):
+    """Reused upstream working clone — one per test, not one per upstream commit."""
+    work = tmp_path / 'origin-work'
+    if not work.exists():
+        _git(tmp_path, 'clone', '-q', str(origin), str(work))
+        _configure_git(work)
+    return work
+
+
+def _advance_origin(tmp_path, origin, files, message):
+    work = _origin_work_clone(tmp_path, origin)
+    for name, content in files.items():
+        path = work / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        _git(work, 'add', name)
+    _git(work, 'commit', '-q', '-m', message)
+    _git(work, 'push', '-q', 'origin', 'HEAD:main')
+
+
+def _patch_agent_update(monkeypatch, agent, *, gateway=None):
+    monkeypatch.setattr(updates, '_AGENT_DIR', agent)
+    monkeypatch.setattr(updates, 'REPO_ROOT', agent)
+    monkeypatch.setattr(
+        updates, '_select_apply_compare_ref',
+        lambda path, channel='stable', target=None: 'origin/main',
+    )
+    monkeypatch.setattr(updates, '_schedule_restart', lambda delay=2.0: None)
+    if gateway is None:
+        gateway = lambda: (True, {'status': 'completed'})
+    monkeypatch.setattr(updates, '_ensure_gateway_restart_for_agent_update', gateway)
+
+
+def _prepare_history(tmp_path, history, *, dirty_tracked=False, untracked_collider=False):
+    origin, agent = _make_agent_pair(tmp_path)
+    if history in {'ahead', 'diverged'}:
+        (agent / 'local-only.txt').write_bytes(b'local-only-commit\n')
+        _git(agent, 'add', 'local-only.txt')
+        _git(agent, 'commit', '-q', '-m', 'local-only')
+
+    origin_files = {}
+    if history in {'behind', 'diverged'}:
+        origin_files['upstream-new.txt'] = b'upstream-new\n'
+    if untracked_collider:
+        origin_files['collide.txt'] = _UNTRACKED_UPSTREAM
+    if dirty_tracked and history in {'behind', 'diverged'}:
+        origin_files['tracked.txt'] = _TRACKED_UPSTREAM
+    if origin_files:
+        _advance_origin(tmp_path, origin, origin_files, f'upstream-{history}')
+
+    if dirty_tracked:
+        (agent / 'tracked.txt').write_bytes(_DIRTY_BYTES)
+    if untracked_collider:
+        (agent / 'collide.txt').write_bytes(_UNTRACKED_LOCAL)
+    return origin, agent
+
+
+def _recovery_has_bytes(agent, result, rel, expected):
+    branch = result.get('recovery_ref') or result.get('backup_branch')
+    assert branch, f'expected recovery ref, got {result!r}'
+    assert _git_bytes(agent, 'show', f'{branch}:{rel}') == expected
+    # The recovery ref itself must still exist after the update attempt.
+    _git(agent, 'rev-parse', '--verify', branch)
+    return branch
+
+
+@pytest.mark.parametrize('history', ['behind', 'ahead', 'diverged'])
+@pytest.mark.parametrize('dirt', ['dirty_tracked', 'untracked_collider', 'both'])
+def test_real_repo_normal_update_preserves_local_bytes_or_aborts(tmp_path, monkeypatch, history, dirt):
+    """Normal Agent apply must not destroy dirty tracked or untracked collider bytes."""
+    dirty_tracked = dirt in {'dirty_tracked', 'both'}
+    untracked_collider = dirt in {'untracked_collider', 'both'}
+    _origin, agent = _prepare_history(
+        tmp_path, history,
+        dirty_tracked=dirty_tracked,
+        untracked_collider=untracked_collider,
+    )
+    head_before = _git(agent, 'rev-parse', 'HEAD')
+    _patch_agent_update(monkeypatch, agent)
+
+    result = updates._apply_update_inner('agent')
+
+    if untracked_collider:
+        # Upstream began tracking collide.txt. Local bytes must survive in the
+        # recovery artifact (or the update must abort before HEAD moves).
+        if not result.get('ok'):
+            assert _git(agent, 'rev-parse', 'HEAD') == head_before
+            assert (agent / 'collide.txt').read_bytes() == _UNTRACKED_LOCAL
+        else:
+            branch = _recovery_has_bytes(agent, result, 'collide.txt', _UNTRACKED_LOCAL)
+            recovered = _git_bytes(agent, 'show', f'{branch}:collide.txt')
+            assert recovered == _UNTRACKED_LOCAL
+            assert recovered != _UNTRACKED_UPSTREAM
+            assert 'collide.txt' in (result.get('message') or '') or result.get('untracked_colliders')
+            assert _git(agent, 'rev-parse', 'HEAD') == _git(agent, 'rev-parse', 'origin/main')
+
+    if dirty_tracked and result.get('ok') and not result.get('stash_conflict'):
+        # Stash restore may put dirty bytes back when they do not collide.
+        restored = (agent / 'tracked.txt').read_bytes()
+        if restored != _DIRTY_BYTES:
+            _recovery_has_bytes(agent, result, 'tracked.txt', _DIRTY_BYTES)
+    elif dirty_tracked and result.get('ok') and result.get('stash_conflict'):
+        _recovery_has_bytes(agent, result, 'tracked.txt', _DIRTY_BYTES)
+        assert 'git -C' in result['message']
+    elif dirty_tracked and not result.get('ok'):
+        assert (agent / 'tracked.txt').read_bytes() == _DIRTY_BYTES or result.get('backup_branch')
+
+
+@pytest.mark.parametrize('history', ['behind', 'ahead', 'diverged'])
+@pytest.mark.parametrize('dirt', ['dirty_tracked', 'both'])
+def test_real_repo_force_update_recovery_reloads_dirty_bytes(tmp_path, monkeypatch, history, dirt):
+    """Force update must put exact dirty tracked bytes on the returned recovery ref."""
+    _origin, agent = _prepare_history(
+        tmp_path, history,
+        dirty_tracked=True,
+        untracked_collider=(dirt == 'both'),
+    )
+    wt_before = (agent / 'tracked.txt').read_bytes()
+    assert wt_before == _DIRTY_BYTES
+    _patch_agent_update(monkeypatch, agent)
+
+    result = updates.apply_force_update('agent')
+
+    if result.get('refused_rewind'):
+        # Ahead of origin/main: rewind guard must not mutate dirty bytes.
+        assert (agent / 'tracked.txt').read_bytes() == _DIRTY_BYTES
+        return
+
+    assert result.get('backup_branch') or result.get('recovery_ref'), result
+    _recovery_has_bytes(agent, result, 'tracked.txt', _DIRTY_BYTES)
+    if dirt == 'both' and (agent / 'collide.txt').exists() is False:
+        _recovery_has_bytes(agent, result, 'collide.txt', _UNTRACKED_LOCAL)
+
+
+@pytest.mark.parametrize('history', ['behind', 'ahead', 'diverged'])
+def test_real_repo_snapshot_failure_aborts_before_mutation(tmp_path, monkeypatch, history):
+    _origin, agent = _prepare_history(
+        tmp_path, history, dirty_tracked=True, untracked_collider=True,
+    )
+    head_before = _git(agent, 'rev-parse', 'HEAD')
+    dirty_before = (agent / 'tracked.txt').read_bytes()
+    untracked_before = (agent / 'collide.txt').read_bytes()
+    mutating = []
+    real_run = updates._run_git
+
+    def spy(args, cwd, timeout=10):
+        if args and args[0] in _MUTATING_GIT:
+            mutating.append(list(args))
+        return real_run(args, cwd, timeout=timeout)
+
+    monkeypatch.setattr(updates, '_run_git', spy)
+    monkeypatch.setattr(
+        updates, '_create_update_recovery_snapshot',
+        lambda path, sync=None: {'ok': False, 'error': 'injected snapshot failure'},
+    )
+    _patch_agent_update(monkeypatch, agent)
+
+    result = updates._apply_update_inner('agent')
+    assert result['ok'] is False
+    assert 'aborted before mutating' in result['message'] or 'recovery snapshot' in result['message']
+    assert _git(agent, 'rev-parse', 'HEAD') == head_before
+    assert (agent / 'tracked.txt').read_bytes() == dirty_before
+    assert (agent / 'collide.txt').read_bytes() == untracked_before
+    assert mutating == []
+
+    mutating.clear()
+    result_force = updates.apply_force_update('agent')
+    assert result_force['ok'] is False
+    assert _git(agent, 'rev-parse', 'HEAD') == head_before
+    assert (agent / 'tracked.txt').read_bytes() == dirty_before
+    if result_force.get('refused_rewind'):
+        assert (agent / 'collide.txt').read_bytes() == untracked_before
+    else:
+        assert 'aborted' in result_force['message']
+        assert not any(args and args[0] in {'reset', 'checkout', 'clean'} for args in mutating)
+
+
+@pytest.mark.parametrize('history', ['behind', 'ahead', 'diverged'])
+def test_real_repo_stash_restore_conflict_retains_recovery_ref(tmp_path, monkeypatch, history):
+    origin, agent = _prepare_history(
+        tmp_path, history, dirty_tracked=True, untracked_collider=False,
+    )
+    # Ensure origin also changed tracked.txt so stash restore conflicts after pull/reset.
+    if history == 'ahead':
+        _advance_origin(tmp_path, origin, {'tracked.txt': _TRACKED_UPSTREAM}, 'conflict-ahead')
+    _patch_agent_update(monkeypatch, agent)
+
+    result = updates._apply_update_inner('agent')
+    branch = result.get('recovery_ref') or result.get('backup_branch')
+    assert branch, result
+    _git(agent, 'rev-parse', '--verify', branch)
+    assert _git_bytes(agent, 'show', f'{branch}:tracked.txt') == _DIRTY_BYTES
+    if result.get('stash_conflict') or not result.get('ok'):
+        assert 'git -C' in result['message']
+        assert branch in result['message']
+
+
+@pytest.mark.parametrize('history', ['behind', 'ahead', 'diverged'])
+def test_real_repo_gateway_restart_failure_retains_recovery_ref(tmp_path, monkeypatch, history):
+    _origin, agent = _prepare_history(
+        tmp_path, history, dirty_tracked=True, untracked_collider=True,
+    )
+    _patch_agent_update(
+        monkeypatch, agent,
+        gateway=lambda: (False, {
+            'status': 'failed',
+            'message': 'gateway restart exploded',
+        }),
+    )
+
+    result = updates._apply_update_inner('agent')
+    assert result['ok'] is False
+    assert result.get('gateway_restart') == 'failed'
+    branch = result.get('recovery_ref') or result.get('backup_branch')
+    assert branch, result
+    _git(agent, 'rev-parse', '--verify', branch)
+    assert _git_bytes(agent, 'show', f'{branch}:tracked.txt') == _DIRTY_BYTES
+    assert _git_bytes(agent, 'show', f'{branch}:collide.txt') == _UNTRACKED_LOCAL
+    assert branch in result['message']
+    assert 'git -C' in result['message']
+
+    # Force update needs its own checkout: the apply above already moved this
+    # one to upstream, so a force run there would have nothing dirty to protect.
+    force_root = tmp_path / 'force'
+    force_root.mkdir()
+    _origin2, agent2 = _prepare_history(
+        force_root, history, dirty_tracked=True, untracked_collider=True,
+    )
+    _patch_agent_update(
+        monkeypatch, agent2,
+        gateway=lambda: (False, {
+            'status': 'failed',
+            'message': 'gateway restart exploded',
+        }),
+    )
+
+    force = updates.apply_force_update('agent')
+    if force.get('refused_rewind'):
+        assert (agent2 / 'tracked.txt').read_bytes() == _DIRTY_BYTES
+        return
+    assert force.get('gateway_restart') == 'failed'
+    force_branch = force.get('recovery_ref') or force.get('backup_branch')
+    assert force_branch, force
+    _git(agent2, 'rev-parse', '--verify', force_branch)
+    assert _git_bytes(agent2, 'show', f'{force_branch}:tracked.txt') == _DIRTY_BYTES
+    assert _git_bytes(agent2, 'show', f'{force_branch}:collide.txt') == _UNTRACKED_LOCAL
+    assert force_branch in force['message']
+
+
+def test_real_repo_local_commit_plus_untracked_collider_with_newly_tracked_upstream(
+    tmp_path, monkeypatch,
+):
+    """Exact reviewer probe: local-only commit + untracked path origin starts tracking."""
+    _origin, agent = _prepare_history(
+        tmp_path, 'diverged', dirty_tracked=False, untracked_collider=True,
+    )
+    assert (agent / 'local-only.txt').read_bytes() == b'local-only-commit\n'
+    assert (agent / 'collide.txt').read_bytes() == _UNTRACKED_LOCAL
+    head_before = _git(agent, 'rev-parse', 'HEAD')
+    _patch_agent_update(monkeypatch, agent)
+
+    result = updates._apply_update_inner('agent')
+    if not result.get('ok'):
+        assert _git(agent, 'rev-parse', 'HEAD') == head_before
+        assert (agent / 'collide.txt').read_bytes() == _UNTRACKED_LOCAL
+        return
+    branch = _recovery_has_bytes(agent, result, 'collide.txt', _UNTRACKED_LOCAL)
+    assert _git_bytes(agent, 'show', f'{branch}:local-only.txt') == b'local-only-commit\n'
+    recovered = _git_bytes(agent, 'show', f'{branch}:collide.txt')
+    assert recovered == _UNTRACKED_LOCAL
+    assert recovered != _UNTRACKED_UPSTREAM

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1038,6 +1038,9 @@ def test_apply_update_status_lock_error_returns_lock_conflict(tmp_path):
     from api import updates as mod
     with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
          patch(f'{_MODULE}._select_apply_compare_ref', return_value='origin/main'), \
+         patch(f'{_MODULE}._describe_checkout_sync', return_value={
+             'relationship': 'behind', 'ahead': 0, 'behind': 1, 'dirty_tracked': False,
+         }), \
          patch(f'{_MODULE}._run_git') as mock_run_git:
         mock_run_git.side_effect = [
             ('', True),   # fetch succeeds
@@ -1053,6 +1056,9 @@ def test_apply_update_pull_lock_error_returns_lock_conflict(tmp_path):
     from api import updates as mod
     with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
          patch(f'{_MODULE}._select_apply_compare_ref', return_value='origin/main'), \
+         patch(f'{_MODULE}._describe_checkout_sync', return_value={
+             'relationship': 'behind', 'ahead': 0, 'behind': 1, 'dirty_tracked': False,
+         }), \
          patch(f'{_MODULE}.STREAMS', {}), \
          patch(f'{_MODULE}._run_git') as mock_run_git:
         mock_run_git.side_effect = [
@@ -1329,6 +1335,12 @@ def test_apply_update_pull_lock_restores_stash(tmp_path, monkeypatch):
         updates, '_select_apply_compare_ref',
         lambda path, channel='stable', target=None: 'origin/main'
     )
+    monkeypatch.setattr(
+        updates, '_describe_checkout_sync',
+        lambda path, compare_ref: {
+            'relationship': 'behind', 'ahead': 0, 'behind': 1, 'dirty_tracked': True,
+        },
+    )
 
     result = updates._apply_update_inner('webui')
     assert result['ok'] is False
@@ -1380,6 +1392,12 @@ def test_apply_update_pull_lock_no_stash_when_clean(tmp_path, monkeypatch):
     monkeypatch.setattr(
         updates, '_select_apply_compare_ref',
         lambda path, channel='stable', target=None: 'origin/main'
+    )
+    monkeypatch.setattr(
+        updates, '_describe_checkout_sync',
+        lambda path, compare_ref: {
+            'relationship': 'behind', 'ahead': 0, 'behind': 1, 'dirty_tracked': False,
+        },
     )
 
     result = updates._apply_update_inner('webui')

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1406,3 +1406,53 @@ def test_apply_update_pull_lock_no_stash_when_clean(tmp_path, monkeypatch):
     # No stash pop on a clean pull-lock path.
     assert not any(c[0] == 'stash' for c in git_calls)
 
+
+def test_real_repo_force_dirty_tracked_recovery_contains_exact_bytes(tmp_path, monkeypatch):
+    """Force-update recovery artifact must reload the exact dirty tracked bytes."""
+    from tests.test_update_stash_recovery import (
+        _DIRTY_BYTES,
+        _git_bytes,
+        _patch_agent_update,
+        _prepare_history,
+    )
+
+    _origin, agent = _prepare_history(
+        tmp_path, 'behind', dirty_tracked=True, untracked_collider=False,
+    )
+    _patch_agent_update(monkeypatch, agent)
+    result = updates.apply_force_update('agent')
+    assert result.get('ok') is True, result
+    branch = result.get('recovery_ref') or result.get('backup_branch')
+    assert branch, result
+    assert _git_bytes(agent, 'show', f'{branch}:tracked.txt') == _DIRTY_BYTES
+
+
+def test_real_repo_normal_untracked_collider_does_not_keep_only_upstream_bytes(
+    tmp_path, monkeypatch,
+):
+    """Normal apply must recover exact untracked collider bytes, not only upstream."""
+    from tests.test_update_stash_recovery import (
+        _UNTRACKED_LOCAL,
+        _UNTRACKED_UPSTREAM,
+        _git,
+        _git_bytes,
+        _patch_agent_update,
+        _prepare_history,
+    )
+
+    _origin, agent = _prepare_history(
+        tmp_path, 'behind', dirty_tracked=False, untracked_collider=True,
+    )
+    head_before = _git(agent, 'rev-parse', 'HEAD')
+    _patch_agent_update(monkeypatch, agent)
+    result = updates._apply_update_inner('agent')
+    if not result.get('ok'):
+        assert _git(agent, 'rev-parse', 'HEAD') == head_before
+        assert (agent / 'collide.txt').read_bytes() == _UNTRACKED_LOCAL
+        return
+    branch = result.get('recovery_ref') or result.get('backup_branch')
+    assert branch, result
+    recovered = _git_bytes(agent, 'show', f'{branch}:collide.txt')
+    assert recovered == _UNTRACKED_LOCAL
+    assert recovered != _UNTRACKED_UPSTREAM
+


### PR DESCRIPTION
## Summary
- Detect dirty/ahead/behind/diverged agent checkouts before updating, and preserve local commits on timestamped backup branches/stashes instead of failing with opaque ff-only errors.
- Agent updates safe-reset to the compare ref after backup; WebUI stays fail-closed with a clear recovery path. Adds `scripts/diagnose_agent_checkout.py` and `GET /api/updates/diagnose`.

## Test plan
- [x] `./scripts/test.sh tests/test_update_stash_recovery.py tests/test_updates.py tests/test_update_channels.py`
- [x] Live agent update twice (ff + idempotent up-to-date)
- [x] Live ahead-commit recovery created `hermes-update-backup/*` and realigned to `origin/main`
- [x] Smedley/Biggy WebUIs still responding after updates
- [ ] Restart WebUI processes so Settings → Update loads the new updater code


Made with [Cursor](https://cursor.com)