### PR TITLE
fix(restart): don't SIGTERM the gateway when restart CLI becomes the gateway

### DIFF
--- a/api/agent_health.py
+++ b/api/agent_health.py
@@ -456,7 +456,12 @@ def _runtime_detail_subset(runtime_status: dict[str, Any] | None) -> dict[str, A
 # cached briefly so a dashboard rerender that fans out to multiple panels does
 # not hammer the gateway.
 
-_REMOTE_PROBE_TIMEOUT_S: float = 2.0
+# A single slow answer (plugin loading at startup, model-cache refresh stalls
+# on NAS-class hardware) routinely exceeds 2s; a 2s cap turned a healthy
+# gateway into a false-positive "not responding" banner (#6730). 5s absorbs
+# those stalls while still bounding a full three-path walk of a dead gateway
+# to ~15s.
+_REMOTE_PROBE_TIMEOUT_S: float = 5.0
 _REMOTE_PROBE_CACHE_TTL_S: float = 5.0
 _REMOTE_PROBE_PATHS: tuple[str, ...] = ("/health/detailed", "/health", "/v1/health")
 # A gateway health payload is small JSON; cap the 2xx body read so a large or
@@ -643,7 +648,7 @@ def _probe_remote_gateway(base_url: str, *, now: float | None = None) -> dict[st
     Result is cached for ``_REMOTE_PROBE_CACHE_TTL_S`` seconds per base_url.
 
     Concurrency (single-flight): when several dashboard panels fan out on a cold
-    cache, only the first "leader" thread runs the ~2s-per-path network probe;
+    cache, only the first "leader" thread runs the ~5s-per-path network probe;
     latecomers wait on ``_remote_probe_cond`` for the leader's cached result
     rather than each hammering the (possibly dead) gateway (#5455, #2476). The
     leader always clears the in-flight marker and wakes waiters — even on error —
@@ -684,7 +689,7 @@ def _probe_remote_gateway(base_url: str, *, now: float | None = None) -> dict[st
                 _remote_probe_cache["url"] = base_url
                 # Expire from the moment the probe COMPLETES, not from the
                 # leader's entry time: walking every path of a hung gateway
-                # takes len(paths) * timeout (~6s) which exceeds the 5s TTL, so
+                # takes len(paths) * timeout (~15s) which exceeds the 5s TTL, so
                 # `current + TTL` would write an already-expired cache line.
                 # Waiters woken right after this would then miss the cache and
                 # each re-probe the dead gateway — collapsing single-flight and

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -95,21 +95,31 @@ def _read_canonical_gateway_pid(pid_file: Path) -> int | None:
     Hermes writes ``gateway.pid`` as a JSON object (``{"pid": 4242, ...}``),
     so the file must be JSON-decoded and its ``pid`` member extracted.  A
     legacy top-level bare integer (``"4242"``) is still accepted.  Anything
-    else — missing/invalid ``pid`` member, string/float/bool value, or
-    unreadable content — returns None so callers fail closed.  ``int()`` is
-    never used to coerce, because it would accept ``"4242"`` and truncate
-    ``4242.9``, misclassifying a stuck child as the healthy gateway.
+    else — missing/invalid ``pid`` member, string/float/bool value, unreadable
+    content, non-UTF-8 bytes, or unparseable JSON (including the Python 3.11+
+    integer-string conversion limit on oversized digit strings) — returns
+    None so callers fail closed.  The read/parse is deliberately
+    non-throwing: an escaping exception would propagate out of the
+    background restart thread and skip the timed-out child's terminate/kill
+    cleanup, leaking a genuinely hung restart child.  ``int()`` is never used
+    to coerce, because it would accept ``"4242"`` and truncate ``4242.9``,
+    misclassifying a stuck child as the healthy gateway.
     """
     try:
         raw = pid_file.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # Missing/unreadable/non-UTF-8 file: cannot confirm the canonical PID.
         return None
     if not raw:
         return None
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
-        # Legacy plain-integer file (e.g. "4242").
+    except ValueError:
+        # Non-JSON content, or a JSON value json.loads refused (e.g. an
+        # oversized integer beyond the interpreter's digit-conversion limit).
+        # ``json.JSONDecodeError`` and ``UnicodeDecodeError`` are ValueError
+        # subclasses, so this also covers malformed JSON.  Fall back to a
+        # legacy plain-integer file (e.g. "4242").
         try:
             value = int(raw)
         except ValueError:
@@ -316,9 +326,21 @@ def restart_active_profile_gateway(
                 try:
                     proc.wait(timeout=background_wait_seconds)
                 except subprocess.TimeoutExpired:
-                    if _subprocess_became_gateway(
-                        proc, active_home, proc_started_at=proc_started_at
-                    ):
+                    try:
+                        became_gateway = _subprocess_became_gateway(
+                            proc, active_home, proc_started_at=proc_started_at
+                        )
+                    except Exception:
+                        # Fail closed: a verifier exception must never skip
+                        # termination.  If we cannot confirm the child IS the
+                        # healthy gateway, treat it as "not confirmed" and fall
+                        # through to the terminate/kill cleanup below.
+                        logger.exception(
+                            "Gateway identity verification raised; treating the "
+                            "timed-out restart process as NOT the gateway."
+                        )
+                        became_gateway = False
+                    if became_gateway:
                         # Single-container image: no service manager, so the
                         # restart CLI became the gateway itself. Killing it
                         # would SIGTERM the healthy replacement and drop every

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -9,6 +9,8 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
+from datetime import datetime
 from pathlib import Path
 
 from api.profiles import (
@@ -25,8 +27,15 @@ _GATEWAY_RESTART_LOCK = threading.Lock()
 
 # Name of the gateway's persisted runtime status file, written by the gateway
 # process itself (gateway/status.py) into the HERMES_HOME it was launched with.
-# The record carries the gateway's own PID under the "pid" key.
+# The record carries the gateway's own PID under the "pid" key and a
+# timezone-aware ISO-8601 "updated_at" timestamp.
 _GATEWAY_RUNTIME_STATUS_FILE = "gateway_state.json"
+
+# Canonical gateway PID file, written by the gateway alongside the runtime
+# status record. Used to cross-check that the PID recorded in
+# ``gateway_state.json`` belongs to the current gateway generation rather than
+# a stale record whose PID was later reused by an unrelated process.
+_GATEWAY_PID_FILE = "gateway.pid"
 
 
 def _resolve_hermes_command() -> str:
@@ -58,7 +67,33 @@ def _release_lock() -> None:
         pass
 
 
-def _subprocess_became_gateway(proc: subprocess.Popen, hermes_home: Path) -> bool:
+def _record_updated_at_epoch(runtime_status: dict) -> float | None:
+    """Return the record's ``updated_at`` as epoch seconds, or ``None`` when
+    missing or unparseable.
+
+    The gateway writes a timezone-aware ISO-8601 timestamp (the same format
+    ``gateway/status.py`` uses and ``api/agent_health.py`` already parses).
+    Naive or unparseable timestamps are refused — they cannot prove the record
+    belongs to the current gateway generation, so the caller must fail closed.
+    """
+    raw_updated_at = runtime_status.get("updated_at")
+    if not isinstance(raw_updated_at, str) or not raw_updated_at:
+        return None
+    try:
+        updated_at = datetime.fromisoformat(raw_updated_at)
+    except (TypeError, ValueError):
+        return None
+    if updated_at.tzinfo is None:
+        return None
+    return updated_at.timestamp()
+
+
+def _subprocess_became_gateway(
+    proc: subprocess.Popen,
+    hermes_home: Path,
+    *,
+    proc_started_at: float | None = None,
+) -> bool:
     """Return True when the restart subprocess has itself become the gateway.
 
     Single-container deployments have no service manager, so ``hermes gateway
@@ -67,9 +102,20 @@ def _subprocess_became_gateway(proc: subprocess.Popen, hermes_home: Path) -> boo
     The gateway writes ``gateway_state.json`` into the HERMES_HOME it was
     launched with (the same ``hermes_home`` we put on the subprocess env),
     recording its own PID under the ``pid`` key.  When that recorded PID
-    equals the subprocess PID and the gateway self-reports as running, the
+    equals the subprocess PID and the gateway self-reports as **running**, the
     timeout means "restart succeeded and this process IS the gateway", not
     "restart hung" — terminating it would SIGTERM the healthy replacement.
+
+    The exemption is deliberately narrow.  The gateway writes ``starting``
+    *before* potentially-blocking plugin/MCP/platform initialization and only
+    flips to ``running`` once fully up, so a ``starting`` record may be a
+    restart child wedged during startup and must still fall through to the
+    240s cleanup + terminate.  Raw PID equality alone also cannot prove
+    process generation: a stale record from a previous gateway generation
+    whose PID was later reused would falsely match.  The PID is therefore
+    validated against canonical metadata — the record must postdate the
+    restart subprocess (``proc_started_at`` start-time proof) and, when the
+    canonical ``gateway.pid`` file is present, must agree with it.
 
     Any unverifiable input fails closed (returns False), preserving the
     previous terminate-on-timeout behaviour for genuinely hung restarts.
@@ -86,12 +132,35 @@ def _subprocess_became_gateway(proc: subprocess.Popen, hermes_home: Path) -> boo
         return False
     if not isinstance(runtime_status, dict):
         return False
-    if runtime_status.get("gateway_state") not in ("running", "starting"):
+    # Only a CONFIRMED running gateway is exempt.  A ``starting`` record is
+    # not proof the child finished initializing — it may be wedged mid-startup.
+    if runtime_status.get("gateway_state") != "running":
         return False
     try:
-        return int(runtime_status.get("pid")) == proc_pid
+        recorded_pid = int(runtime_status.get("pid"))
     except (TypeError, ValueError):
         return False
+    if recorded_pid != proc_pid:
+        return False
+    # Generation proof via start-time metadata: a record written before the
+    # restart subprocess was spawned belongs to a previous gateway generation
+    # (stale record).  With PID reuse it would falsely match the raw equality.
+    if proc_started_at is not None:
+        record_time = _record_updated_at_epoch(runtime_status)
+        if record_time is None or record_time < proc_started_at:
+            return False
+    # Cross-check the recorded PID against the canonical ``gateway.pid`` file
+    # when present.  A mismatching or unreadable pid file means the record is
+    # not the current gateway generation -> fail closed.
+    try:
+        pid_file = hermes_home / _GATEWAY_PID_FILE
+        if pid_file.exists():
+            canonical_pid = int(pid_file.read_text(encoding="utf-8").strip())
+            if canonical_pid != recorded_pid:
+                return False
+    except (OSError, ValueError):
+        return False
+    return True
 
 
 def _gateway_restart_profile_context(profile: str | None = None) -> tuple[Path, str | None]:
@@ -166,6 +235,10 @@ def restart_active_profile_gateway(
             text=True,
             env=env,
         )
+        # Spawn moment of the restart child.  Used as the generation boundary
+        # for the terminate-exemption: only a gateway_state.json record written
+        # AFTER this instant can belong to this subprocess generation.
+        proc_started_at = time.time()
 
         try:
             stdout, stderr = proc.communicate(timeout=quick_timeout_seconds)
@@ -202,7 +275,9 @@ def restart_active_profile_gateway(
                 try:
                     proc.wait(timeout=background_wait_seconds)
                 except subprocess.TimeoutExpired:
-                    if _subprocess_became_gateway(proc, active_home):
+                    if _subprocess_became_gateway(
+                        proc, active_home, proc_started_at=proc_started_at
+                    ):
                         # Single-container image: no service manager, so the
                         # restart CLI became the gateway itself. Killing it
                         # would SIGTERM the healthy replacement and drop every

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -32,9 +32,10 @@ _GATEWAY_RESTART_LOCK = threading.Lock()
 _GATEWAY_RUNTIME_STATUS_FILE = "gateway_state.json"
 
 # Canonical gateway PID file, written by the gateway alongside the runtime
-# status record. Used to cross-check that the PID recorded in
-# ``gateway_state.json`` belongs to the current gateway generation rather than
-# a stale record whose PID was later reused by an unrelated process.
+# status record as a JSON object (``{"pid": 4242, ...}``). Used to cross-check
+# that the PID recorded in ``gateway_state.json`` belongs to the current
+# gateway generation rather than a stale record whose PID was later reused by
+# an unrelated process.
 _GATEWAY_PID_FILE = "gateway.pid"
 
 
@@ -88,6 +89,41 @@ def _record_updated_at_epoch(runtime_status: dict) -> float | None:
     return updated_at.timestamp()
 
 
+def _read_canonical_gateway_pid(pid_file: Path) -> int | None:
+    """Return the canonical gateway PID from a ``gateway.pid`` file, or None.
+
+    Hermes writes ``gateway.pid`` as a JSON object (``{"pid": 4242, ...}``),
+    so the file must be JSON-decoded and its ``pid`` member extracted.  A
+    legacy top-level bare integer (``"4242"``) is still accepted.  Anything
+    else — missing/invalid ``pid`` member, string/float/bool value, or
+    unreadable content — returns None so callers fail closed.  ``int()`` is
+    never used to coerce, because it would accept ``"4242"`` and truncate
+    ``4242.9``, misclassifying a stuck child as the healthy gateway.
+    """
+    try:
+        raw = pid_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        # Legacy plain-integer file (e.g. "4242").
+        try:
+            value = int(raw)
+        except ValueError:
+            return None
+        return value if type(value) is int else None
+    if isinstance(payload, dict):
+        pid = payload.get("pid")
+    else:
+        pid = payload
+    if type(pid) is not int:
+        return None
+    return pid
+
+
 def _subprocess_became_gateway(
     proc: subprocess.Popen,
     hermes_home: Path,
@@ -113,9 +149,11 @@ def _subprocess_became_gateway(
     240s cleanup + terminate.  Raw PID equality alone also cannot prove
     process generation: a stale record from a previous gateway generation
     whose PID was later reused would falsely match.  The PID is therefore
-    validated against canonical metadata — the record must postdate the
-    restart subprocess (``proc_started_at`` start-time proof) and, when the
-    canonical ``gateway.pid`` file is present, must agree with it.
+    validated against canonical metadata — both PID values must be real
+    integers (no ``int()`` coercion, so string/float PIDs fail closed), the
+    record must postdate the restart subprocess (``proc_started_at``
+    start-time proof), and, when the canonical ``gateway.pid`` file is
+    present, the recorded PID must agree with the JSON-decoded value.
 
     Any unverifiable input fails closed (returns False), preserving the
     previous terminate-on-timeout behaviour for genuinely hung restarts.
@@ -136,9 +174,11 @@ def _subprocess_became_gateway(
     # not proof the child finished initializing — it may be wedged mid-startup.
     if runtime_status.get("gateway_state") != "running":
         return False
-    try:
-        recorded_pid = int(runtime_status.get("pid"))
-    except (TypeError, ValueError):
+    # Strict integer PID: ``int()`` would accept "4242" and truncate 4242.9,
+    # failing open (exempting a stuck child) when the canonical pid file is
+    # absent.  Only a genuine int can prove identity.
+    recorded_pid = runtime_status.get("pid")
+    if type(recorded_pid) is not int:
         return False
     if recorded_pid != proc_pid:
         return False
@@ -150,16 +190,13 @@ def _subprocess_became_gateway(
         if record_time is None or record_time < proc_started_at:
             return False
     # Cross-check the recorded PID against the canonical ``gateway.pid`` file
-    # when present.  A mismatching or unreadable pid file means the record is
-    # not the current gateway generation -> fail closed.
-    try:
-        pid_file = hermes_home / _GATEWAY_PID_FILE
-        if pid_file.exists():
-            canonical_pid = int(pid_file.read_text(encoding="utf-8").strip())
-            if canonical_pid != recorded_pid:
-                return False
-    except (OSError, ValueError):
-        return False
+    # when present.  A mismatching, unreadable, or non-integer pid file means
+    # the record is not the current gateway generation -> fail closed.
+    pid_file = hermes_home / _GATEWAY_PID_FILE
+    if pid_file.exists():
+        canonical_pid = _read_canonical_gateway_pid(pid_file)
+        if canonical_pid is None or canonical_pid != recorded_pid:
+            return False
     return True
 
 
@@ -228,6 +265,14 @@ def restart_active_profile_gateway(
                 cli_profile,
                 active_home,
             )
+        # Spawn moment of the restart child.  Used as the generation boundary
+        # for the terminate-exemption: only a gateway_state.json record written
+        # AFTER this instant can belong to this subprocess generation.
+        # Captured BEFORE ``Popen``: a fast-starting child can write its
+        # ``running`` record while the parent is still inside ``Popen``, and a
+        # post-Popen capture would make that fresh record look older than the
+        # spawn moment, terminating the healthy replacement.
+        proc_started_at = time.time()
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -235,10 +280,6 @@ def restart_active_profile_gateway(
             text=True,
             env=env,
         )
-        # Spawn moment of the restart child.  Used as the generation boundary
-        # for the terminate-exemption: only a gateway_state.json record written
-        # AFTER this instant can belong to this subprocess generation.
-        proc_started_at = time.time()
 
         try:
             stdout, stderr = proc.communicate(timeout=quick_timeout_seconds)

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -21,6 +22,11 @@ from api.profiles import (
 logger = logging.getLogger(__name__)
 
 _GATEWAY_RESTART_LOCK = threading.Lock()
+
+# Name of the gateway's persisted runtime status file, written by the gateway
+# process itself (gateway/status.py) into the HERMES_HOME it was launched with.
+# The record carries the gateway's own PID under the "pid" key.
+_GATEWAY_RUNTIME_STATUS_FILE = "gateway_state.json"
 
 
 def _resolve_hermes_command() -> str:
@@ -50,6 +56,42 @@ def _release_lock() -> None:
     except RuntimeError:
         # The lock may already have been released by another path.
         pass
+
+
+def _subprocess_became_gateway(proc: subprocess.Popen, hermes_home: Path) -> bool:
+    """Return True when the restart subprocess has itself become the gateway.
+
+    Single-container deployments have no service manager, so ``hermes gateway
+    restart`` falls through to ``run_gateway()`` and the CLI process becomes
+    the gateway itself: it binds the API-server port and never exits (#6730).
+    The gateway writes ``gateway_state.json`` into the HERMES_HOME it was
+    launched with (the same ``hermes_home`` we put on the subprocess env),
+    recording its own PID under the ``pid`` key.  When that recorded PID
+    equals the subprocess PID and the gateway self-reports as running, the
+    timeout means "restart succeeded and this process IS the gateway", not
+    "restart hung" — terminating it would SIGTERM the healthy replacement.
+
+    Any unverifiable input fails closed (returns False), preserving the
+    previous terminate-on-timeout behaviour for genuinely hung restarts.
+    """
+    try:
+        proc_pid = int(proc.pid)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    try:
+        runtime_status = json.loads(
+            (hermes_home / _GATEWAY_RUNTIME_STATUS_FILE).read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(runtime_status, dict):
+        return False
+    if runtime_status.get("gateway_state") not in ("running", "starting"):
+        return False
+    try:
+        return int(runtime_status.get("pid")) == proc_pid
+    except (TypeError, ValueError):
+        return False
 
 
 def _gateway_restart_profile_context(profile: str | None = None) -> tuple[Path, str | None]:
@@ -160,6 +202,20 @@ def restart_active_profile_gateway(
                 try:
                     proc.wait(timeout=background_wait_seconds)
                 except subprocess.TimeoutExpired:
+                    if _subprocess_became_gateway(proc, active_home):
+                        # Single-container image: no service manager, so the
+                        # restart CLI became the gateway itself. Killing it
+                        # would SIGTERM the healthy replacement and drop every
+                        # active session/SSE stream (#6730). Treat the timeout
+                        # as success: release the lock and leave it running.
+                        logger.warning(
+                            "Gateway restart process timed out after %.1fs but the "
+                            "subprocess has become the gateway itself (PID %s owns "
+                            "gateway_state.json); leaving it running.",
+                            background_wait_seconds,
+                            proc.pid,
+                        )
+                        return
                     logger.error(
                         "Gateway restart process timed out after %.1fs. Terminating process.",
                         background_wait_seconds,

--- a/tests/test_5455_agent_health_single_flight.py
+++ b/tests/test_5455_agent_health_single_flight.py
@@ -2,9 +2,9 @@
 
 Pre-fix behaviour: ``_probe_remote_gateway`` held ``_remote_probe_lock`` only
 around the cache read and the cache write; the network probe itself
-(``_http_probe`` per path, each up to ~2s) ran with no lock held.  On a cold
+(``_http_probe`` per path, each up to ~5s) ran with no lock held.  On a cold
 cache a dashboard that fans out to N panels therefore fired N concurrent probe
-sets at the (possibly dead) gateway, each blocking for up to ~6s.
+sets at the (possibly dead) gateway, each blocking for up to ~15s.
 
 Fix: single-flight.  The first "leader" thread marks the base_url in-flight and
 runs the probe; latecomers wait on ``_remote_probe_cond`` for the leader's

--- a/tests/test_agent_health_remote.py
+++ b/tests/test_agent_health_remote.py
@@ -293,3 +293,24 @@ def test_oversized_remote_body_does_not_hang_and_skips_parse(monkeypatch):
     assert captured_amt and all(a is not None for a in captured_amt)
     assert payload["alive"] is True
     assert "gateway_state" not in payload["details"]
+
+
+def test_remote_probe_timeout_absorbes_slow_health_answer(monkeypatch):
+    """#6730: the per-path probe timeout must be long enough that a slow
+    (/health > 2s on NAS-class hardware) but healthy gateway is not declared
+    remote_gateway_unreachable, while still being the exact value the probe
+    hands to the HTTP client."""
+    monkeypatch.setenv("HERMES_API_URL", "http://gateway:8080")
+    captured_timeouts: list[float | None] = []
+
+    def fake_urlopen(req, timeout=None):
+        captured_timeouts.append(timeout)
+        return _FakeResp(200)
+
+    with mock.patch.object(agent_health.urllib_request, "urlopen", fake_urlopen):
+        payload = agent_health.build_agent_health_payload()
+
+    assert payload["alive"] is True
+    assert captured_timeouts and captured_timeouts[0] == agent_health._REMOTE_PROBE_TIMEOUT_S
+    # Regression floor: 2.0s produced false-positive "not responding" banners.
+    assert captured_timeouts[0] >= 5.0

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -374,6 +374,60 @@ def test_restart_timeout_still_terminates_for_stale_generation_record(monkeypatc
     assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
 
 
+def test_restart_timeout_still_terminates_when_canonical_pid_file_unreadable(monkeypatch, tmp_path):
+    """Re-gate (#6733): malformed canonical metadata must fail CLOSED.  The
+    old parse let ``UnicodeDecodeError`` escape ``_read_canonical_gateway_pid``,
+    so the background thread released ``_GATEWAY_RESTART_LOCK`` in its
+    ``finally`` but SKIPPED ``terminate()``/``kill()`` — a genuinely hung
+    restart child survived.  State + PID + generation all match here; only the
+    non-UTF-8 ``gateway.pid`` blocks the exemption, and the child must still
+    be terminated with the lock released."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=proc.pid,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_bytes(bytes([0xFF, 0xFE, 0x00, 0x01]) + b"binary-pid")
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is True
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_timeout_still_terminates_when_identity_verification_raises(monkeypatch, tmp_path):
+    """Re-gate (#6733): if ``_subprocess_became_gateway`` itself throws, the
+    call site must treat the exception as \"not confirmed\" and still run the
+    terminate/kill cleanup — a verifier exception must never skip the
+    timed-out child's termination."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+
+    def _exploding_verifier(*args, **kwargs):
+        raise RuntimeError("verifier boom")
+
+    monkeypatch.setattr(gateway_restart, "_subprocess_became_gateway", _exploding_verifier)
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is True
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
 def test_subprocess_became_gateway_true_for_matching_running_record(tmp_path):
     _write_gateway_state(tmp_path, gateway_state="running", pid=4242)
     proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
@@ -484,6 +538,47 @@ def test_subprocess_became_gateway_false_when_canonical_pid_file_invalid_json(tm
         updated_at=_future_timestamp(),
     )
     (tmp_path / "gateway.pid").write_text("not-a-pid", encoding="utf-8")
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is False
+    )
+
+
+def test_subprocess_became_gateway_false_when_canonical_pid_file_not_utf8(tmp_path):
+    """Re-gate (#6733): non-UTF-8 ``gateway.pid`` content must fail closed
+    instead of raising out of the verifier.  An escaping ``UnicodeDecodeError``
+    skipped the timed-out child's terminate cleanup (fail-open leak)."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_bytes(bytes([0xFF, 0xFE, 0x00, 0x01]) + b"binary-pid")
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is False
+    )
+
+
+def test_subprocess_became_gateway_false_when_canonical_pid_file_oversized_integer(tmp_path):
+    """Re-gate (#6733): a ``gateway.pid`` whose integer exceeds the
+    interpreter's string-conversion digit limit raises ValueError from both
+    ``json.loads`` and ``int()``; the read must stay non-throwing and fail
+    closed rather than skipping the timed-out child's cleanup."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_text("9" * 5000, encoding="utf-8")
     proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
     assert (
         gateway_restart._subprocess_became_gateway(

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -1,6 +1,7 @@
 """Health route and shared gateway restart helper checks."""
 
 import io
+import json
 import subprocess
 import threading
 import types
@@ -20,6 +21,7 @@ class MockPopen:
         communicate_timeout=False,
         wait_timeout=False,
         env=None,
+        pid=None,
     ):
         self.args = args
         self.env = env or {}
@@ -32,6 +34,7 @@ class MockPopen:
         self.killed = False
         self.communicate_timeout_arg = None
         self.wait_timeout_arg = None
+        self.pid = pid
 
     def communicate(self, timeout=None):
         self.communicate_timeout_arg = timeout
@@ -236,6 +239,88 @@ def test_restart_active_profile_gateway_timeout_releases_lock_after_background_w
     assert proc.communicate_timeout_arg == 2.0
     assert proc.wait_timeout_arg == 240.0
     assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def _became_gateway_proc(tmp_path, *, pid=4242, wait_timeout=True):
+    return MockPopen(
+        ["/mock/bin/hermes", "gateway", "restart"],
+        communicate_timeout=True,
+        wait_timeout=wait_timeout,
+        pid=pid,
+        env={"HERMES_HOME": str(tmp_path)},
+    )
+
+
+def _write_gateway_state(tmp_path, **fields):
+    (tmp_path / "gateway_state.json").write_text(
+        json.dumps(fields), encoding="utf-8"
+    )
+
+
+def test_restart_timeout_does_not_terminate_when_subprocess_became_gateway(monkeypatch, tmp_path):
+    """#6730: single-container `hermes gateway restart` becomes the gateway
+    itself (no service manager). The 240s background-wait timeout must NOT
+    SIGTERM it — that killed the healthy replacement gateway and dropped every
+    active session/SSE stream."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+    _write_gateway_state(tmp_path, gateway_state="running", pid=proc.pid)
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    # The subprocess IS the gateway: it must be left running, not terminated.
+    assert proc.terminated is False
+    assert proc.killed is False
+    # Lock still released so the next Restart Service click is not blocked.
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_timeout_still_terminates_when_subprocess_is_not_gateway(monkeypatch, tmp_path):
+    """Fail closed: without a gateway_state.json naming this subprocess PID,
+    the old terminate-on-timeout behaviour must be preserved."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+    # No gateway_state.json written: unverifiable -> terminate.
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is True
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_subprocess_became_gateway_true_for_matching_running_record(tmp_path):
+    _write_gateway_state(tmp_path, gateway_state="running", pid=4242)
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert gateway_restart._subprocess_became_gateway(proc, tmp_path) is True
+
+
+def test_subprocess_became_gateway_false_on_pid_mismatch(tmp_path):
+    _write_gateway_state(tmp_path, gateway_state="running", pid=999)
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert gateway_restart._subprocess_became_gateway(proc, tmp_path) is False
+
+
+def test_subprocess_became_gateway_false_on_stopped_state(tmp_path):
+    _write_gateway_state(tmp_path, gateway_state="stopped", pid=4242)
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert gateway_restart._subprocess_became_gateway(proc, tmp_path) is False
+
+
+def test_subprocess_became_gateway_false_on_missing_state_file(tmp_path):
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert gateway_restart._subprocess_became_gateway(proc, tmp_path) is False
 
 
 def test_restart_active_profile_gateway_busy_reports_contention(monkeypatch):

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -4,7 +4,9 @@ import io
 import json
 import subprocess
 import threading
+import time
 import types
+from datetime import datetime, timedelta, timezone
 
 import api.gateway_restart as gateway_restart
 import api.routes as routes
@@ -257,14 +259,27 @@ def _write_gateway_state(tmp_path, **fields):
     )
 
 
+def _future_timestamp() -> str:
+    """A timezone-aware ``updated_at`` guaranteed to postdate any subprocess
+    spawned during the test (matches what a gateway that became the restart
+    child would write after finishing initialization)."""
+    return (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+
+
 def test_restart_timeout_does_not_terminate_when_subprocess_became_gateway(monkeypatch, tmp_path):
     """#6730: single-container `hermes gateway restart` becomes the gateway
     itself (no service manager). The 240s background-wait timeout must NOT
     SIGTERM it — that killed the healthy replacement gateway and dropped every
-    active session/SSE stream."""
+    active session/SSE stream.  Exemption requires a confirmed ``running``
+    record that postdates the restart subprocess and names its PID."""
     gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
     proc = _became_gateway_proc(tmp_path)
-    _write_gateway_state(tmp_path, gateway_state="running", pid=proc.pid)
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=proc.pid,
+        updated_at=_future_timestamp(),
+    )
 
     monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
     monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
@@ -300,6 +315,65 @@ def test_restart_timeout_still_terminates_when_subprocess_is_not_gateway(monkeyp
     assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
 
 
+def test_restart_timeout_still_terminates_for_same_pid_starting_record(monkeypatch, tmp_path):
+    """CHANGES_REQUESTED (#6733): the gateway writes ``starting`` BEFORE
+    potentially-blocking plugin/MCP/platform initialization.  A restart child
+    wedged during startup therefore matches a same-PID ``starting`` record —
+    the termination exemption must NOT apply, and the 240s cleanup must still
+    terminate it (the old code exempted ``starting`` and leaked the process)."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+    # Same PID, fresh timestamp — only the ``starting`` state blocks the
+    # exemption, isolating the state gate from the generation gate.
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="starting",
+        pid=proc.pid,
+        updated_at=_future_timestamp(),
+    )
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is True
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_timeout_still_terminates_for_stale_generation_record(monkeypatch, tmp_path):
+    """CHANGES_REQUESTED (#6733): a ``running`` record whose ``updated_at``
+    predates the restart subprocess belongs to a previous gateway generation.
+    With PID reuse such a stale record can falsely match raw PID equality —
+    the record must postdate the subprocess spawn, otherwise the genuinely
+    stuck child is terminated instead of exempted."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+    stale_updated_at = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+    # Same PID, ``running`` state — only the stale generation blocks the
+    # exemption, isolating the generation gate from the state gate.
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=proc.pid,
+        updated_at=stale_updated_at,
+    )
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is True
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
 def test_subprocess_became_gateway_true_for_matching_running_record(tmp_path):
     _write_gateway_state(tmp_path, gateway_state="running", pid=4242)
     proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
@@ -310,6 +384,45 @@ def test_subprocess_became_gateway_false_on_pid_mismatch(tmp_path):
     _write_gateway_state(tmp_path, gateway_state="running", pid=999)
     proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
     assert gateway_restart._subprocess_became_gateway(proc, tmp_path) is False
+
+
+def test_subprocess_became_gateway_false_when_canonical_pid_file_mismatches(tmp_path):
+    """CHANGES_REQUESTED (#6733): the recorded PID must agree with the
+    canonical ``gateway.pid`` file when present.  A mismatch means the record
+    is not the current gateway generation — fail closed."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_text("7777", encoding="utf-8")
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is False
+    )
+
+
+def test_subprocess_became_gateway_true_when_canonical_pid_file_matches(tmp_path):
+    """A ``running`` record that postdates the subprocess AND agrees with the
+    canonical ``gateway.pid`` file is the current generation — exempt."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_text("4242", encoding="utf-8")
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is True
+    )
 
 
 def test_subprocess_became_gateway_false_on_stopped_state(tmp_path):

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -396,7 +396,11 @@ def test_subprocess_became_gateway_false_when_canonical_pid_file_mismatches(tmp_
         pid=4242,
         updated_at=_future_timestamp(),
     )
-    (tmp_path / "gateway.pid").write_text("7777", encoding="utf-8")
+    # Hermes writes gateway.pid as a JSON object, not a plain integer.
+    (tmp_path / "gateway.pid").write_text(
+        json.dumps({"pid": 7777, "started_at": "2026-08-03T20:00:00+00:00"}),
+        encoding="utf-8",
+    )
     proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
     assert (
         gateway_restart._subprocess_became_gateway(
@@ -408,7 +412,29 @@ def test_subprocess_became_gateway_false_when_canonical_pid_file_mismatches(tmp_
 
 def test_subprocess_became_gateway_true_when_canonical_pid_file_matches(tmp_path):
     """A ``running`` record that postdates the subprocess AND agrees with the
-    canonical ``gateway.pid`` file is the current generation — exempt."""
+    canonical ``gateway.pid`` file is the current generation — exempt.  Uses
+    the real JSON-object shape Hermes writes (``{"pid": 4242, ...}``)."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_text(
+        json.dumps({"pid": 4242, "started_at": "2026-08-03T20:00:00+00:00"}),
+        encoding="utf-8",
+    )
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is True
+    )
+
+
+def test_subprocess_became_gateway_true_with_legacy_plain_integer_pid_file(tmp_path):
+    """A legacy plain-integer ``gateway.pid`` (``"4242"``) is still accepted."""
     _write_gateway_state(
         tmp_path,
         gateway_state="running",
@@ -423,6 +449,92 @@ def test_subprocess_became_gateway_true_when_canonical_pid_file_matches(tmp_path
         )
         is True
     )
+
+
+def test_subprocess_became_gateway_false_when_canonical_pid_file_pid_not_integer(tmp_path):
+    """CORE (#6733 re-gate): a non-integer ``pid`` in the canonical JSON
+    ``gateway.pid`` file (string/float) must fail closed, never exempt."""
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    for bad_pid in ("4242", 4242.9, True):
+        _write_gateway_state(
+            tmp_path,
+            gateway_state="running",
+            pid=4242,
+            updated_at=_future_timestamp(),
+        )
+        (tmp_path / "gateway.pid").write_text(
+            json.dumps({"pid": bad_pid}), encoding="utf-8"
+        )
+        assert (
+            gateway_restart._subprocess_became_gateway(
+                proc, tmp_path, proc_started_at=time.time() - 60
+            )
+            is False
+        ), f"canonical pid {bad_pid!r} must fail closed"
+
+
+def test_subprocess_became_gateway_false_when_canonical_pid_file_invalid_json(tmp_path):
+    """CORE (#6733 re-gate): an unreadable/non-JSON/non-integer ``gateway.pid``
+    must fail closed (the old ``int()``-on-raw-file parse raised and killed the
+    healthy replacement)."""
+    _write_gateway_state(
+        tmp_path,
+        gateway_state="running",
+        pid=4242,
+        updated_at=_future_timestamp(),
+    )
+    (tmp_path / "gateway.pid").write_text("not-a-pid", encoding="utf-8")
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    assert (
+        gateway_restart._subprocess_became_gateway(
+            proc, tmp_path, proc_started_at=time.time() - 60
+        )
+        is False
+    )
+
+
+def test_subprocess_became_gateway_false_on_non_integer_runtime_pid(tmp_path):
+    """CORE (#6733 re-gate): a string/float PID in ``gateway_state.json`` must
+    fail closed.  ``int()`` accepted ``"4242"`` and truncated ``4242.9``, so
+    with no canonical pid file a genuinely hung child was exempted."""
+    proc = MockPopen(["/mock/bin/hermes", "gateway", "restart"], pid=4242)
+    for bad_pid in ("4242", 4242.9, True):
+        _write_gateway_state(tmp_path, gateway_state="running", pid=bad_pid)
+        assert (
+            gateway_restart._subprocess_became_gateway(proc, tmp_path) is False
+        ), f"runtime pid {bad_pid!r} must fail closed"
+
+
+def test_restart_timeout_exempts_child_that_wrote_state_during_popen(monkeypatch, tmp_path):
+    """CORE (#6733 re-gate): ``proc_started_at`` must be captured BEFORE
+    ``Popen``.  A fast-starting child can write its ``running`` record while
+    the parent is still inside ``Popen``; a post-Popen capture makes that
+    fresh record look older than the spawn moment and the healthy replacement
+    is terminated.  The pre-Popen capture keeps the exemption intact."""
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = _became_gateway_proc(tmp_path)
+
+    def _popen_writes_state(*args, **kwargs):
+        # The child writes its running record before Popen returns control to
+        # the parent (i.e. before any post-Popen proc_started_at capture).
+        _write_gateway_state(
+            tmp_path,
+            gateway_state="running",
+            pid=proc.pid,
+            updated_at=datetime.now(timezone.utc).isoformat(),
+        )
+        return proc
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", _popen_writes_state)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.terminated is False
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
 
 
 def test_subprocess_became_gateway_false_on_stopped_state(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the single-container Docker image "Restart Service" kill loop: clicking the button on the health banner launched `hermes gateway restart`, which (with no service manager in the image) fell through to `run_gateway()` and **became the gateway itself**. `api/gateway_restart.py::_wait_and_release` then waited out `background_wait_seconds` (240s), timed out, and called `proc.terminate()` — SIGTERM-ing the healthy replacement gateway and dropping every active chat session and SSE stream, every time.

Also relaxes the remote-gateway health probe timeout that invited the click: `_REMOTE_PROBE_TIMEOUT_S = 2.0s` produced false-positive "not responding" banners on NAS-class hardware where a healthy `/health` answer occasionally takes >2s.

## Root Cause

1. **The WebUI killer.** `_wait_and_release` assumes the restart CLI delegates to a service manager and exits. In the single-container image there is no service manager, so the CLI never exits, `proc.wait(timeout=240)` always times out, and `proc.terminate()` kills the gateway 240s after every Restart Service click.
2. **Why the CLI becomes the gateway.** `hermes_cli/gateway.py`'s restart fallback (no service manager) runs `run_gateway(verbose=0)` in the foreground — the CLI process *is* the gateway, binds the API-server port, and never exits. The existing `_HERMES_GATEWAY == "1"` kill-loop guard only covers restarts initiated *from inside* the gateway, not WebUI-launched ones.
3. **The false-positive banner.** `_REMOTE_PROBE_TIMEOUT_S = 2.0` in `api/agent_health.py` is too tight for slow hardware; one slow `/health` answer flips the payload to `remote_gateway_unreachable` and shows "not responding" for a healthy gateway.

## Change

**`api/gateway_restart.py`** — on background-wait timeout, before terminating, check whether the subprocess has itself become the gateway:

- New helper `_subprocess_became_gateway(proc, hermes_home)`: reads `gateway_state.json` from the same HERMES_HOME the subprocess was launched with and returns `True` only when the gateway self-reports `running`/`starting` **and** its recorded `pid` equals the subprocess PID (the gateway writes its own PID into that file at startup).
- When that holds, the timeout means "restart succeeded and this process IS the gateway" — log a warning, release the lock (via the existing `finally`), and leave the process running. No `terminate()`, no `kill()`.
- **Fails closed**: any unverifiable input (missing/unreadable state file, PID mismatch, non-running state) preserves the previous terminate-on-timeout behaviour, so a genuinely hung restart is still cleaned up.

**`api/agent_health.py`** — raise `_REMOTE_PROBE_TIMEOUT_S` from 2.0 to 5.0s (within the issue's suggested 5–8s range). Chose the constant raise over a double-probe because it is the lower-risk option: no test asserts the old value, the single-flight tests count probe *sets* via `len(_REMOTE_PROBE_PATHS)` and would have broken under a second probe pass, and a full three-path walk of a dead gateway stays bounded at ~15s.

Out of scope (per issue): the supervised-gateway sidecar/init for the single-container image is a long-term follow-up (#5231).

## Verification

New tests (all fail before the fix, pass after):

- `tests/test_health_restart.py`:
  - `test_restart_timeout_does_not_terminate_when_subprocess_became_gateway` — 240s timeout with a `gateway_state.json` naming the subprocess PID → process is **not** terminated, lock released. (Pre-fix: `terminated is True`.)
  - `test_restart_timeout_still_terminates_when_subprocess_is_not_gateway` — no state file → old terminate behaviour preserved.
  - `test_subprocess_became_gateway_true_for_matching_running_record` / `false_on_pid_mismatch` / `false_on_stopped_state` / `false_on_missing_state_file` — helper unit tests (fail pre-fix: helper did not exist).
- `tests/test_agent_health_remote.py`:
  - `test_remote_probe_timeout_absorbes_slow_health_answer` — asserts the probe hands `_REMOTE_PROBE_TIMEOUT_S` to the HTTP client and that it is ≥ 5.0s. (Pre-fix: `2.0 >= 5.0` fails.)

Run: `./scripts/test.sh` (repo `.venv`, Python 3.11–3.13)

- `tests/test_health_restart.py tests/test_agent_health_remote.py tests/test_5455_agent_health_single_flight.py tests/test_gateway_lifecycle_controls.py tests/test_update_banner_fixes.py tests/test_issue716_agent_heartbeat.py tests/test_issue1879_cross_container_gateway_liveness.py tests/test_agent_health_pid_path_fallback.py tests/test_gateway_status_agent_health.py tests/test_issue3194_gateway_configured_banner.py` → **217 passed**
- `tests/test_update_banner_fixes.py tests/test_gateway_sse_reconnect_dedupe.py tests/test_vietnamese_locale.py tests/test_issue1879_cross_container_gateway_liveness.py tests/test_5455_agent_health_single_flight.py` → **149 passed**

Could not verify: an end-to-end run against the actual single-container image with a live gateway (no container runtime in this environment); the fix shape matches the issue's own local verification (removing the timeout `terminate()` broke the kill loop).

## Closes

Closes #6730
