### PR TITLE
Add cooperative extension identity handle

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -271,6 +271,35 @@ overrides and returns schema defaults. Extension-owned storage uses a separate
 browser-local namespace, and clearing storage removes that namespace without
 changing settings.
 
+### Cooperative extension identity
+
+An injected extension can claim a stable browser-page identity together with its
+existing settings and storage accessors:
+
+```js
+const ext = window.hermesExt.register("desktop-companion");
+if (ext) {
+  ext.settings.set("show_badge", false);
+  ext.storage.set("lastPanel", "settings");
+}
+```
+
+`register(id)` trims the ID and succeeds only for an ID in the effective-enabled,
+Core-sanitized manifest inventory that was present at the initial page boot. It
+returns `null` for empty, malformed, unknown, or untrusted IDs without creating
+settings or storage state. Re-registering the same ID in one page returns the
+same handle object; different IDs receive different handles. The handle exposes
+only the canonical `id`, `settings`, and `storage` fields, backed by the same
+factories used by the legacy accessors.
+
+Manifest enable/disable changes still take effect after a WebUI reload. A handle
+already created in the current page may remain cached across a status refresh;
+this is expected and does not implement runtime unload. This identity is a
+cooperative attribution convenience for extensions sharing the page—not a
+sandbox, isolation mechanism, capability or permission system, or security
+boundary. Extensions still execute with the full WebUI session authority
+described above.
+
 ## URL rules
 
 Injected asset URLs are deliberately restricted:

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -229,9 +229,9 @@
     return !!(meta&&meta.storage_owned&&Array.isArray(meta.settings_schema)&&meta.settings_schema.length);
   }
 
-  function settingsForExtension(id){
+  function settingsForExtension(id,metadata){
     const clean=extensionId(id);
-    const meta=schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    const meta=metadata||schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
     const schema=supportsSettings(meta)?meta.settings_schema:[];
     const key=settingsKey(clean);
     function current(){
@@ -278,9 +278,9 @@
     };
   }
 
-  function storageForExtension(id){
+  function storageForExtension(id,metadata){
     const clean=extensionId(id);
-    const meta=schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    const meta=metadata||schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
     const allowed=!!meta.storage_owned;
     const key=storageKey(clean);
     return {
@@ -316,11 +316,12 @@
     if(!clean) return null;
     const existing=registrations.get(clean);
     if(existing) return existing;
-    if(!schemas.has(clean)) return null;
+    const trusted=trustedExtensions.get(clean);
+    if(!trusted) return null;
     const handle=Object.freeze({
       id:clean,
-      settings:settingsForExtension(clean),
-      storage:storageForExtension(clean),
+      settings:settingsForExtension(clean,trusted),
+      storage:storageForExtension(clean,trusted),
     });
     registrations.set(clean,handle);
     return handle;

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -6,6 +6,7 @@
   const FIELD_TYPES=new Set(['boolean','string','number','integer','enum']);
   const schemas=new Map();
   const trustedExtensions=new Map();
+  const registrations=new Map();
   let trustedSeeded=false;
 
   function extensionId(value){
@@ -309,6 +310,22 @@
     };
   }
 
+  function registerExtension(id){
+    if(typeof id!=='string') return null;
+    const clean=extensionId(id);
+    if(!clean) return null;
+    const existing=registrations.get(clean);
+    if(existing) return existing;
+    if(!schemas.has(clean)) return null;
+    const handle=Object.freeze({
+      id:clean,
+      settings:settingsForExtension(clean),
+      storage:storageForExtension(clean),
+    });
+    registrations.set(clean,handle);
+    return handle;
+  }
+
   const api={
     normalizeSchemas,
     primeFromStatus,
@@ -325,5 +342,6 @@
   window.hermesExt.storage=window.hermesExt.storage||{};
   window.hermesExt.settings.forExtension=settingsForExtension;
   window.hermesExt.storage.forExtension=storageForExtension;
+  window.hermesExt.register=registerExtension;
   primeFromStatus(window.__HERMES_EXTENSION_CONFIG__||{});
 })();

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -232,6 +232,7 @@
   function settingsForExtension(id,metadata){
     const clean=extensionId(id);
     const meta=metadata||schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    const isTrusted=metadata?true:schemas.has(clean);
     const schema=supportsSettings(meta)?meta.settings_schema:[];
     const key=settingsKey(clean);
     function current(){
@@ -249,7 +250,7 @@
     }
     return {
       extensionId:clean,
-      trusted:schemas.has(clean),
+      trusted:isTrusted,
       storageOwned:!!meta.storage_owned,
       supported:supportsSettings(meta),
       schema,

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -229,10 +229,7 @@
     return !!(meta&&meta.storage_owned&&Array.isArray(meta.settings_schema)&&meta.settings_schema.length);
   }
 
-  function settingsForExtension(id,metadata){
-    const clean=extensionId(id);
-    const meta=metadata||schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
-    const isTrusted=metadata?true:schemas.has(clean);
+  function settingsAccessor(clean,meta,isTrusted){
     const schema=supportsSettings(meta)?meta.settings_schema:[];
     const key=settingsKey(clean);
     function current(){
@@ -279,9 +276,13 @@
     };
   }
 
-  function storageForExtension(id,metadata){
+  function settingsForExtension(id){
     const clean=extensionId(id);
-    const meta=metadata||schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    const meta=schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    return settingsAccessor(clean,meta,schemas.has(clean));
+  }
+
+  function storageAccessor(clean,meta){
     const allowed=!!meta.storage_owned;
     const key=storageKey(clean);
     return {
@@ -311,6 +312,12 @@
     };
   }
 
+  function storageForExtension(id){
+    const clean=extensionId(id);
+    const meta=schemas.get(clean)||{id:clean,name:clean,storage_owned:false,settings_schema:[]};
+    return storageAccessor(clean,meta);
+  }
+
   function registerExtension(id){
     if(typeof id!=='string') return null;
     const clean=extensionId(id);
@@ -321,8 +328,8 @@
     if(!trusted) return null;
     const handle=Object.freeze({
       id:clean,
-      settings:settingsForExtension(clean,trusted),
-      storage:storageForExtension(clean,trusted),
+      settings:settingsAccessor(clean,trusted,true),
+      storage:storageAccessor(clean,trusted),
     });
     registrations.set(clean,handle);
     return handle;

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -182,6 +182,24 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
         }};
         eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
 
+        const forgedMetadata = {{
+          id: 'forged.ext',
+          name: 'Forged',
+          storage_owned: true,
+          settings_schema: [{{key: 'owned', type: 'boolean', default: false}}]
+        }};
+        const forgedSettings = window.HermesExtensionSettings.settingsForExtension(
+          'forged.ext', forgedMetadata
+        );
+        const forgedStorage = window.HermesExtensionSettings.storageForExtension(
+          'forged.ext', forgedMetadata
+        );
+        assert.strictEqual(forgedSettings.trusted, false);
+        assert.strictEqual(forgedSettings.set('owned', true).ok, false);
+        assert.strictEqual(forgedStorage.set('owned', true), false);
+        assert.strictEqual(store.has('hermes.ext.settings.forged.ext'), false);
+        assert.strictEqual(store.has('hermes.ext.storage.forged.ext'), false);
+
         const beforeUnknown = {{reads, writes, removes}};
         assert.strictEqual(window.hermesExt.register(''), null);
         assert.strictEqual(window.hermesExt.register('   unknown.ext   '), null);

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -243,8 +243,10 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
         const deferred = window.hermesExt.register('deferred.ext');
         assert.ok(deferred);
         assert.deepStrictEqual(deferred.settings.values, {{enabled: false, mode: 'deferred'}});
+        assert.strictEqual(deferred.settings.trusted, true);
         assert.strictEqual(deferred.storage.set('note', 'deferred-note'), true);
         assert.strictEqual(deferred.storage.get('note'), 'deferred-note');
+        assert.strictEqual(window.hermesExt.settings.forExtension('deferred.ext').trusted, false);
 
         assert.strictEqual(window.hermesExt.register('alpha.ext'), alpha);
         assert.strictEqual(alpha.settings.get('enabled'), true);

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -135,3 +135,109 @@ def test_extension_settings_runtime_normalizes_persists_resets_and_clears():
         """
     )
     _run_node(script)
+
+
+def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const assert = require('assert');
+        const store = new Map();
+        let reads = 0;
+        let writes = 0;
+        let removes = 0;
+        global.window = {{
+          __HERMES_EXTENSION_CONFIG__: {{
+            extensions: [{{
+              id: 'alpha.ext',
+              name: 'Alpha',
+              storage_owned: true,
+              settings_schema: [
+                {{key: 'enabled', type: 'boolean', default: false}},
+                {{key: 'mode', type: 'string', default: 'alpha'}}
+              ]
+            }}, {{
+              id: 'beta.ext',
+              name: 'Beta',
+              storage_owned: true,
+              settings_schema: [
+                {{key: 'enabled', type: 'boolean', default: true}},
+                {{key: 'mode', type: 'string', default: 'beta'}}
+              ]
+            }}]
+          }},
+          localStorage: {{
+            getItem(key) {{ reads += 1; return store.has(key) ? store.get(key) : null; }},
+            setItem(key, value) {{ writes += 1; store.set(key, String(value)); }},
+            removeItem(key) {{ removes += 1; store.delete(key); }}
+          }}
+        }};
+        eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
+
+        const beforeUnknown = {{reads, writes, removes}};
+        assert.strictEqual(window.hermesExt.register(''), null);
+        assert.strictEqual(window.hermesExt.register('   unknown.ext   '), null);
+        assert.strictEqual(window.hermesExt.register(null), null);
+        assert.strictEqual(window.hermesExt.register(42), null);
+        assert.strictEqual(window.hermesExt.register({{toString() {{ return 'alpha.ext'; }}}}), null);
+        assert.strictEqual(window.hermesExt.register(Symbol('alpha.ext')), null);
+        assert.deepStrictEqual({{reads, writes, removes}}, beforeUnknown);
+        assert.deepStrictEqual([...store.keys()], []);
+
+        const alpha = window.hermesExt.register('  alpha.ext  ');
+        assert.ok(alpha);
+        assert.strictEqual(alpha.id, 'alpha.ext');
+        assert.strictEqual(Object.isFrozen(alpha), true);
+        assert.deepStrictEqual(Object.keys(alpha).sort(), ['id', 'settings', 'storage']);
+        assert.deepStrictEqual(alpha.settings.values, {{enabled: false, mode: 'alpha'}});
+        assert.strictEqual(alpha.settings.set('enabled', true).ok, true);
+        assert.strictEqual(alpha.storage.set('note', 'alpha-note'), true);
+        assert.deepStrictEqual(JSON.parse(store.get('hermes.ext.settings.alpha.ext')), {{enabled: true}});
+        assert.deepStrictEqual(JSON.parse(store.get('hermes.ext.storage.alpha.ext')), {{note: 'alpha-note'}});
+
+        assert.strictEqual(window.hermesExt.register('alpha.ext'), alpha);
+        assert.strictEqual(window.hermesExt.register(' alpha.ext '), alpha);
+
+        const beta = window.hermesExt.register('beta.ext');
+        assert.ok(beta);
+        assert.strictEqual(beta.id, 'beta.ext');
+        assert.notStrictEqual(beta, alpha);
+        assert.notStrictEqual(beta.settings, alpha.settings);
+        assert.notStrictEqual(beta.storage, alpha.storage);
+        assert.strictEqual(beta.storage.set('note', 'beta-note'), true);
+        assert.strictEqual(beta.settings.set('enabled', false).ok, true);
+        assert.strictEqual(alpha.storage.get('note'), 'alpha-note');
+        assert.strictEqual(beta.storage.get('note'), 'beta-note');
+        assert.strictEqual(alpha.settings.get('enabled'), true);
+        assert.strictEqual(beta.settings.get('enabled'), false);
+
+        const legacySettings = window.HermesExtensionSettings.settingsForExtension('alpha.ext');
+        const legacyStorage = window.HermesExtensionSettings.storageForExtension('alpha.ext');
+        assert.strictEqual(legacySettings.get('enabled'), true);
+        assert.strictEqual(legacyStorage.get('note'), 'alpha-note');
+        assert.strictEqual(window.hermesExt.settings.forExtension('alpha.ext').get('mode'), 'alpha');
+        assert.strictEqual(window.hermesExt.storage.forExtension('beta.ext').get('note'), 'beta-note');
+
+        window.HermesExtensionSettings.primeFromStatus({{
+          extensions: [{{
+            id: 'beta.ext',
+            name: 'Beta after refresh',
+            storage_owned: true,
+            settings_schema: [{{key: 'different', type: 'string', default: 'late'}}]
+          }}, {{
+            id: 'late.ext',
+            name: 'Late',
+            storage_owned: true,
+            settings_schema: [{{key: 'enabled', type: 'boolean', default: false}}]
+          }}]
+        }});
+
+        assert.strictEqual(window.hermesExt.register('alpha.ext'), alpha);
+        assert.strictEqual(alpha.settings.get('enabled'), true);
+        assert.strictEqual(alpha.storage.get('note'), 'alpha-note');
+        assert.strictEqual(window.hermesExt.register('late.ext'), null);
+        assert.strictEqual(store.has('hermes.ext.settings.late.ext'), false);
+        assert.strictEqual(store.has('hermes.ext.storage.late.ext'), false);
+        """
+    )
+    _run_node(script)

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -164,6 +164,14 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
                 {{key: 'enabled', type: 'boolean', default: true}},
                 {{key: 'mode', type: 'string', default: 'beta'}}
               ]
+            }}, {{
+              id: 'deferred.ext',
+              name: 'Deferred',
+              storage_owned: true,
+              settings_schema: [
+                {{key: 'enabled', type: 'boolean', default: false}},
+                {{key: 'mode', type: 'string', default: 'deferred'}}
+              ]
             }}]
           }},
           localStorage: {{
@@ -231,6 +239,12 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
             settings_schema: [{{key: 'enabled', type: 'boolean', default: false}}]
           }}]
         }});
+
+        const deferred = window.hermesExt.register('deferred.ext');
+        assert.ok(deferred);
+        assert.deepStrictEqual(deferred.settings.values, {{enabled: false, mode: 'deferred'}});
+        assert.strictEqual(deferred.storage.set('note', 'deferred-note'), true);
+        assert.strictEqual(deferred.storage.get('note'), 'deferred-note');
 
         assert.strictEqual(window.hermesExt.register('alpha.ext'), alpha);
         assert.strictEqual(alpha.settings.get('enabled'), true);


### PR DESCRIPTION
## Summary

- Add `window.hermesExt.register(id)` as the extension identity and ownership entry point (roadmap E0).
- Bind registration to the Core-sanitized, effective-enabled manifest inventory present at page boot.
- Return a stable frozen `{id, settings, storage}` handle for valid IDs; empty, malformed, unknown, and untrusted IDs fail closed with `null` and no namespace side effects.
- Preserve the existing settings/storage accessors and reload-required enable/disable lifecycle.
- Document that this is cooperative attribution, not a sandbox, capability system, permission system, isolation mechanism, or security boundary.

## State and lifecycle

The new page-local private `registrations` map owns handle identity. Existing browser-local settings and storage remain owned by their current `localStorage` namespaces. Re-registering the same active ID is idempotent. Status refresh cannot elevate an ID absent from the initial trusted boot inventory, while an already loaded page may retain its cached handle until reload. No runtime unload is introduced.

## Siblings checked

- Boot-time runtime manifest injection
- Settings-panel status refresh
- Reload-required extension toggle behavior
- Legacy `HermesExtensionSettings` and `hermesExt.settings/storage` accessors
- Existing `registerHermesSkin`, `registerHermesTtsEngine`, `registerHermesSessionOpenHandler`, and `renderTranscript` behavior

## Test proof

Base-fail before the implementation:

```text
./scripts/test.sh tests/test_extension_settings_runtime.py::test_hermes_ext_register_runtime_identity_and_reload_lifecycle -q
exit 1: TypeError: window.hermesExt.register is not a function
```

Head verification:

```text
node --check static/extension_settings.js
exit 0

./scripts/test.sh tests/test_extension_settings_runtime.py -q
2 passed

./scripts/test.sh tests/test_extensions_settings_panel.py tests/test_extension_status_endpoint.py -q
60 passed

./scripts/test.sh tests/test_extension_settings_runtime.py tests/test_extensions_settings_panel.py tests/test_extension_status_endpoint.py tests/test_extension_hooks.py tests/test_extension_session_hooks.py tests/test_extension_tts_engine_registration.py tests/test_extension_theme_registration.py -q
118 passed

git diff --check
exit 0
```

## Non-goals

No runtime unload, capability enforcement, sandboxing, permissions, backend route changes, library-extension migration, second compatibility reference, turn-lifecycle events (B1), message actions (A3), browser-local slash commands (A1), read-only session/transcript APIs (E5), code-block renderers (C1), managed extension panels (A4), or agent-tool/MCP consent bridge (D1) work is included.

Closes #6793
