### PR TITLE
Fix webui gateway access error in multiple container

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -45,6 +45,9 @@ GID=1000
 # REQUIRED if you expose the container on anything other than 127.0.0.1.
 # Without a password, anyone who can reach the port can run commands as
 # the agent.
+#
+# All three compose files forward this into the WebUI container, so
+# uncommenting it here is sufficient — no compose edit needed:
 # HERMES_WEBUI_PASSWORD=change-me-to-something-strong
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -118,3 +121,15 @@ GID=1000
 # bind), ALL THREE containers must mount the SAME host path and run as the
 # SAME UID/GID. Mismatched UIDs → "Permission denied" → the WebUI crashes
 # on every HTTP request because it can't read its own auth signing key.
+
+# ──────────────────────────────────────────────────────────────────────────
+# Gateway API server — multi-container only
+# ──────────────────────────────────────────────────────────────────────────
+# The two/three-container compose files forward this into the hermes-agent
+# container. The agent only starts the gateway API listener (port 8642) when
+# a usable API_SERVER_KEY is present (>=16 chars) — API_SERVER_ENABLED alone
+# does nothing. Without a key, the gateway daemon still runs (messaging +
+# cron) but the WebUI's Tasks/System pill shows "Gateway endpoint not
+# reachable". Set a long random string here to enable it; the same value is
+# forwarded to the WebUI as HERMES_WEBUI_GATEWAY_API_KEY automatically:
+# API_SERVER_KEY=replace-with-a-long-random-string

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Normalize line endings to LF in the repository.
+* text=auto
+
+# Shell scripts must stay LF on checkout too. A CRLF shebang (`#!/bin/bash\r`)
+# breaks the Docker image: the kernel can't find interpreter `/bin/bash\r`, so
+# local `docker compose up -d --build` on Windows machines with
+# `core.autocrlf=true` fails with `exec /hermeswebui_init.bash: no such file
+# or directory`.
+*.sh text eol=lf
+*.bash text eol=lf

--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -51,6 +51,15 @@ services:
       # Defaults to 1000 to match WANTED_UID/WANTED_GID in the webui service.
       - HERMES_UID=${UID:-1000}
       - HERMES_GID=${GID:-1000}
+      # Gateway API server (port 8642). The WebUI's Tasks/cron health probe
+      # reaches this listener via HERMES_API_URL below. The agent only starts
+      # the listener when API_SERVER_KEY is a usable value (>=16 chars); set
+      # it in .env to enable the gateway API. Without a key the gateway daemon
+      # still runs (messaging + cron) but port 8642 stays unbound and the
+      # WebUI reports "Gateway endpoint not reachable".
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${API_SERVER_KEY:-}
       # Bind-mount permission handling for the agent — narrow set of overrides.
       # NOTE: The agent's HERMES_HOME_MODE applies to the HERMES_HOME *directory*
       # mode (default 0700) — NOT to credential files like the WebUI's variant.
@@ -132,14 +141,18 @@ services:
       #   echo "UID=$(id -u)" >> .env && echo "GID=$(id -g)" >> .env
       - WANTED_UID=${UID:-1000}
       - WANTED_GID=${GID:-1000}
+      # Forward the API server key so the WebUI's gateway health probe can
+      # authenticate (must match the agent's API_SERVER_KEY above).
+      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}
+      # Optional: enable password auth. Set HERMES_WEBUI_PASSWORD in .env
+      # (required if you expose the port beyond 127.0.0.1).
+      - HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}
       # NOTE: When using bind-mount volumes shared across containers, ALL containers
       # that write to the same host directory must run as the same UID/GID.
       # If hermes-agent initialises the state dir as root (UID 0), hermes-webui
       # will get a PermissionError accessing those paths — including a crash on every
       # HTTP request if the auth signing-key file is unreadable. Either set WANTED_UID
       # to match the agent container's UID, or use a named Docker volume (preferred).
-      # Optional: set a password for remote access
-      # - HERMES_WEBUI_PASSWORD=your-secret-password
       # Bind-mount permission handling for the WebUI (fixes #1389, #1399).
       # NOTE: WebUI's HERMES_HOME_MODE is a credential-file threshold (allow
       # group bits on .env/.signing_key/etc.), DIFFERENT from the agent's

--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -67,6 +67,15 @@ services:
       # The agent image's entrypoint already supports usermod remapping.
       - HERMES_UID=${UID:-1000}
       - HERMES_GID=${GID:-1000}
+      # Gateway API server (port 8642). The WebUI's Tasks/cron health probe
+      # reaches this listener via HERMES_API_URL below. The agent only starts
+      # the listener when API_SERVER_KEY is a usable value (>=16 chars); set
+      # it in .env to enable the gateway API. Without a key the gateway daemon
+      # still runs (messaging + cron) but port 8642 stays unbound and the
+      # WebUI reports "Gateway endpoint not reachable".
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${API_SERVER_KEY:-}
       # Bind-mount permission handling for the agent — narrow set of overrides.
       # NOTE: The agent's HERMES_HOME_MODE applies to the HERMES_HOME *directory*
       # mode (default 0700) — NOT to credential files like the WebUI's variant.
@@ -117,8 +126,12 @@ services:
       #   echo "UID=$(id -u)" >> .env && echo "GID=$(id -g)" >> .env
       - WANTED_UID=${UID:-1000}
       - WANTED_GID=${GID:-1000}
-      # Optional: set a password for remote access
-      # - HERMES_WEBUI_PASSWORD=your-secret-password
+      # Forward the API server key so the WebUI's gateway health probe can
+      # authenticate (must match the agent's API_SERVER_KEY above).
+      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}
+      # Optional: enable password auth. Set HERMES_WEBUI_PASSWORD in .env
+      # (required if you expose the port beyond 127.0.0.1).
+      - HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}
       # Bind-mount permission handling for the WebUI (fixes #1389, #1399).
       # NOTE: WebUI's HERMES_HOME_MODE is a credential-file threshold (allow
       # group bits on .env/.signing_key/etc.), DIFFERENT from the agent's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,9 @@ services:
       - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui
       # Default workspace directory shown on first launch
 #      - HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace
-      # Optional: set a password for remote access
-      # - HERMES_WEBUI_PASSWORD=your-secret-password
+      # Optional: enable password auth. Set HERMES_WEBUI_PASSWORD in .env
+      # (required if you expose the port beyond 127.0.0.1).
+      - HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}
       #
       # Bind-mount permission handling (fixes #1389, #1399):
       #   When you mount an EXISTING ~/.hermes directory (the common case),

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -193,6 +193,22 @@ cp .env.docker.example .env
 docker compose -f docker-compose.two-container.yml up -d
 ```
 
+The compose files forward `API_SERVER_KEY` from `.env` into the `hermes-agent`
+container. The agent only starts the gateway API listener (port 8642) when
+`API_SERVER_KEY` is a usable value (>=16 chars) — `API_SERVER_ENABLED` alone
+does nothing. Without a key, the gateway daemon still runs but port 8642 stays
+unbound and the WebUI keeps showing **"Gateway endpoint not reachable"**. To
+enable scheduled ticking and the green gateway pill, set a long random string
+in `.env`:
+
+```bash
+echo "API_SERVER_KEY=$(openssl rand -hex 24)" >> .env
+docker compose -f docker-compose.two-container.yml up -d --force-recreate
+```
+
+The compose file forwards the same value to the WebUI as
+`HERMES_WEBUI_GATEWAY_API_KEY`, so the health probe authenticates automatically.
+
 The three-container layout adds the dashboard but is otherwise the same shape. If you must stay single-container, you can run `hermes gateway` inside the container as a long-lived background process, but the compose split is sturdier.
 
 If you maintain a custom compose file, make sure the **WebUI service** points at

--- a/tests/test_docker_compose_gateway_and_password_forwarding.py
+++ b/tests/test_docker_compose_gateway_and_password_forwarding.py
@@ -1,0 +1,92 @@
+"""Regression coverage for two Docker-compose gaps found in the field.
+
+1. Gateway API not reachable out of the box. The two/three-container compose
+   files set ``HERMES_API_URL=http://hermes-agent:8642`` on the WebUI but
+   never configured the agent to listen on 8642. The agent image only starts
+   its API-server listener when ``API_SERVER_KEY`` is a usable value (>=16
+   chars); ``API_SERVER_ENABLED`` alone does nothing. The compose files now
+   forward ``API_SERVER_KEY`` from ``.env`` and bind the listener on
+   0.0.0.0, and the WebUI receives the matching
+   ``HERMES_WEBUI_GATEWAY_API_KEY`` so its health probe authenticates.
+
+2. ``HERMES_WEBUI_PASSWORD`` set in ``.env`` had no effect. Docker Compose
+   uses ``.env`` only for variable interpolation — a value is not injected
+   into a container unless the compose file references it. All three compose
+   files now forward ``HERMES_WEBUI_PASSWORD`` into the WebUI service.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+MULTI = ("docker-compose.two-container.yml", "docker-compose.three-container.yml")
+ALL = ("docker-compose.yml",) + MULTI
+
+
+# ── 1: gateway API server forwarding (multi-container only) ────────────────
+
+
+def test_agent_service_enables_api_server():
+    """The agent service must carry the API-server env block so a user who
+    sets API_SERVER_KEY in .env gets a listening 8642 without editing the
+    compose file."""
+    for fn in MULTI:
+        src = (REPO / fn).read_text(encoding="utf-8")
+        assert "- API_SERVER_ENABLED=true" in src, (
+            f"{fn}: agent must declare API_SERVER_ENABLED."
+        )
+        assert "- API_SERVER_HOST=0.0.0.0" in src, (
+            f"{fn}: API server must bind 0.0.0.0 — the default 127.0.0.1 is "
+            "unreachable from the WebUI container over the compose network."
+        )
+        assert "- API_SERVER_KEY=${API_SERVER_KEY:-}" in src, (
+            f"{fn}: agent must forward API_SERVER_KEY from .env so the gateway "
+            "API listener can start (the agent requires a usable key, >=16 chars)."
+        )
+
+
+def test_webui_service_forwards_gateway_api_key():
+    """The WebUI must receive the same API_SERVER_KEY so its /health/detailed
+    probe authenticates instead of 401ing into 'Gateway endpoint not
+    reachable'."""
+    for fn in MULTI:
+        src = (REPO / fn).read_text(encoding="utf-8")
+        assert "- HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}" in src, (
+            f"{fn}: WebUI must forward HERMES_WEBUI_GATEWAY_API_KEY from the "
+            "same API_SERVER_KEY so the gateway health probe authenticates."
+        )
+
+
+# ── 2: HERMES_WEBUI_PASSWORD forwarding (all compose files) ────────────────
+
+
+def test_webui_service_forwards_password():
+    """HERMES_WEBUI_PASSWORD set in .env must reach the WebUI container.
+    .env is only for compose interpolation; without this forwarding line the
+    password silently does nothing."""
+    for fn in ALL:
+        src = (REPO / fn).read_text(encoding="utf-8")
+        assert "- HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}" in src, (
+            f"{fn}: WebUI must forward HERMES_WEBUI_PASSWORD from .env — "
+            "setting it only in .env does nothing unless the compose file "
+            "references it."
+        )
+
+
+def test_env_example_documents_api_server_key():
+    """.env.docker.example must tell users the API server needs a usable
+    API_SERVER_KEY (>=16 chars) and that it is forwarded automatically."""
+    example = (REPO / ".env.docker.example").read_text(encoding="utf-8")
+    assert "API_SERVER_KEY" in example, (
+        ".env.docker.example must document API_SERVER_KEY."
+    )
+    assert ">=16" in example, (
+        ".env.docker.example must state the API_SERVER_KEY length floor "
+        "(>=16 chars) — shorter keys are silently ignored by the agent."
+    )
+    assert "HERMES_WEBUI_GATEWAY_API_KEY" in example, (
+        ".env.docker.example must mention that the WebUI key is forwarded "
+        "automatically from the same API_SERVER_KEY."
+    )


### PR DESCRIPTION
## Summary

Three Docker deployment defects fixed in this PR: (1) the multi-container
gateway API was unreachable out of the box, (2) `HERMES_WEBUI_PASSWORD` set
in `.env` had no effect, and (3) locally-built images from Windows
checkouts crashed at startup because of a CRLF shebang.

Reproduced all three against `master` before writing any code, fixed the
chokepoints (the compose `environment:` blocks and line-ending policy), and
verified each end-to-end with real container runs.

## Problem 1 — Gateway API not reachable (two/three-container)

The multi-container compose files set `HERMES_API_URL=http://hermes-agent:8642`
on the WebUI but never configured the agent to listen on 8642. The
`nousresearch/hermes-agent:latest` image only starts its API-server listener
when `API_SERVER_KEY` is a usable value (>=16 chars) — `API_SERVER_ENABLED`
alone does nothing (verified in `gateway/config.py`). Result: the gateway
daemon runs (messaging + cron) but port 8642 stays unbound, and the WebUI
shows **"Gateway endpoint not reachable"** (`remote_gateway_unreachable`),
which also masks cron ticking.

## Problem 2 — `HERMES_WEBUI_PASSWORD` in `.env` had no effect

Docker Compose uses `.env` only for variable interpolation; a value is never
injected into a container unless the compose file references it. All three
compose files left `HERMES_WEBUI_PASSWORD` commented out in `environment:`,
so setting it in `.env` silently did nothing and password auth stayed off.

## Problem 3 — CRLF shebang breaks local `docker build` on Windows

`docker_init.bash` and the other shell scripts are committed as LF (repo
blobs verified LF; GHCR images unaffected). On Windows with
`core.autocrlf=true`, git checks them out as CRLF. A local `docker compose up
-d --build` then bakes `#!/bin/bash\r` into the image and the kernel can't
resolve `/bin/bash\r`, failing with
`exec /hermeswebui_init.bash: no such file or directory`.

## Changes

| File | Change |
|---|---|
| `docker-compose.two-container.yml` | Agent: add `API_SERVER_ENABLED=true`, `API_SERVER_HOST=0.0.0.0`, `API_SERVER_KEY=${API_SERVER_KEY:-}`. WebUI: forward `HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}` and `HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}` |
| `docker-compose.three-container.yml` | Same agent + WebUI changes as above |
| `docker-compose.yml` | WebUI: forward `HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}` |
| `.env.docker.example` | Document `API_SERVER_KEY` requirement (>=16 chars, auto-forwarded to the WebUI key) and password forwarding |
| `docs/docker.md` | Document the gateway API key requirement and `openssl rand -hex 24` recipe in the scheduled-jobs section |
| `.gitattributes` | New: `* text=auto`, `*.sh text eol=lf`, `*.bash text eol=lf` so shell scripts stay LF even with `core.autocrlf=true` |
| `tests/test_docker_compose_gateway_and_password_forwarding.py` | New regression tests (4) pinning the forwarding lines in all three compose files and the `.env.docker.example` documentation |

Empty env vars pass through as empty strings when unset, so behavior is
unchanged for users who don't set the new keys (the agent still refuses to
start the listener without a usable key; empty `HERMES_WEBUI_PASSWORD` stays
disabled).

## Verification

Automated:
- New test file: 4/4 pass (`test_agent_service_enables_api_server`,
  `test_webui_service_forwards_gateway_api_key`,
  `test_webui_service_forwards_password`,
  `test_env_example_documents_api_server_key`)
- Existing `tests/test_docker_docs_and_readonly.py`: 15/15 pass
- `docker compose config` validates for all three compose files
- Shell scripts are byte-identical to HEAD after the `.gitattributes` fix
  (`git hash-object` matches the index blob; staged diff contains no script
  content changes)

Live (each issue reproduced first on the old config, then fixed):

| Check | Before | After |
|---|---|---|
| `/api/gateway/status` | `remote_gateway_unreachable`, `state: down` | `alive / remote_gateway / gateway_state: running` |
| Agent listening on 8642 | none (`/proc/net/tcp` empty) | `0.0.0.0:8642` LISTEN |
| `/api/auth/status` with password in `.env` | `auth_enabled: false` | `auth_enabled: true`, `password_auth_enabled: true` |
| Login with `.env` password | — | HTTP 200 `{"ok": true}` |
| Local `docker compose up -d --build` (Windows CRLF) | `exec /hermeswebui_init.bash: no such file or directory` | container healthy, password auth on |

All verification deployments used isolated state dirs and named volumes; no
host `~/.hermes` was touched, and all test containers/volumes/images were
removed afterwards.

## Notes / what I could not verify

- The agent image version used for live testing was
  `nousresearch/hermes-agent:latest`; the API-server key gating is
  implemented in that image's `gateway/config.py` and could change in future
  releases.
- Password forwarding is verified for the single and two-container paths;
  the three-container dashboard service was left unchanged (it reads shared
  `hermes-home` state directly, not the gateway API).
- Did not run the full pytest suite (~11.5k tests) — only the Docker-related
  source-level tests that cover the changed files; CI shards will run the
  rest.
- The `.gitattributes` fix applies on future checkouts; any already-dirty CRLF
  working trees need `git add --renormalize .` once.