### PR TITLE
fix: bound oversized paginated message content

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8748,23 +8748,38 @@ def _renderable_content_preview_for_limited_payload(content):
     ]
     if not text_indexes:
         return None
-    original_chars = len("".join(content[index]["text"] for index in text_indexes).strip())
+    joined_text = "".join(content[index]["text"] for index in text_indexes)
+    original_chars = len(joined_text)
     if original_chars <= _LIMITED_RENDERABLE_CONTENT_MAX_CHARS:
         return None
 
-    remaining = preview_chars
-    last_text_index = text_indexes[-1]
+    # Match msgContent()'s visible-text semantics without letting leading/trailing
+    # whitespace consume the payload budget. Keep each surviving character in
+    # its original text block so interleaved non-text blocks retain their order.
+    visible_text = joined_text.strip()
+    bounded_visible_chars = min(len(visible_text), preview_chars)
+    visible_start = len(joined_text) - len(joined_text.lstrip())
+    visible_end = visible_start + bounded_visible_chars
     bounded_content = list(content)
+    cursor = 0
     for index in text_indexes:
         part = content[index]
-        clipped_part = dict(part)
         text = part["text"]
-        take = min(len(text), remaining)
-        clipped_part["text"] = text[:take]
-        remaining -= take
-        if index == last_text_index:
-            clipped_part["text"] += _LIMITED_RENDERABLE_CONTENT_NOTICE
+        part_start = cursor
+        part_end = cursor + len(text)
+        slice_start = max(part_start, visible_start)
+        slice_end = min(part_end, visible_end)
+        clipped_part = dict(part)
+        if slice_start < slice_end:
+            clipped_part["text"] = text[
+                slice_start - part_start : slice_end - part_start
+            ]
+        else:
+            clipped_part["text"] = ""
         bounded_content[index] = clipped_part
+        cursor = part_end
+    last_text_index = text_indexes[-1]
+    bounded_content[last_text_index]["text"] += _LIMITED_RENDERABLE_CONTENT_NOTICE
     return bounded_content, original_chars
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -8610,6 +8610,7 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
 
 
 _LIMITED_TOOL_CONTENT_MAX_CHARS = 4096
+_LIMITED_RENDERABLE_CONTENT_MAX_CHARS = 64 * 1024
 # Server-side ceiling on the ?msg_limit= tail-window size. A client could
 # otherwise request msg_limit=1000000 and force the server to assemble and
 # serialize an unbounded message payload (the frontend's own pagination grows
@@ -8682,6 +8683,10 @@ _LIMITED_TOOL_CONTENT_NOTICE = (
     "\n\n[Tool output truncated in paginated session response; "
     "load the full transcript to inspect the complete result.]"
 )
+_LIMITED_RENDERABLE_CONTENT_NOTICE = (
+    "\n\n[Message content truncated in paginated session response; "
+    "the complete content remains stored in the session.]"
+)
 
 
 def _tool_message_for_limited_payload(message):
@@ -8715,9 +8720,78 @@ def _tool_message_for_limited_payload(message):
     return clipped
 
 
+def _renderable_content_preview_for_limited_payload(content):
+    """Return ``(bounded_content, original_chars)`` for oversized display text."""
+    preview_chars = max(
+        0,
+        _LIMITED_RENDERABLE_CONTENT_MAX_CHARS - len(_LIMITED_RENDERABLE_CONTENT_NOTICE),
+    )
+    if isinstance(content, str):
+        original_chars = len(content)
+        if original_chars <= _LIMITED_RENDERABLE_CONTENT_MAX_CHARS:
+            return None
+        return content[:preview_chars] + _LIMITED_RENDERABLE_CONTENT_NOTICE, original_chars
+
+    if not isinstance(content, list):
+        # msgContent() renders top-level objects only as "[object Object]".
+        # Keep their structure untouched rather than projecting fields into text.
+        return None
+
+    text_indexes = [
+        index
+        for index, part in enumerate(content)
+        if (
+            isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+        )
+    ]
+    if not text_indexes:
+        return None
+    original_chars = len("".join(content[index]["text"] for index in text_indexes).strip())
+    if original_chars <= _LIMITED_RENDERABLE_CONTENT_MAX_CHARS:
+        return None
+
+    remaining = preview_chars
+    last_text_index = text_indexes[-1]
+    bounded_content = list(content)
+    for index in text_indexes:
+        part = content[index]
+        clipped_part = dict(part)
+        text = part["text"]
+        take = min(len(text), remaining)
+        clipped_part["text"] = text[:take]
+        remaining -= take
+        if index == last_text_index:
+            clipped_part["text"] += _LIMITED_RENDERABLE_CONTENT_NOTICE
+        bounded_content[index] = clipped_part
+    return bounded_content, original_chars
+
+
+def _renderable_message_for_limited_payload(message):
+    """Return a bounded copy of oversized user/assistant content for display loads."""
+    if not isinstance(message, dict):
+        return message
+    role = str(message.get("role") or "").strip().lower()
+    if role not in ("user", "assistant"):
+        return message
+    bounded = _renderable_content_preview_for_limited_payload(message.get("content"))
+    if bounded is None:
+        return message
+    bounded_content, original_chars = bounded
+    clipped = dict(message)
+    clipped["content"] = bounded_content
+    clipped["_content_truncated"] = True
+    clipped["_content_original_chars"] = original_chars
+    return clipped
+
+
 def _messages_for_limited_payload(messages) -> list:
-    """Bound hidden tool-result payloads before sending a msg_limit response."""
-    return [_tool_message_for_limited_payload(msg) for msg in list(messages or [])]
+    """Bound oversized display content before sending a msg_limit response."""
+    return [
+        _renderable_message_for_limited_payload(_tool_message_for_limited_payload(msg))
+        for msg in list(messages or [])
+    ]
 
 
 def _limited_webui_messages_for_display(session, state_db_messages) -> list:
@@ -13055,22 +13129,33 @@ def handle_get(handler, parsed) -> bool:
             if synth is None:
                 # 'no_foreign_state' / 'invalid_sid' — nothing to render.
                 return bad(handler, "Session not found", 404)
-            # Build the legacy dict response from the synthesized Session so
-            # the wire shape stays byte-equivalent to the previous inline
-            # synthesis (the frontend has been reading these exact keys).
-            msgs = list(synth.messages or [])
+            # Build the legacy dict response from the synthesized Session while
+            # applying the same display window as the ordinary sidecar path.
+            all_msgs = list(synth.messages or [])
+            if load_messages:
+                msgs, messages_offset = _message_window_for_display(
+                    all_msgs,
+                    msg_limit=msg_limit,
+                    msg_before=msg_before,
+                    expand_renderable=expand_renderable,
+                )
+                if msg_limit is not None:
+                    msgs = _messages_for_limited_payload(msgs)
+            else:
+                msgs = []
+                messages_offset = 0
             sess = {
                 "session_id": synth.session_id,
                 "title": synth.title,
                 "workspace": synth.workspace,
                 "model": synth.model,
-                "message_count": len(msgs),
+                "message_count": len(all_msgs),
                 "created_at": synth.created_at,
                 "updated_at": synth.updated_at,
                 "last_message_at": (
                     (cli_meta or {}).get("last_message_at")
                     or (cli_meta or {}).get("updated_at", 0)
-                    or ((msgs or [{}])[-1].get("timestamp", 0))
+                    or ((all_msgs or [{}])[-1].get("timestamp", 0))
                 ),
                 "pinned": bool(getattr(synth, "pinned", False)),
                 "archived": bool(getattr(synth, "archived", False)),
@@ -13100,8 +13185,13 @@ def handle_get(handler, parsed) -> bool:
                 "read_only": bool(getattr(synth, "read_only", False)),
                 "messages": msgs,
                 "tool_calls": [],
+                "_messages_truncated": (
+                    load_messages and msg_limit is not None and messages_offset > 0
+                ),
+                "_messages_offset": messages_offset,
+                "_msg_limit_max": _MAX_MSG_LIMIT,
             }
-            attach_todo_state(sess, msgs)
+            attach_todo_state(sess, all_msgs)
             sess = _merge_cli_sidebar_metadata(sess, cli_meta)
             return j(handler, {"session": redact_session_data(sess)})
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3827,7 +3827,9 @@ async function _loadOlderMessages() {
 //   2. Bump _messagesGeneration before mutating S.messages so any
 //      in-flight prefetch's post-await generation check bails out.
 async function _ensureAllMessagesLoaded() {
-  if (!_messagesTruncated || !S.session) return;
+  const hasContentTruncatedMessage=()=>
+    (S.messages||[]).some(message=>message&&message._content_truncated===true);
+  if ((!_messagesTruncated&&!hasContentTruncatedMessage()) || !S.session) return;
   if (_loadingOlder) {
     // A prefetch is mid-flight (between the `_loadingOlder = true` line
     // and its post-await guards). Bumping the generation token now
@@ -3840,7 +3842,7 @@ async function _ensureAllMessagesLoaded() {
     while (_loadingOlder) {
       await new Promise(resolve => setTimeout(resolve, 16));
     }
-    if (!_messagesTruncated || !S.session) return;
+    if ((!_messagesTruncated&&!hasContentTruncatedMessage()) || !S.session) return;
   }
   _loadingOlder = true;
   try {

--- a/static/ui.js
+++ b/static/ui.js
@@ -18518,12 +18518,25 @@ function ensureLiveWorklogShell(){
 
 // ── Edit + Regenerate ──
 
-function editMessage(btn) {
-  if(S.busy) return;
-  const row = btn.closest('[data-msg-idx]');
+async function editMessage(btn) {
+  if(S.busy||!S.session) return;
+  let row=btn.closest('[data-msg-idx]');
   if(!row) return;
-  const msgIdx = parseInt(row.dataset.msgIdx, 10);
-  const originalText = row.dataset.rawText || '';
+  let msgIdx=parseInt(row.dataset.msgIdx,10);
+  const initialSid=S.session.session_id;
+  const absoluteMsgIdx=_oldestIdx+msgIdx;
+  const displayedMessage=S.messages[msgIdx];
+  if(displayedMessage&&displayedMessage._content_truncated===true){
+    if(typeof _ensureAllMessagesLoaded!=='function') return;
+    await _ensureAllMessagesLoaded();
+    if(!S.session||S.session.session_id!==initialSid) return;
+    renderMessages();
+    msgIdx=absoluteMsgIdx;
+    row=document.querySelector(`[data-msg-idx="${msgIdx}"]`);
+    if(!row) return;
+  }
+  const authoritativeMessage=S.messages[msgIdx];
+  const originalText=authoritativeMessage?msgContent(authoritativeMessage):(row.dataset.rawText||'');
   const body = row.querySelector('.msg-body');
   if(!body || row.dataset.editing) return;
   row.dataset.editing = '1';
@@ -18610,16 +18623,17 @@ async function regenerateResponse(btn) {
   const assistantIdx = parseInt(row.dataset.msgIdx, 10);
   const absoluteKeepCount = _oldestIdx + assistantIdx;
   const initialSid = S.session.session_id;
-  let lastUserText = '';
-  for(let i = assistantIdx - 1; i >= 0; i--) {
-    const m = S.messages[i];
-    if(m && m.role === 'user') { lastUserText = msgContent(m); break; }
-  }
-  if(!lastUserText) return;
   if(typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
+  let lastUserText = '';
+  const lastUserSearchStart=Math.min(absoluteKeepCount-1,S.messages.length-1);
+  for(let i=lastUserSearchStart;i>=0;i--){
+    const m=S.messages[i];
+    if(m&&m.role==='user'){ lastUserText=msgContent(m); break; }
+  }
+  if(!lastUserText) return;
   try {
     await api('/api/session/truncate', {method:'POST', body:JSON.stringify({
       session_id: initialSid,

--- a/tests/test_limited_session_content_actions.py
+++ b/tests/test_limited_session_content_actions.py
@@ -1,0 +1,211 @@
+"""Regression coverage for clipped paginated session content actions.
+
+The paginated session API may return a display-only preview marked with
+``_content_truncated``. Frontend actions that can mutate durable session state
+must first replace those previews with the authoritative full transcript.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_JS = REPO / "static" / "sessions.js"
+UI_JS = REPO / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER = r"""
+const fs = require('fs');
+const sessions = fs.readFileSync(process.argv[1], 'utf8');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+const scenario = process.argv[3];
+
+function sliceBetween(src, startNeedle, endNeedle) {
+  const start = src.indexOf(startNeedle);
+  if (start < 0) throw new Error('start not found: ' + startNeedle);
+  const end = src.indexOf(endNeedle, start);
+  if (end < 0) throw new Error('end not found: ' + endNeedle);
+  return src.slice(start, end);
+}
+
+(async () => {
+  if (scenario === 'ensure') {
+    const fnSrc = sliceBetween(
+      sessions,
+      'async function _ensureAllMessagesLoaded()',
+      '\n\nconst SESSION_ARCHIVED_PAGE_SIZE'
+    );
+    let apiCalls = 0;
+    let _messagesTruncated = false;
+    let _loadingOlder = false;
+    let _loadingSessionId = null;
+    let _oldestIdx = 0;
+    let _messagesGeneration = 0;
+    const S = {
+      session: {session_id: 's1'},
+      messages: [{role: 'user', content: 'PREVIEW', _content_truncated: true}],
+    };
+    const window = {};
+    function _bumpMessagesGeneration(){ _messagesGeneration += 1; }
+    function _syncToolCallsForLoadedMessages(){}
+    async function api(url) {
+      apiCalls += 1;
+      if (url.includes('msg_limit=')) throw new Error('full reload must not use msg_limit');
+      return {session: {
+        messages: [{role: 'user', content: 'FULL-ORIGINAL'}],
+        message_count: 1,
+        tool_calls: [],
+      }};
+    }
+    eval(fnSrc);
+    await _ensureAllMessagesLoaded();
+    process.stdout.write(JSON.stringify({
+      apiCalls,
+      content: S.messages[0].content,
+      marker: Boolean(S.messages[0]._content_truncated),
+      oldestIdx: _oldestIdx,
+    }));
+    return;
+  }
+
+  if (scenario === 'regenerate') {
+    const fnSrc = sliceBetween(
+      ui,
+      'async function regenerateResponse(',
+      '\n\n// postProcessRenderedMessages()'
+    );
+    const S = {
+      busy: false,
+      session: {session_id: 's1'},
+      messages: [
+        {role: 'user', content: 'PREVIEW', _content_truncated: true},
+        {role: 'assistant', content: 'answer'},
+      ],
+    };
+    let _oldestIdx = 0;
+    let composer = {value: ''};
+    let sentText = null;
+    let truncateBody = null;
+    const btn = {closest(){ return {dataset: {msgIdx: '1'}}; }};
+    function msgContent(m){ return String((m && m.content) || ''); }
+    async function _ensureAllMessagesLoaded(){
+      S.messages = [
+        {role: 'user', content: 'FULL-ORIGINAL'},
+        {role: 'assistant', content: 'answer'},
+      ];
+    }
+    async function api(_url, options){ truncateBody = JSON.parse(options.body); }
+    function renderMessages(){}
+    function $(id){ if (id !== 'msg') throw new Error('unexpected element'); return composer; }
+    async function send(){ sentText = composer.value; }
+    function setStatus(){}
+    function t(key){ return key; }
+    eval(fnSrc);
+    await regenerateResponse(btn);
+    process.stdout.write(JSON.stringify({sentText, truncateBody}));
+    return;
+  }
+
+  if (scenario === 'edit') {
+    let start = ui.indexOf('async function editMessage(');
+    if (start < 0) start = ui.indexOf('function editMessage(');
+    if (start < 0) throw new Error('editMessage not found');
+    const end = ui.indexOf('\n\nfunction cancelEdit(', start);
+    if (end < 0) throw new Error('editMessage end not found');
+    const fnSrc = ui.slice(start, end);
+    const S = {
+      busy: false,
+      session: {session_id: 's1'},
+      messages: [{role: 'user', content: 'PREVIEW', _content_truncated: true}],
+    };
+    let _oldestIdx = 0;
+    let ensureCalls = 0;
+    let textarea = null;
+    const body = {replaceWith(){}};
+    function makeRow(rawText) {
+      return {
+        dataset: {msgIdx: '0', rawText},
+        querySelector(selector) {
+          if (selector === '.msg-body') return body;
+          return null;
+        },
+      };
+    }
+    const initialRow = makeRow('PREVIEW');
+    const refreshedRow = makeRow('FULL-ORIGINAL');
+    const btn = {closest(){ return initialRow; }};
+    const document = {
+      querySelector(){ return refreshedRow; },
+      createElement(tag) {
+        if (tag === 'textarea') {
+          textarea = {
+            className: '', value: '', style: {}, scrollHeight: 0,
+            addEventListener(){}, after(){}, focus(){}, setSelectionRange(){},
+          };
+          return textarea;
+        }
+        return {
+          className: '', innerHTML: '', remove(){},
+          querySelector(){ return {}; },
+        };
+      },
+    };
+    function msgContent(m){ return String((m && m.content) || ''); }
+    async function _ensureAllMessagesLoaded(){
+      ensureCalls += 1;
+      S.messages = [{role: 'user', content: 'FULL-ORIGINAL'}];
+    }
+    function renderMessages(){}
+    function requestAnimationFrame(cb){ cb(); }
+    function autoResizeTextarea(){}
+    async function submitEdit(){}
+    eval(fnSrc);
+    await editMessage(btn);
+    process.stdout.write(JSON.stringify({ensureCalls, value: textarea && textarea.value}));
+    return;
+  }
+
+  throw new Error('unknown scenario: ' + scenario);
+})().catch(err => { console.error(err.stack || err); process.exit(1); });
+"""
+
+
+def _run(scenario: str) -> dict:
+    assert NODE is not None
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(SESSIONS_JS), str(UI_JS), scenario],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"node driver failed: {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def test_ensure_all_messages_reloads_content_truncated_preview_without_row_truncation():
+    result = _run("ensure")
+
+    assert result == {
+        "apiCalls": 1,
+        "content": "FULL-ORIGINAL",
+        "marker": False,
+        "oldestIdx": 0,
+    }
+
+
+def test_regenerate_reads_last_user_text_after_authoritative_full_reload():
+    result = _run("regenerate")
+
+    assert result["sentText"] == "FULL-ORIGINAL"
+    assert result["truncateBody"] == {"session_id": "s1", "keep_count": 1}
+
+
+def test_edit_loads_authoritative_content_before_populating_textarea():
+    result = _run("edit")
+
+    assert result == {"ensureCalls": 1, "value": "FULL-ORIGINAL"}

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -434,6 +434,57 @@ def test_structured_preview_does_not_expose_non_text_blocks():
     assert "HIDDEN_RAW_PART" not in preview
 
 
+def test_structured_preview_bounds_large_leading_whitespace_and_keeps_visible_text():
+    huge_content = [{"type": "text", "text": (" " * 100_000) + "answer"}]
+    session = _FakeSession([
+        {"role": "assistant", "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    message = payload["messages"][0]
+    preview = "".join(
+        part["text"]
+        for part in message["content"]
+        if isinstance(part, dict) and part.get("type") == "text"
+    ).strip()
+    assert message["_content_truncated"] is True
+    assert message["_content_original_chars"] == len(huge_content[0]["text"])
+    assert len(preview) <= 64 * 1024
+    assert preview.startswith("answer")
+    assert "Message content truncated" in preview
+
+
+def test_structured_preview_does_not_spend_visible_budget_on_whitespace_only_block():
+    huge_content = [
+        {"type": "text", "text": " " * 70_000},
+        {"type": "thinking", "text": "HIDDEN_THOUGHT"},
+        {"type": "text", "text": "ANSWER" + ("x" * 70_000)},
+    ]
+    session = _FakeSession([
+        {"role": "assistant", "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    bounded_content = payload["messages"][0]["content"]
+    preview = "".join(
+        part["text"]
+        for part in bounded_content
+        if isinstance(part, dict) and part.get("type") == "text"
+    ).strip()
+    assert len(preview) <= 64 * 1024
+    assert preview.startswith("ANSWER")
+    assert "Message content truncated" in preview
+    assert bounded_content[1] == huge_content[1]
+
+
 def test_structured_preview_does_not_expose_top_level_dict_text():
     secret = "DICT_SECRET" * 10_000
     huge_content = {"type": "text", "text": secret}

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from urllib.parse import urlparse
 
+import pytest
+
 
 class _FakeSession:
     def __init__(self, messages):
@@ -26,6 +28,15 @@ class _FakeSession:
         self.pending_attachments = []
         self.pending_started_at = None
         self.composer_draft = {}
+        self.created_at = 1
+        self.updated_at = 2
+        self.profile = "default"
+        self.is_cli_session = True
+        self.source_tag = "cli"
+        self.raw_source = "cli"
+        self.session_source = "cli"
+        self.source_label = "CLI"
+        self.read_only = False
 
     def compact(self):
         return {
@@ -61,6 +72,28 @@ def _invoke(session, query=None):
          patch("api.routes._clear_stale_stream_state", return_value=False), \
          patch("api.routes._lookup_cli_session_metadata", return_value={}), \
          patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes.redact_session_data", side_effect=lambda raw: raw), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(), parsed)
+    return captured["data"]["session"]
+
+
+def _invoke_synthesized(session, query):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    parsed = urlparse(f"/api/session?{query}")
+    with patch("api.routes.get_session", side_effect=KeyError), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={"profile": "default"}), \
+         patch("api.routes._session_visible_to_active_profile", return_value=True), \
+         patch("api.routes._claim_or_synthesize_cli_session", return_value=(session, "materialized")), \
+         patch("api.routes._merge_cli_sidebar_metadata", side_effect=lambda raw, _meta: raw), \
          patch("api.routes.redact_session_data", side_effect=lambda raw: raw), \
          patch("api.routes.j", side_effect=fake_j):
         routes.handle_get(SimpleNamespace(), parsed)
@@ -277,3 +310,182 @@ def test_msg_limit_tail_preserves_list_tool_content_type_when_truncated():
     assert not isinstance(tool_msg["content"], str)
     assert tool_msg["content"][0]["type"] == "text"
     assert "Tool output truncated" in tool_msg["content"][0]["text"]
+
+
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_msg_limit_tail_truncates_oversized_renderable_text_without_mutating_session(role):
+    # Matches the measured shape that made WKWebView spin at 100% CPU: one
+    # multi-megabyte historical text row inside an otherwise paginated load.
+    huge_content = "x" * 5_378_133
+    session = _FakeSession([
+        {"role": role, "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    message = payload["messages"][0]
+    assert message["role"] == role
+    assert message["_content_truncated"] is True
+    assert message["_content_original_chars"] == len(huge_content)
+    assert len(message["content"]) < len(huge_content)
+    assert "Message content truncated" in message["content"]
+    assert session.messages[0]["content"] == huge_content
+
+
+@pytest.mark.parametrize(
+    "huge_content",
+    [
+        "x" * 100_000,
+        [{"type": "text", "text": "x" * 100_000}],
+        {"type": "text", "text": "x" * 100_000},
+    ],
+    ids=["string", "text-block-list", "top-level-dict"],
+)
+def test_full_load_preserves_oversized_renderable_content(huge_content):
+    session = _FakeSession([
+        {"role": "user", "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0",
+    )
+
+    assert payload["messages"][0]["content"] == huge_content
+    assert "_content_truncated" not in payload["messages"][0]
+
+
+def test_msg_limit_tail_reserves_notice_space_inside_renderable_content_limit():
+    content = "x" * ((64 * 1024) + 1)
+    session = _FakeSession([
+        {"role": "user", "content": content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    bounded = payload["messages"][0]["content"]
+    assert len(bounded) <= 64 * 1024
+    assert len(bounded) < len(content)
+    assert "Message content truncated" in bounded
+
+
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_msg_limit_tail_truncates_oversized_structured_renderable_content(role):
+    huge_content = [{"type": "text", "text": "x" * 5_378_133}]
+    session = _FakeSession([
+        {"role": role, "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    message = payload["messages"][0]
+    assert message["_content_truncated"] is True
+    assert isinstance(message["content"], list)
+    visible_text = "".join(
+        part["text"]
+        for part in message["content"]
+        if isinstance(part, dict) and part.get("type") == "text"
+    ).strip()
+    assert len(visible_text) <= 64 * 1024
+    assert "Message content truncated" in visible_text
+    assert session.messages[0]["content"] == huge_content
+
+
+def test_structured_preview_does_not_expose_non_text_blocks():
+    huge_content = [
+        {"type": "thinking", "text": "HIDDEN_THOUGHT"},
+        {"type": "text", "text": "visible answer" + "x" * 100_000},
+        {"type": "tool_use", "id": "call-1", "name": "example", "text": "HIDDEN_TOOL_INPUT"},
+        {"type": "text", "text": "continued"},
+        "HIDDEN_RAW_PART",
+    ]
+    session = _FakeSession([
+        {"role": "assistant", "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    bounded_content = payload["messages"][0]["content"]
+    assert isinstance(bounded_content, list)
+    assert bounded_content[0] == huge_content[0]
+    assert bounded_content[2] == huge_content[2]
+    assert bounded_content[4] == huge_content[4]
+    preview = "".join(
+        part["text"]
+        for part in bounded_content
+        if isinstance(part, dict) and part.get("type") == "text"
+    ).strip()
+    assert preview.startswith("visible answer")
+    assert "Message content truncated" in preview
+    assert "HIDDEN_THOUGHT" not in preview
+    assert "HIDDEN_TOOL_INPUT" not in preview
+    assert "HIDDEN_RAW_PART" not in preview
+
+
+def test_structured_preview_does_not_expose_top_level_dict_text():
+    secret = "DICT_SECRET" * 10_000
+    huge_content = {"type": "text", "text": secret}
+    session = _FakeSession([
+        {"role": "assistant", "content": huge_content},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    message = payload["messages"][0]
+    assert isinstance(message["content"], dict)
+    assert message["content"] == huge_content
+    assert "_content_truncated" not in message
+    assert session.messages[0]["content"] == huge_content
+
+
+def test_synthesized_session_msg_limit_uses_window_and_renderable_guard():
+    huge_content = "x" * 100_000
+    session = _FakeSession([
+        {"role": "user", "content": "older"},
+        {"role": "user", "content": huge_content},
+    ])
+
+    payload = _invoke_synthesized(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1",
+    )
+
+    assert payload["message_count"] == 2
+    assert payload["_messages_truncated"] is True
+    assert payload["_messages_offset"] == 1
+    assert len(payload["messages"]) == 1
+    message = payload["messages"][0]
+    assert len(message["content"]) == 64 * 1024
+    assert message["_content_truncated"] is True
+    assert "Message content truncated" in message["content"]
+    assert session.messages[1]["content"] == huge_content
+
+
+def test_synthesized_session_full_load_preserves_oversized_content():
+    huge_content = "x" * 100_000
+    session = _FakeSession([
+        {"role": "user", "content": huge_content},
+    ])
+
+    payload = _invoke_synthesized(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0",
+    )
+
+    assert payload["messages"][0]["content"] == huge_content
+    assert "_content_truncated" not in payload["messages"][0]


### PR DESCRIPTION
## Thinking Path

- Paginated `GET /api/session` responses already bound oversized hidden `role:"tool"` rows, but equally large `user` or `assistant` rows still passed through unchanged.
- A real restored session contained one historical user string of roughly 5.38 million characters. The API returned successfully, but native WKWebView remained stuck on `Loading conversation...` while its WebContent process consumed sustained CPU.
- The narrow boundary is the existing paginated-display payload helper: bound only the copied response rows after the visible window is selected, without changing storage, full-history retrieval, export, or model context.
- Structured content must retain the frontend's current visibility semantics: only `type:"text"` blocks count toward visible text, while hidden reasoning/tool/raw blocks are never projected into a new preview.

## What Changed

- Added a 64 KiB visible-content ceiling for oversized `user` and `assistant` rows in paginated session responses.
- Reused the existing `_content_truncated` and `_content_original_chars` response metadata.
- Kept the existing tool-result limiter intact and composed both guards at the existing `_messages_for_limited_payload(...)` chokepoint.
- Preserved source messages through shallow copied rows and copied structured text blocks.
- Left bare/no-`msg_limit` full-session retrieval exact and unchanged.
- Made full-history loading also recognize clipped-content markers, so edit and regenerate actions recover authoritative text before mutating durable session state.
- Added regression coverage for user and assistant strings, structured text-block lists, the `limit + 1` boundary, source immutability, hidden-block privacy, top-level object semantics, full-load preservation, and edit/regenerate safety.

## Why It Matters

One oversized historical renderable row could turn an otherwise bounded tail request into a multi-megabyte initial render and permanently stall WKWebView. The guard keeps paginated display payloads renderable while preserving the complete transcript as the source of truth.

## Verification

- RED on current `origin/master`: the new regressions failed because paginated user/assistant content remained unbounded.
- GREEN on this branch after rebasing to current `origin/master`:
  - Backend payload, frontend action/race, branching, and neighboring regression suite: **219 passed**.
- `.venv/bin/python -m py_compile api/routes.py tests/test_session_tail_payload.py` passed.
- `git diff --check` passed.
- Ruff passes for the changed test files; pre-existing `api/routes.py` findings are outside this patch.
- Static added-line scan found no real credential, shell-injection, eval/exec, or unsafe-deserialization issue. The only secret-pattern match is the synthetic `DICT_SECRET` privacy-test sentinel.
- Real patched-response check, without printing message bodies:
  - 54 returned rows, approximately 508 KB serialized response.
  - Largest display row reduced from 5,378,015 to exactly 65,536 characters.
  - Full source retrieval remained exact.
- Native Hermes Agent 1.7.3 on macOS 15.7.7 loaded the previously blocked 302-message session instead of remaining on `Loading conversation...`.

## Risks / Follow-ups

- This is a display-payload guard, not a storage or model-context truncation mechanism.
- Bare/no-`msg_limit` callers intentionally continue to receive the full transcript.
- Top-level objects are left structurally unchanged because the current frontend renders them only as an object placeholder; projecting arbitrary fields such as `text` could disclose content that was not previously visible.
- A separate long-session renderer issue remains: in a controlled 120-second idle measurement after restart, the attributed WebContent process stayed at 60.2–62.1% CPU (60.6% mean) while backend health remained `ok` with zero active runs and streams. This PR fixes the permanent oversized-row loading failure; it does **not** claim to fix that residual CPU loop. The open upstream PR #6668 addresses a distinct virtual-measurement retry-loop mechanism and may be relevant to that follow-up: https://github.com/nesquena/hermes-webui/pull/6668
- Related native-app report: https://github.com/hermes-webui/hermes-swift-mac/issues/95

## Contract Routing

Task type: focused paginated-session display safety fix.

Touched areas:
- `api/routes.py`: copied response shaping for `GET /api/session` when `msg_limit` is present.
- `static/sessions.js`: authoritative full-history reload when a display row carries `_content_truncated`.
- `static/ui.js`: edit/regenerate actions resolve full text before destructive session operations.
- `tests/test_session_tail_payload.py`: observable response, privacy, immutability, and full-load invariants.
- `tests/test_limited_session_content_actions.py`: clipped-preview action safety.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/GUIDELINES.md`
- `docs/CONTRACTS.md`

Scope boundaries:
- No persisted session mutation.
- No export or model-context change.
- No visual-layout or control-surface change.
- No new dependency or build step.

Evidence needed before claiming done:
- RED/GREEN regression proof, neighboring tests, real response-size verification, native-app loading verification, and explicit residual-CPU disclosure.

## Release Note

Prevent oversized user or assistant messages from blocking paginated session rendering while preserving complete session history.

## Model Used

AI-assisted with OpenAI GPT-5.6 SOL through Hermes Agent. Notable tools: repository tests and Git inspection, native macOS/WebKit process measurement, live API shape checks without message-body disclosure, and independent fail-closed code review.
