### PR TITLE
fix: close mobile sidebar drawer when opening main-view create forms

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -395,6 +395,18 @@ async function switchPanel(name, opts = {}) {
     if (typeof _kanbanStopPolling === 'function') _kanbanStopPolling();
   }
   _currentPanel = nextPanel;
+  // Mobile drawer visibility: a rail/tab click on a phone should surface the
+  // panel synchronously, NOT after the panel's async data load. If the re-open
+  // stayed at the bottom of this function, a form opened from inside the drawer
+  // (e.g. openWorkspaceCreate closing the drawer) would race the deferred
+  // re-open and the drawer would win, covering the main-view form.
+  if (opts.fromRailClick && typeof _isDesktopWidth === 'function' && !_isDesktopWidth()) {
+    const sidebar = document.querySelector('.sidebar');
+    if (sidebar) {
+      sidebar.classList.remove('mobile-session-page');
+      sidebar.classList.add('mobile-panel-drawer', 'mobile-open');
+    }
+  }
   // Update nav tabs (rail + mobile sidebar-nav share data-panel)
   document.querySelectorAll('[data-panel]').forEach(t => t.classList.toggle('active', t.dataset.panel === nextPanel));
   // Refresh aria-expanded on the newly-active rail button to mirror sidebar state.
@@ -426,13 +438,6 @@ async function switchPanel(name, opts = {}) {
   if (nextPanel === 'settings') {
     switchSettingsSection(_currentSettingsSection);
     loadSettingsPanel();
-  }
-  if (opts.fromRailClick && typeof _isDesktopWidth === 'function' && !_isDesktopWidth()) {
-    const sidebar = document.querySelector('.sidebar');
-    if (sidebar) {
-      sidebar.classList.remove('mobile-session-page');
-      sidebar.classList.add('mobile-panel-drawer', 'mobile-open');
-    }
   }
   _resyncChatSidebarAfterPanelSwitch();
   if (nextPanel === 'chat' && typeof syncTopbar === 'function') syncTopbar();
@@ -1545,6 +1550,10 @@ function openCronCreate(){
   _cronSkillsCache = null;
   api('/api/skills').then(d=>{_cronSkillsCache=d.skills||[]; _bindCronSkillPicker();}).catch(()=>{});
   loadCronProfiles().then(()=>_refreshCronProfileSelect('')).catch(()=>{});
+  // Mobile: the cron form lives in the main view, which is covered by the
+  // full-screen sidebar drawer. Close the drawer so the form is visible (mirror
+  // openCronDetail's behaviour); no-op on desktop.
+  _closeMobileSidebarAfterPanelSelection();
 }
 
 function openCronEdit(job){
@@ -5105,6 +5114,10 @@ function openSkillCreate() {
   _editingSkillName = null;
   _skillMode = 'create';
   _renderSkillForm({ name: '', category: '', content: '', isEdit: false });
+  // Mobile: the new-skill form lives in the main view, which is covered by the
+  // full-screen sidebar drawer. Close the drawer so the form is visible (mirror
+  // openSkillDetail's behaviour); no-op on desktop.
+  _closeMobileSidebarAfterPanelSelection();
 }
 
 function _renderSkillForm({ name, category, content, isEdit }) {
@@ -6153,6 +6166,10 @@ function openWorkspaceCreate(){
   _workspacePreFormDetail = _currentWorkspaceDetail ? { ..._currentWorkspaceDetail } : null;
   _workspaceMode = 'create';
   _renderWorkspaceForm({ name:'', path:'', isEdit:false });
+  // Mobile: the add-space form lives in the main view, which is covered by the
+  // full-screen sidebar drawer. Close the drawer so the form is visible (mirror
+  // openWorkspaceDetail's behaviour); no-op on desktop.
+  _closeMobileSidebarAfterPanelSelection();
 }
 
 function editCurrentWorkspace(){
@@ -7256,6 +7273,10 @@ function openProfileCreate(){
   _profilePreFormDetail = _currentProfileDetail ? { ..._currentProfileDetail } : null;
   _profileMode = 'create';
   _renderProfileForm();
+  // Mobile: the new-profile form lives in the main view, which is covered by the
+  // full-screen sidebar drawer. Close the drawer so the form is visible (mirror
+  // openWorkspaceDetail's behaviour); no-op on desktop.
+  _closeMobileSidebarAfterPanelSelection();
 }
 
 function _renderProfileForm(){


### PR DESCRIPTION
## Summary

On phones (≤640px), clicking the panel **+** button (Spaces / Profiles / Skills / Cron) popped the on-screen keyboard but showed no dialog/form. The sidebar is a full-screen drawer (`.sidebar.mobile-open`, z-index 200) on mobile; the create forms render in the main view **underneath** it. The input's `focus()` still fired → keyboard only, form invisible.

## Root cause

- `openXxxCreate()` functions rendered their form into the main-view container but — unlike their `openXxxDetail()` siblings — did not close the mobile drawer. All detail functions call `_closeMobileSidebarAfterPanelSelection()`; the four create functions missed it.
- Second layer (race): `switchPanel()` is async and its `fromRailClick` drawer re-open block ran *after* `await loadXxxPanel()`. Clicking **+** while a panel load was still pending closed the drawer, then the resumed switchPanel re-opened it, re-covering the form.

## Changes (`static/panels.js` only)

1. Add `_closeMobileSidebarAfterPanelSelection()` to `openWorkspaceCreate`, `openProfileCreate`, `openSkillCreate`, `openCronCreate` (mirrors their `*_Detail` siblings; no-op on desktop).
2. Move the `fromRailClick && !_isDesktopWidth()` drawer re-open in `switchPanel()` into the synchronous section (right after `_currentPanel = nextPanel`), so it cannot race and re-cover a drawer closed from inside the drawer.

## Verification

- Playwright mobile viewport (390×844): hamburger → Spaces tab → **+** → drawer closes within ~300ms and stays closed (>1s), form visible, focus on the path input. Also verified the race window (click **+** while panel load pending).
- Desktop (1280×800): no behavior change (drawer logic is mobile-only via `_isDesktopWidth()`).
- Mobile detail open (list item) still closes the drawer correctly.
- Tests: 97 passed (mobile layout + workspace suites) on top of latest origin/master.