### PR TITLE
fix(models): resolve the default model from model.name too

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3185,7 +3185,13 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
     if isinstance(model_cfg, str):
         default_model = model_cfg.strip()
     elif isinstance(model_cfg, dict):
-        cfg_default = str(model_cfg.get("default") or "").strip()
+        # `name` is the key the agent/gateway path reads; `default` is the
+        # WebUI-era spelling. Accept both — a config that only sets `name`
+        # (the shape `hermes` itself writes) otherwise resolves to "" here and
+        # the model picker renders a bare "default" chip. Same precedence as
+        # every other resolver in this tree (see _resolve_* below, and
+        # api/streaming.py's effective-model lookup).
+        cfg_default = str(model_cfg.get("default") or model_cfg.get("name") or "").strip()
         if cfg_default:
             default_model = cfg_default
 


### PR DESCRIPTION
### Problem

`get_effective_default_model()` reads only `model.default` from config.yaml,
but a config written by `hermes` itself sets the model under `model.name`.

With a name-only config it returns `""`, `/api/models` reports
`default_model: ""`, and the model picker renders a bare "default" chip
instead of the configured model.

### Change

Accept both spellings — `model_cfg.get("default") or model_cfg.get("name")`.

This is the idiom already used everywhere else in the tree, which is why the
bug is narrow to this one function:

- `api/config.py` — the `_resolve_*` helpers
- `api/streaming.py` — effective-model lookup
- `hermes_cli/status.py`, `hermes_cli/dump.py`

### Testing

`tests/test_auxiliary_models_settings.py` and
`tests/test_update_banner_fixes.py` — 170 passed against current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)