### PR TITLE
fix: close mobile sidebar after project quick-create '+'

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7538,6 +7538,12 @@ function _attachProjectQuickCreateButton(chip, project){
       // project-assigned session appears deterministically.
       try{ if(typeof renderSessionListFromCache==='function') renderSessionListFromCache(); }catch(_){}
       try{ if(typeof renderSessionList==='function') void renderSessionList({deferWhileInteracting:false}); }catch(_){}
+      // Mobile: the sidebar is a full-screen drawer over the main view — close
+      // it after the project conversation is created so the user actually sees
+      // the new session (mirrors $('btnNewChat').onclick in boot.js and the
+      // #5409 close in _openSidebarSession). Failure path keeps the drawer open
+      // so the toast stays visible for retry.
+      if(typeof closeMobileSidebar==='function') closeMobileSidebar();
     }catch(err){
       _setActiveProjectFilter(previousProject);
       if(typeof showToast==='function') showToast('New conversation failed: '+(err&&err.message||err));

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -265,9 +265,15 @@ class TestQuickCreateMobileDrawer:
         block = self._quick_create_block()
         render_idx = block.find("renderSessionList({deferWhileInteracting:false})")
         close_idx = block.find("closeMobileSidebar")
+        catch_idx = block.find("catch(err)")
         assert render_idx != -1, "sidebar repaint call not found in quick-create handler"
         assert close_idx != -1, "closeMobileSidebar not found in quick-create handler"
+        assert catch_idx != -1, "success-path try/catch not found in quick-create handler"
         assert close_idx > render_idx, (
             "closeMobileSidebar must run after the sidebar repaint in the success path"
+        )
+        assert close_idx < catch_idx, (
+            "closeMobileSidebar must stay in the success path (try block) — moving it "
+            "into the catch branch would keep the drawer open over the error toast"
         )
 

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -229,3 +229,45 @@ class TestProjectChipLongPressTouch:
         # touch tuning so the native callout/selection doesn't compete with the gesture
         assert "touch-action:manipulation" in chip_rule
         assert "user-select:none" in chip_rule
+
+
+class TestQuickCreateMobileDrawer:
+    """The project-chip "+" (quick-create) must close the mobile sidebar drawer.
+
+    On phones the sidebar is a full-screen drawer (`.sidebar.mobile-open`,
+    z-index 200) covering the main chat view. The quick-create button creates
+    the new project conversation but never closed the drawer, so on mobile the
+    tap *looked* like a no-op — the session was created, just hidden underneath.
+    Mirrors `$('btnNewChat').onclick` in boot.js and the #5409 close in
+    `_openSidebarSession`.
+    """
+
+    def _quick_create_block(self):
+        idx = SESSIONS_JS.find("function _attachProjectQuickCreateButton(")
+        assert idx != -1, "project quick-create helper not found in sessions.js"
+        # Function body incl. the full onclick success path (~3K covers it).
+        return SESSIONS_JS[idx: idx + 3000]
+
+    def test_quick_create_success_path_closes_mobile_drawer(self):
+        block = self._quick_create_block()
+        assert "closeMobileSidebar" in block, (
+            "project quick-create + must close the mobile sidebar after "
+            "newSession so the new conversation is visible on phones"
+        )
+        # Guarded call, matching the _openSidebarSession (#5409) convention.
+        assert "typeof closeMobileSidebar==='function'" in block
+
+    def test_quick_create_close_runs_after_sidebar_repaint(self):
+        """The close must sit in the success path after the sidebar repaint —
+        not before newSession (the drawer would reopen over the pending load)
+        and not in the catch branch (failure should keep the drawer open so the
+        user can see the toast and retry)."""
+        block = self._quick_create_block()
+        render_idx = block.find("renderSessionList({deferWhileInteracting:false})")
+        close_idx = block.find("closeMobileSidebar")
+        assert render_idx != -1, "sidebar repaint call not found in quick-create handler"
+        assert close_idx != -1, "closeMobileSidebar not found in quick-create handler"
+        assert close_idx > render_idx, (
+            "closeMobileSidebar must run after the sidebar repaint in the success path"
+        )
+


### PR DESCRIPTION
## Bug

On phones (<=640px), tapping the per-project **+** button (quick-create, next to each project chip in the sidebar) creates the new project conversation **but the sidebar drawer stays open**, covering the main chat view. The tap *looks* like a no-op — the session is actually created, just hidden underneath the full-screen drawer (`.sidebar.mobile-open`, z-index 200).

## Root cause

`_attachProjectQuickCreateButton()` in `static/sessions.js` never calls `closeMobileSidebar()` after `newSession()`. The global new-chat entry points all close the drawer (`btnNewChat.onclick` in `boot.js`, Cmd/Ctrl+K, `_openSidebarSession` #5409) — the project quick-create handler was the only path missing it.

## Fix

Close the mobile sidebar in the success path of the quick-create handler, **after** the sidebar repaint (so the newly created project conversation is immediately visible), with the same `typeof closeMobileSidebar==='function'` guard used elsewhere. The failure path keeps the drawer open so the error toast stays visible for retry.

## Verification

- Playwright (390x844): hamburger → drawer `mobile-open` → tap project **+** → drawer closes, main view shows the new project-bound session (`/session/<id>`, project_id set), no overlay.
- 2 new static regression tests in `tests/test_project_chip_ui.py` pin the guarded close call and its position after the repaint.
- `tests/test_project_chip_ui.py` + `tests/test_mobile_layout.py`: 91 passed.