### PR TITLE
fix(insights): preserve period selector chevron

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -279,7 +279,7 @@
         </div>
       </div>
       <div class="panel-head-sub" style="padding:0 12px 8px">
-        <select id="insightsPeriod" onchange="loadInsights()" style="width:100%;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px">
+        <select id="insightsPeriod" class="insights-period-select" onchange="loadInsights()">
           <option value="7">7 days</option>
           <option value="30" selected>30 days</option>
           <option value="90">90 days</option>

--- a/static/style.css
+++ b/static/style.css
@@ -2231,6 +2231,7 @@
 .field-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:5px;opacity:.8;}
   select{width:100%;background:var(--input-bg);border:1px solid var(--border2);border-radius:8px;color:var(--text);padding:8px 28px 8px 10px;font-size:12px;outline:none;appearance:none;margin-bottom:6px;cursor:pointer;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238888aa' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 10px center;}
   select:focus{border-color:var(--accent);box-shadow:0 0 0 2px var(--accent-bg);}
+  .insights-period-select{border-radius:6px;padding:6px 28px 6px 10px;font-size:12px;margin-bottom:0;}
   optgroup{color:var(--muted);font-size:11px;font-weight:700;}
   option{background:var(--bg);color:var(--text);padding:6px;}
   .sidebar-actions{display:flex;gap:6px;}


### PR DESCRIPTION
# Pull Request Title

fix(insights): preserve period selector chevron affordance

# Pull Request Description

### Thinking Path
- The Insights period filter (`#insightsPeriod`) is a `<select>` element but was lacking visual affordance (a chevron) making it appear as a static label.
- The `background:` shorthand inline style on the element in `index.html` was resetting `background-image` to `none`, erasing the inline-SVG chevron inherited from the base `select` CSS rule.
- The inline `padding: 4px 8px` was also erasing the right padding (`28px`) needed to reserve space for the chevron.
- This PR moves the specific insights-period styling out of the inline style into a proper CSS class (`.insights-period-select`), preserving the base rule's chevron, width, color, and `appearance:none`.

### What Changed
- **`static/index.html`**: Replaced the inline `style` on `#insightsPeriod` with the `insights-period-select` class.
- **`static/style.css`**: Added `.insights-period-select` class to supply the precise layout deltas (tighter border radius, smaller padding, no bottom margin) while keeping the global `<select>` chevron inherited.

### Why It Matters
Users can now clearly see that the time period filter is an interactive dropdown (e.g. 7 days / 30 days / 90 days), rather than confusing it for a static label.

### Verification
- [x] Verified through automated DOM validation (`scratch_test.py`) that the `#insightsPeriod` element uses the `.insights-period-select` class.
- [x] Verified that `.insights-period-select` CSS is present and provides the correct right-padding (`28px`).
- [x] Verified that the base `select` chevron CSS rules (`background-image`, `appearance:none`) correctly apply.

### Risks / Follow-ups
None — this is a safe CSS scope change localized solely to the insights panel.