### PR TITLE
fix(sidebar): last-writer-wins title reconcile for state.db renames (#3986)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -5836,6 +5836,7 @@ def _read_state_db_sidebar_overrides(
             source_expr = 's.source' if 'source' in session_cols else 'NULL AS source'
             session_source_expr = 's.session_source' if 'session_source' in session_cols else 'NULL AS session_source'
             title_expr = 's.title' if 'title' in session_cols else 'NULL AS title'
+            last_activity_expr = 's.last_activity_at' if 'last_activity_at' in session_cols else 'NULL AS last_activity_at'
             message_count_expr = 's.message_count' if 'message_count' in session_cols else 'NULL AS message_count'
 
             cur.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'messages'")
@@ -5859,7 +5860,7 @@ def _read_state_db_sidebar_overrides(
                 placeholders = ','.join('?' * len(chunk))
                 cur.execute(
                     f"""
-                    SELECT s.id, {source_expr}, {session_source_expr}, {title_expr}, {message_count_expr}
+                    SELECT s.id, {source_expr}, {session_source_expr}, {title_expr}, {last_activity_expr}, {message_count_expr}
                     FROM sessions s
                     WHERE s.id IN ({placeholders})
                     """,
@@ -5888,6 +5889,11 @@ def _read_state_db_sidebar_overrides(
                     if row['message_count'] is not None:
                         try:
                             entry['_state_db_message_count'] = max(0, int(row['message_count'] or 0))
+                        except (TypeError, ValueError):
+                            pass
+                    if row['last_activity_at'] is not None:
+                        try:
+                            entry['_state_db_last_activity_at'] = float(row['last_activity_at'])
                         except (TypeError, ValueError):
                             pass
                     if entry:
@@ -5999,6 +6005,7 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
         state_db_source_label = entry.pop('_state_db_source_label', None)
         state_db_message_count = entry.pop('_state_db_message_count', None)
         state_db_last_message_at = entry.pop('_state_db_last_message_at', None)
+        state_db_last_activity_at = entry.pop('_state_db_last_activity_at', None)
         state_db_display_title = entry.pop('_state_db_display_title', None)
         if state_db_source == 'webui':
             session['source_tag'] = state_db_source_tag
@@ -6052,10 +6059,21 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
                     session['last_message_at'] = max(float(session.get('last_message_at') or 0), state_last)
                     session['updated_at'] = max(float(session.get('updated_at') or 0), state_last)
         title = session.get('title')
+        # Last-writer-wins title reconcile (#3986): the sidecar title is
+        # authoritative when the WebUI wrote it last (its `updated_at` moves
+        # on every WebUI save, including renames); the state.db title is
+        # authoritative when the agent side wrote last (its `last_activity_at`
+        # moves on TUI/CLI/Desktop activity, including renames). Legacy
+        # generic/placeholder WebUI titles keep the existing unconditional
+        # state.db adoption so #3994's placeholder fix is preserved.
+        state_db_is_newer = bool(
+            state_db_last_activity_at
+            and state_db_last_activity_at > float(session.get('updated_at') or 0)
+        )
         if (
             state_db_title
             and state_db_title != title
-            and _sidebar_title_is_generic_webui(title)
+            and (_sidebar_title_is_generic_webui(title) or state_db_is_newer)
         ):
             session['_state_db_title'] = state_db_title
             session['display_title'] = state_db_title

--- a/tests/test_issue3986_state_db_title_authority.py
+++ b/tests/test_issue3986_state_db_title_authority.py
@@ -98,11 +98,23 @@ def test_equal_timestamps_keep_sidecar_title(base_session):
     assert session["title"] == "Old sidecar title"
 
 
-def test_overrides_query_carries_last_activity_at():
-    # Source-shape guard: the sidebar overrides query must fetch
-    # last_activity_at or the last-writer comparison silently degrades.
-    import inspect
-    from api import models
-    src = inspect.getsource(models._read_state_db_sidebar_overrides)
-    assert "last_activity_expr" in src
-    assert "last_activity_at" in src
+def test_overrides_query_returns_last_activity_from_real_db(tmp_path):
+    # Database-backed guard (Greptile #6875 review): the overrides query must
+    # actually return state.db last_activity_at to the reconcile path, not
+    # just contain the column name in source.
+    import sqlite3
+    from api.models import _read_state_db_sidebar_overrides
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, "
+        "last_activity_at REAL, message_count INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO sessions VALUES ('sid-db', 'tui', 'State Title', 200.0, 5)"
+    )
+    conn.commit()
+    conn.close()
+    overrides = _read_state_db_sidebar_overrides(db, {"sid-db"})
+    assert overrides["sid-db"]["_state_db_title"] == "State Title"
+    assert overrides["sid-db"]["_state_db_last_activity_at"] == 200.0

--- a/tests/test_issue3986_state_db_title_authority.py
+++ b/tests/test_issue3986_state_db_title_authority.py
@@ -1,0 +1,108 @@
+"""Last-writer-wins title reconcile for #3986.
+
+The WebUI sidebar shows a session's sidecar title unless state.db overrides
+it. #3994 added adoption of the state.db title only when the sidecar title is
+still a generic/placeholder ("Hermes WebUI" / "Hermes WebUI #N"). This module
+extends that reconcile with a last-writer-wins rule: when the agent side
+(state.db `last_activity_at`) wrote after the WebUI side (sidecar
+`updated_at`), the state.db title wins even for non-placeholder titles —
+covering TUI/CLI/Desktop renames of sessions that already have a real WebUI
+title. The WebUI-wrote-last direction (a WebUI rename with
+`sync_to_insights` off, where state.db still holds the old title) keeps the
+sidecar title, preserving #3994's no-clobber guarantee.
+"""
+
+import pytest
+
+
+def _apply(session, metadata_entry):
+    from api.models import _apply_sidebar_state_db_override_metadata
+    sessions = [dict(session)]
+    _apply_sidebar_state_db_override_metadata(sessions, {session["session_id"]: dict(metadata_entry)})
+    return sessions[0]
+
+
+@pytest.fixture
+def base_session():
+    return {
+        "session_id": "sid-3986",
+        "title": "Old sidecar title",
+        "updated_at": 100,
+        "last_message_at": 100,
+        "message_count": 10,
+    }
+
+
+def test_state_db_title_wins_when_agent_wrote_last(base_session):
+    # TUI/CLI rename: state.db last_activity_at is newer than the sidecar
+    # updated_at -> the (non-placeholder) sidecar title must be replaced.
+    session = _apply(
+        base_session,
+        {
+            "_state_db_title": "New TUI title",
+            "_state_db_last_activity_at": 200,
+        },
+    )
+    assert session["display_title"] == "New TUI title"
+    assert session["_state_db_title"] == "New TUI title"
+
+
+def test_sidecar_title_kept_when_webui_wrote_last(base_session):
+    # WebUI rename with sync_to_insights off: sidecar updated_at is newer than
+    # state.db last_activity_at -> state.db's old title must NOT clobber the
+    # sidecar title the user set in the WebUI.
+    session = _apply(
+        base_session,
+        {
+            "_state_db_title": "Old state title",
+            "_state_db_last_activity_at": 50,
+        },
+    )
+    assert session.get("display_title") is None
+    assert session.get("_state_db_title") is None
+    assert session["title"] == "Old sidecar title"
+
+
+def test_generic_placeholder_title_still_adopts_state_db_title(base_session):
+    # #3994 regression guard: generic placeholder titles keep the
+    # unconditional state.db adoption regardless of timestamps.
+    session = dict(base_session)
+    session["title"] = "Hermes WebUI #42"
+    session = _apply(
+        session,
+        {
+            "_state_db_title": "Real title",
+            "_state_db_last_activity_at": 50,
+        },
+    )
+    assert session["display_title"] == "Real title"
+
+
+def test_null_state_db_title_keeps_sidecar_title(base_session):
+    # state.db title NULL (legacy sessions): no override at all.
+    session = _apply(base_session, {"_state_db_last_activity_at": 500})
+    assert session.get("display_title") is None
+    assert session["title"] == "Old sidecar title"
+
+
+def test_equal_timestamps_keep_sidecar_title(base_session):
+    # No strictly-newer writer: prefer the sidecar (no clobber on ties).
+    session = _apply(
+        base_session,
+        {
+            "_state_db_title": "Tied title",
+            "_state_db_last_activity_at": 100,
+        },
+    )
+    assert session.get("display_title") is None
+    assert session["title"] == "Old sidecar title"
+
+
+def test_overrides_query_carries_last_activity_at():
+    # Source-shape guard: the sidebar overrides query must fetch
+    # last_activity_at or the last-writer comparison silently degrades.
+    import inspect
+    from api import models
+    src = inspect.getsource(models._read_state_db_sidebar_overrides)
+    assert "last_activity_expr" in src
+    assert "last_activity_at" in src


### PR DESCRIPTION
## Closing — the maintainer's review is correct

Thanks @nesquena-hermes for the precise gate review. Both blockers are accepted:

1. **`last_activity_at` is an activity clock, not a title-write clock** — `touch_session_activity()` advances it on any agent-side message while `set_session_title()` does not, so ordinary TUI activity can masquerade as a rename and clobber a fresh WebUI rename. Confirmed against `hermes_state.py:5310` (the UPDATE touches only `title`). The last-writer-wins inference is unsound without a title-specific revision.
2. **Unguarded `float()` on sidecar `updated_at`** — would break `/api/sessions` for malformed rows.

Closing rather than shipping the generic-only subset, since that behavior already exists on master via #3994. The remaining work is the coordinated title-specific revision (agent `set_session_title` bumps a dedicated `title_changed_at`-style column; WebUI sidecar records a title revision), which is a larger cross-repo design step — a natural candidate to outline in #3986 for future pickup.

Thanks again for the thorough review — it saved a data-loss bug from shipping.