### PR TITLE
Add extension turn lifecycle events

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -289,8 +289,8 @@ Core-sanitized manifest inventory that was present at the initial page boot. It
 returns `null` for empty, malformed, unknown, or untrusted IDs without creating
 settings or storage state. Re-registering the same ID in one page returns the
 same handle object; different IDs receive different handles. The handle exposes
-only the canonical `id`, `settings`, and `storage` fields, backed by the same
-factories used by the legacy accessors.
+only the canonical `id`, `settings`, `storage`, and `events` fields. Settings and
+storage are backed by the same factories used by the legacy accessors.
 
 Manifest enable/disable changes still take effect after a WebUI reload. A handle
 already created in the current page may remain cached across a status refresh;
@@ -299,6 +299,48 @@ cooperative attribution convenience for extensions sharing the page—not a
 sandbox, isolation mechanism, capability or permission system, or security
 boundary. Extensions still execute with the full WebUI session authority
 described above.
+
+### Turn lifecycle events
+
+A registered extension can react when a chat turn observed by the current page
+starts or reaches a terminal state:
+
+```js
+const ext = window.hermesExt.register("desktop-companion");
+const stop = ext && ext.events.on("turn:complete", event => {
+  console.log(event.sessionId, event.streamId, event.status);
+});
+
+// Remove the listener when the extension no longer needs it.
+if (stop) stop();
+```
+
+The supported event types are `turn:start`, `turn:complete`, `turn:error`, and
+`turn:cancel`. The frozen event object always contains `type`, `sessionId`,
+`streamId`, and `timestamp` (Unix seconds). Start events also contain
+`startedAt`; terminal events contain `endedAt` and may contain `status`.
+`events.on(type, handler)` returns an idempotent unsubscribe function, or `null`
+for an unsupported type or non-function handler. An exception in one extension
+listener is logged and does not prevent other listeners or the chat UI from
+continuing.
+
+The version-1 mapping is deliberately small: attaching a confirmed live chat
+stream emits `turn:start`; SSE `done` emits `turn:complete`; SSE `cancel` and
+application errors classified as `cancelled` or `interrupted` emit
+`turn:cancel`; other application errors and an unrecoverable live-stream
+connection failure emit `turn:error`. Transport-only `stream_end` does not emit
+a second terminal event.
+
+Core suppresses reconnect duplicates so a recently observed
+`sessionId`/`streamId` pair produces at most one start event and one terminal
+event. `sessionId` is the owner of the original stream; server-side compression
+or session rotation at completion does not change that lifecycle identity.
+
+This is a page-local, live-stream notification surface. It does not replay
+history, report turns that finish without this page observing their stream, or
+provide token, tool, approval, or metrics events. It follows the same cooperative
+trust model as `register(id)` and adds no sandbox or permission boundary. A
+durable or global agent event stream is a separate Core contract.
 
 ## URL rules
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -302,7 +302,7 @@ described above.
 
 ### Turn lifecycle events
 
-A registered extension can react when a chat turn observed by the current page
+A registered extension can react when a session turn observed by the current page
 starts or reaches a terminal state:
 
 ```js
@@ -324,7 +324,7 @@ for an unsupported type or non-function handler. An exception in one extension
 listener is logged and does not prevent other listeners or the chat UI from
 continuing.
 
-The version-1 mapping is deliberately small: attaching a confirmed live chat
+The version-1 mapping is deliberately small: attaching a confirmed live session
 stream emits `turn:start`; SSE `done` emits `turn:complete`; SSE `cancel` and
 application errors classified as `cancelled` or `interrupted` emit
 `turn:cancel`; other application errors and an unrecoverable live-stream
@@ -340,7 +340,8 @@ This is a page-local, live-stream notification surface. It does not replay
 history, report turns that finish without this page observing their stream, or
 provide token, tool, approval, or metrics events. It follows the same cooperative
 trust model as `register(id)` and adds no sandbox or permission boundary. A
-durable or global agent event stream is a separate Core contract.
+durable or global agent event stream is a separate Core contract. Ephemeral
+`/btw` answer streams are not included in this version.
 
 ## URL rules
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -335,6 +335,11 @@ Core suppresses reconnect duplicates so a recently observed
 `sessionId`/`streamId` pair produces at most one start event and one terminal
 event. `sessionId` is the owner of the original stream; server-side compression
 or session rotation at completion does not change that lifecycle identity.
+Terminal callbacks run after Core has cleared the original stream ownership,
+applied the current session's immediate terminal transcript projection, and
+returned the owned pane to its idle state. They do not wait for unrelated
+follow-up work such as notifications, queued turns, or optional recovery
+refreshes.
 
 This is a page-local, live-stream notification surface. It does not replay
 history, report turns that finish without this page observing their stream, or

--- a/static/extension_settings.js
+++ b/static/extension_settings.js
@@ -4,9 +4,13 @@
   const SETTINGS_PREFIX='hermes.ext.settings.';
   const STORAGE_PREFIX='hermes.ext.storage.';
   const FIELD_TYPES=new Set(['boolean','string','number','integer','enum']);
+  const TURN_LIFECYCLE_TYPES=new Set(['turn:start','turn:complete','turn:error','turn:cancel']);
+  const TURN_LIFECYCLE_STATE_LIMIT=512;
   const schemas=new Map();
   const trustedExtensions=new Map();
   const registrations=new Map();
+  const turnLifecycleListeners=new Map();
+  const turnLifecycleStates=new Map();
   let trustedSeeded=false;
 
   function extensionId(value){
@@ -318,6 +322,90 @@
     return storageAccessor(clean,meta);
   }
 
+  function eventAccessor(clean){
+    return Object.freeze({
+      on(type,handler){
+        if(!TURN_LIFECYCLE_TYPES.has(type)||typeof handler!=='function') return null;
+        let listenersByExtension=turnLifecycleListeners.get(type);
+        if(!listenersByExtension){
+          listenersByExtension=new Map();
+          turnLifecycleListeners.set(type,listenersByExtension);
+        }
+        let listeners=listenersByExtension.get(clean);
+        if(!listeners){
+          listeners=new Set();
+          listenersByExtension.set(clean,listeners);
+        }
+        listeners.add(handler);
+        let active=true;
+        return function unsubscribe(){
+          if(!active) return false;
+          active=false;
+          listeners.delete(handler);
+          if(!listeners.size) listenersByExtension.delete(clean);
+          if(!listenersByExtension.size) turnLifecycleListeners.delete(type);
+          return true;
+        };
+      },
+    });
+  }
+
+  function turnLifecycleKey(sessionId,streamId){
+    return `${sessionId}\u0000${streamId}`;
+  }
+
+  function rememberTurnLifecycleState(key,state){
+    if(turnLifecycleStates.has(key)) turnLifecycleStates.delete(key);
+    turnLifecycleStates.set(key,state);
+    while(turnLifecycleStates.size>TURN_LIFECYCLE_STATE_LIMIT){
+      turnLifecycleStates.delete(turnLifecycleStates.keys().next().value);
+    }
+  }
+
+  function dispatchTurnLifecycle(type,raw){
+    if(!TURN_LIFECYCLE_TYPES.has(type)||!raw||typeof raw!=='object') return false;
+    const sessionId=typeof raw.sessionId==='string'?raw.sessionId.trim():'';
+    const streamId=typeof raw.streamId==='string'?raw.streamId.trim():'';
+    if(!sessionId||!streamId) return false;
+
+    const key=turnLifecycleKey(sessionId,streamId);
+    const previous=turnLifecycleStates.get(key)||{started:false,terminal:false};
+    const terminal=type!=='turn:start';
+    if((type==='turn:start'&&(previous.started||previous.terminal))||(terminal&&previous.terminal)) return false;
+    rememberTurnLifecycleState(key,{
+      started:previous.started||type==='turn:start',
+      terminal:previous.terminal||terminal,
+    });
+
+    const now=Date.now()/1000;
+    const event={
+      type,
+      sessionId,
+      streamId,
+      timestamp:Number.isFinite(raw.timestamp)?raw.timestamp:now,
+    };
+    if(type==='turn:start') event.startedAt=Number.isFinite(raw.startedAt)?raw.startedAt:event.timestamp;
+    else event.endedAt=Number.isFinite(raw.endedAt)?raw.endedAt:event.timestamp;
+    if(typeof raw.status==='string'&&raw.status.trim()) event.status=raw.status.trim();
+    const frozenEvent=Object.freeze(event);
+    const listenersByExtension=turnLifecycleListeners.get(type);
+    if(!listenersByExtension) return true;
+    for(const [extensionId,listeners] of listenersByExtension){
+      for(const listener of [...listeners]){
+        try{
+          listener(frozenEvent);
+        }catch(error){
+          if(typeof console!=='undefined'&&typeof console.error==='function'){
+            try{
+              console.error(`[Hermes extensions] ${extensionId} ${type} listener failed:`,error);
+            }catch(_loggingError){ }
+          }
+        }
+      }
+    }
+    return true;
+  }
+
   function registerExtension(id){
     if(typeof id!=='string') return null;
     const clean=extensionId(id);
@@ -330,6 +418,7 @@
       id:clean,
       settings:settingsAccessor(clean,trusted,true),
       storage:storageAccessor(clean,trusted),
+      events:eventAccessor(clean),
     });
     registrations.set(clean,handle);
     return handle;
@@ -341,6 +430,7 @@
     namespaceForExtension,
     settingsForExtension,
     storageForExtension,
+    _dispatchTurnLifecycle:dispatchTurnLifecycle,
     resetSettingsForExtension(id){return settingsForExtension(id).reset();},
     clearStorageForExtension(id){return storageForExtension(id).clear();},
   };

--- a/static/messages.js
+++ b/static/messages.js
@@ -2066,9 +2066,26 @@ function closeOtherLiveStreams(activeSid){
   }
 }
 
+function _dispatchExtensionTurnLifecycle(type,sessionId,streamId,details={}){
+  const runtime=typeof window!=='undefined'&&window.HermesExtensionSettings;
+  const dispatch=runtime&&runtime._dispatchTurnLifecycle;
+  if(typeof dispatch!=='function') return false;
+  try{
+    return dispatch(type,{sessionId,streamId,...details});
+  }catch(error){
+    if(typeof console!=='undefined'&&typeof console.error==='function'){
+      try{console.error('[Hermes extensions] lifecycle dispatch failed:',error);}catch(_loggingError){ }
+    }
+    return false;
+  }
+}
+
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
+  const _extensionTurnStartedAt=(S.session&&S.session.session_id===activeSid&&Number.isFinite(S.session.pending_started_at))
+    ?S.session.pending_started_at
+    :Date.now()/1000;
   // #4416: start (or, on reconnect for the SAME stream, keep) tracking whether
   // the tab was hidden during this stream so the done-notification fires for a
   // backgrounded tab. A reconnect with a different streamId re-seeds (the old
@@ -6082,6 +6099,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(isSessionViewed) _markSessionViewed(completedSid, completedMessageCount);
         _clearOwnerInflightState();
+        _dispatchExtensionTurnLifecycle('turn:complete',activeSid,streamId,{
+          status:d.status||'completed',
+          endedAt:Date.now()/1000,
+        });
         if(typeof _markSessionCompletedInList==='function'){
           _markSessionCompletedInList(completedSession, activeSid);
         }
@@ -6492,6 +6513,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _clearClarifyForOwner('terminal');
       let d={};
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
+      const _extensionErrorType=(d.type==='cancelled'||d.type==='interrupted')?'turn:cancel':'turn:error';
+      _dispatchExtensionTurnLifecycle(_extensionErrorType,activeSid,streamId,{
+        status:d.status||d.type||(_extensionErrorType==='turn:cancel'?'cancelled':'error'),
+        endedAt:Date.now()/1000,
+      });
       const currentSid=S.session&&S.session.session_id;
       const eventSid=d.old_session_id||d.session_id||'';
       const continuationSid=(d.session&&d.session.session_id)||d.new_session_id||d.continuation_session_id||'';
@@ -6748,6 +6774,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _clearClarifyForOwner('cancelled');
       let _cancelData={};
       try{ _cancelData=JSON.parse(e.data||'{}')||{}; }catch(_){ _cancelData={}; }
+      _dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId,{
+        status:_cancelData.status||_cancelData.type||'cancelled',
+        endedAt:Date.now()/1000,
+      });
       _flushReasoningToAnchor();
       _applyToAnchor('cancel',{
         status:_cancelData.status||_cancelData.type||'cancelled',
@@ -7046,6 +7076,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         trackBackgroundError(activeSid,_errTitle,'Connection interrupted');
       }
     }
+    _dispatchExtensionTurnLifecycle('turn:error',activeSid,streamId,{
+      status:'connection_lost',
+      endedAt:Date.now()/1000,
+    });
     _setActivePaneIdleIfOwner();
   }
 
@@ -7088,6 +7122,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){}
     }
     const replayParams=(reconnecting||replayOnly)?_runJournalReplayParams():'';
+    _dispatchExtensionTurnLifecycle('turn:start',activeSid,streamId,{
+      startedAt:_extensionTurnStartedAt,
+    });
     _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,{withCredentials:true}));
   })();
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -6099,10 +6099,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(isSessionViewed) _markSessionViewed(completedSid, completedMessageCount);
         _clearOwnerInflightState();
-        _dispatchExtensionTurnLifecycle('turn:complete',activeSid,streamId,{
-          status:d.status||'completed',
-          endedAt:Date.now()/1000,
-        });
         if(typeof _markSessionCompletedInList==='function'){
           _markSessionCompletedInList(completedSession, activeSid);
         }
@@ -6329,6 +6325,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(isActiveSession) _queueDrainSid=activeSid;
         renderSessionList();
         _setActivePaneIdleIfOwner();
+        _dispatchExtensionTurnLifecycle('turn:complete',activeSid,streamId,{
+          status:d.status||'completed',
+          endedAt:Date.now()/1000,
+        });
         playNotificationSound();
         // #4416: notify if the tab was hidden at ANY point during this stream
         // (not just at done-receive time, which a throttled background-tab SSE
@@ -6514,10 +6514,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       let d={};
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
       const _extensionErrorType=(d.type==='cancelled'||d.type==='interrupted')?'turn:cancel':'turn:error';
-      _dispatchExtensionTurnLifecycle(_extensionErrorType,activeSid,streamId,{
-        status:d.status||d.type||(_extensionErrorType==='turn:cancel'?'cancelled':'error'),
-        endedAt:Date.now()/1000,
-      });
       const currentSid=S.session&&S.session.session_id;
       const eventSid=d.old_session_id||d.session_id||'';
       const continuationSid=(d.session&&d.session.session_id)||d.new_session_id||d.continuation_session_id||'';
@@ -6615,6 +6611,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       _setActivePaneIdleIfOwner();
       renderSessionList(); // clear streaming indicator immediately on apperror
+      _dispatchExtensionTurnLifecycle(_extensionErrorType,activeSid,streamId,{
+        status:d.status||d.type||(_extensionErrorType==='turn:cancel'?'cancelled':'error'),
+        endedAt:Date.now()/1000,
+      });
     });
 
     source.addEventListener('warning',e=>{
@@ -6774,10 +6774,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _clearClarifyForOwner('cancelled');
       let _cancelData={};
       try{ _cancelData=JSON.parse(e.data||'{}')||{}; }catch(_){ _cancelData={}; }
-      _dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId,{
-        status:_cancelData.status||_cancelData.type||'cancelled',
-        endedAt:Date.now()/1000,
-      });
       _flushReasoningToAnchor();
       _applyToAnchor('cancel',{
         status:_cancelData.status||_cancelData.type||'cancelled',
@@ -6821,6 +6817,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // a second GET race where the visible cancelled work briefly collapses to only
       // the fallback "Task cancelled" marker (#4076).
       const _cancelSessionPayload=_cancelData&&typeof _cancelData.session==='object'?_cancelData.session:null;
+      renderSessionList();
+      _setActivePaneIdleIfOwner();
       (async()=>{
         try{
           if(_applyCancelSessionPayload(_cancelSessionPayload)) return;
@@ -6846,10 +6844,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             if(_wasFollowingAtCancelFb && typeof scrollToBottom==='function') scrollToBottom();
             _markSessionViewed(activeSid, S.messages.length);
           }
+        }finally{
+          _dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId,{
+            status:_cancelData.status||_cancelData.type||'cancelled',
+            endedAt:Date.now()/1000,
+          });
         }
       })();
-      renderSessionList();
-      _setActivePaneIdleIfOwner();
     });
 
     for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
@@ -7076,11 +7077,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         trackBackgroundError(activeSid,_errTitle,'Connection interrupted');
       }
     }
+    _setActivePaneIdleIfOwner();
     _dispatchExtensionTurnLifecycle('turn:error',activeSid,streamId,{
       status:'connection_lost',
       endedAt:Date.now()/1000,
     });
-    _setActivePaneIdleIfOwner();
   }
 
   (async()=>{

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -214,7 +214,7 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
         assert.ok(alpha);
         assert.strictEqual(alpha.id, 'alpha.ext');
         assert.strictEqual(Object.isFrozen(alpha), true);
-        assert.deepStrictEqual(Object.keys(alpha).sort(), ['id', 'settings', 'storage']);
+        assert.deepStrictEqual(Object.keys(alpha).sort(), ['events', 'id', 'settings', 'storage']);
         assert.deepStrictEqual(alpha.settings.values, {{enabled: false, mode: 'alpha'}});
         assert.strictEqual(alpha.settings.set('enabled', true).ok, true);
         assert.strictEqual(alpha.storage.set('note', 'alpha-note'), true);

--- a/tests/test_extension_turn_lifecycle.py
+++ b/tests/test_extension_turn_lifecycle.py
@@ -1,0 +1,228 @@
+"""Behavioral coverage for extension turn-lifecycle subscriptions."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+
+ROOT = Path(__file__).parent.parent
+EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    brace = source.index("){", start) + 1
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"function {name} body not found")
+
+
+def _event_listener_body(source: str, event_name: str) -> str:
+    start = source.index(f"source.addEventListener('{event_name}'")
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"event listener {event_name!r} body not found")
+
+
+def _run_node(script: str):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for extension lifecycle runtime tests")
+    result = subprocess.run(
+        [node, "-e", script],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_registered_extension_receives_bounded_turn_lifecycle_events():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const assert = require('assert');
+        const store = new Map();
+        const loggedErrors = [];
+        global.window = {{
+          __HERMES_EXTENSION_CONFIG__: {{
+            extensions: [
+              {{id: 'alpha.ext', storage_owned: false}},
+              {{id: 'beta.ext', storage_owned: false}},
+            ],
+          }},
+          localStorage: {{
+            getItem(key) {{ return store.has(key) ? store.get(key) : null; }},
+            setItem(key, value) {{ store.set(key, String(value)); }},
+            removeItem(key) {{ store.delete(key); }},
+          }},
+        }};
+        global.console = {{
+          error(...args) {{ loggedErrors.push(args.map(String).join(' ')); }},
+        }};
+        eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
+
+        const alpha = window.hermesExt.register('alpha.ext');
+        const beta = window.hermesExt.register('beta.ext');
+        assert.deepStrictEqual(Object.keys(alpha).sort(), ['events', 'id', 'settings', 'storage']);
+        assert.strictEqual(Object.isFrozen(alpha.events), true);
+
+        const alphaEvents = [];
+        const betaEvents = [];
+        const unsubscribeStart = alpha.events.on('turn:start', event => {{
+          assert.strictEqual(Object.isFrozen(event), true);
+          alphaEvents.push(event);
+        }});
+        alpha.events.on('turn:complete', () => {{ throw new Error('extension failure'); }});
+        alpha.events.on('turn:complete', event => alphaEvents.push(event));
+        alpha.events.on('turn:error', event => alphaEvents.push(event));
+        alpha.events.on('turn:cancel', event => alphaEvents.push(event));
+        beta.events.on('turn:complete', event => betaEvents.push(event));
+
+        assert.strictEqual(typeof unsubscribeStart, 'function');
+        assert.strictEqual(alpha.events.on('token', () => {{}}), null);
+        assert.strictEqual(alpha.events.on('turn:start', null), null);
+
+        const emit = window.HermesExtensionSettings._dispatchTurnLifecycle;
+        assert.strictEqual(typeof emit, 'function');
+        assert.strictEqual(emit('turn:start', {{sessionId: '', streamId: 'stream-a'}}), false);
+        assert.strictEqual(emit('turn:start', {{sessionId: 'session-a', streamId: ''}}), false);
+        assert.strictEqual(emit('token', {{sessionId: 'session-a', streamId: 'stream-a'}}), false);
+
+        assert.strictEqual(emit('turn:start', {{
+          sessionId: 'session-a', streamId: 'stream-a', startedAt: 10,
+        }}), true);
+        assert.strictEqual(emit('turn:start', {{
+          sessionId: 'session-a', streamId: 'stream-a', startedAt: 11,
+        }}), false);
+        assert.strictEqual(emit('turn:complete', {{
+          sessionId: 'session-a', streamId: 'stream-a', status: 'completed', endedAt: 20,
+        }}), true);
+        assert.strictEqual(emit('turn:error', {{
+          sessionId: 'session-a', streamId: 'stream-a', status: 'late-error', endedAt: 21,
+        }}), false);
+        assert.strictEqual(emit('turn:cancel', {{
+          sessionId: 'session-a', streamId: 'stream-a', status: 'late-cancel', endedAt: 22,
+        }}), false);
+
+        assert.strictEqual(emit('turn:start', {{sessionId: 'session-b', streamId: 'stream-b'}}), true);
+        assert.strictEqual(emit('turn:error', {{
+          sessionId: 'session-b', streamId: 'stream-b', status: 'provider_error',
+        }}), true);
+        assert.strictEqual(emit('turn:start', {{sessionId: 'session-c', streamId: 'stream-c'}}), true);
+        assert.strictEqual(emit('turn:cancel', {{
+          sessionId: 'session-c', streamId: 'stream-c', status: 'cancelled',
+        }}), true);
+
+        unsubscribeStart();
+        unsubscribeStart();
+        assert.strictEqual(emit('turn:start', {{sessionId: 'session-d', streamId: 'stream-d'}}), true);
+
+        assert.deepStrictEqual(
+          alphaEvents.map(event => [event.type, event.sessionId, event.streamId, event.status || null]),
+            [
+              ['turn:start', 'session-a', 'stream-a', null],
+              ['turn:complete', 'session-a', 'stream-a', 'completed'],
+              ['turn:start', 'session-b', 'stream-b', null],
+              ['turn:error', 'session-b', 'stream-b', 'provider_error'],
+              ['turn:start', 'session-c', 'stream-c', null],
+              ['turn:cancel', 'session-c', 'stream-c', 'cancelled'],
+            ],
+        );
+        assert.deepStrictEqual(
+          betaEvents.map(event => [event.type, event.sessionId, event.streamId]),
+          [['turn:complete', 'session-a', 'stream-a']],
+        );
+        assert.strictEqual(loggedErrors.length, 1);
+        assert.match(loggedErrors[0], /alpha[.]ext.*turn:complete.*extension failure/);
+        """
+    )
+    _run_node(script)
+
+
+def test_live_stream_bridge_forwards_normalized_lifecycle_details():
+    bridge = _function_body(MESSAGES_JS, "_dispatchExtensionTurnLifecycle")
+    script = textwrap.dedent(
+        f"""
+        const assert = require('assert');
+        const calls = [];
+        global.window = {{
+          HermesExtensionSettings: {{
+            _dispatchTurnLifecycle(type, details) {{
+              calls.push([type, details]);
+              return 'delivered';
+            }},
+          }},
+        }};
+        eval({json.dumps(bridge)});
+
+        assert.strictEqual(
+          _dispatchExtensionTurnLifecycle(
+            'turn:error', 'session-a', 'stream-a', {{status: 'connection_lost'}},
+          ),
+          'delivered',
+        );
+        assert.deepStrictEqual(calls, [[
+          'turn:error',
+          {{sessionId: 'session-a', streamId: 'stream-a', status: 'connection_lost'}},
+        ]]);
+
+        delete window.HermesExtensionSettings;
+        assert.strictEqual(
+          _dispatchExtensionTurnLifecycle('turn:start', 'session-b', 'stream-b'),
+          false,
+        );
+
+        window.HermesExtensionSettings = {{
+          _dispatchTurnLifecycle() {{ throw new Error('broken extension runtime'); }},
+        }};
+        global.console = {{error() {{}}}};
+        assert.strictEqual(
+          _dispatchExtensionTurnLifecycle('turn:start', 'session-c', 'stream-c'),
+          false,
+        );
+        """
+    )
+    _run_node(script)
+
+
+def test_live_stream_terminal_paths_use_original_stream_owner_identity():
+    attach_start = MESSAGES_JS.index("function attachLiveStream(")
+    attach_body = MESSAGES_JS[attach_start : MESSAGES_JS.index("\nfunction transcript(", attach_start)]
+    done = _event_listener_body(MESSAGES_JS, "done")
+    application_error = _event_listener_body(MESSAGES_JS, "apperror")
+    cancel = _event_listener_body(MESSAGES_JS, "cancel")
+    connection_error = _function_body(MESSAGES_JS, "_handleStreamError")
+
+    start_dispatch = attach_body.index("_dispatchExtensionTurnLifecycle('turn:start',activeSid,streamId")
+    dead_reconnect_return = attach_body.index("_scheduleAnchorRegistryCleanup(120000);")
+    event_source_attach = attach_body.index("_wireSSE(new EventSource", start_dispatch)
+    assert dead_reconnect_return < start_dispatch < event_source_attach
+    assert "_dispatchExtensionTurnLifecycle('turn:complete',activeSid,streamId" in done
+    assert "_dispatchExtensionTurnLifecycle(_extensionErrorType,activeSid,streamId" in application_error
+    assert "_dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId" in cancel
+    assert "_dispatchExtensionTurnLifecycle('turn:error',activeSid,streamId" in connection_error
+
+    assert "_dispatchExtensionTurnLifecycle('turn:complete',completedSid" not in done
+    assert "_dispatchExtensionTurnLifecycle(_extensionErrorType,d.session_id" not in application_error
+    assert "_dispatchExtensionTurnLifecycle('turn:cancel',_cancelData.session_id" not in cancel

--- a/tests/test_extension_turn_lifecycle.py
+++ b/tests/test_extension_turn_lifecycle.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import textwrap
@@ -10,8 +11,173 @@ import pytest
 
 
 ROOT = Path(__file__).parent.parent
+STATIC = ROOT / "static"
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
 MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+INDEX_HTML = (STATIC / "index.html").read_text(encoding="utf-8")
+UI_JS = (STATIC / "ui.js").read_text(encoding="utf-8")
+SUPPORT_SCRIPTS = [
+    (STATIC / name).read_text(encoding="utf-8")
+    for name in ("i18n.js", "icons.js", "assistant_turn_anchors.js")
+]
+HARNESS_HTML = re.sub(r"<script\b[^>]*>.*?</script>", "", INDEX_HTML, flags=re.I | re.S)
+HARNESS_HTML = re.sub(r"<link\b[^>]*>", "", HARNESS_HTML, flags=re.I)
+
+
+_MOCK_EVENT_SOURCE = r"""
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances = [];
+  constructor(url) {
+    this.url = String(url);
+    this.readyState = MockEventSource.OPEN;
+    this.listeners = new Map();
+    MockEventSource.instances.push(this);
+  }
+  addEventListener(name, listener) {
+    const listeners = this.listeners.get(name) || [];
+    listeners.push(listener);
+    this.listeners.set(name, listeners);
+  }
+  removeEventListener(name, listener) {
+    this.listeners.set(name, (this.listeners.get(name) || []).filter(fn => fn !== listener));
+  }
+  async emit(name, payload) {
+    const event = {type: name, data: JSON.stringify(payload), lastEventId: ''};
+    await Promise.all((this.listeners.get(name) || []).map(listener => listener(event)));
+  }
+  close() { this.readyState = MockEventSource.CLOSED; }
+}
+window.EventSource = MockEventSource;
+window.MockEventSource = MockEventSource;
+"""
+
+
+_STABILIZE_UNRELATED_UI = r"""
+appendLiveCompressionCard = () => false;
+resetTurnWorkspaceMutations = () => {};
+_resetStreamScrollFollow = () => {};
+ensureLiveWorklogShell = () => {};
+_shouldUseLiveProseFade = () => false;
+_shouldFollowMessagesOnDomReplace = () => false;
+_isMessagePaneNearBottom = () => false;
+_markSessionViewed = () => {};
+setBusy = value => { S.busy = Boolean(value); };
+setComposerStatus = () => {};
+setStatus = () => {};
+syncTopbar = () => {};
+renderMessages = () => {};
+renderSessionList = () => {};
+renderSessionArtifacts = () => {};
+loadDir = () => {};
+playNotificationSound = () => {};
+sendBrowserNotification = () => {};
+api = async () => ({});
+"""
+
+
+_LIFECYCLE_SCENARIO = r"""
+async ({kind}) => {
+  const activeSid = 'session-a';
+  const streamId = `stream-${kind}`;
+  const lifecycle = [];
+  const extension = window.hermesExt.register('lifecycle-probe');
+  if (!extension) throw new Error('lifecycle probe did not register');
+  for (const type of ['turn:start', 'turn:complete', 'turn:error', 'turn:cancel']) {
+    extension.events.on(type, event => {
+      const lastMessage = Array.isArray(S.messages) ? S.messages.at(-1) : null;
+      lifecycle.push({
+        event: {...event},
+        activeStreamId: S.activeStreamId || null,
+        busy: Boolean(S.busy),
+        currentSid: S.session && S.session.session_id || null,
+        lastContent: lastMessage && lastMessage.content || null,
+      });
+    });
+  }
+
+  S.session = {session_id: activeSid, messages: [{role: 'user', content: 'question'}]};
+  S.messages = [{role: 'user', content: 'question'}];
+  S.toolCalls = [];
+  S.activeStreamId = streamId;
+  S.busy = true;
+  attachLiveStream(activeSid, streamId, []);
+  const source = MockEventSource.instances.at(-1);
+  if (!source) throw new Error('attachLiveStream did not construct EventSource');
+
+  if (kind === 'done') {
+    await source.emit('done', {
+      status: 'completed',
+      stream_id: streamId,
+      session: {
+        session_id: activeSid,
+        messages: [{role: 'assistant', content: 'settled-done'}],
+        tool_calls: [],
+      },
+    });
+  } else if (kind === 'apperror') {
+    await source.emit('apperror', {
+      type: 'provider_error',
+      status: 'provider_error',
+      message: 'provider failed',
+      session_id: activeSid,
+      session: {
+        session_id: activeSid,
+        messages: [{role: 'assistant', content: 'settled-error'}],
+      },
+    });
+  } else if (kind === 'apperror-cancel') {
+    await source.emit('apperror', {
+      type: 'interrupted',
+      status: 'interrupted',
+      message: 'interrupted',
+      session_id: activeSid,
+      session: {
+        session_id: activeSid,
+        messages: [{role: 'assistant', content: 'settled-interrupted'}],
+      },
+    });
+  } else if (kind === 'cancel') {
+    await source.emit('cancel', {
+      type: 'cancelled',
+      status: 'cancelled',
+      session_id: activeSid,
+      session: {
+        session_id: activeSid,
+        messages: [{role: 'assistant', content: 'settled-cancel'}],
+      },
+    });
+  } else if (kind === 'connection-error') {
+    const nativeSetTimeout = window.setTimeout;
+    api = async url => String(url).includes('/api/chat/stream/status')
+      ? {active: false, replay_available: false}
+      : {};
+    window.setTimeout = callback => {
+      queueMicrotask(callback);
+      return 1;
+    };
+    try {
+      await source.emit('error', {});
+      await new Promise((resolve, reject) => {
+        const deadline = Date.now() + 2000;
+        const poll = () => {
+          if (lifecycle.some(entry => entry.event.type === 'turn:error')) return resolve();
+          if (Date.now() >= deadline) return reject(new Error('connection terminal event not observed'));
+          nativeSetTimeout(poll, 0);
+        };
+        poll();
+      });
+    } finally {
+      window.setTimeout = nativeSetTimeout;
+    }
+  } else {
+    throw new Error(`unknown lifecycle scenario: ${kind}`);
+  }
+  return lifecycle;
+}
+"""
 
 
 def _function_body(source: str, name: str) -> str:
@@ -206,6 +372,91 @@ def test_live_stream_bridge_forwards_normalized_lifecycle_details():
     _run_node(script)
 
 
+@pytest.fixture(scope="module")
+def lifecycle_browser():
+    playwright_api = pytest.importorskip("playwright.sync_api")
+    with playwright_api.sync_playwright() as playwright:
+        browser = playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        yield browser
+        browser.close()
+
+
+def _run_lifecycle_scenario(browser, kind: str) -> list[dict]:
+    page = browser.new_page()
+    page.route(
+        "**/*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="text/html"
+            if route.request.url == "http://harness.test/"
+            else "text/plain",
+            body=HARNESS_HTML if route.request.url == "http://harness.test/" else "",
+        ),
+    )
+    page.add_init_script(_MOCK_EVENT_SOURCE)
+    try:
+        page.goto("http://harness.test/", wait_until="domcontentloaded")
+        page.evaluate(
+            """
+            window.__HERMES_EXTENSION_CONFIG__ = {
+              extensions: [{id: 'lifecycle-probe', storage_owned: false}],
+            };
+            """
+        )
+        for script in SUPPORT_SCRIPTS:
+            page.add_script_tag(content=script)
+        page.add_script_tag(content=EXTENSION_SETTINGS_JS.read_text(encoding="utf-8"))
+        page.add_script_tag(content=UI_JS)
+        page.add_script_tag(content=MESSAGES_JS)
+        page.evaluate(_STABILIZE_UNRELATED_UI)
+        return page.evaluate(_LIFECYCLE_SCENARIO, {"kind": kind})
+    finally:
+        page.close()
+
+
+@pytest.mark.parametrize(
+    ("kind", "terminal_type", "terminal_status", "last_content"),
+    [
+        ("done", "turn:complete", "completed", "settled-done"),
+        ("apperror", "turn:error", "provider_error", "settled-error"),
+        ("apperror-cancel", "turn:cancel", "interrupted", "settled-interrupted"),
+        ("cancel", "turn:cancel", "cancelled", "settled-cancel"),
+        (
+            "connection-error",
+            "turn:error",
+            "connection_lost",
+            "**Connection interrupted:** The browser lost the live SSE connection before the response finished. If the worker completed, reopening this session should restore the settled transcript.",
+        ),
+    ],
+)
+def test_real_sse_terminal_callback_observes_settled_core_state(
+    lifecycle_browser,
+    kind,
+    terminal_type,
+    terminal_status,
+    last_content,
+):
+    lifecycle = _run_lifecycle_scenario(lifecycle_browser, kind)
+
+    assert [entry["event"]["type"] for entry in lifecycle] == [
+        "turn:start",
+        terminal_type,
+    ]
+    start, terminal = lifecycle
+    assert start["activeStreamId"] == f"stream-{kind}"
+    assert start["busy"] is True
+    assert terminal["event"]["sessionId"] == "session-a"
+    assert terminal["event"]["streamId"] == f"stream-{kind}"
+    assert terminal["event"]["status"] == terminal_status
+    assert terminal["activeStreamId"] is None
+    assert terminal["busy"] is False
+    assert terminal["currentSid"] == "session-a"
+    assert terminal["lastContent"] == last_content
+
+
 def test_live_stream_terminal_paths_use_original_stream_owner_identity():
     attach_start = MESSAGES_JS.index("function attachLiveStream(")
     attach_body = MESSAGES_JS[attach_start : MESSAGES_JS.index("\nfunction transcript(", attach_start)]
@@ -222,6 +473,22 @@ def test_live_stream_terminal_paths_use_original_stream_owner_identity():
     assert "_dispatchExtensionTurnLifecycle(_extensionErrorType,activeSid,streamId" in application_error
     assert "_dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId" in cancel
     assert "_dispatchExtensionTurnLifecycle('turn:error',activeSid,streamId" in connection_error
+
+    assert done.index("_setActivePaneIdleIfOwner()") < done.index(
+        "_dispatchExtensionTurnLifecycle('turn:complete'"
+    )
+    assert application_error.index("renderSessionList()") < application_error.index(
+        "_dispatchExtensionTurnLifecycle(_extensionErrorType"
+    )
+    assert cancel.index("await api(") < cancel.index(
+        "_dispatchExtensionTurnLifecycle('turn:cancel'"
+    )
+    assert cancel.index("_setActivePaneIdleIfOwner()") < cancel.index(
+        "_dispatchExtensionTurnLifecycle('turn:cancel'"
+    )
+    assert connection_error.index("_setActivePaneIdleIfOwner()") < connection_error.index(
+        "_dispatchExtensionTurnLifecycle('turn:error'"
+    )
 
     assert "_dispatchExtensionTurnLifecycle('turn:complete',completedSid" not in done
     assert "_dispatchExtensionTurnLifecycle(_extensionErrorType,d.session_id" not in application_error

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -531,6 +531,7 @@ global.EventSource=FakeEventSource;
 const attachStart=messagesSrc.indexOf('function attachLiveStream(');
 const attachEnd=messagesSrc.indexOf('\nfunction transcript(){',attachStart);
 if(attachStart<0||attachEnd<0) throw new Error('attachLiveStream source boundary not found');
+eval(extractFunc(messagesSrc,'_dispatchExtensionTurnLifecycle'));
 eval(messagesSrc.slice(attachStart,attachEnd));
 attachLiveStream('sid-1','stream-1');
 const source=FakeEventSource.instances[0];


### PR DESCRIPTION
## Thinking Path

The extension roadmap approved in hermes-webui/hermes-webui-extensions#40 puts B1 immediately after the E0 identity handle. Core already owns the authoritative live session stream and its terminal paths, so the narrowest stable contract is a page-local facade on the registered extension handle instead of another extension polling private DOM state.

This intentionally does not implement the broader durable agent-event and metrics surface discussed in #5711. It maps only the session-turn lifecycle that the current page actually observes.

## What Changed

- Add `ext.events.on(type, handler)` to trusted `hermesExt.register(id)` handles.
- Support `turn:start`, `turn:complete`, `turn:error`, and `turn:cancel`.
- Normalize and freeze event payloads with stable original `sessionId` + `streamId` ownership.
- Suppress reconnect duplicates and accept only the first terminal event for a recent stream.
- Isolate listener and dispatch failures from the chat UI.
- Wire the existing main live-stream start, done, application-error, cancel, and unrecoverable connection-error paths.
- Deliver terminal callbacks only after Core has cleared stream ownership, projected the immediate terminal state, and returned the owned pane to idle.
- Document the version-1 SSE mapping, unsubscribe contract, trust boundary, ordering, and page-local limitations.

## Why It Matters

Extensions such as mobile haptics can stop inferring completion from private composer DOM state. The same small contract also enables sounds, local notifications, and completion analytics without making Core expose token/tool payloads or inventing a second backend event system.

Release-note wording: Registered WebUI extensions can subscribe to page-local session-turn start, completion, error, and cancellation events through `ext.events`.

## Contract Routing

- Canonical public contract: `docs/EXTENSIONS.md`.
- State owner: browser-page extension runtime; lifecycle state is in-memory and bounded to recent session/stream pairs.
- Authoritative signal owner: the existing Core live session SSE consumer in `static/messages.js`.
- Durability: none; reload resets subscriptions and dedupe state.
- Explicitly out of scope: history replay, off-page/global delivery, `/btw` ephemeral streams, tokens, tools, approvals, metrics, permissions, runtime unload, and the broader #5711 event/metrics design.

## Verification

Red proof before implementation, against the `origin/master` runtime:

```text
./scripts/test.sh tests/test_extension_turn_lifecycle.py -q
1 failed: registered handle exposed only id/settings/storage; expected events
```

Current branch (`7c5add1903bb6074cf220522346bd1950bad9b79`):

```text
./scripts/test.sh tests/test_extension_hooks.py tests/test_extension_session_hooks.py tests/test_extension_settings_runtime.py tests/test_extension_sidecar_proxy.py tests/test_extension_status_endpoint.py tests/test_extension_theme_registration.py tests/test_extension_tts_engine_registration.py tests/test_extension_turn_lifecycle.py tests/test_extensions_settings_panel.py tests/test_issue4746_extension_gallery.py -q
174 passed

./scripts/test.sh tests/test_cancel_interrupt.py tests/test_cancel_stream_owner_guard.py tests/test_cancelled_turn_status.py tests/test_issue1298_cancel_and_activity.py tests/test_issue1361_cancel_data_loss.py tests/test_issue6623_cancel_owner_race.py tests/test_issue893_cancel_preserves_partial.py tests/test_sse_relay_apperror_closes.py tests/test_stale_stream_pending_recovery.py tests/test_stream_end_recovery_gating.py tests/test_issue5720_reasoning_owner.py -q
118 passed

./scripts/test.sh tests/test_compression_phantom_barrier.py -q
8 passed

./scripts/test.sh tests/test_static_js_runtime_lint.py tests/test_ruff_forward_lint.py -q
4 passed, 1 optional local ESLint-tool skip

node --check static/extension_settings.js
exit 0

node --check static/messages.js
exit 0

./.venv/bin/python scripts/ruff_lint.py --diff origin/master
2 changed Python files; 0 findings

./.venv/bin/python scripts/critical_markdown_check.py docs/EXTENSIONS.md
1 file OK

git diff origin/master --check
exit 0
```

The real-browser lifecycle regression loads the shipping extension runtime, UI, and `attachLiveStream`, replaces only EventSource/API transport, and executes start plus five terminal rows: done, application error, interrupted application error, explicit cancel, and exhausted reconnect/connection error. Every terminal callback observes `S.activeStreamId === null`, an idle pane, and the settled terminal transcript projection.

## Risks / Follow-ups

- This is not a global agent event feed. A turn that completes while the page never observes its live stream produces no event here; #5711 remains the place for a durable/global design.
- The recent-stream dedupe cache is deliberately bounded, and all subscriptions reset on reload.
- Ephemeral `/btw` answers are excluded from version 1.
- No visible UI changed. Browser automation now covers every v1 terminal classification through the real `attachLiveStream` listeners.
- The local checkout does not carry the optional npm ESLint binary, so the direct npm lint command was not re-run locally. The curated runtime-lint pytest guard passed locally, and the fresh GitHub lint job is authoritative for the pushed head.
- A skeptical reviewer may object that a trusted extension can still replace same-origin globals. That is true under the existing cooperative extension trust model; the bridge fails closed if its dispatcher is absent or throws, but this PR does not claim sandboxing.

Refs hermes-webui/hermes-webui-extensions#40
Refs #5711

## Model Used

OpenAI Codex (GPT-5; the exact serving variant is not exposed to the agent). AI assistance was used for implementation, tests, documentation, and review; the maintainer set the product direction and explicitly authorized publication of this Draft PR.
