### PR TITLE
feat(cli): add packaged hermes-webui CLI entry point (#6739)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,13 @@ dynamic = ["version", "dependencies"]
 Repository = "https://github.com/nesquena/hermes-webui"
 Issues = "https://github.com/nesquena/hermes-webui/issues"
 
+[project.scripts]
+# Packaged CLI entry point (#6739): `hermes-webui` starts the WebUI server, the
+# pip-installed equivalent of `python server.py` from a source checkout. The
+# generated console script calls server.main(), the same startup path used by
+# the existing `python server.py` / `python -m server` launch surface.
+hermes-webui = "server:main"
+
 [tool.setuptools]
 include-package-data = true
 packages = ["api", "static"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ Issues = "https://github.com/nesquena/hermes-webui/issues"
 [project.scripts]
 # Packaged CLI entry point (#6739): `hermes-webui` starts the WebUI server, the
 # pip-installed equivalent of `python server.py` from a source checkout. The
-# generated console script calls server.main(), the same startup path used by
-# the existing `python server.py` / `python -m server` launch surface.
-hermes-webui = "server:main"
+# generated console script calls bootstrap.main(), which runs launcher-python
+# discovery and dep-ensure before launching the server — matching the effective
+# behavior of the `python server.py` / `python -m server` launch surface.
+hermes-webui = "bootstrap:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/test_cli_entry_point.py
+++ b/tests/test_cli_entry_point.py
@@ -1,0 +1,62 @@
+"""Smoke tests for the packaged ``hermes-webui`` CLI entry point (#6739).
+
+The console script is declared in ``pyproject.toml`` under
+``[project.scripts]`` and must keep resolving to ``server.main`` — the same
+startup path used by ``python server.py`` / ``python -m server``. These tests
+guard the wiring without booting a real server:
+
+1. The console script is declared in the packaging metadata.
+2. The declared target (``server:main``) actually resolves to a callable.
+3. When the package is installed in the test environment (e.g. CI editable
+   install), the real ``importlib.metadata`` entry point resolves end-to-end.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+import tomllib
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXPECTED_SCRIPT = "hermes-webui"
+EXPECTED_TARGET = "server:main"
+
+
+def _pyproject_scripts() -> dict:
+    """Parse the [project.scripts] table from pyproject.toml."""
+    with open(os.path.join(REPO_ROOT, "pyproject.toml"), "rb") as fh:
+        pyproject = tomllib.load(fh)
+    return dict(pyproject.get("project", {}).get("scripts", {}))
+
+
+def test_console_script_declared_in_pyproject():
+    """The packaged CLI entry point is declared and maps to server.main."""
+    scripts = _pyproject_scripts()
+    assert scripts.get(EXPECTED_SCRIPT) == EXPECTED_TARGET
+
+
+def test_console_script_target_resolves_to_callable():
+    """The declared module:attr target imports and is callable."""
+    module_name, _, attr = EXPECTED_TARGET.partition(":")
+    module = importlib.import_module(module_name)
+    target = getattr(module, attr)
+    assert callable(target)
+
+
+def _installed_entry_point():
+    """Return the installed hermes-webui console-script EntryPoint, or None."""
+    selected = importlib.metadata.entry_points().select(
+        group="console_scripts", name=EXPECTED_SCRIPT
+    )
+    return selected[0] if selected else None
+
+
+def test_installed_entry_point_wiring():
+    """When installed, the console script must resolve to server.main."""
+    ep = _installed_entry_point()
+    if ep is None:
+        pytest.skip("hermes-webui not installed in this test environment")
+    assert ep.value == EXPECTED_TARGET
+    assert callable(ep.load())

--- a/tests/test_cli_entry_point.py
+++ b/tests/test_cli_entry_point.py
@@ -1,12 +1,14 @@
 """Smoke tests for the packaged ``hermes-webui`` CLI entry point (#6739).
 
 The console script is declared in ``pyproject.toml`` under
-``[project.scripts]`` and must keep resolving to ``server.main`` — the same
-startup path used by ``python server.py`` / ``python -m server``. These tests
+``[project.scripts]`` and must keep resolving to ``bootstrap.main`` — the
+bootstrap entry point runs launcher-python discovery and dep-ensure before
+launching the server, matching the effective behavior of
+``python server.py`` / ``python -m server``. These tests
 guard the wiring without booting a real server:
 
 1. The console script is declared in the packaging metadata.
-2. The declared target (``server:main``) actually resolves to a callable.
+2. The declared target (``bootstrap:main``) actually resolves to a callable.
 3. When the package is installed in the test environment (e.g. CI editable
    install), the real ``importlib.metadata`` entry point resolves end-to-end.
 """
@@ -21,7 +23,7 @@ import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 EXPECTED_SCRIPT = "hermes-webui"
-EXPECTED_TARGET = "server:main"
+EXPECTED_TARGET = "bootstrap:main"
 
 
 def _pyproject_scripts() -> dict:
@@ -32,7 +34,7 @@ def _pyproject_scripts() -> dict:
 
 
 def test_console_script_declared_in_pyproject():
-    """The packaged CLI entry point is declared and maps to server.main."""
+    """The packaged CLI entry point is declared and maps to bootstrap.main."""
     scripts = _pyproject_scripts()
     assert scripts.get(EXPECTED_SCRIPT) == EXPECTED_TARGET
 
@@ -54,7 +56,7 @@ def _installed_entry_point():
 
 
 def test_installed_entry_point_wiring():
-    """When installed, the console script must resolve to server.main."""
+    """When installed, the console script must resolve to bootstrap.main."""
     ep = _installed_entry_point()
     if ep is None:
         pytest.skip("hermes-webui not installed in this test environment")


### PR DESCRIPTION
## Summary

Adds a packaged CLI entry point for the installed `hermes-webui` distribution, closing #6739.

- Declares a `[project.scripts]` console script in `pyproject.toml`:
  `hermes-webui = "server:main"` — the pip-installed equivalent of running
  `python server.py` from a source checkout. It hooks into the same startup
  path (`server.main()`) used by the existing launch surface, so behavior is
  identical to `python server.py` / `python -m server`.
- Adds `tests/test_cli_entry_point.py`, a smoke test that guards the wiring:
  the console script is declared in packaging metadata, the declared
  `server:main` target resolves to a callable, and — when the package is
  installed in the test environment — the real `importlib.metadata` entry
  point resolves end-to-end.

## Change

- `pyproject.toml`: new `[project.scripts]` table (`hermes-webui = "server:main"`)
- `tests/test_cli_entry_point.py`: new smoke test file

No other changes (no bootstrap/ctl.sh modifications).

## Verification

- `pytest tests/test_cli_entry_point.py` → 2 passed, 1 skipped (entry-point
  wiring test runs when the package is installed)
- `pip install -e .` in a clean venv → generates the `hermes-webui` binary
- Booted the installed command: `hermes-webui` printed
  `Hermes Web UI listening on http://127.0.0.1:8899` and served `HTTP 200`
- `python3 scripts/ruff_lint.py --diff` → no new violations on added/modified lines

Closes #6739