### PR TITLE
fix: resolve pre-compression snapshot ids on /api/chat/start

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -9576,28 +9576,21 @@ def _pre_compression_continuation_session_id(session) -> str | None:
                 seen.add(child_sid)
                 if _row_value(child, "pre_compression_snapshot", False):
                     frontier.append(child_sid)
-                else:
-                    candidates.append(child)
+                    continue
+                # User forks (session_source="fork") are not compression
+                # continuations: starting a turn on one would fork the archived
+                # conversation instead of continuing it (#6745 review).
+                if str(_row_value(child, "session_source") or "").strip().lower() == "fork":
+                    continue
+                candidates.append(child)
 
-        if not candidates:
+        # Fail closed on ambiguity: only a uniquely resolvable continuation is
+        # safe to hand to the client or to start a turn on. With several
+        # candidates (or none) the lineage is stale or racy — don't guess
+        # (#6745 review).
+        if len(candidates) != 1:
             return None
-        latest = max(
-            candidates,
-            key=lambda child: (
-                float(
-                    _safe_first(
-                        _row_value(child, "updated_at"),
-                        _row_value(child, "created_at"),
-                        0,
-                    ) or 0
-                ),
-                # Secondary tiebreaker so the index-fast-path and the sidecar-scan
-                # path resolve byte-identically on an updated_at/created_at tie
-                # (otherwise the chosen sid could differ by iteration order).
-                str(_safe_first(_row_value(child, "session_id"), "") or ""),
-            ),
-        )
-        latest_sid = _safe_first(_row_value(latest, "session_id", None)) or None
+        latest_sid = _safe_first(_row_value(candidates[0], "session_id", None)) or None
         # Only hand the client a well-formed session id (it gets written to URL/localStorage).
         if latest_sid and not is_safe_session_id(latest_sid):
             return None
@@ -22150,17 +22143,43 @@ def _handle_chat_start(handler, body, diag=None):
         # continuation hint, so the typed message lands in the active session.
         if getattr(s, "pre_compression_snapshot", False):
             continuation_sid = _pre_compression_continuation_session_id(s)
-            if continuation_sid:
-                try:
-                    s = _get_or_materialize_session(
-                        continuation_sid, refresh_cli_messages=True
-                    )
-                except KeyError:
-                    logger.warning(
-                        "resolved continuation %s for snapshot %s but it is not loadable; continuing with snapshot",
-                        continuation_sid,
-                        body["session_id"],
-                    )
+            if not continuation_sid:
+                # Sealed snapshot without a uniquely resolvable live
+                # continuation: the gateway rejects appends to snapshots, so a
+                # turn started here would run and then fail to persist. Fail
+                # closed with a retryable 409 instead (#6745 review).
+                logger.warning(
+                    "refusing chat/start on archived snapshot %s: no unique loadable continuation",
+                    body["session_id"],
+                )
+                return bad(
+                    handler,
+                    f"session {body['session_id']} was archived by compression; reload its continuation session",
+                    409,
+                )
+            try:
+                s = _get_or_materialize_session(
+                    continuation_sid, refresh_cli_messages=True
+                )
+            except PermissionError:
+                # Read-only continuation (imported/subagent): preserve the 403
+                # contract of the direct-id load above (#6745 review).
+                return bad(
+                    handler,
+                    "Read-only imported sessions cannot be continued from WebUI",
+                    403,
+                )
+            except KeyError:
+                logger.warning(
+                    "resolved continuation %s for snapshot %s but it is not loadable; refusing to append to the sealed snapshot",
+                    continuation_sid,
+                    body["session_id"],
+                )
+                return bad(
+                    handler,
+                    f"session {body['session_id']} was archived by compression; its continuation {continuation_sid} is not loadable, reload and retry",
+                    409,
+                )
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
         active_profile = _get_active_profile_name()

--- a/api/routes.py
+++ b/api/routes.py
@@ -22142,6 +22142,25 @@ def _handle_chat_start(handler, body, diag=None):
                 pass
         except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
+        # A mobile client can still hold a pre-compression snapshot id after
+        # context compression. The gateway refuses appends to a closed
+        # snapshot ("closed by compression; adopt its live continuation"), so a
+        # full agent turn would run and then fail to persist (response_len=0).
+        # Resolve to the live continuation here, mirroring the GET /api/session
+        # continuation hint, so the typed message lands in the active session.
+        if getattr(s, "pre_compression_snapshot", False):
+            continuation_sid = _pre_compression_continuation_session_id(s)
+            if continuation_sid:
+                try:
+                    s = _get_or_materialize_session(
+                        continuation_sid, refresh_cli_messages=True
+                    )
+                except KeyError:
+                    logger.warning(
+                        "resolved continuation %s for snapshot %s but it is not loadable; continuing with snapshot",
+                        continuation_sid,
+                        body["session_id"],
+                    )
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
         active_profile = _get_active_profile_name()

--- a/tests/test_chat_start_resolves_pre_compression_snapshot.py
+++ b/tests/test_chat_start_resolves_pre_compression_snapshot.py
@@ -289,3 +289,27 @@ def test_chat_start_fork_only_child_does_not_unblock_snapshot(monkeypatch, tmp_p
 
     assert captured["handler"].response_status == 409
     assert "session_id" not in captured
+
+
+def test_chat_start_compressed_fork_lineage_still_resolves(monkeypatch, tmp_path):
+    """A fork that itself underwent compression (fork sidecar sealed as a
+    snapshot) must still resolve to its live continuation.
+
+    Greptile P1 concern: the continuation of a compressed fork would inherit
+    session_source=\"fork\" and be wrongly excluded. In this data model that
+    cannot happen — the gateway has no session_source column and the webui
+    materializer reads it from gateway metadata (always None); the only
+    writer of session_source=\"fork\" is /api/session/branch. This test pins
+    the behavior so the lineage stays resolvable.
+    """
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(
+        SNAPSHOT_ID,
+        pre_compression_snapshot=True,
+        session_source="fork",
+    )
+    _make_session(CONT_ID, parent_session_id=SNAPSHOT_ID)
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["session_id"] == CONT_ID

--- a/tests/test_chat_start_resolves_pre_compression_snapshot.py
+++ b/tests/test_chat_start_resolves_pre_compression_snapshot.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 from io import BytesIO
-from types import SimpleNamespace
 
 SNAPSHOT_ID = "snap123"
 CONT_ID = "cont456"
@@ -50,9 +49,31 @@ def _seed_session_dir(monkeypatch, tmp_path):
     return models
 
 
+class _FakeHandler:
+    """Minimal BaseHTTPRequestHandler-shaped fake: bad() writes the status
+    via handler.send_response, so the error-path tests can assert the real
+    status code the client would receive."""
+
+    def __init__(self):
+        self.wfile = BytesIO()
+        self.response_status = None
+        self.headers = {}
+        self.rfile = BytesIO()
+
+    def send_response(self, status):
+        self.response_status = status
+
+    def send_header(self, *args, **kwargs):
+        pass
+
+    def end_headers(self):
+        pass
+
+
 def _call_chat_start(monkeypatch, session_id, message="continue this work"):
     """Invoke the real POST /api/chat/start handler and capture which session
-    the agent turn would be started on (via the _start_run seam)."""
+    the agent turn would be started on (via the _start_run seam) plus the
+    response status (via the fake handler / j seam)."""
     import api.routes as routes
 
     captured = {}
@@ -88,11 +109,11 @@ def _call_chat_start(monkeypatch, session_id, message="continue this work"):
 
     body = {"session_id": session_id, "message": message}
     body_bytes = json.dumps(body).encode()
-    handler = SimpleNamespace(
-        headers={"Content-Length": str(len(body_bytes))},
-        rfile=BytesIO(body_bytes),
-    )
+    handler = _FakeHandler()
+    handler.headers = {"Content-Length": str(len(body_bytes))}
+    handler.rfile = BytesIO(body_bytes)
     routes._handle_chat_start(handler, body)
+    captured["handler"] = handler
     return captured
 
 
@@ -152,12 +173,119 @@ def test_chat_start_follows_multi_hop_snapshot_chain(monkeypatch, tmp_path):
     assert captured["session_id"] == CONT_ID
 
 
-def test_chat_start_snapshot_without_continuation_falls_through(monkeypatch, tmp_path):
-    """A snapshot with no visible continuation degrades to the requested
-    session instead of erroring — the gateway still owns the final refusal."""
+def test_chat_start_snapshot_without_continuation_is_refused(monkeypatch, tmp_path):
+    """A sealed snapshot with no uniquely resolvable continuation must NOT
+    start a turn on the snapshot — the gateway rejects appends to archived
+    sessions, so the turn would run and then fail to persist. Fail closed
+    with a retryable 409 (#6745 review: the previous fallthrough enshrined
+    the defect)."""
     _seed_session_dir(monkeypatch, tmp_path)
     _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
 
     captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
 
-    assert captured["session_id"] == SNAPSHOT_ID
+    assert captured["handler"].response_status == 409
+    assert "session_id" not in captured  # _start_run must never be reached
+
+
+def test_chat_start_unloadable_continuation_is_refused(monkeypatch, tmp_path):
+    """Resolver found a continuation, but materializing it raises KeyError
+    (stale/racy lineage): refuse with a retryable 409 carrying both ids
+    instead of falling through to the sealed snapshot (#6745 review)."""
+    import api.routes as routes
+
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session(CONT_ID, parent_session_id=SNAPSHOT_ID)
+
+    real = routes._get_or_materialize_session
+
+    def selective_materialize(sid, **kwargs):
+        if sid == CONT_ID:
+            raise KeyError(sid)
+        return real(sid, **kwargs)
+
+    monkeypatch.setattr(routes, "_get_or_materialize_session", selective_materialize)
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["handler"].response_status == 409
+    assert "session_id" not in captured  # _start_run must never be reached
+
+
+def test_chat_start_read_only_continuation_is_refused(monkeypatch, tmp_path):
+    """A read-only continuation (imported/subagent) must return the same 403
+    as the direct-id path, not escape to a 500 (#6745 review finding 2)."""
+    import api.routes as routes
+
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session(CONT_ID, parent_session_id=SNAPSHOT_ID)
+
+    real = routes._get_or_materialize_session
+
+    def selective_materialize(sid, **kwargs):
+        if sid == CONT_ID:
+            raise PermissionError("read-only imported session")
+        return real(sid, **kwargs)
+
+    monkeypatch.setattr(routes, "_get_or_materialize_session", selective_materialize)
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["handler"].response_status == 403
+    assert "session_id" not in captured  # _start_run must never be reached
+
+
+def test_chat_start_ambiguous_continuations_are_refused(monkeypatch, tmp_path):
+    """Two non-fork children of the snapshot = ambiguous lineage: the
+    resolver must not guess. Refuse with 409 (#6745 review)."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session("cont456", parent_session_id=SNAPSHOT_ID)
+    _make_session("cont789", parent_session_id=SNAPSHOT_ID)
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["handler"].response_status == 409
+    assert "session_id" not in captured
+
+
+def test_chat_start_fork_child_is_not_used_as_continuation(monkeypatch, tmp_path):
+    """A user fork of the snapshot (session_source="fork") is not a
+    compression continuation: the turn must land on the real continuation,
+    even when the fork is the newest child (#6745 review).
+
+    The fork is saved AFTER the continuation so the pre-fix resolver (which
+    picked the newest candidate) would choose the fork — this test is red
+    without the fork exclusion.
+    """
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session(CONT_ID, parent_session_id=SNAPSHOT_ID)
+    _make_session(
+        "fork999",
+        parent_session_id=SNAPSHOT_ID,
+        session_source="fork",
+    )
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["session_id"] == CONT_ID
+
+
+def test_chat_start_fork_only_child_does_not_unblock_snapshot(monkeypatch, tmp_path):
+    """A snapshot whose only child is a fork still has no continuation: 409,
+    no run. The fork must not be mistaken for the live lineage."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session(
+        "fork999",
+        parent_session_id=SNAPSHOT_ID,
+        session_source="fork",
+    )
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["handler"].response_status == 409
+    assert "session_id" not in captured

--- a/tests/test_chat_start_resolves_pre_compression_snapshot.py
+++ b/tests/test_chat_start_resolves_pre_compression_snapshot.py
@@ -1,0 +1,163 @@
+"""Regression tests — /api/chat/start must canonicalize a pre-compression
+snapshot id to its live continuation.
+
+Root cause: after context compression, the archived session sidecar is marked
+``pre_compression_snapshot`` and the gateway refuses appends to it ("Session
+'X' is closed by compression; adopt its live continuation before appending
+messages"). The GET /api/session path already surfaces a
+``continuation_session_id`` hint, but the chat/start path passed the stale id
+straight through: the agent ran a full turn and then failed to persist
+(response_len=0) — a silent token + UX failure for any client (e.g. a mobile
+app) still holding the archived id.
+
+Fix: in ``_handle_chat_start``, after materializing the requested session,
+resolve pre-compression snapshots to their live continuation (the same
+``_pre_compression_continuation_session_id`` helper the read path uses) and
+start the turn on the continuation.
+
+These tests fail on origin/master (the turn starts on the snapshot) and pass
+with the fix.
+"""
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from types import SimpleNamespace
+
+SNAPSHOT_ID = "snap123"
+CONT_ID = "cont456"
+MID_ID = "mid789"
+
+
+def _seed_session_dir(monkeypatch, tmp_path):
+    """Point the session store at an isolated tmp dir (mirror #5532 harness).
+
+    The resolver in api/routes.py reads SESSION_DIR / SESSION_INDEX_FILE from
+    ITS OWN api.config imports (routes.SESSION_DIR), not from api.models — so
+    both module attributes must be patched or the resolver checks the real
+    session store and finds no backing files for the fixtures.
+    """
+    import api.models as models
+    import api.routes as routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    return models
+
+
+def _call_chat_start(monkeypatch, session_id, message="continue this work"):
+    """Invoke the real POST /api/chat/start handler and capture which session
+    the agent turn would be started on (via the _start_run seam)."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_start_run(session, **kwargs):
+        captured["session_id"] = session.session_id
+        return {"_status": 200}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+
+    # Keep the turn hermetic: stub the heavy resolution/launch seams.
+    monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **kw: None)
+    monkeypatch.setattr(
+        routes,
+        "_resolve_chat_workspace_with_recovery",
+        lambda s, ws: "/tmp/ws",
+    )
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda *a, **kw: ("deepseek/deepseek-v4-flash", "deepseek", "deepseek/deepseek-v4-flash"),
+    )
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda s, p: (None, None, {}))
+    monkeypatch.setattr(
+        routes,
+        "_repair_foreign_session_model_provider",
+        lambda *a, **kw: "deepseek",
+    )
+    monkeypatch.setattr(routes, "_start_run", fake_start_run)
+    monkeypatch.setattr(routes, "j", fake_j)
+
+    body = {"session_id": session_id, "message": message}
+    body_bytes = json.dumps(body).encode()
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(body_bytes))},
+        rfile=BytesIO(body_bytes),
+    )
+    routes._handle_chat_start(handler, body)
+    return captured
+
+
+def _make_session(session_id, **kwargs):
+    from api.models import Session
+
+    session = Session(
+        session_id=session_id,
+        profile="default",
+        messages=[{"id": "u1", "role": "user", "content": "old", "timestamp": 1.0}],
+        **kwargs,
+    )
+    session.save()
+    return session
+
+
+def test_chat_start_on_snapshot_starts_turn_on_live_continuation(monkeypatch, tmp_path):
+    """A pre-compression snapshot id must resolve to its live continuation.
+
+    Fail-without-fix: _start_run receives the snapshot id and the turn would
+    then be rejected at persistence by the gateway ("closed by compression").
+    """
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(
+        SNAPSHOT_ID,
+        pre_compression_snapshot=True,
+    )
+    _make_session(
+        CONT_ID,
+        parent_session_id=SNAPSHOT_ID,
+        pre_compression_snapshot=False,
+    )
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["session_id"] == CONT_ID
+
+
+def test_chat_start_follows_multi_hop_snapshot_chain(monkeypatch, tmp_path):
+    """Repeated compression (snapshot -> snapshot -> live) must still land on
+    the newest visible continuation, not an intermediate archived session."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+    _make_session(
+        MID_ID,
+        parent_session_id=SNAPSHOT_ID,
+        pre_compression_snapshot=True,
+    )
+    _make_session(
+        CONT_ID,
+        parent_session_id=MID_ID,
+        pre_compression_snapshot=False,
+    )
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["session_id"] == CONT_ID
+
+
+def test_chat_start_snapshot_without_continuation_falls_through(monkeypatch, tmp_path):
+    """A snapshot with no visible continuation degrades to the requested
+    session instead of erroring — the gateway still owns the final refusal."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    _make_session(SNAPSHOT_ID, pre_compression_snapshot=True)
+
+    captured = _call_chat_start(monkeypatch, SNAPSHOT_ID)
+
+    assert captured["session_id"] == SNAPSHOT_ID


### PR DESCRIPTION
## Summary

When a conversation crosses the compression threshold, the gateway seals the old session and continues in a new one linked via `parent_session_id`. A client that still holds the pre-compression session id (backgrounded tab, stale bookmark) then POSTs to `/api/chat/start` with the sealed snapshot id. Before this PR the turn started on the sealed snapshot anyway: the gateway refused the append ("Session ... is closed by compression; adopt its live continuation"), the turn died with `session_persistence_failed`, and the user's message vanished — a full paid turn, discarded. Round 1's attempt to canonicalize snapshot→continuation was reviewed and found to fail open; this revision addresses that review.

## Changes (round 2, per review)

- **Fail closed:** `/api/chat/start` on a compression snapshot returns **409** when no unique loadable continuation exists, **403** when the continuation is read-only. It never starts a run on a sealed snapshot.
- **Resolver** (`_pre_compression_continuation_session_id`): requires **exactly one** candidate; the previous "newest" guess among multiple continuations is gone (ambiguity → 409).
- **Fork/child exclusion:** children stamped `session_source="fork"` are not continuation candidates — writing there would fork the archived conversation. A user fork created before its parent's compression is refused (409) rather than mistaken for the live lineage.
- Round 1's regression test asserted the unsafe fallthrough as correct; it was inverted, and error-path tests were added (unloadable → 409, read-only → 403, ambiguous → 409, fork-only → 409, compressed-fork lineage still resolves). **9 tests.**

## Proof

- With fix: 9/9 pass. Round-1 code: 6 fail. `origin/master`: all 9 fail (no canonicalization exists).
- Adjacent suites (compression recovery, truncation watermark): 23/23 pass.
- Greptile P1 (compressed fork's continuation inheriting `session_source="fork"`): verified impossible — the gateway `sessions` table has no `session_source` column, and the webui materializer reads it only from gateway metadata (always NULL). Pinned by `test_chat_start_compressed_fork_lineage_still_resolves`.

## Known limitations (named)

- The guard keys on the sidecar `pre_compression_snapshot` flag, written by the webui's in-process compression flow (streaming.py:4404/4447). A sidecar materialized after **gateway-side** sealing may lack the flag, so the guard would not fire for it (fail-open upstream on gateway-routed deployments). Follow-up: stamp the flag during materialization from state.db `end_reason='compression'`.
- Sibling turn-start paths — `start_session_turn` (process-wakeup) and `_handle_goal` — do not yet resolve snapshot→continuation. Same defect class; out of scope here, follow-up at the shared chokepoint.
- Continuations that exist only in gateway state.db (never materialized webui-side) resolve to 409 without a named continuation; the sidebar lists them.
- A snapshot whose only child is a compression-recovery fork resolves to 409 (the fork filter excludes `session_source="fork"` children, recovery forks included). Fail-closed and consistent with the "exclude forks" ask; distinguishing recovery forks via `compression_recovery_source_session_id` is a tracked follow-up.

## Release note

Fix: resolve pre-compression snapshot ids on /api/chat/start — fail closed (409/403) instead of starting turns on archived sessions.
