### PR TITLE
Release exp-v0.52.185: preserve displayed conclusion in session forks (#6735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Fixed
 
+- **Branching a session no longer cuts the fork short or drops the assistant conclusion you selected.** The branch/fork operation sliced its `keep_count` boundary against the raw stored transcript, but that count is computed by the frontend against the merged display view (`GET /api/session`). When the two differ — replayed sidecar/state.db duplicate rows, filtered prefixes, compression-continuation stitching — the fork cut too early, sometimes stopping mid tool-run and omitting the final answer. The fork now rebuilds its source transcript through the exact same display-merge path the frontend counts against, so the slice lands on the row you actually chose. Thanks @ruizanthony. (#6735)
+
 - **A phantom "Compressing context" barrier no longer sticks in the transcript when a compression event is lost or delayed.** If the automatic-compression `compressed` SSE event was dropped or arrived late, the compression UI could stay stuck in its running state after the turn already finished, leaving a permanent "Compressing context" placeholder. When a turn reaches its terminal `done` while the compression UI is still running, that stale state is now cleared through the canonical teardown, covering both the session-rotating (A→B) and non-rotating (A→A) compression paths. Thanks @soria-clawd-bot. (#6572)
 
 - **Repeated completions in the same session now raise a fresh notification instead of silently updating one in the background.** Same-session desktop/PWA notifications share a per-session tag; without re-notification, a second completion silently replaced the first in the OS notification center (Windows Action Center) with no new alert. Same-tag notifications now re-alert, so each completion is surfaced. Thanks @webtecnica. (#6681, #6673)


### PR DESCRIPTION
Release **exp-v0.52.185** (experimental channel).

CHANGELOG stamp for #6735 (@ruizanthony) — session-branching lineage fix, already merged to master as `e7da197d4`.

**What shipped:** branching sliced `keep_count` against the raw transcript, but the frontend counts against `GET /api/session`'s merged display view — so forks cut too early when the merged view dedupes rows (stopped mid tool-run, dropped the conclusion). The fork now rebuilds its source transcript through the exact same display-merge path.

**Gate (fresh, at rebased head):**
- Codex: **SAFE TO SHIP** — verified the fork path (routes.py:15320) and GET display path (routes.py:12779) use matching messaging classification + identical profile/backstop/lineage/truncation/merge/parent-backfill args; messaging-no-CLI never reads state.db; keep_count=None copies full transcript; compression-continuation/_partial/backstop all verified (88 tests + real-helper route probe)
- Full 5-shard suite green (bar the 2 known box-baseline env flakes); focused branching suite 44/44; ruff diff-gate clean
- Backend data-integrity (no render surface) → no screenshot owed
- Stale CHANGES_REQUESTED (merge-parity concern) verified resolved by the re-push + confirmed by the fresh Codex gate, then superseded

CHANGELOG-only release PR from fresh master; feature code already on master.
