### PR TITLE
fix(goals): prevent profile goal contract drift

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,6 +59,7 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       auth.py              Optional password authentication, signed cookies, passkeys/WebAuthn
       config.py            Discovery, globals, model detection, reloadable config
       helpers.py           HTTP helpers: j(), bad(), require(), safe_resolve(), security headers
+      goals.py             Persistent-goal commands and profile-scoped native GoalManager bridge
       models.py            Session model + CRUD, per-session profile tracking, CLI/state.db bridge
       profiles.py          Profile state management, hermes_cli wrapper
       onboarding.py        First-run onboarding status, real provider config writes, OAuth linking, readiness detection
@@ -393,6 +394,25 @@ read_file_content(workspace, rel):
     - Enforces MAX_FILE_BYTES = 200KB size limit
     - Reads as UTF-8 with errors='replace' (binary files show replacement chars)
     - Returns {path, content, size, lines}
+
+### 4.8 Persistent Goal Profile Boundary
+
+`api/goals.py` exposes the WebUI `/goal` command payloads and post-turn evaluation hook.
+Hermes Agent's native `GoalManager` is the authoritative owner of goal evaluation,
+continuation decisions, wait barriers, failure counters, contracts, subgoals, and
+`state.db` persistence.
+
+For a profile-scoped WebUI session, the bridge binds that profile's Hermes home with
+the Agent's context-local `set_hermes_home_override()` API before constructing or
+calling the native manager. The override is reset in a `finally` block after every
+operation, so concurrent sessions using the same session ID under different profiles
+cannot cross-read or cross-write goal state. Goal snapshot rollback uses the same
+scoped native persistence path.
+
+Older Hermes Agent versions that do not expose the context-local home API continue
+through `_LegacyProfileGoalManager`, which pins persistence to the selected profile's
+explicit `state.db` path. Keep this fallback compatibility-only: new goal semantics
+belong in Hermes Agent's native manager rather than a second WebUI implementation.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -402,17 +402,21 @@ Hermes Agent's native `GoalManager` is the authoritative owner of goal evaluatio
 continuation decisions, wait barriers, failure counters, contracts, subgoals, and
 `state.db` persistence.
 
-For a profile-scoped WebUI session, the bridge binds that profile's Hermes home with
-the Agent's context-local `set_hermes_home_override()` API before constructing or
-calling the native manager. The override is reset in a `finally` block after every
-operation, so concurrent sessions using the same session ID under different profiles
-cannot cross-read or cross-write goal state. Goal snapshot rollback uses the same
-scoped native persistence path.
+For a profile-scoped WebUI session, the bridge delegates only when the Agent exposes
+both the context-local `set_hermes_home_override()` API and call-time default
+`SessionDB` path resolution. The bridge probes the resolved default path under the
+selected context before constructing the native manager, then binds that profile's
+Hermes home before every native call. The override is reset in a `finally` block after
+every operation, so concurrent sessions using the same session ID under different
+profiles cannot cross-read or cross-write goal state. Goal snapshot rollback uses the
+same scoped native persistence path.
 
-Older Hermes Agent versions that do not expose the context-local home API continue
-through `_LegacyProfileGoalManager`, which pins persistence to the selected profile's
-explicit `state.db` path. Keep this fallback compatibility-only: new goal semantics
-belong in Hermes Agent's native manager rather than a second WebUI implementation.
+Older Hermes Agent versions that lack either capability continue through
+`_LegacyProfileGoalManager`, which pins persistence to the selected profile's explicit
+`state.db` path. This includes intermediate versions whose context API is present but
+whose default `SessionDB()` path remains frozen at module import. Keep this fallback
+compatibility-only: new goal semantics belong in Hermes Agent's native manager rather
+than a second WebUI implementation.
 
 ---
 

--- a/api/goals.py
+++ b/api/goals.py
@@ -82,6 +82,35 @@ def _profile_home_context_api():
     return set_hermes_home_override, reset_hermes_home_override
 
 
+def _native_profile_context_api(profile_home: str | Path):
+    """Return context setters only when SessionDB resolves that context at call time."""
+    context_api = _profile_home_context_api()
+    if context_api is None:
+        return None
+    try:
+        from hermes_state import _default_db_path  # type: ignore
+    except Exception:  # pragma: no cover - depends on installed hermes-agent
+        return None
+    if not callable(_default_db_path):
+        return None
+
+    home = Path(profile_home).expanduser().resolve()
+    set_home, reset_home = context_api
+    try:
+        token = set_home(home)
+    except Exception:  # pragma: no cover - depends on installed hermes-agent
+        return None
+    try:
+        resolved_db_path = Path(_default_db_path()).expanduser().resolve()
+    except Exception:  # pragma: no cover - depends on installed hermes-agent
+        return None
+    finally:
+        reset_home(token)
+    if resolved_db_path != home / "state.db":
+        return None
+    return context_api
+
+
 class _ProfileGoalManager:
     """Run the native GoalManager under a context-local profile home."""
 
@@ -307,8 +336,8 @@ def _manager(session_id: str, *, profile_home: str | Path | None = None):
     if GoalManager is None:
         return None
     if profile_home and GoalManager is _NativeGoalManager and GoalState is not None:
-        context_api = _profile_home_context_api()
         try:
+            context_api = _native_profile_context_api(profile_home)
             if context_api is not None:
                 return _ProfileGoalManager(
                     session_id=session_id,

--- a/api/goals.py
+++ b/api/goals.py
@@ -73,8 +73,70 @@ def _profile_db(profile_home: str | Path):
     return db
 
 
+def _profile_home_context_api():
+    """Return the native context-local Hermes home setters when available."""
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    except Exception:  # pragma: no cover - depends on installed hermes-agent
+        return None
+    return set_hermes_home_override, reset_hermes_home_override
+
+
 class _ProfileGoalManager:
-    """Small WebUI-local GoalManager adapter with explicit profile persistence."""
+    """Run the native GoalManager under a context-local profile home."""
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        profile_home: str | Path,
+        default_max_turns: int = 20,
+        context_api=None,
+    ):
+        if _NativeGoalManager is None:
+            raise RuntimeError("Hermes goal manager unavailable")
+        context_api = context_api or _profile_home_context_api()
+        if context_api is None:
+            raise RuntimeError("Hermes profile context unavailable")
+        self.session_id = session_id
+        self.profile_home = Path(profile_home).expanduser().resolve()
+        self._set_home, self._reset_home = context_api
+        self._manager = self._scoped(
+            _NativeGoalManager,
+            session_id=session_id,
+            default_max_turns=default_max_turns,
+        )
+
+    def _scoped(self, func, *args, **kwargs):
+        token = self._set_home(self.profile_home)
+        try:
+            return func(*args, **kwargs)
+        finally:
+            self._reset_home(token)
+
+    @property
+    def state(self):
+        return self._manager.state
+
+    def __getattr__(self, name):
+        value = getattr(self._manager, name)
+        if not callable(value):
+            return value
+
+        def scoped_call(*args, **kwargs):
+            return self._scoped(value, *args, **kwargs)
+
+        return scoped_call
+
+    def _restore_state(self, snapshot) -> None:
+        from hermes_cli.goals import save_goal  # type: ignore
+
+        self._manager._state = snapshot
+        self._scoped(save_goal, self.session_id, snapshot)
+
+
+class _LegacyProfileGoalManager:
+    """Explicit-DB fallback for Hermes versions without profile context."""
 
     def __init__(self, session_id: str, *, profile_home: str | Path, default_max_turns: int = 20):
         if GoalState is None:
@@ -193,7 +255,7 @@ class _ProfileGoalManager:
         if judge_goal is None:
             verdict, reason = "continue", "goal judge unavailable"
         else:
-            verdict, reason = judge_goal(state.goal, str(last_response or ""))
+            verdict, reason, *_ = judge_goal(state.goal, str(last_response or ""))
         state.last_verdict = verdict
         state.last_reason = reason
 
@@ -245,8 +307,16 @@ def _manager(session_id: str, *, profile_home: str | Path | None = None):
     if GoalManager is None:
         return None
     if profile_home and GoalManager is _NativeGoalManager and GoalState is not None:
+        context_api = _profile_home_context_api()
         try:
-            return _ProfileGoalManager(
+            if context_api is not None:
+                return _ProfileGoalManager(
+                    session_id=session_id,
+                    profile_home=profile_home,
+                    default_max_turns=_default_max_turns(),
+                    context_api=context_api,
+                )
+            return _LegacyProfileGoalManager(
                 session_id=session_id,
                 profile_home=profile_home,
                 default_max_turns=_default_max_turns(),
@@ -407,6 +477,9 @@ def restore_goal_state(session_id: str, snapshot: Any, *, profile_home: str | Pa
             pass
         return
     if isinstance(mgr, _ProfileGoalManager):
+        mgr._restore_state(snapshot)
+        return
+    if isinstance(mgr, _LegacyProfileGoalManager):
         mgr._state = snapshot
         mgr._save(snapshot)
         return

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -244,6 +244,42 @@ def test_profile_goal_context_isolated_across_threads(monkeypatch, tmp_path):
     assert get_hermes_home() == original_home
 
 
+def test_profile_goal_falls_back_when_session_db_path_is_frozen(monkeypatch, tmp_path):
+    """A context API alone cannot make an import-time SessionDB path profile-safe."""
+    from api import goals as webui_goals
+    from hermes_cli import goals as native_goals
+    import hermes_state
+
+    frozen_db_path = tmp_path / "frozen-home" / "state.db"
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", frozen_db_path)
+    webui_goals._DB_CACHE.clear()
+    native_goals._DB_CACHE.clear()
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    try:
+        assert webui_goals.goal_command_payload(
+            "shared-session", "goal-a", profile_home=profile_a
+        )["ok"] is True
+        assert webui_goals.goal_command_payload(
+            "shared-session", "goal-b", profile_home=profile_b
+        )["ok"] is True
+
+        assert webui_goals.goal_state_snapshot(
+            "shared-session", profile_home=profile_a
+        ).goal == "goal-a"
+        assert webui_goals.goal_state_snapshot(
+            "shared-session", profile_home=profile_b
+        ).goal == "goal-b"
+    finally:
+        for cache in (webui_goals._DB_CACHE, native_goals._DB_CACHE):
+            for db in cache.values():
+                close = getattr(db, "close", None)
+                if close is not None:
+                    close()
+            cache.clear()
+
+
 def test_profile_goal_context_resets_when_native_call_raises(monkeypatch, tmp_path):
     """A failed delegated call cannot leak its profile into the next task."""
     from api import goals as webui_goals

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -128,6 +128,158 @@ def test_has_active_goal_reports_only_active_state(monkeypatch):
     assert webui_goals.has_active_goal("") is False
 
 
+def test_profile_goal_evaluation_supports_native_judge_contract(monkeypatch, tmp_path):
+    """Profile goals accept the current five-field native judge result."""
+    from api import goals as webui_goals
+    from hermes_cli import goals as native_goals
+
+    judge = lambda *args, **kwargs: ("continue", "work remains", False, None, False)
+    monkeypatch.setattr(webui_goals, "judge_goal", judge)
+    monkeypatch.setattr(native_goals, "judge_goal", judge)
+    monkeypatch.syspath_prepend(str(Path(native_goals.__file__).resolve().parents[1]))
+    from hermes_constants import get_hermes_home
+
+    original_home = get_hermes_home()
+    webui_goals._DB_CACHE.clear()
+    native_goals._DB_CACHE.clear()
+    __import__("hermes_state")
+
+    home = tmp_path / "profile"
+    webui_goals.goal_command_payload("sid-native-contract", "finish it", profile_home=home)
+    decision = webui_goals.evaluate_goal_after_turn(
+        "sid-native-contract",
+        "not finished",
+        profile_home=home,
+    )
+    state = webui_goals.goal_state_snapshot("sid-native-contract", profile_home=home)
+
+    assert decision["verdict"] == "continue"
+    assert decision["should_continue"] is True
+    assert state.turns_used == 1
+    assert state.last_verdict == "continue"
+
+    snapshot = webui_goals.goal_state_snapshot("sid-native-contract", profile_home=home)
+    webui_goals.goal_command_payload("sid-native-contract", "replacement", profile_home=home)
+    webui_goals.restore_goal_state("sid-native-contract", snapshot, profile_home=home)
+    restored = webui_goals.goal_state_snapshot("sid-native-contract", profile_home=home)
+    assert restored.goal == "finish it"
+    assert restored.turns_used == 1
+    assert get_hermes_home() == original_home
+
+
+def test_profile_goal_evaluation_preserves_native_wait_semantics(monkeypatch, tmp_path):
+    """Profile goals park when the native judge returns a wait directive."""
+    from api import goals as webui_goals
+    from hermes_cli import goals as native_goals
+
+    judge = lambda *args, **kwargs: (
+        "wait",
+        "rate limited",
+        False,
+        {"seconds": 30},
+        False,
+    )
+    monkeypatch.setattr(webui_goals, "judge_goal", judge)
+    monkeypatch.setattr(native_goals, "judge_goal", judge)
+    monkeypatch.syspath_prepend(str(Path(native_goals.__file__).resolve().parents[1]))
+    webui_goals._DB_CACHE.clear()
+    native_goals._DB_CACHE.clear()
+    __import__("hermes_state")
+
+    home = tmp_path / "profile"
+    webui_goals.goal_command_payload("sid-native-wait", "finish it", profile_home=home)
+    decision = webui_goals.evaluate_goal_after_turn(
+        "sid-native-wait",
+        "rate limited",
+        profile_home=home,
+    )
+    state = webui_goals.goal_state_snapshot("sid-native-wait", profile_home=home)
+
+    assert decision["verdict"] == "wait"
+    assert decision["should_continue"] is False
+    assert state.waiting_until > 0
+    assert state.waiting_reason == "rate limited"
+
+
+def test_profile_goal_context_isolated_across_threads(monkeypatch, tmp_path):
+    """Concurrent profiles with the same session id cannot cross-write goals."""
+    from api import goals as webui_goals
+    from hermes_cli import goals as native_goals
+
+    monkeypatch.syspath_prepend(str(Path(native_goals.__file__).resolve().parents[1]))
+    from hermes_constants import get_hermes_home
+
+    original_home = get_hermes_home()
+    webui_goals._DB_CACHE.clear()
+    native_goals._DB_CACHE.clear()
+    __import__("hermes_state")
+    barrier = threading.Barrier(2)
+    failures = []
+
+    def set_goal(profile):
+        try:
+            barrier.wait()
+            result = webui_goals.goal_command_payload(
+                "shared-session",
+                f"goal-{profile}",
+                profile_home=tmp_path / profile,
+            )
+            assert result["ok"] is True
+        except Exception as exc:
+            failures.append(exc)
+
+    threads = [threading.Thread(target=set_goal, args=(profile,)) for profile in ("a", "b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert failures == []
+    assert webui_goals.goal_state_snapshot(
+        "shared-session", profile_home=tmp_path / "a"
+    ).goal == "goal-a"
+    assert webui_goals.goal_state_snapshot(
+        "shared-session", profile_home=tmp_path / "b"
+    ).goal == "goal-b"
+    assert get_hermes_home() == original_home
+
+
+def test_profile_goal_context_resets_when_native_call_raises(monkeypatch, tmp_path):
+    """A failed delegated call cannot leak its profile into the next task."""
+    from api import goals as webui_goals
+    from hermes_cli import goals as native_goals
+
+    monkeypatch.syspath_prepend(str(Path(native_goals.__file__).resolve().parents[1]))
+    from hermes_constants import (
+        get_hermes_home,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    class RaisingGoalManager:
+        state = None
+
+        def __init__(self, session_id, default_max_turns=20):
+            self.session_id = session_id
+            self.default_max_turns = default_max_turns
+
+        def explode(self):
+            raise RuntimeError("boom")
+
+    original_home = get_hermes_home()
+    monkeypatch.setattr(webui_goals, "_NativeGoalManager", RaisingGoalManager)
+    manager = webui_goals._ProfileGoalManager(
+        "sid-context-reset",
+        profile_home=tmp_path / "profile",
+        context_api=(set_hermes_home_override, reset_hermes_home_override),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        manager.explode()
+
+    assert get_hermes_home() == original_home
+
+
 def test_goal_continuation_decision_emits_status_and_normal_user_prompt(monkeypatch):
     """Post-turn hook returns the visible status event plus a normal continuation prompt."""
     from api import goals as webui_goals


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI promises persistent goals that continue after each incomplete turn.
- Profile-scoped WebUI sessions used a local copy of `GoalManager.evaluate_after_turn()` rather than the native Hermes implementation.
- Hermes' judge contract evolved from a two-value result to five values (`verdict`, `reason`, parse failure, wait directive, transport failure), while the WebUI copy still unpacked two.
- The resulting `ValueError` was caught by the WebUI goal hook and converted to a non-continuing error decision, leaving the goal active but idle.
- Hermes now exposes a context-local home override, so profile isolation no longer requires duplicating the goal engine.

## What Changed

- Run profile-scoped goal operations through the native Hermes `GoalManager` under a context-local profile home.
- Reset the profile context in `finally` after every delegated operation.
- Gate native delegation on both context-local home support and call-time default `SessionDB` path resolution; otherwise use the explicit-DB fallback.
- Preserve snapshot rollback for both native and legacy profile managers.
- Add regressions for:
  - the current five-field judge result;
  - native `WAIT` state and persistence;
  - same-session concurrent profile isolation;
  - the v2026.5.28–v2026.7.20 frozen-`DEFAULT_DB_PATH` compatibility range;
  - snapshot restoration;
  - context cleanup after success and exception paths.

## Why It Matters

An incomplete goal turn no longer silently stops because WebUI's profile adapter drifted from Hermes' native goal contract. Delegating to the native manager also keeps newer wait, parse-failure, transport-failure, contract, and subgoal semantics from drifting independently in WebUI.

## Verification

- Original regression before the fix: `test_profile_goal_evaluation_supports_native_judge_contract` failed with `decision["verdict"] == "error"` instead of `"continue"`.
- Review regression before the capability gate: `test_profile_goal_falls_back_when_session_db_path_is_frozen` reproduced profile A reading `goal-b` after profile B wrote the same session ID through a frozen default DB path.
- `./scripts/test.sh tests/test_goal_command_webui.py tests/test_stage326_pending_goal_continuation_race.py tests/test_issue_1932_goal_hook_unrelated_turns.py tests/test_webui_gateway_chat_backend.py -q`
  - `77 passed`
- Current-Agent capability probe: native delegation selected and the previous Hermes home restored after the probe.
- Actual Hermes Agent `v2026.7.20` compatibility canary: `_LegacyProfileGoalManager` selected and two profiles with the same session ID retained separate `goal-a` / `goal-b` state.
- Diff-scoped Ruff/new-code checks: pass.
- `git diff --check`: pass.
- Full-suite attempt reached `8,441 passed` before 22 unrelated `test_jump_to_answer_scroll_settle.py` failures and a 60-second pytest-timeout internal error; that entire file then passed independently (`26 passed`). CI remains the authoritative full-matrix check.
- Independent pre-commit review: pass; no security or logic findings.

## Contract Routing

Task type: narrow runtime compatibility bug fix.

Touched areas:
- `api/goals.py` profile-scoped goal persistence/evaluation adapter
- goal/runtime regression tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/hermes-run-adapter-contract.md`

State owner and invariant:
- Hermes `GoalManager` remains the authoritative goal-state owner.
- `HERMES_HOME` selection is task-local and is restored on every exit.
- Concurrent profiles cannot read or write each other's goal state.

This restores documented behavior; it does not intentionally change the persistent-goal contract.

## Risks / Follow-ups

- Hermes builds without either required capability—including the intermediate frozen-default-path range—continue through the explicit-DB fallback; it accepts extra judge result fields but intentionally retains its older feature subset.
- Automatic release of a native `WAIT` barrier is outside this focused repair and remains part of broader continuation scheduling work.
- No UI or interaction changes; screenshots are not applicable.

Release-note wording: Profile-scoped persistent goals no longer stop silently when WebUI runs with current Hermes goal-judge semantics.

## Model Used

OpenAI Codex provider, `gpt-5.6-sol`, with Hermes tool orchestration, isolated worktrees, TDD, and an independent reviewer subagent.
