### PR TITLE
fix(navigation): preserve mobile action mirror order

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1718,13 +1718,15 @@ function _syncNavActionMirrors(){
   const rail=document.querySelector('.rail');
   const sidebar=document.querySelector('.sidebar-nav');
   if(!rail||!sidebar)return;
+  const anchor=sidebar.querySelector('.dashboard-link,[data-dashboard-link]')||sidebar.querySelector('[data-panel="logs"]');
   const sources=Array.from(rail.querySelectorAll('.nav-tab:not([data-panel]):not([data-dashboard-link])')).filter(source=>source.id);
   const mirrors=Array.from(sidebar.querySelectorAll('[data-nav-action-mirror]'));
   const sourceIds=new Set(sources.map(source=>source.id));
   mirrors.forEach(mirror=>{
     if(!sourceIds.has(mirror.getAttribute('data-nav-action-mirror')))mirror.remove();
   });
-  sources.forEach(source=>{
+  let next=anchor||null;
+  sources.slice().reverse().forEach(source=>{
     const sourceVisible=(()=>{
       if(source.hidden||source.getAttribute('aria-hidden')==='true')return false;
       if(source.classList.contains('nav-tab-hidden'))return false;
@@ -1748,12 +1750,12 @@ function _syncNavActionMirrors(){
         if(mirror._navActionSource)mirror._navActionSource.click();
         if(typeof closeMobileSidebar==='function')closeMobileSidebar();
       });
-      const anchor=sidebar.querySelector('.dashboard-link,[data-dashboard-link]')||sidebar.querySelector('[data-panel="logs"]');
-      sidebar.insertBefore(mirror,anchor||null);
     }else{
       mirror.innerHTML=source.innerHTML;
       _stripInlineEventHandlers(mirror);
     }
+    if(mirror.parentNode!==sidebar||mirror.nextElementSibling!==next)sidebar.insertBefore(mirror,next);
+    next=mirror;
     mirror._navActionSource=source;
     mirror.classList.toggle('nav-action-visible',sourceVisible);
     const label=source.getAttribute('data-tooltip')||source.getAttribute('aria-label')||'';

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -462,7 +462,17 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             };
           }
           appendChild(child) { child.parentNode = this; this.children.push(child); return child; }
+          get nextElementSibling() {
+            if (!this.parentNode) return null;
+            const index = this.parentNode.children.indexOf(this);
+            return index >= 0 ? this.parentNode.children[index + 1] || null : null;
+          }
           insertBefore(child, anchor) {
+            if (child.parentNode) this.insertBeforeMoves = (this.insertBeforeMoves || 0) + 1;
+            if (child.parentNode) {
+              const currentIdx = child.parentNode.children.indexOf(child);
+              if (currentIdx >= 0) child.parentNode.children.splice(currentIdx, 1);
+            }
             const idx = anchor ? this.children.indexOf(anchor) : -1;
             child.parentNode = this;
             if (idx >= 0) this.children.splice(idx, 0, child);
@@ -507,6 +517,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             return [];
           }
           querySelector(sel) {
+            if (sel.startsWith('.nav-tab[data-panel="')) return this.children.find(el => el.classList.contains('nav-tab') && el.getAttribute('data-panel') === sel.slice(21, -2)) || null;
             if (sel.startsWith('[data-nav-action-mirror="')) {
               const id = sel.slice(25, -2);
               return this.children.find(el => el.getAttribute('data-nav-action-mirror') === id) || null;
@@ -520,7 +531,10 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         const rail = new El('nav');
         const sidebar = new El('div');
         const source = new El('button');
+        const source2 = new El('button');
         const dashboard = new El('button');
+        const chatPanel = new El('button');
+        const settingsPanel = new El('button');
         let clicked = 0;
         let sidebarClosed = 0;
         source.id = 'hwxThemeCreatorRailBtn';
@@ -530,8 +544,21 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         source.onclick = () => { clicked += 100; };
         source.innerHTML = '<svg></svg>';
         source.click = () => { clicked += 1; };
+        source2.id = 'hwxTypographyRailBtn';
+        source2.classList.add('rail-btn', 'nav-tab', 'has-tooltip');
+        source2.setAttribute('data-tooltip', 'Typography');
+        source2.innerHTML = '<svg></svg>';
+        chatPanel.id = 'chatMobileBtn';
+        chatPanel.classList.add('nav-tab');
+        chatPanel.setAttribute('data-panel', 'chat');
+        settingsPanel.id = 'settingsMobileBtn';
+        settingsPanel.classList.add('nav-tab');
+        settingsPanel.setAttribute('data-panel', 'settings');
         dashboard.classList.add('dashboard-link');
+        dashboard.id = 'dashboardMobileBtn';
+        sidebar.appendChild(chatPanel);
         sidebar.appendChild(dashboard);
+        sidebar.appendChild(settingsPanel);
         let observerCallback = null;
         let observedRail = null;
         let observedOptions = null;
@@ -561,17 +588,53 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         const helpers = Function(extractFn('_stripInlineEventHandlers') + '\\n' + extractFn('_syncNavActionMirrors') + '\\n' + extractFn('_initNavActionMirrors') + '; return { _initNavActionMirrors };')();
         helpers._initNavActionMirrors();
         rail.appendChild(source);
+        rail.appendChild(source2);
         observerCallback();
         const mirror = sidebar.children.find(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn');
+        const mirror2 = sidebar.children.find(el => el.getAttribute('data-nav-action-mirror') === 'hwxTypographyRailBtn');
         source.hidden = true;
         observerCallback();
         const mirrorHiddenWhenSourceHidden = !mirror.classList.contains('nav-action-visible');
         source.hidden = false;
         observerCallback();
         mirror.click();
-        const mirrorBeforeDashboard = sidebar.children[0] === mirror;
+        const mirrorBeforeDashboard = sidebar.children[1] === mirror && sidebar.children[2] === mirror2 && sidebar.children[3] === dashboard;
+        const initialOrder = sidebar.children.map(el => el.id);
+        const tasksPanel = new El('button');
+        tasksPanel.id = 'tasksMobileBtn';
+        tasksPanel.classList.add('nav-tab');
+        tasksPanel.setAttribute('data-panel', 'tasks');
+        const logsPanel = new El('button');
+        logsPanel.id = 'logsMobileBtn';
+        logsPanel.classList.add('nav-tab');
+        logsPanel.setAttribute('data-panel', 'logs');
+        sidebar.appendChild(tasksPanel);
+        sidebar.appendChild(logsPanel);
+        ['tasks', 'logs'].forEach(panel => {
+          const node = sidebar.querySelector('.nav-tab[data-panel="' + panel + '"]');
+          if (node) sidebar.insertBefore(node, dashboard);
+        });
+        const preSyncOrder = sidebar.children.map(el => el.id);
+        const movesBeforeReconcile = sidebar.insertBeforeMoves || 0;
+        observerCallback();
+        const reconciledOrder = sidebar.children.map(el => el.id);
+        const reconciliationMoves = (sidebar.insertBeforeMoves || 0) - movesBeforeReconcile;
+        const movesBeforeNoOpSync = sidebar.insertBeforeMoves || 0;
+        observerCallback();
+        const noOpSyncMoves = (sidebar.insertBeforeMoves || 0) - movesBeforeNoOpSync;
         source.remove();
         observerCallback();
+        const mirrorRemoved = !sidebar.children.some(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn');
+        dashboard.remove();
+        logsPanel.remove();
+        const source3 = new El('button');
+        source3.id = 'hwxNoAnchorRailBtn';
+        source3.classList.add('rail-btn', 'nav-tab');
+        source3.setAttribute('aria-label', 'No anchor');
+        rail.appendChild(source3);
+        observerCallback();
+        const noAnchorMirror = sidebar.children.find(el => el.getAttribute('data-nav-action-mirror') === 'hwxNoAnchorRailBtn');
+        const noAnchorMirrorAppended = noAnchorMirror?.parentNode === sidebar && sidebar.children.at(-1) === noAnchorMirror;
         console.log(JSON.stringify({
           observerArmed: observedRail === rail,
           observerAttributes: !!(observedOptions && observedOptions.attributes),
@@ -584,7 +647,13 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
           mirrorOnclickAttribute: mirror.getAttribute('onclick'),
           mirrorOnclickProperty: mirror.onclick === null,
           mirrorBeforeDashboard,
-          mirrorRemoved: !sidebar.children.some(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn'),
+          initialOrder,
+          preSyncOrder,
+          reconciledOrder,
+          reconciliationMoves,
+          noOpSyncMoves,
+          mirrorRemoved,
+          noAnchorMirrorAppended,
           clicked,
           sidebarClosed,
         }));
@@ -610,7 +679,35 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         "mirrorOnclickAttribute": None,
         "mirrorOnclickProperty": True,
         "mirrorBeforeDashboard": True,
+        "initialOrder": [
+            "chatMobileBtn",
+            "hwxThemeCreatorRailBtnMobile",
+            "hwxTypographyRailBtnMobile",
+            "dashboardMobileBtn",
+            "settingsMobileBtn",
+        ],
+        "preSyncOrder": [
+            "chatMobileBtn",
+            "hwxThemeCreatorRailBtnMobile",
+            "hwxTypographyRailBtnMobile",
+            "tasksMobileBtn",
+            "logsMobileBtn",
+            "dashboardMobileBtn",
+            "settingsMobileBtn",
+        ],
+        "reconciledOrder": [
+            "chatMobileBtn",
+            "tasksMobileBtn",
+            "logsMobileBtn",
+            "hwxThemeCreatorRailBtnMobile",
+            "hwxTypographyRailBtnMobile",
+            "dashboardMobileBtn",
+            "settingsMobileBtn",
+        ],
+        "reconciliationMoves": 2,
+        "noOpSyncMoves": 0,
         "mirrorRemoved": True,
+        "noAnchorMirrorAppended": True,
         "clicked": 1,
         "sidebarClosed": 1,
     }


### PR DESCRIPTION
## Thinking Path

Core already mirrors extension rail actions into `.sidebar-nav`, but it positioned each mirror only when first created. Profile tab-order reconciliation later moves native mobile tabs before Dashboard, leaving existing extension mirrors above those native tabs.

The shared fix belongs in `_syncNavActionMirrors()`: reconcile existing mirrors as well as new ones, in source order, immediately before Dashboard. The reconciliation is idempotent so already-correct mirrors are not detached, preserving keyboard focus during ordinary rail mutations.

## What Changed

- Reconcile mobile extension-action mirrors in reverse source order against a rolling anchor.
- Skip DOM moves when a mirror is already in the correct position.
- Preserve append behavior when neither Dashboard nor Logs is available as an anchor.
- Extend the existing behavioral regression to cover:
  - two mirrored extension actions;
  - native-tab reorder after mirror creation;
  - required reconciliation moves;
  - zero moves on a no-op sync;
  - stale mirror removal;
  - missing-anchor creation;
  - existing visibility and click-forwarding behavior.

## Why It Matters

After switching profiles or applying a different tab order, extension actions could jump directly beneath Chat in mobile navigation. This restores the intended order for every non-panel extension action without extension-specific workarounds and without periodically dropping keyboard focus.

## Visual Validation

Captured from isolated standalone WebUI instances at a `600 × 900` viewport using the same Typography extension and tab-order transition:

- **Before:** Typography is directly below Chat, ahead of native panels.

![Before: Typography appears directly below Chat before native mobile panels](https://github.com/user-attachments/assets/27512de2-5b57-4b34-9b7a-81c24f3b0168)

- **After:** Typography remains after native panels, immediately before Dashboard and Settings.

![After: Typography remains after native mobile panels before Dashboard and Settings](https://github.com/user-attachments/assets/4e406ed1-13c7-429f-830c-7340181f1879)

## Verification

- `161 passed` across the focused Dashboard-link test and neighboring mobile/sidebar suites.
- The updated focused regression fails against the pre-fix parent and passes against this commit.
- Isolated Chromium fold/profile transition confirms the mirror moves from index 1 to index 10, immediately before Dashboard.
- `node --check static/ui.js`
- `python3 -m py_compile tests/test_dashboard_link_ui.py`
- `git diff --check`
- Independent adversarial Claude Opus 5 review: **APPROVE**, no blockers, exact commit `048c2eb9b822e19e21ff6470334f8c051966ad6a` signed off for publication.

## Risks / Follow-ups

- Scope is limited to Core's existing mobile action-mirror reconciliation.
- Desktop rail behavior, extension click handlers, visibility propagation, and Dashboard behavior are unchanged.
- No new dependency or abstraction was added.

Release note: Preserve extension action order in mobile navigation after profile and tab-order changes without disrupting keyboard focus.

## Model Used

- Nous Research Hermes Agent: `gpt-5.6-sol` for diagnosis, specification, review, and verification.
- OpenAI Codex: `gpt-5.6-luna` with max reasoning for implementation and remediation.
- Anthropic Claude Code: `claude-opus-5` with high/medium effort for adversarial review and final sign-off.

