### PR TITLE
fix(profiles): remove request-time HERMES_HOME process writes

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -684,7 +684,9 @@ class cron_profile_context_for_home:
             self._home_override_mod = _resolve_hermes_home_override()
             self._home_override_token = None
             self._home_override_installed = False
-            self._env_mirrored = False
+            # Always mirror to env var for cron scopes (fix for #6857)
+            self._prev_env = os.environ.get('HERMES_HOME')
+            os.environ['HERMES_HOME'] = str(self._home)
             if self._home_override_mod is not None:
                 try:
                     self._home_override_token = self._home_override_mod.set_hermes_home_override(
@@ -694,12 +696,8 @@ class cron_profile_context_for_home:
                 except Exception:
                     self._home_override_token = None
                     self._home_override_installed = False
-            if not self._home_override_installed:
-                self._prev_env = os.environ.get('HERMES_HOME')
-                os.environ['HERMES_HOME'] = str(self._home)
-                self._env_mirrored = True
-            else:
-                self._prev_env = None
+            # Note: _env_mirrored is no longer used; we always restore env var below
+            self._env_mirrored = True  # kept for compatibility but not used
 
             # Re-patch cron.jobs module-level constants (see main context manager
             # below for the rationale).
@@ -746,11 +744,11 @@ class cron_profile_context_for_home:
                     )
                 except Exception:
                     pass
-            elif getattr(self, '_env_mirrored', False):
-                if self._prev_env is None:
-                    os.environ.pop('HERMES_HOME', None)
-                else:
-                    os.environ['HERMES_HOME'] = self._prev_env
+            # Always restore env var mirror for cron scopes
+            if self._prev_env is None:
+                os.environ.pop('HERMES_HOME', None)
+            else:
+                os.environ['HERMES_HOME'] = self._prev_env
             if self._prev_cj is not None:
                 try:
                     import cron.jobs as _cj
@@ -793,7 +791,9 @@ class cron_profile_context:
             self._home_override_mod = _resolve_hermes_home_override()
             self._home_override_token = None
             self._home_override_installed = False
-            self._env_mirrored = False
+            # Always mirror to env var for cron scopes (fix for #6857)
+            self._prev_env = os.environ.get('HERMES_HOME')
+            os.environ['HERMES_HOME'] = str(home)
             if self._home_override_mod is not None:
                 try:
                     self._home_override_token = self._home_override_mod.set_hermes_home_override(
@@ -803,12 +803,8 @@ class cron_profile_context:
                 except Exception:
                     self._home_override_token = None
                     self._home_override_installed = False
-            if not self._home_override_installed:
-                self._prev_env = os.environ.get('HERMES_HOME')
-                os.environ['HERMES_HOME'] = str(home)
-                self._env_mirrored = True
-            else:
-                self._prev_env = None
+            # Note: _env_mirrored is no longer used; we always restore env var below
+            self._env_mirrored = True  # kept for compatibility but not used
 
             # Re-patch cron.jobs module-level constants. They are snapshot at
             # import time (line 68-71 of cron/jobs.py) and don't participate in
@@ -854,13 +850,11 @@ class cron_profile_context:
                     )
                 except Exception:
                     pass
-            elif getattr(self, '_env_mirrored', False):
-                if self._prev_env is None:
-                    os.environ.pop('HERMES_HOME', None)
-                else:
-                    os.environ['HERMES_HOME'] = self._prev_env
-
-            # Restore cron.jobs module constants
+            # Always restore env var mirror for cron scopes
+            if self._prev_env is None:
+                os.environ.pop('HERMES_HOME', None)
+            else:
+                os.environ['HERMES_HOME'] = self._prev_env
             if self._prev_cj is not None:
                 try:
                     import cron.jobs as _cj

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1298,8 +1298,9 @@ def profile_env_for_background_worker(
     log = logger_override or logger
     raw_profile = session if isinstance(session, str) else getattr(session, "profile", "")
     profile = str(raw_profile or "").strip()
-    if not profile or profile == "default":
-        yield
+    if not profile or _is_root_profile(profile):
+        with _root_home_override_scope():
+            yield
         return
 
     try:
@@ -1487,13 +1488,11 @@ def profile_env_for_active_request_readonly(
     environment first. It also sets a context-local Hermes-home override so
     agent-side auth-store reads stay on the active profile without mutating
     process-global ``os.environ``.
-
-    No-ops for the default/root profile, which is the common single-profile
-    deployment case.
     """
     profile = (get_active_profile_name() or "").strip()
     if not profile or _is_root_profile(profile):
-        yield
+        with _root_home_override_scope():
+            yield
         return
     try:
         from api.config import _clear_thread_env, _set_thread_env, _thread_ctx
@@ -1590,7 +1589,8 @@ def profile_env_for_active_request(
     """
     profile = (get_active_profile_name() or "").strip()
     if not profile or _is_root_profile(profile):
-        yield
+        with _root_home_override_scope():
+            yield
         return
     with profile_env_for_background_worker(
         profile, purpose, logger_override=logger_override
@@ -1620,7 +1620,9 @@ def profile_scope_for_detached_worker(
     valid) into the worker, then enter this scope at the top of the worker body.
     It sets the request-profile TLS for this (worker) thread and applies the
     profile env via ``profile_env_for_background_worker``, restoring both on exit.
-    No-op for the default/root profile.
+    The default/root path installs the explicit root-home ContextVar override
+    instead of no-opping, so a named→default switch cannot leave the old named
+    home active inside the scope (#6857).
 
     Unlike ``profile_env_for_active_request`` (which reads the *current* thread's
     TLS and must NOT clear it — the request thread keeps using it after the call),
@@ -1629,7 +1631,8 @@ def profile_scope_for_detached_worker(
     """
     name = (profile_name or "").strip()
     if not name or _is_root_profile(name):
-        yield
+        with _root_home_override_scope():
+            yield
         return
     set_request_profile(name)
     try:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1250,6 +1250,36 @@ def _home_override_active() -> bool:
 
 
 @contextmanager
+def _root_home_override_scope():
+    """Install the explicit root-home ContextVar override in default/root scopes.
+
+    Named-profile scopes install a profile-home override; the default/root
+    scopes previously no-opped, so after a named→default switch the in-process
+    home resolver (ContextVar base value / stale env) could keep resolving the
+    old named home inside the scope (#6857). Pin the resolved root home
+    explicitly so scoped readers resolve the default home consistently. No-op
+    on agents without the override API (pre-v0.18 legacy env behavior).
+    """
+    mod = _resolve_hermes_home_override()
+    token = None
+    if mod is not None:
+        try:
+            token = mod.set_hermes_home_override(
+                str(get_hermes_home_for_profile(""))
+            )
+        except Exception:
+            token = None
+    try:
+        yield
+    finally:
+        if token is not None:
+            try:
+                mod.reset_hermes_home_override(token)
+            except Exception:
+                pass
+
+
+@contextmanager
 def profile_env_for_background_worker(
     session,
     purpose: str = "background worker",
@@ -1712,6 +1742,16 @@ def init_profile_state() -> None:
     else:
         _active_profile = _read_active_profile_file()
         home = get_active_hermes_home()
+    # #6857: one-time STARTUP publication. init_profile_state() runs outside any
+    # ContextVar override and before any request scope exists; origin/master
+    # unconditionally published the resolved home here. Legacy/unscoped readers
+    # and module imports that snapshot HERMES_HOME depend on this base value —
+    # e.g. on the supported Windows migration path the WebUI canonical home
+    # (%USERPROFILE%\\.hermes) must win over the agent fallback
+    # (%LOCALAPPDATA%\\hermes). This is the single allowed process-global write:
+    # request-time and process-switch writes remain prohibited (they race across
+    # concurrent per-profile requests); single-threaded init makes this safe.
+    os.environ['HERMES_HOME'] = str(home)
     _set_hermes_home(home)
     install_cron_scheduler_profile_isolation()
     _reload_dotenv(home)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -7,6 +7,13 @@ HERMES_HOME directory is used for config, skills, memory, cron, and API keys.
 Profile switches update os.environ['HERMES_HOME'] and monkey-patch module-level
 cached paths in hermes-agent modules (skills_tool, skill_manager_tool,
 cron/jobs) that snapshot HERMES_HOME at import time.
+
+#6857: since hermes-agent v0.18.0 the context-local home override
+(hermes_constants.set_hermes_home_override) is the in-process home resolver,
+so request-time writes to the process-global os.environ['HERMES_HOME'] are
+skipped when the override is available — the env key is a residual
+cross-profile write vector for readers that call os.getenv() directly.
+Pre-v0.18 agents keep the legacy env-mirror behavior.
 """
 import json
 import logging
@@ -668,8 +675,31 @@ class cron_profile_context_for_home:
         _cron_env_lock.acquire()
         _push_cron_profile_context_depth()
         try:
-            self._prev_env = os.environ.get('HERMES_HOME')
-            os.environ['HERMES_HOME'] = str(self._home)
+            # #6857: when the context-local home override is available
+            # (hermes-agent >= 0.18), pin the home via the override instead of
+            # mutating the process-global os.environ mirror. The env mirror is
+            # a residual cross-profile write vector for readers that call
+            # os.getenv() directly outside this scope. Pre-v0.18 agents keep
+            # the legacy env behavior.
+            self._home_override_mod = _resolve_hermes_home_override()
+            self._home_override_token = None
+            self._home_override_installed = False
+            self._env_mirrored = False
+            if self._home_override_mod is not None:
+                try:
+                    self._home_override_token = self._home_override_mod.set_hermes_home_override(
+                        str(self._home)
+                    )
+                    self._home_override_installed = True
+                except Exception:
+                    self._home_override_token = None
+                    self._home_override_installed = False
+            if not self._home_override_installed:
+                self._prev_env = os.environ.get('HERMES_HOME')
+                os.environ['HERMES_HOME'] = str(self._home)
+                self._env_mirrored = True
+            else:
+                self._prev_env = None
 
             # Re-patch cron.jobs module-level constants (see main context manager
             # below for the rationale).
@@ -709,10 +739,18 @@ class cron_profile_context_for_home:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            if self._prev_env is None:
-                os.environ.pop('HERMES_HOME', None)
-            else:
-                os.environ['HERMES_HOME'] = self._prev_env
+            if getattr(self, '_home_override_installed', False):
+                try:
+                    self._home_override_mod.reset_hermes_home_override(
+                        self._home_override_token
+                    )
+                except Exception:
+                    pass
+            elif getattr(self, '_env_mirrored', False):
+                if self._prev_env is None:
+                    os.environ.pop('HERMES_HOME', None)
+                else:
+                    os.environ['HERMES_HOME'] = self._prev_env
             if self._prev_cj is not None:
                 try:
                     import cron.jobs as _cj
@@ -747,9 +785,30 @@ class cron_profile_context:
         _cron_env_lock.acquire()
         _push_cron_profile_context_depth()
         try:
-            self._prev_env = os.environ.get('HERMES_HOME')
             home = get_active_hermes_home()
-            os.environ['HERMES_HOME'] = str(home)
+            # #6857: when the context-local home override is available
+            # (hermes-agent >= 0.18), pin the home via the override instead of
+            # mutating the process-global os.environ mirror. Pre-v0.18 agents
+            # keep the legacy env behavior.
+            self._home_override_mod = _resolve_hermes_home_override()
+            self._home_override_token = None
+            self._home_override_installed = False
+            self._env_mirrored = False
+            if self._home_override_mod is not None:
+                try:
+                    self._home_override_token = self._home_override_mod.set_hermes_home_override(
+                        str(home)
+                    )
+                    self._home_override_installed = True
+                except Exception:
+                    self._home_override_token = None
+                    self._home_override_installed = False
+            if not self._home_override_installed:
+                self._prev_env = os.environ.get('HERMES_HOME')
+                os.environ['HERMES_HOME'] = str(home)
+                self._env_mirrored = True
+            else:
+                self._prev_env = None
 
             # Re-patch cron.jobs module-level constants. They are snapshot at
             # import time (line 68-71 of cron/jobs.py) and don't participate in
@@ -787,11 +846,19 @@ class cron_profile_context:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            # Restore env var
-            if self._prev_env is None:
-                os.environ.pop('HERMES_HOME', None)
-            else:
-                os.environ['HERMES_HOME'] = self._prev_env
+            # Restore the home pin (override when available, else env mirror).
+            if getattr(self, '_home_override_installed', False):
+                try:
+                    self._home_override_mod.reset_hermes_home_override(
+                        self._home_override_token
+                    )
+                except Exception:
+                    pass
+            elif getattr(self, '_env_mirrored', False):
+                if self._prev_env is None:
+                    os.environ.pop('HERMES_HOME', None)
+                else:
+                    os.environ['HERMES_HOME'] = self._prev_env
 
             # Restore cron.jobs module constants
             if self._prev_cj is not None:
@@ -907,6 +974,11 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
                         # HERMES_WEBUI_ISOLATED_PROFILE=0) on the runtime-env path
                         # the same way _reload_dotenv() protects the live env.
                         if k in _PROTECTED_ENV_KEYS:
+                            continue
+                        if k == 'HERMES_HOME' and _home_override_active():
+                            # #6857: the ContextVar override is the in-process home
+                            # resolver; a profile .env must not re-mirror the
+                            # process-global HERMES_HOME (residual write vector).
                             continue
                         env[k] = v
         except Exception:
@@ -1094,6 +1166,11 @@ def _apply_profile_env_to_process(
     secret_env_names: set[str],
 ) -> dict[str, Optional[str]]:
     scoped_keys = set(safe_runtime_env) | set(secret_env_names)
+    if _home_override_active():
+        # #6857: never mirror HERMES_HOME into the process env when the
+        # ContextVar override is the home resolver — the env key is a residual
+        # cross-profile write vector for readers that call os.getenv() directly.
+        scoped_keys.discard('HERMES_HOME')
     previous_env = {key: process_env.get(key) for key in scoped_keys}
     for key in secret_env_names:
         if key not in safe_runtime_env:
@@ -1160,6 +1237,16 @@ def _resolve_hermes_home_override():
         return mod
     _hermes_home_override_available = False
     return None
+
+
+def _home_override_active() -> bool:
+    """True when the ContextVar home override is importable (function form).
+
+    Named distinctly from the module-level ``_hermes_home_override_available``
+    cache variable (set by ``_resolve_hermes_home_override()`` and monkeypatched
+    as a plain bool by existing tests) so the two never collide (#6857).
+    """
+    return _resolve_hermes_home_override() is not None
 
 
 @contextmanager
@@ -1296,10 +1383,25 @@ def profile_env_for_background_worker(
                 safe_runtime_env,
                 secret_env_names=secret_env_names,
             )
-            had_hermes_home = "HERMES_HOME" in os.environ
-            old_hermes_home = os.environ.get("HERMES_HOME")
-            os.environ.update(safe_runtime_env)
-            os.environ["HERMES_HOME"] = str(profile_home_path)
+            if not _home_override_installed:
+                # #6857: when the ContextVar override is installed (hermes-agent
+                # >= 0.18), it is the sole in-process home resolver — do NOT
+                # mirror HERMES_HOME into the process env, which is a residual
+                # cross-profile write vector for readers that call os.getenv()
+                # directly outside this scope. Pre-v0.18 agents keep the legacy
+                # env-mirror behavior.
+                had_hermes_home = "HERMES_HOME" in os.environ
+                old_hermes_home = os.environ.get("HERMES_HOME")
+                os.environ.update(safe_runtime_env)
+                os.environ["HERMES_HOME"] = str(profile_home_path)
+            else:
+                # Still apply non-home runtime env keys (provider credentials,
+                # TERMINAL_*) for readers that bypass the thread-local channel.
+                os.environ.update(
+                    {k: v for k, v in safe_runtime_env.items() if k != "HERMES_HOME"}
+                )
+                had_hermes_home = False
+                old_hermes_home = None
         yield
     finally:
         try:
@@ -1309,9 +1411,9 @@ def profile_env_for_background_worker(
                         os.environ.pop(key, None)
                     else:
                         os.environ[key] = old_value
-                if had_hermes_home:
+                if not _home_override_installed and had_hermes_home:
                     os.environ["HERMES_HOME"] = old_hermes_home or ""
-                else:
+                elif not _home_override_installed:
                     os.environ.pop("HERMES_HOME", None)
                 if should_restore_skill_modules and skill_home_snapshot is not None:
                     restore_skill_home_modules(skill_home_snapshot)
@@ -1510,8 +1612,17 @@ def profile_scope_for_detached_worker(
 
 
 def _set_hermes_home(home: Path):
-    """Set HERMES_HOME env var and monkey-patch cached module-level paths."""
-    os.environ['HERMES_HOME'] = str(home)
+    """Set HERMES_HOME env var and monkey-patch cached module-level paths.
+
+    The process-global env write is skipped when the context-local home
+    override is available (hermes-agent >= 0.18): the override is the sole
+    in-process home resolver, and mutating ``os.environ['HERMES_HOME']`` at
+    request time is a residual cross-profile write vector (#6857). Module
+    patching is kept as harmless belt-and-braces. Pre-v0.18 agents (resolver
+    returns None) keep the legacy env-mirror behavior.
+    """
+    if not _home_override_active():
+        os.environ['HERMES_HOME'] = str(home)
 
     patch_skill_home_modules(home)
 
@@ -1568,6 +1679,16 @@ def _reload_dotenv(home: Path):
                             "Ignoring protected key %s in profile .env %s; "
                             "operator/deployment env takes precedence",
                             k, env_path,
+                        )
+                        continue
+                    if k == 'HERMES_HOME' and _home_override_active():
+                        # #6857: the ContextVar override is the in-process home
+                        # resolver; a profile .env must not re-mirror the
+                        # process-global HERMES_HOME (residual write vector).
+                        logger.debug(
+                            "Ignoring HERMES_HOME in profile .env %s; "
+                            "context-local override is the home resolver",
+                            env_path,
                         )
                         continue
                     os.environ[k] = v

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -684,9 +684,6 @@ class cron_profile_context_for_home:
             self._home_override_mod = _resolve_hermes_home_override()
             self._home_override_token = None
             self._home_override_installed = False
-            # Always mirror to env var for cron scopes (fix for #6857)
-            self._prev_env = os.environ.get('HERMES_HOME')
-            os.environ['HERMES_HOME'] = str(self._home)
             if self._home_override_mod is not None:
                 try:
                     self._home_override_token = self._home_override_mod.set_hermes_home_override(
@@ -696,8 +693,14 @@ class cron_profile_context_for_home:
                 except Exception:
                     self._home_override_token = None
                     self._home_override_installed = False
-            # Note: _env_mirrored is no longer used; we always restore env var below
-            self._env_mirrored = True  # kept for compatibility but not used
+            # #6857: mirror to the process env only on the legacy path. With the
+            # ContextVar override installed it is the sole in-process home
+            # resolver for this scope; writing os.environ here would leak this
+            # profile's home to unrelated threads and requests.
+            self._env_mirrored = not self._home_override_installed
+            self._prev_env = os.environ.get('HERMES_HOME') if self._env_mirrored else None
+            if self._env_mirrored:
+                os.environ['HERMES_HOME'] = str(self._home)
 
             # Re-patch cron.jobs module-level constants (see main context manager
             # below for the rationale).
@@ -744,11 +747,12 @@ class cron_profile_context_for_home:
                     )
                 except Exception:
                     pass
-            # Always restore env var mirror for cron scopes
-            if self._prev_env is None:
-                os.environ.pop('HERMES_HOME', None)
-            else:
-                os.environ['HERMES_HOME'] = self._prev_env
+            # Restore the env mirror only when this scope installed it (#6857).
+            if self._env_mirrored:
+                if self._prev_env is None:
+                    os.environ.pop('HERMES_HOME', None)
+                else:
+                    os.environ['HERMES_HOME'] = self._prev_env
             if self._prev_cj is not None:
                 try:
                     import cron.jobs as _cj
@@ -791,9 +795,6 @@ class cron_profile_context:
             self._home_override_mod = _resolve_hermes_home_override()
             self._home_override_token = None
             self._home_override_installed = False
-            # Always mirror to env var for cron scopes (fix for #6857)
-            self._prev_env = os.environ.get('HERMES_HOME')
-            os.environ['HERMES_HOME'] = str(home)
             if self._home_override_mod is not None:
                 try:
                     self._home_override_token = self._home_override_mod.set_hermes_home_override(
@@ -803,8 +804,12 @@ class cron_profile_context:
                 except Exception:
                     self._home_override_token = None
                     self._home_override_installed = False
-            # Note: _env_mirrored is no longer used; we always restore env var below
-            self._env_mirrored = True  # kept for compatibility but not used
+            # #6857: mirror to the process env only on the legacy path (see
+            # cron_profile_context_for_home above for the rationale).
+            self._env_mirrored = not self._home_override_installed
+            self._prev_env = os.environ.get('HERMES_HOME') if self._env_mirrored else None
+            if self._env_mirrored:
+                os.environ['HERMES_HOME'] = str(home)
 
             # Re-patch cron.jobs module-level constants. They are snapshot at
             # import time (line 68-71 of cron/jobs.py) and don't participate in
@@ -850,11 +855,12 @@ class cron_profile_context:
                     )
                 except Exception:
                     pass
-            # Always restore env var mirror for cron scopes
-            if self._prev_env is None:
-                os.environ.pop('HERMES_HOME', None)
-            else:
-                os.environ['HERMES_HOME'] = self._prev_env
+            # Restore the env mirror only when this scope installed it (#6857).
+            if self._env_mirrored:
+                if self._prev_env is None:
+                    os.environ.pop('HERMES_HOME', None)
+                else:
+                    os.environ['HERMES_HOME'] = self._prev_env
             if self._prev_cj is not None:
                 try:
                     import cron.jobs as _cj
@@ -1638,7 +1644,7 @@ def profile_scope_for_detached_worker(
         clear_request_profile()
 
 
-def _set_hermes_home(home: Path):
+def _set_hermes_home(home: Path, *, publish_env: bool = False):
     """Set HERMES_HOME env var and monkey-patch cached module-level paths.
 
     The process-global env write is skipped when the context-local home
@@ -1647,8 +1653,15 @@ def _set_hermes_home(home: Path):
     request time is a residual cross-profile write vector (#6857). Module
     patching is kept as harmless belt-and-braces. Pre-v0.18 agents (resolver
     returns None) keep the legacy env-mirror behavior.
+
+    ``publish_env=True`` marks a deliberate *process-wide publication* (the
+    supported ``switch_profile(..., process_wide=True)`` path). The env write
+    must happen there: otherwise the process baseline keeps advertising the
+    previous home and every unscoped reader (gateway lifecycle, subprocesses,
+    default-path helpers) follows a stale — possibly deleted — profile home
+    after a named→default switch (#6857 re-gate).
     """
-    if not _home_override_active():
+    if publish_env or not _home_override_active():
         os.environ['HERMES_HOME'] = str(home)
 
     patch_skill_home_modules(home)
@@ -1815,7 +1828,11 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
         if process_wide:
             global _active_profile
             _active_profile = name
-            _set_hermes_home(home)
+            # #6857 re-gate: a deliberate process-wide switch must publish the
+            # new home to the process env (legacy/unscoped readers, subprocess
+            # spawns). Omitting it left a named→default switch advertising the
+            # previous — possibly deleted — profile home process-wide.
+            _set_hermes_home(home, publish_env=True)
             _reload_dotenv(home)
 
     if process_wide:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1322,14 +1322,23 @@ def _run_gateway_lifecycle_command(action: str) -> subprocess.CompletedProcess:
     cmd.extend(["gateway", action])
 
     env = os.environ.copy()
+    # #6857: the process env can hold a stale named/deleted home after a
+    # named→default switch; resolve the active home through the profile
+    # authority and pin it explicitly so start/stop/restart always target the
+    # canonical home (root when no named profile is active).
+    #
+    # Fail closed: this spawns a gateway process, so silently inheriting
+    # HERMES_HOME from os.environ would let a stale/deleted profile home leak
+    # into subprocess state — the exact failure mode #6857 is about. Raising
+    # surfaces as a 500 via the route's generic handler instead.
     try:
-        # #6857: the process env can hold a stale named/deleted home after a
-        # named→default switch; resolve the active home through the profile
-        # authority and pin it explicitly so start/stop/restart always target
-        # the canonical home (root when no named profile is active).
         env["HERMES_HOME"] = str(get_active_hermes_home())
     except Exception as exc:
-        logger.debug("Could not resolve active HERMES_HOME for gateway lifecycle: %s", exc)
+        raise RuntimeError(
+            "Could not resolve the active HERMES_HOME for the gateway "
+            f"{action} command; refusing to fall back to the process env value, "
+            "which can point at a stale or deleted profile home."
+        ) from exc
     env.setdefault("PYTHONUTF8", "1")
     env.setdefault("BROWSER", "echo")
     return subprocess.run(

--- a/api/routes.py
+++ b/api/routes.py
@@ -1301,7 +1301,7 @@ def _run_gateway_lifecycle_command(action: str) -> subprocess.CompletedProcess:
         raise ValueError("unsupported gateway action")
 
     from api import config as api_config
-    from api.profiles import get_active_profile_name
+    from api.profiles import get_active_hermes_home, get_active_profile_name
 
     agent_dir = getattr(api_config, "_AGENT_DIR", None)
     if not agent_dir:
@@ -1322,6 +1322,14 @@ def _run_gateway_lifecycle_command(action: str) -> subprocess.CompletedProcess:
     cmd.extend(["gateway", action])
 
     env = os.environ.copy()
+    try:
+        # #6857: the process env can hold a stale named/deleted home after a
+        # named→default switch; resolve the active home through the profile
+        # authority and pin it explicitly so start/stop/restart always target
+        # the canonical home (root when no named profile is active).
+        env["HERMES_HOME"] = str(get_active_hermes_home())
+    except Exception as exc:
+        logger.debug("Could not resolve active HERMES_HOME for gateway lifecycle: %s", exc)
     env.setdefault("PYTHONUTF8", "1")
     env.setdefault("BROWSER", "echo")
     return subprocess.run(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2776,6 +2776,23 @@ def _resolve_streaming_hermes_home_override():
     return None
 
 
+def _publish_turn_hermes_home(profile_home, *, override_installed: bool) -> bool:
+    """#6857: mirror this turn's profile home into the process env, or not.
+
+    ``os.environ`` is process-global, so writing the turn's home there leaks it
+    into every concurrent turn / thread in the same process. When the
+    context-local home override is installed (hermes-agent >= 0.18) it is the
+    sole in-process home resolver, and the env write is redundant — skip it.
+
+    Returns True when the env var was written (the caller must restore the
+    previous value when the turn ends), False when the env was left untouched.
+    """
+    if not profile_home or override_installed:
+        return False
+    os.environ['HERMES_HOME'] = profile_home
+    return True
+
+
 def _set_streaming_hermes_home_override(profile_home: str):
     """Install the context-local home override if available.
 
@@ -9023,6 +9040,10 @@ def _run_agent_streaming(
     old_session_id = None
     old_session_platform = None
     old_hermes_home = None
+    # #6857: only restore HERMES_HOME when this turn mirrored it into the env
+    # (legacy path). With a ContextVar override installed the turn never writes
+    # the env var, so a restore would clobber a concurrent turn's value.
+    _mirror_hermes_home_env = False
     old_profile_env = {}
     result = None
     _result_partial_pre_call_context = []
@@ -9634,7 +9655,12 @@ def _run_agent_streaming(
             old_session_id = os.environ.get('HERMES_SESSION_ID')
             old_session_platform = os.environ.get('HERMES_SESSION_PLATFORM')
             old_session_chat_id = os.environ.get('HERMES_SESSION_CHAT_ID')
-            old_hermes_home = os.environ.get('HERMES_HOME')
+            # #6857: mirror HERMES_HOME into the process env only on the legacy
+            # path (no ContextVar override installed for this turn). With the
+            # override active the env write is redundant and leaks this
+            # session's profile home into concurrent turns/threads.
+            _mirror_hermes_home_env = not _streaming_override_installed
+            old_hermes_home = os.environ.get('HERMES_HOME') if _mirror_hermes_home_env else None
             os.environ.update(_safe_profile_runtime_env)
             os.environ['TERMINAL_CWD'] = str(s.workspace)
             os.environ['HERMES_EXEC_ASK'] = '1'
@@ -9645,7 +9671,11 @@ def _run_agent_streaming(
             # _build_agent_thread_env above.
             os.environ['HERMES_SESSION_CHAT_ID'] = str(session_id)
             if _profile_home:
-                os.environ['HERMES_HOME'] = _profile_home
+                # #6857: publish to the process env only on the legacy path; the
+                # ContextVar override is the sole home resolver when installed.
+                _mirror_hermes_home_env = _publish_turn_hermes_home(
+                    _profile_home, override_installed=_streaming_override_installed
+                )
                 # Prefer context-local Hermes-home overrides when available.
                 # In that mode, tools.skills_tool._skills_dir() and
                 # tools.skill_manager_tool._skills_dir() can resolve the active
@@ -12653,8 +12683,9 @@ def _run_agent_streaming(
                 else: os.environ['HERMES_SESSION_PLATFORM'] = old_session_platform
                 if old_session_chat_id is None: os.environ.pop('HERMES_SESSION_CHAT_ID', None)
                 else: os.environ['HERMES_SESSION_CHAT_ID'] = old_session_chat_id
-                if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
-                else: os.environ['HERMES_HOME'] = old_hermes_home
+                if _mirror_hermes_home_env:
+                    if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
+                    else: os.environ['HERMES_HOME'] = old_hermes_home
 
     except Exception as e:
         print('[webui] stream error:\n' + traceback.format_exc(), flush=True)

--- a/tests/test_gateway_lifecycle_controls.py
+++ b/tests/test_gateway_lifecycle_controls.py
@@ -93,6 +93,91 @@ def test_gateway_start_runs_profile_scoped_agent_cli_and_returns_status(monkeypa
     assert kwargs["text"] is True
 
 
+def test_gateway_lifecycle_env_injects_active_profile_home(monkeypatch, tmp_path):
+    """#6857: the lifecycle subprocess env must pin HERMES_HOME to the active
+    profile's resolved home (named profile)."""
+    from api import config, profiles, routes
+
+    agent_dir = _fake_agent(tmp_path)
+    monkeypatch.setattr(config, "_AGENT_DIR", agent_dir)
+    monkeypatch.setattr(config, "PYTHON_EXE", sys.executable)
+    named_home = tmp_path / "hermes" / "profiles" / "work"
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: named_home)
+    monkeypatch.setattr(
+        routes,
+        "_gateway_status_payload",
+        lambda: {
+            "running": True,
+            "configured": True,
+            "platforms": [],
+            "last_active": "",
+            "session_count": 0,
+            "health": {},
+        },
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="gateway started\n", stderr="")
+
+    monkeypatch.setattr(routes.subprocess, "run", fake_run)
+
+    handler, data = _call_post(monkeypatch, "/api/gateway/start", {"name": "telegram"})
+
+    assert handler.status == 200
+    assert data["ok"] is True
+    cmd, kwargs = calls[0]
+    assert cmd[2:] == ["--profile", "work", "gateway", "start"]
+    assert kwargs["env"]["HERMES_HOME"] == str(named_home)
+
+
+def test_gateway_lifecycle_env_overrides_stale_home_on_default_path(monkeypatch, tmp_path):
+    """#6857: after a named→default switch the process env can still hold the
+    stale named/deleted home; the default-path subprocess must receive the
+    canonical root home instead."""
+    from api import config, profiles, routes
+
+    agent_dir = _fake_agent(tmp_path)
+    monkeypatch.setattr(config, "_AGENT_DIR", agent_dir)
+    monkeypatch.setattr(config, "PYTHON_EXE", sys.executable)
+    stale_named_home = tmp_path / "hermes" / "profiles" / "deleted"
+    root_home = tmp_path / "hermes"
+    # Simulate the stale process-global env left by a named→default switch.
+    monkeypatch.setenv("HERMES_HOME", str(stale_named_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: root_home)
+    monkeypatch.setattr(
+        routes,
+        "_gateway_status_payload",
+        lambda: {
+            "running": True,
+            "configured": True,
+            "platforms": [],
+            "last_active": "",
+            "session_count": 0,
+            "health": {},
+        },
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="gateway stopped\n", stderr="")
+
+    monkeypatch.setattr(routes.subprocess, "run", fake_run)
+
+    handler, data = _call_post(monkeypatch, "/api/gateway/stop")
+
+    assert handler.status == 200
+    assert data["ok"] is True
+    cmd, kwargs = calls[0]
+    assert cmd[2:] == ["gateway", "stop"]  # no --profile on the default path
+    assert kwargs["env"]["HERMES_HOME"] == str(root_home)
+    assert kwargs["env"]["HERMES_HOME"] != str(stale_named_home)
+
+
 def test_gateway_action_contention_returns_409_without_spawning(monkeypatch, tmp_path):
     """A second lifecycle action while one holds the lock returns 409 and does
     NOT spawn an overlapping `hermes gateway` subprocess (server-side

--- a/tests/test_gateway_lifecycle_controls.py
+++ b/tests/test_gateway_lifecycle_controls.py
@@ -178,6 +178,34 @@ def test_gateway_lifecycle_env_overrides_stale_home_on_default_path(monkeypatch,
     assert kwargs["env"]["HERMES_HOME"] != str(stale_named_home)
 
 
+def test_gateway_lifecycle_fails_closed_when_home_unresolved(monkeypatch, tmp_path):
+    """#6857 re-gate: when the active home cannot be resolved, the lifecycle
+    command must fail closed (500) instead of silently inheriting a possibly
+    stale/deleted HERMES_HOME from the process env."""
+    from api import config, profiles, routes
+
+    agent_dir = _fake_agent(tmp_path)
+    monkeypatch.setattr(config, "_AGENT_DIR", agent_dir)
+    monkeypatch.setattr(config, "PYTHON_EXE", sys.executable)
+    stale_named_home = tmp_path / "hermes" / "profiles" / "deleted"
+    monkeypatch.setenv("HERMES_HOME", str(stale_named_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    def _unresolvable():
+        raise RuntimeError("profile state unavailable")
+
+    monkeypatch.setattr(profiles, "get_active_hermes_home", _unresolvable)
+    spawned = []
+    monkeypatch.setattr(routes.subprocess, "run", lambda *a, **k: spawned.append((a, k)))
+
+    handler, data = _call_post(monkeypatch, "/api/gateway/start")
+
+    assert handler.status == 500
+    assert data["ok"] is False
+    assert "HERMES_HOME" in data["error"]
+    assert spawned == []  # no gateway process spawned against a stale home
+
+
 def test_gateway_action_contention_returns_409_without_spawning(monkeypatch, tmp_path):
     """A second lifecycle action while one holds the lock returns 409 and does
     NOT spawn an overlapping `hermes gateway` subprocess (server-side

--- a/tests/test_issue5567_profile_home_override.py
+++ b/tests/test_issue5567_profile_home_override.py
@@ -121,6 +121,65 @@ def test_override_is_cleared_after_worker_exits(tmp_path, monkeypatch):
     assert hermes_constants.get_hermes_home_override() is None
 
 
+@pytest.mark.skipif(
+    not HAS_OVERRIDE,
+    reason="requires the v0.18.0 override to assert root-home scoping",
+)
+def test_default_root_scopes_install_canonical_root_home_override(tmp_path, monkeypatch):
+    """#6857 re-gate: default/root scopes must pin the canonical root home.
+
+    After a named→default switch (or an active-profile delete), the in-process
+    resolver can keep seeing the old named home. Each default/root scope must
+    install the explicit root-home ContextVar override while entered, then
+    restore the PREVIOUS (named) token on exit — including on exception.
+    """
+    root_home = str(profiles_api.get_hermes_home_for_profile(""))
+    named_home = _seed_profile_home(tmp_path, "alpha", provider="anthropic", model="claude-x")
+
+    # Start with a NAMED-home override installed (stale named state).
+    named_token = hermes_constants.set_hermes_home_override(str(named_home))
+    try:
+        assert hermes_constants.get_hermes_home_override() == str(named_home)
+        monkeypatch.setattr(profiles_api, "get_active_profile_name", lambda: "default")
+
+        scopes = [
+            (
+                "profile_env_for_background_worker",
+                lambda: profiles_api.profile_env_for_background_worker(""),
+            ),
+            (
+                "profile_env_for_active_request_readonly",
+                lambda: profiles_api.profile_env_for_active_request_readonly(),
+            ),
+            (
+                "profile_env_for_active_request",
+                lambda: profiles_api.profile_env_for_active_request(),
+            ),
+            (
+                "profile_scope_for_detached_worker",
+                lambda: profiles_api.profile_scope_for_detached_worker("default"),
+            ),
+        ]
+
+        for label, factory in scopes:
+            with factory():
+                # The resolver sees the canonical root home inside the scope.
+                assert hermes_constants.get_hermes_home_override() == root_home, label
+                assert hermes_constants.get_hermes_home() == Path(root_home), label
+            # The PREVIOUS (named) token is restored on exit.
+            assert hermes_constants.get_hermes_home_override() == str(named_home), label
+
+        # And on exception: entering the scope then raising must also restore.
+        for label, factory in scopes:
+            with pytest.raises(RuntimeError):
+                with factory():
+                    assert hermes_constants.get_hermes_home_override() == root_home, label
+                    raise RuntimeError("boom")
+            assert hermes_constants.get_hermes_home_override() == str(named_home), label
+    finally:
+        hermes_constants.reset_hermes_home_override(named_token)
+
+
 def test_graceful_degradation_resolver_is_optional():
     """On an agent WITHOUT the override, the resolver returns None and the CM
     falls back to the pre-existing os.environ mirror — never raises. We assert

--- a/tests/test_issue803.py
+++ b/tests/test_issue803.py
@@ -387,6 +387,34 @@ def test_switch_profile_process_wide_false_does_not_mutate_global():
         p._active_profile = original_global
 
 
+def test_switch_profile_process_wide_true_publishes_hermes_home():
+    """#6857 re-gate: the supported process-wide switch must publish the new
+    home to the process env. After a named→default switch the baseline env can
+    still point at the (possibly deleted) named profile; unscoped readers —
+    gateway lifecycle subprocesses, default-path helpers — would follow it."""
+    import api.profiles as p
+
+    original_global = p._active_profile
+    original_env_home = os.environ.get('HERMES_HOME')
+    stale = Path('/nonexistent') / 'stale-named-profile-home'
+    try:
+        os.environ['HERMES_HOME'] = str(stale)
+        result = p.switch_profile('default', process_wide=True)
+        assert isinstance(result, dict)
+        expected = str(p.get_active_hermes_home())
+        assert expected != str(stale)  # the switch really targets another home
+        assert os.environ.get('HERMES_HOME') == expected, (
+            "process_wide=True must publish the active home to "
+            "os.environ['HERMES_HOME'], not keep the stale value"
+        )
+    finally:
+        p._active_profile = original_global
+        if original_env_home is None:
+            os.environ.pop('HERMES_HOME', None)
+        else:
+            os.environ['HERMES_HOME'] = original_env_home
+
+
 # ── 5. Concurrent threads see independent profile context ────────────────────
 
 def test_concurrent_threads_see_independent_profiles():

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -131,3 +131,33 @@ def test_streaming_thread_env_allows_profile_terminal_cwd_override():
     assert env["HERMES_SESSION_PLATFORM"] == "webui"
     assert env["HERMES_HOME"] == "/active/profile/home"
     assert env["TERMINAL_ENV"] == "ssh"
+
+
+def test_turn_env_publish_skips_hermes_home_when_override_installed(monkeypatch):
+    """#6857: with the context-local override installed, a chat send must not
+    write its profile home into the process-global env (that write is what
+    leaked one session's home into concurrent turns)."""
+    from api.streaming import _publish_turn_hermes_home
+
+    monkeypatch.setenv("HERMES_HOME", "/baseline/root-home")
+    assert _publish_turn_hermes_home("/profiles/alice", override_installed=True) is False
+    assert os.environ.get("HERMES_HOME") == "/baseline/root-home"
+
+
+def test_turn_env_publish_mirrors_home_on_legacy_path(monkeypatch):
+    """Legacy agents (no override available) keep the env mirror and must
+    therefore be restored by the caller when the turn ends."""
+    from api.streaming import _publish_turn_hermes_home
+
+    monkeypatch.setenv("HERMES_HOME", "/baseline/root-home")
+    assert _publish_turn_hermes_home("/profiles/alice", override_installed=False) is True
+    assert os.environ.get("HERMES_HOME") == "/profiles/alice"
+
+
+def test_turn_env_publish_noops_without_profile_home(monkeypatch):
+    """No profile home for the turn → nothing to publish, env stays untouched."""
+    from api.streaming import _publish_turn_hermes_home
+
+    monkeypatch.setenv("HERMES_HOME", "/baseline/root-home")
+    assert _publish_turn_hermes_home("", override_installed=False) is False
+    assert os.environ.get("HERMES_HOME") == "/baseline/root-home"

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -552,7 +552,7 @@ def test_streaming_profile_home_mutation_avoids_long_lived_cron_cache_patch():
 
 def test_sessiondb_on_threadpool_executor_in_cron_scope(tmp_path, monkeypatch):
     """Regression test for #6857: SessionDB() on a fresh ThreadPoolExecutor inside a cron scope must respect the profile home."""
-    sqlite_mod = pytest.importorskip("hermes_agent.db.sqlite")  # auto-skip when hermes-agent is unavailable
+    sqlite_mod = pytest.importorskip("hermes_state")  # auto-skip when hermes-agent is unavailable
     SessionDB = sqlite_mod.SessionDB
 
     default_home = tmp_path / "default_home"

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -549,3 +549,48 @@ def test_streaming_profile_home_mutation_avoids_long_lived_cron_cache_patch():
     assert "_STREAMING_CRON_PROFILE_HOME.reset(_streaming_cron_profile_home_token)" in src
     assert "def _patch_streaming_profile_module_caches" not in src
     assert "old_profile_module_cache_snapshot" not in src
+
+def test_sessiondb_on_threadpool_executor_in_cron_scope(tmp_path, monkeypatch):
+    """Regression test for #6857: SessionDB() on a fresh ThreadPoolExecutor inside a cron scope must respect the profile home."""
+    sqlite_mod = pytest.importorskip("hermes_agent.db.sqlite")  # auto-skip when hermes-agent is unavailable
+    SessionDB = sqlite_mod.SessionDB
+
+    default_home = tmp_path / "default_home"
+    named_home = default_home / "profiles" / "named"
+    
+    # Initialize the profile structure
+    (default_home / "profiles").mkdir(parents=True)
+    named_home.mkdir(parents=True)
+    
+    # Point HERMES_HOME env to default_home (so default profile is active by default)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    
+    from api import profiles as p
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
+    
+    # Helper to run SessionDB() in a thread and return the db_path
+    def get_sessiondb_path_via_thread():
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(lambda: SessionDB().db_path)
+            return future.result()
+    
+    # Test 1: Inside a named-profile cron scope (TLS set to named), SessionDB should use the named profile
+    p.set_request_profile("named")
+    try:
+        with p.cron_profile_context():
+            db_path = get_sessiondb_path_via_thread()
+            expected = named_home / "state.db"
+            assert db_path == expected, f"Expected {expected}, got {db_path}"
+    finally:
+        p.clear_request_profile()
+    
+    # Test 2: Inside a default-profile cron scope (TLS set to default), SessionDB should use the default profile
+    p.set_request_profile("default")
+    try:
+        with p.cron_profile_context():
+            db_path = get_sessiondb_path_via_thread()
+            expected = default_home / "state.db"
+            assert db_path == expected, f"Expected {expected}, got {db_path}"
+    finally:
+        p.clear_request_profile()

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -568,11 +568,16 @@ def test_sessiondb_on_threadpool_executor_in_cron_scope(tmp_path, monkeypatch):
     from api import profiles as p
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
     
-    # Helper to run SessionDB() in a thread and return the db_path
+    # Helper to run SessionDB() in a thread and return the db_path. The armed
+    # context must be copied explicitly: production executors (cron / agent
+    # tool-call boundaries) enter the worker via copy_context().run(), which is
+    # what makes the ContextVar override — not os.environ — the transport.
     def get_sessiondb_path_via_thread():
         from concurrent.futures import ThreadPoolExecutor
+        import contextvars
+        ctx = contextvars.copy_context()
         with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(lambda: SessionDB().db_path)
+            future = executor.submit(ctx.run, lambda: SessionDB().db_path)
             return future.result()
     
     # Test 1: Inside a named-profile cron scope (TLS set to named), SessionDB should use the named profile
@@ -582,6 +587,11 @@ def test_sessiondb_on_threadpool_executor_in_cron_scope(tmp_path, monkeypatch):
             db_path = get_sessiondb_path_via_thread()
             expected = named_home / "state.db"
             assert db_path == expected, f"Expected {expected}, got {db_path}"
+            # #6857 re-gate: the cron scope must not publish its home to the
+            # process env — that is the channel that leaked to other threads.
+            assert os.environ.get("HERMES_HOME") == str(default_home), (
+                "cron scope leaked its profile home into os.environ"
+            )
     finally:
         p.clear_request_profile()
     
@@ -592,5 +602,6 @@ def test_sessiondb_on_threadpool_executor_in_cron_scope(tmp_path, monkeypatch):
             db_path = get_sessiondb_path_via_thread()
             expected = default_home / "state.db"
             assert db_path == expected, f"Expected {expected}, got {db_path}"
+            assert os.environ.get("HERMES_HOME") == str(default_home)
     finally:
         p.clear_request_profile()


### PR DESCRIPTION
## Summary
Stops mutating the process-global `os.environ['HERMES_HOME']` in the WebUI server now that the ContextVar override is the home resolver (Option C, #5567 / hermes-agent >= 0.18). The env mirror was accepted as a stopgap ("Option A") in #2321 and never removed — it remains a residual cross-profile write vector: any code path reading `HERMES_HOME` from the environment OUTSIDE a request context sees the last-switched profile.

## Change (`api/profiles.py`)
- Scoped contexts (`cron_profile_context_for_home`, `cron_profile_context`, `profile_env_for_background_worker`, `_set_hermes_home`) now install the **ContextVar override** (`set_hermes_home_override`) instead of mirroring into the process env; the env write remains only as the pre-v0.18 fallback (resolver returns None). Exit paths reset the override instead of restoring the env.
- `_apply_profile_env_to_process` and `_reload_dotenv` no longer mirror `HERMES_HOME` into the process env when the override is active.
- New `_home_override_active()` helper (distinct name from the module-level `_hermes_home_override_available` cache variable, which existing tests monkeypatch as a plain bool — they never collide).

## Verification
- `tests/test_issue3957_profile_providers_models.py` (wakeup/profile/credential/root/scrub subset): **33 passed**.
- `tests/test_issue5567_profile_home_override.py`: **11 passed** (monkeypatch-bool compat preserved).

Closes #6857