### PR TITLE
fix: match cron new-run dot to the red unread badge and refresh it live

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -1001,10 +1001,20 @@ async function loadCronGatewayNotice() {
   }
 }
 
+let _cronLoadGeneration = 0;  // monotonically bumped per loadCrons() entry; stale loads bail
+
 async function loadCrons(animate) {
   const box = $('cronList');
   const refreshBtn = $('cronRefreshBtn');
   loadCronGatewayNotice();
+  // #6767 stale-refresh guard: loadCrons() is async, and both the poller and
+  // switchPanel('tasks') can fire it. If a request started earlier resolves
+  // after a newer one (e.g. the poller fired, then the user reopened the panel
+  // and switchPanel started a fresh load), applying the older response would
+  // overwrite the newer list/detail with stale data. Bump a generation token
+  // at entry and bail once a superseded request realises it is no longer the
+  // latest, so only the newest render wins.
+  const _cronLoadSeq = ++_cronLoadGeneration;
   if (animate && refreshBtn) {
     refreshBtn.style.opacity = '0.5';
     refreshBtn.disabled = true;
@@ -1013,6 +1023,7 @@ async function loadCrons(animate) {
     await loadCronProfiles();
     const allProfilesQS = _showAllCronProfiles ? '?all_profiles=1' : '';
     const data = await api('/api/crons' + allProfilesQS);
+    if (_cronLoadSeq !== _cronLoadGeneration) return;  // superseded by a newer load
     _cronList = data.jobs || [];
     _cronOtherProfileCount = Number(data.other_profile_count || 0);
     if (_showAllCronProfiles && !_cronList.some(job => job && job.read_only)) {

--- a/static/panels.js
+++ b/static/panels.js
@@ -12734,12 +12734,12 @@ function startCronPolling(){
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
         updateCronBadge();
-        // A cron just completed while the panel may be open. The badge above
-        // already counted the unread run, so live-refresh the rendered list
-        // (and any open detail) so the per-job "new run" dot is visible without
-        // a manual refresh — otherwise the badge says "N new" while the list
-        // looks unchanged.
-        if ($('cronList')) loadCrons();
+        // A cron just completed while the Scheduled Tasks panel may be open.
+        // The badge above already counted the unread run; refresh the list only
+        // when this panel is the active view (switchPanel already reloads it on
+        // open), so we don't re-render a hidden panel or fire an avoidable
+        // /api/crons request while the user is on another screen.
+        if (_currentPanel === 'tasks' && $('cronList')) loadCrons();
       }
     }catch(e){}
   },30000);

--- a/static/panels.js
+++ b/static/panels.js
@@ -12734,6 +12734,12 @@ function startCronPolling(){
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
         updateCronBadge();
+        // A cron just completed while the panel may be open. The badge above
+        // already counted the unread run, so live-refresh the rendered list
+        // (and any open detail) so the per-job "new run" dot is visible without
+        // a manual refresh — otherwise the badge says "N new" while the list
+        // looks unchanged.
+        if ($('cronList')) loadCrons();
       }
     }catch(e){}
   },30000);

--- a/static/style.css
+++ b/static/style.css
@@ -5623,7 +5623,7 @@ main.main > #mainPlugin{display:none;}
 
 /* ── Cron alert badge ── */
 .cron-badge{position:absolute;top:2px;right:2px;background:#e53e3e;color:#fff;font-size:9px;font-weight:700;min-width:14px;height:14px;line-height:14px;text-align:center;border-radius:7px;padding:0 3px;}
-.cron-new-dot{width:7px;height:7px;border-radius:50%;background:var(--success,#22c55e);flex-shrink:0;animation:cron-dot-pulse 2s ease-in-out infinite;}
+.cron-new-dot{width:7px;height:7px;border-radius:50%;background:#e53e3e;flex-shrink:0;animation:cron-dot-pulse 2s ease-in-out infinite;}
 .cron-agent-badge{flex-shrink:0;font-size:12px;line-height:1;}
 .cron-script-badge{flex-shrink:0;font-size:12px;line-height:1;opacity:.92;}
 .cron-script-job-banner{margin-bottom:12px;}
@@ -5634,7 +5634,7 @@ main.main > #mainPlugin{display:none;}
 .detail-badge.cron-mode-badge.script{background:rgba(148,163,184,.14);color:var(--text-secondary);}
 .detail-badge.cron-mode-badge.agent{background:rgba(99,179,237,.14);color:#90cdf4;}
 @keyframes cron-dot-pulse{0%,100%{opacity:1;}50%{opacity:.4;}}
-.has-new-run{border-color:var(--success,#22c55e)!important;box-shadow:0 0 0 1px var(--success,#22c55e);}
+.has-new-run{border-color:#e53e3e!important;box-shadow:0 0 0 1px #e53e3e;}
 
 /* ── Background error banner ── */
 /* ── Archived sessions ── */

--- a/tests/test_issue1140_cron_badge_per_job.py
+++ b/tests/test_issue1140_cron_badge_per_job.py
@@ -6,9 +6,11 @@ Verifies that:
 3. openCronDetail() clears the unread state for the viewed job
 4. Badge only clears when all unread jobs are viewed (not on panel open)
 5. _renderCronDetail() adds has-new-run class to Last Output card
+6. loadCrons() bails on a superseded (stale) response (#6767 P1)
 """
 
 import pytest
+from pathlib import Path
 
 # ── Static file tests (no server needed) ──
 
@@ -130,4 +132,104 @@ def test_cron_unread_markers_share_badge_red():
     # Sanity: the badge this matches against really is the same red.
     assert RED in badge, f'.cron-badge should use {RED} in rule: {badge}'
 
+
+# ── #6767 P1 stale-refresh guard (node harness) ──────────────────────────────
+# Two overlapping loadCrons() calls must not let the older response clobber the
+# newer one. We stub api() so /api/crons resolves on demand, fire two loads, and
+# resolve the FIRST one's /api/crons LAST. If the generation guard works, the
+# older (superseded) load bails before touching the DOM, and only the newer
+# response's job list is applied.
+
+PANELS_JS_PATH = Path(__file__).resolve().parents[1] / "static" / "panels.js"
+import subprocess  # noqa: E402
+import json  # noqa: E402
+import shutil  # noqa: E402
+
+_NODE = shutil.which("node")
+
+@pytest.mark.skipif(_NODE is None, reason="node not on PATH")
+def test_cron_load_stale_response_does_not_overwrite_newer():
+    script = f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(PANELS_JS_PATH))}, 'utf8');
+function extractFunc(name) {{
+  const re = new RegExp('(async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+// Minimal DOM / deps that loadCrons touches.
+let _cronList = [];
+let _cronOtherProfileCount = 0;
+let _showAllCronProfiles = false;
+const _cronNewJobIds = new Set();
+let _currentCronDetail = null;
+let _currentCronDetailKey = null;
+let _cronMode = null;
+let appliedList = null;   // what the LAST load actually wrote
+let resolves = [];        // resolver for each /api/crons call, in order
+const pending = [];       // deferred for each api call
+function makeDeferred() {{
+  let resolve; const p = new Promise(r => {{ resolve = r; }});
+  pending.push({{ resolve }});
+  return p;
+}}
+function loadCronProfiles() {{ return Promise.resolve(); }}
+function loadCronGatewayNotice() {{}}
+function api(url) {{ return makeDeferred(); }}
+function $(id) {{
+  if (id === 'cronList') return {{ innerHTML: '', appendChild() {{}}, style: {{}} }};
+  if (id === 'cronRefreshBtn') return null;
+  return null;
+}}
+function esc(s) {{ return String(s); }}
+function t(s) {{ return s; }}
+function _cronStatusMeta(job) {{ return {{ state: 'active', label: 'on', listClass: 'active' }}; }}
+function _cronItemId(job) {{ return 'cron-' + job.id; }}
+function _cronJobKey(job) {{ return String(job.id); }}
+function _cronProfileLabel(p) {{ return p; }}
+function _cronOwnerProfileName(job) {{ return 'default'; }}
+function _appendCronProfileToggle(box) {{}}
+function _clearCronDetail() {{}}
+function _renderCronDetail(job) {{}}
+let _cronLoadGeneration = 0;
+eval(extractFunc('loadCrons'));
+(async () => {{
+  // Fire load #1 and load #2 without awaiting either.
+  const p1 = loadCrons();
+  const p2 = loadCrons();
+  // Both suspend at await loadCronProfiles(); yield until each has reached its
+  // api() call so pending[0] and pending[1] exist (p1 then p2, in order).
+  while (pending.length < 2) await Promise.resolve();
+  const d1 = pending[0];
+  const d2 = pending[1];
+  // Resolve the NEWER request first and let it fully apply, then resolve the
+  // OLDER one last — exactly the race Greptile flagged.
+  d2.resolve({{ jobs: [{{ id: 'newer', name: 'Newer' }}] }});
+  await p2;                       // newer load applies -> _cronList = ['newer']
+  d1.resolve({{ jobs: [{{ id: 'stale', name: 'Stale' }}] }});
+  await p1;                       // older load must bail before applying
+  console.log(JSON.stringify({{
+    list: Array.isArray(_cronList) ? _cronList.map(j => j.id) : _cronList,
+    loadGen: _cronLoadGeneration,
+  }}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    result = subprocess.run([_NODE, "-e", script], check=True,
+                            capture_output=True, text=True, timeout=30)
+    payload = json.loads(result.stdout)
+    # The OLDER response (stale) resolved last, but must NOT have been applied —
+    # only the newer render (job 'newer') should be in the list.
+    assert payload["list"] == ["newer"], \
+        f"stale response overwrote newer view; list={payload['list']}"
+    # Both loads ran, so the generation token advanced by 2.
+    assert payload["loadGen"] == 2, \
+        f"expected generation to advance to 2, got {payload['loadGen']}"
 

--- a/tests/test_issue1140_cron_badge_per_job.py
+++ b/tests/test_issue1140_cron_badge_per_job.py
@@ -98,3 +98,36 @@ def test_cron_css_classes_exist():
     assert 'cron-dot-pulse' in src, 'cron-dot-pulse animation not found'
 
 
+def test_cron_unread_markers_share_badge_red():
+    """The new-run dot and the Last Output highlight must match the rail badge red (#e53e3e).
+
+    #1140 regression: the dot used the green --success colour, so an unread job
+    read as "success" instead of "unread". Both markers must be the same red as
+    the sidebar .cron-badge so the per-task indicator visually matches the count.
+    """
+    with open('static/style.css') as f:
+        src = f.read()
+
+    RED = '#e53e3e'
+
+    def rule_body(selector):
+        start = src.find(selector + '{')
+        assert start != -1, f'{selector} CSS rule not found'
+        end = src.find('}', start)
+        return src[start:end]
+
+    dot = rule_body('.cron-new-dot')
+    has_new_run = rule_body('.has-new-run')
+    badge = rule_body('.cron-badge')
+
+    # Both unread markers explicitly use the same red as the rail badge,
+    # not a --success fallback.
+    assert RED in dot, f'.cron-new-dot should use {RED} in rule: {dot}'
+    assert RED in has_new_run, f'.has-new-run should use {RED} in rule: {has_new_run}'
+    # The red is hard-coded (not the --success variable that used to leak in).
+    assert '--success' not in dot, '.cron-new-dot must not fall back to --success green'
+    assert '--success' not in has_new_run, '.has-new-run must not fall back to --success green'
+    # Sanity: the badge this matches against really is the same red.
+    assert RED in badge, f'.cron-badge should use {RED} in rule: {badge}'
+
+

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -535,3 +535,110 @@ eval(extractFunc('startCronPolling'));
         "toastCalls": [],
         "badgeUpdates": 1,
     }
+
+
+# ── #6767 live-refresh guard (active-panel + present cron list) ──────────────
+#
+# The existing polling harness above stops at updateCronBadge(). PR #6767 added
+# one line after it: `if (_currentPanel === 'tasks' && $('cronList')) loadCrons();`
+# Those three free names (_currentPanel, $, loadCrons) are all undefined in the
+# old harness, so the line can throw into startCronPolling's broad catch and be
+# silently swallowed while the old assertions still pass. These tests stub all
+# three and pin the four behaviours the reviewer asked for.
+#
+# StartCronPolling body is extracted and eval'd with the shared helper plus new
+# deps: _currentPanel (active panel), $ (DOM lookup returning a cronList node
+# when present) and a loadCrons spy.
+
+def _cron_polling_refresh_script(current_panel, cron_list_present):
+    return f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(PANELS_JS_PATH))}, 'utf8');
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+let _cronPollSince = 10;
+let _cronPollTimer = null;
+let _cronUnreadCount = 0;
+let _cronPollGeneration = 0;
+const _cronNewJobIds = new Set();
+let badgeUpdates = 0;
+let loadCronsCalls = 0;
+let _currentPanel = {json.dumps(current_panel)};
+global.document = {{ hidden: false }};
+global.setInterval = (fn, _ms) => {{ global.__tick = fn; return 1; }};
+async function api(_url) {{
+  return {{
+    completions: [{{
+      job_id: 'job6767',
+      session_id: 'cron_job6767_20260610_080000',
+      message_count: 3,
+      name: 'Nightly Backup',
+      status: 'success',
+      completed_at: 25,
+      toast_notifications: false
+    }}]
+  }};
+}}
+function showToast(...args) {{}}
+function t(...args) {{ return args.join('|'); }}
+function updateCronBadge() {{ badgeUpdates += 1; }}
+function _markSessionCompletionUnreadIfBackground(sid, count) {{}}
+function $(id) {{ return id === 'cronList' && {json.dumps(cron_list_present)} ? {{ tagName: 'UL' }} : null; }}
+function loadCrons() {{ loadCronsCalls += 1; }}
+eval(extractFunc('startCronPolling'));
+(async() => {{
+  startCronPolling();
+  await global.__tick();
+  console.log(JSON.stringify({{
+    unreadJobs: Array.from(_cronNewJobIds),
+    badgeUpdates,
+    loadCronsCalls
+  }}));
+}})().catch(err => {{
+  console.error(err);
+  process.exit(1);
+}});
+"""
+
+@pytest.mark.parametrize(
+    "current_panel,cron_list_present,expected_refresh",
+    [
+        # 1. active Scheduled Tasks panel + existing list → refresh exactly once
+        ("tasks", True, 1),
+        # 2. another panel open → no live refresh (hidden list, avoidable request)
+        ("sessions", True, 0),
+        # 3. tasks panel but no cron list element yet → no refresh
+        ("tasks", False, 0),
+        # 4. other panel + no list → definitely no refresh (defensive)
+        ("sessions", False, 0),
+    ],
+)
+def test_cron_polling_live_refresh_guard(
+    current_panel, cron_list_present, expected_refresh
+):
+    """#6767: loadCrons() is called precisely when the Scheduled Tasks panel is
+    active AND its list is mounted — and unread-set/badge updates always happen."""
+    script = _cron_polling_refresh_script(current_panel, cron_list_present)
+    payload = _run_node(script)
+
+    # The guard decides whether the list is refreshed...
+    assert payload["loadCronsCalls"] == expected_refresh, (
+        f"panel={current_panel}, list={cron_list_present}: "
+        f"expected {expected_refresh} loadCrons() call(s), "
+        f"got {payload['loadCronsCalls']}"
+    )
+
+    # ...but the unread bookkeeping always runs regardless of panel/list state.
+    assert payload["unreadJobs"] == ["job6767"], "job must always be marked unread"
+    assert payload["badgeUpdates"] == 1, "badge must always be updated"


### PR DESCRIPTION
## Summary

When a scheduled job completes while you have the WebUI open, the red count badge on the **Scheduled Tasks** nav icon updates immediately — but it was easy to be unable to tell *which* job it was pointing at, for two reasons:

1. **Wrong colour.** The per-job "new run" indicator (the small dot next to the job, and the highlight on the Last Output card) used the green `--success` colour, so it read as "success" rather than "unread notification", and sat right next to the job's *green* "active" tag — easy to miss against the *red* badge.
2. **Stale list.** The polling loop (`startCronPolling`) added the job ID to `_cronNewJobIds` and updated the badge count, but never re-rendered the job list. So the badge said "N new" while the open list stayed unchanged until you hit refresh or switched panels.

## Changes

- `static/style.css`: `.cron-new-dot` and `.has-new-run` now use the same red (`#e53e3e`) as the `.cron-badge`, so the per-task marker visually matches the sidebar badge.
- `static/panels.js`: after `updateCronBadge()` in `startCronPolling`, live-refresh the job list (`loadCrons()` when the panel is mounted) so the per-job dot appears immediately when a completion is detected — no manual refresh needed.

## Test plan

- `node --check static/panels.js` — passes
- `pytest tests/test_issue1140_cron_badge_per_job.py` — 7 passed
- `pytest tests/test_cron_toast_notifications.py` — 12 passed (includes `test_cron_polling_suppresses_toasts_but_keeps_unread_badges`)
- `pytest tests/test_issue5960_cron_unread_profile_scope.py tests/test_issue3460_cron_session_unread.py tests/test_issue4026_collapsible_paused_crons.py` — 29 passed

## Before / after

The dot next to an unread job changes from green to red, matching the red badge. Viewing the job still clears the dot (unchanged logic in `openCronDetail`).

## Notes

Couldn't run the browser/smoke UI tests here (no Playwright runtime + no system `python3-venv` in this environment); verified via static tests and syntax check instead.