### PR TITLE
fix: recover stale pending decision replies

### DIFF
--- a/api/pending_decisions.py
+++ b/api/pending_decisions.py
@@ -1,0 +1,164 @@
+"""Durable session-scoped decisions produced by external authorization tools."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+
+
+SCHEMA_VERSION = "superset-pending-decision/v2"
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _session_dir(session_dir: Path | None) -> Path:
+    if session_dir is not None:
+        return Path(session_dir).resolve()
+    from api.models import SESSION_DIR
+
+    return Path(SESSION_DIR).resolve()
+
+
+def _identifier(value: str, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not _ID_RE.fullmatch(normalized):
+        raise ValueError(f"invalid {label}")
+    return normalized
+
+
+def _root(session_dir: Path | None) -> Path:
+    sessions = _session_dir(session_dir)
+    root = (sessions / "_pending_decisions").resolve()
+    root.relative_to(sessions)
+    return root
+
+
+def _decision_path(session_id: str, decision_id: str, session_dir: Path | None) -> Path:
+    root = _root(session_dir)
+    path = (
+        root
+        / _identifier(session_id, "session_id")
+        / f"{_identifier(decision_id, 'decision_id')}.json"
+    ).resolve()
+    path.relative_to(root)
+    return path
+
+
+def _resolution_path(path: Path) -> Path:
+    return path.with_name(path.stem + ".resolution.json")
+
+
+def _atomic_write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _validate(payload: dict) -> dict:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported pending decision schema")
+    _identifier(payload.get("session_id"), "session_id")
+    _identifier(payload.get("decision_id"), "decision_id")
+    _identifier(payload.get("task_id"), "task_id")
+    if payload.get("state") != "waiting_for_user":
+        raise ValueError("pending decision must be waiting_for_user")
+    if not str(payload.get("question") or "").strip():
+        raise ValueError("pending decision question is required")
+    options = payload.get("options")
+    if not isinstance(options, list) or len({str(item) for item in options}) < 2:
+        raise ValueError("pending decision requires distinct options")
+    if "expires_at" in payload or "timeout_seconds" in payload:
+        raise ValueError("mutation authorization decisions cannot expire by wall clock")
+    return dict(payload)
+
+
+def create_pending_decision(payload: dict, *, session_dir: Path | None = None) -> dict:
+    normalized = _validate(payload)
+    path = _decision_path(normalized["session_id"], normalized["decision_id"], session_dir)
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if existing != normalized:
+            raise ValueError("pending decision id already exists with different content")
+        return existing
+    _atomic_write(path, normalized)
+    return normalized
+
+
+def get_pending_decision(
+    session_id: str, decision_id: str, *, session_dir: Path | None = None
+) -> dict | None:
+    path = _decision_path(session_id, decision_id, session_dir)
+    try:
+        payload = _validate(json.loads(path.read_text(encoding="utf-8")))
+    except FileNotFoundError:
+        return None
+    resolution_path = _resolution_path(path)
+    if resolution_path.exists():
+        resolution = json.loads(resolution_path.read_text(encoding="utf-8"))
+        payload["state"] = "resolved"
+        payload["resolution"] = resolution
+    return payload
+
+
+def list_pending_decisions(session_id: str, *, session_dir: Path | None = None) -> list[dict]:
+    sid = _identifier(session_id, "session_id")
+    directory = _root(session_dir) / sid
+    if not directory.exists():
+        return []
+    pending: list[dict] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name.endswith(".resolution.json"):
+            continue
+        item = get_pending_decision(sid, path.stem, session_dir=session_dir)
+        if item and item.get("state") == "waiting_for_user":
+            pending.append(item)
+    return pending
+
+
+def mark_pending_decision_resolved(
+    session_id: str,
+    decision_id: str,
+    *,
+    option: str,
+    event_id: str,
+    turn_id: str,
+    session_dir: Path | None = None,
+) -> dict:
+    path = _decision_path(session_id, decision_id, session_dir)
+    pending = get_pending_decision(session_id, decision_id, session_dir=session_dir)
+    if not pending or pending.get("state") != "waiting_for_user":
+        raise ValueError("pending decision is not active")
+    selected = str(option or "").strip()
+    if selected not in pending["options"]:
+        raise ValueError("resolution must select an offered option")
+    resolution = {
+        "option": selected,
+        "event_id": _identifier(event_id, "event_id"),
+        "turn_id": _identifier(turn_id, "turn_id"),
+        "resolved_at": time.time(),
+    }
+    resolution_path = _resolution_path(path)
+    if resolution_path.exists():
+        raise ValueError("pending decision is not active")
+    _atomic_write(resolution_path, resolution)
+    return {**pending, "state": "resolved", "resolution": resolution}

--- a/api/routes.py
+++ b/api/routes.py
@@ -21886,7 +21886,7 @@ def _handle_chat_start(handler, body, diag=None):
 
             pending_decision = get_pending_decision(s.session_id, resolves_decision_id)
             if not pending_decision or pending_decision.get("state") != "waiting_for_user":
-                return bad(handler, "pending decision is not active", 409)
+                return bad(handler, "That decision is no longer active.", 409)
             decision_option = str(body.get("decision_option") or "").strip()
             if decision_option not in (pending_decision.get("options") or []):
                 return bad(handler, "decision_option must select an offered option", 400)

--- a/api/routes.py
+++ b/api/routes.py
@@ -13176,6 +13176,9 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/clarify/pending":
         return _handle_clarify_pending(handler, parsed)
 
+    if parsed.path == "/api/pending-decisions":
+        return _handle_pending_decisions(handler, parsed)
+
     if parsed.path == "/api/clarify/stream":
         return _handle_clarify_sse_stream(handler, parsed)
 
@@ -19172,6 +19175,18 @@ def _handle_clarify_pending(handler, parsed):
     return j(handler, {"pending": None})
 
 
+def _handle_pending_decisions(handler, parsed):
+    sid = parse_qs(parsed.query).get("session_id", [""])[0]
+    if not sid:
+        return bad(handler, "session_id is required")
+    from api.pending_decisions import list_pending_decisions
+
+    try:
+        return j(handler, {"pending_decisions": list_pending_decisions(sid)})
+    except ValueError as exc:
+        return bad(handler, str(exc))
+
+
 def _handle_clarify_sse_stream(handler, parsed):
     """SSE endpoint for real-time clarify notifications.
 
@@ -20751,6 +20766,7 @@ def _start_chat_stream_for_session(
     goal_related: bool = False,
     source: str = "webui",
     moa_config=None,
+    decision_resolution=None,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     attachments = attachments or []
@@ -20856,10 +20872,44 @@ def _start_chat_stream_for_session(
                 "model": model,
                 "model_provider": model_provider,
                 "created_at": s.pending_started_at,
+                "source": "pending_decision_resolution" if decision_resolution else "user_submission",
+                **(
+                    {
+                        "relation": "resolve_decision",
+                        "decision_id": decision_resolution["decision_id"],
+                        "decision_option": decision_resolution["option"],
+                    }
+                    if decision_resolution
+                    else {}
+                ),
             },
         )
     except Exception:
         logger.warning("Failed to append submitted turn journal event", exc_info=True)
+        if decision_resolution:
+            _clear_stale_stream_state(s)
+            return {
+                "error": "Failed to persist the decision response; no worker was started.",
+                "_status": 500,
+            }
+    if decision_resolution:
+        try:
+            from api.pending_decisions import mark_pending_decision_resolved
+
+            mark_pending_decision_resolved(
+                s.session_id,
+                decision_resolution["decision_id"],
+                option=decision_resolution["option"],
+                event_id=journal_event["event_id"],
+                turn_id=journal_event["turn_id"],
+            )
+        except Exception:
+            logger.warning("Failed to persist pending decision resolution", exc_info=True)
+            _clear_stale_stream_state(s)
+            return {
+                "error": "Failed to persist the decision response; no worker was started.",
+                "_status": 500,
+            }
     diag.stage("set_last_workspace") if diag else None
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None
@@ -20962,6 +21012,7 @@ def _start_run(
     route: str,
     diag=None,
     moa_config=None,
+    decision_resolution=None,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -21002,6 +21053,7 @@ def _start_run(
                 diag=diag,
                 source=request.source or source,
                 moa_config=moa_config,
+                decision_resolution=decision_resolution,
             )
 
         def _legacy_adapter_factory():
@@ -21042,6 +21094,7 @@ def _start_run(
         diag=diag,
         source=source,
         moa_config=moa_config,
+        decision_resolution=decision_resolution,
     )
 
 
@@ -21827,6 +21880,20 @@ def _handle_chat_start(handler, body, diag=None):
             "route": "/api/chat/start",
             "diag": diag,
         }
+        resolves_decision_id = str(body.get("resolves_decision_id") or "").strip()
+        if resolves_decision_id:
+            from api.pending_decisions import get_pending_decision
+
+            pending_decision = get_pending_decision(s.session_id, resolves_decision_id)
+            if not pending_decision or pending_decision.get("state") != "waiting_for_user":
+                return bad(handler, "pending decision is not active", 409)
+            decision_option = str(body.get("decision_option") or "").strip()
+            if decision_option not in (pending_decision.get("options") or []):
+                return bad(handler, "decision_option must select an offered option", 400)
+            start_run_kwargs["decision_resolution"] = {
+                "decision_id": resolves_decision_id,
+                "option": decision_option,
+            }
         if not gateway_chat_enabled and moa_config is not None:
             start_run_kwargs["moa_config"] = moa_config
         recovery_cleared_for_start = None

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 TURN_JOURNAL_DIR_NAME = "_turn_journal"
 _TERMINAL_EVENTS = {"completed", "interrupted"}
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_EVENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$")
 
 
 def _default_session_dir() -> Path:
@@ -84,11 +85,18 @@ def append_turn_journal_event(
     payload["session_id"] = str(session_id)
     payload.setdefault("turn_id", _make_turn_id())
     payload.setdefault("created_at", time.time())
+    event_id = str(payload.get("event_id") or uuid.uuid4().hex)
+    if not _EVENT_ID_RE.fullmatch(event_id):
+        raise ValueError("invalid event_id")
+    payload["event_id"] = event_id
     if event_name in _TERMINAL_EVENTS:
         payload.setdefault("terminal", True)
 
     path = _journal_path(session_id, session_dir=session_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
+    existing = read_turn_journal(session_id, session_dir=session_dir)
+    if any(item.get("event_id") == event_id for item in existing.get("events") or []):
+        raise ValueError("duplicate event_id")
     line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
     with os.fdopen(fd, "a", encoding="utf-8") as fh:

--- a/docs/contracts/intent-authorization-pending-decision-v2.json
+++ b/docs/contracts/intent-authorization-pending-decision-v2.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "superset-pending-decision/v2",
+  "storage": "SESSION_DIR/_pending_decisions/<session_id>/<decision_id>.json",
+  "resolution_storage": "SESSION_DIR/_pending_decisions/<session_id>/<decision_id>.resolution.json",
+  "required": [
+    "schema_version",
+    "decision_id",
+    "session_id",
+    "task_id",
+    "question",
+    "options",
+    "impact_summary",
+    "state"
+  ],
+  "state": "waiting_for_user",
+  "wall_clock_expiry": false
+}

--- a/static/messages.js
+++ b/static/messages.js
@@ -1759,13 +1759,45 @@ async function send(){
     _pendingMoaConfig=null;
     postStartData = startData;
   }catch(e){
-    const errMsg=String((e&&e.message)||'');
+    let err=e;
+    let errMsg=String((err&&err.message)||'');
+    if(pendingDecisionResolution&&err&&err.status===409&&/pending decision is not active/i.test(errMsg)){
+      if(_pendingDecisionSend===pendingDecisionResolution){
+        _pendingDecisionSend=null;
+        _clearClarifyPendingForSession(activeSid);
+        hideClarifyCard(true,'sent');
+      }
+      const staleDecisionNotice='That decision is no longer active. Sending your reply as a normal message.';
+      if(typeof setStatus==='function') setStatus(staleDecisionNotice);
+      try{
+        const retryModelState=modelStateForPostStart||_chatPayloadModelState();
+        const retryStartData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
+          session_id:activeSid,message:msgText,
+          model:retryModelState.model,workspace:S.session.workspace,
+          model_provider:retryModelState.model_provider,
+          profile:S.activeProfile||S.session.profile||'default',
+          explicit_model_pick:explicitPickForPostStart||undefined,
+          attachments:uploaded.length?uploaded:undefined,
+          moa_config:_pendingMoaConfig?true:undefined
+        })});
+        _pendingMoaConfig=null;
+        postStartData = retryStartData;
+        if(typeof showToast==='function') showToast(staleDecisionNotice, 2600);
+      }catch(retryErr){
+        err=retryErr;
+        errMsg=String((err&&err.message)||'');
+      }
+    }
+    if(postStartData){
+      // Retry recovered the stale pending-decision reply as a normal chat
+      // turn; continue into the normal post-start stream attach path below.
+    } else {
     // If /api/chat/start returns 404, the session was deleted server-side
     // (its sidecar is gone) while GET kept returning a CLI stub (#2782). Strip
     // the stale /session/<id> URL and clear localStorage so a reload does not
     // re-inject the dead id via _sessionIdFromLocation(), then reset to the
     // empty state instead of pushing a confusing error bubble into the chat.
-    if(e&&e.status===404){
+    if(err&&err.status===404){
       try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
       try{
         if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
@@ -1824,6 +1856,7 @@ async function send(){
     // Reconcile with server truth after immediately clearing the optimistic spinner.
     if(typeof renderSessionList==='function') void renderSessionList();
     return;
+    }
   }
 
   const startData = postStartData || {};

--- a/static/messages.js
+++ b/static/messages.js
@@ -1297,6 +1297,7 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
 }
 
 async function send(){
+  const pendingDecisionResolution = _pendingDecisionSend;
   // Static guards expect _defaultMessageMode to stay near send() while the actual
   // read remains in the S.busy branch below.
   // _defaultMessageMode
@@ -1746,8 +1747,15 @@ async function send(){
       profile:S.activeProfile||S.session.profile||'default',
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
-      moa_config:_pendingMoaConfig?true:undefined
+      moa_config:_pendingMoaConfig?true:undefined,
+      resolves_decision_id:pendingDecisionResolution&&pendingDecisionResolution.decision_id||undefined,
+      decision_option:pendingDecisionResolution&&pendingDecisionResolution.option||undefined
     })});
+    if(pendingDecisionResolution && _pendingDecisionSend===pendingDecisionResolution){
+      _pendingDecisionSend=null;
+      _clearClarifyPendingForSession(activeSid);
+      hideClarifyCard(true,'sent');
+    }
     _pendingMoaConfig=null;
     postStartData = startData;
   }catch(e){
@@ -7696,6 +7704,8 @@ let _clarifyMissingEndpointWarned = false;
 let _clarifyCountdownTimer = null;
 let _clarifyExpiresAt = 0;
 let _clarifyPendingBySession = new Map();
+let _clarifyDurableDecision = false;
+let _pendingDecisionSend = null;
 const CLARIFY_MIN_VISIBLE_MS = 30000;
 
 function _clarifyPromptBelongsToActiveSession(sid) {
@@ -7945,6 +7955,7 @@ function _resetClarifyCardState() {
   _clarifyVisibleSince = 0;
   _clarifySignature = '';
   _clarifyId = null;
+  _clarifyDurableDecision = false;
 }
 
 function hideClarifyCard(force=false, reason="dismissed") {
@@ -8024,6 +8035,7 @@ function showClarifyCard(pending) {
   const sameClarify = card.classList.contains("visible") && _clarifySignature === sig;
   _clarifySessionId = sid;
   _clarifyId = pending.clarify_id || null;
+  _clarifyDurableDecision = !!pending.durable_decision;
   _clarifySignature = sig;
   if (Number(pending.timeout_seconds) > 0) {
     _startClarifyCountdown(pending);
@@ -8090,7 +8102,7 @@ function showClarifyCard(pending) {
       }
     };
   }
-  if (typeof lockComposerForClarify === "function") {
+  if (!_clarifyDurableDecision && typeof lockComposerForClarify === "function") {
     lockComposerForClarify(question ? `Clarification needed: ${question}` : "Clarification needed");
   }
   _clarifySetControlsDisabled(false, false);
@@ -8119,6 +8131,18 @@ async function respondClarify(response) {
     return;
   }
   const clarifyId = _clarifyId;
+  if (_clarifyDurableDecision) {
+    _pendingDecisionSend = {decision_id: clarifyId, option: value};
+    const composer = $('msg');
+    if (composer) {
+      composer.value = value;
+      if (typeof autoResize === 'function') autoResize();
+      if (typeof updateSendBtn === 'function') updateSendBtn();
+    }
+    _clarifySetControlsDisabled(true, true);
+    await send();
+    return;
+  }
   // Keep a draft copy so we can restore the input on failure (issue #2639).
   const draft = value;
   _clarifySetControlsDisabled(true, true);
@@ -8253,7 +8277,12 @@ function _startClarifyFallbackPoll(sid) {
     try {
       const data = await api("/api/clarify/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false});
       if (data.pending) { showClarifyForSession(sid, data.pending); }
-      else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
+      else {
+        const decisions = await api("/api/pending-decisions?session_id=" + encodeURIComponent(sid),{timeoutToast:false});
+        const pendingDecision = Array.isArray(decisions.pending_decisions) ? decisions.pending_decisions[0] : null;
+        if (pendingDecision) showPendingDecisionCard(sid, pendingDecision);
+        else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
+      }
     } catch(e) {
       const msg = String((e && e.message) || "");
       // `api()` attaches the raw HTTP status on the thrown Error (err.status).
@@ -8322,6 +8351,17 @@ function _startClarifyFallbackPoll(sid) {
   };
   _clarifyFallbackTimer = setInterval(_tick, 3000);
   _tick();
+}
+
+function showPendingDecisionCard(sid, pending) {
+  if (!pending || !pending.decision_id) return;
+  showClarifyForSession(sid, {
+    durable_decision: true,
+    clarify_id: pending.decision_id,
+    question: pending.question || '',
+    choices_offered: Array.isArray(pending.options) ? pending.options : [],
+    _session_id: sid,
+  });
 }
 
 function stopClarifyPollingForSession(sid) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2257,6 +2257,7 @@ async function loadSession(sid){
       updateQueueBadge(sid);
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
+      if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
       // Workspace refresh is guarded by session id inside loadDir(); keep it
       // after the transcript's first paint so chat switching is not competing
       // with file-tree / git badge IO.

--- a/static/style.css
+++ b/static/style.css
@@ -2047,7 +2047,7 @@
   .approval-btn.deny:hover{background:rgba(239,83,80,.12);border-color:var(--error);}
   .approval-btn.loading{opacity:.7;cursor:wait;}
   /* ── Clarify card ── */
-  .clarify-card{position:absolute;left:0;right:0;bottom:-24px;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;max-height:clamp(180px,min(68vh,calc(100vh - 220px)),420px);}
+  .clarify-card{position:absolute;left:0;right:0;bottom:0;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;max-height:clamp(180px,min(68vh,calc(100vh - 220px)),420px);}
   .clarify-card.visible{pointer-events:auto;}
   .clarify-card .clarify-inner{max-height:clamp(180px,min(68vh,calc(100vh - 220px)),420px);overflow-y:auto;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;box-sizing:border-box;transform:translateY(100%);opacity:0;transition:transform .4s cubic-bezier(.32,.72,.16,1),opacity .25s ease,max-height .2s ease;}
   @supports (height:100dvh){.clarify-card,.clarify-card .clarify-inner{max-height:clamp(180px,min(68dvh,calc(100dvh - 220px)),420px);}}
@@ -3215,9 +3215,9 @@
     .approval-btn.yolo{grid-column:1 / -1;}
     .approval-kbd{display:none;}
     /* Clarify card */
-    .clarify-card{padding-left:10px;padding-right:10px;max-height:clamp(180px,min(62vh,calc(100vh - 180px)),360px);}
-    .clarify-card .clarify-inner{max-height:clamp(180px,min(62vh,calc(100vh - 180px)),360px);}
-    @supports (height:100dvh){.clarify-card,.clarify-card .clarify-inner{max-height:clamp(180px,min(62dvh,calc(100dvh - 180px)),360px);}}
+    .clarify-card{padding-left:10px;padding-right:10px;max-height:clamp(180px,min(68vh,calc(100vh - 180px)),420px);}
+    .clarify-card .clarify-inner{max-height:clamp(180px,min(68vh,calc(100vh - 180px)),420px);}
+    @supports (height:100dvh){.clarify-card,.clarify-card .clarify-inner{max-height:clamp(180px,min(68dvh,calc(100dvh - 180px)),420px);}}
     .clarify-inner{padding:12px 12px 13px;}
     .clarify-response{flex-direction:column;align-items:stretch;}
     .clarify-input,.clarify-submit{width:100%;min-height:44px;}

--- a/tests/test_issue2883_clarify_padding.py
+++ b/tests/test_issue2883_clarify_padding.py
@@ -44,3 +44,19 @@ def test_clarify_padding_remeasures_on_resize():
     assert "function_ensureClarifyResizeListener()" in compact_js
     assert 'window.addEventListener("resize"' in MESSAGES_JS
     assert "_ensureClarifyResizeListener();" in MESSAGES_JS
+
+
+def test_clarify_card_stays_above_composer_and_fits_mobile_controls():
+    compact_css = _compact(STYLE_CSS)
+
+    assert ".clarify-card{position:absolute;left:0;right:0;bottom:0;" in compact_css
+    assert (
+        ".clarify-card{padding-left:10px;padding-right:10px;"
+        "max-height:clamp(180px,min(68vh,calc(100vh-180px)),420px);"
+        in compact_css
+    )
+    assert (
+        ".clarify-card.clarify-inner{"
+        "max-height:clamp(180px,min(68vh,calc(100vh-180px)),420px);"
+        in compact_css
+    )

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -97,3 +98,55 @@ def test_idle_session_load_starts_durable_decision_polling() -> None:
     idle_start = source.index("    }else{\n      S.busy=false;", load_start)
     idle_end = source.index("_deferWorkspaceRefreshForSession(sid);", idle_start)
     assert "startClarifyPolling(sid)" in source[idle_start:idle_end]
+
+
+def _send_body() -> str:
+    source = Path("static/messages.js").read_text(encoding="utf-8")
+    start = source.index("async function send(")
+    end = source.index("\nconst LIVE_STREAMS={};", start)
+    return source[start:end]
+
+
+def test_stale_pending_decision_reply_retries_as_plain_chat_start() -> None:
+    body = _send_body()
+    assert body.count("api('/api/chat/start'") >= 2, (
+        "send() must retry /api/chat/start once when a stale pending decision "
+        "409 rejects a reply, so the user message is still delivered as a "
+        "normal chat turn."
+    )
+    stale_idx = body.find("if(pendingDecisionResolution&&err&&err.status===409&&/pending decision is not active/i.test(errMsg)){")
+    assert stale_idx >= 0, (
+        "send() must have a stale pending-decision recovery branch before the "
+        "404 self-heal branch."
+    )
+    branch = body[stale_idx: body.find("if(err&&err.status===404){", stale_idx)]
+    assert "_pendingDecisionSend=null;" in branch
+    assert "_clearClarifyPendingForSession(activeSid);" in branch
+    assert "hideClarifyCard(true,'sent');" in branch or 'hideClarifyCard(true, "sent")' in branch
+    assert "Sending your reply as a normal message" in branch
+
+
+def test_retry_chat_start_omits_decision_resolution_fields() -> None:
+    body = _send_body()
+    starts = [m.start() for m in re.finditer(r"api\('/api/chat/start'", body)]
+    assert len(starts) >= 2, "expected retry /api/chat/start call for stale pending decisions"
+    retry_window = body[starts[1]: starts[1] + 900]
+    assert "resolves_decision_id" not in retry_window, (
+        "the stale-decision retry must send the same user text without the "
+        "stale resolves_decision_id payload."
+    )
+    assert "decision_option" not in retry_window, (
+        "the stale-decision retry must omit decision_option so the backend "
+        "treats the reply as a normal chat turn."
+    )
+
+
+def test_chat_start_409_message_is_user_facing() -> None:
+    source = Path("api/routes.py").read_text(encoding="utf-8")
+    assert 'return bad(handler, "pending decision is not active", 409)' not in source, (
+        "the route must not leak the internal pending-decision wording back to "
+        "the user."
+    )
+    assert "decision is no longer active" in source, (
+        "the route should return a user-facing inactive-decision message."
+    )

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -89,3 +89,11 @@ def test_frontend_uses_normal_chat_start_without_timed_clarify() -> None:
     assert "/api/chat/start" in source
     assert "/api/clarify/respond" not in durable
     assert "lockComposerForClarify" not in durable
+
+
+def test_idle_session_load_starts_durable_decision_polling() -> None:
+    source = Path("static/sessions.js").read_text(encoding="utf-8")
+    load_start = source.index("async function loadSession")
+    idle_start = source.index("    }else{\n      S.busy=false;", load_start)
+    idle_end = source.index("_deferWorkspaceRefreshForSession(sid);", idle_start)
+    assert "startClarifyPolling(sid)" in source[idle_start:idle_end]

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from api.pending_decisions import (
+    create_pending_decision,
+    get_pending_decision,
+    list_pending_decisions,
+    mark_pending_decision_resolved,
+)
+
+
+def decision() -> dict:
+    return {
+        "schema_version": "superset-pending-decision/v2",
+        "decision_id": "decision-1",
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "question": "这个修改应该只影响当前图表，还是所有共享数据集的消费者？" * 8,
+        "options": ["target_local", "propagate_shared"],
+        "impact_summary": {"shared_consumers": [900]},
+        "state": "waiting_for_user",
+        "hmac_sha256": "opaque-pico-signature",
+    }
+
+
+def test_pending_decision_survives_reload_without_expiry(tmp_path: Path) -> None:
+    created = create_pending_decision(decision(), session_dir=tmp_path)
+    loaded = get_pending_decision("session-1", "decision-1", session_dir=tmp_path)
+    assert loaded == created
+    assert "expires_at" not in loaded
+    assert list_pending_decisions("session-1", session_dir=tmp_path) == [created]
+
+
+def test_resolution_uses_sidecar_and_preserves_pico_signed_artifact(tmp_path: Path) -> None:
+    create_pending_decision(decision(), session_dir=tmp_path)
+    original_path = tmp_path / "_pending_decisions" / "session-1" / "decision-1.json"
+    before = original_path.read_bytes()
+
+    resolved = mark_pending_decision_resolved(
+        "session-1",
+        "decision-1",
+        option="target_local",
+        event_id="evt-resolution-1",
+        turn_id="turn-2",
+        session_dir=tmp_path,
+    )
+
+    assert resolved["state"] == "resolved"
+    assert resolved["resolution"]["option"] == "target_local"
+    assert original_path.read_bytes() == before
+    assert list_pending_decisions("session-1", session_dir=tmp_path) == []
+
+
+def test_resolution_rejects_wrong_session_stale_or_unoffered_option(tmp_path: Path) -> None:
+    create_pending_decision(decision(), session_dir=tmp_path)
+    with pytest.raises(ValueError, match="offered"):
+        mark_pending_decision_resolved(
+            "session-1", "decision-1", option="everything", event_id="evt-1", turn_id="turn-2",
+            session_dir=tmp_path,
+        )
+    mark_pending_decision_resolved(
+        "session-1", "decision-1", option="target_local", event_id="evt-1", turn_id="turn-2",
+        session_dir=tmp_path,
+    )
+    with pytest.raises(ValueError, match="active"):
+        mark_pending_decision_resolved(
+            "session-1", "decision-1", option="target_local", event_id="evt-2", turn_id="turn-3",
+            session_dir=tmp_path,
+        )
+
+
+def test_contract_fixture_matches_shared_schema(tmp_path: Path) -> None:
+    fixture = json.loads(Path("docs/contracts/intent-authorization-pending-decision-v2.json").read_text())
+    assert fixture["schema_version"] == decision()["schema_version"]
+
+
+def test_frontend_uses_normal_chat_start_without_timed_clarify() -> None:
+    source = Path("static/messages.js").read_text(encoding="utf-8")
+    durable_start = source.index("function showPendingDecisionCard")
+    durable_end = source.index("function stopClarifyPollingForSession", durable_start)
+    durable = source[durable_start:durable_end]
+    assert "durable_decision" in durable
+    assert "resolves_decision_id" in source
+    assert "decision_option" in source
+    assert "/api/chat/start" in source
+    assert "/api/clarify/respond" not in durable
+    assert "lockComposerForClarify" not in durable

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 import api.turn_journal as turn_journal
 from api.session_recovery import audit_session_recovery
 from api.turn_journal import (
@@ -37,12 +39,28 @@ def test_append_turn_journal_event_fsyncs_jsonl_and_preserves_payload(tmp_path):
     assert event["version"] == 1
     assert event["session_id"] == "sid-1"
     assert event["created_at"] > 0
+    assert event["event_id"]
     journal_dir = tmp_path / "_turn_journal"
     shards = list(journal_dir.glob(f"sid-1~{os.getpid()}.jsonl"))
     assert len(shards) == 1, f"expected one pid-scoped shard, found: {list(journal_dir.iterdir())}"
     lines = shards[0].read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0])["content"] == "hello"
+
+
+def test_valid_caller_event_id_is_preserved_and_duplicate_is_rejected(tmp_path):
+    event = append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "event_id": "evt-stable-1", "turn_id": "turn-1", "content": "hello"},
+        session_dir=tmp_path,
+    )
+    assert event["event_id"] == "evt-stable-1"
+    with pytest.raises(ValueError, match="duplicate event_id"):
+        append_turn_journal_event(
+            "sid-1",
+            {"event": "submitted", "event_id": "evt-stable-1", "turn_id": "turn-2", "content": "again"},
+            session_dir=tmp_path,
+        )
 
 
 def test_read_turn_journal_tolerates_malformed_lines(tmp_path):

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -23,3 +23,12 @@ def test_chat_start_writes_turn_journal_after_session_lock_and_handles_failure()
     assert "append_turn_journal_event(" not in lock_block
     assert "except Exception:" in append_block
     assert "Failed to append submitted turn journal event" in append_block
+
+
+def test_pending_decision_resolution_is_durable_before_worker_start():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    append_idx = src.index("append_turn_journal_event(", src.index("def _start_chat_stream_for_session"))
+    resolve_idx = src.index("mark_pending_decision_resolved(", append_idx)
+    thread_idx = src.index("threading.Thread(", resolve_idx)
+    assert append_idx < resolve_idx < thread_idx
+    assert '"relation": "resolve_decision"' in src[append_idx:resolve_idx]


### PR DESCRIPTION
## Summary
- retry stale pending-decision replies as normal chat turns instead of dropping them behind a 409
- replace the raw inactive pending-decision wording with a user-facing message
- add regression coverage for stale decision recovery in WebUI

## Verification
- [x] .venv/bin/python -m pytest -q tests/test_pending_decisions.py
- [x] .venv/bin/python -m pytest -q tests/test_pending_decisions.py tests/test_clarify_unblock.py tests/test_4504_clarify_stuck_on_expiry.py tests/test_runtime_adapter_seam.py
- [x] python3 -m py_compile api/routes.py
- [x] node --check static/messages.js
