### PR TITLE
Release exp-v0.52.161: HTML inline preview no-store (#6706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Fixed
 
+- **Inline HTML previews no longer show stale content after an edit.** The `/api/media` HTML response and the inline-preview `fetch()` used a 1-hour private cache, so an agent-edited HTML file kept showing the old render until a manual full-page refresh. HTML responses now send `Cache-Control: no-store` (non-HTML media keeps its `private, max-age=3600`) and the inline fetch passes `{cache:'no-store'}`, so a re-opened preview always reflects the current file. Thanks @happy5318. (#6706)
+
 - **CLI sessions (Claude Code, Codex) are readable again on named profiles.** External-agent transcripts scanned straight from `~/.claude/projects` / `~/.codex/` carry no Hermes profile (`profile: None`), so once the active profile was a named (non-root) one, the detail-load profile gate 404'd every one of them — the row showed in the sidebar and then rendered "Session not available in web UI." when clicked. These profile-less external-agent rows are now exempted from the visibility gate so they open identically on root and named profiles; every state.db-backed row (CLI/messaging/cron) that *does* carry a profile stays fully scoped. Thanks @kk17. (#6690)
 
 - **Workspace artifact links with Windows backslash paths now open.** `openArtifactPath()` / `_workspacePathExists()` split on `/`, so a Windows absolute artifact path like `D:\workspace\dir\file` never matched the workspace-prefix strip and was treated as a single filename — `/api/list` never resolved it and the click reported "cannot open file." Both the path and the session workspace are now normalized to `/` separators before the prefix strip and existence check; POSIX paths are byte-identical to before. Thanks @fatbee0808. (#6763)

--- a/api/routes.py
+++ b/api/routes.py
@@ -19163,7 +19163,11 @@ def _handle_media(handler, parsed):
     ) else "attachment"
     # _serve_file_bytes sends Content-Security-Policy when csp is set.
     csp = "sandbox allow-scripts" if html_inline_ok else None
-    return _serve_file_bytes(handler, target, mime, disposition, "private, max-age=3600", csp=csp)
+    # HTML inline previews change frequently (agent edits + re-renders).
+    # Use no-store so the browser always fetches fresh content, avoiding stale
+    # previews that require a manual full-page refresh to update.
+    cache_control = "no-store" if mime == "text/html" else "private, max-age=3600"
+    return _serve_file_bytes(handler, target, mime, disposition, cache_control, csp=csp)
 
 
 def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:

--- a/static/ui.js
+++ b/static/ui.js
@@ -19105,7 +19105,7 @@ function loadHtmlInline(container){
     const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
     const publicMediaUrl='api/media?path='+encodeURIComponent(path);
     const mediaUrl=publicMediaUrl+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
-    fetch(mediaUrl)
+    fetch(mediaUrl, {cache:'no-store'})
       .then(r=>{if(!r.ok) throw new Error(r.status); return r.text();})
       .then(html=>{
         if(html.length>HTML_MAX_SIZE){

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -849,6 +849,12 @@ class TestMediaEndpointIntegration(unittest.TestCase):
                 any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
             )
             self.assertEqual(body, html_bytes)
+            # HTML responses must use no-store to prevent stale preview on
+            # re-send of the same MEDIA: link (attachment branch).
+            self.assertEqual(
+                headers.get("Cache-Control"), "no-store",
+                "HTML attachment must use Cache-Control: no-store"
+            )
 
             body, status, headers = self._get(f"/api/media?path={encoded}&inline=1")
             self.assertEqual(status, 200)
@@ -859,6 +865,11 @@ class TestMediaEndpointIntegration(unittest.TestCase):
                 any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
             )
             self.assertEqual(body, html_bytes)
+            # Inline HTML preview must also use no-store (inline branch).
+            self.assertEqual(
+                headers.get("Cache-Control"), "no-store",
+                "Inline HTML preview must use Cache-Control: no-store"
+            )
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -197,7 +197,10 @@ class TestLoadHtmlInlineFunction:
         body = ui[idx:idx + 1200]
         assert 'const mediaSessionId=' in body
         assert "'&session_id='+encodeURIComponent(mediaSessionId)" in body
-        assert 'fetch(mediaUrl' in body
+        assert "fetch(mediaUrl, {cache:'no-store'})" in body, (
+            "loadHtmlInline must fetch with cache:'no-store' to bypass "
+            "browser cache for stale HTML preview (got body without no-store)"
+        )
         assert "const publicMediaUrl='api/media?path='+encodeURIComponent(path);" in body
         assert "const openUrl=publicMediaUrl+'&inline=1';" in body
 

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -197,7 +197,7 @@ class TestLoadHtmlInlineFunction:
         body = ui[idx:idx + 1200]
         assert 'const mediaSessionId=' in body
         assert "'&session_id='+encodeURIComponent(mediaSessionId)" in body
-        assert 'fetch(mediaUrl)' in body
+        assert 'fetch(mediaUrl' in body
         assert "const publicMediaUrl='api/media?path='+encodeURIComponent(path);" in body
         assert "const openUrl=publicMediaUrl+'&inline=1';" in body
 


### PR DESCRIPTION
## Batch exp release — 1 tight preview-freshness fix (batch 3)

### Included
- **#6706** fix: HTML inline preview shows stale content after file update — @happy5318. `/api/media` HTML responses now send `Cache-Control: no-store` (non-HTML media keeps `private, max-age=3600`) and the inline preview fetch passes `{cache:'no-store'}`, so an agent-edited HTML preview refreshes without a manual full-page reload.

### Gate (at this exact staged head)
- Full single-process suite (prod venv, `-p no:xdist`): green.
- Codex regression gate: SAFE TO SHIP.
- Browser smoke gate: CLEAN — 0 console errors.
- ESLint runtime gate + `node -c ui.js` + Python ast: clean.

Tight, additive, fail-safe (no-store scoped strictly to `text/html`; other media caching unchanged). Ships as `exp-v0.52.161`.
