### PR TITLE
feat: link bare session references

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -172,6 +172,39 @@ Each test has:
 
 Work through sections in order. Each section builds on the previous.
 
+## Explicit Session References and Responsive Navigation
+
+SETUP: Have one session in the default/root profile and another session in a
+different profile. If possible, also use a running session with a visible live
+tail and a compressed session whose parent has a continuation.
+
+STEPS:
+
+1. In a settled assistant or user message, activate `@session:<sid>` and
+   `@session:<profile>/<sid>` at desktop width. Confirm the destination session,
+   profile chip, transcript owner, and URL agree.
+2. Open the destination directly as `/session/<sid>?profile=<profile>`. Repeat
+   with duplicate `?profile` parameters and an invalid value.
+3. Reload while the explicit profile URL is active, then repeat the open from a
+   sidebar row and from a narrow/mobile drawer.
+4. For a continuation parent, open the parent ID and confirm the visible URL and
+   transcript settle on the canonical continuation owner. During a running
+   session, make transcript hydration fail or reload offline only if the live
+   recovery tail is available.
+
+EXPECT: A valid explicit reference switches profile and loads the requested
+owner transactionally. Duplicate/invalid `?profile` input stays on the previous
+session and does not silently fall back to the active profile. A continuation
+uses the same owner and does not consume another profile's live tail. A valid
+running tail remains usable if transcript hydration is degraded; an explicit
+load with neither transcript nor safe recovery fails and restores the previous
+view.
+
+RESPONSIVE CHECK: Verify the same outcome at wide desktop, narrow desktop/tablet,
+and mobile widths. The profile chip, session list, transcript, and drawer must
+not show different owners during or after the switch; no stale skeleton or
+profile label may remain after a failure.
+
 ---
 
 ## Section 1: Initial Load and Empty State

--- a/docs/rfcs/canonical-session-resolution.md
+++ b/docs/rfcs/canonical-session-resolution.md
@@ -84,6 +84,35 @@ correct visible session target, not moving execution ownership.
    should still use the stale-route recovery path. A present archived parent with
    a live continuation is not a 404; it is a canonicalization problem.
 
+## Explicit References and Ownership
+
+Rendered references use one of these forms:
+
+- `@session:<sid>` for an unqualified session ID.
+- `@session:<profile>/<sid>` for an explicit profile owner.
+
+The URL equivalent is `/session/<sid>?profile=<profile>`. A single valid
+`?profile` value is authoritative for that navigation; it takes precedence over
+the active profile, default/root aliases, and remembered browser state. A
+duplicate or invalid profile value fails closed: the browser must leave the
+current session visible and must not fall back to an unqualified load.
+
+An explicit open validates the requested session and profile before switching
+profiles, then uses the canonical `switchToProfile()` lifecycle. A same-ID
+selection is a no-op only when the visible session owner matches the active
+profile and any requested owner. Otherwise it performs normal resolution and
+loading. If a metadata response names a continuation, the continuation is the
+next explicit target: its session ID and profile are validated again, and any
+persisted or in-memory live-recovery entry for each resolved cross-profile ID is
+quarantined. Only the accepted final ID is cleared from the recovery store after
+successful navigation; unrelated IDs are untouched.
+
+`messages=1` responses for explicit navigation must include the requested session
+identity and matching owner before messages, tool calls, todos, usage, or cache
+state are changed. A running session with a valid live recovery tail may still
+complete as a degraded load when transcript hydration fails. An explicit load
+without that safe recovery state fails and restores the previous profile/session.
+
 ## Entry Point Matrix
 
 | Entry point | Input | Expected resolution |

--- a/static/boot.js
+++ b/static/boot.js
@@ -130,7 +130,15 @@ function _rootPrefillNeedsFreshComposer(urlSession, savedLocal, prefillIntent){
   return !urlSession&&!!savedLocal&&_prefillHasDraftText(prefillIntent);
 }
 function _profileQueryBlocksSavedLocalRestore(profileIntent, urlSession){
-  return !!(profileIntent&&profileIntent.hasParam&&profileIntent.valid&&!urlSession);
+  return !!(profileIntent&&profileIntent.hasParam&&!urlSession);
+}
+async function _restoreBootSession(urlSession, profileIntent, savedSession){
+  if(profileIntent&&profileIntent.hasParam){
+    if(!urlSession||!profileIntent.valid||typeof _openSessionReference!=='function') return false;
+    return await _openSessionReference(urlSession,profileIntent.name)===true;
+  }
+  if(!savedSession||typeof loadSession!=='function') return false;
+  return await loadSession(savedSession,{preserveActiveInput:true})===true;
 }
 function _shouldStartFreshPwaChat(action,urlSession){
   return action==='new-chat'&&!urlSession;
@@ -3621,27 +3629,32 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const titleLabel=$('titlebarProfileLabel');
   if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
   const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;
+  const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const _savedLocalBeforeProfileSwitch=localStorage.getItem('hermes-webui-session');
   const _profileSwitchProfileBefore=S.activeProfile||'default';
   const _profileSwitchIsDefaultBefore=!!S.activeProfileIsDefault;
   let _profileSwitchCompleted=false;
   let _profileSwitchChangedProfile=false;
+  let _profileIntentBlocked=false;
   if(profileIntent&&profileIntent.hasParam){
-    try{
-      if(profileIntent.valid){
-        if(typeof switchToProfile==='function'){
-          _profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;
-          if(_profileSwitchCompleted){
-            _profileSwitchChangedProfile=(S.activeProfile||'default')!==_profileSwitchProfileBefore||!!S.activeProfileIsDefault!==_profileSwitchIsDefaultBefore;
-            if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
-          }
-        }
-      }else{
-        console.warn('[boot] ignored invalid profile query', profileIntent.name);
-        if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
+    if(urlSession){
+      _profileIntentBlocked=!profileIntent.valid;
+    }else if(!profileIntent.valid){
+      console.warn('[boot] ignored invalid profile query', profileIntent.name);
+      _profileIntentBlocked=true;
+    }else if(typeof switchToProfile==='function'){
+      try{
+        _profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;
+        if(_profileSwitchCompleted){
+          _profileSwitchChangedProfile=(S.activeProfile||'default')!==_profileSwitchProfileBefore||!!S.activeProfileIsDefault!==_profileSwitchIsDefaultBefore;
+          if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
+        }else _profileIntentBlocked=true;
+      }catch(e){
+        console.warn('[boot] profile query switch failed', e);
+        _profileIntentBlocked=true;
       }
-    }catch(e){
-      console.warn('[boot] profile query switch failed', e);
+    }else{
+      _profileIntentBlocked=true;
     }
   }
   if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)) fetchReasoningChip();
@@ -3739,7 +3752,6 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
   if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
-  const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const pwaLaunchAction=(window.HermesPWA&&typeof window.HermesPWA.launchAction==='function')
     ? window.HermesPWA.launchAction()
     : null;
@@ -3765,7 +3777,14 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     }catch(_){}
   }
   const savedLocal=localStorage.getItem('hermes-webui-session');
-  const saved=urlSession||savedLocal;
+  if(_profileIntentBlocked&&!urlSession){
+    S._bootReady=true;
+    syncTopbar();syncWorkspacePanelState();
+    $('emptyState').style.display='';
+    await renderSessionList();
+    return;
+  }
+  const saved=urlSession||(_profileQueryBlocksSavedLocal?null:savedLocal);
   if(saved){
     try{
       const savedSidebarOnlyState=(!urlSession&&savedLocal)
@@ -3794,7 +3813,23 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
         await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();
         return;
       }
-      await loadSession(saved, {preserveActiveInput:true});
+      const restoreIntent=(urlSession&&profileIntent&&profileIntent.hasParam)?profileIntent:null;
+      const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);
+      if(loaded!==true){
+        if(urlSession){
+          S._bootReady=true;
+          syncTopbar();syncWorkspacePanelState();
+          $('emptyState').style.display='';
+          await renderSessionList();
+          return;
+        }
+        try{localStorage.removeItem('hermes-webui-session');}catch(_){ }
+        S._bootReady=true;
+        syncTopbar();syncWorkspacePanelState();
+        $('emptyState').style.display='';
+        await renderSessionList();
+        return;
+      }
       // Hard refresh starts from the static HTML model list. Hydrate the live
       // catalog after the saved session is known, then re-apply that session's
       // model before S._bootReady lets syncModelChip reveal the composer label.
@@ -3842,7 +3877,16 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       }
       S._bootReady=true;
       syncTopbar();syncWorkspacePanelState();await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();await checkInflightOnBoot(saved);await _finalizeComposerPrefillOnBoot(prefillIntent);return;}
-    catch(e){localStorage.removeItem('hermes-webui-session');}
+    catch(e){
+      if(urlSession){
+        S._bootReady=true;
+        syncTopbar();syncWorkspacePanelState();
+        $('emptyState').style.display='';
+        await renderSessionList();
+        return;
+      }
+      localStorage.removeItem('hermes-webui-session');
+    }
   }
   // no saved session - show empty state, wait for user to hit +
   S._bootReady=true;

--- a/static/panels.js
+++ b/static/panels.js
@@ -6965,6 +6965,7 @@ function _openProfileSwitchSessionBrowser(){
 }
 
 async function switchToProfile(name) {
+  const options=arguments[1]||{};
   // ── #4671 profile-switch loading-skeleton — FOUR-GUARD CONTRACT ───────────────
   // The skeleton must never be clobbered by the OLD profile's content and must never
   // strand. Four interacting pieces of state cooperate; an edit touching one without
@@ -6988,7 +6989,11 @@ async function switchToProfile(name) {
   // already on this profile, so paths like activateCurrentProfile() (which
   // doesn't pre-check) can't flash a skeleton→restore for a click that changes
   // nothing. (#4662 Opus gate)
-  if (name && name === S.activeProfile) return true;
+  if (name && !options.force && (
+    name === S.activeProfile ||
+    (typeof _profileMatchesActiveProfile === 'function' &&
+      _profileMatchesActiveProfile(name,S.activeProfile||'default'))
+  )) return true;
   S._pendingSessionToolsets=null;
   // Profile switches are per-client cookie/TLS scoped, so a running stream in
   // the current session can safely continue while this tab moves to another
@@ -7003,7 +7008,43 @@ async function switchToProfile(name) {
   const _titlebarLabel = $('titlebarProfileLabel');
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
-  const _openingExistingSidebarSession = !!(typeof _profileSwitchOpeningExistingSession !== 'undefined' && _profileSwitchOpeningExistingSession);
+  const _openingExistingSidebarSession = !!options.openExistingSession ||
+    !!(typeof _profileSwitchOpeningExistingSession !== 'undefined' && _profileSwitchOpeningExistingSession);
+  const _navigationGeneration=Number.isFinite(options.navigationGeneration)
+    ? Number(options.navigationGeneration) : null;
+  const _navigationIsCurrent=()=>_navigationGeneration===null||
+    (typeof _sessionNavigationGeneration==='undefined'||_sessionNavigationGeneration===_navigationGeneration);
+  const _preNavigationBrowserState=_navigationGeneration===null?null:{
+    defaultModel:window._defaultModel,
+    activeProvider:window._activeProvider,
+    profileDefaultWorkspace:S._profileDefaultWorkspace,
+    profileSwitchWorkspace:S._profileSwitchWorkspace,
+    pendingProfileModel:S._pendingProfileModel,
+    pendingProfileModelProvider:S._pendingProfileModelProvider,
+    persistedModel:localStorage.getItem('hermes-webui-model'),
+    persistedModelState:localStorage.getItem('hermes-webui-model-state'),
+  };
+  const _restorePreNavigationBrowserState=()=>{
+    if(!_preNavigationBrowserState) return;
+    window._defaultModel=_preNavigationBrowserState.defaultModel;
+    window._activeProvider=_preNavigationBrowserState.activeProvider;
+    S._profileDefaultWorkspace=_preNavigationBrowserState.profileDefaultWorkspace;
+    S._profileSwitchWorkspace=_preNavigationBrowserState.profileSwitchWorkspace;
+    S._pendingProfileModel=_preNavigationBrowserState.pendingProfileModel;
+    S._pendingProfileModelProvider=_preNavigationBrowserState.pendingProfileModelProvider;
+    if(_preNavigationBrowserState.persistedModel===null) localStorage.removeItem('hermes-webui-model');
+    else localStorage.setItem('hermes-webui-model',_preNavigationBrowserState.persistedModel);
+    if(_preNavigationBrowserState.persistedModelState===null) localStorage.removeItem('hermes-webui-model-state');
+    else localStorage.setItem('hermes-webui-model-state',_preNavigationBrowserState.persistedModelState);
+  };
+  const _abortSupersededNavigation=async()=>{
+    if(_navigationIsCurrent()) return false;
+    if(_switchGen===_profileSwitchGeneration&&!options.navigationRollback){
+      const compensated=await switchToProfile(_prevProfileName,{openExistingSession:true,force:true,navigationRollback:true});
+      if(compensated===true) _restorePreNavigationBrowserState();
+    }
+    return true;
+  };
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
   if (_titlebarBtn) { _titlebarBtn.classList.add('switching'); _titlebarBtn.disabled = true; }
   // Optimistic name update — shows the target name right away
@@ -7035,7 +7076,7 @@ async function switchToProfile(name) {
     S.session.active_stream_id ||
     S.session.pending_user_message
   ));
-  if (_openingExistingSidebarSession && S.session) {
+  if (_openingExistingSidebarSession) {
     // A cross-profile sidebar click is about to load a concrete existing session.
     // Do not create or retag a blank intermediary session in the destination profile.
     sessionInProgress = true;
@@ -7069,6 +7110,7 @@ async function switchToProfile(name) {
     // the single source of truth for switch failure and is gated on _switchGen, so the
     // error surfaces ONLY when the CURRENT switch genuinely fails (@rodboev review, #4662).
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }), timeoutToast: false });
+    if(await _abortSupersededNavigation()) return false;
     if (_switchGen !== _profileSwitchGeneration) return false;
     S.activeProfile = data.active || name;
     S.activeProfileIsDefault = !!data.is_default;
@@ -7104,15 +7146,32 @@ async function switchToProfile(name) {
     // Apply the profile defaults returned by /api/profile/switch immediately.
     // Refreshing the full model/workspace catalogs is useful, but it should not
     // hold the visible switch animation open.
-    if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
-    else localStorage.removeItem('hermes-webui-model');
+    // Existing-session navigation is transactional: switch the profile cookie
+    // so the target session can be validated, but leave the visible/session
+    // model and workspace surfaces under the previous session's ownership.
+    // loadSession() adopts the validated target values; compensation therefore
+    // never has to undo a transient target-model dropdown repaint.
+    const _applyProfileDefaults=!_openingExistingSidebarSession;
+    if(_applyProfileDefaults){
+      if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
+      else {
+        localStorage.removeItem('hermes-webui-model');
+        localStorage.removeItem('hermes-webui-model-state');
+      }
+    }
     _skillsData = null;
     _workspaceList = null;
-    if (data.default_model) window._defaultModel = data.default_model;
-    if (data.default_model_provider) window._activeProvider = data.default_model_provider;
+    if (_applyProfileDefaults&&data.default_model) window._defaultModel = data.default_model;
+    else if(_applyProfileDefaults){
+      window._defaultModel = null;
+      S._pendingProfileModel = null;
+      S._pendingProfileModelProvider = null;
+    }
+    if (_applyProfileDefaults&&data.default_model_provider) window._activeProvider = data.default_model_provider;
+    else if(_applyProfileDefaults) window._activeProvider = null;
 
     // ── Apply model ────────────────────────────────────────────────────────
-    if (data.default_model) {
+    if (_applyProfileDefaults&&data.default_model) {
       const sel = $('modelSelect');
       const providerId = data.default_model_provider || window._activeProvider || null;
       const existingDefaultOpt = sel ? Array.from(sel.options).find(o => o.value === data.default_model) : null;
@@ -7151,12 +7210,12 @@ async function switchToProfile(name) {
     if (S.session && !sessionInProgress) {
       S.session.profile = data.active || name;
     }
-    if (typeof refreshProfileTransitionReasoningChip === 'function') {
+    if (_applyProfileDefaults&&typeof refreshProfileTransitionReasoningChip === 'function') {
       refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────
-    if (data.default_workspace) {
+    if (_applyProfileDefaults&&data.default_workspace) {
       // Always store the persistent profile default — used for blank-page display
       // and workspace auto-bind throughout the session lifecycle (#804, #823).
       S._profileDefaultWorkspace = data.default_workspace;
@@ -7176,6 +7235,9 @@ async function switchToProfile(name) {
           S.session.workspace = data.default_workspace;
         } catch (_) {}
       }
+    } else if(_applyProfileDefaults){
+      S._profileDefaultWorkspace = null;
+      S._profileSwitchWorkspace = null;
     }
 
     // ── Session ────────────────────────────────────────────────────────────
@@ -7189,6 +7251,7 @@ async function switchToProfile(name) {
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
+      if(await _abortSupersededNavigation()) return false;
       if (_switchGen !== _profileSwitchGeneration) return false;
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
       showToast(t('profile_switched', name));
@@ -7197,6 +7260,7 @@ async function switchToProfile(name) {
       // Start a new session for the new profile so nothing gets cross-tagged.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});
+      if(await _abortSupersededNavigation()) return false;
       if (_switchGen !== _profileSwitchGeneration) return false;
       // Keep topbar chips (workspace/profile) in sync after creating the
       // new profile-scoped session.
@@ -7206,6 +7270,7 @@ async function switchToProfile(name) {
       // this render the first allowed to paint the new profile's rows.
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
+      if(await _abortSupersededNavigation()) return false;
       // Re-check generation after the awaited list render: a newer switch can be
       // started while renderSessionList() is in flight, and without this guard
       // the superseded switch would clear the newer switch's workspace skeleton
@@ -7234,6 +7299,7 @@ async function switchToProfile(name) {
       // #4671: lift the embargo immediately before the switch-owned render (see above).
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
+      if(await _abortSupersededNavigation()) return false;
       if (_switchGen !== _profileSwitchGeneration) return;
       if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
       syncTopbar();
@@ -7242,6 +7308,7 @@ async function switchToProfile(name) {
       if (S.session && S.session.workspace) {
         const dirLoad = loadDir('.');
         if (workspaceVisible) await dirLoad;
+        if(await _abortSupersededNavigation()) return false;
       } else if (typeof clearWorkspaceTreeSkeleton === 'function') {
         // New profile has no bound workspace — clear the up-front skeleton so it
         // doesn't strand (#4662 Opus gate).
@@ -7251,6 +7318,7 @@ async function switchToProfile(name) {
     }
 
     await _profileSwitchPanelLoad();
+    if(await _abortSupersededNavigation()) return false;
     _refreshProfileSwitchBackground(_switchGen);
     return true;
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -24,6 +24,7 @@ let _loadingSessionId = null;
 // concurrent loads can still race and overwrite each other unless we compare
 // the generation token as well.
 let _loadSessionGeneration = 0;
+let _sessionNavigationGeneration = 0;
 // #3306: Snapshot of S.messages captured by loadSession() right before it
 // clears them on a force-reload of the active session. Consumed by
 // _ensureMessagesLoaded() when calling _carryForwardEphemeralTurnFields so
@@ -151,6 +152,12 @@ function _profileMatchesActiveProfile(profile, activeProfile){
   const activeName = (typeof activeProfile === 'string' && activeProfile.trim()) ? activeProfile.trim() : 'default';
   if(eventName === activeName) return true;
   return eventName === 'default' && !!S.activeProfileIsDefault;
+}
+function _profileMatchesProfileState(profile, activeProfile, activeIsDefault){
+  const eventName = (typeof profile === 'string' && profile.trim()) ? profile.trim() : 'default';
+  const activeName = (typeof activeProfile === 'string' && activeProfile.trim()) ? activeProfile.trim() : 'default';
+  if(eventName === activeName) return true;
+  return eventName === 'default' && !!activeIsDefault;
 }
 
 function _sessionEventProfilesMatch(eventProfile, activeProfile){
@@ -1083,14 +1090,17 @@ function _serverLiveSnapshotInflight(snapshot, uploaded){
 }
 
 function _selectLiveRecoveryInflight(localInflight, serverLiveSnapshot, activeStreamId){
-  if(!serverLiveSnapshot) return localInflight||null;
-  if(!localInflight||!_inflightHasVisibleLiveState(localInflight)) return serverLiveSnapshot;
+  const requestedActiveId=String(activeStreamId||'').trim();
+  const localId=String(localInflight&&localInflight.streamId||'').trim();
+  const serverId=String(serverLiveSnapshot&&serverLiveSnapshot.streamId||'').trim();
+  const localVisible=!!(localInflight&&_inflightHasVisibleLiveState(localInflight));
+  const localMatchesActive=!!(requestedActiveId&&localId&&localId===requestedActiveId);
+  const serverMatchesActive=!!(requestedActiveId&&serverId&&serverId===requestedActiveId);
+  if(!serverMatchesActive) return localVisible&&localMatchesActive?localInflight:null;
+  if(!localInflight||!localVisible) return serverLiveSnapshot;
 
   // The run journal owns the Worklog projection. A same-stream browser tail
   // wins only when it advanced after the metadata snapshot was read.
-  const requestedActiveId=String(activeStreamId||'').trim();
-  const localId=String(localInflight.streamId||'').trim();
-  const serverId=String(serverLiveSnapshot.streamId||'').trim();
   const activeId=requestedActiveId||serverId;
   const selectDurableSnapshot=()=>{
     if(activeId&&localId===activeId&&Array.isArray(localInflight.todos)&&localInflight.todoStateMeta){
@@ -1098,9 +1108,6 @@ function _selectLiveRecoveryInflight(localInflight, serverLiveSnapshot, activeSt
     }
     return serverLiveSnapshot;
   };
-  if(requestedActiveId&&serverId&&serverId!==requestedActiveId){
-    return localId===requestedActiveId?localInflight:null;
-  }
   if(activeId&&localId!==activeId) return selectDurableSnapshot();
 
   const localSeq=Math.max(0,Number(localInflight.lastRunJournalSeq)||0);
@@ -1646,48 +1653,180 @@ function _sessionProfileMismatchFromError(e){
   return null;
 }
 
-async function _switchProfileForSessionLoad(profile){
-  const name=String(profile||'').trim();
-  if(!name) throw new Error('missing profile');
-  if(name===S.activeProfile) return;
-  if(typeof _invalidateSessionListRenders==='function') _invalidateSessionListRenders();
-  if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(true);
-  if(typeof showSessionListSkeleton==='function') showSessionListSkeleton(name);
+function _sessionReferenceIdIsValid(value){
+  return /^[A-Za-z0-9_-]{1,256}$/.test(String(value||''));
+}
+function _sessionReferenceProfileIsValid(value){
+  return /^[a-z0-9][a-z0-9_-]{0,63}$/.test(String(value||''));
+}
+function _parseSessionReference(sid, profile){
+  const id=String(sid||'');
+  if(!_sessionReferenceIdIsValid(id)) return null;
+  if(profile===null||typeof profile==='undefined') return {sid:id,profile:null};
+  const name=String(profile);
+  return _sessionReferenceProfileIsValid(name)?{sid:id,profile:name}:null;
+}
+function _sessionProfilesMatch(expected, actual){
+  const left=String(expected||'').trim()||'default';
+  const right=String(actual||'').trim()||'default';
+  if(left===right) return true;
+  const activeName=String((S&&S.activeProfile)||'').trim()||'default';
+  const activeIsDefault=!!(S&&S.activeProfileIsDefault);
+  if((right===activeName&&_profileMatchesProfileState(left,right,activeIsDefault))||
+    (left===activeName&&_profileMatchesProfileState(right,left,activeIsDefault))) return true;
+  const rootAlias=name=>name==='default'||(
+    typeof _cronProfileNameIsRootAlias==='function'&&_cronProfileNameIsRootAlias(name));
+  const matches=(eventName,activeName)=>_profileMatchesProfileState(eventName,activeName,rootAlias(activeName));
+  return matches(left,right)||matches(right,left);
+}
+function _sessionPayloadProfileForExpected(session, expectedProfile){
+  const raw=session&&typeof session.profile==='string'?session.profile.trim():'';
+  if(_sessionReferenceProfileIsValid(raw)) return raw;
+  const isMissing=!session||session.profile===null||typeof session.profile==='undefined'||session.profile==='';
+  if(!isMissing) return null;
+  const activeName=String((S&&S.activeProfile)||'').trim()||'default';
+  return _profileMatchesProfileState(expectedProfile,activeName,!!(S&&S.activeProfileIsDefault))
+    ? activeName : null;
+}
+function _quarantineExplicitInflight(sid, enabled){
+  if(!enabled||!sid||typeof INFLIGHT==='undefined'||!INFLIGHT) return;
+  delete INFLIGHT[sid];
+}
+async function _preflightSessionReference(sid, profile){
   try{
-    const data=await api('/api/profile/switch',{method:'POST',body:JSON.stringify({name}),timeoutToast:false});
-    S.activeProfile=data.active||name;
-    S.activeProfileIsDefault=!!data.is_default;
-    if(typeof _resetCronUnreadForProfileSwitch==='function'){
-      _resetCronUnreadForProfileSwitch();
+    const data=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+    const session=data&&data.session;
+    const returnedProfile=_sessionPayloadProfileForExpected(session,profile);
+    if(!session||String(session.session_id||'')!==sid||!returnedProfile) return null;
+    return _sessionProfilesMatch(profile,returnedProfile)?{profile:returnedProfile}:null;
+  }catch(e){
+    const mismatch=_sessionProfileMismatchFromError(e);
+    if(!mismatch||mismatch.session_id!==sid||!_sessionReferenceProfileIsValid(mismatch.profile)) return null;
+    return _sessionProfilesMatch(profile,mismatch.profile)?{profile:mismatch.profile}:null;
+  }
+}
+async function _restoreSessionReference(previous, rollbackUrl){
+  const rollbackGeneration=++_sessionNavigationGeneration;
+  const previousProfile=previous.profile||'default';
+  if(!_sessionProfilesMatch(previousProfile,S.activeProfile||'default')){
+    if(typeof switchToProfile!=='function'||await switchToProfile(previousProfile,{
+      openExistingSession:true,force:true,navigationRollback:true
+    })!==true) return false;
+  }
+  if(_sessionNavigationGeneration!==rollbackGeneration) return false;
+  if(previous.sid){
+    const restored=await loadSession(previous.sid,{
+      _preloadNotified:true,
+      skipProfileResolve:true,
+      skipLineageResolve:true,
+      expectedSessionId:previous.sid,
+      expectedProfile:previousProfile,
+      _navigationGeneration:rollbackGeneration,
+      force:true,
+      clearProfileIntent:!previous.explicitProfile
+    });
+    if(restored!==true) return false;
+    if(previous.explicitProfile) S._verifiedSessionProfileIntent={sid:previous.sid,profile:previous.explicitProfile};
+    else S._verifiedSessionProfileIntent=null;
+    if(!rollbackUrl) _setActiveSessionUrl(previous.sid,previous.explicitProfile||null);
+  }else{
+    if(typeof stopSessionStream==='function') stopSessionStream();
+    S.session=null;S.messages=[];S.toolCalls=[];S.activeStreamId=null;S.busy=false;
+    S._verifiedSessionProfileIntent=null;
+  }
+  if(rollbackUrl&&typeof history!=='undefined'&&history.replaceState){
+    try{history.replaceState(history.state||null,'',rollbackUrl);}catch(_){ }
+  }
+  return true;
+}
+async function _openSessionReference(sid, profile, navigationOptions){
+  navigationOptions=navigationOptions||{};
+  const rollbackUrl=typeof navigationOptions.rollbackUrl==='string'?navigationOptions.rollbackUrl:null;
+  const restoreRollbackUrl=()=>{
+    if(!rollbackUrl||typeof history==='undefined'||!history.replaceState) return;
+    try{history.replaceState(history.state||null,'',rollbackUrl);}catch(_){ }
+  };
+  const requested=_parseSessionReference(sid,profile);
+  if(!requested){restoreRollbackUrl();return false;}
+  if(typeof _hermesNotifySessionOpen==='function'){
+    try{
+      const pre=_hermesNotifySessionOpen(requested.sid,null,{
+        preload:true,opts:{...navigationOptions,explicitProfile:requested.profile}
+      });
+      if(pre&&pre.cancel===true){restoreRollbackUrl();return false;}
+    }catch(_){restoreRollbackUrl();return false;}
+  }
+  if(requested.profile===null){
+    try{return await loadSession(requested.sid,{clearProfileIntent:true,_preloadNotified:true})===true;}
+    catch(_){return false;}
+  }
+  const navigationGeneration=++_sessionNavigationGeneration;
+  const canonicalSid=requested.sid;
+  const previous={
+    sid:S.session&&S.session.session_id?String(S.session.session_id):null,
+    profile:String(S.activeProfile||'').trim()||'default',
+    explicitProfile:S._verifiedSessionProfileIntent&&S._verifiedSessionProfileIntent.sid===S.session?.session_id
+      ? S._verifiedSessionProfileIntent.profile:null,
+    url:typeof window!=='undefined'&&window.location
+      ? window.location.pathname+window.location.search+window.location.hash : null,
+  };
+  try{
+    const preflight=await _preflightSessionReference(canonicalSid,requested.profile);
+    if(_sessionNavigationGeneration!==navigationGeneration) return false;
+    if(!preflight){restoreRollbackUrl();return false;}
+    const profileChanged=!_sessionProfilesMatch(requested.profile,previous.profile);
+    if(profileChanged){
+      if(typeof switchToProfile!=='function'||await switchToProfile(requested.profile,{
+        openExistingSession:true,navigationGeneration
+      })!==true) throw new Error('profile switch failed');
     }
-    if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
-    else localStorage.removeItem('hermes-webui-model');
-    if(data.default_model) window._defaultModel=data.default_model;
-    if(data.default_model_provider) window._activeProvider=data.default_model_provider;
-    if(typeof refreshProfileTransitionReasoningChip==='function'){
-      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
-    }
-    if(typeof startGatewaySSE==='function') startGatewaySSE();
-    if(typeof syncTopbar==='function') syncTopbar();
-    if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
-    if(typeof renderSessionList==='function') await renderSessionList();
-  }catch(switchErr){
-    // The switch POST failed, so we're still on the previous profile and its
-    // caches are intact. Clear the up-front skeleton and re-render the real
-    // list so the sidebar doesn't strand on the skeleton (the #4671 strand bug
-    // — _sessionListSkeletonActive hard-gates renderSessionListFromCache + the
-    // SSE/poll repaints until an unrelated full render fires). Mirror the
-    // canonical switch's catch in panels.js, then rethrow so loadSession's
-    // catch(switchErr) still routes into the generic error handler.
-    if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
-    _sessionListSkeletonActive=false;
-    if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
-    throw switchErr;
+    if(_sessionNavigationGeneration!==navigationGeneration) return false;
+    _quarantineExplicitInflight(canonicalSid,profileChanged);
+    const sameSession=!!(S.session&&S.session.session_id===canonicalSid);
+    const force=sameSession&&(!_sessionReferenceProfileIsValid(S.session.profile)||
+      !_sessionProfilesMatch(S.session.profile,requested.profile));
+    const acceptedSession={sid:canonicalSid};
+    const loaded=await loadSession(canonicalSid,{
+      _explicitPrepared:true,
+      _preloadNotified:true,
+      skipProfileResolve:true,
+      skipLineageResolve:true,
+      expectedSessionId:canonicalSid,
+      expectedProfile:requested.profile,
+      _acceptedSessionId:acceptedSession,
+      _navigationGeneration:navigationGeneration,
+      _ignorePersistedInflight:profileChanged,
+      force
+    });
+    const acceptedSid=acceptedSession.sid||canonicalSid;
+    const acceptedProfile=_sessionPayloadProfileForExpected(S.session,requested.profile);
+    if(loaded!==true||!_sessionReferenceIdIsValid(acceptedSid)||!S.session||String(S.session.session_id)!==acceptedSid||
+      !acceptedProfile||!_sessionProfilesMatch(acceptedProfile,requested.profile)||
+      !_sessionProfilesMatch(requested.profile,S.activeProfile||'default')) throw new Error('session identity validation failed');
+    if(profileChanged&&typeof clearInflightState==='function') clearInflightState(acceptedSid);
+    S._verifiedSessionProfileIntent={sid:acceptedSid,profile:requested.profile};
+    _setActiveSessionUrl(acceptedSid,requested.profile);
+    return true;
+  }catch(_){
+    if(_sessionNavigationGeneration!==navigationGeneration) return false;
+    let restored=false;
+    try{restored=await _restoreSessionReference(previous,rollbackUrl||previous.url);}catch(_){ }
+    if(!restored) restoreRollbackUrl();
+    return false;
   }
 }
 
 async function loadSession(sid){
   const opts = arguments[1] || {};
+  const hasNavigationGeneration=Object.prototype.hasOwnProperty.call(opts,'_navigationGeneration');
+  let navigationGeneration;
+  if(hasNavigationGeneration){
+    if(opts._navigationGeneration!==_sessionNavigationGeneration) return false;
+    navigationGeneration=opts._navigationGeneration;
+  }else navigationGeneration=++_sessionNavigationGeneration;
+  if(Object.prototype.hasOwnProperty.call(opts,'explicitProfile')&&!opts._explicitPrepared){
+    return _openSessionReference(sid,opts.explicitProfile);
+  }
   // Resolve canonical lineage SID BEFORE both the direct and sidebar preload
   // notifications so extensions always see the canonical session id, not the
   // raw sidebar click id (which may differ after lineage folding).
@@ -1695,19 +1834,21 @@ async function loadSession(sid){
     const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);
     if(resolvedSid&&resolvedSid!==sid) sid=resolvedSid;
   }
+  if(typeof _quarantineExplicitInflight==='function'){
+    _quarantineExplicitInflight(sid,!!opts._ignorePersistedInflight);
+  }
   // Extension pre-open hook — fires once per sidebar click, not on every call.
   // _openSidebarSession passes _preloadNotified:true so the hook isn't re-fired
   // when loadSession runs the actual navigation inside it.
   if(!opts.skipExtHooks && !opts._preloadNotified && typeof _hermesNotifySessionOpen==='function'){
     var _preResult=_hermesNotifySessionOpen(sid, null, {preload:true, opts:opts});
     if(_preResult&&_preResult.cancel===true){
-      return;
+      return false;
     }
   }
-  const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
-  const sameSessionForceReload = forceReload && currentSid===sid;
-  // Clicking the already-open session in the sidebar is a no-op. Reloading it
+  // Clicking the already-open session in the sidebar is a no-op only while the
+  // visible owner still matches the active/expected owner. Reloading it
   // tears down active pane state and can reset the long-session scroll window
   // to the top even though the user did not navigate anywhere. Explicit
   // refresh paths pass {force:true} when external state.db changes arrive.
@@ -1723,7 +1864,29 @@ async function loadSession(sid){
   // for the same sid is a legitimate supersede (generation bump below) that
   // cross-session ordering tests rely on. Coalescing at the entry point would
   // drop the superseding fetch and leave a stale first load in charge.
-  if(currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid)){
+  const visibleSessionProfile=S.session&&(
+    typeof _sessionPayloadProfileForExpected==='function'
+      ? _sessionPayloadProfileForExpected(S.session,S.activeProfile||'default')
+      : (typeof S.session.profile==='string'&&S.session.profile.trim()
+        ? S.session.profile.trim() : null));
+  const profilesMatch=(expected,actual)=>typeof _sessionProfilesMatch==='function'
+    ? _sessionProfilesMatch(expected,actual)
+    : String(expected||'').trim()===String(actual||'').trim();
+  const expectedProfileForVisible=opts.expectedProfile&&S.session&&(
+    typeof _sessionPayloadProfileForExpected==='function'
+      ? _sessionPayloadProfileForExpected(S.session,opts.expectedProfile)
+      : (typeof S.session.profile==='string'&&S.session.profile.trim()
+        ? S.session.profile.trim() : null));
+  const visibleOwnerMatchesActive=!!(visibleSessionProfile&&profilesMatch(
+    visibleSessionProfile,S.activeProfile||'default'));
+  const expectedOwnerMatchesVisible=!opts.expectedProfile||!!(
+    expectedProfileForVisible&&profilesMatch(opts.expectedProfile,expectedProfileForVisible)&&
+    profilesMatch(opts.expectedProfile,S.activeProfile||'default'));
+  const ownerMismatch=currentSid===sid&&(!visibleOwnerMatchesActive||!expectedOwnerMatchesVisible);
+  const forceReload = !!opts.force||ownerMismatch;
+  const sameSessionForceReload = forceReload && currentSid===sid;
+  if(currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid) &&
+    visibleOwnerMatchesActive&&expectedOwnerMatchesVisible){
     // Re-selecting the already-open session is a no-op for transcript/scroll, but
     // it is still a *visit*: clear a stale sidebar unread dot (e.g. one a
     // background completion left on the open, unfocused pane) before returning.
@@ -1734,12 +1897,24 @@ async function loadSession(sid){
         Number(S.session.last_message_at || S.session.updated_at || 0)
       );
     }
-    return;
+    if(opts.expectedProfile){
+      const activeSessionProfile=_sessionPayloadProfileForExpected(S.session,opts.expectedProfile);
+      if(!activeSessionProfile||
+        !_sessionProfilesMatch(opts.expectedProfile,activeSessionProfile)||
+        !_sessionProfilesMatch(opts.expectedProfile,S.activeProfile||'default')) return false;
+      S._verifiedSessionProfileIntent={sid,profile:opts.expectedProfile};
+      _setActiveSessionUrl(sid,opts.expectedProfile);
+    }else if(opts.clearProfileIntent){
+      S._verifiedSessionProfileIntent=null;
+      _setActiveSessionUrl(sid,null);
+    }
+    return true;
   }
   // Mark this session as the in-flight load. Subsequent loadSession() calls
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   const _loadGeneration = ++_loadSessionGeneration;
-  const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
+  const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration &&
+    navigationGeneration===_sessionNavigationGeneration;
   _loadingSessionId = sid;
   if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
   // Reset scroll state for fresh session navigation — the reader expects to
@@ -1777,7 +1952,7 @@ async function loadSession(sid){
     // continuation can't wipe S.messages / write the loading placeholder /
     // close streams for the session the user actually landed on (#1060 guard,
     // extended to cover the new pre-switch await).
-    if (!_isCurrentLoad()) return;
+    if (!_isCurrentLoad()) return false;
     // Snapshot the live turn before msgInner is replaced. Preserves the activity
     // timer, partial response, and tool cards so switching back does not rebuild
     // the stream UI from scratch.
@@ -1858,11 +2033,13 @@ async function loadSession(sid){
     if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
-        return;
+        return false;
       }
       try{
         if(typeof showToast==='function') showToast(`Switching to ${profileMismatch.profile} profile for this session…`,2200);
-        await _switchProfileForSessionLoad(profileMismatch.profile);
+        if(await switchToProfile(profileMismatch.profile,{openExistingSession:true,navigationGeneration})!==true){
+          throw new Error('profile switch failed');
+        }
         // Post-await stale-load guard (Codex): the profile switch above does a
         // network POST + session-list re-render, during which the user may have
         // navigated to a different session. If we no longer own the load, bail
@@ -1870,7 +2047,7 @@ async function loadSession(sid){
         // continuation can't hijack the UI back to the old target.
         if (!_isCurrentLoad()) {
           _rearmActiveSessionStream();
-          return;
+          return false;
         }
         if (_isCurrentLoad()) _loadingSessionId = null;
         return loadSession(sid,{...opts,skipProfileResolve:true,force:true,_preloadNotified:true});
@@ -1888,7 +2065,7 @@ async function loadSession(sid){
     // or self-heal.
     if (!_isCurrentLoad()) {
       _rearmActiveSessionStream();
-      return;
+      return false;
     }
     if(_msgInner){
       if(e.status===404){
@@ -1951,7 +2128,7 @@ async function loadSession(sid){
         && typeof startSessionStream === 'function') {
       startSessionStream(currentSid);
     }
-    return;
+    return false;
   }
   // Guard: api() may have redirected (401) and returned undefined; in that case
   // the browser is already navigating away, so abort the rest of this flow.
@@ -1964,7 +2141,7 @@ async function loadSession(sid){
     // #2971: re-arm the still-displayed session's stream (defensive — harmless
     // if the 401 redirect is already tearing the page down). Idempotent.
     _rearmActiveSessionStream();
-    return;
+    return false;
   }
   // Stale response? A newer loadSession() call has already started (#1060).
   if (!_isCurrentLoad()) {
@@ -1974,18 +2151,45 @@ async function loadSession(sid){
     // Re-arm the genuinely-displayed S.session (idempotent — no-ops once the
     // newer load arms its own sid).
     _rearmActiveSessionStream();
-    return;
+    return false;
   }
+  let returnedSession=data&&data.session;
+  const returnedSid=returnedSession&&String(returnedSession.session_id||'');
+  const returnedProfile=opts.expectedProfile
+    ? _sessionPayloadProfileForExpected(returnedSession,opts.expectedProfile) : null;
+  if(!returnedSession||returnedSid!==String(sid)||
+    (opts.expectedSessionId&&returnedSid!==String(opts.expectedSessionId))||
+    (opts.expectedProfile&&(
+      !returnedProfile||
+      !_sessionProfilesMatch(opts.expectedProfile,returnedProfile)||
+      !_sessionProfilesMatch(opts.expectedProfile,S.activeProfile||'default')))){
+    if(_isCurrentLoad()) _loadingSessionId=null;
+    _rearmActiveSessionStream();
+    return false;
+  }
+  if(opts.expectedProfile&&returnedProfile!==returnedSession.profile){
+    returnedSession={...returnedSession,profile:returnedProfile};
+    data={...data,session:returnedSession};
+  }
+  if(opts._acceptedSessionId) opts._acceptedSessionId.sid=returnedSid;
   // #2980: if this (current) load resolved a hidden pre-compression snapshot,
   // follow the backend's continuation hint to the visible continuation so a
   // mobile reload mid-compression doesn't strand the user on a hidden snapshot.
   // Do NOT write URL/localStorage here — let the re-entrant loadSession update
   // them only once the continuation actually loads, so a rejected/deleted/
   // cross-profile continuation can't poison restore state with an unusable id.
-  const continuationSid=(data.session&&data.session.continuation_session_id)||'';
+  const continuationSid=String((data.session&&data.session.continuation_session_id)||'');
+  if(continuationSid&&!_sessionReferenceIdIsValid(continuationSid)){
+    if(_isCurrentLoad()) _loadingSessionId=null;
+    return false;
+  }
   if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
+    if(typeof _quarantineExplicitInflight==='function'){
+      _quarantineExplicitInflight(continuationSid,!!opts._ignorePersistedInflight);
+    }
     _loadingSessionId=null;
-    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true});
+    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,
+      expectedSessionId:continuationSid,force:true,_preloadNotified:true});
   }
   S.session=data.session;
   if(typeof _adoptRegenerationRevision==='function') _adoptRegenerationRevision(data.session);
@@ -2062,8 +2266,10 @@ async function loadSession(sid){
     Number(data.session.message_count || 0),
     Number(data.session.last_message_at || data.session.updated_at || 0)
   );
-  try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
-  _setActiveSessionUrl(S.session.session_id);
+  if(!opts.expectedProfile&&!opts.clearProfileIntent&&currentSid===sid){
+    try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){ }
+    _setActiveSessionUrl(S.session.session_id);
+  }
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
 
 
@@ -2074,7 +2280,7 @@ async function loadSession(sid){
   // then merge the local INFLIGHT live tail. INFLIGHT is a recovery tail, not a
   // complete transcript; treating it as the full source makes long sessions look
   // like they lost history after switching away and back.
-  if(!INFLIGHT[sid]&&activeStreamId&&typeof loadInflightState==='function'){
+  if(!opts._ignorePersistedInflight&&!INFLIGHT[sid]&&activeStreamId&&typeof loadInflightState==='function'){
     const stored=loadInflightState(sid, activeStreamId);
     if(stored){
       INFLIGHT[sid]={
@@ -2119,6 +2325,7 @@ async function loadSession(sid){
   const serverLiveSnapshot=activeStreamId
     ? _serverLiveSnapshotInflight(S.session.runtime_journal_snapshot, S.session.pending_attachments||[])
     : null;
+  let _messageLoadFailed=false;
   const hadLiveRecoveryInflight=!!INFLIGHT[sid];
   const liveRecoveryInflight=_selectLiveRecoveryInflight(INFLIGHT[sid], serverLiveSnapshot, activeStreamId);
   if(liveRecoveryInflight) INFLIGHT[sid]=liveRecoveryInflight;
@@ -2135,17 +2342,24 @@ async function loadSession(sid){
     // this session's INFLIGHT snapshot, not leave prior-session rows in place.
     if(typeof clearLiveToolCards==='function') clearLiveToolCards();
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration,
+        expectedSessionId:opts.expectedSessionId,expectedProfile:opts.expectedProfile});
     } catch(e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
-        return;
+        return false;
+      }
+      if(e&&e.code==='session_payload_identity'){
+        _loadingSessionId=null;
+        _rearmActiveSessionStream();
+        return false;
       }
       S.messages=inflightMessages;
+      _messageLoadFailed=true;
     }
     if (!_isCurrentLoad()) {
       _rearmActiveSessionStream();
-      return;
+      return false;
     }
     const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);
     if(liveTailPrepared){
@@ -2179,7 +2393,7 @@ async function loadSession(sid){
     let didReconnect=false;
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
       INFLIGHT[sid].reattach=false;
-      if (!_isCurrentLoad()) return;
+      if (!_isCurrentLoad()) return false;
       didReconnect=true;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
@@ -2241,11 +2455,12 @@ async function loadSession(sid){
     // "messages already populated" early-return inside _ensureMessagesLoaded
     // does NOT skip the swap to the new transcript.
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration,
+        expectedSessionId:opts.expectedSessionId,expectedProfile:opts.expectedProfile});
     } catch (e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
-        return;
+        return false;
       }
       // Network errors, server failures, or SSE drops (Chrome error codes 4/5)
       // can cause _ensureMessagesLoaded to throw. Without a try/catch here the
@@ -2255,12 +2470,14 @@ async function loadSession(sid){
       if (_msgInner) {
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
-      if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
+      if (typeof showToast === 'function' && !(e&&e.code==='session_payload_identity')) {
+        showToast('Failed to load conversation messages', 3000, 'error');
+      }
       if (_isCurrentLoad()) _loadingSessionId = null;
-      return;
+      return false;
     }
     // Stale? A newer loadSession() call has already started (#1060).
-    if (!_isCurrentLoad()) return;
+    if (!_isCurrentLoad()) return false;
 
     // Restore any queued message that survived page refresh or tab restore.
     if(typeof queueSessionMessage==='function'){
@@ -2412,10 +2629,30 @@ async function loadSession(sid){
   } else {
     _hideHandoffHint();
   }
+  const recoveryActiveStreamId=String(activeStreamId||'').trim();
+  const recoveryInflight=INFLIGHT[sid];
+  const recoveryStreamId=String(recoveryInflight&&recoveryInflight.streamId||'').trim();
+  if(_messageLoadFailed&&opts.expectedProfile&&!(recoveryActiveStreamId&&recoveryStreamId&&
+    recoveryStreamId===recoveryActiveStreamId&&_inflightHasVisibleLiveState(recoveryInflight))) return false;
   // Extension post-load hook
   if(!opts.skipExtHooks && typeof _hermesNotifySessionOpen==='function'){
     try{ _hermesNotifySessionOpen(sid, S.session, {loaded:true, opts:opts}); }catch(_){}
   }
+  try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){ }
+  if(opts._ignorePersistedInflight&&typeof clearInflightState==='function'){
+    clearInflightState(opts._acceptedSessionId&&opts._acceptedSessionId.sid||sid);
+  }
+  if(opts.expectedProfile){
+    S._verifiedSessionProfileIntent={sid,profile:opts.expectedProfile};
+    _setActiveSessionUrl(sid,opts.expectedProfile);
+  }else if(opts.clearProfileIntent||currentSid!==sid){
+    S._verifiedSessionProfileIntent=null;
+    _setActiveSessionUrl(sid,null);
+  }else{
+    if(S._verifiedSessionProfileIntent&&S._verifiedSessionProfileIntent.sid!==sid) S._verifiedSessionProfileIntent=null;
+    _setActiveSessionUrl(sid);
+  }
+  return true;
 }
 
 // ── Handoff hint logic ──────────────────────────────────────────────────────
@@ -2498,12 +2735,12 @@ async function _ensureSidebarSessionProfile(session){
 }
 
 async function _openSidebarSession(session, loadOpts={}){
-  if(!session||!session.session_id) return;
+  if(!session||!session.session_id) return false;
   // Extension pre-open hook — before any side-effects (external import, profile switching).
   // Handler returns {cancel:true} to prevent the open.
   if(!loadOpts.skipExtHooks && typeof _hermesNotifySessionOpen==='function'){
     var _preResult=_hermesNotifySessionOpen(session.session_id, null, {preload:true, opts:loadOpts});
-    if(_preResult&&_preResult.cancel===true) return;
+    if(_preResult&&_preResult.cancel===true) return false;
   }
   // #5409: close mobile sidebar AFTER veto guard passes — only close if open proceeds.
   if(typeof closeMobileSidebar==='function')closeMobileSidebar();
@@ -2511,10 +2748,16 @@ async function _openSidebarSession(session, loadOpts={}){
     try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify(_externalImportPayload(session))});}
     catch(_e){ /* import failed -- fall through to read-only view */ }
   }
-  await _ensureSidebarSessionProfile(session);
+  const profileSwitched=await _ensureSidebarSessionProfile(session);
+  if(_showAllProfiles&&_sidebarSessionProfileName(session)&&
+    !_profileMatchesActiveProfile(_sidebarSessionProfileName(session),S.activeProfile||'default')&&!profileSwitched) return false;
   // Tell loadSession to skip its pre-hook — we already ran it above.
-  await loadSession(session.session_id, Object.assign({}, loadOpts, {_preloadNotified:true}));
+  const options=Object.assign({},loadOpts,{_preloadNotified:true});
+  if(!Object.prototype.hasOwnProperty.call(options,'explicitProfile')) options.clearProfileIntent=true;
+  let loaded=false;
+  try{loaded=await loadSession(session.session_id,options);}catch(_){loaded=false;}
   renderSessionListFromCache();
+  return loaded===true;
 }
 
 function _isReadOnlySession(session) {
@@ -3181,7 +3424,21 @@ async function _ensureMessagesLoaded(sid, opts) {
   }
   if (!_ownsLoad()) return;
   // Guard: api() may have redirected (401) and returned undefined.
-  if (!data || !data.session) return;
+  const returnedSession=data&&data.session;
+  const expectedSid=opts.expectedSessionId?String(opts.expectedSessionId):'';
+  const returnedSid=returnedSession&&String(returnedSession.session_id||'');
+  const returnedProfile=opts.expectedProfile
+    ? _sessionPayloadProfileForExpected(returnedSession,opts.expectedProfile) : null;
+  if(!returnedSession&&(!expectedSid&&!opts.expectedProfile)) return;
+  if(!returnedSession || (expectedSid&&returnedSid!==expectedSid) ||
+    (opts.expectedProfile&&(
+      !returnedProfile||
+      !_sessionProfilesMatch(opts.expectedProfile,returnedProfile)||
+      !_sessionProfilesMatch(opts.expectedProfile,S.activeProfile||'default')))){
+    const identityError=new Error('session messages payload identity mismatch');
+    identityError.code='session_payload_identity';
+    throw identityError;
+  }
   _messagesTruncated = !!data.session._messages_truncated;
   _oldestIdx = data.session._messages_offset || 0;
   _msgLimitMax = data.session._msg_limit_max || _MSG_LIMIT_MAX;
@@ -4182,10 +4439,11 @@ function _profileQueryIntentFromLocation(){
   try{
     const qs=new URLSearchParams(window.location.search||'');
     if(!qs.has('profile')) return empty;
-    const name=String(qs.get('profile')||'');
+    const values=qs.getAll('profile');
+    const name=String(values[0]||'');
     return {
       hasParam:true,
-      valid:/^[a-z0-9][a-z0-9_-]{0,63}$/.test(name),
+      valid:values.length===1&&/^[a-z0-9][a-z0-9_-]{0,63}$/.test(name),
       name
     };
   }catch(_e){return empty;}
@@ -4193,6 +4451,7 @@ function _profileQueryIntentFromLocation(){
 function _consumeProfileQueryParamFromLocation(){
   if(typeof window==='undefined'||!window.location||!window.history||typeof window.history.replaceState!=='function') return;
   try{
+    if(!_profileQueryIntentFromLocation().valid) return;
     const current=new URL(window.location.href);
     const before=current.searchParams.toString();
     current.searchParams.delete('profile');
@@ -4222,7 +4481,7 @@ function _appRootPath(){
     return base.pathname || '/';
   }catch(_e){return '/';}
 }
-function _sessionUrlForSid(sid){
+function _sessionUrlForSid(sid, explicitProfile){
   const encoded=encodeURIComponent(sid);
   let base;
   try{base=new URL(`session/${encoded}`, document.baseURI||window.location.origin+'/');}
@@ -4234,6 +4493,13 @@ function _sessionUrlForSid(sid){
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');
+    if(arguments.length>1){
+      current.searchParams.delete('profile');
+      if(explicitProfile!==null&&typeof explicitProfile!=='undefined'&&
+        _sessionReferenceProfileIsValid(String(explicitProfile))){
+        current.searchParams.set('profile',String(explicitProfile));
+      }
+    }
     const retained=new URLSearchParams();
     current.searchParams.forEach((value,key)=>{
       if(key!=='action'||value!=='new-chat') retained.append(key,value);
@@ -4243,9 +4509,34 @@ function _sessionUrlForSid(sid){
   }catch(_e){}
   return base.pathname+base.search+base.hash;
 }
-function _setActiveSessionUrl(sid){
+function _setActiveSessionUrl(sid, explicitProfile){
   if(typeof window==='undefined'||!window.history||!sid) return;
-  const next=_sessionUrlForSid(sid);
+  const state=typeof S!=='undefined'?S:null;
+  let hasExplicitProfile=arguments.length>1;
+  let profileForUrl=explicitProfile;
+  if(!hasExplicitProfile){
+    const verified=state&&state._verifiedSessionProfileIntent;
+    const session=state&&state.session;
+    const verifiedProfile=verified&&verified.profile;
+    const sessionProfile=session&&_sessionPayloadProfileForExpected(session,verifiedProfile);
+    if(state&&_sessionReferenceProfileIsValid(verifiedProfile)&&session&&String(session.session_id||'')===String(sid)&&
+      sessionProfile&&_sessionProfilesMatch(verifiedProfile,sessionProfile)&&
+      _sessionProfilesMatch(verifiedProfile,state.activeProfile||'default')){
+      hasExplicitProfile=true;
+      profileForUrl=verifiedProfile;
+      state._verifiedSessionProfileIntent={sid:String(sid),profile:verifiedProfile};
+    }else{
+      const locationIntent=typeof _profileQueryIntentFromLocation==='function'?_profileQueryIntentFromLocation():null;
+      if(locationIntent&&locationIntent.hasParam){
+        hasExplicitProfile=true;
+        profileForUrl=null;
+        if(state) state._verifiedSessionProfileIntent=null;
+      }
+    }
+  }else if(profileForUrl===null||typeof profileForUrl==='undefined'){
+    if(state) state._verifiedSessionProfileIntent=null;
+  }
+  const next=hasExplicitProfile?_sessionUrlForSid(sid,profileForUrl):_sessionUrlForSid(sid);
   if(next && next!==(window.location.pathname+window.location.search+window.location.hash)){
     let consumeLaunchAction=false;
     try{
@@ -9033,23 +9324,48 @@ async function _handleShowAllProfilesStorageEvent(e){
   if(typeof renderSessionList==='function') await renderSessionList({deferWhileInteracting:false});
 }
 
+function _handleSessionPopstate(){
+  const sid=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
+  const intent=(typeof _profileQueryIntentFromLocation==='function')
+    ? _profileQueryIntentFromLocation() : {hasParam:false,valid:false,name:''};
+  if(!sid) return false;
+  if(intent.hasParam&&!intent.valid){
+    if(typeof showToast==='function') showToast('Invalid session profile link.',3000,'error');
+    return false;
+  }
+  const currentSid=S.session&&S.session.session_id;
+  const sameSid=currentSid===sid;
+  if(sameSid&&intent.hasParam&&S._verifiedSessionProfileIntent&&
+    S._verifiedSessionProfileIntent.sid===sid&&S._verifiedSessionProfileIntent.profile===intent.name&&
+    _sessionProfilesMatch(intent.name,S.activeProfile||'default')&&
+    _sessionProfilesMatch(intent.name,S.session&&S.session.profile)) return true;
+  if(S.busy){
+    if(typeof showToast==='function') showToast('Finish the current turn before switching sessions.',3000);
+    return false;
+  }
+  if(intent.hasParam){
+    let rollbackUrl=null;
+    if(currentSid){
+      try{
+        const verified=S._verifiedSessionProfileIntent;
+        rollbackUrl=verified&&verified.sid===currentSid
+          ? _sessionUrlForSid(currentSid,verified.profile)
+          : _sessionUrlForSid(currentSid,null);
+      }catch(_){ }
+    }
+    return rollbackUrl
+      ? _openSessionReference(sid,intent.name,{rollbackUrl})
+      : _openSessionReference(sid,intent.name);
+  }
+  return loadSession(sid,{clearProfileIntent:true});
+}
+
 if(typeof window!=='undefined'){
   window.addEventListener('storage', (e) => {
     void _handleActiveSessionStorageEvent(e);
     void _handleShowAllProfilesStorageEvent(e);
   });
-  window.addEventListener('popstate', () => {
-    const sid=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
-    if(!sid || (S.session && S.session.session_id===sid)) return;
-    // Refuse to switch sessions mid-stream — same UX guard the storage-event
-    // handler had. A user mid-turn who hits browser Back should NOT lose the
-    // active stream. They can hit Back again once the turn ends.
-    if(S.busy){
-      if(typeof showToast==='function') showToast('Finish the current turn before switching sessions.',3000);
-      return;
-    }
-    void loadSession(sid);
-  });
+  window.addEventListener('popstate', () => { void _handleSessionPopstate(); });
 }
 
 async function removeWorktree(session){

--- a/static/ui.js
+++ b/static/ui.js
@@ -5,7 +5,7 @@
 // legacy reverse-scan over S.messages — that keeps new clients working
 // against old servers (Phase 1 may not yet be deployed everywhere).
 // See api/todo_state.py for the wire contract.
-const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',activeProfileIsDefault:true,showHiddenWorkspaceFiles:false,todos:[],todoStateMeta:null,_pendingSessionToolsets:null};
+const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',activeProfileIsDefault:true,showHiddenWorkspaceFiles:false,todos:[],todoStateMeta:null,_pendingSessionToolsets:null,_verifiedSessionProfileIntent:null};
 
 function assistantDisplayName(){
   if(S.activeProfile&&S.activeProfile!=='default') return S.activeProfile.charAt(0).toUpperCase()+S.activeProfile.slice(1);
@@ -1493,26 +1493,128 @@ function _scheduleMessageVirtualizedRender(force){
 const _renderCache = new Map();
 const _renderCacheMax = 300;
 function _clearRenderCache(){ _renderCache.clear(); }
-function _renderCacheKey(text, isUser){
+function _renderCacheKey(text, isUser, linkSessionReferences=true){
   // Fold render_user_markdown state into user-message keys so toggling the
   // setting invalidates cached plain-text renders (#3870).
-  const p = isUser ? (window._renderUserMarkdown ? 'um' : 'u') : 'a';
+  const p = (isUser ? (window._renderUserMarkdown ? 'um' : 'u') : 'a')+
+    (linkSessionReferences?'s':'l');
   // Short content: use the full string as key (cheap Map lookup).
   // Long content: length + prefix + suffix is good enough — collisions on
   // 20-char prefix+suffix are vanishingly rare for chat messages.
   if(text.length <= 500) return p + ':' + text;
   return p + ':' + text.length + ':' + text.slice(0,20) + ':' + text.slice(-20);
 }
-function _getCachedRender(text, isUser){
-  const key = _renderCacheKey(text, isUser);
+function _linkBareSessionReferences(html){
+  const source=String(html||'');
+  const reference=/@session:(?:(?:[a-z0-9][a-z0-9_-]{0,63})\/)?[A-Za-z0-9_-]{1,256}/gi;
+  const protectedTags=new Set(['a','code','pre','script','style','textarea']);
+  let out='',cursor=0,protectedStack=[];
+  const renderText=(text)=>{
+    let result='',last=0,match;
+    reference.lastIndex=0;
+    while((match=reference.exec(text))){
+      const start=match.index;
+      let end=start+match[0].length;
+      const before=text[start-1]||'',after=text[end]||'',afterNext=text[end+1]||'';
+      const entityAfter=/^&(?:quot|apos|amp|lt|gt|#\d+|#x[0-9a-f]+);/i.test(text.slice(end,end+24));
+      const beforeWindow=text.slice(Math.max(0,start-24),start);
+      const entityBefore=(beforeWindow.match(/&(?:quot|apos|amp|lt|gt|#\d+|#x[0-9a-f]+);$/i)||[''])[0];
+      const entityBeforeUrl=!!entityBefore&&/[/:?#&=%]/.test(text[start-entityBefore.length-1]||'');
+      const entityBeforeAmp=/&(?:amp|#38);$/i.test(beforeWindow);
+      const danglingHtmlAttribute=/^["'][^<>]{0,160}(?:>|\s+[a-z_:][a-z0-9_:.-]*\s*=)/i
+        .test(text.slice(end,end+192));
+      const urlLikeAfter=/[A-Za-z0-9_\/#=%-]/.test(after)||
+        (after==='.'&&/[A-Za-z0-9_]/.test(afterNext))||
+        (after==='?'&&/[A-Za-z0-9_=&%#/-]/.test(afterNext))||
+        (after===':'&&/[/?#]/.test(afterNext))||
+        (after==='&'&&!entityAfter);
+      if(before==='\\'||/[A-Za-z0-9]/.test(before)||/[/:?#&=%]/.test(before)||
+        entityBeforeAmp||entityBeforeUrl||danglingHtmlAttribute||
+        urlLikeAfter) continue;
+      let openingUnderscores=0;
+      for(let i=start-1;i>=0&&text[i]==='_'&&openingUnderscores<3;i--) openingUnderscores++;
+      const trailingUnderscores=(text.slice(start,end).match(/_+$/)||[''])[0].length;
+      const wrapperUnderscores=(openingUnderscores===1||openingUnderscores===2)&&trailingUnderscores>=openingUnderscores
+        ? openingUnderscores : 0;
+      let value=match[0].slice('@session:'.length);
+      if(wrapperUnderscores){
+        end-=wrapperUnderscores;
+        value=value.slice(0,-wrapperUnderscores);
+      }
+      const parts=value.split('/');
+      const profile=parts.length===2?parts[0]:null;
+      const sid=parts.length===2?parts[1]:parts[0];
+      if(!sid||!/^[A-Za-z0-9_-]{1,256}$/.test(sid)||
+        (profile!==null&&!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(profile))) continue;
+      const label=text.slice(start,end);
+      let href='';
+      try{
+        if(typeof _sessionUrlForSid==='function') href=_sessionUrlForSid(sid,profile);
+        else href=`session/${encodeURIComponent(sid)}`;
+      }catch(_){ href=`session/${encodeURIComponent(sid)}`; }
+      result+=text.slice(last,start);
+      result+=`<a class="session-link" href="${esc(href)}" data-session-ref="1" data-session-id="${esc(sid)}"${profile!==null?` data-session-profile="${esc(profile)}"`:''}>${esc(label)}</a>`;
+      last=end;
+    }
+    return result+text.slice(last);
+  };
+  while(cursor<source.length){
+    const tagStart=source.indexOf('<',cursor);
+    if(tagStart<0){
+      out+=protectedStack.length?source.slice(cursor):renderText(source.slice(cursor));
+      break;
+    }
+    if(tagStart>cursor) out+=protectedStack.length?source.slice(cursor,tagStart):renderText(source.slice(cursor,tagStart));
+    if(source.startsWith('<!--',tagStart)){
+      const commentEnd=source.indexOf('-->',tagStart+4);
+      if(commentEnd<0){out+=source.slice(tagStart);break;}
+      const end=commentEnd+3;
+      out+=source.slice(tagStart,end);cursor=end;continue;
+    }
+    let tagEnd=-1,quote='';
+    for(let i=tagStart+1;i<source.length;i++){
+      const ch=source[i];
+      if(quote){
+        if(ch===quote) quote='';
+        continue;
+      }
+      if(ch==='"'||ch==="'"){quote=ch;continue;}
+      if(ch==='>'){tagEnd=i;break;}
+    }
+    if(tagEnd<0){out+=source.slice(tagStart);break;}
+    const tag=source.slice(tagStart,tagEnd+1);
+    out+=tag;
+    const tagMatch=tag.match(/^<\/?\s*([a-z][a-z0-9-]*)\b/i);
+    if(tagMatch){
+      const tagName=tagMatch[1].toLowerCase();
+      if(protectedTags.has(tagName)){
+        if(/^<\//.test(tag)){
+          if(protectedStack[protectedStack.length-1]===tagName) protectedStack.pop();
+        }else if(!/\/\s*>$/.test(tag)) protectedStack.push(tagName);
+      }
+    }
+    cursor=tagEnd+1;
+  }
+  return out;
+}
+function _getCachedRender(text, isUser, options){
+  const linkSessionReferences=!(options&&options.linkSessionReferences===false);
+  let key = _renderCacheKey(text, isUser, linkSessionReferences);
+  if(linkSessionReferences){
+    try{
+      const location=new URL(window.location.href);
+      key+=`|session-link-url:${location.search}${location.hash}`;
+    }catch(_){ }
+  }
   const hit = _renderCache.get(key);
   if(hit !== undefined) return hit;
   const rendered = isUser
     ? (window._renderUserMarkdown ? renderMd(text) : _renderUserFencedBlocks(text))
     : renderMd(_stripXmlToolCallsDisplay(String(text)));
+  const finalHtml=linkSessionReferences?_linkBareSessionReferences(rendered):rendered;
   if(_renderCache.size > _renderCacheMax) _renderCache.clear();
-  _renderCache.set(key, rendered);
-  return rendered;
+  _renderCache.set(key, finalHtml);
+  return finalHtml;
 }
 // ── Message-level media snapshot stamping ─────────────────────────────────
 // /api/media serves a file's CURRENT bytes. Since ETag revalidation (#6922),
@@ -2557,6 +2659,14 @@ document.addEventListener('click', e => {
   if(!e.target || !e.target.closest) return;
   const sessionLink=e.target.closest('a.session-link[href]');
   if(sessionLink){
+    if(sessionLink.getAttribute('data-session-ref')==='1'&&typeof _openSessionReference==='function'){
+      e.preventDefault();
+      const sid=sessionLink.getAttribute('data-session-id')||'';
+      const profile=sessionLink.hasAttribute('data-session-profile')
+        ? sessionLink.getAttribute('data-session-profile') : null;
+      void _openSessionReference(sid,profile);
+      return;
+    }
     const href=sessionLink.getAttribute('href')||'';
     const m=href.match(/(?:^|\/)session\/([^?#]+)/i);
     if(m&&typeof loadSession==='function'){
@@ -17013,7 +17123,7 @@ function renderMessages(options){
         return _renderAttachmentHtml(fname,fileUrl);
       }).join('')}</div>`;
     }
-    let bodyHtml = _getCachedRender(displayContent, isUser);
+    let bodyHtml = _getCachedRender(displayContent, isUser, {linkSessionReferences:!m._live});
     // Message-level media snapshots: settled assistant messages carry a
     // path→digest map (written at settle time) freezing the file bytes the
     // turn emitted. Stamp it AFTER the text-keyed render cache so identical
@@ -17240,7 +17350,7 @@ function renderMessages(options){
         if(_ERR_MSG_RE.test(String(partDisplayText||'').trim())) orderedSeg.dataset.error='1';
         if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))) orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
         const isLastTextPart=partIdx===lastTextPartIdx;
-        const partBodyHtml=_getCachedRender(partDisplayText,false);
+        const partBodyHtml=_getCachedRender(partDisplayText,false,{linkSessionReferences:!m._live});
         // Message-level media snapshots: transparent ordered segments carry the
         // same per-message path→digest map as the main transcript; stamp it so
         // historical previews freeze (&snap=) instead of following overwrites.

--- a/tests/test_1694_root_saved_running_policy.py
+++ b/tests/test_1694_root_saved_running_policy.py
@@ -35,7 +35,7 @@ def test_root_boot_distinguishes_url_session_from_localstorage_saved_session():
         "root `/` policy can differ from explicit `/session/<sid>` reload"
     )
     compact = block.replace(" ", "")
-    assert "constsaved=urlSession||savedLocal" in compact, (
+    assert "constsaved=urlSession||(_profileQueryBlocksSavedLocal?null:savedLocal)" in compact, (
         "boot should still prefer explicit URL sessions over saved localStorage sessions"
     )
 
@@ -45,7 +45,7 @@ def test_root_saved_running_session_is_checked_before_load_session_projection():
     block = _boot_saved_session_block()
     guard = "!urlSession&&savedLocal"
     guard_pos = block.replace(" ", "").find(guard)
-    load_pos = block.find("await loadSession(saved, {preserveActiveInput:true})")
+    load_pos = block.find("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);")
     assert guard_pos >= 0, (
         "root `/` boot must have a !urlSession && savedLocal guard for saved "
         "running sessions before projecting them into the active pane"
@@ -107,7 +107,7 @@ def test_root_archived_saved_session_clears_stale_localstorage_pointer():
     guard_pos = block.find(clear_guard, helper_pos)
     clear_pos = block.find("localStorage.removeItem('hermes-webui-session')", guard_pos)
     render_pos = block.find("await renderSessionList()", helper_pos)
-    load_pos = block.find("await loadSession(saved, {preserveActiveInput:true})")
+    load_pos = block.find("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);")
     assert guard_pos > helper_pos, "archived sidebar-only path must be distinguished"
     assert clear_pos > guard_pos, "archived saved session must clear stale localStorage pointer"
     assert clear_pos < render_pos, "stale pointer should be cleared before the sidebar-only return"

--- a/tests/test_4961_url_query_prefill.py
+++ b/tests/test_4961_url_query_prefill.py
@@ -157,7 +157,7 @@ console.log(JSON.stringify(result));
         "if(savedSidebarOnlyState&&savedSidebarOnlyState.sidebarOnly){",
         saved_state_pos,
     )
-    load_pos = BOOT_JS.find("await loadSession(saved, {preserveActiveInput:true});")
+    load_pos = BOOT_JS.find("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);")
     assert prefill_guard >= 0
     assert saved_state_pos >= 0
     assert saved_guard > saved_state_pos
@@ -355,8 +355,8 @@ console.log(JSON.stringify({
         first_await_pos,
     )
     new_pos = BOOT_JS.find("await newSession(true);", active_profile_pos)
-    load_pos = BOOT_JS.find("await loadSession(saved, {preserveActiveInput:true});", active_profile_pos)
-    saved_pos = BOOT_JS.find("const saved=urlSession||savedLocal;")
+    load_pos = BOOT_JS.find("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);", active_profile_pos)
+    saved_pos = BOOT_JS.find("const saved=urlSession||(_profileQueryBlocksSavedLocal?null:savedLocal);")
     check_pos = BOOT_JS.find("await checkInflightOnBoot(saved);", load_pos)
     apply_pos = BOOT_JS.find("await _finalizeComposerPrefillOnBoot(prefillIntent);", check_pos)
     assert saved_pos >= 0

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -146,8 +146,8 @@ global.switchToProfile = async (name) => {
   const afterPrefill = window.location.pathname + window.location.search + window.location.hash;
   const profilePos = bootSrc.indexOf("const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;");
   const renderPos = bootSrc.indexOf("await renderSessionList();", profilePos);
-  const savedPos = bootSrc.indexOf("const saved=urlSession||savedLocal;", profilePos);
-  const loadPos = bootSrc.indexOf("await loadSession(saved, {preserveActiveInput:true});", profilePos);
+  const savedPos = bootSrc.indexOf("const saved=urlSession||(_profileQueryBlocksSavedLocal?null:savedLocal);", profilePos);
+  const loadPos = bootSrc.indexOf("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);", profilePos);
   const consumePos = bootSrc.indexOf("if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();", profilePos);
   const completedPos = bootSrc.indexOf("_profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;", profilePos);
   const changedPos = bootSrc.indexOf("_profileSwitchChangedProfile=", completedPos);
@@ -502,8 +502,8 @@ global.switchToProfile = async (name) => { switched.push(name); };
     assert payload["intent"] == {"hasParam": True, "valid": False, "name": "../bad"}
     assert payload["switched"] == []
     assert payload["warns"] == [["[boot] ignored invalid profile query", "../bad"]]
-    assert payload["url"] == "/app/?q=hello&keep=1#frag"
-    assert payload["historyCalls"] == [{"state": None, "title": "", "url": "/app/?q=hello&keep=1#frag"}]
+    assert payload["url"] == "/app/?profile=../bad&q=hello&keep=1#frag"
+    assert payload["historyCalls"] == []
 
 
 def test_prefill_cleanup_still_strips_q_prompt_and_send():
@@ -577,7 +577,7 @@ console.log(JSON.stringify({
     assert payload == {
         "blocksImplicit": True,
         "allowsExplicit": False,
-        "ignoresInvalid": False,
+        "ignoresInvalid": True,
         "implicitAfter": None,
         "explicitAfter": "saved-local",
     }
@@ -665,7 +665,7 @@ console.log(JSON.stringify({{ beforeDestination, afterPreviousResponse, afterDes
         assert refresh in background
 
 
-def test_profile_transitions_fetch_destination_reasoning_after_hiding_stale_chip():
+def test_existing_session_profile_switch_defers_reasoning_until_validated_load():
     source = f"""
 const uiSrc = {UI_JS!r};
 const panelsSrc = {PANELS_JS!r};
@@ -716,7 +716,6 @@ eval(extractFunc(uiSrc, 'fetchReasoningChip'));
 eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
 eval(extractFunc(uiSrc, 'syncTopbar'));
 eval(extractFunc(panelsSrc, 'switchToProfile'));
-eval(extractFunc(sessionsSrc, '_switchProfileForSessionLoad'));
 const pending = [];
 const reasoningUrls = [];
 global.api = (url) => {{
@@ -739,12 +738,11 @@ fetchReasoningChip();
   S.session = {{ model: 'old-model', model_provider: 'old-provider', profile: 'default' }};
   _currentReasoningEffort = 'low'; _currentReasoningEffortsSupported = ['low', 'high']; _profileTransitionReasoningContext = null; _lastReasoningFetchKey = null;
   fetchReasoningChip();
-  await _switchProfileForSessionLoad('vops');
-  const directLoad = {{ hidden: els.composerReasoningWrap.style.display, urls: reasoningUrls.slice(2) }};
+      await switchToProfile('vops', {{ openExistingSession: true }});
+  const directLoad = {{ hidden: els.composerReasoningWrap.style.display || null, urls: reasoningUrls.slice(2) }};
   pending[2]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
   const directLoadAfterOld = _currentReasoningEffort;
-  pending[3]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
-  console.log(JSON.stringify({{ blankBoot, blankBootAfterOld, blankBootAfterNew, directLoad, directLoadAfterOld, directLoadAfterNew: _currentReasoningEffort }}));
+  console.log(JSON.stringify({{ blankBoot, blankBootAfterOld, blankBootAfterNew, directLoad, directLoadAfterOld }}));
 }})().catch(err => {{ console.error(err); process.exit(1); }});
 """
     payload = json.loads(_run_node(source))
@@ -755,11 +753,10 @@ fetchReasoningChip();
     assert payload["blankBootAfterOld"] == ""
     assert payload["blankBootAfterNew"] == "high"
     assert payload["directLoad"] == {
-        "hidden": "none",
-        "urls": ["/api/reasoning?model=old-model&provider=old-provider", "/api/reasoning?model=gpt-high&provider=openai"],
+        "hidden": None,
+        "urls": ["/api/reasoning?model=old-model&provider=old-provider"],
     }
-    assert payload["directLoadAfterOld"] == ""
-    assert payload["directLoadAfterNew"] == "high"
+    assert payload["directLoadAfterOld"] == "low"
 
 
 def test_blank_profile_transition_context_clears_before_explicit_model_change():

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -116,7 +116,7 @@ def test_576_panel_restore_gated_on_workspace():
 
 def test_576_restore_happens_after_load_session():
     """boot.js: loadSession() must come before the panel restore guard."""
-    load_pos    = BOOT_JS.find("await loadSession(saved, {preserveActiveInput:true})")
+    load_pos    = BOOT_JS.find("const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);")
     restore_pos = BOOT_JS.find("panelPref")
     assert load_pos != -1, "loadSession call not found in boot.js"
     assert restore_pos != -1, "workspace panel restore guard not found"

--- a/tests/test_bugfix_sweep.py
+++ b/tests/test_bugfix_sweep.py
@@ -148,7 +148,7 @@ def test_cross_profile_session_deep_links_switch_profile_instead_of_self_healing
     assert '"code": "session_profile_mismatch"' in routes
     assert 'if method == "GET" and path == "/api/session":' in routes
     assert "function _sessionProfileMismatchFromError" in sessions
-    assert "_switchProfileForSessionLoad(profileMismatch.profile)" in sessions
+    assert "switchToProfile(profileMismatch.profile,{openExistingSession:true,navigationGeneration})" in sessions
     assert "skipProfileResolve:true" in sessions
 
 

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -118,10 +118,8 @@ def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded
         "loadSession() should check ownership in multiple await/catch paths, "
         "including stale _ensureMessagesLoaded catch branches"
     )
-    ensure_call = _normalise_ws("await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});")
-    assert ensure_call in norm, (
-        "loadSession() must pass generation into _ensureMessagesLoaded() for stale-owner checks"
-    )
+    assert "expectedSessionId:opts.expectedSessionId" in norm
+    assert "expectedProfile:opts.expectedProfile" in norm
     assert (
         "showToast('Failed to load session" in LOAD_SESSION_SRC
         or "showToast('Failed to load conversation messages" in LOAD_SESSION_SRC
@@ -206,6 +204,7 @@ function createEnvironment() {
   globalThis._loadingSessionId = null;
   globalThis._loadingOlder = false;
   globalThis._loadSessionGeneration = 0;
+  globalThis._sessionNavigationGeneration = 0;
   globalThis._pendingCarryForwardSnapshot = null;
   globalThis._messagesTruncated = false;
   globalThis._oldestIdx = 0;

--- a/tests/test_extension_session_hooks.py
+++ b/tests/test_extension_session_hooks.py
@@ -308,7 +308,7 @@ def test_preload_veto_only_on_preload_phase():
 def test_continuation_retry_carries_preload_notified_flag():
     body = _extract_block(SESSIONS_JS, "async function loadSession(sid)")
     idx_cont = body.index("continuationSid=")
-    cont_branch = body[idx_cont:idx_cont + 400]
+    cont_branch = body[idx_cont:body.index("S.session=data.session", idx_cont)]
     assert "_preloadNotified:true" in cont_branch
 
 

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -172,7 +172,10 @@ def test_load_session_same_sid_noop_does_not_mask_pending_switch_back():
     # protected ownership invariant is unchanged: the guard still requires
     # (!_loadingSessionId || _loadingSessionId===sid) and still early-returns
     # before _loadingSessionId=sid.
-    guard = "if(currentSid===sid&&!forceReload&&(!_loadingSessionId||_loadingSessionId===sid)){"
+    guard = (
+        "if(currentSid===sid&&!forceReload&&(!_loadingSessionId||_loadingSessionId===sid)"
+        "&&visibleOwnerMatchesActive&&expectedOwnerMatchesVisible){"
+    )
     assert guard in compact, (
         "same-session no-op must be owned by the current load target: "
         "another in-flight sid must not suppress a pending switch-back"
@@ -183,7 +186,7 @@ def test_load_session_same_sid_noop_does_not_mask_pending_switch_back():
     # The guarded block must still early-return for the same-session no-op,
     # while now also acknowledging the visit to clear a stale unread dot.
     assert "_sessionVisitHasUnreadState(sid)" in compact[guard_pos:guard_pos + 600]
-    assert "return;}" in compact[guard_pos:guard_pos + 900]
+    assert "returntrue;}" in compact[guard_pos:guard_pos + 1200]
 
 
 def test_load_session_preserves_existing_worklog_content_without_destructive_fallback():

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -16,7 +16,7 @@ def test_boot_call_before_session_load():
     """fetchReasoningChip() should be called before session load in boot sequence."""
     with open("static/boot.js") as f:
         src = f.read()
-    boot_marker = "await loadSession(saved, {preserveActiveInput:true});"
+    boot_marker = "const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);"
     boot_pos = src.index(boot_marker)
     fetch_pos = src.index("fetchReasoningChip()", src.index("_profileQueryIntentFromLocation"))
     assert fetch_pos < boot_pos, \

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -114,7 +114,7 @@ def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_d
     assert "let orderedTransparentParts=_transparentStreamOrderedParts(m);" in UI_JS
     assert "if(message._anchor_activity_scene) return null;" in UI_JS
     assert "const partDisplayText=_transparentOrderedDisplayText(part.text);" in UI_JS
-    assert "const partBodyHtml=_getCachedRender(partDisplayText,false);" in UI_JS
+    assert "const partBodyHtml=_getCachedRender(partDisplayText,false,{linkSessionReferences:!m._live});" in UI_JS
     assert "const transparentOrderedToolIds=new Set();" in UI_JS
     assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid, transparentPersistedSnippetByTid);" in UI_JS
     assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -675,7 +675,7 @@ def test_load_session_schedules_session_visit_model_refresh_before_message_load(
 
     assign_idx = body.index("S.session=data.session")
     message_load_idx = body.index("await _ensureMessagesLoaded(sid", assign_idx)
-    failure_return_idx = body.index("return;", message_load_idx)
+    failure_return_idx = body.index("return false;", message_load_idx)
     model_block_idx = body.index("if(typeof populateModelDropdown==='function')", assign_idx)
     guard_helper_idx = body.index("const isActiveModelRefreshSession", model_block_idx)
     promise_idx = body.index("const modelRefreshPromise=_deferSessionSideEffect", model_block_idx)

--- a/tests/test_issue5177_hidden_tab_blank_gap.py
+++ b/tests/test_issue5177_hidden_tab_blank_gap.py
@@ -157,8 +157,15 @@ def test_ensure_messages_loaded_called_with_keep_stale_flag():
     # the keep-stale flag so the early-return inside _ensureMessagesLoaded
     # cannot skip the swap when stale messages are still in place.
     block = _load_session_block(_compact(SESSIONS_JS))
-    # Both INFLIGHT and idle paths.
-    assert block.count("await_ensureMessagesLoaded(sid,{force:_keepStaleUntilLoaded,loadGeneration:_loadGeneration})") == 2
+    expected = (
+        "await_ensureMessagesLoaded(sid,{"
+        "force:_keepStaleUntilLoaded,"
+        "loadGeneration:_loadGeneration,"
+        "expectedSessionId:opts.expectedSessionId,"
+        "expectedProfile:opts.expectedProfile"
+        "})"
+    )
+    assert block.count(expected) == 2
 
 
 def test_ensure_messages_loaded_supports_force_override():

--- a/tests/test_issue5960_cron_unread_profile_scope.py
+++ b/tests/test_issue5960_cron_unread_profile_scope.py
@@ -67,7 +67,7 @@ def test_successful_profile_switch_resets_unread_cron_state():
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_session_load_profile_switch_resets_unread_cron_state():
-    switch = _extract_function(SESSIONS_JS, "_switchProfileForSessionLoad")
+    switch = _extract_function(PANELS_JS, "switchToProfile")
     reset = _extract_function(PANELS_JS, "_resetCronUnreadForProfileSwitch")
     script = f"""
 let _cronPollSince=10;
@@ -77,12 +77,31 @@ const _cronNewJobIds=new Set(['old-profile-job']);
 global.S={{activeProfile:'default'}};
 global.api=async()=>({{active:'alternate',is_default:false}});
 global.localStorage={{removeItem(){{}}}};
+global.window={{}};
+global.$=()=>null;
+global.t=key=>key;
+global.showToast=()=>{{}};
+global.syncTopbar=()=>{{}};
+var _profileSwitchGeneration=0;
+global._profileSwitchPanelLoad=async()=>{{}};
+global._refreshProfileSwitchBackground=()=>{{}};
+global._invalidateSessionListRenders=()=>{{}};
+global._setProfileSwitchListEmbargo=()=>{{}};
+global.showSessionListSkeleton=()=>{{}};
+global.bumpWorkspaceTreeGen=()=>{{}};
+global.startGatewaySSE=()=>{{}};
+global.applyBotName=()=>{{}};
+global.animateNextSessionListRefresh=()=>{{}};
+global.closeSessionActionMenu=()=>{{}};
+global.renderSessionList=async()=>{{}};
+global.syncTopbar=()=>{{}};
+global.showToast=()=>{{}};
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
 function _clearCronSessionCompletionUnreadForInactiveProfiles(){{}}
 {reset}
 {switch}
 (async()=>{{
-  await _switchProfileForSessionLoad('alternate');
+  await switchToProfile('alternate');
   process.stdout.write(JSON.stringify({{
     profile:S.activeProfile,
     unread:Array.from(_cronNewJobIds),
@@ -166,7 +185,7 @@ def test_profile_switch_clears_persisted_old_profile_cron_markers_only():
     has_unread = _extract_function(SESSIONS_JS, "_hasUnreadForSession")
     has_marker = _extract_function(SESSIONS_JS, "_hasSessionCompletionUnread")
     reset = _extract_function(PANELS_JS, "_resetCronUnreadForProfileSwitch")
-    switch = _extract_function(SESSIONS_JS, "_switchProfileForSessionLoad")
+    switch = _extract_function(PANELS_JS, "switchToProfile")
     script = f"""
 const store={{'hermes-session-completion-unread':JSON.stringify({{}})}};
 global.localStorage={{
@@ -185,8 +204,24 @@ let renders=0;
 global.S={{activeProfile:'profile-a',activeProfileIsDefault:false}};
 global._allSessions=[];
 global.api=async()=>({{active:'profile-b',is_default:false}});
+global.window={{}};
+global.$=()=>null;
+global.t=key=>key;
+global.showToast=()=>{{}};
+global.syncTopbar=()=>{{}};
+var _profileSwitchGeneration=0;
+global._profileSwitchPanelLoad=async()=>{{}};
+global._refreshProfileSwitchBackground=()=>{{}};
+global._invalidateSessionListRenders=()=>{{}};
+global._setProfileSwitchListEmbargo=()=>{{}};
+global.showSessionListSkeleton=()=>{{}};
+global.bumpWorkspaceTreeGen=()=>{{}};
+global.startGatewaySSE=()=>{{}};
+global.applyBotName=()=>{{}};
+global.animateNextSessionListRefresh=()=>{{}};
+global.closeSessionActionMenu=()=>{{}};
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
-global.renderSessionListFromCache=()=>{{ renders+=1; }};
+global.renderSessionList=async()=>{{ renders+=1; }};
 function _getSessionViewedCounts(){{ return _sessionViewedCounts; }}
 function _saveSessionViewedCounts(){{}}
 function _setSessionViewedCount(sid, count){{
@@ -215,7 +250,7 @@ function _clearSessionCompletionUnread(sid){{
     chat:_hasUnreadForSession({{session_id:'chat-session'}}),
     newCron:_hasUnreadForSession({{session_id:'new-cron-session'}}),
   }};
-  await _switchProfileForSessionLoad('profile-b');
+  await switchToProfile('profile-b');
   const after={{
     oldCron:_hasUnreadForSession({{session_id:'old-cron-session'}}),
     chat:_hasUnreadForSession({{session_id:'chat-session'}}),

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -124,12 +124,12 @@ def test_pre_switch_draft_flush_rechecks_stale_loading_guard():
     """The awaited draft-save in loadSession yields the event loop. On a rapid
     session switch (B then quickly C) the stale B continuation must bail out
     before the destructive state-clearing block, or it would wipe the
-    freshly-loaded C state. The guard is `if (!_isCurrentLoad()) return;`
+    freshly-loaded C state. The guard is `if (!_isCurrentLoad()) return false;`
     placed AFTER the awaited save and BEFORE the `S.messages = []` clear
     (Codex pre-release CORE catch, #3471)."""
     body = _load_session_clear_block()
     await_idx = body.find("await _saveComposerDraftNow(currentSid")
-    guard_idx = body.find("if (!_isCurrentLoad()) return;", await_idx)
+    guard_idx = body.find("if (!_isCurrentLoad()) return false;", await_idx)
     clear_idx = body.find("S.messages = [];", await_idx)
     assert await_idx != -1, "pre-switch awaited draft save not found"
     assert guard_idx != -1, "stale-loading guard missing after the awaited draft save"

--- a/tests/test_media_message_snapshots.py
+++ b/tests/test_media_message_snapshots.py
@@ -760,7 +760,7 @@ def test_frontend_stamp_source_invariants():
     assert "_stampMediaSnapshots(bodyHtml, m._media_snapshots)" in src
     # Transparent segments: original _getCachedRender line is preserved (source
     # window contract), stamping applied on the next line via *_Stamped.
-    assert "_getCachedRender(partDisplayText,false);" in src
+    assert "_getCachedRender(partDisplayText,false,{linkSessionReferences:!m._live});" in src
     assert "_stampMediaSnapshots(partBodyHtml,m._media_snapshots)" in src
     # Worklog scene prose path is intentionally NOT stamped (folded view; the
     # scene render chain is exercised by harness-extracted tests that would

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -58,13 +58,13 @@ def test_boot_model_hydration_prefers_active_session_over_persisted_model():
 
 def test_hard_refresh_hydrates_saved_session_model_before_revealing_model_chip():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
-    load_marker = "await loadSession(saved, {preserveActiveInput:true});"
+    load_marker = "const loaded=await _restoreBootSession(urlSession,restoreIntent,saved);"
     assert load_marker in boot_js
     restore_end = "await checkInflightOnBoot(saved);"
     saved_restore = boot_js[boot_js.index(load_marker) : boot_js.index(restore_end, boot_js.index(load_marker))]
     assert "await _startBootModelDropdown();" in saved_restore
     assert saved_restore.index("await _startBootModelDropdown();") > saved_restore.index(load_marker)
-    assert saved_restore.index("await _startBootModelDropdown();") < saved_restore.index("S._bootReady=true;"), (
+    assert saved_restore.index("await _startBootModelDropdown();") < saved_restore.rfind("S._bootReady=true;"), (
         "hard refresh must hydrate/re-apply the active session model before S._bootReady lets syncModelChip display stale static HTML defaults"
     )
 

--- a/tests/test_pr6778_session_references.py
+++ b/tests/test_pr6778_session_references.py
@@ -1,0 +1,1296 @@
+"""Behavioral coverage for settled bare-session references and profile opens."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.js_source_extract import extract_function
+from tests.test_cross_session_message_load_isolation import (
+    ENSURE_MESSAGES_LOADED_SRC,
+    INFLIGHT_HAS_VISIBLE_STATE_SRC,
+    LOAD_SESSION_SRC,
+    MERGE_PENDING_SESSION_MESSAGE_SRC,
+    SELECT_LIVE_RECOVERY_INFLIGHT_SRC,
+    _NODE_SCRIPT_TEMPLATE,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+UI_SRC = (ROOT / "static/ui.js").read_text(encoding="utf-8")
+SESSIONS_SRC = (ROOT / "static/sessions.js").read_text(encoding="utf-8")
+PANELS_SRC = (ROOT / "static/panels.js").read_text(encoding="utf-8")
+BOOT_SRC = (ROOT / "static/boot.js").read_text(encoding="utf-8")
+MESSAGES_SRC = (ROOT / "static/messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> str:
+    result = subprocess.run(
+        [NODE],
+        input=source,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def _extract(source: str, name: str, prefix: str = "function") -> str:
+    return extract_function(source, name, prefix=prefix)
+
+
+def _render_driver(request: str) -> str:
+    session_helpers = "\n".join(
+        f"eval({code!r});"
+        for code in (
+            _extract(SESSIONS_SRC, "_sessionReferenceProfileIsValid"),
+            _extract(SESSIONS_SRC, "_sessionUrlForSid"),
+        )
+    )
+    ui_helpers = "\n".join(
+        f"eval({code!r});"
+        for code in (
+            _extract(UI_SRC, "_matchBacktickFenceLine"),
+            _extract(UI_SRC, "_isBacktickFenceClose"),
+            _extract(UI_SRC, "_renderUserFencedBlocks"),
+            _extract(UI_SRC, "_stripXmlToolCallsDisplay"),
+            _extract(UI_SRC, "renderMd"),
+            _extract(UI_SRC, "_renderCacheKey"),
+            _extract(UI_SRC, "_linkBareSessionReferences"),
+            _extract(UI_SRC, "_getCachedRender"),
+        )
+    )
+    return """
+global.window = {
+  _renderUserMarkdown: true,
+  location: { href: 'https://example.test/app/', pathname: '/app/', search: '', hash: '' },
+};
+global.document = { baseURI: 'https://example.test/app/' };
+global.localStorage = { getItem(){ return null; }, setItem(){}, removeItem(){} };
+global.history = { replaceState(){}, pushState(){} };
+const esc = s => String(s ?? '').replace(/[&<>"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const _dynamicModelLabels = {};
+function _isSafeDataImageUri() { return false; }
+function _inlineMediaHtmlForRef(ref) {
+  return '<img class="msg-media-img" src="api/media?path=' + encodeURIComponent(String(ref || '')) + '" alt="image">';
+}
+const _renderCache = new Map();
+const _renderCacheMax = 300;
+""" + session_helpers + "\n" + ui_helpers + f"""
+const request = {request};
+window._renderUserMarkdown = request.userMarkdown !== false;
+process.stdout.write(_getCachedRender(String(request.text || ''), !!request.user,
+  {{linkSessionReferences: request.linkSessionReferences !== false}}));
+"""
+
+
+def _render(
+    text: str,
+    *,
+    user: bool = False,
+    user_markdown: bool = True,
+    link_session_references: bool = True,
+) -> str:
+    request = json.dumps({
+        "text": text,
+        "user": user,
+        "userMarkdown": user_markdown,
+        "linkSessionReferences": link_session_references,
+    })
+    return _run_node(_render_driver(request))
+
+
+def test_settled_assistant_and_user_rendering_link_valid_wrappers_and_profiles():
+    text = (
+        "_@session:abc123_ __@session:def456__ &quot;@session:quoted123&quot; "
+        "«@session:guillemet123» 「@session:cjk123」 @session:p/abc123 @session:a_b "
+        "__@session:tail___"
+    )
+    for user, user_markdown in ((False, True), (True, True), (True, False)):
+        out = _render(text, user=user, user_markdown=user_markdown)
+        assert out.count('data-session-ref="1"') == 8
+        assert 'data-session-id="a_b"' in out
+        assert 'data-session-id="tail_"' in out
+        assert 'data-session-profile="p"' in out
+        assert 'href="/app/session/abc123' in out
+        assert 'href="/app/session/abc123?profile=p' in out
+        assert out.count('data-session-id="abc123"') == 2
+
+
+def test_settled_user_plain_renderer_links_bare_text_but_not_fenced_code():
+    out = _render(
+        "plain @session:user123\n\n```text\n@session:code123\n```",
+        user=True,
+        user_markdown=False,
+    )
+    assert out.count('data-session-ref="1"') == 1
+    assert '@session:code123' in out
+    assert 'data-session-id="code123"' not in out
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "`@session:inline123`",
+        "[existing](https://example.test/session/existing?ref=@session:link123)",
+        "![image](https://example.test/@session:image123.png)",
+        "https://example.test/path/@session:url123?q=@session:query123",
+        "@session:",
+        "@session:p/",
+        "@session:p//abc123",
+        "@session:p/abc123/extra",
+        "@session:abc.def",
+    ],
+)
+def test_settled_rendering_protects_code_links_images_urls_and_malformed_source(text):
+    out = _render(text)
+    assert 'data-session-ref="1"' not in out
+    if text.startswith("@session"):
+        assert out.count("@session") == 1
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<code></a>@session:x</code>",
+        "<pre></code>@session:x</pre>",
+        '<a href="/target"></code>@session:x</a>',
+    ],
+)
+def test_settled_rendering_keeps_references_in_malformed_protected_markup(text):
+    out = _render(text)
+    assert 'data-session-ref="1"' not in out
+    assert "@session:x" in out
+
+
+def test_valid_reference_stops_before_punctuation_without_prefix_link():
+    out = _render("@session:p/not-valid!")
+    assert out.count('data-session-ref="1"') == 1
+    assert 'data-session-id="not-valid"' in out
+    assert out.endswith('!</p>')
+
+
+@pytest.mark.parametrize("punctuation", [".", "?", ":"])
+def test_terminal_prose_punctuation_is_not_treated_as_a_url_suffix(punctuation):
+    out = _render(f"See @session:abc123{punctuation}")
+    assert out.count('data-session-ref="1"') == 1
+    assert f"@session:abc123</a>{punctuation}" in out
+
+
+def test_escaped_reference_remains_literal():
+    out = _render(r"\@session:escaped123")
+    assert 'data-session-ref="1"' not in out
+    assert "@session:escaped123" in out
+
+
+def test_live_render_cache_path_does_not_link_and_does_not_reuse_settled_html():
+    text = "@session:live123"
+    live = _render(text, link_session_references=False)
+    settled = _render(text)
+    assert 'data-session-ref="1"' not in live
+    assert settled.count('data-session-ref="1"') == 1
+    assert "_getCachedRender(displayContent, isUser, {linkSessionReferences:!m._live})" in UI_SRC
+    assert "_getCachedRender(partDisplayText,false,{linkSessionReferences:!m._live})" in UI_SRC
+
+
+def test_final_html_tokenizer_does_not_split_on_quoted_tag_delimiters():
+    linker = _extract(UI_SRC, "_linkBareSessionReferences")
+    source = f"""
+const esc = value => String(value);
+const _sessionUrlForSid = sid => '/session/' + sid;
+eval({linker!r});
+const html = '<span title="x > @session:attribute123">safe</span>';
+process.stdout.write(_linkBareSessionReferences(html));
+"""
+    assert _run_node(source) == '<span title="x > @session:attribute123">safe</span>'
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '<span title="x > @session:attribute123">safe</span>',
+        '<img alt="x > @session:imageattr123" src="x">',
+    ],
+)
+def test_rendered_raw_html_attribute_residue_is_not_linked_as_prose(source):
+    out = _render(source)
+    assert 'data-session-ref="1"' not in out
+
+
+def test_finalized_linker_handles_many_references_and_hostile_unfinished_candidate():
+    references = " ".join(f"@session:s{i}" for i in range(1500))
+    linked = _render(references)
+    assert linked.count('data-session-ref="1"') == 1500
+
+    unfinished = "@session:" + ("a" * 100_000)
+    preserved = _render(unfinished)
+    assert 'data-session-ref="1"' not in preserved
+    assert preserved.count("@session:") == 1
+    assert preserved.count("a") == 100_000
+
+
+def test_streaming_incremental_writes_keep_bare_references_as_text():
+    smd_write = _extract(MESSAGES_SRC, "_smdWrite")
+    source = f"""
+let writes = [];
+let _smdParser = {{}};
+let _smdWrittenLen = 0;
+let _smdWrittenText = '';
+const assistantBody = {{ textContent: '', innerHTML: '' }};
+const window = {{ smd: {{ parser_write(_parser, text) {{ writes.push(String(text)); }} }} }};
+function _scheduleStreamingKatex() {{}}
+eval({smd_write!r});
+_smdWrite('@session:smd123');
+_smdWrittenLen = 0;
+_smdWrittenText = '';
+_smdParser = {{}};
+_smdWrite('@session:fade123', true);
+process.stdout.write(JSON.stringify(writes));
+"""
+    writes = json.loads(_run_node(source))
+    assert writes == ["@session:smd123", "@session:fade123"]
+    assert "<a" not in "".join(writes)
+
+
+def test_profile_query_intent_rejects_duplicates_and_invalid_values():
+    profile_intent = _extract(SESSIONS_SRC, "_profileQueryIntentFromLocation")
+    source = f"""
+global.window = {{ location: {{ search: '?profile=ops&profile=other' }} }};
+eval({profile_intent!r});
+const duplicate = _profileQueryIntentFromLocation();
+window.location.search = '?profile=../bad';
+const invalid = _profileQueryIntentFromLocation();
+process.stdout.write(JSON.stringify({{duplicate, invalid}}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["duplicate"]["hasParam"] is True
+    assert payload["duplicate"]["valid"] is False
+    assert payload["invalid"]["valid"] is False
+
+
+def _navigation_base() -> str:
+    functions = "\n".join(
+        f"globalThis.{name}=(0,eval)('('+{code!r}+')');"
+        for name, code in (
+            ("_profileMatchesActiveProfile", _extract(SESSIONS_SRC, "_profileMatchesActiveProfile")),
+            ("_profileMatchesProfileState", _extract(SESSIONS_SRC, "_profileMatchesProfileState")),
+            ("_sessionReferenceIdIsValid", _extract(SESSIONS_SRC, "_sessionReferenceIdIsValid")),
+            ("_sessionReferenceProfileIsValid", _extract(SESSIONS_SRC, "_sessionReferenceProfileIsValid")),
+            ("_parseSessionReference", _extract(SESSIONS_SRC, "_parseSessionReference")),
+            ("_sessionProfilesMatch", _extract(SESSIONS_SRC, "_sessionProfilesMatch")),
+            ("_sessionPayloadProfileForExpected", _extract(SESSIONS_SRC, "_sessionPayloadProfileForExpected")),
+            ("_quarantineExplicitInflight", _extract(SESSIONS_SRC, "_quarantineExplicitInflight")),
+            ("_profileQueryIntentFromLocation", _extract(SESSIONS_SRC, "_profileQueryIntentFromLocation")),
+            ("_sessionProfileMismatchFromError", _extract(SESSIONS_SRC, "_sessionProfileMismatchFromError")),
+            ("_preflightSessionReference", _extract(SESSIONS_SRC, "_preflightSessionReference", "async function")),
+            ("_restoreSessionReference", _extract(SESSIONS_SRC, "_restoreSessionReference", "async function")),
+            ("_sessionUrlForSid", _extract(SESSIONS_SRC, "_sessionUrlForSid")),
+            ("_setActiveSessionUrl", _extract(SESSIONS_SRC, "_setActiveSessionUrl")),
+            ("_openSessionReference", _extract(SESSIONS_SRC, "_openSessionReference", "async function")),
+        )
+    )
+    return """
+var _sessionNavigationGeneration = 0;
+var S = {
+  activeProfile: 'default', activeProfileIsDefault: true,
+  session: { session_id: 'old', profile: 'default' },
+  messages: ['old-message'], toolCalls: ['old-tool'], activeStreamId: 'old-stream', busy: true,
+};
+var apiMode = 'mismatch';
+var loadMode = 'success';
+var calls = [];
+var profileSwitchCalls = [];
+var INFLIGHT = {};
+var clearedInflight = [];
+var _loadingOlder=false;
+var _messagesTruncated=false;
+var _oldestIdx=7;
+var _messageRenderWindowSize=80;
+var _pendingCarryForwardSnapshot={owner:'old'};
+var _messageUserUnpinned=true;
+var _scrollPinned=false;
+const storage = {
+  'hermes-webui-session': 'old',
+  'hermes-webui-model': 'old-model',
+  'hermes-webui-model-state': 'old-model-state',
+};
+global.localStorage = {
+  getItem(key){ return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null; },
+  setItem(key, value){ storage[key] = String(value); },
+  removeItem(key){ delete storage[key]; },
+};
+global.window = {
+  location: { href: 'https://example.test/app/session/old?keep=1#h', pathname: '/app/session/old', search: '?keep=1', hash: '#h' },
+};
+global.document = { baseURI: 'https://example.test/app/' };
+function setUrl(value){
+  const next = new URL(value, window.location.href);
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.history = { replaceState(_s, _t, value){ setUrl(value); }, pushState(_s, _t, value){ setUrl(value); } };
+window.history = global.history;
+function _cronProfileNameIsRootAlias(name){ return name === 'root'; }
+function clearInflightState(sid){ clearedInflight.push(sid); }
+global.api = async (url, options = {}) => {
+  if (options.method === 'POST') {
+    const body = JSON.parse(options.body || '{}');
+    S.activeProfile = body.name;
+    S.activeProfileIsDefault = body.name === 'default' || body.name === 'root';
+    return { active: body.name, is_default: S.activeProfileIsDefault };
+  }
+  if (apiMode === 'wrong-mismatch') {
+    const error = new Error('mismatch');
+    error.status = 409;
+    error.body = JSON.stringify({ code: 'session_profile_mismatch', session_id: 'other', profile: 'ops' });
+    throw error;
+  }
+  if (apiMode === 'mismatch') {
+    const error = new Error('mismatch');
+    error.status = 409;
+    error.body = JSON.stringify({ code: 'session_profile_mismatch', session_id: 'target', profile: 'ops' });
+    throw error;
+  }
+  return { session: { session_id: 'target', profile: 'ops' } };
+};
+global.switchToProfile = async (profile, options = {}) => {
+  profileSwitchCalls.push({profile, options});
+  S.activeProfile = profile;
+  S.activeProfileIsDefault = profile === 'default' || profile === 'root';
+  return true;
+};
+global.loadSession = async (sid, options) => {
+  calls.push({ sid, options, inflightAtLoad: INFLIGHT[sid] || null });
+  if (sid === 'old') {
+    S.session = { session_id: 'old', profile: 'default' };
+    S.messages = ['old-message'];
+    S.toolCalls = ['old-tool'];
+    S.busy = true;
+    _loadingOlder=false;
+    _messagesTruncated=false;
+    _oldestIdx=7;
+    _messageRenderWindowSize=80;
+    _pendingCarryForwardSnapshot={owner:'old'};
+    _messageUserUnpinned=true;
+    _scrollPinned=false;
+    localStorage.setItem('hermes-webui-session', 'old');
+    return true;
+  }
+  S.session = { session_id: loadMode === 'wrong-sid' ? 'other' : sid, profile: loadMode === 'wrong-profile' ? 'other' : 'ops' };
+  S.messages = ['target-message'];
+  S.toolCalls = ['target-tool'];
+  S.busy = false;
+  _loadingOlder=true;
+  _messagesTruncated=true;
+  _oldestIdx=999;
+  _messageRenderWindowSize=1;
+  _pendingCarryForwardSnapshot={owner:'target'};
+  _messageUserUnpinned=false;
+  _scrollPinned=true;
+  localStorage.setItem('hermes-webui-session', S.session.session_id);
+  if (loadMode !== 'success') history.pushState(null, '', '/app/session/' + encodeURIComponent(S.session.session_id));
+  return loadMode === 'fail' ? false : true;
+};
+""" + functions + "\n"
+
+
+def _navigation_run(body: str) -> dict:
+    return json.loads(_run_node(_navigation_base() + body))
+
+
+def test_explicit_reference_success_switches_owner_and_keeps_query():
+    payload = _navigation_run(
+        """
+(async () => {
+  const result = await _openSessionReference('target', 'ops');
+  process.stdout.write(JSON.stringify({
+    result, active: S.activeProfile, session: S.session.session_id,
+    href: window.location.pathname + window.location.search + window.location.hash,
+        persisted: localStorage.getItem('hermes-webui-session'),
+        options: calls[0] && calls[0].options,
+        profileSwitch: profileSwitchCalls[0],
+  }));
+})();
+"""
+    )
+    assert payload["result"] is True
+    assert payload["active"] == "ops"
+    assert payload["session"] == "target"
+    assert payload["href"] == "/app/session/target?keep=1&profile=ops#h"
+    assert payload["persisted"] == "target"
+    assert payload["options"]["skipProfileResolve"] is True
+    assert payload["options"]["_ignorePersistedInflight"] is True
+    assert payload["profileSwitch"]["profile"] == "ops"
+    assert payload["profileSwitch"]["options"]["openExistingSession"] is True
+
+
+def test_explicit_preload_hook_keeps_extension_payload_shape():
+    payload = _navigation_run(
+        """
+var hookArgs = null;
+global._hermesNotifySessionOpen = (...args) => { hookArgs = args; return {}; };
+(async () => {
+  const result = await _openSessionReference('target', 'ops');
+  process.stdout.write(JSON.stringify({result, hookArgs}));
+})();
+"""
+    )
+    assert payload["result"] is True
+    assert payload["hookArgs"][0] == "target"
+    assert payload["hookArgs"][1] is None
+    assert payload["hookArgs"][2]["preload"] is True
+    assert payload["hookArgs"][2]["opts"]["explicitProfile"] == "ops"
+
+
+def test_same_sid_explicit_profile_forces_real_load_and_promotes_owner_query():
+    payload = _navigation_run(
+        """
+S.session = {session_id: 'target', profile: 'default'};
+S.messages = ['same-session-old'];
+(async () => {
+  const result = await _openSessionReference('target', 'ops');
+  process.stdout.write(JSON.stringify({
+    result, active: S.activeProfile, session: S.session,
+    href: window.location.pathname + window.location.search + window.location.hash,
+    options: calls[0] && calls[0].options,
+  }));
+})();
+"""
+    )
+    assert payload["result"] is True
+    assert payload["active"] == "ops"
+    assert payload["session"] == {"session_id": "target", "profile": "ops"}
+    assert payload["href"] == "/app/session/target?keep=1&profile=ops#h"
+    assert payload["options"]["force"] is True
+
+
+@pytest.mark.parametrize("load_mode", ["wrong-sid", "wrong-profile", "fail"])
+def test_explicit_reference_wrong_response_or_message_failure_rolls_back(load_mode):
+    payload = _navigation_run(
+        f"""
+loadMode = {load_mode!r};
+(async () => {{
+  const result = await _openSessionReference('target', 'ops');
+  process.stdout.write(JSON.stringify({{
+    result, active: S.activeProfile, session: S.session.session_id,
+    messages: S.messages, toolCalls: S.toolCalls, busy: S.busy,
+    href: window.location.pathname + window.location.search + window.location.hash,
+    persisted: localStorage.getItem('hermes-webui-session'),
+    model: localStorage.getItem('hermes-webui-model'),
+    modelState: localStorage.getItem('hermes-webui-model-state'),
+    loadState: {{_loadingOlder,_messagesTruncated,_oldestIdx,_messageRenderWindowSize,
+      _pendingCarryForwardSnapshot,_messageUserUnpinned,_scrollPinned}},
+  }}));
+}})();
+"""
+    )
+    assert payload["result"] is False
+    assert payload["active"] == "default"
+    assert payload["session"] == "old"
+    assert payload["messages"] == ["old-message"]
+    assert payload["toolCalls"] == ["old-tool"]
+    assert payload["href"] == "/app/session/old?keep=1#h"
+    assert payload["persisted"] == "old"
+    assert payload["model"] == "old-model"
+    assert payload["modelState"] == "old-model-state"
+    assert payload["loadState"] == {
+        "_loadingOlder": False,
+        "_messagesTruncated": False,
+        "_oldestIdx": 7,
+        "_messageRenderWindowSize": 80,
+        "_pendingCarryForwardSnapshot": {"owner": "old"},
+        "_messageUserUnpinned": True,
+        "_scrollPinned": False,
+    }
+
+
+def test_explicit_history_failure_restores_previous_url_and_preflight_does_not_load():
+    payload = _navigation_run(
+        """
+(async () => {
+  setUrl('/app/session/target?profile=ops#h');
+  loadMode = 'fail';
+  const failed = await _openSessionReference('target', 'ops', {rollbackUrl:'/app/session/old?keep=1#h'});
+  const afterLoadFailure = window.location.pathname + window.location.search + window.location.hash;
+  apiMode = 'wrong-mismatch';
+  setUrl('/app/session/target?profile=ops#h');
+  const rejected = await _openSessionReference('target', 'ops', {rollbackUrl:'/app/session/old?keep=1#h'});
+  process.stdout.write(JSON.stringify({
+    failed, rejected, afterLoadFailure,
+    afterPreflightFailure: window.location.pathname + window.location.search + window.location.hash,
+    calls,
+  }));
+})();
+"""
+    )
+    assert payload["failed"] is False
+    assert payload["rejected"] is False
+    assert payload["afterLoadFailure"] == "/app/session/old?keep=1#h"
+    assert payload["afterPreflightFailure"] == "/app/session/old?keep=1#h"
+    assert [call["sid"] for call in payload["calls"]] == ["target", "old"]
+
+
+def test_explicit_reference_rejects_wrong_mismatch_owner_or_sid_without_discovery():
+    payload = _navigation_run(
+        """
+(async () => {
+  apiMode = 'wrong-mismatch';
+  const wrongSid = await _openSessionReference('target', 'ops');
+  const wrongOwner = await _openSessionReference('target', 'other');
+  process.stdout.write(JSON.stringify({ wrongSid, wrongOwner, calls }));
+})();
+"""
+    )
+    assert payload["wrongSid"] is False
+    assert payload["wrongOwner"] is False
+    assert payload["calls"] == []
+
+
+def test_profile_matching_uses_root_alias_without_mutating_active_state():
+    source = f"""
+var S = {{ activeProfileIsDefault: false }};
+function _cronProfileNameIsRootAlias(name) {{ return name === 'root'; }}
+globalThis._profileMatchesActiveProfile = (0,eval)('('+{_extract(SESSIONS_SRC, '_profileMatchesActiveProfile')!r}+')');
+globalThis._profileMatchesProfileState = (0,eval)('('+{_extract(SESSIONS_SRC, '_profileMatchesProfileState')!r}+')');
+globalThis._sessionProfilesMatch = (0,eval)('('+{_extract(SESSIONS_SRC, '_sessionProfilesMatch')!r}+')');
+const alias = _sessionProfilesMatch('default', 'root');
+const unrelated = _sessionProfilesMatch('ops', 'other');
+process.stdout.write(JSON.stringify({{alias, unrelated, activeDefault: S.activeProfileIsDefault}}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {"alias": True, "unrelated": False, "activeDefault": False}
+
+
+def test_profile_matching_uses_authoritative_active_default_before_roster_cache():
+    source = f"""
+var S = {{activeProfile:'main', activeProfileIsDefault:true}};
+function _cronProfileNameIsRootAlias() {{ return false; }}
+globalThis._profileMatchesProfileState = (0,eval)('('+{_extract(SESSIONS_SRC, '_profileMatchesProfileState')!r}+')');
+globalThis._sessionProfilesMatch = (0,eval)('('+{_extract(SESSIONS_SRC, '_sessionProfilesMatch')!r}+')');
+process.stdout.write(JSON.stringify({{
+  forward:_sessionProfilesMatch('default','main'),
+  reverse:_sessionProfilesMatch('main','default'),
+}}));
+"""
+    assert json.loads(_run_node(source)) == {"forward": True, "reverse": True}
+
+
+def test_profileless_legacy_payload_is_accepted_only_when_active_owner_proves_it():
+    preflight = _extract(SESSIONS_SRC, "_preflightSessionReference", "async function")
+    helper_names = (
+        "_sessionReferenceProfileIsValid",
+        "_profileMatchesProfileState",
+        "_sessionProfilesMatch",
+        "_sessionPayloadProfileForExpected",
+        "_sessionProfileMismatchFromError",
+    )
+    helpers = "\n".join(
+        f"globalThis.{name}=(0,eval)('('+{_extract(SESSIONS_SRC, name)!r}+')');"
+        for name in helper_names
+    )
+    source = f"""
+var S={{activeProfile:'main',activeProfileIsDefault:true}};
+function _cronProfileNameIsRootAlias(){{return false;}}
+global.api=async()=>({{session:{{session_id:'legacy',profile:null}}}});
+{helpers}
+globalThis._preflightSessionReference=(0,eval)('('+{preflight!r}+')');
+(async()=>{{
+  const root=await _preflightSessionReference('legacy','default');
+  const unrelated=await _preflightSessionReference('legacy','ops');
+  process.stdout.write(JSON.stringify({{root,unrelated}}));
+}})();
+"""
+    assert json.loads(_run_node(source)) == {"root": {"profile": "main"}, "unrelated": None}
+
+
+def test_explicit_reference_does_not_use_unscoped_sidebar_lineage_resolution():
+    payload = _navigation_run(
+        """
+global._resolveSessionIdFromSidebarLineage = () => 'other-profile-tip';
+(async () => {
+  const result = await _openSessionReference('target', 'ops');
+  process.stdout.write(JSON.stringify({result, calledSid:calls[0] && calls[0].sid}));
+})();
+"""
+    )
+    assert payload == {"result": True, "calledSid": "target"}
+
+
+def test_cross_profile_same_sid_inflight_is_quarantined_on_failure():
+    payload = _navigation_run(
+        """
+INFLIGHT.target={streamId:'default-stream',messages:['default-live']};
+loadMode='fail';
+(async () => {
+  const result=await _openSessionReference('target','ops');
+  process.stdout.write(JSON.stringify({
+    result,
+    inflightAtLoad:calls[0]&&calls[0].inflightAtLoad,
+    restored:INFLIGHT.target,
+    ignored:calls[0]&&calls[0].options._ignorePersistedInflight,
+  }));
+})();
+"""
+    )
+    assert payload["result"] is False
+    assert payload["inflightAtLoad"] is None
+    assert "restored" not in payload
+    assert payload["ignored"] is True
+
+
+def _canonical_switch_source() -> str:
+    return _extract(PANELS_SRC, "switchToProfile", "async function")
+
+
+def _canonical_switch_harness(race: str) -> dict:
+    source = f"""
+var S={{activeProfile:'default',activeProfileIsDefault:true,
+  session:{{session_id:'same',profile:'default'}},messages:['visible']}};
+var _profileSwitchGeneration=0;
+var _profileSwitchOpeningExistingSession=false;
+var _sessionNavigationGeneration=1;
+var _sessionListSkeletonActive=false;
+var _workspacePanelMode='closed';
+var posts=[];
+var renderStarted=false;
+var renderCount=0;
+var lifecycle=[];
+global.window={{}};
+global.localStorage={{getItem(){{return null;}},removeItem(){{}},setItem(){{}}}};
+global.$=()=>null;
+global.t=()=>'';
+global._invalidateSessionListRenders=()=>lifecycle.push('invalidate-list');
+global._setProfileSwitchListEmbargo=(on)=>lifecycle.push(on?'embargo-on':'embargo-off');
+global.showSessionListSkeleton=(name)=>lifecycle.push('skeleton:'+name);
+global.bumpWorkspaceTreeGen=()=>lifecycle.push('workspace-generation');
+global.startGatewaySSE=()=>lifecycle.push('gateway-sse');
+global.applyBotName=()=>lifecycle.push('bot-name');
+global._clearPersistedModelState=()=>lifecycle.push('clear-model');
+global.refreshProfileTransitionReasoningChip=()=>lifecycle.push('reasoning');
+global._resetCronUnreadForProfileSwitch=()=>lifecycle.push('cron-reset');
+global.animateNextSessionListRefresh=()=>{{}};
+global.closeSessionActionMenu=()=>{{}};
+global.syncTopbar=()=>{{}};
+global.showToast=()=>{{}};
+global._profileSwitchPanelLoad=async()=>{{}};
+global._refreshProfileSwitchBackground=()=>{{}};
+global.api=async(url,options)=>{{
+  const name=JSON.parse(options.body).name;
+  posts.push(name);
+  {race}
+  return {{active:name,is_default:name==='default'}};
+}};
+global.renderSessionList=async()=>{{
+  renderStarted=true;
+  renderCount+=1;
+  if(renderCount===1) _sessionNavigationGeneration=2;
+}};
+eval({_canonical_switch_source()!r});
+(async()=>{{
+  const result=await switchToProfile('ops',{{openExistingSession:true,navigationGeneration:1}});
+  process.stdout.write(JSON.stringify({{result,posts,active:S.activeProfile,activeDefault:S.activeProfileIsDefault,
+    session:S.session,renderStarted,lifecycle}}));
+}})();
+"""
+    return json.loads(_run_node(source))
+
+
+def test_canonical_switch_compensates_exact_post_render_same_sid_supersession():
+    payload = _canonical_switch_harness("")
+    assert payload["result"] is False
+    assert payload["posts"] == ["ops", "default"]
+    assert payload["active"] == "default"
+    assert payload["activeDefault"] is True
+    assert payload["session"] == {"session_id": "same", "profile": "default"}
+    assert "workspace-generation" in payload["lifecycle"]
+    assert "gateway-sse" in payload["lifecycle"]
+
+
+def test_canonical_switch_compensates_when_navigation_supersedes_profile_post():
+    payload = _canonical_switch_harness(
+        "if(posts.length===1) { _sessionNavigationGeneration=2; }"
+    )
+    assert payload["result"] is False
+    assert payload["posts"] == ["ops", "default"]
+    assert payload["active"] == "default"
+
+
+def _canonical_switch_model_workspace_harness() -> dict:
+    source = f"""
+var S={{activeProfile:'default',activeProfileIsDefault:true,
+  session:{{session_id:'same',profile:'default'}},messages:['visible'],
+  _profileDefaultWorkspace:'/default-workspace',_profileSwitchWorkspace:'/default-pending-workspace',
+  _pendingProfileModel:'default-model',_pendingProfileModelProvider:'default-provider'}};
+var _profileSwitchGeneration=0;
+var _profileSwitchOpeningExistingSession=false;
+var _sessionNavigationGeneration=1;
+var _sessionListSkeletonActive=false;
+var _workspacePanelMode='closed';
+var _workspaceList=null;
+var _skillsData=null;
+var renderCount=0;
+var posts=[];
+var lifecycle=[];
+var storage={{'hermes-webui-model':'default-model'}};
+global.window={{_defaultModel:'default-model',_activeProvider:'default-provider'}};
+global.localStorage={{
+  getItem(key){{return Object.prototype.hasOwnProperty.call(storage,key)?storage[key]:null;}},
+  setItem(key,value){{storage[key]=String(value);}},
+  removeItem(key){{delete storage[key];}},
+}};
+global.$=()=>null;
+global.t=()=>' ';
+global._invalidateSessionListRenders=()=>lifecycle.push('invalidate-list');
+global._setProfileSwitchListEmbargo=(on)=>lifecycle.push(on?'embargo-on':'embargo-off');
+global.showSessionListSkeleton=(name)=>lifecycle.push('skeleton:'+name);
+global.bumpWorkspaceTreeGen=()=>lifecycle.push('workspace-generation');
+global.startGatewaySSE=()=>lifecycle.push('gateway-sse');
+global.applyBotName=()=>lifecycle.push('bot-name');
+global._clearPersistedModelState=()=>{{
+  lifecycle.push('clear-model');
+  localStorage.removeItem('hermes-webui-model');
+  localStorage.removeItem('hermes-webui-model-state');
+}};
+global._applyModelToDropdown=(model)=>model;
+global._modelStateForSelect=()=>({{model:'ops-model',model_provider:'ops-provider'}});
+global.refreshProfileTransitionReasoningChip=()=>lifecycle.push('reasoning');
+global._resetCronUnreadForProfileSwitch=()=>lifecycle.push('cron-reset');
+global.animateNextSessionListRefresh=()=>{{}};
+global.closeSessionActionMenu=()=>{{}};
+global.syncTopbar=()=>{{}};
+global.showToast=()=>{{}};
+global._profileSwitchPanelLoad=async()=>{{}};
+global._refreshProfileSwitchBackground=()=>{{}};
+global.api=async(url,options)=>{{
+  const name=JSON.parse(options.body).name;
+  posts.push(name);
+  if(name==='ops') return {{active:'ops',is_default:false,default_model:'ops-model',default_model_provider:'ops-provider',default_workspace:'/ops-workspace'}};
+  return {{active:'default',is_default:true}};
+}};
+global.renderSessionList=async()=>{{
+  renderCount+=1;
+  if(renderCount===1) _sessionNavigationGeneration=2;
+}};
+eval({_canonical_switch_source()!r});
+(async()=>{{
+  const result=await switchToProfile('ops',{{openExistingSession:true,navigationGeneration:1}});
+  const state=(key)=>Object.prototype.hasOwnProperty.call(storage,key)
+    ? {{present:true,value:storage[key]}} : {{present:false}};
+  process.stdout.write(JSON.stringify({{result,posts,active:S.activeProfile,activeDefault:S.activeProfileIsDefault,
+    session:S.session,model:window._defaultModel,provider:window._activeProvider,
+    profileDefaultWorkspace:S._profileDefaultWorkspace,profileSwitchWorkspace:S._profileSwitchWorkspace,
+    pendingModel:S._pendingProfileModel,pendingProvider:S._pendingProfileModelProvider,
+    persistedModel:state('hermes-webui-model'),persistedModelState:state('hermes-webui-model-state'),lifecycle}}));
+}})();
+"""
+    return json.loads(_run_node(source))
+
+
+def test_superseded_profile_switch_restores_pre_navigation_model_workspace_and_storage():
+    payload = _canonical_switch_model_workspace_harness()
+    assert payload["result"] is False
+    assert payload["posts"] == ["ops", "default"]
+    assert payload["active"] == "default"
+    assert payload["activeDefault"] is True
+    assert payload["session"] == {"session_id": "same", "profile": "default"}
+    assert payload["model"] == "default-model"
+    assert payload["provider"] == "default-provider"
+    assert payload["profileDefaultWorkspace"] == "/default-workspace"
+    assert payload["profileSwitchWorkspace"] == "/default-pending-workspace"
+    assert payload["pendingModel"] == "default-model"
+    assert payload["pendingProvider"] == "default-provider"
+    assert payload["persistedModel"] == {"present": True, "value": "default-model"}
+    assert payload["persistedModelState"] == {"present": False}
+    assert "clear-model" not in payload["lifecycle"]
+
+
+def test_running_inflight_fallback_is_successful_for_ordinary_loads_but_not_explicit_owners():
+    result = _run_actual_load(
+        """
+createEnvironment();
+S.activeProfile='default'; S.activeProfileIsDefault=true;
+globalThis._sessionNavigationGeneration=1;
+const saved={};
+globalThis.localStorage={getItem:(k)=>saved[k]||null,setItem:(k,v)=>{saved[k]=String(v);},removeItem:(k)=>{delete saved[k];}};
+const apiHost=makeHarness(); globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const meta=apiHost.enqueue('/api/session?session_id=sid-ordinary&messages=0&resolve_model=0');
+const msgs=apiHost.enqueue('/api/session?session_id=sid-ordinary&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1');
+INFLIGHT['sid-ordinary']={streamId:'stream-ordinary',messages:[{role:'assistant',content:'ordinary live tail'}],toolCalls:[]};
+(async()=>{
+  const pending=loadSession('sid-ordinary',{skipProfileResolve:true,skipLineageResolve:true,
+    _navigationGeneration:1,force:true});
+  await Promise.resolve();
+  meta._resolve({session:{session_id:'sid-ordinary',profile:'default',active_stream_id:'stream-ordinary',message_count:2}});
+  while(!apiHost.pending.some((entry)=>entry.url===msgs.url)) await Promise.resolve();
+  msgs._reject(new Error('transcript unavailable'));
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,saved:saved['hermes-webui-session'],sid:S.session&&S.session.session_id,messages:S.messages}));
+})();
+"""
+    )
+    assert result["result"] is True
+    assert result["saved"] == "sid-ordinary"
+    assert result["sid"] == "sid-ordinary"
+    assert result["messages"][0]["content"] == "ordinary live tail"
+
+
+def _actual_load_script(scenario: str) -> str:
+    helpers = "\n".join(
+        f"globalThis.{name}=(0,eval)('('+{_extract(SESSIONS_SRC, name)!r}+')');"
+        for name in (
+            "_sessionReferenceIdIsValid",
+            "_sessionReferenceProfileIsValid",
+            "_parseSessionReference",
+            "_profileMatchesActiveProfile",
+            "_profileMatchesProfileState",
+            "_sessionProfilesMatch",
+            "_sessionPayloadProfileForExpected",
+            "_quarantineExplicitInflight",
+            "_serverLiveSnapshotToolId",
+            "_serverLiveSnapshotInflight",
+        )
+    )
+    source = _NODE_SCRIPT_TEMPLATE
+    for marker, value in (
+        ("__INFLIGHT_HAS_VISIBLE_STATE_SRC__", INFLIGHT_HAS_VISIBLE_STATE_SRC),
+        ("__SELECT_LIVE_RECOVERY_INFLIGHT_SRC__", SELECT_LIVE_RECOVERY_INFLIGHT_SRC),
+        ("__MERGE_PENDING_SESSION_MESSAGE_SRC__", MERGE_PENDING_SESSION_MESSAGE_SRC),
+        ("__LOAD_SESSION_SRC__", LOAD_SESSION_SRC),
+        ("__ENSURE_MESSAGES_LOADED_SRC__", ENSURE_MESSAGES_LOADED_SRC),
+    ):
+        source = source.replace(marker, value)
+    source = source.split("async function waitForQueued", 1)[0]
+    return source.replace(
+        "globalThis._resolveSessionIdFromSidebarLineage = (sid) => sid;",
+        "globalThis._resolveSessionIdFromSidebarLineage = (sid) => sid;\n"
+        "globalThis._cronProfileNameIsRootAlias = () => false;\n"
+        "globalThis._messageComparableText = (m) => String(m && m.content || '');\n"
+        "globalThis._ensureInflightLiveAssistantMessage = () => {};\n"
+        "globalThis._projectInflightMessagesForActivityBursts = (inflight) => Array.isArray(inflight && inflight.messages) ? inflight.messages : [];\n"
+        "globalThis._prepareRunningLiveTail = () => false;\n"
+        "globalThis._dropCurrentTurnAssistantMessages = (messages) => messages;\n"
+        "globalThis._mergeInflightTailMessages = (messages, tail) => messages.concat(tail || []);\n"
+        "globalThis._renderRuntimeJournalAnchorActivityScene = () => false;\n"
+        "globalThis.appendThinking = () => {};\n"
+        "globalThis.placeLiveToolCardsHost = () => {};\n"
+        "globalThis.ensureLiveWorklogShell = () => {};\n"
+        "globalThis.ensureRunActivityForCurrentTurn = () => {};\n"
+        "globalThis.appendLiveToolCard = () => {};\n"
+        "globalThis.document = {getElementById: () => null};\n"
+        + helpers,
+    ) + scenario
+
+
+def _run_actual_load(scenario: str) -> dict:
+    return json.loads(_run_node(_actual_load_script(scenario)))
+
+
+def _actual_open_script(scenario: str) -> str:
+    open_helpers = "\n".join(
+        _extract(SESSIONS_SRC, name, prefix)
+        for name, prefix in (
+            ("_preflightSessionReference", "async function"),
+            ("_restoreSessionReference", "async function"),
+            ("_openSessionReference", "async function"),
+        )
+    )
+    return _actual_load_script("") + "\n" + open_helpers + scenario
+
+
+@pytest.mark.parametrize("payload", [{"session": {"session_id": "other", "profile": "ops"}}, {"session": {"session_id": "wanted", "profile": "other"}}, {}])
+def test_messages_payload_identity_fails_before_transcript_mutation(payload):
+    payload_json = json.dumps(payload)
+    result = json.loads(_run_node(
+        f"""
+{_extract(SESSIONS_SRC, '_sessionReferenceProfileIsValid')}
+{_extract(SESSIONS_SRC, '_profileMatchesProfileState')}
+{_extract(SESSIONS_SRC, '_sessionProfilesMatch')}
+{_extract(SESSIONS_SRC, '_sessionPayloadProfileForExpected')}
+{ENSURE_MESSAGES_LOADED_SRC}
+var _loadingSessionId='wanted', _loadSessionGeneration=1, _msgLimitMax=500;
+var _messagesTruncated=false, _oldestIdx=0, _messageRenderWindowSize=20;
+var _pendingCarryForwardSnapshot=null, _sameSessionForceReloadHint=null;
+var MESSAGE_RENDER_WINDOW_DEFAULT=50, INFLIGHT={{}};
+var S={{session:{{session_id:'wanted',profile:'ops'}},messages:[{{role:'assistant',content:'old'}}],toolCalls:['old-tool'],busy:false,activeStreamId:null}};
+var syncCalls=0, clearCalls=0, cacheCalls=0;
+global._cronProfileNameIsRootAlias=()=>false;
+global._messageReloadLimitForSession=()=>2;
+global._clearSameSessionForceReloadHint=()=>{{}};
+global._syncToolCallsForLoadedMessages=()=>{{syncCalls++;}};
+global.clearLiveToolCards=()=>{{clearCalls++;}};
+global.clearVisibleMessageRowCache=()=>{{cacheCalls++;}};
+global._currentMessageRenderWindowSize=()=>20;
+global._messageRenderableMessageCount=()=>1;
+global._isSessionActivelyViewedForList=()=>true;
+global._setSessionViewedCount=()=>{{}};
+global.syncTopbar=()=>{{}};
+global.window={{}};
+global.api=async()=>({payload_json});
+(async()=>{{
+  let error=null;
+      try{{await _ensureMessagesLoaded('wanted',{{force:true,loadGeneration:1,expectedSessionId:'wanted',expectedProfile:'ops'}});}}
+  catch(e){{error={{code:e.code||'',message:String(e.message||e)}};}}
+  process.stdout.write(JSON.stringify({{error,messages:S.messages,toolCalls:S.toolCalls,syncCalls,clearCalls,cacheCalls}}));
+}})();
+""",
+    ))
+    assert result["error"]["code"] == "session_payload_identity"
+    assert result["messages"] == [{"role": "assistant", "content": "old"}]
+    assert result["toolCalls"] == ["old-tool"]
+    assert result["syncCalls"] == 0
+    assert result["clearCalls"] == 0
+    assert result["cacheCalls"] == 0
+
+
+def test_explicit_live_recovery_survives_failed_transcript_hydration_and_is_saved():
+    result = _run_actual_load(
+        """
+createEnvironment();
+S.activeProfile='ops';
+S.activeProfileIsDefault=false;
+globalThis._sessionNavigationGeneration=1;
+const saved={};
+globalThis.localStorage={getItem:(k)=>saved[k]||null,setItem:(k,v)=>{saved[k]=String(v);},removeItem:(k)=>{delete saved[k];}};
+const apiHost=makeHarness();
+globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const meta=apiHost.enqueue('/api/session?session_id=sid-live&messages=0&resolve_model=0');
+const msgs=apiHost.enqueue('/api/session?session_id=sid-live&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1', null, 'reject');
+INFLIGHT['sid-live']={streamId:'stream-live',messages:[{role:'assistant',content:'live tail'}],toolCalls:[{name:'live-tool'}]};
+(async()=>{
+  const pending=loadSession('sid-live',{_explicitPrepared:true,_preloadNotified:true,skipProfileResolve:true,skipLineageResolve:true,
+    expectedSessionId:'sid-live',expectedProfile:'ops',_navigationGeneration:1,force:true});
+  await Promise.resolve();
+  meta._resolve({session:{session_id:'sid-live',profile:'ops',active_stream_id:'stream-live',message_count:4}});
+  while(!apiHost.pending.some((entry)=>entry.url===msgs.url)) await Promise.resolve();
+  msgs._reject(new Error('transcript unavailable'));
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,saved:saved['hermes-webui-session'],sid:S.session&&S.session.session_id,messages:S.messages,active:S.activeStreamId}));
+})();
+"""
+    )
+    assert result["result"] is True
+    assert result["saved"] == "sid-live"
+    assert result["sid"] == "sid-live"
+    assert result["active"] == "stream-live"
+    assert result["messages"][0]["content"] == "live tail"
+
+
+def test_explicit_wrong_stream_recovery_does_not_survive_failed_transcript_hydration():
+    result = _run_actual_load(
+        """
+createEnvironment();
+S.activeProfile='ops';
+S.activeProfileIsDefault=false;
+globalThis._sessionNavigationGeneration=1;
+const apiHost=makeHarness();
+globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const meta=apiHost.enqueue('/api/session?session_id=sid-live&messages=0&resolve_model=0');
+const msgs=apiHost.enqueue('/api/session?session_id=sid-live&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1', null, 'reject');
+INFLIGHT['sid-live']={streamId:'stale-stream',messages:[{role:'assistant',content:'stale live tail'}],toolCalls:[]};
+(async()=>{
+  const pending=loadSession('sid-live',{_explicitPrepared:true,_preloadNotified:true,skipProfileResolve:true,skipLineageResolve:true,
+    expectedSessionId:'sid-live',expectedProfile:'ops',_navigationGeneration:1,force:true});
+  await Promise.resolve();
+  meta._resolve({session:{session_id:'sid-live',profile:'ops',active_stream_id:'current-stream',message_count:4}});
+  while(!apiHost.pending.some((entry)=>entry.url===msgs.url)) await Promise.resolve();
+  msgs._reject(new Error('transcript unavailable'));
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,messages:S.messages,active:S.activeStreamId,inflight:INFLIGHT['sid-live']||null}));
+})();
+"""
+    )
+    assert result["result"] is False
+    assert result["messages"] != [{"role": "assistant", "content": "stale live tail"}]
+    assert result["active"] is None
+    assert result["inflight"] is None
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        {"stream_id": "stale-stream", "messages": [{"role": "assistant", "content": "stale server tail"}]},
+        {"stream_id": "", "messages": [{"role": "assistant", "content": "empty-id server tail"}]},
+        {"messages": [{"role": "assistant", "content": "missing-id server tail"}]},
+    ],
+    ids=["stale-id", "empty-id", "missing-id"],
+)
+def test_explicit_invalid_server_snapshot_rolls_back_after_transcript_hydration_failure(snapshot):
+    result = json.loads(_run_node(_actual_open_script(
+        """
+createEnvironment();
+S.activeProfile='ops'; S.activeProfileIsDefault=false; S.session=null; S.messages=[];
+globalThis._sessionNavigationGeneration=0;
+globalThis.switchToProfile=async()=>true;
+const saved={};
+globalThis.localStorage={getItem:(k)=>saved[k]||null,setItem:(k,v)=>{saved[k]=String(v);},removeItem:(k)=>{delete saved[k];}};
+const apiHost=makeHarness(); globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const preflight=apiHost.enqueue('/api/session?session_id=sid-live&messages=0&resolve_model=0');
+const metadata=apiHost.enqueue('/api/session?session_id=sid-live&messages=0&resolve_model=0');
+const msgs=apiHost.enqueue('/api/session?session_id=sid-live&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1', null, 'reject');
+(async()=>{
+  const pending=_openSessionReference('sid-live','ops');
+  await Promise.resolve();
+  preflight._resolve({session:{session_id:'sid-live',profile:'ops'}});
+  while(!apiHost.pending.some((entry)=>entry.url===metadata.url)) await Promise.resolve();
+  metadata._resolve({session:{session_id:'sid-live',profile:'ops',active_stream_id:'current-stream',runtime_journal_snapshot:__SNAPSHOT__}});
+  while(!apiHost.pending.some((entry)=>entry.url===msgs.url)) await Promise.resolve();
+  msgs._reject(new Error('transcript unavailable'));
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,sid:S.session&&S.session.session_id,messages:S.messages,active:S.activeStreamId,
+    inflight:INFLIGHT['sid-live']||null,saved:saved['hermes-webui-session']||null}));
+})();
+"""
+        .replace("__SNAPSHOT__", json.dumps(snapshot))
+    )))
+    assert result["result"] is False
+    assert result["sid"] is None
+    assert result["messages"] == []
+    assert result["active"] is None
+    assert result["inflight"] is None
+    assert result["saved"] is None
+
+
+def test_explicit_hydration_failure_without_live_recovery_rolls_back_to_empty_boot():
+    result = json.loads(_run_node(_actual_open_script(
+        """
+createEnvironment();
+S.activeProfile='ops'; S.activeProfileIsDefault=false; S.session=null; S.messages=[];
+globalThis._sessionNavigationGeneration=0;
+globalThis.switchToProfile=async()=>true;
+const saved={};
+globalThis.localStorage={getItem:(k)=>saved[k]||null,setItem:(k,v)=>{saved[k]=String(v);},removeItem:(k)=>{delete saved[k];}};
+const apiHost=makeHarness(); globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const preflight=apiHost.enqueue('/api/session?session_id=sid-no-live&messages=0&resolve_model=0');
+const metadata=apiHost.enqueue('/api/session?session_id=sid-no-live&messages=0&resolve_model=0');
+const msgs=apiHost.enqueue('/api/session?session_id=sid-no-live&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1');
+(async()=>{
+  const pending=_openSessionReference('sid-no-live','ops');
+  await Promise.resolve();
+  preflight._resolve({session:{session_id:'sid-no-live',profile:'ops'}});
+  while(!apiHost.pending.some((entry)=>entry.url===metadata.url)) await Promise.resolve();
+  metadata._resolve({session:{session_id:'sid-no-live',profile:'ops',active_stream_id:null}});
+  while(!apiHost.pending.some((entry)=>entry.url===msgs.url)) await Promise.resolve();
+  msgs._reject(new Error('transcript unavailable'));
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,active:S.activeProfile,sid:S.session,messages:S.messages,saved:saved['hermes-webui-session']||null}));
+})();
+"""
+    )))
+    assert result == {
+        "result": False,
+        "active": "ops",
+        "sid": None,
+        "messages": [],
+        "saved": None,
+    }
+
+
+def test_continuation_cross_profile_inflight_is_quarantined_and_accepted_sid_cleared():
+    result = _run_actual_load(
+        """
+createEnvironment();
+S.activeProfile='ops'; S.activeProfileIsDefault=false;
+globalThis._sessionNavigationGeneration=1;
+const persisted={continuation:{streamId:'stream-live',messages:[{role:'assistant',content:'wrong-owner'}]}};
+const cleared=[];
+globalThis.localStorage={getItem:(k)=>k==='hermes-webui-inflight-state'?JSON.stringify(persisted):null,setItem:()=>{},removeItem:()=>{}};
+globalThis.clearInflightState=(sid)=>{cleared.push(sid); delete persisted[sid];};
+let loadStateCalls=0;
+globalThis.loadInflightState=(sid)=>{loadStateCalls++; return persisted[sid]||null;};
+const apiHost=makeHarness(); globalThis.apiHost=apiHost; globalThis.api=apiHost.api;
+const parentMeta=apiHost.enqueue('/api/session?session_id=parent&messages=0&resolve_model=0');
+const childMeta=apiHost.enqueue('/api/session?session_id=continuation&messages=0&resolve_model=0');
+const childMsgs=apiHost.enqueue('/api/session?session_id=continuation&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1');
+INFLIGHT.continuation={streamId:'stream-live',messages:[{role:'assistant',content:'wrong-owner'}],toolCalls:[{name:'wrong'}]};
+INFLIGHT.parent={streamId:'stream-live',messages:[{role:'assistant',content:'wrong-parent-owner'}]};
+INFLIGHT.unrelated={streamId:'other',messages:[{role:'assistant',content:'keep'}]};
+(async()=>{
+  const pending=loadSession('parent',{_explicitPrepared:true,_preloadNotified:true,skipProfileResolve:true,skipLineageResolve:true,
+    expectedSessionId:'parent',expectedProfile:'ops',_navigationGeneration:1,_ignorePersistedInflight:true,force:true});
+  parentMeta._resolve({session:{session_id:'parent',profile:'ops',active_stream_id:'stream-live',continuation_session_id:'continuation'}});
+  while(!apiHost.pending.some((entry)=>entry.url===childMeta.url)) await Promise.resolve();
+  childMeta._resolve({session:{session_id:'continuation',profile:'ops',active_stream_id:null,messages:[]}});
+  while(!apiHost.pending.some((entry)=>entry.url===childMsgs.url)) await Promise.resolve();
+  childMsgs._resolve({session:{session_id:'continuation',profile:'ops',messages:[{role:'assistant',content:'accepted'}],_messages_truncated:false}});
+  const result=await pending;
+  process.stdout.write(JSON.stringify({result,sid:S.session&&S.session.session_id,inflight:Object.keys(INFLIGHT),cleared,loadStateCalls}));
+})();
+"""
+    )
+    assert result["result"] is True
+    assert result["sid"] == "continuation"
+    assert "parent" not in result["inflight"]
+    assert "continuation" not in result["inflight"]
+    assert "unrelated" in result["inflight"]
+    assert result["loadStateCalls"] == 0
+    assert "continuation" in result["cleared"]
+
+
+def test_load_session_rejects_wrong_sid_and_profile_before_assigning_payload():
+    load_session = _extract(SESSIONS_SRC, "loadSession", "async function")
+    validators = "\n".join(
+        f"globalThis.{name}=(0,eval)('('+{_extract(SESSIONS_SRC, name)!r}+')');"
+        for name in ("_sessionReferenceIdIsValid", "_sessionReferenceProfileIsValid", "_profileMatchesActiveProfile", "_profileMatchesProfileState", "_sessionProfilesMatch", "_sessionPayloadProfileForExpected", "_quarantineExplicitInflight")
+    )
+    source = f"""
+var _loadingSessionId = null;
+var _loadSessionGeneration = 0;
+var _sessionNavigationGeneration = 0;
+var _verifiedSessionProfileIntent = null;
+var _yoloEnabled = false;
+var INFLIGHT = {{}};
+var S = {{ activeProfile: 'ops', activeProfileIsDefault: false, session: {{session_id:'old',profile:'ops'}}, messages:['old'], toolCalls:[], busy:false, activeStreamId:null, pendingFiles:[] }};
+global.window = {{ location: {{ href:'https://example.test/app/session/old', pathname:'/app/session/old', search:'', hash:'' }} }};
+global.document = {{ baseURI:'https://example.test/app/' }};
+global.localStorage = {{ getItem(){{return 'old';}}, setItem(){{}}, removeItem(){{}} }};
+global.history = {{ replaceState(){{}}, pushState(){{}} }};
+function $(id) {{ return id === 'msg' ? {{value:''}} : {{innerHTML:''}}; }}
+function stopApprovalPolling(){{}} function hideApprovalCard(){{}} function _updateYoloPill(){{}}
+function _rearmActiveSessionStream(){{}} async function _saveComposerDraftNow(){{}}
+function _clearSameSessionForceReloadHint(){{}}
+global.api = async () => ({{ session: {{ session_id: 'other', profile: 'ops' }} }});
+{validators}
+globalThis.loadSession = (0,eval)('('+{load_session!r}+')');
+(async () => {{
+  const wrongSid = await loadSession('wanted', {{_explicitPrepared:true, skipProfileResolve:true, expectedSessionId:'wanted', expectedProfile:'ops', force:true, _preloadNotified:true}});
+  global.api = async () => ({{ session: {{ session_id: 'wanted', profile: 'other' }} }});
+  const wrongProfile = await loadSession('wanted', {{_explicitPrepared:true, skipProfileResolve:true, expectedSessionId:'wanted', expectedProfile:'ops', force:true, _preloadNotified:true}});
+  process.stdout.write(JSON.stringify({{wrongSid, wrongProfile, session:S.session.session_id, profile:S.session.profile}}));
+}})();
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {"wrongSid": False, "wrongProfile": False, "session": "old", "profile": "ops"}
+
+
+def test_session_url_helper_preserves_unrelated_query_and_hash_with_explicit_clear():
+    url_helper = _extract(SESSIONS_SRC, "_sessionUrlForSid")
+    profile_validator = _extract(SESSIONS_SRC, "_sessionReferenceProfileIsValid")
+    source = f"""
+global.window = {{
+  location: {{ href: 'https://example.test/app/?keep=1&profile=old#h', search: '?keep=1&profile=old', hash: '#h' }},
+}};
+global.document = {{ baseURI: 'https://example.test/app/' }};
+globalThis._sessionReferenceProfileIsValid = (0,eval)('('+{profile_validator!r}+')');
+eval({url_helper!r});
+process.stdout.write(JSON.stringify({{
+  explicit: _sessionUrlForSid('abc123', 'ops'),
+  cleared: _sessionUrlForSid('abc123', null),
+}}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["explicit"] == "/app/session/abc123?keep=1&profile=ops#h"
+    assert payload["cleared"] == "/app/session/abc123?keep=1#h"
+
+
+def test_central_url_promotion_retains_verified_profile_and_clears_stale_unverified_query():
+    payload = _navigation_run(
+        """
+S.activeProfile='ops';
+S.activeProfileIsDefault=false;
+S.session={session_id:'continuation',profile:'ops'};
+S._verifiedSessionProfileIntent={sid:'parent',profile:'ops'};
+setUrl('/app/session/parent?keep=1&profile=ops#h');
+_setActiveSessionUrl('continuation');
+const retained=window.location.pathname+window.location.search+window.location.hash;
+const verified=S._verifiedSessionProfileIntent;
+S.activeProfile='default';
+S.activeProfileIsDefault=true;
+S.session={session_id:'plain',profile:'default'};
+S._verifiedSessionProfileIntent=null;
+setUrl('/app/session/continuation?keep=1&profile=ops#h');
+_setActiveSessionUrl('plain');
+const cleared=window.location.pathname+window.location.search+window.location.hash;
+process.stdout.write(JSON.stringify({retained,verified,cleared}));
+"""
+    )
+    assert payload == {
+        "retained": "/app/session/continuation?keep=1&profile=ops#h",
+        "verified": {"sid": "continuation", "profile": "ops"},
+        "cleared": "/app/session/plain?keep=1#h",
+    }
+
+
+def test_popstate_routes_same_sid_different_profile_and_clears_profileless_intent():
+    popstate = _extract(SESSIONS_SRC, "_handleSessionPopstate")
+    sid_from_location = _extract(SESSIONS_SRC, "_sessionIdFromLocation")
+    profile_intent = _extract(SESSIONS_SRC, "_profileQueryIntentFromLocation")
+    profile_state = _extract(SESSIONS_SRC, "_profileMatchesProfileState")
+    profile_matches = _extract(SESSIONS_SRC, "_sessionProfilesMatch")
+    source = f"""
+var S = {{activeProfile:'ops', activeProfileIsDefault:false, session:{{session_id:'same', profile:'ops'}}, busy:false, _verifiedSessionProfileIntent:{{sid:'same', profile:'ops'}}}};
+global.window = {{location:{{pathname:'/app/session/same', search:'?profile=other'}}}};
+global._openSessionReference = async (...args) => {{ calls.push(['open', ...args]); return true; }};
+global.loadSession = async (...args) => {{ calls.push(['load', ...args]); return true; }};
+var calls = [];
+function _cronProfileNameIsRootAlias(name) {{ return name === 'root'; }}
+eval({sid_from_location!r});
+eval({profile_intent!r});
+eval({profile_state!r});
+eval({profile_matches!r});
+eval({popstate!r});
+(async () => {{
+  await _handleSessionPopstate();
+  window.location.search = '';
+  await _handleSessionPopstate();
+  process.stdout.write(JSON.stringify(calls));
+}})();
+"""
+    calls = json.loads(_run_node(source))
+    assert calls == [
+        ["open", "same", "other"],
+        ["load", "same", {"clearProfileIntent": True}],
+    ]
+
+
+def test_boot_restore_helper_fails_closed_for_invalid_or_duplicate_explicit_intent():
+    restore = _extract(BOOT_SRC, "_restoreBootSession", "async function")
+    intent = _extract(SESSIONS_SRC, "_profileQueryIntentFromLocation")
+    source = f"""
+var calls = [];
+global.window = {{location:{{search:'?profile=ops&profile=other'}}}};
+global._openSessionReference = async (...args) => {{ calls.push(['open', ...args]); return true; }};
+global.loadSession = async (...args) => {{ calls.push(['load', ...args]); return true; }};
+eval({intent!r});
+eval({restore!r});
+(async () => {{
+  const duplicate = _profileQueryIntentFromLocation();
+  const duplicateResult = await _restoreBootSession('sid', duplicate, 'saved');
+  window.location.search = '?profile=../bad';
+  const invalid = _profileQueryIntentFromLocation();
+  const invalidResult = await _restoreBootSession('sid', invalid, 'saved');
+  process.stdout.write(JSON.stringify({{duplicateResult, invalidResult, calls}}));
+}})();
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {"duplicateResult": False, "invalidResult": False, "calls": []}
+
+
+def test_boot_restore_helper_uses_explicit_production_open_and_returns_boolean():
+    restore = _extract(BOOT_SRC, "_restoreBootSession", "async function")
+    source = f"""
+var calls = [];
+global._openSessionReference = async (...args) => {{ calls.push(['open', ...args]); return true; }};
+global.loadSession = async (...args) => {{ calls.push(['load', ...args]); return true; }};
+eval({restore!r});
+(async () => {{
+  const explicit = await _restoreBootSession('sid', {{hasParam:true, valid:true, name:'ops'}}, 'saved');
+  const ordinary = await _restoreBootSession(null, null, 'saved');
+  process.stdout.write(JSON.stringify({{explicit, ordinary, calls}}));
+}})();
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["explicit"] is True
+    assert payload["ordinary"] is True
+    assert payload["calls"][0] == ["open", "sid", "ops"]
+    assert payload["calls"][1][0] == "load"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -15,6 +15,7 @@ import urllib.parse
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
+from tests.js_source_extract import extract_function
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -593,22 +594,16 @@ def test_queue_card_cross_session_helper_used_only_for_session_change(cleanup_te
     not on same-session navigation/force-reload code paths.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    load_start = src.find("async function loadSession(sid){")
-    assert load_start >= 0
-    load_end = src.find("  // Sync context usage indicator from session data", load_start)
-    load_body = src[load_start:load_end]
+    load_body = extract_function(src, "loadSession", prefix="async function")
     cross_start = load_body.find("if (currentSid && currentSid !== sid) {")
     cross_end = load_body.find("if (currentSid !== sid || forceReload) {", cross_start)
     assert cross_start >= 0 and cross_end >= 0
     assert "_clearQueueCardDisplay(currentSid);" in load_body[cross_start:cross_end], (
         "queue-card clear helper must be inside the cross-session branch"
     )
-    same_session_idx = load_body.find(
-        "if(currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid)){"
-    )
+    same_session_idx = load_body.find("if(currentSid===sid && !forceReload && (")
     assert same_session_idx >= 0, (
-        "same-session no-op guard must still exist (now a block that first clears "
-        "a stale unread dot before returning) and must precede the cross-session branch"
+        "owner-safe same-session no-op guard must exist before the cross-session branch"
     )
     assert same_session_idx < cross_start
 
@@ -764,18 +759,17 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
 
 def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test_sessions):
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
-    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
-    # grab the wrong one. (rfind = the substantive restore branch.)
-    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
+    load_body = extract_function(src, "loadSession", prefix="async function")
+    inflight_idx = load_body.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1200]
+    ensure_idx = load_body.find("await _ensureMessagesLoaded(sid", inflight_idx)
+    merge_idx = load_body.find("_mergeInflightTailMessages(S.messages,inflightMessages)", inflight_idx)
 
-    assert "await _ensureMessagesLoaded(sid" in inflight_block, (
+    assert ensure_idx >= 0, (
         "returning to an active stream should load the persisted transcript before adding the live tail"
     )
-    assert "_mergeInflightTailMessages(S.messages,inflightMessages)" in inflight_block, (
-        "INFLIGHT messages should be merged as a tail, not replace the full transcript"
+    assert merge_idx > ensure_idx, (
+        "INFLIGHT messages should be merged as a tail after loading the persisted transcript"
     )
     assert "function _mergeInflightTailMessages" in src, (
         "sessions.js should centralize INFLIGHT tail merge logic for regression coverage"

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -935,11 +935,11 @@ def test_load_session_rearms_stream_on_every_early_return():
         "helper must (re)arm startSessionStream for the currently-shown S.session"
     )
 
-    # Isolate the loadSession body. Widened window: the #4946 visit-ack helpers
-    # added inside loadSession pushed the fetch-error catch's stream restart past
-    # the old 14000-char cutoff.
+    # Isolate loadSession using the next top-level function boundary. The local
+    # brace parser cannot distinguish braces in JavaScript regex literals.
     fn_ix = js.index("async function loadSession(")
-    body = js[fn_ix:fn_ix + 16000]
+    fn_end = js.index("\nfunction _isMessagingSession(", fn_ix)
+    body = js[fn_ix:fn_end]
 
     # The unconditional teardown must still be there (this is what creates the
     # dead-stream window the re-arm closes).
@@ -962,9 +962,9 @@ def test_load_session_rearms_stream_on_every_early_return():
     # the updated authoritative-load check that still permits the same-session
     # guard when no different in-flight load is running; it's idempotent so
     # the real-switch path is unaffected.
-    guard_ix = body.index("currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid)")
-    pre_guard = body[max(0, guard_ix - 600):guard_ix]
-    assert "_rearmActiveSessionStream()" in pre_guard, (
+    guard_ix = body.index("if(currentSid===sid && !forceReload && (")
+    rearm_ix = body.rfind("_rearmActiveSessionStream()", 0, guard_ix)
+    assert rearm_ix >= 0, (
         "a re-arm must run before the same-session no-op guard so a "
         "previously-killed stream is revived on re-selecting the session"
     )

--- a/tests/test_session_cross_tab_sync.py
+++ b/tests/test_session_cross_tab_sync.py
@@ -32,7 +32,7 @@ def test_storage_event_does_not_globally_switch_tabs():
 
 def test_session_switch_updates_url_path_for_tab_local_anchor():
     assert "function _sessionIdFromLocation()" in SESSIONS_JS
-    assert "function _setActiveSessionUrl(sid)" in SESSIONS_JS
+    assert "function _setActiveSessionUrl(sid, explicitProfile)" in SESSIONS_JS
     assert "'/session/'" in SESSIONS_JS
     assert "_setActiveSessionUrl(S.session.session_id)" in SESSIONS_JS
     assert "_setActiveSessionUrl(S.session.session_id)" in COMMANDS_JS
@@ -42,7 +42,7 @@ def test_session_switch_updates_url_path_for_tab_local_anchor():
 def test_boot_prefers_url_session_over_local_storage_session():
     assert "const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;" in BOOT_JS
     assert "const savedLocal=localStorage.getItem('hermes-webui-session');" in BOOT_JS
-    assert "const saved=urlSession||savedLocal;" in BOOT_JS
+    assert "const saved=urlSession||(_profileQueryBlocksSavedLocal?null:savedLocal);" in BOOT_JS
     assert "const savedSidebarOnlyState=(!urlSession&&savedLocal)" in BOOT_JS
     assert "? await _savedSessionSidebarOnlyState(savedLocal)" in BOOT_JS
     assert "if(savedSidebarOnlyState&&savedSidebarOnlyState.sidebarOnly)" in BOOT_JS

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -97,12 +97,20 @@ def test_post_load_reack_is_guarded_by_active_view():
 
 def test_same_session_reselect_clears_stale_unread():
     block = _load_session_block()
-    guard = block.find("if(currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid)){")
-    unread_check = block.find("_sessionVisitHasUnreadState(sid)", guard)
+    guard = block.find(
+        "if(currentSid===sid && !forceReload && (!_loadingSessionId || _loadingSessionId===sid) &&"
+    )
+    owner_check = block.find(
+        "visibleOwnerMatchesActive&&expectedOwnerMatchesVisible", guard
+    )
+    unread_check = block.find("_sessionVisitHasUnreadState(sid)", owner_check)
     acknowledge = block.find("_acknowledgeSessionVisit(", unread_check)
-    ret = block.find("return;", acknowledge)
+    ret = block.find("return true;", acknowledge)
 
     assert guard != -1, "same-session no-op guard must still exist"
+    assert owner_check != -1 and guard < owner_check < unread_check, (
+        "same-session no-op must verify visible and expected profile ownership"
+    )
     assert unread_check != -1 and guard < unread_check, (
         "re-selecting the already-open session must check for stale unread state"
     )

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -12,6 +12,8 @@ import sys
 import unittest
 from unittest import mock
 
+from tests.js_source_extract import extract_function
+
 # Ensure repo is on sys.path so api.config can be imported
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
@@ -283,9 +285,12 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
     def test_sync_topbar_before_render_session_list(self):
         """syncTopbar() should be called before renderSessionList()
         so the chips are correct when the UI re-renders."""
-        idx = PANELS_JS.find('if (sessionInProgress)')
+        switch_profile = extract_function(
+            PANELS_JS, "switchToProfile", prefix="async function"
+        )
+        idx = switch_profile.find('if (sessionInProgress)')
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = switch_profile[idx:]
 
         pos_sync = block.find('syncTopbar()')
         pos_render = block.find('await renderSessionList()')

--- a/tests/test_v050254_opus_followups.py
+++ b/tests/test_v050254_opus_followups.py
@@ -23,10 +23,9 @@ def test_popstate_handler_guards_busy_state():
     prevent.
     """
     src = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
-    popstate_idx = src.find("addEventListener('popstate'")
+    popstate_idx = src.find("function _handleSessionPopstate()")
     assert popstate_idx != -1, "popstate handler missing from sessions.js"
-    # Look at the next ~600 chars of the handler body.
-    body = src[popstate_idx : popstate_idx + 600]
+    body = src[popstate_idx : src.find("\n\nif(typeof window", popstate_idx)]
     assert "S.busy" in body, (
         "popstate handler must check S.busy before calling loadSession() — "
         "otherwise mid-stream users lose their turn when they hit browser Back. "

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -46,6 +46,6 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     # through the cached wrapper _getCachedRender.  Both paths accept the
     # already-stripped displayContent, so the invariant holds either way.
     assert ("_renderUserFencedBlocks(displayContent)" in render_prefix or
-            "_getCachedRender(displayContent, isUser)" in render_prefix)
+            "_getCachedRender(displayContent, isUser, {linkSessionReferences:!m._live})" in render_prefix)
     assert "const newRawText=String(displayContent).trim();" in render_prefix
     assert "row.dataset.rawText=newRawText;" in render_prefix


### PR DESCRIPTION
## Thinking Path

- Bare `@session:<profile>/<id>` and `@session:<id>` references appear as plain implementation syntax in settled WebUI messages instead of opening the referenced conversation.
- The earlier live-stream transform mixed parsing with incremental DOM updates, repeatedly reprocessed growing output, and did not keep explicit profile ownership durable through URL and history state.
- This revision links bare references only when a message is settled or replayed. It handles explicit-profile navigation as a validated transaction before it promotes session, profile, or URL state.
- The change keeps the existing Markdown renderer, session loader, profile aliases, and `session-link` click delegation. It adds no backend route, dependency, framework, build step, or streaming scanner.

## What Changed

- Link valid bare session references after finalized Markdown rendering for assistant messages and both user-rendering modes.
- Keep active streaming and transparent live rerenders as plain text. Settled and live render cache entries are separate, so a live entry cannot reuse finalized linked HTML.
- Preserve code, existing anchors, images, URLs, escaped references, malformed references and malformed protected markup, raw structured content, emphasis wrappers, entities, Unicode wrappers, and ordinary terminal punctuation.
- Encode optional profile ownership in generated hrefs and data attributes, then route clicks through `_openSessionReference()`.
- Validate the requested session ID, requested profile, returned session ID, and returned profile before a profile-qualified open succeeds.
- Preserve root/default aliases and accept a legacy profileless payload only when the active profile state proves the requested owner.
- Make profile switches generation-aware, compensate superseded switches, quarantine same-SID inflight state across profile owners, and restore prior session, model, URL, composer, polling, and inflight state after a failed transaction.
- Require degraded local live recovery to match the server-declared active stream. During an existing-session profile switch, defer target model, provider, workspace, and reasoning defaults until the target session is validated.
- Preserve verified profile intent through canonical or continuation URL updates. Clear stale or unverified `?profile=` state during ordinary navigation.
- Route profile-qualified boot restore and same-SID profile changes through the same production transaction.
- Add Node-backed behavioral regressions plus neighboring source-contract updates for navigation, rendering, races, rollback, URL state, profile aliases, hostile input, and scaling.

## Why It Matters

- Session references emitted by Hermes Agent become usable navigation links after the message settles.
- A profile-qualified reference opens only the named owner. A stale or mismatched profile cannot silently discover and open another profile's session.
- Failed or superseded navigation does not strand the UI on a partially switched profile or reuse another profile's live transcript state.
- Active streaming avoids repeated whole-prefix link transformation and keeps its existing DOM lifecycle unchanged.

## Screenshots

Before: bare session reference rendered as plain text, desktop at 1280 × 720.

<img width="1280" height="720" alt="Bare session reference shown as plain text before the change" src="https://raw.githubusercontent.com/starship-s/hermes-webui/d251cc9b8606023f4d631dddbcb23f3e948c8069/pr-evidence/session-ref-links/before-desktop.png" />

After: the same reference rendered through the existing internal session link, desktop at 1280 × 720.

<img width="1280" height="720" alt="Bare session reference rendered as an internal session link after the change" src="https://raw.githubusercontent.com/starship-s/hermes-webui/d251cc9b8606023f4d631dddbcb23f3e948c8069/pr-evidence/session-ref-links/after-desktop.png" />

Narrow viewport: internal session link at 390 × 844.

<img width="390" height="844" alt="Internal session link rendered without clipping at a narrow viewport" src="https://raw.githubusercontent.com/starship-s/hermes-webui/d251cc9b8606023f4d631dddbcb23f3e948c8069/pr-evidence/session-ref-links/after-narrow.png" />

## Verification

Focused session-reference behavior:

`./scripts/test.sh tests/test_pr6778_session_references.py -q`

Result: `59 passed`.

Renderer, streaming, profile/navigation, rollback, race, and neighboring coverage:

```bash
./scripts/test.sh \
  tests/test_pr6778_session_references.py \
  tests/test_renderer_js_behaviour.py \
  tests/test_5682_profile_query_switch.py \
  tests/test_anchor_prose_incremental_finalize.py \
  tests/test_smooth_text_fade.py \
  tests/test_regressions.py \
  tests/test_smd_media_in_stream.py \
  tests/test_streaming_katex_live_render.py \
  tests/test_issue2713_streaming_segment_flush.py \
  tests/test_streaming_markdown.py \
  tests/test_issue4717_empty_profile_skeleton.py \
  tests/test_1694_root_saved_running_policy.py \
  tests/test_4961_url_query_prefill.py \
  tests/test_bugbatch_apr2026.py \
  tests/test_issue1103_reasoning_chip_visibility.py \
  tests/test_issue1611_session_profile_filtering.py \
  tests/test_issue342.py \
  tests/test_new_chat_default_model_frontend.py \
  tests/test_session_copy_link_action.py \
  tests/test_session_cross_tab_sync.py \
  tests/test_issue_new_chat_draft_restore.py \
  tests/test_v050254_opus_followups.py \
  tests/test_issue5367_transparent_live_row_reconcile.py \
  tests/test_issue5700_worklog_event_timestamps.py \
  tests/test_live_to_final_anchor_visible_order.py \
  tests/test_issue5720_reasoning_owner.py \
  tests/test_cross_session_message_load_isolation.py \
  tests/test_extension_session_hooks.py \
  tests/test_inflight_stream_reuse.py \
  tests/test_issue2386_localstorage_quota.py \
  tests/test_issue4756_session_visit_model_refresh.py \
  tests/test_session_channel_option_x.py \
  tests/test_bugfix_sweep.py \
  tests/test_hard_refresh_session_restore.py \
  tests/test_issue3397_transparent_stream_prose_segments.py \
  tests/test_media_message_snapshots.py \
  tests/test_workspace_display_prefix.py \
  tests/test_issue5960_cron_unread_profile_scope.py \
  tests/test_issue5177_hidden_tab_blank_gap.py \
  tests/test_session_unread_dot_on_visit.py \
  tests/test_sprint40_ui_polish.py \
  tests/test_webui_external_refresh_frontend.py \
  -q
```

Result: `796 passed, 1 skipped, 18 subtests passed`.

Repository lint, syntax, and hygiene:

`npm run lint:runtime`

`node --check static/ui.js && node --check static/sessions.js && node --check static/panels.js && node --check static/boot.js`

`git diff --check`

Result: runtime ESLint, JavaScript syntax, and diff hygiene passed. Diff-scoped Ruff checked 24 modified or new Python test files: five whole-file findings were pre-existing, with no findings on added lines.

Full repository suite:

`./scripts/test.sh -q`

Result: `15047 passed, 185 skipped, 1 xfailed, 2 xpassed, 45 subtests passed; 6 failures`.

Five failures reproduce on the unchanged base: one provider-deletion environment test, two non-Git workspace-boundary tests, and two local TLS probe tests. The sixth, an HTTP worker-slot timing test, passed when rerun alone on both the candidate and unchanged base.

## Risks / Follow-ups

- Bare references become clickable only after message finalization. This is intentional and avoids parsing or DOM reconciliation during active streaming.
- A cross-profile link performs a metadata preflight and may switch the profile cookie/context before the full session load. The visible session's model, provider, workspace, and reasoning state remain unchanged until the target session is validated.
- Link labels continue to show the session reference rather than resolving a title. Title lookup would require asynchronous metadata in the renderer and remains outside this change.
- Native CI and automated review must be revalidated on the published SHA.

## Models Used

- Hermes Agent / `gpt-5.6-sol` (`Default`) via OpenAI Codex: Investigation, architecture, remediation, verification, and PR preparation.
- Codex CLI / `gpt-5.6-luna` (`max`) via OpenAI Codex fast tier: Initial implementation and regression coverage on the clean redesign branch.
