### PR TITLE
fix(transcript): project internal wakeups as progress

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -309,22 +309,27 @@ the server worker claims the intent and enters the ordinary `start_session_turn(
 The record carries a stable continuation id, originating stream, profile home, goal
 turn number, bounded attempt count, and claim owner. Every read-modify-write transaction
 holds a process-local lock **and** an OS file lock; durable replacement is atomic, fsynced,
-and mode `0600`. The owner id is regenerated after `fork()`, failed replacements invalidate
-the in-memory cache, and unreadable registries are quarantined with mode `0600`. Together
-these rules prevent lost updates and double dispatch across overlapping WebUI processes.
+and mode `0600`. One process also holds a lifetime worker-leadership lock, acquired only
+after the HTTP server owns its port. The owner id and process-local locks are regenerated
+after `fork()`, and each stream bind must match both the current owner and exact claim id.
+Invalid JSON is quarantined with mode `0600`; operating-system read errors propagate and
+fail closed instead of replacing temporarily inaccessible state. Together these rules
+prevent lost updates, stale binds, and double dispatch across overlapping WebUI processes.
 Repeated judge callbacks for the same source stream are idempotent, competing worker
 claims start at most one turn, and a restarted worker only requeues an active,
 unjudged goal intent. If the persisted goal counter already advanced, recovery derives a
 fresh prompt from the current goal state rather than replaying the stale attempted prompt.
 Completed or inactive goals are never resurrected.
 
-A provider result with no final answer, no token/reasoning/tool activity, and no
-explicit error is retryable only for a server-owned goal continuation. The current
-attempt is settled visibly as an automatic retry and the same intent is requeued with
-bounded exponential backoff. Any observed activity disables replay to avoid duplicate
-tool or external side effects. This mechanism persists the *next-turn intent*; it does
-not keep an in-process agent run alive across a WebUI service restart and is not a
-general-purpose browser queue.
+A provider result with no final answer, no token/reasoning/tool/approval/clarify/process
+activity, no cancellation, and no explicit error is retryable only for a server-owned
+goal continuation. The current attempt is settled visibly as an automatic retry, its SSE
+stream is explicitly closed, and the same intent is requeued with bounded exponential
+backoff. Any observed activity disables replay to avoid duplicate tool or external side
+effects. A WebUI-owned durable intent remains on the WebUI local/Gateway settlement path;
+it is never handed to `runner-local`, whose adapter contract owns its own post-turn goal
+evaluation. This mechanism persists the *next-turn intent*; it does not keep an in-process
+agent run alive across a WebUI service restart and is not a general-purpose browser queue.
 
 ### 4.4 Agent Invocation (_run_agent_streaming)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,8 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       __init__.py          Package marker
       auth.py              Optional password authentication, signed cookies, passkeys/WebAuthn
       config.py            Discovery, globals, model detection, reloadable config
+      goals.py             WebUI wrapper around Hermes GoalManager state/evaluation
+      goal_continuations.py Durable one-intent-per-session dispatcher for automatic goal turns
       helpers.py           HTTP helpers: j(), bad(), require(), safe_resolve(), security headers
       goals.py             Persistent-goal commands and profile-scoped native GoalManager bridge
       models.py            Session model + CRUD, per-session profile tracking, CLI/state.db bridge
@@ -110,6 +112,7 @@ State directory (runtime data, separate from source):
     workspaces.json    Registered workspaces list
     last_workspace.txt Last-used workspace path
     settings.json      User settings (default model, workspace, send key, password hash)
+    goal-continuations.json Atomic 0600 registry for pending automatic /goal turns
     projects.json      Session project groups (name, color, id)
 
 Log file:
@@ -294,6 +297,34 @@ is caught).
 
 Fallback sync endpoint: POST /api/chat still exists and holds the connection open until
 the agent finishes. The frontend never uses it but it can be useful for debugging.
+
+#### 4.3.1 Automatic goal continuation ownership
+
+After the post-turn goal judge returns `continue`, the streaming backend writes one
+continuation intent per session to `goal-continuations.json` **before** emitting the
+`goal_continue` SSE event. `static/messages.js` treats that event as presentation-only;
+the server worker claims the intent and enters the ordinary `start_session_turn()` /
+`_start_run()` admission path with source `goal_continuation`.
+
+The record carries a stable continuation id, originating stream, profile home, goal
+turn number, bounded attempt count, and claim owner. Every read-modify-write transaction
+holds a process-local lock **and** an OS file lock; durable replacement is atomic, fsynced,
+and mode `0600`. The owner id is regenerated after `fork()`, failed replacements invalidate
+the in-memory cache, and unreadable registries are quarantined with mode `0600`. Together
+these rules prevent lost updates and double dispatch across overlapping WebUI processes.
+Repeated judge callbacks for the same source stream are idempotent, competing worker
+claims start at most one turn, and a restarted worker only requeues an active,
+unjudged goal intent. If the persisted goal counter already advanced, recovery derives a
+fresh prompt from the current goal state rather than replaying the stale attempted prompt.
+Completed or inactive goals are never resurrected.
+
+A provider result with no final answer, no token/reasoning/tool activity, and no
+explicit error is retryable only for a server-owned goal continuation. The current
+attempt is settled visibly as an automatic retry and the same intent is requeued with
+bounded exponential backoff. Any observed activity disables replay to avoid duplicate
+tool or external side effects. This mechanism persists the *next-turn intent*; it does
+not keep an in-process agent run alive across a WebUI service restart and is not a
+general-purpose browser queue.
 
 ### 4.4 Agent Invocation (_run_agent_streaming)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,30 @@
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.
 
+## Durable `/goal` continuation gate
+
+Automatic goal turns are owned by the server, not by an open browser tab. Run the
+focused deterministic matrix with an isolated WebUI state directory:
+
+```bash
+./scripts/test.sh -q \
+  tests/test_goal_server_continuation.py \
+  tests/test_goal_server_continuation_multiprocess.py \
+  tests/test_goal_server_continuation_callsite.py \
+  tests/test_stage326_pending_goal_continuation_race.py \
+  tests/test_goal_command_webui.py \
+  tests/test_issue5121_provider_auth_terminal_error.py
+```
+
+The gate proves atomic persistence and permissions, cross-process transaction exclusion,
+fork-safe owner identity, duplicate-judge idempotency, competing-claim exclusion,
+inactive-goal refusal, restart recovery with a current prompt, bounded empty response
+retries, and fail-closed behavior after any token/reasoning/tool activity.
+The callsite tests additionally pin persistence-before-SSE ordering, browser
+observation-only behavior, worker lifecycle, and both local and Gateway streaming
+backends. A manual/live check should close or reload the browser after a `continue`
+verdict and confirm that the next turn still starts and settles in the same session.
+
 ---
 
 ## Static JS runtime lint (brick-class regression guard)

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,13 +25,18 @@ focused deterministic matrix with an isolated WebUI state directory:
   tests/test_goal_server_continuation_callsite.py \
   tests/test_stage326_pending_goal_continuation_race.py \
   tests/test_goal_command_webui.py \
-  tests/test_issue5121_provider_auth_terminal_error.py
+  tests/test_issue5121_provider_auth_terminal_error.py \
+  tests/test_webui_gateway_chat_backend.py \
+  tests/test_agent_runtime_revision_guard.py
 ```
 
-The gate proves atomic persistence and permissions, cross-process transaction exclusion,
-fork-safe owner identity, duplicate-judge idempotency, competing-claim exclusion,
-inactive-goal refusal, restart recovery with a current prompt, bounded empty response
-retries, and fail-closed behavior after any token/reasoning/tool activity.
+The gate proves atomic persistence and permissions, cross-process transaction and worker
+leadership exclusion, fork-safe owner identity and locks, exact claim/owner fencing,
+duplicate-judge idempotency, competing-claim exclusion, inactive-goal refusal, restart
+recovery with readable evidence and a current prompt, bounded empty-response retries,
+explicit SSE closure, cancellation fencing, and fail-closed behavior after any
+token/reasoning/tool/approval/clarify/process activity. It also proves that a WebUI-owned
+durable intent cannot escape to the runner-owned lifecycle.
 The callsite tests additionally pin persistence-before-SSE ordering, browser
 observation-only behavior, worker lifecycle, and both local and Gateway streaming
 backends. A manual/live check should close or reload the browser after a `continue`

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1038,7 +1038,7 @@ def _start_async_delegation_wakeup_turn(
             resp = start_session_turn(
                 session_id,
                 wakeup_prompt,
-                source="process_wakeup",
+                source="async_delegation",
             )
             raw_status = (resp or {}).get("_status")
             if raw_status is None:

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1823,6 +1823,9 @@ def start_drain_thread() -> bool:
 
 
 def stop_drain_thread(timeout: float = 2.0) -> None:
+    from api.goal_continuations import stop_goal_continuation_worker
+
+    stop_goal_continuation_worker(timeout=timeout)
     _DRAIN_STOP.set()
     th = _DRAIN_THREAD
     if th is not None and th.is_alive():

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -911,7 +911,6 @@ def _settle_gateway_empty_response(
 
 def _emit_gateway_empty_response_events(put_gateway_event, error_payload, session_id):
     """Close an empty Gateway turn with a replayable terminal session payload."""
-    put_gateway_event("apperror", error_payload)
     try:
         from api.streaming import _session_payload_with_full_messages
 
@@ -1001,6 +1000,16 @@ def _run_gateway_chat_streaming(
         # path (the teardown finally below never runs when we early-return here).
         clear_session_writeback_owner_if_owned(session_id, stream_id)
         return
+    if goal_related:
+        from api.goal_continuations import mark_goal_continuation_worker_started
+
+        if not mark_goal_continuation_worker_started(session_id, stream_id):
+            with STREAMS_LOCK:
+                STREAMS.pop(stream_id, None)
+                STREAM_GOAL_RELATED.pop(stream_id, None)
+            unregister_stream_owner(stream_id)
+            clear_session_writeback_owner_if_owned(session_id, stream_id)
+            return
     register_active_run(
         stream_id,
         session_id=session_id,
@@ -1541,13 +1550,32 @@ def _run_gateway_chat_streaming(
                         from api.goals import goal_state_snapshot
 
                         goal_state = goal_state_snapshot(session_id, profile_home=profile_home)
-                        continuation_record = schedule_goal_continuation(
-                            session_id,
-                            continuation_prompt,
-                            source_stream_id=stream_id,
-                            profile_home=profile_home,
-                            goal_turns_used=int(getattr(goal_state, "turns_used", 0) or 0),
-                        )
+                        try:
+                            continuation_record = schedule_goal_continuation(
+                                session_id,
+                                continuation_prompt,
+                                source_stream_id=stream_id,
+                                profile_home=profile_home,
+                                goal_turns_used=int(getattr(goal_state, "turns_used", 0) or 0),
+                            )
+                        except Exception as schedule_exc:
+                            logger.exception(
+                                "Failed to persist Gateway goal continuation for session %s",
+                                session_id,
+                            )
+                            put_gateway_event("goal", {
+                                "session_id": session_id,
+                                "state": "needs_attention",
+                                "message": "Goal continuation could not be persisted.",
+                                "message_key": "goal_continuation_schedule_failed",
+                            })
+                            put_gateway_event("apperror", {
+                                "type": "goal_continuation_schedule_failed",
+                                "label": "Goal continuation stopped",
+                                "message": str(schedule_exc)[:500],
+                            })
+                            put_gateway_event("stream_end", {"session_id": session_id})
+                            return
                         PENDING_GOAL_CONTINUATION.add(session_id)
                         put_gateway_event("goal_continue", {
                             "session_id": session_id,

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1480,7 +1480,7 @@ def _run_gateway_chat_streaming(
             s.model_provider = model_provider
 
             def _restore_cancelled_success_writeback():
-                if pending_source == "process_wakeup":
+                if pending_source in {"process_wakeup", "async_delegation"}:
                     s.context_messages = previous_context
                     s.messages = previous_messages
                     s.process_wakeup_pause = dict(previous_process_wakeup_pause)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -911,6 +911,7 @@ def _settle_gateway_empty_response(
 
 def _emit_gateway_empty_response_events(put_gateway_event, error_payload, session_id):
     """Close an empty Gateway turn with a replayable terminal session payload."""
+    put_gateway_event("apperror", error_payload)
     try:
         from api.streaming import _session_payload_with_full_messages
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -912,9 +912,22 @@ def _settle_gateway_empty_response(
 def _emit_gateway_empty_response_events(put_gateway_event, error_payload, session_id):
     """Close an empty Gateway turn with a replayable terminal session payload."""
     put_gateway_event("apperror", error_payload)
-    terminal_session = error_payload.get("session") if isinstance(error_payload, dict) else None
-    if terminal_session is not None:
-        put_gateway_event("done", {"session": terminal_session, "usage": {}})
+    try:
+        from api.streaming import _session_payload_with_full_messages
+
+        s = get_session(session_id)
+        gateway_session_payload = redact_session_data(
+            _session_payload_with_full_messages(s, tool_calls=[])
+        )
+    except Exception:
+        gateway_fallback_payload = (
+            error_payload.get("session") if isinstance(error_payload, dict) else None
+        )
+        if gateway_fallback_payload is not None:
+            put_gateway_event("done", {"session": gateway_fallback_payload, "usage": {}})
+    else:
+        if gateway_session_payload is not None:
+            put_gateway_event("done", {"session": gateway_session_payload, "usage": {}})
     put_gateway_event("stream_end", {"session_id": session_id})
 
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -807,7 +807,16 @@ def stop_gateway_run(run_id: str) -> bool:
         return False
 
 
-def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, model_provider, terminal_error):
+def _settle_gateway_terminal_error(
+    session_id,
+    stream_id,
+    workspace,
+    model,
+    model_provider,
+    terminal_error,
+    *,
+    error_classification_override=None,
+):
     from api.streaming import (
         _classify_provider_error,
         _materialize_pending_user_turn_before_error,
@@ -822,6 +831,11 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
         if not _stream_writeback_is_current(session, stream_id):
             return None
         error_classification = _classify_provider_error(terminal_error)
+        if isinstance(error_classification_override, dict):
+            error_classification = {
+                **error_classification,
+                **error_classification_override,
+            }
         error_payload = _provider_error_payload(
             terminal_error,
             error_classification["type"],
@@ -871,6 +885,37 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
         if terminal_session_persisted:
             error_payload["terminal_session_persisted_session_id"] = session.session_id
         return error_payload
+
+
+def _settle_gateway_empty_response(
+    session_id,
+    stream_id,
+    workspace,
+    model,
+    model_provider,
+):
+    return _settle_gateway_terminal_error(
+        session_id,
+        stream_id,
+        workspace,
+        model,
+        model_provider,
+        "Gateway returned no assistant message for this turn.",
+        error_classification_override={
+            "label": "Gateway returned no response",
+            "type": "gateway_empty_response",
+            "hint": "Check that Hermes Gateway API server is running and reachable.",
+        },
+    )
+
+
+def _emit_gateway_empty_response_events(put_gateway_event, error_payload, session_id):
+    """Close an empty Gateway turn with a replayable terminal session payload."""
+    put_gateway_event("apperror", error_payload)
+    terminal_session = error_payload.get("session") if isinstance(error_payload, dict) else None
+    if terminal_session is not None:
+        put_gateway_event("done", {"session": terminal_session, "usage": {}})
+    put_gateway_event("stream_end", {"session_id": session_id})
 
 
 def _gateway_event_blocks_empty_retry(event: str) -> bool:
@@ -1297,12 +1342,20 @@ def _run_gateway_chat_streaming(
                         put_gateway_event,
                     )
                     return
-            put_gateway_event("apperror", {
-                "label": "Gateway returned no response",
-                "type": "gateway_empty_response",
-                "message": "Gateway returned no assistant message for this turn.",
-                "hint": "Check that Hermes Gateway API server is running and reachable.",
-            })
+            error_payload = _settle_gateway_empty_response(
+                session_id,
+                stream_id,
+                workspace,
+                model,
+                model_provider,
+            )
+            if error_payload is None:
+                return
+            _emit_gateway_empty_response_events(
+                put_gateway_event,
+                error_payload,
+                session_id,
+            )
             return
         with _get_session_agent_lock(session_id):
             s = get_session(session_id)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -873,6 +873,16 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
         return error_payload
 
 
+def _gateway_event_blocks_empty_retry(event: str) -> bool:
+    return str(event or "") in {
+        "approval",
+        "clarify",
+        "tool_call",
+        "tool_result",
+        "tool_progress",
+    }
+
+
 def _stream_writeback_is_current(session: Any, stream_id: str) -> bool:
     return bool(stream_id and getattr(session, "active_stream_id", None) == stream_id)
 
@@ -955,8 +965,12 @@ def _run_gateway_chat_streaming(
 
     success_writeback_committed = False
     runs_api_pending_marked = True
+    non_retryable_activity_seen = False
 
     def put_gateway_event(event, data):
+        nonlocal non_retryable_activity_seen
+        if _gateway_event_blocks_empty_retry(event):
+            non_retryable_activity_seen = True
         if cancel_event.is_set() and not success_writeback_committed and event not in ("cancel", "error", "apperror"):
             return
         if event == "apperror" and isinstance(data, dict):
@@ -1257,6 +1271,29 @@ def _run_gateway_chat_streaming(
             put_gateway_event("apperror", error_payload)
             return
         if not assistant_text:
+            _gateway_turn_source = getattr(s, "pending_user_source", None) or "webui"
+            if _gateway_turn_source == "goal_continuation":
+                from api.goal_continuations import (
+                    requeue_goal_continuation_after_no_response,
+                )
+
+                _gateway_retry_had_activity = bool(
+                    non_retryable_activity_seen
+                    or STREAM_PARTIAL_TEXT.get(stream_id)
+                    or STREAM_REASONING_TEXT.get(stream_id)
+                    or STREAM_LIVE_TOOL_CALLS.get(stream_id)
+                )
+                if requeue_goal_continuation_after_no_response(
+                    session_id,
+                    stream_id,
+                    had_activity=_gateway_retry_had_activity,
+                ):
+                    _emit_gateway_goal_retry_scheduled(
+                        session_id,
+                        stream_id,
+                        put_gateway_event,
+                    )
+                    return
             put_gateway_event("apperror", {
                 "label": "Gateway returned no response",
                 "type": "gateway_empty_response",
@@ -1394,7 +1431,16 @@ def _run_gateway_chat_streaming(
             from api.profiles import get_hermes_home_for_profile
 
             profile_home = get_hermes_home_for_profile(getattr(s, "profile", None))
-            if goal_related and has_active_goal(session_id, profile_home=profile_home):
+            gateway_goal_is_active = (
+                has_active_goal(session_id, profile_home=profile_home)
+                if goal_related
+                else False
+            )
+            if goal_related and not gateway_goal_is_active:
+                from api.goal_continuations import complete_goal_continuation
+
+                complete_goal_continuation(session_id, stream_id)
+            if goal_related and gateway_goal_is_active:
                 put_gateway_event("goal", {
                     "session_id": session_id,
                     "state": "evaluating",
@@ -1422,6 +1468,17 @@ def _run_gateway_chat_streaming(
                 if decision.get("should_continue"):
                     continuation_prompt = str(decision.get("continuation_prompt") or "").strip()
                     if continuation_prompt:
+                        from api.goal_continuations import schedule_goal_continuation
+                        from api.goals import goal_state_snapshot
+
+                        goal_state = goal_state_snapshot(session_id, profile_home=profile_home)
+                        continuation_record = schedule_goal_continuation(
+                            session_id,
+                            continuation_prompt,
+                            source_stream_id=stream_id,
+                            profile_home=profile_home,
+                            goal_turns_used=int(getattr(goal_state, "turns_used", 0) or 0),
+                        )
                         PENDING_GOAL_CONTINUATION.add(session_id)
                         put_gateway_event("goal_continue", {
                             "session_id": session_id,
@@ -1431,7 +1488,13 @@ def _run_gateway_chat_streaming(
                             "message_key": decision.get("message_key") or "goal_continuing",
                             "message_args": decision.get("message_args") or [],
                             "decision": decision,
+                            "server_scheduled": True,
+                            "continuation_id": continuation_record.get("continuation_id"),
                         })
+                elif goal_related:
+                    from api.goal_continuations import complete_goal_continuation
+
+                    complete_goal_continuation(session_id, stream_id)
         except Exception as goal_exc:
             logger.debug(
                 "Gateway goal continuation hook failed for session %s: %s",
@@ -1493,3 +1556,67 @@ def _run_gateway_chat_streaming(
         # the process lifetime (compare-and-clear: only clears if still owned by
         # this stream, mirroring the local streaming teardown).
         clear_session_writeback_owner_if_owned(session_id, stream_id)
+        try:
+            from api.goal_continuations import (
+                fail_goal_continuation,
+                wake_goal_continuation_worker,
+            )
+
+            fail_goal_continuation(
+                session_id,
+                stream_id,
+                "gateway goal continuation ended without a durable judge settlement",
+            )
+            wake_goal_continuation_worker()
+        except Exception:
+            logger.debug("Gateway goal-continuation teardown wake failed", exc_info=True)
+
+
+def _emit_gateway_goal_retry_scheduled(session_id, stream_id, put_gateway_event):
+    """Settle a silent goal turn while preserving the historical success path order."""
+    from api.goal_continuations import get_goal_continuation
+    from api.streaming import (
+        _materialize_pending_user_turn_before_error,
+        _session_payload_with_full_messages,
+    )
+
+    with _get_session_agent_lock(session_id):
+        session = get_session(session_id)
+        if not _stream_writeback_is_current(session, stream_id):
+            return False
+        retry_record = get_goal_continuation(session_id) or {}
+        retry_attempts = int(retry_record.get("attempts") or 0)
+        retry_max = int(retry_record.get("max_attempts") or 0)
+        retry_message = (
+            "The provider returned no content before any activity. "
+            f"Retrying this goal continuation automatically "
+            f"({retry_attempts + 1}/{retry_max})."
+        )
+        _materialize_pending_user_turn_before_error(session)
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.pending_user_source = None
+        session.messages.append({
+            "role": "assistant",
+            "content": retry_message,
+            "timestamp": int(time.time()),
+            "_goal_retry": True,
+        })
+        session.save()
+        retry_session = redact_session_data(
+            _session_payload_with_full_messages(session, tool_calls=[])
+        )
+    put_gateway_event("warning", {
+        "type": "goal_retry_scheduled",
+        "message": retry_message,
+        "retry_scheduled": True,
+        "attempt": retry_attempts + 1,
+        "max_attempts": retry_max,
+    })
+    put_gateway_event("done", {
+        "session": retry_session,
+        "goal_retry_scheduled": True,
+    })
+    return True

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1287,6 +1287,7 @@ def _run_gateway_chat_streaming(
                     session_id,
                     stream_id,
                     had_activity=_gateway_retry_had_activity,
+                    cancellation_check=cancel_event.is_set,
                 ):
                     _emit_gateway_goal_retry_scheduled(
                         session_id,
@@ -1617,6 +1618,11 @@ def _emit_gateway_goal_retry_scheduled(session_id, stream_id, put_gateway_event)
     })
     put_gateway_event("done", {
         "session": retry_session,
+        "goal_retry_scheduled": True,
+    })
+    put_gateway_event("stream_end", {
+        "session_id": session_id,
+        "stream_id": stream_id,
         "goal_retry_scheduled": True,
     })
     return True

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -880,6 +880,8 @@ def _gateway_event_blocks_empty_retry(event: str) -> bool:
         "tool_call",
         "tool_result",
         "tool_progress",
+        "tool",
+        "tool_complete",
     }
 
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1400,6 +1400,12 @@ def _run_gateway_chat_streaming(
             from api.streaming import _active_turn_authority, _materialize_active_turn_user
 
             active_turn_identity = _active_turn_authority(s, stream_id, msg_text)
+            # ``_materialize_active_turn_user`` routes through the
+            # ``stamp_message_source`` choke point, which now falls back to the
+            # content-shape wakeup backstop when the resolved source is the
+            # default ``webui``. Gateway-run wake turns (api_server self-POST)
+            # therefore still get a durable ``_source='process_wakeup'`` stamp
+            # for the hide/collapse contract without a second call site here.
             user_msg = _materialize_active_turn_user(
                 active_turn_identity,
                 str(msg_text or ""),

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -31,6 +31,8 @@ DEFAULT_MAX_ATTEMPTS = 3
 _BUSY_RETRY_SECONDS = 0.25
 _IDLE_POLL_SECONDS = 0.5
 _MAX_START_FAILURES = 5
+_STARTING_LEASE_SECONDS = 30.0
+_RUNNING_HEARTBEAT_GRACE_SECONDS = 30.0
 
 _REGISTRY_LOCK = threading.RLock()
 _REGISTRY: dict[str, Any] | None = None
@@ -364,6 +366,9 @@ def schedule_goal_continuation(
             "status": "pending",
             "owner_id": _current_owner_id(),
             "claim_id": None,
+            "claim_started_at": None,
+            "admitted_at": None,
+            "last_heartbeat_at": None,
             "attempts": 0,
             "max_attempts": attempts_limit,
             "start_failures": 0,
@@ -402,6 +407,8 @@ def bind_goal_continuation_stream(
         record["status"] = "running"
         record["stream_id"] = stream
         record["attempts"] = int(record.get("attempts") or 0) + 1
+        record["admitted_at"] = timestamp
+        record["last_heartbeat_at"] = timestamp
         record["updated_at"] = timestamp
         registry["intents"][sid] = record
         _save_locked()
@@ -431,9 +438,13 @@ def adopt_legacy_browser_goal_stream(session_id: str, stream_id: str, prompt: st
         record["status"] = "running"
         record["stream_id"] = stream
         record["claim_id"] = None
+        record["claim_started_at"] = None
         record["attempts"] = int(record.get("attempts") or 0) + 1
         record["owner_id"] = _current_owner_id()
-        _record_now(record, time.time())
+        timestamp = time.time()
+        record["admitted_at"] = timestamp
+        record["last_heartbeat_at"] = timestamp
+        _record_now(record, timestamp)
         _save_locked()
         return True
 
@@ -490,6 +501,9 @@ def _release_start_claim(
         record["status"] = "pending"
         record["stream_id"] = None
         record["claim_id"] = None
+        record["claim_started_at"] = None
+        record["admitted_at"] = None
+        record["last_heartbeat_at"] = None
         if not busy:
             record["start_failures"] = int(record.get("start_failures") or 0) + 1
         failures = int(record.get("start_failures") or 0)
@@ -530,6 +544,7 @@ def drain_goal_continuations_once(
             claim_id = uuid.uuid4().hex
             record["status"] = "starting"
             record["claim_id"] = claim_id
+            record["claim_started_at"] = timestamp
             record["owner_id"] = _current_owner_id()
             record["last_error"] = None
             _record_now(record, timestamp)
@@ -593,7 +608,9 @@ def drain_goal_continuations_once(
             record["stream_id"] = stream_id
             record["attempts"] = int(record.get("attempts") or 0) + 1
             record["owner_id"] = _current_owner_id()
-            _record_now(record, time.time())
+            record["admitted_at"] = timestamp
+            record["last_heartbeat_at"] = timestamp
+            _record_now(record, timestamp)
             _save_locked()
         elif record.get("status") == "running" and record.get("stream_id") == stream_id:
             pass
@@ -659,6 +676,9 @@ def requeue_goal_continuation_after_no_response(
         record["status"] = "pending"
         record["stream_id"] = None
         record["claim_id"] = None
+        record["claim_started_at"] = None
+        record["admitted_at"] = None
+        record["last_heartbeat_at"] = None
         record["owner_id"] = _current_owner_id()
         record["available_at"] = timestamp + _retry_delay(attempts)
         record["last_error"] = "empty provider response; automatic retry scheduled"
@@ -760,6 +780,176 @@ def _default_run_summary_loader(session_id: str, stream_id: str) -> dict[str, An
     return summary
 
 
+def _default_run_active(session_id: str, stream_id: str) -> bool:
+    """Return whether the admitted stream still has a live WebUI worker."""
+    sid = str(session_id or "").strip()
+    stream = str(stream_id or "").strip()
+    if not sid or not stream:
+        return False
+    try:
+        from api import config
+
+        with config.ACTIVE_RUNS_LOCK:
+            run = (config.ACTIVE_RUNS or {}).get(stream)
+            if isinstance(run, dict) and str(run.get("session_id") or "") == sid:
+                return True
+    except Exception:
+        logger.debug("Goal continuation live-run check failed", exc_info=True)
+        raise
+    return False
+
+
+def reconcile_goal_continuations_once(
+    *,
+    active_run_check: Callable[[str, str], bool] | None = None,
+    run_summary_loader: Callable[[str, str], Any] | None = None,
+    now: float | None = None,
+) -> int:
+    """Reconcile expired admission leases and orphaned running streams.
+
+    A successful ``start_session_turn`` response is only admission, not proof
+    that a worker ever started. ``starting`` claims therefore expire, while a
+    ``running`` record must periodically prove liveness through the in-process
+    run registries. Automatic replay is allowed only when the journal proves
+    there was no observable model/tool activity; otherwise the record fails
+    closed for explicit inspection.
+    """
+    timestamp = float(time.time() if now is None else now)
+    active_check = active_run_check or _default_run_active
+    summary_loader = run_summary_loader or _default_run_summary_loader
+    changed = 0
+
+    with _registry_transaction() as registry:
+        candidates = [
+            copy.deepcopy(record)
+            for record in registry["intents"].values()
+            if isinstance(record, dict) and record.get("status") in {"starting", "running"}
+        ]
+
+    for snapshot in candidates:
+        sid = str(snapshot.get("session_id") or "")
+        status = str(snapshot.get("status") or "")
+        continuation_id = str(snapshot.get("continuation_id") or "")
+        stream_id = str(snapshot.get("stream_id") or "")
+        if status == "starting":
+            lease_anchor = float(
+                snapshot.get("claim_started_at")
+                or snapshot.get("updated_at")
+                or snapshot.get("created_at")
+                or 0.0
+            )
+            if lease_anchor and timestamp - lease_anchor < _STARTING_LEASE_SECONDS:
+                continue
+            with _registry_transaction() as registry:
+                record = registry["intents"].get(sid)
+                if (
+                    not isinstance(record, dict)
+                    or record.get("status") != "starting"
+                    or str(record.get("continuation_id") or "") != continuation_id
+                    or str(record.get("claim_id") or "")
+                    != str(snapshot.get("claim_id") or "")
+                ):
+                    continue
+                record["status"] = "pending"
+                record["claim_id"] = None
+                record["claim_started_at"] = None
+                record["owner_id"] = _current_owner_id()
+                record["available_at"] = timestamp
+                record["last_error"] = "starting claim lease expired before stream admission"
+                _record_now(record, timestamp)
+                _save_locked()
+                changed += 1
+            continue
+
+        heartbeat_anchor = float(
+            snapshot.get("last_heartbeat_at")
+            or snapshot.get("admitted_at")
+            or snapshot.get("updated_at")
+            or 0.0
+        )
+        if heartbeat_anchor and timestamp - heartbeat_anchor < _RUNNING_HEARTBEAT_GRACE_SECONDS:
+            continue
+        try:
+            live = bool(active_check(sid, stream_id))
+        except Exception:
+            logger.warning("Goal continuation liveness check failed for %s", sid, exc_info=True)
+            continue
+        if live:
+            with _registry_transaction() as registry:
+                record = registry["intents"].get(sid)
+                if (
+                    not isinstance(record, dict)
+                    or record.get("status") != "running"
+                    or str(record.get("continuation_id") or "") != continuation_id
+                    or str(record.get("stream_id") or "") != stream_id
+                ):
+                    continue
+                record["last_heartbeat_at"] = timestamp
+                _record_now(record, timestamp)
+                _save_locked()
+                changed += 1
+            continue
+
+        try:
+            summary = summary_loader(sid, stream_id) or {}
+            observable_activity = bool(summary.get("observable_activity"))
+            terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
+            evidence_error = None
+        except Exception as exc:
+            logger.warning("Goal continuation orphan evidence failed for %s", sid, exc_info=True)
+            observable_activity = True
+            terminal_state = "unknown"
+            evidence_error = f"run evidence unavailable: {type(exc).__name__}: {exc}"
+
+        with _registry_transaction() as registry:
+            record = registry["intents"].get(sid)
+            if (
+                not isinstance(record, dict)
+                or record.get("status") != "running"
+                or str(record.get("continuation_id") or "") != continuation_id
+                or str(record.get("stream_id") or "") != stream_id
+            ):
+                continue
+            attempts = int(record.get("attempts") or 0)
+            max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
+            if evidence_error:
+                record["status"] = "failed"
+                record["last_error"] = evidence_error[:500]
+            elif observable_activity:
+                record["status"] = "failed"
+                record["last_error"] = (
+                    "orphaned goal continuation emitted observable activity; automatic replay refused"
+                )
+            elif terminal_state in {"completed", "done", "cancelled"}:
+                record["status"] = "failed"
+                record["last_error"] = (
+                    f"orphaned goal continuation reached {terminal_state} without a durable judge verdict"
+                )
+            elif attempts >= max_attempts:
+                record["status"] = "failed"
+                record["last_error"] = f"orphan recovery exhausted {attempts}/{max_attempts} attempts"
+            else:
+                record["status"] = "pending"
+                record["stream_id"] = None
+                record["claim_id"] = None
+                record["claim_started_at"] = None
+                record["admitted_at"] = None
+                record["last_heartbeat_at"] = None
+                record["owner_id"] = _current_owner_id()
+                record["available_at"] = timestamp + _retry_delay(attempts)
+                record["last_error"] = (
+                    "admitted stream had no live worker or observable activity "
+                    f"({terminal_state}); retry scheduled"
+                )
+            _record_now(record, timestamp)
+            _save_locked()
+            changed += 1
+
+    if changed:
+        _WORKER_WAKE.set()
+    return changed
+
+
 def _call_loader(loader: Callable[..., Any], record: dict[str, Any]) -> Any:
     try:
         return loader(record["session_id"], profile_home=record.get("profile_home"))
@@ -822,6 +1012,9 @@ def recover_goal_continuations(
                         "status": "pending",
                         "owner_id": _current_owner_id(),
                         "claim_id": None,
+                        "claim_started_at": None,
+                        "admitted_at": None,
+                        "last_heartbeat_at": None,
                         "attempts": 0,
                         "start_failures": 0,
                         "available_at": timestamp,
@@ -862,6 +1055,9 @@ def recover_goal_continuations(
                 record["status"] = "pending"
                 record["stream_id"] = None
                 record["claim_id"] = None
+                record["claim_started_at"] = None
+                record["admitted_at"] = None
+                record["last_heartbeat_at"] = None
                 record["owner_id"] = _current_owner_id()
                 record["available_at"] = timestamp
                 record["last_error"] = f"recovered after {terminal_state} terminal state"
@@ -884,6 +1080,10 @@ def _worker_loop() -> None:
     except Exception:
         logger.warning("Goal continuation startup recovery failed", exc_info=True)
     while not _WORKER_STOP.is_set():
+        try:
+            reconcile_goal_continuations_once()
+        except Exception:
+            logger.warning("Goal continuation reconciliation failed", exc_info=True)
         try:
             started = drain_goal_continuations_once()
         except Exception:

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -1129,29 +1129,32 @@ def wake_goal_continuation_worker() -> None:
 
 
 def _worker_loop() -> None:
-    while not _WORKER_STOP.is_set():
-        if _WORKER_LEADER_FD is None:
-            if not _try_acquire_worker_leadership():
-                _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
-                _WORKER_WAKE.clear()
-                continue
+    try:
+        while not _WORKER_STOP.is_set():
+            if _WORKER_LEADER_FD is None:
+                if not _try_acquire_worker_leadership():
+                    _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
+                    _WORKER_WAKE.clear()
+                    continue
+                try:
+                    recover_goal_continuations()
+                except Exception:
+                    logger.warning("Goal continuation startup recovery failed", exc_info=True)
             try:
-                recover_goal_continuations()
+                reconcile_goal_continuations_once()
             except Exception:
-                logger.warning("Goal continuation startup recovery failed", exc_info=True)
-        try:
-            reconcile_goal_continuations_once()
-        except Exception:
-            logger.warning("Goal continuation reconciliation failed", exc_info=True)
-        try:
-            started = drain_goal_continuations_once()
-        except Exception:
-            logger.warning("Goal continuation drain failed", exc_info=True)
-            started = 0
-        if started:
-            continue
-        _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
-        _WORKER_WAKE.clear()
+                logger.warning("Goal continuation reconciliation failed", exc_info=True)
+            try:
+                started = drain_goal_continuations_once()
+            except Exception:
+                logger.warning("Goal continuation drain failed", exc_info=True)
+                started = 0
+            if started:
+                continue
+            _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
+            _WORKER_WAKE.clear()
+    finally:
+        _release_worker_leadership()
 
 
 def start_goal_continuation_worker() -> bool:

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -459,7 +459,13 @@ def legacy_browser_goal_prompt_matches(session_id: str, prompt: str) -> bool:
         record = registry["intents"].get(sid)
         return bool(
             isinstance(record, dict)
-            and record.get("status") in {"pending", "starting", "running"}
+            and record.get("status") in {
+                "pending",
+                "starting",
+                "running",
+                "completed",
+                "cancelled",
+            }
             and str(record.get("prompt") or "").strip() == expected_prompt
         )
 
@@ -493,6 +499,8 @@ def _release_start_claim(
     with _registry_transaction() as registry:
         record = registry["intents"].get(session_id)
         if not isinstance(record, dict) or record.get("claim_id") != claim_id:
+            return
+        if record.get("status") not in {"starting", "running"}:
             return
         # bind_goal_continuation_stream may already have moved the record to
         # running; a route-start exception still returns ownership to pending.
@@ -538,7 +546,10 @@ def drain_goal_continuations_once(
             if float(record.get("available_at") or 0.0) > timestamp:
                 continue
             if not _call_goal_active(active_check, record):
-                registry["intents"].pop(sid, None)
+                record["status"] = "cancelled"
+                record["available_at"] = None
+                record["last_error"] = "goal inactive before continuation claim"
+                _record_now(record, timestamp)
                 _save_locked()
                 continue
             claim_id = uuid.uuid4().hex
@@ -567,6 +578,13 @@ def drain_goal_continuations_once(
         return 0
     if start_turn is None:
         from api.routes import start_session_turn as start_turn
+    if not _call_goal_active(active_check, selected):
+        cancel_goal_continuation(
+            sid,
+            reason="goal became inactive before continuation admission",
+            now=timestamp,
+        )
+        return 0
     try:
         response = start_turn(
             sid,
@@ -697,7 +715,43 @@ def complete_goal_continuation(session_id: str, stream_id: str | None = None) ->
             return False
         if expected_stream and record.get("stream_id") != expected_stream:
             return False
-        registry["intents"].pop(sid, None)
+        record["status"] = "completed"
+        record["claim_id"] = None
+        record["claim_started_at"] = None
+        record["completed_at"] = time.time()
+        record["last_error"] = None
+        _record_now(record, record["completed_at"])
+        _save_locked()
+        return True
+
+
+def cancel_goal_continuation(
+    session_id: str,
+    stream_id: str | None = None,
+    *,
+    reason: str = "goal continuation cancelled",
+    now: float | None = None,
+) -> bool:
+    """Durably fence a continuation against later admission or retry."""
+    sid = str(session_id or "").strip()
+    expected_stream = str(stream_id or "").strip()
+    timestamp = float(time.time() if now is None else now)
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if not isinstance(record, dict):
+            return False
+        current_stream = str(record.get("stream_id") or "").strip()
+        if expected_stream and current_stream and current_stream != expected_stream:
+            return False
+        if record.get("status") in {"completed", "cancelled"}:
+            return True
+        record["status"] = "cancelled"
+        record["claim_id"] = None
+        record["claim_started_at"] = None
+        record["available_at"] = None
+        record["last_error"] = str(reason or "goal continuation cancelled")[:500]
+        record["cancelled_at"] = timestamp
+        _record_now(record, timestamp)
         _save_locked()
         return True
 
@@ -733,14 +787,14 @@ def _replace_goal_continuation_for_test(record: dict[str, Any]) -> None:
 
 
 def _default_goal_state_loader(session_id: str, *, profile_home: str | None = None) -> dict[str, Any]:
-    from api.goals import CONTINUATION_PROMPT_TEMPLATE, goal_state_snapshot
+    from api.goals import CONTINUATION_PROMPT_TEMPLATE, goal_state_snapshot_strict
     from api.models import get_session
 
     try:
         get_session(session_id)
     except (KeyError, FileNotFoundError):
         return {"status": "missing", "turns_used": 0}
-    state = goal_state_snapshot(session_id, profile_home=profile_home)
+    state = goal_state_snapshot_strict(session_id, profile_home=profile_home)
     goal_text = str(getattr(state, "goal", "") or "").strip()
     continuation_prompt = (
         CONTINUATION_PROMPT_TEMPLATE.format(goal=goal_text)
@@ -760,7 +814,9 @@ def _default_run_summary_loader(session_id: str, stream_id: str) -> dict[str, An
     from api.run_journal import latest_run_summary, read_run_events
 
     summary = latest_run_summary(session_id, stream_id)
-    events = (read_run_events(session_id, stream_id) or {}).get("events") or []
+    run_events = read_run_events(session_id, stream_id) or {}
+    events = run_events.get("events") or []
+    summary["evidence_unavailable"] = bool(run_events.get("malformed"))
     activity_prefixes = (
         "token",
         "reason",
@@ -831,6 +887,25 @@ def reconcile_goal_continuations_once(
         status = str(snapshot.get("status") or "")
         continuation_id = str(snapshot.get("continuation_id") or "")
         stream_id = str(snapshot.get("stream_id") or "")
+        if str(snapshot.get("owner_id") or "") != _current_owner_id():
+            with _registry_transaction() as registry:
+                record = registry["intents"].get(sid)
+                if (
+                    not isinstance(record, dict)
+                    or record.get("status") not in {"starting", "running"}
+                    or str(record.get("continuation_id") or "") != continuation_id
+                    or str(record.get("owner_id") or "") == _current_owner_id()
+                ):
+                    continue
+                record["status"] = "failed"
+                record["claim_id"] = None
+                record["last_error"] = (
+                    "foreign owner still owns an unjudged continuation; automatic replay refused"
+                )
+                _record_now(record, timestamp)
+                _save_locked()
+                changed += 1
+            continue
         if status == "starting":
             lease_anchor = float(
                 snapshot.get("claim_started_at")
@@ -894,7 +969,11 @@ def reconcile_goal_continuations_once(
             summary = summary_loader(sid, stream_id) or {}
             observable_activity = bool(summary.get("observable_activity"))
             terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
-            evidence_error = None
+            evidence_error = (
+                "run journal contains malformed evidence; automatic replay refused"
+                if summary.get("evidence_unavailable")
+                else None
+            )
         except Exception as exc:
             logger.warning("Goal continuation orphan evidence failed for %s", sid, exc_info=True)
             observable_activity = True
@@ -973,7 +1052,6 @@ def recover_goal_continuations(
     """
     timestamp = float(time.time() if now is None else now)
     state_loader = goal_state_loader or _default_goal_state_loader
-    summary_loader = run_summary_loader or _default_run_summary_loader
     recovered = 0
     with _registry_transaction() as registry:
         for sid in list(registry["intents"]):
@@ -988,7 +1066,12 @@ def recover_goal_continuations(
             state_status = str((state or {}).get("status") or "") if isinstance(state, dict) else ""
             turns_used = int((state or {}).get("turns_used") or 0) if isinstance(state, dict) else 0
             if state_status != "active":
-                registry["intents"].pop(sid, None)
+                record["status"] = "cancelled"
+                record["claim_id"] = None
+                record["last_error"] = (
+                    f"goal became {state_status or 'unavailable'}; continuation cancelled"
+                )
+                _record_now(record, timestamp)
                 recovered += 1
                 continue
             origin_turns = int(record.get("goal_turns_used") or 0)
@@ -1024,43 +1107,14 @@ def recover_goal_continuations(
                 _record_now(record, timestamp)
                 recovered += 1
                 continue
-            try:
-                summary = summary_loader(sid, str(record.get("stream_id") or "")) or {}
-            except Exception:
-                logger.warning("Goal continuation run-summary recovery failed for %s", sid, exc_info=True)
-                record["status"] = "failed"
-                record["claim_id"] = None
-                record["last_error"] = (
-                    "run evidence was unavailable during recovery; automatic replay refused"
-                )
-                _record_now(record, timestamp)
-                recovered += 1
-                continue
-            terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
-            observable_activity = bool(summary.get("observable_activity"))
-            attempts = int(record.get("attempts") or 0)
-            max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
-            if observable_activity:
-                record["status"] = "failed"
-                record["last_error"] = (
-                    "interrupted goal turn emitted observable activity; automatic replay refused"
-                )
-            elif terminal_state in {"completed", "done"}:
-                record["status"] = "failed"
-                record["last_error"] = "completed goal turn lacks a durable judge verdict; replay refused"
-            elif attempts >= max_attempts:
-                record["status"] = "failed"
-                record["last_error"] = f"goal continuation recovery exhausted {attempts}/{max_attempts} attempts"
-            else:
-                record["status"] = "pending"
-                record["stream_id"] = None
-                record["claim_id"] = None
-                record["claim_started_at"] = None
-                record["admitted_at"] = None
-                record["last_heartbeat_at"] = None
-                record["owner_id"] = _current_owner_id()
-                record["available_at"] = timestamp
-                record["last_error"] = f"recovered after {terminal_state} terminal state"
+            # A foreign owner may still be alive even when this process now
+            # holds scheduler leadership (rolling restart / timed-out shutdown).
+            # Without a positively fenced owner lease, replay is unsafe.
+            record["status"] = "failed"
+            record["claim_id"] = None
+            record["last_error"] = (
+                "foreign owner still owns an unjudged continuation; automatic replay refused"
+            )
             _record_now(record, timestamp)
             recovered += 1
         if recovered:
@@ -1075,11 +1129,16 @@ def wake_goal_continuation_worker() -> None:
 
 
 def _worker_loop() -> None:
-    try:
-        recover_goal_continuations()
-    except Exception:
-        logger.warning("Goal continuation startup recovery failed", exc_info=True)
     while not _WORKER_STOP.is_set():
+        if _WORKER_LEADER_FD is None:
+            if not _try_acquire_worker_leadership():
+                _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
+                _WORKER_WAKE.clear()
+                continue
+            try:
+                recover_goal_continuations()
+            except Exception:
+                logger.warning("Goal continuation startup recovery failed", exc_info=True)
         try:
             reconcile_goal_continuations_once()
         except Exception:
@@ -1100,9 +1159,6 @@ def start_goal_continuation_worker() -> bool:
     with _WORKER_LIFECYCLE_LOCK:
         if _WORKER_THREAD is not None and _WORKER_THREAD.is_alive():
             return False
-        if not _try_acquire_worker_leadership():
-            logger.info("Goal continuation worker leadership is held by another process")
-            return False
         _WORKER_STOP.clear()
         _WORKER_WAKE.clear()
         _WORKER_THREAD = threading.Thread(
@@ -1114,7 +1170,6 @@ def start_goal_continuation_worker() -> bool:
             _WORKER_THREAD.start()
         except BaseException:
             _WORKER_THREAD = None
-            _release_worker_leadership()
             raise
         return True
 

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -1,0 +1,783 @@
+"""Durable, server-owned continuation scheduler for WebUI ``/goal`` turns.
+
+The browser may observe ``goal_continue`` events, but it is never the authority
+that starts the next turn.  A small atomic registry survives tab closure, SSE
+reconnects, and WebUI restarts.  Each record represents one logical continuation
+and is claimed before ``routes.start_session_turn`` is called.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable
+
+from api.config import STATE_DIR
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_PATH = Path(STATE_DIR) / "goal-continuations.json"
+REGISTRY_VERSION = 1
+_OWNER_PID = os.getpid()
+OWNER_ID = f"webui-{_OWNER_PID}-{uuid.uuid4().hex}"
+DEFAULT_MAX_ATTEMPTS = 3
+_BUSY_RETRY_SECONDS = 0.25
+_IDLE_POLL_SECONDS = 0.5
+_MAX_START_FAILURES = 5
+
+_REGISTRY_LOCK = threading.RLock()
+_REGISTRY: dict[str, Any] | None = None
+_WORKER_WAKE = threading.Event()
+_WORKER_STOP = threading.Event()
+_WORKER_THREAD: threading.Thread | None = None
+_WORKER_LIFECYCLE_LOCK = threading.Lock()
+
+
+def _current_owner_id() -> str:
+    """Return a process-unique owner, regenerating after ``fork()``."""
+    global OWNER_ID, _OWNER_PID
+    pid = os.getpid()
+    if pid != _OWNER_PID:
+        _OWNER_PID = pid
+        OWNER_ID = f"webui-{pid}-{uuid.uuid4().hex}"
+    return OWNER_ID
+
+
+@contextmanager
+def _registry_process_lock():
+    """Serialize registry transactions across WebUI processes.
+
+    Atomic rename prevents torn JSON but not lost updates: every writer must hold
+    this lock while reloading, mutating, and replacing the registry.
+    """
+    lock_path = Path(REGISTRY_PATH).with_name(f".{Path(REGISTRY_PATH).name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.chmod(lock_path, 0o600)
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(fd).st_size < 1:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+@contextmanager
+def _registry_transaction():
+    """Hold both process-local and OS locks and refresh durable truth."""
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        with _registry_process_lock():
+            _REGISTRY = None
+            registry = _load_locked()
+            try:
+                yield registry
+            except BaseException:
+                # Never retain a mutation that failed before durable replacement.
+                _REGISTRY = None
+                raise
+
+
+def _empty_registry() -> dict[str, Any]:
+    return {"version": REGISTRY_VERSION, "intents": {}}
+
+
+def _validated_registry(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict) or raw.get("version") != REGISTRY_VERSION:
+        return _empty_registry()
+    intents = raw.get("intents")
+    if not isinstance(intents, dict):
+        return _empty_registry()
+    clean: dict[str, dict[str, Any]] = {}
+    for sid, record in intents.items():
+        sid = str(sid or "").strip()
+        if not sid or not isinstance(record, dict):
+            continue
+        if str(record.get("session_id") or "").strip() != sid:
+            continue
+        prompt = str(record.get("prompt") or "").strip()
+        continuation_id = str(record.get("continuation_id") or "").strip()
+        if not prompt or not continuation_id:
+            continue
+        clean[sid] = copy.deepcopy(record)
+    return {"version": REGISTRY_VERSION, "intents": clean}
+
+
+def _load_locked() -> dict[str, Any]:
+    global _REGISTRY
+    if _REGISTRY is not None:
+        return _REGISTRY
+    try:
+        raw = json.loads(Path(REGISTRY_PATH).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raw = _empty_registry()
+    except Exception:
+        path = Path(REGISTRY_PATH)
+        quarantine = path.with_name(
+            f"{path.name}.corrupt-{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        )
+        try:
+            os.replace(path, quarantine)
+            os.chmod(quarantine, 0o600)
+            _fsync_parent(path)
+            logger.error(
+                "Goal continuation registry was unreadable and was quarantined at %s",
+                quarantine,
+                exc_info=True,
+            )
+        except Exception:
+            logger.error(
+                "Goal continuation registry is unreadable and could not be quarantined",
+                exc_info=True,
+            )
+        raw = _empty_registry()
+    _REGISTRY = _validated_registry(raw)
+    return _REGISTRY
+
+
+def _fsync_parent(path: Path) -> None:
+    try:
+        fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _save_locked() -> None:
+    global _REGISTRY
+    registry = _load_locked()
+    path = Path(REGISTRY_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(registry, ensure_ascii=False, sort_keys=True, indent=2) + "\n").encode("utf-8")
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    fd = os.open(str(tmp), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        os.chmod(path, 0o600)
+        _fsync_parent(path)
+    except BaseException:
+        _REGISTRY = None
+        raise
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def get_goal_continuation(session_id: str) -> dict[str, Any] | None:
+    sid = str(session_id or "").strip()
+    if not sid:
+        return None
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        return copy.deepcopy(record) if isinstance(record, dict) else None
+
+
+def _record_now(record: dict[str, Any], now: float) -> dict[str, Any]:
+    record["updated_at"] = float(now)
+    return record
+
+
+def schedule_goal_continuation(
+    session_id: str,
+    prompt: str,
+    *,
+    source_stream_id: str,
+    profile_home: str | Path | None,
+    goal_turns_used: int,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Persist one logical continuation before emitting ``goal_continue``.
+
+    Repeated scheduling from the same judged stream is idempotent.  A later
+    judged stream replaces the preceding running record with the next logical
+    continuation.
+    """
+    sid = str(session_id or "").strip()
+    text = str(prompt or "").strip()
+    source_stream = str(source_stream_id or "").strip()
+    if not sid or not text or not source_stream:
+        raise ValueError("session_id, prompt, and source_stream_id are required")
+    timestamp = float(time.time() if now is None else now)
+    attempts_limit = max(1, int(max_attempts or DEFAULT_MAX_ATTEMPTS))
+    with _registry_transaction() as registry:
+        existing = registry["intents"].get(sid)
+        if (
+            isinstance(existing, dict)
+            and existing.get("source_stream_id") == source_stream
+            and existing.get("prompt") == text
+        ):
+            return copy.deepcopy(existing)
+        record = {
+            "version": REGISTRY_VERSION,
+            "session_id": sid,
+            "continuation_id": uuid.uuid4().hex,
+            "source_stream_id": source_stream,
+            "stream_id": None,
+            "prompt": text,
+            "profile_home": str(Path(profile_home).expanduser().resolve()) if profile_home else None,
+            "goal_turns_used": max(0, int(goal_turns_used or 0)),
+            "status": "pending",
+            "owner_id": _current_owner_id(),
+            "claim_id": None,
+            "attempts": 0,
+            "max_attempts": attempts_limit,
+            "start_failures": 0,
+            "available_at": timestamp,
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "last_error": None,
+        }
+        registry["intents"][sid] = record
+        _save_locked()
+    _WORKER_WAKE.set()
+    return copy.deepcopy(record)
+
+
+def bind_goal_continuation_stream(session_id: str, stream_id: str) -> bool:
+    """Bind an admitted server stream before its worker thread can finish.
+
+    ``routes`` calls this after pending-state persistence and before ``thr.start``
+    to close the fast-empty-response race with the scheduler's return path.
+    """
+    sid = str(session_id or "").strip()
+    stream = str(stream_id or "").strip()
+    if not sid or not stream:
+        return False
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if not isinstance(record, dict) or record.get("status") != "starting":
+            return False
+        record["status"] = "running"
+        record["stream_id"] = stream
+        record["attempts"] = int(record.get("attempts") or 0) + 1
+        record["owner_id"] = _current_owner_id()
+        _record_now(record, time.time())
+        _save_locked()
+        return True
+
+
+def adopt_legacy_browser_goal_stream(session_id: str, stream_id: str, prompt: str) -> bool:
+    """Attach an old-tab continuation POST to the matching durable intent.
+
+    A record already in ``starting`` belongs to the server scheduler and must not
+    be stolen; the browser request is then rejected by the route so only one
+    admission can win.  The prompt must also match exactly so an unrelated human
+    message can never consume a legacy goal marker or burn the goal budget.
+    """
+    sid = str(session_id or "").strip()
+    stream = str(stream_id or "").strip()
+    expected_prompt = str(prompt or "").strip()
+    if not sid or not stream or not expected_prompt:
+        return False
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if (
+            not isinstance(record, dict)
+            or record.get("status") != "pending"
+            or str(record.get("prompt") or "").strip() != expected_prompt
+        ):
+            return False
+        record["status"] = "running"
+        record["stream_id"] = stream
+        record["claim_id"] = None
+        record["attempts"] = int(record.get("attempts") or 0) + 1
+        record["owner_id"] = _current_owner_id()
+        _record_now(record, time.time())
+        _save_locked()
+        return True
+
+
+def legacy_browser_goal_prompt_matches(session_id: str, prompt: str) -> bool:
+    """Return true only for an old-tab replay of the current durable intent."""
+    sid = str(session_id or "").strip()
+    expected_prompt = str(prompt or "").strip()
+    if not sid or not expected_prompt:
+        return False
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        return bool(
+            isinstance(record, dict)
+            and record.get("status") in {"pending", "starting", "running"}
+            and str(record.get("prompt") or "").strip() == expected_prompt
+        )
+
+
+def _default_goal_active(session_id: str, *, profile_home: str | None = None) -> bool:
+    from api.goals import has_active_goal
+    from api.models import get_session
+
+    try:
+        get_session(session_id)
+    except (KeyError, FileNotFoundError):
+        return False
+    return bool(has_active_goal(session_id, profile_home=profile_home))
+
+
+def _call_goal_active(check: Callable[..., bool], record: dict[str, Any]) -> bool:
+    try:
+        return bool(check(record["session_id"], profile_home=record.get("profile_home")))
+    except TypeError:
+        return bool(check(record["session_id"]))
+
+
+def _release_start_claim(
+    session_id: str,
+    claim_id: str,
+    *,
+    now: float,
+    error: str,
+    busy: bool,
+) -> None:
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(session_id)
+        if not isinstance(record, dict) or record.get("claim_id") != claim_id:
+            return
+        # bind_goal_continuation_stream may already have moved the record to
+        # running; a route-start exception still returns ownership to pending.
+        if record.get("status") == "running":
+            record["attempts"] = max(0, int(record.get("attempts") or 0) - 1)
+        record["status"] = "pending"
+        record["stream_id"] = None
+        record["claim_id"] = None
+        if not busy:
+            record["start_failures"] = int(record.get("start_failures") or 0) + 1
+        failures = int(record.get("start_failures") or 0)
+        if failures >= _MAX_START_FAILURES:
+            record["status"] = "failed"
+        record["available_at"] = now + (_BUSY_RETRY_SECONDS if busy else min(30.0, 2.0 ** max(0, failures - 1)))
+        record["last_error"] = str(error or "turn start failed")[:500]
+        _record_now(record, now)
+        _save_locked()
+    _WORKER_WAKE.set()
+
+
+def drain_goal_continuations_once(
+    *,
+    start_turn: Callable[..., dict[str, Any]] | None = None,
+    is_goal_active: Callable[..., bool] | None = None,
+    now: float | None = None,
+) -> int:
+    """Claim and dispatch at most one due continuation.
+
+    Returns one only after a server-side turn was accepted.  Busy sessions
+    release the claim without consuming a provider attempt.
+    """
+    timestamp = float(time.time() if now is None else now)
+    active_check = is_goal_active or _default_goal_active
+    selected: dict[str, Any] | None = None
+    with _registry_transaction() as registry:
+        for sid in sorted(registry["intents"]):
+            record = registry["intents"].get(sid)
+            if not isinstance(record, dict) or record.get("status") != "pending":
+                continue
+            if float(record.get("available_at") or 0.0) > timestamp:
+                continue
+            if not _call_goal_active(active_check, record):
+                registry["intents"].pop(sid, None)
+                _save_locked()
+                continue
+            claim_id = uuid.uuid4().hex
+            record["status"] = "starting"
+            record["claim_id"] = claim_id
+            record["owner_id"] = _current_owner_id()
+            record["last_error"] = None
+            _record_now(record, timestamp)
+            _save_locked()
+            selected = copy.deepcopy(record)
+            break
+    if selected is None:
+        return 0
+
+    sid = selected["session_id"]
+    claim_id = selected["claim_id"]
+    if _WORKER_STOP.is_set() and start_turn is None:
+        _release_start_claim(
+            sid,
+            claim_id,
+            now=time.time(),
+            error="WebUI shutdown in progress",
+            busy=True,
+        )
+        return 0
+    if start_turn is None:
+        from api.routes import start_session_turn as start_turn
+    try:
+        response = start_turn(sid, selected["prompt"], source="goal_continuation") or {}
+    except Exception as exc:
+        _release_start_claim(sid, claim_id, now=timestamp, error=f"{type(exc).__name__}: {exc}", busy=False)
+        logger.warning("Goal continuation start raised for session %s", sid, exc_info=True)
+        return 0
+
+    try:
+        status = int(response.get("_status", 200) or 200)
+    except (TypeError, ValueError):
+        status = 500
+    stream_id = str(response.get("stream_id") or "").strip()
+    if status == 409:
+        _release_start_claim(sid, claim_id, now=timestamp, error="session busy", busy=True)
+        return 0
+    if status >= 400 or not stream_id:
+        _release_start_claim(
+            sid,
+            claim_id,
+            now=timestamp,
+            error=str(response.get("error") or f"turn start returned HTTP {status}"),
+            busy=False,
+        )
+        return 0
+
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if not isinstance(record, dict) or record.get("claim_id") != claim_id:
+            # A very fast worker may already have replaced the record with the
+            # next continuation.  Never overwrite that newer generation.
+            return 1
+        if record.get("status") == "starting":
+            record["status"] = "running"
+            record["stream_id"] = stream_id
+            record["attempts"] = int(record.get("attempts") or 0) + 1
+            record["owner_id"] = _current_owner_id()
+            _record_now(record, time.time())
+            _save_locked()
+        elif record.get("status") == "running" and record.get("stream_id") == stream_id:
+            pass
+        else:
+            return 1
+    return 1
+
+
+def _retry_delay(attempts: int) -> float:
+    return min(30.0, 2.0 ** max(0, int(attempts or 0) - 1))
+
+
+def requeue_goal_continuation_after_no_response(
+    session_id: str,
+    stream_id: str,
+    *,
+    had_activity: bool,
+    now: float | None = None,
+) -> bool:
+    """Requeue a truly empty goal turn without replaying an active turn.
+
+    Any token, reasoning, tool, approval, or partial signal makes replay unsafe;
+    the record then becomes terminally failed for explicit user inspection.
+    """
+    sid = str(session_id or "").strip()
+    stream = str(stream_id or "").strip()
+    timestamp = float(time.time() if now is None else now)
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if (
+            not isinstance(record, dict)
+            or record.get("status") != "running"
+            or record.get("stream_id") != stream
+        ):
+            return False
+        attempts = int(record.get("attempts") or 0)
+        max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
+        if had_activity:
+            record["status"] = "failed"
+            record["last_error"] = "empty terminal response after observable activity; automatic replay refused"
+            _record_now(record, timestamp)
+            _save_locked()
+            return False
+        if attempts >= max_attempts:
+            record["status"] = "failed"
+            record["last_error"] = f"empty provider response after {attempts}/{max_attempts} attempts"
+            _record_now(record, timestamp)
+            _save_locked()
+            return False
+        record["status"] = "pending"
+        record["stream_id"] = None
+        record["claim_id"] = None
+        record["owner_id"] = _current_owner_id()
+        record["available_at"] = timestamp + _retry_delay(attempts)
+        record["last_error"] = "empty provider response; automatic retry scheduled"
+        _record_now(record, timestamp)
+        _save_locked()
+    _WORKER_WAKE.set()
+    return True
+
+
+def complete_goal_continuation(session_id: str, stream_id: str | None = None) -> bool:
+    sid = str(session_id or "").strip()
+    expected_stream = str(stream_id or "").strip()
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if not isinstance(record, dict):
+            return False
+        if expected_stream and record.get("stream_id") != expected_stream:
+            return False
+        registry["intents"].pop(sid, None)
+        _save_locked()
+        return True
+
+
+def fail_goal_continuation(session_id: str, stream_id: str, reason: str) -> bool:
+    """Settle a claimed intent that ended without a judge-owned successor."""
+    sid = str(session_id or "").strip()
+    expected_stream = str(stream_id or "").strip()
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if (
+            not isinstance(record, dict)
+            or record.get("status") != "running"
+            or record.get("stream_id") != expected_stream
+        ):
+            return False
+        record["status"] = "failed"
+        record["claim_id"] = None
+        record["last_error"] = str(reason or "goal continuation ended without settlement")[:500]
+        _record_now(record, time.time())
+        _save_locked()
+        return True
+
+
+def _replace_goal_continuation_for_test(record: dict[str, Any]) -> None:
+    """Test-only durable replacement helper (kept explicit to avoid raw writes)."""
+    sid = str(record.get("session_id") or "").strip()
+    if not sid:
+        raise ValueError("record session_id required")
+    with _registry_transaction() as registry:
+        registry["intents"][sid] = copy.deepcopy(record)
+        _save_locked()
+
+
+def _default_goal_state_loader(session_id: str, *, profile_home: str | None = None) -> dict[str, Any]:
+    from api.goals import CONTINUATION_PROMPT_TEMPLATE, goal_state_snapshot
+    from api.models import get_session
+
+    try:
+        get_session(session_id)
+    except (KeyError, FileNotFoundError):
+        return {"status": "missing", "turns_used": 0}
+    state = goal_state_snapshot(session_id, profile_home=profile_home)
+    goal_text = str(getattr(state, "goal", "") or "").strip()
+    continuation_prompt = (
+        CONTINUATION_PROMPT_TEMPLATE.format(goal=goal_text)
+        if goal_text and CONTINUATION_PROMPT_TEMPLATE
+        else None
+    )
+    return {
+        "status": str(getattr(state, "status", "") or ""),
+        "turns_used": int(getattr(state, "turns_used", 0) or 0),
+        "continuation_prompt": continuation_prompt,
+    }
+
+
+def _default_run_summary_loader(session_id: str, stream_id: str) -> dict[str, Any]:
+    if not stream_id:
+        return {"terminal_state": "unknown", "observable_activity": False}
+    from api.run_journal import latest_run_summary, read_run_events
+
+    summary = latest_run_summary(session_id, stream_id)
+    events = (read_run_events(session_id, stream_id) or {}).get("events") or []
+    activity_prefixes = (
+        "token",
+        "reason",
+        "tool",
+        "progress",
+        "approval",
+        "clarify",
+        "assistant",
+        "process",
+        "bg_",
+    )
+    summary["observable_activity"] = any(
+        str(event.get("event") or "").lower().startswith(activity_prefixes)
+        for event in events
+        if isinstance(event, dict)
+    )
+    return summary
+
+
+def _call_loader(loader: Callable[..., Any], record: dict[str, Any]) -> Any:
+    try:
+        return loader(record["session_id"], profile_home=record.get("profile_home"))
+    except TypeError:
+        return loader(record["session_id"])
+
+
+def recover_goal_continuations(
+    *,
+    goal_state_loader: Callable[..., Any] | None = None,
+    run_summary_loader: Callable[..., Any] | None = None,
+    now: float | None = None,
+) -> int:
+    """Recover records owned by a previous WebUI process.
+
+    A goal whose turn counter advanced has already been judged: a fresh pending
+    generation is derived and the old stream is never replayed.  An unjudged
+    empty/interrupted turn is made pending only while its bounded attempt budget
+    remains.  Completed-but-unjudged turns fail closed rather than duplicating a
+    possibly side-effectful turn.
+    """
+    timestamp = float(time.time() if now is None else now)
+    state_loader = goal_state_loader or _default_goal_state_loader
+    summary_loader = run_summary_loader or _default_run_summary_loader
+    recovered = 0
+    with _registry_transaction() as registry:
+        for sid in list(registry["intents"]):
+            record = registry["intents"].get(sid)
+            if not isinstance(record, dict):
+                continue
+            if record.get("status") not in {"starting", "running"}:
+                continue
+            if record.get("owner_id") == _current_owner_id():
+                continue
+            state = _call_loader(state_loader, record)
+            state_status = str((state or {}).get("status") or "") if isinstance(state, dict) else ""
+            turns_used = int((state or {}).get("turns_used") or 0) if isinstance(state, dict) else 0
+            if state_status != "active":
+                registry["intents"].pop(sid, None)
+                recovered += 1
+                continue
+            origin_turns = int(record.get("goal_turns_used") or 0)
+            if turns_used > origin_turns:
+                current_prompt = str((state or {}).get("continuation_prompt") or "").strip()
+                if not current_prompt:
+                    record["status"] = "failed"
+                    record["last_error"] = (
+                        "goal advanced but no current continuation prompt could be derived; replay refused"
+                    )
+                    _record_now(record, timestamp)
+                    recovered += 1
+                    continue
+                record.update(
+                    {
+                        "continuation_id": uuid.uuid4().hex,
+                        "source_stream_id": f"recovery:{record.get('stream_id') or record.get('source_stream_id')}",
+                        "stream_id": None,
+                        "prompt": current_prompt,
+                        "goal_turns_used": turns_used,
+                        "status": "pending",
+                        "owner_id": _current_owner_id(),
+                        "claim_id": None,
+                        "attempts": 0,
+                        "start_failures": 0,
+                        "available_at": timestamp,
+                        "last_error": None,
+                    }
+                )
+                _record_now(record, timestamp)
+                recovered += 1
+                continue
+            try:
+                summary = summary_loader(sid, str(record.get("stream_id") or "")) or {}
+            except Exception:
+                logger.warning("Goal continuation run-summary recovery failed for %s", sid, exc_info=True)
+                summary = {"terminal_state": "unknown"}
+            terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
+            observable_activity = bool(summary.get("observable_activity"))
+            attempts = int(record.get("attempts") or 0)
+            max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
+            if observable_activity:
+                record["status"] = "failed"
+                record["last_error"] = (
+                    "interrupted goal turn emitted observable activity; automatic replay refused"
+                )
+            elif terminal_state in {"completed", "done"}:
+                record["status"] = "failed"
+                record["last_error"] = "completed goal turn lacks a durable judge verdict; replay refused"
+            elif attempts >= max_attempts:
+                record["status"] = "failed"
+                record["last_error"] = f"goal continuation recovery exhausted {attempts}/{max_attempts} attempts"
+            else:
+                record["status"] = "pending"
+                record["stream_id"] = None
+                record["claim_id"] = None
+                record["owner_id"] = _current_owner_id()
+                record["available_at"] = timestamp
+                record["last_error"] = f"recovered after {terminal_state} terminal state"
+            _record_now(record, timestamp)
+            recovered += 1
+        if recovered:
+            _save_locked()
+    if recovered:
+        _WORKER_WAKE.set()
+    return recovered
+
+
+def wake_goal_continuation_worker() -> None:
+    _WORKER_WAKE.set()
+
+
+def _worker_loop() -> None:
+    try:
+        recover_goal_continuations()
+    except Exception:
+        logger.warning("Goal continuation startup recovery failed", exc_info=True)
+    while not _WORKER_STOP.is_set():
+        try:
+            started = drain_goal_continuations_once()
+        except Exception:
+            logger.warning("Goal continuation drain failed", exc_info=True)
+            started = 0
+        if started:
+            continue
+        _WORKER_WAKE.wait(_IDLE_POLL_SECONDS)
+        _WORKER_WAKE.clear()
+
+
+def start_goal_continuation_worker() -> bool:
+    global _WORKER_THREAD
+    with _WORKER_LIFECYCLE_LOCK:
+        if _WORKER_THREAD is not None and _WORKER_THREAD.is_alive():
+            return False
+        _WORKER_STOP.clear()
+        _WORKER_WAKE.clear()
+        _WORKER_THREAD = threading.Thread(
+            target=_worker_loop,
+            name="hermes-webui-goal-continuations",
+            daemon=True,
+        )
+        _WORKER_THREAD.start()
+        return True
+
+
+def stop_goal_continuation_worker(timeout: float = 2.0) -> None:
+    _WORKER_STOP.set()
+    _WORKER_WAKE.set()
+    thread = _WORKER_THREAD
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=timeout)

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -641,6 +641,31 @@ def _retry_delay(attempts: int) -> float:
     return min(30.0, 2.0 ** max(0, int(attempts or 0) - 1))
 
 
+def mark_goal_continuation_worker_started(
+    session_id: str,
+    stream_id: str,
+    *,
+    now: float | None = None,
+) -> bool:
+    """Fence actual worker entry before ACTIVE_RUNS registration or effects."""
+    sid = str(session_id or "").strip()
+    stream = str(stream_id or "").strip()
+    timestamp = float(time.time() if now is None else now)
+    with _registry_transaction() as registry:
+        record = registry["intents"].get(sid)
+        if (
+            not isinstance(record, dict)
+            or record.get("status") != "running"
+            or str(record.get("stream_id") or "") != stream
+        ):
+            return False
+        record["worker_started_at"] = timestamp
+        record["last_heartbeat_at"] = timestamp
+        _record_now(record, timestamp)
+        _save_locked()
+        return True
+
+
 def requeue_goal_continuation_after_no_response(
     session_id: str,
     stream_id: str,
@@ -696,6 +721,7 @@ def requeue_goal_continuation_after_no_response(
         record["claim_id"] = None
         record["claim_started_at"] = None
         record["admitted_at"] = None
+        record["worker_started_at"] = None
         record["last_heartbeat_at"] = None
         record["owner_id"] = _current_owner_id()
         record["available_at"] = timestamp + _retry_delay(attempts)
@@ -995,6 +1021,12 @@ def reconcile_goal_continuations_once(
                 or str(record.get("stream_id") or "") != stream_id
             ):
                 continue
+            if record.get("worker_started_at"):
+                record["last_heartbeat_at"] = timestamp
+                _record_now(record, timestamp)
+                _save_locked()
+                changed += 1
+                continue
             # The first liveness/journal reads happened outside the registry
             # transaction. A worker may have entered — or emitted durable
             # activity — in that gap. Revalidate both proofs while the intent
@@ -1056,6 +1088,7 @@ def reconcile_goal_continuations_once(
                 record["claim_id"] = None
                 record["claim_started_at"] = None
                 record["admitted_at"] = None
+                record["worker_started_at"] = None
                 record["last_heartbeat_at"] = None
                 record["owner_id"] = _current_owner_id()
                 record["available_at"] = timestamp + _retry_delay(attempts)

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -855,6 +855,18 @@ def _default_run_active(session_id: str, stream_id: str) -> bool:
     return False
 
 
+def _run_summary_evidence(summary: Any) -> tuple[bool, str, str | None]:
+    payload = summary if isinstance(summary, dict) else {}
+    observable_activity = bool(payload.get("observable_activity"))
+    terminal_state = str(payload.get("terminal_state") or "unknown").strip().lower()
+    evidence_error = (
+        "run journal contains malformed evidence; automatic replay refused"
+        if payload.get("evidence_unavailable")
+        else None
+    )
+    return observable_activity, terminal_state, evidence_error
+
+
 def reconcile_goal_continuations_once(
     *,
     active_run_check: Callable[[str, str], bool] | None = None,
@@ -967,13 +979,7 @@ def reconcile_goal_continuations_once(
 
         try:
             summary = summary_loader(sid, stream_id) or {}
-            observable_activity = bool(summary.get("observable_activity"))
-            terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
-            evidence_error = (
-                "run journal contains malformed evidence; automatic replay refused"
-                if summary.get("evidence_unavailable")
-                else None
-            )
+            observable_activity, terminal_state, evidence_error = _run_summary_evidence(summary)
         except Exception as exc:
             logger.warning("Goal continuation orphan evidence failed for %s", sid, exc_info=True)
             observable_activity = True
@@ -989,6 +995,43 @@ def reconcile_goal_continuations_once(
                 or str(record.get("stream_id") or "") != stream_id
             ):
                 continue
+            # The first liveness/journal reads happened outside the registry
+            # transaction. A worker may have entered — or emitted durable
+            # activity — in that gap. Revalidate both proofs while the intent
+            # fence is held before any replay transition.
+            try:
+                revalidated_live = bool(active_check(sid, stream_id))
+            except Exception:
+                logger.warning(
+                    "Goal continuation liveness recheck failed for %s",
+                    sid,
+                    exc_info=True,
+                )
+                continue
+            if revalidated_live:
+                record["last_heartbeat_at"] = timestamp
+                _record_now(record, timestamp)
+                _save_locked()
+                changed += 1
+                continue
+            try:
+                latest_summary = summary_loader(sid, stream_id) or {}
+                latest_activity, latest_terminal, latest_error = _run_summary_evidence(
+                    latest_summary
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Goal continuation orphan evidence recheck failed for %s",
+                    sid,
+                    exc_info=True,
+                )
+                latest_activity = True
+                latest_terminal = "unknown"
+                latest_error = f"run evidence unavailable: {type(exc).__name__}: {exc}"
+            observable_activity = observable_activity or latest_activity
+            if latest_terminal != "unknown":
+                terminal_state = latest_terminal
+            evidence_error = evidence_error or latest_error
             attempts = int(record.get("attempts") or 0)
             max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
             if evidence_error:

--- a/api/goal_continuations.py
+++ b/api/goal_continuations.py
@@ -38,6 +38,8 @@ _WORKER_WAKE = threading.Event()
 _WORKER_STOP = threading.Event()
 _WORKER_THREAD: threading.Thread | None = None
 _WORKER_LIFECYCLE_LOCK = threading.Lock()
+_WORKER_LEADER_FD: int | None = None
+_WORKER_LEADER_PID: int | None = None
 
 
 def _current_owner_id() -> str:
@@ -48,6 +50,103 @@ def _current_owner_id() -> str:
         _OWNER_PID = pid
         OWNER_ID = f"webui-{pid}-{uuid.uuid4().hex}"
     return OWNER_ID
+
+
+def _after_fork_child() -> None:
+    """Discard process-local locks and worker ownership inherited by fork."""
+    global _REGISTRY_LOCK, _REGISTRY, _WORKER_STOP, _WORKER_WAKE
+    global _WORKER_THREAD, _WORKER_LIFECYCLE_LOCK
+    global _WORKER_LEADER_FD, _WORKER_LEADER_PID
+    global _OWNER_PID, OWNER_ID
+
+    if _WORKER_LEADER_FD is not None:
+        try:
+            os.close(_WORKER_LEADER_FD)
+        except OSError:
+            pass
+    _REGISTRY_LOCK = threading.RLock()
+    _REGISTRY = None
+    _WORKER_STOP = threading.Event()
+    _WORKER_WAKE = threading.Event()
+    _WORKER_THREAD = None
+    _WORKER_LIFECYCLE_LOCK = threading.Lock()
+    _WORKER_LEADER_FD = None
+    _WORKER_LEADER_PID = None
+    _OWNER_PID = os.getpid()
+    OWNER_ID = f"webui-{_OWNER_PID}-{uuid.uuid4().hex}"
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_after_fork_child)
+
+
+def _worker_leader_lock_path() -> Path:
+    path = Path(REGISTRY_PATH)
+    return path.with_name(f".{path.name}.worker.lock")
+
+
+def _try_acquire_worker_leadership() -> bool:
+    """Hold one process-wide scheduler lease for a shared registry."""
+    global _WORKER_LEADER_FD, _WORKER_LEADER_PID
+    pid = os.getpid()
+    if _WORKER_LEADER_FD is not None and _WORKER_LEADER_PID == pid:
+        return True
+    if _WORKER_LEADER_FD is not None:
+        try:
+            os.close(_WORKER_LEADER_FD)
+        except OSError:
+            pass
+        _WORKER_LEADER_FD = None
+        _WORKER_LEADER_PID = None
+
+    path = _worker_leader_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.chmod(path, 0o600)
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        os.close(fd)
+        return False
+    _WORKER_LEADER_FD = fd
+    _WORKER_LEADER_PID = pid
+    return True
+
+
+def _release_worker_leadership() -> None:
+    global _WORKER_LEADER_FD, _WORKER_LEADER_PID
+    fd = _WORKER_LEADER_FD
+    if fd is None:
+        return
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        logger.debug("Goal continuation worker leadership unlock failed", exc_info=True)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        _WORKER_LEADER_FD = None
+        _WORKER_LEADER_PID = None
 
 
 @contextmanager
@@ -136,10 +235,16 @@ def _load_locked() -> dict[str, Any]:
     if _REGISTRY is not None:
         return _REGISTRY
     try:
-        raw = json.loads(Path(REGISTRY_PATH).read_text(encoding="utf-8"))
+        text = Path(REGISTRY_PATH).read_text(encoding="utf-8")
     except FileNotFoundError:
-        raw = _empty_registry()
-    except Exception:
+        _REGISTRY = _empty_registry()
+        return _REGISTRY
+    except OSError:
+        logger.error("Goal continuation registry cannot be read", exc_info=True)
+        raise
+    try:
+        raw = json.loads(text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
         path = Path(REGISTRY_PATH)
         quarantine = path.with_name(
             f"{path.name}.corrupt-{int(time.time())}-{uuid.uuid4().hex[:8]}"
@@ -149,13 +254,13 @@ def _load_locked() -> dict[str, Any]:
             os.chmod(quarantine, 0o600)
             _fsync_parent(path)
             logger.error(
-                "Goal continuation registry was unreadable and was quarantined at %s",
+                "Goal continuation registry contained invalid JSON and was quarantined at %s",
                 quarantine,
                 exc_info=True,
             )
         except Exception:
             logger.error(
-                "Goal continuation registry is unreadable and could not be quarantined",
+                "Goal continuation registry is corrupt and could not be quarantined",
                 exc_info=True,
             )
         raw = _empty_registry()
@@ -273,28 +378,34 @@ def schedule_goal_continuation(
     return copy.deepcopy(record)
 
 
-def bind_goal_continuation_stream(session_id: str, stream_id: str) -> bool:
-    """Bind an admitted server stream before its worker thread can finish.
-
-    ``routes`` calls this after pending-state persistence and before ``thr.start``
-    to close the fast-empty-response race with the scheduler's return path.
-    """
+def bind_goal_continuation_stream(
+    session_id: str,
+    stream_id: str,
+    *,
+    claim_id: str,
+) -> bool:
+    """Fence and bind an admitted stream before its worker can finish."""
     sid = str(session_id or "").strip()
     stream = str(stream_id or "").strip()
-    if not sid or not stream:
+    claim = str(claim_id or "").strip()
+    if not sid or not stream or not claim:
         return False
+    timestamp = time.time()
     with _registry_transaction() as registry:
         record = registry["intents"].get(sid)
         if not isinstance(record, dict) or record.get("status") != "starting":
             return False
+        if str(record.get("claim_id") or "") != claim:
+            return False
+        if str(record.get("owner_id") or "") != _current_owner_id():
+            return False
         record["status"] = "running"
         record["stream_id"] = stream
         record["attempts"] = int(record.get("attempts") or 0) + 1
-        record["owner_id"] = _current_owner_id()
-        _record_now(record, time.time())
+        record["updated_at"] = timestamp
+        registry["intents"][sid] = record
         _save_locked()
         return True
-
 
 def adopt_legacy_browser_goal_stream(session_id: str, stream_id: str, prompt: str) -> bool:
     """Attach an old-tab continuation POST to the matching durable intent.
@@ -442,7 +553,12 @@ def drain_goal_continuations_once(
     if start_turn is None:
         from api.routes import start_session_turn as start_turn
     try:
-        response = start_turn(sid, selected["prompt"], source="goal_continuation") or {}
+        response = start_turn(
+            sid,
+            selected["prompt"],
+            source="goal_continuation",
+            continuation_claim_id=claim_id,
+        ) or {}
     except Exception as exc:
         _release_start_claim(sid, claim_id, now=timestamp, error=f"{type(exc).__name__}: {exc}", busy=False)
         logger.warning("Goal continuation start raised for session %s", sid, exc_info=True)
@@ -495,6 +611,7 @@ def requeue_goal_continuation_after_no_response(
     stream_id: str,
     *,
     had_activity: bool,
+    cancellation_check: Callable[[], bool] | None = None,
     now: float | None = None,
 ) -> bool:
     """Requeue a truly empty goal turn without replaying an active turn.
@@ -515,6 +632,18 @@ def requeue_goal_continuation_after_no_response(
             return False
         attempts = int(record.get("attempts") or 0)
         max_attempts = max(1, int(record.get("max_attempts") or DEFAULT_MAX_ATTEMPTS))
+        try:
+            cancelled = bool(cancellation_check and cancellation_check())
+        except Exception:
+            logger.warning("Goal continuation cancellation check failed closed", exc_info=True)
+            cancelled = True
+        if cancelled:
+            record["status"] = "failed"
+            record["claim_id"] = None
+            record["last_error"] = "goal continuation was cancelled; automatic replay refused"
+            _record_now(record, timestamp)
+            _save_locked()
+            return False
         if had_activity:
             record["status"] = "failed"
             record["last_error"] = "empty terminal response after observable activity; automatic replay refused"
@@ -706,7 +835,14 @@ def recover_goal_continuations(
                 summary = summary_loader(sid, str(record.get("stream_id") or "")) or {}
             except Exception:
                 logger.warning("Goal continuation run-summary recovery failed for %s", sid, exc_info=True)
-                summary = {"terminal_state": "unknown"}
+                record["status"] = "failed"
+                record["claim_id"] = None
+                record["last_error"] = (
+                    "run evidence was unavailable during recovery; automatic replay refused"
+                )
+                _record_now(record, timestamp)
+                recovered += 1
+                continue
             terminal_state = str(summary.get("terminal_state") or "unknown").strip().lower()
             observable_activity = bool(summary.get("observable_activity"))
             attempts = int(record.get("attempts") or 0)
@@ -764,6 +900,9 @@ def start_goal_continuation_worker() -> bool:
     with _WORKER_LIFECYCLE_LOCK:
         if _WORKER_THREAD is not None and _WORKER_THREAD.is_alive():
             return False
+        if not _try_acquire_worker_leadership():
+            logger.info("Goal continuation worker leadership is held by another process")
+            return False
         _WORKER_STOP.clear()
         _WORKER_WAKE.clear()
         _WORKER_THREAD = threading.Thread(
@@ -771,13 +910,25 @@ def start_goal_continuation_worker() -> bool:
             name="hermes-webui-goal-continuations",
             daemon=True,
         )
-        _WORKER_THREAD.start()
+        try:
+            _WORKER_THREAD.start()
+        except BaseException:
+            _WORKER_THREAD = None
+            _release_worker_leadership()
+            raise
         return True
 
 
-def stop_goal_continuation_worker(timeout: float = 2.0) -> None:
+def stop_goal_continuation_worker(timeout: float = 2.0) -> bool:
+    global _WORKER_THREAD
     _WORKER_STOP.set()
     _WORKER_WAKE.set()
     thread = _WORKER_THREAD
     if thread is not None and thread.is_alive():
         thread.join(timeout=timeout)
+    alive = bool(thread is not None and thread.is_alive())
+    with _WORKER_LIFECYCLE_LOCK:
+        if not alive and thread is _WORKER_THREAD:
+            _WORKER_THREAD = None
+            _release_worker_leadership()
+    return not alive

--- a/api/goals.py
+++ b/api/goals.py
@@ -167,12 +167,20 @@ class _ProfileGoalManager:
 class _LegacyProfileGoalManager:
     """Explicit-DB fallback for Hermes versions without profile context."""
 
-    def __init__(self, session_id: str, *, profile_home: str | Path, default_max_turns: int = 20):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        profile_home: str | Path,
+        default_max_turns: int = 20,
+        strict_load: bool = False,
+    ):
         if GoalState is None:
             raise RuntimeError("Hermes goal state unavailable")
         self.session_id = session_id
         self.profile_home = Path(profile_home).expanduser().resolve()
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS or 20)
+        self.strict_load = bool(strict_load)
         self._state = self._load()
 
     @property
@@ -182,11 +190,15 @@ class _LegacyProfileGoalManager:
     def _load(self):
         db = _profile_db(self.profile_home)
         if db is None or not self.session_id:
+            if self.strict_load:
+                raise RuntimeError("profile goal database unavailable")
             return None
         try:
             raw = db.get_meta(_meta_key(self.session_id))
         except Exception as exc:
             logger.debug("GoalManager profile get_meta failed: %s", exc)
+            if self.strict_load:
+                raise
             return None
         if not raw:
             return None
@@ -194,6 +206,8 @@ class _LegacyProfileGoalManager:
             return GoalState.from_json(raw)  # type: ignore[union-attr]
         except Exception as exc:
             logger.warning("GoalManager profile state parse failed for %s: %s", self.session_id, exc)
+            if self.strict_load:
+                raise
             return None
 
     def _save(self, state) -> None:
@@ -494,6 +508,23 @@ def goal_state_snapshot(session_id: str, *, profile_home: str | Path | None = No
     return copy.deepcopy(getattr(mgr, "state", None))
 
 
+def goal_state_snapshot_strict(
+    session_id: str,
+    *,
+    profile_home: str | Path | None = None,
+) -> Any:
+    """Load goal state without converting I/O or parse failures to absence."""
+    if profile_home and GoalManager is _NativeGoalManager and GoalState is not None:
+        mgr = _ProfileGoalManager(
+            session_id=str(session_id or ""),
+            profile_home=profile_home,
+            default_max_turns=_default_max_turns(),
+            strict_load=True,
+        )
+        return copy.deepcopy(mgr.state)
+    return goal_state_snapshot(session_id, profile_home=profile_home)
+
+
 def restore_goal_state(session_id: str, snapshot: Any, *, profile_home: str | Path | None = None) -> None:
     """Restore a prior goal state after kickoff stream creation fails."""
     mgr = _manager(str(session_id or ""), profile_home=profile_home)
@@ -548,12 +579,25 @@ def goal_command_payload(
     text = str(args or "").strip()
     lower = text.lower()
 
+    def _cancel_durable_continuation(reason: str) -> None:
+        try:
+            from api.goal_continuations import cancel_goal_continuation
+
+            cancel_goal_continuation(sid, reason=reason)
+        except Exception:
+            logger.warning(
+                "Failed to durably cancel goal continuation for %s",
+                sid,
+                exc_info=True,
+            )
+
     if not text or lower == "status":
         state = getattr(mgr, "state", None)
         status_payload = _goal_status_payload(state)
         return _payload(action="status", state=state, **status_payload)
 
     if lower == "pause":
+        _cancel_durable_continuation("goal paused by user")
         state = mgr.pause(reason="user-paused")
         if state is None:
             return _payload(
@@ -594,6 +638,7 @@ def goal_command_payload(
 
     if lower in ("clear", "stop", "done"):
         had = bool(mgr.has_goal())
+        _cancel_durable_continuation("goal cleared by user")
         mgr.clear()
         return _payload(
             action="clear",

--- a/api/goals.py
+++ b/api/goals.py
@@ -298,7 +298,10 @@ class _LegacyProfileGoalManager:
         if judge_goal is None:
             verdict, reason = "continue", "goal judge unavailable"
         else:
-            verdict, reason, *_ = judge_goal(state.goal, str(last_response or ""))
+            judge_result = judge_goal(state.goal, str(last_response or ""))
+            if not isinstance(judge_result, (tuple, list)) or len(judge_result) < 2:
+                raise RuntimeError("goal judge returned an invalid result")
+            verdict, reason = str(judge_result[0]), str(judge_result[1])
         state.last_verdict = verdict
         state.last_reason = reason
 

--- a/api/goals.py
+++ b/api/goals.py
@@ -514,14 +514,17 @@ def goal_state_snapshot_strict(
     profile_home: str | Path | None = None,
 ) -> Any:
     """Load goal state without converting I/O or parse failures to absence."""
-    if profile_home and GoalManager is _NativeGoalManager and GoalState is not None:
-        mgr = _ProfileGoalManager(
-            session_id=str(session_id or ""),
-            profile_home=profile_home,
-            default_max_turns=_default_max_turns(),
-            strict_load=True,
-        )
-        return copy.deepcopy(mgr.state)
+    if profile_home:
+        sid = str(session_id or "")
+        db = _profile_db(profile_home)
+        if db is None:
+            raise RuntimeError("profile goal database unavailable")
+        raw = db.get_meta(_meta_key(sid))
+        if not raw:
+            return None
+        if GoalState is None:
+            raise RuntimeError("Hermes goal state unavailable")
+        return copy.deepcopy(GoalState.from_json(raw))
     return goal_state_snapshot(session_id, profile_home=profile_home)
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -44,7 +44,7 @@ from api.agent_sessions import (
     read_importable_agent_session_rows,
     read_session_lineage_metadata,
 )
-from api.process_event_utils import stamp_message_source
+from api.process_event_utils import stamp_message_source, stamp_wakeup_source_if_untagged, wakeup_event_key
 
 logger = logging.getLogger(__name__)
 CLI_VISIBLE_SESSION_LIMIT = 20
@@ -10085,6 +10085,42 @@ def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
     return True
 
 
+def _normalize_wakeup_rows_for_display(messages):
+    """Stamp untagged wakeup rows and drop duplicate completion wakeups.
+
+    Display-side backstop for wake deliveries that persist without a durable
+    ``_source`` (self-POST wake turns, gateway-side turns merged from
+    state.db): stamp them so the never-render / ``[[SILENT]]``-collapse
+    contract holds, and collapse same-event completion rows (eager + merged
+    twins, or stale post-restart redeliveries) to the first occurrence.
+    Watch-match wakeups are stamped but never deduplicated (they can fire
+    several times for one process legitimately). Model context in state.db
+    is untouched — this only shapes the WebUI store projection.
+    """
+    if not isinstance(messages, list) or not messages:
+        return messages
+    seen_keys = set()
+    normalized = []
+    dropped = 0
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            stamp_wakeup_source_if_untagged(msg)
+            if msg.get("_source") in {"process_wakeup", "async_delegation"}:
+                key = wakeup_event_key(msg.get("content"))
+                if key is not None:
+                    if key in seen_keys:
+                        dropped += 1
+                        continue
+                    seen_keys.add(key)
+        normalized.append(msg)
+    if dropped:
+        logger.info(
+            "dropped %d duplicate process-completion wakeup row(s) during merge",
+            dropped,
+        )
+    return normalized
+
+
 def merge_session_messages_append_only(
     sidecar_messages: list,
     state_messages: list,
@@ -10341,7 +10377,7 @@ def merge_session_messages_append_only(
         merged_messages.append(msg)
         _remember_merged_message(msg, source="sidecar")
     if _sidecar_has_terminal_partial_error(sidecar_messages):
-        return merged_messages
+        return _normalize_wakeup_rows_for_display(merged_messages)
     sidecar_visible_lookup = _build_visible_duplicate_lookup(sidecar_visible_keys)
     state_multimodal_mirror_keys = {}
     ambiguous_state_multimodal_mirrors = set()
@@ -10669,7 +10705,7 @@ def merge_session_messages_append_only(
         seen_visible_keys.add(visible_key)
         merged_messages.append(msg)
         _remember_merged_message(msg, source="state")
-    return merged_messages
+    return _normalize_wakeup_rows_for_display(merged_messages)
 
 
 @overload

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -175,6 +175,97 @@ def build_active_turn_token(stream_id: Any, started_at: Any) -> str | None:
     return f"{str(stream_id).strip()}:{started:.17g}"
 
 
+_WORKSPACE_TAG_RE = re.compile(r"\A\[Workspace::v1: [^\n]*\]\n{0,2}")
+_INTERNAL_WAKEUP_PREFIX = "[INTERNAL BACKGROUND EVENT"
+
+
+def _strip_workspace_tag(text: Any) -> str:
+    """Remove a leading ``[Workspace::v1: ...]`` tag line, if present."""
+    return _WORKSPACE_TAG_RE.sub("", str(text or ""), count=1)
+
+
+def is_wakeup_user_text(text: Any) -> bool:
+    """Whether *text* is a process-wakeup payload in any delivery shape.
+
+    Matches the raw agent-side formatter envelope (optionally preceded by a
+    workspace tag line) and the WebUI-internal wrapped prompt
+    (``[INTERNAL BACKGROUND EVENT ...``). This is the ONLY signal available
+    on delivery paths that carry no durable source metadata — e.g. the
+    api_server adapter's self-POSTed wake turns, which arrive as ordinary
+    user messages (``deliver_wake`` → ``/v1/chat/completions``).
+    """
+    body = _strip_workspace_tag(text)
+    if body.startswith(_INTERNAL_WAKEUP_PREFIX):
+        return True
+    return bool(
+        _WAKEUP_COMPLETION_RE.match(body)
+        or _WAKEUP_WATCH_MATCH_RE.match(body)
+        or _ASYNC_DELEGATION_HEADER_RE.match(body)
+    )
+
+
+def wakeup_event_key(text: Any) -> tuple | None:
+    """Return a dedup key ``("completion", sid, exit_code)`` for a completion
+    wakeup text, else None.
+
+    A process completes exactly once, so two rows with the same key are the
+    same event delivered twice (eager row + state.db merge row, or a stale
+    post-restart redelivery). Watch-match wakeups deliberately return None:
+    they can legitimately fire several times for one process and must never
+    be deduplicated.
+    """
+    body = _strip_workspace_tag(text)
+    async_match = _ASYNC_DELEGATION_HEADER_RE.match(body)
+    if async_match is not None:
+        return ("async_delegation", async_match.group("id"))
+    m = _WAKEUP_COMPLETION_RE.match(body)
+    if m is None and body.startswith(_INTERNAL_WAKEUP_PREFIX):
+        # The wrapper wraps the raw envelope; ``\A`` anchors make ``search``
+        # useless, so re-match on the sliced inner block.
+        inner = body.find("[IMPORTANT: Background process ")
+        if inner >= 0:
+            m = _WAKEUP_COMPLETION_RE.match(body[inner:])
+    if m is None:
+        return None
+    return ("completion", m.group("sid"), m.group("exit_code"))
+
+
+def stamp_wakeup_source_if_untagged(msg: Any) -> bool:
+    """Backstop: stamp ``_source='process_wakeup'`` on a wakeup-shaped user
+    message that carries no explicit source.
+
+    Wakeup rows are never renderable (the UI contract), and the ``[[SILENT]]``
+    collapse keys on this marker — both break when a delivery path (self-POST
+    wake, state.db merge of a gateway-run turn) persists the row untagged.
+    Only user-role messages without an existing ``_source`` are touched, so
+    human turns stay untouched even in the pathological case of a user
+    pasting the exact envelope. Never raises.
+    """
+    try:
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            return False
+        if msg.get("_source"):
+            return False
+        content = msg.get("content")
+        # isinstance guard first: never coerce exotic content objects (the
+        # merge key-cache perf contract counts str() calls on message rows).
+        if not isinstance(content, str) or not is_wakeup_user_text(content):
+            return False
+        body = _strip_workspace_tag(content)
+        source = (
+            "async_delegation"
+            if _ASYNC_DELEGATION_HEADER_RE.match(body)
+            else "process_wakeup"
+        )
+        msg["_source"] = source
+        attach_wakeup_display_meta(msg, source)
+        attach_internal_event_meta(msg, source)
+        return True
+    except Exception:
+        logger.debug("wakeup source backstop failed", exc_info=True)
+        return False
+
+
 def stamp_message_source(
     msg: Any,
     source: Any,
@@ -193,6 +284,11 @@ def stamp_message_source(
     if isinstance(msg, dict) and active_turn_token:
         msg["_active_turn_token"] = str(active_turn_token)
     if not isinstance(msg, dict) or not source or source == "webui":
+        # No explicit source: fall back to the content-shape backstop so
+        # wakeup deliveries that arrive untagged (self-POST wake turns,
+        # gateway-side turns merged from state.db) still carry the durable
+        # marker the UI hide/collapse contract needs.
+        stamp_wakeup_source_if_untagged(msg)
         return
     msg["_source"] = source
     attach_wakeup_display_meta(msg, source)

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -247,14 +247,23 @@ def stamp_wakeup_source_if_untagged(msg: Any) -> bool:
     Wakeup rows are never renderable (the UI contract), and the ``[[SILENT]]``
     collapse keys on this marker — both break when a delivery path (self-POST
     wake, state.db merge of a gateway-run turn) persists the row untagged.
-    Only user-role messages without an existing ``_source`` are touched, so
-    human turns stay untouched even in the pathological case of a user
-    pasting the exact envelope. Never raises.
+    Only user-role messages without an existing ``_source`` and with an
+    independent trusted-internal provenance signal are touched. Text shape
+    alone is never authority: a human pasting the exact envelope stays human.
+    Never raises.
     """
     try:
         if not isinstance(msg, dict) or msg.get("role") != "user":
             return False
         if msg.get("_source"):
+            return False
+        trusted_internal = bool(
+            msg.get("_transport_internal") is True
+            or msg.get("_user_originated") is False
+            or str(msg.get("_display_kind") or "")
+            in {"internal_event", "process_wakeup", "async_delegation_complete"}
+        )
+        if not trusted_internal:
             return False
         content = msg.get("content")
         # isinstance guard first: never coerce exotic content objects (the

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass
+import hashlib
 import logging
 import math
 import re
@@ -215,19 +216,28 @@ def wakeup_event_key(text: Any) -> tuple | None:
     be deduplicated.
     """
     body = _strip_workspace_tag(text)
-    async_match = _ASYNC_DELEGATION_HEADER_RE.match(body)
-    if async_match is not None:
-        return ("async_delegation", async_match.group("id"))
-    m = _WAKEUP_COMPLETION_RE.match(body)
-    if m is None and body.startswith(_INTERNAL_WAKEUP_PREFIX):
-        # The wrapper wraps the raw envelope; ``\A`` anchors make ``search``
-        # useless, so re-match on the sliced inner block.
+    canonical_body = body
+    if body.startswith(_INTERNAL_WAKEUP_PREFIX):
         inner = body.find("[IMPORTANT: Background process ")
         if inner >= 0:
-            m = _WAKEUP_COMPLETION_RE.match(body[inner:])
+            if body.endswith("]]"):
+                canonical_body = body[inner:-1]
+            else:
+                canonical_body = body[inner:]
+    async_match = _ASYNC_DELEGATION_HEADER_RE.match(canonical_body)
+    if async_match is not None:
+        payload_digest = hashlib.sha256(canonical_body.encode("utf-8")).hexdigest()
+        return ("async_delegation", async_match.group("id"), payload_digest)
+    m = _WAKEUP_COMPLETION_RE.match(canonical_body)
     if m is None:
         return None
-    return ("completion", m.group("sid"), m.group("exit_code"))
+    payload_digest = hashlib.sha256(canonical_body.encode("utf-8")).hexdigest()
+    return (
+        "completion",
+        m.group("sid"),
+        m.group("exit_code"),
+        payload_digest,
+    )
 
 
 def stamp_wakeup_source_if_untagged(msg: Any) -> bool:
@@ -283,7 +293,9 @@ def stamp_message_source(
     """
     if isinstance(msg, dict) and active_turn_token:
         msg["_active_turn_token"] = str(active_turn_token)
-    if not isinstance(msg, dict) or not source or source == "webui":
+    if not isinstance(msg, dict) or source == "webui":
+        return
+    if not source:
         # No explicit source: fall back to the content-shape backstop so
         # wakeup deliveries that arrive untagged (self-POST wake turns,
         # gateway-side turns merged from state.db) still carry the durable

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -73,6 +73,10 @@ _WAKEUP_WATCH_MATCH_RE = re.compile(
     r"Command: (?P<cmd>[^\n]*)\n"
     r"Matched output:\n"
 )
+_ASYNC_DELEGATION_HEADER_RE = re.compile(
+    r"^\s*\[ASYNC DELEGATION(?: BATCH)? COMPLETE\s+—\s+(?P<id>[^\]\s]+)\]",
+    re.IGNORECASE,
+)
 
 
 def wakeup_display_meta(text: Any) -> dict | None:
@@ -138,6 +142,26 @@ def attach_wakeup_display_meta(msg: Any, source: Any) -> None:
         msg["_wakeup_meta"] = meta
 
 
+def attach_internal_event_meta(msg: Any, source: Any) -> None:
+    """Keep transport events auditable without attributing them to the user."""
+    if not isinstance(msg, dict) or source not in {"process_wakeup", "async_delegation"}:
+        return
+    msg["_display_kind"] = "internal_event"
+    msg["_user_originated"] = False
+    if source != "async_delegation":
+        return
+    msg["_event_kind"] = "workflow.async_delegation.terminal"
+    try:
+        match = _ASYNC_DELEGATION_HEADER_RE.match(str(msg.get("content") or ""))
+    except Exception:
+        match = None
+    if not match:
+        return
+    delegation_id = match.group("id")
+    msg["_event_id"] = f"async_delegation:{delegation_id}:terminal"
+    msg["_workflow_id"] = f"delegation:{delegation_id}"
+
+
 def build_active_turn_token(stream_id: Any, started_at: Any) -> str | None:
     """Return the exact eager-row token for one active WebUI turn."""
     if not stream_id:
@@ -172,6 +196,7 @@ def stamp_message_source(
         return
     msg["_source"] = source
     attach_wakeup_display_meta(msg, source)
+    attach_internal_event_meta(msg, source)
 
 
 def _claim_bounded_local(delegation_id: str) -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -23361,10 +23361,37 @@ def _start_run(
         runtime_adapter_runner_enabled,
     )
 
-    runner_owned = runtime_adapter_runner_enabled() and source != "goal_continuation"
-    if runtime_adapter_enabled() or runner_owned:
-        if regeneration is not None and runner_owned:
+    def _direct_start():
+        return _start_chat_stream_for_session(
+            s,
+            msg=msg,
+            attachments=attachments,
+            workspace=workspace,
+            model=model,
+            model_provider=model_provider,
+            normalized_model=normalized_model,
+            diag=diag,
+            source=source,
+            moa_config=moa_config,
+            external_runtime_owned=gateway_chat_enabled,
+            regeneration=regeneration,
+            goal_related=goal_related,
+            continuation_claim_id=continuation_claim_id,
+        )
+
+    # A runner-owned continuation must stay with the WebUI scheduler.  The
+    # legacy adapter remains valid when it is explicitly enabled.
+    if (
+        source == "goal_continuation"
+        and runtime_adapter_runner_enabled()
+        and not runtime_adapter_enabled()
+    ):
+        return _direct_start()
+
+    if runtime_adapter_enabled() or runtime_adapter_runner_enabled():
+        if regeneration is not None and runtime_adapter_runner_enabled():
             return {"error": "Regeneration is not supported by the runner backend.", "code": "unsupported_regeneration_backend", "_status": 409}
+
         def _legacy_start_run(request: StartRunRequest) -> dict:
             return _start_chat_stream_for_session(
                 s,
@@ -23413,22 +23440,7 @@ def _start_run(
             return {"error": str(exc), "_status": 501}
         return _chat_start_response_from_run_start(result)
 
-    return _start_chat_stream_for_session(
-        s,
-        msg=msg,
-        attachments=attachments,
-        workspace=workspace,
-        model=model,
-        model_provider=model_provider,
-        normalized_model=normalized_model,
-        diag=diag,
-        source=source,
-        moa_config=moa_config,
-        external_runtime_owned=gateway_chat_enabled,
-        regeneration=regeneration,
-        goal_related=goal_related,
-        continuation_claim_id=continuation_claim_id,
-    )
+    return _direct_start()
 
 
 def _process_wakeup_revalidation_provider(model, provider) -> str:

--- a/api/routes.py
+++ b/api/routes.py
@@ -23260,7 +23260,16 @@ def _start_chat_stream_for_session(
             s.pending_attachments = []
             s.pending_started_at = None
             s.pending_user_source = None
-            s.save()
+            try:
+                save_session = getattr(s, "save", None)
+                if callable(save_session):
+                    save_session()
+            except Exception:
+                logger.warning(
+                    "Failed to persist stream-start rollback for session %s",
+                    s.session_id,
+                    exc_info=True,
+                )
         raise
     response = {
         "stream_id": stream_id,

--- a/api/routes.py
+++ b/api/routes.py
@@ -21279,7 +21279,7 @@ def _handle_session_sse_stream(handler, parsed):
                     "session_id": sid,
                     "stream_id": recover_stream_id,
                     "pending_started_at": pending_started_at,
-                    "source": "subscribe_recovery",
+                    "source": getattr(recover_session, "pending_user_source", None) or "subscribe_recovery",
                     "recovered": True,
                 })
             else:
@@ -22815,6 +22815,7 @@ def _start_regeneration_stream_locked(
                 "model": model,
                 "model_provider": model_provider,
                 "created_at": s.pending_started_at,
+                "source": s.pending_user_source or turn.source or "webui",
             },
         )
         diag.stage("stream_registration") if diag else None
@@ -23210,6 +23211,7 @@ def _start_chat_stream_for_session(
                 "model": model,
                 "model_provider": model_provider,
                 "created_at": s.pending_started_at,
+                "source": s.pending_user_source or source or "webui",
             },
         )
     except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -23632,7 +23632,7 @@ def start_session_turn(
                     session_id,
                     exc_info=True,
                 )
-        if turn_source == "process_wakeup":
+        if turn_source in {"process_wakeup", "async_delegation"}:
             _credential_state_changed = False
             try:
                 _credential_state_changed = process_wakeup_pause_credential_state_changed(s)

--- a/api/routes.py
+++ b/api/routes.py
@@ -23241,6 +23241,23 @@ def _start_chat_stream_for_session(
     try:
         thr.start()
     except Exception:
+        if goal_related:
+            try:
+                from api.goal_continuations import (
+                    requeue_goal_continuation_after_no_response,
+                )
+
+                if requeue_goal_continuation_after_no_response(
+                    s.session_id,
+                    stream_id,
+                    had_activity=False,
+                ):
+                    PENDING_GOAL_CONTINUATION.add(s.session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to release goal continuation after thread-start failure",
+                    exc_info=True,
+                )
         if backend_is_gateway:
             try:
                 from api.gateway_chat import _finish_gateway_run_starting

--- a/api/routes.py
+++ b/api/routes.py
@@ -23047,6 +23047,7 @@ def _start_chat_stream_for_session(
     moa_config=None,
     external_runtime_owned: bool | None = None,
     regeneration=None,
+    continuation_claim_id: str | None = None,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     if external_runtime_owned is None:
@@ -23145,7 +23146,11 @@ def _start_chat_stream_for_session(
                 if source == "goal_continuation":
                     from api.goal_continuations import bind_goal_continuation_stream
 
-                    if not bind_goal_continuation_stream(s.session_id, stream_id):
+                    if not bind_goal_continuation_stream(
+                        s.session_id,
+                        stream_id,
+                        claim_id=continuation_claim_id,
+                    ):
                         return {
                             "error": "durable goal continuation claim is no longer current",
                             "_status": 409,
@@ -23328,6 +23333,7 @@ def _start_run(
     gateway_chat_enabled: bool | None = None,
     regeneration=None,
     goal_related: bool = False,
+    continuation_claim_id: str | None = None,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -23355,8 +23361,9 @@ def _start_run(
         runtime_adapter_runner_enabled,
     )
 
-    if runtime_adapter_enabled() or runtime_adapter_runner_enabled():
-        if regeneration is not None and runtime_adapter_runner_enabled():
+    runner_owned = runtime_adapter_runner_enabled() and source != "goal_continuation"
+    if runtime_adapter_enabled() or runner_owned:
+        if regeneration is not None and runner_owned:
             return {"error": "Regeneration is not supported by the runner backend.", "code": "unsupported_regeneration_backend", "_status": 409}
         def _legacy_start_run(request: StartRunRequest) -> dict:
             return _start_chat_stream_for_session(
@@ -23373,6 +23380,7 @@ def _start_run(
                 external_runtime_owned=gateway_chat_enabled,
                 regeneration=regeneration,
                 goal_related=goal_related,
+                continuation_claim_id=continuation_claim_id,
             )
 
         def _legacy_adapter_factory():
@@ -23419,6 +23427,7 @@ def _start_run(
         external_runtime_owned=gateway_chat_enabled,
         regeneration=regeneration,
         goal_related=goal_related,
+        continuation_claim_id=continuation_claim_id,
     )
 
 
@@ -23478,6 +23487,7 @@ def start_session_turn(
     message: str,
     *,
     source: str = "process_wakeup",
+    continuation_claim_id: str | None = None,
 ):
     """Start a server-side agent turn for ``session_id`` with ``message``.
 
@@ -23676,6 +23686,7 @@ def start_session_turn(
         source=turn_source,
         route="start_session_turn",
         goal_related=(turn_source == "goal_continuation"),
+        continuation_claim_id=continuation_claim_id,
     )
 
     # ── Defect B: live-view of server-initiated turns ──────────────────────

--- a/api/routes.py
+++ b/api/routes.py
@@ -23249,6 +23249,18 @@ def _start_chat_stream_for_session(
                 _clear_gateway_run_starting(stream_id)
             except Exception:
                 logger.debug("Failed to record gateway run-start failure for stream %s", stream_id, exc_info=True)
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+            STREAM_GOAL_RELATED.pop(stream_id, None)
+        unregister_stream_owner(stream_id)
+        clear_session_writeback_owner_if_owned(s.session_id, stream_id)
+        if getattr(s, "active_stream_id", None) == stream_id:
+            s.active_stream_id = None
+            s.pending_user_message = None
+            s.pending_attachments = []
+            s.pending_started_at = None
+            s.pending_user_source = None
+            s.save()
         raise
     response = {
         "stream_id": stream_id,

--- a/api/routes.py
+++ b/api/routes.py
@@ -15940,6 +15940,13 @@ def handle_post(handler, parsed) -> bool:
                     logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
+        try:
+            from api.goal_continuations import complete_goal_continuation
+
+            complete_goal_continuation(sid)
+            PENDING_GOAL_CONTINUATION.discard(sid)
+        except Exception:
+            logger.debug("Failed to prune goal continuation for deleted session %s", sid, exc_info=True)
         # Evict outside the mutation lock: lifecycle commit may perform provider
         # I/O and must not hold a per-session Session lock.
         from api.config import _evict_session_agent
@@ -23069,12 +23076,24 @@ def _start_chat_stream_for_session(
         diag.stage("stale_stream_cleanup") if diag else None
         _clear_stale_stream_state(s)
 
-    # #1932: check if this session has a pending goal continuation flag.
-    # The streaming hook sets PENDING_GOAL_CONTINUATION when goal_continue fires,
-    # so the next chat/start for this session is automatically treated as goal-related.
-    if not goal_related and s.session_id in PENDING_GOAL_CONTINUATION:
+    # ``goal_continuation`` is a server-owned source.  Mark it explicitly so
+    # judge execution never depends on the legacy browser-consumed marker.
+    if source == "goal_continuation":
         goal_related = True
-        PENDING_GOAL_CONTINUATION.discard(s.session_id)
+
+    # #1932 compatibility: only an old-tab replay whose prompt exactly matches
+    # the current durable intent is goal-related.  An ordinary user turn keeps
+    # normal priority even while a continuation marker exists.
+    legacy_goal_marker_consumed = False
+    if not goal_related and s.session_id in PENDING_GOAL_CONTINUATION:
+        from api.goal_continuations import legacy_browser_goal_prompt_matches
+
+        legacy_goal_marker_consumed = legacy_browser_goal_prompt_matches(
+            s.session_id,
+            msg,
+        )
+        if legacy_goal_marker_consumed:
+            goal_related = True
 
     # process_complete wakeup (ours-original, Option B): if this session has a
     # pending process_complete marker (set by api/background_process.py drain),
@@ -23123,6 +23142,24 @@ def _start_chat_stream_for_session(
                         backend_is_gateway=backend_is_gateway,
                     )
                 stream_id = uuid.uuid4().hex
+                if source == "goal_continuation":
+                    from api.goal_continuations import bind_goal_continuation_stream
+
+                    if not bind_goal_continuation_stream(s.session_id, stream_id):
+                        return {
+                            "error": "durable goal continuation claim is no longer current",
+                            "_status": 409,
+                        }
+                    PENDING_GOAL_CONTINUATION.discard(s.session_id)
+                elif legacy_goal_marker_consumed:
+                    from api.goal_continuations import adopt_legacy_browser_goal_stream
+
+                    if not adopt_legacy_browser_goal_stream(s.session_id, stream_id, msg):
+                        return {
+                            "error": "server already owns this goal continuation",
+                            "_status": 409,
+                        }
+                    PENDING_GOAL_CONTINUATION.discard(s.session_id)
                 diag.stage("save_pending_state") if diag else None
                 was_hidden_empty_session = _is_hidden_empty_session(s)
                 _prepare_chat_start_session_for_stream(
@@ -23290,6 +23327,7 @@ def _start_run(
     moa_config=None,
     gateway_chat_enabled: bool | None = None,
     regeneration=None,
+    goal_related: bool = False,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -23334,6 +23372,7 @@ def _start_run(
                 moa_config=moa_config,
                 external_runtime_owned=gateway_chat_enabled,
                 regeneration=regeneration,
+                goal_related=goal_related,
             )
 
         def _legacy_adapter_factory():
@@ -23356,7 +23395,10 @@ def _start_run(
                     provider=model_provider,
                     model=model,
                     source=source,
-                    metadata={"route": route},
+                    metadata={
+                        "route": route,
+                        **({"goal_related": True} if goal_related else {}),
+                    },
                 )
             )
         except NotImplementedError as exc:
@@ -23376,6 +23418,7 @@ def _start_run(
         moa_config=moa_config,
         external_runtime_owned=gateway_chat_enabled,
         regeneration=regeneration,
+        goal_related=goal_related,
     )
 
 
@@ -23632,6 +23675,7 @@ def start_session_turn(
         normalized_model=normalized_model,
         source=turn_source,
         route="start_session_turn",
+        goal_related=(turn_source == "goal_continuation"),
     )
 
     # ── Defect B: live-view of server-initiated turns ──────────────────────

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -581,11 +581,36 @@ def mark_session_title_generated(session) -> None:
     session.manual_title = False
 
 
+_INTERNAL_USER_SOURCES = frozenset({
+    'process_wakeup',
+    'async_delegation',
+    'goal_continuation',
+    'internal_event',
+})
+_INTERNAL_USER_DISPLAY_KINDS = frozenset({
+    'process_wakeup',
+    'async_delegation_complete',
+    'internal_event',
+})
+
+
+def _is_semantic_user_message(message) -> bool:
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return False
+    if message.get('_user_originated') is False:
+        return False
+    if str(message.get('_source') or '').strip() in _INTERNAL_USER_SOURCES:
+        return False
+    if str(message.get('_display_kind') or '').strip() in _INTERNAL_USER_DISPLAY_KINDS:
+        return False
+    return True
+
+
 def _truncate_at_last_user(messages):
     history = messages or []
     last_user_idx = None
     for i in range(len(history) - 1, -1, -1):
-        if isinstance(history[i], dict) and history[i].get('role') == 'user':
+        if _is_semantic_user_message(history[i]):
             last_user_idx = i
             break
     if last_user_idx is None:
@@ -972,7 +997,7 @@ def retry_last(session_id: str) -> dict[str, Any]:
             history = s.messages or []
             last_user_idx = None
             for i in range(len(history) - 1, -1, -1):
-                if history[i].get('role') == 'user':
+                if _is_semantic_user_message(history[i]):
                     last_user_idx = i
                     break
             if last_user_idx is None:
@@ -1016,7 +1041,7 @@ def undo_last(session_id: str) -> dict[str, Any]:
             history = s.messages or []
             last_user_idx = None
             for i in range(len(history) - 1, -1, -1):
-                if history[i].get('role') == 'user':
+                if _is_semantic_user_message(history[i]):
                     last_user_idx = i
                     break
             if last_user_idx is None:

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -1111,6 +1111,10 @@ def session_status(session_id: str) -> dict[str, Any]:
         # bookkeeping). Otherwise report None so the poller waits for a REAL
         # server_turn_started instead of latching a ghost.
         'active_stream_id': _live_active_stream_id(s),
+        'pending_user_source': getattr(s, 'pending_user_source', None) or None,
+        'pending_user_message': getattr(s, 'pending_user_message', None) or None,
+        'pending_started_at': getattr(s, 'pending_started_at', None) or None,
+        'pending_attachments': getattr(s, 'pending_attachments', None) or [],
         'input_tokens': inp,
         'output_tokens': out,
         'total_tokens': inp + out,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8660,6 +8660,22 @@ def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
             rt['is_anthropic_oauth'] = getattr(agent, '_is_anthropic_oauth')
 
 
+def _goal_retry_event_has_observable_activity(event: str) -> bool:
+    """Return whether an emitted local SSE event makes replay unsafe."""
+    normalized = str(event or '').strip().lower()
+    return normalized.startswith((
+        'token',
+        'reason',
+        'tool',
+        'approval',
+        'clarify',
+        'process',
+        'bg_',
+        'assistant',
+        'intermediate',
+    ))
+
+
 def _run_agent_streaming(
     session_id,
     msg_text,
@@ -9044,11 +9060,15 @@ def _run_agent_streaming(
     _metering_thread = threading.Thread(target=_metering_ticker, daemon=True)
 
     _success_writeback_committed = False
+    _goal_retry_observable_activity = False
 
     def put(event, data):
+        nonlocal _goal_retry_observable_activity
         # If cancelled, drop all further events except the cancel event itself
         if cancel_event.is_set() and not _success_writeback_committed and event not in ('cancel', 'apperror'):
             return
+        if _goal_retry_event_has_observable_activity(event):
+            _goal_retry_observable_activity = True
         event_id = None
         if run_journal is not None:
             try:
@@ -11148,7 +11168,8 @@ def _run_agent_streaming(
                         )
 
                         _goal_retry_had_activity = bool(
-                            _token_sent
+                            _goal_retry_observable_activity
+                            or _token_sent
                             or STREAM_PARTIAL_TEXT.get(stream_id)
                             or STREAM_REASONING_TEXT.get(stream_id)
                             or STREAM_LIVE_TOOL_CALLS.get(stream_id)
@@ -11167,6 +11188,7 @@ def _run_agent_streaming(
                             session_id,
                             stream_id,
                             had_activity=_goal_retry_had_activity,
+                            cancellation_check=cancel_event.is_set,
                         ):
                             _goal_retry_record = get_goal_continuation(session_id) or {}
                             _goal_retry_attempts = int(_goal_retry_record.get('attempts') or 0)
@@ -11207,6 +11229,11 @@ def _run_agent_streaming(
                                 'session': redact_session_data(
                                     _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
                                 ),
+                                'goal_retry_scheduled': True,
+                            })
+                            put('stream_end', {
+                                'session_id': session_id,
+                                'stream_id': stream_id,
                                 'goal_retry_scheduled': True,
                             })
                             return

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -13329,6 +13329,21 @@ def cancel_stream(stream_id: str) -> bool:
     # would race that teardown and return None.
     if not _cancel_session_id and _snap_owner_session_id:
         _cancel_session_id = _snap_owner_session_id
+    if _cancel_session_id:
+        try:
+            from api.goal_continuations import cancel_goal_continuation
+
+            cancel_goal_continuation(
+                _cancel_session_id,
+                stream_id,
+                reason="stream cancelled by user",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to durably cancel goal continuation for stream %s",
+                stream_id,
+                exc_info=True,
+            )
     # Use the snapshots captured under streams_lock above (the worker's finally
     # may have popped the live buffers by now via agent.interrupt()). For the
     # ACTIVE_RUNS-only path (stream absent) the snapshots are None → fall back to

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -13553,10 +13553,7 @@ def cancel_stream(stream_id: str) -> bool:
                 logger.debug("Failed to clear session state on cancel for %s", _cancel_session_id)
 
     if _emit_cancel_event and q:
-        _payload = _cancel_event_payload(
-            'Cancelled by user',
-            session=_cancel_session_payload,
-        )
+        _payload = _cancel_event_payload('Cancelled by user', session=_cancel_session_payload)
         try:
             from api.run_journal import append_run_event
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11138,6 +11138,78 @@ def _run_agent_streaming(
                         put('cancel', _cancel_event_payload('Cancelled by user'))
                         return
                     _err_str = str(_last_err) if _last_err else ''
+                    if (
+                        _classification['type'] == 'no_response'
+                        and _turn_pending_source == 'goal_continuation'
+                    ):
+                        from api.goal_continuations import (
+                            get_goal_continuation,
+                            requeue_goal_continuation_after_no_response,
+                        )
+
+                        _goal_retry_had_activity = bool(
+                            _token_sent
+                            or STREAM_PARTIAL_TEXT.get(stream_id)
+                            or STREAM_REASONING_TEXT.get(stream_id)
+                            or STREAM_LIVE_TOOL_CALLS.get(stream_id)
+                            or any(
+                                isinstance(_goal_retry_msg, dict)
+                                and _goal_retry_msg.get('role') in {'assistant', 'tool'}
+                                and bool(
+                                    _message_text(_goal_retry_msg.get('content', '')).strip()
+                                    or _goal_retry_msg.get('tool_calls')
+                                    or _goal_retry_msg.get('reasoning')
+                                )
+                                for _goal_retry_msg in _all_result_messages[_prev_len:]
+                            )
+                        )
+                        if requeue_goal_continuation_after_no_response(
+                            session_id,
+                            stream_id,
+                            had_activity=_goal_retry_had_activity,
+                        ):
+                            _goal_retry_record = get_goal_continuation(session_id) or {}
+                            _goal_retry_attempts = int(_goal_retry_record.get('attempts') or 0)
+                            _goal_retry_max = int(_goal_retry_record.get('max_attempts') or 0)
+                            _goal_retry_message = (
+                                'The provider returned no content before any activity. '
+                                f'Retrying this goal continuation automatically '
+                                f'({_goal_retry_attempts + 1}/{_goal_retry_max}).'
+                            )
+                            _materialize_pending_user_turn_before_error(s)
+                            s.active_stream_id = None
+                            s.pending_user_message = None
+                            s.pending_attachments = []
+                            s.pending_started_at = None
+                            s.pending_user_source = None
+                            s.messages.append({
+                                'role': 'assistant',
+                                'content': _goal_retry_message,
+                                'timestamp': int(time.time()),
+                                '_goal_retry': True,
+                            })
+                            try:
+                                s.save()
+                            except Exception:
+                                logger.warning(
+                                    'Failed to persist automatic goal retry status for %s',
+                                    session_id,
+                                    exc_info=True,
+                                )
+                            put('warning', {
+                                'type': 'goal_retry_scheduled',
+                                'message': _goal_retry_message,
+                                'retry_scheduled': True,
+                                'attempt': _goal_retry_attempts + 1,
+                                'max_attempts': _goal_retry_max,
+                            })
+                            put('done', {
+                                'session': redact_session_data(
+                                    _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
+                                ),
+                                'goal_retry_scheduled': True,
+                            })
+                            return
                     if _is_quota:
                         _err_label = _classification['label']
                         _err_type = _classification['type']
@@ -12203,15 +12275,24 @@ def _run_agent_streaming(
             except Exception:
                 logger.debug("Failed to drain pending steer for session %s", session_id)
             # /goal parity: after a successful assistant turn, run the Hermes
-            # GoalManager judge before terminal done/stream_end events. The
-            # frontend surfaces the status line and queues continuation_prompt as
-            # a normal next user message so /queue and user input keep priority.
+            # GoalManager judge before terminal done/stream_end events.  The
+            # continuation intent is durably persisted and dispatched by the
+            # server; goal_continue is observation-only for browser clients.
             # #1932: only evaluate when the turn was goal-related (set via
             # STREAM_GOAL_RELATED or goal_related parameter).
             try:
                 from api.goals import evaluate_goal_after_turn, has_active_goal
 
-                if not goal_related or not has_active_goal(session_id, profile_home=_profile_home):
+                _goal_is_active = (
+                    has_active_goal(session_id, profile_home=_profile_home)
+                    if goal_related
+                    else False
+                )
+                if goal_related and not _goal_is_active:
+                    from api.goal_continuations import complete_goal_continuation
+
+                    complete_goal_continuation(session_id, stream_id)
+                if not goal_related or not _goal_is_active:
                     _goal_decision = {}
                 else:
                     _last_goal_response = ''
@@ -12256,8 +12337,19 @@ def _run_agent_streaming(
                 if decision.get('should_continue'):
                     continuation_prompt = str(decision.get('continuation_prompt') or '').strip()
                     if continuation_prompt:
-                        # #1932: mark this session as pending a goal continuation
-                        # so the next /chat/start creates a goal-related stream.
+                        from api.goal_continuations import schedule_goal_continuation
+                        from api.goals import goal_state_snapshot
+
+                        _goal_state = goal_state_snapshot(session_id, profile_home=_profile_home)
+                        _continuation_record = schedule_goal_continuation(
+                            session_id,
+                            continuation_prompt,
+                            source_stream_id=stream_id,
+                            profile_home=_profile_home,
+                            goal_turns_used=int(getattr(_goal_state, 'turns_used', 0) or 0),
+                        )
+                        # Retain the in-memory marker only for mixed-version tabs;
+                        # the server registry above is the execution authority.
                         PENDING_GOAL_CONTINUATION.add(session_id)
                         put('goal_continue', {
                             'session_id': session_id,
@@ -12267,7 +12359,13 @@ def _run_agent_streaming(
                             'message_key': decision.get('message_key') or 'goal_continuing',
                             'message_args': decision.get('message_args') or [],
                             'decision': decision,
+                            'server_scheduled': True,
+                            'continuation_id': _continuation_record.get('continuation_id'),
                         })
+                elif goal_related:
+                    from api.goal_continuations import complete_goal_continuation
+
+                    complete_goal_continuation(session_id, stream_id)
             except Exception as _goal_exc:
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
             with _stream_writeback_stage(_writeback_timings, "done_payload"):
@@ -12838,15 +12936,24 @@ def _run_agent_streaming(
                     "Failed to clear session writeback owner for stream %s", stream_id,
                     exc_info=True,
                 )
-            # NOTE: do NOT discard PENDING_GOAL_CONTINUATION here. The marker
-            # is set by goal_continue (line ~3328) inside the SAME function
-            # call and consumed atomically by `_start_chat_stream_for_session`
-            # in routes.py (around line 6522) when the next stream starts.
-            # Discarding here in the streaming worker's `finally` would
-            # almost always race ahead of the frontend's SSE-receive →
-            # POST /api/chat/start round-trip and erase the marker before
-            # the next stream can read it, breaking the goal-continuation
-            # chain. Stage-326 critical fix per Opus advisor review.
+            # NOTE: do NOT discard PENDING_GOAL_CONTINUATION here. The durable
+            # scheduler consumes the marker when its server-owned stream starts;
+            # mixed-version browser tabs may also race safely against that start.
+
+        try:
+            from api.goal_continuations import (
+                fail_goal_continuation,
+                wake_goal_continuation_worker,
+            )
+
+            fail_goal_continuation(
+                session_id,
+                stream_id,
+                "goal continuation stream ended without a durable judge settlement",
+            )
+            wake_goal_continuation_worker()
+        except Exception:
+            logger.debug("goal-continuation teardown wake failed", exc_info=True)
 
         # ── Defer-path fix: turn-teardown idle-hook ────────────────────────
         # The session has just transitioned active→idle: unregister_active_run

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -19,6 +19,7 @@ import sys
 import subprocess
 import threading
 import time
+import uuid
 import traceback
 import copy
 import inspect
@@ -8710,6 +8711,16 @@ def _run_agent_streaming(
                 exc_info=True,
             )
         return
+    if goal_related:
+        from api.goal_continuations import mark_goal_continuation_worker_started
+
+        if not mark_goal_continuation_worker_started(session_id, stream_id):
+            with STREAMS_LOCK:
+                STREAMS.pop(stream_id, None)
+                STREAM_GOAL_RELATED.pop(stream_id, None)
+            unregister_stream_owner(stream_id)
+            clear_session_writeback_owner_if_owned(session_id, stream_id)
+            return
     register_active_run(
         stream_id,
         session_id=session_id,
@@ -12368,13 +12379,32 @@ def _run_agent_streaming(
                         from api.goals import goal_state_snapshot
 
                         _goal_state = goal_state_snapshot(session_id, profile_home=_profile_home)
-                        _continuation_record = schedule_goal_continuation(
-                            session_id,
-                            continuation_prompt,
-                            source_stream_id=stream_id,
-                            profile_home=_profile_home,
-                            goal_turns_used=int(getattr(_goal_state, 'turns_used', 0) or 0),
-                        )
+                        try:
+                            _continuation_record = schedule_goal_continuation(
+                                session_id,
+                                continuation_prompt,
+                                source_stream_id=stream_id,
+                                profile_home=_profile_home,
+                                goal_turns_used=int(getattr(_goal_state, 'turns_used', 0) or 0),
+                            )
+                        except Exception as _schedule_exc:
+                            logger.exception(
+                                "Failed to persist goal continuation for session %s",
+                                session_id,
+                            )
+                            put('goal', {
+                                'session_id': session_id,
+                                'state': 'needs_attention',
+                                'message': 'Goal continuation could not be persisted.',
+                                'message_key': 'goal_continuation_schedule_failed',
+                            })
+                            put('apperror', {
+                                'type': 'goal_continuation_schedule_failed',
+                                'label': 'Goal continuation stopped',
+                                'message': str(_schedule_exc)[:500],
+                            })
+                            put('stream_end', {'session_id': session_id})
+                            return
                         # Retain the in-memory marker only for mixed-version tabs;
                         # the server registry above is the execution authority.
                         PENDING_GOAL_CONTINUATION.add(session_id)
@@ -13523,14 +13553,34 @@ def cancel_stream(stream_id: str) -> bool:
                 logger.debug("Failed to clear session state on cancel for %s", _cancel_session_id)
 
     if _emit_cancel_event and q:
-        _cancel_event_id = STREAM_LAST_EVENT_ID.get(stream_id)
-        if _cancel_event_id and hasattr(q, "note_last_event_id"):
+        _payload = _cancel_event_payload(
+            'Cancelled by user',
+            session=_cancel_session_payload,
+        )
+        try:
+            from api.run_journal import append_run_event
+
+            _cancel_row = append_run_event(
+                _cancel_session_id,
+                stream_id,
+                'cancel',
+                _payload,
+            )
+            _cancel_event_id = str(_cancel_row.get('event_id') or '')
+        except Exception:
+            _cancel_event_id = f"{stream_id}:cancel:{uuid.uuid4().hex}"
+            logger.debug(
+                "Failed to journal cancel event for stream %s",
+                stream_id,
+                exc_info=True,
+            )
+        STREAM_LAST_EVENT_ID[stream_id] = _cancel_event_id
+        if hasattr(q, "note_last_event_id"):
             try:
                 q.note_last_event_id(_cancel_event_id)
             except Exception:
                 logger.debug("Failed to note cancel event_id %s for stream %s", _cancel_event_id, stream_id, exc_info=True)
         try:
-            _payload = _cancel_event_payload('Cancelled by user', session=_cancel_session_payload)
             q.put_nowait(('cancel', _payload))
         except Exception:
             logger.debug("Failed to put cancel event to queue")

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -682,7 +682,10 @@ Suggested regression coverage:
 Non-goals for Slice 3c:
 
 - no runner process, sidecar, or execution-survives-WebUI-restart claim;
-- no durable WebUI-owned queue or goal scheduler;
+- no durable WebUI-owned queue or goal scheduler, except the bounded automatic
+  next-turn intent proposed in [#6885](https://github.com/nesquena/hermes-webui/issues/6885):
+  one idempotent intent per session, admitted through the existing turn path,
+  browser-observation-only, and explicitly replaceable by the future runner;
 - no migration of `AIAgent` construction, post-turn goal evaluation, or the
   agent continuation loop out of the legacy path;
 - no change to `/goal` command semantics, queue ordering semantics, or supported

--- a/docs/rfcs/webui-run-state-consistency-contract.md
+++ b/docs/rfcs/webui-run-state-consistency-contract.md
@@ -57,6 +57,30 @@ Transparent Stream, or Final answer only; `S.messages`, `INFLIGHT`, renderer
 caches, and DOM remain projections or recovery caches rather than independent
 semantic owners.
 
+### Proposed bounded goal-intent exception (#6885)
+
+Issue [#6885](https://github.com/nesquena/hermes-webui/issues/6885) proposes a
+narrow compatibility exception to the earlier Slice 3c prohibition on a durable
+WebUI-owned goal scheduler. The browser must not be the only owner of an automatic
+`/goal` continuation after the server's post-turn judge has already returned
+`continue`. The current-path compatibility layer may therefore persist **one next
+turn intent per session** and dispatch it through the existing admitted-turn path,
+provided that:
+
+- it is not a generic queue and does not create another goal evaluator;
+- repeated judge callbacks and worker claims are idempotent;
+- restart recovery verifies that the goal is still active and the recorded turn
+  has not already been judged;
+- an empty provider result is retried only before any token, reasoning, or tool
+  activity, with a finite attempt budget;
+- the browser remains an observation surface and cannot originate duplicate work;
+- the implementation does not claim that an in-process agent run itself survives
+  a WebUI restart; a later runner/runtime backend should absorb this intent.
+
+This exception changes only automatic next-turn ownership. It does not authorize a
+server-side `/queue` scheduler, runner surrogate, duplicated active-run registry,
+or migration of the Hermes GoalManager judge into WebUI.
+
 This RFC remains `Proposed` because its broader cross-layer contract also covers
 model-context reconstruction, compression handoff, session metadata, and future
 runtime-adapter migration. Shipped Anchor coverage strengthens invariants 2, 3,

--- a/server.py
+++ b/server.py
@@ -606,11 +606,9 @@ def main() -> None:
         print(f'  [tip] No password set. Any process on this machine can read sessions', flush=True)
         print(f'        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
         print(f'        enable authentication.', flush=True)
-
     oidc_startup_warning = get_oidc_startup_warning()
     if oidc_startup_warning:
         print(f'[!!] WARNING: {oidc_startup_warning}', flush=True)
-
     ok, missing, errors = verify_hermes_imports()
     if not ok and _HERMES_FOUND:
         print(f'[!!] Warning: Hermes agent found but missing modules: {missing}', flush=True)
@@ -626,11 +624,9 @@ def main() -> None:
             print('     Agent features may not work correctly.', flush=True)
         else:
             print('[ok] Agent dependencies installed successfully.', flush=True)
-
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     SESSION_DIR.mkdir(parents=True, exist_ok=True)
     DEFAULT_WORKSPACE.mkdir(parents=True, exist_ok=True)
-
     try:
         from api.gateway_watcher import start_watcher
 
@@ -650,10 +646,12 @@ def main() -> None:
 
     try:
         from api.background_process import start_drain_thread
+        from api.goal_continuations import start_goal_continuation_worker
+        start_goal_continuation_worker()
         if start_drain_thread():
             print('[ok] bg_task_complete drain thread started', flush=True)
     except Exception as e:
-        print(f'[!!] WARNING: bg_task_complete drain failed to start: {e}', flush=True)
+        print(f'[!!] WARNING: WebUI worker startup failed: {e}', flush=True)
 
     try:
         from api.background_process import start_session_channel_reaper
@@ -727,6 +725,8 @@ def main() -> None:
         _log_shutdown_audit()
         try:
             from api.gateway_watcher import stop_watcher
+            from api.goal_continuations import stop_goal_continuation_worker
+            stop_goal_continuation_worker()
             stop_watcher()
         except Exception:
             logger.debug("Failed to stop gateway watcher during shutdown")

--- a/server.py
+++ b/server.py
@@ -646,8 +646,6 @@ def main() -> None:
 
     try:
         from api.background_process import start_drain_thread
-        from api.goal_continuations import start_goal_continuation_worker
-        start_goal_continuation_worker()
         if start_drain_thread():
             print('[ok] bg_task_complete drain thread started', flush=True)
     except Exception as e:
@@ -682,6 +680,13 @@ def main() -> None:
         except Exception as e:
             print(f'[!!] WARNING: TLS setup failed ({e}), falling back to HTTP', flush=True)
             scheme = 'http'
+
+    try:
+        from api.goal_continuations import start_goal_continuation_worker
+        if start_goal_continuation_worker():
+            print('[ok] Durable goal continuation worker started', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: Durable goal continuation worker failed to start: {e}', flush=True)
 
     print(f'  Hermes Web UI listening on {scheme}://{HOST}:{PORT}', flush=True)
     if HOST in ('127.0.0.1', '::1') or within_container:

--- a/server.py
+++ b/server.py
@@ -666,6 +666,8 @@ def main() -> None:
 
     _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
+    from api.goal_continuations import start_goal_continuation_worker
+    start_goal_continuation_worker()
 
     from api.config import TLS_ENABLED, TLS_CERT, TLS_KEY
     scheme = 'https' if TLS_ENABLED else 'http'
@@ -680,13 +682,6 @@ def main() -> None:
         except Exception as e:
             print(f'[!!] WARNING: TLS setup failed ({e}), falling back to HTTP', flush=True)
             scheme = 'http'
-
-    try:
-        from api.goal_continuations import start_goal_continuation_worker
-        if start_goal_continuation_worker():
-            print('[ok] Durable goal continuation worker started', flush=True)
-    except Exception as e:
-        print(f'[!!] WARNING: Durable goal continuation worker failed to start: {e}', flush=True)
 
     print(f'  Hermes Web UI listening on {scheme}://{HOST}:{PORT}', flush=True)
     if HOST in ('127.0.0.1', '::1') or within_container:
@@ -730,21 +725,19 @@ def main() -> None:
         _log_shutdown_audit()
         try:
             from api.gateway_watcher import stop_watcher
-            from api.goal_continuations import stop_goal_continuation_worker
-            stop_goal_continuation_worker()
             stop_watcher()
         except Exception:
             logger.debug("Failed to stop gateway watcher during shutdown")
-        try:
-            from api.session_lifecycle import drain_all_on_shutdown
-            drain_all_on_shutdown()
-        except Exception:
-            logger.debug("Failed to drain lifecycle on shutdown", exc_info=True)
         try:
             from api.background_process import stop_drain_thread
             stop_drain_thread()
         except Exception:
             logger.debug("Failed to stop bg_task_complete drain thread during shutdown", exc_info=True)
+        try:
+            from api.session_lifecycle import drain_all_on_shutdown
+            drain_all_on_shutdown()
+        except Exception:
+            logger.debug("Failed to drain lifecycle on shutdown", exc_info=True)
         try:
             from api.background_process import stop_session_channel_reaper
             stop_session_channel_reaper()

--- a/static/messages.js
+++ b/static/messages.js
@@ -2229,7 +2229,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let liveReasoningText = reasoningText;
   let visibleInterimSnippets=[];
   let _latestGoalStatus=null;
-  let _pendingGoalContinuation=null;
   let assistantRow=null;
   let assistantBody=null;
   // On reconnect with recorded burst anchors, the rendered DOM has multiple
@@ -6061,14 +6060,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const continuation_prompt=String(d.continuation_prompt||d.text||'').trim();
         if(!continuation_prompt||sid!==activeSid)return;
         _applyToAnchor('goal_continue',d,e);
-        const _modelState=_chatPayloadModelState();
-        _pendingGoalContinuation={
-          sid,
-          text:continuation_prompt,
-          model:_modelState.model,
-          model_provider:_modelState.model_provider,
-          profile:S.activeProfile||'default',
-        };
+        // The durable server scheduler owns dispatch.  This event is status-only,
+        // matching the bg_task_complete server-started live-view notification.
         const toast=t('goal_continuing_toast');
         const cmsg=_resolveGoalMessage(d);
         showToast((toast&&cmsg&&cmsg!==toast)?cmsg.split('\n')[0]:toast,2200);
@@ -6372,18 +6365,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(!lastAsst&&d.session&&Array.isArray(d.session.messages)){
           lastAsst=[...d.session.messages].reverse().find(m=>m&&m.role==='assistant')||null;
-        }
-        if(isActiveSession&&_pendingGoalContinuation&&typeof queueSessionMessage==='function'){
-          const _goalNext=_pendingGoalContinuation;
-          _pendingGoalContinuation=null;
-          queueSessionMessage(_goalNext.sid,{
-            text:_goalNext.text,
-            files:[],
-            model:_goalNext.model,
-            model_provider:_goalNext.model_provider,
-            profile:_goalNext.profile,
-          });
-          if(typeof updateQueueBadge==='function')updateQueueBadge(_goalNext.sid);
         }
         if(isActiveSession) _queueDrainSid=activeSid;
         renderSessionList();

--- a/static/messages.js
+++ b/static/messages.js
@@ -7929,7 +7929,7 @@ const _SESSION_STREAM_HIDDEN_POLL_MAX_FALSE = 20; // ~2 min at the 6s cadence
 // signal, a poll that fires while another session is in the current pane
 // would attach nothing AND stop polling, leaving the turn invisible until
 // the next user interaction.
-function _attachServerInitiatedStream(sid, streamId, recovered) {
+function _attachServerInitiatedStream(sid, streamId, recovered, source) {
   let handedOff = false;
   try {
     streamId = String(streamId || '');
@@ -7950,6 +7950,7 @@ function _attachServerInitiatedStream(sid, streamId, recovered) {
     if (S.session && S.session.session_id === sid) {
       S.session.active_stream_id = streamId;
       if (!S.session.pending_started_at) S.session.pending_started_at = Date.now()/1000;
+      if (source && !S.session.pending_user_source) S.session.pending_user_source = String(source);
     }
     if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();
     else if (typeof appendThinking === 'function') appendThinking();
@@ -8035,7 +8036,7 @@ function _startHiddenActiveStreamPoll(sid) {
               _sessionStreamHiddenPollFalseStreamId = streamKey;
               _sessionStreamHiddenPollFalseCount = 0;
             }
-            const attached = _attachServerInitiatedStream(sid, streamId, true);
+            const attached = _attachServerInitiatedStream(sid, streamId, true, d.pending_user_source);
             if (attached) {
               _stopHiddenActiveStreamPoll();
             } else {
@@ -8267,6 +8268,7 @@ function startSessionStream(sid) {
           S.session.active_stream_id = streamId;
           if (typeof d.pending_started_at === 'number') S.session.pending_started_at = d.pending_started_at;
           else if (!S.session.pending_started_at) S.session.pending_started_at = Date.now()/1000;
+          if (d.source && !S.session.pending_user_source) S.session.pending_user_source = String(d.source);
         }
         if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();
         else if (typeof appendThinking === 'function') appendThinking();

--- a/static/ui.js
+++ b/static/ui.js
@@ -17023,7 +17023,7 @@ function renderMessages(options){
     }
     const isUser=m.role==='user';
     const isProcessWakeup=m&&m._source==='process_wakeup';
-    if(!isUser) content=_projectInternalProgressContent(S.messages, rawIdx, content);
+    if(!isUser&&typeof _projectInternalProgressContent==='function') content=_projectInternalProgressContent(S.messages, rawIdx, content);
     if(!isUser&&_isMarkerOnlyAssistantCompressionMessage(m)){
       content='**Error:** No response received after context compression. Please retry.';
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -635,6 +635,7 @@ function _hasLaterRenderableAssistant(messages, rawIdx){
   const rows=Array.isArray(messages)?messages:[];
   for(let i=Number(rawIdx)+1;i<rows.length;i++){
     const candidate=rows[i];
+    if(candidate&&candidate.role==='user'&&!_isInternalTransportMessage(candidate)) return false;
     if(candidate&&candidate.role==='assistant'&&_messageIsRenderable(candidate)) return true;
   }
   return false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -17072,9 +17072,10 @@ function renderMessages(options){
     if(recoveryHtml) bodyHtml += recoveryHtml;
     const statusHtml = (!isUser&&m._statusCard) ? _statusCardHtml(m._statusCard) : '';
     const isEditableUser=isUser&&rawIdx===lastUserRawIdx;
+    const followsInternalTransport=!isUser&&_assistantFollowsInternalTransport(S.messages,rawIdx);
     const editBtn  = isEditableUser ? `<button class="msg-action-btn" title="${t('edit_message')}" onclick="editMessage(this)">${li('pencil',13)}</button>` : '';
     const undoBtn  = isLastAssistant ? `<button class="msg-action-btn" title="${t('undo_exchange')}" onclick="undoLastExchange()">${li('undo',13)}</button>` : '';
-    const retryBtn = isLastAssistant ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';
+    const retryBtn = isLastAssistant&&!followsInternalTransport ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';
     const copyBtn  = `<button class="msg-copy-btn msg-action-btn" title="${t('copy')}" onclick="copyMsg(this)">${li('copy',13)}</button>`;
     const readOnlySession=typeof _isReadOnlySession==='function'
       ? _isReadOnlySession(S.session)
@@ -19372,12 +19373,15 @@ async function regenerateResponse(btn) {
   if(!S.session || S.busy) return;
   const row=btn&&btn.closest&&btn.closest('[data-msg-idx]');
   if(!row)return;
-  const clickedAbsoluteIndex=_oldestIdx+parseInt(row.dataset.msgIdx,10);
+  const assistantIdx=parseInt(row.dataset.msgIdx,10);
+  if(!Number.isInteger(assistantIdx)||_assistantFollowsInternalTransport(S.messages,assistantIdx))return;
+  const clickedAbsoluteIndex=_oldestIdx+assistantIdx;
   const initialSid = S.session.session_id;
   if(typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
+  if(_assistantFollowsInternalTransport(S.messages,clickedAbsoluteIndex))return;
   if(!S.session.regeneration_revision){ setStatus(t('regen_failed')); return; }
   let latestAssistantIndex=-1;
   for(let i=S.messages.length-1;i>=0;i--){

--- a/static/ui.js
+++ b/static/ui.js
@@ -615,9 +615,47 @@ function _cancelMessageVirtualizedRender(){
     _messageVirtualScrollRaf=0;
   }
 }
+function _isInternalTransportMessage(m){
+  if(!m||typeof m!=='object') return false;
+  return m._display_kind==='internal_event'
+    || m._user_originated===false
+    || m._source==='process_wakeup'
+    || m._source==='async_delegation';
+}
+function _assistantFollowsInternalTransport(messages, rawIdx){
+  const rows=Array.isArray(messages)?messages:[];
+  for(let i=Number(rawIdx)-1;i>=0;i--){
+    const candidate=rows[i];
+    if(!candidate||candidate.role==='tool') continue;
+    if(candidate.role==='user') return _isInternalTransportMessage(candidate);
+  }
+  return false;
+}
+function _hasLaterRenderableAssistant(messages, rawIdx){
+  const rows=Array.isArray(messages)?messages:[];
+  for(let i=Number(rawIdx)+1;i<rows.length;i++){
+    const candidate=rows[i];
+    if(candidate&&candidate.role==='assistant'&&_messageIsRenderable(candidate)) return true;
+  }
+  return false;
+}
+function _projectInternalProgressContent(messages, rawIdx, content){
+  const text=String(content||'').trim();
+  if(!text||!_assistantFollowsInternalTransport(messages, rawIdx)) return content;
+  if(!_hasLaterRenderableAssistant(messages, rawIdx)) return content;
+  let summary=text
+    .replace(/^\s*#\s*CONCLUSION\s*\n\s*---\s*\n?/i,'')
+    .replace(/^\s*>?\s*🟢\s*Réponse\s*\/\s*recommandation\s*:\s*/i,'')
+    .split(/\n\s*\n/,1)[0]
+    .replace(/\s+/g,' ')
+    .trim();
+  if(!summary) summary='Étape interne terminée';
+  if(summary.length>240) summary=summary.slice(0,237).trimEnd()+'…';
+  return `**Progression** — ${summary}`;
+}
 function _messageIsRenderable(m){
   if(!m||!m.role||m.role==='tool') return false;
-  if(m._source === 'process_wakeup') return !!(msgContent(m)||m.attachments?.length);
+  if(_isInternalTransportMessage(m)) return false;
   if(_isContextCompactionMessage(m)||_isPreservedCompressionTaskListMessage(m)) return false;
   if(_isRecoveryControlMessage(m)) return false;
   const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
@@ -16983,8 +17021,9 @@ function renderMessages(options){
         }
       }
     }
-    const isProcessWakeup=m&&m._source==='process_wakeup';
     const isUser=m.role==='user';
+    const isProcessWakeup=m&&m._source==='process_wakeup';
+    if(!isUser) content=_projectInternalProgressContent(S.messages, rawIdx, content);
     if(!isUser&&_isMarkerOnlyAssistantCompressionMessage(m)){
       content='**Error:** No response received after context compression. Please retry.';
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -17072,7 +17072,7 @@ function renderMessages(options){
     if(recoveryHtml) bodyHtml += recoveryHtml;
     const statusHtml = (!isUser&&m._statusCard) ? _statusCardHtml(m._statusCard) : '';
     const isEditableUser=isUser&&rawIdx===lastUserRawIdx;
-    const followsInternalTransport=!isUser&&_assistantFollowsInternalTransport(S.messages,rawIdx);
+    const followsInternalTransport=!isUser&&typeof _assistantFollowsInternalTransport==='function'&&_assistantFollowsInternalTransport(S.messages,rawIdx);
     const editBtn  = isEditableUser ? `<button class="msg-action-btn" title="${t('edit_message')}" onclick="editMessage(this)">${li('pencil',13)}</button>` : '';
     const undoBtn  = isLastAssistant ? `<button class="msg-action-btn" title="${t('undo_exchange')}" onclick="undoLastExchange()">${li('undo',13)}</button>` : '';
     const retryBtn = isLastAssistant&&!followsInternalTransport ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';

--- a/tests/test_agent_runtime_revision_guard.py
+++ b/tests/test_agent_runtime_revision_guard.py
@@ -441,6 +441,48 @@ def test_runner_owned_start_run_does_not_enter_local_stream_barrier(monkeypatch)
     assert len(calls) == 1
 
 
+def test_server_owned_goal_continuation_never_hands_execution_to_runner(monkeypatch):
+    """A WebUI-owned durable intent stays on the WebUI/Gateway settlement path."""
+    from api import routes
+
+    local_calls = []
+    session = types.SimpleNamespace(session_id="goal-session", profile=None)
+    monkeypatch.setenv("HERMES_WEBUI_RUNTIME_ADAPTER", "runner-local")
+    monkeypatch.setattr("api.runtime_adapter.runtime_adapter_enabled", lambda: False)
+    monkeypatch.setattr("api.runtime_adapter.runtime_adapter_runner_enabled", lambda: True)
+    monkeypatch.setattr(
+        routes,
+        "_runtime_runner_client_factory",
+        lambda: (_ for _ in ()).throw(AssertionError("durable WebUI intent escaped to runner")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "_start_chat_stream_for_session",
+        lambda *args, **kwargs: local_calls.append(kwargs) or {
+            "stream_id": "local-goal-stream",
+            "session_id": session.session_id,
+        },
+    )
+
+    response = routes._start_run(
+        session,
+        msg="continue",
+        attachments=[],
+        workspace="/tmp/workspace",
+        model="test-model",
+        model_provider="test-provider",
+        normalized_model=False,
+        source="goal_continuation",
+        route="start_session_turn",
+        goal_related=True,
+        continuation_claim_id="claim-1",
+    )
+
+    assert response["stream_id"] == "local-goal-stream"
+    assert len(local_calls) == 1
+    assert local_calls[0]["continuation_claim_id"] == "claim-1"
+
+
 @pytest.mark.parametrize("gateway_owned", [False, True])
 def test_stream_admission_uses_one_gateway_ownership_snapshot(monkeypatch, gateway_owned):
     """The barrier and worker must share one immutable backend decision."""

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -588,10 +588,11 @@ def test_autonomous_wakeup_acks_after_successful_turn_acceptance(monkeypatch):
     delivery = _install_fake_durable_delivery_api(monkeypatch)
     from api import routes
 
+    started = []
     monkeypatch.setattr(
         routes,
         "start_session_turn",
-        lambda *_args, **_kwargs: {"_status": 200, "stream_id": "stream-1"},
+        lambda *args, **kwargs: started.append((args, kwargs)) or {"_status": 200, "stream_id": "stream-1"},
     )
     monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
     evt = _async_delegation_event()
@@ -611,6 +612,22 @@ def test_autonomous_wakeup_acks_after_successful_turn_acceptance(monkeypatch):
     assert delivery["release"] == []
     assert registry.completion_queue.qsize() == 0
     assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+    assert started[0][1]["source"] == "async_delegation"
+
+
+def test_async_delegation_source_stamps_internal_event_identity():
+    msg = {
+        "role": "user",
+        "content": "[ASYNC DELEGATION BATCH COMPLETE — deleg_test123]\nresult",
+    }
+
+    peu.stamp_message_source(msg, "async_delegation")
+
+    assert msg["_source"] == "async_delegation"
+    assert msg["_display_kind"] == "internal_event"
+    assert msg["_user_originated"] is False
+    assert msg["_event_id"] == "async_delegation:deleg_test123:terminal"
+    assert msg["_workflow_id"] == "delegation:deleg_test123"
 
 
 def test_background_and_next_turn_consumers_share_one_atomic_claim(monkeypatch):

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -363,7 +363,7 @@ def test_fast_terminal_settlement_cannot_be_resurrected_by_drain(continuation_st
         is_goal_active=lambda *_args, **_kwargs: True,
         now=time.time() + 1,
     ) == 1
-    assert gc.get_goal_continuation("session-a") is None
+    assert gc.get_goal_continuation("session-a")["status"] == "completed"
 
 
 def test_mixed_version_browser_can_adopt_only_an_unclaimed_matching_intent(continuation_store):
@@ -497,7 +497,7 @@ def test_empty_retry_is_refused_when_cancellation_wins_the_settlement_race(conti
     assert "cancel" in record["last_error"].lower()
 
 
-def test_restart_recovers_only_unjudged_active_goal(continuation_store):
+def test_restart_fails_closed_for_unjudged_foreign_goal(continuation_store):
     gc, _path = continuation_store
     clock = time.time()
     _schedule(gc, turns=4, now=clock)
@@ -516,8 +516,8 @@ def test_restart_recovers_only_unjudged_active_goal(continuation_store):
         now=200.0,
     ) == 1
     recovered = gc.get_goal_continuation("session-a")
-    assert recovered["status"] == "pending"
-    assert recovered["owner_id"] == "test-owner"
+    assert recovered["status"] == "failed"
+    assert "foreign owner" in recovered["last_error"]
 
 
 def test_restart_fails_closed_when_run_evidence_is_unreadable(continuation_store):
@@ -543,7 +543,7 @@ def test_restart_fails_closed_when_run_evidence_is_unreadable(continuation_store
     ) == 1
     recovered = gc.get_goal_continuation("session-a")
     assert recovered["status"] == "failed"
-    assert "evidence" in recovered["last_error"].lower()
+    assert "foreign owner" in recovered["last_error"].lower()
 
 
 def test_unreadable_registry_is_not_quarantined_as_corrupt(continuation_store, monkeypatch):
@@ -586,7 +586,7 @@ def test_restart_refuses_replay_after_observable_activity(continuation_store):
     ) == 1
     recovered = gc.get_goal_continuation("session-a")
     assert recovered["status"] == "failed"
-    assert "observable activity" in recovered["last_error"]
+    assert "foreign owner" in recovered["last_error"]
 
 
 def test_restart_never_replays_a_turn_already_judged(continuation_store):
@@ -650,7 +650,7 @@ def test_terminal_settlement_is_stream_owned_and_deletion_can_prune_it(continuat
     assert gc.fail_goal_continuation("session-a", "owned-stream", "terminal failure") is True
     assert gc.get_goal_continuation("session-a")["status"] == "failed"
     assert gc.complete_goal_continuation("session-a") is True
-    assert gc.get_goal_continuation("session-a") is None
+    assert gc.get_goal_continuation("session-a")["status"] == "completed"
 
 
 def test_inactive_goal_discards_pending_intent(continuation_store):
@@ -662,7 +662,7 @@ def test_inactive_goal_discards_pending_intent(continuation_store):
         is_goal_active=lambda *_args, **_kwargs: False,
         now=time.time() + 1,
     ) == 0
-    assert gc.get_goal_continuation("session-a") is None
+    assert gc.get_goal_continuation("session-a")["status"] == "cancelled"
 
 
 def test_timed_out_worker_stop_blocks_restart_until_old_thread_exits(continuation_store, monkeypatch):
@@ -680,4 +680,123 @@ def test_timed_out_worker_stop_blocks_restart_until_old_thread_exits(continuatio
     assert gc.stop_goal_continuation_worker(timeout=0.01) is False
     assert gc.start_goal_continuation_worker() is False
     release.set()
+    assert gc.stop_goal_continuation_worker(timeout=1) is True
+
+
+def test_claim_revalidates_goal_before_starting_turn(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    checks = iter([True, False])
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: pytest.fail("paused goal must not start"),
+        is_goal_active=lambda *_args, **_kwargs: next(checks),
+        now=time.time() + 1,
+    ) == 0
+    assert gc.get_goal_continuation("session-a")["status"] == "cancelled"
+
+
+def test_foreign_running_owner_is_never_replayed_automatically(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, turns=4)
+    record = gc.get_goal_continuation("session-a")
+    record.update({
+        "status": "running",
+        "stream_id": "old-live-stream",
+        "owner_id": "foreign-owner",
+        "attempts": 1,
+    })
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {"status": "active", "turns_used": 4},
+        run_summary_loader=lambda *_args, **_kwargs: {
+            "terminal_state": "unknown",
+            "observable_activity": False,
+        },
+        now=200.0,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "failed"
+    assert "foreign owner" in recovered["last_error"]
+
+
+def test_cancelled_retry_cannot_be_admitted_later(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "cancel-stream", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+    assert gc.requeue_goal_continuation_after_no_response(
+        "session-a", "cancel-stream", had_activity=False, now=clock + 2,
+    ) is True
+    assert gc.cancel_goal_continuation(
+        "session-a", "cancel-stream", reason="user cancelled", now=clock + 2.1,
+    ) is True
+    assert gc.get_goal_continuation("session-a")["status"] == "cancelled"
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: pytest.fail("cancelled retry must not start"),
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=200.0,
+    ) == 0
+
+
+def test_completed_tombstone_rejects_delayed_legacy_tab(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    prompt = gc.get_goal_continuation("session-a")["prompt"]
+    assert gc.complete_goal_continuation("session-a") is True
+    assert gc.legacy_browser_goal_prompt_matches("session-a", prompt) is True
+    assert gc.adopt_legacy_browser_goal_stream("session-a", "late-stream", prompt) is False
+
+
+def test_malformed_journal_is_evidence_unavailable(monkeypatch):
+    import api.run_journal as journal
+
+    monkeypatch.setattr(journal, "latest_run_summary", lambda *_args: {"terminal_state": "unknown"})
+    monkeypatch.setattr(
+        journal,
+        "read_run_events",
+        lambda *_args: {"events": [], "malformed": [{"line": 1}]},
+    )
+    summary = __import__("api.goal_continuations", fromlist=["x"])._default_run_summary_loader(
+        "session-a", "stream-a"
+    )
+    assert summary["evidence_unavailable"] is True
+
+
+def test_strict_goal_snapshot_propagates_profile_read_failure(monkeypatch, tmp_path):
+    import api.goals as goals
+
+    class BrokenDB:
+        def get_meta(self, _key):
+            raise PermissionError("goal state unreadable")
+
+    monkeypatch.setattr(goals, "_profile_db", lambda _home: BrokenDB())
+    with pytest.raises(PermissionError, match="unreadable"):
+        goals.goal_state_snapshot_strict("session-a", profile_home=tmp_path)
+
+
+def test_standby_worker_retries_leadership(continuation_store, monkeypatch):
+    gc, _path = continuation_store
+    acquired = threading.Event()
+    attempts = iter([False, True])
+
+    def try_acquire():
+        result = next(attempts, True)
+        if result:
+            acquired.set()
+        return result
+
+    monkeypatch.setattr(gc, "_try_acquire_worker_leadership", try_acquire)
+    monkeypatch.setattr(gc, "recover_goal_continuations", lambda: 0)
+    monkeypatch.setattr(gc, "reconcile_goal_continuations_once", lambda: 0)
+    monkeypatch.setattr(gc, "drain_goal_continuations_once", lambda: 0)
+    monkeypatch.setattr(gc, "_IDLE_POLL_SECONDS", 0.01)
+
+    assert gc.start_goal_continuation_worker() is True
+    assert acquired.wait(1)
     assert gc.stop_goal_continuation_worker(timeout=1) is True

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -141,6 +141,55 @@ def test_reconcile_admitted_run_without_worker_or_activity_requeues(continuation
     assert "no live worker" in current["last_error"]
 
 
+def test_reconcile_rechecks_liveness_inside_settlement_transaction(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "late-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+    checks = iter([False, True])
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: next(checks),
+        run_summary_loader=lambda _sid, _stream: {
+            "terminal_state": "unknown",
+            "observable_activity": False,
+        },
+        now=131.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "running"
+    assert current["stream_id"] == "late-stream"
+    assert current["last_heartbeat_at"] == 131.0
+
+
+def test_reconcile_rechecks_journal_inside_settlement_transaction(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "late-effect"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+    summaries = iter([
+        {"terminal_state": "unknown", "observable_activity": False},
+        {"terminal_state": "interrupted", "observable_activity": True},
+    ])
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: False,
+        run_summary_loader=lambda _sid, _stream: next(summaries),
+        now=131.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "failed"
+    assert "observable activity" in current["last_error"]
+
+
 def test_reconcile_live_run_refreshes_durable_heartbeat(continuation_store):
     gc, _path = continuation_store
     _schedule(gc, now=100.0)

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -801,3 +801,40 @@ def test_standby_worker_retries_leadership(continuation_store, monkeypatch):
     assert gc.start_goal_continuation_worker() is True
     assert acquired.wait(1)
     assert gc.stop_goal_continuation_worker(timeout=1) is True
+
+
+def test_legacy_profile_goal_manager_accepts_current_five_field_judge_result(monkeypatch):
+    import api.goals as goals
+
+    state = SimpleNamespace(
+        goal="finish the durable workflow",
+        status="active",
+        turns_used=0,
+        max_turns=4,
+        last_turn_at=0.0,
+        last_verdict=None,
+        last_reason=None,
+        paused_reason=None,
+    )
+    manager = object.__new__(goals._LegacyProfileGoalManager)
+    manager.session_id = "session-a"
+    manager.profile_home = Path("/profiles/default")
+    manager.default_max_turns = 4
+    manager.strict_load = False
+    manager._state = state
+    manager._save = lambda _state: None
+
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *_args, **_kwargs: ("continue", "result missing", False, None, False),
+    )
+    monkeypatch.setattr(goals, "CONTINUATION_PROMPT_TEMPLATE", "Continue: {goal}")
+
+    decision = manager.evaluate_after_turn("INCOMPLETE", user_initiated=True)
+
+    assert state.turns_used == 1
+    assert state.last_verdict == "continue"
+    assert state.last_reason == "result missing"
+    assert decision["should_continue"] is True
+    assert decision["continuation_prompt"] == "Continue: finish the durable workflow"

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -166,6 +166,60 @@ def test_reconcile_rechecks_liveness_inside_settlement_transaction(continuation_
     assert current["last_heartbeat_at"] == 131.0
 
 
+def test_durable_worker_entry_fence_prevents_watchdog_replay(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "fenced-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+    assert gc.mark_goal_continuation_worker_started(
+        "session-a",
+        "fenced-stream",
+        now=130.5,
+    )
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: False,
+        run_summary_loader=lambda _sid, _stream: {
+            "terminal_state": "unknown",
+            "observable_activity": False,
+        },
+        now=161.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "running"
+    assert current["stream_id"] == "fenced-stream"
+    assert current["worker_started_at"] == 130.5
+    assert current["last_heartbeat_at"] == 161.0
+
+
+def test_stale_worker_cannot_enter_after_watchdog_requeue(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "stale-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+    gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: False,
+        run_summary_loader=lambda _sid, _stream: {
+            "terminal_state": "unknown",
+            "observable_activity": False,
+        },
+        now=131.0,
+    )
+
+    assert not gc.mark_goal_continuation_worker_started(
+        "session-a",
+        "stale-stream",
+        now=131.1,
+    )
+
+
 def test_reconcile_rechecks_journal_inside_settlement_transaction(continuation_store):
     gc, _path = continuation_store
     _schedule(gc, now=100.0)

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -1,0 +1,425 @@
+"""Vertical contract for durable, server-owned /goal continuations."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def continuation_store(tmp_path, monkeypatch):
+    from api import goal_continuations as gc
+
+    path = tmp_path / "goal-continuations.json"
+    monkeypatch.setattr(gc, "REGISTRY_PATH", path)
+    monkeypatch.setattr(gc, "OWNER_ID", "test-owner")
+    monkeypatch.setattr(gc, "_REGISTRY", None)
+    monkeypatch.setattr(gc, "_WORKER_WAKE", threading.Event())
+    gc._WORKER_STOP.clear()
+    yield gc, path
+    gc.stop_goal_continuation_worker(timeout=0.2)
+
+
+def _schedule(gc, sid="session-a", stream="judge-stream-a", turns=1, **kwargs):
+    return gc.schedule_goal_continuation(
+        sid,
+        "continue the approved goal",
+        source_stream_id=stream,
+        profile_home="/profiles/default",
+        goal_turns_used=turns,
+        **kwargs,
+    )
+
+
+def test_schedule_is_atomic_durable_and_idempotent(continuation_store):
+    gc, path = continuation_store
+
+    first = _schedule(gc)
+    duplicate = _schedule(gc)
+
+    assert first["continuation_id"] == duplicate["continuation_id"]
+    assert first["status"] == "pending"
+    assert path.exists()
+    assert path.stat().st_mode & 0o777 == 0o600
+    payload = json.loads(path.read_text())
+    assert list(payload["intents"]) == ["session-a"]
+    assert payload["intents"]["session-a"]["prompt"] == "continue the approved goal"
+
+
+def test_corrupt_registry_is_quarantined_before_new_state_is_written(continuation_store):
+    gc, path = continuation_store
+    path.write_text("{not-json", encoding="utf-8")
+    gc._REGISTRY = None
+
+    _schedule(gc)
+
+    assert json.loads(path.read_text())["intents"]["session-a"]["status"] == "pending"
+    quarantined = list(path.parent.glob(f"{path.name}.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{not-json"
+    assert quarantined[0].stat().st_mode & 0o777 == 0o600
+
+
+def test_failed_atomic_replace_does_not_leave_phantom_cached_intent(continuation_store, monkeypatch):
+    gc, path = continuation_store
+    _schedule(gc)
+    original_replace = gc.os.replace
+
+    def fail_registry_replace(src, dst):
+        if str(dst) == str(path):
+            raise OSError("simulated durable replace failure")
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(gc.os, "replace", fail_registry_replace)
+    with pytest.raises(OSError, match="simulated durable replace failure"):
+        gc.schedule_goal_continuation(
+            "session-b",
+            "prompt-b",
+            source_stream_id="source-b",
+            profile_home=None,
+            goal_turns_used=1,
+        )
+    monkeypatch.setattr(gc.os, "replace", original_replace)
+
+    assert gc.get_goal_continuation("session-a") is not None
+    assert gc.get_goal_continuation("session-b") is None
+
+
+def test_drain_starts_exactly_one_server_turn_and_marks_it_running(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    calls = []
+
+    def start_turn(session_id, prompt, *, source):
+        calls.append((session_id, prompt, source))
+        return {"stream_id": "server-stream-1", "_status": 200}
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=start_turn,
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=time.time() + 1,
+    ) == 1
+    record = gc.get_goal_continuation("session-a")
+    assert calls == [("session-a", "continue the approved goal", "goal_continuation")]
+    assert record["status"] == "running"
+    assert record["stream_id"] == "server-stream-1"
+    assert record["attempts"] == 1
+
+
+def test_shutdown_stop_refuses_new_default_dispatch_and_releases_claim(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    gc._WORKER_STOP.set()
+
+    assert gc.drain_goal_continuations_once(
+        is_goal_active=lambda *_args, **_kwargs: True,
+    ) == 0
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "pending"
+    assert record["attempts"] == 0
+    assert "shutdown" in record["last_error"].lower()
+
+
+def test_concurrent_drains_cannot_double_start_one_intent(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    barrier = threading.Barrier(2)
+    calls = []
+
+    def start_turn(session_id, prompt, *, source):
+        calls.append((session_id, prompt, source))
+        barrier.wait(timeout=2)
+        return {"stream_id": "server-stream-1", "_status": 200}
+
+    results = []
+
+    def drain():
+        results.append(
+            gc.drain_goal_continuations_once(
+                start_turn=start_turn,
+                is_goal_active=lambda *_args, **_kwargs: True,
+                now=time.time() + 1,
+            )
+        )
+
+    first = threading.Thread(target=drain)
+    first.start()
+    deadline = time.time() + 2
+    while not calls and time.time() < deadline:
+        time.sleep(0.01)
+    second = threading.Thread(target=drain)
+    second.start()
+    barrier.wait(timeout=2)
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert len(calls) == 1
+    assert sorted(results) == [0, 1]
+
+
+def test_busy_session_releases_claim_without_consuming_provider_attempt(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 409},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=time.time() + 1,
+    ) == 0
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "pending"
+    assert record["attempts"] == 0
+
+
+def test_route_start_failure_after_bind_does_not_consume_provider_attempt(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+
+    def failing_start(session_id, _prompt, **_kwargs):
+        assert gc.bind_goal_continuation_stream(session_id, "never-started-stream")
+        raise RuntimeError("thread start failed")
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=failing_start,
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=time.time() + 1,
+    ) == 0
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "pending"
+    assert record["attempts"] == 0
+    assert record["start_failures"] == 1
+
+
+def test_mixed_version_browser_can_adopt_only_an_unclaimed_matching_intent(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+
+    assert gc.adopt_legacy_browser_goal_stream(
+        "session-a", "unrelated-stream", "human override"
+    ) is False
+    assert gc.get_goal_continuation("session-a")["status"] == "pending"
+    assert gc.adopt_legacy_browser_goal_stream(
+        "session-a", "browser-stream", "continue the approved goal"
+    ) is True
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "running"
+    assert record["stream_id"] == "browser-stream"
+    assert record["attempts"] == 1
+    assert gc.adopt_legacy_browser_goal_stream(
+        "session-a", "duplicate-stream", "continue the approved goal"
+    ) is False
+
+
+def test_unrelated_user_turn_keeps_priority_over_legacy_goal_marker(continuation_store, monkeypatch):
+    gc, _path = continuation_store
+    from api import routes
+    from api.config import PENDING_GOAL_CONTINUATION
+
+    _schedule(gc)
+    session = SimpleNamespace(session_id="session-a", active_stream_id=None)
+    PENDING_GOAL_CONTINUATION.add(session.session_id)
+    monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
+    monkeypatch.setattr(routes, "_active_run_stream_for_session", lambda _sid: None)
+    monkeypatch.setattr(routes, "_is_hidden_empty_session", lambda _session: False)
+
+    def admitted(*_args, **_kwargs):
+        raise RuntimeError("ordinary turn reached normal admission")
+
+    monkeypatch.setattr(routes, "_prepare_chat_start_session_for_stream", admitted)
+
+    with pytest.raises(RuntimeError, match="normal admission"):
+        routes._start_chat_stream_for_session(
+            session,
+            msg="human override",
+            attachments=[],
+            workspace="/tmp",
+            model="test-model",
+            source="webui",
+            external_runtime_owned=False,
+        )
+
+    assert gc.get_goal_continuation("session-a")["status"] == "pending"
+    assert session.session_id in PENDING_GOAL_CONTINUATION
+    assert gc.legacy_browser_goal_prompt_matches("session-a", "human override") is False
+    assert gc.legacy_browser_goal_prompt_matches(
+        "session-a", "continue the approved goal"
+    ) is True
+
+
+def test_empty_goal_response_is_requeued_with_bounded_backoff(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, max_attempts=3, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-1", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+
+    assert gc.requeue_goal_continuation_after_no_response(
+        "session-a",
+        "server-stream-1",
+        had_activity=False,
+        now=clock + 2,
+    ) is True
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "pending"
+    assert record["attempts"] == 1
+    assert record["available_at"] > clock + 2
+
+
+def test_empty_retry_is_refused_after_activity_or_attempt_exhaustion(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, max_attempts=1, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-1", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+
+    assert gc.requeue_goal_continuation_after_no_response(
+        "session-a", "server-stream-1", had_activity=True, now=clock + 2
+    ) is False
+    assert gc.get_goal_continuation("session-a")["status"] == "failed"
+
+    gc.complete_goal_continuation("session-a")
+    _schedule(gc, stream="judge-stream-b", max_attempts=1, now=clock + 3)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-2", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 4,
+    )
+    assert gc.requeue_goal_continuation_after_no_response(
+        "session-a", "server-stream-2", had_activity=False, now=clock + 5
+    ) is False
+    assert gc.get_goal_continuation("session-a")["status"] == "failed"
+
+
+def test_restart_recovers_only_unjudged_active_goal(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, turns=4, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-1", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+    record = gc.get_goal_continuation("session-a")
+    record["owner_id"] = "dead-owner"
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {"status": "active", "turns_used": 4},
+        run_summary_loader=lambda *_args, **_kwargs: {"terminal_state": "no_response"},
+        now=200.0,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "pending"
+    assert recovered["owner_id"] == "test-owner"
+
+
+def test_restart_refuses_replay_after_observable_activity(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, turns=4, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-1", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+    record = gc.get_goal_continuation("session-a")
+    record["owner_id"] = "dead-owner"
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {"status": "active", "turns_used": 4},
+        run_summary_loader=lambda *_args, **_kwargs: {
+            "terminal_state": "running",
+            "observable_activity": True,
+        },
+        now=200.0,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "failed"
+    assert "observable activity" in recovered["last_error"]
+
+
+def test_restart_never_replays_a_turn_already_judged(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, turns=4, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "server-stream-1", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+    record = gc.get_goal_continuation("session-a")
+    record["owner_id"] = "dead-owner"
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {
+            "status": "active",
+            "turns_used": 5,
+            "continuation_prompt": "CURRENT_PROMPT_AFTER_JUDGE",
+        },
+        run_summary_loader=lambda *_args, **_kwargs: {"terminal_state": "completed"},
+        now=200.0,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "pending"
+    assert recovered["goal_turns_used"] == 5
+    assert recovered["attempts"] == 0
+    assert recovered["continuation_id"] != record["continuation_id"]
+    assert recovered["prompt"] == "CURRENT_PROMPT_AFTER_JUDGE"
+
+
+def test_restart_fails_closed_if_goal_advanced_without_current_prompt(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, turns=4)
+    record = gc.get_goal_continuation("session-a")
+    record.update({"status": "running", "stream_id": "continued-stream", "owner_id": "dead-owner"})
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {"status": "active", "turns_used": 5},
+        run_summary_loader=lambda *_args, **_kwargs: {"terminal_state": "completed"},
+        now=200.0,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "failed"
+    assert "no current continuation prompt" in recovered["last_error"]
+
+
+def test_terminal_settlement_is_stream_owned_and_deletion_can_prune_it(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "owned-stream", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+
+    assert gc.fail_goal_continuation("session-a", "other-stream", "wrong owner") is False
+    assert gc.fail_goal_continuation("session-a", "owned-stream", "terminal failure") is True
+    assert gc.get_goal_continuation("session-a")["status"] == "failed"
+    assert gc.complete_goal_continuation("session-a") is True
+    assert gc.get_goal_continuation("session-a") is None
+
+
+def test_inactive_goal_discards_pending_intent(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: pytest.fail("inactive goal must not start"),
+        is_goal_active=lambda *_args, **_kwargs: False,
+        now=time.time() + 1,
+    ) == 0
+    assert gc.get_goal_continuation("session-a") is None

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -776,6 +776,7 @@ def test_strict_goal_snapshot_propagates_profile_read_failure(monkeypatch, tmp_p
             raise PermissionError("goal state unreadable")
 
     monkeypatch.setattr(goals, "_profile_db", lambda _home: BrokenDB())
+    monkeypatch.setattr(goals, "GoalState", None)
     with pytest.raises(PermissionError, match="unreadable"):
         goals.goal_state_snapshot_strict("session-a", profile_home=tmp_path)
 

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -93,6 +93,111 @@ def test_failed_atomic_replace_does_not_leave_phantom_cached_intent(continuation
     assert gc.get_goal_continuation("session-b") is None
 
 
+def test_reconcile_expired_starting_claim_requeues_without_burning_attempt(continuation_store):
+    gc, _path = continuation_store
+    record = _schedule(gc, now=100.0)
+    record.update(
+        status="starting",
+        claim_id="claim-stuck",
+        owner_id=gc._current_owner_id(),
+        updated_at=100.0,
+    )
+    gc._replace_goal_continuation_for_test(record)
+
+    assert gc.reconcile_goal_continuations_once(now=131.0) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "pending"
+    assert current["claim_id"] is None
+    assert current["attempts"] == 0
+    assert current["available_at"] == 131.0
+    assert "lease expired" in current["last_error"]
+
+
+def test_reconcile_admitted_run_without_worker_or_activity_requeues(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "orphan-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    ) == 1
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: False,
+        run_summary_loader=lambda _sid, _stream: {
+            "terminal_state": "unknown",
+            "observable_activity": False,
+        },
+        now=131.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "pending"
+    assert current["stream_id"] is None
+    assert current["claim_id"] is None
+    assert current["attempts"] == 1
+    assert current["available_at"] > 131.0
+    assert "no live worker" in current["last_error"]
+
+
+def test_reconcile_live_run_refreshes_durable_heartbeat(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "live-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: True,
+        run_summary_loader=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("live runs must not inspect terminal evidence")
+        ),
+        now=131.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "running"
+    assert current["stream_id"] == "live-stream"
+    assert current["last_heartbeat_at"] == 131.0
+
+
+def test_default_liveness_ignores_sse_channel_without_worker(monkeypatch, continuation_store):
+    gc, _path = continuation_store
+    from api import config
+
+    monkeypatch.setattr(config, "STREAMS", {"stream-a": object()})
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    assert gc._default_run_active("session-a", "stream-a") is False
+
+    config.ACTIVE_RUNS["stream-a"] = {"session_id": "session-a"}
+    assert gc._default_run_active("session-a", "stream-a") is True
+
+
+def test_reconcile_orphan_after_observable_activity_fails_closed(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc, now=100.0)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"_status": 200, "stream_id": "unsafe-stream"},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=100.0,
+    )
+
+    assert gc.reconcile_goal_continuations_once(
+        active_run_check=lambda _sid, _stream: False,
+        run_summary_loader=lambda _sid, _stream: {
+            "terminal_state": "interrupted",
+            "observable_activity": True,
+        },
+        now=131.0,
+    ) == 1
+
+    current = gc.get_goal_continuation("session-a")
+    assert current["status"] == "failed"
+    assert "observable activity" in current["last_error"]
+
 def test_drain_starts_exactly_one_server_turn_and_marks_it_running(continuation_store):
     gc, _path = continuation_store
     _schedule(gc)

--- a/tests/test_goal_server_continuation.py
+++ b/tests/test_goal_server_continuation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import threading
 import time
 from types import SimpleNamespace
@@ -19,6 +20,9 @@ def continuation_store(tmp_path, monkeypatch):
     monkeypatch.setattr(gc, "OWNER_ID", "test-owner")
     monkeypatch.setattr(gc, "_REGISTRY", None)
     monkeypatch.setattr(gc, "_WORKER_WAKE", threading.Event())
+    monkeypatch.setattr(gc, "_WORKER_THREAD", None)
+    monkeypatch.setattr(gc, "_WORKER_LEADER_FD", None, raising=False)
+    monkeypatch.setattr(gc, "_WORKER_LEADER_PID", None, raising=False)
     gc._WORKER_STOP.clear()
     yield gc, path
     gc.stop_goal_continuation_worker(timeout=0.2)
@@ -94,7 +98,7 @@ def test_drain_starts_exactly_one_server_turn_and_marks_it_running(continuation_
     _schedule(gc)
     calls = []
 
-    def start_turn(session_id, prompt, *, source):
+    def start_turn(session_id, prompt, *, source, continuation_claim_id):
         calls.append((session_id, prompt, source))
         return {"stream_id": "server-stream-1", "_status": 200}
 
@@ -130,7 +134,7 @@ def test_concurrent_drains_cannot_double_start_one_intent(continuation_store):
     barrier = threading.Barrier(2)
     calls = []
 
-    def start_turn(session_id, prompt, *, source):
+    def start_turn(session_id, prompt, *, source, continuation_claim_id):
         calls.append((session_id, prompt, source))
         barrier.wait(timeout=2)
         return {"stream_id": "server-stream-1", "_status": 200}
@@ -179,8 +183,12 @@ def test_route_start_failure_after_bind_does_not_consume_provider_attempt(contin
     gc, _path = continuation_store
     _schedule(gc)
 
-    def failing_start(session_id, _prompt, **_kwargs):
-        assert gc.bind_goal_continuation_stream(session_id, "never-started-stream")
+    def failing_start(session_id, _prompt, *, continuation_claim_id, **_kwargs):
+        assert gc.bind_goal_continuation_stream(
+            session_id,
+            "never-started-stream",
+            claim_id=continuation_claim_id,
+        )
         raise RuntimeError("thread start failed")
 
     assert gc.drain_goal_continuations_once(
@@ -192,6 +200,65 @@ def test_route_start_failure_after_bind_does_not_consume_provider_attempt(contin
     assert record["status"] == "pending"
     assert record["attempts"] == 0
     assert record["start_failures"] == 1
+
+
+def test_bind_requires_current_claim_and_owner(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+    observed = {}
+
+    def start_turn(session_id, _prompt, *, continuation_claim_id, **_kwargs):
+        observed["claim_id"] = continuation_claim_id
+        assert gc.bind_goal_continuation_stream(
+            session_id,
+            "wrong-claim-stream",
+            claim_id="stale-claim",
+        ) is False
+        record = gc.get_goal_continuation(session_id)
+        record["owner_id"] = "foreign-owner"
+        gc._replace_goal_continuation_for_test(record)
+        assert gc.bind_goal_continuation_stream(
+            session_id,
+            "foreign-owner-stream",
+            claim_id=continuation_claim_id,
+        ) is False
+        record["owner_id"] = gc._current_owner_id()
+        gc._replace_goal_continuation_for_test(record)
+        assert gc.bind_goal_continuation_stream(
+            session_id,
+            "owned-stream",
+            claim_id=continuation_claim_id,
+        ) is True
+        return {"stream_id": "owned-stream", "_status": 200}
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=start_turn,
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=time.time() + 1,
+    ) == 1
+    assert observed["claim_id"]
+    assert gc.get_goal_continuation("session-a")["stream_id"] == "owned-stream"
+
+
+def test_fast_terminal_settlement_cannot_be_resurrected_by_drain(continuation_store):
+    gc, _path = continuation_store
+    _schedule(gc)
+
+    def start_turn(session_id, _prompt, *, continuation_claim_id, **_kwargs):
+        assert gc.bind_goal_continuation_stream(
+            session_id,
+            "fast-terminal-stream",
+            claim_id=continuation_claim_id,
+        )
+        assert gc.complete_goal_continuation(session_id, "fast-terminal-stream")
+        return {"stream_id": "fast-terminal-stream", "_status": 200}
+
+    assert gc.drain_goal_continuations_once(
+        start_turn=start_turn,
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=time.time() + 1,
+    ) == 1
+    assert gc.get_goal_continuation("session-a") is None
 
 
 def test_mixed_version_browser_can_adopt_only_an_unclaimed_matching_intent(continuation_store):
@@ -300,6 +367,31 @@ def test_empty_retry_is_refused_after_activity_or_attempt_exhaustion(continuatio
     assert gc.get_goal_continuation("session-a")["status"] == "failed"
 
 
+def test_empty_retry_is_refused_when_cancellation_wins_the_settlement_race(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {
+            "stream_id": "cancelled-stream",
+            "_status": 200,
+        },
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+
+    assert gc.requeue_goal_continuation_after_no_response(
+        "session-a",
+        "cancelled-stream",
+        had_activity=False,
+        cancellation_check=lambda: True,
+        now=clock + 2,
+    ) is False
+    record = gc.get_goal_continuation("session-a")
+    assert record["status"] == "failed"
+    assert "cancel" in record["last_error"].lower()
+
+
 def test_restart_recovers_only_unjudged_active_goal(continuation_store):
     gc, _path = continuation_store
     clock = time.time()
@@ -321,6 +413,49 @@ def test_restart_recovers_only_unjudged_active_goal(continuation_store):
     recovered = gc.get_goal_continuation("session-a")
     assert recovered["status"] == "pending"
     assert recovered["owner_id"] == "test-owner"
+
+
+def test_restart_fails_closed_when_run_evidence_is_unreadable(continuation_store):
+    gc, _path = continuation_store
+    clock = time.time()
+    _schedule(gc, now=clock)
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": "evidence-stream", "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=clock + 1,
+    )
+    record = gc.get_goal_continuation("session-a")
+    record["owner_id"] = "dead-owner"
+    gc._replace_goal_continuation_for_test(record)
+
+    def unreadable_summary(*_args, **_kwargs):
+        raise PermissionError("journal evidence is unreadable")
+
+    assert gc.recover_goal_continuations(
+        goal_state_loader=lambda *_args, **_kwargs: {"status": "active", "turns_used": 1},
+        run_summary_loader=unreadable_summary,
+        now=clock + 2,
+    ) == 1
+    recovered = gc.get_goal_continuation("session-a")
+    assert recovered["status"] == "failed"
+    assert "evidence" in recovered["last_error"].lower()
+
+
+def test_unreadable_registry_is_not_quarantined_as_corrupt(continuation_store, monkeypatch):
+    gc, path = continuation_store
+    _schedule(gc)
+    gc._REGISTRY = None
+    original_read_text = Path.read_text
+
+    def deny_registry_read(self, *args, **kwargs):
+        if self == path:
+            raise PermissionError("simulated permission failure")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_registry_read)
+    with pytest.raises(PermissionError, match="simulated permission failure"):
+        gc.get_goal_continuation("session-a")
+    assert path.exists(), "valid but unreadable state must not be quarantined or replaced"
 
 
 def test_restart_refuses_replay_after_observable_activity(continuation_store):
@@ -423,3 +558,21 @@ def test_inactive_goal_discards_pending_intent(continuation_store):
         now=time.time() + 1,
     ) == 0
     assert gc.get_goal_continuation("session-a") is None
+
+
+def test_timed_out_worker_stop_blocks_restart_until_old_thread_exits(continuation_store, monkeypatch):
+    gc, _path = continuation_store
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_worker():
+        entered.set()
+        release.wait(5)
+
+    monkeypatch.setattr(gc, "_worker_loop", blocked_worker)
+    assert gc.start_goal_continuation_worker() is True
+    assert entered.wait(1)
+    assert gc.stop_goal_continuation_worker(timeout=0.01) is False
+    assert gc.start_goal_continuation_worker() is False
+    release.set()
+    assert gc.stop_goal_continuation_worker(timeout=1) is True

--- a/tests/test_goal_server_continuation_callsite.py
+++ b/tests/test_goal_server_continuation_callsite.py
@@ -43,6 +43,9 @@ def test_server_starts_and_stops_durable_goal_worker():
     stop = server.index("stop_goal_continuation_worker()", shutdown)
     lifecycle_drain = server.index("drain_all_on_shutdown()", shutdown)
     assert stop < lifecycle_drain, "new goal turns must be disabled before shutdown drains"
+    bind = server.index("httpd = QuietHTTPServer")
+    start = server.index("start_goal_continuation_worker()")
+    assert bind < start, "the durable worker must not start before the server owns its port"
 
 
 def test_empty_response_retry_is_limited_to_server_goal_continuations():

--- a/tests/test_goal_server_continuation_callsite.py
+++ b/tests/test_goal_server_continuation_callsite.py
@@ -1,0 +1,54 @@
+"""Call-surface regressions for server-owned goal continuation delivery."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_both_streaming_backends_persist_before_goal_continue_event():
+    for relative in ("api/streaming.py", "api/gateway_chat.py"):
+        source = (ROOT / relative).read_text()
+        schedule = source.find("schedule_goal_continuation(")
+        event = source.find('"goal_continue"', schedule)
+        if event < 0:
+            event = source.find("'goal_continue'", schedule)
+        assert schedule >= 0, f"{relative} must persist the continuation intent"
+        assert event > schedule, f"{relative} must persist before emitting goal_continue"
+
+
+def test_server_turn_marks_goal_continuation_explicitly_goal_related():
+    routes = (ROOT / "api/routes.py").read_text()
+    start = routes.index("def start_session_turn(")
+    body = routes[start : routes.index("def _handle_bg_task_complete_ack", start)]
+    assert 'turn_source == "goal_continuation"' in body
+    assert "goal_related=" in body
+    assert "bind_goal_continuation_stream" in routes
+    assert "adopt_legacy_browser_goal_stream" in routes
+
+
+def test_browser_observes_goal_continue_but_never_dispatches_it():
+    messages = (ROOT / "static/messages.js").read_text()
+    handler = messages.index("source.addEventListener('goal_continue'")
+    body = messages[handler : messages.index("source.addEventListener('done'", handler)]
+    assert "queueSessionMessage" not in body
+    assert "_pendingGoalContinuation" not in messages
+
+
+def test_server_starts_and_stops_durable_goal_worker():
+    server = (ROOT / "server.py").read_text()
+    assert "start_goal_continuation_worker" in server
+    assert "stop_goal_continuation_worker" in server
+    shutdown = server.index("finally:\n        httpd.server_close()")
+    stop = server.index("stop_goal_continuation_worker()", shutdown)
+    lifecycle_drain = server.index("drain_all_on_shutdown()", shutdown)
+    assert stop < lifecycle_drain, "new goal turns must be disabled before shutdown drains"
+
+
+def test_empty_response_retry_is_limited_to_server_goal_continuations():
+    streaming = (ROOT / "api/streaming.py").read_text()
+    gateway = (ROOT / "api/gateway_chat.py").read_text()
+    assert "requeue_goal_continuation_after_no_response" in streaming
+    assert "requeue_goal_continuation_after_no_response" in gateway
+    assert "had_activity=" in streaming
+    assert "had_activity=" in gateway

--- a/tests/test_goal_server_continuation_callsite.py
+++ b/tests/test_goal_server_continuation_callsite.py
@@ -37,15 +37,20 @@ def test_browser_observes_goal_continue_but_never_dispatches_it():
 
 def test_server_starts_and_stops_durable_goal_worker():
     server = (ROOT / "server.py").read_text()
+    background = (ROOT / "api" / "background_process.py").read_text()
+    assert "start_drain_thread" in server
+    assert "stop_drain_thread" in server
     assert "start_goal_continuation_worker" in server
-    assert "stop_goal_continuation_worker" in server
+    assert "stop_goal_continuation_worker" in background
     shutdown = server.index("finally:\n        httpd.server_close()")
-    stop = server.index("stop_goal_continuation_worker()", shutdown)
+    stop = server.index("stop_drain_thread()", shutdown)
     lifecycle_drain = server.index("drain_all_on_shutdown()", shutdown)
     assert stop < lifecycle_drain, "new goal turns must be disabled before shutdown drains"
     bind = server.index("httpd = QuietHTTPServer")
     start = server.index("start_goal_continuation_worker()")
     assert bind < start, "the durable worker must not start before the server owns its port"
+    drain_stop = background.index("def stop_drain_thread(")
+    assert background.index("stop_goal_continuation_worker", drain_stop) > drain_stop
 
 
 def test_empty_response_retry_is_limited_to_server_goal_continuations():

--- a/tests/test_goal_server_continuation_callsite.py
+++ b/tests/test_goal_server_continuation_callsite.py
@@ -60,3 +60,31 @@ def test_empty_response_retry_is_limited_to_server_goal_continuations():
     assert "requeue_goal_continuation_after_no_response" in gateway
     assert "had_activity=" in streaming
     assert "had_activity=" in gateway
+
+
+def test_worker_entry_is_durably_fenced_before_active_run_registration():
+    for relative in ("api/streaming.py", "api/gateway_chat.py"):
+        source = (ROOT / relative).read_text()
+        fence = source.index("mark_goal_continuation_worker_started")
+        active = source.index("register_active_run(", fence)
+        assert fence < active
+
+
+def test_schedule_failure_is_visible_and_stops_before_done():
+    for relative in ("api/streaming.py", "api/gateway_chat.py"):
+        source = (ROOT / relative).read_text()
+        failed = source.index("goal_continuation_schedule_failed")
+        done = source.index("done", failed)
+        block = source[failed:done]
+        assert "apperror" in block
+        assert "stream_end" in block
+        assert "return" in block
+
+
+def test_thread_start_failure_requeues_modern_and_legacy_goal_streams():
+    routes = (ROOT / "api/routes.py").read_text()
+    chat_start = routes.index("def _start_chat_stream_for_session(")
+    start = routes.index("thr.start()", chat_start)
+    block = routes[start : routes.index("raise", start) + len("raise")]
+    assert "if goal_related:" in block
+    assert "requeue_goal_continuation_after_no_response" in block

--- a/tests/test_goal_server_continuation_multiprocess.py
+++ b/tests/test_goal_server_continuation_multiprocess.py
@@ -8,6 +8,8 @@ import os
 import time
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -44,6 +46,34 @@ def _schedule_one(path: str, session_id: str, ready, done) -> None:
 def _owner_after_fork(path: str, output) -> None:
     gc = _configure(path)
     output.put((os.getpid(), gc._current_owner_id()))
+
+
+def _hold_worker_leader_lock(path: str, acquired, release) -> None:
+    import fcntl
+
+    registry = Path(path)
+    lock_path = registry.with_name(f".{registry.name}.worker.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        acquired.set()
+        release.wait(10)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _schedule_while_parent_lock_is_held(path: str, output) -> None:
+    gc = _configure(path)
+    gc.schedule_goal_continuation(
+        "fork-child-session",
+        "continue",
+        source_stream_id="source",
+        profile_home=None,
+        goal_turns_used=1,
+    )
+    output.put("scheduled")
 
 
 def test_registry_transaction_blocks_cross_process_lost_update(tmp_path):
@@ -94,3 +124,55 @@ def test_owner_identity_is_regenerated_after_fork(tmp_path):
     assert child_pid != os.getpid()
     assert child_owner != parent_owner
     assert child_owner.startswith(f"webui-{child_pid}-")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX worker leadership lock probe")
+def test_live_foreign_worker_leadership_blocks_second_worker(tmp_path, monkeypatch):
+    path = tmp_path / "goal-continuations.json"
+    ctx = multiprocessing.get_context("fork")
+    acquired = ctx.Event()
+    release = ctx.Event()
+    holder = ctx.Process(target=_hold_worker_leader_lock, args=(str(path), acquired, release))
+    holder.start()
+    assert acquired.wait(5)
+
+    gc = _configure(str(path))
+    monkeypatch.setattr(gc, "_worker_loop", lambda: None)
+    try:
+        assert gc.start_goal_continuation_worker() is False
+    finally:
+        gc.stop_goal_continuation_worker(timeout=0.2)
+        release.set()
+        holder.join(5)
+    assert holder.exitcode == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork-specific inherited-lock regression")
+def test_child_reinitializes_inherited_registry_lock_after_fork(tmp_path):
+    path = tmp_path / "goal-continuations.json"
+    gc = _configure(str(path))
+    ctx = multiprocessing.get_context("fork")
+    lock_held = ctx.Event()
+    release = ctx.Event()
+
+    def hold_parent_thread_lock():
+        with gc._REGISTRY_LOCK:
+            lock_held.set()
+            release.wait(10)
+
+    import threading
+
+    holder = threading.Thread(target=hold_parent_thread_lock, daemon=True)
+    holder.start()
+    assert lock_held.wait(2)
+    output = ctx.Queue()
+    child = ctx.Process(target=_schedule_while_parent_lock_is_held, args=(str(path), output))
+    child.start()
+    child.join(3)
+    release.set()
+    holder.join(2)
+    if child.is_alive():
+        child.terminate()
+        child.join(2)
+    assert child.exitcode == 0, "child inherited a locked process-local RLock"
+    assert output.get(timeout=1) == "scheduled"

--- a/tests/test_goal_server_continuation_multiprocess.py
+++ b/tests/test_goal_server_continuation_multiprocess.py
@@ -1,0 +1,96 @@
+"""Cross-process safety contracts for the durable /goal registry."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _configure(path: str):
+    from api import goal_continuations as gc
+
+    gc.REGISTRY_PATH = Path(path)
+    gc._REGISTRY = None
+    return gc
+
+
+def _hold_registry_transaction(path: str, acquired, release) -> None:
+    gc = _configure(path)
+    with gc._registry_transaction():
+        acquired.set()
+        release.wait(10)
+
+
+def _schedule_one(path: str, session_id: str, ready, done) -> None:
+    gc = _configure(path)
+    ready.wait(10)
+    gc.schedule_goal_continuation(
+        session_id,
+        f"prompt-{session_id}",
+        source_stream_id=f"source-{session_id}",
+        profile_home=None,
+        goal_turns_used=1,
+        now=time.time(),
+    )
+    done.set()
+
+
+def _owner_after_fork(path: str, output) -> None:
+    gc = _configure(path)
+    output.put((os.getpid(), gc._current_owner_id()))
+
+
+def test_registry_transaction_blocks_cross_process_lost_update(tmp_path):
+    """A second writer cannot load stale JSON while another transaction is open."""
+    path = tmp_path / "goal-continuations.json"
+    ctx = multiprocessing.get_context("fork")
+    acquired = ctx.Event()
+    release = ctx.Event()
+    writer_ready = ctx.Event()
+    writer_done = ctx.Event()
+
+    holder = ctx.Process(target=_hold_registry_transaction, args=(str(path), acquired, release))
+    writer = ctx.Process(
+        target=_schedule_one,
+        args=(str(path), "session-b", writer_ready, writer_done),
+    )
+    holder.start()
+    assert acquired.wait(5)
+    writer.start()
+    writer_ready.set()
+    assert not writer_done.wait(0.3), "second process bypassed the registry transaction lock"
+
+    release.set()
+    assert writer_done.wait(5)
+    holder.join(5)
+    writer.join(5)
+    assert holder.exitcode == 0
+    assert writer.exitcode == 0
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert list(data["intents"]) == ["session-b"]
+    assert (tmp_path / ".goal-continuations.json.lock").stat().st_mode & 0o777 == 0o600
+
+
+def test_owner_identity_is_regenerated_after_fork(tmp_path):
+    path = tmp_path / "goal-continuations.json"
+    ctx = multiprocessing.get_context("fork")
+    output = ctx.Queue()
+    from api import goal_continuations as gc
+
+    parent_owner = gc._current_owner_id()
+    child = ctx.Process(target=_owner_after_fork, args=(str(path), output))
+    child.start()
+    child_pid, child_owner = output.get(timeout=5)
+    child.join(5)
+
+    assert child.exitcode == 0
+    assert child_pid != os.getpid()
+    assert child_owner != parent_owner
+    assert child_owner.startswith(f"webui-{child_pid}-")

--- a/tests/test_goal_server_continuation_multiprocess.py
+++ b/tests/test_goal_server_continuation_multiprocess.py
@@ -139,7 +139,9 @@ def test_live_foreign_worker_leadership_blocks_second_worker(tmp_path, monkeypat
     gc = _configure(str(path))
     monkeypatch.setattr(gc, "_worker_loop", lambda: None)
     try:
-        assert gc.start_goal_continuation_worker() is False
+        # Every server starts a standby thread. It retries the leadership lock
+        # after the current owner exits instead of remaining schedulerless.
+        assert gc.start_goal_continuation_worker() is True
     finally:
         gc.stop_goal_continuation_worker(timeout=0.2)
         release.set()

--- a/tests/test_hidden_tab_server_initiated_turn.py
+++ b/tests/test_hidden_tab_server_initiated_turn.py
@@ -38,6 +38,15 @@ def test_session_status_exposes_active_stream_id_field():
     assert "_live_active_stream_id(" in SESSION_OPS
 
 
+def test_session_status_exposes_pending_user_source_for_hidden_poll():
+    """session_status() must expose pending fields so the hidden-tab poller can
+    reconstruct the pending turn with the correct provenance."""
+    assert "'pending_user_source'" in SESSION_OPS
+    assert "'pending_user_message'" in SESSION_OPS
+    assert "'pending_started_at'" in SESSION_OPS
+    assert "'pending_attachments'" in SESSION_OPS
+
+
 def test_live_active_stream_id_is_stale_safe():
     """The helper only returns an id that is actually live in STREAMS/ACTIVE_RUNS.
 
@@ -76,7 +85,7 @@ def test_frontend_declares_hidden_poll_lifecycle():
     """The hidden-tab active-stream poll start/stop/attach functions exist."""
     assert "function _startHiddenActiveStreamPoll(sid)" in MESSAGES_JS
     assert "function _stopHiddenActiveStreamPoll()" in MESSAGES_JS
-    assert "function _attachServerInitiatedStream(sid, streamId, recovered)" in MESSAGES_JS
+    assert "function _attachServerInitiatedStream(sid, streamId, recovered, source)" in MESSAGES_JS
 
 
 def test_hidden_poll_hits_session_status_and_attaches_as_replay():
@@ -93,7 +102,7 @@ def test_hidden_poll_hits_session_status_and_attaches_as_replay():
     assert "api/session/status?session_id=" in body
     assert "d.active_stream_id" in body
     # attaches as replay (recovered=true) — turn is already mid-flight
-    assert "_attachServerInitiatedStream(sid, streamId, true)" in body
+    assert "_attachServerInitiatedStream(sid, streamId, true, d.pending_user_source)" in body
 
 
 def test_hidden_poll_started_on_both_hidden_paths():
@@ -138,7 +147,7 @@ def test_attach_returns_bool_and_bails_false_on_non_current_pane():
     false (so the poll keeps retrying for the right pane) — never a bare
     `return;` that the caller can't distinguish from success.
     """
-    fn_idx = MESSAGES_JS.find("function _attachServerInitiatedStream(sid, streamId, recovered)")
+    fn_idx = MESSAGES_JS.find("function _attachServerInitiatedStream(sid, streamId, recovered, source)")
     assert fn_idx != -1, "_attachServerInitiatedStream signature not found"
     body = MESSAGES_JS[fn_idx:fn_idx + 4000]
     # Non-current pane bails with an explicit false, not a bare return.
@@ -175,7 +184,7 @@ def test_poll_stops_only_when_attach_succeeds():
     # Window 2400: the multi-pane follow-up adds an explanatory comment block
     # before the attach call, pushing it past a narrower slice.
     body = MESSAGES_JS[start:start + 3200]
-    assert "const attached = _attachServerInitiatedStream(sid, streamId, true)" in body
+    assert "const attached = _attachServerInitiatedStream(sid, streamId, true, d.pending_user_source)" in body
     # Stop the poll only on a true attach (the false branch keeps polling within
     # the bounded-retry budget rather than stopping).
     assert "if (attached) {" in body

--- a/tests/test_internal_retry_semantics.py
+++ b/tests/test_internal_retry_semantics.py
@@ -1,0 +1,37 @@
+"""Retry/undo must target the last human turn, never internal transport."""
+
+from api.session_ops import _is_semantic_user_message, _truncate_at_last_user
+
+
+def test_semantic_user_filter_excludes_all_internal_markers():
+    assert _is_semantic_user_message({"role": "user", "content": "hello"})
+    assert not _is_semantic_user_message({
+        "role": "user",
+        "content": "wake",
+        "_user_originated": False,
+    })
+    assert not _is_semantic_user_message({
+        "role": "user",
+        "content": "wake",
+        "_source": "async_delegation",
+    })
+    assert not _is_semantic_user_message({
+        "role": "user",
+        "content": "wake",
+        "_display_kind": "internal_event",
+    })
+
+
+def test_context_truncation_skips_internal_user_transport():
+    rows = [
+        {"role": "user", "content": "human"},
+        {"role": "assistant", "content": "reply"},
+        {
+            "role": "user",
+            "content": "internal completion",
+            "_source": "async_delegation",
+            "_user_originated": False,
+        },
+        {"role": "assistant", "content": "internal reply"},
+    ]
+    assert _truncate_at_last_user(rows) == []

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -910,6 +910,9 @@ def test_goal_continuation_empty_response_is_retried_without_apperror(tmp_path, 
         event == "done" and data.get("goal_retry_scheduled") is True
         for event, data in events
     )
+    event_names = [event for event, _data in events]
+    assert "stream_end" in event_names
+    assert event_names.index("done") < event_names.index("stream_end")
     assert not any(event == "apperror" for event, _data in events)
     record = gc.get_goal_continuation(session.session_id)
     assert record["status"] == "pending"
@@ -963,6 +966,88 @@ def test_goal_continuation_empty_response_after_activity_is_not_replayed(tmp_pat
         event == "apperror" and data.get("type") == "no_response"
         for event, data in events
     )
+    assert not any(
+        event == "warning" and data.get("type") == "goal_retry_scheduled"
+        for event, data in events
+    )
+    assert gc.get_goal_continuation(session.session_id)["status"] == "failed"
+
+
+@pytest.mark.parametrize("activity_event", ["approval", "clarify"])
+def test_goal_continuation_empty_response_after_user_mediated_activity_is_not_replayed(
+    tmp_path,
+    monkeypatch,
+    activity_event,
+):
+    from api import goal_continuations as gc
+
+    monkeypatch.setattr(gc, "REGISTRY_PATH", tmp_path / "goal-continuations.json")
+    monkeypatch.setattr(gc, "_REGISTRY", None)
+    monkeypatch.setattr(gc, "OWNER_ID", "streaming-test-owner")
+    callbacks = {}
+    if activity_event == "approval":
+        import tools.approval as approval
+
+        monkeypatch.setattr(
+            approval,
+            "register_gateway_notify",
+            lambda sid, cb: callbacks.setdefault(sid, cb),
+        )
+        monkeypatch.setattr(
+            approval,
+            "unregister_gateway_notify",
+            lambda sid: callbacks.pop(sid, None),
+        )
+    else:
+        from api import clarify
+
+        monkeypatch.setattr(
+            clarify,
+            "register_gateway_notify",
+            lambda sid, cb: callbacks.setdefault(sid, cb),
+        )
+        monkeypatch.setattr(
+            clarify,
+            "unregister_gateway_notify",
+            lambda sid: callbacks.pop(sid, None),
+        )
+
+    stream_id = f"stream-goal-{activity_event}-no-retry"
+    session = _prepare_session(
+        f"goal_{activity_event}_no_retry",
+        stream_id,
+        pending_user_message="continue the active goal",
+        partial_source="goal_continuation",
+    )
+    gc.schedule_goal_continuation(
+        session.session_id,
+        session.pending_user_message,
+        source_stream_id="prior-judge-stream",
+        profile_home=tmp_path,
+        goal_turns_used=1,
+        now=100.0,
+    )
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": stream_id, "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=101.0,
+    )
+
+    class ActivityThenEmptyAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            callback = callbacks[self.session_id]
+            callback({"session_id": self.session_id, "kind": activity_event})
+            return {"messages": list(kwargs.get("conversation_history") or [])}
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        stream_id,
+        ActivityThenEmptyAgent,
+        workspace=str(tmp_path),
+    )
+    events = _queue_events(fake_queue)
+    assert any(event == activity_event for event, _data in events)
     assert not any(
         event == "warning" and data.get("type") == "goal_retry_scheduled"
         for event, data in events

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -986,17 +986,24 @@ def test_goal_continuation_empty_response_after_user_mediated_activity_is_not_re
     monkeypatch.setattr(gc, "OWNER_ID", "streaming-test-owner")
     callbacks = {}
     if activity_event == "approval":
-        import tools.approval as approval
+        approval = types.ModuleType("tools.approval")
+        tools_pkg = types.ModuleType("tools")
+        tools_pkg.__path__ = []
+        tools_pkg.__dict__["approval"] = approval
+        monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+        monkeypatch.setitem(sys.modules, "tools.approval", approval)
 
         monkeypatch.setattr(
             approval,
             "register_gateway_notify",
             lambda sid, cb: callbacks.setdefault(sid, cb),
+            raising=False,
         )
         monkeypatch.setattr(
             approval,
             "unregister_gateway_notify",
             lambda sid: callbacks.pop(sid, None),
+            raising=False,
         )
     else:
         from api import clarify

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -858,3 +858,113 @@ def test_non_auth_seeded_replayed_assistant_does_not_satisfy_current_turn(tmp_pa
     assert apperrors, "expected apperror for seeded replay silent failure"
     assert apperrors[-1]["type"] == "no_response"
     assert not any(event == "done" for event, _ in events)
+
+
+def test_goal_continuation_empty_response_is_retried_without_apperror(tmp_path, monkeypatch):
+    from api import goal_continuations as gc
+
+    monkeypatch.setattr(gc, "REGISTRY_PATH", tmp_path / "goal-continuations.json")
+    monkeypatch.setattr(gc, "_REGISTRY", None)
+    monkeypatch.setattr(gc, "OWNER_ID", "streaming-test-owner")
+
+    session = _prepare_session(
+        "goal_empty_retry",
+        "stream_goal_empty_retry",
+        pending_user_message="continue the active goal",
+        partial_source="goal_continuation",
+    )
+    gc.schedule_goal_continuation(
+        session.session_id,
+        session.pending_user_message,
+        source_stream_id="prior-judge-stream",
+        profile_home=tmp_path,
+        goal_turns_used=1,
+        now=100.0,
+    )
+    assert gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {
+            "stream_id": "stream_goal_empty_retry",
+            "_status": 200,
+        },
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=101.0,
+    ) == 1
+
+    class EmptyResponseAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            return {"messages": list(kwargs.get("conversation_history") or [])}
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_goal_empty_retry",
+        EmptyResponseAgent,
+        workspace=str(tmp_path),
+    )
+    events = _queue_events(fake_queue)
+    assert any(
+        event == "warning" and data.get("type") == "goal_retry_scheduled"
+        for event, data in events
+    )
+    assert any(
+        event == "done" and data.get("goal_retry_scheduled") is True
+        for event, data in events
+    )
+    assert not any(event == "apperror" for event, _data in events)
+    record = gc.get_goal_continuation(session.session_id)
+    assert record["status"] == "pending"
+    assert record["attempts"] == 1
+
+
+def test_goal_continuation_empty_response_after_activity_is_not_replayed(tmp_path, monkeypatch):
+    from api import goal_continuations as gc
+
+    monkeypatch.setattr(gc, "REGISTRY_PATH", tmp_path / "goal-continuations.json")
+    monkeypatch.setattr(gc, "_REGISTRY", None)
+    monkeypatch.setattr(gc, "OWNER_ID", "streaming-test-owner")
+
+    session = _prepare_session(
+        "goal_activity_no_retry",
+        "stream_goal_activity_no_retry",
+        pending_user_message="continue the active goal",
+        partial_source="goal_continuation",
+    )
+    gc.schedule_goal_continuation(
+        session.session_id,
+        session.pending_user_message,
+        source_stream_id="prior-judge-stream",
+        profile_home=tmp_path,
+        goal_turns_used=1,
+        now=100.0,
+    )
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {
+            "stream_id": "stream_goal_activity_no_retry",
+            "_status": 200,
+        },
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=101.0,
+    )
+
+    class ActivityThenEmptyAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            self.stream_delta_callback("observable partial")
+            return {"messages": list(kwargs.get("conversation_history") or [])}
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_goal_activity_no_retry",
+        ActivityThenEmptyAgent,
+        workspace=str(tmp_path),
+    )
+    events = _queue_events(fake_queue)
+    assert any(
+        event == "apperror" and data.get("type") == "no_response"
+        for event, data in events
+    )
+    assert not any(
+        event == "warning" and data.get("type") == "goal_retry_scheduled"
+        for event, data in events
+    )
+    assert gc.get_goal_continuation(session.session_id)["status"] == "failed"

--- a/tests/test_process_wakeup_rendering.py
+++ b/tests/test_process_wakeup_rendering.py
@@ -127,6 +127,12 @@ const markerWakeupContent = [
   '',
   '[Attached files: result.txt]',
 ].join(String.fromCharCode(10));
+const humanBoundary = [
+  {role: 'user', content: '[ASYNC DELEGATION BATCH COMPLETE — deleg_boundary]', _source: 'async_delegation'},
+  {role: 'assistant', content: '# CONCLUSION\n---\n> 🟢 Réponse / recommandation: critical internal result'},
+  {role: 'user', content: 'unrelated human request'},
+  {role: 'assistant', content: 'answer to unrelated request'},
+];
 
 process.stdout.write(JSON.stringify({
   visible: visible.map(e => ({rawIdx: e.rawIdx, role: e.m.role, source: e.m._source || '', text: String(e.m.content).slice(0, 32)})),
@@ -136,6 +142,7 @@ process.stdout.write(JSON.stringify({
   attachmentOnlyRenderable: _messageIsRenderable(attachmentOnlyWakeup),
   projectedIntermediate: _projectInternalProgressContent(S.messages, 2, S.messages[2].content),
   projectedFinal: _projectInternalProgressContent(S.messages, 4, S.messages[4].content),
+  projectedBeforeHumanBoundary: _projectInternalProgressContent(humanBoundary, 1, humanBoundary[1].content),
   strippedWakeupDisplay: _stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(markerWakeupContent)),
 }));
 """
@@ -188,6 +195,11 @@ def test_intermediate_internal_reply_is_compact_but_latest_candidate_final_is_un
     result = _run_driver()
     assert result["projectedIntermediate"] == "**Progression** — phase one done"
     assert result["projectedFinal"].startswith("# CONCLUSION")
+
+
+def test_internal_projection_never_crosses_a_real_user_boundary():
+    result = _run_driver()
+    assert result["projectedBeforeHumanBoundary"].startswith("# CONCLUSION")
 
 
 def test_process_wakeup_uses_compact_status_row_not_normal_user_bubble():

--- a/tests/test_process_wakeup_rendering.py
+++ b/tests/test_process_wakeup_rendering.py
@@ -1,10 +1,10 @@
 """Regression coverage for process-wakeup transcript rendering.
 
-A background-process wakeup is stored as a synthetic user turn
-(`_source: "process_wakeup"`).  It must be visible by default, but it must not
-look like a human-authored chat bubble.  Keeping it in the visible message list
-also preserves the user-turn boundary between the assistant response that
-preceded the notification and the assistant response produced by the wakeup.
+A background-process or delegation wakeup is stored as an internal user turn.
+It remains in the durable transcript and model context, but the executive
+projection must not attribute it to the human. Earlier assistant replies to
+internal turns are collapsed to one bounded progress line; the latest reply
+remains the candidate final answer.
 """
 
 import json
@@ -75,6 +75,10 @@ if(heightStart !== -1 && heightEnd !== -1) eval(src.slice(heightStart, heightEnd
 if(src.indexOf('function _isProcessWakeupMessage') !== -1) eval(extractFunc('_isProcessWakeupMessage'));
 eval(extractFunc('_stripWorkspaceDisplayPrefix'));
 eval(extractFunc('_stripAttachedFilesMarkerForDisplay'));
+eval(extractFunc('_isInternalTransportMessage'));
+eval(extractFunc('_assistantFollowsInternalTransport'));
+eval(extractFunc('_hasLaterRenderableAssistant'));
+eval(extractFunc('_projectInternalProgressContent'));
 eval(extractFunc('_messageIsRenderable'));
 eval(extractFunc('_getVisibleMessagesWithIdx'));
 eval(extractFunc('_messageVirtualRoleForEntry'));
@@ -88,7 +92,9 @@ const wakeup = {
 S.messages = [
   {role: 'assistant', content: 'previous assistant report', timestamp: 1783405252.05},
   wakeup,
-  {role: 'assistant', content: 'assistant response to wakeup', timestamp: 1783405254.10},
+  {role: 'assistant', content: '# CONCLUSION\n---\n> 🟢 Réponse / recommandation: phase one done\n\nVerbose internal details', timestamp: 1783405254.10},
+  {role: 'user', content: '[ASYNC DELEGATION BATCH COMPLETE — deleg_abc]', _source: 'async_delegation', timestamp: 1783405255.10},
+  {role: 'assistant', content: '# CONCLUSION\n---\n> 🟢 Réponse / recommandation: final answer', timestamp: 1783405256.10},
 ];
 
 const visible = _getVisibleMessagesWithIdx();
@@ -128,6 +134,8 @@ process.stdout.write(JSON.stringify({
   virtualRole,
   virtualHeight,
   attachmentOnlyRenderable: _messageIsRenderable(attachmentOnlyWakeup),
+  projectedIntermediate: _projectInternalProgressContent(S.messages, 2, S.messages[2].content),
+  projectedFinal: _projectInternalProgressContent(S.messages, 4, S.messages[4].content),
   strippedWakeupDisplay: _stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(markerWakeupContent)),
 }));
 """
@@ -146,19 +154,19 @@ def _run_driver():
     return json.loads(proc.stdout)
 
 
-def test_process_wakeup_message_stays_visible_and_preserves_turn_boundary():
+def test_internal_wakeups_stay_out_of_the_executive_projection():
     result = _run_driver()
 
     assert result["visible"] == [
         {"rawIdx": 0, "role": "assistant", "source": "", "text": "previous assistant report"},
-        {"rawIdx": 1, "role": "user", "source": "process_wakeup", "text": "[IMPORTANT: Background process p"},
-        {"rawIdx": 2, "role": "assistant", "source": "", "text": "assistant response to wakeup"},
+        {"rawIdx": 2, "role": "assistant", "source": "", "text": "# CONCLUSION\n---\n> 🟢 Réponse / "},
+        {"rawIdx": 4, "role": "assistant", "source": "", "text": "# CONCLUSION\n---\n> 🟢 Réponse / "},
     ]
-    assert result["turns"] == [
-        ["assistant:previous assistant report"],
-        ["user:process_wakeup:[IMPORTANT: Background process proc"],
-        ["assistant:assistant response to wakeup"],
-    ]
+    assert result["turns"] == [[
+        "assistant:previous assistant report",
+        "assistant:# CONCLUSION\n---\n> 🟢 Réponse / recommandation: phase one done\n\nVerbose internal details",
+        "assistant:# CONCLUSION\n---\n> 🟢 Réponse / recommandation: final answer",
+    ]]
 
 
 def test_process_wakeup_has_its_own_virtual_height_role():
@@ -169,11 +177,17 @@ def test_process_wakeup_has_its_own_virtual_height_role():
     assert 1 <= result["virtualHeight"] <= 120
 
 
-def test_attachment_only_process_wakeup_is_visible_and_display_markers_are_stripped():
+def test_attachment_only_process_wakeup_is_internal_and_display_markers_are_stripped():
     result = _run_driver()
 
-    assert result["attachmentOnlyRenderable"] is True
+    assert result["attachmentOnlyRenderable"] is False
     assert result["strippedWakeupDisplay"] == "Visible wakeup text"
+
+
+def test_intermediate_internal_reply_is_compact_but_latest_candidate_final_is_unchanged():
+    result = _run_driver()
+    assert result["projectedIntermediate"] == "**Progression** — phase one done"
+    assert result["projectedFinal"].startswith("# CONCLUSION")
 
 
 def test_process_wakeup_uses_compact_status_row_not_normal_user_bubble():

--- a/tests/test_process_wakeup_rendering.py
+++ b/tests/test_process_wakeup_rendering.py
@@ -202,6 +202,67 @@ def test_internal_projection_never_crosses_a_real_user_boundary():
     assert result["projectedBeforeHumanBoundary"].startswith("# CONCLUSION")
 
 
+def test_regenerate_never_replays_an_internal_transport_as_human_input():
+    driver = r"""
+const fs=require('fs');
+const src=fs.readFileSync(process.argv[1],'utf8');
+function extractFunc(name){
+  let start=src.indexOf('function '+name);
+  if(start===-1) throw new Error(name+' not found');
+  if(src.slice(Math.max(0,start-6),start)==='async ') start-=6;
+  const params=src.indexOf('(',start);
+  let depth=0,close=-1;
+  for(let i=params;i<src.length;i++){
+    if(src[i]==='(') depth++;
+    else if(src[i]===')'&&--depth===0){close=i;break;}
+  }
+  const brace=src.indexOf('{',close); depth=0;
+  for(let i=brace;i<src.length;i++){
+    if(src[i]==='{') depth++;
+    else if(src[i]==='}'&&--depth===0) return src.slice(start,i+1);
+  }
+  throw new Error(name+' body did not close');
+}
+function msgContent(m){return String((m&&m.content)||'');}
+global._oldestIdx=0;
+global.S={busy:false,session:{session_id:'sid'},messages:[
+  {role:'user',content:'[ASYNC DELEGATION COMPLETE]',_source:'async_delegation',_user_originated:false},
+  {role:'assistant',content:'internal result'},
+]};
+let apiCalls=0,sends=0;
+global.api=async()=>{apiCalls++;};
+global.send=async()=>{sends++;};
+global.renderMessages=()=>{};
+global.setStatus=()=>{};
+global.t=(x)=>x;
+global.$=()=>({value:''});
+eval(extractFunc('_isInternalTransportMessage'));
+eval(extractFunc('_assistantFollowsInternalTransport'));
+eval(extractFunc('regenerateResponse'));
+(async()=>{
+  await regenerateResponse({closest:()=>({dataset:{msgIdx:'1'}})});
+  process.stdout.write(JSON.stringify({apiCalls,sends}));
+})().catch(err=>{console.error(err);process.exit(1);});
+"""
+    proc = subprocess.run(
+        [NODE, "-e", driver, str(UI_JS_PATH)],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"apiCalls": 0, "sends": 0}
+
+
+def test_internal_reply_does_not_offer_regenerate_action():
+    ui = UI_JS_PATH.read_text(encoding="utf-8")
+    render_start = ui.index("const isEditableUser=")
+    render_block = ui[render_start : render_start + 1200]
+    assert "_assistantFollowsInternalTransport(S.messages,rawIdx)" in render_block
+    assert "isLastAssistant&&!followsInternalTransport" in render_block
+
+
 def test_process_wakeup_uses_compact_status_row_not_normal_user_bubble():
     ui = UI_JS_PATH.read_text(encoding="utf-8")
     marker = "const isProcessWakeup="

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -78,6 +78,56 @@ def test_gateway_terminal_error_successful_save_is_marked_persisted(monkeypatch,
     assert payload["terminal_session_persisted_session_id"] == session.session_id
 
 
+def test_gateway_empty_response_is_persisted_before_terminal_sse(monkeypatch, tmp_path):
+    import api.gateway_chat as gateway_chat
+    import api.models as models
+    import api.streaming as streaming
+
+    session = models.Session(
+        session_id="gateway_empty_response",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        model_provider="openai",
+        messages=[],
+        context_messages=[],
+    )
+    session.active_stream_id = "gateway-empty-stream"
+    session.pending_user_message = "continue the durable goal"
+    session.pending_user_source = "goal_continuation"
+    session.pending_attachments = []
+    session.pending_started_at = 100.0
+    saved = []
+    session.save = lambda: saved.append(True)
+    monkeypatch.setattr(gateway_chat, "get_session", lambda _sid: session)
+    monkeypatch.setattr(gateway_chat, "_stream_writeback_is_current", lambda *_args: True)
+    monkeypatch.setattr(streaming, "_snapshot_and_append_partial_on_error", lambda *_args: None)
+
+    payload = gateway_chat._settle_gateway_empty_response(
+        session.session_id,
+        session.active_stream_id,
+        str(tmp_path),
+        "gpt-4o",
+        "openai",
+    )
+
+    assert saved
+    assert payload["type"] == "gateway_empty_response"
+    assert payload["terminal_session_persisted"] is True
+    assert session.active_stream_id is None
+    assert session.pending_user_message is None
+    assert any(m.get("role") == "user" for m in session.messages)
+    assert any(m.get("role") == "assistant" and m.get("_error") for m in session.messages)
+
+    events = []
+    gateway_chat._emit_gateway_empty_response_events(
+        lambda name, data: events.append((name, data)),
+        payload,
+        session.session_id,
+    )
+    assert [name for name, _data in events] == ["apperror", "done", "stream_end"]
+    assert events[1][1]["session"]["session_id"] == session.session_id
+
+
 def test_stream_status_exposes_replay_summary():
     status_pos = ROUTES_SRC.index('parsed.path == "/api/chat/stream/status"')
     block = ROUTES_SRC[status_pos : status_pos + 900]

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -124,8 +124,9 @@ def test_gateway_empty_response_is_persisted_before_terminal_sse(monkeypatch, tm
         payload,
         session.session_id,
     )
-    assert [name for name, _data in events] == ["done", "stream_end"]
-    assert events[0][1]["session"]["session_id"] == session.session_id
+    assert [name for name, _data in events] == ["apperror", "done", "stream_end"]
+    assert events[0][1]["type"] == "gateway_empty_response"
+    assert events[1][1]["session"]["session_id"] == session.session_id
 
 
 def test_stream_status_exposes_replay_summary():

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -124,8 +124,8 @@ def test_gateway_empty_response_is_persisted_before_terminal_sse(monkeypatch, tm
         payload,
         session.session_id,
     )
-    assert [name for name, _data in events] == ["apperror", "done", "stream_end"]
-    assert events[1][1]["session"]["session_id"] == session.session_id
+    assert [name for name, _data in events] == ["done", "stream_end"]
+    assert events[0][1]["session"]["session_id"] == session.session_id
 
 
 def test_stream_status_exposes_replay_summary():

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -1,3 +1,4 @@
+import ast
 import importlib
 import io
 import queue
@@ -449,18 +450,27 @@ def test_runner_local_chat_start_selection_does_not_fallback_to_legacy():
     assert 'return {"error": str(exc), "_status": 501}' in helper_body
     assert 'return j(handler, {"error": response["error"]}, status=501)' in start_body
     assert "runner-local chat backend is not configured" in src
-    # The adapter branch inside the helper still calls _start_chat_stream_for_session
-    # through the _legacy_start_run delegate before the trailing legacy-direct
-    # fallthrough (the function returns the legacy direct call when the flag
-    # is off — no `else:` keyword anymore since each branch returns).
-    adapter_branch_start = helper_body.index(flag_branch)
-    # Slice up to the final (post-flag) return _start_chat_stream_for_session
-    # — there are two occurrences: one inside _legacy_start_run, one at the
-    # fallthrough; we want both inside the branch slice.
-    fallthrough = helper_body.rindex("return _start_chat_stream_for_session(")
-    adapter_branch = helper_body[adapter_branch_start:fallthrough]
-    assert "_start_chat_stream_for_session(" in adapter_branch, "legacy-journal delegate should still call the legacy path"
-    assert "runtime_adapter_runner_enabled()" in adapter_branch or "runtime_adapter_runner_enabled()" in helper_body
+    # Bound the assertion to the actual nested legacy-journal delegate instead
+    # of relying on the relative order of unrelated helper calls in _start_run.
+    tree = ast.parse(src)
+    start_run_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_start_run"
+    )
+    legacy_start_run_nodes = [
+        node
+        for node in ast.walk(start_run_node)
+        if isinstance(node, ast.FunctionDef) and node.name == "_legacy_start_run"
+    ]
+    assert len(legacy_start_run_nodes) == 1
+    legacy_start_run = legacy_start_run_nodes[0]
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_start_chat_stream_for_session"
+        for node in ast.walk(legacy_start_run)
+    ), "legacy-journal delegate should still call the legacy path"
 
 
 def test_chat_start_adapter_path_preserves_legacy_response_shape():

--- a/tests/test_stage326_pending_goal_continuation_race.py
+++ b/tests/test_stage326_pending_goal_continuation_race.py
@@ -1,21 +1,10 @@
-"""Stage-326 integration test for #1951's PENDING_GOAL_CONTINUATION chain.
+"""Regression tests for the legacy goal marker during server-owned delivery.
 
-Opus advisor flagged a critical race during stage-326 review: the original
-#1951 PR placed a `PENDING_GOAL_CONTINUATION.discard(session_id)` in the
-streaming worker's `finally` block. Because `goal_continue` sets the marker
-inside the SAME function call (line ~3328) that the `finally` then discards
-it (line ~3553), the marker would be erased before the frontend could
-receive the SSE event, post the next /chat/start, and trigger the
-consumer-side `if session_id in PENDING_GOAL_CONTINUATION` check in
-routes.py.
-
-The fix removes the discard from streaming.py's finally and relies on the
-consumer in routes.py to discard atomically when the marker is read.
-
-These tests exercise the full chain to guard against the regression:
-1. The streaming finally must NOT discard the marker
-2. Setting the marker survives the streaming finally
-3. routes.py consumer discards atomically on read
+The durable goal-continuation registry is now authoritative.  The in-memory
+``PENDING_GOAL_CONTINUATION`` set remains only for mixed-version browser tabs
+and must still be consumed exactly once by whichever stream starts next.  A
+server-owned stream is already explicitly goal-related, so marker consumption
+is unconditional rather than gated by ``not goal_related``.
 """
 import re
 from pathlib import Path
@@ -55,29 +44,29 @@ def test_streaming_finally_does_not_discard_pending_goal_continuation():
     )
 
 
-def test_routes_consumer_discards_atomically_on_read():
-    """The routes.py consumer must discard the marker after consuming it,
-    so the marker is single-use (one continuation = one auto-flag).
-    """
+def test_routes_consumer_discards_only_after_matching_adoption():
+    """Unrelated user turns retain priority; matching legacy replays are single-use."""
     src = _read_routes()
 
-    # Find the consumption check.
-    m = re.search(
-        r"if not goal_related and s\.session_id in PENDING_GOAL_CONTINUATION:.*?PENDING_GOAL_CONTINUATION\.discard",
-        src,
-        re.DOTALL,
+    gate_idx = src.index("if not goal_related and s.session_id in PENDING_GOAL_CONTINUATION:")
+    adopt_idx = src.index("elif legacy_goal_marker_consumed:", gate_idx)
+    lock_idx = src.index("session_lock =", gate_idx)
+    gate_block = src[gate_idx:lock_idx]
+    assert "legacy_browser_goal_prompt_matches" in gate_block
+    assert "PENDING_GOAL_CONTINUATION.discard" not in gate_block
+
+    server_branch = src[
+        src.index('if source == "goal_continuation":', gate_idx):adopt_idx
+    ]
+    assert server_branch.index("bind_goal_continuation_stream") < server_branch.index(
+        "PENDING_GOAL_CONTINUATION.discard"
     )
-    assert m is not None, (
-        "routes.py must consume PENDING_GOAL_CONTINUATION atomically: "
-        "check + set goal_related + discard in the same block"
-    )
-    # The discard must be within ~10 lines of the check (atomic block).
-    block = m.group(0)
-    line_count = block.count("\n")
-    assert line_count <= 10, (
-        f"PENDING_GOAL_CONTINUATION check + discard span {line_count} lines; "
-        "should be tight atomic block"
-    )
+
+    adoption_block = src[adopt_idx:adopt_idx + 900]
+    adopt_call = adoption_block.index("adopt_legacy_browser_goal_stream")
+    discard_call = adoption_block.index("PENDING_GOAL_CONTINUATION.discard")
+    prepare_call = adoption_block.index("_prepare_chat_start_session_for_stream")
+    assert adopt_call < discard_call < prepare_call
 
 
 def test_pending_goal_continuation_is_a_set():

--- a/tests/test_stage364_opus_live_sse_event_id.py
+++ b/tests/test_stage364_opus_live_sse_event_id.py
@@ -104,6 +104,15 @@ def test_cleanup_pops_stream_last_event_id():
     )
 
 
+def test_cancel_allocates_a_new_journal_event_id():
+    cancel_idx = STREAMING_PY.find("if _emit_cancel_event and q:")
+    cancel_block = STREAMING_PY[cancel_idx:cancel_idx + 1800]
+    assert "append_run_event(" in cancel_block
+    assert "'cancel'" in cancel_block
+    assert "STREAM_LAST_EVENT_ID[stream_id] = _cancel_event_id" in cancel_block
+    assert "_cancel_event_id = STREAM_LAST_EVENT_ID.get(stream_id)" not in cancel_block
+
+
 def test_imports_present():
     """STREAM_LAST_EVENT_ID must be imported in both streaming.py (writer)
     and routes.py (reader)."""

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -10,6 +10,8 @@ def test_chat_start_appends_submitted_turn_journal_before_worker_thread_start():
     assert save_idx < append_idx < thread_idx
     assert '"event": "submitted"' in src[append_idx:thread_idx]
     assert '"role": "user"' in src[append_idx:thread_idx]
+    assert '"source"' in src[append_idx:thread_idx]
+    assert 'pending_user_source' in src[append_idx:thread_idx]
 
 
 def test_chat_start_writes_turn_journal_after_session_lock_and_handles_failure():

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -1,10 +1,8 @@
 """Tests for the wakeup ``_source`` backstop and completion-row dedup.
 
-Wakeup deliveries that arrive without durable source metadata (api_server
-self-POST wake turns, gateway-side turns merged from state.db) must still be
-stamped ``_source='process_wakeup'`` so the never-render UI contract and the
-``[[SILENT]]`` turn collapse keep working, and duplicate deliveries of the
-same completion must collapse to a single store row.
+Wakeup deliveries with trusted internal provenance but missing ``_source``
+must still be stamped so the never-render UI contract and dedup keep working.
+Text shape alone is not authority: a human may paste the same envelope.
 """
 
 from api.models import _normalize_wakeup_rows_for_display
@@ -73,7 +71,7 @@ def test_wakeup_event_key_watch_and_human_are_none():
 
 
 def test_backstop_stamps_untagged_wakeup_row():
-    msg = {"role": "user", "content": RAW_COMPLETION}
+    msg = {"role": "user", "content": RAW_COMPLETION, "_user_originated": False}
     assert stamp_wakeup_source_if_untagged(msg)
     assert msg["_source"] == "process_wakeup"
     assert msg["_wakeup_meta"]["task_id"] == "proc_5b9fcce4cbff"
@@ -85,6 +83,10 @@ def test_backstop_leaves_human_and_stamped_rows_untouched():
     assert not stamp_wakeup_source_if_untagged(human)
     assert "_source" not in human
 
+    pasted = {"role": "user", "content": RAW_COMPLETION}
+    assert not stamp_wakeup_source_if_untagged(pasted)
+    assert "_source" not in pasted
+
     stamped = {"role": "user", "content": RAW_COMPLETION, "_source": "telegram"}
     assert not stamp_wakeup_source_if_untagged(stamped)
     assert stamped["_source"] == "telegram"
@@ -94,7 +96,7 @@ def test_backstop_leaves_human_and_stamped_rows_untouched():
 
 
 def test_stamp_message_source_falls_back_to_backstop():
-    msg = {"role": "user", "content": PREFIXED_COMPLETION}
+    msg = {"role": "user", "content": PREFIXED_COMPLETION, "_user_originated": False}
     stamp_message_source(msg, None)
     assert msg["_source"] == "process_wakeup"
 
@@ -110,8 +112,8 @@ def test_stamp_message_source_falls_back_to_backstop():
 
 
 def test_normalize_collapses_eager_and_merged_twins():
-    eager = {"role": "user", "content": RAW_COMPLETION, "_active_turn_token": "t:1"}
-    merged = {"role": "user", "content": PREFIXED_COMPLETION}
+    eager = {"role": "user", "content": RAW_COMPLETION, "_active_turn_token": "t:1", "_user_originated": False}
+    merged = {"role": "user", "content": PREFIXED_COMPLETION, "_user_originated": False}
     reply = {"role": "assistant", "content": "[[SILENT]]"}
     out = _normalize_wakeup_rows_for_display([eager, merged, reply])
     assert len(out) == 2
@@ -123,10 +125,10 @@ def test_normalize_collapses_eager_and_merged_twins():
 def test_normalize_keeps_distinct_processes_and_watch_rows():
     other = RAW_COMPLETION.replace("proc_5b9fcce4cbff", "proc_000011112222")
     rows = [
-        {"role": "user", "content": RAW_COMPLETION},
-        {"role": "user", "content": other},
-        {"role": "user", "content": WATCH_MATCH},
-        {"role": "user", "content": WATCH_MATCH},
+        {"role": "user", "content": RAW_COMPLETION, "_user_originated": False},
+        {"role": "user", "content": other, "_user_originated": False},
+        {"role": "user", "content": WATCH_MATCH, "_user_originated": False},
+        {"role": "user", "content": WATCH_MATCH, "_user_originated": False},
     ]
     out = _normalize_wakeup_rows_for_display(rows)
     # Two completions (distinct sids) + both watch rows survive.
@@ -138,8 +140,8 @@ def test_normalize_keeps_divergent_payloads_for_same_process_identity():
     partial = RAW_COMPLETION.replace("error Couldn't", "partial output: Couldn't")
     final = RAW_COMPLETION.replace("error Couldn't", "final output: Couldn't")
     out = _normalize_wakeup_rows_for_display([
-        {"role": "user", "content": partial},
-        {"role": "user", "content": final},
+        {"role": "user", "content": partial, "_user_originated": False},
+        {"role": "user", "content": final, "_user_originated": False},
     ])
     assert [row["content"] for row in out] == [partial, final]
 
@@ -150,7 +152,7 @@ def test_normalize_stamps_previously_stamped_rows_into_dedup():
         "content": RAW_COMPLETION,
         "_source": "process_wakeup",
     }
-    second = {"role": "user", "content": PREFIXED_COMPLETION}
+    second = {"role": "user", "content": PREFIXED_COMPLETION, "_user_originated": False}
     out = _normalize_wakeup_rows_for_display([first, second])
     assert len(out) == 1
     assert out[0] is first
@@ -169,7 +171,7 @@ def test_async_delegation_shape_key_and_backstop_metadata():
         "async_delegation",
         "deleg_c60b0f8e",
     )
-    msg = {"role": "user", "content": ASYNC_DELEGATION}
+    msg = {"role": "user", "content": ASYNC_DELEGATION, "_user_originated": False}
     assert stamp_wakeup_source_if_untagged(msg)
     assert msg["_source"] == "async_delegation"
     assert msg["_display_kind"] == "internal_event"
@@ -178,7 +180,7 @@ def test_async_delegation_shape_key_and_backstop_metadata():
     assert msg["_workflow_id"] == "delegation:deleg_c60b0f8e"
 
 
-def test_normalize_collapses_state_and_sidecar_async_twins():
+def test_normalize_keeps_untrusted_state_row_separate_from_internal_twin():
     state_row = {
         "role": "user",
         "content": ASYNC_DELEGATION,
@@ -192,7 +194,8 @@ def test_normalize_collapses_state_and_sidecar_async_twins():
         "_event_id": "async_delegation:deleg_c60b0f8e:terminal",
     }
     out = _normalize_wakeup_rows_for_display([state_row, sidecar_row])
-    assert len(out) == 1
+    assert len(out) == 2
     assert out[0] is state_row
-    assert out[0]["_source"] == "async_delegation"
-    assert out[0]["_event_id"] == "async_delegation:deleg_c60b0f8e:terminal"
+    assert "_source" not in out[0]
+    assert out[1] is sidecar_row
+    assert out[1]["_source"] == "async_delegation"

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -60,8 +60,9 @@ def test_is_wakeup_user_text_rejects_human_text():
 
 
 def test_wakeup_event_key_completion_shapes_agree():
-    key = ("completion", "proc_5b9fcce4cbff", "1")
-    assert wakeup_event_key(RAW_COMPLETION) == key
+    key = wakeup_event_key(RAW_COMPLETION)
+    assert key is not None
+    assert key[:3] == ("completion", "proc_5b9fcce4cbff", "1")
     assert wakeup_event_key(PREFIXED_COMPLETION) == key
     assert wakeup_event_key(WRAPPED_COMPLETION) == key
 
@@ -103,7 +104,8 @@ def test_stamp_message_source_falls_back_to_backstop():
 
     msg3 = {"role": "user", "content": RAW_COMPLETION}
     stamp_message_source(msg3, "webui", active_turn_token="s1:1.0")
-    assert msg3["_source"] == "process_wakeup"
+    assert "_source" not in msg3
+    assert "_display_kind" not in msg3
     assert msg3["_active_turn_token"] == "s1:1.0"
 
 
@@ -132,6 +134,16 @@ def test_normalize_keeps_distinct_processes_and_watch_rows():
     assert all(m["_source"] == "process_wakeup" for m in out)
 
 
+def test_normalize_keeps_divergent_payloads_for_same_process_identity():
+    partial = RAW_COMPLETION.replace("error Couldn't", "partial output: Couldn't")
+    final = RAW_COMPLETION.replace("error Couldn't", "final output: Couldn't")
+    out = _normalize_wakeup_rows_for_display([
+        {"role": "user", "content": partial},
+        {"role": "user", "content": final},
+    ])
+    assert [row["content"] for row in out] == [partial, final]
+
+
 def test_normalize_stamps_previously_stamped_rows_into_dedup():
     first = {
         "role": "user",
@@ -151,7 +163,9 @@ def test_normalize_passes_through_empty_and_non_list():
 
 def test_async_delegation_shape_key_and_backstop_metadata():
     assert is_wakeup_user_text(ASYNC_DELEGATION)
-    assert wakeup_event_key(ASYNC_DELEGATION) == (
+    key = wakeup_event_key(ASYNC_DELEGATION)
+    assert key is not None
+    assert key[:2] == (
         "async_delegation",
         "deleg_c60b0f8e",
     )

--- a/tests/test_wakeup_source_backstop.py
+++ b/tests/test_wakeup_source_backstop.py
@@ -1,0 +1,184 @@
+"""Tests for the wakeup ``_source`` backstop and completion-row dedup.
+
+Wakeup deliveries that arrive without durable source metadata (api_server
+self-POST wake turns, gateway-side turns merged from state.db) must still be
+stamped ``_source='process_wakeup'`` so the never-render UI contract and the
+``[[SILENT]]`` turn collapse keep working, and duplicate deliveries of the
+same completion must collapse to a single store row.
+"""
+
+from api.models import _normalize_wakeup_rows_for_display
+from api.process_event_utils import (
+    is_wakeup_user_text,
+    stamp_message_source,
+    stamp_wakeup_source_if_untagged,
+    wakeup_event_key,
+)
+
+RAW_COMPLETION = (
+    "[IMPORTANT: Background process proc_5b9fcce4cbff completed (exit_code=1).\n"
+    "Command: exec yarn build --outDir /tmp/build --emptyOutDir\n"
+    "Output:\n"
+    "yarn run v1.22.22\n"
+    "error Couldn't find a package.json file in \"/a0\"\n"
+    "]"
+)
+PREFIXED_COMPLETION = (
+    "[Workspace::v1: /workspace/project/.worktrees/hermes-70ce773a]\n"
+    + RAW_COMPLETION
+)
+WRAPPED_COMPLETION = (
+    "[INTERNAL BACKGROUND EVENT — this is internal orchestration input, "
+    "not a user message.\nUse it to resume the current task.\n"
+    "Technical event follows:\n" + RAW_COMPLETION + "]"
+)
+WATCH_MATCH = (
+    '[IMPORTANT: Background process proc_aaaabbbbcccc matched watch pattern "DONE".\n'
+    "Command: make test\n"
+    "Matched output:\nDONE\n]"
+)
+ASYNC_DELEGATION = (
+    "[ASYNC DELEGATION BATCH COMPLETE — deleg_c60b0f8e]\n"
+    "A background fan-out of 1 subagent(s) has finished.\n\n"
+    "--- ✓ TASK 1/1 ---\nTOKEN_OK"
+)
+
+
+def test_is_wakeup_user_text_shapes():
+    assert is_wakeup_user_text(RAW_COMPLETION)
+    assert is_wakeup_user_text(PREFIXED_COMPLETION)
+    assert is_wakeup_user_text(WRAPPED_COMPLETION)
+    assert is_wakeup_user_text(WATCH_MATCH)
+
+
+def test_is_wakeup_user_text_rejects_human_text():
+    assert not is_wakeup_user_text("Bonjour, peux-tu vérifier le build ?")
+    assert not is_wakeup_user_text("")
+    assert not is_wakeup_user_text(None)
+    # Mentioning a completion mid-paragraph is not the pinned envelope.
+    assert not is_wakeup_user_text("voici le log: " + RAW_COMPLETION)
+
+
+def test_wakeup_event_key_completion_shapes_agree():
+    key = ("completion", "proc_5b9fcce4cbff", "1")
+    assert wakeup_event_key(RAW_COMPLETION) == key
+    assert wakeup_event_key(PREFIXED_COMPLETION) == key
+    assert wakeup_event_key(WRAPPED_COMPLETION) == key
+
+
+def test_wakeup_event_key_watch_and_human_are_none():
+    assert wakeup_event_key(WATCH_MATCH) is None
+    assert wakeup_event_key("hello") is None
+
+
+def test_backstop_stamps_untagged_wakeup_row():
+    msg = {"role": "user", "content": RAW_COMPLETION}
+    assert stamp_wakeup_source_if_untagged(msg)
+    assert msg["_source"] == "process_wakeup"
+    assert msg["_wakeup_meta"]["task_id"] == "proc_5b9fcce4cbff"
+    assert msg["_wakeup_meta"]["exit_code"] == 1
+
+
+def test_backstop_leaves_human_and_stamped_rows_untouched():
+    human = {"role": "user", "content": "peux-tu relancer le build ?"}
+    assert not stamp_wakeup_source_if_untagged(human)
+    assert "_source" not in human
+
+    stamped = {"role": "user", "content": RAW_COMPLETION, "_source": "telegram"}
+    assert not stamp_wakeup_source_if_untagged(stamped)
+    assert stamped["_source"] == "telegram"
+
+    assistant = {"role": "assistant", "content": RAW_COMPLETION}
+    assert not stamp_wakeup_source_if_untagged(assistant)
+
+
+def test_stamp_message_source_falls_back_to_backstop():
+    msg = {"role": "user", "content": PREFIXED_COMPLETION}
+    stamp_message_source(msg, None)
+    assert msg["_source"] == "process_wakeup"
+
+    msg2 = {"role": "user", "content": "hello"}
+    stamp_message_source(msg2, "webui")
+    assert "_source" not in msg2
+
+    msg3 = {"role": "user", "content": RAW_COMPLETION}
+    stamp_message_source(msg3, "webui", active_turn_token="s1:1.0")
+    assert msg3["_source"] == "process_wakeup"
+    assert msg3["_active_turn_token"] == "s1:1.0"
+
+
+def test_normalize_collapses_eager_and_merged_twins():
+    eager = {"role": "user", "content": RAW_COMPLETION, "_active_turn_token": "t:1"}
+    merged = {"role": "user", "content": PREFIXED_COMPLETION}
+    reply = {"role": "assistant", "content": "[[SILENT]]"}
+    out = _normalize_wakeup_rows_for_display([eager, merged, reply])
+    assert len(out) == 2
+    assert out[0]["_source"] == "process_wakeup"
+    assert out[0]["_active_turn_token"] == "t:1"  # first occurrence kept
+    assert out[1] is reply
+
+
+def test_normalize_keeps_distinct_processes_and_watch_rows():
+    other = RAW_COMPLETION.replace("proc_5b9fcce4cbff", "proc_000011112222")
+    rows = [
+        {"role": "user", "content": RAW_COMPLETION},
+        {"role": "user", "content": other},
+        {"role": "user", "content": WATCH_MATCH},
+        {"role": "user", "content": WATCH_MATCH},
+    ]
+    out = _normalize_wakeup_rows_for_display(rows)
+    # Two completions (distinct sids) + both watch rows survive.
+    assert len(out) == 4
+    assert all(m["_source"] == "process_wakeup" for m in out)
+
+
+def test_normalize_stamps_previously_stamped_rows_into_dedup():
+    first = {
+        "role": "user",
+        "content": RAW_COMPLETION,
+        "_source": "process_wakeup",
+    }
+    second = {"role": "user", "content": PREFIXED_COMPLETION}
+    out = _normalize_wakeup_rows_for_display([first, second])
+    assert len(out) == 1
+    assert out[0] is first
+
+
+def test_normalize_passes_through_empty_and_non_list():
+    assert _normalize_wakeup_rows_for_display([]) == []
+    assert _normalize_wakeup_rows_for_display(None) is None
+
+
+def test_async_delegation_shape_key_and_backstop_metadata():
+    assert is_wakeup_user_text(ASYNC_DELEGATION)
+    assert wakeup_event_key(ASYNC_DELEGATION) == (
+        "async_delegation",
+        "deleg_c60b0f8e",
+    )
+    msg = {"role": "user", "content": ASYNC_DELEGATION}
+    assert stamp_wakeup_source_if_untagged(msg)
+    assert msg["_source"] == "async_delegation"
+    assert msg["_display_kind"] == "internal_event"
+    assert msg["_user_originated"] is False
+    assert msg["_event_id"] == "async_delegation:deleg_c60b0f8e:terminal"
+    assert msg["_workflow_id"] == "delegation:deleg_c60b0f8e"
+
+
+def test_normalize_collapses_state_and_sidecar_async_twins():
+    state_row = {
+        "role": "user",
+        "content": ASYNC_DELEGATION,
+        "_db_persisted": True,
+        "id": 5,
+    }
+    sidecar_row = {
+        "role": "user",
+        "content": ASYNC_DELEGATION,
+        "_source": "async_delegation",
+        "_event_id": "async_delegation:deleg_c60b0f8e:terminal",
+    }
+    out = _normalize_wakeup_rows_for_display([state_row, sidecar_row])
+    assert len(out) == 1
+    assert out[0] is state_row
+    assert out[0]["_source"] == "async_delegation"
+    assert out[0]["_event_id"] == "async_delegation:deleg_c60b0f8e:terminal"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -36,7 +36,15 @@ def test_gateway_chat_backend_is_default_off_for_truthy_values():
 
 
 def test_gateway_approval_and_tool_activity_block_automatic_empty_retry():
-    for event in ("approval", "clarify", "tool_call", "tool_result", "tool_progress"):
+    for event in (
+        "approval",
+        "clarify",
+        "tool_call",
+        "tool_result",
+        "tool_progress",
+        "tool",
+        "tool_complete",
+    ):
         assert gateway_chat._gateway_event_blocks_empty_retry(event) is True
     for event in ("warning", "status", "goal_status", "done", ""):
         assert gateway_chat._gateway_event_blocks_empty_retry(event) is False

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -510,7 +510,9 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
         [],
     )
     empty_event_names = [item[0] for item in empty_events]
-    assert "apperror" not in empty_event_names
+    assert "apperror" in empty_event_names
+    empty_apperror = next(item[1] for item in empty_events if item[0] == "apperror")
+    assert empty_apperror["type"] == "gateway_empty_response"
     assert empty_event_names[-2:] == ["done", "stream_end"]
     empty_saved = models.get_session(s.session_id)
     assert empty_saved.messages[-1].get("_error") is True

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -865,6 +865,75 @@ def test_gateway_chat_worker_emits_goal_continue_for_goal_related_turn(tmp_path,
     assert saved.messages[-1]["content"] == "goal reply"
 
 
+def test_gateway_empty_goal_retry_closes_old_sse_before_next_turn(tmp_path, monkeypatch):
+    from api import goal_continuations as gc
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(gc, "REGISTRY_PATH", tmp_path / "goal-continuations.json")
+    monkeypatch.setattr(gc, "_REGISTRY", None)
+    monkeypatch.setattr(gc, "OWNER_ID", "gateway-test-owner")
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+    s = new_session()
+    stream_id = "stream-gateway-empty-goal-retry"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "continue"
+    s.pending_user_source = "goal_continuation"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    gc.schedule_goal_continuation(
+        s.session_id,
+        "continue",
+        source_stream_id="prior-judge-stream",
+        profile_home=tmp_path,
+        goal_turns_used=1,
+        now=100.0,
+    )
+    gc.drain_goal_continuations_once(
+        start_turn=lambda *_args, **_kwargs: {"stream_id": stream_id, "_status": 200},
+        is_goal_active=lambda *_args, **_kwargs: True,
+        now=101.0,
+    )
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "continue",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+        goal_related=True,
+    )
+
+    events = []
+    while not subscriber.empty():
+        events.append(subscriber.get_nowait())
+    event_names = [item[0] for item in events]
+    assert "done" in event_names
+    assert "stream_end" in event_names
+    assert event_names.index("done") < event_names.index("stream_end")
+    assert gc.get_goal_continuation(s.session_id)["status"] == "pending"
+
+
 def test_gateway_chat_worker_skips_goal_judge_for_non_goal_turn(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -35,6 +35,13 @@ def test_gateway_chat_backend_is_default_off_for_truthy_values():
         assert webui_gateway_chat_enabled({}, env) is False
 
 
+def test_gateway_approval_and_tool_activity_block_automatic_empty_retry():
+    for event in ("approval", "clarify", "tool_call", "tool_result", "tool_progress"):
+        assert gateway_chat._gateway_event_blocks_empty_retry(event) is True
+    for event in ("warning", "status", "goal_status", "done", ""):
+        assert gateway_chat._gateway_event_blocks_empty_retry(event) is False
+
+
 def test_gateway_chat_backend_only_accepts_explicit_gateway_aliases():
     for value in ("gateway", "api_server", "api-server", " Gateway "):
         assert webui_chat_backend_mode({}, {"HERMES_WEBUI_CHAT_BACKEND": value}) == "gateway"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -509,9 +509,11 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
         empty_stream_id,
         [],
     )
-    empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
-    assert empty_errors[-1]["type"] == "gateway_empty_response"
-    assert empty_errors[-1]["session_id"] == s.session_id
+    empty_event_names = [item[0] for item in empty_events]
+    assert "apperror" not in empty_event_names
+    assert empty_event_names[-2:] == ["done", "stream_end"]
+    empty_saved = models.get_session(s.session_id)
+    assert empty_saved.messages[-1].get("_error") is True
 
     response_error[0] = "Gateway provider failed without a known classification"
     unknown_stream_id = "stream-gateway-unknown-terminal-error-test"
@@ -827,6 +829,13 @@ def test_gateway_chat_worker_emits_goal_continue_for_goal_related_turn(tmp_path,
             "message_key": "goal_continuing",
             "message_args": ["one step remains"],
         },
+    )
+    from api import goal_continuations
+
+    monkeypatch.setattr(
+        goal_continuations,
+        "mark_goal_continuation_worker_started",
+        lambda *_args, **_kwargs: True,
     )
 
     s = new_session()


### PR DESCRIPTION
## Summary

- classify async delegation completions as an explicit internal transport source
- persist internal-event display metadata without attributing synthetic wakeups to the user
- stamp untagged state.db wakeups and collapse state/sidecar twins by stable event key
- include the canonical payload digest so divergent outputs from one process are never collapsed
- remove process and delegation transport rows from the executive transcript
- collapse earlier internal-turn conclusions into concise progress lines while keeping the final assistant conclusion intact
- stop progress projection at the next genuine user turn and never infer internal origin from an explicit `webui` source

## Root cause

Background process and async delegation wakeups are injected as synthetic `user` turns so the parent agent can continue. One copy can arrive from Agent `state.db` without source metadata while the WebUI sidecar persists an enriched copy. The append-only merge previously kept both, exposed the untagged row as human-authored, and rendered every intermediate parent response as a full conclusion.

## Behavior

Internal wakeups remain in the durable transcript and model context for recovery and diagnostics. Untagged process/delegation rows are stamped at the merge choke point, and byte-equivalent terminal events collapse to their first occurrence. Divergent payloads remain distinct. An explicit human `webui` source is authoritative even when its text resembles an internal envelope. The main conversation now projects a single human request, parent-authored progress, and the last conclusion candidate. Earlier internal-turn responses are represented as a compact `Progression` line only inside the same internal-event chain.

Async delegation rows carry `internal_event`, `user_originated=false`, event kind, stable event ID and workflow ID metadata when the delegation header provides an ID.

## Verification

- 149 focused wakeup, delegation, state reconciliation and rendering tests passed on the current `master`
- 122 combined goal + event-projection tests passed on the exact N+1 integration SHA
- JavaScript syntax, Ruff and `git diff --check` passed
- an isolated real `delegate_task` completion persisted exactly one `async_delegation` internal event with `user_originated=false`, canonical `event_id` / `workflow_id`, and zero synthetic-user violations
- the browser showed one genuine human request, no internal transport text or bubble, the final assistant answer intact, and no console errors; deterministic rendering tests cover the earlier-response `Progression` projection
