### PR TITLE
fix(api): adjacency-based orphaned tool_calls stripping (#6545)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5067,33 +5067,43 @@ def _sanitize_messages_for_api(
         if sanitized.get('role'):
             clean.append(sanitized)
 
-    # Third pass: strip orphaned tool_calls from assistant messages — calls whose id
-    # has no matching tool-role response in the clean list.  Strict providers (DeepSeek,
-    # newer OpenAI) reject with 400 when an assistant message references a tool call that
-    # was never answered (e.g. session aborted before results flushed).
-    answered_ids: set = set()
-    for msg in clean:
-        if msg.get('role') == 'tool':
-            tid = msg.get('tool_call_id') or ''
-            if tid:
-                answered_ids.add(tid)
-
+    # Third pass: strip orphaned tool_calls from assistant messages.  A call is kept
+    # only when its tool-role response IMMEDIATELY follows the assistant message
+    # (before any non-tool message).  A response that merely exists somewhere else in
+    # the list — e.g. replayed/out-of-order insert after an interrupted MCP round —
+    # does NOT satisfy the adjacency rule strict providers enforce: the downstream
+    # repair/transport phase re-derives tool_calls from the trailing sequence, and a
+    # non-adjacent call becomes `tool_calls: []`, which DeepSeek-style providers
+    # reject with HTTP 400 (#6545).
     filtered_clean = []
-    for msg in clean:
+    i = 0
+    n = len(clean)
+    while i < n:
+        msg = clean[i]
         if msg.get('role') == 'assistant' and msg.get('tool_calls'):
+            adjacent_answered: set = set()
+            j = i + 1
+            while j < n and clean[j].get('role') == 'tool':
+                tid = clean[j].get('tool_call_id') or ''
+                if tid:
+                    adjacent_answered.add(tid)
+                j += 1
             kept = [
                 tc for tc in msg['tool_calls']
                 if isinstance(tc, dict) and
-                (tc.get('id') or tc.get('call_id') or '') in answered_ids
+                (tc.get('id') or tc.get('call_id') or '') in adjacent_answered
             ]
             if not kept:
-                # All calls orphaned: drop tool_calls key; if no content, drop message.
+                # All calls non-adjacent/orphaned: drop tool_calls key; if no
+                # content, drop message.
                 msg = {k: v for k, v in msg.items() if k != 'tool_calls'}
                 if not str(msg.get('content') or '').strip():
+                    i += 1
                     continue
             else:
                 msg = dict(msg, tool_calls=kept)
         filtered_clean.append(msg)
+        i += 1
 
     # Fourth pass: drop _recovered user messages unless removing one would fuse
     # two same-role neighbours.  Operating on filtered_clean (post orphaned-tool/
@@ -5166,30 +5176,36 @@ def _api_safe_message_positions(messages):
         if sanitized.get('role'):
             out.append((idx, sanitized))
 
-    # Third pass: strip orphaned tool_calls from assistant messages (mirrors
-    # _sanitize_messages_for_api pass 3).
-    answered_ids: set = set()
-    for _idx, msg in out:
-        if msg.get('role') == 'tool':
-            tid = msg.get('tool_call_id') or ''
-            if tid:
-                answered_ids.add(tid)
-
+    # Third pass: strip orphaned tool_calls from assistant messages — adjacency-based
+    # (mirrors _sanitize_messages_for_api pass 3, #6545).  A call is kept only when its
+    # tool-role response immediately follows the assistant message.
     filtered_out = []
-    for idx, msg in out:
+    i = 0
+    n = len(out)
+    while i < n:
+        idx, msg = out[i]
         if msg.get('role') == 'assistant' and msg.get('tool_calls'):
+            adjacent_answered: set = set()
+            j = i + 1
+            while j < n and out[j][1].get('role') == 'tool':
+                tid = out[j][1].get('tool_call_id') or ''
+                if tid:
+                    adjacent_answered.add(tid)
+                j += 1
             kept = [
                 tc for tc in msg['tool_calls']
                 if isinstance(tc, dict) and
-                (tc.get('id') or tc.get('call_id') or '') in answered_ids
+                (tc.get('id') or tc.get('call_id') or '') in adjacent_answered
             ]
             if not kept:
                 msg = {k: v for k, v in msg.items() if k != 'tool_calls'}
                 if not str(msg.get('content') or '').strip():
+                    i += 1
                     continue
             else:
                 msg = dict(msg, tool_calls=kept)
         filtered_out.append((idx, msg))
+        i += 1
 
     # Fourth pass: drop _recovered user messages unless removing one would fuse
     # two same-role neighbours — mirrors _sanitize_messages_for_api pass 4 (#4283).

--- a/tests/test_issue6545_toolcalls_adjacency.py
+++ b/tests/test_issue6545_toolcalls_adjacency.py
@@ -1,0 +1,167 @@
+"""Tests for #6545: adjacency-based orphaned tool_calls stripping.
+
+Pass 3 of _sanitize_messages_for_api / _api_safe_message_positions kept a
+tool_call whenever its tool-role response existed ANYWHERE in the clean list.
+After an interrupted MCP tool round, a replayed/out-of-order insert can leave a
+stale tool_call on a later assistant message whose response sits far earlier in
+the transcript. The downstream agent repair then re-derives tool_calls from the
+trailing sequence and produces ``tool_calls: []``, which strict providers
+(DeepSeek V4, Console Go) reject with HTTP 400 (#6545).
+
+A call is now kept only when its tool-role response IMMEDIATELY follows the
+assistant message — the adjacency rule strict providers enforce anyway. These
+tests pin the three fixtures requested in the issue review: a valid same-turn
+call/result pair, duplicate call IDs across separate turns, and a
+duplicate-only (content-empty) assistant message.
+"""
+
+from api.streaming import _sanitize_messages_for_api, _api_safe_message_positions
+
+
+def _tc(call_id):
+    return {"id": call_id, "type": "function", "function": {"name": "f", "arguments": "{}"}}
+
+
+def _tool(call_id):
+    return {"role": "tool", "tool_call_id": call_id, "content": "ok"}
+
+
+def _assistant(content, call_ids=()):
+    msg = {"role": "assistant", "content": content}
+    if call_ids:
+        msg["tool_calls"] = [_tc(c) for c in call_ids]
+    return msg
+
+
+def _user(content="u"):
+    return {"role": "user", "content": content}
+
+
+def _assistant_messages(out, content):
+    return [m for m in out if m.get("role") == "assistant" and m.get("content") == content]
+
+
+# ── _sanitize_messages_for_api ──────────────────────────────────────────
+
+
+def test_valid_same_turn_pair_survives():
+    """A call whose tool response immediately follows stays intact."""
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+    ]
+    out = _sanitize_messages_for_api(msgs)
+    first = _assistant_messages(out, "first")[0]
+    assert [tc["id"] for tc in first["tool_calls"]] == ["call_1"]
+
+
+def test_stale_call_with_remote_response_stripped():
+    """A call id whose response exists earlier (non-adjacent) is stripped.
+
+    This is the #6545 crash shape: after an interrupted tool round the final
+    assistant message re-carries a call id answered ~2 turns earlier. The
+    response exists in the list, but not immediately after this message.
+    """
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+        _assistant("second stale", ["call_1"]),
+        _user(),
+    ]
+    out = _sanitize_messages_for_api(msgs)
+    stale = _assistant_messages(out, "second stale")[0]
+    assert "tool_calls" not in stale
+    # the original turn keeps its call
+    first = _assistant_messages(out, "first")[0]
+    assert [tc["id"] for tc in first["tool_calls"]] == ["call_1"]
+
+
+def test_duplicate_ids_across_separate_turns():
+    """Same call id in two turns: only the adjacency-satisfying one survives."""
+    msgs = [
+        _user(),
+        _assistant("t1", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+        _assistant("t2", ["call_2"]),
+        _tool("call_2"),
+        _user(),
+        _assistant("t3 stale", ["call_1"]),
+        _user(),
+    ]
+    out = _sanitize_messages_for_api(msgs)
+    assert [tc["id"] for tc in _assistant_messages(out, "t1")[0]["tool_calls"]] == ["call_1"]
+    assert [tc["id"] for tc in _assistant_messages(out, "t2")[0]["tool_calls"]] == ["call_2"]
+    assert "tool_calls" not in _assistant_messages(out, "t3 stale")[0]
+
+
+def test_duplicate_only_content_empty_assistant_dropped():
+    """All calls stripped AND no content -> the assistant message is dropped."""
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+        _assistant("", ["call_1"]),  # duplicate-only, empty content
+        _user(),
+    ]
+    out = _sanitize_messages_for_api(msgs)
+    # no assistant message with empty content may survive
+    assert not any(
+        m.get("role") == "assistant" and not str(m.get("content") or "").strip()
+        for m in out
+    )
+    # and the original turn still has its call
+    first = _assistant_messages(out, "first")[0]
+    assert [tc["id"] for tc in first["tool_calls"]] == ["call_1"]
+
+
+def test_duplicate_only_content_present_keeps_text():
+    """All calls stripped but content present -> message survives without key."""
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+        _assistant("I have the answer", ["call_1"]),
+        _user(),
+    ]
+    out = _sanitize_messages_for_api(msgs)
+    kept = _assistant_messages(out, "I have the answer")[0]
+    assert "tool_calls" not in kept
+    assert kept["content"] == "I have the answer"
+
+
+# ── _api_safe_message_positions (mirror) ────────────────────────────────
+
+
+def test_positions_mirror_strips_non_adjacent():
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+        _assistant("stale", ["call_1"]),
+        _user(),
+    ]
+    out = _api_safe_message_positions(msgs)
+    stale = [m for _i, m in out if m.get("content") == "stale"][0]
+    assert "tool_calls" not in stale
+    first = [m for _i, m in out if m.get("content") == "first"][0]
+    assert [tc["id"] for tc in first["tool_calls"]] == ["call_1"]
+
+
+def test_positions_mirror_keeps_same_turn_pair():
+    msgs = [
+        _user(),
+        _assistant("first", ["call_1"]),
+        _tool("call_1"),
+        _user(),
+    ]
+    out = _api_safe_message_positions(msgs)
+    first = [m for _i, m in out if m.get("content") == "first"][0]
+    assert [tc["id"] for tc in first["tool_calls"]] == ["call_1"]


### PR DESCRIPTION
## Summary

Fixes the WebUI layer of #6545 (per the maintainer's request in the issue thread, 2026-08-10): the orphaned-`tool_calls` stripping in `_sanitize_messages_for_api` and `_api_safe_message_positions` (Pass 3) now uses **adjacency** instead of a transcript-global answered-id set.

## Root cause

After an interrupted MCP tool round, a replayed/out-of-order insert can leave a stale `tool_call` (same `call_id`) on a later assistant message whose tool-role response sits far earlier in the list. The old Pass 3 collected answered ids **globally** (`answered_ids` over the whole list), so the stale call counted as answered and survived.

The downstream agent repair (`repair_message_sequence` Pass 0) then merges the trailing assistant messages and **unions** their `tool_calls` — the stale call is re-derived onto the merged message as `tool_calls: []`, which strict providers (DeepSeek V4, Console Go) reject with `HTTP 400: Invalid 'messages[N].tool_calls': empty array` (#6545).

## Fix

A call is kept only when its tool-role response **immediately follows** the assistant message (before any non-tool message) — the adjacency rule strict providers enforce anyway. Non-adjacent calls are stripped; if no calls remain, the `tool_calls` key is dropped, and a content-empty assistant message is removed entirely. Applied identically to both `_sanitize_messages_for_api` and `_api_safe_message_positions`.

## Verification

- **A/B repro** against the corrupted session (`20260810_102548_bd851193`): old logic → `tool_calls: []` at request index 161 (provider `messages[162]`, 164 total); new logic → zero empty arrays. The previously-crashing session continues in the WebUI without 400.
- **7 new unit tests** covering the fixtures requested in the issue review: valid same-turn call/result pair, duplicate call IDs across separate turns, duplicate-only content-empty assistant message (dropped), duplicate-only with content (text kept), plus mirrors for `_api_safe_message_positions`. All 7 pass (verified by direct invocation; the local `tests/` server fixture is incompatible with the locally installed hermes-agent version here, the CI test setup runs them under pytest like the existing `test_title_sanitization.py`).

## Notes

- The **agent-side layer** (the dedup pass inside `sanitize_api_messages` that *creates* a fresh `[]` after the empty-drop) is intentionally not touched here — the maintainer asked to keep both layers fail-closed. Candidate agent-side PRs: `nousresearch/hermes-agent` #83279 / #83315.
