### PR TITLE
fix(models): drop stale Codex fallback entries

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3127,6 +3127,11 @@ def model_with_provider_context(model_id: str, model_provider: str | None = None
     if _is_plugin_model_provider(provider):
         return f"@{provider}:{model}"
 
+    # Codex live/cache models are intentionally absent from the static catalog,
+    # so bare same-provider IDs can be claimed by overlapping providers.* entries.
+    if provider == "openai-codex":
+        return f"@{provider}:{model}"
+
     # If the selected provider is already the configured provider, leaving the
     # model bare preserves provider-specific base_url/proxy settings.
     if provider == config_provider:

--- a/api/config.py
+++ b/api/config.py
@@ -1706,7 +1706,6 @@ _PROVIDER_MODELS = {
         {"id": "gpt-5.5", "label": "GPT-5.5"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
-        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3 Codex Spark"},
     ],
     "google": [
         {"id": "gemini-3.1-pro-preview",            "label": "Gemini 3.1 Pro Preview"},
@@ -1908,11 +1907,12 @@ def _seed_provider_models_from_core() -> None:
     """Enrich existing provider model lists with missing IDs from hermes_cli.
 
     The core's _PROVIDER_MODELS is the authoritative curated list of agent-capable
-    models per provider.  The WebUI's static dict above is a display-oriented copy
-    (with {id, label} entries) that can go stale when new models are added to the
-    core without a matching WebUI update.  This function bridges the gap by
-    injecting any missing model IDs from the core into **existing** WebUI provider
-    entries.
+    models for ordinary providers.  The WebUI's static dict above is a
+    display-oriented copy (with {id, label} entries) that can go stale when new
+    models are added to the core without a matching WebUI update.  This function
+    bridges the gap by injecting any missing model IDs from the core into
+    **existing** WebUI provider entries.  OpenAI Codex is excluded because its
+    account-entitlement-aware live/cache path owns catalog freshness.
 
     Constrains seeding to providers already in the WebUI catalog — does NOT add
     brand-new providers.  Adding new vendors is a maintainer curation decision.
@@ -1943,6 +1943,8 @@ def _seed_provider_models_from_core() -> None:
             _webui_key_by_canonical[_canon] = _wk
 
     for provider_id, core_models in _core_pm.items():
+        if provider_id == "openai-codex":
+            continue
         if not isinstance(core_models, list):
             continue
 

--- a/api/config.py
+++ b/api/config.py
@@ -1694,26 +1694,19 @@ _PROVIDER_MODELS = {
     ],
     "openai": [
         {"id": "gpt-5.5",      "label": "GPT-5.5"},
-        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
     ],
     "openai-api": [
         {"id": "gpt-5.5",      "label": "GPT-5.5"},
-        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
     ],
     "openai-codex": [
         {"id": "gpt-5.5", "label": "GPT-5.5"},
-        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
-        {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
-        {"id": "gpt-5.2-codex", "label": "GPT-5.2 Codex"},
-        {"id": "gpt-5.1-codex-max", "label": "GPT-5.1 Codex Max"},
-        {"id": "gpt-5.1-codex-mini", "label": "GPT-5.1 Codex Mini"},
-        {"id": "codex-mini-latest", "label": "Codex Mini (latest)"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3 Codex Spark"},
     ],
     "google": [
         {"id": "gemini-3.1-pro-preview",            "label": "Gemini 3.1 Pro Preview"},

--- a/tests/test_4413_seed_provider_models.py
+++ b/tests/test_4413_seed_provider_models.py
@@ -42,9 +42,11 @@ def _deepcopy_providers():
 def restore_providers():
     """Restore _PROVIDER_MODELS to its pre-test state."""
     snapshot = _deepcopy_providers()
-    yield
-    _PROVIDER_MODELS.clear()
-    _PROVIDER_MODELS.update(snapshot)
+    try:
+        yield
+    finally:
+        _PROVIDER_MODELS.clear()
+        _PROVIDER_MODELS.update(snapshot)
 
 
 def _patch_core_pm(fake_pm: dict):
@@ -100,6 +102,28 @@ class TestSeederAddsMissingModels:
         assert zai_ids.count("glm-5.2") == 1, (
             f"glm-5.2 appears {zai_ids.count('glm-5.2')} times — should be 1"
         )
+
+    def test_codex_entitlement_models_are_not_seeded(self, restore_providers):
+        """Core Codex entries must not become static WebUI fallback entries."""
+        retired_or_account_specific = {"gpt-5.3-codex", "gpt-5.3-codex-spark"}
+        _PROVIDER_MODELS["openai-codex"] = [
+            model
+            for model in _PROVIDER_MODELS["openai-codex"]
+            if model["id"] not in retired_or_account_specific
+        ]
+        fake_pm = {
+            "openai-codex": sorted(retired_or_account_specific),
+            "zai": ["glm-9.99-experimental"],
+        }
+
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        codex_ids = {model["id"] for model in _PROVIDER_MODELS["openai-codex"]}
+        assert retired_or_account_specific.isdisjoint(codex_ids)
+        assert "glm-9.99-experimental" in {
+            model["id"] for model in _PROVIDER_MODELS["zai"]
+        }
 
     def test_no_op_without_hermes_cli(self, restore_providers):
         """Seeder must be a no-op (not raise) when hermes_cli is unavailable."""

--- a/tests/test_issue1189_openai_codex_detection.py
+++ b/tests/test_issue1189_openai_codex_detection.py
@@ -76,12 +76,6 @@ def test_openai_codex_static_model_list_present():
     )
     models = config._PROVIDER_MODELS["openai-codex"]
     assert len(models) > 0, "openai-codex must have at least one static model"
-    # Sanity: contains codex-specific variants as well as shared gpt-5.x
-    ids = {m["id"] for m in models}
-    assert any("codex" in mid for mid in ids), (
-        "openai-codex group should expose at least one codex-specific model "
-        "(otherwise it's redundant with the openai group)"
-    )
 
 
 def test_openai_codex_display_name_present():

--- a/tests/test_issue1189_openai_codex_detection.py
+++ b/tests/test_issue1189_openai_codex_detection.py
@@ -5,8 +5,7 @@ in the model picker when OPENAI_API_KEY is configured.
 The env-var detection block in ``api/config.py`` previously mapped
 ``OPENAI_API_KEY`` to only the ``openai`` provider group; the
 ``openai-codex`` group has its own static model list in
-``_PROVIDER_MODELS`` (9 models: gpt-5.5, gpt-5.4, codex-specific
-variants, etc.) but no automatic detection path.
+``_PROVIDER_MODELS`` but no automatic detection path.
 
 Note (cross-tool): hermes-agent's ``openai-codex`` provider config
 declares ``auth_type="oauth_external"`` with a default

--- a/tests/test_issue1680_codex_spark.py
+++ b/tests/test_issue1680_codex_spark.py
@@ -55,14 +55,7 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
     result = config.get_available_models()
 
     codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
-    # Resilient to test-isolation pollution: when a sibling test replaces
-    # sys.modules['hermes_cli.models'] without restoring it, list_available_providers
-    # may report a different provider list and `calls` won't be ['openai-codex'].
-    # Skip rather than fail — the contract under test is "Codex group surfaces
-    # gpt-5.3-codex-spark when hermes_cli.provider_model_ids returns it".
-    if calls != ["openai-codex"]:
-        import pytest
-        pytest.skip(f"hermes_cli stub not active for openai-codex (likely test-isolation pollution from sibling test). Got calls={calls}")
+    assert "openai-codex" in calls
     assert codex_groups, "OpenAI Codex group should be present"
     assert "gpt-5.3-codex-spark" in _flatten_ids(codex_groups)
     assert codex_groups[0]["models"][0]["label"] == "GPT 5.4"

--- a/tests/test_issue1807_codex_provider_card_live_models.py
+++ b/tests/test_issue1807_codex_provider_card_live_models.py
@@ -83,7 +83,8 @@ def test_codex_provider_card_keeps_static_fallback_when_live_catalog_empty(monke
 
     codex = _codex_provider()
     ids = [m["id"] for m in codex["models"]]
+    expected_ids = [m["id"] for m in config._PROVIDER_MODELS["openai-codex"]]
 
-    assert "gpt-5.5-mini" in ids
-    assert "codex-mini-latest" in ids
-    assert codex["models_total"] == len(ids)
+    assert ids == expected_ids
+    assert "gpt-5.3-codex-spark" in ids
+    assert codex["models_total"] == len(expected_ids)

--- a/tests/test_issue1807_codex_provider_card_live_models.py
+++ b/tests/test_issue1807_codex_provider_card_live_models.py
@@ -86,5 +86,5 @@ def test_codex_provider_card_keeps_static_fallback_when_live_catalog_empty(monke
     expected_ids = [m["id"] for m in config._PROVIDER_MODELS["openai-codex"]]
 
     assert ids == expected_ids
-    assert "gpt-5.3-codex-spark" in ids
+    assert "gpt-5.3-codex-spark" not in ids
     assert codex["models_total"] == len(expected_ids)

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -5,6 +5,7 @@ env-var fallback detection.
 """
 import sys
 import types
+
 import pytest
 import api.config as config
 
@@ -116,16 +117,6 @@ def test_shared_opencode_api_key_detects_zen_and_go(monkeypatch):
     finally:
         config.cfg.clear()
         config.cfg.update(old_cfg)
-
-
-def test_openai_codex_model_catalog_includes_gpt54():
-    """openai-codex catalog must include gpt-5.4 and the standard Codex lineup."""
-    assert "openai-codex" in config._PROVIDER_MODELS
-    ids = [m["id"] for m in config._PROVIDER_MODELS["openai-codex"]]
-    assert "gpt-5.4" in ids, f"gpt-5.4 missing from openai-codex catalog: {ids}"
-    assert "gpt-5.4-mini" in ids, f"gpt-5.4-mini missing from openai-codex catalog: {ids}"
-    assert "gpt-5.3-codex" in ids, f"gpt-5.3-codex missing from openai-codex catalog: {ids}"
-    assert "gpt-5.2-codex" in ids, f"gpt-5.2-codex missing from openai-codex catalog: {ids}"
 
 
 def test_openai_codex_display_name():

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -552,6 +552,43 @@ def test_bare_codex_gpt_runtime_bridge_routes_to_codex(monkeypatch):
     assert base_url is None
 
 
+def test_live_only_codex_model_beats_overlapping_configured_provider(monkeypatch):
+    """Live-only Codex models must not be hijacked by another configured provider."""
+    import api.config as config
+
+    monkeypatch.setitem(config.cfg, "model", {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    })
+    monkeypatch.setitem(config.cfg, "providers", {
+        "shared-relay": {
+            "base_url": "https://relay.example/v1",
+            "models": {"gpt-5.3-codex": {}},
+        }
+    })
+    monkeypatch.setitem(
+        config._PROVIDER_MODELS,
+        "openai-codex",
+        [
+            model for model in config._PROVIDER_MODELS["openai-codex"]
+            if model.get("id") != "gpt-5.3-codex"
+        ],
+    )
+
+    runtime_model = config.model_with_provider_context(
+        "gpt-5.3-codex", "openai-codex"
+    )
+    resolved = config.resolve_model_provider(runtime_model)
+
+    assert runtime_model == "@openai-codex:gpt-5.3-codex"
+    assert resolved == (
+        "gpt-5.3-codex",
+        "openai-codex",
+        "https://chatgpt.com/backend-api/codex",
+    )
+
+
 def test_non_openrouter_slash_model_provider_context_stays_unqualified():
     """Portal/custom slash IDs must not be blindly wrapped as @provider:model."""
     import api.config as config


### PR DESCRIPTION
## Thinking Path

- The `openai-codex` fallback belongs to the ChatGPT/Codex subscription provider. Whether the same model ID remains active through the OpenAI API does not establish that it remains selectable through this provider.
- Account-aware live discovery and the visible local Codex cache are authoritative. The static list is only the degraded fallback.
- Generic Agent-core seeding bypassed that provider-specific boundary and could silently restore retired or entitlement-dependent Codex entries.
- Live-only Codex model IDs still need explicit provider context at runtime. Otherwise, an overlapping configured provider can claim the same bare model ID.

## What Changed

- Removed the nonexistent `gpt-5.5-mini` entry from the static OpenAI, OpenAI API, and OpenAI Codex fallbacks.
- Removed `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, and `codex-mini-latest` from the static OpenAI Codex fallback.
- Kept `gpt-5.3-codex-spark` out of the unconditional fallback because the fallback has no account-tier evidence.
- Excluded `openai-codex` from generic Agent-core seeding. Its existing live/cache path remains responsible for account-specific catalog freshness, including Spark for entitled accounts.
- Qualified Codex selections as `@openai-codex:<model>` before same-provider bare passthrough. This preserves Codex routing when another configured provider advertises the same live-only model ID.
- Updated the focused fallback, seeder, and routing tests. Removed a stale Spark-test skip that triggered even when the intended Codex lookup occurred.

## Why It Matters

- Degraded catalog loading no longer advertises retired or entitlement-dependent subscription choices.
- API model support remains separate from the ChatGPT/Codex subscription fallback.
- Live-discovered Codex models cannot be redirected to an overlapping configured provider.
- The Codex provider group remains explicit through its provider ID, authentication, and routing. It does not need a model ID containing `codex` as a UI sentinel.

## Verification

Focused provider, resolver, seeder, and Codex tests:

`./scripts/test.sh tests/test_provider_mismatch.py tests/test_model_resolver.py tests/test_opencode_providers.py tests/test_4413_seed_provider_models.py tests/test_issue1189_openai_codex_detection.py tests/test_issue1680_codex_spark.py tests/test_issue1807_codex_provider_card_live_models.py -q`

Result: `165 passed`

Routing regression:

- Before the fix, a live-only `gpt-5.3-codex` selection resolved to an overlapping `shared-relay` provider.
- After the fix, the same selection resolves to `openai-codex` and preserves the configured Codex base URL.

Additional checks:

- `python3 -m py_compile` on all changed Python files: passed
- `git diff --check`: passed
- Merge-tree against current `master`: clean

## Risks / Follow-ups

- Live discovery or the visible local Codex cache can still supply Spark and other account-authorized models by design.
- No screenshot is included because this is catalog-data and routing-boundary cleanup with no layout or interaction change.

## Model Used

- OpenAI / GPT-5.6 Sol for investigation, orchestration, implementation follow-up, and verification.
- OpenAI / GPT-5.6 Luna for implementation and independent review.
