### PR TITLE
fix: classify Matrix gateway sessions as messaging

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -47,6 +47,7 @@ MESSAGING_SOURCES = {
     'slack',
     'telegram',
     'weixin',
+    'matrix',
 }
 
 CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
@@ -68,6 +69,7 @@ SOURCE_LABELS = {
     'webhook': 'Webhook',
     'webui': 'WebUI',
     'weixin': 'Weixin',
+    'matrix': 'Matrix',
 }
 
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2390,7 +2390,7 @@ const _HANDOFF_THRESHOLD = 10;  // conversation rounds
 const _HANDOFF_STORAGE_PREFIX = 'handoff:';
 const _HANDOFF_SUFFIX_DISMISSED_AT = 'dismissed_at';
 const _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT = 'summary_handled_at';
-const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback']);
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback', 'matrix']);
 const _MESSAGING_SOURCE_LABELS = {
   weixin: 'WeChat',
   telegram: 'Telegram',
@@ -2399,6 +2399,7 @@ const _MESSAGING_SOURCE_LABELS = {
   email: 'Email',
   wecom: 'WeCom',
   wecom_callback: 'WeCom Callback',
+  matrix: 'Matrix',
 };
 
 function _isMessagingSession(session) {

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1019,6 +1019,7 @@ def test_agent_session_source_normalization_contract():
         'telegram': ('messaging', 'Telegram'),
         'discord': ('messaging', 'Discord'),
         'slack': ('messaging', 'Slack'),
+        'matrix': ('messaging', 'Matrix'),
         'cron': ('cron', 'Cron'),
         'webhook': ('webhook', 'Webhook'),
         'tool': ('tool', 'Tool'),
@@ -1044,16 +1045,17 @@ def test_sessions_js_treats_email_as_messaging_source():
     raw_section = src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
     label_section = src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
 
-    for raw_source in ("email", "wecom", "wecom_callback"):
+    for raw_source in ("email", "wecom", "wecom_callback", "matrix"):
         assert f"'{raw_source}'" in raw_section, f"Missing raw source {raw_source!r} in _MESSAGING_RAW_SOURCES"
 
     assert "email: 'Email'" in label_section
     assert "wecom: 'WeCom'" in label_section
     assert "wecom_callback: 'WeCom Callback'" in label_section
+    assert "matrix: 'Matrix'" in label_section
 
 
-def test_sessions_js_treats_wecom_sidecars_as_messaging_behaviorally():
-    """Stale WeCom sidecars with session_source=other should still route as messaging."""
+def test_sessions_js_treats_messaging_sidecars_behaviorally():
+    """Stale messaging sidecars with session_source=other should still route as messaging."""
     src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
     start = src.index("const _MESSAGING_RAW_SOURCES")
     end = src.index("/**", start)
@@ -1064,6 +1066,7 @@ const cases = [
   {{ session_source: 'other', source: 'wecom' }},
   {{ session_source: 'other', raw_source: 'wecom_callback' }},
   {{ session_source: 'other', source_tag: 'wecom' }},
+  {{ session_source: 'other', source: 'matrix' }},
   {{ session_source: 'messaging', source: 'anything' }},
 ];
 for (const c of cases) {{


### PR DESCRIPTION
## Thinking Path

- WebUI buckets gateway sessions by source. `matrix` is missing from the messaging lists, so Matrix sessions fall through to `other`.
- Same bug was fixed for WeCom in #3653 and email in #2457. This adds `matrix` the same way.

Note: I use the WebUI in browsers and through the Hermex iOS app.

## What Changed

- `matrix` added to `MESSAGING_SOURCES` and `SOURCE_LABELS` in `api/agent_sessions.py`.
- `matrix` added to `_MESSAGING_RAW_SOURCES` and `_MESSAGING_SOURCE_LABELS` in `static/sessions.js`.
- Tests: matrix cases in the normalization contract test and the sessions.js checks; the WeCom sidecar test renamed to cover messaging sidecars generally.

## Why It Matters

- Matrix sessions get the same messaging treatment as the other chat platforms. No gateway or schema changes.

## Verification

- `./scripts/test.sh tests/test_gateway_sync.py tests/test_issue3586_cli_session_source_label.py tests/test_issue3603_external_session_import_gate.py -q` — 78 passed. The three touched tests failed before the fix for the right reason: matrix normalized to `other`, `matrix` missing from both JS lists.
- `node --check static/sessions.js` and `git diff --check` — clean.
- Not verified against a live Matrix gateway; the change mirrors the accepted WeCom and email fixes.

## Risks / Follow-ups

- Messaging sources are listed by hand in two files; deriving them from the agent's platform enum would remove that. Same note as #3653.

## Contract Routing

- Bug fix in session source classification. Touches only the two source lists and their tests. Docs read: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`.

## Model Used

- AI-assisted: Kimi v3 (Moonshot AI) via Kimi Code CLI. A human reviewed the diff and this description.

Refs #3622, #3653, #2457.

Release note: Matrix gateway sessions now classify as messaging and get a Matrix label in the sidebar.
