### PR TITLE
fix: clear stale compression state on session switch

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1734,6 +1734,13 @@ async function loadSession(sid){
   _yoloEnabled=false;_updateYoloPill();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
   if(typeof hideClarifyCard==='function') hideClarifyCard(forceReload, forceReload?'external-refresh':'dismissed');
+  // #6572: clear stale compression state when switching sessions.
+  // The compression UI state is per-session and must not leak across loads.
+  // Without this, a compression card from a prior session can appear as a
+  // phantom "Compressing context" barrier on a fresh session that never
+  // triggered compression.
+  if(typeof clearCompressionUi==='function') clearCompressionUi();
+  else window._compressionUi=null;
   // Show loading indicator immediately for responsiveness.
   // Cleared by renderMessages() once full session data arrives.
   // Persist the current composer draft before switching away so it can be


### PR DESCRIPTION
## Problem

When switching sessions via `loadSession()`, the `window._compressionUi` state was not cleared, causing phantom "Compressing context" barriers to appear on fresh sessions that never triggered compression.

## Root Cause

`loadSession()` tears down approval/clarify/composer state but missed the compression UI state (`window._compressionUi`). This state is per-session and must not leak across session switches.

## Evidence

Bootstrap logs showed no compression output during the affected time window, yet the frontend displayed a compression card. The compression card appeared because `window._compressionUi` had residual state from a prior session.

## Fix

Clear compression state immediately after `hideClarifyCard()` in the `loadSession()` teardown sequence.

## Relationship to PR #6572

- **PR #6572** (merged): Handles the case where `compressed` SSE events are lost/delayed by clearing `running` state on `done` event
- **This PR**: Handles the case where session switch leaks stale compression state

Both fixes are complementary and address different scenarios where phantom compression UI can appear.

## Testing

Manual verification on local deployment confirmed the fix prevents stale compression state from appearing on fresh sessions after switching from a session that had active compression.

## Screenshot

Before: Fresh session showing phantom "Compressing context" barrier
After: Fresh session shows correct state (no compression card unless actually compressing)