### PR TITLE
fix: close leaked state.db read-only connections in session discoverability/recovery

### DIFF
--- a/api/session_discoverability.py
+++ b/api/session_discoverability.py
@@ -17,6 +17,7 @@ import threading
 import shutil
 import sqlite3
 from collections import Counter
+from contextlib import closing
 from pathlib import Path
 from typing import Iterable
 
@@ -102,7 +103,7 @@ def _read_state_db(state_db_path: Path | None) -> dict[str, dict]:
     if state_db_path is None or not state_db_path.exists():
         return {}
     try:
-        with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+        with closing(sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True)) as conn:
             conn.row_factory = sqlite3.Row
             tables = {row[0] for row in conn.execute("select name from sqlite_master where type='table'")}
             if "sessions" not in tables:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -32,6 +32,7 @@ import os
 import shutil
 import sqlite3
 import threading
+from contextlib import closing
 from pathlib import Path
 
 from api.turn_journal import (
@@ -381,7 +382,7 @@ def _state_db_has_session(session_id: str, state_db_path: Path | None) -> bool:
     if state_db_path is None or not state_db_path.exists():
         return True
     try:
-        with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+        with closing(sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True)) as conn:
             cur = conn.execute(
                 "select 1 from sqlite_master where type='table' and name='sessions'"
             )
@@ -446,7 +447,7 @@ def _read_state_db_missing_sidecar_rows(
     if state_db_path is None or not state_db_path.exists():
         return []
     try:
-        with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+        with closing(sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True)) as conn:
             conn.row_factory = sqlite3.Row
             session_cols = {row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
             message_cols = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}


### PR DESCRIPTION
Fixes #6822

## What

Wraps the three remaining bare `sqlite3.connect(...) as conn:` call sites in
`api/session_discoverability.py` and `api/session_recovery.py` with
`contextlib.closing()`.

## Why

`sqlite3.Connection.__exit__` only commits/rolls back the transaction, it
never closes the connection. Used directly as a context manager (`with
sqlite3.connect(...) as conn:`), the connection and its FDs (main db file +
`-wal`/`-shm` sidecars for these read-only URI opens) leak for the life of
the process. On a long-lived server that polls session state on every
discoverability/recovery pass, this accumulates until the process hits the
default 256 soft FD limit (macOS), after which further file opens/writes
start failing, including, ironically, the ability to keep accepting new
sessions.

Same root cause as #1421, #1494, #2233, #3904. This PR is the same
one-line-per-site fix applied to the last two files that still had the
un-wrapped pattern.

## Change

```diff
- with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+ with closing(sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True)) as conn:
```

applied at 3 call sites:
- `api/session_discoverability.py::_read_state_db`
- `api/session_recovery.py::_state_db_has_session`
- `api/session_recovery.py::_read_state_db_missing_sidecar_rows`

No behavior change, `closing()` still runs the connection's `__exit__`
(commit semantics unchanged for these read-only connections) and additionally
guarantees `.close()` on the way out, matching the pattern already used
elsewhere in both files.

## Testing

Manual: ran the affected code paths locally under repeated polling and
confirmed FD count (`lsof -p <pid> | wc -l`) stays flat instead of climbing
by 1 (x2-3 sidecars) per poll.

No behavioral test added since this is a resource-lifecycle fix with no
observable output change. Happy to add a regression test if maintainers
want one (e.g. an FD-count assertion around N repeated calls).