### PR TITLE
fix(profiles): start list cache TTL after row build

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2114,7 +2114,7 @@ def list_profiles_api() -> list:
         else:
             rows = _build_profile_rows_fast()
             if rows is not None:
-                _LIST_PROFILES_CACHE = (rows, now)
+                _LIST_PROFILES_CACHE = (rows, time.time())
 
     if rows is None:
         # Fallback: cheap helpers unavailable — use the original (slow) path,

--- a/tests/test_issue5364_skills_stats_thundering_herd.py
+++ b/tests/test_issue5364_skills_stats_thundering_herd.py
@@ -301,6 +301,30 @@ class TestListProfilesSingleFlight:
         assert len(results) == n_threads
         assert all(r and r[0]["name"] == "default" for r in results)
 
+    def test_slow_build_gets_full_cache_ttl(self, mod, monkeypatch):
+        build_calls = []
+        clock = [0.0]
+
+        def _slow_build():
+            build_calls.append(1)
+            clock[0] += 0.08
+            return [{"name": "default", "path": "/x"}]
+
+        with (
+            patch.object(time, "time", side_effect=lambda: clock[0]),
+            patch.object(mod, "_is_isolated_profile_mode", return_value=False),
+            patch.object(mod, "get_active_profile_name", return_value="default"),
+            patch.object(mod, "_build_profile_rows_fast", side_effect=_slow_build),
+        ):
+            monkeypatch.setattr(mod, "_LIST_PROFILES_CACHE_TTL", 0.05)
+            mod._LIST_PROFILES_CACHE = None
+            mod.list_profiles_api()
+            mod.list_profiles_api()
+
+        assert len(build_calls) == 1, (
+            "cache age must start after a slow build completes, not before it starts"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. #4783 contract preserved: the cheap mtime probe still runs on every call


### PR DESCRIPTION
## Thinking Path

- A slow `/api/profiles` cache miss can finish with an already-expired cache entry when profile-row construction takes longer than the cache TTL, causing the next request to rebuild the rows immediately.
- `list_profiles_api()` stored the request-entry timestamp after row construction, so build time consumed the new entry's TTL.
- Timestamping the entry when `_build_profile_rows_fast()` completes gives every successful build the full configured TTL.
- The change stays inside the existing list-cache lock and leaves isolated-profile and fallback paths unchanged.

## What Changed

- Store the `_LIST_PROFILES_CACHE` timestamp after successful profile-row construction.
- Add deterministic regression coverage with a controlled clock that advances past the configured TTL during the build.

## Why It Matters

- Slow profile-row builds remain reusable for the full cache window.
- Immediate follow-up requests no longer repeat an expensive build solely because the first build exceeded the TTL.
- Preserves the profile-list single-flight behavior introduced in #5368, along with existing invalidation and fallback behavior.

## Verification

Base regression proof:

`./scripts/test.sh tests/test_issue5364_skills_stats_thundering_herd.py::TestListProfilesSingleFlight::test_slow_build_gets_full_cache_ttl -q`

Result on unmodified `origin/master`: `1 failed` because the row builder runs twice.

Targeted and adjacent coverage:

`./scripts/test.sh tests/test_issue5364_skills_stats_thundering_herd.py tests/test_issue4783_profile_skills_mtime_cache.py -q`

Result: `17 passed`

Static checks:

`./.venv/bin/python scripts/ruff_lint.py --diff origin/master`

Result: no new violations on added or modified lines.

`git diff --check`

Result: passed.

## Risks / Follow-ups

- Runtime impact is limited to one additional wall-clock read after a successful row build.
- No public API, configuration, or documentation surface changes.

## Models Used

| Harness | Provider | Model | Effort | Role |
| --- | --- | --- | --- | --- |
| Hermes Agent | OpenAI Codex | `gpt-5.6-sol` | Default | Coordinator: investigation, planning, orchestration, verification |
| Codex CLI | OpenAI Codex | `gpt-5.6-luna` | Max | Implementation: deterministic regression test |
| Codex CLI | OpenAI Codex | `gpt-5.6-luna` | High | Independent review: adversarial correctness validation |
| Claude Code | Anthropic | `claude-opus-5` | Medium | Independent review: production-readiness validation |

