### PR TITLE
fix(typography): route native controls through UI font

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -26,6 +26,7 @@
     --border-subtle:rgba(0,0,0,.08);--border-muted:rgba(0,0,0,.12);
     font-family:var(--font-ui);font-size:14px;line-height:1.6;
   }
+  button,input,select,textarea{font-family:var(--font-ui);}
   /* ── Font size modifiers ── */
   /* ── Font size preference: scale key UI text elements ── */
   /* Default is 14px (no attribute needed). Small=12px, Large=16px, Extra Large=18px. */
@@ -2415,7 +2416,7 @@
   .msg-body th{background:rgba(255,255,255,.07);padding:6px 10px;text-align:left;font-weight:600;border:1px solid var(--border2);}
   .msg-body td{padding:5px 10px;border:1px solid rgba(255,255,255,.06);}
   .msg-body tr:nth-child(even){background:rgba(255,255,255,.03);}
-  .markdown-table-filter{display:block;width:min(260px,100%);margin:8px 0 4px;padding:5px 8px;border:1px solid var(--border2);border-radius:6px;background:var(--input-bg);color:var(--text);font:inherit;font-size:12px;}
+  .markdown-table-filter{display:block;width:min(260px,100%);margin:8px 0 4px;padding:5px 8px;border:1px solid var(--border2);border-radius:6px;background:var(--input-bg);color:var(--text);font:inherit;font-family:var(--font-ui);font-size:12px;}
   .markdown-table-filter:focus{outline:1px solid var(--accent);outline-offset:1px;}
   .markdown-table-sort{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;min-height:20px;padding:0;border:0;background:transparent;color:inherit;font:inherit;font-weight:inherit;text-align:left;cursor:pointer;}
   .markdown-table-sort:focus-visible{outline:1px solid var(--accent);outline-offset:2px;}

--- a/tests/test_typography_contract.py
+++ b/tests/test_typography_contract.py
@@ -158,12 +158,24 @@ def test_playwright_regression_ensures_font_contract_for_syntax_and_edit_surface
   </style>
 </head>
 <body>
+  <button id="buttonSentinel">button</button>
+  <input id="inputSentinel">
+  <select id="selectSentinel"><option>select</option></select>
+  <textarea id="textareaSentinel"></textarea>
   <div class="msg-body">
     <p>inline <code id="inlineCode" class="language-js">token</code> sample.</p>
     <pre id="fencedPre" class="language-js"><code id="fencedCode" class="language-js">fenced token</code></pre>
+    <input class="markdown-table-filter" id="markdownTableFilter">
+    <table>
+      <thead><tr><th><button class="markdown-table-sort" id="markdownTableSort">sort</button></th></tr></thead>
+      <tbody><tr><td id="markdownTableCell">row</td></tr></tbody>
+    </table>
   </div>
   <textarea class="msg-edit-area" id="msgEditArea"></textarea>
   <textarea id="previewEditArea" style="{preview_style_match.group(1)}"></textarea>
+  <div class="detail-form-row">
+    <textarea id="detailFormTextarea"></textarea>
+  </div>
 </body>
 </html>
 """
@@ -205,6 +217,22 @@ def test_playwright_regression_ensures_font_contract_for_syntax_and_edit_surface
             preview_edit_font = page.eval_on_selector(
                 "#previewEditArea",
                 "el => getComputedStyle(el).fontFamily",
+            )
+            component_fonts = page.evaluate(
+                """
+                () => Object.fromEntries(
+                  ["markdownTableFilter", "markdownTableSort", "markdownTableCell", "detailFormTextarea"]
+                    .map(id => [id, getComputedStyle(document.getElementById(id)).fontFamily])
+                )
+                """
+            )
+            native_control_fonts = page.evaluate(
+                """
+                () => Object.fromEntries(
+                  ["buttonSentinel", "inputSentinel", "selectSentinel", "textareaSentinel"]
+                    .map(id => [id, getComputedStyle(document.getElementById(id)).fontFamily])
+                )
+                """
             )
             runtime_token_font = page.evaluate("""
                 () => {
@@ -248,6 +276,13 @@ def test_playwright_regression_ensures_font_contract_for_syntax_and_edit_surface
     assert "MonoFontSentinel" in fenced_code_font
     assert "ConvoFontSentinel" in message_edit_font
     assert "MonoFontSentinel" in preview_edit_font
+    for control_id, font in native_control_fonts.items():
+        assert "UiFontSentinel" in font, f"{control_id} computed {font!r}"
+    assert "UiFontSentinel" in component_fonts["markdownTableFilter"]
+    assert "MonoFontSentinel" in component_fonts["markdownTableSort"]
+    assert "MonoFontSentinel" in component_fonts["markdownTableCell"]
+    assert component_fonts["markdownTableSort"] == component_fonts["markdownTableCell"]
+    assert "MonoFontSentinel" in component_fonts["detailFormTextarea"]
     assert "RuntimeMono" in runtime_token_font
     assert "EditedRuntimeMono" in edited_runtime_token_font
     assert "LinkedRuntimeMono" in linked_stylesheet_font


### PR DESCRIPTION
## Thinking Path

The three-font contract added in #5918 documents `--font-ui` for application chrome and form controls, but native browser controls do not consistently inherit `font-family` from `:root`. In Chromium, a plain button computed to Arial and a plain textarea to the browser monospace default even when `--font-ui` was overridden.

The smallest root-cause correction is an element-level UI token route for native controls. Existing class and ID selectors remain more specific, so conversation editors and technical surfaces keep their semantic fonts. The Markdown table filter needs an explicit UI route after its `font:inherit` shorthand, while the sortable table header deliberately keeps inheriting the table's mono font.

## Contract Routing

Task type: contract implementation correction and regression coverage.

Touched areas: core typography CSS and browser-computed typography tests.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `THEMES.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`

Scope boundaries: no token renames, theme/skin edits, JavaScript changes, extension changes, or deployment-local overlay changes.

This is not an intentional contract change. It makes core behavior match the existing documented contract.

## What Changed

- Route plain `button`, `input`, `select`, and `textarea` elements through `var(--font-ui)`.
- Keep the Markdown table filter on the UI token after its existing `font:inherit` shorthand.
- Extend the existing Chromium regression to cover all four native control types.
- Pin semantic exceptions in the same computed-style test:
  - message editor: `--font-conversation`
  - preview editor and technical detail textarea: `--font-mono`
  - Markdown sort control and table cell: matching `--font-mono`

## Why It Matters

Without this route, the documented UI token does not reach a broad set of native controls. Users can see mixed browser-default and configured fonts across settings, dialogs, onboarding, import/export, terminal, Kanban, and other application controls.

The fix stays at the shared CSS boundary and preserves stronger semantic routes instead of copying font stacks into individual components or skins.

## Screenshots

The isolated real instances override `--font-ui` with Georgia to make token routing visually obvious. The before instance leaves native settings controls in Arial; the after instance routes them to Georgia.

### Desktop, 1024 × 768

| Before | After |
|---|---|
| ![Before: settings controls retain browser default fonts](https://raw.githubusercontent.com/starship-s/hermes-webui/1d856713782a9cdf644a8503307065630a215187/docs/pr-evidence/form-control-font-contract/before-desktop-1024x768.png) | ![After: settings controls use the UI font token](https://raw.githubusercontent.com/starship-s/hermes-webui/1d856713782a9cdf644a8503307065630a215187/docs/pr-evidence/form-control-font-contract/after-desktop-1024x768.png) |

### Mobile, 390 × 844

| Before | After |
|---|---|
| ![Before mobile: settings controls retain browser default fonts](https://raw.githubusercontent.com/starship-s/hermes-webui/1d856713782a9cdf644a8503307065630a215187/docs/pr-evidence/form-control-font-contract/before-mobile-390x844.png) | ![After mobile: settings controls use the UI font token](https://raw.githubusercontent.com/starship-s/hermes-webui/1d856713782a9cdf644a8503307065630a215187/docs/pr-evidence/form-control-font-contract/after-mobile-390x844.png) |

## Verification

- Parent-fail proof: the new Chromium assertion fails on the parent with `buttonSentinel computed 'Arial'`.
- Cascade proof: the intermediate control rule still failed for the Markdown filter with `ConvoFontSentinel`; the final explicit filter route passes.
- Real-instance computed styles with a Georgia UI token:
  - before, desktop/mobile: search and settings button `Arial`; composer `Georgia, serif`
  - after, desktop/mobile: search, settings button, and composer `Georgia, serif`
- Focused and adjacent test shard:
  - `./scripts/test.sh tests/test_typography_contract.py tests/test_graphite_skin.py tests/test_embedded_workspace_terminal.py tests/test_ui_tool_call_cleanup.py tests/test_issue2966_markdown_table_enhancer.py -q`
  - `82 passed`
- `python3 -m py_compile tests/test_typography_contract.py`
- `python3 scripts/ruff_lint.py --diff origin/master`
- `git diff --check origin/master...HEAD`
- Two fresh Codex adversarial reviews: `VERDICT: CLEAN` on exact SHA `3be73657fb8c6774675f14b9c9bef51e80817acf`.
- Independent Claude Opus review: `VERDICT: APPROVE` on the same exact SHA.
- Native GitHub checks: `22/22` passed on the same exact SHA, including browser smoke, lint, three live-to-final browser checks, and all Python 3.11/3.12/3.13 shards.
- Final Greptile review: `5/5`, safe to merge, no actionable issues, last reviewed commit `3be73657fb8c6774675f14b9c9bef51e80817acf`.
- Hosted source head and all four immutable evidence PNGs were read back and hash-verified after push.

## Risks / Follow-ups

- Risk is limited to font-family routing. Size, weight, spacing, behavior, and accessibility semantics are unchanged.
- Higher-specificity component routes remain authoritative, including conversation and technical editors.
- Markdown filter chrome intentionally uses the UI token while sortable table headers continue matching mono table data.
- Public documentation already defines controls as UI surfaces, so no docs change is needed.
- All required native GitHub checks and the final hosted-head Greptile review are green on the exact contributor SHA.

## Model Used

- OpenAI `gpt-5.6-sol` through Hermes Agent for investigation, specification, orchestration, verification, evidence capture, and PR preparation.
- OpenAI Codex `gpt-5.6-luna` at maximum reasoning effort for implementation and adversarial review.
- Anthropic `claude-opus-5` through Claude Code for independent correctness review.
- Greptile automated review for the published exact-SHA review gate.
