### PR TITLE
fix(session): dedupe snapshots and bound initial tail loads

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1125,6 +1125,183 @@ def _load_session_from_path(path: Path) -> "Session | None":
     return Session(**data)
 
 
+def _reverse_json_array_pair(data: bytes, absolute_base: int, expected_open: int):
+    """Find the closing bracket of the final top-level array efficiently.
+
+    The root-object sentinel distinguishes the huge top-level ``messages`` array
+    from arrays nested inside the final message. We can identify its closing
+    bracket without traversing the array's contents; ``expected_open`` comes from
+    the small metadata prefix and is retained as the pair's opening coordinate.
+    """
+    end = len(data) - 1
+    while end >= 0 and data[end] in b" \\t\\r\\n":
+        end -= 1
+    if end >= 0 and data[end] == ord("}"):
+        end -= 1
+    stack = [(ord("{"), -1)]  # root object sentinel
+    in_string = False
+    idx = end
+    while idx >= 0:
+        byte = data[idx]
+        if byte == ord('"'):
+            slashes = 0
+            probe = idx - 1
+            while probe >= 0 and data[probe] == ord('\\'):
+                slashes += 1
+                probe -= 1
+            if slashes % 2 == 0:
+                in_string = not in_string
+        elif not in_string:
+            if byte == ord("]"):
+                if len(stack) == 1:
+                    return expected_open, absolute_base + idx
+                stack.append((ord("["), idx))
+            elif byte == ord("}"):
+                stack.append((ord("{"), idx))
+            elif byte in (ord("{"), ord("[")) and len(stack) > 1:
+                expected, _close_idx = stack[-1]
+                if byte != expected:
+                    return None
+                stack.pop()
+        idx -= 1
+    return None
+
+
+def _reverse_json_tail_start(data: bytes, open_idx: int, close_idx: int, value_limit: int) -> int | None:
+    """Return the byte offset of the Nth-last value in a JSON array."""
+    if value_limit <= 0:
+        return close_idx
+    stack = []
+    in_string = False
+    commas = 0
+    idx = close_idx - 1
+    while idx > open_idx:
+        byte = data[idx]
+        if byte == ord('"'):
+            slashes = 0
+            probe = idx - 1
+            while probe > open_idx and data[probe] == ord('\\'):
+                slashes += 1
+                probe -= 1
+            if slashes % 2 == 0:
+                in_string = not in_string
+        elif not in_string:
+            if byte == ord("}"):
+                stack.append(ord("{"))
+            elif byte == ord("]"):
+                stack.append(ord("["))
+            elif byte in (ord("{"), ord("[")) and stack:
+                if byte != stack[-1]:
+                    return None
+                stack.pop()
+            elif byte == ord(",") and not stack:
+                commas += 1
+                if commas >= value_limit:
+                    return idx + 1
+        idx -= 1
+    return open_idx + 1
+
+
+def _decode_json_values(raw: bytes) -> list:
+    """Decode comma-separated JSON values without wrapping the whole sidecar."""
+    text = raw.decode("utf-8")
+    decoder = json.JSONDecoder()
+    values = []
+    pos = 0
+    while pos < len(text):
+        while pos < len(text) and (text[pos].isspace() or text[pos] == ","):
+            pos += 1
+        if pos >= len(text):
+            break
+        value, pos = decoder.raw_decode(text, pos)
+        values.append(value)
+    return values
+
+
+def read_session_message_tail(session_id: str, value_limit: int) -> tuple[list, int]:
+    """Read only the newest raw message rows from a sidecar JSON file.
+
+    This is the cold display path for ``?messages=1&msg_limit=N``. It never
+    calls ``Session.load`` and never deserializes the full transcript. The
+    returned offset is the raw array index of the first returned value, derived
+    from the persisted ``message_count`` metadata when available.
+    """
+    if not is_safe_session_id(session_id):
+        return [], 0
+    try:
+        limit = max(1, int(value_limit))
+    except (TypeError, ValueError):
+        return [], 0
+    path = SESSION_DIR / f"{session_id}.json"
+    if not path.exists():
+        return [], 0
+    try:
+        file_size = path.stat().st_size
+        with path.open("rb") as handle:
+            head = handle.read(min(file_size, 256 * 1024))
+            marker = re.search(rb'"messages"\s*:', head)
+            if marker is None:
+                return [], 0
+            open_rel = head.find(b"[", marker.end())
+            if open_rel < 0:
+                return [], 0
+            expected_open = open_rel
+            window_size = min(file_size, max(256 * 1024, 1024 * 1024))
+            pair = None
+            while True:
+                start = max(0, file_size - window_size)
+                handle.seek(start)
+                window = handle.read(file_size - start)
+                pair = _reverse_json_array_pair(window, start, expected_open)
+                if pair is not None:
+                    break
+                if start == 0 or window_size >= min(file_size, 128 * 1024 * 1024):
+                    return [], 0
+                window_size = min(file_size, window_size * 2)
+            open_abs, close_abs = pair
+            # Scan from the close bracket backward. If the Nth-last value starts
+            # before the current window, expand and retry with a larger window.
+            while True:
+                start_abs = _reverse_json_tail_start(
+                    window,
+                    max(0, open_abs - start),
+                    close_abs - start,
+                    limit,
+                )
+                if start_abs is None:
+                    return [], 0
+                value_start_abs = start + start_abs
+                if value_start_abs >= start:
+                    handle.seek(value_start_abs)
+                    raw = handle.read(close_abs - value_start_abs)
+                    values = _decode_json_values(raw)
+                    if values:
+                        break
+                if start == 0 or window_size >= min(file_size, 128 * 1024 * 1024):
+                    return [], 0
+                window_size = min(file_size, window_size * 2)
+                start = max(0, file_size - window_size)
+                handle.seek(start)
+                window = handle.read(file_size - start)
+                pair = _reverse_json_array_pair(window, start, expected_open)
+                if pair is None:
+                    return [], 0
+                open_abs, close_abs = pair
+            prefix = _read_metadata_json_prefix(path)
+            total_count = None
+            if prefix:
+                try:
+                    metadata = json.loads(prefix)
+                    total_count = int(metadata.get("message_count"))
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    total_count = None
+            offset = max(0, total_count - len(values)) if total_count is not None else 0
+            return values, offset
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        logger.debug("Failed to read bounded message tail for %s", session_id, exc_info=True)
+        return [], 0
+
+
 def _lookup_index_message_count(session_id):
     """Return the indexed message count without loading the full session file."""
     return _index_message_count_map().get(str(session_id))

--- a/api/models.py
+++ b/api/models.py
@@ -1126,19 +1126,14 @@ def _load_session_from_path(path: Path) -> "Session | None":
 
 
 def _reverse_json_array_pair(data: bytes, absolute_base: int, expected_open: int):
-    """Find the closing bracket of the final top-level array efficiently.
-
-    The root-object sentinel distinguishes the huge top-level ``messages`` array
-    from arrays nested inside the final message. We can identify its closing
-    bracket without traversing the array's contents; ``expected_open`` comes from
-    the small metadata prefix and is retained as the pair's opening coordinate.
-    """
+    """Find the closing bracket paired with the top-level messages array."""
     end = len(data) - 1
-    while end >= 0 and data[end] in b" \\t\\r\\n":
+    while end >= 0 and data[end] in b" \t\r\n":
         end -= 1
     if end >= 0 and data[end] == ord("}"):
         end -= 1
-    stack = [(ord("{"), -1)]  # root object sentinel
+    stack = [(ord("{"), -1)]
+    top_level_arrays_seen = 0
     in_string = False
     idx = end
     while idx >= 0:
@@ -1153,17 +1148,38 @@ def _reverse_json_array_pair(data: bytes, absolute_base: int, expected_open: int
                 in_string = not in_string
         elif not in_string:
             if byte == ord("]"):
-                if len(stack) == 1:
+                if len(stack) == 1 and top_level_arrays_seen:
                     return expected_open, absolute_base + idx
                 stack.append((ord("["), idx))
             elif byte == ord("}"):
                 stack.append((ord("{"), idx))
             elif byte in (ord("{"), ord("[")) and len(stack) > 1:
-                expected, _close_idx = stack[-1]
+                expected, close_idx = stack[-1]
                 if byte != expected:
                     return None
+                absolute_open = absolute_base + idx
+                if byte == ord("[") and absolute_open == expected_open:
+                    return expected_open, absolute_base + close_idx
+                if byte == ord("[") and len(stack) == 2:
+                    # Modern Session.save() writes messages before the
+                    # top-level tool_calls array. If the messages opener is
+                    # outside this EOF window, the first completed top-level
+                    # array after tool_calls is its matching close.
+                    key_end = idx - 1
+                    while key_end >= 0 and data[key_end] in b" \t\r\n:":
+                        key_end -= 1
+                    key_start = key_end - 1
+                    while key_start >= 0 and data[key_start] != ord('"'):
+                        key_start -= 1
+                    key = data[key_start + 1:key_end].decode("utf-8", errors="ignore")
+                    if key == "messages":
+                        return expected_open, absolute_base + close_idx
+                    if key == "tool_calls":
+                        top_level_arrays_seen += 1
                 stack.pop()
         idx -= 1
+    # If the suffix window began after the messages opener, the parser cannot
+    # prove the opener/close pair. Returning None forces bounded expansion.
     return None
 
 
@@ -1199,7 +1215,7 @@ def _reverse_json_tail_start(data: bytes, open_idx: int, close_idx: int, value_l
                 if commas >= value_limit:
                     return idx + 1
         idx -= 1
-    return open_idx + 1
+    return None if open_idx <= 0 else open_idx + 1
 
 
 def _decode_json_values(raw: bytes) -> list:
@@ -1216,6 +1232,48 @@ def _decode_json_values(raw: bytes) -> list:
         value, pos = decoder.raw_decode(text, pos)
         values.append(value)
     return values
+
+
+def read_session_auxiliary_metadata(session_id: str) -> dict:
+    """Read small/terminal session fields without deserializing messages."""
+    if not is_safe_session_id(session_id):
+        return {}
+    path = SESSION_DIR / f"{session_id}.json"
+    if not path.exists():
+        return {}
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            handle.seek(max(0, size - min(size, 64 * 1024 * 1024)))
+            suffix = handle.read()
+        text = suffix.decode("utf-8")
+        decoder = json.JSONDecoder()
+
+        def value_for(key, end=None):
+            marker = f'"{key}"'
+            pos = text.rfind(marker) if end is None else text.rfind(marker, 0, end)
+            if pos < 0:
+                return None
+            colon = text.find(":", pos + len(marker))
+            if colon < 0:
+                return None
+            value_start = colon + 1
+            while value_start < len(text) and text[value_start].isspace():
+                value_start += 1
+            value, _ = decoder.raw_decode(text, value_start)
+            return value
+
+        anchor = value_for("anchor_activity_scenes")
+        tool_calls = value_for("tool_calls", text.rfind('"anchor_activity_scenes"') if '"anchor_activity_scenes"' in text else None)
+        result = {}
+        if isinstance(anchor, dict):
+            result["anchor_activity_scenes"] = anchor
+        if isinstance(tool_calls, list):
+            result["tool_calls"] = tool_calls
+        return result
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        logger.debug("Failed to read bounded session auxiliary metadata for %s", session_id, exc_info=True)
+        return {}
 
 
 def read_session_message_tail(session_id: str, value_limit: int) -> tuple[list, int]:
@@ -1239,10 +1297,14 @@ def read_session_message_tail(session_id: str, value_limit: int) -> tuple[list, 
         file_size = path.stat().st_size
         with path.open("rb") as handle:
             head = handle.read(min(file_size, 256 * 1024))
-            marker = re.search(rb'"messages"\s*:', head)
+            try:
+                head_text = head.decode("utf-8")
+            except UnicodeDecodeError:
+                head_text = head.decode("utf-8", errors="ignore")
+            marker = _find_top_level_json_key(head_text, "messages")
             if marker is None:
                 return [], 0
-            open_rel = head.find(b"[", marker.end())
+            open_rel = head.find(b"[", marker)
             if open_rel < 0:
                 return [], 0
             expected_open = open_rel
@@ -1268,15 +1330,17 @@ def read_session_message_tail(session_id: str, value_limit: int) -> tuple[list, 
                     close_abs - start,
                     limit,
                 )
-                if start_abs is None:
-                    return [], 0
-                value_start_abs = start + start_abs
-                if value_start_abs >= start:
-                    handle.seek(value_start_abs)
-                    raw = handle.read(close_abs - value_start_abs)
-                    values = _decode_json_values(raw)
-                    if values:
-                        break
+                if start_abs is not None:
+                    value_start_abs = start + start_abs
+                    if value_start_abs >= start:
+                        handle.seek(value_start_abs)
+                        raw = handle.read(close_abs - value_start_abs)
+                        try:
+                            values = _decode_json_values(raw)
+                        except (UnicodeError, ValueError, json.JSONDecodeError):
+                            values = []
+                        if values:
+                            break
                 if start == 0 or window_size >= min(file_size, 128 * 1024 * 1024):
                     return [], 0
                 window_size = min(file_size, window_size * 2)
@@ -1364,6 +1428,33 @@ def model_explicit_pick_signature(model, model_provider) -> str:
     _m = str(model or "").strip()
     _p = str(model_provider or "").strip().lower()
     return f"{_m}\x1f{_p}"
+
+
+def _deduplicate_stable_message_ids_for_persistence(messages):
+    """Remove repeated stable-ID snapshots before serializing a session."""
+    output = []
+    by_id = {}
+    for message in list(messages or []):
+        if not isinstance(message, dict):
+            output.append(message)
+            continue
+        message_id = message.get("id")
+        if message_id is None or isinstance(message_id, bool):
+            output.append(message)
+            continue
+        existing_index = by_id.get(message_id)
+        if existing_index is None:
+            by_id[message_id] = len(output)
+            output.append(message)
+            continue
+        existing = output[existing_index]
+        if not isinstance(existing, dict):
+            continue
+        for key, value in message.items():
+            if key in {"content", "reasoning"} and not value and existing.get(key):
+                continue
+            existing[key] = value
+    return output
 
 
 class Session:
@@ -1591,6 +1682,8 @@ class Session:
             'process_wakeup_pause',
             'share_token', 'share_created_at',
         ]
+        self.messages = _deduplicate_stable_message_ids_for_persistence(self.messages)
+        self.context_messages = _deduplicate_stable_message_ids_for_persistence(self.context_messages)
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         # #5854: message_count and a compact anchor-scene fingerprint go in the
         # metadata prefix (BEFORE messages) so load_metadata_only() and the

--- a/api/models.py
+++ b/api/models.py
@@ -1248,14 +1248,46 @@ def read_session_auxiliary_metadata(session_id: str) -> dict:
             suffix = handle.read()
         text = suffix.decode("utf-8")
         decoder = json.JSONDecoder()
+        top_level_keys = {}
+        leading = len(text) - len(text.lstrip())
+        root_object_in_buffer = text[leading:leading + 1] == "{"
+        key_depth = 1 if root_object_in_buffer else 0
+        depth = key_depth
+        index = leading + 1 if root_object_in_buffer else 0
+        while index < len(text):
+            char = text[index]
+            if char == '"':
+                start = index
+                index += 1
+                escaped = False
+                while index < len(text):
+                    if escaped:
+                        escaped = False
+                    elif text[index] == "\\":
+                        escaped = True
+                    elif text[index] == '"':
+                        break
+                    index += 1
+                if index >= len(text):
+                    break
+                if depth == key_depth:
+                    key = json.loads(text[start:index + 1])
+                    probe = index + 1
+                    while probe < len(text) and text[probe].isspace():
+                        probe += 1
+                    if probe < len(text) and text[probe] == ":":
+                        top_level_keys.setdefault(key, probe)
+                index += 1
+                continue
+            if char in "[{":
+                depth += 1
+            elif char in "]}":
+                depth = max(0, depth - 1)
+            index += 1
 
-        def value_for(key, end=None):
-            marker = f'"{key}"'
-            pos = text.rfind(marker) if end is None else text.rfind(marker, 0, end)
-            if pos < 0:
-                return None
-            colon = text.find(":", pos + len(marker))
-            if colon < 0:
+        def value_for(key):
+            colon = top_level_keys.get(key)
+            if colon is None:
                 return None
             value_start = colon + 1
             while value_start < len(text) and text[value_start].isspace():
@@ -1264,7 +1296,7 @@ def read_session_auxiliary_metadata(session_id: str) -> dict:
             return value
 
         anchor = value_for("anchor_activity_scenes")
-        tool_calls = value_for("tool_calls", text.rfind('"anchor_activity_scenes"') if '"anchor_activity_scenes"' in text else None)
+        tool_calls = value_for("tool_calls")
         result = {}
         if isinstance(anchor, dict):
             result["anchor_activity_scenes"] = anchor
@@ -1304,7 +1336,8 @@ def read_session_message_tail(session_id: str, value_limit: int) -> tuple[list, 
             marker = _find_top_level_json_key(head_text, "messages")
             if marker is None:
                 return [], 0
-            open_rel = head.find(b"[", marker)
+            marker_byte = len(head_text[:marker].encode("utf-8"))
+            open_rel = head.find(b"[", marker_byte)
             if open_rel < 0:
                 return [], 0
             expected_open = open_rel

--- a/api/routes.py
+++ b/api/routes.py
@@ -8932,6 +8932,22 @@ def _sidecar_file_exceeds_threshold(session_id, threshold_bytes) -> bool:
         return False
 
 
+def _state_db_messages_for_bounded_tail(session, sidecar_messages):
+    """Read only the state.db suffix needed to reconcile a bounded sidecar tail."""
+    reader_kwargs = {
+        "profile": getattr(session, "profile", None) or None,
+        "limit": _STATE_DB_DISPLAY_ROW_BACKSTOP,
+    }
+    timestamps = [_message_timestamp_as_float(msg) for msg in list(sidecar_messages or [])]
+    valid_timestamps = [ts for ts in timestamps if ts is not None]
+    if len(valid_timestamps) == len(timestamps) and valid_timestamps:
+        reader_kwargs["since_timestamp"] = min(valid_timestamps)
+    return get_state_db_session_messages(
+        getattr(session, "session_id", None),
+        **reader_kwargs,
+    )
+
+
 def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before=None):
     """Return (timestamp floor, sidecar messages) for bounded state.db tail reads.
 
@@ -12838,6 +12854,15 @@ def handle_get(handler, parsed) -> bool:
                 sid,
                 metadata_only=(not load_messages or _initial_bounded_load),
             )
+            if _initial_bounded_load and (
+                getattr(s, "truncation_watermark", None) not in (None, "")
+                or getattr(s, "truncation_boundary", None) not in (None, "")
+            ):
+                # Tail-only reconciliation cannot safely reconstruct a deleted
+                # prefix. Rare truncation/recovery sessions retain the full-load
+                # path rather than risking transcript resurrection or loss.
+                s = get_session(sid, metadata_only=False)
+                _initial_bounded_load = False
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
@@ -12903,13 +12928,12 @@ def handle_get(handler, parsed) -> bool:
                         msg_before=msg_before,
                     )
                 if _tail_loaded:
-                    # Preserve the existing reconciliation contract. The sidecar
-                    # tail avoids the multi-gigabyte parse, while state.db remains
-                    # authoritative for rows that were appended or repaired after
-                    # the sidecar snapshot.
-                    state_db_messages = get_state_db_session_messages(
-                        sid,
-                        profile=_session_profile,
+                    # Reconcile only the bounded state.db suffix. A successful
+                    # sidecar tail must not materialize the complete database
+                    # transcript on the latency-sensitive initial request.
+                    state_db_messages = _state_db_messages_for_bounded_tail(
+                        s,
+                        limited_sidecar_messages,
                     )
                 else:
                     _state_db_reader_kwargs = {"profile": _session_profile}
@@ -12998,7 +13022,23 @@ def handle_get(handler, parsed) -> bool:
                             _summary_message_count = max(0, int(metadata_count))
                     except (TypeError, ValueError):
                         pass
-            else:
+            if load_messages:
+                if getattr(s, "_display_tail_loaded", False):
+                    # Reconciliation can append state.db rows that were committed
+                    # after the sidecar snapshot. Keep the absolute cursor/count in
+                    # the same coordinate space as the merged suffix, not the stale
+                    # sidecar metadata alone.
+                    _sidecar_tail_count = len(limited_sidecar_messages or [])
+                    _tail_base_count = int(
+                        getattr(s, "_display_tail_total_count", 0) or 0
+                    )
+                    _tail_offset = int(getattr(s, "_display_tail_offset", 0) or 0)
+                    _merged_tail_extra = max(0, len(_all_msgs) - _sidecar_tail_count)
+                    s._display_tail_total_count = max(
+                        _tail_base_count,
+                        _tail_offset + len(_all_msgs),
+                        _tail_base_count + _merged_tail_extra,
+                    )
                 _summary_message_count = None
                 _summary_last_message_at = None
             if load_messages:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9619,6 +9619,7 @@ from api.models import (
     get_cli_sessions,
     get_cli_session_messages,
     get_state_db_session_messages,
+    read_session_message_tail,
     get_state_db_session_message_prefix_summary,
     get_state_db_session_message_keys_before_timestamp,
     get_state_db_session_summary,
@@ -12824,7 +12825,14 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             if _diag: _diag.stage("t1_after_get_session_check")
-            s = get_session(sid, metadata_only=(not load_messages))
+            # Keep the initial bounded display request metadata-only. A full
+            # Session.load() here would deserialize the complete sidecar before
+            # the tail window can be sliced (#session-load-tail).
+            _initial_bounded_load = msg_limit is not None and msg_before is None
+            s = get_session(
+                sid,
+                metadata_only=(not load_messages or _initial_bounded_load),
+            )
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
@@ -12856,7 +12864,25 @@ def handle_get(handler, parsed) -> bool:
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
-                if msg_limit is not None:
+                _tail_loaded = False
+                if _initial_bounded_load and not is_messaging_session:
+                    try:
+                        _tail_budget = max(300, int(msg_limit) * 10)
+                        _tail, _tail_offset = read_session_message_tail(sid, _tail_budget)
+                        _metadata_count = getattr(s, "_metadata_message_count", None)
+                        if _tail or _metadata_count == 0:
+                            limited_sidecar_messages = _tail
+                            s._display_tail_loaded = True
+                            s._display_tail_offset = max(0, int(_tail_offset or 0))
+                            s._display_tail_total_count = (
+                                max(int(_metadata_count), s._display_tail_offset + len(_tail))
+                                if _metadata_count is not None
+                                else s._display_tail_offset + len(_tail)
+                            )
+                            _tail_loaded = True
+                    except (TypeError, ValueError, OSError):
+                        logger.debug("Bounded session tail read failed for %s", sid, exc_info=True)
+                if not _tail_loaded and msg_limit is not None:
                     (
                         state_db_since_timestamp,
                         limited_sidecar_messages,
@@ -12865,21 +12891,26 @@ def handle_get(handler, parsed) -> bool:
                         msg_limit,
                         msg_before=msg_before,
                     )
-                _state_db_reader_kwargs = {"profile": _session_profile}
-                if state_db_since_timestamp is not None:
-                    _state_db_reader_kwargs["since_timestamp"] = state_db_since_timestamp
-                # Apply the display-path row backstop ONLY on provably-safe
-                # reads where no truncation_boundary prefix is required for the
-                # merge — see _state_db_backstop_limit_for_display. Compressed
-                # sessions and msg_before paging need their full prefix rows for
-                # correct reconciliation, so those stay uncapped.
-                _backstop = _state_db_backstop_limit_for_display(s, msg_before)
-                if _backstop is not None:
-                    _state_db_reader_kwargs["limit"] = _backstop
-                state_db_messages = get_state_db_session_messages(
-                    sid,
-                    **_state_db_reader_kwargs,
-                )
+                if _tail_loaded:
+                    # The WebUI sidecar is authoritative for this initial
+                    # display tail. Avoid a second unbounded state.db merge.
+                    state_db_messages = []
+                else:
+                    _state_db_reader_kwargs = {"profile": _session_profile}
+                    if state_db_since_timestamp is not None:
+                        _state_db_reader_kwargs["since_timestamp"] = state_db_since_timestamp
+                    # Apply the display-path row backstop ONLY on provably-safe
+                    # reads where no truncation_boundary prefix is required for the
+                    # merge — see _state_db_backstop_limit_for_display. Compressed
+                    # sessions and msg_before paging need their full prefix rows for
+                    # correct reconciliation, so those stay uncapped.
+                    _backstop = _state_db_backstop_limit_for_display(s, msg_before)
+                    if _backstop is not None:
+                        _state_db_reader_kwargs["limit"] = _backstop
+                    state_db_messages = get_state_db_session_messages(
+                        sid,
+                        **_state_db_reader_kwargs,
+                    )
             elif not is_messaging_session:
                 # Metadata-only callers still need the same append-only
                 # reconciliation contract as full loads so stale/replayed
@@ -12961,6 +12992,8 @@ def handle_get(handler, parsed) -> bool:
                     msg_before=msg_before,
                     expand_renderable=expand_renderable,
                 )
+                if getattr(s, "_display_tail_loaded", False):
+                    _messages_offset += int(getattr(s, "_display_tail_offset", 0) or 0)
                 if msg_limit is not None:
                     _truncated_msgs = _messages_for_limited_payload(_truncated_msgs)
                 _truncated_msgs = _hydrate_anchor_activity_scenes(
@@ -13047,7 +13080,12 @@ def handle_get(handler, parsed) -> bool:
                     _messages_offset,
                     len(_truncated_msgs),
                 )
-            _merged_message_count = _summary_message_count if _summary_message_count is not None else len(_all_msgs)
+            if getattr(s, "_display_tail_loaded", False):
+                _merged_message_count = int(
+                    getattr(s, "_display_tail_total_count", len(_all_msgs)) or len(_all_msgs)
+                )
+            else:
+                _merged_message_count = _summary_message_count if _summary_message_count is not None else len(_all_msgs)
             _merged_last_message_at = _summary_last_message_at if _summary_last_message_at is not None else 0
             if _summary_last_message_at is None and _all_msgs:
                 try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9620,6 +9620,7 @@ from api.models import (
     get_cli_session_messages,
     get_state_db_session_messages,
     read_session_message_tail,
+    read_session_auxiliary_metadata,
     get_state_db_session_message_prefix_summary,
     get_state_db_session_message_keys_before_timestamp,
     get_state_db_session_summary,
@@ -12828,7 +12829,11 @@ def handle_get(handler, parsed) -> bool:
             # Keep the initial bounded display request metadata-only. A full
             # Session.load() here would deserialize the complete sidecar before
             # the tail window can be sliced (#session-load-tail).
-            _initial_bounded_load = msg_limit is not None and msg_before is None
+            _initial_bounded_load = (
+                msg_limit is not None
+                and msg_before is None
+                and _sidecar_file_exceeds_threshold(sid, _SIDECAR_BYTE_TAIL_THRESHOLD)
+            )
             s = get_session(
                 sid,
                 metadata_only=(not load_messages or _initial_bounded_load),
@@ -12870,8 +12875,14 @@ def handle_get(handler, parsed) -> bool:
                         _tail_budget = max(300, int(msg_limit) * 10)
                         _tail, _tail_offset = read_session_message_tail(sid, _tail_budget)
                         _metadata_count = getattr(s, "_metadata_message_count", None)
-                        if _tail or _metadata_count == 0:
+                        if _tail:
                             limited_sidecar_messages = _tail
+                            _auxiliary = read_session_auxiliary_metadata(sid)
+                            if _auxiliary:
+                                s.anchor_activity_scenes = _auxiliary.get(
+                                    "anchor_activity_scenes", {}
+                                )
+                                s.tool_calls = _auxiliary.get("tool_calls", [])
                             s._display_tail_loaded = True
                             s._display_tail_offset = max(0, int(_tail_offset or 0))
                             s._display_tail_total_count = (
@@ -12892,9 +12903,14 @@ def handle_get(handler, parsed) -> bool:
                         msg_before=msg_before,
                     )
                 if _tail_loaded:
-                    # The WebUI sidecar is authoritative for this initial
-                    # display tail. Avoid a second unbounded state.db merge.
-                    state_db_messages = []
+                    # Preserve the existing reconciliation contract. The sidecar
+                    # tail avoids the multi-gigabyte parse, while state.db remains
+                    # authoritative for rows that were appended or repaired after
+                    # the sidecar snapshot.
+                    state_db_messages = get_state_db_session_messages(
+                        sid,
+                        profile=_session_profile,
+                    )
                 else:
                     _state_db_reader_kwargs = {"profile": _session_profile}
                     if state_db_since_timestamp is not None:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5270,6 +5270,39 @@ def _deduplicate_context_messages(messages):
     return deduped
 
 
+def _deduplicate_stable_message_ids(messages):
+    """Collapse repeated snapshots that carry the same stable message ID.
+
+    Streaming providers may replay the same in-flight assistant object between
+    tool events. Content-based dedupe must not remove identical answers from
+    separate turns, but a stable ID identifies one logical row unambiguously.
+    Keep the first row's position and merge later metadata into it.
+    """
+    output = []
+    by_id = {}
+    for message in list(messages or []):
+        if not isinstance(message, dict):
+            output.append(message)
+            continue
+        message_id = message.get("id")
+        if message_id is None or isinstance(message_id, bool):
+            output.append(message)
+            continue
+        existing_index = by_id.get(message_id)
+        if existing_index is None:
+            by_id[message_id] = len(output)
+            output.append(message)
+            continue
+        existing = output[existing_index]
+        if not isinstance(existing, dict):
+            continue
+        for key, value in message.items():
+            if key in {"content", "reasoning"} and not value and existing.get(key):
+                continue
+            existing[key] = value
+    return output
+
+
 def _assign_stable_message_ids(result_messages, *existing_arrays):
     """Mint a stable, session-unique integer ``id`` on model-result rows lacking one.
 
@@ -6301,6 +6334,9 @@ def _merge_display_messages_after_agent_result(
     the current user turn onward. Synthetic compaction/reference markers remain
     internal recovery material and must not become visible user/assistant turns.
     """
+    previous_display = _deduplicate_stable_message_ids(previous_display)
+    previous_context = _deduplicate_stable_message_ids(previous_context)
+    result_messages = _deduplicate_stable_message_ids(result_messages)
     previous_display = [
         m for m in list(previous_display or [])
         if not _is_context_compression_marker(m)

--- a/scripts/repair_duplicate_message_snapshots.py
+++ b/scripts/repair_duplicate_message_snapshots.py
@@ -49,7 +49,7 @@ class JSONReader:
                 return value
             except (json.JSONDecodeError, UnicodeDecodeError):
                 if not self._fill():
-                    raise ValueError("truncated JSON value")
+                    raise ValueError("truncated JSON value") from None
 
     def byte(self):
         self.skip_ws()

--- a/scripts/repair_duplicate_message_snapshots.py
+++ b/scripts/repair_duplicate_message_snapshots.py
@@ -64,6 +64,15 @@ def write_json(handle, value):
 
 
 def repair(source: Path, destination: Path):
+    source = source.resolve()
+    destination = destination.resolve()
+    try:
+        same_file = destination.exists() and source.samefile(destination)
+    except OSError:
+        same_file = False
+    if source == destination or same_file:
+        raise ValueError("source and destination must be different files")
+
     seen_ids = set()
     input_messages = 0
     output_messages = 0

--- a/scripts/repair_duplicate_message_snapshots.py
+++ b/scripts/repair_duplicate_message_snapshots.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Stream-repair duplicate stable-ID message snapshots in a session sidecar."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+class JSONReader:
+    def __init__(self, handle, chunk_size=1024 * 1024):
+        self.handle = handle
+        self.chunk_size = chunk_size
+        self.buffer = b""
+        self.eof = False
+
+    def _fill(self):
+        if self.eof:
+            return False
+        chunk = self.handle.read(self.chunk_size)
+        if chunk:
+            self.buffer += chunk
+            return True
+        self.eof = True
+        return False
+
+    def skip_ws(self):
+        while True:
+            stripped = self.buffer.lstrip(b" \t\r\n")
+            consumed = len(self.buffer) - len(stripped)
+            if consumed:
+                self.buffer = stripped
+            if self.buffer or self.eof:
+                return
+            self._fill()
+
+    def consume(self, count):
+        self.buffer = self.buffer[count:]
+
+    def value(self):
+        decoder = json.JSONDecoder()
+        while True:
+            self.skip_ws()
+            try:
+                text = self.buffer.decode("utf-8")
+                value, end = decoder.raw_decode(text)
+                consumed = len(text[:end].encode("utf-8"))
+                self.consume(consumed)
+                return value
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                if not self._fill():
+                    raise ValueError("truncated JSON value")
+
+    def byte(self):
+        self.skip_ws()
+        if not self.buffer and not self.eof:
+            self._fill()
+            self.skip_ws()
+        return self.buffer[:1]
+
+
+def write_json(handle, value):
+    handle.write(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+
+
+def repair(source: Path, destination: Path):
+    seen_ids = set()
+    input_messages = 0
+    output_messages = 0
+    duplicate_messages = 0
+    first_field = True
+    message_count_seen = False
+    with source.open("rb") as source_handle, destination.open("w", encoding="utf-8") as out:
+        reader = JSONReader(source_handle)
+        reader.skip_ws()
+        if reader.byte() != b"{":
+            raise ValueError("sidecar root is not an object")
+        reader.consume(1)
+        out.write("{")
+        while True:
+            reader.skip_ws()
+            if reader.byte() == b",":
+                reader.consume(1)
+                continue
+            if reader.byte() == b"}":
+                reader.consume(1)
+                if message_count_seen:
+                    if not first_field:
+                        out.write(",")
+                    out.write('"message_count":')
+                    out.write(str(output_messages))
+                out.write("}")
+                break
+            key = reader.value()
+            if not isinstance(key, str):
+                raise ValueError("object key is not a string")
+            reader.skip_ws()
+            if reader.byte() != b":":
+                raise ValueError("missing object colon")
+            reader.consume(1)
+            if key == "message_count":
+                reader.value()
+                message_count_seen = True
+                continue
+            if not first_field:
+                out.write(",")
+            out.write(json.dumps(key, ensure_ascii=False, separators=(",", ":")))
+            out.write(":")
+            first_field = False
+            if key != "messages":
+                write_json(out, reader.value())
+                continue
+
+            if reader.byte() != b"[":
+                raise ValueError("messages is not an array")
+            reader.consume(1)
+            out.write("[")
+            first_message = True
+            while True:
+                reader.skip_ws()
+                if reader.byte() == b",":
+                    reader.consume(1)
+                    continue
+                if reader.byte() == b"]":
+                    reader.consume(1)
+                    out.write("]")
+                    break
+                message = reader.value()
+                input_messages += 1
+                message_id = message.get("id") if isinstance(message, dict) else None
+                duplicate = (
+                    message_id is not None
+                    and not isinstance(message_id, bool)
+                    and message_id in seen_ids
+                )
+                if message_id is not None and not isinstance(message_id, bool):
+                    seen_ids.add(message_id)
+                if duplicate:
+                    duplicate_messages += 1
+                    continue
+                if not first_message:
+                    out.write(",")
+                write_json(out, message)
+                first_message = False
+                output_messages += 1
+    return {
+        "input_messages": input_messages,
+        "output_messages": output_messages,
+        "duplicate_messages_removed": duplicate_messages,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Write a repaired sidecar to a separate destination; replace the source only after validation and backup."
+    )
+    parser.add_argument("source", type=Path)
+    parser.add_argument("destination", type=Path)
+    args = parser.parse_args()
+    result = repair(args.source, args.destination)
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repair_duplicate_message_snapshots.py
+++ b/tests/test_repair_duplicate_message_snapshots.py
@@ -1,0 +1,14 @@
+import pytest
+
+from scripts.repair_duplicate_message_snapshots import repair
+
+
+def test_repair_rejects_same_source_and_destination_without_truncating(tmp_path):
+    source = tmp_path / "session.json"
+    original = '{"message_count":1,"messages":[{"id":1,"role":"user","content":"hello"}]}'
+    source.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="different"):
+        repair(source, source)
+
+    assert source.read_text(encoding="utf-8") == original

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -252,6 +252,61 @@ def test_same_assistant_text_across_different_turns_is_preserved():
     ]
 
 
+def test_same_stable_id_snapshot_is_collapsed_but_identical_answers_with_new_ids_survive():
+    repeated_snapshot = {
+        "role": "assistant",
+        "id": 354,
+        "content": "",
+        "reasoning": "planning",
+        "codex_reasoning_items": [{"summary": "planning"}],
+    }
+    result_messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "id": 1, "content": "same answer"},
+        repeated_snapshot,
+        {"role": "tool", "id": 2, "content": "result", "tool_call_id": "call-1"},
+        dict(repeated_snapshot),
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "id": 3, "content": "same answer"},
+    ]
+
+    merged = streaming._merge_display_messages_after_agent_result(
+        previous_display=[],
+        previous_context=[],
+        result_messages=result_messages,
+        msg_text="second",
+    )
+
+    assert sum(message.get("id") == 354 for message in merged) == 1
+    assert sum(message.get("content") == "same answer" for message in merged) == 2
+
+
+
+def test_session_save_collapses_repeated_stable_id_snapshots(_isolate_state):
+    snapshot = {
+        "role": "assistant",
+        "id": 354,
+        "content": "",
+        "reasoning": "planning",
+        "codex_reasoning_items": [{"summary": "planning"}],
+    }
+    session = Session(
+        session_id="save_snapshot_dedupe",
+        messages=[
+            {"role": "user", "content": "prompt"},
+            snapshot,
+            dict(snapshot),
+            {"role": "assistant", "id": 355, "content": "answer"},
+        ],
+    )
+
+    session.save()
+    loaded = Session.load("save_snapshot_dedupe")
+
+    assert [message.get("id") for message in loaded.messages] == [None, 354, 355]
+
+
+
 def test_llm_title_generated_survives_save_and_load(_isolate_state):
     s = Session(
         session_id="generated_title",

--- a/tests/test_session_tail_reader.py
+++ b/tests/test_session_tail_reader.py
@@ -102,3 +102,37 @@ def test_read_session_message_tail_expands_when_recent_value_crosses_initial_win
 
     assert [message["content"] for message in tail] == ["three", "four"]
     assert offset == 2
+
+
+def test_read_session_message_tail_handles_multibyte_metadata_and_top_level_auxiliary_fields(tmp_path, monkeypatch):
+    from api import models
+
+    sid = "tail_reader_multibyte_metadata"
+    path = tmp_path / f"{sid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "title": "😀" * 20 + "[",
+                "message_count": 3,
+                "messages": [
+                    {"role": "user", "content": "one"},
+                    {"role": "assistant", "content": "two"},
+                    {"role": "assistant", "content": "three"},
+                ],
+                "tool_calls": [],
+                "anchor_activity_scenes": {"real": {"message_index": 2}},
+                "extra": {"anchor_activity_scenes": {"fake": {"message_index": 0}}},
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+
+    tail, offset = models.read_session_message_tail(sid, 3)
+    auxiliary = models.read_session_auxiliary_metadata(sid)
+
+    assert [message["content"] for message in tail] == ["one", "two", "three"]
+    assert offset == 0
+    assert auxiliary["anchor_activity_scenes"] == {"real": {"message_index": 2}}

--- a/tests/test_session_tail_reader.py
+++ b/tests/test_session_tail_reader.py
@@ -20,7 +20,10 @@ def test_read_session_message_tail_reads_only_recent_rows_from_large_sidecar(tmp
                 "session_id": sid,
                 "title": "large",
                 "message_count": len(messages),
+                "compression_anchor_details": {"messages": [{"role": "assistant", "content": "not the transcript"}]},
                 "messages": messages,
+                "tool_calls": [{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+                "anchor_activity_scenes": {"scene-1": {"message_index": 202}},
                 "_db_persisted": True,
             },
             separators=(",", ":"),
@@ -33,9 +36,40 @@ def test_read_session_message_tail_reads_only_recent_rows_from_large_sidecar(tmp
 
     assert [message["content"] for message in tail] == ["new-1", "result", "new-2"]
     assert offset == 200
+    aux = models.read_session_auxiliary_metadata(sid)
+    assert aux["tool_calls"][0]["id"] == "call-1"
+    assert aux["anchor_activity_scenes"]["scene-1"]["message_index"] == 202
 
 
-def test_read_session_message_tail_does_not_use_full_session_loader(tmp_path, monkeypatch):
+def test_read_session_message_tail_expands_when_recent_value_crosses_initial_window(tmp_path, monkeypatch):
+    from api import models
+
+    sid = "tail_reader_large_value"
+    path = tmp_path / f"{sid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "message_count": 2,
+                "messages": [
+                    {"role": "user", "content": "old"},
+                    {"role": "assistant", "content": "x" * (1024 * 1024 + 128 * 1024)},
+                ],
+                "tool_calls": [],
+                "anchor_activity_scenes": {},
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+
+    tail, offset = models.read_session_message_tail(sid, 1)
+
+    assert len(tail) == 1
+    assert len(tail[0]["content"]) == 1024 * 1024 + 128 * 1024
+    assert offset == 1
+
     from api import models
 
     sid = "tail_reader_no_full_load"

--- a/tests/test_session_tail_reader.py
+++ b/tests/test_session_tail_reader.py
@@ -1,0 +1,70 @@
+import json
+
+
+def test_read_session_message_tail_reads_only_recent_rows_from_large_sidecar(tmp_path, monkeypatch):
+    from api import models
+
+    sid = "tail_reader_large"
+    path = tmp_path / f"{sid}.json"
+    messages = [
+        {"role": "user", "content": f"old-{idx}"}
+        for idx in range(200)
+    ] + [
+        {"role": "assistant", "content": "new-1", "timestamp": 201.0},
+        {"role": "tool", "content": "result", "tool_call_id": "call-1"},
+        {"role": "assistant", "content": "new-2", "timestamp": 203.0},
+    ]
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": "large",
+                "message_count": len(messages),
+                "messages": messages,
+                "_db_persisted": True,
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    tail, offset = models.read_session_message_tail(sid, 3)
+
+    assert [message["content"] for message in tail] == ["new-1", "result", "new-2"]
+    assert offset == 200
+
+
+def test_read_session_message_tail_does_not_use_full_session_loader(tmp_path, monkeypatch):
+    from api import models
+
+    sid = "tail_reader_no_full_load"
+    path = tmp_path / f"{sid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": "large",
+                "message_count": 4,
+                "messages": [
+                    {"role": "user", "content": "one"},
+                    {"role": "assistant", "content": "two"},
+                    {"role": "user", "content": "three"},
+                    {"role": "assistant", "content": "four"},
+                ],
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(
+        models.Session,
+        "load",
+        classmethod(lambda cls, _sid: (_ for _ in ()).throw(AssertionError("full load used"))),
+    )
+
+    tail, offset = models.read_session_message_tail(sid, 2)
+
+    assert [message["content"] for message in tail] == ["three", "four"]
+    assert offset == 2

--- a/tests/test_session_tail_route.py
+++ b/tests/test_session_tail_route.py
@@ -8,12 +8,19 @@ def test_initial_bounded_session_load_uses_metadata_and_tail_reader():
     from tests.test_session_tail_payload import _FakeSession
 
     session = _FakeSession([
-        {"role": "assistant", "content": "tail-a"},
-        {"role": "assistant", "content": "tail-b"},
+        {"role": "assistant", "content": "tail-a", "timestamp": 10.0},
+        {"role": "assistant", "content": "tail-b", "timestamp": 20.0},
     ])
     session.__dict__["_metadata_message_count"] = 1000
     captured = {}
     get_session_calls = []
+    state_db_calls = []
+
+    state_db_newer = [
+        {"role": "assistant", "content": "tail-a", "timestamp": 10.0},
+        {"role": "assistant", "content": "tail-b", "timestamp": 20.0},
+        {"role": "assistant", "content": "newer", "timestamp": 30.0},
+    ]
 
     def fake_get_session(sid, metadata_only=False):
         get_session_calls.append((sid, metadata_only))
@@ -24,12 +31,16 @@ def test_initial_bounded_session_load_uses_metadata_and_tail_reader():
         captured["status"] = status
         return data
 
+    def fake_state_db_reader(sid, **kwargs):
+        state_db_calls.append((sid, kwargs))
+        return state_db_newer
+
     with patch("api.routes.get_session", side_effect=fake_get_session), \
          patch("api.routes.read_session_message_tail", return_value=(session.messages, 998)), \
          patch("api.routes._clear_stale_stream_state", return_value=False), \
          patch("api.routes._lookup_cli_session_metadata", return_value={}), \
          patch("api.routes._sidecar_file_exceeds_threshold", return_value=True), \
-         patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes.get_state_db_session_messages", side_effect=fake_state_db_reader), \
          patch("api.routes.redact_session_data", side_effect=lambda raw: raw), \
          patch("api.routes.j", side_effect=fake_j):
         routes.handle_get(
@@ -41,8 +52,18 @@ def test_initial_bounded_session_load_uses_metadata_and_tail_reader():
 
     assert get_session_calls == [("tail_payload_001", True)]
     assert [message["content"] for message in captured["session"]["messages"]] == [
-        "tail-a",
         "tail-b",
+        "newer",
     ]
-    assert captured["session"]["message_count"] == 1000
-    assert captured["session"]["_messages_offset"] == 998
+    assert captured["session"]["message_count"] == 1001
+    assert captured["session"]["_messages_offset"] == 999
+    assert state_db_calls == [
+        (
+            "tail_payload_001",
+            {
+                "profile": None,
+                "since_timestamp": 10.0,
+                "limit": routes._STATE_DB_DISPLAY_ROW_BACKSTOP,
+            },
+        )
+    ]

--- a/tests/test_session_tail_route.py
+++ b/tests/test_session_tail_route.py
@@ -28,7 +28,8 @@ def test_initial_bounded_session_load_uses_metadata_and_tail_reader():
          patch("api.routes.read_session_message_tail", return_value=(session.messages, 998)), \
          patch("api.routes._clear_stale_stream_state", return_value=False), \
          patch("api.routes._lookup_cli_session_metadata", return_value={}), \
-         patch("api.routes.get_state_db_session_messages", side_effect=AssertionError("unbounded state.db read")), \
+         patch("api.routes._sidecar_file_exceeds_threshold", return_value=True), \
+         patch("api.routes.get_state_db_session_messages", return_value=[]), \
          patch("api.routes.redact_session_data", side_effect=lambda raw: raw), \
          patch("api.routes.j", side_effect=fake_j):
         routes.handle_get(

--- a/tests/test_session_tail_route.py
+++ b/tests/test_session_tail_route.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+def test_initial_bounded_session_load_uses_metadata_and_tail_reader():
+    import api.routes as routes
+    from tests.test_session_tail_payload import _FakeSession
+
+    session = _FakeSession([
+        {"role": "assistant", "content": "tail-a"},
+        {"role": "assistant", "content": "tail-b"},
+    ])
+    session.__dict__["_metadata_message_count"] = 1000
+    captured = {}
+    get_session_calls = []
+
+    def fake_get_session(sid, metadata_only=False):
+        get_session_calls.append((sid, metadata_only))
+        return session
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["session"] = data["session"]
+        captured["status"] = status
+        return data
+
+    with patch("api.routes.get_session", side_effect=fake_get_session), \
+         patch("api.routes.read_session_message_tail", return_value=(session.messages, 998)), \
+         patch("api.routes._clear_stale_stream_state", return_value=False), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}), \
+         patch("api.routes.get_state_db_session_messages", side_effect=AssertionError("unbounded state.db read")), \
+         patch("api.routes.redact_session_data", side_effect=lambda raw: raw), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(
+            SimpleNamespace(),
+            urlparse(
+                "/api/session?session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=2"
+            ),
+        )
+
+    assert get_session_calls == [("tail_payload_001", True)]
+    assert [message["content"] for message in captured["session"]["messages"]] == [
+        "tail-a",
+        "tail-b",
+    ]
+    assert captured["session"]["message_count"] == 1000
+    assert captured["session"]["_messages_offset"] == 998


### PR DESCRIPTION
## Summary

Fix two related large-session failures in the WebUI:

1. Initial bounded session loads no longer deserialize a multi-gigabyte sidecar before slicing the requested tail.
2. Replayed in-flight assistant reasoning snapshots with the same stable message ID are no longer persisted as millions of duplicate transcript rows.

## Root cause confirmed

Session `e6a43eed3c92` was not a genuine million-turn conversation. Independent streaming forensics found:

- Sidecar: 2,322.66 MiB and 1,044,970 JSON message objects.
- Only 1,054 unique assistant IDs; 1,041,481 duplicate-ID assistant rows.
- 1,042,541 assistant rows had empty visible content.
- 994,136 rows repeated the same reasoning snapshot.
- 1,041,381 rows shared one timestamp.
- Canonical `state.db` contained only 6,118 rows for the session.
- Approximately 1.90 GB was repeated `codex_reasoning_items` data.

This was a persistence/recording duplication bug, amplified by the old full-sidecar load path.

## What changed

### Safe bounded loading

- Initial `messages=1&msg_limit=N` loads use metadata-only loading only for sidecars above the existing byte threshold.
- Reverse JSON tail reading is anchored to the top-level `messages` array rather than a later `tool_calls` array.
- Window expansion retries when a recent JSON value crosses the initial EOF window.
- Nested `messages` keys, trailing `tool_calls`, and `anchor_activity_scenes` are handled.
- State.db reconciliation remains active; newer or repaired rows are not hidden.
- Initial tail reconciliation queries only the state.db suffix at the sidecar tail timestamp floor and applies the existing 50,000-row display backstop; it does not materialize the complete database transcript.
- The reported message count and absolute pagination cursor are recomputed after suffix reconciliation, so newer state.db rows cannot make the response internally inconsistent.
- Bounded auxiliary reads restore session-level tool calls and activity scenes needed by the returned window.
- Existing fallback behavior remains for stale, empty, legacy, or unsupported sidecars.

### Duplication prevention

- Stable-ID snapshots are collapsed at the streaming merge boundary.
- The persistence boundary applies the same defense before serializing a session.
- Identical assistant answers with different stable IDs remain separate turns.

### Repair utility

Added `scripts/repair_duplicate_message_snapshots.py`. It incrementally rewrites a separate destination without `json.load()` on the entire sidecar and updates `message_count` to the repaired count. The caller must choose when to make the replacement and should retain a backup.

## Validation

- Focused affected suite: **98 passed** (including state.db read-backstop, multibyte metadata, nested auxiliary-key, and repair safety coverage).
- Python compilation passed.
- Changed-line Ruff gate passed with no new violations.
- `git diff --check` passed.
- Full suite collection was attempted: **14,234 tests collected**, but collection was blocked by the unrelated missing optional `playwright` module in `tests/test_compression_phantom_barrier.py`.
- Live repaired-sidecar loads after restart:
  - `e6a43eed3c92`: 0.121 seconds, repaired count 3,146.
  - `03efe6053c9c`: 0.077 seconds, repaired count 2,295.
- The Discord gateway process remained running while the WebUI alone was restarted.

## Local repair performed

Both affected sidecars were backed up at:

`/home/andy/webui-snapshots/duplicate-sidecar-repair-20260810_103728/`

Then repaired:

- `e6a43eed3c92`: 1,044,970 → 3,146 rows; 1,041,824 duplicate rows removed.
- `03efe6053c9c`: 2,446 → 2,295 rows; 151 duplicate rows removed.

## AI usage

Implemented and verified with Hermes Agent using GPT-5.6 Luna; focused tests and live endpoint measurements were run locally.

## Related issue

Related to #6881.
