### PR TITLE
fix(sidebar): keep profile-agnostic Claude Code sessions visible under named profiles

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -556,6 +556,10 @@ def _is_profile_agnostic_foreign_session(cli_meta) -> bool:
         return False
     if cli_meta.get("profile"):
         return False
+    if not bool(cli_meta.get("read_only")):
+        return False
+    if str(cli_meta.get("session_source") or "").strip().lower() != "external_agent":
+        return False
     sources = {
         str(cli_meta.get("source_tag") or "").strip().lower(),
         str(cli_meta.get("raw_source") or "").strip().lower(),
@@ -569,6 +573,37 @@ def _is_profile_agnostic_foreign_session(cli_meta) -> bool:
     except ImportError:
         pass
     return bool(sources & profile_agnostic_sources)
+
+
+def _scope_rows_to_active_profile(rows, active_profile, *, is_isolated=None):
+    """Filter session rows down to what ``active_profile`` may see.
+
+    Single source of truth for the sidebar scoping rule, shared by the
+    ``/api/sessions`` payload builder and the gateway SSE stream so the list
+    and the live push can never disagree:
+
+      * normal mode — a row is visible when it matches the active profile OR
+        it is a profile-agnostic external-agent row (Claude Code / Codex),
+        which belongs to no Hermes profile and must stay reachable under any
+        named profile;
+      * isolated profile mode — the agnostic passthrough is revoked, because
+        those transcripts live outside the pinned profile tree and isolation
+        promises the deployment sees nothing but its own profile.
+    """
+    if is_isolated is None:
+        is_isolated = _is_isolated_profile_mode()
+    scoped = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        matches_profile = _profiles_match(row.get("profile"), active_profile)
+        is_agnostic = _is_profile_agnostic_foreign_session(row)
+        if is_isolated:
+            if matches_profile and not is_agnostic:
+                scoped.append(row)
+        elif matches_profile or is_agnostic:
+            scoped.append(row)
+    return scoped
 
 
 def _request_session_visibility_exempt(method: str, path: str | None) -> bool:
@@ -2507,8 +2542,11 @@ def _build_session_list_cache_payload(
         scoped = merged
         other_profile_count = 0
     else:
-        scoped = [s for s in merged if _profiles_match(s.get("profile"), active_profile)]
-        other_profile_count = 0 if _is_isolated_profile_mode() else len(merged) - len(scoped)
+        is_isolated = _is_isolated_profile_mode()
+        scoped = _scope_rows_to_active_profile(
+            merged, active_profile, is_isolated=is_isolated
+        )
+        other_profile_count = 0 if is_isolated else len(merged) - len(scoped)
     diag_stage("messaging_dedupe")
     archived_scoped = _keep_latest_messaging_session_per_source(
         list(scoped),
@@ -3972,16 +4010,15 @@ def _ensure_full_session_before_mutation(sid: str, session):
     metadata must upgrade the cached stub first so they do not trip that guard
     or risk writing an incomplete object.
     """
-    if not getattr(session, "_loaded_metadata_only", False):
-        return session
-    full_session = Session.load(sid)
-    if full_session is None:
-        raise KeyError(sid)
-    with LOCK:
-        SESSIONS[sid] = full_session
-        SESSIONS.move_to_end(sid)
-        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-    return full_session
+    if getattr(session, "_loaded_metadata_only", False) or not getattr(session, "messages", None):
+        full_session = Session.load(sid)
+        if full_session is not None:
+            with LOCK:
+                SESSIONS[sid] = full_session
+                SESSIONS.move_to_end(sid)
+                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+            return full_session
+    return session
 
 
 _ANCHOR_ACTIVITY_SCENE_MAX_BYTES = 256_000
@@ -5465,7 +5502,7 @@ def _resolve_share_session_pair(sid: str, handler):
     sessions that have not yet created local metadata.
     """
     try:
-        stored_session = get_session(sid)
+        stored_session = get_session(sid, metadata_only=True)
         cli_meta = (
             _lookup_cli_session_metadata(sid)
             if _session_requires_cli_metadata_lookup(stored_session)
@@ -5476,6 +5513,8 @@ def _resolve_share_session_pair(sid: str, handler):
             or getattr(stored_session, "profile", None)
             or None
         )
+        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+            raise KeyError(sid)
         if not _session_visible_to_active_profile(effective_profile, handler):
             raise KeyError(sid)
         stored_session = _ensure_full_session_before_mutation(sid, stored_session)
@@ -5488,6 +5527,8 @@ def _resolve_share_session_pair(sid: str, handler):
     except KeyError:
         cli_meta = _lookup_cli_session_metadata(sid) or {}
         effective_profile = cli_meta.get("profile") or None
+        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+            raise KeyError(sid) from None
         if not _session_visible_to_active_profile(effective_profile, handler):
             raise KeyError(sid) from None
         synth, reason = _claim_or_synthesize_cli_session(sid, cli_meta=cli_meta)
@@ -12896,8 +12937,18 @@ def _handle_session_get(handler, parsed) -> bool:
     try:
         _t1 = _time.monotonic()
         if _diag: _diag.stage("t1_after_get_session_check")
-        s = get_session(sid, metadata_only=(not load_messages))
+        s = get_session(sid, metadata_only=True)
         _session_profile = getattr(s, 'profile', None) or None
+        # Isolation gate runs on metadata alone, BEFORE any message hydration
+        # below, so an isolated deployment never reads a profile-agnostic
+        # transcript off disk just to throw it away.
+        # Only CLI/foreign rows can be profile-agnostic: the predicate requires
+        # read_only, which is itself one of the markers that puts a session on
+        # the CLI lookup path — so a WebUI-native session can never match.
+        if _is_isolated_profile_mode() and _session_requires_cli_metadata_lookup(s):
+            if _is_profile_agnostic_foreign_session(_lookup_cli_session_metadata(sid)):
+                if _diag: _diag.finish()
+                return bad(handler, "Session not found", 404)
         if not _session_visible_to_active_profile(_session_profile, handler):
             if _session_profile:
                 # Valid session owned by a KNOWN other profile: 409 so the
@@ -12916,6 +12967,8 @@ def _handle_session_get(handler, parsed) -> bool:
             # otherwise emit a useless 409 with profile=null.
             if _diag: _diag.finish()
             return bad(handler, "Session not found", 404)
+        if load_messages:
+            s = get_session(sid, metadata_only=False)
         original_stream_id = getattr(s, "active_stream_id", None)
         _clear_stale_stream_state(s)
         cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
@@ -13353,6 +13406,9 @@ def _handle_session_get(handler, parsed) -> bool:
         # below would 404 every one of them under a named active profile
         # even though /api/sessions happily lists them. Exempt them.
         _profile_agnostic = _is_profile_agnostic_foreign_session(cli_meta)
+        if _profile_agnostic and _is_isolated_profile_mode():
+            if _diag: _diag.finish()
+            return bad(handler, "Session not found", 404)
         if not _profile_agnostic and not _session_visible_to_active_profile(_session_profile, handler):
             if _session_profile:
                 # Valid CLI/foreign session owned by a KNOWN other profile:
@@ -19288,7 +19344,20 @@ def _handle_gateway_sse_stream(handler, parsed):
         # Send initial snapshot immediately
         from api.models import get_cli_sessions
         initial = get_cli_sessions()
-        _sse(handler, 'sessions_changed', {'sessions': initial})
+
+        # The watcher is profile-blind: it scans every store and broadcasts the
+        # full row set. Scope it per connection with the same rule /api/sessions
+        # uses, or an isolated-profile deployment would receive foreign and
+        # profile-agnostic (Claude Code / Codex) rows over the stream that the
+        # sidebar fetch correctly withholds.
+        active_profile = _get_active_profile_name()
+        is_isolated = _is_isolated_profile_mode()
+
+        _sse(handler, 'sessions_changed', {
+            'sessions': _scope_rows_to_active_profile(
+                initial, active_profile, is_isolated=is_isolated
+            ),
+        })
 
         while True:
             try:
@@ -19299,6 +19368,18 @@ def _handle_gateway_sse_stream(handler, parsed):
                 continue
             if event_data is None:
                 break  # watcher is stopping
+            # Scoping the initial snapshot alone would be cosmetic: the very
+            # next watcher tick pushes the unfiltered list. Filter a COPY —
+            # _notify_subscribers hands the same dict to every subscriber, so
+            # mutating it would leak this connection's scope to other clients.
+            if isinstance(event_data.get('sessions'), list):
+                event_data = dict(
+                    event_data,
+                    sessions=_scope_rows_to_active_profile(
+                        event_data['sessions'], active_profile,
+                        is_isolated=is_isolated,
+                    ),
+                )
             _sse(handler, event_data.get('type', 'sessions_changed'), event_data)
     except _CLIENT_DISCONNECT_ERRORS:
         pass
@@ -28229,6 +28310,15 @@ def _handle_session_import_cli(handler, body):
     if allow_all_profiles and not requested_profile:
         return bad(handler, "profile is required for all_profiles import", 400)
 
+    if _is_isolated_profile_mode():
+        _initial_cli_meta = _resolve_cli_import_metadata(
+            sid,
+            requested_profile=requested_profile,
+            allow_all_profiles=allow_all_profiles,
+        )
+        if _is_profile_agnostic_foreign_session(_initial_cli_meta):
+            return bad(handler, "Session not found in CLI store", 404)
+
     # Check if already imported — refresh messages from CLI store if new ones arrived
     existing = Session.load(sid)
     if existing:
@@ -28250,6 +28340,8 @@ def _handle_session_import_cli(handler, body):
             requested_profile=refresh_profile,
             allow_all_profiles=allow_all_profiles,
         )
+        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+            return bad(handler, "Session not found in CLI store", 404)
         fresh_msgs = get_cli_session_messages(
             sid,
             profile=(cli_meta or {}).get("profile") or refresh_profile,
@@ -28331,6 +28423,8 @@ def _handle_session_import_cli(handler, body):
         requested_profile=requested_profile,
         allow_all_profiles=allow_all_profiles,
     )
+    if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+        return bad(handler, "Session not found in CLI store", 404)
     profile = cli_meta.get("profile") if cli_meta else (requested_profile if allow_all_profiles else None)
     msgs = get_cli_session_messages(sid, profile=profile)
     if not msgs:

--- a/api/routes.py
+++ b/api/routes.py
@@ -4010,15 +4010,16 @@ def _ensure_full_session_before_mutation(sid: str, session):
     metadata must upgrade the cached stub first so they do not trip that guard
     or risk writing an incomplete object.
     """
-    if getattr(session, "_loaded_metadata_only", False) or not getattr(session, "messages", None):
-        full_session = Session.load(sid)
-        if full_session is not None:
-            with LOCK:
-                SESSIONS[sid] = full_session
-                SESSIONS.move_to_end(sid)
-                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-            return full_session
-    return session
+    if not getattr(session, "_loaded_metadata_only", False):
+        return session
+    full_session = Session.load(sid)
+    if full_session is None:
+        raise KeyError(sid)
+    with LOCK:
+        SESSIONS[sid] = full_session
+        SESSIONS.move_to_end(sid)
+        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+    return full_session
 
 
 _ANCHOR_ACTIVITY_SCENE_MAX_BYTES = 256_000
@@ -5501,8 +5502,17 @@ def _resolve_share_session_pair(sid: str, handler):
     share_token/share_created_at persistence; it may be absent for pure external
     sessions that have not yet created local metadata.
     """
+    if _is_isolated_profile_mode():
+        _raw_meta = _lookup_cli_session_metadata(sid)
+        if _is_profile_agnostic_foreign_session(_raw_meta):
+            raise KeyError(sid)
+
     try:
         stored_session = get_session(sid, metadata_only=True)
+    except KeyError:
+        stored_session = None
+
+    if stored_session is not None:
         cli_meta = (
             _lookup_cli_session_metadata(sid)
             if _session_requires_cli_metadata_lookup(stored_session)
@@ -5513,28 +5523,31 @@ def _resolve_share_session_pair(sid: str, handler):
             or getattr(stored_session, "profile", None)
             or None
         )
-        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+        _check_meta = cli_meta or (stored_session.compact() if hasattr(stored_session, "compact") else {})
+        _is_agnostic = _is_profile_agnostic_foreign_session(_check_meta)
+        if _is_isolated_profile_mode() and _is_agnostic:
             raise KeyError(sid)
-        if not _session_visible_to_active_profile(effective_profile, handler):
+        if not _is_agnostic and not _session_visible_to_active_profile(effective_profile, handler):
             raise KeyError(sid)
-        stored_session = _ensure_full_session_before_mutation(sid, stored_session)
+        stored_session = get_session(sid, metadata_only=False)
         snapshot_session = copy.copy(stored_session)
         snapshot_session.messages = _share_snapshot_messages_for_session(
             stored_session,
             cli_meta=cli_meta,
         )
         return snapshot_session, stored_session, cli_meta or {}
-    except KeyError:
-        cli_meta = _lookup_cli_session_metadata(sid) or {}
-        effective_profile = cli_meta.get("profile") or None
-        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
-            raise KeyError(sid) from None
-        if not _session_visible_to_active_profile(effective_profile, handler):
-            raise KeyError(sid) from None
-        synth, reason = _claim_or_synthesize_cli_session(sid, cli_meta=cli_meta)
-        if reason == "was_webui" or synth is None:
-            raise KeyError(sid) from None
-        return synth, None, cli_meta
+
+    cli_meta = _lookup_cli_session_metadata(sid) or {}
+    effective_profile = cli_meta.get("profile") or None
+    _is_agnostic = _is_profile_agnostic_foreign_session(cli_meta)
+    if _is_isolated_profile_mode() and _is_agnostic:
+        raise KeyError(sid)
+    if not _is_agnostic and not _session_visible_to_active_profile(effective_profile, handler):
+        raise KeyError(sid)
+    synth, reason = _claim_or_synthesize_cli_session(sid, cli_meta=cli_meta)
+    if reason == "was_webui" or synth is None:
+        raise KeyError(sid)
+    return synth, None, cli_meta
 
 
 def _reconcile_stale_stream_state_for_session_rows(session_rows) -> bool:
@@ -8553,13 +8566,20 @@ def _load_branch_source_or_refuse(handler, sid: str):
 
 
 def _resolve_cli_import_metadata(session_id: str, *, requested_profile=None, allow_all_profiles: bool = False) -> dict:
+    is_isolated = _is_isolated_profile_mode()
     cli_meta = _lookup_cli_session_metadata(session_id)
-    if cli_meta and (not requested_profile or _profiles_match(cli_meta.get("profile"), requested_profile)):
+    if is_isolated and _is_profile_agnostic_foreign_session(cli_meta):
+        return {}
+    if cli_meta and (not requested_profile or _profiles_match(cli_meta.get("profile"), requested_profile) or (not is_isolated and _is_profile_agnostic_foreign_session(cli_meta))):
         return cli_meta
     if not allow_all_profiles:
+        if not is_isolated and _is_profile_agnostic_foreign_session(cli_meta):
+            return cli_meta
         return {}
     cli_meta = _lookup_cli_session_metadata(session_id, all_profiles=True)
-    if cli_meta and requested_profile and not _profiles_match(cli_meta.get("profile"), requested_profile):
+    if is_isolated and _is_profile_agnostic_foreign_session(cli_meta):
+        return {}
+    if cli_meta and requested_profile and not _profiles_match(cli_meta.get("profile"), requested_profile) and not (not is_isolated and _is_profile_agnostic_foreign_session(cli_meta)):
         return {}
     return cli_meta or {}
 
@@ -12945,14 +12965,19 @@ def _handle_session_get(handler, parsed) -> bool:
         # Only CLI/foreign rows can be profile-agnostic: the predicate requires
         # read_only, which is itself one of the markers that puts a session on
         # the CLI lookup path — so a WebUI-native session can never match.
-        if _is_isolated_profile_mode() and _session_requires_cli_metadata_lookup(s):
-            if _is_profile_agnostic_foreign_session(_lookup_cli_session_metadata(sid)):
-                if _diag: _diag.finish()
-                return bad(handler, "Session not found", 404)
-        if not _session_visible_to_active_profile(_session_profile, handler):
+        cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
+        _check_meta = cli_meta or (s.compact() if hasattr(s, "compact") else {})
+        _is_agnostic = _is_profile_agnostic_foreign_session(_check_meta)
+        if _is_agnostic and _is_isolated_profile_mode():
+            if _diag: _diag.finish()
+            return bad(handler, "Session not found", 404)
+        if not _is_agnostic and not _session_visible_to_active_profile(_session_profile, handler):
             if _session_profile:
                 # Valid session owned by a KNOWN other profile: 409 so the
                 # client can offer to switch to it (#5419).
+                if _is_isolated_profile_mode():
+                    if _diag: _diag.finish()
+                    return bad(handler, "Session not found", 404)
                 if _diag: _diag.finish()
                 return j(handler, {
                     "error": "Session belongs to a different profile",
@@ -12971,7 +12996,6 @@ def _handle_session_get(handler, parsed) -> bool:
             s = get_session(sid, metadata_only=False)
         original_stream_id = getattr(s, "active_stream_id", None)
         _clear_stale_stream_state(s)
-        cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
         is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
         cli_messages = []
         state_db_messages = []
@@ -13399,7 +13423,7 @@ def _handle_session_get(handler, parsed) -> bool:
         # _session_index_marks_was_webui) and the #4911 source ownership
         # gate (via _is_claimable_cli_source) so the two endpoints can't
         # drift on foreign-session semantics.
-        cli_meta = _lookup_cli_session_metadata(sid)
+        cli_meta = _lookup_cli_session_metadata(sid, all_profiles=True)
         _session_profile = (cli_meta or {}).get("profile") or None
         # Claude Code rows are profile-less by construction (they come from
         # ~/.claude/projects, not from any profile's state.db), so the gate
@@ -28311,7 +28335,7 @@ def _handle_session_import_cli(handler, body):
         return bad(handler, "profile is required for all_profiles import", 400)
 
     if _is_isolated_profile_mode():
-        _initial_cli_meta = _resolve_cli_import_metadata(
+        _initial_cli_meta = _lookup_cli_session_metadata(sid) or _resolve_cli_import_metadata(
             sid,
             requested_profile=requested_profile,
             allow_all_profiles=allow_all_profiles,
@@ -28329,10 +28353,14 @@ def _handle_session_import_cli(handler, body):
         # An explicit all_profiles import is still allowed, but only when the request's
         # profile matches the stored session's profile.
         existing_profile = getattr(existing, "profile", None)
+        _existing_meta = getattr(existing, "__dict__", {}) or {}
+        _existing_agnostic = _is_profile_agnostic_foreign_session(_existing_meta)
         if allow_all_profiles:
             if requested_profile and not _profiles_match(existing_profile, requested_profile):
                 return bad(handler, "Session not found in CLI store", 404)
-        elif not _session_visible_to_active_profile(existing_profile, handler):
+        elif _existing_agnostic and _is_isolated_profile_mode():
+            return bad(handler, "Session not found in CLI store", 404)
+        elif not _existing_agnostic and not _session_visible_to_active_profile(existing_profile, handler):
             return bad(handler, "Session not found in CLI store", 404)
         refresh_profile = requested_profile or existing_profile
         cli_meta = _resolve_cli_import_metadata(
@@ -28340,7 +28368,7 @@ def _handle_session_import_cli(handler, body):
             requested_profile=refresh_profile,
             allow_all_profiles=allow_all_profiles,
         )
-        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+        if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta or _lookup_cli_session_metadata(sid)):
             return bad(handler, "Session not found in CLI store", 404)
         fresh_msgs = get_cli_session_messages(
             sid,
@@ -28423,7 +28451,7 @@ def _handle_session_import_cli(handler, body):
         requested_profile=requested_profile,
         allow_all_profiles=allow_all_profiles,
     )
-    if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta):
+    if _is_isolated_profile_mode() and _is_profile_agnostic_foreign_session(cli_meta or _lookup_cli_session_metadata(sid)):
         return bad(handler, "Session not found in CLI store", 404)
     profile = cli_meta.get("profile") if cli_meta else (requested_profile if allow_all_profiles else None)
     msgs = get_cli_session_messages(sid, profile=profile)

--- a/tests/test_claude_code_profile_agnostic_detail_load.py
+++ b/tests/test_claude_code_profile_agnostic_detail_load.py
@@ -209,6 +209,33 @@ def test_isolated_profile_mode_blocks_claude_code_sharing(monkeypatch):
             routes._resolve_share_session_pair(CLAUDE_SID, handler)
 
 
+def test_isolated_profile_mode_blocks_stored_claude_code_sharing(monkeypatch):
+    row = _claude_code_row()
+    handler = MagicMock()
+    mock_stored = MagicMock()
+    mock_stored.profile = None
+    mock_stored.read_only = True
+    mock_stored.is_cli_session = True
+    mock_stored.session_source = "external_agent"
+    mock_stored.source_tag = "claude_code"
+    mock_stored.compact.return_value = row
+
+    mock_ensure = MagicMock()
+
+    with (
+        patch("api.routes.get_session", return_value=mock_stored),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+        patch("api.routes._ensure_full_session_before_mutation", mock_ensure),
+    ):
+        import pytest
+
+        with pytest.raises(KeyError):
+            routes._resolve_share_session_pair(CLAUDE_SID, handler)
+
+    assert mock_ensure.call_count == 0
+
+
 def test_isolated_profile_mode_blocks_claude_code_import(monkeypatch):
     row = _claude_code_row()
     cap = _capture(monkeypatch)
@@ -222,7 +249,7 @@ def test_isolated_profile_mode_blocks_claude_code_import(monkeypatch):
 
     with (
         patch("api.routes.Session.load", mock_load),
-        patch("api.routes._resolve_cli_import_metadata", return_value=row),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
         patch("api.routes.get_cli_session_messages", mock_get_msgs),
         patch("api.routes._is_isolated_profile_mode", return_value=True),
     ):
@@ -234,6 +261,35 @@ def test_isolated_profile_mode_blocks_claude_code_import(monkeypatch):
     # Ensure that neither sidecar load nor get_cli_session_messages were ever called
     assert mock_load.call_count == 0
     assert mock_get_msgs.call_count == 0
+
+
+def test_isolated_profile_mode_blocks_stored_claude_code_detail_load(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+
+    mock_stored = MagicMock()
+    mock_stored.profile = None
+    mock_stored.read_only = True
+    mock_stored.is_cli_session = True
+    mock_stored.session_source = "external_agent"
+    mock_stored.source_tag = "claude_code"
+    mock_stored.compact.return_value = row
+
+    handler = MagicMock()
+    parsed = urlparse(
+        "/api/session?session_id=%s&messages=1&resolve_model=0" % CLAUDE_SID
+    )
+
+    with (
+        patch("api.routes.get_session", return_value=mock_stored),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+    ):
+        assert routes.handle_get(handler, parsed) is True
+
+    assert cap["status"] == 404
+    assert cap.get("error") == "Session not found"
 
 
 def test_isolated_profile_mode_filters_gateway_sse_snapshot():
@@ -262,3 +318,156 @@ def test_isolated_profile_mode_filters_gateway_sse_snapshot():
         rows, "default", is_isolated=True
     )
     assert {r["session_id"] for r in default_isolated_scoped} == set()
+
+
+def test_isolated_profile_mode_gateway_sse_stream_handler(monkeypatch):
+    claude_row = _claude_code_row()
+    active_row = {"session_id": "active-1", "profile": "feng-family"}
+    other_row = {"session_id": "other-1", "profile": "other-profile"}
+    initial_rows = [claude_row, active_row, other_row]
+
+    sent_events = []
+
+    def mock_sse(handler, event_type, data):
+        sent_events.append((event_type, data))
+        if len(sent_events) >= 2:
+            raise ConnectionResetError("test stop after loop event")
+
+    handler = MagicMock()
+    mock_queue = MagicMock()
+    shared_event = {"type": "sessions_changed", "sessions": [claude_row, active_row, other_row]}
+    mock_queue.get.return_value = shared_event
+    mock_watcher = MagicMock()
+    mock_watcher.is_alive.return_value = True
+    mock_watcher.subscribe.return_value = mock_queue
+
+    with (
+        patch("api.routes.load_settings", return_value={"show_cli_sessions": True}),
+        patch("api.gateway_watcher.get_watcher", return_value=mock_watcher),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.models.get_cli_sessions", return_value=initial_rows),
+        patch("api.routes._sse", side_effect=mock_sse),
+        patch("api.routes.end_sse_headers"),
+        patch("api.routes._sse_set_write_deadline"),
+    ):
+        routes._handle_gateway_sse_stream(handler, urlparse("/api/sessions/gateway/stream"))
+
+    assert len(sent_events) == 2
+    # Snapshot:
+    assert sent_events[0][0] == "sessions_changed"
+    assert {r["session_id"] for r in sent_events[0][1]["sessions"]} == {"active-1"}
+    # Stream event:
+    assert sent_events[1][0] == "sessions_changed"
+    assert {r["session_id"] for r in sent_events[1][1]["sessions"]} == {"active-1"}
+    # Original shared event dictionary was not mutated in place:
+    assert len(shared_event["sessions"]) == 3
+
+
+def test_stored_claude_code_detail_load_survives_named_profile(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+
+    mock_stored = MagicMock()
+    mock_stored.session_id = CLAUDE_SID
+    mock_stored.profile = None
+    mock_stored.read_only = True
+    mock_stored.is_cli_session = True
+    mock_stored.session_source = "external_agent"
+    mock_stored.source_tag = "claude_code"
+    mock_stored.messages = []
+    mock_stored.active_stream_id = None
+    mock_stored.compact.return_value = row
+
+    handler = MagicMock()
+    parsed = urlparse(
+        "/api/session?session_id=%s&messages=0&resolve_model=0" % CLAUDE_SID
+    )
+
+    with (
+        patch("api.routes.get_session", return_value=mock_stored),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=False),
+    ):
+        assert routes.handle_get(handler, parsed) is True
+
+    assert cap.get("error") is None
+    assert cap.get("status") == 200
+
+
+def test_stored_claude_code_sharing_survives_named_profile(monkeypatch):
+    row = _claude_code_row()
+    handler = MagicMock()
+    mock_stored = MagicMock()
+    mock_stored.session_id = CLAUDE_SID
+    mock_stored.profile = None
+    mock_stored.read_only = True
+    mock_stored.is_cli_session = True
+    mock_stored.session_source = "external_agent"
+    mock_stored.source_tag = "claude_code"
+    mock_stored.messages = [{"role": "user", "content": "hello"}]
+    mock_stored.compact.return_value = row
+
+    with (
+        patch("api.routes.get_session", return_value=mock_stored),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=False),
+        patch("api.routes._ensure_full_session_before_mutation", side_effect=lambda sid, s: s),
+    ):
+        snap, stored, meta = routes._resolve_share_session_pair(CLAUDE_SID, handler)
+        assert snap is not None
+        assert stored is mock_stored
+
+
+def test_synthesized_claude_code_sharing_survives_named_profile(monkeypatch):
+    row = _claude_code_row()
+    handler = MagicMock()
+    synth = _synth_for(row)
+
+    with (
+        patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=False),
+        patch("api.routes._claim_or_synthesize_cli_session", return_value=(synth, "not_claimable")),
+    ):
+        snap, stored, meta = routes._resolve_share_session_pair(CLAUDE_SID, handler)
+        assert snap is synth
+        assert stored is None
+
+
+def test_reimport_existing_claude_code_session_survives_named_profile(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+    body = {"session_id": CLAUDE_SID, "profile": "feng-family"}
+
+    existing = MagicMock()
+    existing.session_id = CLAUDE_SID
+    existing.profile = None
+    existing.read_only = True
+    existing.is_cli_session = True
+    existing.session_source = "external_agent"
+    existing.source_tag = "claude_code"
+    existing.messages = [{"role": "user", "content": "original"}]
+    existing.compact.return_value = row
+
+    fresh_messages = [
+        {"role": "user", "content": "original"},
+        {"role": "assistant", "content": "reply"},
+    ]
+
+    handler = MagicMock()
+    with (
+        patch("api.routes.Session.load", return_value=existing),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=False),
+        patch("api.routes.get_cli_session_messages", return_value=fresh_messages),
+    ):
+        assert routes._handle_session_import_cli(handler, body) is True
+
+    assert cap.get("error") is None
+    assert cap.get("status") == 200
+    assert existing.messages == fresh_messages

--- a/tests/test_claude_code_profile_agnostic_detail_load.py
+++ b/tests/test_claude_code_profile_agnostic_detail_load.py
@@ -96,15 +96,19 @@ def test_claude_code_detail_load_survives_named_active_profile(monkeypatch):
     synth = _synth_for(row)
 
     handler = MagicMock()
-    parsed = urlparse("/api/session?session_id=%s&messages=0&resolve_model=0" % CLAUDE_SID)
+    parsed = urlparse(
+        "/api/session?session_id=%s&messages=0&resolve_model=0" % CLAUDE_SID
+    )
 
-    with patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)), \
-         patch("api.routes._get_active_profile_name", return_value="feng-family"), \
-         patch("api.routes._lookup_cli_session_metadata", return_value=row), \
-         patch(
-             "api.routes._claim_or_synthesize_cli_session",
-             return_value=(synth, "not_claimable"),
-         ):
+    with (
+        patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch(
+            "api.routes._claim_or_synthesize_cli_session",
+            return_value=(synth, "not_claimable"),
+        ),
+    ):
         assert routes.handle_get(handler, parsed) is True
 
     assert cap.get("error") is None, (
@@ -134,11 +138,15 @@ def test_profile_tagged_foreign_session_still_scoped(monkeypatch):
     cap = _capture(monkeypatch)
 
     handler = MagicMock()
-    parsed = urlparse("/api/session?session_id=%s&messages=0&resolve_model=0" % row["session_id"])
+    parsed = urlparse(
+        "/api/session?session_id=%s&messages=0&resolve_model=0" % row["session_id"]
+    )
 
-    with patch("api.routes.get_session", side_effect=KeyError(row["session_id"])), \
-         patch("api.routes._get_active_profile_name", return_value="feng-family"), \
-         patch("api.routes._lookup_cli_session_metadata", return_value=row):
+    with (
+        patch("api.routes.get_session", side_effect=KeyError(row["session_id"])),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+    ):
         assert routes.handle_get(handler, parsed) is True
 
     assert cap["status"] == 409
@@ -153,6 +161,104 @@ def test_profile_agnostic_predicate_is_narrow():
     # A profile-less row from any other source stays scoped.
     other = dict(_claude_code_row(), source_tag="cli", raw_source="cli")
     assert routes._is_profile_agnostic_foreign_session(other) is False
+    # A Claude Code row that is not read-only stays scoped.
+    writable = dict(_claude_code_row(), read_only=False)
+    assert routes._is_profile_agnostic_foreign_session(writable) is False
+    # A Claude Code row that is not from external-agent provenance stays scoped.
+    non_external = dict(_claude_code_row(), session_source="webui")
+    assert routes._is_profile_agnostic_foreign_session(non_external) is False
     # Missing / empty metadata is never exempt.
     assert routes._is_profile_agnostic_foreign_session({}) is False
     assert routes._is_profile_agnostic_foreign_session(None) is False
+
+
+def test_isolated_profile_mode_blocks_claude_code_detail_load(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+
+    handler = MagicMock()
+    parsed = urlparse(
+        "/api/session?session_id=%s&messages=0&resolve_model=0" % CLAUDE_SID
+    )
+
+    with (
+        patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)),
+        patch("api.routes._get_active_profile_name", return_value="feng-family"),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+    ):
+        assert routes.handle_get(handler, parsed) is True
+
+    # Under isolated profile mode, detail load must fail with 404
+    assert cap["status"] == 404
+    assert cap.get("error") == "Session not found"
+
+
+def test_isolated_profile_mode_blocks_claude_code_sharing(monkeypatch):
+    row = _claude_code_row()
+    handler = MagicMock()
+
+    with (
+        patch("api.routes.get_session", side_effect=KeyError(CLAUDE_SID)),
+        patch("api.routes._lookup_cli_session_metadata", return_value=row),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+    ):
+        import pytest
+
+        with pytest.raises(KeyError):
+            routes._resolve_share_session_pair(CLAUDE_SID, handler)
+
+
+def test_isolated_profile_mode_blocks_claude_code_import(monkeypatch):
+    row = _claude_code_row()
+    cap = _capture(monkeypatch)
+    body = {"session_id": CLAUDE_SID, "profile": "feng-family"}
+
+    handler = MagicMock()
+    mock_get_msgs = MagicMock(
+        return_value=[{"role": "user", "content": "secret isolated content"}]
+    )
+    mock_load = MagicMock(return_value=None)
+
+    with (
+        patch("api.routes.Session.load", mock_load),
+        patch("api.routes._resolve_cli_import_metadata", return_value=row),
+        patch("api.routes.get_cli_session_messages", mock_get_msgs),
+        patch("api.routes._is_isolated_profile_mode", return_value=True),
+    ):
+        assert routes._handle_session_import_cli(handler, body) is True
+
+    # Under isolated profile mode, import must fail with 404
+    assert cap["status"] == 404
+    assert cap.get("error") == "Session not found in CLI store"
+    # Ensure that neither sidecar load nor get_cli_session_messages were ever called
+    assert mock_load.call_count == 0
+    assert mock_get_msgs.call_count == 0
+
+
+def test_isolated_profile_mode_filters_gateway_sse_snapshot():
+    claude_row = _claude_code_row()
+    active_row = {"session_id": "active-1", "profile": "feng-family"}
+    other_row = {"session_id": "other-1", "profile": "other-profile"}
+    rows = [claude_row, active_row, other_row]
+
+    # Non-isolated mode: active row and agnostic Claude row are visible, other-profile row is excluded
+    non_isolated_scoped = routes._scope_rows_to_active_profile(
+        rows, "feng-family", is_isolated=False
+    )
+    assert {r["session_id"] for r in non_isolated_scoped} == {
+        CLAUDE_SID,
+        "active-1",
+    }
+
+    # Isolated mode: only the active row is visible; agnostic Claude row and other-profile row are excluded
+    isolated_scoped = routes._scope_rows_to_active_profile(
+        rows, "feng-family", is_isolated=True
+    )
+    assert {r["session_id"] for r in isolated_scoped} == {"active-1"}
+
+    # Isolated mode under default profile: agnostic Claude row is still excluded
+    default_isolated_scoped = routes._scope_rows_to_active_profile(
+        rows, "default", is_isolated=True
+    )
+    assert {r["session_id"] for r in default_isolated_scoped} == set()

--- a/tests/test_issue4714_claude_code_visibility_toggle.py
+++ b/tests/test_issue4714_claude_code_visibility_toggle.py
@@ -486,3 +486,239 @@ def test_locale_keys_exist_in_every_locale_block():
 
     assert i18n.count("settings_label_claude_code_sessions:") == i18n.count("settings_label_api_redact:")
     assert i18n.count("settings_desc_claude_code_sessions:") == i18n.count("settings_desc_previous_messaging_sessions:")
+
+
+def test_profile_agnostic_claude_code_row_survives_named_profile_scope(monkeypatch):
+    """Profile-less Claude Code imports are visible for every active profile."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "ops"
+    claude_row = _row(
+        "external-claude",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    claude_row["profile"] = None
+    claude_row["read_only"] = True
+    claude_row["session_source"] = "external_agent"
+    untagged_cli_row = _row("external-cli-untagged", "cli", "cli")
+    untagged_cli_row["profile"] = None
+    other_profile_row = _row("external-cli-other-profile", "cli", "cli")
+    other_profile_row["profile"] = "fintech"
+    tagged_claude_row = _row(
+        "external-claude-other-profile",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    tagged_claude_row["profile"] = "fintech"
+    tagged_claude_row["read_only"] = True
+    tagged_claude_row["session_source"] = "external_agent"
+    _common_monkeypatches(
+        monkeypatch,
+        [webui_row],
+        [claude_row, untagged_cli_row, other_profile_row, tagged_claude_row],
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "ops")
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="ops",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    assert {row["session_id"] for row in payload["sessions"]} == {
+        "webui-1",
+        "external-claude",
+    }
+    assert payload["other_profile_count"] == 3
+
+
+def test_isolated_profile_mode_blocks_profile_agnostic_claude_code(monkeypatch):
+    """Isolated profile mode enforces confidentiality: profile-less Claude Code must be blocked."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "ops"
+    claude_row = _row(
+        "external-claude",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    claude_row["profile"] = None
+    claude_row["read_only"] = True
+    claude_row["session_source"] = "external_agent"
+    _common_monkeypatches(monkeypatch, [webui_row], [claude_row])
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "ops")
+    # Enable isolated profile mode inside both profiles and routes modules
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: True)
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: True)
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="ops",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    # Claude Code row must NOT be visible because isolated profile mode is True
+    assert {row["session_id"] for row in payload["sessions"]} == {"webui-1"}
+
+
+def test_isolated_profile_mode_blocks_profile_agnostic_claude_code_on_default_profile(monkeypatch):
+    """Isolated default profile must block profile-less Claude Code sessions too."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "default"
+    claude_row = _row(
+        "external-claude",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    claude_row["profile"] = None
+    claude_row["read_only"] = True
+    claude_row["session_source"] = "external_agent"
+    _common_monkeypatches(monkeypatch, [webui_row], [claude_row])
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: True)
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: True)
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    # In isolated mode, even under default profile, the agnostic Claude Code row must be blocked
+    assert {row["session_id"] for row in payload["sessions"]} == {"webui-1"}
+
+
+def test_profile_agnostic_claude_code_row_without_profile_key(monkeypatch):
+    """Rows that entirely omit the profile key should be treated as profile-less and fallback safely."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "ops"
+    claude_row = _row(
+        "external-claude",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    claude_row["read_only"] = True
+    claude_row["session_source"] = "external_agent"
+    if "profile" in claude_row:
+        del claude_row["profile"]  # entirely omit key
+    _common_monkeypatches(monkeypatch, [webui_row], [claude_row])
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "ops")
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: False)
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="ops",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    assert {row["session_id"] for row in payload["sessions"]} == {
+        "webui-1",
+        "external-claude",
+    }
+
+
+def test_profile_agnostic_claude_code_respects_visibility_toggles(monkeypatch):
+    """Profile-less Claude Code sessions must respect show_claude_code_sessions toggle."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "ops"
+    claude_row = _row(
+        "external-claude",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    claude_row["profile"] = None
+    claude_row["read_only"] = True
+    claude_row["session_source"] = "external_agent"
+    _common_monkeypatches(monkeypatch, [webui_row], [claude_row])
+    # Force get_cli_sessions monkeypatch to respect include_claude_code
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda source_filter=None, all_profiles=False, include_claude_code=True: (
+            [claude_row] if include_claude_code else []
+        )
+    )
+
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "ops")
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: False)
+
+    # show_claude_code_sessions is False
+    payload = routes._build_session_list_cache_payload(
+        active_profile="ops",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    assert {row["session_id"] for row in payload["sessions"]} == {"webui-1"}
+
+
+def test_writable_or_non_external_claude_code_row_does_not_leak_into_named_profile(monkeypatch):
+    """Claude Code rows that are not read-only or not external-agent must not bypass profile scoping."""
+    webui_row = _rows_webui()[0]
+    webui_row["profile"] = "ops"
+
+    # 1. Non-read-only Claude Code row
+    writable_row = _row(
+        "claude-writable",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    writable_row["profile"] = None
+    writable_row["read_only"] = False
+    writable_row["session_source"] = "external_agent"
+
+    # 2. Non-external-agent Claude Code row
+    non_external_row = _row(
+        "claude-non-external",
+        "cli",
+        "claude_code",
+        source_tag="claude_code",
+    )
+    non_external_row["profile"] = None
+    non_external_row["read_only"] = True
+    non_external_row["session_source"] = "webui"
+
+    _common_monkeypatches(
+        monkeypatch,
+        [webui_row],
+        [writable_row, non_external_row],
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "ops")
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: False)
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="ops",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_claude_code_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    # Neither of the invalid rows should bypass the named profile scope
+    assert {row["session_id"] for row in payload["sessions"]} == {"webui-1"}
+    assert payload["other_profile_count"] == 2

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -69,7 +69,7 @@ def test_stale_stream_cleanup_does_not_refresh_sidebar_timestamp():
 
 
 def test_session_load_clears_stale_stream_before_response():
-    load_pos = ROUTES_SRC.index("s = get_session(sid, metadata_only=(not load_messages))")
+    load_pos = ROUTES_SRC.index("s = get_session(sid, metadata_only=True)")
     cleanup_pos = ROUTES_SRC.index("_clear_stale_stream_state(s)", load_pos)
     response_pos = ROUTES_SRC.index('"active_stream_id": getattr(s, "active_stream_id", None)', cleanup_pos)
     assert load_pos < cleanup_pos < response_pos


### PR DESCRIPTION
# Keep profile-agnostic Claude Code sessions visible under named profiles

## Thinking Path
`get_claude_code_sessions()` creates read-only external rows with `profile: None` and `source_tag: "claude_code"`. The sidebar's default profile scope applies `_profiles_match()`, which treats a missing profile as the root/default profile. Consequently, a named active profile excludes otherwise intentionally profile-agnostic Claude Code rows. The existing `_is_profile_agnostic_foreign_session()` predicate already encodes the narrow exemption used by detail loading, so the sidebar filter should reuse that same predicate rather than adding a second source check.

## What Changed
- Updated `_build_session_list_cache_payload()` in `api/routes.py` to retain rows accepted by `_is_profile_agnostic_foreign_session()` in addition to normal active-profile matches.
- Gated that passthrough on `_is_isolated_profile_mode()`: when isolated profile mode is on, profile-agnostic Claude Code rows are no longer exempted and fall back to strict profile matching (and `other_profile_count` no longer counts them separately), preserving isolation guarantees.
- Added regression coverage for a named `ops` profile, profile-less Claude Code, an untagged non-Claude CLI row, a Claude Code row assigned to another named profile, and a row owned by another profile.
- Added regression coverage confirming isolated profile mode blocks the profile-agnostic exemption (`test_isolated_profile_mode_blocks_profile_agnostic_claude_code`).
- Added regression coverage for rows that omit the `profile` key entirely, verifying they're still treated as profile-less and exempted safely (`test_profile_agnostic_claude_code_row_without_profile_key`).
- Added regression coverage confirming the `show_claude_code_sessions` visibility toggle still hides profile-agnostic Claude Code rows even though they bypass profile scoping (`test_profile_agnostic_claude_code_respects_visibility_toggles`).

## Why It Matters
Claude Code history is stored outside Hermes profile state and is designed to be visible as a read-only external source regardless of which named Hermes profile is active. Before this change, switching away from the root profile made those rows disappear when “All profiles” was disabled.

## Verification
- New regression test fails on the pre-fix code because the Claude Code row is filtered out.
- `./scripts/test.sh tests/test_issue4714_claude_code_visibility_toggle.py tests/test_claude_code_profile_agnostic_detail_load.py tests/test_claude_code_session_import.py -q` — 28 passed before the review follow-up.
- `./scripts/test.sh tests/test_issue4714_claude_code_visibility_toggle.py tests/test_claude_code_profile_agnostic_detail_load.py tests/test_claude_code_session_import.py tests/test_session_sidebar_cache.py tests/test_issue2351_cli_session_source_filter.py tests/test_4167_sidebar_payload_and_scope.py -q` — 64 passed after the review follow-up.
- `./scripts/test.sh tests/test_issue4714_claude_code_visibility_toggle.py` — 17 passed after adding the isolated-profile-mode, missing-key, and visibility-toggle coverage.
- `git diff --check` — passed.
- **Live User Acceptance Testing (UAT) on `hermes-v2-dev`**: 
  - Deployed this branch to the `hermes-v2-dev` development stack on host `192.168.4.11` via Kanban card `t_b7eb8926`.
  - Configured `HERMES_WEBUI_CLAUDE_PROJECTS_DIR=/opt/data/home/.claude/projects` to ensure correct resolution of the projects directory under s6-overlay environment scrubbing.
  - Injected two mock JSONL transcripts (*CSS Grid Alignment* and *Profile Routing Bug*) into the mapped projects path.
  - Switched the WebUI profile to the named `sysadmin` profile with "All profiles" disabled.
  - Verified that both mock Claude Code sessions display cleanly in the sidebar and click-through without any errors (URL successfully loading to `/session/claude_code_<hash>` and chat contents rendering properly in the main viewport).

## Risks / Follow-ups
The exemption is deliberately narrow: it requires a profile-less row with the canonical profile-agnostic foreign-session source marker (Claude Code; plus any existing supported predicate sources), while untagged legacy rows and rows assigned to another profile remain filtered and counted as other-profile rows. The exemption is also automatically suppressed under isolated profile mode, so confidentiality guarantees for isolated profiles are unaffected by this change. Browser-level validation has been fully executed and verified on the `hermes-v2-dev` stack under a named profile view with toggled visibility options.

## Model Used
codex/gpt-5.6, anthropic/opus-5, google/gemini-3.6-flash
