### PR TITLE
fix(session): allow archive/delete of imported api_server sessions

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -582,6 +582,10 @@ def read_importable_agent_session_rows(
         origin_chat_id_expr = _optional_col('origin_chat_id', session_cols)
         origin_user_id_expr = _optional_col('origin_user_id', session_cols)
         platform_expr = _optional_col('platform', session_cols)
+        # #6843: imported/read-only rows (e.g. api_server) are archived by the
+        # WebUI directly in state.db (no sidecar); surface the flag so the
+        # sidebar can drop them from the default visible list.
+        archived_expr = _optional_col('archived', session_cols, '0')
         # Older/minimal state.db schemas can have NO ``messages`` table at all,
         # or a ``messages`` table without a ``session_id`` / ``timestamp`` column.
         # The projection SQL below joins ``messages`` and aggregates
@@ -692,6 +696,7 @@ def read_importable_agent_session_rows(
         select_sql = f"""
             SELECT s.id, s.title, s.model, s.message_count,
                    s.started_at, s.source,
+                   {archived_expr} AS archived,
                    {session_source_expr},
                    {user_id_expr},
                    {chat_id_expr},

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -123,6 +123,38 @@ def _with_normalized_source(row: dict) -> dict:
     return {**row, **normalized}
 
 
+# #6843: imported/read-only rows of the api_server class are local state.db
+# rows without a WebUI sidecar. They are the ONLY state.db-only rows the WebUI
+# treats as importable/read-only: archiving/deleting them is WebUI-local view
+# state applied directly to the state.db row (some ids are not path-safe as
+# sidecar filenames, e.g. ``miloco:agent:main:...``). Gateway, messaging, cron,
+# subagent, and other sidecar-less rows keep their existing visibility rules.
+_API_SERVER_CLASS_SOURCES = frozenset({"api", "api_server"})
+
+
+def _api_server_class_markers(row: dict) -> set[str]:
+    """Normalized source markers for a session row ('' for missing keys).
+
+    Mirrors routes._is_api_server_sidecar_row: every source field is lowercased
+    and normalized so ``api-server`` / ``api server`` match ``api_server``.
+    """
+    markers = set()
+    for key in ("source", "source_tag", "raw_source", "session_source", "source_label"):
+        marker = str(row.get(key) or "").strip().lower()
+        if marker.endswith(" session"):
+            marker = marker[: -len(" session")].strip()
+        markers.add(marker.replace("-", "_").replace(" ", "_"))
+    return markers
+
+
+def is_api_server_class_row(row: dict) -> bool:
+    """Return True when a session row belongs to the imported/read-only
+    ``api_server`` class (#6843)."""
+    if not isinstance(row, dict):
+        return False
+    return bool(_api_server_class_markers(row) & _API_SERVER_CLASS_SOURCES)
+
+
 def _optional_col(name: str, columns: set[str], fallback: str = "NULL") -> str:
     return f"s.{name}" if name in columns else f"{fallback} AS {name}"
 
@@ -696,7 +728,7 @@ def read_importable_agent_session_rows(
         select_sql = f"""
             SELECT s.id, s.title, s.model, s.message_count,
                    s.started_at, s.source,
-                   {archived_expr} AS archived,
+                   {archived_expr},
                    {session_source_expr},
                    {user_id_expr},
                    {chat_id_expr},

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -132,27 +132,19 @@ def _with_normalized_source(row: dict) -> dict:
 _API_SERVER_CLASS_SOURCES = frozenset({"api", "api_server"})
 
 
-def _api_server_class_markers(row: dict) -> set[str]:
-    """Normalized source markers for a session row ('' for missing keys).
-
-    Mirrors routes._is_api_server_sidecar_row: every source field is lowercased
-    and normalized so ``api-server`` / ``api server`` match ``api_server``.
-    """
-    markers = set()
-    for key in ("source", "source_tag", "raw_source", "session_source", "source_label"):
-        marker = str(row.get(key) or "").strip().lower()
-        if marker.endswith(" session"):
-            marker = marker[: -len(" session")].strip()
-        markers.add(marker.replace("-", "_").replace(" ", "_"))
-    return markers
-
-
 def is_api_server_class_row(row: dict) -> bool:
     """Return True when a session row belongs to the imported/read-only
-    ``api_server`` class (#6843)."""
+    ``api_server`` class (#6843).
+
+    Exact membership on the authoritative ``source`` field only (#6855):
+    no hyphen/space normalization and no derived-label fallback, mirroring
+    ``routes._is_api_server_class_state_db_source``. A raw source like
+    ``api-server`` must NOT be classified as the api_server class by the
+    sidebar projection — only the exact ``api`` / ``api_server`` values may.
+    """
     if not isinstance(row, dict):
         return False
-    return bool(_api_server_class_markers(row) & _API_SERVER_CLASS_SOURCES)
+    return str(row.get("source") or "").strip().lower() in _API_SERVER_CLASS_SOURCES
 
 
 def _optional_col(name: str, columns: set[str], fallback: str = "NULL") -> str:

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -136,15 +136,17 @@ def is_api_server_class_row(row: dict) -> bool:
     """Return True when a session row belongs to the imported/read-only
     ``api_server`` class (#6843).
 
-    Exact membership on the authoritative ``source`` field only (#6855):
-    no hyphen/space normalization and no derived-label fallback, mirroring
+    EXACT raw membership on the authoritative ``source`` field only (#6855):
+    no trimming, no case-folding, no hyphen/space normalization and no
+    derived-label fallback, mirroring
     ``routes._is_api_server_class_state_db_source``. A raw source like
-    ``api-server`` must NOT be classified as the api_server class by the
-    sidebar projection — only the exact ``api`` / ``api_server`` values may.
+    ``api-server``, ``API_SERVER`` or `` api_server`` must NOT be classified
+    as the api_server class by the sidebar projection — only the exact
+    ``api`` / ``api_server`` values may (rows are stored canonically).
     """
     if not isinstance(row, dict):
         return False
-    return str(row.get("source") or "").strip().lower() in _API_SERVER_CLASS_SOURCES
+    return str(row.get("source") or "") in _API_SERVER_CLASS_SOURCES
 
 
 def _optional_col(name: str, columns: set[str], fallback: str = "NULL") -> str:

--- a/api/models.py
+++ b/api/models.py
@@ -1194,7 +1194,7 @@ def model_explicit_pick_signature(model, model_provider) -> str:
 
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
-                 workspace=str(DEFAULT_WORKSPACE), created_workspace=None,
+                 workspace=str(DEFAULT_WORKSPACE),
                  model=DEFAULT_MODEL,
                  model_provider=None,
                  messages=None, created_at=None, updated_at=None,
@@ -1247,21 +1247,6 @@ class Session:
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
-        # #6672: immutable snapshot of the workspace at session creation time.
-        # s.workspace is updated on every turn when the user switches workspaces
-        # mid-session via the WebUI header dropdown; interpolating the live
-        # value into the system prompt would mutate msg[0] and invalidate LLM
-        # prefix caches (APC/Radix Tree) for the whole transcript. Freeze the
-        # original workspace here and keep the active workspace out of the
-        # system prompt (mid-session switches ride on the [Workspace::v1: ...]
-        # tag appended to the active user turn instead). Legacy sessions
-        # without a persisted created_workspace fall back to the workspace
-        # recorded on disk, which is the best available approximation.
-        self.created_workspace = (
-            str(Path(created_workspace).expanduser().resolve())
-            if created_workspace
-            else self.workspace
-        )
         self.model = model
         self.model_provider = str(model_provider).strip().lower() if model_provider else None
         # #5979: signature of the model the user DELIBERATELY picked this session
@@ -1394,7 +1379,7 @@ class Session:
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
         METADATA_FIELDS = [
-            'session_id', 'title', 'workspace', 'created_workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
+            'session_id', 'title', 'workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
             'pinned', 'archived', 'project_id', 'profile',
             'input_tokens', 'output_tokens', 'estimated_cost',
             'cache_read_tokens', 'cache_write_tokens',
@@ -1777,10 +1762,6 @@ class Session:
             # Only emit 'parent_session_id' when set (the /branch fork link, #1342).
             # Sessions without a fork must not leak None — see test_session_lineage_metadata_api.
             **({'parent_session_id': self.parent_session_id} if self.parent_session_id else {}),
-            # #6672: immutable workspace captured at session creation, exposed so
-            # the UI can distinguish it from the live `workspace` field (which
-            # updates on mid-session switches without touching the system prompt).
-            'created_workspace': getattr(self, 'created_workspace', None) or self.workspace,
             **({
                 'compression_recovery_source_session_id': self.compression_recovery_source_session_id,
                 'compression_recovery_action': self.compression_recovery_action,

--- a/api/models.py
+++ b/api/models.py
@@ -10970,8 +10970,17 @@ def _cleanup_manifest_thread_lock(hermes_home):
         return lock
 
 
-def delete_cli_session(sid) -> bool:
-    """Delete a CLI session while serializing manifest and DB cleanup."""
+def delete_cli_session(sid, require_source_in: tuple[str, ...] | None = None) -> bool:
+    """Delete a CLI session while serializing manifest and DB cleanup.
+
+    ``require_source_in`` (optional, #6855): when given, the row's CURRENT
+    ``sessions.source`` must be an exact member of this set INSIDE the
+    ``BEGIN IMMEDIATE`` transaction that deletes it. The route-level
+    authorization is re-verified atomically with the destructive act so a
+    source flipped between check and act cannot erase a non-api_server row.
+    On mismatch the transaction rolls back and nothing is deleted (fail
+    closed). None keeps the historical behavior (no provenance gate).
+    """
     try:
         from api.profiles import get_active_hermes_home
         hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
@@ -10981,13 +10990,13 @@ def delete_cli_session(sid) -> bool:
     try:
         with _cleanup_manifest_thread_lock(hermes_home):
             with _cleanup_manifest_process_lock(hermes_home):
-                return _delete_cli_session_locked(sid, hermes_home)
+                return _delete_cli_session_locked(sid, hermes_home, require_source_in)
     except Exception:
         logger.warning("Failed to delete CLI session %s from state.db", sid, exc_info=True)
         return False
 
 
-def _delete_cli_session_locked(sid, hermes_home) -> bool:
+def _delete_cli_session_locked(sid, hermes_home, require_source_in: tuple[str, ...] | None = None) -> bool:
     """Delete a CLI session from state.db using Hermes' session semantics.
 
     A scoped transaction implements the Agent invariant while giving branch and
@@ -11028,6 +11037,27 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
             }
             if not {"id", "parent_session_id"}.issubset(columns):
                 return False
+
+            # #6855 review: the provenance decision must be authoritative AND
+            # atomic with the destructive act. When a source gate is required,
+            # revalidate the row's CURRENT source inside this BEGIN IMMEDIATE
+            # transaction (which holds the write lock) — a source flipped
+            # between route-level authorization and deletion must fail closed
+            # here, leaving the row and every artifact untouched. Exact
+            # membership only; a missing ``source`` column or row also denies.
+            if require_source_in is not None:
+                if "source" not in columns:
+                    conn.rollback()
+                    return False
+                src_row = conn.execute(
+                    "SELECT source FROM sessions WHERE id = ?", (sid,)
+                ).fetchone()
+                if (
+                    not src_row
+                    or str(src_row[0] or "").strip().lower() not in require_source_in
+                ):
+                    conn.rollback()
+                    return False
 
             selected = ["id", "parent_session_id"]
             for column in (

--- a/api/models.py
+++ b/api/models.py
@@ -1194,7 +1194,7 @@ def model_explicit_pick_signature(model, model_provider) -> str:
 
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
-                 workspace=str(DEFAULT_WORKSPACE),
+                 workspace=str(DEFAULT_WORKSPACE), created_workspace=None,
                  model=DEFAULT_MODEL,
                  model_provider=None,
                  messages=None, created_at=None, updated_at=None,
@@ -1247,6 +1247,21 @@ class Session:
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
+        # #6672: immutable snapshot of the workspace at session creation time.
+        # s.workspace is updated on every turn when the user switches workspaces
+        # mid-session via the WebUI header dropdown; interpolating the live
+        # value into the system prompt would mutate msg[0] and invalidate LLM
+        # prefix caches (APC/Radix Tree) for the whole transcript. Freeze the
+        # original workspace here and keep the active workspace out of the
+        # system prompt (mid-session switches ride on the [Workspace::v1: ...]
+        # tag appended to the active user turn instead). Legacy sessions
+        # without a persisted created_workspace fall back to the workspace
+        # recorded on disk, which is the best available approximation.
+        self.created_workspace = (
+            str(Path(created_workspace).expanduser().resolve())
+            if created_workspace
+            else self.workspace
+        )
         self.model = model
         self.model_provider = str(model_provider).strip().lower() if model_provider else None
         # #5979: signature of the model the user DELIBERATELY picked this session
@@ -1379,7 +1394,7 @@ class Session:
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
         METADATA_FIELDS = [
-            'session_id', 'title', 'workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
+            'session_id', 'title', 'workspace', 'created_workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
             'pinned', 'archived', 'project_id', 'profile',
             'input_tokens', 'output_tokens', 'estimated_cost',
             'cache_read_tokens', 'cache_write_tokens',
@@ -1762,6 +1777,10 @@ class Session:
             # Only emit 'parent_session_id' when set (the /branch fork link, #1342).
             # Sessions without a fork must not leak None — see test_session_lineage_metadata_api.
             **({'parent_session_id': self.parent_session_id} if self.parent_session_id else {}),
+            # #6672: immutable workspace captured at session creation, exposed so
+            # the UI can distinguish it from the live `workspace` field (which
+            # updates on mid-session switches without touching the system prompt).
+            'created_workspace': getattr(self, 'created_workspace', None) or self.workspace,
             **({
                 'compression_recovery_source_session_id': self.compression_recovery_source_session_id,
                 'compression_recovery_action': self.compression_recovery_action,

--- a/api/models.py
+++ b/api/models.py
@@ -7748,6 +7748,13 @@ def _load_cli_sessions_uncached(
         if _sidecar_meta.get('title'):
             _title = _sidecar_meta['title']
         _archived = bool(_sidecar_meta.get('archived'))
+        # #6843: imported/read-only rows (e.g. api_server) have no WebUI
+        # sidecar and are archived by the WebUI directly in state.db. When no
+        # sidecar exists, honor the state.db `archived` flag so archived
+        # foreign rows stop flooding the default sidebar; a WebUI sidecar (if
+        # present) still wins.
+        if not _archived and not (SESSION_DIR / f"{sid}.json").exists():
+            _archived = bool(row.get('archived'))
         _display_title = _title or f'{_source.title()} Session'
         cli_sessions.append({
             'session_id': sid,
@@ -11287,7 +11294,12 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
                 Returns True when every artifact is gone (or was absent).
                 """
                 if not is_safe_session_id(removed_id):
-                    return False
+                    # Non-path-safe ids (e.g. imported api_server rows like
+                    # ``miloco:...``) never have sidecar/artifact files on
+                    # disk — they are state.db-only rows. The DB row was
+                    # already deleted in the transaction above, so there is
+                    # nothing to clean and this is NOT a failure (#6843).
+                    return True
                 ok = True
                 for suffix in (".json", ".jsonl"):
                     artifact = sessions_dir / f"{removed_id}{suffix}"

--- a/api/models.py
+++ b/api/models.py
@@ -38,6 +38,7 @@ from api.workspace import get_last_workspace
 from api.usage import prompt_cache_hit_percent
 from api.agent_sessions import (
     _is_continuation_session,
+    is_api_server_class_row,
     is_cli_session_row,
     normalize_agent_session_source,
     open_state_db_readonly,
@@ -7748,12 +7749,20 @@ def _load_cli_sessions_uncached(
         if _sidecar_meta.get('title'):
             _title = _sidecar_meta['title']
         _archived = bool(_sidecar_meta.get('archived'))
-        # #6843: imported/read-only rows (e.g. api_server) have no WebUI
+        # #6843: imported/read-only api_server-class rows have no WebUI
         # sidecar and are archived by the WebUI directly in state.db. When no
         # sidecar exists, honor the state.db `archived` flag so archived
-        # foreign rows stop flooding the default sidebar; a WebUI sidecar (if
-        # present) still wins.
-        if not _archived and not (SESSION_DIR / f"{sid}.json").exists():
+        # foreign rows stop flooding the default sidebar — but ONLY for the
+        # api_server class (the same source condition the archive handler
+        # uses). Gateway/messaging/cron/subagent rows are sidecar-less too,
+        # and their state.db `archived` value is owned by the agent, so
+        # honoring it here would hide legitimately-visible sessions. A WebUI
+        # sidecar (if present) still wins.
+        if (
+            not _archived
+            and not (SESSION_DIR / f"{sid}.json").exists()
+            and is_api_server_class_row(row)
+        ):
             _archived = bool(row.get('archived'))
         _display_title = _title or f'{_source.title()} Session'
         cli_sessions.append({

--- a/api/models.py
+++ b/api/models.py
@@ -11054,7 +11054,7 @@ def _delete_cli_session_locked(sid, hermes_home, require_source_in: tuple[str, .
                 ).fetchone()
                 if (
                     not src_row
-                    or str(src_row[0] or "").strip().lower() not in require_source_in
+                    or str(src_row[0] or "") not in require_source_in
                 ):
                     conn.rollback()
                     return False

--- a/api/routes.py
+++ b/api/routes.py
@@ -8103,6 +8103,20 @@ def _state_db_session_source(sid: str) -> str:
     return str(row[0] or "").strip().lower()
 
 
+def _is_api_server_class_state_db_source(source: str) -> bool:
+    """Return True when a state.db ``sessions.source`` is the imported/read-only
+    ``api_server`` class (#6843).
+
+    Mirrors the archive handler's read_only/source condition: ONLY these rows
+    may carry ids that are not path-safe as sidecar filenames (colons, ...),
+    because the WebUI archives/deletes them directly in state.db. Any other
+    real state.db row (messaging, gateway, cron, subagent, ...) keeps the
+    path-safe id requirement.
+    """
+    marker = str(source or "").strip().lower().replace("-", "_")
+    return marker in {"api", "api_server"}
+
+
 def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
     """Flip the ``archived`` flag on a state.db-only session row.
 
@@ -15929,13 +15943,16 @@ def handle_post(handler, parsed) -> bool:
         if not sid:
             return bad(handler, "session_id is required")
         if not is_safe_session_id(sid):
-            # #6843: imported external rows (e.g. api_server) can carry ids
-            # that are not path-safe as sidecar filenames (colons, ...). They
-            # are still genuine local state.db rows, so allow the delete when
-            # the row exists there; the sidecar-unlink below is a safe no-op
-            # and delete_cli_session() removes the state.db row with a
-            # parameterized query.
-            if not _state_db_session_source(sid):
+            # #6843: imported api_server-class rows (e.g. ``miloco:...``) can
+            # carry ids that are not path-safe as sidecar filenames (colons,
+            # ...). They are still genuine local state.db rows, so allow the
+            # delete when the row's source is the imported/read-only
+            # api_server class; the sidecar-unlink below is a safe no-op and
+            # delete_cli_session() removes the state.db row with a
+            # parameterized query. ANY other real state.db row (messaging,
+            # gateway, cron, subagent, ...) must keep the path-safe id
+            # requirement so an unsafe id can't bypass the guard.
+            if not _is_api_server_class_state_db_source(_state_db_session_source(sid)):
                 return bad(handler, "Invalid session_id", 400)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -8128,6 +8128,12 @@ def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
     raised an unhandled ``ValueError`` -> HTTP 500, #6843).
 
     Returns True when the row was found and updated, False otherwise.
+    Older/minimal state.db schemas may not have the optional ``archived``
+    column at all; the sidebar projection already tolerates that via
+    ``_optional_col``, so the UPDATE must too — an unconditional UPDATE would
+    raise a suppressed SQLite "no such column" error that surfaces as a
+    misleading 404 and leaves the imported session visible and unarchivable
+    (review #6855).
     """
     if not sid:
         return False
@@ -8138,6 +8144,14 @@ def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
             return False
         import sqlite3 as _sqlite
         with closing(_sqlite.connect(str(db_path))) as _conn:
+            # Make the UPDATE conditional on the column's existence: add the
+            # WebUI-local view-state column first when the agent schema is too
+            # old to have it (same tolerance as the projection's _optional_col).
+            cols = {row[1] for row in _conn.execute("PRAGMA table_info(sessions)")}
+            if "archived" not in cols:
+                _conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0"
+                )
             cur = _conn.execute(
                 "UPDATE sessions SET archived = ? WHERE id = ?",
                 (1 if archived else 0, sid),
@@ -15942,18 +15956,6 @@ def handle_post(handler, parsed) -> bool:
         sid = body.get("session_id", "")
         if not sid:
             return bad(handler, "session_id is required")
-        if not is_safe_session_id(sid):
-            # #6843: imported api_server-class rows (e.g. ``miloco:...``) can
-            # carry ids that are not path-safe as sidecar filenames (colons,
-            # ...). They are still genuine local state.db rows, so allow the
-            # delete when the row's source is the imported/read-only
-            # api_server class; the sidecar-unlink below is a safe no-op and
-            # delete_cli_session() removes the state.db row with a
-            # parameterized query. ANY other real state.db row (messaging,
-            # gateway, cron, subagent, ...) must keep the path-safe id
-            # requirement so an unsafe id can't bypass the guard.
-            if not _is_api_server_class_state_db_source(_state_db_session_source(sid)):
-                return bad(handler, "Invalid session_id", 400)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
@@ -16005,6 +16007,20 @@ def handle_post(handler, parsed) -> bool:
                     logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
+        # #6843: imported api_server-class rows (e.g. ``miloco:...``) can carry
+        # ids that are not path-safe as sidecar filenames (colons, ...). They
+        # are still genuine local state.db rows, so allow the delete when the
+        # row's source is the imported/read-only api_server class. ANY other
+        # real state.db row (messaging, gateway, cron, subagent, ...) must keep
+        # the path-safe id requirement so an unsafe id can't bypass the guard.
+        # Checked AFTER the standard cleanup: for state.db-only rows the
+        # sidecar unlink / index prune / .json.bak unlink above are safe
+        # no-ops, and delete_cli_session() below removes the state.db row with
+        # a parameterized query.
+        if not is_safe_session_id(sid) and not _is_api_server_class_state_db_source(
+            _state_db_session_source(sid)
+        ):
+            return bad(handler, "Invalid session_id", 400)
         # Evict outside the mutation lock: lifecycle commit may perform provider
         # I/O and must not hold a per-session Session lock.
         from api.config import _evict_session_agent

--- a/api/routes.py
+++ b/api/routes.py
@@ -8117,6 +8117,20 @@ def _is_api_server_class_state_db_source(source: str) -> bool:
     return marker in {"api", "api_server"}
 
 
+def _delete_unsafe_id_authorized(sid: str) -> bool:
+    """Return True when a non-path-safe session id may be deleted.
+
+    Only imported/read-only api_server-class state.db rows may carry ids that
+    are not path-safe as sidecar filenames (colons, ...) (#6843). The check
+    must run BEFORE any destructive cleanup (SESSIONS.pop, sidecar unlink,
+    index prune, .json.bak unlink): a rejected unsafe id must leave the
+    sidecar / backup / index / cache state intact (#6855).
+    """
+    if is_safe_session_id(sid):
+        return True
+    return _is_api_server_class_state_db_source(_state_db_session_source(sid))
+
+
 def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
     """Flip the ``archived`` flag on a state.db-only session row.
 
@@ -15963,6 +15977,8 @@ def handle_post(handler, parsed) -> bool:
         sid = body.get("session_id", "")
         if not sid:
             return bad(handler, "session_id is required")
+        if not _delete_unsafe_id_authorized(sid):
+            return bad(handler, "Invalid session_id", 400)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
@@ -16014,20 +16030,9 @@ def handle_post(handler, parsed) -> bool:
                     logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
-        # #6843: imported api_server-class rows (e.g. ``miloco:...``) can carry
-        # ids that are not path-safe as sidecar filenames (colons, ...). They
-        # are still genuine local state.db rows, so allow the delete when the
-        # row's source is the imported/read-only api_server class. ANY other
-        # real state.db row (messaging, gateway, cron, subagent, ...) must keep
-        # the path-safe id requirement so an unsafe id can't bypass the guard.
-        # Checked AFTER the standard cleanup: for state.db-only rows the
-        # sidecar unlink / index prune / .json.bak unlink above are safe
-        # no-ops, and delete_cli_session() below removes the state.db row with
-        # a parameterized query.
-        if not is_safe_session_id(sid) and not _is_api_server_class_state_db_source(
-            _state_db_session_source(sid)
-        ):
-            return bad(handler, "Invalid session_id", 400)
+        # The api_server-class authorization for unsafe ids already ran at the
+        # top of this handler (before any destructive cleanup) — see
+        # _delete_unsafe_id_authorized (#6855).
         # Evict outside the mutation lock: lifecycle commit may perform provider
         # I/O and must not hold a per-session Session lock.
         from api.config import _evict_session_agent
@@ -17136,6 +17141,18 @@ def handle_post(handler, parsed) -> bool:
             # previously 400'd for read_only rows and crashed with an
             # unhandled ValueError -> HTTP 500 for unsafe ids).
             if cli_meta.get("read_only") or not is_safe_session_id(sid):
+                # #6855: the state.db `archived` flag is WebUI-local view
+                # state that the sidebar projection ONLY honors for the
+                # imported/read-only api_server class (api/models.py:7592
+                # is_api_server_class_row). Flipping it for any OTHER
+                # read-only source (telegram, ...) would return 200 yet leave
+                # the row visible — a silent no-op that misleads the user.
+                # Require api_server-class provenance here; other read-only
+                # sources keep the prior rejection.
+                if not _is_api_server_class_state_db_source(
+                    _state_db_session_source(sid) or _arch_source_tag
+                ):
+                    return bad(handler, "Read-only imported sessions cannot be archived from WebUI", 400)
                 if not _set_state_db_session_archived(sid, bool(body.get("archived", True))):
                     return bad(handler, "Session not found", 404)
                 publish_session_list_changed(

--- a/api/routes.py
+++ b/api/routes.py
@@ -770,6 +770,26 @@ def _worktree_retained_payload_for_session_id(sid: str) -> dict:
         return {}
 
 
+def _pre_delete_session_metadata(sid: str):
+    """Capture the session object BEFORE destructive delete cleanup (#6855).
+
+    The delete handler previously resolved ``get_session()`` and the worktree
+    payload AFTER ``SESSIONS.pop`` and sidecar deletion, so by the time they
+    ran the session was already gone — silently dropping ``worktree_retained``
+    and the session-delete profile. This helper is called right before the
+    pop, while the session is still resolvable. state.db-only unsafe ids are
+    never in ``SESSIONS``, so it returns None for them and the handler falls
+    back to the CLI metadata captured at authorization time.
+    """
+    try:
+        return get_session(sid, metadata_only=True)
+    except KeyError:
+        return None
+    except Exception:
+        logger.debug("Failed to resolve session for deleted session %s", sid)
+        return None
+
+
 def _active_profile_config_path() -> Path:
     """Return config.yaml for the request's active WebUI profile.
 
@@ -8073,12 +8093,19 @@ def _session_deleted_tombstone_marks_was_webui(sid: str) -> bool:
 
 
 def _state_db_session_source(sid: str) -> str:
-    """Return the lowercased ``sessions.source`` for ``sid`` from state.db.
+    """Return the authoritative ``sessions.source`` for ``sid`` from state.db.
 
     Cheap single-row lookup used to distinguish delegated ``subagent`` children
     (which have a recoverable state.db transcript) from genuinely-deleted WebUI
     sessions.  Returns "" on any error / missing row so callers fall back to
     their existing behaviour.
+
+    The raw stored value is returned WITHOUT normalization (#6855): the
+    api_server-class provenance gates consume this value and must fail closed,
+    so ``strip().lower()`` widening here would let non-canonical sources like
+    ``API_SERVER`` or `` api_server`` authorize destructive paths. Rows are
+    stored canonically (``api`` / ``api_server`` / ``subagent`` / ...), so
+    callers comparing against those exact lowercase values are unaffected.
 
     The lookup is a parameterized SQL query, so it is safe for session ids that
     are not path-safe (e.g. imported external rows like
@@ -8100,7 +8127,7 @@ def _state_db_session_source(sid: str) -> str:
         return ""
     if not row:
         return ""
-    return str(row[0] or "").strip().lower()
+    return str(row[0] or "")
 
 
 def _is_api_server_class_state_db_source(source: str) -> bool:
@@ -8112,13 +8139,13 @@ def _is_api_server_class_state_db_source(source: str) -> bool:
     because the WebUI archives/deletes them directly in state.db. Any other
     real state.db row (messaging, gateway, cron, subagent, ...) keeps the
     path-safe id requirement.
-    Exact membership only (#6855): no hyphen/space normalization, no
-    derived-label fallback. A raw source like ``api-server`` (effectively
-    unknown) must NOT authorize the destructive delete/archive paths —
-    only the exact ``api`` / ``api_server`` values may.
+    EXACT raw membership only (#6855): no trimming, no case-folding, no
+    hyphen/space normalization and no derived-label fallback. A genuine
+    api_server row is always stored canonically (``api`` / ``api_server``); a
+    non-canonical value like ``API_SERVER``, `` api_server`` or ``api_serverx``
+    must NOT authorize the destructive delete/archive paths — fail closed.
     """
-    marker = str(source or "").strip().lower()
-    return marker in {"api", "api_server"}
+    return str(source or "") in {"api", "api_server"}
 
 
 def _delete_unsafe_id_authorized(sid: str) -> bool:
@@ -8202,7 +8229,7 @@ def _set_state_db_session_archived(
                     ).fetchone()
                     if (
                         not src_row
-                        or str(src_row[0] or "").strip().lower() not in require_source_in
+                        or str(src_row[0] or "") not in require_source_in
                     ):
                         _conn.rollback()
                         return False
@@ -16022,18 +16049,18 @@ def handle_post(handler, parsed) -> bool:
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
-        # A delegated subagent child (#5307) is view-only and owned by the
-        # delegate runner — deleting it would erase its state.db transcript.
+        # Delegated subagent children (#5307) are view-only; deleting one
+        # would erase its state.db transcript.
         if _session_is_subagent_view_only(sid):
             return bad(handler, "Subagent sessions are view-only and cannot be deleted from WebUI", 400)
         is_messaging_session = _is_messaging_session_id(sid)
         state_db_cleanup_failed = False
-        # Serialize with recovery, bound contention so a timeout can't delay the delete.
+        # Serialize with recovery so lock contention can't delay the delete.
         session_lock = _get_session_agent_lock(sid)
         if not session_lock.acquire(timeout=5):
             return bad(handler, "Session busy, try again", 503)
         try:
-            # #6855: unsafe-id source revalidated inside the delete txn (atomic check+act).
+            # #6855: unsafe-id source revalidated in the delete txn (atomic check+act).
             if unsafe_id and not is_messaging_session:
                 try:
                     from api.models import delete_cli_session
@@ -16043,6 +16070,7 @@ def handle_post(handler, parsed) -> bool:
                     logger.warning("Failed to delete CLI session %s", sid, exc_info=True)
                 if state_db_cleanup_failed:
                     return bad(handler, "Invalid session_id", 400)
+            session_for_delete = _pre_delete_session_metadata(sid)
             with LOCK:
                 SESSIONS.pop(sid, None)
             try:
@@ -16071,14 +16099,17 @@ def handle_post(handler, parsed) -> bool:
                     logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
-        try:
-            event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)
-        except KeyError:
-            event_profile = None
-        except Exception:
-            logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
-            event_profile = None
-        worktree_retained = _worktree_retained_payload_for_session_id(sid)
+        # #6855 review: the session object was captured BEFORE SESSIONS.pop +
+        # sidecar deletion (see _pre_delete_session_metadata) — reading it here
+        # would raise KeyError and silently drop worktree_retained/profile.
+        if session_for_delete is not None:
+            event_profile = getattr(session_for_delete, "profile", None)
+            worktree_retained = _worktree_retained_payload(session_for_delete)
+        else:
+            # state.db-only unsafe id: never in SESSIONS, so the profile comes
+            # from the CLI metadata captured at authorization time (#6855).
+            event_profile = cli_meta_for_delete.get("profile")
+            worktree_retained = {}
         # The api_server-class authorization for unsafe ids already ran at the
         # top of this handler (before any destructive cleanup) — see
         # _delete_unsafe_id_authorized (#6855).

--- a/api/routes.py
+++ b/api/routes.py
@@ -8149,9 +8149,16 @@ def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
             # old to have it (same tolerance as the projection's _optional_col).
             cols = {row[1] for row in _conn.execute("PRAGMA table_info(sessions)")}
             if "archived" not in cols:
-                _conn.execute(
-                    "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0"
-                )
+                try:
+                    _conn.execute(
+                        "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0"
+                    )
+                except _sqlite.OperationalError:
+                    # Concurrent archive requests can both observe the column
+                    # missing and race the ALTER (review #6855); the second one
+                    # fails with "duplicate column name". Tolerate it — the
+                    # UPDATE below targets the column either way.
+                    pass
             cur = _conn.execute(
                 "UPDATE sessions SET archived = ? WHERE id = ?",
                 (1 if archived else 0, sid),

--- a/api/routes.py
+++ b/api/routes.py
@@ -16178,7 +16178,28 @@ def handle_post(handler, parsed) -> bool:
             try:
                 from api.models import delete_cli_session
 
-                state_db_cleanup_failed = not delete_cli_session(sid)
+                # #6855 review: the destructive call must authorize on the
+                # provenance resolved at the call site
+                # (``cli_meta_for_delete``), not on the upstream read_only
+                # projection staying correct. Rows that reach this branch are
+                # WebUI-owned; an api_server-class (imported/read-only) row
+                # must never be erased here — fail closed, and when a source
+                # WAS resolved, re-verify that exact source inside the delete
+                # transaction (same fail-closed shape as the unsafe-id path,
+                # scoped to the call-site provenance instead of the
+                # api_server-class set).
+                resolved_source = (cli_meta_for_delete.get("source_tag") or "")
+                if _is_api_server_class_state_db_source(resolved_source):
+                    state_db_cleanup_failed = True
+                elif resolved_source:
+                    state_db_cleanup_failed = not delete_cli_session(
+                        sid, require_source_in=(resolved_source,)
+                    )
+                else:
+                    # No state.db row surfaced at the call site (typical
+                    # sidecar-only WebUI session): the historical unrestricted
+                    # cleanup is a no-op returning True for absent rows.
+                    state_db_cleanup_failed = not delete_cli_session(sid)
             except Exception:
                 state_db_cleanup_failed = True
                 logger.warning("Failed to delete CLI session %s", sid, exc_info=True)

--- a/api/routes.py
+++ b/api/routes.py
@@ -8079,8 +8079,12 @@ def _state_db_session_source(sid: str) -> str:
     (which have a recoverable state.db transcript) from genuinely-deleted WebUI
     sessions.  Returns "" on any error / missing row so callers fall back to
     their existing behaviour.
+
+    The lookup is a parameterized SQL query, so it is safe for session ids that
+    are not path-safe (e.g. imported external rows like
+    ``miloco:agent:main:...`` whose ids contain colons) — see #6843.
     """
-    if not sid or not is_safe_session_id(sid):
+    if not sid:
         return ""
     try:
         from api.models import _active_state_db_path
@@ -8097,6 +8101,43 @@ def _state_db_session_source(sid: str) -> str:
     if not row:
         return ""
     return str(row[0] or "").strip().lower()
+
+
+def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
+    """Flip the ``archived`` flag on a state.db-only session row.
+
+    Imported/read-only rows (e.g. ``api_server``) are local ``state.db`` rows
+    without a WebUI sidecar, and some ids are not path-safe enough to
+    materialize as ``webui/sessions/*.json`` sidecars. Archiving them is
+    WebUI-local view state, so update the agent's ``sessions.archived`` column
+    in place rather than materializing a writable sidecar (which previously
+    raised an unhandled ``ValueError`` -> HTTP 500, #6843).
+
+    Returns True when the row was found and updated, False otherwise.
+    """
+    if not sid:
+        return False
+    try:
+        from api.models import _active_state_db_path
+        db_path = _active_state_db_path()
+        if not db_path or not Path(db_path).exists():
+            return False
+        import sqlite3 as _sqlite
+        with closing(_sqlite.connect(str(db_path))) as _conn:
+            cur = _conn.execute(
+                "UPDATE sessions SET archived = ? WHERE id = ?",
+                (1 if archived else 0, sid),
+            )
+            _conn.commit()
+            return cur.rowcount > 0
+    except Exception:
+        logger.debug(
+            "Failed to set archived=%s for state.db session %s",
+            archived,
+            sid,
+            exc_info=True,
+        )
+        return False
 
 
 def _is_subagent_child_session_id(sid: str) -> bool:
@@ -15888,7 +15929,14 @@ def handle_post(handler, parsed) -> bool:
         if not sid:
             return bad(handler, "session_id is required")
         if not is_safe_session_id(sid):
-            return bad(handler, "Invalid session_id", 400)
+            # #6843: imported external rows (e.g. api_server) can carry ids
+            # that are not path-safe as sidecar filenames (colons, ...). They
+            # are still genuine local state.db rows, so allow the delete when
+            # the row exists there; the sidecar-unlink below is a safe no-op
+            # and delete_cli_session() removes the state.db row with a
+            # parameterized query.
+            if not _state_db_session_source(sid):
+                return bad(handler, "Invalid session_id", 400)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
@@ -17033,8 +17081,6 @@ def handle_post(handler, parsed) -> bool:
             cli_meta = _lookup_cli_session_metadata(sid)
             if not cli_meta:
                 return bad(handler, "Session not found", 404)
-            if cli_meta.get("read_only"):
-                return bad(handler, "Read-only imported sessions cannot be archived from WebUI", 400)
             # Delegated subagent children (#5307) are view-only and owned by the
             # delegate runner — never materialize one into a writable WebUI
             # sidecar via the archive fallback (the 3rd of the shared
@@ -17042,6 +17088,22 @@ def handle_post(handler, parsed) -> bool:
             _arch_source_tag = (cli_meta.get("source_tag") or cli_meta.get("raw_source") or "").strip().lower()
             if _arch_source_tag == "subagent" or _is_subagent_child_session_id(sid):
                 return bad(handler, "Subagent sessions cannot be archived from WebUI", 400)
+            # #6843: imported/read-only rows (e.g. api_server) are local
+            # state.db rows without a WebUI sidecar, and some ids are not
+            # path-safe enough to materialize as a sidecar (colons, ...).
+            # Archiving is WebUI-local view state: flip the state.db `archived`
+            # flag directly instead of materializing a writable sidecar (which
+            # previously 400'd for read_only rows and crashed with an
+            # unhandled ValueError -> HTTP 500 for unsafe ids).
+            if cli_meta.get("read_only") or not is_safe_session_id(sid):
+                if not _set_state_db_session_archived(sid, bool(body.get("archived", True))):
+                    return bad(handler, "Session not found", 404)
+                publish_session_list_changed(
+                    "session_archive",
+                    profile=cli_meta.get("profile"),
+                    session_id=sid,
+                )
+                return j(handler, {"ok": True, "session": None})
             if _is_messaging_session_record(cli_meta):
                 s = Session(
                     session_id=sid,

--- a/api/routes.py
+++ b/api/routes.py
@@ -8112,8 +8112,12 @@ def _is_api_server_class_state_db_source(source: str) -> bool:
     because the WebUI archives/deletes them directly in state.db. Any other
     real state.db row (messaging, gateway, cron, subagent, ...) keeps the
     path-safe id requirement.
+    Exact membership only (#6855): no hyphen/space normalization, no
+    derived-label fallback. A raw source like ``api-server`` (effectively
+    unknown) must NOT authorize the destructive delete/archive paths —
+    only the exact ``api`` / ``api_server`` values may.
     """
-    marker = str(source or "").strip().lower().replace("-", "_")
+    marker = str(source or "").strip().lower()
     return marker in {"api", "api_server"}
 
 
@@ -8131,7 +8135,9 @@ def _delete_unsafe_id_authorized(sid: str) -> bool:
     return _is_api_server_class_state_db_source(_state_db_session_source(sid))
 
 
-def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
+def _set_state_db_session_archived(
+    sid: str, archived: bool, require_source_in: tuple[str, ...] | None = None
+) -> bool:
     """Flip the ``archived`` flag on a state.db-only session row.
 
     Imported/read-only rows (e.g. ``api_server``) are local ``state.db`` rows
@@ -8140,6 +8146,13 @@ def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
     WebUI-local view state, so update the agent's ``sessions.archived`` column
     in place rather than materializing a writable sidecar (which previously
     raised an unhandled ``ValueError`` -> HTTP 500, #6843).
+
+    ``require_source_in`` (optional, #6855): when given, the row's CURRENT
+    ``sessions.source`` must be an exact member of this set INSIDE the same
+    ``BEGIN IMMEDIATE`` transaction as the UPDATE. The route-level class
+    check is re-verified atomically with the mutation (no cached-metadata
+    fallback, no check/act gap): a source flipped between the two fails
+    closed with the flag untouched.
 
     Returns True when the row was found and updated, False otherwise.
     Older/minimal state.db schemas may not have the optional ``archived``
@@ -8158,27 +8171,53 @@ def _set_state_db_session_archived(sid: str, archived: bool) -> bool:
             return False
         import sqlite3 as _sqlite
         with closing(_sqlite.connect(str(db_path))) as _conn:
-            # Make the UPDATE conditional on the column's existence: add the
-            # WebUI-local view-state column first when the agent schema is too
-            # old to have it (same tolerance as the projection's _optional_col).
-            cols = {row[1] for row in _conn.execute("PRAGMA table_info(sessions)")}
-            if "archived" not in cols:
+            _conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Make the UPDATE conditional on the column's existence: add the
+                # WebUI-local view-state column first when the agent schema is too
+                # old to have it (same tolerance as the projection's _optional_col).
+                cols = {row[1] for row in _conn.execute("PRAGMA table_info(sessions)")}
+                if "archived" not in cols:
+                    try:
+                        _conn.execute(
+                            "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0"
+                        )
+                    except _sqlite.OperationalError:
+                        # Concurrent archive requests can both observe the column
+                        # missing and race the ALTER (review #6855); with
+                        # BEGIN IMMEDIATE the loser waits and then sees the
+                        # column already present, but tolerate it anyway — the
+                        # UPDATE below targets the column either way.
+                        pass
+                # #6855: authoritative source revalidation in the SAME
+                # transaction as the UPDATE. The route's pre-check may have
+                # raced; this SELECT holds the write lock, so the source read
+                # here is the current one and the UPDATE is conditional on it.
+                if require_source_in is not None:
+                    if "source" not in cols:
+                        _conn.rollback()
+                        return False
+                    src_row = _conn.execute(
+                        "SELECT source FROM sessions WHERE id = ?", (sid,)
+                    ).fetchone()
+                    if (
+                        not src_row
+                        or str(src_row[0] or "").strip().lower() not in require_source_in
+                    ):
+                        _conn.rollback()
+                        return False
+                cur = _conn.execute(
+                    "UPDATE sessions SET archived = ? WHERE id = ?",
+                    (1 if archived else 0, sid),
+                )
+                _conn.commit()
+                return cur.rowcount > 0
+            except Exception:
                 try:
-                    _conn.execute(
-                        "ALTER TABLE sessions ADD COLUMN archived INTEGER DEFAULT 0"
-                    )
-                except _sqlite.OperationalError:
-                    # Concurrent archive requests can both observe the column
-                    # missing and race the ALTER (review #6855); the second one
-                    # fails with "duplicate column name". Tolerate it — the
-                    # UPDATE below targets the column either way.
+                    _conn.rollback()
+                except Exception:
                     pass
-            cur = _conn.execute(
-                "UPDATE sessions SET archived = ? WHERE id = ?",
-                (1 if archived else 0, sid),
-            )
-            _conn.commit()
-            return cur.rowcount > 0
+                raise
     except Exception:
         logger.debug(
             "Failed to set archived=%s for state.db session %s",
@@ -15979,29 +16018,31 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "session_id is required")
         if not _delete_unsafe_id_authorized(sid):
             return bad(handler, "Invalid session_id", 400)
+        unsafe_id = not is_safe_session_id(sid)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
         # A delegated subagent child (#5307) is view-only and owned by the
-        # delegate runner. Deleting it here would call delete_cli_session() and
-        # erase the child's state.db transcript — refuse it.
+        # delegate runner — deleting it would erase its state.db transcript.
         if _session_is_subagent_view_only(sid):
             return bad(handler, "Subagent sessions are view-only and cannot be deleted from WebUI", 400)
         is_messaging_session = _is_messaging_session_id(sid)
-        worktree_retained = _worktree_retained_payload_for_session_id(sid)
-        try:
-            event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)
-        except KeyError:
-            event_profile = None
-        except Exception:
-            logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
-            event_profile = None
-        # Serialize with recovery, but bound contention so a browser timeout
-        # cannot be followed by a delayed server-side delete.
+        state_db_cleanup_failed = False
+        # Serialize with recovery, bound contention so a timeout can't delay the delete.
         session_lock = _get_session_agent_lock(sid)
         if not session_lock.acquire(timeout=5):
             return bad(handler, "Session busy, try again", 503)
         try:
+            # #6855: unsafe-id source revalidated inside the delete txn (atomic check+act).
+            if unsafe_id and not is_messaging_session:
+                try:
+                    from api.models import delete_cli_session
+                    state_db_cleanup_failed = not delete_cli_session(sid, require_source_in=("api", "api_server"))
+                except Exception:
+                    state_db_cleanup_failed = True
+                    logger.warning("Failed to delete CLI session %s", sid, exc_info=True)
+                if state_db_cleanup_failed:
+                    return bad(handler, "Invalid session_id", 400)
             with LOCK:
                 SESSIONS.pop(sid, None)
             try:
@@ -16009,20 +16050,20 @@ def handle_post(handler, parsed) -> bool:
                 p.relative_to(SESSION_DIR.resolve())
             except Exception:
                 return bad(handler, "Invalid session_id", 400)
+            try:
+                prune_session_from_index(sid)
+            except Exception:
+                logger.debug("Failed to prune index entry: %s", sid, exc_info=True)
+            try:
+                p.with_suffix('.json.bak').unlink(missing_ok=True)
+            except Exception:
+                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
             sidecar_deleted = False
             try:
                 p.unlink(missing_ok=True)
             except Exception:
                 logger.debug("Failed to unlink session file %s", p)
             sidecar_deleted = not p.exists()
-            try:
-                prune_session_from_index(sid)
-            except Exception:
-                logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-            try:
-                p.with_suffix('.json.bak').unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
             if sidecar_deleted and not is_messaging_session:
                 try:
                     _record_webui_deleted_session_tombstone(sid)
@@ -16030,6 +16071,14 @@ def handle_post(handler, parsed) -> bool:
                     logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
+        try:
+            event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)
+        except KeyError:
+            event_profile = None
+        except Exception:
+            logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
+            event_profile = None
+        worktree_retained = _worktree_retained_payload_for_session_id(sid)
         # The api_server-class authorization for unsafe ids already ran at the
         # top of this handler (before any destructive cleanup) — see
         # _delete_unsafe_id_authorized (#6855).
@@ -16038,9 +16087,23 @@ def handle_post(handler, parsed) -> bool:
         from api.config import _evict_session_agent
         _evict_session_agent(sid)
         try:
-            from api.upload import _session_attachment_dir
+            if unsafe_id:
+                # #6855 review: unsafe state.db-only ids are NOT path-safe as
+                # attachment directories — the sanitizer in api/upload.py
+                # collapses distinct ids (e.g. ``victim:session`` and
+                # ``victim_session``) onto the SAME directory, so cleaning it
+                # here would erase another session's attachments (reproduced
+                # cross-session data loss). Imported api_server rows never
+                # upload through the WebUI anyway; skip attachment cleanup for
+                # them entirely.
+                logger.debug(
+                    "Skipping attachment cleanup for unsafe session id %s (identity collision risk, #6855)",
+                    sid,
+                )
+            else:
+                from api.upload import _session_attachment_dir
 
-            shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
+                shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
         except Exception:
             logger.debug("Failed to clean attachment dir for deleted session %s", sid)
         # Remove the turn-journal shards and the run-journal directory so a
@@ -16078,8 +16141,9 @@ def handle_post(handler, parsed) -> bool:
             logger.debug("Failed to close workspace terminal for deleted session %s", sid)
         # Also delete from CLI state.db for CLI sessions shown in sidebar,
         # but never erase external messaging channel memory via WebUI delete.
-        state_db_cleanup_failed = False
-        if not is_messaging_session:
+        # Unsafe ids already ran the authoritative (in-transaction) delete
+        # above (#6855) — do not run it a second time.
+        if not is_messaging_session and not unsafe_id:
             try:
                 from api.models import delete_cli_session
 
@@ -17149,11 +17213,21 @@ def handle_post(handler, parsed) -> bool:
                 # the row visible — a silent no-op that misleads the user.
                 # Require api_server-class provenance here; other read-only
                 # sources keep the prior rejection.
-                if not _is_api_server_class_state_db_source(
-                    _state_db_session_source(sid) or _arch_source_tag
-                ):
+                # #6855: no cached-metadata fallback — the archive decision
+                # must come from the AUTHORITATIVE current state.db source
+                # (``_arch_source_tag`` was previously OR-ed in, letting a
+                # real telegram row with stale api_server metadata archive
+                # with 200). And the UPDATE below revalidates that same
+                # source inside its own BEGIN IMMEDIATE transaction, so the
+                # check and the act are one atomic step (mirroring the
+                # delete-path fix).
+                if not _is_api_server_class_state_db_source(_state_db_session_source(sid)):
                     return bad(handler, "Read-only imported sessions cannot be archived from WebUI", 400)
-                if not _set_state_db_session_archived(sid, bool(body.get("archived", True))):
+                if not _set_state_db_session_archived(
+                    sid,
+                    bool(body.get("archived", True)),
+                    require_source_in=("api", "api_server"),
+                ):
                     return bad(handler, "Session not found", 404)
                 publish_session_list_changed(
                     "session_archive",

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -724,6 +724,77 @@ def test_delete_safe_id_still_cleans_attachments(isolated_state_db, monkeypatch,
     )
 
 
+def test_delete_path_safe_api_server_class_row_fails_closed(
+    isolated_state_db, monkeypatch
+):
+    """Re-gate r5 (#6855): the path-safe state.db delete must not erase an
+    api_server-class row. The branch is reached only for WebUI-owned rows, but
+    the destructive call authorizes on the provenance resolved at the call
+    site (``cli_meta_for_delete``) — an api_server-class row that slips past
+    the upstream read_only guard must survive with ``state_db_cleanup_failed``
+    reported (fail closed), never be deleted by an unrestricted call.
+    """
+    sid = "path-safe-ro-import-1"
+    _make_state_db(isolated_state_db["db"], sid, source="api_server", title="API imported")
+    # Deliberately NO ``read_only`` key: the destructive call must not depend
+    # on the upstream read_only projection staying correct (#6855).
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api_server",
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+
+    assert models.is_safe_session_id(sid) is True
+    assert routes._is_messaging_session_id(sid) is False, (
+        "precondition: the api_server row is not messaging, so the branch runs"
+    )
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 200, captured
+    assert captured["payload"]["state_db_cleanup_failed"] is True, (
+        "path-safe api_server-class delete must report cleanup failure, not erase the row"
+    )
+    assert _row_exists(isolated_state_db["db"], sid) is True, (
+        "api_server-class row must survive the path-safe delete (#6855)"
+    )
+
+
+def test_delete_path_safe_webui_row_deletes_with_exact_source_gate(
+    isolated_state_db, monkeypatch
+):
+    """Re-gate r5 (#6855): a WebUI-owned path-safe row is deleted with the
+    exact source resolved at the call site re-verified inside the delete
+    transaction — the positive counterpart of the api_server-class denial.
+    """
+    sid = "path-safe-webui-own-1"
+    _make_state_db(isolated_state_db["db"], sid, source="webui", title="Safe")
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+
+    assert models.is_safe_session_id(sid) is True
+    assert routes._is_messaging_session_id(sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 200, captured
+    assert captured["payload"]["state_db_cleanup_failed"] is False, captured
+    assert _row_exists(isolated_state_db["db"], sid) is False, (
+        "WebUI-owned row must be deleted by the path-safe delete (#6855)"
+    )
+
+
 def test_archive_no_metadata_fallback_when_source_lookup_empty(
     isolated_state_db, monkeypatch
 ):

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -27,6 +27,7 @@ imported/read-only api_server class (a messaging row still 400s).
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
@@ -217,11 +218,54 @@ def test_archive_api_server_session_flips_state_db_instead_of_500(
     assert _read_archived(isolated_state_db["db"], sid) == 0
 
 
-def test_archive_read_only_imported_session_flips_state_db_instead_of_400(
+def test_archive_read_only_api_server_session_hides_from_listing(
     isolated_state_db, monkeypatch
 ):
-    """A read_only imported row is WebUI-local view state for archiving: flip
-    state.db instead of the previous blanket 400."""
+    """A read_only imported row of the api_server class is WebUI-local view
+    state for archiving: flip state.db instead of the previous blanket 400,
+    AND confirm end-to-end that the row actually disappears from the default
+    visible sidebar (review #6855) — the state.db flag alone is not proof of
+    visibility, since the sidebar only consumes `archived` for api_server
+    class rows.
+    """
+    sid = "ro-api-server-imported-1"
+    _make_state_db(isolated_state_db["db"], sid, source="api_server", title="API imported")
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api_server",
+        "read_only": True,
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+
+    before = _sidebar_sessions()
+    assert any(s.get("session_id") == sid for s in before["sessions"]), (
+        "read_only api_server row must appear in the default sidebar before archive"
+    )
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert _read_archived(isolated_state_db["db"], sid) == 1
+    after = _sidebar_sessions()
+    assert all(s.get("session_id") != sid for s in after["sessions"]), (
+        "archived read_only api_server row must leave the default visible sidebar (#6855)"
+    )
+
+
+def test_archive_read_only_telegram_session_still_400s(
+    isolated_state_db, monkeypatch
+):
+    """A read_only row from a NON-api_server source (telegram) must keep the
+    prior 400 rejection (review #6855): the sidebar only consumes the state.db
+    `archived` flag for api_server-class rows, so flipping it for a telegram
+    row would return 200 yet leave the session visible — a silent no-op. The
+    flag must stay untouched and the row must stay visible.
+    """
     sid = "ro-telegram-imported-1"
     _make_state_db(isolated_state_db["db"], sid, source="telegram", title="Telegram chat")
     cli_meta = {
@@ -237,9 +281,17 @@ def test_archive_read_only_imported_session_flips_state_db_instead_of_400(
     captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
     assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
 
-    assert captured["status"] == 200
-    assert captured["payload"]["ok"] is True
-    assert _read_archived(isolated_state_db["db"], sid) == 1
+    assert captured["status"] == 400
+    assert "Read-only imported sessions cannot be archived" in str(
+        captured["payload"].get("error", "")
+    )
+    assert _read_archived(isolated_state_db["db"], sid) == 0, (
+        "state.db archived flag must not be flipped for a rejected read-only telegram row"
+    )
+    sessions = _sidebar_sessions()
+    assert any(s.get("session_id") == sid for s in sessions["sessions"]), (
+        "rejected read-only telegram row must stay visible in the default sidebar"
+    )
 
 
 def test_archived_api_server_session_stops_flooding_sidebar(
@@ -373,4 +425,49 @@ def test_delete_unsafe_messaging_session_still_400s(isolated_state_db, monkeypat
     assert "Invalid session_id" in str(captured["payload"].get("error", ""))
     assert _row_exists(isolated_state_db["db"], sid) is True, (
         "messaging row must survive an unsafe-id delete attempt"
+    )
+
+
+def test_delete_rejected_unsafe_messaging_session_leaves_artifacts_intact(
+    isolated_state_db, monkeypatch
+):
+    """A rejected unsafe-id delete must leave ALL artifacts intact (review
+    #6855): the api_server-class authorization now runs BEFORE the destructive
+    cleanup, so the sidecar, the .json.bak snapshot, the session index entry
+    and the state.db row all survive the 400.
+    """
+    sid = "discord:guild:channel:msg:0a1b2c3d4e5f"
+    _make_state_db(isolated_state_db["db"], sid, source="discord",
+                   title="DC Chat", archived=0)
+
+    # Seed the artifacts the cleanup path would otherwise remove: a sidecar,
+    # its .json.bak snapshot and a session-index entry for the rejected id.
+    sessions_dir = isolated_state_db["sessions_dir"]
+    sidecar = sessions_dir / f"{sid}.json"
+    sidecar.write_text('{"session_id": "%s"}' % sid, encoding="utf-8")
+    (sessions_dir / f"{sid}.json.bak").write_text(
+        '{"session_id": "%s"}' % sid, encoding="utf-8"
+    )
+    index_path = isolated_state_db["index_path"]
+    index_path.write_text(
+        json.dumps([{"session_id": sid, "source_tag": "discord"}]), encoding="utf-8"
+    )
+
+    assert models.is_safe_session_id(sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Invalid session_id" in str(captured["payload"].get("error", ""))
+    assert sidecar.exists(), "sidecar must survive a rejected unsafe-id delete"
+    assert (sessions_dir / f"{sid}.json.bak").exists(), (
+        ".json.bak snapshot must survive a rejected unsafe-id delete"
+    )
+    index_entries = json.loads(index_path.read_text(encoding="utf-8"))
+    assert any(e.get("session_id") == sid for e in index_entries), (
+        "session index entry must survive a rejected unsafe-id delete"
+    )
+    assert _row_exists(isolated_state_db["db"], sid) is True, (
+        "state.db row must survive a rejected unsafe-id delete"
     )

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -480,15 +480,22 @@ def test_delete_rejected_unsafe_messaging_session_leaves_artifacts_intact(
 
 
 def test_api_server_class_source_predicates_require_exact_membership():
-    """Finding 1 (#6855): the api_server-class predicates must be EXACT
-    membership on the authoritative source. ``api-server`` (hyphen) is an
-    effectively-unknown source and must NOT authorize the destructive paths
-    (previously the hyphen was normalized to ``api_server``)."""
+    """Findings 1 + re-gate r4 (#6855): the api_server-class predicates must
+    be EXACT raw membership on the authoritative source. ``api-server``
+    (hyphen), ``API_SERVER`` (case), `` api_server`` (whitespace) and
+    ``api_serverx`` (prefix/suffix) are all effectively-unknown sources and
+    must NOT authorize the destructive paths (previously strip().lower()
+    normalized them into the set)."""
     from api.agent_sessions import is_api_server_class_row
 
     assert routes._is_api_server_class_state_db_source("api_server") is True
     assert routes._is_api_server_class_state_db_source("api") is True
-    assert routes._is_api_server_class_state_db_source("API_SERVER") is True
+    assert routes._is_api_server_class_state_db_source("API_SERVER") is False
+    assert routes._is_api_server_class_state_db_source("Api_Server") is False
+    assert routes._is_api_server_class_state_db_source(" api_server") is False
+    assert routes._is_api_server_class_state_db_source("api_server ") is False
+    assert routes._is_api_server_class_state_db_source("api_serverx") is False
+    assert routes._is_api_server_class_state_db_source("xapi_server") is False
     assert routes._is_api_server_class_state_db_source("api-server") is False
     assert routes._is_api_server_class_state_db_source("api server") is False
     assert routes._is_api_server_class_state_db_source("telegram") is False
@@ -496,7 +503,11 @@ def test_api_server_class_source_predicates_require_exact_membership():
 
     assert is_api_server_class_row({"source": "api_server"}) is True
     assert is_api_server_class_row({"source": "api"}) is True
-    assert is_api_server_class_row({"source": "API_SERVER"}) is True
+    assert is_api_server_class_row({"source": "API_SERVER"}) is False
+    assert is_api_server_class_row({"source": " api_server"}) is False
+    assert is_api_server_class_row({"source": "api_server "}) is False
+    assert is_api_server_class_row({"source": "api_serverx"}) is False
+    assert is_api_server_class_row({"source": "xapi_server"}) is False
     assert is_api_server_class_row({"source": "api-server"}) is False
     assert is_api_server_class_row({"source": "telegram", "source_tag": "api_server"}) is False, (
         "derived labels must not upgrade a non-api_server authoritative source"
@@ -518,6 +529,76 @@ def test_delete_unsafe_api_server_hyphen_source_still_400s(isolated_state_db, mo
     assert captured["status"] == 400, captured
     assert "Invalid session_id" in str(captured["payload"].get("error", ""))
     assert _row_exists(isolated_state_db["db"], sid) is True
+
+
+@pytest.mark.parametrize(
+    "raw_source",
+    [
+        "API_SERVER",
+        "Api_Server",
+        " api_server",
+        "api_server ",
+        "api_serverx",
+        "xapi_server",
+        " api ",
+    ],
+)
+def test_delete_unsafe_id_noncanonical_api_server_source_still_400s(
+    isolated_state_db, monkeypatch, raw_source
+):
+    """Re-gate r4 (#6855): only the EXACT canonical ``api``/``api_server``
+    raw source authorizes the unsafe-id delete bypass. Uppercase, whitespace,
+    prefix and suffix variants of ``api_server`` must fail closed — the row
+    and its sidecar survive (previously ``strip().lower()`` normalized them
+    into the set and delete removed the row)."""
+    sid = "noncanon:%s:imported:1a2b3c4d5e6f" % raw_source.replace(" ", "_")
+    _make_state_db(isolated_state_db["db"], sid, source=raw_source, title=None)
+    sidecar = isolated_state_db["sessions_dir"] / f"{sid}.json"
+    sidecar.write_text('{"session_id": "%s"}' % sid, encoding="utf-8")
+
+    assert models.is_safe_session_id(sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Invalid session_id" in str(captured["payload"].get("error", ""))
+    assert _row_exists(isolated_state_db["db"], sid) is True, (
+        "non-canonical api_server row must survive a rejected unsafe-id delete"
+    )
+    assert sidecar.exists(), "sidecar must survive a rejected non-canonical unsafe-id delete"
+
+
+@pytest.mark.parametrize(
+    "raw_source",
+    ["API_SERVER", " api_server", "api_serverx", "xapi_server"],
+)
+def test_archive_unsafe_id_noncanonical_api_server_source_still_400s(
+    isolated_state_db, monkeypatch, raw_source
+):
+    """Re-gate r4 (#6855): archive of an unsafe id whose state.db source is a
+    non-canonical api_server variant fails closed — the ``archived`` flag is
+    untouched (previously ``strip().lower()`` authorized it and set the flag,
+    which the sidebar never consumes for non-canonical rows)."""
+    sid = "archnoncanon:%s:imported:1a2b3c4d5e6f" % raw_source.replace(" ", "_")
+    _make_state_db(isolated_state_db["db"], sid, source=raw_source, title=None)
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": raw_source,
+        "raw_source": raw_source,
+        "session_source": "other",
+        "read_only": True,
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] == 400, captured
+    assert _read_archived(isolated_state_db["db"], sid) == 0, (
+        "archive must fail closed for non-canonical api_server sources (#6855)"
+    )
 
 
 def test_delete_unsafe_id_source_flip_fails_closed_atomically(isolated_state_db, monkeypatch):

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -1,0 +1,268 @@
+"""Regression tests for #6843 — archive/delete of imported ``api_server`` sessions.
+
+Imported ``api_server`` rows are local Hermes ``state.db`` rows with no WebUI
+sidecar; many carry ids that are not path-safe as sidecar filenames (colons,
+e.g. ``miloco:agent:main:miloco-suggest:miloco-suggest:<hash>``). Before the
+fix:
+
+* ``POST /api/session/archive`` tried to materialize a writable sidecar and
+  crashed with an unhandled ``ValueError`` (unsafe session_id) -> HTTP 500, or
+  refused ``read_only`` imported rows with a 400;
+* ``POST /api/session/delete`` rejected the same ids with
+  ``Invalid session_id`` (400);
+* the sidebar projection only honored sidecar ``archived`` state, so rows
+  archived in state.db kept flooding the default list as
+  ``Api_Server Session``.
+
+The fix archives/deletes these rows directly in state.db (archive is
+WebUI-local view state — no sidecar materialization) and makes the sidebar
+projection honor the state.db ``archived`` flag when no sidecar exists.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import api.models as models
+import api.routes as routes
+from api.models import SESSIONS
+
+
+def _make_state_db(path: Path, sid: str, *, source: str = "api_server",
+                   title: str | None = None, archived: int = 0,
+                   message_count: int = 2) -> None:
+    """Create a minimal state.db with one session row and a few messages.
+
+    Schema mirrors hermes_state.SessionDB closely enough for
+    read_importable_agent_session_rows / delete_cli_session.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            model TEXT,
+            model_config TEXT,
+            parent_session_id TEXT,
+            started_at REAL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            title TEXT,
+            cwd TEXT,
+            archived INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sessions "
+        "(id, source, model, message_count, started_at, title, cwd, archived) "
+        "VALUES (?, ?, 'deepseek/deepseek-chat', ?, 1781024055.0, ?, '/root', ?)",
+        (sid, source, message_count, title, archived),
+    )
+    for i in range(message_count):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (sid, "user" if i % 2 == 0 else "assistant", f"msg {i}", 1781024055.0 + i),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _read_archived(db: Path, sid: str) -> int | None:
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute("SELECT archived FROM sessions WHERE id = ?", (sid,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _row_exists(db: Path, sid: str) -> bool:
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute("SELECT 1 FROM sessions WHERE id = ?", (sid,)).fetchone() is not None
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path, monkeypatch):
+    """Point the whole session/state.db stack at an isolated tmp dir.
+
+    ``get_active_hermes_home`` is the single chokepoint used by
+    ``_active_state_db_path``, ``_resolve_cli_sessions_context`` (sidebar
+    projection) and ``delete_cli_session``, so patching it routes all of them
+    to ``tmp_path/state.db``.
+    """
+    import api.profiles as _profiles
+
+    db = tmp_path / "state.db"
+    sessions_dir = tmp_path / "webui-sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    index_path = sessions_dir / "_index.json"
+    index_path.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(_profiles, "get_active_hermes_home", lambda: str(tmp_path))
+    monkeypatch.setattr(models, "get_claude_code_sessions", lambda: [])
+    monkeypatch.setattr(models, "SESSION_DIR", sessions_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_path)
+    monkeypatch.setattr(routes, "SESSION_DIR", sessions_dir)
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", index_path)
+    SESSIONS.clear()
+    return {"db": db, "sessions_dir": sessions_dir, "index_path": index_path}
+
+
+def _capture_post(monkeypatch, body):
+    captured = {}
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: body)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload,
+            status=status,
+        )
+        or True,
+    )
+    return captured
+
+
+def _sidebar_sessions():
+    """Build the default visible sidebar payload the same way /api/sessions does."""
+    return routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+        show_claude_code_sessions=False,
+        include_archived=False,
+        exclude_hidden=True,
+        visible_only=True,
+        show_webhook_sessions=False,
+        source_filter=None,
+        sidebar_source=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+def test_archive_api_server_session_flips_state_db_instead_of_500(
+    isolated_state_db, monkeypatch
+):
+    """Archiving an imported api_server row with an unsafe (colon) id must not
+    crash (previously an unhandled ValueError -> HTTP 500): it flips the
+    state.db `archived` flag directly and returns ok."""
+    sid = "miloco:agent:main:miloco-suggest:miloco-suggest:9f8e7d6c5b4a"
+    _make_state_db(isolated_state_db["db"], sid, title=None, archived=0)
+
+    assert models.is_safe_session_id(sid) is False, (
+        "precondition: the imported id is not path-safe (no sidecar possible)"
+    )
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert _read_archived(isolated_state_db["db"], sid) == 1
+
+    # Round-trip: unarchive restores the flag (archive is a toggle).
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": False})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+    assert captured["status"] == 200
+    assert _read_archived(isolated_state_db["db"], sid) == 0
+
+
+def test_archive_read_only_imported_session_flips_state_db_instead_of_400(
+    isolated_state_db, monkeypatch
+):
+    """A read_only imported row is WebUI-local view state for archiving: flip
+    state.db instead of the previous blanket 400."""
+    sid = "ro-telegram-imported-1"
+    _make_state_db(isolated_state_db["db"], sid, source="telegram", title="Telegram chat")
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "telegram",
+        "raw_source": "telegram",
+        "session_source": "messaging",
+        "read_only": True,
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert _read_archived(isolated_state_db["db"], sid) == 1
+
+
+def test_archived_api_server_session_stops_flooding_sidebar(
+    isolated_state_db, monkeypatch
+):
+    """The #6843 flood: untitled api_server rows render as `Api_Server Session`
+    in the default sidebar; once archived via the WebUI they must disappear
+    from the visible list (state.db archived flag honored, no sidecar)."""
+    sid = "miloco:agent:main:miloco-suggest:miloco-suggest:1a2b3c4d5e6f"
+    _make_state_db(isolated_state_db["db"], sid, title=None, archived=0)
+
+    before = _sidebar_sessions()
+    row = next(
+        (s for s in before["sessions"] if s.get("session_id") == sid),
+        None,
+    )
+    assert row is not None, "untitled api_server row must appear in the sidebar"
+    assert row["title"] == "Api_Server Session"
+    assert row["archived"] is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+    assert captured["status"] == 200
+
+    after = _sidebar_sessions()
+    assert all(s.get("session_id") != sid for s in after["sessions"]), (
+        "archived api_server row must leave the default visible sidebar (#6843)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_api_server_session_removes_state_db_row(
+    isolated_state_db, monkeypatch
+):
+    """Deleting an imported api_server row with an unsafe (colon) id must not
+    be rejected with Invalid session_id: the state.db row is removed."""
+    sid = "miloco:agent:main:miloco-suggest:miloco-suggest:0a1b2c3d4e5f"
+    _make_state_db(isolated_state_db["db"], sid, title=None, archived=0)
+
+    assert models.is_safe_session_id(sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["state_db_cleanup_failed"] is False
+    assert _row_exists(isolated_state_db["db"], sid) is False
+    assert not (isolated_state_db["sessions_dir"] / f"{sid}.json").exists()

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -471,3 +471,254 @@ def test_delete_rejected_unsafe_messaging_session_leaves_artifacts_intact(
     assert _row_exists(isolated_state_db["db"], sid) is True, (
         "state.db row must survive a rejected unsafe-id delete"
     )
+
+
+# ---------------------------------------------------------------------------
+# Re-gate r3 (#6855): exact-membership, atomic check+act, attachment identity,
+# archive fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_api_server_class_source_predicates_require_exact_membership():
+    """Finding 1 (#6855): the api_server-class predicates must be EXACT
+    membership on the authoritative source. ``api-server`` (hyphen) is an
+    effectively-unknown source and must NOT authorize the destructive paths
+    (previously the hyphen was normalized to ``api_server``)."""
+    from api.agent_sessions import is_api_server_class_row
+
+    assert routes._is_api_server_class_state_db_source("api_server") is True
+    assert routes._is_api_server_class_state_db_source("api") is True
+    assert routes._is_api_server_class_state_db_source("API_SERVER") is True
+    assert routes._is_api_server_class_state_db_source("api-server") is False
+    assert routes._is_api_server_class_state_db_source("api server") is False
+    assert routes._is_api_server_class_state_db_source("telegram") is False
+    assert routes._is_api_server_class_state_db_source("") is False
+
+    assert is_api_server_class_row({"source": "api_server"}) is True
+    assert is_api_server_class_row({"source": "api"}) is True
+    assert is_api_server_class_row({"source": "API_SERVER"}) is True
+    assert is_api_server_class_row({"source": "api-server"}) is False
+    assert is_api_server_class_row({"source": "telegram", "source_tag": "api_server"}) is False, (
+        "derived labels must not upgrade a non-api_server authoritative source"
+    )
+
+
+def test_delete_unsafe_api_server_hyphen_source_still_400s(isolated_state_db, monkeypatch):
+    """Finding 1 end-to-end: an unsafe id backed by an ``api-server``
+    (hyphen) row is NOT the api_server class — delete must 400 and the row
+    must survive (the hyphen was previously normalized to api_server)."""
+    sid = "hyphen:api:server:imported:1a2b3c4d5e6f"
+    _make_state_db(isolated_state_db["db"], sid, source="api-server", title=None)
+
+    assert models.is_safe_session_id(sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Invalid session_id" in str(captured["payload"].get("error", ""))
+    assert _row_exists(isolated_state_db["db"], sid) is True
+
+
+def test_delete_unsafe_id_source_flip_fails_closed_atomically(isolated_state_db, monkeypatch):
+    """Finding 2 (#6855): the api_server-class source is revalidated INSIDE
+    the BEGIN IMMEDIATE delete transaction. A source that flips between the
+    route-level check and the delete (authorization saw api_server, the row
+    is now gateway — a non-api_server, non-messaging source) must fail
+    closed: 400, row survives, sidecar untouched. (A flip to a messaging
+    source is independently protected by the messaging guard, which skips
+    the state.db delete entirely.)"""
+    sid = "flip:agent:main:0a1b2c3d4e5f"
+    _make_state_db(isolated_state_db["db"], sid, source="gateway", title="Gateway run")
+    # Simulate the TOCTOU: the route-level pre-check sees api_server...
+    monkeypatch.setattr(routes, "_state_db_session_source", lambda s: "api_server")
+    # ...but the state.db row the transaction reads is really gateway.
+    sidecar = isolated_state_db["sessions_dir"] / f"{sid}.json"
+    sidecar.write_text('{"session_id": "%s"}' % sid, encoding="utf-8")
+
+    assert models.is_safe_session_id(sid) is False
+    assert routes._is_messaging_session_id(sid) is False, (
+        "precondition: gateway is not messaging, so the in-transaction gate is what denies"
+    )
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Invalid session_id" in str(captured["payload"].get("error", ""))
+    assert _row_exists(isolated_state_db["db"], sid) is True, (
+        "gateway row must survive an unsafe-id delete whose source flipped after authz"
+    )
+    assert sidecar.exists(), "sidecar must survive the atomic denial"
+
+
+def test_delete_cli_session_require_source_in_gates_atomically(isolated_state_db):
+    """Finding 2 unit level: delete_cli_session(require_source_in=...) denies
+    a row whose CURRENT source is not an exact member — inside the same
+    transaction — and still deletes when it is."""
+    db = isolated_state_db["db"]
+    tel = "tel-gated-001"
+    _make_state_db(db, tel, source="telegram", title="Telegram chat")
+    assert models.delete_cli_session(tel, require_source_in=("api", "api_server")) is False
+    assert _row_exists(db, tel) is True, "denied source must leave the row intact"
+
+    api = "api-gated-001"
+    _make_state_db(db, api, source="api_server", title="API imported")
+    assert models.delete_cli_session(api, require_source_in=("api", "api_server")) is True
+    assert _row_exists(db, api) is False
+
+
+def test_delete_unsafe_id_skips_attachment_cleanup_collision(
+    isolated_state_db, monkeypatch, tmp_path
+):
+    """Finding 3 (#6855): the attachment sanitizer collapses distinct ids
+    (``victim:session`` vs ``victim_session``) onto ONE directory. Deleting
+    an unsafe id must therefore SKIP attachment cleanup, so the safe
+    session's uploads are never erased (reproduced cross-session data loss)."""
+    import re as _re
+
+    import api.upload as upload
+
+    root = tmp_path / "attachments"
+
+    def fake_dir(session_id, *, root=root):
+        dest = (
+            root / _re.sub(r"[^\w.\-]", "_", str(session_id or "session"))[:120]
+        ).resolve()
+        dest.mkdir(parents=True, exist_ok=True)
+        return dest
+
+    monkeypatch.setattr(upload, "_session_attachment_dir", fake_dir)
+
+    safe_sid = "victim_session"
+    unsafe_sid = "victim:session"
+    # Both ids sanitize to the same directory in the real code; mirror that.
+    assert fake_dir(unsafe_sid) == fake_dir(safe_sid)
+
+    _make_state_db(isolated_state_db["db"], unsafe_sid, source="api_server", title=None)
+    victim_file = fake_dir(safe_sid) / "photo.png"
+    victim_file.write_bytes(b"data")
+
+    assert models.is_safe_session_id(unsafe_sid) is False
+
+    captured = _capture_post(monkeypatch, {"session_id": unsafe_sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 200, captured
+    assert victim_file.exists(), (
+        "deleting unsafe id %r must not erase %r's attachments "
+        "(identity collision, #6855)" % (unsafe_sid, safe_sid)
+    )
+
+
+def test_delete_safe_id_still_cleans_attachments(isolated_state_db, monkeypatch, tmp_path):
+    """Finding 3 guard: the skip is scoped to UNSAFE ids only — a normal
+    safe-id delete still removes its own attachment directory."""
+    import re as _re
+
+    import api.upload as upload
+
+    root = tmp_path / "attachments"
+
+    def fake_dir(session_id, *, root=root):
+        dest = (
+            root / _re.sub(r"[^\w.\-]", "_", str(session_id or "session"))[:120]
+        ).resolve()
+        dest.mkdir(parents=True, exist_ok=True)
+        return dest
+
+    monkeypatch.setattr(upload, "_session_attachment_dir", fake_dir)
+
+    sid = "safe_sess_att_001"
+    _make_state_db(isolated_state_db["db"], sid, source="webui", title="Safe")
+    attach = fake_dir(sid)
+    (attach / "doc.pdf").write_bytes(b"data")
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 200, captured
+    assert not (attach / "doc.pdf").exists(), (
+        "safe-id delete must still clean its own attachments"
+    )
+
+
+def test_archive_no_metadata_fallback_when_source_lookup_empty(
+    isolated_state_db, monkeypatch
+):
+    """Finding 4 (#6855): when the authoritative state.db source lookup
+    returns empty/error, archive must NOT fall back to the cached metadata
+    source_tag. A real telegram row with stale api_server metadata must 400
+    with the archived flag untouched (previously archived with HTTP 200)."""
+    sid = "ro-telegram-stale-meta-1"
+    _make_state_db(isolated_state_db["db"], sid, source="telegram", title="Telegram chat")
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api",
+        "read_only": True,
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+    # Authoritative lookup fails/returns empty — the OLD code OR-ed in the
+    # cached `_arch_source_tag` (api_server) and archived the telegram row.
+    monkeypatch.setattr(routes, "_state_db_session_source", lambda s: "")
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Read-only imported sessions cannot be archived" in str(
+        captured["payload"].get("error", "")
+    )
+    assert _read_archived(isolated_state_db["db"], sid) == 0, (
+        "archive must fail closed when the authoritative source lookup is empty (#6855)"
+    )
+
+
+def test_archive_source_flip_fails_closed_in_transaction(isolated_state_db, monkeypatch):
+    """Finding 4 (#6855): the archive UPDATE revalidates the authoritative
+    source inside the same transaction. When the pre-check passes
+    (api_server) but the row's current source is telegram, the archive must
+    fail closed with the flag untouched (mirrors the delete-path fix)."""
+    sid = "ro-telegram-flip-1"
+    _make_state_db(isolated_state_db["db"], sid, source="telegram", title="Telegram chat")
+    cli_meta = {
+        "session_id": sid,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api",
+        "read_only": True,
+        "profile": "default",
+    }
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda s: cli_meta)
+    # Pre-check sees api_server (patched)...
+    monkeypatch.setattr(routes, "_state_db_session_source", lambda s: "api_server")
+
+    captured = _capture_post(monkeypatch, {"session_id": sid, "archived": True})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+
+    assert captured["status"] in (400, 404), captured
+    assert _read_archived(isolated_state_db["db"], sid) == 0, (
+        "archive flag must stay untouched when the in-transaction source check denies"
+    )
+
+
+def test_set_state_db_archived_require_source_in(isolated_state_db):
+    """Finding 4 unit level: _set_state_db_session_archived with
+    require_source_in=... flips only exact api_server-class rows, atomically."""
+    db = isolated_state_db["db"]
+    tel = "ro-tel-unit-1"
+    _make_state_db(db, tel, source="telegram", title="Telegram chat")
+    assert routes._set_state_db_session_archived(
+        tel, True, require_source_in=("api", "api_server")
+    ) is False
+    assert _read_archived(db, tel) == 0
+
+    api = "ro-api-unit-1"
+    _make_state_db(db, api, source="api_server", title="API imported")
+    assert routes._set_state_db_session_archived(
+        api, True, require_source_in=("api", "api_server")
+    ) is True
+    assert _read_archived(db, api) == 1

--- a/tests/test_6843_api_server_session_archive_delete.py
+++ b/tests/test_6843_api_server_session_archive_delete.py
@@ -17,6 +17,13 @@ fix:
 The fix archives/deletes these rows directly in state.db (archive is
 WebUI-local view state — no sidecar materialization) and makes the sidebar
 projection honor the state.db ``archived`` flag when no sidecar exists.
+
+Review regressions covered (#6855): the ``archived`` projection must not break
+older state.db schemas without an ``archived`` column, the state.db
+``archived`` fallback is scoped to the api_server class only (gateway /
+messaging / cron / subagent rows keep their existing visibility), and the
+delete bypass for non-path-safe ids requires the row's source to be the
+imported/read-only api_server class (a messaging row still 400s).
 """
 from __future__ import annotations
 
@@ -33,15 +40,19 @@ from api.models import SESSIONS
 
 def _make_state_db(path: Path, sid: str, *, source: str = "api_server",
                    title: str | None = None, archived: int = 0,
-                   message_count: int = 2) -> None:
+                   message_count: int = 2,
+                   include_archived_col: bool = True) -> None:
     """Create a minimal state.db with one session row and a few messages.
 
     Schema mirrors hermes_state.SessionDB closely enough for
     read_importable_agent_session_rows / delete_cli_session.
+    ``include_archived_col=False`` reproduces older agent schemas that have NO
+    ``archived`` column (the #6843 projection must not break on those).
     """
+    archived_ddl = ", archived INTEGER DEFAULT 0" if include_archived_col else ""
     conn = sqlite3.connect(str(path))
     conn.executescript(
-        """
+        f"""
         CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY,
             source TEXT,
@@ -53,8 +64,7 @@ def _make_state_db(path: Path, sid: str, *, source: str = "api_server",
             end_reason TEXT,
             message_count INTEGER DEFAULT 0,
             title TEXT,
-            cwd TEXT,
-            archived INTEGER DEFAULT 0
+            cwd TEXT{archived_ddl}
         );
         CREATE TABLE IF NOT EXISTS messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -65,12 +75,20 @@ def _make_state_db(path: Path, sid: str, *, source: str = "api_server",
         );
         """
     )
-    conn.execute(
-        "INSERT OR REPLACE INTO sessions "
-        "(id, source, model, message_count, started_at, title, cwd, archived) "
-        "VALUES (?, ?, 'deepseek/deepseek-chat', ?, 1781024055.0, ?, '/root', ?)",
-        (sid, source, message_count, title, archived),
-    )
+    if include_archived_col:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions "
+            "(id, source, model, message_count, started_at, title, cwd, archived) "
+            "VALUES (?, ?, 'deepseek/deepseek-chat', ?, 1781024055.0, ?, '/root', ?)",
+            (sid, source, message_count, title, archived),
+        )
+    else:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions "
+            "(id, source, model, message_count, started_at, title, cwd) "
+            "VALUES (?, ?, 'deepseek/deepseek-chat', ?, 1781024055.0, ?, '/root')",
+            (sid, source, message_count, title),
+        )
     for i in range(message_count):
         conn.execute(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
@@ -133,6 +151,15 @@ def _capture_post(monkeypatch, body):
         "j",
         lambda handler, payload, status=200, extra_headers=None: captured.update(
             payload=payload,
+            status=status,
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda handler, msg, status=400: captured.update(
+            payload={"error": msg},
             status=status,
         )
         or True,
@@ -244,6 +271,61 @@ def test_archived_api_server_session_stops_flooding_sidebar(
 
 
 # ---------------------------------------------------------------------------
+# Session-visibility regression (review #6855)
+# ---------------------------------------------------------------------------
+
+
+def test_non_archived_gateway_session_stays_visible(isolated_state_db, monkeypatch):
+    """A non-archived gateway/discord session must still appear in /api/sessions.
+
+    Regression for the #6843 review: the archived-column projection broke on
+    older state.db schemas that have NO ``archived`` column (the generated
+    ``0 AS archived AS archived`` SQL raised, so the whole projection died and
+    sidecar-less gateway/messaging/cron rows vanished), and the sidecar-less
+    ``archived`` fallback must not hide non-api_server rows.
+    """
+    sid = "gw_dc_visible_001"
+    _make_state_db(
+        isolated_state_db["db"],
+        sid,
+        source="discord",
+        title="DC Visible Chat",
+        include_archived_col=False,
+    )
+
+    sessions = _sidebar_sessions()
+    row = next(
+        (s for s in sessions["sessions"] if s.get("session_id") == sid),
+        None,
+    )
+    assert row is not None, "non-archived gateway/discord session must stay visible"
+    assert row["archived"] is False
+
+
+def test_state_db_archived_flag_only_hides_api_server_class(isolated_state_db, monkeypatch):
+    """The state.db ``archived`` fallback is scoped to the api_server class.
+
+    A gateway/discord row with ``archived=1`` in state.db (no sidecar) is
+    agent-owned state and must KEEP its existing visibility — only imported
+    api_server-class rows are hidden by the fallback (#6843 review).
+    """
+    gw_sid = "gw_dc_archived_002"
+    _make_state_db(isolated_state_db["db"], gw_sid, source="discord",
+                   title="DC Archived Chat", archived=1)
+
+    api_sid = "miloco:agent:main:miloco-suggest:miloco-suggest:3c4d5e6f7a8b"
+    _make_state_db(isolated_state_db["db"], api_sid, title=None, archived=1)
+
+    sessions = _sidebar_sessions()
+    assert any(s.get("session_id") == gw_sid for s in sessions["sessions"]), (
+        "archived-in-state.db gateway row must stay visible (agent-owned state)"
+    )
+    assert all(s.get("session_id") != api_sid for s in sessions["sessions"]), (
+        "archived api_server row must leave the default visible sidebar (#6843)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Delete
 # ---------------------------------------------------------------------------
 
@@ -266,3 +348,29 @@ def test_delete_api_server_session_removes_state_db_row(
     assert captured["payload"]["state_db_cleanup_failed"] is False
     assert _row_exists(isolated_state_db["db"], sid) is False
     assert not (isolated_state_db["sessions_dir"] / f"{sid}.json").exists()
+
+
+def test_delete_unsafe_messaging_session_still_400s(isolated_state_db, monkeypatch):
+    """An unsafe id whose state.db row is a messaging session must still 400.
+
+    The #6843 delete bypass is scoped to the imported/read-only api_server
+    class. A non-path-safe id backed by a real messaging row (e.g. a discord
+    gateway session id containing colons) must NOT bypass the guard — the row
+    and its transcript must be left intact (review #6855).
+    """
+    sid = "discord:guild:channel:msg:9f8e7d6c5b4a"
+    _make_state_db(isolated_state_db["db"], sid, source="discord",
+                   title="DC Chat", archived=0)
+
+    assert models.is_safe_session_id(sid) is False, (
+        "precondition: the messaging id is not path-safe"
+    )
+
+    captured = _capture_post(monkeypatch, {"session_id": sid})
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
+
+    assert captured["status"] == 400, captured
+    assert "Invalid session_id" in str(captured["payload"].get("error", ""))
+    assert _row_exists(isolated_state_db["db"], sid) is True, (
+        "messaging row must survive an unsafe-id delete attempt"
+    )

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -313,7 +313,11 @@ def test_read_only_source_badge_ui_guards_are_present():
     assert 'data-source-key="claude_code"' in style_css
     assert ".session-item.read-only-session:hover .session-source-chip" in style_css
     assert "Read-only imported sessions cannot be deleted" in routes_py
-    assert "Read-only imported sessions cannot be archived" in routes_py
+    # #6843: archiving a read-only imported row is WebUI-local view state and
+    # now works via _set_state_db_session_archived (a state.db flag flip, no
+    # sidecar materialization) instead of a blanket 400; deletion stays refused
+    # because it would destroy the foreign store's transcript.
+    assert "_set_state_db_session_archived" in routes_py
 
 
 def test_messaging_source_badge_not_gated_on_is_cli_session():

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -45,8 +45,13 @@ def test_session_events_publish_for_minimal_sidebar_mutations():
     assert 'publish_session_list_changed(\n            "session_rename",' in ROUTES
     assert '_persist_generated_session_title(s, next_title, event_reason="session_title_regenerate")' in ROUTES
     assert "session_id=sid" in ROUTES
-    assert 'event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)' in ROUTES
-    assert "Failed to resolve profile for deleted session" in ROUTES
+    # #6855 review: the session-delete profile comes from the object captured
+    # BEFORE SESSIONS.pop + sidecar deletion (a post-delete get_session()
+    # would raise KeyError and drop the profile), or from the CLI metadata
+    # captured at authorization time for state.db-only unsafe ids.
+    assert "session_for_delete = _pre_delete_session_metadata(sid)" in ROUTES
+    assert 'event_profile = getattr(session_for_delete, "profile", None)' in ROUTES
+    assert 'event_profile = cli_meta_for_delete.get("profile")' in ROUTES
     assert '_publish_session_list_changed("session_delete", profile=event_profile)' in ROUTES
     assert 'publish_session_list_changed(\n                "session_branch",' in ROUTES
     assert 'publish_session_list_changed(\n            "session_pin",' in ROUTES


### PR DESCRIPTION
## Summary
External `api_server`-sourced sessions appeared in the sidebar with the fallback title `Api_Server Session`, could not be archived or deleted from the UI, and accumulated (136+ in a day) cluttering the sidebar.

## Root Cause
- `POST /api/session/archive` returned 400 for `read_only` rows; non-path-safe ids (e.g. `miloco:...`) crashed with `ValueError` → HTTP 500.
- `POST /api/session/delete` rejected non-path-safe ids with `Invalid session_id` even when a matching state.db row existed.
- `_load_cli_sessions_uncached` ignored the `archived` flag for sidecar-less rows, so archived imported sessions stayed visible.

## Change
- `api/routes.py`: new `_set_state_db_session_archived()` (direct state.db UPDATE of view state); `_state_db_session_source()` relaxed to recognize colon ids (parameterized query is safe); archive now flips `archived` for `read_only`/non-path-safe rows (subagent rows still blocked); delete no longer rejects non-path-safe ids that have a state.db row.
- `api/agent_sessions.py`: state.db projection now selects `archived` (fallback 0 for old schemas).
- `api/models.py`: `_load_cli_sessions_uncached` honors `archived` when no WebUI sidecar exists (sidecar still wins when present); `_clean_artifacts_for_id` returns True for non-path-safe ids (state.db-only rows have no disk artifacts — was falsely marking cleanup failed).
- Tests: `tests/test_6843_api_server_session_archive_delete.py` (4 new: archive 200 + row leaves sidebar, delete removes state.db row, unsafe-id handling) + updated `test_claude_code_session_import.py`.

## Verification
- `tests/test_6843_api_server_session_archive_delete.py` + `tests/test_claude_code_session_import.py`: **15 passed**.

Closes #6843