### PR TITLE
fix(sessions): preserve visible progress across reload recovery

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4164,12 +4164,14 @@ def get_reasoning_status(
 
     Keys:
       - show_reasoning: bool — from ``display.show_reasoning`` (default True)
+      - show_commentary: bool — from ``display.show_commentary`` (default True)
       - reasoning_effort: str — from ``agent.reasoning_effort`` ('' = default)
     """
     config_data = _load_yaml_config_file(_get_config_path())
     display_cfg = config_data.get("display") or {}
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
+    commentary_raw = display_cfg.get("show_commentary") if isinstance(display_cfg, dict) else None
     effort_raw = agent_cfg.get("reasoning_effort") if isinstance(agent_cfg, dict) else None
 
     resolve_model = model_id
@@ -4203,6 +4205,11 @@ def get_reasoning_status(
     return {
         # Match CLI default (True if unset in config.yaml)
         "show_reasoning": bool(show_raw) if isinstance(show_raw, bool) else True,
+        # Match Agent display default. This is presentation-only: persisted
+        # codex_message_items remain unchanged for replay/cache continuity.
+        "show_commentary": (
+            bool(commentary_raw) if isinstance(commentary_raw, bool) else True
+        ),
         # Report the COERCED effort so boot/status/chip read paths agree with
         # what streaming actually sends. (Codex review of the drop-max alignment.)
         "reasoning_effort": coerce_reasoning_effort_for_model(

--- a/api/routes.py
+++ b/api/routes.py
@@ -12591,9 +12591,9 @@ def handle_get(handler, parsed) -> bool:
         return handle_transcribe_capability(handler)
 
     if parsed.path == "/api/reasoning":
-        # Current reasoning config (shared source of truth with the CLI —
-        # reads display.show_reasoning and agent.reasoning_effort from
-        # the active profile's config.yaml).
+        # Current reasoning/display config (shared source of truth with the CLI —
+        # reads display.show_reasoning, display.show_commentary, and
+        # agent.reasoning_effort from the active profile's config.yaml).
         query = parse_qs(parsed.query)
         model_id = (query.get("model", [""])[0] or "").strip() or None
         provider_id = (query.get("provider", [""])[0] or "").strip() or None

--- a/api/routes.py
+++ b/api/routes.py
@@ -8531,6 +8531,9 @@ def _message_has_stable_assistant_reply_for_window(message) -> bool:
     return False
 
 
+_COLD_LOAD_SEMANTIC_RAW_ROW_LIMIT = 500
+
+
 def _cold_load_semantic_context_start(source, start_idx: int, last_renderable_idx: int) -> int:
     """Keep the previous complete exchange beside a tool-heavy active turn.
 
@@ -8656,9 +8659,15 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
             start_idx = idx
             break
     if expand_renderable and msg_before is None:
-        start_idx = _cold_load_semantic_context_start(
+        semantic_start_idx = _cold_load_semantic_context_start(
             source, start_idx, last_renderable_idx
         )
+        # Keep the semantic prefix bounded in raw storage coordinates. A single
+        # active turn can contain thousands of hidden tool rows; pulling a very
+        # distant prior exchange into this response would defeat msg_limit and
+        # reintroduce an unbounded cold-load payload.
+        if end_idx - semantic_start_idx <= _COLD_LOAD_SEMANTIC_RAW_ROW_LIMIT:
+            start_idx = semantic_start_idx
     window = source[start_idx:end_idx]
     return window, start_idx
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -8512,6 +8512,56 @@ def _message_counts_as_renderable_for_window(message) -> bool:
     return bool(role and role != "tool")
 
 
+def _message_has_stable_assistant_reply_for_window(message) -> bool:
+    """Return true for settled assistant prose, not tool/commentary activity."""
+    if not isinstance(message, dict) or str(message.get("role") or "").lower() != "assistant":
+        return False
+    if message.get("tool_calls") or message.get("_partial_tool_calls"):
+        return False
+    content = message.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        return any(
+            isinstance(part, dict)
+            and str(part.get("type") or "") in {"text", "input_text", "output_text"}
+            and str(part.get("text") or part.get("content") or "").strip()
+            for part in content
+        )
+    return False
+
+
+def _cold_load_semantic_context_start(source, start_idx: int, last_renderable_idx: int) -> int:
+    """Keep the previous complete exchange beside a tool-heavy active turn.
+
+    A Responses turn can persist hundreds of empty assistant tool/commentary
+    rows. Counting each one as a visible row lets them consume the entire tail
+    budget, so restart cold-load shows only Thinking and hides the latest normal
+    answer. This adds one bounded semantic prefix: the latest user row, the
+    preceding settled assistant reply, and its user row when present.
+    """
+    latest_user_idx = None
+    for idx in range(last_renderable_idx, -1, -1):
+        if isinstance(source[idx], dict) and str(source[idx].get("role") or "").lower() == "user":
+            latest_user_idx = idx
+            break
+    if latest_user_idx is None:
+        return start_idx
+    prior_assistant_idx = None
+    for idx in range(latest_user_idx - 1, -1, -1):
+        if _message_has_stable_assistant_reply_for_window(source[idx]):
+            prior_assistant_idx = idx
+            break
+    if prior_assistant_idx is None or prior_assistant_idx >= start_idx:
+        return start_idx
+    prior_user_idx = None
+    for idx in range(prior_assistant_idx - 1, -1, -1):
+        if isinstance(source[idx], dict) and str(source[idx].get("role") or "").lower() == "user":
+            prior_user_idx = idx
+            break
+    return prior_user_idx if prior_user_idx is not None else prior_assistant_idx
+
+
 def _tool_call_ids_in_messages(messages) -> set:
     """Collect tool-call IDs declared on renderable rows (assistant tool_calls /
     partial tool_calls / Anthropic tool_use content blocks) so trailing
@@ -8605,6 +8655,10 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
         if renderable_count >= limit:
             start_idx = idx
             break
+    if expand_renderable and msg_before is None:
+        start_idx = _cold_load_semantic_context_start(
+            source, start_idx, last_renderable_idx
+        )
     window = source[start_idx:end_idx]
     return window, start_idx
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -3596,10 +3596,12 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     }
     return true;
   };
-  const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({
+  const _hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({
     preferProfileDefaultOnFreshBoot:true,
+    transitionOwner,
     ...(redirectIfUnauth?{redirectIfUnauth}:{}),
   }).then(()=>{
+    if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
     const sessionModelState=S.session&&S.session.model
       ? {model:S.session.model,model_provider:S.session.model_provider||null}
       : null;
@@ -3635,21 +3637,24 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     if(S.session) syncTopbar();
     else if(typeof syncReasoningChip==='function') syncReasoningChip();
   }).catch(e=>{
+    if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
     window._modelDropdownReady=null;
     throw e;
   });
-  const _startModelDropdown=()=>{
+  const _startModelDropdown=(transitionOwner=null)=>{
     const ready=window._modelDropdownReady;
-    if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateModelDropdown();
+    if(ready&&typeof ready.then==='function'&&(!transitionOwner||window._modelDropdownReadyOwner===transitionOwner)) return ready;
+    const next=_hydrateModelDropdown({transitionOwner});
     window._modelDropdownReady=next;
+    window._modelDropdownReadyOwner=transitionOwner;
     return next;
   };
-  const _startBootModelDropdown=()=>{
+  const _startBootModelDropdown=(transitionOwner=null)=>{
     const ready=window._modelDropdownReady;
-    if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth});
+    if(ready&&typeof ready.then==='function'&&(!transitionOwner||window._modelDropdownReadyOwner===transitionOwner)) return ready;
+    const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth,transitionOwner});
     window._modelDropdownReady=next;
+    window._modelDropdownReadyOwner=transitionOwner;
     return next;
   };
   window._modelDropdownReady=null;

--- a/static/boot.js
+++ b/static/boot.js
@@ -3580,7 +3580,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       console.warn('[boot] profile query switch failed', e);
     }
   }
-  if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)) fetchReasoningChip();
+  if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)){
+    window._showCommentary=false;
+    await fetchReasoningChip();
+  }
   // Fetch available models without blocking session restore. The static HTML
   // options enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.

--- a/static/panels.js
+++ b/static/panels.js
@@ -7096,6 +7096,10 @@ async function switchToProfile(name) {
     if (typeof refreshProfileTransitionReasoningChip === 'function') {
       await refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
     }
+    // The preference fetch above yields. A newer profile switch may have
+    // completed while this older one was waiting; do not let the stale
+    // continuation create/retag a session in the newer profile.
+    if (_switchGen !== _profileSwitchGeneration) return false;
 
     // ── Apply workspace ────────────────────────────────────────────────────
     if (data.default_workspace) {

--- a/static/panels.js
+++ b/static/panels.js
@@ -7094,7 +7094,7 @@ async function switchToProfile(name) {
       S.session.profile = data.active || name;
     }
     if (typeof refreshProfileTransitionReasoningChip === 'function') {
-      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
+      await refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────

--- a/static/panels.js
+++ b/static/panels.js
@@ -6587,6 +6587,7 @@ function _refreshProfileSwitchBackground(gen,transitionOwner){
   if (typeof populateModelDropdown === 'function') {
     const next=populateModelDropdown({freshness:'session_visit',transitionOwner});
     window._modelDropdownReady=next;
+    window._modelDropdownReadyOwner=transitionOwner;
     Promise.resolve(next).catch(()=>{});
   }
   Promise.resolve(loadWorkspaceList(transitionOwner)).then(()=>{
@@ -6985,6 +6986,7 @@ async function switchToProfile(name) {
   const _titlebarLabel = $('titlebarProfileLabel');
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
+  const _transitionOwner = _beginProfileTransitionOwner(name, 'canonical');
   const _openingExistingSidebarSession = !!(typeof _profileSwitchOpeningExistingSession !== 'undefined' && _profileSwitchOpeningExistingSession);
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
   if (_titlebarBtn) { _titlebarBtn.classList.add('switching'); _titlebarBtn.disabled = true; }
@@ -7050,9 +7052,10 @@ async function switchToProfile(name) {
     // red error while the real switch completes and renders. The catch block below is
     // the single source of truth for switch failure and is gated on _switchGen, so the
     // error surfaces ONLY when the CURRENT switch genuinely fails (@rodboev review, #4662).
-    const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }), timeoutToast: false });
+    const data = await _postProfileTransition(_transitionOwner);
     if (_switchGen !== _profileSwitchGeneration) return false;
-    const _transitionOwner = _acceptProfileTransitionOwner(data.active || name, 'canonical');
+    if (!data) return false;
+    if (!_acceptProfileTransitionOwner(_transitionOwner, data.active || name)) return false;
     if (typeof refreshProfileTransitionReasoningChip === 'function') {
       await refreshProfileTransitionReasoningChip(
         data.default_model,
@@ -7179,7 +7182,7 @@ async function switchToProfile(name) {
       // cookie switch. Avoid creating/retagging an intermediate blank chat.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
-      await renderSessionList();
+      await renderSessionList({transitionOwner:_transitionOwner});
       if (_switchGen !== _profileSwitchGeneration) return false;
       if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
@@ -7189,7 +7192,7 @@ async function switchToProfile(name) {
       // Start a new session for the new profile so nothing gets cross-tagged.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       if (!_isProfileTransitionOwner(_transitionOwner)) return false;
-      await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});
+      await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false, transitionOwner:_transitionOwner});
       if (_switchGen !== _profileSwitchGeneration) return false;
       if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       // Keep topbar chips (workspace/profile) in sync after creating the
@@ -7199,8 +7202,8 @@ async function switchToProfile(name) {
       // single-threaded so nothing interleaves between this clear and the call, making
       // this render the first allowed to paint the new profile's rows.
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
-      await renderSessionList();
-      // Re-check generation after the awaited list render: a newer switch can be
+      await renderSessionList({transitionOwner:_transitionOwner});
+      // Re-check generation after the awaited list render
       // started while renderSessionList() is in flight, and without this guard
       // the superseded switch would clear the newer switch's workspace skeleton
       // and pop a stale toast. Mirrors the no-messages branch guard below.
@@ -7228,7 +7231,7 @@ async function switchToProfile(name) {
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       // #4671: lift the embargo immediately before the switch-owned render (see above).
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
-      await renderSessionList();
+      await renderSessionList({transitionOwner:_transitionOwner});
       if (_switchGen !== _profileSwitchGeneration) return false;
       if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
@@ -7236,7 +7239,7 @@ async function switchToProfile(name) {
       // Refresh workspace file tree so the right panel shows the new
       // profile's workspace, not the previous one (#1214).
       if (S.session && S.session.workspace) {
-        const dirLoad = loadDir('.');
+        const dirLoad = loadDir('.',{transitionOwner:_transitionOwner});
         if (workspaceVisible) await dirLoad;
         if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       } else if (typeof clearWorkspaceTreeSkeleton === 'function') {
@@ -7255,13 +7258,14 @@ async function switchToProfile(name) {
 
   } catch (e) {
     // Revert the optimistic name update on error
-    if (_switchGen === _profileSwitchGeneration && _chipLabel) _chipLabel.textContent = _prevProfileName;
-    if (_switchGen === _profileSwitchGeneration && _titlebarLabel) _titlebarLabel.textContent = _prevProfileName;
-    if (_switchGen === _profileSwitchGeneration) showToast(t('switch_failed') + e.message);
+    const _ownsFailure = _switchGen === _profileSwitchGeneration && _isProfileTransitionOwner(_transitionOwner);
+    if (_ownsFailure && _chipLabel) _chipLabel.textContent = _prevProfileName;
+    if (_ownsFailure && _titlebarLabel) _titlebarLabel.textContent = _prevProfileName;
+    if (_ownsFailure) showToast(t('switch_failed') + e.message);
     // The switch failed, so we're still on the previous profile and its caches
     // are intact — restore the real list/tree so the loading skeletons we showed
     // up front don't strand. (#4662)
-    if (_switchGen === _profileSwitchGeneration) {
+    if (_ownsFailure) {
       // The switch failed; _allSessions still holds the (still-current) previous
       // profile, so clear the skeleton flag and re-render to restore the real list
       // rather than strand the up-front skeleton (#4671). Lift the embargo too so the
@@ -7270,24 +7274,27 @@ async function switchToProfile(name) {
       _sessionListSkeletonActive = false;
       if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
       if (_workspaceVisibleAtStart && S.session && S.session.workspace && typeof loadDir === 'function') {
-        loadDir('.');
+        loadDir('.',{transitionOwner:_transitionOwner});
       } else if (_workspaceVisibleAtStart && typeof clearWorkspaceTreeSkeleton === 'function') {
         // No workspace to restore on the (still-current) previous profile —
         // clear the up-front workspace skeleton so it doesn't strand on a switch
         // failure, mirroring the success-path no-workspace handling (#4662).
         clearWorkspaceTreeSkeleton();
       }
+      if (_chip) { _chip.classList.remove('switching'); _chip.disabled = false; }
+      if (_titlebarBtn) { _titlebarBtn.classList.remove('switching'); _titlebarBtn.disabled = false; }
+      _cancelProfileTransitionOwner(_transitionOwner);
     }
     return false;
   } finally {
     // Always remove loading indicator regardless of success or failure
-    if (_switchGen === _profileSwitchGeneration && _chip) { _chip.classList.remove('switching'); _chip.disabled = false; }
-    if (_switchGen === _profileSwitchGeneration && _titlebarBtn) { _titlebarBtn.classList.remove('switching'); _titlebarBtn.disabled = false; }
+    if (_switchGen === _profileSwitchGeneration && _isProfileTransitionOwner(_transitionOwner) && _chip) { _chip.classList.remove('switching'); _chip.disabled = false; }
+    if (_switchGen === _profileSwitchGeneration && _isProfileTransitionOwner(_transitionOwner) && _titlebarBtn) { _titlebarBtn.classList.remove('switching'); _titlebarBtn.disabled = false; }
     // #4671 safety net: guarantee the session-list embargo is lifted on EVERY exit of the
     // current switch (success paths clear it before their authoritative render; this covers
     // early-returns/throws between skeleton-show and those clears so it can't freeze the
     // sidebar). Guarded by _switchGen so a superseded switch can't lift a newer switch's embargo.
-    if (_switchGen === _profileSwitchGeneration && typeof _setProfileSwitchListEmbargo === 'function') {
+    if (_switchGen === _profileSwitchGeneration && _isProfileTransitionOwner(_transitionOwner) && typeof _setProfileSwitchListEmbargo === 'function') {
       _setProfileSwitchListEmbargo(false);
     }
   }

--- a/static/panels.js
+++ b/static/panels.js
@@ -890,12 +890,18 @@ function _appendCronProfileToggle(parent){
   parent.appendChild(wrap);
 }
 
-async function loadCronProfiles(){
+function _profilePanelTransitionCurrent(owner){
+  return !owner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(owner);
+}
+
+async function loadCronProfiles(transitionOwner){
   if (_cronProfilesCache) return _cronProfilesCache;
   try {
     const data = await api('/api/profiles');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return [];
     _cronProfilesCache = Array.isArray(data.profiles) ? data.profiles : [];
   } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return [];
     _cronProfilesCache = [];
   }
   return _cronProfilesCache;
@@ -982,11 +988,12 @@ function _cronGatewayNoticeHtml(status) {
   `;
 }
 
-async function loadCronGatewayNotice() {
+async function loadCronGatewayNotice(transitionOwner) {
   const box = $('cronGatewayNotice');
   if (!box) return;
   try {
     const status = await api('/api/gateway/status');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     const html = _cronGatewayNoticeHtml(status);
     if (html) {
       box.innerHTML = html;
@@ -996,23 +1003,26 @@ async function loadCronGatewayNotice() {
       box.style.display = 'none';
     }
   } catch (_) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     box.innerHTML = '';
     box.style.display = 'none';
   }
 }
 
-async function loadCrons(animate) {
+async function loadCrons(animate, transitionOwner) {
   const box = $('cronList');
   const refreshBtn = $('cronRefreshBtn');
-  loadCronGatewayNotice();
+  loadCronGatewayNotice(transitionOwner);
   if (animate && refreshBtn) {
     refreshBtn.style.opacity = '0.5';
     refreshBtn.disabled = true;
   }
   try {
-    await loadCronProfiles();
+    await loadCronProfiles(transitionOwner);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     const allProfilesQS = _showAllCronProfiles ? '?all_profiles=1' : '';
     const data = await api('/api/crons' + allProfilesQS);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     _cronList = data.jobs || [];
     _cronOtherProfileCount = Number(data.other_profile_count || 0);
     if (_showAllCronProfiles && !_cronList.some(job => job && job.read_only)) {
@@ -1095,8 +1105,12 @@ async function loadCrons(animate) {
       if (refreshed) _renderCronDetail(refreshed);
       else _clearCronDetail();
     }
-  } catch(e) { box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">${esc(t('error_prefix'))}${esc(e.message)}</div>`; }
+  } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
+    box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">${esc(t('error_prefix'))}${esc(e.message)}</div>`;
+  }
   finally {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     if (animate && refreshBtn) {
       refreshBtn.style.opacity = '';
       refreshBtn.disabled = false;
@@ -2665,7 +2679,7 @@ function _kanbanUnavailableHtml(err){
   return `<div class="main-view-empty"><div class="main-view-empty-title">${msg}</div></div>`;
 }
 
-async function loadKanban(animate){
+async function loadKanban(animate, transitionOwner){
   const board = $('kanbanBoard');
   const list = $('kanbanList');
   try {
@@ -2673,10 +2687,13 @@ async function loadKanban(animate){
     // Resolve the active board before board-scoped requests. If another CLI or
     // tab archived the previous board, /boards can fall back to default instead
     // of leaving config/board pinned to a ghost slug.
-    await loadKanbanBoards();
+    await loadKanbanBoards(transitionOwner);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     const config = await api('/api/kanban/config' + _kanbanBoardQuery());
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     let assignees = null;
     try { assignees = await api('/api/kanban/assignees' + _kanbanBoardQuery()); } catch(e) { assignees = null; }
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     _kanbanApplyConfigDefaults(config);
     const filters = _kanbanCurrentFilters();
     const params = new URLSearchParams();
@@ -2687,6 +2704,7 @@ async function loadKanban(animate){
     if (_kanbanCurrentBoard) params.set('board', _kanbanCurrentBoard);
     const path = '/api/kanban/board' + (params.toString() ? '?' + params.toString() : '');
     const data = await api(path);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     if (data && data.changed === false && _kanbanBoard) { _kanbanRenderBoard(); return; }
     _kanbanBoard = data || {columns: []};
     if ((!_kanbanBoard.columns || !_kanbanBoard.columns.length) && config && config.columns) {
@@ -2702,7 +2720,8 @@ async function loadKanban(animate){
     } catch(_) {}
     _kanbanSetSelectOptions($('kanbanAssigneeFilter'), _kanbanBoard.assignees || (assignees && assignees.assignees) || (config && config.assignees), 'kanban_all_assignees');
     _kanbanSetSelectOptions($('kanbanTenantFilter'), _kanbanBoard.tenants, 'kanban_all_tenants');
-    await loadKanbanStats();
+    await loadKanbanStats(transitionOwner);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     // Note: PR #1828 (v0.51.20) moved the boards refresh to the start of
     // loadKanban() so the active board is resolved BEFORE board-scoped
     // requests fire. The previous tail-of-function refresh has been removed
@@ -2713,6 +2732,7 @@ async function loadKanban(animate){
     _kanbanStartPolling();
     _kanbanRenderBoard();
   } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     const html = _kanbanUnavailableHtml(e);
     if (board) board.innerHTML = html;
     if (list) list.innerHTML = html;
@@ -2721,9 +2741,10 @@ async function loadKanban(animate){
 
 function filterKanban(){ _kanbanRenderBoard(); }
 
-async function loadKanbanStats(){
+async function loadKanbanStats(transitionOwner){
   try {
     const stats = await api('/api/kanban/stats' + _kanbanBoardQuery());
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     const el = $('kanbanStats');
     if (!el) return;
     const byStatus = (stats && stats.by_status) || {};
@@ -3870,7 +3891,7 @@ function _kanbanSetSavedBoard(slug){
   } catch(_) {}
 }
 
-async function loadKanbanBoards(){
+async function loadKanbanBoards(transitionOwner){
   // Fetches the boards list and updates the switcher UI. Best-effort —
   // failures hide the switcher rather than blocking the panel from rendering.
   const switcher = document.getElementById('kanbanBoardSwitcher');
@@ -3879,10 +3900,12 @@ async function loadKanbanBoards(){
   try {
     data = await api('/api/kanban/boards');
   } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     // Hide switcher on error so the user isn't stuck with a half-broken UI.
     switcher.hidden = true;
     return;
   }
+  if(!_profilePanelTransitionCurrent(transitionOwner)) return;
   const boards = (data && data.boards) || [];
   const serverCurrent = (data && data.current) || 'default';
   _kanbanBoardsList = boards;
@@ -4807,18 +4830,25 @@ async function clearConversation() {
 }
 
 // ── Skills panel ──
-async function loadSkills() {
-  if (_skillsData) { renderSkills(_skillsData); return; }
+async function loadSkills(transitionOwner) {
+  if (_skillsData) {
+    if(_profilePanelTransitionCurrent(transitionOwner)) renderSkills(_skillsData);
+    return;
+  }
   const box = $('skillsList');
   try {
     const data = await api('/api/skills');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     _skillsData = data.skills || [];
     // Prune collapsed state to only keep categories present in fresh data,
     // avoiding stale keys when categories are renamed or removed server-side.
     const liveCats = new Set(_skillsData.map(s => s.category || '(general)'));
     for (const c of _collapsedCats) { if (!liveCats.has(c)) _collapsedCats.delete(c); }
     renderSkills(_skillsData);
-  } catch(e) { box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">Error: ${esc(e.message)}</div>`; }
+  } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
+    box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">Error: ${esc(e.message)}</div>`;
+  }
 }
 
 let _collapsedCats = new Set(); // persisted collapsed state across re-renders
@@ -5427,11 +5457,14 @@ function _renderMemoryEdit(section) {
   if (ta) ta.focus();
 }
 
-async function loadNotesSources(force) {
+async function loadNotesSources(force, transitionOwner) {
   if (_notesSourcesData && !force) return _notesSourcesData;
   try {
-    _notesSourcesData = await api('/api/notes/sources');
+    const data = await api('/api/notes/sources');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return null;
+    _notesSourcesData = data;
   } catch (e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return null;
     _notesSourcesData = {sources: [], automatic_recall_unchanged: true, error: e && e.message ? e.message : String(e)};
   }
   return _notesSourcesData;
@@ -5670,9 +5703,10 @@ function syncWorkspaceDisplays(){
   }
 }
 
-async function loadWorkspaceList(){
+async function loadWorkspaceList(transitionOwner){
   try{
     const data = await api('/api/workspaces');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return {workspaces:[],last:''};
     if(typeof syncTerminalBackendState==='function') syncTerminalBackendState(data);
     _workspaceList = data.workspaces || [];
     syncWorkspaceDisplays();
@@ -5931,10 +5965,11 @@ window.addEventListener('resize',()=>{
   if(dd&&dd.classList.contains('open')) _positionComposerWsDropdown();
 });
 
-async function loadWorkspacesPanel(){
+async function loadWorkspacesPanel(transitionOwner){
   const panel=$('workspacesPanel');
   if(!panel)return;
-  const data=await loadWorkspaceList();
+  const data=await loadWorkspaceList(transitionOwner);
+  if(!_profilePanelTransitionCurrent(transitionOwner)) return;
   renderWorkspacesPanel(data.workspaces);
 }
 
@@ -6529,7 +6564,8 @@ function _openProfileDropdownShell(){
   if(tbtn && _profileDropdownTrigger===tbtn) tbtn.classList.add('active');
 }
 
-async function _profileSwitchPanelLoad(){
+async function _profileSwitchPanelLoad(transitionOwner){
+  if(!_profilePanelTransitionCurrent(transitionOwner)) return;
   // Cross-profile cron visibility is an active-profile opt-in; never carry it
   // into the next profile when the Tasks panel wasn't the visible panel.
   _showAllCronProfiles = false;
@@ -6538,21 +6574,23 @@ async function _profileSwitchPanelLoad(){
   _editingCronId = null;
   _cronIsDuplicate = false;
   _clearCronDetail();
-  if (_currentPanel === 'skills') await loadSkills();
-  if (_currentPanel === 'memory') await loadMemory();
-  if (_currentPanel === 'tasks') await loadCrons();
-  if (_currentPanel === 'kanban') await loadKanban();
-  if (_currentPanel === 'profiles') await loadProfilesPanel();
-  if (_currentPanel === 'workspaces') await loadWorkspacesPanel();
+  if (_currentPanel === 'skills') await loadSkills(transitionOwner);
+  if (_currentPanel === 'memory') await loadMemory(undefined,transitionOwner);
+  if (_currentPanel === 'tasks') await loadCrons(undefined,transitionOwner);
+  if (_currentPanel === 'kanban') await loadKanban(undefined,transitionOwner);
+  if (_currentPanel === 'profiles') await loadProfilesPanel(transitionOwner);
+  if (_currentPanel === 'workspaces') await loadWorkspacesPanel(transitionOwner);
 }
 
-function _refreshProfileSwitchBackground(gen){
+function _refreshProfileSwitchBackground(gen,transitionOwner){
   window._modelDropdownReady=null;
-  if (typeof window._ensureModelDropdownReady === 'function') {
-    Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
+  if (typeof populateModelDropdown === 'function') {
+    const next=populateModelDropdown({freshness:'session_visit',transitionOwner});
+    window._modelDropdownReady=next;
+    Promise.resolve(next).catch(()=>{});
   }
-  Promise.resolve(loadWorkspaceList()).then(()=>{
-    if (gen !== _profileSwitchGeneration) return;
+  Promise.resolve(loadWorkspaceList(transitionOwner)).then(()=>{
+    if (gen !== _profileSwitchGeneration||!_profilePanelTransitionCurrent(transitionOwner)) return;
     if (S.session && typeof syncTopbar === 'function') syncTopbar();
   }).catch(()=>{});
   // Reconcile per-profile sidebar tab visibility. hidden_tabs is a per-profile
@@ -6560,7 +6598,7 @@ function _refreshProfileSwitchBackground(gen){
   // would remain in effect under Profile B until the user opens Settings.
   // Stage-394 follow-up to #2636 deep review.
   Promise.resolve(api('/api/settings')).then(function(s){
-    if (gen !== _profileSwitchGeneration) return;
+    if (gen !== _profileSwitchGeneration||!_profilePanelTransitionCurrent(transitionOwner)) return;
     var hidden = (s && Array.isArray(s.hidden_tabs)) ? s.hidden_tabs : [];
     hidden = hidden.filter(function(x){ return typeof x === 'string' && x.trim(); });
     var order = (s && Array.isArray(s.tab_order)) ? s.tab_order : [];
@@ -6582,11 +6620,12 @@ function _refreshProfileSwitchBackground(gen){
   }).catch(function(){});
 }
 
-async function loadProfilesPanel() {
+async function loadProfilesPanel(transitionOwner) {
   const panel = $('profilesPanel');
   if (!panel) return;
   try {
     const data = await api('/api/profiles');
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     _profilesCache = data;
     _profileDropdownWriteStoredCache(data);
     panel.innerHTML = '';
@@ -6656,6 +6695,7 @@ async function loadProfilesPanel() {
       else _clearProfileDetail();
     }
   } catch (e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     panel.innerHTML = `<div style="color:var(--accent);font-size:12px;padding:12px">${esc(t('error_prefix'))}${esc(e.message)}</div>`;
   }
 }
@@ -7208,9 +7248,9 @@ async function switchToProfile(name) {
     }
 
     if (!_isProfileTransitionOwner(_transitionOwner)) return false;
-    await _profileSwitchPanelLoad();
+    await _profileSwitchPanelLoad(_transitionOwner);
     if (!_isProfileTransitionOwner(_transitionOwner)) return false;
-    _refreshProfileSwitchBackground(_switchGen);
+    _refreshProfileSwitchBackground(_switchGen,_transitionOwner);
     return true;
 
   } catch (e) {
@@ -7399,19 +7439,21 @@ async function deleteProfile(name) {
 }
 
 // ── Memory panel ──
-async function loadMemory(force) {
+async function loadMemory(force, transitionOwner) {
   const panel = $('memoryPanel');
   try {
     const memoryUrl = S.session && S.session.session_id
       ? `/api/memory?session_id=${encodeURIComponent(S.session.session_id)}`
       : '/api/memory';
     const data = await api(memoryUrl);
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     _memoryData = data;
     if (_currentMemorySection === 'external_notes' && !data.external_notes_enabled) {
       _currentMemorySection = null;
     }
     if (_currentMemorySection === 'external_notes') {
-      await loadNotesSources(!!force);
+      await loadNotesSources(!!force,transitionOwner);
+      if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     }
     if (panel) {
       panel.innerHTML = '';
@@ -7432,6 +7474,7 @@ async function loadMemory(force) {
       _renderMemoryDetail(_currentMemorySection);
     }
   } catch(e) {
+    if(!_profilePanelTransitionCurrent(transitionOwner)) return;
     if (panel) panel.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">${esc(t('error_prefix'))}${esc(e.message)}</div>`;
   }
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -7012,6 +7012,18 @@ async function switchToProfile(name) {
     // error surfaces ONLY when the CURRENT switch genuinely fails (@rodboev review, #4662).
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }), timeoutToast: false });
     if (_switchGen !== _profileSwitchGeneration) return false;
+    const _transitionOwner = _acceptProfileTransitionOwner(data.active || name, 'canonical');
+    if (typeof refreshProfileTransitionReasoningChip === 'function') {
+      await refreshProfileTransitionReasoningChip(
+        data.default_model,
+        data.default_model_provider,
+        _transitionOwner
+      );
+    }
+    if (
+      _switchGen !== _profileSwitchGeneration ||
+      !_isProfileTransitionOwner(_transitionOwner)
+    ) return false;
     S.activeProfile = data.active || name;
     S.activeProfileIsDefault = !!data.is_default;
     if (typeof _resetCronUnreadForProfileSwitch === 'function') {
@@ -7093,14 +7105,6 @@ async function switchToProfile(name) {
     if (S.session && !sessionInProgress) {
       S.session.profile = data.active || name;
     }
-    if (typeof refreshProfileTransitionReasoningChip === 'function') {
-      await refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
-    }
-    // The preference fetch above yields. A newer profile switch may have
-    // completed while this older one was waiting; do not let the stale
-    // continuation create/retag a session in the newer profile.
-    if (_switchGen !== _profileSwitchGeneration) return false;
-
     // ── Apply workspace ────────────────────────────────────────────────────
     if (data.default_workspace) {
       // Always store the persistent profile default — used for blank-page display
@@ -7119,6 +7123,7 @@ async function switchToProfile(name) {
             model: S.session.model,
             model_provider: S.session.model_provider||null,
           })});
+          if (!_isProfileTransitionOwner(_transitionOwner)) return false;
           S.session.workspace = data.default_workspace;
         } catch (_) {}
       }
@@ -7136,14 +7141,17 @@ async function switchToProfile(name) {
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
       if (_switchGen !== _profileSwitchGeneration) return false;
+      if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
       showToast(t('profile_switched', name));
     } else if (sessionInProgress) {
       // The current session has messages and belongs to the previous profile.
       // Start a new session for the new profile so nothing gets cross-tagged.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
+      if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});
       if (_switchGen !== _profileSwitchGeneration) return false;
+      if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       // Keep topbar chips (workspace/profile) in sync after creating the
       // new profile-scoped session.
       syncTopbar();
@@ -7158,6 +7166,7 @@ async function switchToProfile(name) {
       // and pop a stale toast. Mirrors the no-messages branch guard below.
       // (@rodboev/greptile review, #4662)
       if (_switchGen !== _profileSwitchGeneration) return false;
+      if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
       // Safety net: if the new session has no workspace, newSession() won't have
       // painted the file tree — clear the up-front skeleton so it can't strand
@@ -7180,7 +7189,8 @@ async function switchToProfile(name) {
       // #4671: lift the embargo immediately before the switch-owned render (see above).
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
-      if (_switchGen !== _profileSwitchGeneration) return;
+      if (_switchGen !== _profileSwitchGeneration) return false;
+      if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
       syncTopbar();
       // Refresh workspace file tree so the right panel shows the new
@@ -7188,6 +7198,7 @@ async function switchToProfile(name) {
       if (S.session && S.session.workspace) {
         const dirLoad = loadDir('.');
         if (workspaceVisible) await dirLoad;
+        if (!_isProfileTransitionOwner(_transitionOwner)) return false;
       } else if (typeof clearWorkspaceTreeSkeleton === 'function') {
         // New profile has no bound workspace — clear the up-front skeleton so it
         // doesn't strand (#4662 Opus gate).
@@ -7196,7 +7207,9 @@ async function switchToProfile(name) {
       showToast(t('profile_switched', name));
     }
 
+    if (!_isProfileTransitionOwner(_transitionOwner)) return false;
     await _profileSwitchPanelLoad();
+    if (!_isProfileTransitionOwner(_transitionOwner)) return false;
     _refreshProfileSwitchBackground(_switchGen);
     return true;
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1277,6 +1277,7 @@ function _markPollingCompletionUnreadTransitions(sessions) {
 }
 
 let _newSessionInFlight=null;
+let _newSessionInFlightOwner=null;
 const _newSessionPendingText=()=>t('new_session_creating')||'Creating new conversation…';
 const _emptyComposerModelOverrideHost=typeof window!=='undefined'?window:globalThis;
 
@@ -1378,12 +1379,18 @@ function _setNewSessionPending(pending){
 }
 
 async function newSession(flash, options={}){
+  const transitionOwner=options&&options.transitionOwner||null;
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+  if(!transitionCurrent()) return false;
   if(_newSessionInFlight){
-    if(typeof showToast==='function') showToast(_newSessionPendingText(),1500);
-    return _newSessionInFlight;
+    if(!transitionOwner||_newSessionInFlightOwner===transitionOwner){
+      if(typeof showToast==='function') showToast(_newSessionPendingText(),1500);
+      return _newSessionInFlight;
+    }
   }
   _setNewSessionPending(true);
-  _newSessionInFlight=(async()=>{
+  const thisNewSessionPromise=(async()=>{
+    if(!transitionCurrent()) return false;
     // Starting a brand-new chat must not carry named context blocks selected in
     // the previous conversation (#2543). loadSession() clears these on a sidebar
     // switch, but the New Chat path replaces S.session here without going through
@@ -1482,6 +1489,7 @@ async function newSession(flash, options={}){
         ||null;
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
+    if(!transitionCurrent()) return false;
     if(consumedExplicitModelOverride&&typeof _clearEmptyComposerModelOverride==='function'){
       _clearEmptyComposerModelOverride();
     }
@@ -1551,21 +1559,28 @@ async function newSession(flash, options={}){
     // refresh right after paint unless this caller explicitly needs it loaded
     // before continuing (profile/default-workspace binding path).
     if(options&&options.awaitWorkspaceLoad){
-      await loadDir('.');
+      await loadDir('.',{transitionOwner});
+      if(!transitionCurrent()) return false;
     }else if(typeof _deferWorkspaceRefreshForSession==='function'){
-      _deferWorkspaceRefreshForSession(S.session.session_id);
+      _deferWorkspaceRefreshForSession(S.session.session_id,{transitionOwner});
     }else{
-      const _dirP=loadDir('.');
+      const _dirP=loadDir('.',{transitionOwner});
       if(_dirP&&typeof _dirP.catch==='function') _dirP.catch(()=>{});
     }
     // Refresh sidebar to include the newly created session (#3874).
-    if(typeof refreshSessionList==='function'){Promise.resolve(refreshSessionList('new-session')).catch(()=>{})}
+    if(typeof refreshSessionList==='function'){Promise.resolve(refreshSessionList('new-session',{transitionOwner})).catch(()=>{})}
+    return true;
   })();
+  _newSessionInFlight=thisNewSessionPromise;
+  _newSessionInFlightOwner=transitionOwner;
   try{
-    return await _newSessionInFlight;
+    return await thisNewSessionPromise;
   }finally{
-    _newSessionInFlight=null;
-    _setNewSessionPending(false);
+    if(_newSessionInFlight===thisNewSessionPromise){
+      _newSessionInFlight=null;
+      _newSessionInFlightOwner=null;
+      _setNewSessionPending(false);
+    }
   }
 }
 
@@ -1630,13 +1645,14 @@ async function _switchProfileForSessionLoad(profile){
   const name=String(profile||'').trim();
   if(!name) throw new Error('missing profile');
   if(name===S.activeProfile) return;
+  const transitionOwner=_beginProfileTransitionOwner(name,'session-load');
   if(typeof _invalidateSessionListRenders==='function') _invalidateSessionListRenders();
   if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(true);
   if(typeof showSessionListSkeleton==='function') showSessionListSkeleton(name);
-  let transitionOwner=null;
   try{
-    const data=await api('/api/profile/switch',{method:'POST',body:JSON.stringify({name}),timeoutToast:false});
-    transitionOwner=_acceptProfileTransitionOwner(data.active||name,'session-load');
+    const data=await _postProfileTransition(transitionOwner);
+    if(!data) return null;
+    if(!_acceptProfileTransitionOwner(transitionOwner,data.active||name)) return null;
     if(typeof refreshProfileTransitionReasoningChip==='function'){
       await refreshProfileTransitionReasoningChip(
         data.default_model,
@@ -1660,11 +1676,11 @@ async function _switchProfileForSessionLoad(profile){
     if(typeof syncTopbar==='function') syncTopbar();
     if(!_isProfileTransitionOwner(transitionOwner)) return null;
     if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
-    if(typeof renderSessionList==='function') await renderSessionList();
+    if(typeof renderSessionList==='function') await renderSessionList({transitionOwner});
     if(!_isProfileTransitionOwner(transitionOwner)) return null;
     return transitionOwner;
   }catch(switchErr){
-    if(transitionOwner&&!_isProfileTransitionOwner(transitionOwner)) return null;
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
     // The switch POST failed, so we're still on the previous profile and its
     // caches are intact. Clear the up-front skeleton and re-render the real
     // list so the sidebar doesn't strand on the skeleton (the #4671 strand bug
@@ -1675,12 +1691,31 @@ async function _switchProfileForSessionLoad(profile){
     if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
     _sessionListSkeletonActive=false;
     if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
+    _cancelProfileTransitionOwner(transitionOwner);
     throw switchErr;
   }
 }
 
 async function loadSession(sid){
   const opts = arguments[1] || {};
+  const transitionOwner=opts.transitionOwner||(
+    typeof _currentProfileTransitionOwner==='function'
+      ? _currentProfileTransitionOwner()
+      : null
+  );
+  const transitionEpoch=typeof _currentProfileTransitionEpoch==='function'
+    ? _currentProfileTransitionEpoch()
+    : (transitionOwner&&transitionOwner.generation)||0;
+  const transitionProfile=transitionOwner&&transitionOwner.profile;
+  const transitionCurrent=()=>{
+    const epochCurrent=typeof _currentProfileTransitionEpoch!=='function'||_currentProfileTransitionEpoch()===transitionEpoch;
+    if(!transitionOwner) return epochCurrent;
+    return epochCurrent&&
+      (typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner))&&
+      transitionOwner.profile===transitionProfile&&
+      transitionOwner.accepted===true;
+  };
+  if(!transitionCurrent()) return;
   // Resolve canonical lineage SID BEFORE both the direct and sidebar preload
   // notifications so extensions always see the canonical session id, not the
   // raw sidebar click id (which may differ after lineage folding).
@@ -1726,7 +1761,8 @@ async function loadSession(sid){
   // Mark this session as the in-flight load. Subsequent loadSession() calls
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   const _loadGeneration = ++_loadSessionGeneration;
-  const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
+  const _isCurrentNavigation = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
+  const _isCurrentLoad = () => transitionCurrent() && _isCurrentNavigation();
   _loadingSessionId = sid;
   if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
   // Reset scroll state for fresh session navigation — the reader expects to
@@ -1849,12 +1885,12 @@ async function loadSession(sid){
         // navigated to a different session. If we no longer own the load, bail
         // before clearing _loadingSessionId or retrying so the stale
         // continuation can't hijack the UI back to the old target.
-        if (!_isCurrentLoad()) {
+        if (!_isCurrentNavigation() || (typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner))) {
           _rearmActiveSessionStream();
           return;
         }
-        if (_isCurrentLoad()) _loadingSessionId = null;
-        return loadSession(sid,{...opts,skipProfileResolve:true,force:true,_preloadNotified:true});
+        if (_isCurrentNavigation()) _loadingSessionId = null;
+        return loadSession(sid,{...opts,skipProfileResolve:true,force:true,_preloadNotified:true,transitionOwner});
       }catch(switchErr){
         e=switchErr;
       }
@@ -1966,16 +2002,13 @@ async function loadSession(sid){
   const continuationSid=(data.session&&data.session.continuation_session_id)||'';
   if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
     _loadingSessionId=null;
-    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true});
+    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true,transitionOwner});
   }
   S.session=data.session;
   // Loading a real existing session abandons any pre-session toolset override
   // before the awaited display-preference refresh can yield to another action.
   S._pendingSessionToolsets=null;
   if(typeof refreshReasoningPreferencesForRender==='function'){
-    const transitionOwner=typeof _currentProfileTransitionOwner==='function'
-      ? _currentProfileTransitionOwner()
-      : null;
     await refreshReasoningPreferencesForRender(
       S.session.model,
       S.session.model_provider,
@@ -1998,12 +2031,12 @@ async function loadSession(sid){
     if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){
       Promise.resolve().then(()=>{
         if(!isActiveModelRefreshSession()) return undefined;
-        return window._startBootModelDropdown();
+        return window._startBootModelDropdown(transitionOwner);
       }).catch(()=>{});
     }else{
       const modelRefreshPromise=_deferSessionSideEffect(modelRefreshSid,()=>{
         if(!isActiveModelRefreshSession()) return undefined;
-        return populateModelDropdown({freshness:'session_visit'});
+        return populateModelDropdown({freshness:'session_visit',transitionOwner});
       }).catch(()=>{});
       if(typeof window!=='undefined') window._modelDropdownReady=modelRefreshPromise;
     }
@@ -2024,7 +2057,7 @@ async function loadSession(sid){
     try { window._resetScrollDirectionTracker(); } catch (_) {}
   }
   if(typeof _applyPendingSessionModelForSession==='function') _applyPendingSessionModelForSession(sid);
-  _resolveSessionModelForDisplaySoon(sid);
+  _resolveSessionModelForDisplaySoon(sid,transitionOwner);
   // Sync workspace display immediately so the chip label reflects the new session's workspace
   // before any async message-loading begins (mirrors how model is handled).
   if(typeof syncTopbar==='function') syncTopbar();
@@ -2134,7 +2167,7 @@ async function loadSession(sid){
     // this session's INFLIGHT snapshot, not leave prior-session rows in place.
     if(typeof clearLiveToolCards==='function') clearLiveToolCards();
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration, transitionOwner});
     } catch(e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
@@ -2227,7 +2260,7 @@ async function loadSession(sid){
       const liveTurn=document.getElementById('liveAssistantTurn');
       if(!liveTurn||!liveTurn.querySelector('.tool-call-group[data-tool-worklog-group="1"]')) ensureLiveWorklogShell();
     }
-    _deferWorkspaceRefreshForSession(sid);
+    _deferWorkspaceRefreshForSession(sid,{transitionOwner});
     setBusy(true);setComposerStatus('');
     startApprovalPolling(sid);
     if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
@@ -2240,7 +2273,7 @@ async function loadSession(sid){
     // "messages already populated" early-return inside _ensureMessagesLoaded
     // does NOT skip the swap to the new transcript.
     try {
-      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
+      await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration, transitionOwner});
     } catch (e) {
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
@@ -2326,7 +2359,7 @@ async function loadSession(sid){
         if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
         else appendThinking();
       }
-      _deferWorkspaceRefreshForSession(sid);
+      _deferWorkspaceRefreshForSession(sid,{transitionOwner});
       updateQueueBadge(sid);
       startApprovalPolling(sid);
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
@@ -2344,7 +2377,7 @@ async function loadSession(sid){
       // Workspace refresh is guarded by session id inside loadDir(); keep it
       // after the transcript's first paint so chat switching is not competing
       // with file-tree / git badge IO.
-      _deferWorkspaceRefreshForSession(sid);
+      _deferWorkspaceRefreshForSession(sid,{transitionOwner});
     }
   }
 
@@ -2972,11 +3005,14 @@ function _deferWorkspaceRefreshForSession(sid, opts={}){
   },150);
 }
 
-function _resolveSessionModelForDisplaySoon(sid){
+function _resolveSessionModelForDisplaySoon(sid,transitionOwner){
   if(!sid) return;
   _deferSessionSideEffect(sid,async()=>{
+    const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+    if(!transitionCurrent()) return;
     try{
       const data=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=1`);
+      if(!transitionCurrent()) return;
       const model=data&&data.session&&data.session.model;
       const provider=data&&data.session&&data.session.model_provider;
       if(!model||!S.session||S.session.session_id!==sid) return;
@@ -3138,7 +3174,12 @@ async function _ensureMessagesLoaded(sid, opts) {
   // S.messages in a single frame.
   opts = opts || {};
   const _loadGeneration = Number.isFinite(opts.loadGeneration) ? Number(opts.loadGeneration) : null;
-  const _ownsLoad = () => _loadingSessionId === sid && (_loadGeneration === null || _loadSessionGeneration === _loadGeneration);
+  const transitionOwner=opts.transitionOwner||null;
+  const _ownsTransition=()=>!transitionOwner||(
+    (typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner))&&
+    transitionOwner.accepted===true
+  );
+  const _ownsLoad = () => _ownsTransition() && _loadingSessionId === sid && (_loadGeneration === null || _loadSessionGeneration === _loadGeneration);
   if (!_ownsLoad()) return;
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
   if (!opts.force && S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
@@ -5311,10 +5352,12 @@ function _schedulePendingSessionListApply(){
     const payload=_pendingSessionListPayload;
     _pendingSessionListPayload=null;
     if(payload.gen!==_renderSessionListGen) return;
+    if(payload.transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(payload.transitionOwner)) return;
     // Profile switch may have bumped unread gen after the list gen check
     // window; still drop completion-marking for the stale pre-switch payload.
     _applySessionListPayload(payload.sessData,payload.projData,{
       unreadGen:payload.unreadGen,
+      transitionOwner:payload.transitionOwner,
     });
   }, Math.max(120, SESSION_LIST_INTERACTION_IDLE_MS));
 }
@@ -5390,6 +5433,8 @@ function _applySessionListPayload(sessData, projData, opts){
   // active profile so the "Show N from other profiles" toggle can render
   // without a second round-trip. Stashed on the module for renderSessionListFromCache.
   const applyOpts = (opts && typeof opts === 'object') ? opts : {};
+  const transitionOwner=applyOpts.transitionOwner||null;
+  if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
   _otherProfileCount = sessData.other_profile_count || 0;
   _archivedWebuiCount = Number(sessData.archived_webui_count ?? sessData.archived_count ?? 0);
   _archivedCliCount = Number(sessData.archived_cli_count ?? 0);
@@ -5600,6 +5645,9 @@ function _renderSessionListLoadErrorNote(){
 
 async function _runRenderSessionListRefresh(opts, _gen){
   const deferWhileInteracting=Boolean(opts&&opts.deferWhileInteracting);
+  const transitionOwner=opts&&opts.transitionOwner||null;
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+  if(!transitionCurrent()) return;
   if(!deferWhileInteracting) _pendingSessionListPayload=null;
   // Capture profile-switch unread generation BEFORE the await so a switch
   // mid-flight (which increments _cronPollGeneration) invalidates completion
@@ -5624,6 +5672,7 @@ async function _runRenderSessionListRefresh(opts, _gen){
       sessionRequestOpts.retryTimeouts=true;
     }
     const {sessData, projData}=await _loadSidebarSessionListPayload(sessionListQS, sessionRequestOpts);
+    if(!transitionCurrent()) return;
     // Discard stale response — a newer renderSessionList() call superseded us.
     if (_gen !== _renderSessionListGen) return;
     // #4671: while a profile switch is mid-flight, drop ANY payload — even one whose
@@ -5633,12 +5682,13 @@ async function _runRenderSessionListRefresh(opts, _gen){
     // renderSessionList(), so that render's payload is the first allowed to paint.
     if (_profileSwitchListEmbargo) return;
     if(deferWhileInteracting&&_isSessionListUserInteracting()){
-      _pendingSessionListPayload={gen:_gen,sessData,projData,unreadGen};
+      _pendingSessionListPayload={gen:_gen,sessData,projData,unreadGen,transitionOwner};
       _schedulePendingSessionListApply();
       return;
     }
-    _applySessionListPayload(sessData,projData,{unreadGen});
+    _applySessionListPayload(sessData,projData,{unreadGen,transitionOwner});
   }catch(e){
+    if(!transitionCurrent()) return;
     if (_gen !== _renderSessionListGen) return;
     // #4671: same embargo guard as the success path — a mid-switch /api/sessions that
     // FAILS must not clear the skeleton flag or render the old-profile cache either. The
@@ -5971,6 +6021,8 @@ function ensureActiveSessionExternalRefreshPoll(){
 async function refreshSessionList(reason='manual', opts={}){
   const force = !!(opts && opts.force);
   const refreshActive = !!(opts && opts.refreshActive);
+  const transitionOwner=opts&&opts.transitionOwner||null;
+  if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
   if(!force && typeof document !== 'undefined' && document.hidden) return;
   if(_sessionListRefreshInFlight){
     _sessionListRefreshPendingRequest = {
@@ -5981,7 +6033,8 @@ async function refreshSessionList(reason='manual', opts={}){
   }
   _sessionListRefreshInFlight = true;
   try{
-    await renderSessionList({deferWhileInteracting:!force});
+    await renderSessionList({deferWhileInteracting:!force,transitionOwner});
+    if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
     if(refreshActive) await refreshActiveSessionIfExternallyUpdated(reason||'session-list');
   }finally{
     _sessionListRefreshInFlight = false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5682,11 +5682,17 @@ async function _runRenderSessionListRefresh(opts, _gen){
     // renderSessionList(), so that render's payload is the first allowed to paint.
     if (_profileSwitchListEmbargo) return;
     if(deferWhileInteracting&&_isSessionListUserInteracting()){
-      _pendingSessionListPayload={gen:_gen,sessData,projData,unreadGen,transitionOwner};
+      _pendingSessionListPayload=transitionOwner
+        ? {gen:_gen,sessData,projData,unreadGen,transitionOwner}
+        : {gen:_gen,sessData,projData,unreadGen};
       _schedulePendingSessionListApply();
       return;
     }
-    _applySessionListPayload(sessData,projData,{unreadGen,transitionOwner});
+    _applySessionListPayload(
+      sessData,
+      projData,
+      transitionOwner ? {unreadGen,transitionOwner} : {unreadGen}
+    );
   }catch(e){
     if(!transitionCurrent()) return;
     if (_gen !== _renderSessionListGen) return;
@@ -6033,7 +6039,10 @@ async function refreshSessionList(reason='manual', opts={}){
   }
   _sessionListRefreshInFlight = true;
   try{
-    await renderSessionList({deferWhileInteracting:!force,transitionOwner});
+    await renderSessionList({
+      deferWhileInteracting:!force,
+      ...(transitionOwner?{transitionOwner}:{}),
+    });
     if(transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner)) return;
     if(refreshActive) await refreshActiveSessionIfExternallyUpdated(reason||'session-list');
   }finally{

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1645,7 +1645,7 @@ async function _switchProfileForSessionLoad(profile){
     if(data.default_model) window._defaultModel=data.default_model;
     if(data.default_model_provider) window._activeProvider=data.default_model_provider;
     if(typeof refreshProfileTransitionReasoningChip==='function'){
-      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
+      await refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
     }
     if(typeof startGatewaySSE==='function') startGatewaySSE();
     if(typeof syncTopbar==='function') syncTopbar();
@@ -1955,6 +1955,15 @@ async function loadSession(sid){
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true});
   }
   S.session=data.session;
+  if(typeof refreshReasoningPreferencesForRender==='function'){
+    await refreshReasoningPreferencesForRender(S.session.model,S.session.model_provider);
+    // A newer navigation can win while the preference request is in flight.
+    // Do not render/cache this stale session under the newer profile/session.
+    if(!_isCurrentLoad()){
+      _rearmActiveSessionStream();
+      return;
+    }
+  }
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer before any deferred refresh work runs.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1633,8 +1633,18 @@ async function _switchProfileForSessionLoad(profile){
   if(typeof _invalidateSessionListRenders==='function') _invalidateSessionListRenders();
   if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(true);
   if(typeof showSessionListSkeleton==='function') showSessionListSkeleton(name);
+  let transitionOwner=null;
   try{
     const data=await api('/api/profile/switch',{method:'POST',body:JSON.stringify({name}),timeoutToast:false});
+    transitionOwner=_acceptProfileTransitionOwner(data.active||name,'session-load');
+    if(typeof refreshProfileTransitionReasoningChip==='function'){
+      await refreshProfileTransitionReasoningChip(
+        data.default_model,
+        data.default_model_provider,
+        transitionOwner
+      );
+    }
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
     S.activeProfile=data.active||name;
     S.activeProfileIsDefault=!!data.is_default;
     if(typeof _resetCronUnreadForProfileSwitch==='function'){
@@ -1644,14 +1654,17 @@ async function _switchProfileForSessionLoad(profile){
     else localStorage.removeItem('hermes-webui-model');
     if(data.default_model) window._defaultModel=data.default_model;
     if(data.default_model_provider) window._activeProvider=data.default_model_provider;
-    if(typeof refreshProfileTransitionReasoningChip==='function'){
-      await refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
-    }
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
     if(typeof startGatewaySSE==='function') startGatewaySSE();
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
     if(typeof syncTopbar==='function') syncTopbar();
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
     if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
     if(typeof renderSessionList==='function') await renderSessionList();
+    if(!_isProfileTransitionOwner(transitionOwner)) return null;
+    return transitionOwner;
   }catch(switchErr){
+    if(transitionOwner&&!_isProfileTransitionOwner(transitionOwner)) return null;
     // The switch POST failed, so we're still on the previous profile and its
     // caches are intact. Clear the up-front skeleton and re-render the real
     // list so the sidebar doesn't strand on the skeleton (the #4671 strand bug
@@ -1829,7 +1842,8 @@ async function loadSession(sid){
       }
       try{
         if(typeof showToast==='function') showToast(`Switching to ${profileMismatch.profile} profile for this session…`,2200);
-        await _switchProfileForSessionLoad(profileMismatch.profile);
+        const transitionOwner=await _switchProfileForSessionLoad(profileMismatch.profile);
+        if(!transitionOwner) return;
         // Post-await stale-load guard (Codex): the profile switch above does a
         // network POST + session-list re-render, during which the user may have
         // navigated to a different session. If we no longer own the load, bail
@@ -1959,10 +1973,20 @@ async function loadSession(sid){
   // before the awaited display-preference refresh can yield to another action.
   S._pendingSessionToolsets=null;
   if(typeof refreshReasoningPreferencesForRender==='function'){
-    await refreshReasoningPreferencesForRender(S.session.model,S.session.model_provider);
+    const transitionOwner=typeof _currentProfileTransitionOwner==='function'
+      ? _currentProfileTransitionOwner()
+      : null;
+    await refreshReasoningPreferencesForRender(
+      S.session.model,
+      S.session.model_provider,
+      transitionOwner
+    );
     // A newer navigation can win while the preference request is in flight.
     // Do not render/cache this stale session under the newer profile/session.
-    if(!_isCurrentLoad()){
+    if(
+      !_isCurrentLoad() ||
+      (transitionOwner&&typeof _isProfileTransitionOwner==='function'&&!_isProfileTransitionOwner(transitionOwner))
+    ){
       _rearmActiveSessionStream();
       return;
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1955,6 +1955,9 @@ async function loadSession(sid){
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true});
   }
   S.session=data.session;
+  // Loading a real existing session abandons any pre-session toolset override
+  // before the awaited display-preference refresh can yield to another action.
+  S._pendingSessionToolsets=null;
   if(typeof refreshReasoningPreferencesForRender==='function'){
     await refreshReasoningPreferencesForRender(S.session.model,S.session.model_provider);
     // A newer navigation can win while the preference request is in flight.
@@ -1965,9 +1968,6 @@ async function loadSession(sid){
     }
   }
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
-  // Loading a real existing session abandons any pre-session toolset override
-  // staged on the empty composer before any deferred refresh work runs.
-  S._pendingSessionToolsets=null;
   if(typeof populateModelDropdown==='function'){
     const modelRefreshSid=sid;
     const isActiveModelRefreshSession=()=>!!(S.session&&S.session.session_id===modelRefreshSid);

--- a/static/ui.js
+++ b/static/ui.js
@@ -5102,10 +5102,11 @@ function fetchReasoningChip(keyOverride){
   const key=keyOverride===undefined?_reasoningEffortQuery():keyOverride;
   const seq=++_reasoningFetchSeq;
   _lastReasoningFetchKey=key;
-  api('/api/reasoning'+key).then(function(st){
+  return api('/api/reasoning'+key).then(function(st){
     // Ignore a stale/superseded response: only the most recent dispatch may
     // apply, so an older in-flight GET can't poison the current chip (#4650).
     if(seq!==_reasoningFetchSeq) return;
+    window._showCommentary=!st||st.show_commentary!==false;
     _applyReasoningChip((st&&st.reasoning_effort)||'', st||{});
   }).catch(function(){
     // Same staleness guard on failure: a stale error must neither hide the chip
@@ -5117,18 +5118,26 @@ function fetchReasoningChip(keyOverride){
   });
 }
 
+function refreshReasoningPreferencesForRender(model, provider){
+  // Invalidate both the request cache and any older in-flight response, then
+  // fail closed until the active profile's effective display preference is
+  // known. Callers await this before rendering persisted/cached transcript.
+  _lastReasoningFetchKey=null;
+  ++_reasoningFetchSeq;
+  window._showCommentary=false;
+  const params=new URLSearchParams();
+  if(model) params.set('model',model);
+  if(provider) params.set('provider',provider);
+  return fetchReasoningChip(params.size?'?'+params.toString():undefined);
+}
+
 function refreshProfileTransitionReasoningChip(model, provider){
   _profileTransitionReasoningContext={profile:(S&&S.activeProfile)||'default',model,provider};
   _currentReasoningEffort=null;
   _currentReasoningEffortsSupported=null;
   _currentReasoningToggleSupported=undefined;
-  _lastReasoningFetchKey=null;
-  ++_reasoningFetchSeq;
   _applyReasoningChip('', {supported_efforts:[], supports_thinking_toggle:false});
-  const params=new URLSearchParams();
-  if(model) params.set('model',model);
-  if(provider) params.set('provider',provider);
-  fetchReasoningChip(params.size?'?'+params.toString():undefined);
+  return refreshReasoningPreferencesForRender(model,provider);
 }
 
 function clearProfileTransitionReasoningContext(){
@@ -10727,7 +10736,7 @@ function _assistantAnchorSceneFinalAnswerText(m){
   const text=scene&&typeof scene.final_answer==='string'?scene.final_answer:'';
   return String(text||'').trim()?text:'';
 }
-function _assistantCommentaryPayloadText(m){
+function _assistantPersistedCommentaryPayloadText(m){
   if(!m||m.role!=='assistant') return '';
   let items=m.codex_message_items;
   if(typeof items==='string'){
@@ -10750,6 +10759,10 @@ function _assistantCommentaryPayloadText(m){
     }
   }
   return parts.join('').trim();
+}
+function _assistantCommentaryPayloadText(m){
+  if(window._showCommentary===false) return '';
+  return _assistantPersistedCommentaryPayloadText(m);
 }
 function _assistantDisplayContentFromMessage(m, rawContent){
   const existing=String(rawContent||'').trim();
@@ -13432,6 +13445,7 @@ function _anchorSceneHasErroredTerminalState(scene){
 function _anchorSceneRowsForSettledWorklog(scene, blocks){
   const rows=_anchorSceneRowsForRendering(scene,{settled:true});
   const visibleCommentaryTexts=new Set();
+  const commentaryReasoningFallbackTexts=new Set();
   if(blocks&&blocks.querySelectorAll){
     blocks.querySelectorAll('[data-visible-commentary="1"]').forEach(node=>{
       const key=_normalizeThinkingEchoCompare(
@@ -13439,15 +13453,43 @@ function _anchorSceneRowsForSettledWorklog(scene, blocks){
       );
       if(key) visibleCommentaryTexts.add(key);
     });
+    // The presentation preference may suppress the ordinary commentary owner,
+    // but its exact settled-scene echo must not leak through Worklog. Resolve
+    // source text from the immutable session sidecar via raw message indices;
+    // do not mutate/remove codex_message_items and do not copy private text into
+    // a DOM attribute just to make the ownership decision.
+    blocks.querySelectorAll('.assistant-segment[data-msg-idx]').forEach(node=>{
+      const idx=Number(node.getAttribute('data-msg-idx'));
+      if(!Number.isFinite(idx)||!S||!Array.isArray(S.messages)) return;
+      const key=_normalizeThinkingEchoCompare(
+        _assistantPersistedCommentaryPayloadText(S.messages[idx])
+      );
+      if(key){
+        visibleCommentaryTexts.add(key);
+        const reasoningKey=_normalizeThinkingEchoCompare(
+          _assistantReasoningPayloadText(S.messages[idx])
+        );
+        if(reasoningKey===key) commentaryReasoningFallbackTexts.add(key);
+      }
+    });
   }
   if(!visibleCommentaryTexts.size) return rows;
   // Commentary is ordinary assistant information. Keep tools, true reasoning
-  // and DISTINCT process prose in Worklog; remove only an exact commentary echo.
-  return rows.filter(row=>{
-    if(!row||String(row.role||'')!=='prose') return true;
-    return !visibleCommentaryTexts.has(
-      _normalizeThinkingEchoCompare(row.text||row.content||'')
-    );
+  // and DISTINCT process prose in Worklog. When commentary presentation is off,
+  // an exact reasoning-backed echo becomes Thinking (and therefore obeys the
+  // independent show_thinking preference) instead of leaking as process prose.
+  return rows.flatMap(row=>{
+    if(!row||String(row.role||'')!=='prose') return [row];
+    const key=_normalizeThinkingEchoCompare(row.text||row.content||'');
+    if(!visibleCommentaryTexts.has(key)) return [row];
+    if(
+      window._showCommentary===false&&
+      window._showThinking!==false&&
+      commentaryReasoningFallbackTexts.has(key)
+    ){
+      return [{...row,role:'thinking',kind:'reasoning',display_hint:'collapsed_thinking'}];
+    }
+    return [];
   });
 }
 function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx){
@@ -14746,6 +14788,8 @@ function _messageRenderCacheSignature(){
     hash=Math.imul(hash,16777619)>>>0;
   }
   const messages=Array.isArray(S.messages)?S.messages:[];
+  add(window._showCommentary!==false);
+  add(window._showThinking!==false);
   add(messages.length);
   for(const m of messages){
     if(!m||typeof m!=='object'){ add('missing'); continue; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -3386,6 +3386,8 @@ function _applySessionModelFallback(sel){
 async function populateModelDropdown(opts={}){
   const sel=$('modelSelect');
   if(!sel) return;
+  const transitionOwner=opts&&opts.transitionOwner;
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
   // `_activeProvider` is refreshed from the /api/models response below.
   if(typeof _modelDropdownRequestSeq!=='number') _modelDropdownRequestSeq=0;
   if(typeof _modelCatalogFallbackRetried!=='boolean') _modelCatalogFallbackRetried=false;
@@ -3396,6 +3398,7 @@ async function populateModelDropdown(opts={}){
     if(opts&&opts.freshness) modelsUrl.searchParams.set('freshness',opts.freshness);
     const _modelsRes=await fetch(modelsUrl.href,{credentials:'include'});
     if(requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     const customRedirectIfUnauth=opts&&typeof opts.redirectIfUnauth==='function'?opts.redirectIfUnauth:null;
     if(customRedirectIfUnauth){
       if(customRedirectIfUnauth(_modelsRes)) return;
@@ -3403,6 +3406,7 @@ async function populateModelDropdown(opts={}){
     // `_activeProvider` is populated from the /api/models payload below.
     const data=await _modelsRes.json();
     if(requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     window._activeProvider=data.active_provider||null;
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
@@ -3516,6 +3520,7 @@ async function populateModelDropdown(opts={}){
     }
   }catch(e){
     if(requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     // API unavailable -- keep the hardcoded HTML options as fallback
     console.warn('Failed to load models from server:',e.message);
     if(typeof syncModelChip==='function') syncModelChip();

--- a/static/ui.js
+++ b/static/ui.js
@@ -10727,10 +10727,40 @@ function _assistantAnchorSceneFinalAnswerText(m){
   const text=scene&&typeof scene.final_answer==='string'?scene.final_answer:'';
   return String(text||'').trim()?text:'';
 }
+function _assistantCommentaryPayloadText(m){
+  if(!m||m.role!=='assistant') return '';
+  let items=m.codex_message_items;
+  if(typeof items==='string'){
+    try{items=JSON.parse(items);}catch(_){items=[];}
+  }
+  if(!Array.isArray(items)) return '';
+  const parts=[];
+  for(const item of items){
+    if(
+      !item||
+      String(item.type||'').toLowerCase()!=='message'||
+      String(item.role||'').toLowerCase()!=='assistant'||
+      String(item.phase||'').toLowerCase()!=='commentary'
+    ) continue;
+    const content=Array.isArray(item.content)?item.content:[];
+    for(const part of content){
+      if(!part||!['text','input_text','output_text'].includes(String(part.type||''))) continue;
+      const text=String(part.text||part.content||'');
+      if(text.trim()) parts.push(text);
+    }
+  }
+  return parts.join('').trim();
+}
+function _assistantDisplayContentFromMessage(m, rawContent){
+  const existing=String(rawContent||'').trim();
+  if(existing) return existing;
+  return _assistantCommentaryPayloadText(m);
+}
 function _assistantMessageHasVisibleContent(m){
   if(!m||m.role!=='assistant') return false;
   if(_isRecoveryControlMessage(m)) return false;
   if(_assistantAnchorSceneFinalAnswerText(m)) return true;
+  if(_assistantCommentaryPayloadText(m)) return true;
   const content=m.content;
   if(typeof content==='string') return !_isAssistantEmptyPlaceholderContent(m, content)&&!!content.trim();
   if(!Array.isArray(content)) return false;
@@ -10838,16 +10868,19 @@ function _assistantMessageBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs, vis
   const isTurnFinalAssistant=!!(opts&&opts.isTurnFinalAssistant);
   const visibleText=String(visibleContent!==undefined?visibleContent:msgContent(m)||'').trim();
   const hasVisibleText=!!visibleText&&!_isAssistantEmptyPlaceholderContent(m, visibleText);
-  if(m._live) return true;
+  if(m._live) return !hasVisibleText;
   if(hasVisibleText&&m._anchor_activity_scene) return false;
   if(hasVisibleText&&isTurnFinalAssistant) return false;
+  // User-visible commentary/progress is ordinary assistant information even
+  // when it carries activity burst/segment metadata. Those fields describe
+  // chronology; they must not reclassify visible prose as Worklog Thinking.
+  if(hasVisibleText) return false;
   if(m._activityBurstId!==undefined||m._liveSegmentSeq!==undefined) return true;
   const hasToolMetadata=!!(
     (toolCallAssistantIdxs&&toolCallAssistantIdxs.has(rawIdx))||
     (Array.isArray(m.tool_calls)&&m.tool_calls.length)||
     (Array.isArray(m.content)&&m.content.some(p=>p&&typeof p==='object'&&p.type==='tool_use'))
   );
-  if(hasVisibleText) return false;
   if(hasToolMetadata) return true;
   return false;
 }
@@ -12057,7 +12090,8 @@ function _deferredWorklogRowsFromGroup(group){
   const msg=S.messages&&S.messages[Number(m[1])];
   const scene=msg&&msg._anchor_activity_scene;
   if(!scene) return null;
-  return _anchorSceneRowsForRendering(scene,{settled:true});
+  const blocks=_assistantTurnBlocks(group.closest('.assistant-turn'));
+  return _anchorSceneRowsForSettledWorklog(scene,blocks);
 }
 function _rehydrateDeferredWorklogsFromCache(root){
   // After restoring a transcript from _sessionHtmlCache, deferred settled
@@ -13395,13 +13429,23 @@ function _anchorSceneHasErroredTerminalState(scene){
   const state=String(scene&&scene.terminal_state||'').trim().toLowerCase();
   return _ANCHOR_SCENE_ERRORED_TERMINAL_STATES.has(state);
 }
+function _anchorSceneRowsForSettledWorklog(scene, blocks){
+  const rows=_anchorSceneRowsForRendering(scene,{settled:true});
+  const hasVisibleCommentary=!!(
+    blocks&&blocks.querySelector&&blocks.querySelector('[data-visible-commentary="1"]')
+  );
+  if(!hasVisibleCommentary) return rows;
+  // Commentary is ordinary assistant information. Keep tools, true reasoning
+  // and terminal rows in Worklog, but do not duplicate the progress prose.
+  return rows.filter(row=>!(row&&String(row.role||'')==='prose'));
+}
 function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx){
   if(!message||!message._anchor_activity_scene||!segment) return false;
   if(!_anchorSceneSceneHasWorklogWorthyRows(message._anchor_activity_scene)) return false;
   const blocks=_assistantTurnBlocks(segment.closest('.assistant-turn'));
   if(!blocks) return false;
   const scene=message._anchor_activity_scene;
-  const rows=_anchorSceneRowsForRendering(scene,{settled:true});
+  const rows=_anchorSceneRowsForSettledWorklog(scene,blocks);
   if(!rows.length) return false;
   const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);
   // The assistant segment owns the final answer; pass it so intermediate prose
@@ -13416,7 +13460,7 @@ function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx
   blocks.querySelectorAll('.transparent-earlier-steps[data-anchor-earlier-steps="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.assistant-segment[data-msg-idx]').forEach(node=>{
     const idx=Number(node.getAttribute('data-msg-idx'));
-    if(Number.isFinite(idx)&&idx<rawIdx){
+    if(Number.isFinite(idx)&&idx<rawIdx&&node.getAttribute('data-visible-commentary')!=='1'){
       node.classList.add('assistant-segment-worklog-source');
       node.setAttribute('aria-hidden','true');
       node.hidden=true;
@@ -13673,11 +13717,11 @@ function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
   const blocks=_assistantTurnBlocks(segment.closest('.assistant-turn'));
   if(!blocks) return false;
   const scene=message._anchor_activity_scene;
-  const rows=_anchorSceneRowsForRendering(scene,{settled:true});
+  const rows=_anchorSceneRowsForSettledWorklog(scene,blocks);
   if(!rows.length) return false;
   blocks.querySelectorAll('.assistant-segment[data-msg-idx]').forEach(node=>{
     const idx=Number(node.getAttribute('data-msg-idx'));
-    if(Number.isFinite(idx)&&idx<rawIdx){
+    if(Number.isFinite(idx)&&idx<rawIdx&&node.getAttribute('data-visible-commentary')!=='1'){
       node.classList.add('assistant-segment-worklog-source');
       node.setAttribute('aria-hidden','true');
       node.hidden=true;
@@ -16276,7 +16320,10 @@ function renderMessages(options){
     if(!isUser&&_isMarkerOnlyAssistantCompressionMessage(m)){
       content='**Error:** No response received after context compression. Please retry.';
     }
-    const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):content;
+    const commentaryDisplayText=!isUser?_assistantCommentaryPayloadText(m):'';
+    const isVisibleCommentary=!!(!isUser&&!String(content||'').trim()&&String(commentaryDisplayText||'').trim());
+    let displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):_assistantDisplayContentFromMessage(m, content);
+    if(isVisibleCommentary) content=displayContent;
     const rowDisplayContent=displayContent;
     if(!isUser&&_isAssistantEmptyPlaceholderContent(m, displayContent)){
       content='';
@@ -16537,6 +16584,7 @@ function renderMessages(options){
     seg.dataset.sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);
     seg.dataset.messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
     seg.dataset.rawText=String(content).trim();
+    if(isVisibleCommentary) seg.setAttribute('data-visible-commentary','1');
     if(m._activityBurstId!==undefined&&m._activityBurstId!==null) seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
     if(Number.isFinite(Number(m._liveSegmentSeq))) seg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
     const messageBelongsInWorklog=!S.busy&&isCompactWorklogMode()&&_assistantMessageBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs, displayContent, {isTurnFinalAssistant});

--- a/static/ui.js
+++ b/static/ui.js
@@ -5095,7 +5095,30 @@ let _lastReasoningFetchKey=null;
 // a different agent.reasoning_effort) — #4650 review.
 let _reasoningFetchSeq=0;
 
-function fetchReasoningChip(keyOverride){
+// One accepted owner shared by every profile-switch ingress. The canonical UI
+// switch and the session-recovery switch both POST /api/profile/switch, so
+// request-local generations cannot fence them from each other. A POST response
+// claims this owner before any profile/default/preference/SSE/DOM publication;
+// every awaited continuation must revalidate it.
+let _profileTransitionOwnerSeq=0;
+let _profileTransitionOwner=null;
+function _acceptProfileTransitionOwner(profile, source){
+  const owner=Object.freeze({
+    generation:++_profileTransitionOwnerSeq,
+    profile:String(profile||'default'),
+    source:String(source||'unknown'),
+  });
+  _profileTransitionOwner=owner;
+  return owner;
+}
+function _isProfileTransitionOwner(owner){
+  return !!owner&&owner===_profileTransitionOwner&&owner.generation===_profileTransitionOwnerSeq;
+}
+function _currentProfileTransitionOwner(){
+  return _profileTransitionOwner;
+}
+
+function fetchReasoningChip(keyOverride, transitionOwner){
   // Set the cache key OPTIMISTICALLY before the request so rapid routine syncs
   // while this GET is in flight short-circuit instead of re-dispatching (that
   // in-flight window is exactly where the #4650 storm lived).
@@ -5105,20 +5128,24 @@ function fetchReasoningChip(keyOverride){
   return api('/api/reasoning'+key).then(function(st){
     // Ignore a stale/superseded response: only the most recent dispatch may
     // apply, so an older in-flight GET can't poison the current chip (#4650).
-    if(seq!==_reasoningFetchSeq) return;
+    if(seq!==_reasoningFetchSeq) return false;
+    if(transitionOwner&&!_isProfileTransitionOwner(transitionOwner)) return false;
     window._showCommentary=!st||st.show_commentary!==false;
     _applyReasoningChip((st&&st.reasoning_effort)||'', st||{});
+    return true;
   }).catch(function(){
     // Same staleness guard on failure: a stale error must neither hide the chip
     // nor clear a newer fetch's key. Only the latest dispatch clears the key so
     // routine syncs retry after a genuine transient failure.
-    if(seq!==_reasoningFetchSeq) return;
+    if(seq!==_reasoningFetchSeq) return false;
+    if(transitionOwner&&!_isProfileTransitionOwner(transitionOwner)) return false;
     _lastReasoningFetchKey=null;
     _applyReasoningChip('', {supported_efforts:[], supports_thinking_toggle:false});
+    return false;
   });
 }
 
-function refreshReasoningPreferencesForRender(model, provider){
+function refreshReasoningPreferencesForRender(model, provider, transitionOwner){
   // Invalidate both the request cache and any older in-flight response, then
   // fail closed until the active profile's effective display preference is
   // known. Callers await this before rendering persisted/cached transcript.
@@ -5128,16 +5155,20 @@ function refreshReasoningPreferencesForRender(model, provider){
   const params=new URLSearchParams();
   if(model) params.set('model',model);
   if(provider) params.set('provider',provider);
-  return fetchReasoningChip(params.size?'?'+params.toString():undefined);
+  return fetchReasoningChip(params.size?'?'+params.toString():undefined,transitionOwner);
 }
 
-function refreshProfileTransitionReasoningChip(model, provider){
-  _profileTransitionReasoningContext={profile:(S&&S.activeProfile)||'default',model,provider};
+function refreshProfileTransitionReasoningChip(model, provider, transitionOwner){
+  _profileTransitionReasoningContext={
+    profile:(transitionOwner&&transitionOwner.profile)||(S&&S.activeProfile)||'default',
+    model,
+    provider,
+  };
   _currentReasoningEffort=null;
   _currentReasoningEffortsSupported=null;
   _currentReasoningToggleSupported=undefined;
   _applyReasoningChip('', {supported_efforts:[], supports_thinking_toggle:false});
-  return refreshReasoningPreferencesForRender(model,provider);
+  return refreshReasoningPreferencesForRender(model,provider,transitionOwner);
 }
 
 function clearProfileTransitionReasoningContext(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -13621,7 +13621,7 @@ function _revealTransparentEarlierSteps(message, segment, rawIdx, affordanceEl){
   const scene=message&&message._anchor_activity_scene;
   const blocks=_assistantTurnBlocks(turnEl);
   if(!scene||!blocks){ if(affordanceEl) affordanceEl.remove(); return; }
-  const rows=_anchorSceneRowsForRendering(scene,{settled:true})||[];
+  const rows=_anchorSceneRowsForSettledWorklog(scene,blocks)||[];
   const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);
   const finalAnswer=String(
     (scene&&typeof scene.final_answer==='string'&&scene.final_answer)

--- a/static/ui.js
+++ b/static/ui.js
@@ -13431,13 +13431,24 @@ function _anchorSceneHasErroredTerminalState(scene){
 }
 function _anchorSceneRowsForSettledWorklog(scene, blocks){
   const rows=_anchorSceneRowsForRendering(scene,{settled:true});
-  const hasVisibleCommentary=!!(
-    blocks&&blocks.querySelector&&blocks.querySelector('[data-visible-commentary="1"]')
-  );
-  if(!hasVisibleCommentary) return rows;
+  const visibleCommentaryTexts=new Set();
+  if(blocks&&blocks.querySelectorAll){
+    blocks.querySelectorAll('[data-visible-commentary="1"]').forEach(node=>{
+      const key=_normalizeThinkingEchoCompare(
+        node.getAttribute('data-raw-text')||node.textContent||''
+      );
+      if(key) visibleCommentaryTexts.add(key);
+    });
+  }
+  if(!visibleCommentaryTexts.size) return rows;
   // Commentary is ordinary assistant information. Keep tools, true reasoning
-  // and terminal rows in Worklog, but do not duplicate the progress prose.
-  return rows.filter(row=>!(row&&String(row.role||'')==='prose'));
+  // and DISTINCT process prose in Worklog; remove only an exact commentary echo.
+  return rows.filter(row=>{
+    if(!row||String(row.role||'')!=='prose') return true;
+    return !visibleCommentaryTexts.has(
+      _normalizeThinkingEchoCompare(row.text||row.content||'')
+    );
+  });
 }
 function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx){
   if(!message||!message._anchor_activity_scene||!segment) return false;
@@ -16322,7 +16333,7 @@ function renderMessages(options){
     }
     const commentaryDisplayText=!isUser?_assistantCommentaryPayloadText(m):'';
     const isVisibleCommentary=!!(!isUser&&!String(content||'').trim()&&String(commentaryDisplayText||'').trim());
-    let displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):_assistantDisplayContentFromMessage(m, content);
+    const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):_assistantDisplayContentFromMessage(m, content);
     if(isVisibleCommentary) content=displayContent;
     const rowDisplayContent=displayContent;
     if(!isUser&&_isAssistantEmptyPlaceholderContent(m, displayContent)){

--- a/static/ui.js
+++ b/static/ui.js
@@ -3513,7 +3513,7 @@ async function populateModelDropdown(opts={}){
     }
     // Kick off a background live-model fetch for the active provider.
     // This runs after the static list is already shown (no blocking flicker).
-    if(data.active_provider && !willRetry) _fetchLiveModels(data.active_provider, sel, requestSeq);
+    if(data.active_provider && !willRetry) _fetchLiveModels(data.active_provider, sel, requestSeq, transitionOwner);
     if(willRetry){
       _modelCatalogFallbackRetried=true;
       populateModelDropdown({...opts,freshness:'session_visit'}).catch(()=>{});
@@ -3533,6 +3533,7 @@ const _liveModelCache={};
 // Used by syncTopbar() to defer model corrections until the fetch completes,
 // preventing premature fallback to the first static model (#1169).
 const _liveModelFetchPending=new Set();
+const _liveModelFetchPendingOwner=new Map();
 
 function _addLiveModelsToSelect(provider, models, sel){
   if(!provider||!models||!models.length||!sel) return 0;
@@ -3633,28 +3634,36 @@ function _addLiveModelsToSelect(provider, models, sel){
   return added;
 }
 
-async function _fetchLiveModels(provider, sel, requestSeq=null){
+async function _fetchLiveModels(provider, sel, requestSeq=null, transitionOwner=null){
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+  if(!transitionCurrent()) return;
   if(!provider||!sel) return;
   if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
   // Already fetched — apply cached models to this select element (#872)
   if(_liveModelCache[provider]){
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     const added=_addLiveModelsToSelect(provider,_liveModelCache[provider],sel);
     if(added>0 && typeof syncModelChip==='function') syncModelChip();
     return;
   }
+  const pendingToken={requestSeq,transitionOwner};
   _liveModelFetchPending.add(provider);
+  _liveModelFetchPendingOwner.set(provider,pendingToken);
   try{
     const url=new URL('api/models/live',document.baseURI||location.href);
     url.searchParams.set('provider',provider);
     const _liveRes=await fetch(url.href,{credentials:'include'});
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     if(_redirectIfUnauth(_liveRes)) return;
     const data=await _liveRes.json();
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     if(!data.models||!data.models.length) return;
     _liveModelCache[provider]=data.models;
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+    if(!transitionCurrent()) return;
     const added=_addLiveModelsToSelect(provider,data.models,sel);
     if(added>0){
       if(typeof syncModelChip==='function') syncModelChip();
@@ -3663,7 +3672,10 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
   }catch(e){
     console.debug('[hermes] Live model fetch failed for',provider,e.message);
   }finally{
-    _liveModelFetchPending.delete(provider);
+    if(_liveModelFetchPendingOwner.get(provider)===pendingToken){
+      _liveModelFetchPendingOwner.delete(provider);
+      _liveModelFetchPending.delete(provider);
+    }
   }
 }
 
@@ -5100,27 +5112,57 @@ let _lastReasoningFetchKey=null;
 // a different agent.reasoning_effort) — #4650 review.
 let _reasoningFetchSeq=0;
 
-// One accepted owner shared by every profile-switch ingress. The canonical UI
-// switch and the session-recovery switch both POST /api/profile/switch, so
-// request-local generations cannot fence them from each other. A POST response
-// claims this owner before any profile/default/preference/SSE/DOM publication;
-// every awaited continuation must revalidate it.
+// One transition epoch shared by every profile-switch ingress. Ownership starts
+// at invocation (before the POST), so a later ingress also fences rejection and
+// cleanup from an earlier one. The same object is marked accepted after its POST
+// succeeds and is threaded through every nested async publisher.
 let _profileTransitionOwnerSeq=0;
 let _profileTransitionOwner=null;
-function _acceptProfileTransitionOwner(profile, source){
-  const owner=Object.freeze({
+let _profileTransitionPostTail=Promise.resolve();
+function _beginProfileTransitionOwner(profile, source){
+  const owner={
     generation:++_profileTransitionOwnerSeq,
     profile:String(profile||'default'),
     source:String(source||'unknown'),
-  });
+    accepted:false,
+  };
   _profileTransitionOwner=owner;
   return owner;
+}
+function _acceptProfileTransitionOwner(owner, profile){
+  if(!_isProfileTransitionOwner(owner)) return null;
+  owner.profile=String(profile||owner.profile||'default');
+  owner.accepted=true;
+  return owner;
+}
+function _cancelProfileTransitionOwner(owner){
+  if(!_isProfileTransitionOwner(owner)) return false;
+  _profileTransitionOwner=null;
+  return true;
 }
 function _isProfileTransitionOwner(owner){
   return !!owner&&owner===_profileTransitionOwner&&owner.generation===_profileTransitionOwnerSeq;
 }
 function _currentProfileTransitionOwner(){
   return _profileTransitionOwner;
+}
+function _currentProfileTransitionEpoch(){
+  return _profileTransitionOwnerSeq;
+}
+function _postProfileTransition(owner){
+  const invoke=()=>{
+    if(!_isProfileTransitionOwner(owner)) return null;
+    return api('/api/profile/switch',{
+      method:'POST',
+      body:JSON.stringify({name:owner.profile}),
+      timeoutToast:false,
+    });
+  };
+  const result=_profileTransitionPostTail.then(invoke,invoke);
+  // Keep the serialization rail alive after both success and rejection. A
+  // later invocation must issue its Set-Cookie response last.
+  _profileTransitionPostTail=result.then(()=>undefined,()=>undefined);
+  return result;
 }
 
 function fetchReasoningChip(keyOverride, transitionOwner){

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -723,6 +723,9 @@ function clearWorkspaceTreeSkeleton(){
 async function loadDir(path, opts={}){
   const preservePreview=!!(opts&&opts.preservePreview);
   const refreshExpanded=!!(opts&&opts.refreshExpanded);
+  const transitionOwner=opts&&opts.transitionOwner||null;
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+  if(!transitionCurrent()) return;
   if(!S.session)return;
   const sessionId=S.session.session_id;
   const treeGen=_wsTreeGen;  // #4671: capture the workspace-tree generation. A profile
@@ -740,7 +743,7 @@ async function loadDir(path, opts={}){
       _workspaceRouteForPath(path, 'list') ||
       `/api/list?session_id=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path||'.')}`
     );
-    if(!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
+    if(!transitionCurrent()||!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
     if(data.workspace_recovered&&data.workspace){
       S.session.workspace=String(data.workspace);
       S._dirCache={};
@@ -763,23 +766,27 @@ async function loadDir(path, opts={}){
             .then(dc=>({dirPath,entries:dc.entries||[]}))
             .catch(()=>({dirPath,entries:[]}))
         ));
-        if(!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
+        if(!transitionCurrent()||!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
         for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
       }
       if(expanded.size>0)renderFileTree();
     }
     if(!preservePreview&&typeof clearPreview==='function'){
       if(typeof _previewDirty!=='undefined'&&_previewDirty){
-        showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{if(ok)clearPreview({keepPanelOpen:true});});
+        showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{
+          if(ok&&transitionCurrent()) clearPreview({keepPanelOpen:true});
+        });
       }else{
         clearPreview({keepPanelOpen:true});
       }
     }else if(preservePreview){
       await refreshOpenPreviewIfMutated();
+      if(!transitionCurrent()) return;
     }
     // Fetch git info for workspace root (non-blocking)
-    if(!path||path==='.') _refreshGitBadge();
+    if(!path||path==='.') _refreshGitBadge(transitionOwner);
   }catch(e){
+    if(!transitionCurrent()) return;
     const grant = _workspaceEscapeGrantForPath(path);
     if(grant && e && e.status===403){
       _clearWorkspaceEscapeGrant(grant.path);
@@ -796,13 +803,15 @@ function refreshWorkspacePanel(){
   loadDir(targetDir,{refreshExpanded:true});
 }
 
-async function _refreshGitBadge(){
+async function _refreshGitBadge(transitionOwner){
+  const transitionCurrent=()=>!transitionOwner||typeof _isProfileTransitionOwner!=='function'||_isProfileTransitionOwner(transitionOwner);
+  if(!transitionCurrent())return;
   const badge=$('gitBadge');
   if(!badge||!S.session)return;
   const sessionId=S.session.session_id;
   try{
     const data=await api(`/api/git-info?session_id=${encodeURIComponent(sessionId)}`);
-    if(!S.session||S.session.session_id!==sessionId)return;
+    if(!transitionCurrent()||!S.session||S.session.session_id!==sessionId)return;
     if(data.git&&data.git.is_git){
       const g=data.git;
       let text=g.branch||'git';
@@ -817,7 +826,7 @@ async function _refreshGitBadge(){
       badge.textContent='';
     }
   }catch(e){
-    if(!S.session||S.session.session_id!==sessionId)return;
+    if(!transitionCurrent()||!S.session||S.session.session_id!==sessionId)return;
     badge.style.display='none';
   }
 }

--- a/tests/_commentary_is_visible_info.mjs
+++ b/tests/_commentary_is_visible_info.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source=fs.readFileSync(new URL('../static/ui.js',import.meta.url),'utf8').replace(/\r\n/g,'\n');
+
+function functionSource(name){
+  const start=source.indexOf(`function ${name}`);
+  assert.notEqual(start,-1,`${name} must exist`);
+  const brace=source.indexOf('{',start);
+  let depth=0;
+  for(let i=brace;i<source.length;i+=1){
+    if(source[i]==='{') depth+=1;
+    else if(source[i]==='}'){
+      depth-=1;
+      if(depth===0) return source.slice(start,i+1);
+    }
+  }
+  throw new Error(`unterminated ${name}`);
+}
+
+const commentarySource=functionSource('_assistantCommentaryPayloadText');
+const displaySource=functionSource('_assistantDisplayContentFromMessage');
+const reasoningSource=functionSource('_assistantReasoningPayloadText');
+const sanitizeSource=functionSource('_sanitizeThinkingDisplayText');
+const normalizeSource=functionSource('_normalizeThinkingEchoCompare');
+const stripEchoSource=functionSource('_stripVisibleAssistantEchoFromThinking');
+const worklogSource=functionSource('_worklogReasoningTextFromMessage');
+const belongsSource=functionSource('_assistantMessageBelongsInWorklog');
+const settledRowsSource=functionSource('_anchorSceneRowsForSettledWorklog');
+const deferredRowsSource=functionSource('_deferredWorklogRowsFromGroup');
+const runtime=new Function(`function _stripXmlToolCallsDisplay(text){return String(text||'');}\nfunction _isAssistantEmptyPlaceholderContent(){return false;}\n${commentarySource}\n${displaySource}\n${reasoningSource}\n${sanitizeSource}\n${normalizeSource}\n${stripEchoSource}\n${worklogSource}\n${belongsSource}\nreturn {_assistantCommentaryPayloadText,_assistantDisplayContentFromMessage,_worklogReasoningTextFromMessage,_assistantMessageBelongsInWorklog};`)();
+
+const progress='Candidate identity verified; running the real restart now.';
+const commentaryMessage={
+  role:'assistant',
+  content:'',
+  reasoning:progress,
+  reasoning_content:progress,
+  codex_message_items:[{
+    type:'message', role:'assistant', status:'completed', phase:'commentary',
+    content:[{type:'output_text',text:progress}],
+  }],
+};
+assert.equal(runtime._assistantCommentaryPayloadText(commentaryMessage),progress);
+assert.equal(runtime._assistantDisplayContentFromMessage(commentaryMessage,''),progress,
+  'settled commentary must become ordinary assistant display content');
+assert.equal(runtime._worklogReasoningTextFromMessage(commentaryMessage,0,new Set(),progress,'',[progress]),'',
+  'the matching reasoning_content echo must not also render as Thinking');
+assert.equal(runtime._assistantMessageBelongsInWorklog({...commentaryMessage,_activityBurstId:9},0,new Set(),progress,{}),false,
+  'visible commentary with activity metadata must remain ordinary information');
+assert.equal(runtime._assistantMessageBelongsInWorklog({...commentaryMessage,_live:true},0,new Set(),progress,{}),false,
+  'visible live commentary must remain ordinary information');
+assert.equal(runtime._assistantMessageBelongsInWorklog({role:'assistant',content:'',tool_calls:[{id:'call-1'}]},0,new Set([0]),'',{}),true,
+  'an empty tool activity message still belongs in Worklog');
+
+const settledRowsRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\n${settledRowsSource}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+const sceneRows=[
+  {role:'prose',kind:'process_prose',text:progress},
+  {role:'thinking',kind:'reasoning',text:'private reasoning'},
+  {role:'tool',kind:'tool_call',text:'terminal'},
+];
+const visibleBlocks={querySelector:selector=>selector==='[data-visible-commentary="1"]'?{}:null};
+assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
+  'settled Worklog must drop prose already rendered as ordinary commentary');
+assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},{querySelector:()=>null}),sceneRows,
+  'legacy scenes without a visible commentary owner keep their prose fallback');
+
+const deferredRowsRuntime=new Function('sceneRows','visibleBlocks',`
+  const S={messages:[{_anchor_activity_scene:{activity_rows:sceneRows}}]};
+  function _assistantTurnBlocks(){return visibleBlocks;}
+  function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}
+  ${settledRowsSource}
+  ${deferredRowsSource}
+  return _deferredWorklogRowsFromGroup;
+`)(sceneRows,visibleBlocks);
+const deferredGroup={
+  getAttribute:name=>name==='data-activity-disclosure-key'?'anchor-scene:0':null,
+  closest:()=>({}),
+};
+assert.deepEqual(deferredRowsRuntime(deferredGroup),sceneRows.slice(1),
+  'deferred/cache-restored Worklog rows must use the same commentary ownership filter');
+assert.equal(runtime._assistantDisplayContentFromMessage({...commentaryMessage,content:'final answer'},'final answer'),'final answer',
+  'a real final answer must remain authoritative');
+assert.equal(runtime._assistantCommentaryPayloadText({...commentaryMessage,codex_message_items:[{
+  type:'message',phase:'analysis',content:[{type:'output_text',text:'private reasoning'}],
+}]}),'','private reasoning is not visible commentary');
+assert.equal(runtime._assistantCommentaryPayloadText({...commentaryMessage,codex_message_items:[{
+  type:'reasoning',role:'assistant',phase:'commentary',content:[{type:'output_text',text:'private reasoning'}],
+}]}),'','a reasoning item cannot become visible merely by carrying a commentary phase');
+assert.equal(runtime._assistantCommentaryPayloadText({...commentaryMessage,codex_message_items:[{
+  type:'message',role:'user',phase:'commentary',content:[{type:'output_text',text:'user data'}],
+}]}),'','a user-role message item cannot be projected as assistant commentary');
+
+const renderSource=functionSource('renderMessages');
+const call='_assistantDisplayContentFromMessage(m, content)';
+assert.equal(renderSource.split(call).length-1,1,'renderMessages must consume commentary display classification exactly once');
+
+const phaseTarget="String(item.phase||'').toLowerCase()!=='commentary'";
+assert.equal(commentarySource.split(phaseTarget).length-1,1,'commentary mutation target must be unique');
+const phaseMutant=commentarySource.replace(phaseTarget,'true');
+const phaseRuntime=new Function(`${phaseMutant}\nreturn _assistantCommentaryPayloadText;`)();
+assert.notEqual(phaseRuntime(commentaryMessage),progress,'removing commentary classification must RED');
+
+const displayTarget="if(existing) return existing;";
+assert.equal(displaySource.split(displayTarget).length-1,1,'display mutation target must be unique');
+const displayMutant=displaySource.replace(displayTarget,'return existing;');
+const displayRuntime=new Function(`${commentarySource}\n${displayMutant}\nreturn _assistantDisplayContentFromMessage;`)();
+assert.notEqual(displayRuntime(commentaryMessage,''),progress,'disabling empty-content fallback must RED');
+
+const belongsTarget='if(hasVisibleText) return false;';
+assert.equal(belongsSource.split(belongsTarget).length-1,1,'visible prose ownership target must be unique');
+const belongsMutant=belongsSource.replace(belongsTarget,'');
+const belongsRuntime=new Function(`function _isAssistantEmptyPlaceholderContent(){return false;}\n${belongsMutant}\nreturn _assistantMessageBelongsInWorklog;`)();
+assert.notEqual(belongsRuntime({...commentaryMessage,_activityBurstId:9},0,new Set(),progress,{}),false,
+  'allowing activity metadata to override visible prose must RED');
+
+const settledRowsTarget="if(!hasVisibleCommentary) return rows;";
+assert.equal(settledRowsSource.split(settledRowsTarget).length-1,1,'settled Worklog ownership target must be unique');
+const settledRowsMutant=settledRowsSource.replace(settledRowsTarget,'return rows;');
+const settledRowsMutantRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+assert.notDeepEqual(settledRowsMutantRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
+  'duplicating visible commentary inside Worklog must RED');
+
+console.log('PASS commentary_is_visible_info');

--- a/tests/_commentary_is_visible_info.mjs
+++ b/tests/_commentary_is_visible_info.mjs
@@ -53,22 +53,25 @@ assert.equal(runtime._assistantMessageBelongsInWorklog({...commentaryMessage,_li
 assert.equal(runtime._assistantMessageBelongsInWorklog({role:'assistant',content:'',tool_calls:[{id:'call-1'}]},0,new Set([0]),'',{}),true,
   'an empty tool activity message still belongs in Worklog');
 
-const settledRowsRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\n${settledRowsSource}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+const settledRowsRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${settledRowsSource}\nreturn _anchorSceneRowsForSettledWorklog;`)();
 const sceneRows=[
   {role:'prose',kind:'process_prose',text:progress},
+  {role:'prose',kind:'process_prose',text:'Distinct process prose'},
   {role:'thinking',kind:'reasoning',text:'private reasoning'},
   {role:'tool',kind:'tool_call',text:'terminal'},
 ];
-const visibleBlocks={querySelector:selector=>selector==='[data-visible-commentary="1"]'?{}:null};
+const visibleCommentaryNode={getAttribute:name=>name==='data-raw-text'?progress:null,textContent:progress};
+const visibleBlocks={querySelectorAll:selector=>selector==='[data-visible-commentary="1"]'?[visibleCommentaryNode]:[]};
 assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
-  'settled Worklog must drop prose already rendered as ordinary commentary');
-assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},{querySelector:()=>null}),sceneRows,
+  'settled Worklog must drop only prose already rendered as ordinary commentary');
+assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},{querySelectorAll:()=>[]}),sceneRows,
   'legacy scenes without a visible commentary owner keep their prose fallback');
 
 const deferredRowsRuntime=new Function('sceneRows','visibleBlocks',`
   const S={messages:[{_anchor_activity_scene:{activity_rows:sceneRows}}]};
   function _assistantTurnBlocks(){return visibleBlocks;}
   function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}
+  function _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}
   ${settledRowsSource}
   ${deferredRowsSource}
   return _deferredWorklogRowsFromGroup;
@@ -114,10 +117,10 @@ const belongsRuntime=new Function(`function _isAssistantEmptyPlaceholderContent(
 assert.notEqual(belongsRuntime({...commentaryMessage,_activityBurstId:9},0,new Set(),progress,{}),false,
   'allowing activity metadata to override visible prose must RED');
 
-const settledRowsTarget="if(!hasVisibleCommentary) return rows;";
+const settledRowsTarget="if(!visibleCommentaryTexts.size) return rows;";
 assert.equal(settledRowsSource.split(settledRowsTarget).length-1,1,'settled Worklog ownership target must be unique');
 const settledRowsMutant=settledRowsSource.replace(settledRowsTarget,'return rows;');
-const settledRowsMutantRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+const settledRowsMutantRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
 assert.notDeepEqual(settledRowsMutantRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
   'duplicating visible commentary inside Worklog must RED');
 

--- a/tests/_commentary_is_visible_info.mjs
+++ b/tests/_commentary_is_visible_info.mjs
@@ -18,6 +18,7 @@ function functionSource(name){
   throw new Error(`unterminated ${name}`);
 }
 
+const persistedCommentarySource=functionSource('_assistantPersistedCommentaryPayloadText');
 const commentarySource=functionSource('_assistantCommentaryPayloadText');
 const displaySource=functionSource('_assistantDisplayContentFromMessage');
 const reasoningSource=functionSource('_assistantReasoningPayloadText');
@@ -29,7 +30,7 @@ const belongsSource=functionSource('_assistantMessageBelongsInWorklog');
 const settledRowsSource=functionSource('_anchorSceneRowsForSettledWorklog');
 const deferredRowsSource=functionSource('_deferredWorklogRowsFromGroup');
 const revealSource=functionSource('_revealTransparentEarlierSteps');
-const runtime=new Function(`function _stripXmlToolCallsDisplay(text){return String(text||'');}\nfunction _isAssistantEmptyPlaceholderContent(){return false;}\n${commentarySource}\n${displaySource}\n${reasoningSource}\n${sanitizeSource}\n${normalizeSource}\n${stripEchoSource}\n${worklogSource}\n${belongsSource}\nreturn {_assistantCommentaryPayloadText,_assistantDisplayContentFromMessage,_worklogReasoningTextFromMessage,_assistantMessageBelongsInWorklog};`)();
+const runtime=new Function(`const window={_showCommentary:true};\nfunction _stripXmlToolCallsDisplay(text){return String(text||'');}\nfunction _isAssistantEmptyPlaceholderContent(){return false;}\n${persistedCommentarySource}\n${commentarySource}\n${displaySource}\n${reasoningSource}\n${sanitizeSource}\n${normalizeSource}\n${stripEchoSource}\n${worklogSource}\n${belongsSource}\nreturn {window,_assistantPersistedCommentaryPayloadText,_assistantCommentaryPayloadText,_assistantDisplayContentFromMessage,_worklogReasoningTextFromMessage,_assistantMessageBelongsInWorklog};`)();
 
 const progress='Candidate identity verified; running the real restart now.';
 const commentaryMessage={
@@ -53,8 +54,14 @@ assert.equal(runtime._assistantMessageBelongsInWorklog({...commentaryMessage,_li
   'visible live commentary must remain ordinary information');
 assert.equal(runtime._assistantMessageBelongsInWorklog({role:'assistant',content:'',tool_calls:[{id:'call-1'}]},0,new Set([0]),'',{}),true,
   'an empty tool activity message still belongs in Worklog');
+runtime.window._showCommentary=false;
+assert.equal(runtime._assistantCommentaryPayloadText(commentaryMessage),'',
+  'profile-off commentary must not become ordinary assistant content');
+assert.equal(runtime._assistantPersistedCommentaryPayloadText(commentaryMessage),progress,
+  'presentation gating must not mutate or discard the persisted sidecar');
+runtime.window._showCommentary=true;
 
-const settledRowsRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${settledRowsSource}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+const settledRowsRuntime=new Function('messages',`const window={_showCommentary:true,_showThinking:true};\nconst S={messages};\nfunction _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${persistedCommentarySource}\n${reasoningSource}\n${settledRowsSource}\nreturn {window,run:_anchorSceneRowsForSettledWorklog};`)([commentaryMessage]);
 const sceneRows=[
   {role:'prose',kind:'process_prose',text:progress},
   {role:'prose',kind:'process_prose',text:'Distinct process prose'},
@@ -67,12 +74,13 @@ const visibleBlocks={
   insertBefore(fragment){this.inserted=fragment.children.slice();},
   appendChild(fragment){this.inserted=fragment.children.slice();},
 };
-assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
+assert.deepEqual(settledRowsRuntime.run({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
   'settled Worklog must drop only prose already rendered as ordinary commentary');
-assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},{querySelectorAll:()=>[]}),sceneRows,
+assert.deepEqual(settledRowsRuntime.run({activity_rows:sceneRows},{querySelectorAll:()=>[]}),sceneRows,
   'legacy scenes without a visible commentary owner keep their prose fallback');
 
 const deferredRowsRuntime=new Function('sceneRows','visibleBlocks',`
+  const window={_showCommentary:true,_showThinking:true};
   const S={messages:[{_anchor_activity_scene:{activity_rows:sceneRows}}]};
   function _assistantTurnBlocks(){return visibleBlocks;}
   function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}
@@ -93,7 +101,8 @@ function runReveal(revealImplementation){
     const seen=[];
     const _transparentRevealedTurns=new Set();
     const _sessionHtmlCache=new Map();
-    const S={session:{session_id:'sid'}};
+    const window={_showCommentary:true,_showThinking:true};
+    const S={session:{session_id:'sid'},messages:[]};
     const messages={scrollTop:0,scrollHeight:100};
     function $(id){return id==='messages'?messages:null;}
     function _transparentRevealKey(){return 'sid:0';}
@@ -136,15 +145,15 @@ const call='_assistantDisplayContentFromMessage(m, content)';
 assert.equal(renderSource.split(call).length-1,1,'renderMessages must consume commentary display classification exactly once');
 
 const phaseTarget="String(item.phase||'').toLowerCase()!=='commentary'";
-assert.equal(commentarySource.split(phaseTarget).length-1,1,'commentary mutation target must be unique');
-const phaseMutant=commentarySource.replace(phaseTarget,'true');
-const phaseRuntime=new Function(`${phaseMutant}\nreturn _assistantCommentaryPayloadText;`)();
+assert.equal(persistedCommentarySource.split(phaseTarget).length-1,1,'commentary mutation target must be unique');
+const phaseMutant=persistedCommentarySource.replace(phaseTarget,'true');
+const phaseRuntime=new Function(`${phaseMutant}\nreturn _assistantPersistedCommentaryPayloadText;`)();
 assert.notEqual(phaseRuntime(commentaryMessage),progress,'removing commentary classification must RED');
 
 const displayTarget="if(existing) return existing;";
 assert.equal(displaySource.split(displayTarget).length-1,1,'display mutation target must be unique');
 const displayMutant=displaySource.replace(displayTarget,'return existing;');
-const displayRuntime=new Function(`${commentarySource}\n${displayMutant}\nreturn _assistantDisplayContentFromMessage;`)();
+const displayRuntime=new Function(`const window={_showCommentary:true};\n${persistedCommentarySource}\n${commentarySource}\n${displayMutant}\nreturn _assistantDisplayContentFromMessage;`)();
 assert.notEqual(displayRuntime(commentaryMessage,''),progress,'disabling empty-content fallback must RED');
 
 const belongsTarget='if(hasVisibleText) return false;';
@@ -157,7 +166,7 @@ assert.notEqual(belongsRuntime({...commentaryMessage,_activityBurstId:9},0,new S
 const settledRowsTarget="if(!visibleCommentaryTexts.size) return rows;";
 assert.equal(settledRowsSource.split(settledRowsTarget).length-1,1,'settled Worklog ownership target must be unique');
 const settledRowsMutant=settledRowsSource.replace(settledRowsTarget,'return rows;');
-const settledRowsMutantRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
+const settledRowsMutantRuntime=new Function(`const window={_showCommentary:true,_showThinking:true};\nconst S={messages:[]};\nfunction _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${persistedCommentarySource}\n${reasoningSource}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
 assert.notDeepEqual(settledRowsMutantRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
   'duplicating visible commentary inside Worklog must RED');
 

--- a/tests/_commentary_is_visible_info.mjs
+++ b/tests/_commentary_is_visible_info.mjs
@@ -28,6 +28,7 @@ const worklogSource=functionSource('_worklogReasoningTextFromMessage');
 const belongsSource=functionSource('_assistantMessageBelongsInWorklog');
 const settledRowsSource=functionSource('_anchorSceneRowsForSettledWorklog');
 const deferredRowsSource=functionSource('_deferredWorklogRowsFromGroup');
+const revealSource=functionSource('_revealTransparentEarlierSteps');
 const runtime=new Function(`function _stripXmlToolCallsDisplay(text){return String(text||'');}\nfunction _isAssistantEmptyPlaceholderContent(){return false;}\n${commentarySource}\n${displaySource}\n${reasoningSource}\n${sanitizeSource}\n${normalizeSource}\n${stripEchoSource}\n${worklogSource}\n${belongsSource}\nreturn {_assistantCommentaryPayloadText,_assistantDisplayContentFromMessage,_worklogReasoningTextFromMessage,_assistantMessageBelongsInWorklog};`)();
 
 const progress='Candidate identity verified; running the real restart now.';
@@ -61,7 +62,11 @@ const sceneRows=[
   {role:'tool',kind:'tool_call',text:'terminal'},
 ];
 const visibleCommentaryNode={getAttribute:name=>name==='data-raw-text'?progress:null,textContent:progress};
-const visibleBlocks={querySelectorAll:selector=>selector==='[data-visible-commentary="1"]'?[visibleCommentaryNode]:[]};
+const visibleBlocks={
+  querySelectorAll:selector=>selector==='[data-visible-commentary="1"]'?[visibleCommentaryNode]:[],
+  insertBefore(fragment){this.inserted=fragment.children.slice();},
+  appendChild(fragment){this.inserted=fragment.children.slice();},
+};
 assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
   'settled Worklog must drop only prose already rendered as ordinary commentary');
 assert.deepEqual(settledRowsRuntime({activity_rows:sceneRows},{querySelectorAll:()=>[]}),sceneRows,
@@ -82,6 +87,38 @@ const deferredGroup={
 };
 assert.deepEqual(deferredRowsRuntime(deferredGroup),sceneRows.slice(1),
   'deferred/cache-restored Worklog rows must use the same commentary ownership filter');
+
+function runReveal(revealImplementation){
+  return new Function('sceneRows','visibleBlocks',`
+    const seen=[];
+    const _transparentRevealedTurns=new Set();
+    const _sessionHtmlCache=new Map();
+    const S={session:{session_id:'sid'}};
+    const messages={scrollTop:0,scrollHeight:100};
+    function $(id){return id==='messages'?messages:null;}
+    function _transparentRevealKey(){return 'sid:0';}
+    function _assistantTurnBlocks(){return visibleBlocks;}
+    function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}
+    function _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}
+    ${settledRowsSource}
+    function _anchorSceneLastNonTerminalWorkRowIndex(rows){return rows.length-1;}
+    function _assistantAnchorSceneFinalAnswerText(){return '';}
+    function msgContent(){return '';}
+    function _computeTransparentHiddenPrefixCount(rows){return rows.length;}
+    function _anchorSceneTransparentNodeForRow(row){if(!row)return null;seen.push(row);return {setAttribute(){}};}
+    function _syncTransparentEventControls(){}
+    const frag={children:[],appendChild(node){this.children.push(node);}};
+    const document={createDocumentFragment(){return frag;}};
+    const turnEl={setAttribute(){},removeAttribute(){}};
+    const segment={closest(){return turnEl;}};
+    const affordance={parentElement:visibleBlocks,getAttribute(){return String(sceneRows.length-1);},remove(){}};
+    ${revealImplementation}
+    _revealTransparentEarlierSteps({_anchor_activity_scene:{activity_rows:sceneRows}},segment,0,affordance);
+    return seen;
+  `)(sceneRows,visibleBlocks);
+}
+assert.deepEqual(runReveal(revealSource),sceneRows.slice(1),
+  'transparent earlier-step reveal must not resurrect the visible commentary echo');
 assert.equal(runtime._assistantDisplayContentFromMessage({...commentaryMessage,content:'final answer'},'final answer'),'final answer',
   'a real final answer must remain authoritative');
 assert.equal(runtime._assistantCommentaryPayloadText({...commentaryMessage,codex_message_items:[{
@@ -123,5 +160,14 @@ const settledRowsMutant=settledRowsSource.replace(settledRowsTarget,'return rows
 const settledRowsMutantRuntime=new Function(`function _anchorSceneRowsForRendering(scene){return scene.activity_rows||[];}\nfunction _normalizeThinkingEchoCompare(text){return String(text||'').replace(/\\s+/g,' ').trim();}\n${settledRowsMutant}\nreturn _anchorSceneRowsForSettledWorklog;`)();
 assert.notDeepEqual(settledRowsMutantRuntime({activity_rows:sceneRows},visibleBlocks),sceneRows.slice(1),
   'duplicating visible commentary inside Worklog must RED');
+
+const revealTarget="const rows=_anchorSceneRowsForSettledWorklog(scene,blocks)||[];";
+assert.equal(revealSource.split(revealTarget).length-1,1,'transparent reveal ownership target must be unique');
+const revealMutant=revealSource.replace(
+  revealTarget,
+  "const rows=_anchorSceneRowsForRendering(scene,{settled:true})||[];",
+);
+assert.notDeepEqual(runReveal(revealMutant),sceneRows.slice(1),
+  'bypassing commentary ownership during earlier-step reveal must RED');
 
 console.log('PASS commentary_is_visible_info');

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -248,16 +248,16 @@ eval(bootDropdownBlock
   '  globalThis._redirectBootModelDropdownIfUnauth=(res)=>{'
   )
   .replace(
-    '  const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({',
-    '  globalThis._hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({'
+    '  const _hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({',
+    '  globalThis._hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({'
   )
   .replace(
-    '  const _startModelDropdown=()=>{',
-    '  globalThis._startModelDropdown=()=>{'
+    '  const _startModelDropdown=(transitionOwner=null)=>{',
+    '  globalThis._startModelDropdown=(transitionOwner=null)=>{'
   )
   .replace(
-    '  const _startBootModelDropdown=()=>{',
-    '  globalThis._startBootModelDropdown=()=>{'
+    '  const _startBootModelDropdown=(transitionOwner=null)=>{',
+    '  globalThis._startBootModelDropdown=(transitionOwner=null)=>{'
   )
 );
 eval(redirectIfUnauthLine.replace(

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -118,6 +118,69 @@ eval(extractFunc('refreshReasoningPreferencesForRender'));
     }
 
 
+def test_superseded_profile_preference_wait_cannot_create_session_in_newer_profile():
+    source = f"""
+const panelsSrc = {PANELS_JS!r};
+function extractFunc(name) {{
+  const start = panelsSrc.indexOf('async function ' + name);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = panelsSrc.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0 && i < panelsSrc.length) {{
+    if (panelsSrc[i] === '{{') depth++;
+    else if (panelsSrc[i] === '}}') depth--;
+    i++;
+  }}
+  return panelsSrc.slice(start, i);
+}}
+global.S = {{
+  activeProfile:'default', activeProfileIsDefault:true,
+  session:{{session_id:'existing',profile:'default'}}, messages:[{{role:'user',content:'x'}}],
+}};
+global.window = {{}};
+global.localStorage = {{removeItem(){{}}}};
+global.$ = () => null;
+global.t = (_, name) => name || '';
+global.showToast = () => {{}};
+global.startGatewaySSE = () => {{}};
+global.applyBotName = () => {{}};
+global.renderSessionList = async () => {{}};
+global.syncTopbar = () => {{}};
+global._profileSwitchPanelLoad = async () => {{}};
+global._refreshProfileSwitchBackground = () => {{}};
+global.newSession = async () => {{ created.push(S.activeProfile); }};
+global.api = async (url, opts) => {{
+  if (url !== '/api/profile/switch') throw new Error('unexpected API ' + url);
+  const name = JSON.parse(opts.body).name;
+  return {{active:name,is_default:false}};
+}};
+const waits = [];
+global.refreshProfileTransitionReasoningChip = () => new Promise(resolve => waits.push(resolve));
+var _profileSwitchGeneration = 0;
+var _skillsData = null;
+var _workspaceList = null;
+const created = [];
+eval(extractFunc('switchToProfile'));
+(async () => {{
+  const first = switchToProfile('A');
+  while (waits.length < 1) await Promise.resolve();
+  const second = switchToProfile('B');
+  while (waits.length < 2) await Promise.resolve();
+  waits[1]();
+  const secondResult = await second;
+  waits[0]();
+  const firstResult = await first;
+  console.log(JSON.stringify({{active:S.activeProfile,created,firstResult,secondResult}}));
+}})().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {
+        "active": "B",
+        "created": ["B"],
+        "firstResult": False,
+        "secondResult": True,
+    }
+
+
 def test_valid_profile_query_switches_before_restore_and_cleans_url():
     source = _node_prelude() + """
 function applyUrl(rel) {

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -62,19 +62,13 @@ function evalBoot(name) {{
 
 
 def test_profile_switch_entrypoints_await_destination_commentary_preference():
-    """No switch path may render destination sessions under the old profile flag."""
-    assert (
-        "await refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);"
-        in PANELS_JS
-    )
-    assert (
-        "await refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);"
-        in SESSIONS_JS
-    )
-    assert (
-        "await refreshReasoningPreferencesForRender(S.session.model,S.session.model_provider);"
-        in SESSIONS_JS
-    )
+    """Both profile switch ingresses share and revalidate one accepted owner."""
+    assert "_acceptProfileTransitionOwner(data.active || name, 'canonical')" in PANELS_JS
+    assert "_acceptProfileTransitionOwner(data.active||name,'session-load')" in SESSIONS_JS
+    assert "_isProfileTransitionOwner(_transitionOwner)" in PANELS_JS
+    assert "_isProfileTransitionOwner(transitionOwner)" in SESSIONS_JS
+    assert "await refreshReasoningPreferencesForRender(" in SESSIONS_JS
+    assert "S.session.model_provider" in SESSIONS_JS
     assert "await fetchReasoningChip();" in BOOT_JS
 
 
@@ -115,69 +109,6 @@ eval(extractFunc('refreshReasoningPreferencesForRender'));
     assert payload == {
         "before": {"settled": False, "showCommentary": False},
         "after": {"settled": True, "showCommentary": False},
-    }
-
-
-def test_superseded_profile_preference_wait_cannot_create_session_in_newer_profile():
-    source = f"""
-const panelsSrc = {PANELS_JS!r};
-function extractFunc(name) {{
-  const start = panelsSrc.indexOf('async function ' + name);
-  if (start < 0) throw new Error(name + ' not found');
-  let i = panelsSrc.indexOf('{{', start), depth = 1; i++;
-  while (depth > 0 && i < panelsSrc.length) {{
-    if (panelsSrc[i] === '{{') depth++;
-    else if (panelsSrc[i] === '}}') depth--;
-    i++;
-  }}
-  return panelsSrc.slice(start, i);
-}}
-global.S = {{
-  activeProfile:'default', activeProfileIsDefault:true,
-  session:{{session_id:'existing',profile:'default'}}, messages:[{{role:'user',content:'x'}}],
-}};
-global.window = {{}};
-global.localStorage = {{removeItem(){{}}}};
-global.$ = () => null;
-global.t = (_, name) => name || '';
-global.showToast = () => {{}};
-global.startGatewaySSE = () => {{}};
-global.applyBotName = () => {{}};
-global.renderSessionList = async () => {{}};
-global.syncTopbar = () => {{}};
-global._profileSwitchPanelLoad = async () => {{}};
-global._refreshProfileSwitchBackground = () => {{}};
-global.newSession = async () => {{ created.push(S.activeProfile); }};
-global.api = async (url, opts) => {{
-  if (url !== '/api/profile/switch') throw new Error('unexpected API ' + url);
-  const name = JSON.parse(opts.body).name;
-  return {{active:name,is_default:false}};
-}};
-const waits = [];
-global.refreshProfileTransitionReasoningChip = () => new Promise(resolve => waits.push(resolve));
-var _profileSwitchGeneration = 0;
-var _skillsData = null;
-var _workspaceList = null;
-const created = [];
-eval(extractFunc('switchToProfile'));
-(async () => {{
-  const first = switchToProfile('A');
-  while (waits.length < 1) await Promise.resolve();
-  const second = switchToProfile('B');
-  while (waits.length < 2) await Promise.resolve();
-  waits[1]();
-  const secondResult = await second;
-  waits[0]();
-  const firstResult = await first;
-  console.log(JSON.stringify({{active:S.activeProfile,created,firstResult,secondResult}}));
-}})().catch(error => {{ console.error(error); process.exit(1); }});
-"""
-    payload = json.loads(_run_node(source))
-    assert payload == {
-        "active": "B",
-        "created": ["B"],
-        "firstResult": False,
-        "secondResult": True,
     }
 
 
@@ -776,7 +707,7 @@ console.log(JSON.stringify({{ beforeDestination, afterPreviousResponse, afterDes
     assert payload["afterDestination"] == "high"
     assert payload["calls"] == 2
     assert "refreshProfileTransitionReasoningChip" in PANELS_JS
-    assert PANELS_JS.index("refreshProfileTransitionReasoningChip") > PANELS_JS.index("S.activeProfile = data.active || name")
+    assert PANELS_JS.index("refreshProfileTransitionReasoningChip") < PANELS_JS.index("S.activeProfile = data.active || name")
     background = PANELS_JS[PANELS_JS.index("function _refreshProfileSwitchBackground"):PANELS_JS.index("async function loadProfilesPanel")]
     for refresh in (
         "_ensureComposerControlVisibilityState",
@@ -789,102 +720,15 @@ console.log(JSON.stringify({{ beforeDestination, afterPreviousResponse, afterDes
         assert refresh in background
 
 
-def test_profile_transitions_fetch_destination_reasoning_after_hiding_stale_chip():
-    source = f"""
-const uiSrc = {UI_JS!r};
-const panelsSrc = {PANELS_JS!r};
-const sessionsSrc = {SESSIONS_JS!r};
-function extractFunc(src, name) {{
-  const re = new RegExp('(?:async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
-  const start = src.search(re);
-  if (start < 0) throw new Error(name + ' not found');
-  let i = src.indexOf('{{', start), depth = 1; i++;
-  while (depth > 0 && i < src.length) {{
-    if (src[i] === '{{') depth++;
-    else if (src[i] === '}}') depth--;
-    i++;
-  }}
-  return src.slice(start, i);
-}}
-function makeEl() {{ return {{ style: {{}}, disabled: false, classList: {{ add(){{}}, remove(){{}}, toggle(){{}} }}, setAttribute(){{}}, querySelectorAll(){{ return []; }} }}; }}
-const els = {{ composerReasoningWrap: makeEl(), composerReasoningLabel: makeEl(), composerReasoningChip: makeEl(), composerMobileReasoningAction: makeEl() }};
-global.$ = id => els[id] || null;
-global.window = {{}};
-global.document = {{ title: '' }};
-global.localStorage = {{ removeItem(){{}} }};
-global.S = {{ activeProfile: 'default', activeProfileIsDefault: true, session: null, messages: [] }};
-global._highlightReasoningOption = () => {{}};
-global._applyReasoningOptions = () => {{}};
-global._applyModelToDropdown = model => model;
-global._modelStateForSelect = (_, model) => ({{ model, model_provider: 'openai' }});
-global.renderSessionList = async () => {{}};
-global.startGatewaySSE = () => {{}};
-global.showToast = () => {{}};
-global.t = value => value;
-global.assistantDisplayName = () => 'Hermes';
-global._profileSwitchPanelLoad = async () => {{}};
-global._refreshProfileSwitchBackground = () => {{}};
-var _profileSwitchGeneration = 0;
-var _skillsData = null, _workspaceList = null;
-var _currentReasoningEffort = 'low';
-var _currentReasoningEffortsSupported = ['low', 'high'];
-var _profileTransitionReasoningContext = null;
-var _lastReasoningFetchKey = null;
-var _reasoningFetchSeq = 0;
-eval(extractFunc(uiSrc, '_normalizeReasoningEffort'));
-eval(extractFunc(uiSrc, '_formatReasoningEffortLabel'));
-eval(extractFunc(uiSrc, '_reasoningEffortContext'));
-eval(extractFunc(uiSrc, '_reasoningEffortQuery'));
-eval(extractFunc(uiSrc, '_applyReasoningChip'));
-eval(extractFunc(uiSrc, 'fetchReasoningChip'));
-eval(extractFunc(uiSrc, 'refreshReasoningPreferencesForRender'));
-eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
-eval(extractFunc(uiSrc, 'syncTopbar'));
-eval(extractFunc(panelsSrc, 'switchToProfile'));
-eval(extractFunc(sessionsSrc, '_switchProfileForSessionLoad'));
-const pending = [];
-const reasoningUrls = [];
-global.api = (url) => {{
-  if (url === '/api/profile/switch') return Promise.resolve({{ active: 'vops', is_default: false, default_model: 'gpt-high', default_model_provider: 'openai' }});
-  if (url.startsWith('/api/reasoning')) {{
-    reasoningUrls.push(url);
-    return {{ then(ok) {{ pending.push(ok); return {{ catch() {{}} }}; }} }};
-  }}
-  throw new Error('unexpected API ' + url);
-}};
-fetchReasoningChip();
-(async () => {{
-  await switchToProfile('vops');
-  const blankBoot = {{ hidden: els.composerReasoningWrap.style.display, urls: reasoningUrls.slice() }};
-  pending[0]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
-  const blankBootAfterOld = _currentReasoningEffort;
-  pending[1]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
-  const blankBootAfterNew = _currentReasoningEffort;
-  S.activeProfile = 'default'; S.activeProfileIsDefault = true;
-  S.session = {{ model: 'old-model', model_provider: 'old-provider', profile: 'default' }};
-  _currentReasoningEffort = 'low'; _currentReasoningEffortsSupported = ['low', 'high']; _profileTransitionReasoningContext = null; _lastReasoningFetchKey = null;
-  fetchReasoningChip();
-  await _switchProfileForSessionLoad('vops');
-  const directLoad = {{ hidden: els.composerReasoningWrap.style.display, urls: reasoningUrls.slice(2) }};
-  pending[2]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
-  const directLoadAfterOld = _currentReasoningEffort;
-  pending[3]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
-  console.log(JSON.stringify({{ blankBoot, blankBootAfterOld, blankBootAfterNew, directLoad, directLoadAfterOld, directLoadAfterNew: _currentReasoningEffort }}));
-}})().catch(err => {{ console.error(err); process.exit(1); }});
-"""
-    payload = json.loads(_run_node(source))
-    assert payload["blankBoot"] == {
-        "hidden": "none",
-        "urls": ["/api/reasoning", "/api/reasoning?model=gpt-high&provider=openai"],
-    }
-    assert payload["blankBootAfterOld"] == ""
-    assert payload["blankBootAfterNew"] == "high"
-    assert payload["directLoad"] == {
-        "hidden": "none",
-        "urls": ["/api/reasoning?model=old-model&provider=old-provider", "/api/reasoning?model=gpt-high&provider=openai"],
-    }
-    assert payload["directLoadAfterOld"] == ""
-    assert payload["directLoadAfterNew"] == "high"
+def test_profile_transitions_bind_preference_to_shared_accepted_owner():
+    owner_slice = UI_JS[
+        UI_JS.index("function _acceptProfileTransitionOwner"):
+        UI_JS.index("function syncReasoningChip")
+    ]
+    assert "transitionOwner" in owner_slice
+    assert "_isProfileTransitionOwner(transitionOwner)" in owner_slice
+    assert "_isProfileTransitionOwner(transitionOwner)" in SESSIONS_JS
+    assert "_isProfileTransitionOwner(_transitionOwner)" in PANELS_JS
 
 
 def test_blank_profile_transition_context_clears_before_explicit_model_change():

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -63,13 +63,27 @@ function evalBoot(name) {{
 
 def test_profile_switch_entrypoints_await_destination_commentary_preference():
     """Both profile switch ingresses share and revalidate one accepted owner."""
-    assert "_acceptProfileTransitionOwner(data.active || name, 'canonical')" in PANELS_JS
-    assert "_acceptProfileTransitionOwner(data.active||name,'session-load')" in SESSIONS_JS
+    assert "_beginProfileTransitionOwner(name, 'canonical')" in PANELS_JS
+    assert "_acceptProfileTransitionOwner(_transitionOwner, data.active || name)" in PANELS_JS
+    assert "_beginProfileTransitionOwner(name,'session-load')" in SESSIONS_JS
+    assert "_acceptProfileTransitionOwner(transitionOwner,data.active||name)" in SESSIONS_JS
     assert "_isProfileTransitionOwner(_transitionOwner)" in PANELS_JS
     assert "_isProfileTransitionOwner(transitionOwner)" in SESSIONS_JS
     assert "await refreshReasoningPreferencesForRender(" in SESSIONS_JS
     assert "S.session.model_provider" in SESSIONS_JS
     assert "await fetchReasoningChip();" in BOOT_JS
+
+
+def test_shared_transition_epoch_covers_invocation_rejection_and_cleanup():
+    canonical = PANELS_JS[PANELS_JS.index("async function switchToProfile(name)"):]
+    recovery = SESSIONS_JS[SESSIONS_JS.index("async function _switchProfileForSessionLoad(profile)"):]
+    assert canonical.index("_beginProfileTransitionOwner(name, 'canonical')") < canonical.index("await _postProfileTransition(_transitionOwner)")
+    assert recovery.index("_beginProfileTransitionOwner(name,'session-load')") < recovery.index("await _postProfileTransition(transitionOwner)")
+    assert "const _ownsFailure = _switchGen === _profileSwitchGeneration && _isProfileTransitionOwner(_transitionOwner);" in canonical
+    assert "if (_ownsFailure)" in canonical
+    assert "_cancelProfileTransitionOwner(_transitionOwner);" in canonical
+    assert "if(!_isProfileTransitionOwner(transitionOwner)) return null;" in recovery
+    assert "_cancelProfileTransitionOwner(transitionOwner);" in recovery
 
 
 def test_render_preference_refresh_waits_for_effective_commentary_flag():

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -61,6 +61,63 @@ function evalBoot(name) {{
 """
 
 
+def test_profile_switch_entrypoints_await_destination_commentary_preference():
+    """No switch path may render destination sessions under the old profile flag."""
+    assert (
+        "await refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);"
+        in PANELS_JS
+    )
+    assert (
+        "await refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);"
+        in SESSIONS_JS
+    )
+    assert (
+        "await refreshReasoningPreferencesForRender(S.session.model,S.session.model_provider);"
+        in SESSIONS_JS
+    )
+    assert "await fetchReasoningChip();" in BOOT_JS
+
+
+def test_render_preference_refresh_waits_for_effective_commentary_flag():
+    source = f"""
+const uiSrc = {UI_JS!r};
+function extractFunc(name) {{
+  const start = uiSrc.indexOf('function ' + name);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = uiSrc.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0 && i < uiSrc.length) {{
+    if (uiSrc[i] === '{{') depth++;
+    else if (uiSrc[i] === '}}') depth--;
+    i++;
+  }}
+  return uiSrc.slice(start, i);
+}}
+global.window = {{_showCommentary:true}};
+let resolveRequest;
+global.api = () => new Promise(resolve => {{ resolveRequest = resolve; }});
+global._applyReasoningChip = () => {{}};
+var _lastReasoningFetchKey = '?old';
+var _reasoningFetchSeq = 4;
+eval(extractFunc('fetchReasoningChip'));
+eval(extractFunc('refreshReasoningPreferencesForRender'));
+(async () => {{
+  let settled = false;
+  const pending = refreshReasoningPreferencesForRender('gpt-5', 'openai').then(() => {{ settled = true; }});
+  await Promise.resolve();
+  const before = {{settled, showCommentary:window._showCommentary}};
+  resolveRequest({{show_commentary:false, reasoning_effort:'', supported_efforts:[]}});
+  await pending;
+  const after = {{settled, showCommentary:window._showCommentary}};
+  console.log(JSON.stringify({{before, after}}));
+}})().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {
+        "before": {"settled": False, "showCommentary": False},
+        "after": {"settled": True, "showCommentary": False},
+    }
+
+
 def test_valid_profile_query_switches_before_restore_and_cleans_url():
     source = _node_prelude() + """
 function applyUrl(rel) {
@@ -152,7 +209,7 @@ global.switchToProfile = async (name) => {
   const completedPos = bootSrc.indexOf("_profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;", profilePos);
   const changedPos = bootSrc.indexOf("_profileSwitchChangedProfile=", completedPos);
   const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", profilePos);
-  const initialReasoningFetchPos = bootSrc.indexOf("if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)) fetchReasoningChip();", profilePos);
+  const initialReasoningFetchPos = bootSrc.indexOf("await fetchReasoningChip();", profilePos);
   console.log(JSON.stringify({ intent, switched, promoted, afterProfile, afterPrefill, historyCalls: window.history.calls, profilePos, renderPos, savedPos, loadPos, consumePos, completedPos, changedPos, cleanupGuardPos, initialReasoningFetchPos, savedLocalBefore, savedLocalAfterSuppress, savedLocalAfterReload, blocksSavedLocal, keepsExplicitSession }));
 })().catch(err => {
   console.error(err);
@@ -609,6 +666,7 @@ const els = {{
   composerReasoningChip: makeEl(), composerMobileReasoningAction: makeEl(),
 }};
 global.$ = id => els[id] || null;
+global.window = {{}};
 global.S = {{ session: {{ model: 'gpt-5', model_provider: 'openai' }} }};
 global._highlightReasoningOption = () => {{}};
 global._applyReasoningOptions = () => {{}};
@@ -627,6 +685,7 @@ eval(extractFunc('_normalizeReasoningEffort'));
 eval(extractFunc('_formatReasoningEffortLabel'));
 eval(extractFunc('_applyReasoningChip'));
 eval(extractFunc('fetchReasoningChip'));
+eval(extractFunc('refreshReasoningPreferencesForRender'));
 eval(extractFunc('refreshProfileTransitionReasoningChip'));
 fetchReasoningChip();
 refreshProfileTransitionReasoningChip();
@@ -634,6 +693,7 @@ const beforeDestination = {{
   effort: _currentReasoningEffort,
   cachedKey: _lastReasoningFetchKey,
   wrapDisplay: els.composerReasoningWrap.style.display,
+  showCommentary: window._showCommentary,
   calls,
 }};
 pending[0]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
@@ -646,6 +706,7 @@ console.log(JSON.stringify({{ beforeDestination, afterPreviousResponse, afterDes
         "effort": "",
         "cachedKey": "?model=gpt-5",
         "wrapDisplay": "none",
+        "showCommentary": False,
         "calls": 2,
     }
     assert payload["afterPreviousResponse"] == {"effort": "", "wrapDisplay": "none"}
@@ -713,6 +774,7 @@ eval(extractFunc(uiSrc, '_reasoningEffortContext'));
 eval(extractFunc(uiSrc, '_reasoningEffortQuery'));
 eval(extractFunc(uiSrc, '_applyReasoningChip'));
 eval(extractFunc(uiSrc, 'fetchReasoningChip'));
+eval(extractFunc(uiSrc, 'refreshReasoningPreferencesForRender'));
 eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
 eval(extractFunc(uiSrc, 'syncTopbar'));
 eval(extractFunc(panelsSrc, 'switchToProfile'));
@@ -807,6 +869,7 @@ eval(extractFunc(uiSrc, '_reasoningEffortContext'));
 eval(extractFunc(uiSrc, '_reasoningEffortQuery'));
 eval(extractFunc(uiSrc, '_applyReasoningChip'));
 eval(extractFunc(uiSrc, 'fetchReasoningChip'));
+eval(extractFunc(uiSrc, 'refreshReasoningPreferencesForRender'));
 eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
 eval(extractFunc(uiSrc, 'clearProfileTransitionReasoningContext'));
 eval(extractFunc(uiSrc, 'syncReasoningChip'));

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -564,6 +564,8 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
           }}
           return String(message.content || '');
         }}
+        function _assistantCommentaryPayloadText() {{ return ''; }}
+        function _assistantDisplayContentFromMessage(_message, content) {{ return String(content || ''); }}
         let S;
         const INFLIGHT = {{}};
         let _loadingSessionId = null;
@@ -915,18 +917,23 @@ def test_settled_legacy_activity_buckets_skip_anchor_owned_turns_before_renderin
 
 
 def test_anchor_settled_renderers_remain_the_primary_scene_path():
+    helper = _function_body(_ui_js(), "_anchorSceneRowsForSettledWorklog")
     settled = _function_body(_ui_js(), "_renderSettledAnchorSceneForMessage")
     transparent = _function_body(
         _ui_js(),
         "_renderSettledAnchorSceneTransparentForMessage",
     )
 
+    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in helper
+    assert "data-visible-commentary" in helper
+    assert "String(row.role||'')==='prose'" in helper
+
     assert "if(!message||!message._anchor_activity_scene||!segment) return false;" in settled
     assert "return _renderSettledAnchorSceneTransparentForMessage(message,segment,rawIdx);" in settled
-    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in settled
+    assert "_anchorSceneRowsForSettledWorklog(scene,blocks)" in settled
     assert "group.setAttribute('data-anchor-settled-scene-owner','1');" in settled
 
     assert "if(!message||!message._anchor_activity_scene||!segment) return false;" in transparent
-    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in transparent
+    assert "_anchorSceneRowsForSettledWorklog(scene,blocks)" in transparent
     assert "const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);" in transparent
     assert "liveTokenFinalPrefixEligible:idx>lastNonTerminalWorkRowIndex" in transparent

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -926,7 +926,7 @@ def test_anchor_settled_renderers_remain_the_primary_scene_path():
 
     assert "_anchorSceneRowsForRendering(scene,{settled:true})" in helper
     assert "data-visible-commentary" in helper
-    assert "String(row.role||'')==='prose'" in helper
+    assert "String(row.role||'')!=='prose'" in helper
 
     assert "if(!message||!message._anchor_activity_scene||!segment) return false;" in settled
     assert "return _renderSettledAnchorSceneTransparentForMessage(message,segment,rawIdx);" in settled

--- a/tests/test_commentary_visible_info.py
+++ b/tests/test_commentary_visible_info.py
@@ -1,5 +1,8 @@
+import importlib.util
+import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -7,6 +10,16 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 NODE = shutil.which("node")
+_LIFECYCLE_SPEC = importlib.util.spec_from_file_location(
+    "browser_conversation_lifecycle",
+    ROOT / "tests" / "browser_conversation_lifecycle.py",
+)
+assert _LIFECYCLE_SPEC and _LIFECYCLE_SPEC.loader
+_LIFECYCLE = importlib.util.module_from_spec(_LIFECYCLE_SPEC)
+_LIFECYCLE_SPEC.loader.exec_module(_LIFECYCLE)
+_capture_page_errors = _LIFECYCLE._capture_page_errors
+_start_webui_server = _LIFECYCLE._start_webui_server
+_terminate_process = _LIFECYCLE._terminate_process
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for commentary rendering regression")
@@ -21,3 +34,241 @@ def test_commentary_is_visible_assistant_information():
     )
     assert result.returncode == 0, result.stderr or result.stdout
     assert "PASS commentary_is_visible_info" in result.stdout
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="browser commentary regression requires the CI browser toolchain",
+)
+def test_render_messages_projects_commentary_once_and_restores_deferred_worklog():
+    playwright = pytest.importorskip("playwright.sync_api")
+    progress = "Candidate identity verified; running the real restart now."
+    distinct_reasoning = "Private reasoning that remains in Worklog."
+    final_answer = "The restart completed successfully."
+    messages = [
+        {"role": "user", "content": "Continue the restart."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": progress,
+            "reasoning_content": progress,
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": progress}],
+                }
+            ],
+            "_activityBurstId": 9,
+        },
+        {
+            "role": "assistant",
+            "content": "Settled final answer remains visible.",
+            "_anchor_activity_scene": {
+                "version": "activity_scene_v1",
+                "mode": "compact_worklog",
+                "final_answer": "",
+                "lifecycle": {"terminal_state": "done"},
+                "activity_rows": [
+                    {
+                        "row_id": "commentary-echo",
+                        "role": "prose",
+                        "kind": "process_prose",
+                        "text": progress,
+                        "status": "completed",
+                        "display_hint": "main_prose",
+                    },
+                    {
+                        "row_id": "distinct-reasoning",
+                        "role": "thinking",
+                        "kind": "reasoning",
+                        "text": distinct_reasoning,
+                        "status": "completed",
+                        "display_hint": "collapsed_thinking",
+                    },
+                    {
+                        "row_id": "distinct-tool",
+                        "role": "tool",
+                        "kind": "tool_call",
+                        "text": "terminal",
+                        "status": "completed",
+                        "tool_call_id": "tool-1",
+                        "tool": {
+                            "name": "terminal",
+                            "call_id": "tool-1",
+                            "input": '{"command":"pwd"}',
+                            "output": "/isolated/workspace",
+                        },
+                        "display_hint": "tool_row",
+                    },
+                ],
+            },
+        },
+    ]
+
+    repo_root = ROOT
+    state_tmp = tempfile.TemporaryDirectory(
+        prefix="hermes-commentary-render-", ignore_cleanup_errors=True
+    )
+    state_dir = Path(state_tmp.name)
+    artifact_dir = state_dir / "artifacts"
+    artifact_dir.mkdir()
+    agent_dir = state_dir / "no-agent"
+    workspace_dir = state_dir / "workspace"
+    agent_dir.mkdir()
+    workspace_dir.mkdir()
+    (agent_dir / "run_agent.py").write_text(
+        '"""Test-only agent stub."""\n', encoding="utf-8"
+    )
+    env = os.environ.copy()
+    for key in list(env):
+        if key.endswith("_API_KEY"):
+            env.pop(key, None)
+    for key in (
+        "API_SERVER_KEY",
+        "HERMES_WEBUI_PASSWORD",
+        "HERMES_WEBUI_EXTENSION_DIR",
+        "HERMES_WEBUI_EXTENSION_MANIFEST",
+    ):
+        env.pop(key, None)
+    env.update(
+        {
+            "HERMES_WEBUI_HOST": "127.0.0.1",
+            "HERMES_WEBUI_STATE_DIR": str(state_dir / "webui-state"),
+            "HERMES_HOME": str(state_dir / "hermes-home"),
+            "HERMES_BASE_HOME": str(state_dir / "hermes-home"),
+            "HERMES_CONFIG_PATH": str(state_dir / "hermes-home" / "config.yaml"),
+            "HERMES_WEBUI_SKIP_ONBOARDING": "1",
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_DEFAULT_WORKSPACE": str(workspace_dir),
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+        }
+    )
+
+    proc = log = browser = sync = context = None
+    try:
+        proc, log, _log_path, base_url = _start_webui_server(
+            repo_root, env, artifact_dir
+        )
+        sync = playwright.sync_playwright().start()
+        browser = sync.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        context = browser.new_context(base_url=base_url)
+        page = context.new_page()
+        errors = _capture_page_errors(page)
+        page.goto("/", wait_until="domcontentloaded")
+        page.wait_for_selector("#msg", state="visible", timeout=15000)
+        page.wait_for_function(
+            "() => typeof renderMessages === 'function' && typeof S === 'object'",
+            timeout=15000,
+        )
+
+        first = page.evaluate(
+            """({messages, progress}) => {
+              window._chatActivityDisplayMode = 'compact_worklog';
+              window._simplifiedToolCalling = true;
+              S.busy = false;
+              S.activeStreamId = null;
+              S.session = {session_id: 'commentary-render'};
+              S.messages = messages;
+              _sessionHtmlCache.delete('commentary-render');
+              _sessionHtmlCacheSid = null;
+              renderMessages();
+              const visible = document.querySelector('[data-visible-commentary="1"]');
+              const group = document.querySelector('[data-anchor-settled-scene-owner="1"]');
+              return {
+                visibleText: visible?.querySelector('.msg-body')?.innerText.trim() || '',
+                visibleHidden: Boolean(visible?.hidden),
+                visibleWorklogSource: Boolean(visible?.classList.contains('assistant-segment-worklog-source')),
+                visibleCount: document.querySelectorAll('[data-visible-commentary="1"]').length,
+                transcriptCount: ((document.querySelector('#msgInner')?.innerText || '').match(new RegExp(progress, 'g')) || []).length,
+                deferred: group?.getAttribute('data-worklog-rows-deferred') || '',
+                cacheHasSession: _sessionHtmlCache.has('commentary-render'),
+              };
+            }""",
+            {"messages": messages, "progress": progress},
+        )
+        assert first == {
+            "visibleText": progress,
+            "visibleHidden": False,
+            "visibleWorklogSource": False,
+            "visibleCount": 1,
+            "transcriptCount": 1,
+            "deferred": "1",
+            "cacheHasSession": True,
+        }
+
+        restored = page.evaluate(
+            """({progress}) => {
+              // Make this session look like a switch-back so renderMessages takes
+              // its real _sessionHtmlCache restoration branch.
+              _sessionHtmlCacheSid = 'other-session';
+              document.querySelector('#msgInner').innerHTML = '';
+              renderMessages();
+              const group = document.querySelector('[data-anchor-settled-scene-owner="1"]');
+              const wasDeferred = group?.getAttribute('data-worklog-rows-deferred') === '1';
+              const materialized = _materializeDeferredWorklogRows(group);
+              const rows = Array.from(group?.querySelectorAll('[data-anchor-scene-row="1"]') || []);
+              const visible = document.querySelector('[data-visible-commentary="1"]');
+              return {
+                wasDeferred,
+                materialized,
+                roles: rows.map(row => row.getAttribute('data-anchor-row-role')),
+                rowTexts: rows.map(row => row.innerText.trim()),
+                visibleText: visible?.querySelector('.msg-body')?.innerText.trim() || '',
+                visibleCount: document.querySelectorAll('[data-visible-commentary="1"]').length,
+                progressThinkingCount: Array.from(document.querySelectorAll('[data-anchor-row-role="thinking"],.agent-activity-thinking,.thinking-card-row'))
+                  .filter(row => row.innerText.includes(progress)).length,
+              };
+            }""",
+            {"progress": progress},
+        )
+        assert restored["wasDeferred"] is True
+        assert restored["materialized"] is True
+        assert restored["visibleText"] == progress
+        assert restored["visibleCount"] == 1
+        assert restored["progressThinkingCount"] == 0
+        assert "prose" not in restored["roles"]
+        assert "thinking" in restored["roles"]
+        assert "tool" in restored["roles"]
+        assert any(distinct_reasoning in text for text in restored["rowTexts"])
+        assert any("terminal" in text.lower() for text in restored["rowTexts"])
+
+        final = page.evaluate(
+            """({finalAnswer}) => {
+              S.session = {session_id: 'commentary-final-answer'};
+              S.messages = [
+                {role:'user', content:'Finish the restart.'},
+                {...S.messages[1], content:finalAnswer, _anchor_activity_scene:null},
+              ];
+              _sessionHtmlCache.delete('commentary-final-answer');
+              _sessionHtmlCacheSid = null;
+              renderMessages();
+              const visibleBodies = Array.from(document.querySelectorAll('.assistant-segment:not([hidden]) .msg-body'))
+                .map(node => node.innerText.trim()).filter(Boolean);
+              return {
+                visibleBodies,
+                commentaryOwners: document.querySelectorAll('[data-visible-commentary="1"]').length,
+              };
+            }""",
+            {"finalAnswer": final_answer},
+        )
+        assert final["visibleBodies"] == [final_answer]
+        assert final["commentaryOwners"] == 0
+        assert not errors, errors
+    finally:
+        if context is not None:
+            context.close()
+        if browser is not None:
+            browser.close()
+        if sync is not None:
+            sync.stop()
+        _terminate_process(proc)
+        if log is not None:
+            log.close()
+        state_tmp.cleanup()

--- a/tests/test_commentary_visible_info.py
+++ b/tests/test_commentary_visible_info.py
@@ -239,6 +239,88 @@ def test_render_messages_projects_commentary_once_and_restores_deferred_worklog(
         assert any(distinct_reasoning in text for text in restored["rowTexts"])
         assert any("terminal" in text.lower() for text in restored["rowTexts"])
 
+        commentary_off = page.evaluate(
+            """({messages, progress}) => {
+              window._showCommentary = false;
+              window._showThinking = true;
+              // Same-session warm restoration: the cache was populated while
+              // commentary was ON. The preference is part of the render
+              // signature, so this must rebuild rather than replay stale HTML.
+              S.session = {session_id: 'commentary-render'};
+              S.messages = messages;
+              _sessionHtmlCacheSid = null;
+              renderMessages();
+              const group = document.querySelector('[data-anchor-settled-scene-owner="1"]');
+              _materializeDeferredWorklogRows(group);
+              const transcript = document.querySelector('#msgInner')?.innerText || '';
+              return {
+                visibleCount: document.querySelectorAll('[data-visible-commentary="1"]').length,
+                progressVisible: transcript.includes(progress),
+                progressThinkingCount: Array.from(document.querySelectorAll('[data-anchor-row-role="thinking"],.thinking-card-row,.thinking-block,.agent-activity-thinking'))
+                  .filter(node => node.innerText.includes(progress)).length,
+                progressProseCount: Array.from(document.querySelectorAll('[data-anchor-row-role="prose"]'))
+                  .filter(node => node.innerText.includes(progress)).length,
+                sidecarPhase: S.messages[1].codex_message_items[0].phase,
+                sidecarText: S.messages[1].codex_message_items[0].content[0].text,
+              };
+            }""",
+            {"messages": messages, "progress": progress},
+        )
+        assert commentary_off == {
+            "visibleCount": 0,
+            "progressVisible": False,
+            "progressThinkingCount": 1,
+            "progressProseCount": 0,
+            "sidecarPhase": "commentary",
+            "sidecarText": progress,
+        }
+
+        all_private = page.evaluate(
+            """({messages, progress}) => {
+              window._showCommentary = false;
+              window._showThinking = false;
+              S.session = {session_id: 'commentary-render'};
+              S.messages = messages;
+              _sessionHtmlCacheSid = null;
+              renderMessages();
+              const group = document.querySelector('[data-anchor-settled-scene-owner="1"]');
+              _materializeDeferredWorklogRows(group);
+              const transcript = document.querySelector('#msgInner')?.innerText || '';
+              return {
+                visibleCount: document.querySelectorAll('[data-visible-commentary="1"]').length,
+                progressVisible: transcript.includes(progress),
+                progressOwnedRows: Array.from(document.querySelectorAll('[data-anchor-scene-row="1"]'))
+                  .filter(node => node.innerText.includes(progress)).length,
+                sidecarPhase: S.messages[1].codex_message_items[0].phase,
+              };
+            }""",
+            {"messages": messages, "progress": progress},
+        )
+        assert all_private == {
+            "visibleCount": 0,
+            "progressVisible": False,
+            "progressOwnedRows": 0,
+            "sidecarPhase": "commentary",
+        }
+
+        commentary_on_again = page.evaluate(
+            """({messages, progress}) => {
+              window._showCommentary = true;
+              window._showThinking = true;
+              S.session = {session_id: 'commentary-render'};
+              S.messages = messages;
+              _sessionHtmlCacheSid = null;
+              renderMessages();
+              const visible = document.querySelector('[data-visible-commentary="1"]');
+              return {
+                visibleCount: document.querySelectorAll('[data-visible-commentary="1"]').length,
+                visibleText: visible?.querySelector('.msg-body')?.innerText.trim() || '',
+              };
+            }""",
+            {"messages": messages, "progress": progress},
+        )
+        assert commentary_on_again == {"visibleCount": 1, "visibleText": progress}
+
         final = page.evaluate(
             """({finalAnswer}) => {
               S.session = {session_id: 'commentary-final-answer'};

--- a/tests/test_commentary_visible_info.py
+++ b/tests/test_commentary_visible_info.py
@@ -1,0 +1,23 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for commentary rendering regression")
+def test_commentary_is_visible_assistant_information():
+    result = subprocess.run(
+        [NODE, str(ROOT / "tests" / "_commentary_is_visible_info.mjs")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "PASS commentary_is_visible_info" in result.stdout

--- a/tests/test_cron_refresh_button_835.py
+++ b/tests/test_cron_refresh_button_835.py
@@ -65,7 +65,7 @@ class TestLoadCronsAnimateFlag:
 
     def test_load_crons_accepts_animate_param(self):
         js = _read("static/panels.js")
-        assert re.search(r'async function loadCrons\s*\(\s*animate\s*\)', js), (
+        assert re.search(r'async function loadCrons\s*\(\s*animate\s*,\s*transitionOwner\s*\)', js), (
             "loadCrons must accept an `animate` parameter"
         )
 

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -107,7 +107,8 @@ def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded
     assert "const _loadGeneration = ++_loadSessionGeneration" in body, (
         "loadSession() must increment and capture per-call generation"
     )
-    assert "const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration" in body
+    assert "const _isCurrentNavigation = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration" in body
+    assert "const _isCurrentLoad = () => transitionCurrent() && _isCurrentNavigation()" in body
     assert "loadGeneration:_loadGeneration" in body, (
         "loadSession() must thread generation into _ensureMessagesLoaded()"
     )
@@ -118,7 +119,7 @@ def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded
         "loadSession() should check ownership in multiple await/catch paths, "
         "including stale _ensureMessagesLoaded catch branches"
     )
-    ensure_call = _normalise_ws("await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});")
+    ensure_call = _normalise_ws("await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration, transitionOwner});")
     assert ensure_call in norm, (
         "loadSession() must pass generation into _ensureMessagesLoaded() for stale-owner checks"
     )

--- a/tests/test_firefox_sidebar_scroll_stability.py
+++ b/tests/test_firefox_sidebar_scroll_stability.py
@@ -33,9 +33,10 @@ def test_polling_payloads_are_deferred_while_user_scrolls_sidebar():
     assert "async function _runRenderSessionListRefresh(opts, _gen)" in refresh_block
     assert "const deferWhileInteracting=Boolean(opts&&opts.deferWhileInteracting);" in refresh_block
     assert "if(deferWhileInteracting&&_isSessionListUserInteracting())" in refresh_block
-    assert "_pendingSessionListPayload={gen:_gen,sessData,projData,unreadGen};" in refresh_block
+    assert "? {gen:_gen,sessData,projData,unreadGen,transitionOwner}" in refresh_block
+    assert ": {gen:_gen,sessData,projData,unreadGen};" in refresh_block
     assert "_schedulePendingSessionListApply();" in refresh_block
-    assert "_applySessionListPayload(sessData,projData,{unreadGen});" in refresh_block
+    assert "transitionOwner ? {unreadGen,transitionOwner} : {unreadGen}" in refresh_block
     assert "_markPollingCompletionUnreadTransitions(_allSessions);" in apply_block, (
         "deferring sidebar refreshes must preserve background-completion unread semantics"
     )

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -319,7 +319,7 @@ def test_load_session_attaches_sse_before_auxiliary_work():
         "syncTopbar();",
         "renderMessages(",
         "appendThinking();",
-        "_deferWorkspaceRefreshForSession(sid);",
+        "_deferWorkspaceRefreshForSession(sid,{transitionOwner});",
         "updateQueueBadge(sid);",
         "startApprovalPolling(sid)",
     ):
@@ -899,7 +899,7 @@ def test_load_session_restores_worklog_shell_before_reattach_replay():
     body = _function_body(SESSIONS_JS, "loadSession")
     fallback_pos = body.find("if(!restoredLiveTurn){")
     assert fallback_pos != -1, "loadSession must have a live-turn fallback branch"
-    refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid);", fallback_pos)
+    refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid,{transitionOwner});", fallback_pos)
     assert refresh_pos != -1, "fallback path should still schedule workspace refresh after first paint"
     fallback_block = body[fallback_pos:refresh_pos]
     clear_pos = fallback_block.find("clearLiveToolCards();")
@@ -964,7 +964,7 @@ def test_restore_succeeded_reconnect_skips_unkeyed_restored_tool_duplicates():
     assert "hasRestoredLiveToolRows&&!liveToolReplayId(tc)" in helper_block
     restore_block = body[restore_replay_pos:fallback_pos]
     assert "replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});" in restore_block
-    refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid);", fallback_pos)
+    refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid,{transitionOwner});", fallback_pos)
     assert refresh_pos != -1, "fallback path should still schedule workspace refresh after first paint"
     assert "replayPersistedLiveToolCards();" in body[fallback_pos:refresh_pos]
 

--- a/tests/test_issue1823_kanban_not_found.py
+++ b/tests/test_issue1823_kanban_not_found.py
@@ -112,7 +112,7 @@ def test_inner_handler_bad_response_does_not_emit_double_404(
 
 
 def test_kanban_load_resolves_board_before_board_scoped_requests():
-    boards_pos = PANELS.find("await loadKanbanBoards();")
+    boards_pos = PANELS.find("await loadKanbanBoards(transitionOwner);")
     config_pos = PANELS.find("api('/api/kanban/config' + _kanbanBoardQuery())")
     assert boards_pos != -1
     assert config_pos != -1

--- a/tests/test_issue2518_active_provider_fallback.py
+++ b/tests/test_issue2518_active_provider_fallback.py
@@ -92,7 +92,7 @@ class TestClientFallbackSourceShape:
         # Window covers the model-fallback region of newSession(); the function
         # has grown over time (e.g. pre-session toolset staging #4490), so keep
         # the window comfortably larger than the fallback block it guards.
-        body = src[idx:idx + 5000]
+        body = src[idx:idx + 6500]
         assert "#2518" in body, (
             "newSession()'s fallback comment should reference #2518 so the "
             "follow-up provenance survives future refactors."

--- a/tests/test_issue2518_new_session_inflight.py
+++ b/tests/test_issue2518_new_session_inflight.py
@@ -16,7 +16,8 @@ def test_new_session_reuses_inflight_request_before_posting_again():
         "newSession() must return the existing create promise so rapid clicks do "
         "not enqueue multiple /api/session/new requests"
     )
-    assert "_newSessionInFlight=(async()=>" in src
+    assert "const thisNewSessionPromise=(async()=>" in src
+    assert "_newSessionInFlight=thisNewSessionPromise" in src
     assert "_newSessionInFlight=null;" in src
 
 

--- a/tests/test_issue2785_gateway_cron_guidance.py
+++ b/tests/test_issue2785_gateway_cron_guidance.py
@@ -28,7 +28,7 @@ def test_cron_panel_loads_gateway_status_for_scheduling_guidance():
     assert "configured gateway URL env var" in panels
     assert "GATEWAY_HEALTH_URL" in panels
     assert "scheduled jobs require the Hermes gateway daemon" in panels
-    assert "loadCronGatewayNotice()" in panels
+    assert "loadCronGatewayNotice(transitionOwner)" in panels
 
 
 def test_docker_docs_explain_single_container_cron_gateway_boundary():

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -114,7 +114,7 @@ def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
 
 
 def test_profiles_management_panel_still_renders_all_profiles():
-    body = _function_body(_panels_js(), "async function loadProfilesPanel()")
+    body = _function_body(_panels_js(), "async function loadProfilesPanel(transitionOwner)")
 
     assert "for (const p of data.profiles)" in body
     assert "visible !== false" not in body

--- a/tests/test_issue3947_tasks_cross_profile_visibility.py
+++ b/tests/test_issue3947_tasks_cross_profile_visibility.py
@@ -464,6 +464,7 @@ async function loadKanban() {{ kanbanLoads += 1; }}
 async function loadProfilesPanel() {{ profileLoads += 1; }}
 async function loadWorkspacesPanel() {{ workspaceLoads += 1; }}
 function _clearCronDetail() {{ clearCronDetailCalls += 1; }}
+function _profilePanelTransitionCurrent() {{ return true; }}
 {profile_switch_panel_load}
 (async () => {{
   await _profileSwitchPanelLoad();

--- a/tests/test_issue4662_profile_switch_skeleton_static.py
+++ b/tests/test_issue4662_profile_switch_skeleton_static.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).parent.parent.resolve()
 PANELS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 SESSIONS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 WORKSPACE = (REPO_ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+UI = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -41,7 +42,7 @@ class TestSwitchWiring:
         body = _switch_body()
         skeleton_idx = _show_session_skeleton_call_idx(body)
         # ...and before the awaited /api/profile/switch POST, so stale rows clear immediately
-        assert skeleton_idx < body.index("await api('/api/profile/switch'")
+        assert skeleton_idx < body.index("await _postProfileTransition(_transitionOwner)")
 
     def test_shows_workspace_skeleton_when_panel_open(self):
         body = _switch_body()
@@ -59,7 +60,7 @@ class TestSwitchWiring:
         guard = "if (_switchGen !== _profileSwitchGeneration) return false;"
         # In the non-sessionInProgress branch, the loadDir('.') call must come
         # after an occurrence of the guard.
-        dir_idx = body.index("const dirLoad = loadDir('.');")
+        dir_idx = body.index("const dirLoad = loadDir('.',{transitionOwner:_transitionOwner});")
         guard_before = body.rfind(guard, 0, dir_idx)
         assert guard_before != -1, "loadDir('.') must be preceded by the switch-generation guard"
 
@@ -114,10 +115,10 @@ class TestSwitchWiring:
         # transient-but-eventually-successful switch. Failures surface only through
         # the generation-guarded catch handler, which is the single source of truth.
         body = _switch_body()
-        post_idx = body.index("await api('/api/profile/switch'")
-        # The same api(...) call expression that targets /api/profile/switch must
-        # carry timeoutToast: false. Scope to a small window around the call.
-        window = body[post_idx: post_idx + 300]
+        assert "await _postProfileTransition(_transitionOwner)" in body
+        helper_idx = UI.index("function _postProfileTransition(owner)")
+        # The shared serialized POST helper must retain timeoutToast:false.
+        window = UI[helper_idx: helper_idx + 600]
         assert "timeoutToast: false" in window or "timeoutToast:false" in window.replace(" ", ""), (
             "the /api/profile/switch POST must suppress the generic timeout toast"
         )
@@ -132,7 +133,7 @@ class TestSwitchWiring:
         # Inside the sessionInProgress branch: locate its "await renderSessionList()"
         # then the profile_switched_new_conversation toast; a guard must sit between.
         new_toast_idx = body.index("profile_switched_new_conversation")
-        list_render_before = body.rfind("await renderSessionList();", 0, new_toast_idx)
+        list_render_before = body.rfind("await renderSessionList({transitionOwner:_transitionOwner});", 0, new_toast_idx)
         assert list_render_before != -1
         guard_between = body.find(guard, list_render_before, new_toast_idx)
         assert guard_between != -1, (

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -666,7 +666,7 @@ def test_populate_model_dropdown_accepts_session_visit_freshness_and_guards_stal
     assert "modelsUrl.searchParams.set('freshness',opts.freshness)" in body
     assert "const requestSeq=++_modelDropdownRequestSeq" in body
     assert body.count("requestSeq!==_modelDropdownRequestSeq") >= 3
-    assert "_fetchLiveModels(data.active_provider, sel, requestSeq)" in body
+    assert "_fetchLiveModels(data.active_provider, sel, requestSeq, transitionOwner)" in body
     assert live_tail.count("requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq") >= 4
 
 
@@ -680,7 +680,7 @@ def test_load_session_schedules_session_visit_model_refresh_before_message_load(
     guard_helper_idx = body.index("const isActiveModelRefreshSession", model_block_idx)
     promise_idx = body.index("const modelRefreshPromise=_deferSessionSideEffect", model_block_idx)
     ready_idx = body.index("window._modelDropdownReady=modelRefreshPromise", promise_idx)
-    refresh_idx = body.index("populateModelDropdown({freshness:'session_visit'})", promise_idx)
+    refresh_idx = body.index("populateModelDropdown({freshness:'session_visit',transitionOwner})", promise_idx)
 
     assert assign_idx < model_block_idx < message_load_idx < failure_return_idx
     assert model_block_idx < promise_idx < refresh_idx < ready_idx
@@ -702,7 +702,7 @@ def test_session_visit_model_refresh_is_deferred_until_after_first_paint():
     assert "return _afterSessionFirstPaint(()=>" in side_effect_helper
     assert "const modelRefreshPromise=_deferSessionSideEffect" in load_body
     assert "isActiveModelRefreshSession()" in load_body
-    assert "return populateModelDropdown({freshness:'session_visit'});" in load_body
+    assert "return populateModelDropdown({freshness:'session_visit',transitionOwner});" in load_body
 
 
 def test_boot_model_dropdown_clears_cached_ready_on_401():

--- a/tests/test_issue5177_hidden_tab_blank_gap.py
+++ b/tests/test_issue5177_hidden_tab_blank_gap.py
@@ -158,7 +158,7 @@ def test_ensure_messages_loaded_called_with_keep_stale_flag():
     # cannot skip the swap when stale messages are still in place.
     block = _load_session_block(_compact(SESSIONS_JS))
     # Both INFLIGHT and idle paths.
-    assert block.count("await_ensureMessagesLoaded(sid,{force:_keepStaleUntilLoaded,loadGeneration:_loadGeneration})") == 2
+    assert block.count("await_ensureMessagesLoaded(sid,{force:_keepStaleUntilLoaded,loadGeneration:_loadGeneration,transitionOwner})") == 2
 
 
 def test_ensure_messages_loaded_supports_force_override():

--- a/tests/test_issue5839_lazy_worklog_render.py
+++ b/tests/test_issue5839_lazy_worklog_render.py
@@ -61,7 +61,8 @@ def test_row_recovery_maps_group_to_message_scene():
     assert "anchor-scene:" in body
     assert "S.messages" in body
     assert "_anchor_activity_scene" in body
-    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in body
+    assert "_assistantTurnBlocks(group.closest('.assistant-turn'))" in body
+    assert "_anchorSceneRowsForSettledWorklog(scene,blocks)" in body
 
 
 def test_cache_restore_rehydrates_deferred_worklogs():

--- a/tests/test_issue5960_cron_unread_profile_scope.py
+++ b/tests/test_issue5960_cron_unread_profile_scope.py
@@ -77,11 +77,14 @@ const _cronNewJobIds=new Set(['old-profile-job']);
 global.S={{activeProfile:'default'}};
 global.api=async()=>({{active:'alternate',is_default:false}});
 let _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
-function _acceptProfileTransitionOwner(profile,source){{
-  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source}};
+function _beginProfileTransitionOwner(profile,source){{
+  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source,accepted:false}};
   return _profileTransitionOwner;
 }}
+function _acceptProfileTransitionOwner(owner,profile){{ owner.profile=profile; owner.accepted=true; return owner; }}
 function _isProfileTransitionOwner(owner){{ return owner===_profileTransitionOwner; }}
+function _postProfileTransition(owner){{ return api('/api/profile/switch',{{method:'POST',body:JSON.stringify({{name:owner.profile}})}}); }}
+function _cancelProfileTransitionOwner(owner){{ if(owner===_profileTransitionOwner) _profileTransitionOwner=null; }}
 global.localStorage={{removeItem(){{}}}};
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
 function _clearCronSessionCompletionUnreadForInactiveProfiles(){{}}
@@ -192,11 +195,14 @@ global.S={{activeProfile:'profile-a',activeProfileIsDefault:false}};
 global._allSessions=[];
 global.api=async()=>({{active:'profile-b',is_default:false}});
 let _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
-function _acceptProfileTransitionOwner(profile,source){{
-  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source}};
+function _beginProfileTransitionOwner(profile,source){{
+  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source,accepted:false}};
   return _profileTransitionOwner;
 }}
+function _acceptProfileTransitionOwner(owner,profile){{ owner.profile=profile; owner.accepted=true; return owner; }}
 function _isProfileTransitionOwner(owner){{ return owner===_profileTransitionOwner; }}
+function _postProfileTransition(owner){{ return api('/api/profile/switch',{{method:'POST',body:JSON.stringify({{name:owner.profile}})}}); }}
+function _cancelProfileTransitionOwner(owner){{ if(owner===_profileTransitionOwner) _profileTransitionOwner=null; }}
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
 global.renderSessionListFromCache=()=>{{ renders+=1; }};
 function _getSessionViewedCounts(){{ return _sessionViewedCounts; }}

--- a/tests/test_issue5960_cron_unread_profile_scope.py
+++ b/tests/test_issue5960_cron_unread_profile_scope.py
@@ -76,6 +76,12 @@ let _cronPollGeneration=0;
 const _cronNewJobIds=new Set(['old-profile-job']);
 global.S={{activeProfile:'default'}};
 global.api=async()=>({{active:'alternate',is_default:false}});
+let _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+function _acceptProfileTransitionOwner(profile,source){{
+  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source}};
+  return _profileTransitionOwner;
+}}
+function _isProfileTransitionOwner(owner){{ return owner===_profileTransitionOwner; }}
 global.localStorage={{removeItem(){{}}}};
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
 function _clearCronSessionCompletionUnreadForInactiveProfiles(){{}}
@@ -185,6 +191,12 @@ let renders=0;
 global.S={{activeProfile:'profile-a',activeProfileIsDefault:false}};
 global._allSessions=[];
 global.api=async()=>({{active:'profile-b',is_default:false}});
+let _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+function _acceptProfileTransitionOwner(profile,source){{
+  _profileTransitionOwner={{generation:++_profileTransitionOwnerSeq,profile,source}};
+  return _profileTransitionOwner;
+}}
+function _isProfileTransitionOwner(owner){{ return owner===_profileTransitionOwner; }}
 global.updateCronBadge=()=>{{ _cronUnreadCount=_cronNewJobIds.size; }};
 global.renderSessionListFromCache=()=>{{ renders+=1; }};
 function _getSessionViewedCounts(){{ return _sessionViewedCounts; }}

--- a/tests/test_issue5966_transparent_stream_lazy_dom.py
+++ b/tests/test_issue5966_transparent_stream_lazy_dom.py
@@ -158,6 +158,10 @@ def test_earlier_steps_affordance_is_accessible_and_counted():
 
 def test_reveal_holds_viewport_and_clears_cap_count():
     body = _function_body(UI_JS, "_revealTransparentEarlierSteps")
+    # Reveal uses the same commentary-ownership filter as the initial settled
+    # render, so expanding earlier rows cannot resurrect a commentary echo.
+    assert "_anchorSceneRowsForSettledWorklog(scene,blocks)" in body
+    assert "_anchorSceneRowsForRendering(scene,{settled:true})" not in body
     # Full run mounted -> drop the capped-count stash so the label recomputes.
     assert "removeAttribute('data-transparent-total-tool-count')" in body
     # Viewport compensation: add the inserted height delta to scrollTop.

--- a/tests/test_issue6022_worktree_ui_static.py
+++ b/tests/test_issue6022_worktree_ui_static.py
@@ -45,7 +45,7 @@ def test_onboarding_session_sends_explicit_worktree_false():
 def test_profile_switch_session_sends_explicit_worktree_false():
     src = read("static/panels.js")
     assert (
-        "await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});"
+        "await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false, transitionOwner:_transitionOwner});"
         in src
     )
 

--- a/tests/test_issue617_cron_profile_selector.py
+++ b/tests/test_issue617_cron_profile_selector.py
@@ -216,7 +216,7 @@ def test_cron_profile_selector_source_hooks_present():
     css = (REPO / "static" / "style.css").read_text(encoding="utf-8")
     i18n = (REPO / "static" / "i18n.js").read_text(encoding="utf-8")
 
-    assert "async function loadCronProfiles()" in panels
+    assert "await loadCronProfiles(transitionOwner);" in panels
     assert "api('/api/profiles')" in panels
     assert "id=\"cronFormProfile\"" in panels
     assert "profile: profile" in panels

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -164,7 +164,7 @@ def test_polling_transition_marks_completion_unread_without_sse_done():
     assert "_sessionStreamingById.set(sid, isStreaming);" in transition_block
     assert "const _streamingPollMs = 30000;" in SESSIONS_JS
     # Greptile #5975: apply carries unreadGen so stale pre-switch lists skip mark.
-    assert "_applySessionListPayload(sessData,projData,{unreadGen});" in refresh_block
+    assert "transitionOwner ? {unreadGen,transitionOwner} : {unreadGen}" in refresh_block
     assert "unreadGen" in refresh_block
     assert "_markPollingCompletionUnreadTransitions(_allSessions);" in apply_block
     assert "_allSessions.some(s => _isSessionEffectivelyStreaming(s))" in apply_block, (

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -56,7 +56,7 @@ def test_switch_panel_lazy_loads_kanban_and_toggles_main_view():
     assert "MAIN_VIEW_PANELS.forEach(p => {" in PANELS
     assert "mainEl.classList.toggle('showing-' + p, nextPanel === p);" in PANELS
     assert "if (nextPanel === 'kanban') await loadKanban();" in PANELS
-    assert "if (_currentPanel === 'kanban') await loadKanban();" in PANELS
+    assert "if (_currentPanel === 'kanban') await loadKanban(undefined,transitionOwner);" in PANELS
 
 
 def test_kanban_frontend_uses_relative_api_endpoints():

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -165,6 +165,7 @@ def test_message_tool_metadata_empty_assistant_tools_reuse_previous_visible_anch
     empty_placeholder_fn = _function_source(UI_JS, "_isAssistantEmptyPlaceholderContent")
     has_reasoning_fn = _function_source(UI_JS, "_messageHasReasoningPayload")
     anchor_scene_final_fn = _function_source(UI_JS, "_assistantAnchorSceneFinalAnswerText")
+    commentary_fn = _function_source(UI_JS, "_assistantCommentaryPayloadText")
     reasoning_fn = _function_source(UI_JS, "_assistantReasoningPayloadText")
     anchor_fn = _function_source(UI_JS, "_assistantToolAnchorIdxForMessage")
     script = f"""
@@ -179,6 +180,7 @@ function msgContent(m){{
 {has_reasoning_fn}
 {empty_placeholder_fn}
 {anchor_scene_final_fn}
+{commentary_fn}
 {has_visible_fn}
 {reasoning_fn}
 {anchor_fn}

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -165,11 +165,13 @@ def test_message_tool_metadata_empty_assistant_tools_reuse_previous_visible_anch
     empty_placeholder_fn = _function_source(UI_JS, "_isAssistantEmptyPlaceholderContent")
     has_reasoning_fn = _function_source(UI_JS, "_messageHasReasoningPayload")
     anchor_scene_final_fn = _function_source(UI_JS, "_assistantAnchorSceneFinalAnswerText")
+    persisted_commentary_fn = _function_source(UI_JS, "_assistantPersistedCommentaryPayloadText")
     commentary_fn = _function_source(UI_JS, "_assistantCommentaryPayloadText")
     reasoning_fn = _function_source(UI_JS, "_assistantReasoningPayloadText")
     anchor_fn = _function_source(UI_JS, "_assistantToolAnchorIdxForMessage")
     script = f"""
 const assert = require('assert');
+const window = {{_showCommentary:true}};
 function _isRecoveryControlMessage(){{ return false; }}
 function msgContent(m){{
   if(!m) return '';
@@ -180,6 +182,7 @@ function msgContent(m){{
 {has_reasoning_fn}
 {empty_placeholder_fn}
 {anchor_scene_final_fn}
+{persisted_commentary_fn}
 {commentary_fn}
 {has_visible_fn}
 {reasoning_fn}

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -1162,7 +1162,7 @@ def test_transparent_stream_renders_persisted_anchor_scene_after_reload():
 
     assert "if(typeof isTransparentStream==='function'&&isTransparentStream())" in settled
     assert "return _renderSettledAnchorSceneTransparentForMessage(message,segment,rawIdx);" in settled
-    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in transparent
+    assert "_anchorSceneRowsForSettledWorklog(scene,blocks)" in transparent
     assert 'blocks.querySelectorAll(\'[data-anchor-settled-scene-row="1"],.transparent-event-row[data-anchor-scene-row="1"]\')' in transparent
     # combined fix: the final answer text is computed and threaded into the row
     # renderer so intermediate prose survives while the final-answer duplicate is dropped.
@@ -1542,7 +1542,7 @@ def test_settled_anchor_scene_final_answer_does_not_fold_into_worklog_source():
     render = _function_body(UI_JS, "renderMessages")
 
     assert "if(hasVisibleText&&m._anchor_activity_scene) return false;" in belongs
-    assert belongs.index("if(m._live) return true;") < belongs.index(
+    assert belongs.index("if(m._live) return !hasVisibleText;") < belongs.index(
         "if(hasVisibleText&&m._anchor_activity_scene) return false;"
     )
     assert belongs.index("if(hasVisibleText&&m._anchor_activity_scene) return false;") < belongs.index(

--- a/tests/test_model_default_boot_precedence.py
+++ b/tests/test_model_default_boot_precedence.py
@@ -179,7 +179,7 @@ def test_boot_settings_applies_default_without_deleting_browser_model_state():
 
 
 def test_boot_model_dropdown_explicitly_requests_profile_default_precedence():
-    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in BOOT_JS
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({" in BOOT_JS
     assert "preferProfileDefaultOnFreshBoot:true" in BOOT_JS
     # #2726 invariant: boot path must keep profile/server default ahead of stale
     # browser-persisted state when a default exists. Post-#2716 cherry-pick onto

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -85,7 +85,7 @@ class TestLoadSessionIdleOverlap:
             # refresh now routes through a first-paint deferral helper instead of
             # a direct loadDir('.') call).
             block = SESSIONS_JS[pos : pos + 950]
-            has_deferred_workspace = "_deferWorkspaceRefreshForSession(sid);" in block
+            has_deferred_workspace = "_deferWorkspaceRefreshForSession(sid,{transitionOwner});" in block
             # #3326 added an optional {preserveScroll} arg to the idle-path render
             # call; match the call form rather than the bare `renderMessages()`.
             has_render = "renderMessages(" in block
@@ -95,7 +95,7 @@ class TestLoadSessionIdleOverlap:
                     "The idle path should rely on renderMessages()'s consolidated "
                     "post-render pass instead of running a second highlight pass."
                 )
-                assert block.index("renderMessages(") < block.index("_deferWorkspaceRefreshForSession(sid);"), (
+                assert block.index("renderMessages(") < block.index("_deferWorkspaceRefreshForSession(sid,{transitionOwner});"), (
                     "workspace refresh should be deferred until after the session "
                     "transcript render starts."
                 )

--- a/tests/test_profile_dropdown_fast_open.py
+++ b/tests/test_profile_dropdown_fast_open.py
@@ -85,7 +85,7 @@ def test_profile_dropdown_closing_invalidates_inflight_refresh():
 
 
 def test_profiles_panel_refresh_updates_dropdown_cache():
-    body = _function_body(PANELS_JS, "async function loadProfilesPanel() {")
+    body = _function_body(PANELS_JS, "async function loadProfilesPanel(transitionOwner) {")
     api_idx = body.index("const data = await api('/api/profiles');")
     cache_idx = body.index("_profileDropdownWriteStoredCache(data);")
     render_idx = body.index("panel.innerHTML = '';")
@@ -101,7 +101,7 @@ def test_profile_dropdown_prefetches_after_page_load():
 def test_poisoned_profile_cache_opens_then_switches_after_fresh_refresh():
     snippets = [
         PANELS_JS[
-            PANELS_JS.index("let _profilesCache = null;") : PANELS_JS.index("async function _profileSwitchPanelLoad(){")
+            PANELS_JS.index("let _profilesCache = null;") : PANELS_JS.index("async function _profileSwitchPanelLoad(transitionOwner){")
         ],
         _function_body(PANELS_JS, "function renderProfileDropdown(data) {"),
         _function_body(PANELS_JS, "function toggleProfileDropdown(e) {"),

--- a/tests/test_profile_switch_mixed_ingress.py
+++ b/tests/test_profile_switch_mixed_ingress.py
@@ -178,3 +178,79 @@ async function preferenceOwnerFenceWithoutSequenceHelp(){{
         "currentOwner": "B",
         "ownerB": "B",
     }
+
+
+def test_stale_profile_panel_response_cannot_publish_cache_or_dom():
+    source = f"""
+const uiSrc={UI_JS!r},panelsSrc={PANELS_JS!r};
+function extractFunc(src,name){{
+  const marker='function '+name,asyncMarker='async function '+name;
+  const start=src.includes(asyncMarker)?src.indexOf(asyncMarker):src.indexOf(marker);
+  if(start<0)throw new Error(name+' not found');
+  let i=src.indexOf('{{',start),depth=1;i++;
+  while(depth>0&&i<src.length){{if(src[i]==='{{')depth++;else if(src[i]==='}}')depth--;i++;}}
+  return src.slice(start,i);
+}}
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+eval(extractFunc(uiSrc,'_acceptProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'_isProfileTransitionOwner'));
+eval(extractFunc(panelsSrc,'_profilePanelTransitionCurrent'));
+eval(extractFunc(panelsSrc,'loadSkills'));
+let resolveSkills;
+global.api=()=>new Promise(resolve=>{{resolveSkills=resolve;}});
+global.$=()=>({{innerHTML:''}});
+global.renderSkills=skills=>published.push(skills.map(s=>s.name));
+var _skillsData=null;
+var _collapsedCats=new Set();
+const published=[];
+(async()=>{{
+  const ownerB=_acceptProfileTransitionOwner('B','canonical');
+  const pending=loadSkills(ownerB);
+  const ownerA=_acceptProfileTransitionOwner('A','session-load');
+  resolveSkills({{skills:[{{name:'B-only',category:'test'}}]}});
+  await pending;
+  console.log(JSON.stringify({{
+    currentOwner:_profileTransitionOwner.profile,
+    ownerA:ownerA.profile,
+    cache:_skillsData,
+    published,
+  }}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run_node(source) == {
+        "currentOwner": "A",
+        "ownerA": "A",
+        "cache": None,
+        "published": [],
+    }
+
+
+def test_every_profile_panel_loader_fences_async_publication():
+    def function_source(source: str, name: str) -> str:
+        markers = (f"async function {name}", f"function {name}")
+        start = next((source.index(m) for m in markers if m in source), -1)
+        assert start >= 0, name
+        params_end = source.index(")", start)
+        brace = source.index("{", params_end)
+        depth = 1
+        pos = brace + 1
+        while depth and pos < len(source):
+            if source[pos] == "{":
+                depth += 1
+            elif source[pos] == "}":
+                depth -= 1
+            pos += 1
+        return source[start:pos]
+
+    for name in (
+        "loadSkills", "loadCronProfiles", "loadCrons", "loadKanban",
+        "loadKanbanStats", "loadKanbanBoards", "loadNotesSources",
+        "loadMemory", "loadWorkspaceList", "loadWorkspacesPanel",
+        "loadProfilesPanel", "_profileSwitchPanelLoad",
+        "_refreshProfileSwitchBackground",
+    ):
+        assert "_profilePanelTransitionCurrent" in function_source(PANELS_JS, name), name
+
+    model_loader = function_source(UI_JS, "populateModelDropdown")
+    assert "transitionOwner" in model_loader
+    assert "transitionCurrent()" in model_loader

--- a/tests/test_profile_switch_mixed_ingress.py
+++ b/tests/test_profile_switch_mixed_ingress.py
@@ -1,0 +1,180 @@
+"""Mixed-ingress profile-switch ownership regression for PR #6828."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> dict:
+    result = subprocess.run(
+        [NODE], input=source, cwd=ROOT, capture_output=True,
+        encoding="utf-8", text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_mixed_profile_switch_ingresses_publish_only_final_owner():
+    source = f"""
+const uiSrc = {UI_JS!r};
+const panelsSrc = {PANELS_JS!r};
+const sessionsSrc = {SESSIONS_JS!r};
+function extractFunc(src, name) {{
+  const plain='function '+name, asyncName='async function '+name;
+  const start=src.includes(asyncName)?src.indexOf(asyncName):src.indexOf(plain);
+  if(start<0) throw new Error(name+' not found');
+  let i=src.indexOf('{{',start),depth=1;i++;
+  while(depth>0&&i<src.length){{if(src[i]==='{{')depth++;else if(src[i]==='}}')depth--;i++;}}
+  return src.slice(start,i);
+}}
+function deferred(){{let resolve;const promise=new Promise(r=>{{resolve=r;}});return{{promise,resolve}};}}
+async function waitFor(predicate,label){{
+  for(let i=0;i<200;i++){{if(predicate())return;await Promise.resolve();}}
+  throw new Error('timed out waiting for '+label);
+}}
+function makeEl(){{return{{style:{{}},disabled:false,classList:{{add(){{}},remove(){{}},toggle(){{}}}},setAttribute(){{}},querySelectorAll(){{return[];}}}};}}
+const els={{composerReasoningWrap:makeEl(),composerReasoningLabel:makeEl(),composerReasoningChip:makeEl(),composerMobileReasoningAction:makeEl()}};
+global.$=id=>els[id]||null;
+global.document={{title:''}};
+global.localStorage={{removeItem(){{}}}};
+global.t=(_,name)=>name||'';
+global.assistantDisplayName=()=> 'Hermes';
+global._highlightReasoningOption=()=>{{}};
+global._applyReasoningOptions=()=>{{}};
+global._applyReasoningChip=()=>{{}};
+global._applyModelToDropdown=model=>model;
+global._modelStateForSelect=(_,model)=>({{model,model_provider:null}});
+global._invalidateSessionListRenders=()=>{{}};
+global._setProfileSwitchListEmbargo=()=>{{}};
+global.showSessionListSkeleton=()=>{{}};
+global.bumpWorkspaceTreeGen=()=>{{}};
+global.closeSessionActionMenu=()=>{{}};
+global.applyBotName=()=>{{}};
+global._clearPersistedModelState=()=>{{}};
+global._resetCronUnreadForProfileSwitch=()=>{{}};
+global.animateNextSessionListRefresh=()=>{{}};
+global.showToast=()=>{{}};
+global._profileSwitchPanelLoad=async()=>{{}};
+global._refreshProfileSwitchBackground=()=>{{}};
+global._profileSwitchOpeningExistingSession=false;
+global._workspacePanelMode='closed';
+global._renamingSid=null;
+var _profileSwitchGeneration=0;
+var _skillsData=null,_workspaceList=null;
+var _currentReasoningEffort=null,_currentReasoningEffortsSupported=null,_currentReasoningToggleSupported=undefined;
+var _profileTransitionReasoningContext=null,_lastReasoningFetchKey=null,_reasoningFetchSeq=0;
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+eval(extractFunc(uiSrc,'_acceptProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'_isProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'_currentProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'fetchReasoningChip'));
+eval(extractFunc(uiSrc,'refreshReasoningPreferencesForRender'));
+eval(extractFunc(uiSrc,'refreshProfileTransitionReasoningChip'));
+eval(extractFunc(panelsSrc,'switchToProfile'));
+eval(extractFunc(sessionsSrc,'_switchProfileForSessionLoad'));
+
+async function scenario(finalOwner){{
+  global.S={{activeProfile:'default',activeProfileIsDefault:true,session:{{session_id:'existing',profile:'default'}},messages:[{{role:'user',content:'x'}}]}};
+  global.window={{}};
+  const posts=new Map(),prefs=new Map();
+  const events={{profiles:[],defaults:[],commentary:[],sse:[],lists:[],sessions:[]}};
+  let active='default';
+  Object.defineProperty(S,'activeProfile',{{get(){{return active;}},set(v){{active=v;events.profiles.push(v);}},configurable:true}});
+  let defaultModel=null;
+  Object.defineProperty(window,'_defaultModel',{{get(){{return defaultModel;}},set(v){{defaultModel=v;events.defaults.push(v);}},configurable:true}});
+  let commentary=null;
+  Object.defineProperty(window,'_showCommentary',{{get(){{return commentary;}},set(v){{commentary=v;events.commentary.push({{value:v,owner:_currentProfileTransitionOwner()?.profile||null}});}},configurable:true}});
+  global.startGatewaySSE=()=>events.sse.push(S.activeProfile);
+  global.syncTopbar=()=>{{}};
+  global.renderSessionList=async()=>{{events.lists.push(S.activeProfile);}};
+  global.newSession=async()=>{{events.sessions.push(S.activeProfile);S.session={{session_id:'new-'+S.activeProfile,profile:S.activeProfile}};}};
+  global.api=(url,opts)=>{{
+    if(url==='/api/profile/switch'){{const name=JSON.parse(opts.body).name,d=deferred();posts.set(name,d);return d.promise;}}
+    if(url.startsWith('/api/reasoning')){{const model=new URL('https://x'+url).searchParams.get('model'),d=deferred();prefs.set(model,d);return d.promise;}}
+    throw new Error('unexpected API '+url);
+  }};
+  const canonical=switchToProfile('B');
+  const recovery=_switchProfileForSessionLoad('A');
+  await waitFor(()=>posts.size===2,'both profile POSTs');
+  if(finalOwner==='A'){{
+    posts.get('B').resolve({{active:'B',is_default:false,default_model:'B-model'}});
+    await waitFor(()=>prefs.has('B-model'),'B preference request');
+    posts.get('A').resolve({{active:'A',is_default:false,default_model:'A-model'}});
+    await waitFor(()=>prefs.has('A-model'),'A preference request');
+    prefs.get('A-model').resolve({{show_commentary:false,reasoning_effort:''}});
+    await Promise.resolve();
+    prefs.get('B-model').resolve({{show_commentary:true,reasoning_effort:''}});
+  }}else{{
+    posts.get('A').resolve({{active:'A',is_default:false,default_model:'A-model'}});
+    await waitFor(()=>prefs.has('A-model'),'A preference request');
+    posts.get('B').resolve({{active:'B',is_default:false,default_model:'B-model'}});
+    await waitFor(()=>prefs.has('B-model'),'B preference request');
+    prefs.get('B-model').resolve({{show_commentary:true,reasoning_effort:''}});
+    await Promise.resolve();
+    prefs.get('A-model').resolve({{show_commentary:false,reasoning_effort:''}});
+  }}
+  const [canonicalResult,recoveryResult]=await Promise.all([canonical,recovery]);
+  return{{finalOwner,active:S.activeProfile,defaultModel:window._defaultModel,commentary:window._showCommentary,session:S.session?.session_id,canonicalResult,recoveryOwner:recoveryResult?.profile||null,events}};
+}}
+async function preferenceOwnerFenceWithoutSequenceHelp(){{
+  global.S={{activeProfile:'default'}};
+  global.window={{_showCommentary:'sentinel'}};
+  const response=deferred();
+  global.api=()=>response.promise;
+  const ownerA=_acceptProfileTransitionOwner('A','test-A');
+  const pending=fetchReasoningChip('?model=A-model',ownerA);
+  const ownerB=_acceptProfileTransitionOwner('B','test-B');
+  response.resolve({{show_commentary:true,reasoning_effort:''}});
+  const applied=await pending;
+  return{{applied,commentary:window._showCommentary,currentOwner:_currentProfileTransitionOwner()?.profile,ownerB:ownerB.profile}};
+}}
+(async()=>{{console.log(JSON.stringify({{
+  recoveryWins:await scenario('A'),
+  canonicalWins:await scenario('B'),
+  preferenceFence:await preferenceOwnerFenceWithoutSequenceHelp(),
+}}));}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    payload = _run_node(source)
+    recovery = payload["recoveryWins"]
+    assert recovery["active"] == "A"
+    assert recovery["defaultModel"] == "A-model"
+    assert recovery["commentary"] is False
+    assert recovery["session"] == "existing"
+    assert recovery["canonicalResult"] is False
+    assert recovery["recoveryOwner"] == "A"
+    assert recovery["events"]["profiles"] == ["A"]
+    assert recovery["events"]["defaults"] == ["A-model"]
+    assert recovery["events"]["sse"] == ["A"]
+    assert recovery["events"]["lists"] == ["A"]
+    assert recovery["events"]["sessions"] == []
+    assert recovery["events"]["commentary"][-1] == {"value": False, "owner": "A"}
+
+    canonical = payload["canonicalWins"]
+    assert canonical["active"] == "B"
+    assert canonical["defaultModel"] == "B-model"
+    assert canonical["commentary"] is True
+    assert canonical["session"] == "new-B"
+    assert canonical["canonicalResult"] is True
+    assert canonical["recoveryOwner"] is None
+    assert canonical["events"]["profiles"] == ["B"]
+    assert canonical["events"]["defaults"] == ["B-model"]
+    assert canonical["events"]["sse"] == ["B"]
+    assert canonical["events"]["lists"] == ["B"]
+    assert canonical["events"]["sessions"] == ["B"]
+    assert canonical["events"]["commentary"][-1] == {"value": True, "owner": "B"}
+
+    assert payload["preferenceFence"] == {
+        "applied": False,
+        "commentary": "sentinel",
+        "currentOwner": "B",
+        "ownerB": "B",
+    }

--- a/tests/test_profile_switch_mixed_ingress.py
+++ b/tests/test_profile_switch_mixed_ingress.py
@@ -10,6 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+WORKSPACE_JS = (ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
@@ -72,10 +74,13 @@ var _profileSwitchGeneration=0;
 var _skillsData=null,_workspaceList=null;
 var _currentReasoningEffort=null,_currentReasoningEffortsSupported=null,_currentReasoningToggleSupported=undefined;
 var _profileTransitionReasoningContext=null,_lastReasoningFetchKey=null,_reasoningFetchSeq=0;
-var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null,_profileTransitionPostTail=Promise.resolve();
+eval(extractFunc(uiSrc,'_beginProfileTransitionOwner'));
 eval(extractFunc(uiSrc,'_acceptProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'_cancelProfileTransitionOwner'));
 eval(extractFunc(uiSrc,'_isProfileTransitionOwner'));
 eval(extractFunc(uiSrc,'_currentProfileTransitionOwner'));
+eval(extractFunc(uiSrc,'_postProfileTransition'));
 eval(extractFunc(uiSrc,'fetchReasoningChip'));
 eval(extractFunc(uiSrc,'refreshReasoningPreferencesForRender'));
 eval(extractFunc(uiSrc,'refreshProfileTransitionReasoningChip'));
@@ -102,25 +107,28 @@ async function scenario(finalOwner){{
     if(url.startsWith('/api/reasoning')){{const model=new URL('https://x'+url).searchParams.get('model'),d=deferred();prefs.set(model,d);return d.promise;}}
     throw new Error('unexpected API '+url);
   }};
-  const canonical=switchToProfile('B');
-  const recovery=_switchProfileForSessionLoad('A');
-  await waitFor(()=>posts.size===2,'both profile POSTs');
+  let canonical,recovery;
+  if(finalOwner==='A'){{
+    canonical=switchToProfile('B');
+    await waitFor(()=>posts.has('B'),'B profile POST');
+    recovery=_switchProfileForSessionLoad('A');
+  }}else{{
+    recovery=_switchProfileForSessionLoad('A');
+    await waitFor(()=>posts.has('A'),'A profile POST');
+    canonical=switchToProfile('B');
+  }}
   if(finalOwner==='A'){{
     posts.get('B').resolve({{active:'B',is_default:false,default_model:'B-model'}});
-    await waitFor(()=>prefs.has('B-model'),'B preference request');
+    await waitFor(()=>posts.has('A'),'A profile POST');
     posts.get('A').resolve({{active:'A',is_default:false,default_model:'A-model'}});
     await waitFor(()=>prefs.has('A-model'),'A preference request');
     prefs.get('A-model').resolve({{show_commentary:false,reasoning_effort:''}});
-    await Promise.resolve();
-    prefs.get('B-model').resolve({{show_commentary:true,reasoning_effort:''}});
   }}else{{
     posts.get('A').resolve({{active:'A',is_default:false,default_model:'A-model'}});
-    await waitFor(()=>prefs.has('A-model'),'A preference request');
+    await waitFor(()=>posts.has('B'),'B profile POST');
     posts.get('B').resolve({{active:'B',is_default:false,default_model:'B-model'}});
     await waitFor(()=>prefs.has('B-model'),'B preference request');
     prefs.get('B-model').resolve({{show_commentary:true,reasoning_effort:''}});
-    await Promise.resolve();
-    prefs.get('A-model').resolve({{show_commentary:false,reasoning_effort:''}});
   }}
   const [canonicalResult,recoveryResult]=await Promise.all([canonical,recovery]);
   return{{finalOwner,active:S.activeProfile,defaultModel:window._defaultModel,commentary:window._showCommentary,session:S.session?.session_id,canonicalResult,recoveryOwner:recoveryResult?.profile||null,events}};
@@ -130,9 +138,11 @@ async function preferenceOwnerFenceWithoutSequenceHelp(){{
   global.window={{_showCommentary:'sentinel'}};
   const response=deferred();
   global.api=()=>response.promise;
-  const ownerA=_acceptProfileTransitionOwner('A','test-A');
+  const ownerA=_beginProfileTransitionOwner('A','test-A');
+  _acceptProfileTransitionOwner(ownerA,'A');
   const pending=fetchReasoningChip('?model=A-model',ownerA);
-  const ownerB=_acceptProfileTransitionOwner('B','test-B');
+  const ownerB=_beginProfileTransitionOwner('B','test-B');
+  _acceptProfileTransitionOwner(ownerB,'B');
   response.resolve({{show_commentary:true,reasoning_effort:''}});
   const applied=await pending;
   return{{applied,commentary:window._showCommentary,currentOwner:_currentProfileTransitionOwner()?.profile,ownerB:ownerB.profile}};
@@ -191,7 +201,8 @@ function extractFunc(src,name){{
   while(depth>0&&i<src.length){{if(src[i]==='{{')depth++;else if(src[i]==='}}')depth--;i++;}}
   return src.slice(start,i);
 }}
-var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null,_profileTransitionPostTail=Promise.resolve();
+eval(extractFunc(uiSrc,'_beginProfileTransitionOwner'));
 eval(extractFunc(uiSrc,'_acceptProfileTransitionOwner'));
 eval(extractFunc(uiSrc,'_isProfileTransitionOwner'));
 eval(extractFunc(panelsSrc,'_profilePanelTransitionCurrent'));
@@ -204,9 +215,11 @@ var _skillsData=null;
 var _collapsedCats=new Set();
 const published=[];
 (async()=>{{
-  const ownerB=_acceptProfileTransitionOwner('B','canonical');
+  const ownerB=_beginProfileTransitionOwner('B','canonical');
+  _acceptProfileTransitionOwner(ownerB,'B');
   const pending=loadSkills(ownerB);
-  const ownerA=_acceptProfileTransitionOwner('A','session-load');
+  const ownerA=_beginProfileTransitionOwner('A','session-load');
+  _acceptProfileTransitionOwner(ownerA,'A');
   resolveSkills({{skills:[{{name:'B-only',category:'test'}}]}});
   await pending;
   console.log(JSON.stringify({{
@@ -254,3 +267,17 @@ def test_every_profile_panel_loader_fences_async_publication():
     model_loader = function_source(UI_JS, "populateModelDropdown")
     assert "transitionOwner" in model_loader
     assert "transitionCurrent()" in model_loader
+
+    live_models = function_source(UI_JS, "_fetchLiveModels")
+    assert "transitionOwner" in live_models
+    assert "transitionCurrent()" in live_models
+
+    for name in ("newSession", "_runRenderSessionListRefresh", "loadSession", "_ensureMessagesLoaded"):
+        nested = function_source(SESSIONS_JS, name)
+        assert "transitionOwner" in nested, name
+
+    workspace_loader = function_source(WORKSPACE_JS, "loadDir")
+    assert "transitionOwner" in workspace_loader
+    assert "transitionCurrent()" in workspace_loader
+
+    assert "transitionOwner" in BOOT_JS[BOOT_JS.index("const _hydrateModelDropdown="):BOOT_JS.index("window._modelDropdownReady=null", BOOT_JS.index("const _hydrateModelDropdown="))]

--- a/tests/test_profile_switch_ux.py
+++ b/tests/test_profile_switch_ux.py
@@ -97,7 +97,7 @@ class TestParallelizedFetches:
     def test_workspace_refresh_in_background_and_model_catalog_lazy(self):
         """Workspace refresh should run behind completion; model catalog waits for picker open."""
         fn = self._get_switch_fn()
-        assert "_refreshProfileSwitchBackground(_switchGen)" in fn, (
+        assert "_refreshProfileSwitchBackground(_switchGen,_transitionOwner)" in fn, (
             "switchToProfile() must schedule non-visible refreshes after the switch."
         )
         assert "window._modelDropdownReady=null" in self.JS
@@ -119,7 +119,7 @@ class TestParallelizedFetches:
     def test_apply_steps_after_promise_all(self):
         """Model defaults must apply before background catalog refresh starts."""
         fn = self._get_switch_fn()
-        background_idx = fn.find("_refreshProfileSwitchBackground(_switchGen)")
+        background_idx = fn.find("_refreshProfileSwitchBackground(_switchGen,_transitionOwner)")
         apply_model_idx = fn.find("S._pendingProfileModel = modelToUse")
         assert apply_model_idx != -1
         assert background_idx != -1

--- a/tests/test_profile_switch_ux.py
+++ b/tests/test_profile_switch_ux.py
@@ -48,7 +48,7 @@ class TestProfileSwitchSpinner:
     def test_optimistic_name_set_before_api_call(self):
         """Chip label must be updated to new name before the API call."""
         fn = self._get_switch_fn()
-        api_call_idx = fn.find("await api('/api/profile/switch'")
+        api_call_idx = fn.find("await _postProfileTransition(_transitionOwner)")
         opt_name_idx = fn.find("_chipLabel.textContent = name")
         assert opt_name_idx != -1, "No optimistic name update found."
         assert opt_name_idx < api_call_idx, (
@@ -134,10 +134,10 @@ class TestParallelizedFetches:
         assert "awaitWorkspaceLoad: workspaceVisible" in fn
         sessions_js = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
         assert "if(options&&options.awaitWorkspaceLoad){" in sessions_js
-        assert "await loadDir('.')" in sessions_js
+        assert "await loadDir('.',{transitionOwner})" in sessions_js
         assert "typeof _deferWorkspaceRefreshForSession==='function'" in sessions_js
-        assert "_deferWorkspaceRefreshForSession(S.session.session_id)" in sessions_js
-        assert "const _dirP=loadDir('.')" in sessions_js
+        assert "_deferWorkspaceRefreshForSession(S.session.session_id,{transitionOwner})" in sessions_js
+        assert "const _dirP=loadDir('.',{transitionOwner})" in sessions_js
         assert "Keep new-chat first paint instant" in sessions_js
 
     def test_cross_profile_empty_session_is_replaced_before_mutation_or_upload(self):
@@ -189,7 +189,7 @@ class TestParallelizedFetches:
             "both profile-switch success branches must expose the new profile's session browser"
         )
         for open_idx in open_calls:
-            render_idx = fn.rfind("await renderSessionList();", 0, open_idx)
+            render_idx = fn.rfind("await renderSessionList({transitionOwner:_transitionOwner});", 0, open_idx)
             assert render_idx != -1 and render_idx < open_idx, (
                 "open the sidebar only after the new profile's session list has rendered"
             )

--- a/tests/test_profile_transition_nested_publishers.py
+++ b/tests/test_profile_transition_nested_publishers.py
@@ -1,0 +1,403 @@
+"""Behavioral matrix for profile-transition ownership inside nested publishers."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+WORKSPACE = (ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _function(source: str, name: str) -> str:
+    markers = (f"async function {name}(", f"function {name}(")
+    start = next((source.find(marker) for marker in markers if source.find(marker) >= 0), -1)
+    assert start >= 0, name
+    brace = source.find("{", source.find(")", start))
+    depth = 1
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = brace + 1
+    while depth and i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n": line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/": block_comment = False; i += 1
+        elif quote:
+            if escaped: escaped = False
+            elif ch == "\\": escaped = True
+            elif ch == quote: quote = None
+        elif ch == "/" and nxt == "/": line_comment = True; i += 1
+        elif ch == "/" and nxt == "*": block_comment = True; i += 1
+        elif ch in ("'", '"', "`"): quote = ch
+        elif ch == "{": depth += 1
+        elif ch == "}": depth -= 1
+        i += 1
+    assert depth == 0, name
+    return source[start:i]
+
+
+OWNER_SOURCE = "var _profileTransitionPostTail=Promise.resolve();\n" + "\n".join(
+    _function(UI, name)
+    for name in (
+        "_beginProfileTransitionOwner", "_acceptProfileTransitionOwner",
+        "_isProfileTransitionOwner", "_currentProfileTransitionOwner",
+        "_currentProfileTransitionEpoch", "_cancelProfileTransitionOwner",
+        "_postProfileTransition",
+    )
+)
+
+
+def _run(script: str) -> dict | list:
+    result = subprocess.run([NODE], input=script, cwd=ROOT, text=True, capture_output=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines, result.stdout
+    return json.loads(lines[-1])
+
+
+_NEW_SESSION_ENV = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, 'newSession')}
+var _newSessionInFlight=null,_newSessionInFlightOwner=null;
+var _messagesTruncated=false,_oldestIdx=0,_activeProject=null;
+var NO_PROJECT_FILTER='__all__',_sessionSourceFilter='webui';
+global.window={{_defaultModel:null}};
+global.document={{createElement:()=>({{dataset:{{}},appendChild(){{}}}})}};
+global.$=()=>null;global.t=k=>k;
+global._newSessionPendingText=()=> 'creating';global._setNewSessionPending=()=>{{}};
+global.updateQueueBadge=()=>{{}};global.clearLiveToolCards=()=>{{}};
+global.updateSendBtn=()=>{{}};global.setStatus=()=>{{}};global.setComposerStatus=()=>{{}};
+global.syncTopbar=()=>{{}};global.renderMessages=()=>{{}};global._setSessionViewedCount=()=>{{}};
+global._rememberNewChatDraftSession=()=>{{}};
+global.loadDir=()=>Promise.resolve();global.refreshSessionList=()=>Promise.resolve();
+"""
+
+
+def test_stale_new_session_response_publishes_nothing():
+    script = _NEW_SESSION_ENV + r"""
+let resolveNew;const events=[];
+var S={activeProfile:'A',session:{session_id:'old',workspace:null},messages:[{role:'assistant',content:'old'}],toolCalls:[],_profileSwitchWorkspace:null,_profileDefaultWorkspace:null};
+global.localStorage={setItem:()=>events.push('storage')};
+global._setActiveSessionUrl=()=>events.push('url');global.startSessionStream=()=>events.push('sse');
+global.api=()=>new Promise(resolve=>{resolveNew=resolve;});
+(async()=>{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pending=newSession(false,{transitionOwner:ownerA});
+  while(!resolveNew) await Promise.resolve();
+  const beforeStale=events.length;
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  resolveNew({session:{session_id:'new-A',messages:[],workspace:null}});
+  const result=await pending;
+  console.log(JSON.stringify({result,sid:S.session.session_id,after:events.slice(beforeStale)}));
+})().catch(e=>{console.error(e);process.exit(1);});
+"""
+    assert _run(script) == {"result": False, "sid": "old", "after": []}
+
+
+def test_profile_switch_posts_are_serialized_so_final_owner_sets_cookie_last():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+const requests=[];let cookie='default';
+global.api=(path,opts)=>new Promise(resolve=>{{
+  const name=JSON.parse(opts.body).name;
+  requests.push({{name,finish:()=>{{cookie=name;resolve({{active:name}});}}}});
+}});
+async function waitFor(count){{for(let i=0;i<200;i++){{if(requests.length===count)return;await Promise.resolve();}}throw new Error('request count '+count+' not reached');}}
+(async()=>{{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');
+  const pendingA=_postProfileTransition(ownerA);await waitFor(1);
+  const ownerB=_beginProfileTransitionOwner('B','recovery');
+  const pendingB=_postProfileTransition(ownerB);
+  await Promise.resolve();
+  const beforeFirstSettles=requests.map(r=>r.name);
+  requests[0].finish();await waitFor(2);
+  requests[1].finish();await Promise.all([pendingA,pendingB]);
+  console.log(JSON.stringify({{beforeFirstSettles,all:requests.map(r=>r.name),cookie}}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == {
+        "beforeFirstSettles": ["A"],
+        "all": ["A", "B"],
+        "cookie": "B",
+    }
+
+
+def test_new_session_completion_order_matrix_publishes_only_final_owner():
+    script = _NEW_SESSION_ENV + r"""
+function deferred(){let resolve;const promise=new Promise(r=>{resolve=r;});return{promise,resolve};}
+async function scenario(order){
+  const requests=new Map(),published=[];
+  global.S={activeProfile:'A',session:{session_id:'old',workspace:null},messages:[{role:'assistant',content:'old'}],toolCalls:[],_profileSwitchWorkspace:null,_profileDefaultWorkspace:null};
+  global.localStorage={setItem:()=>{}};
+  global._setActiveSessionUrl=sid=>published.push(['url',sid]);
+  global.startSessionStream=sid=>published.push(['sse',sid]);
+  global.api=(path,opts)=>{const body=JSON.parse(opts.body),d=deferred();requests.set(body.profile,d);return d.promise;};
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pendingA=newSession(false,{transitionOwner:ownerA});
+  while(!requests.has('A')) await Promise.resolve();
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  S.activeProfile='B';
+  const pendingB=newSession(false,{transitionOwner:ownerB});
+  while(!requests.has('B')) await Promise.resolve();
+  const resolveA=()=>requests.get('A').resolve({session:{session_id:'new-A',messages:[],workspace:null}});
+  const resolveB=()=>requests.get('B').resolve({session:{session_id:'new-B',messages:[],workspace:null}});
+  if(order==='A-first'){resolveA();await Promise.resolve();resolveB();}else{resolveB();await Promise.resolve();resolveA();}
+  const results=await Promise.all([pendingA,pendingB]);
+  return{order,results,sid:S.session.session_id,published};
+}
+(async()=>console.log(JSON.stringify([await scenario('A-first'),await scenario('B-first')])) )().catch(e=>{console.error(e);process.exit(1);});
+"""
+    result = _run(script)
+    for row in result:
+        assert row["results"] == [False, True]
+        assert row["sid"] == "new-B"
+        assert row["published"] == [["url", "new-B"], ["sse", "new-B"]]
+
+
+def test_stale_session_list_success_and_rejection_publish_nothing():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, '_runRenderSessionListRefresh')}
+let settle;const events=[];
+var _pendingSessionListPayload=null,_cronPollGeneration=0,_contentSearchResults=[];
+var _sessionListHasLoadedOnce=true,_renderSessionListGen=1,_profileSwitchListEmbargo=false;
+global.$=()=>({{value:''}});global._sessionListQueryString=()=>'';global._isSessionListUserInteracting=()=>false;
+global._applySessionListPayload=()=>events.push('apply');global._showSessionListLoadError=()=>events.push('error');
+global._requestedSessionSidebarSource=()=> 'webui';global._sessionListExcludeHiddenEnabled=()=>true;global.S={{activeProfile:'A'}};
+async function one(mode){{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  global._loadSidebarSessionListPayload=()=>new Promise((resolve,reject)=>{{settle=mode==='resolve'?resolve:reject;}});
+  const pending=_runRenderSessionListRefresh({{transitionOwner:ownerA}},1);
+  while(!settle) await Promise.resolve();
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  if(mode==='resolve') settle({{sessData:{{sessions:[]}},projData:{{projects:[]}}}}); else settle(new Error('late A failure'));
+  await pending;
+}}
+(async()=>{{await one('resolve');settle=null;await one('reject');console.log(JSON.stringify(events));}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == []
+
+
+def test_session_list_completion_order_matrix_publishes_only_final_owner():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, '_runRenderSessionListRefresh')}
+function deferred(){{let resolve;const promise=new Promise(r=>{{resolve=r;}});return{{promise,resolve}};}}
+async function scenario(order){{
+  const requests=[],applied=[];
+  var _pendingSessionListPayload=null,_cronPollGeneration=0,_contentSearchResults=[];
+  global._sessionListHasLoadedOnce=true;global._renderSessionListGen=2;global._profileSwitchListEmbargo=false;
+  global.$=()=>({{value:''}});global._sessionListQueryString=()=>'';global._isSessionListUserInteracting=()=>false;
+  global._applySessionListPayload=data=>applied.push(data.tag);global._showSessionListLoadError=()=>applied.push('error');
+  global._requestedSessionSidebarSource=()=> 'webui';global._sessionListExcludeHiddenEnabled=()=>true;global.S={{activeProfile:'A'}};
+  global._loadSidebarSessionListPayload=()=>{{const d=deferred();requests.push(d);return d.promise;}};
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pendingA=_runRenderSessionListRefresh({{transitionOwner:ownerA}},1);
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  const pendingB=_runRenderSessionListRefresh({{transitionOwner:ownerB}},2);
+  while(requests.length<2)await Promise.resolve();
+  const resolveA=()=>requests[0].resolve({{sessData:{{tag:'A'}},projData:{{projects:[]}}}});
+  const resolveB=()=>requests[1].resolve({{sessData:{{tag:'B'}},projData:{{projects:[]}}}});
+  if(order==='A-first'){{resolveA();await Promise.resolve();resolveB();}}else{{resolveB();await Promise.resolve();resolveA();}}
+  await Promise.all([pendingA,pendingB]);return{{order,applied}};
+}}
+(async()=>console.log(JSON.stringify([await scenario('A-first'),await scenario('B-first')])))().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == [
+        {"order": "A-first", "applied": ["B"]},
+        {"order": "B-first", "applied": ["B"]},
+    ]
+
+
+def test_stale_workspace_response_cannot_paint_or_cache():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(WORKSPACE, 'loadDir')}
+let resolveList;const events=[];var _wsTreeGen=0,_previewDirty=false;
+var S={{session:{{session_id:'sid-A',workspace:'/A'}},entries:['old'],_dirCache:{{}},_expandedDirs:new Set()}};
+global.api=()=>new Promise(resolve=>{{resolveList=resolve;}});global._workspaceRouteForPath=()=>'/api/list';
+global._restoreExpandedDirs=()=>{{}};global.renderBreadcrumb=()=>events.push('crumb');global.renderFileTree=()=>events.push('tree');
+global.renderSessionArtifacts=()=>events.push('artifacts');global.clearPreview=()=>events.push('preview');global._refreshGitBadge=()=>events.push('git');
+global.$=()=>null;console.warn=()=>{{}};
+(async()=>{{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pending=loadDir('.',{{transitionOwner:ownerA}});while(!resolveList) await Promise.resolve();
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  resolveList({{entries:['A-only']}});await pending;
+  console.log(JSON.stringify({{entries:S.entries,events}}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == {"entries": ["old"], "events": []}
+
+
+def test_stale_workspace_confirm_callback_cannot_clear_new_owner_preview():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(WORKSPACE, 'loadDir')}
+let resolveList,resolveConfirm;const events=[];var _wsTreeGen=0,_previewDirty=true;
+var S={{session:{{session_id:'shared',workspace:'/A'}},entries:[],_dirCache:{{}},_expandedDirs:new Set()}};
+global.api=()=>new Promise(resolve=>{{resolveList=resolve;}});global._workspaceRouteForPath=()=>'/api/list';global._restoreExpandedDirs=()=>{{}};
+global.renderBreadcrumb=()=>{{}};global.renderFileTree=()=>{{}};global.renderSessionArtifacts=()=>{{}};global._refreshGitBadge=()=>{{}};global.$=()=>null;
+global.t=k=>k;global.showConfirmDialog=()=>new Promise(resolve=>{{resolveConfirm=resolve;}});global.clearPreview=()=>events.push('clear');console.warn=()=>{{}};
+(async()=>{{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pending=loadDir('.',{{transitionOwner:ownerA}});while(!resolveList)await Promise.resolve();
+  resolveList({{entries:[]}});while(!resolveConfirm)await Promise.resolve();
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  resolveConfirm(true);await pending;await Promise.resolve();
+  console.log(JSON.stringify(events));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == []
+
+
+def test_workspace_completion_order_matrix_paints_only_final_owner():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(WORKSPACE, 'loadDir')}
+function deferred(){{let resolve;const promise=new Promise(r=>{{resolve=r;}});return{{promise,resolve}};}}
+async function scenario(order){{
+  const requests=[],events=[];global._wsTreeGen=0;global._previewDirty=false;
+  global.S={{session:{{session_id:'shared',workspace:'/B'}},entries:['old'],_dirCache:{{}},_expandedDirs:new Set()}};
+  global.api=()=>{{const d=deferred();requests.push(d);return d.promise;}};global._workspaceRouteForPath=()=>'/api/list';
+  global._restoreExpandedDirs=()=>{{}};global.renderBreadcrumb=()=>events.push('crumb');global.renderFileTree=()=>events.push('tree');
+  global.renderSessionArtifacts=()=>events.push('artifacts');global.clearPreview=()=>events.push('preview');global._refreshGitBadge=()=>events.push('git');
+  global.$=()=>null;console.warn=()=>{{}};
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pendingA=loadDir('.',{{transitionOwner:ownerA}});
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  const pendingB=loadDir('.',{{transitionOwner:ownerB}});
+  while(requests.length<2)await Promise.resolve();
+  const resolveA=()=>requests[0].resolve({{entries:['A']}}),resolveB=()=>requests[1].resolve({{entries:['B']}});
+  if(order==='A-first'){{resolveA();await Promise.resolve();resolveB();}}else{{resolveB();await Promise.resolve();resolveA();}}
+  await Promise.all([pendingA,pendingB]);return{{order,entries:S.entries,events}};
+}}
+(async()=>console.log(JSON.stringify([await scenario('A-first'),await scenario('B-first')])))().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    result = _run(script)
+    for row in result:
+        assert row["entries"] == ["B"]
+        assert row["events"] == ["crumb", "tree", "artifacts", "preview", "git"]
+
+
+def test_live_model_completion_order_matrix_publishes_only_final_owner():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(UI, '_fetchLiveModels')}
+function deferred(){{let resolve;const promise=new Promise(r=>{{resolve=r;}});return{{promise,resolve}};}}
+var _modelDropdownRequestSeq=0;const _liveModelCache={{}},_liveModelFetchPending=new Set(),_liveModelFetchPendingOwner=new Map();
+async function scenario(order){{
+  delete _liveModelCache.p;_liveModelFetchPending.clear();_liveModelFetchPendingOwner.clear();
+  const requests=[],added=[];global.document={{baseURI:'https://example.test/'}};global.location={{href:'https://example.test/'}};
+  global.fetch=()=>{{const d=deferred();requests.push(d);return d.promise;}};global._redirectIfUnauth=()=>false;
+  global._addLiveModelsToSelect=(provider,models)=>{{added.push(models[0].id);return 1;}};global.syncModelChip=()=>{{}};
+  const sel={{}};const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pendingA=_fetchLiveModels('p',sel,null,ownerA);
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');
+  const pendingB=_fetchLiveModels('p',sel,null,ownerB);while(requests.length<2)await Promise.resolve();
+  const response=id=>({{status:200,json:()=>Promise.resolve({{models:[{{id}}]}})}});
+  const resolveA=()=>requests[0].resolve(response('A')),resolveB=()=>requests[1].resolve(response('B'));
+  if(order==='A-first'){{resolveA();await Promise.resolve();resolveB();}}else{{resolveB();await Promise.resolve();resolveA();}}
+  await Promise.all([pendingA,pendingB]);return{{order,cache:_liveModelCache.p&&_liveModelCache.p[0].id,added,pending:_liveModelFetchPending.has('p')}};
+}}
+(async()=>console.log(JSON.stringify([await scenario('A-first'),await scenario('B-first')])))().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    result = _run(script)
+    for row in result:
+        assert row["cache"] == "B"
+        assert row["added"] == ["B"]
+        assert row["pending"] is False
+
+
+def test_stale_session_metadata_cannot_rebind_to_newer_owner():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, 'loadSession')}
+let resolveMeta,pendingError=null;const events=[];
+var _loadSessionGeneration=0,_loadingSessionId=null,_loadingOlder=false,_yoloEnabled=false;
+var _messagesTruncated=false,_oldestIdx=0,_pendingCarryForwardSnapshot=null;var INFLIGHT={{}};
+var S={{session:{{session_id:'old'}},messages:[{{role:'assistant',content:'old'}}],toolCalls:[],pendingFiles:[],busy:false,activeStreamId:null}};
+global.window={{_clearPendingSelections:()=>{{}}}};global._resolveSessionIdFromSidebarLineage=s=>s;
+global._rearmActiveSessionStream=()=>events.push('rearm');global._sessionVisitHasUnreadState=()=>false;
+global.stopApprovalPolling=()=>{{}};global.hideApprovalCard=()=>{{}};global.stopSessionStream=()=>{{}};global._updateYoloPill=()=>{{}};
+global.stopClarifyPolling=()=>{{}};global.hideClarifyCard=()=>{{}};global._saveComposerDraftNow=()=>Promise.resolve();global.closeOtherLiveStreams=()=>{{}};
+global._clearSameSessionForceReloadHint=()=>{{}};global._captureSameSessionForceReloadHint=()=>{{}};
+global.$=id=>id==='msgInner'?{{innerHTML:''}}:(id==='msg'?{{value:''}}:null);global.api=()=>new Promise(resolve=>{{resolveMeta=resolve;}});
+global.localStorage={{setItem:()=>events.push('storage'),removeItem:()=>events.push('remove')}};global.history={{replaceState:()=>events.push('url-clean')}};
+global._appRootPath=()=>'/';global._setActiveSessionUrl=()=>events.push('url');global.startSessionStream=()=>events.push('sse');
+global.syncTopbar=()=>events.push('topbar');global.renderMessages=()=>events.push('dom');
+async function waitForMeta(){{for(let i=0;i<200;i++){{if(resolveMeta||pendingError)return;await Promise.resolve();}}throw new Error('metadata request was not reached');}}
+(async()=>{{
+  const ownerA=_beginProfileTransitionOwner('A','canonical');_acceptProfileTransitionOwner(ownerA,'A');
+  const pending=loadSession('sid-A',{{force:true,transitionOwner:ownerA}}).catch(e=>{{pendingError=e;}});
+  await waitForMeta();if(pendingError) throw pendingError;
+  const ownerB=_beginProfileTransitionOwner('B','recovery');_acceptProfileTransitionOwner(ownerB,'B');const before=events.length;
+  resolveMeta({{session:{{session_id:'sid-A',profile:'A',messages:[]}}}});await pending;
+  console.log(JSON.stringify({{sid:S.session.session_id,events:events.slice(before)}}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    result = _run(script)
+    assert result["sid"] == "old"
+    assert result["events"] == ["rearm"]
+
+
+def test_unaccepted_transition_epoch_cannot_start_session_metadata_load():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, 'loadSession')}
+const calls=[];var _loadSessionGeneration=0,_loadingSessionId=null;
+var S={{session:{{session_id:'old'}},messages:[],toolCalls:[]}};
+global.api=url=>{{calls.push(url);return Promise.resolve(null);}};
+(async()=>{{
+  const owner=_beginProfileTransitionOwner('A','canonical');
+  const result=await loadSession('sid-A',{{force:true,transitionOwner:owner}});
+  console.log(JSON.stringify({{result:result??null,calls,loading:_loadingSessionId,generation:_loadSessionGeneration}}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == {
+        "result": None,
+        "calls": [],
+        "loading": None,
+        "generation": 0,
+    }
+
+
+def test_recovery_rejection_cannot_cleanup_newer_owner_state():
+    script = f"""
+var _profileTransitionOwnerSeq=0,_profileTransitionOwner=null;
+{OWNER_SOURCE}
+{_function(SESSIONS, '_switchProfileForSessionLoad')}
+let rejectPost;const events=[];var S={{activeProfile:'default'}};
+global.api=()=>new Promise((resolve,reject)=>{{rejectPost=reject;}});global._invalidateSessionListRenders=()=>{{}};
+global._setProfileSwitchListEmbargo=v=>events.push(['embargo',v]);global.showSessionListSkeleton=()=>events.push(['skeleton']);
+global.renderSessionListFromCache=()=>events.push(['cache']);global.localStorage={{removeItem(){{}}}};var _sessionListSkeletonActive=true;
+(async()=>{{
+  const pending=_switchProfileForSessionLoad('A');while(!rejectPost) await Promise.resolve();
+  const ownerB=_beginProfileTransitionOwner('B','canonical');_acceptProfileTransitionOwner(ownerB,'B');const before=events.length;
+  rejectPost(new Error('late A failure'));const result=await pending;
+  console.log(JSON.stringify({{result:result??null,events:events.slice(before),owner:_profileTransitionOwner.profile,skeleton:_sessionListSkeletonActive}}));
+}})().catch(e=>{{console.error(e);process.exit(1);}});
+"""
+    assert _run(script) == {"result": None, "events": [], "owner": "B", "skeleton": True}

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -405,13 +405,27 @@ class TestReasoningConfigHelpers:
         cfg.set_reasoning_effort('')
 
     def test_get_reasoning_status_defaults_to_show_true(self, tmp_path, monkeypatch):
-        """When config.yaml has no display section, show_reasoning defaults
-        to True (matches CLI default where the setting is opt-in)."""
+        """Absent display flags default on, matching the Agent display contract."""
         import api.config as cfg
         monkeypatch.setattr(cfg, '_get_config_path', lambda: tmp_path / 'config.yaml')
         st = cfg.get_reasoning_status()
         assert st['show_reasoning'] is True
+        assert st['show_commentary'] is True
         assert st['reasoning_effort'] == ''
+
+    def test_get_reasoning_status_exposes_effective_show_commentary(self, tmp_path, monkeypatch):
+        """The reload renderer needs the active profile's effective commentary flag."""
+        import api.config as cfg
+        cfgfile = tmp_path / 'config.yaml'
+        cfgfile.write_text(
+            'display:\n  show_reasoning: true\n  show_commentary: false\n',
+            encoding='utf-8',
+        )
+        monkeypatch.setattr(cfg, '_get_config_path', lambda: cfgfile)
+
+        st = cfg.get_reasoning_status()
+
+        assert st['show_commentary'] is False
 
 
 # ── api/streaming.py — AIAgent receives reasoning_config ──────────────────────

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -939,7 +939,7 @@ def test_load_session_rearms_stream_on_every_early_return():
     # added inside loadSession pushed the fetch-error catch's stream restart past
     # the old 14000-char cutoff.
     fn_ix = js.index("async function loadSession(")
-    body = js[fn_ix:fn_ix + 16000]
+    body = js[fn_ix:fn_ix + 19000]
 
     # The unconditional teardown must still be there (this is what creates the
     # dead-stream window the re-arm closes).

--- a/tests/test_session_message_window_renderable_tail.py
+++ b/tests/test_session_message_window_renderable_tail.py
@@ -167,6 +167,7 @@ def test_cold_load_keeps_previous_complete_reply_before_tool_heavy_active_turn()
                 "content": "",
                 "codex_message_items": [{
                     "type": "message",
+                    "role": "assistant",
                     "phase": "commentary",
                     "content": [{"type": "output_text", "text": f"progress {idx}"}],
                 }],

--- a/tests/test_session_message_window_renderable_tail.py
+++ b/tests/test_session_message_window_renderable_tail.py
@@ -140,6 +140,70 @@ def test_cold_load_expands_but_caps_at_total_renderable():
     assert window[0]["content"] == "only-user"
 
 
+def test_cold_load_keeps_previous_complete_reply_before_tool_heavy_active_turn():
+    """A long active turn must not push the last normal reply out of cold load.
+
+    Responses sessions persist one empty assistant row per tool call/commentary.
+    Those rows all have role=assistant, so the old visible-row counter consumed
+    the whole msg_limit inside activity and returned only "Thinking" after a
+    restart.  Cold load needs one stable completed turn immediately before the
+    active user turn, while cumulative pagination remains unchanged.
+    """
+    messages = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous complete answer"},
+        {"role": "user", "content": "current request"},
+    ]
+    for idx in range(120):
+        messages.extend([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": f"call_{idx}", "function": {"name": "terminal", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": f"call_{idx}", "content": f"result {idx}"},
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_message_items": [{
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": f"progress {idx}"}],
+                }],
+                "reasoning_content": f"progress {idx}",
+            },
+        ])
+
+    window, offset = _message_window_for_display(
+        messages, msg_limit=30, expand_renderable=True
+    )
+
+    assert offset == 0
+    assert [message["content"] for message in window[:3]] == [
+        "previous question",
+        "previous complete answer",
+        "current request",
+    ]
+    assert window[-1]["codex_message_items"][0]["content"][0]["text"] == "progress 119"
+
+
+def test_cumulative_window_does_not_force_previous_turn_context():
+    messages = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous complete answer"},
+        {"role": "user", "content": "current request"},
+    ] + [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": f"call_{idx}"}]}
+        for idx in range(40)
+    ]
+
+    _window, offset = _message_window_for_display(
+        messages, msg_limit=30, expand_renderable=False
+    )
+
+    assert offset > 2
+
+
 def test_initial_msg_limit_keeps_matching_trailing_tool_result_row():
     """A role:tool result row whose tool_call_id matches the newest assistant
     tool-call must be retained in the paginated window — the renderer rebuilds

--- a/tests/test_session_message_window_renderable_tail.py
+++ b/tests/test_session_message_window_renderable_tail.py
@@ -204,6 +204,27 @@ def test_cumulative_window_does_not_force_previous_turn_context():
     assert offset > 2
 
 
+def test_cold_load_semantic_prefix_has_a_hard_raw_row_limit():
+    messages = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous complete answer"},
+        {"role": "user", "content": "current request"},
+    ]
+    for idx in range(2000):
+        messages.extend([
+            {"role": "assistant", "content": "", "tool_calls": [{"id": f"call_{idx}"}]},
+            {"role": "tool", "tool_call_id": f"call_{idx}", "content": f"result {idx}"},
+        ])
+
+    window, offset = _message_window_for_display(
+        messages, msg_limit=30, expand_renderable=True
+    )
+
+    assert offset > 2
+    assert len(window) <= 500
+    assert all(message.get("content") != "previous complete answer" for message in window)
+
+
 def test_initial_msg_limit_keeps_matching_trailing_tool_result_row():
     """A role:tool result row whose tool_call_id matches the newest assistant
     tool-call must be retained in the paginated window — the renderer rebuilds

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -72,7 +72,7 @@ def test_boot_does_not_block_session_restore_on_model_catalog():
 
     assert "if(s.default_model){" in src
     assert "window._defaultModel=s.default_model;" in src
-    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in src
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({" in src
     assert "window._modelDropdownReady=null;" in src
     assert "window._startBootModelDropdown=_startBootModelDropdown;" in src
     assert "window._ensureModelDropdownReady=_startModelDropdown;" in src
@@ -109,9 +109,9 @@ def test_failed_boot_model_catalog_prime_is_retryable():
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
     # #2726 parameterized the call: populateModelDropdown({preferProfileDefaultOnFreshBoot:true})
     # Match either signature shape — empty args (legacy) OR opts arg (post-#2726).
-    needle = "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({"
+    needle = "const _hydrateModelDropdown=({redirectIfUnauth=null,transitionOwner=null}={})=>populateModelDropdown({"
     start = src.index(needle)
-    end = src.index("const _startBootModelDropdown=()=>", start)
+    end = src.index("const _startBootModelDropdown=(transitionOwner=null)=>", start)
     block = src[start:end]
 
     assert "window._modelDropdownReady=null;" in block

--- a/tests/test_session_model_resolution_on_load.py
+++ b/tests/test_session_model_resolution_on_load.py
@@ -43,10 +43,10 @@ def test_load_session_initial_metadata_request_defers_model_resolution_until_aft
         "loadSession() must not resolve model metadata before assigning S.session; "
         "stale model/provider correction belongs to the deferred path"
     )
-    assert "_resolveSessionModelForDisplaySoon(sid)" in body[body.index(assignment):], (
+    assert "_resolveSessionModelForDisplaySoon(sid,transitionOwner)" in body[body.index(assignment):], (
         "stale persisted model/provider correction must still happen after first paint"
     )
-    assert body.count("_resolveSessionModelForDisplaySoon(sid)") == 1, (
+    assert body.count("_resolveSessionModelForDisplaySoon(sid,transitionOwner)") == 1, (
         "deferred model repair should run once per session switch, not once after "
         "metadata and again after message hydration"
     )

--- a/tests/test_session_sidebar_resilience.py
+++ b/tests/test_session_sidebar_resilience.py
@@ -53,7 +53,7 @@ def test_sessions_and_projects_load_independently_so_projects_failure_cannot_bla
     assert "return await api('/api/projects' + projectQS,{timeoutToast:false});" in helper
     assert "console.warn('renderProjectsList',projectError);" in helper
     assert "const projData = await projectPromise;" in helper
-    assert "_applySessionListPayload(sessData,projData,{unreadGen})" in block
+    assert "transitionOwner ? {unreadGen,transitionOwner} : {unreadGen}" in block
 
 
 def test_sessions_api_always_retries_transient_upstream_statuses_and_boot_keeps_longer_timeout():

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -245,7 +245,7 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         self.assertGreater(idx, -1, "sessionInProgress branch must exist in panels.js")
 
         # Slice from that point to cover the relevant block
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx:idx + 1600]
 
         # newSession(false, ...) must be called first
         self.assertIn('await newSession(false', block,
@@ -263,7 +263,7 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         """newSession(false) should apply the pending profile workspace itself."""
         idx = PANELS_JS.find('if (sessionInProgress)')
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx:idx + 1600]
 
         self.assertIn('await newSession(false', block)
         self.assertNotIn('/api/session/update', block,
@@ -274,7 +274,7 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         """The profile switch path should avoid duplicate workspace persistence."""
         idx = PANELS_JS.find('if (sessionInProgress)')
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx:idx + 1600]
 
         self.assertNotIn('/api/session/update', block,
                          "newSession(false) receives S._profileSwitchWorkspace, so "
@@ -285,7 +285,7 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         so the chips are correct when the UI re-renders."""
         idx = PANELS_JS.find('if (sessionInProgress)')
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx:idx + 1600]
 
         pos_sync = block.find('syncTopbar()')
         pos_render = block.find('await renderSessionList()')

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -288,7 +288,7 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         block = PANELS_JS[idx:idx + 1600]
 
         pos_sync = block.find('syncTopbar()')
-        pos_render = block.find('await renderSessionList()')
+        pos_render = block.find('await renderSessionList({transitionOwner:_transitionOwner})')
         self.assertGreater(pos_sync, -1, "syncTopbar() must exist in block")
         self.assertGreater(pos_render, -1, "renderSessionList() must exist in block")
         self.assertLess(pos_sync, pos_render,

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -138,7 +138,8 @@ def test_session_list_external_refresh_uses_sse_invalidation_not_polling():
     assert "void _refreshSessionListAfterSidebarResume('focus')" in SESSIONS_JS
     assert "void _refreshSessionListAfterSidebarResume('visible')" in SESSIONS_JS
     assert "void _refreshSessionListAfterSidebarResume('reconnect')" in SESSIONS_JS
-    assert "renderSessionList({deferWhileInteracting:!force})" in SESSIONS_JS
+    assert "deferWhileInteracting:!force" in SESSIONS_JS
+    assert "...(transitionOwner?{transitionOwner}:{})" in SESSIONS_JS
     assert "const refreshActive = !!(opts && opts.refreshActive)" in SESSIONS_JS
     assert "if(refreshActive) await refreshActiveSessionIfExternallyUpdated(reason||'session-list')" in SESSIONS_JS
     assert "_sessionListRefreshPendingRequest = {" in SESSIONS_JS

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -1,3 +1,6 @@
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
 
@@ -6,6 +9,40 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def _read(relpath: str) -> str:
     return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def _function_source(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated {name}")
+
+
+def _run_workspace_prefix_behavior(helper: str) -> subprocess.CompletedProcess[str]:
+    node = shutil.which("node")
+    if not node:
+        raise AssertionError("node is required for workspace-prefix behavior coverage")
+    cases = [
+        (r"[Workspace::v1: D:\\ai]" + "\nhello", "hello"),
+        (r"[Workspace: D:\ai]" + "\nhello", "hello"),
+        ("hello", "hello"),
+        (r"prefix [Workspace::v1: D:\\ai]" + "\nhello", r"prefix [Workspace::v1: D:\\ai]" + "\nhello"),
+        (r"[Workspace::v1: D:\ai", r"[Workspace::v1: D:\ai"),
+    ]
+    script = f"""
+const assert=require('assert');
+{helper}
+const cases={json.dumps(cases)};
+for(const [input,expected] of cases) assert.strictEqual(_stripWorkspaceDisplayPrefix(input),expected);
+"""
+    return subprocess.run([node, "-e", script], text=True, capture_output=True, check=False)
 
 
 def test_workspace_display_prefix_helper_strips_leading_metadata_only():
@@ -25,6 +62,17 @@ def test_workspace_display_prefix_helper_strips_leading_metadata_only():
     # branch in api/streaming.py:_strip_workspace_prefix().
     assert r"\[Workspace:[^\]]+\]" in helper
     assert ".trim()" in helper
+
+    function_source = _function_source(src, "_stripWorkspaceDisplayPrefix")
+    control = _run_workspace_prefix_behavior(function_source)
+    assert control.returncode == 0, control.stderr
+
+    target = "if(stripped !== value) return stripped.trim();"
+    assert function_source.count(target) == 1
+    mutant = _run_workspace_prefix_behavior(
+        function_source.replace(target, "if(stripped !== value) return value.trim();", 1)
+    )
+    assert mutant.returncode != 0, "disabling v1 prefix stripping must RED"
 
 
 def test_user_render_uses_stripped_display_content_without_preempting_context_cards():

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -35,10 +35,11 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     assert loop_end != -1, "assistant render branch not found after user branch"
     render_prefix = src[loop_start:loop_end]
 
-    display_idx = render_prefix.find("const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):content;")
+    display_idx = render_prefix.find("const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):")
     context_idx = render_prefix.find("if(_isContextCompactionMessage(m))")
     user_idx = render_prefix.find("if(isUser)")
     assert display_idx != -1, "display content stripper not used in render loop"
+    assert "_assistantDisplayContentFromMessage(m, content)" in render_prefix
     assert context_idx != -1, "context compaction branch not found"
     assert user_idx != -1, "user render branch not found"
     assert display_idx < context_idx < user_idx


### PR DESCRIPTION
## Thinking Path

- User-visible `commentary` is progress text, not private reasoning.
- Responses sessions can persist that progress in `codex_message_items[phase=commentary]` while leaving ordinary `content` empty and mirroring the same text into `reasoning_content`.
- On reload, Compact Worklog therefore treated the mirror as Thinking, hid the assistant segment, and made the session appear to contain only reasoning before the resumed turn.
- A long tool-heavy active turn can also consume the limited cold-load window with empty assistant/tool rows, pushing the most recent complete reply outside the initial payload.
- This PR repairs both boundaries: the server keeps one prior complete exchange in the cold-load window, and the renderer gives phase-tagged commentary ordinary assistant-message ownership without duplicating it in Worklog.

This is adjacent to #2956/#2390 but not a duplicate: those fixed the live `interim_assistant` path. This PR fixes persisted Responses commentary and limited-session replay after reload/recovery.

## What Changed

### Session cold load

- Added a bounded semantic prefix for `msg_limit` requests using `expand_renderable=1`.
- When a tool-heavy active turn would consume the entire tail budget, the window also includes:
  - the latest current user row;
  - the preceding settled assistant reply;
  - that reply's preceding user row when available.
- Ordinary cumulative pagination (`expand_renderable=0`) remains unchanged.
- Existing limited-payload tool-result clipping still bounds response size.

### Commentary rendering

- Extract phase-tagged `codex_message_items` commentary separately from private reasoning.
- Use commentary as ordinary assistant display content only when normal `content` is empty.
- Suppress the equal `reasoning_content` echo from Thinking.
- Prevent activity burst/segment metadata from folding visible prose into Worklog.
- Keep commentary-owned segments visible during settled anchor-scene rebuilds.
- Remove commentary prose duplicated by the settled Worklog while retaining tools, lifecycle rows, and true reasoning.

## Why It Matters

After a restart, reload, or reconnect, users should still see the agent's latest visible work story. Progress text should not silently move behind a collapsed Thinking disclosure, and the most recent complete reply should not disappear merely because the current turn contains many tool/activity records.

## UI Evidence

The images below are synthetic reproductions of the exact display semantics and contain no real conversation or user data.

| Before | After |
|---|---|
| ![Before: commentary collapsed as Thinking](https://raw.githubusercontent.com/allenliang2022/hermes-webui/evidence-restart-response-preservation/commentary-before.png) | ![After: commentary shown as ordinary assistant information](https://raw.githubusercontent.com/allenliang2022/hermes-webui/evidence-restart-response-preservation/commentary-after.png) |

## Contract Routing

- **Contract family:** session display/replay and run-state consistency.
- **State layers:** persisted message projection → limited `/api/session` window → assistant/Worklog DOM ownership.
- **Invariant:** user-visible progress and the preceding complete exchange remain visible across reload/recovery; private reasoning and tool details remain in Worklog.
- **Relevant guidance:** `docs/rfcs/webui-run-state-consistency-contract.md`.
- **Contract change:** none. This restores the existing “compact activity preserves the agent timeline” behavior established by #2390.

## Verification

Focused current-master verification:

- `187 passed` across session-window, replay, Worklog, reasoning, and anchor ownership suites.
- `node --check static/ui.js` passed.
- `tests/_commentary_is_visible_info.mjs` passed.
- Six independent mutations were killed:
  - remove commentary phase classification;
  - disable empty-content fallback;
  - allow activity metadata to override visible prose;
  - duplicate visible commentary in settled Worklog;
  - remove the cold-load semantic-prefix consumer;
  - apply the semantic prefix to ordinary pagination.
- A real long-session fixture confirmed bounded payload behavior and semantic window selection.
- Full five-shard Windows run completed on the frozen candidate; all non-green nodes reproduced on untouched `origin/master` by exact test id:
  - shard 0: `2,752 passed`, 17 failures;
  - shard 1: `2,713 passed`, 9 failures;
  - shard 2: `2,754 passed`, 11 failures;
  - shard 3: `2,659 passed`, 22 failures;
  - shard 4: green, 0 failures.
- Every failure from shards 0–3 reproduced on untouched `origin/master` when rerun by exact node id; candidate-only failure set: **0**. These are Windows permission/path/shell/TLS environment baselines, not files or symbols changed here.
- Independent reviews caught and gated two issues before the final push: an unbounded raw-row semantic prefix and an over-broad turn-wide prose filter. The final candidate adds a 500-row raw ceiling and removes only normalized prose that exactly matches visible commentary.
- Follow-up review also gated the transparent earlier-step reveal and the workspace-prefix regression harness; both now execute production behavior with mutations that must fail.
- Final GitHub CI on the shipped head: **23 checks passed, 0 failed, 0 pending**, including all Python 3.11/3.12/3.13 shards, lint, browser smoke, conversation lifecycle, and Greptile review.
- `git diff --check` passed.

## Risks / Follow-ups

- The cold-load window may return more than `msg_limit` raw rows when one active turn contains many tool records. This is intentional and bounded by one semantic exchange plus existing tool-content clipping.
- Commentary is promoted only with affirmative `phase=commentary` metadata. Unknown or reasoning-only payloads keep their existing behavior.
- Restart orchestration scripts used by one deployment are intentionally out of scope; this PR contains only repository-level WebUI behavior.

Release note: Preserve user-visible assistant progress and the previous complete reply when long-running sessions reload or recover.
