### PR TITLE
fix(passkeys): derive the RPID from Origin, not Host

### DIFF
--- a/api/passkeys.py
+++ b/api/passkeys.py
@@ -182,6 +182,21 @@ def _host_without_port(host: str) -> str:
 
 
 def rp_context(handler) -> tuple[str, str]:
+    # A reverse proxy that rewrites Host to its own upstream address (common
+    # when a separate SPA front-end proxies /api to this backend) leaves Host
+    # useless for deriving the RPID, while Origin still carries the origin the
+    # browser is actually on. Prefer Origin's hostname: WebAuthn's RPID-origin
+    # check compares against the page's origin, not the backend's.
+    browser_origin = handler.headers.get("Origin", "")
+    if browser_origin:
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(browser_origin)
+            if parsed.hostname:
+                return parsed.hostname, browser_origin
+        except Exception:
+            pass
+    # Fallback: derive from Host header (direct/internal access)
     host = _host_without_port(handler.headers.get("Host", "localhost"))
     proto = handler.headers.get("X-Forwarded-Proto", "").split(",", 1)[0].strip().lower()
     if proto not in {"http", "https"}:


### PR DESCRIPTION
### Problem

When a reverse proxy rewrites `Host` to its own upstream address — which
happens whenever a separate SPA front-end proxies `/api` to this backend —
`rp_context()` derives an RPID that never matches the origin the browser is
actually on. WebAuthn's RPID-origin check then rejects every passkey
registration and login.

### Change

Prefer the `Origin` header's hostname, which proxies do forward, and fall
back to `Host` for direct access. Existing behaviour is unchanged when there
is no proxy, since `Origin` and `Host` agree in that case.

### Testing

`tests/test_passkey_auth.py`, `tests/test_passkey_login_content_length.py`
and `tests/test_auth.py` — 35 passed against current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)