### PR TITLE
fix(streaming): forward MoA reference outputs as labeled blocks (#6743)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9749,6 +9749,46 @@ def _run_agent_streaming(
                         _emit_metering()
                     return
 
+                # (#6743) MoA reference-model outputs arrive through
+                # tool_progress_callback as display events (moa.reference /
+                # moa.progress / moa.phase / moa.aggregating) relayed by the
+                # MoA facade. The WebUI previously dropped the whole family
+                # (only reasoning.available had dedicated handling), so MoA
+                # turns looked like a silent hang until the aggregator's final
+                # answer. Forward each event verbatim as its own SSE event so
+                # the frontend can render labelled collapsible blocks, matching
+                # the CLI/TUI. Display-only: never touches tool cards, the
+                # reasoning index, or the live prompt estimate.
+                if event_type in ('moa.reference', 'moa.progress', 'moa.phase', 'moa.aggregating'):
+                    if event_type == 'moa.reference':
+                        _moa_payload = {'label': name, 'text': preview}
+                        if cb_kwargs.get('moa_index') is not None:
+                            _moa_payload['index'] = cb_kwargs.get('moa_index')
+                        if cb_kwargs.get('moa_count') is not None:
+                            _moa_payload['count'] = cb_kwargs.get('moa_count')
+                    elif event_type == 'moa.progress':
+                        _moa_payload = {'label': name}
+                        if cb_kwargs.get('moa_refs_done') is not None:
+                            _moa_payload['refs_done'] = cb_kwargs.get('moa_refs_done')
+                        if cb_kwargs.get('moa_refs_total') is not None:
+                            _moa_payload['refs_total'] = cb_kwargs.get('moa_refs_total')
+                    elif event_type == 'moa.phase':
+                        _moa_payload = {'phase': cb_kwargs.get('moa_phase')}
+                        if cb_kwargs.get('moa_refs_done') is not None:
+                            _moa_payload['refs_done'] = cb_kwargs.get('moa_refs_done')
+                        if cb_kwargs.get('moa_refs_total') is not None:
+                            _moa_payload['refs_total'] = cb_kwargs.get('moa_refs_total')
+                        if name:
+                            _moa_payload['aggregator'] = name
+                    else:  # moa.aggregating
+                        _moa_payload = {}
+                        if name:
+                            _moa_payload['aggregator'] = name
+                        if cb_kwargs.get('moa_ref_count') is not None:
+                            _moa_payload['ref_count'] = cb_kwargs.get('moa_ref_count')
+                    put(event_type, _moa_payload)
+                    return
+
                 # (#3587) Advance reasoning index at tool-call boundaries.
                 # on_interim_assistant is suppressed for contentless tool-call
                 # messages (run_agent.py:3834), so the index never advances

--- a/static/messages.js
+++ b/static/messages.js
@@ -2519,6 +2519,65 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(typeof updateThinking==='function') updateThinking(text, opts);
     else appendThinking(text, opts);
   }
+  // (#6743) MoA reference-model output block. Each reference arrives as a
+  // `moa.reference` SSE event (forwarded from the agent's MoA facade) with
+  // {label, text, index?, count?}. Render it as a labelled, collapsible card
+  // inside the live assistant turn — CLI/TUI parity. Upsert by label so a
+  // re-sent/replayed event for the same reference updates the same block.
+  function _upsertMoaReference(d){
+    if(!d||!d.label) return;
+    if(!S.session||S.session.session_id!==activeSid) return;
+    if(typeof isFinalAnswerOnlyMode==='function'&&isFinalAnswerOnlyMode()) return;
+    let turn=$('liveAssistantTurn');
+    if(!turn){
+      turn=_createAssistantTurn();
+      turn.id='liveAssistantTurn';
+      if(S.session) turn.dataset.sessionId=S.session.session_id;
+      const inner=$('msgInner');
+      if(inner) inner.appendChild(turn);
+    }
+    const blocks=_assistantTurnBlocks(turn);
+    if(!blocks) return;
+    const key=String(d.label||'');
+    let card=blocks.querySelector('.moa-reference[data-moa-ref="'+CSS.escape(key)+'"]');
+    const counter=(d.index!=null&&d.count!=null)?` <span class="moa-ref-counter">${d.index}/${d.count}</span>`:'';
+    if(!card){
+      card=document.createElement('div');
+      card.className='agent-activity-thinking moa-reference';
+      card.setAttribute('data-moa-ref',key);
+      card.innerHTML=`<div class="thinking-card open"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('layers',14)}</span><span class="thinking-card-label">${esc(String(d.label||''))}${counter}</span><span class="thinking-card-btn-row"><span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre></pre></div></div>`;
+      const liveFooter=blocks.querySelector('#liveRunStatus');
+      if(liveFooter&&liveFooter.parentElement===blocks) blocks.insertBefore(card,liveFooter);
+      else blocks.appendChild(card);
+    }
+    const body=card.querySelector('.thinking-card-body pre');
+    if(body&&d.text!==undefined&&d.text!==null) body.textContent=String(d.text);
+    if(typeof scrollIfPinned==='function') scrollIfPinned();
+  }
+  // (#6743) MoA status line: `moa.progress` (N/M refs done) and
+  // `moa.aggregating` / `moa.phase` ("Aggregating…"). One shared status row
+  // per live turn, kept above #liveRunStatus so it does not fight the footer.
+  function _updateMoaStatus(d, aggregating){
+    if(!S.session||S.session.session_id!==activeSid) return;
+    let turn=$('liveAssistantTurn');
+    if(!turn) return;
+    const blocks=_assistantTurnBlocks(turn);
+    if(!blocks) return;
+    let status=blocks.querySelector('.moa-status');
+    if(!status){
+      status=document.createElement('div');
+      status.className='moa-status';
+      const liveFooter=blocks.querySelector('#liveRunStatus');
+      if(liveFooter&&liveFooter.parentElement===blocks) blocks.insertBefore(status,liveFooter);
+      else blocks.appendChild(status);
+    }
+    if(aggregating){
+      status.textContent=d&&d.aggregator?`Aggregating with ${d.aggregator}…`:'Aggregating…';
+    }else if(d&&d.refs_done!=null&&d.refs_total!=null){
+      status.textContent=`MoA: ${d.refs_done}/${d.refs_total} refs done`;
+    }
+    status.style.display='';
+  }
   // Split a content string into {reasoning, content} by extracting any <think>...
   // blocks (or other known reasoning-tag pairs). If reasoning is already
   // populated on the message (e.g. from a separate on_reasoning stream), the
@@ -5844,6 +5903,36 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           });
         }
       }
+    });
+
+    source.addEventListener('moa.reference',e=>{
+      if(_terminalStateReached||_streamFinalized) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
+      const d=JSON.parse(e.data);
+      _completeAutomaticCompressionOnLiveProgress(activeSid);
+      _upsertMoaReference(d);
+      snapshotLiveTurn();
+    });
+
+    source.addEventListener('moa.progress',e=>{
+      if(_terminalStateReached||_streamFinalized) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
+      const d=JSON.parse(e.data);
+      _updateMoaStatus(d,false);
+    });
+
+    source.addEventListener('moa.phase',e=>{
+      if(_terminalStateReached||_streamFinalized) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
+      const d=JSON.parse(e.data);
+      if(d&&d.phase==='aggregator') _updateMoaStatus(d,true);
+    });
+
+    source.addEventListener('moa.aggregating',e=>{
+      if(_terminalStateReached||_streamFinalized) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
+      const d=JSON.parse(e.data);
+      _updateMoaStatus(d,true);
     });
 
     source.addEventListener('tool',e=>{

--- a/static/style.css
+++ b/static/style.css
@@ -6298,6 +6298,12 @@ body code[class*="language-"],body pre[class*="language-"],body pre code[class*=
 .thinking-card.open .thinking-card-body { max-height: 260px; overflow-y: auto; opacity: 1; padding: 8px 12px; border-top-color: var(--accent-bg-strong); }
 .thinking-card-body pre { font-family:var(--font-mono); font-size: 11px; line-height: 1.6; color: var(--muted); white-space: pre-wrap; word-break: break-word; margin: 0; }
 
+/* ── MoA reference blocks (#6743): labelled collapsible cards, CLI/TUI parity ── */
+.moa-reference .thinking-card-label{font-weight:600;letter-spacing:.02em;}
+.moa-ref-counter{font-weight:500;opacity:.6;font-size:11px;margin-left:2px;}
+.moa-status{margin:2px 0 3px var(--msg-rail);max-width:var(--msg-max);font-size:11px;color:var(--muted);display:flex;align-items:center;gap:6px;opacity:.9;}
+.moa-status::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--accent);opacity:.7;flex:none;animation:hermes-cursor-blink 1.2s infinite;}
+
 /* ── Tool cards: quiet disclosure rows ── */
 .tool-card { background:transparent;border:0;border-left:0;border-radius:0;margin-top:0;margin-bottom:0; }
 .tool-card-header { display:flex;align-items:center;gap:7px;padding:3px 8px;margin-left:-8px;border-radius:7px; }

--- a/tests/test_6743_moa_reference_output.py
+++ b/tests/test_6743_moa_reference_output.py
@@ -1,0 +1,141 @@
+"""Regression tests for #6743 — MoA reference outputs silently dropped in WebUI.
+
+Root cause: ``api/streaming.py``'s ``on_tool`` handled ``reasoning.available``
+but had no branch for the MoA display-event family (``moa.reference`` /
+``moa.progress`` / ``moa.phase`` / ``moa.aggregating``) that the Hermes Agent
+relays through ``tool_progress_callback``. The events fell through every guard
+and were never ``put()`` onto the SSE queue, so the WebUI showed nothing during
+the reference fan-out — only the aggregator's final answer. The CLI/TUI render
+each reference as a labelled block.
+
+Fix (this PR):
+  1. Backend — ``on_tool`` forwards each ``moa.*`` event as its own SSE event
+     with a payload shaped like the gateway's (label/text/index/count for
+     references; refs_done/refs_total for progress; phase/aggregator for
+     phase/aggregating).
+  2. Frontend — ``static/messages.js`` registers ``moa.reference`` /
+     ``moa.progress`` / ``moa.phase`` / ``moa.aggregating`` SSE listeners and
+     renders each reference as a labelled, collapsible ``thinking-card`` block
+     (``_upsertMoaReference``) plus a shared status line (``_updateMoaStatus``).
+  3. CSS — ``.moa-reference`` / ``.moa-ref-counter`` / ``.moa-status``.
+
+These are static source-structure tests (repo convention for streaming issues):
+they pin the fix's shape so a future refactor cannot silently re-drop the
+events.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def extract_fn(src: str, name: str) -> str:
+    """Return the full source of ``function name(...) {...}`` / ``def name(...)``.
+
+    JS functions are brace-counted from the opening ``{``. Python functions are
+    indentation-based: slice from the ``def`` line to the next same-indent
+    ``def``/non-body line (dict literals inside the body would otherwise
+    confuse brace counting).
+    """
+    m = re.search(rf"(?:function|def) {re.escape(name)}\s*\(", src)
+    assert m, f"{name}() not found in source"
+    if src[m.start():m.start() + 3] == "def":
+        line_start = src.rfind("\n", 0, m.start()) + 1
+        indent = src[line_start:m.start()]
+        # End at the next line that starts a top-level statement at the same indent.
+        body_start = m.start()
+        for candidate in re.finditer(rf"\n{re.escape(indent)}def |\n{re.escape(indent)}class |\n{re.escape(indent)}[A-Za-z_]", src[body_start + 1:]):
+            pos = body_start + 1 + candidate.start()
+            # Skip our own def line (the match starts at the same indent but is
+            # the def itself — the first regex hit after the signature is the
+            # first body statement, which is indented deeper, so the next
+            # same-indent hit is a sibling).
+            if pos > body_start + len(m.group(0)):
+                return src[body_start:pos]
+        return src[body_start:]
+    brace = src.index("{", m.end())
+    depth = 1
+    pos = brace + 1
+    while pos < len(src) and depth > 0:
+        ch = src[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        pos += 1
+    return src[m.start():pos]
+
+
+# ── Backend: on_tool must forward the MoA display-event family ────────────
+
+def test_on_tool_forwards_moa_reference():
+    fn = extract_fn(STREAMING_PY, "on_tool")
+    # The MoA branch must be a distinct guard (not folded into tool.started).
+    assert "('moa.reference', 'moa.progress', 'moa.phase', 'moa.aggregating')" in fn
+    # Reference payload must carry the labelled block fields.
+    assert "'label': name" in fn
+    assert "'text': preview" in fn
+    # Progress payload carries the N/M counters.
+    assert "'refs_done'" in fn
+    assert "'refs_total'" in fn
+    # The event is emitted on the SSE queue under its own name.
+    assert "put(event_type, _moa_payload)" in fn
+    # Display-only: it must return before tool-card bookkeeping runs.
+    assert fn.index("moa.reference") < fn.index("event_type in (None, 'tool.started')")
+
+
+def test_on_tool_moa_branch_sits_before_tool_guards():
+    fn = extract_fn(STREAMING_PY, "on_tool")
+    moa_pos = fn.index("('moa.reference', 'moa.progress', 'moa.phase', 'moa.aggregating')")
+    tool_started_pos = fn.index("event_type in (None, 'tool.started')")
+    assert moa_pos < tool_started_pos, "MoA branch must be handled before tool.started guards"
+
+
+def test_on_tool_moa_payload_keeps_aggregator_and_count():
+    fn = extract_fn(STREAMING_PY, "on_tool")
+    # moa.aggregating / moa.phase carry the aggregator label + ref count.
+    assert "'aggregator'" in fn
+    assert "'ref_count'" in fn
+
+
+# ── Frontend: SSE listeners + labelled collapsible block rendering ────────
+
+def test_wire_sse_registers_moa_listeners():
+    fn = extract_fn(MESSAGES_JS, "_wireSSE")
+    for evt in ("moa.reference", "moa.progress", "moa.phase", "moa.aggregating"):
+        assert f"addEventListener('{evt}'" in fn, f"missing {evt} listener in _wireSSE"
+
+
+def test_upsert_moa_reference_renders_labelled_block():
+    fn = extract_fn(MESSAGES_JS, "_upsertMoaReference")
+    # Labelled, collapsible block: model name in header, text in body.
+    assert "data-moa-ref" in fn
+    assert "thinking-card" in fn
+    assert "thinking-card-label" in fn
+    assert "thinking-card-body" in fn
+    assert "esc(String(d.label||''))" in fn
+    # Escaped body text, never raw innerHTML of the reference text.
+    assert "body.textContent=String(d.text)" in fn
+    # Guarded by session identity like every other live-stream handler.
+    assert "S.session.session_id!==activeSid" in fn
+
+
+def test_update_moa_status_shows_progress_and_aggregating():
+    fn = extract_fn(MESSAGES_JS, "_updateMoaStatus")
+    assert "MoA: ${d.refs_done}/${d.refs_total} refs done" in fn
+    assert "Aggregating with ${d.aggregator}" in fn
+
+
+def test_moa_css_classes_present():
+    assert ".moa-reference .thinking-card-label" in STYLE_CSS
+    assert ".moa-ref-counter" in STYLE_CSS
+    assert ".moa-status" in STYLE_CSS
+
+
+def test_moa_status_uses_existing_animation_keyframes():
+    assert "@keyframes hermes-cursor-blink" in STYLE_CSS


### PR DESCRIPTION
## Summary

Fixes #6743 — MoA reference model outputs are silently dropped in the WebUI. With a MoA preset (e.g. `moa:sp-moa`), only the aggregator's final answer appears after a long silent wait; the reference blocks that the CLI/TUI show in real time never surface.

## Root Cause

`api/streaming.py::on_tool()` (the `tool_progress_callback` handler) had dedicated branches for `reasoning.available`/`_thinking` but no branch for the MoA display-event family (`moa.reference`, `moa.progress`, `moa.phase`, `moa.aggregating`). Those events fell through to the `tool.started`/`tool.completed` guards and were silently dropped — the WebUI never emitted them as SSE events.

Verified against the agent side: `agent/moa_loop.py::build_moa_facade` → `_moa_reference_relay` → `agent.tool_progress_callback("moa.reference", label, text, None, moa_index=, moa_count=)` — exactly the 4-positional-args + kwargs shape `on_tool` parses. The TUI (`tui_gateway/server.py:5125-5185`) renders the same family as labelled blocks. The SSE delivery path forwards events verbatim (no whitelist filter) — the drop is solely the missing `on_tool` branch.

## Change

- `api/streaming.py` — new MoA event branch in `on_tool()`: `moa.reference` / `moa.progress` / `moa.phase` / `moa.aggregating` are forwarded as SSE events with the label, text, and `moa_index`/`moa_count` metadata (aggregator phase handled distinctly).
- `static/messages.js` — renderer for the forwarded events: each reference appears as a labelled, collapsible block (model name + live text), matching the CLI/TUI presentation; aggregator phase shows a distinct status row.
- `static/style.css` — styling for the reference blocks (label, collapse affordance, phase row).
- `tests/test_6743_moa_reference_output.py` — 8 tests: backend forwarding of all 4 event types with metadata, frontend renderer output (labels, collapsible structure, aggregator phase), and no-drop regression for the previous fall-through path.

## Verification

- `pytest tests/test_6743_moa_reference_output.py` → 8 passed.
- `node --check static/messages.js` and `py_compile api/streaming.py` clean.

Closes #6743
