### PR TITLE
fix: clean up failed chat worker launches

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2849,6 +2849,7 @@ from api.config import (
     ACTIVE_RUNS_LOCK,
     register_stream_owner,
     register_session_writeback_owner,
+    clear_session_writeback_owner_if_owned,
     stream_owner_session_id,
     unregister_stream_owner,
     CHAT_LOCK,
@@ -21348,6 +21349,30 @@ def _prepare_chat_start_session_for_stream(
     s.save()
 
 
+def _cleanup_chat_start_launch_failure(session, stream_id: str) -> None:
+    """Release state registered before a worker thread successfully starts."""
+    clear_session_writeback_owner_if_owned(session.session_id, stream_id)
+    unregister_stream_owner(stream_id)
+    with STREAMS_LOCK:
+        STREAMS.pop(stream_id, None)
+    STREAM_GOAL_RELATED.pop(stream_id, None)
+    if getattr(session, "active_stream_id", None) != stream_id:
+        return
+    session.active_stream_id = None
+    session.pending_user_message = None
+    session.pending_attachments = []
+    session.pending_started_at = None
+    session.pending_user_source = None
+    try:
+        session.save()
+    except Exception:
+        logger.debug(
+            "Failed to persist chat-start cleanup after worker launch failure for %s",
+            stream_id,
+            exc_info=True,
+        )
+
+
 def _is_hidden_empty_session(s) -> bool:
     return (
         getattr(s, "title", "Untitled") == "Untitled"
@@ -21679,6 +21704,7 @@ def _start_chat_stream_for_session(
                 _clear_gateway_run_starting(stream_id)
             except Exception:
                 logger.debug("Failed to record gateway run-start failure for stream %s", stream_id, exc_info=True)
+        _cleanup_chat_start_launch_failure(s, stream_id)
         raise
     response = {
         "stream_id": stream_id,

--- a/api/routes.py
+++ b/api/routes.py
@@ -21356,21 +21356,33 @@ def _cleanup_chat_start_launch_failure(session, stream_id: str) -> None:
     with STREAMS_LOCK:
         STREAMS.pop(stream_id, None)
     STREAM_GOAL_RELATED.pop(stream_id, None)
-    if getattr(session, "active_stream_id", None) != stream_id:
-        return
-    session.active_stream_id = None
-    session.pending_user_message = None
-    session.pending_attachments = []
-    session.pending_started_at = None
-    session.pending_user_source = None
-    try:
-        session.save()
-    except Exception:
-        logger.debug(
-            "Failed to persist chat-start cleanup after worker launch failure for %s",
-            stream_id,
-            exc_info=True,
-        )
+    # The session-field reset needs the same concurrency discipline as the
+    # registry half: hold the per-session lock and re-resolve the canonical
+    # session before clearing anything. Mutating the passed-in stale object
+    # could wipe a concurrent successor turn's pending fields, and saving it
+    # could resurrect a session deleted while the launch was failing. Same
+    # pattern as the #1533 race fix (routes.py:3077) and the anchor-scene
+    # write guard (routes.py:5140).
+    with _get_session_agent_lock(session.session_id):
+        try:
+            canonical = get_session(session.session_id)
+        except KeyError:
+            return  # session deleted while the thread launch was failing
+        if getattr(canonical, "active_stream_id", None) != stream_id:
+            return  # a successor turn already owns the session
+        canonical.active_stream_id = None
+        canonical.pending_user_message = None
+        canonical.pending_attachments = []
+        canonical.pending_started_at = None
+        canonical.pending_user_source = None
+        try:
+            canonical.save()
+        except Exception:
+            logger.debug(
+                "Failed to persist chat-start cleanup after worker launch failure for %s",
+                stream_id,
+                exc_info=True,
+            )
 
 
 def _is_hidden_empty_session(s) -> bool:

--- a/tests/test_issue6869_gateway_launch_failure.py
+++ b/tests/test_issue6869_gateway_launch_failure.py
@@ -1,0 +1,93 @@
+"""Regression tests for #6869: failed Gateway worker launch cleanup."""
+
+from types import SimpleNamespace
+
+import api.config as config
+import api.routes as routes
+from api import turn_journal
+
+
+def test_gateway_thread_start_failure_releases_writeback_owner_and_stream_state(monkeypatch):
+    """A thread-start exception must not leave one owner per failed Gateway launch."""
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread launch failed")
+
+    def fake_prepare(session, *, stream_id, **kwargs):
+        session.active_stream_id = stream_id
+        session.pending_user_message = kwargs["msg"]
+        session.pending_started_at = 1.0
+        config.register_session_writeback_owner(session.session_id, stream_id)
+
+    monkeypatch.setattr(routes.threading, "Thread", FailingThread)
+    monkeypatch.setattr(routes, "_prepare_chat_start_session_for_stream", fake_prepare)
+    monkeypatch.setattr(routes, "set_last_workspace", lambda _workspace: None)
+    monkeypatch.setattr(routes, "_is_hidden_empty_session", lambda _session: False)
+    monkeypatch.setattr(
+        turn_journal,
+        "append_turn_journal_event",
+        lambda *_args, **_kwargs: {},
+    )
+
+    for index in range(3):
+        session = SimpleNamespace(
+            session_id=f"session-launch-failure-{index}",
+            title="Existing",
+            active_stream_id=None,
+            pending_user_message=None,
+            pending_attachments=[],
+            pending_started_at=None,
+            pending_user_source=None,
+            messages=[{"role": "user", "content": "old"}],
+            workspace="/tmp",
+            model="old-model",
+            model_provider=None,
+            worktree_path=None,
+            profile=None,
+            save=lambda: None,
+        )
+
+        try:
+            routes._start_chat_stream_for_session(
+                session,
+                msg="start gateway turn",
+                attachments=[],
+                workspace="/tmp",
+                model="test-model",
+                external_runtime_owned=True,
+            )
+        except RuntimeError as exc:
+            assert str(exc) == "thread launch failed"
+        else:
+            raise AssertionError("thread-start failure must propagate")
+
+    assert config.SESSION_WRITEBACK_OWNERS == {}
+    assert config.STREAM_SESSION_OWNERS == {}
+    assert config.STREAMS == {}
+
+
+def test_gateway_launch_failure_cleanup_does_not_clear_successor_owner():
+    """Cleanup must be compare-and-clear when a successor already took over."""
+    session = SimpleNamespace(
+        session_id="session-launch-successor",
+        active_stream_id="new-stream",
+        pending_user_message="new prompt",
+        pending_attachments=["new.txt"],
+        pending_started_at=2.0,
+        pending_user_source="webui",
+        save=lambda: None,
+    )
+    config.register_session_writeback_owner(session.session_id, "old-stream")
+    config.register_session_writeback_owner(session.session_id, "new-stream")
+    config.register_stream_owner("old-stream", session.session_id)
+    config.STREAMS["old-stream"] = object()
+
+    routes._cleanup_chat_start_launch_failure(session, "old-stream")
+
+    assert config.session_writeback_owner(session.session_id) == "new-stream"
+    assert session.active_stream_id == "new-stream"
+    assert session.pending_user_message == "new prompt"
+    assert "old-stream" not in config.STREAMS

--- a/tests/test_issue6869_gateway_launch_failure.py
+++ b/tests/test_issue6869_gateway_launch_failure.py
@@ -7,6 +7,32 @@ import api.routes as routes
 from api import turn_journal
 
 
+def _make_session(session_id, *, active_stream_id=None, pending_user_message=None, save=None):
+    return SimpleNamespace(
+        session_id=session_id,
+        title="Existing",
+        active_stream_id=active_stream_id,
+        pending_user_message=pending_user_message,
+        pending_attachments=[],
+        pending_started_at=None,
+        pending_user_source=None,
+        messages=[{"role": "user", "content": "old"}],
+        workspace="/tmp",
+        model="old-model",
+        model_provider=None,
+        worktree_path=None,
+        profile=None,
+        save=save or (lambda: None),
+    )
+
+
+def _register_failed_stream(session_id, stream_id):
+    """Mirror the registry state _prepare_chat_start_session_for_stream installs."""
+    config.register_session_writeback_owner(session_id, stream_id)
+    config.register_stream_owner(stream_id, session_id)
+    config.STREAMS[stream_id] = object()
+
+
 def test_gateway_thread_start_failure_releases_writeback_owner_and_stream_state(monkeypatch):
     """A thread-start exception must not leave one owner per failed Gateway launch."""
     class FailingThread:
@@ -16,16 +42,24 @@ def test_gateway_thread_start_failure_releases_writeback_owner_and_stream_state(
         def start(self):
             raise RuntimeError("thread launch failed")
 
+    canonical_by_id = {}
+
     def fake_prepare(session, *, stream_id, **kwargs):
         session.active_stream_id = stream_id
         session.pending_user_message = kwargs["msg"]
         session.pending_started_at = 1.0
-        config.register_session_writeback_owner(session.session_id, stream_id)
+        _register_failed_stream(session.session_id, stream_id)
+        canonical_by_id[session.session_id] = session
 
     monkeypatch.setattr(routes.threading, "Thread", FailingThread)
     monkeypatch.setattr(routes, "_prepare_chat_start_session_for_stream", fake_prepare)
     monkeypatch.setattr(routes, "set_last_workspace", lambda _workspace: None)
     monkeypatch.setattr(routes, "_is_hidden_empty_session", lambda _session: False)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: canonical_by_id[sid],
+    )
     monkeypatch.setattr(
         turn_journal,
         "append_turn_journal_event",
@@ -33,23 +67,7 @@ def test_gateway_thread_start_failure_releases_writeback_owner_and_stream_state(
     )
 
     for index in range(3):
-        session = SimpleNamespace(
-            session_id=f"session-launch-failure-{index}",
-            title="Existing",
-            active_stream_id=None,
-            pending_user_message=None,
-            pending_attachments=[],
-            pending_started_at=None,
-            pending_user_source=None,
-            messages=[{"role": "user", "content": "old"}],
-            workspace="/tmp",
-            model="old-model",
-            model_provider=None,
-            worktree_path=None,
-            profile=None,
-            save=lambda: None,
-        )
-
+        session = _make_session(f"session-launch-failure-{index}")
         try:
             routes._start_chat_stream_for_session(
                 session,
@@ -63,31 +81,97 @@ def test_gateway_thread_start_failure_releases_writeback_owner_and_stream_state(
             assert str(exc) == "thread launch failed"
         else:
             raise AssertionError("thread-start failure must propagate")
+        assert session.active_stream_id is None
+        assert session.pending_user_message is None
+        assert session.pending_started_at is None
 
     assert config.SESSION_WRITEBACK_OWNERS == {}
     assert config.STREAM_SESSION_OWNERS == {}
     assert config.STREAMS == {}
 
 
-def test_gateway_launch_failure_cleanup_does_not_clear_successor_owner():
-    """Cleanup must be compare-and-clear when a successor already took over."""
-    session = SimpleNamespace(
-        session_id="session-launch-successor",
+def test_gateway_launch_failure_cleanup_does_not_clear_successor_owner(monkeypatch):
+    """A successor fully installed before cleanup keeps its registry ownership."""
+    canonical = _make_session(
+        "session-launch-successor",
         active_stream_id="new-stream",
         pending_user_message="new prompt",
-        pending_attachments=["new.txt"],
-        pending_started_at=2.0,
-        pending_user_source="webui",
         save=lambda: None,
     )
-    config.register_session_writeback_owner(session.session_id, "old-stream")
-    config.register_session_writeback_owner(session.session_id, "new-stream")
-    config.register_stream_owner("old-stream", session.session_id)
-    config.STREAMS["old-stream"] = object()
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: canonical,
+    )
+    stale = _make_session("session-launch-successor")
+    _register_failed_stream(stale.session_id, "old-stream")
+    config.register_session_writeback_owner(stale.session_id, "new-stream")
 
-    routes._cleanup_chat_start_launch_failure(session, "old-stream")
+    routes._cleanup_chat_start_launch_failure(stale, "old-stream")
 
-    assert config.session_writeback_owner(session.session_id) == "new-stream"
-    assert session.active_stream_id == "new-stream"
-    assert session.pending_user_message == "new prompt"
+    assert config.session_writeback_owner(stale.session_id) == "new-stream"
+    assert canonical.active_stream_id == "new-stream"
+    assert canonical.pending_user_message == "new prompt"
     assert "old-stream" not in config.STREAMS
+
+
+def test_gateway_launch_failure_cleanup_does_not_wipe_successor_admitted_during_cleanup(monkeypatch):
+    """A successor admitted mid-cleanup survives: the guard runs on the re-resolved
+    canonical session, not on the stale passed-in object that still shows the
+    failed stream."""
+    saved = []
+
+    canonical = _make_session(
+        "session-launch-race",
+        active_stream_id="new-stream",
+        pending_user_message="successor prompt",
+        save=lambda: saved.append("canonical"),
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: canonical,
+    )
+    stale = _make_session(
+        "session-launch-race",
+        active_stream_id="old-stream",
+        pending_user_message="failed-stream prompt",
+        save=lambda: saved.append("stale"),
+    )
+    _register_failed_stream(stale.session_id, "old-stream")
+    config.register_session_writeback_owner(stale.session_id, "new-stream")
+
+    routes._cleanup_chat_start_launch_failure(stale, "old-stream")
+
+    assert config.session_writeback_owner(stale.session_id) == "new-stream"
+    assert canonical.active_stream_id == "new-stream"
+    assert canonical.pending_user_message == "successor prompt"
+    assert "old-stream" not in config.STREAMS
+    assert saved == [], "cleanup must not save a session it early-returns on"
+
+
+def test_gateway_launch_failure_cleanup_does_not_resurrect_deleted_session(monkeypatch):
+    """A session deleted while the launch was failing must not be recreated:
+    the resolver raises KeyError and cleanup returns without saving anything."""
+    saved = []
+
+    def deleted_resolver(sid, metadata_only=False):
+        raise KeyError(sid)
+
+    monkeypatch.setattr(routes, "get_session", deleted_resolver)
+    stale = _make_session(
+        "session-launch-deleted",
+        active_stream_id="old-stream",
+        pending_user_message="pending prompt",
+        save=lambda: saved.append("stale"),
+    )
+    _register_failed_stream(stale.session_id, "old-stream")
+
+    routes._cleanup_chat_start_launch_failure(stale, "old-stream")
+
+    assert config.session_writeback_owner(stale.session_id) is None
+    assert "old-stream" not in config.STREAM_SESSION_OWNERS
+    assert "old-stream" not in config.STREAMS
+    assert stale.active_stream_id == "old-stream"
+    assert stale.pending_user_message == "pending prompt"
+    assert saved == [], "cleanup must not save a deleted session"


### PR DESCRIPTION
## Thinking Path

- Gateway chat registers session writeback ownership before starting the worker thread.
- If `thread.start()` raises, the worker never enters its `finally` block.
- That left `SESSION_WRITEBACK_OWNERS`, `STREAM_SESSION_OWNERS`, `STREAMS`, and persisted pending session state behind after each failed launch.
- The existing normal worker teardown already uses compare-and-clear ownership, so the launch-failure path should use the same ownership rule rather than unconditionally clearing a session.

## What Changed

- Added `_cleanup_chat_start_launch_failure()` as the shared cleanup path for worker thread launch failures.
- Compare-and-clear the failed stream's writeback owner.
- Remove the failed stream owner and channel.
- Clear persisted pending stream fields only if the session still points at the failed stream.
- Added regression coverage for repeated failed launches and successor ownership.

Closes #6869.

## Why It Matters

A failed worker launch is terminal for that stream. Leaving its ownership records behind causes process-lifetime registry growth and can make a session appear permanently active or pending. The cleanup is scoped to the failed stream, so a successor stream cannot be evicted by an old failure handler.

## Contract Routing

Task type: runtime lifecycle cleanup / Gateway chat startup failure.

Touched areas:
- `api/routes.py` chat-start registration and worker launch boundary
- `tests/test_issue6869_gateway_launch_failure.py` ownership and pending-state regressions

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State invariant: every stream state mutation registered before worker start is released on a thread-launch exception, without clearing a successor's ownership.

## Verification

- Regression test on the old implementation: failed with 3 leaked `SESSION_WRITEBACK_OWNERS` entries.
- Focused ownership/startup suite: **128 passed**.
- Browser-backed compression/lifecycle cluster: **16 passed**.
- `py_compile`: passed.
- Diff-scoped Ruff check: passed.
- `git diff --check`: passed.
- Full repository suite: **14,264 passed, 111 skipped, 3 unrelated failures**.
  - `test_5774b_atomic_config_writes.py::test_atomic_write_preserves_existing_permissions`
  - `test_issue4685_post_compression_context_metering.py::test_post_compression_estimate_uses_compressor_budget_counter_without_metadata_estimators`
  - `test_xsession_wakeup_misroute.py::test_turn_identity_binder_restores_previous_value`
- The two browser errors from the first full run were environment setup failures because Chromium was not installed; after installing Chromium, the browser cluster passed.

## Risks / Follow-ups

- The change only runs when the worker thread fails to start.
- Normal worker teardown and pre-start cancellation keep their existing cleanup paths.
- The three unrelated full-suite failures should be investigated separately; they don't touch this diff.

## Model Used

OpenAI Codex provider, `gpt-5.6-luna`. The change was AI-assisted using repository file inspection, focused test execution, full-suite verification, and GitHub CLI operations.
