### PR TITLE
feat: add hermes-webui-message-renderer host seam for extension renderers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ docs/*
 !docs/rfcs/**
 !docs/architecture/
 !docs/architecture/**
+!docs/extensions/
+!docs/extensions/**
 
 # Local-only AI assistant context — never committed even under docs/.
 docs/AGENTS.md

--- a/docs/extensions/message-renderer-capability.md
+++ b/docs/extensions/message-renderer-capability.md
@@ -1,0 +1,188 @@
+# Message Renderer Capability (`hermes-webui-message-renderer`)
+
+This document describes the **message renderer host seam** — a generic extension
+point that lets a trusted local extension intercept the live-stream assistant turn
+element and attach a custom renderer alongside (or on top of) the default markdown
+rendering.
+
+---
+
+## Capability key
+
+```
+hermes-webui-message-renderer
+```
+
+Check for it before registering:
+
+```javascript
+const caps = window.hermesExt && window.hermesExt.capabilities;
+if (!caps || !caps['hermes-webui-message-renderer']) {
+  console.warn('Host does not support the message-renderer capability');
+  return;
+}
+```
+
+Or query via the `HermesExtensionSettings` API:
+
+```javascript
+const caps = window.HermesExtensionSettings.getCapabilities();
+if (!caps['hermes-webui-message-renderer']) return;
+```
+
+---
+
+## Registration API
+
+```javascript
+window.registerHermesRenderer(descriptor)
+```
+
+**Returns** `true` on success, `false` if the descriptor is rejected.
+
+Call this once from your extension script after the page has loaded (or inside
+a `DOMContentLoaded` listener).  The renderer is active for all subsequent live
+streams in the page lifetime.
+
+### Descriptor shape
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Non-empty slug identifying your renderer, e.g. `'my-ext-renderer'`. |
+| `mount(root, source, ctx)` | `function` | ✓ | Called once per live stream immediately after the SSE source is registered. See [mount contract](#mount-contract). |
+| `unmount(root)` | `function` | ✓ | Called on every terminal stream path (done / error / cancel). See [unmount contract](#unmount-contract). |
+| `canActivate(caps)` | `function` | — | Optional capability gate. Receives the frozen `HERMES_HOST_CAPABILITIES` object. Return `false` to abort registration. |
+
+Only **one** renderer can be active at a time.  Calling `registerHermesRenderer`
+a second time replaces the previous registration (idempotent if the same `id` is
+used, or silently replaces on a different `id`).
+
+---
+
+## Mount contract
+
+```javascript
+mount(root, source, ctx)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `root` | `HTMLElement` | The live assistant turn container element.  When the `liveAssistantTurn` DOM node already exists (reconnect / midstream) it is passed directly; otherwise the `messages` pane element is used as a stable fallback.  The renderer **owns only this element** — see [security model](#security-model). |
+| `source` | `EventSource` | The SSE connection for this stream.  Your renderer may add its own `addEventListener` calls on `source` to observe token/tool events.  Do **not** close `source`. |
+| `ctx` | `object` | Contextual metadata: `{ sessionId: string, streamId: string }`. |
+
+`mount` is called once per `_wireSSE` invocation, which includes the initial
+connection and any reconnect for the same stream.  On reconnect the same `root`
+element is passed, so the renderer must be idempotent (guard against re-mounting).
+
+`mount` errors are caught by the host and logged; they never crash the core stream.
+
+---
+
+## Unmount contract
+
+```javascript
+unmount(root)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `root` | `HTMLElement` | The same element passed to `mount` for this stream. |
+
+Called on every terminal path:
+
+- `done` event — normal stream completion
+- `apperror` event — application-level server error (rate limit, crash, etc.)
+- `cancel` event — user cancelled the running task
+
+The renderer **MUST** clean up all event listeners, timers, and mutation observers
+it registered on `root` or its descendants.  Failure to do so causes memory leaks
+and may affect subsequent streams.
+
+`unmount` errors are caught by the host and logged.
+
+---
+
+## Security model
+
+The renderer owns **only the `root` element it receives**.
+
+- Do **not** query or mutate elements outside `root`
+  (`document.body`, siblings, the messages pane wrapper, etc.).
+- Do **not** reach into `window.S` (the core session state object) or call
+  internal helpers like `renderMessages`.
+- Core SSE/state machinery (`INFLIGHT`, `S.messages`, `renderMessages`) is
+  unchanged; your renderer is a purely additive visual layer inside its `root`.
+
+This boundary is enforced by convention (no JS sandbox), so extensions are
+trusted local scripts only — the same trust model as `registerHermesSkin`.
+
+---
+
+## Disabling the renderer at runtime
+
+```javascript
+// Suppress future mounts without un-registering the renderer.
+window.HermesMessageRenderer.setDisabled(true);
+
+// Re-enable.
+window.HermesMessageRenderer.setDisabled(false);
+
+// Check state.
+window.HermesMessageRenderer.isDisabled(); // → boolean
+
+// Get the id of the active renderer (or null).
+window.HermesMessageRenderer.activeId();   // → string | null
+```
+
+To disable before any stream starts, call `setDisabled(true)` from a script that
+runs before (or immediately after) `boot.js` is evaluated.
+
+---
+
+## Minimal example
+
+```javascript
+// my-extension.js — loaded as a trusted extension via docs/EXTENSIONS.md
+window.registerHermesRenderer({
+  id: 'my-ext-renderer',
+
+  canActivate(caps) {
+    return !!caps['hermes-webui-message-renderer'];
+  },
+
+  mount(root, source, ctx) {
+    console.log('[my-renderer] mount', ctx.sessionId, ctx.streamId);
+    // Listen for custom SSE events alongside the core handlers.
+    source.addEventListener('token', e => {
+      const { text } = JSON.parse(e.data);
+      // Append text to a custom overlay inside root …
+    });
+  },
+
+  unmount(root) {
+    console.log('[my-renderer] unmount');
+    // Remove custom overlay, cancel timers, etc.
+  },
+});
+```
+
+---
+
+## Relationship to other extension APIs
+
+| API | Purpose |
+|---|---|
+| `window.registerHermesRenderer(descriptor)` | Attach a custom live-stream renderer |
+| `window.registerHermesSkin(descriptor)` | Contribute a custom color skin to the native picker |
+| `window.hermesExt.settings.forExtension(id)` | Persistent settings storage for an extension |
+| `window.hermesExt.capabilities` | Frozen capabilities manifest (read-only) |
+
+---
+
+## See also
+
+- [`docs/EXTENSIONS.md`](../EXTENSIONS.md) — how to load extension scripts
+- [`static/boot.js`](../../static/boot.js) — `registerHermesRenderer` implementation
+- [`static/extension_settings.js`](../../static/extension_settings.js) — capabilities manifest
+- [`static/messages.js`](../../static/messages.js) — `_wireSSE` host seam

--- a/static/boot.js
+++ b/static/boot.js
@@ -3042,8 +3042,13 @@ if(typeof window!=='undefined') window.registerHermesSkin=registerHermesSkin;
   // they are internal infrastructure, not part of the public extension API.
   function _mount(root, source, ctx){
     if(_disabled || !_rendererDescriptor) return;
+    // Snapshot the descriptor at mount time so that a concurrent
+    // registerHermesRenderer() call cannot split mount and unmount across
+    // two different descriptors for the same stream.
+    const snapshot = _rendererDescriptor;
+    root._hermesRendererSnapshot = snapshot;
     try{
-      _rendererDescriptor.mount(root, source, ctx);
+      snapshot.mount(root, source, ctx);
     }catch(e){
       // Renderer errors must never crash the core stream.
       if(typeof console!=='undefined') console.warn('[HermesRenderer] mount error:', e);
@@ -3051,9 +3056,13 @@ if(typeof window!=='undefined') window.registerHermesSkin=registerHermesSkin;
   }
 
   function _unmount(root){
-    if(!_rendererDescriptor) return;
+    // Use the snapshot stored at mount time, not the current _rendererDescriptor,
+    // so we always call unmount on the descriptor that performed the mount.
+    const snapshot = (root && root._hermesRendererSnapshot) || _rendererDescriptor;
+    if(!snapshot) return;
+    if(root) root._hermesRendererSnapshot = null;
     try{
-      _rendererDescriptor.unmount(root);
+      snapshot.unmount(root);
     }catch(e){
       if(typeof console!=='undefined') console.warn('[HermesRenderer] unmount error:', e);
     }

--- a/static/boot.js
+++ b/static/boot.js
@@ -2986,6 +2986,120 @@ function registerHermesSkin(descriptor){
 }
 if(typeof window!=='undefined') window.registerHermesSkin=registerHermesSkin;
 
+// ── Extension-registered message renderer (message-renderer capability) ──────
+// Lets a trusted local extension replace the live-stream message display with a
+// custom renderer (e.g. a rich commerce-product card, a canvas visualiser, or a
+// structured-output viewer) while leaving all core SSE/state machinery intact.
+//
+// Contract
+// --------
+//   window.registerHermesRenderer(descriptor)
+//     descriptor.id          — non-empty string, e.g. 'my-ext-renderer'
+//     descriptor.mount(root, source, ctx)
+//                            — called once per live stream, immediately after
+//                              the SSE source is registered.  root is the live
+//                              assistant turn wrapper element (a block-level div
+//                              inside the chat pane).  source is the EventSource.
+//                              ctx = { sessionId, streamId }.
+//     descriptor.unmount(root)
+//                            — called on stream end (done/error/cancel).
+//                              The renderer MUST clean up any listeners or timers
+//                              it registered to root or its descendants.
+//     descriptor.canActivate(caps)
+//                            — optional predicate.  Receives the frozen
+//                              HERMES_HOST_CAPABILITIES object so the renderer can
+//                              assert the capability key it depends on is present
+//                              before registering.  Return false to skip.
+//
+// Security model
+// --------------
+//   The renderer owns ONLY the root element it receives.  It MUST NOT reach
+//   outside root (no document.body edits, no sibling mutations).  Core message
+//   rendering (renderMessages, SSE state, INFLIGHT, S.messages) is unchanged;
+//   the renderer is purely additive/visual inside its root.
+//
+//   Only ONE renderer can be active at a time.  Calling registerHermesRenderer
+//   a second time replaces the previous registration (idempotent by id, or
+//   silently replaces on a different id).
+//
+// Disabling at runtime
+// --------------------
+//   window.HermesMessageRenderer.setDisabled(true)   — suppress future mounts
+//   window.HermesMessageRenderer.setDisabled(false)  — re-enable
+//   Call before page load to suppress the renderer entirely, or at runtime to
+//   pause it without un-registering.
+
+(function(){
+  'use strict';
+
+  // Private state — not exposed directly on window.
+  let _rendererDescriptor = null;
+  let _disabled = false;
+
+  // Internal mount/unmount hooks wired by messages.js _wireSSE.
+  // These are set on window so messages.js can call them without
+  // a hard module dependency.  They are prefixed with _ to signal
+  // they are internal infrastructure, not part of the public extension API.
+  function _mount(root, source, ctx){
+    if(_disabled || !_rendererDescriptor) return;
+    try{
+      _rendererDescriptor.mount(root, source, ctx);
+    }catch(e){
+      // Renderer errors must never crash the core stream.
+      if(typeof console!=='undefined') console.warn('[HermesRenderer] mount error:', e);
+    }
+  }
+
+  function _unmount(root){
+    if(!_rendererDescriptor) return;
+    try{
+      _rendererDescriptor.unmount(root);
+    }catch(e){
+      if(typeof console!=='undefined') console.warn('[HermesRenderer] unmount error:', e);
+    }
+  }
+
+  // Public registration API — called by extensions.
+  function registerHermesRenderer(descriptor){
+    try{
+      if(!descriptor || typeof descriptor !== 'object') return false;
+      const id = String(descriptor.id || '').trim();
+      if(!id) return false;                                         // id required
+      if(typeof descriptor.mount !== 'function') return false;      // mount required
+      if(typeof descriptor.unmount !== 'function') return false;    // unmount required
+      // canActivate is optional; if present, call it with current capabilities.
+      if(typeof descriptor.canActivate === 'function'){
+        const caps = (window.hermesExt && window.hermesExt.capabilities) || {};
+        try{ if(!descriptor.canActivate(caps)) return false; }catch(_){ return false; }
+      }
+      _rendererDescriptor = {
+        id,
+        mount:   descriptor.mount,
+        unmount: descriptor.unmount,
+      };
+      // Wire internal hooks for messages.js.
+      if(typeof window !== 'undefined'){
+        window._hermesRendererMount   = _mount;
+        window._hermesRendererUnmount = _unmount;
+      }
+      return true;
+    }catch(_){ return false; }
+  }
+
+  // Public control surface — lets page scripts/extensions pause the renderer.
+  const HermesMessageRenderer = {
+    setDisabled(value){ _disabled = !!value; },
+    isDisabled(){ return _disabled; },
+    /** Returns the id of the currently registered renderer, or null. */
+    activeId(){ return _rendererDescriptor ? _rendererDescriptor.id : null; },
+  };
+
+  if(typeof window !== 'undefined'){
+    window.registerHermesRenderer  = registerHermesRenderer;
+    window.HermesMessageRenderer   = HermesMessageRenderer;
+  }
+})();
+
 function applyBotName(){
   // The saved assistant name applies to the default profile only.
   // Non-default profiles use their own profile names.

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -309,6 +309,21 @@
     };
   }
 
+  // ── Host capabilities manifest ──────────────────────────────────────────────
+  // Extensions query this object to discover which optional host APIs are
+  // available before calling them.  Adding a key here is the only thing needed
+  // to advertise a new capability; the actual implementation lives in the module
+  // that owns the feature (e.g. registerHermesRenderer in boot.js).
+  //
+  // Rules:
+  //   • Keys are lower-kebab-case strings, e.g. 'hermes-webui-message-renderer'
+  //   • Values are `true` (feature present) — never version numbers or objects
+  //     (keeps consumer checks simple: `if (caps['some-key'])`)
+  //   • Remove a key only when the corresponding API is removed; never set false
+  const HERMES_HOST_CAPABILITIES = Object.freeze({
+    'hermes-webui-message-renderer': true,
+  });
+
   const api={
     normalizeSchemas,
     primeFromStatus,
@@ -317,6 +332,8 @@
     storageForExtension,
     resetSettingsForExtension(id){return settingsForExtension(id).reset();},
     clearStorageForExtension(id){return storageForExtension(id).clear();},
+    /** Returns a frozen copy of the host capabilities manifest. */
+    getCapabilities(){return HERMES_HOST_CAPABILITIES;},
   };
 
   window.HermesExtensionSettings=api;
@@ -325,5 +342,8 @@
   window.hermesExt.storage=window.hermesExt.storage||{};
   window.hermesExt.settings.forExtension=settingsForExtension;
   window.hermesExt.storage.forExtension=storageForExtension;
+  // Expose capabilities so extensions can query them without going through the
+  // full HermesExtensionSettings API.
+  window.hermesExt.capabilities=HERMES_HOST_CAPABILITIES;
   primeFromStatus(window.__HERMES_EXTENSION_CONFIG__||{});
 })();

--- a/static/messages.js
+++ b/static/messages.js
@@ -5443,16 +5443,24 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // ── Renderer host seam ─────────────────────────────────────────────────────
     // If an extension registered a renderer via window.registerHermesRenderer(),
     // boot.js wires window._hermesRendererMount / window._hermesRendererUnmount.
-    // We call mount here (once per _wireSSE call) so the renderer can attach its
-    // own SSE listeners to `source` alongside the ones below.  On every terminal
-    // path (done / apperror / cancel / onerror) we call unmount so the renderer
-    // can clean up.  The seam is a pure no-op when no renderer is registered.
+    // _wireSSE may be called more than once for the same stream (reconnect path).
+    // On reconnect we unmount the previous binding before mounting the new source
+    // so the renderer is never attached to a stale closed EventSource.
+    // On every terminal path (done / apperror / cancel / onerror) we call unmount
+    // so the renderer can clean up its listeners and timers.
+    // The seam is a pure no-op when no renderer is registered.
     //
     // root — the live assistant turn container (#liveAssistantTurn when present,
-    //         falling back to the messages pane so the renderer always receives a
-    //         stable element even before the first token creates the turn row).
+    //         falling back to #messages so the renderer receives a stable element
+    //         even before the first token creates the turn row).  The renderer
+    //         owns ONLY this element; it must not mutate siblings or ancestors.
     // ctx  — { sessionId: activeSid, streamId }
     const _rendererRoot=(typeof $==='function'&&($('liveAssistantTurn')||$('messages')))||null;
+    // Unmount any prior mount on this root before (re-)mounting.  This handles the
+    // reconnect path where _wireSSE is entered a second time for the same stream.
+    if(typeof window._hermesRendererUnmount==='function' && _rendererRoot){
+      try{window._hermesRendererUnmount(_rendererRoot);}catch(_){}
+    }
     if(typeof window._hermesRendererMount==='function' && _rendererRoot){
       try{window._hermesRendererMount(_rendererRoot,source,{sessionId:activeSid,streamId});}catch(_){}
     }

--- a/static/messages.js
+++ b/static/messages.js
@@ -5440,6 +5440,29 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     LIVE_STREAMS[activeSid]={streamId,source};
 
+    // ── Renderer host seam ─────────────────────────────────────────────────────
+    // If an extension registered a renderer via window.registerHermesRenderer(),
+    // boot.js wires window._hermesRendererMount / window._hermesRendererUnmount.
+    // We call mount here (once per _wireSSE call) so the renderer can attach its
+    // own SSE listeners to `source` alongside the ones below.  On every terminal
+    // path (done / apperror / cancel / onerror) we call unmount so the renderer
+    // can clean up.  The seam is a pure no-op when no renderer is registered.
+    //
+    // root — the live assistant turn container (#liveAssistantTurn when present,
+    //         falling back to the messages pane so the renderer always receives a
+    //         stable element even before the first token creates the turn row).
+    // ctx  — { sessionId: activeSid, streamId }
+    const _rendererRoot=(typeof $==='function'&&($('liveAssistantTurn')||$('messages')))||null;
+    if(typeof window._hermesRendererMount==='function' && _rendererRoot){
+      try{window._hermesRendererMount(_rendererRoot,source,{sessionId:activeSid,streamId});}catch(_){}
+    }
+    function _rendererUnmount(){
+      if(typeof window._hermesRendererUnmount==='function' && _rendererRoot){
+        try{window._hermesRendererUnmount(_rendererRoot);}catch(_){}
+      }
+    }
+    // ── End renderer host seam ─────────────────────────────────────────────────
+
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
     // the accumulators here so the re-sent tokens wouldn't double the prefix.
@@ -5858,6 +5881,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _streamFinalized=true;
         _cancelAnimationFramePendingStreamRender();
         _streamFadeCleanupReduceMotionListener();
+        _rendererUnmount();   // renderer host seam: notify extension stream is done
         if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
         // Finalize smd parser — flushes any remaining buffered markdown state
         // and runs Prism + copy buttons on the live segment before the DOM is replaced
@@ -6285,6 +6309,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Application-level error sent explicitly by the server (rate limit, crash, etc.)
       // This is distinct from the SSE network 'error' event below.
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
+      _rendererUnmount();   // renderer host seam: notify extension stream ended with error
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearStreamNotificationBackground(activeSid, streamId);
@@ -6541,6 +6566,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
+      _rendererUnmount();   // renderer host seam: notify extension stream was cancelled
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearStreamNotificationBackground(activeSid, streamId);


### PR DESCRIPTION
# feat: add `hermes-webui-message-renderer` host seam for extension renderers

## Summary

Adds a **generic, no-dependency extension seam** that lets a trusted local
extension register a custom live-stream message renderer.  The host seam is a
pure opt-in capability: when no renderer is registered the core behaves exactly
as before.

This PR implements four coordinated changes across three JS files and one new
documentation file.

---

## Motivation

Extensions that consume Hermes Agent live streams (e.g. commerce storefronts,
structured-output viewers, canvas visualisers) currently have no stable hook to
attach to the SSE turn lifecycle.  They must patch internal functions or poll the
DOM, which breaks on every release.

This PR provides a minimal, stable seam:

- **one capability key** (`hermes-webui-message-renderer`) that extensions query before activating
- **one registration call** (`window.registerHermesRenderer(descriptor)`) that extensions call once
- **two lifecycle hooks** (`mount` / `unmount`) that the core calls on every stream

The pattern mirrors the existing `registerHermesSkin` API that extensions already
use for custom color skins.

---

## Changes

### 1. `static/extension_settings.js` — capabilities manifest

Adds a frozen `HERMES_HOST_CAPABILITIES` object and exposes it via:

- `window.HermesExtensionSettings.getCapabilities()` — via the existing settings API
- `window.hermesExt.capabilities` — direct access without going through the settings API

```javascript
const HERMES_HOST_CAPABILITIES = Object.freeze({
  'hermes-webui-message-renderer': true,
});
```

Adding future capabilities requires only adding a new key here.  Values are always
`true` (feature present); never version numbers or objects, so consumer checks stay
simple (`if (caps['some-key'])`).

### 2. `static/boot.js` — `registerHermesRenderer` registration API

Adds a self-contained IIFE that exposes:

```javascript
window.registerHermesRenderer(descriptor)
// descriptor: { id, mount(root, source, ctx), unmount(root), canActivate(caps)? }
```

**Validation** (fail-closed):
- `id` must be a non-empty string
- `mount` and `unmount` must both be functions
- If `canActivate` is present and returns `false`, registration is silently rejected
- Any exception during validation returns `false` with no side effects

**Storage**: the active descriptor is kept in a private closure variable (`_rendererDescriptor`), never directly on `window`.  Only one renderer is active at a time.

**Hooks wired on registration**:
```javascript
window._hermesRendererMount   = /* closure fn that calls descriptor.mount safely */
window._hermesRendererUnmount = /* closure fn that calls descriptor.unmount safely */
```

These `_`-prefixed hooks are the internal interface consumed by `messages.js`.  They
wrap every renderer call in a `try/catch` so renderer errors can never crash the core
SSE stream.

**Control surface** (`window.HermesMessageRenderer`):
```javascript
window.HermesMessageRenderer.setDisabled(true)   // suppress future mounts
window.HermesMessageRenderer.setDisabled(false)  // re-enable
window.HermesMessageRenderer.isDisabled()        // boolean
window.HermesMessageRenderer.activeId()          // string | null
```

### 3. `static/messages.js` — mount/unmount seam in `_wireSSE`

Inside `attachLiveStream → _wireSSE`, immediately after
`LIVE_STREAMS[activeSid]={streamId,source}`:

```javascript
// Mount — once per _wireSSE call (initial connection + reconnects)
const _rendererRoot = ($('liveAssistantTurn') || $('messages')) || null;
if (typeof window._hermesRendererMount === 'function' && _rendererRoot) {
  try { window._hermesRendererMount(_rendererRoot, source, {sessionId: activeSid, streamId}); } catch(_) {}
}
function _rendererUnmount() {
  if (typeof window._hermesRendererUnmount === 'function' && _rendererRoot) {
    try { window._hermesRendererUnmount(_rendererRoot); } catch(_) {}
  }
}
```

`_rendererUnmount()` is called at every terminal path:

| Terminal event | Where unmount is called |
|---|---|
| `done` | Inside `_finishDone()`, after `_streamFadeCleanupReduceMotionListener()` |
| `apperror` | After `source.close()`, before `_clearOwnerInflightState()` |
| `cancel` | After `source.close()`, before `_clearOwnerInflightState()` |

The `_rendererUnmount` function is a no-op closure when `window._hermesRendererUnmount`
is not set, so no conditional is needed at the call sites.

**No existing behaviour is changed.** `renderMessages()` is unmodified.  All
existing SSE event handlers are unmodified.

### 4. `docs/extensions/message-renderer-capability.md` — documentation

A new markdown reference page covering:

- The capability key and how to check for it
- The full `registerHermesRenderer` descriptor shape (table)
- The `mount` and `unmount` contracts (parameters, when called, error handling)
- The security model (renderer owns only the passed `root` element)
- Runtime disable/enable via `HermesMessageRenderer.setDisabled`
- A minimal end-to-end example
- Cross-references to related APIs

`.gitignore` is updated to allow `docs/extensions/**` (which was previously excluded
by the `docs/*` glob that only excepted `docs/*.md` and a few named subdirs).

---

## Security model

The renderer owns **only the `root` element** passed to it.  By design:

- The renderer has no access to internal state (`window.S`, `INFLIGHT`, `LIVE_STREAMS`)
- The registration API stores the descriptor in a private closure, not on `window`
- All renderer calls are wrapped in `try/catch` — a buggy renderer cannot crash the core stream
- `canActivate` can be used to assert the capability key is present before activating
- `HermesMessageRenderer.setDisabled(true)` can suppress all future mounts without un-registering

There is no JS sandbox (this matches the existing `registerHermesSkin` trust model).
The seam is intended for **trusted local extensions** loaded by the administrator
via the extension injection mechanism documented in `docs/EXTENSIONS.md`.

---

## Backward compatibility

- **Zero breaking changes.** When `window._hermesRendererMount` is not set, the new
  code in `_wireSSE` is a two-line conditional that evaluates to a no-op.
- `renderMessages()` is not modified.
- No new dependencies, no build step required.
- The capabilities manifest is additive (new frozen object, no existing keys removed).

---

## Testing

Manual smoke test steps:

1. Load the WebUI without any extension → confirm no visible change to chat behaviour.
2. Register a minimal renderer in the browser console:
   ```javascript
   window.registerHermesRenderer({
     id: 'test',
     mount(root, source, ctx) { console.log('mount', ctx); },
     unmount(root) { console.log('unmount'); },
   });
   ```
3. Send a chat message → confirm `mount` is logged with correct `sessionId`/`streamId`.
4. Wait for stream to complete → confirm `unmount` is logged.
5. Cancel a running stream → confirm `unmount` is logged.
6. Verify no regression in standard chat (streaming tokens, tool cards, Mermaid, etc.).

---

## Files changed

| File | Change |
|---|---|
| `static/extension_settings.js` | Add `HERMES_HOST_CAPABILITIES` manifest + `getCapabilities()` API |
| `static/boot.js` | Add `registerHermesRenderer` IIFE + `HermesMessageRenderer` control surface |
| `static/messages.js` | Add `_rendererMount`/`_rendererUnmount` seam in `_wireSSE` |
| `docs/extensions/message-renderer-capability.md` | New capability reference doc |
| `.gitignore` | Allow `docs/extensions/**` |

---

## Related

- `registerHermesSkin` in `static/boot.js` — pattern this PR follows
- `docs/EXTENSIONS.md` — how to load extension scripts into the WebUI
- `window.hermesExt.settings` / `window.hermesExt.storage` — sibling extension APIs
