### PR TITLE
fix(commands): search skills by keyword in slash autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 
 ### Slash commands
 - Type `/` in the composer for autocomplete dropdown
+- Plain skills match case-insensitive keywords in their name or description; built-in, agent/plugin, and bundle commands keep prefix matching and take precedence over a same-slug skill
 - Built-in: `/help`, `/clear`, `/compress [focus topic]`, `/compact` (alias), `/model <name>`, `/workspace <name>`, `/new`, `/usage`, `/theme`
 - Arrow keys navigate, Tab/Enter select, Escape closes
 - Unrecognized commands pass through to the agent

--- a/static/commands.js
+++ b/static/commands.js
@@ -187,6 +187,7 @@ function getMatchingCommands(prefix){
   const matches=COMMANDS.filter(c=>c.name.startsWith(q)).map(c=>({...c,source:'builtin'}));
   const seen=new Set(matches.map(c=>c.name));
   const reserved=_getReservedSlashCommandSlugs();
+  const bundleSlugs=new Set(_bundleCommandCache.map(bundle=>bundle.name));
   for(const [name, spec] of Object.entries(SLASH_SUBARG_SOURCES)){
     if(!name.startsWith(q)||seen.has(name))continue;
     matches.push({
@@ -228,9 +229,11 @@ function getMatchingCommands(prefix){
     }
   }
   for(const skill of _skillCommandCache){
-    if(!skill.name.startsWith(q)||seen.has(skill.name)||reserved.has(skill.name))continue;
+    const name=String(skill&&skill.name||'').toLowerCase();
+    const description=String(skill&&skill.desc||'').toLowerCase();
+    if((!name.includes(q)&&!description.includes(q))||seen.has(name)||reserved.has(name)||bundleSlugs.has(name))continue;
     matches.push(skill);
-    seen.add(skill.name);
+    seen.add(name);
   }
   return matches;
 }

--- a/static/commands.js
+++ b/static/commands.js
@@ -228,6 +228,10 @@ function getMatchingCommands(prefix){
       seen.add(bundle.name);
     }
   }
+  // A same-slug bundle owns dispatch. Hold plain skills until the independent
+  // bundle metadata request settles so a slow bundle response cannot briefly
+  // expose a selectable, shadowed skill.
+  if(!_bundleCommandCacheReady)return matches;
   for(const skill of _skillCommandCache){
     const name=String(skill&&skill.name||'').toLowerCase();
     const description=String(skill&&skill.desc||'').toLowerCase();
@@ -2089,8 +2093,9 @@ function refreshSlashCommandDropdown(){
   });
 }
 function ensureSkillCommandsLoadedForAutocomplete(){
-  if(_skillCommandCacheReady||_skillCommandLoadPromise)return;
-  loadSkillCommands().then(()=>{refreshSlashCommandDropdown();});
+  if(!_skillCommandCacheReady&&!_skillCommandLoadPromise){
+    loadSkillCommands().then(()=>{refreshSlashCommandDropdown();});
+  }
   if(!_bundleCommandCacheReady&&!_bundleCommandLoadPromise){
     loadBundleCommands().then(()=>{refreshSlashCommandDropdown();});
   }

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -215,6 +215,18 @@ def _run_commands_js(script_body: str) -> dict:
                 {{
                   name: 'plugin review',
                   description: 'Plugin collisions should stay hidden from slash autocomplete'
+                }},
+                {{
+                  name: 'hermes-upgrade',
+                  description: 'Safely upgrade and verify a Hermes installation'
+                }},
+                {{
+                  name: 'maintenance-guide',
+                  description: 'Plan a safe upgrade and rollback path'
+                }},
+                {{
+                  name: 'reinstall-helper',
+                  description: 'Recover from a failed reinstall'
                 }}
               ]
             }};
@@ -350,6 +362,41 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
     assert result["plugin_sources"] == ["plugin"]
     assert "skills" in result["skills_names"]
     assert "use" in result["use_names"]
+
+
+def test_skill_autocomplete_matches_keyword_in_name_or_description():
+    result = _run_commands_js(
+        """
+        await loadSkillCommands(true);
+        const upgrade = await getSlashAutocompleteMatches('/upgrade');
+        const reinstall = await getSlashAutocompleteMatches('/reinstall');
+        return {
+          upgrade_names: upgrade.map(item => item.name),
+          upgrade_sources: upgrade.map(item => item.source),
+          reinstall_names: reinstall.map(item => item.name),
+          reinstall_sources: reinstall.map(item => item.source)
+        };
+        """
+    )
+
+    assert result["upgrade_names"] == ["hermes-upgrade", "maintenance-guide"]
+    assert result["upgrade_sources"] == ["skill", "skill"]
+    assert result["reinstall_names"] == ["reinstall-helper"]
+    assert result["reinstall_sources"] == ["skill"]
+
+
+def test_skill_autocomplete_hides_keyword_match_shadowed_by_bundle():
+    result = _run_commands_js(
+        """
+        await loadAgentCommandMetadata(true);
+        await loadBundleCommands(true);
+        await loadSkillCommands(true);
+        const matches = await getSlashAutocompleteMatches('/non-colliding');
+        return matches.map(item => ({ name: item.name, source: item.source }));
+        """
+    )
+
+    assert result == []
 
 
 def test_bundle_collisions_stay_hidden_until_agent_metadata_is_ready():

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -367,6 +367,7 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
 def test_skill_autocomplete_matches_keyword_in_name_or_description():
     result = _run_commands_js(
         """
+        await loadBundleCommands(true);
         await loadSkillCommands(true);
         const upgrade = await getSlashAutocompleteMatches('/upgrade');
         const reinstall = await getSlashAutocompleteMatches('/reinstall');
@@ -397,6 +398,66 @@ def test_skill_autocomplete_hides_keyword_match_shadowed_by_bundle():
     )
 
     assert result == []
+
+
+def test_skill_autocomplete_waits_for_bundle_metadata_before_showing_colliding_keyword_match():
+    script = textwrap.dedent(
+        f"""
+        const vm = require('vm');
+        let releaseBundles;
+        const bundlesReady = new Promise(resolve => {{ releaseBundles = resolve; }});
+        const ctx = {{
+          console,
+          localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
+          t: (key) => key,
+          api: async (path) => {{
+            if (path === '/api/commands') return {{ commands: [] }};
+            if (path === '/api/commands/bundles') return bundlesReady;
+            if (path === '/api/skills') return {{ skills: [
+              {{
+                name: 'incident-review',
+                description: 'Handle a non-colliding keyword',
+                category: 'ops'
+              }}
+            ] }};
+            throw new Error('unexpected api path: ' + path);
+          }}
+        }};
+        vm.createContext(ctx);
+        vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
+        (async () => {{
+          await vm.runInContext('loadSkillCommands(true)', ctx);
+          const bundleLoad = vm.runInContext('loadBundleCommands(true)', ctx);
+          const before = await vm.runInContext("getSlashAutocompleteMatches('/non-colliding')", ctx);
+          releaseBundles({{ bundles: [
+            {{
+              name: 'incident-review',
+              description: 'Incident review bundle',
+              skill_count: 3,
+              source: 'bundle'
+            }}
+          ] }});
+          await bundleLoad;
+          const after = await vm.runInContext("getSlashAutocompleteMatches('/non-colliding')", ctx);
+          process.stdout.write(JSON.stringify({{
+            before: before.map(item => ({{ name: item.name, source: item.source }})),
+            after: after.map(item => ({{ name: item.name, source: item.source }}))
+          }}));
+        }})().catch(err => {{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(script)
+        script_path = Path(handle.name)
+    try:
+        proc = subprocess.run(["node", str(script_path)], check=True, capture_output=True, text=True)
+    finally:
+        script_path.unlink(missing_ok=True)
+
+    assert json.loads(proc.stdout) == {"before": [], "after": []}
 
 
 def test_bundle_collisions_stay_hidden_until_agent_metadata_is_ready():

--- a/tests/test_sprint47.py
+++ b/tests/test_sprint47.py
@@ -63,7 +63,9 @@ def test_skill_mutations_invalidate_slash_skill_caches():
 def test_builtin_commands_take_precedence_over_skill_slug_collisions():
     assert "_getReservedSlashCommandSlugs" in COMMANDS_JS
     assert "if(_getReservedSlashCommandSlugs().has(slug)) return null;" in COMMANDS_JS
-    assert "if(!skill.name.startsWith(q)||seen.has(skill.name)||reserved.has(skill.name))continue;" in COMMANDS_JS
+    command_matching = _function_body(COMMANDS_JS, "getMatchingCommands")
+    assert "reserved.has(name)" in command_matching
+    assert "!name.includes(q)&&!description.includes(q)" in command_matching
 
 
 def test_bundle_entries_merge_before_plain_skill_entries():


### PR DESCRIPTION
## Thinking Path
- Composer autocomplete already loads plain skills from `/api/skills`, but only matched a skill when its canonical slug started with the typed text.
- That makes a capability-oriented query such as `/upgrade` miss a skill named `hermes-upgrade`, even though the same query is enough for a user to identify the task they want to run.
- The existing built-in, agent/plugin, and bundle command loops intentionally use prefix matching and establish command ownership/precedence, so this change leaves those loops unchanged.
- Plain-skill matching now uses the existing normalized name/description metadata, while the shared result list continues to suppress reserved command slugs and additionally prevents a description-only skill match from shadowing a same-slug bundle.
- Selecting a match still uses the canonical skill slug, so a search for `/upgrade` inserts `/hermes-upgrade`.

## What Changed
- Match plain skill suggestions by a case-insensitive substring in their canonical name or description.
- Preserve built-in, agent/plugin, and bundle prefix matching plus existing result ordering.
- Keep bundle precedence when a same-slug plain skill matches only through its description, including while bundle metadata is still loading.
- Add executable autocomplete regressions for name-keyword, description-only, bundle-collision, and delayed-bundle-metadata cases.
- Document the keyword-search and command-precedence behavior in the slash-command usage section.
- Update the existing Sprint 47 precedence assertion for the normalized matching implementation.

## Why It Matters
Users can search by the task they want to perform instead of needing to remember the beginning of a skill slug. For example, `/upgrade` now finds `hermes-upgrade`, and `/reinstall` can find a skill whose description advertises reinstall recovery. Command ownership remains predictable: a real command or bundle is never presented as a plain skill with the same slug.

## Contract Routing
Task type: focused composer autocomplete behavior fix.
Touched areas: `getMatchingCommands()` skill branch and existing slash-command regression coverage.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`
Scope boundaries: no command transport, endpoint, persistence, layout, dependency, or changelog changes.
Evidence needed before claiming done: keyword suggestions resolve to canonical skill slugs; reserved command and bundle precedence regressions remain green.

## Verification
- RED (before the implementation): the new keyword regression failed because the plain-skill loop only used `skill.name.startsWith(q)`.
- GREEN: `HERMES_WEBUI_TEST_STATE_ROOT=/tmp/hermes-webui-tests-hermes ./.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_sprint47.py tests/test_cli_only_slash_commands.py` -> `33 passed`.
- `node --check static/commands.js` -> passed.
- `npx eslint -c eslint.runtime-guard.config.mjs "static/**/*.js"` -> passed.
- `python3 scripts/ruff_lint.py --diff origin/master` -> no new violations.
- Isolated real-WebUI browser smoke with an `hermes-upgrade` fixture: typing `/upgrade` showed the skill suggestion and selecting it wrote `/hermes-upgrade` into the composer.
- Independent review found the same-slug bundle shadowing edge case; this revision adds the bundle-slug guard and its executable regression.
- Follow-up review found a cache-readiness race: a colliding plain skill could appear while bundle metadata was pending. The autocomplete now holds plain skills until bundle metadata settles; the delayed-metadata regression was RED before this commit and is GREEN in the updated `34 passed` targeted suite.
- Full `./scripts/test.sh` (after installing the missing local Playwright package and Chromium runtime): `14,283 passed, 89 skipped, 1 xfailed, 2 xpassed`; 3 failures remain in `tests/test_issue1094_provider_bugs.py` and `tests/test_tls_aware_probe.py`.
- Those exact 3 failures reproduce unchanged on a detached `origin/master` worktree, so they are pre-existing environment failures (configured Anthropic key state and local self-signed TLS health-probe behavior), not introduced by this PR.

## Risks / Follow-ups
Low risk. This deliberately broadens only the plain-skill branch. Substring matching can return more skill suggestions for short queries, but built-in, agent/plugin, and bundle commands retain their existing prefix semantics and precedence. No ranking model or fuzzy-search dependency is introduced.

Release-note-ready wording: Slash-command autocomplete can now find a skill by a keyword anywhere in its name or description, while existing command and bundle precedence is preserved.

## Model Used
OpenAI GPT-5.6 Terra


