### PR TITLE
fix: trusted headers must override stale non-trusted sessions

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -746,13 +746,15 @@ def _trusted_auth_bound_profile(handler) -> str | None:
     if mapping is None:
         return None
     groups = set(_trusted_groups_header_value(handler))
-    for group, profile in mapping.items():
-        if group in groups:
-            # A mapping value of "*" means this group is not bound to a
-            # single profile: the session can switch freely across all
-            # profiles (admin access), instead of being locked to one.
-            return None if profile == '*' else profile
-    return 'default'
+    matches = [profile for group, profile in mapping.items() if group in groups]
+    # A mapping value of "*" means the group is not bound to a single
+    # profile: the session can switch freely across all profiles (admin
+    # access). The wildcard dominates concrete mappings regardless of map
+    # order — an identity in both a bound group and a wildcard group must
+    # never end up bound. Among concrete profiles, mapping order wins.
+    if '*' in matches:
+        return None
+    return matches[0] if matches else 'default'
 
 
 def _queue_pending_cookie(handler, cookie_header: str) -> None:
@@ -858,6 +860,7 @@ def reset_trusted_auth_request_state(handler) -> None:
     for name in (
         '_trusted_auth_session_reconciled',
         '_trusted_auth_session_rejected',
+        '_trusted_auth_session_rotated',
         '_trusted_auth_session_info',
         '_trusted_auth_session_cookie_value',
         # Clear any auth cookie queued by a prior request but not yet flushed.
@@ -924,11 +927,26 @@ def ensure_trusted_auth_session(handler) -> dict | None:
             handler._trusted_auth_session_rejected = True
         return _remember_trusted_auth_session(handler, None)
     bound_profile = _trusted_auth_bound_profile(handler)
-    if info and info.get('username') == username and info.get('bound_profile') == bound_profile:
+    # Reuse is only safe when the existing session is itself trusted: a
+    # non-trusted record carrying the same username/bound_profile (which
+    # create_session permits for other auth flows) must not carry its
+    # security context across authentication mechanisms.
+    if (
+        info
+        and info.get('auth_type') == 'trusted'
+        and info.get('username') == username
+        and info.get('bound_profile') == bound_profile
+    ):
         _apply_trusted_session_profile(handler, bound_profile, cookie_value)
         return _remember_trusted_auth_session(handler, info, cookie_value)
     if info:
         invalidate_session(cookie_value)
+        # The request's cookie was just replaced mid-request. An unsafe
+        # request whose CSRF token was minted for the old session will fail
+        # token validation; flag the rotation so the CSRF gate can reject it
+        # as deliberately retryable (the replacement cookie is emitted with
+        # the 403, so a retry/reload succeeds).
+        handler._trusted_auth_session_rotated = True
     cookie_value = create_session(
         auth_type='trusted',
         username=username,

--- a/api/auth.py
+++ b/api/auth.py
@@ -748,7 +748,10 @@ def _trusted_auth_bound_profile(handler) -> str | None:
     groups = set(_trusted_groups_header_value(handler))
     for group, profile in mapping.items():
         if group in groups:
-            return profile
+            # A mapping value of "*" means this group is not bound to a
+            # single profile: the session can switch freely across all
+            # profiles (admin access), instead of being locked to one.
+            return None if profile == '*' else profile
     return 'default'
 
 
@@ -887,15 +890,28 @@ def ensure_trusted_auth_session(handler) -> dict | None:
         return handler._trusted_auth_session_reconciled
     cookie_value = parse_cookie(handler)
     info = get_session_info(cookie_value) if cookie_value and verify_session(cookie_value) else None
-    if info and info.get('auth_type') != 'trusted':
+
+    # A request that arrives through the trusted proxy and asserts an
+    # identity via the trusted header must always be reconciled below,
+    # even when a stale non-trusted session cookie is already present
+    # (e.g. a shared-password session created before trusted-header auth
+    # was enabled, or another trusted user's leftover cookie on a shared
+    # browser). Otherwise that old cookie wins forever and Authelia's
+    # asserted identity/profile binding is silently ignored.
+    from api.routes import _raw_peer_is_trusted_proxy
+
+    trusted_request = (
+        is_trusted_auth_enabled()
+        and _raw_peer_is_trusted_proxy(handler)
+        and bool(_trusted_auth_username(handler))
+    )
+    if info and info.get('auth_type') != 'trusted' and not trusted_request:
         return _remember_trusted_auth_session(handler, info)
     if not is_trusted_auth_enabled():
         if info:
             invalidate_session(cookie_value)
             handler._trusted_auth_session_rejected = True
         return _remember_trusted_auth_session(handler, None)
-    from api.routes import _raw_peer_is_trusted_proxy
-
     if not _raw_peer_is_trusted_proxy(handler):
         if info:
             invalidate_session(cookie_value)

--- a/api/auth.py
+++ b/api/auth.py
@@ -939,13 +939,28 @@ def ensure_trusted_auth_session(handler) -> dict | None:
     ):
         _apply_trusted_session_profile(handler, bound_profile, cookie_value)
         return _remember_trusted_auth_session(handler, info, cookie_value)
+    preserved_profile = None
     if info:
+        if bound_profile is None:
+            # The request's profile cookie is signed against the session
+            # being invalidated. A bound replacement re-signs its own
+            # profile below, but an UNBOUND one (no group map, or a "*"
+            # mapping) would leave the dead signature in place: the next
+            # request rejects it and silently falls back to the process
+            # default profile. Capture the authenticated selection while
+            # the old session can still verify it.
+            try:
+                from api.helpers import get_profile_cookie
+
+                preserved_profile = get_profile_cookie(handler)
+            except Exception:
+                preserved_profile = None
         invalidate_session(cookie_value)
         # The request's cookie was just replaced mid-request. An unsafe
         # request whose CSRF token was minted for the old session will fail
         # token validation; flag the rotation so the CSRF gate can reject it
-        # as deliberately retryable (the replacement cookie is emitted with
-        # the 403, so a retry/reload succeeds).
+        # as deliberately retryable (the replacement cookie and its CSRF
+        # token are emitted with the 403, so a retry/reload succeeds).
         handler._trusted_auth_session_rotated = True
     cookie_value = create_session(
         auth_type='trusted',
@@ -954,6 +969,19 @@ def ensure_trusted_auth_session(handler) -> dict | None:
     )
     _queue_pending_cookie(handler, _auth_cookie_header(cookie_value, handler))
     _apply_trusted_session_profile(handler, bound_profile, cookie_value)
+    if preserved_profile:
+        try:
+            from api.profiles import set_request_profile
+
+            set_request_profile(preserved_profile)
+            _queue_pending_cookie(
+                handler, _build_profile_cookie_header(preserved_profile, cookie_value)
+            )
+        except Exception:
+            logger.warning(
+                "Failed to re-sign profile cookie for rotated unbound session",
+                exc_info=True,
+            )
     info = get_session_info(cookie_value)
     return _remember_trusted_auth_session(handler, info, cookie_value)
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -888,6 +888,46 @@ def _apply_trusted_session_profile(handler, bound_profile: str | None, cookie_va
         _queue_pending_cookie(handler, _build_profile_cookie_header(bound_profile, cookie_value))
 
 
+# Two concurrent requests that both find the SAME stale/mismatched trusted
+# identity (e.g. two tabs polling at once, right after a group→profile
+# remap) must not each mint their own replacement session: cookie B from one
+# response paired with the CSRF token minted for cookie A from the other's
+# response bricks whichever tab receives the mismatched pair. Within this
+# short window, the second request reuses the first request's freshly
+# created replacement instead of creating its own. Keyed by the identity
+# being rotated INTO (username, bound_profile), not by the stale cookie
+# being rotated OUT of, so unrelated identities never collide.
+#
+# Dedicated lock: `create_session()` below acquires `_SESSIONS_LOCK`
+# internally, and that lock is not reentrant, so this critical section must
+# use a lock of its own rather than `_SESSIONS_LOCK` itself.
+_ROTATION_REUSE_WINDOW_S = 5.0
+_ROTATION_REUSE_LOCK = threading.Lock()
+_rotation_reuse_cache: dict[tuple[str, str | None], tuple[str, float]] = {}
+
+
+def _rotated_trusted_session(username: str, bound_profile: str | None) -> str:
+    """Return a fresh replacement session for (username, bound_profile).
+
+    Concurrent callers within :data:`_ROTATION_REUSE_WINDOW_S` of each other
+    get back the SAME cookie value instead of each minting their own. Must be
+    called with the rotation already decided (i.e. after the caller has
+    determined the existing session is stale) — this never returns a session
+    that only optionally needed to rotate.
+    """
+    key = (username, bound_profile)
+    now = time.time()
+    with _ROTATION_REUSE_LOCK:
+        cached = _rotation_reuse_cache.get(key)
+        if cached:
+            cookie_value, expiry = cached
+            if expiry > now and verify_session(cookie_value):
+                return cookie_value
+        cookie_value = create_session(auth_type='trusted', username=username, bound_profile=bound_profile)
+        _rotation_reuse_cache[key] = (cookie_value, now + _ROTATION_REUSE_WINDOW_S)
+        return cookie_value
+
+
 def ensure_trusted_auth_session(handler) -> dict | None:
     if hasattr(handler, '_trusted_auth_session_reconciled'):
         return handler._trusted_auth_session_reconciled
@@ -962,11 +1002,7 @@ def ensure_trusted_auth_session(handler) -> dict | None:
         # as deliberately retryable (the replacement cookie and its CSRF
         # token are emitted with the 403, so a retry/reload succeeds).
         handler._trusted_auth_session_rotated = True
-    cookie_value = create_session(
-        auth_type='trusted',
-        username=username,
-        bound_profile=bound_profile,
-    )
+    cookie_value = _rotated_trusted_session(username, bound_profile)
     _queue_pending_cookie(handler, _auth_cookie_header(cookie_value, handler))
     _apply_trusted_session_profile(handler, bound_profile, cookie_value)
     if preserved_profile:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -240,12 +240,43 @@ def _json_response_body(payload, *, pretty: bool = True) -> bytes:
     return _json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
 
 
+def _inject_rotated_csrf_token(handler, payload):
+    """Attach the replacement session's CSRF token to a JSON payload.
+
+    Trusted-header reconciliation (``ensure_trusted_auth_session``) can
+    rotate the session on ANY request, not just one that then fails CSRF —
+    a plain GET (e.g. the session poll) rotates just as readily. The 403
+    path (``_csrf_rejection_payload``) already hands its replacement token
+    back explicitly; this covers every other response so the open tab never
+    has to hit a `token_mismatch` on its next unsafe request before it has
+    any way to learn the token changed. `csrf_token` already present means
+    the caller (the 403 path) built its own recovery payload — leave it
+    alone.
+    """
+    if not isinstance(payload, dict) or 'csrf_token' in payload:
+        return payload
+    if not getattr(handler, '_trusted_auth_session_rotated', False):
+        return payload
+    replacement = getattr(handler, '_trusted_auth_session_cookie_value', None)
+    if not replacement:
+        return payload
+    from api.auth import csrf_token_for_session, verify_session
+
+    if not verify_session(replacement):
+        return payload
+    token = csrf_token_for_session(replacement)
+    if not token:
+        return payload
+    return {**payload, 'csrf_token': token}
+
+
 def j(handler, payload, status: int=200, extra_headers: dict=None, *, pretty: bool = True) -> None:
     """Send a JSON response.
 
     *extra_headers*: optional dict of additional headers to include
     (e.g., {'Set-Cookie': '...'}).  Headers are sent before end_headers().
     """
+    payload = _inject_rotated_csrf_token(handler, payload)
     body = _json_response_body(payload, pretty=pretty)
     handler.send_response(status)
     handler.send_header('Content-Type', 'application/json; charset=utf-8')

--- a/api/routes.py
+++ b/api/routes.py
@@ -5497,6 +5497,11 @@ def _csrf_rejection_error(handler) -> str:
     reason = getattr(handler, _CSRF_FAILURE_ATTR, "")
     if reason == "origin_mismatch":
         return "Cross-origin mismatch - check reverse proxy headers"
+    if reason == "session_rotated":
+        # Trusted-header reconciliation replaced the session during this
+        # request; the replacement cookie rides on this 403, so a retry with
+        # refreshed state succeeds.
+        return "Session was re-authenticated - retry the request"
     if reason == "token_mismatch":
         return "Session expired - reload the page"
     return "Cross-origin request rejected"
@@ -5517,6 +5522,8 @@ def _check_csrf(handler) -> bool:
     submitted = handler.headers.get(CSRF_HEADER_NAME) or handler.headers.get("X-CSRF-Token")
     if verify_csrf_token(cookie_val or "", submitted or ""):
         return True
+    if getattr(handler, "_trusted_auth_session_rotated", False):
+        return _set_csrf_failure_reason(handler, "session_rotated")
     return _set_csrf_failure_reason(handler, "token_mismatch")
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5507,6 +5507,32 @@ def _csrf_rejection_error(handler) -> str:
     return "Cross-origin request rejected"
 
 
+def _csrf_rejection_payload(handler) -> dict:
+    """JSON body for a CSRF 403, with recovery material on session rotation.
+
+    When trusted-header reconciliation rotated the session mid-request, the
+    open tab still holds the CSRF token minted for the dead session and has no
+    way to obtain the replacement token without a full reload. Hand it back on
+    the rejection itself so the client fetch wrapper can refresh its token and
+    the advertised immediate retry actually succeeds. The recipient is the
+    same-origin, proxy-authenticated browser that owns the replacement session
+    cookie riding on this very response, so this discloses nothing it could
+    not read from the authenticated shell.
+    """
+    payload = {"error": _csrf_rejection_error(handler)}
+    if getattr(handler, _CSRF_FAILURE_ATTR, "") == "session_rotated":
+        replacement = getattr(handler, "_trusted_auth_session_cookie_value", None)
+        if replacement:
+            from api.auth import csrf_token_for_session, verify_session
+
+            if verify_session(replacement):
+                token = csrf_token_for_session(replacement)
+                if token:
+                    payload["reason"] = "session_rotated"
+                    payload["csrf_token"] = token
+    return payload
+
+
 def _check_csrf(handler) -> bool:
     """Reject cross-origin or tokenless authenticated browser unsafe requests."""
     if not _check_same_origin_browser_request(handler):
@@ -5703,7 +5729,7 @@ def _handle_extension_sidecar_proxy(
     # DELETE fell through the CSRF compatibility path that intentionally admits
     # non-browser clients, giving unsafe methods weaker provenance than GET.
     if not _check_same_origin_browser_request(handler, require_provenance=True):
-        return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
+        return j(handler, _csrf_rejection_payload(handler), status=403)
     try:
         request_body = _read_body_bytes(handler) if read_request_body else None
     except ValueError as exc:
@@ -12053,9 +12079,14 @@ def handle_get(handler, parsed) -> bool:
                 from api.auth import csrf_token_for_session, is_auth_enabled, parse_cookie, verify_session
 
                 if is_auth_enabled():
-                    cookie_val = parse_cookie(handler)
+                    # Prefer the session reconciled by trusted-header auth for
+                    # THIS request: when a stale cookie was just rotated,
+                    # parse_cookie() still returns the dead value, the shell
+                    # would render an empty CSRF token, and every subsequent
+                    # unsafe request would 403 until a manual reload.
+                    cookie_val = getattr(handler, "_trusted_auth_session_cookie_value", None)
                     if not cookie_val:
-                        cookie_val = getattr(handler, "_trusted_auth_session_cookie_value", None)
+                        cookie_val = parse_cookie(handler)
                     if cookie_val and verify_session(cookie_val):
                         csrf_token = csrf_token_for_session(cookie_val) or ""
             except Exception:
@@ -13999,7 +14030,7 @@ def handle_post(handler, parsed) -> bool:
         diag.stage("csrf")
     if not _csrf_exempt_path(parsed.path) and not _check_csrf(handler):
         try:
-            return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
+            return j(handler, _csrf_rejection_payload(handler), status=403)
         finally:
             if diag:
                 diag.finish()
@@ -16616,7 +16647,7 @@ def handle_post(handler, parsed) -> bool:
 def handle_patch(handler, parsed) -> bool:
     """Handle all PATCH routes. Returns True if handled, False for 404."""
     if not _check_csrf(handler):
-        return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
+        return j(handler, _csrf_rejection_payload(handler), status=403)
     proxy_result = _handle_extension_sidecar_proxy(
         handler,
         parsed,
@@ -16644,7 +16675,7 @@ def handle_patch(handler, parsed) -> bool:
 def handle_delete(handler, parsed) -> bool:
     """Handle all DELETE routes. Returns True if handled, False for 404."""
     if not _check_csrf(handler):
-        return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
+        return j(handler, _csrf_rejection_payload(handler), status=403)
     proxy_result = _handle_extension_sidecar_proxy(
         handler,
         parsed,
@@ -16680,7 +16711,7 @@ def handle_delete(handler, parsed) -> bool:
 def handle_put(handler, parsed) -> bool:
     """Handle all PUT routes. Returns True if handled, False for 404."""
     if not _check_csrf(handler):
-        return j(handler, {"error": "Cross-origin request rejected"}, status=403)
+        return j(handler, _csrf_rejection_payload(handler), status=403)
     proxy_result = _handle_extension_sidecar_proxy(
         handler,
         parsed,

--- a/static/index.html
+++ b/static/index.html
@@ -44,13 +44,26 @@
       return !/\/api\/(auth\/login|csp-report)$/.test(url.pathname);
     }catch(_){return false;}
   }
+  function adoptRotatedToken(res){
+    // Trusted-header reconciliation can rotate the session mid-request; the
+    // 403 carries the replacement CSRF token so the retry succeeds without a
+    // page reload.
+    if(res&&res.status===403&&typeof res.clone==='function'){
+      try{
+        res.clone().json().then(function(body){
+          if(body&&body.reason==='session_rotated'&&typeof body.csrf_token==='string'&&body.csrf_token)token=body.csrf_token;
+        }).catch(function(){});
+      }catch(_){}
+    }
+    return res;
+  }
   window.fetch=function(input,init){
     if(sameOriginUnsafe(input,init)){
       var opts=init?Object.assign({},init):{};
       var headers=new Headers(opts.headers!==undefined?opts.headers:((input&&input.headers)||{}));
       if(!headers.has('X-Hermes-CSRF-Token'))headers.set('X-Hermes-CSRF-Token',token);
       opts.headers=headers;
-      return originalFetch(input,opts);
+      return originalFetch(input,opts).then(adoptRotatedToken);
     }
     return originalFetch(input,init);
   };

--- a/static/index.html
+++ b/static/index.html
@@ -34,28 +34,44 @@
   var cfg=window.__HERMES_CONFIG__||{},token=cfg.csrfToken||'';
   if(!token||!window.fetch)return;
   var originalFetch=window.fetch.bind(window);
+  function sameOriginUrl(input){
+    try{
+      var raw=(typeof input==='string'||input instanceof URL)?input:(input&&input.url)||'';
+      return new URL(raw,document.baseURI||location.href);
+    }catch(_){return null;}
+  }
   function sameOriginUnsafe(input,init){
     var method=((init&&init.method)||(input&&input.method)||'GET').toUpperCase();
     if(!/^(POST|PUT|PATCH|DELETE)$/.test(method))return false;
-    try{
-      var raw=(typeof input==='string'||input instanceof URL)?input:(input&&input.url)||'';
-      var url=new URL(raw,document.baseURI||location.href);
-      if(url.origin!==location.origin)return false;
-      return !/\/api\/(auth\/login|csp-report)$/.test(url.pathname);
-    }catch(_){return false;}
+    var url=sameOriginUrl(input);
+    if(!url||url.origin!==location.origin)return false;
+    return !/\/api\/(auth\/login|csp-report)$/.test(url.pathname);
+  }
+  // A safe (GET/HEAD) same-origin request can ALSO rotate the trusted-auth
+  // session server-side (e.g. the periodic session poll) — it just doesn't
+  // need the CSRF header attached. Watch its response for a replacement
+  // token too, or the tab keeps sending the dead token until its next
+  // unsafe request happens to trip the 403 recovery path.
+  function sameOriginSafe(input,init){
+    var method=((init&&init.method)||(input&&input.method)||'GET').toUpperCase();
+    if(!/^(GET|HEAD)$/.test(method))return false;
+    var url=sameOriginUrl(input);
+    return !!url&&url.origin===location.origin;
   }
   function adoptRotatedToken(res){
-    // Trusted-header reconciliation can rotate the session mid-request; the
-    // 403 carries the replacement CSRF token so the retry succeeds without a
-    // page reload.
-    if(res&&res.status===403&&typeof res.clone==='function'){
-      try{
-        res.clone().json().then(function(body){
-          if(body&&body.reason==='session_rotated'&&typeof body.csrf_token==='string'&&body.csrf_token)token=body.csrf_token;
-        }).catch(function(){});
-      }catch(_){}
-    }
-    return res;
+    // Returns a promise that resolves only once any replacement token has
+    // been read and adopted — a caller that awaits this fetch and
+    // immediately issues the next unsafe request must see the updated
+    // token, not a stale one still in flight in a detached microtask.
+    if(!res||typeof res.clone!=='function')return Promise.resolve(res);
+    var contentType=(res.headers&&typeof res.headers.get==='function'&&res.headers.get('Content-Type'))||'';
+    if(!/^application\/json/i.test(contentType))return Promise.resolve(res);
+    try{
+      return res.clone().json().then(function(body){
+        if(body&&typeof body.csrf_token==='string'&&body.csrf_token)token=body.csrf_token;
+        return res;
+      }).catch(function(){return res;});
+    }catch(_){return Promise.resolve(res);}
   }
   window.fetch=function(input,init){
     if(sameOriginUnsafe(input,init)){
@@ -64,6 +80,9 @@
       if(!headers.has('X-Hermes-CSRF-Token'))headers.set('X-Hermes-CSRF-Token',token);
       opts.headers=headers;
       return originalFetch(input,opts).then(adoptRotatedToken);
+    }
+    if(sameOriginSafe(input,init)){
+      return originalFetch(input,init).then(adoptRotatedToken);
     }
     return originalFetch(input,init);
   };

--- a/tests/test_trusted_header_auth.py
+++ b/tests/test_trusted_header_auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import shutil
 import subprocess
 import time
@@ -944,32 +945,54 @@ def test_first_unsafe_request_during_rotation_is_deliberately_retryable(monkeypa
     assert routes._check_csrf(handler) is False
     assert routes._csrf_rejection_error(handler) == "Session was re-authenticated - retry the request"
 
-    # The production 403 path flushes the queued replacement cookie.
+    # The production 403 path flushes the queued replacement cookie and hands
+    # back the replacement CSRF token so an open tab can actually retry.
     from api.helpers import j
 
-    j(handler, {"error": routes._csrf_rejection_error(handler)}, status=403)
+    j(handler, routes._csrf_rejection_payload(handler), status=403)
     assert handler.status == 403
     set_cookies = handler.header_values("Set-Cookie")
     assert any(cookie.startswith("hermes_session=") for cookie in set_cookies)
     replacement = handler._trusted_auth_session_cookie_value
     assert auth.verify_session(replacement) is True
+    body = handler.json_body()
+    assert body["reason"] == "session_rotated"
+    assert body["csrf_token"] == auth.csrf_token_for_session(replacement)
 
 
 def test_second_request_after_rotation_succeeds_with_replacement_cookie(monkeypatch):
-    # The retry with the replacement cookie and its CSRF token goes through.
+    # Real client path: the retry may only use material the first RESPONSE
+    # handed back — the replacement cookie from Set-Cookie and the CSRF token
+    # from the 403 body. An open tab cannot mint tokens server-side.
     _trusted_env(monkeypatch)
     stale_cookie = auth.create_session(auth_type="password", username="alice")
-    first = _Handler(headers={"Cookie": f"hermes_session={stale_cookie}", "Remote-User": "alice"})
-    assert auth.check_auth(first, SimpleNamespace(path="/api/sessions", query="")) is True
-    replacement = first._trusted_auth_session_cookie_value
-
-    second = _Handler(
+    first = _Handler(
         headers={
-            "Cookie": f"hermes_session={replacement}",
+            "Cookie": f"hermes_session={stale_cookie}",
             "Remote-User": "alice",
             "Host": "127.0.0.1:8787",
             "Origin": "http://127.0.0.1:8787",
-            auth.CSRF_HEADER_NAME: auth.csrf_token_for_session(replacement),
+            auth.CSRF_HEADER_NAME: auth.csrf_token_for_session(stale_cookie),
+        }
+    )
+    first.command = "POST"
+    assert auth.check_auth(first, SimpleNamespace(path="/api/sessions", query="")) is True
+    assert routes._check_csrf(first) is False
+    from api.helpers import j
+
+    j(first, routes._csrf_rejection_payload(first), status=403)
+    replacement_cookie = next(
+        cookie for cookie in first.header_values("Set-Cookie") if cookie.startswith("hermes_session=")
+    ).split("=", 1)[1].split(";", 1)[0]
+    retry_token = first.json_body()["csrf_token"]
+
+    second = _Handler(
+        headers={
+            "Cookie": f"hermes_session={replacement_cookie}",
+            "Remote-User": "alice",
+            "Host": "127.0.0.1:8787",
+            "Origin": "http://127.0.0.1:8787",
+            auth.CSRF_HEADER_NAME: retry_token,
         }
     )
     second.command = "POST"
@@ -977,5 +1000,124 @@ def test_second_request_after_rotation_succeeds_with_replacement_cookie(monkeypa
     assert auth.check_auth(second, SimpleNamespace(path="/api/sessions", query="")) is True
     assert routes._check_csrf(second) is True
     # No further rotation: the trusted session is reused as-is.
-    assert second._trusted_auth_session_cookie_value == replacement
+    assert second._trusted_auth_session_cookie_value == replacement_cookie
     assert getattr(second, "_trusted_auth_session_rotated", False) is False
+
+
+def test_stale_cookie_shell_renders_replacement_csrf_token(monkeypatch):
+    # Regression (#6798 review): a PRESENT-but-invalidated request cookie must
+    # not leave the shell with an empty CSRF token — that disabled client-side
+    # token injection and bricked every unsafe request for exactly the rotated
+    # user until a manual reload.
+    _trusted_env(monkeypatch)
+    stale_cookie = auth.create_session(auth_type="password", username="alice")
+    handler = _Handler(headers={"Cookie": f"hermes_session={stale_cookie}", "Remote-User": "alice"})
+    monkeypatch.setattr(routes, "_render_index_shell_base", lambda: "csrfToken:__CSRF_TOKEN_JSON__")
+    monkeypatch.setattr("api.extensions.inject_extension_tags", lambda html: html)
+
+    assert auth.check_auth(handler, SimpleNamespace(path="/", query="")) is True
+    routes.handle_get(handler, SimpleNamespace(path="/", query=""))
+
+    replacement = handler._trusted_auth_session_cookie_value
+    assert replacement != stale_cookie
+    expected = auth.csrf_token_for_session(replacement)
+    assert expected
+    assert handler.body_text() == f"csrfToken:{json.dumps(expected)}"
+
+
+def test_unbound_rotation_preserves_authenticated_profile_selection(monkeypatch):
+    # Rotating into an UNBOUND session (wildcard map) must re-sign the
+    # authenticated profile cookie for the replacement session; otherwise the
+    # next request rejects the stale signature and silently falls back to the
+    # process default profile.
+    _trusted_env(monkeypatch, groups_header="Remote-Groups", group_map={"admins": "*"})
+    stale_cookie = auth.create_session(auth_type="password", username="alice")
+    profile_cookie = auth.sign_profile_cookie_value("devops", stale_cookie)
+    handler = _Handler(
+        headers={
+            "Cookie": f"hermes_session={stale_cookie}; hermes_profile={profile_cookie}",
+            "Remote-User": "alice",
+            "Remote-Groups": "admins",
+        }
+    )
+
+    assert auth.check_auth(handler, SimpleNamespace(path="/api/sessions", query="")) is True
+
+    replacement = handler._trusted_auth_session_cookie_value
+    assert handler._trusted_auth_session_info["bound_profile"] is None
+    assert profiles.get_active_profile_name() == "devops"
+    reissued = next(
+        cookie for cookie in handler._pending_set_cookies if cookie.startswith("hermes_profile=")
+    ).split("=", 1)[1].split(";", 1)[0]
+    assert auth.verify_profile_cookie_value(reissued, replacement) == "devops"
+
+    # The follow-up request presenting only response material keeps the profile.
+    second = _Handler(
+        headers={
+            "Cookie": f"hermes_session={replacement}; hermes_profile={reissued}",
+            "Remote-User": "alice",
+            "Remote-Groups": "admins",
+        }
+    )
+    assert auth.check_auth(second, SimpleNamespace(path="/api/sessions", query="")) is True
+    from api.helpers import get_profile_cookie
+
+    assert get_profile_cookie(second) == "devops"
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required to execute the fetch wrapper")
+def test_fetch_wrapper_adopts_rotated_csrf_token_for_retry():
+    # Execute the REAL inline wrapper from index.html: the first unsafe fetch
+    # sends the shell token and receives the rotation 403; the retry must send
+    # the replacement token from that 403 body — no page reload involved.
+    src = (Path(__file__).resolve().parents[1] / "static" / "index.html").read_text(encoding="utf-8")
+    script = next(
+        (
+            match.group(1)
+            for match in re.finditer(r"<script>((?:(?!</script>).)*)</script>", src, re.S)
+            if "X-Hermes-CSRF-Token" in match.group(1)
+        ),
+        None,
+    )
+    assert script, "CSRF fetch wrapper script not found in index.html"
+    harness = """
+'use strict';
+global.window = globalThis;
+global.location = new URL('http://127.0.0.1:8787/');
+global.document = { baseURI: 'http://127.0.0.1:8787/' };
+window.__HERMES_CONFIG__ = { csrfToken: 'OLD_TOKEN' };
+const sentTokens = [];
+window.fetch = function (input, init) {
+  const headers = init && init.headers ? Object.fromEntries(init.headers) : {};
+  sentTokens.push(headers['x-hermes-csrf-token'] || null);
+  if (sentTokens.length === 1) {
+    return Promise.resolve({
+      status: 403,
+      clone() {
+        return {
+          json: () =>
+            Promise.resolve({
+              error: 'Session was re-authenticated - retry the request',
+              reason: 'session_rotated',
+              csrf_token: 'NEW_TOKEN',
+            }),
+        };
+      },
+    });
+  }
+  return Promise.resolve({ status: 200, clone() { return { json: () => Promise.resolve({}) }; } });
+};
+%SCRIPT%
+;(async () => {
+  await fetch('/api/sessions', { method: 'POST' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await fetch('/api/sessions', { method: 'POST' });
+  console.log(JSON.stringify(sentTokens));
+})();
+"""
+    harness = harness.replace("%SCRIPT%", script)
+    result = subprocess.run([NODE, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    first, second = json.loads(result.stdout.strip())
+    assert first == "OLD_TOKEN"
+    assert second == "NEW_TOKEN"

--- a/tests/test_trusted_header_auth.py
+++ b/tests/test_trusted_header_auth.py
@@ -799,3 +799,183 @@ signOut().then(() => process.stdout.write(JSON.stringify(window.location.href)))
 
     assert run_sign_out("https://auth.example.com/logout") == "https://auth.example.com/logout"
     assert run_sign_out(None) == "login"
+
+
+# ── PR #6798: stale non-trusted sessions vs. trusted-header reconciliation ──
+
+
+@pytest.mark.parametrize(
+    "group_map",
+    [
+        {"devs": "dev", "admins": "*"},
+        {"admins": "*", "devs": "dev"},
+    ],
+)
+def test_wildcard_group_dominates_concrete_mappings_regardless_of_order(monkeypatch, group_map):
+    # An identity in both a bound group and a wildcard (unbound/admin) group
+    # must be unbound no matter how the operator ordered the mapping.
+    _trusted_env(monkeypatch, groups_header="Remote-Groups", group_map=group_map)
+    handler = _Handler(headers={"Remote-User": "alice", "Remote-Groups": "devs,admins"})
+
+    info = auth.ensure_trusted_auth_session(handler)
+
+    assert info["auth_type"] == "trusted"
+    assert info["bound_profile"] is None
+    assert auth.trusted_session_allows_active_profile(info) is True
+
+
+def test_wildcard_only_match_creates_unbound_session(monkeypatch):
+    _trusted_env(monkeypatch, groups_header="Remote-Groups", group_map={"admins": "*"})
+    handler = _Handler(headers={"Remote-User": "alice", "Remote-Groups": "admins"})
+
+    info = auth.ensure_trusted_auth_session(handler)
+
+    assert info["auth_type"] == "trusted"
+    assert info["bound_profile"] is None
+    # No profile cookie is forced for an unbound session.
+    pending = getattr(handler, "_pending_set_cookies", [])
+    assert not any(cookie.startswith("hermes_profile=") for cookie in pending)
+
+
+def _stale_session_cases():
+    # (case id, create_session kwargs, group map, groups header value)
+    return [
+        pytest.param({}, None, None, id="legacy-password-no-metadata"),
+        pytest.param(
+            {"auth_type": "password", "username": "mallory", "bound_profile": "other"},
+            None,
+            None,
+            id="non-trusted-different-identity",
+        ),
+        pytest.param(
+            {"auth_type": "password", "username": "alice", "bound_profile": None},
+            {"admins": "*"},
+            "admins",
+            id="non-trusted-exact-match-wildcard-unbound",
+        ),
+        pytest.param(
+            {"auth_type": "password", "username": "alice", "bound_profile": "devops"},
+            {"hermes_devops": "devops"},
+            "hermes_devops",
+            id="non-trusted-exact-match-bound-profile",
+        ),
+    ]
+
+
+@pytest.mark.parametrize("session_kwargs,group_map,groups_value", _stale_session_cases())
+def test_stale_non_trusted_cookie_replaced_on_trusted_get(
+    monkeypatch, session_kwargs, group_map, groups_value
+):
+    # Any non-trusted session presented on a valid trusted request must be
+    # invalidated and replaced by a trusted session — including a non-trusted
+    # record whose username/bound_profile exactly match the proxy assertion
+    # (create_session permits arbitrary metadata for other auth flows).
+    _trusted_env(
+        monkeypatch,
+        groups_header="Remote-Groups" if group_map else None,
+        group_map=group_map,
+    )
+    stale_cookie = auth.create_session(**session_kwargs)
+    headers = {"Cookie": f"hermes_session={stale_cookie}", "Remote-User": "alice"}
+    if groups_value:
+        headers["Remote-Groups"] = groups_value
+    handler = _Handler(headers=headers)
+
+    assert auth.check_auth(handler, SimpleNamespace(path="/api/sessions", query="")) is True
+
+    # The old cookie is dead, the replacement is trusted, exactly one new
+    # auth cookie is queued.
+    assert auth.verify_session(stale_cookie) is False
+    info = handler._trusted_auth_session_info
+    assert info["auth_type"] == "trusted"
+    assert info["username"] == "alice"
+    replacement = handler._trusted_auth_session_cookie_value
+    assert replacement != stale_cookie
+    assert auth.verify_session(replacement) is True
+    auth_cookies = [
+        cookie for cookie in handler._pending_set_cookies if cookie.startswith("hermes_session=")
+    ]
+    assert len(auth_cookies) == 1
+    assert getattr(handler, "_trusted_auth_session_rotated", False) is True
+
+
+def test_untrusted_peer_with_stale_non_trusted_cookie_does_not_rotate(monkeypatch):
+    # The same header from an untrusted network peer must not gain
+    # trusted-session rotation: no invalidation, no trusted cookie.
+    _trusted_env(monkeypatch)
+    stale_cookie = auth.create_session(auth_type="password", username="alice")
+    handler = _Handler(
+        headers={"Cookie": f"hermes_session={stale_cookie}", "Remote-User": "alice"},
+        client_address=("10.0.0.5", 12345),
+    )
+
+    info = auth.ensure_trusted_auth_session(handler)
+
+    assert info["auth_type"] == "password"
+    assert auth.verify_session(stale_cookie) is True
+    assert not hasattr(handler, "_trusted_auth_session_info")
+    assert getattr(handler, "_pending_set_cookies", []) == []
+    assert getattr(handler, "_trusted_auth_session_rotated", False) is False
+
+
+def test_first_unsafe_request_during_rotation_is_deliberately_retryable(monkeypatch):
+    # First browser POST carrying a stale non-trusted cookie plus its CSRF
+    # token: reconciliation rotates the session mid-request, so the CSRF gate
+    # rejects the write with the deliberate retryable reason while the
+    # replacement trusted cookie is emitted on the 403 response.
+    _trusted_env(monkeypatch)
+    stale_cookie = auth.create_session(auth_type="password", username="alice")
+    handler = _Handler(
+        headers={
+            "Cookie": f"hermes_session={stale_cookie}",
+            "Remote-User": "alice",
+            "Host": "127.0.0.1:8787",
+            "Origin": "http://127.0.0.1:8787",
+            auth.CSRF_HEADER_NAME: auth.csrf_token_for_session(stale_cookie),
+        }
+    )
+    handler.command = "POST"
+
+    # Authentication reconciles first (server.py order) and rotates.
+    assert auth.check_auth(handler, SimpleNamespace(path="/api/sessions", query="")) is True
+    assert auth.verify_session(stale_cookie) is False
+
+    # The CSRF gate then sees the old request cookie: deliberate rejection.
+    assert routes._check_csrf(handler) is False
+    assert routes._csrf_rejection_error(handler) == "Session was re-authenticated - retry the request"
+
+    # The production 403 path flushes the queued replacement cookie.
+    from api.helpers import j
+
+    j(handler, {"error": routes._csrf_rejection_error(handler)}, status=403)
+    assert handler.status == 403
+    set_cookies = handler.header_values("Set-Cookie")
+    assert any(cookie.startswith("hermes_session=") for cookie in set_cookies)
+    replacement = handler._trusted_auth_session_cookie_value
+    assert auth.verify_session(replacement) is True
+
+
+def test_second_request_after_rotation_succeeds_with_replacement_cookie(monkeypatch):
+    # The retry with the replacement cookie and its CSRF token goes through.
+    _trusted_env(monkeypatch)
+    stale_cookie = auth.create_session(auth_type="password", username="alice")
+    first = _Handler(headers={"Cookie": f"hermes_session={stale_cookie}", "Remote-User": "alice"})
+    assert auth.check_auth(first, SimpleNamespace(path="/api/sessions", query="")) is True
+    replacement = first._trusted_auth_session_cookie_value
+
+    second = _Handler(
+        headers={
+            "Cookie": f"hermes_session={replacement}",
+            "Remote-User": "alice",
+            "Host": "127.0.0.1:8787",
+            "Origin": "http://127.0.0.1:8787",
+            auth.CSRF_HEADER_NAME: auth.csrf_token_for_session(replacement),
+        }
+    )
+    second.command = "POST"
+
+    assert auth.check_auth(second, SimpleNamespace(path="/api/sessions", query="")) is True
+    assert routes._check_csrf(second) is True
+    # No further rotation: the trusted session is reused as-is.
+    assert second._trusted_auth_session_cookie_value == replacement
+    assert getattr(second, "_trusted_auth_session_rotated", False) is False

--- a/tests/test_trusted_header_auth.py
+++ b/tests/test_trusted_header_auth.py
@@ -1004,6 +1004,85 @@ def test_second_request_after_rotation_succeeds_with_replacement_cookie(monkeypa
     assert getattr(second, "_trusted_auth_session_rotated", False) is False
 
 
+def test_concurrent_rotations_for_same_identity_reuse_one_replacement(monkeypatch):
+    # Two requests that each carry their OWN stale cookie for the same
+    # identity (two tabs, or a poll racing a write, right after a
+    # group→profile remap) must rotate into the SAME replacement session —
+    # not two different ones. Two different replacements would let a client
+    # end up with cookie B from one response paired with the CSRF token
+    # minted for cookie A from the other's response (#6798 review round 4).
+    _trusted_env(monkeypatch)
+    stale_a = auth.create_session(auth_type="password", username="alice")
+    stale_b = auth.create_session(auth_type="password", username="alice")
+    assert stale_a != stale_b
+
+    handler_a = _Handler(headers={"Cookie": f"hermes_session={stale_a}", "Remote-User": "alice"})
+    handler_b = _Handler(headers={"Cookie": f"hermes_session={stale_b}", "Remote-User": "alice"})
+
+    assert auth.check_auth(handler_a, SimpleNamespace(path="/api/sessions", query="")) is True
+    assert auth.check_auth(handler_b, SimpleNamespace(path="/api/sessions", query="")) is True
+
+    replacement_a = handler_a._trusted_auth_session_cookie_value
+    replacement_b = handler_b._trusted_auth_session_cookie_value
+    assert replacement_a == replacement_b
+    assert auth.verify_session(replacement_a) is True
+
+
+def test_concurrent_rotations_for_different_identities_do_not_collide(monkeypatch):
+    # The reuse window must be scoped to the identity being rotated INTO —
+    # two different users rotating at the same time must never be handed
+    # each other's replacement session.
+    _trusted_env(monkeypatch)
+    stale_alice = auth.create_session(auth_type="password", username="alice")
+    stale_bob = auth.create_session(auth_type="password", username="bob")
+
+    handler_alice = _Handler(headers={"Cookie": f"hermes_session={stale_alice}", "Remote-User": "alice"})
+    handler_bob = _Handler(headers={"Cookie": f"hermes_session={stale_bob}", "Remote-User": "bob"})
+
+    assert auth.check_auth(handler_alice, SimpleNamespace(path="/api/sessions", query="")) is True
+    assert auth.check_auth(handler_bob, SimpleNamespace(path="/api/sessions", query="")) is True
+
+    replacement_alice = handler_alice._trusted_auth_session_cookie_value
+    replacement_bob = handler_bob._trusted_auth_session_cookie_value
+    assert replacement_alice != replacement_bob
+    assert auth.get_session_info(replacement_alice)["username"] == "alice"
+    assert auth.get_session_info(replacement_bob)["username"] == "bob"
+
+
+def test_concurrent_rotation_reuse_is_thread_safe(monkeypatch):
+    # Same scenario as test_concurrent_rotations_for_same_identity_reuse_one_replacement,
+    # but with real threads racing the check-then-create critical section in
+    # `_rotated_trusted_session`, to catch a lock ordering/reentrancy
+    # regression that a purely sequential test cannot exercise.
+    import threading
+
+    _trusted_env(monkeypatch)
+    thread_count = 8
+    barrier = threading.Barrier(thread_count)
+    replacements: list[str] = [None] * thread_count
+    errors: list[BaseException] = []
+
+    def worker(index: int) -> None:
+        try:
+            stale = auth.create_session(auth_type="password", username="racer")
+            handler = _Handler(headers={"Cookie": f"hermes_session={stale}", "Remote-User": "racer"})
+            barrier.wait(timeout=5)
+            assert auth.check_auth(handler, SimpleNamespace(path="/api/sessions", query="")) is True
+            replacements[index] = handler._trusted_auth_session_cookie_value
+        except BaseException as exc:  # noqa: BLE001 - surfaced via `errors` below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, errors
+    assert all(replacements), "every worker must have rotated into a replacement session"
+    assert len(set(replacements)) == 1, "all concurrent rotations for one identity must converge on one session"
+
+
 def test_stale_cookie_shell_renders_replacement_csrf_token(monkeypatch):
     # Regression (#6798 review): a PRESENT-but-invalidated request cookie must
     # not leave the shell with an empty CSRF token — that disabled client-side
@@ -1065,11 +1144,7 @@ def test_unbound_rotation_preserves_authenticated_profile_selection(monkeypatch)
     assert get_profile_cookie(second) == "devops"
 
 
-@pytest.mark.skipif(NODE is None, reason="node is required to execute the fetch wrapper")
-def test_fetch_wrapper_adopts_rotated_csrf_token_for_retry():
-    # Execute the REAL inline wrapper from index.html: the first unsafe fetch
-    # sends the shell token and receives the rotation 403; the retry must send
-    # the replacement token from that 403 body — no page reload involved.
+def _extract_csrf_wrapper_script() -> str:
     src = (Path(__file__).resolve().parents[1] / "static" / "index.html").read_text(encoding="utf-8")
     script = next(
         (
@@ -1080,6 +1155,19 @@ def test_fetch_wrapper_adopts_rotated_csrf_token_for_retry():
         None,
     )
     assert script, "CSRF fetch wrapper script not found in index.html"
+    return script
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required to execute the fetch wrapper")
+def test_fetch_wrapper_adopts_rotated_csrf_token_for_retry():
+    # Execute the REAL inline wrapper from index.html: the first unsafe fetch
+    # sends the shell token and receives the rotation 403; the retry must send
+    # the replacement token from that 403 body — no page reload involved, and
+    # with NO artificial delay between the two fetches. The wrapper's
+    # returned promise must not resolve until the token has actually been
+    # adopted, or a caller that awaits fetch() and immediately fires the next
+    # request would still race the token here (#6798 review round 4).
+    script = _extract_csrf_wrapper_script()
     harness = """
 'use strict';
 global.window = globalThis;
@@ -1093,6 +1181,7 @@ window.fetch = function (input, init) {
   if (sentTokens.length === 1) {
     return Promise.resolve({
       status: 403,
+      headers: { get: (name) => (name === 'Content-Type' ? 'application/json' : null) },
       clone() {
         return {
           json: () =>
@@ -1105,12 +1194,18 @@ window.fetch = function (input, init) {
       },
     });
   }
-  return Promise.resolve({ status: 200, clone() { return { json: () => Promise.resolve({}) }; } });
+  return Promise.resolve({
+    status: 200,
+    headers: { get: () => 'application/json' },
+    clone() { return { json: () => Promise.resolve({}) }; },
+  });
 };
 %SCRIPT%
 ;(async () => {
   await fetch('/api/sessions', { method: 'POST' });
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  // No setTimeout here on purpose: firing the second request the instant
+  // the first await resolves proves synchronous adoption, not merely
+  // "eventually consistent" adoption masked by a timing gap.
   await fetch('/api/sessions', { method: 'POST' });
   console.log(JSON.stringify(sentTokens));
 })();
@@ -1121,3 +1216,90 @@ window.fetch = function (input, init) {
     first, second = json.loads(result.stdout.strip())
     assert first == "OLD_TOKEN"
     assert second == "NEW_TOKEN"
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required to execute the fetch wrapper")
+def test_fetch_wrapper_adopts_rotated_csrf_token_from_safe_get():
+    # The session poll is a plain GET, and trusted-header reconciliation can
+    # rotate the session on ANY request — including this one. Its 200 JSON
+    # response carries `csrf_token` with no `reason` field (that field is
+    # reserved for the 403 recovery payload); the wrapper must still adopt
+    # it, and a subsequent unsafe request must carry the new token, again
+    # with no delay between the two calls (#6798 review round 4).
+    script = _extract_csrf_wrapper_script()
+    harness = """
+'use strict';
+global.window = globalThis;
+global.location = new URL('http://127.0.0.1:8787/');
+global.document = { baseURI: 'http://127.0.0.1:8787/' };
+window.__HERMES_CONFIG__ = { csrfToken: 'OLD_TOKEN' };
+const sentTokens = [];
+window.fetch = function (input, init) {
+  const method = (init && init.method) || 'GET';
+  if (method === 'GET') {
+    return Promise.resolve({
+      status: 200,
+      headers: { get: () => 'application/json' },
+      clone() {
+        return { json: () => Promise.resolve({ session_id: 'abc', csrf_token: 'POLL_ROTATED_TOKEN' }) };
+      },
+    });
+  }
+  const headers = init && init.headers ? Object.fromEntries(init.headers) : {};
+  sentTokens.push(headers['x-hermes-csrf-token'] || null);
+  return Promise.resolve({
+    status: 200,
+    headers: { get: () => 'application/json' },
+    clone() { return { json: () => Promise.resolve({}) }; },
+  });
+};
+%SCRIPT%
+;(async () => {
+  await fetch('/api/session?id=abc');
+  await fetch('/api/sessions', { method: 'POST' });
+  console.log(JSON.stringify(sentTokens));
+})();
+"""
+    harness = harness.replace("%SCRIPT%", script)
+    result = subprocess.run([NODE, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    [sent] = json.loads(result.stdout.strip())
+    assert sent == "POLL_ROTATED_TOKEN"
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required to execute the fetch wrapper")
+def test_fetch_wrapper_ignores_non_json_same_origin_responses():
+    # A same-origin GET that is NOT JSON (a static asset, an SSE stream) must
+    # never be probed with .clone().json() — that would try to buffer a
+    # long-lived stream, or throw on a non-JSON body. The wrapper must pass
+    # such responses through untouched and must not crash.
+    script = _extract_csrf_wrapper_script()
+    harness = """
+'use strict';
+global.window = globalThis;
+global.location = new URL('http://127.0.0.1:8787/');
+global.document = { baseURI: 'http://127.0.0.1:8787/' };
+window.__HERMES_CONFIG__ = { csrfToken: 'OLD_TOKEN' };
+let jsonCloneCalls = 0;
+window.fetch = function (input, init) {
+  return Promise.resolve({
+    status: 200,
+    headers: { get: (name) => (name === 'Content-Type' ? 'text/event-stream' : null) },
+    clone() {
+      jsonCloneCalls += 1;
+      return { json: () => Promise.reject(new Error('must not be called on a stream')) };
+    },
+  });
+};
+%SCRIPT%
+;(async () => {
+  const res = await fetch('/api/events?channel=x');
+  console.log(JSON.stringify({ status: res.status, jsonCloneCalls }));
+})();
+"""
+    harness = harness.replace("%SCRIPT%", script)
+    result = subprocess.run([NODE, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    outcome = json.loads(result.stdout.strip())
+    assert outcome["status"] == 200
+    assert outcome["jsonCloneCalls"] == 0


### PR DESCRIPTION
## Problem

When trusted-header auth (#3351) is enabled behind a reverse proxy (Authelia + Caddy `forward_auth` in our case), `ensure_trusted_auth_session()` returns early as soon as a valid **non-trusted** session cookie is present — before ever looking at the asserted headers. Any stale session (e.g. a shared-password login created before trusted-header auth was turned on, or another user's leftover cookie on a shared browser) then silently wins over the proxy-asserted identity, and the group→profile binding is bypassed.

We hit this in production: a user authenticated through Authelia as `vincent` landed in the `default` profile (someone else's workspace, including sensitive history) because of a pre-existing shared-password cookie.

## Fix

- In `ensure_trusted_auth_session()`, when trusted auth is enabled **and** the request comes from a trusted proxy **and** an identity is asserted in the header, reconcile against the headers even if a valid non-trusted session exists — instead of returning the stale session untouched. Behaviour is unchanged for requests that don't come through the trusted proxy or don't assert an identity.
- Small companion feature: a `"*"` value in `GROUP_PROFILE_MAP` now means "not bound to a single profile" (free profile switching), giving admin groups a clean escape hatch instead of being locked to one profile. Mentioned in #6797.

## Testing

Deployed on our production instance (Authelia + Caddy): stale shared-password sessions are now superseded by the asserted identity on the next request, profile binding applies correctly, and `"*"`-mapped admins can switch profiles freely while bound users still get a 403 on switch attempts.

Refs #6797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
