### PR TITLE
fix: sync generated title to state.db for hermes sessions list

### DIFF
--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -198,12 +198,18 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
 
 
 def sync_session_title(session_id: str, title: str, profile: Optional[str] = None) -> None:
-    """Sync a generated title to state.db unconditionally (not gated by sync_to_insights).
+    """Sync an auto-generated title to state.db (not gated by sync_to_insights).
 
     Background title generation writes the title to the WebUI sidecar JSON but
     not to hermes-agent's state.db, so ``hermes sessions list`` shows blank
     titles for WebUI sessions.  This function bridges that gap and is called
     from the background title update/refresh paths after a title is persisted.
+
+    Uses ``set_auto_title_if_empty`` so it will only populate a NULL title and
+    never overwrite a manual rename made via CLI/Gateway/TUI.  This means
+    title refreshes (where state.db already holds the initial auto-title) are
+    effectively no-ops at the state.db layer -- acceptable because the primary
+    goal is ensuring ``hermes sessions list`` is not blank.
     """
     if not title:
         return
@@ -213,7 +219,7 @@ def sync_session_title(session_id: str, title: str, profile: Optional[str] = Non
     try:
         # Ensure the session row exists (idempotent) so the UPDATE has a target.
         db.ensure_session(session_id=session_id, source='webui')
-        db.set_session_title(session_id, title)
+        db.set_auto_title_if_empty(session_id, title)
     except Exception:
         logger.debug("Failed to sync session title to state.db for %s", session_id)
     finally:

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -195,3 +195,29 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             db.close()
         except Exception:
             logger.debug("Failed to close state.db")
+
+
+def sync_session_title(session_id: str, title: str, profile: Optional[str] = None) -> None:
+    """Sync a generated title to state.db unconditionally (not gated by sync_to_insights).
+
+    Background title generation writes the title to the WebUI sidecar JSON but
+    not to hermes-agent's state.db, so ``hermes sessions list`` shows blank
+    titles for WebUI sessions.  This function bridges that gap and is called
+    from the background title update/refresh paths after a title is persisted.
+    """
+    if not title:
+        return
+    db = _get_state_db(profile=profile)
+    if not db:
+        return
+    try:
+        # Ensure the session row exists (idempotent) so the UPDATE has a target.
+        db.ensure_session(session_id=session_id, source='webui')
+        db.set_session_title(session_id, title)
+    except Exception:
+        logger.debug("Failed to sync session title to state.db for %s", session_id)
+    finally:
+        try:
+            db.close()
+        except Exception:
+            logger.debug("Failed to close state.db")

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4469,7 +4469,7 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
             # Sync the generated title to state.db so `hermes sessions list` shows it.
             try:
                 from api.state_sync import sync_session_title
-                sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None))
+                sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None) or 'default')
             except Exception:
                 logger.debug("Failed to sync title to state.db after generation for %s", session_id)
         else:
@@ -4547,7 +4547,7 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
         # Sync the refreshed title to state.db so `hermes sessions list` stays current.
         try:
             from api.state_sync import sync_session_title
-            sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None))
+            sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None) or 'default')
         except Exception:
             logger.debug("Failed to sync refreshed title to state.db for %s", session_id)
         logger.info("Adaptive title refresh: session=%s new_title=%r", session_id, effective_title)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4466,6 +4466,12 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
             else:
                 _put_title_status(put_event, session_id, source, llm_status, effective_title, raw_preview)
             put_event('title', {'session_id': session_id, 'title': effective_title})
+            # Sync the generated title to state.db so `hermes sessions list` shows it.
+            try:
+                from api.state_sync import sync_session_title
+                sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None))
+            except Exception:
+                logger.debug("Failed to sync title to state.db after generation for %s", session_id)
         else:
             _put_title_status(put_event, session_id, 'skipped', source or 'unchanged', effective_title, raw_preview)
     finally:
@@ -4538,6 +4544,12 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
             s.save(touch_updated_at=False)
         _put_title_status(put_event, session_id, 'refreshed', llm_status, effective_title, raw_preview)
         put_event('title', {'session_id': session_id, 'title': effective_title})
+        # Sync the refreshed title to state.db so `hermes sessions list` stays current.
+        try:
+            from api.state_sync import sync_session_title
+            sync_session_title(session_id, effective_title, profile=getattr(s, 'profile', None))
+        except Exception:
+            logger.debug("Failed to sync refreshed title to state.db for %s", session_id)
         logger.info("Adaptive title refresh: session=%s new_title=%r", session_id, effective_title)
     except Exception:
         logger.debug("Background title refresh failed for session %s", session_id, exc_info=True)

--- a/tests/test_3230_preserve_manual_session_title.py
+++ b/tests/test_3230_preserve_manual_session_title.py
@@ -173,6 +173,10 @@ def test_cleared_title_allows_initial_auto_generation(monkeypatch):
         "profile_env_for_background_worker",
         lambda *_args, **_kwargs: contextlib.nullcontext(),
     )
+    monkeypatch.setattr(
+        "api.state_sync.sync_session_title",
+        lambda *_args, **_kwargs: None,
+    )
 
     streaming._run_background_title_update(
         session.session_id,


### PR DESCRIPTION
## Problem

WebUI sessions show blank titles in `hermes sessions list` output.

**Root cause:** Background title generation (`_run_background_title_update` and `_run_background_title_refresh`) writes the generated title to the WebUI sidecar JSON (`~/.hermes/webui/sessions/<id>.json`) but never syncs it to hermes-agent's `state.db`. Since `hermes sessions list` reads from `state.db`, WebUI session titles are always empty.

The existing `sync_session_usage` path cannot cover this because:
1. It is gated by the `sync_to_insights` setting (default: off)
2. It executes before the background title thread completes, so the title is still empty at that point

## Fix

- Add `sync_session_title()` to `api/state_sync.py` — an unconditional (not gated by `sync_to_insights`) title-only sync function
- Call it from both `_run_background_title_update` and `_run_background_title_refresh` in `api/streaming.py` immediately after persisting the title to the sidecar

The sync is wrapped in try/except so state.db unavailability never blocks the WebUI.

## Verification

- Confirmed via `sqlite3 ~/.hermes/state.db` that WebUI session rows exist with `source='webui'` but `title=NULL`
- Confirmed the same sessions have valid titles in their sidecar JSON files
- Both modified files compile cleanly
- `sync_session_title` imports successfully from the project's venv