### PR TITLE
fix(reasoning): allow max effort for supported GPT-5.6 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,11 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Mermaid diagram rendering inline (flowcharts, sequence diagrams, gantt charts)
 - Thinking/reasoning display -- collapsible gold-themed cards for Claude extended thinking and o3 reasoning blocks
 - Provider-aware reasoning effort selector and `/reasoning` command. For GPT-5.6,
-  direct OpenAI/Azure-family routes expose `max` for Sol, Terra, Luna, and their
-  `-pro` model IDs. The ChatGPT-account Codex OAuth route exposes `max` only for
-  the three base model IDs because that route rejects the `-pro` IDs. Unknown
-  GPT-5.6 variants remain capped at `xhigh` until support is explicitly confirmed.
+  direct OpenAI/Azure-family routes expose `max` only for the three documented base
+  model IDs: Sol, Terra, and Luna. The ChatGPT-account Codex OAuth route exposes
+  `max` for those same base IDs; `-pro` model IDs are not a routable provider
+  contract and remain fail-closed at `xhigh` on every lane. Unknown GPT-5.6
+  variants also remain capped at `xhigh` until support is explicitly confirmed.
 - Approval card for dangerous shell commands (allow once / session / always / deny)
 - SSE auto-reconnect on network blips (SSH tunnel resilience)
 - File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Subagent delegation cards -- child agent activity shown with distinct icon and indented border
 - Mermaid diagram rendering inline (flowcharts, sequence diagrams, gantt charts)
 - Thinking/reasoning display -- collapsible gold-themed cards for Claude extended thinking and o3 reasoning blocks
+- Provider-aware reasoning effort selector and `/reasoning` command. For GPT-5.6,
+  direct OpenAI/Azure-family routes expose `max` for Sol, Terra, Luna, and their
+  `-pro` model IDs. The ChatGPT-account Codex OAuth route exposes `max` only for
+  the three base model IDs because that route rejects the `-pro` IDs. Unknown
+  GPT-5.6 variants remain capped at `xhigh` until support is explicitly confirmed.
 - Approval card for dangerous shell commands (allow once / session / always / deny)
 - SSE auto-reconnect on network blips (SSH tunnel resilience)
 - File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured)

--- a/api/config.py
+++ b/api/config.py
@@ -3204,6 +3204,22 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
 # Keep this WebUI-visible set aligned with hermes-agent#29248.
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
+# GPT-5-family model ids that DO accept 'max' on the OpenAI-family lanes.
+# The blanket `gpt-5*` -> strip-'max' rule below predates GPT-5.6, whose
+# published capabilities list 'max' explicitly (and whose Codex transport maps
+# the 'ultra' tier onto the 'max' wire value). Fail-closed: an unrecognised
+# future gpt-5.6-* id does NOT inherit 'max' until it is listed here.
+_OPENAI_MAX_REASONING_MODELS = frozenset({
+    "gpt-5.6-sol", "gpt-5.6-sol-pro",
+    "gpt-5.6-terra", "gpt-5.6-terra-pro",
+    "gpt-5.6-luna", "gpt-5.6-luna-pro",
+})
+_CODEX_MAX_REASONING_MODELS = frozenset({
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+})
+
 
 def parse_reasoning_effort(effort):
     """Parse an effort level into the dict the agent expects.
@@ -3527,12 +3543,17 @@ def _filter_reasoning_efforts_for_provider(
     normalized = list(dict.fromkeys(normalized))
     provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
     bare = _strip_provider_hint_for_reasoning(model_id).lower().rsplit("/", 1)[-1]
-    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap GPT-5 at xhigh
-    # and o-series at high — 'max' is a WebUI-only level none of them accept.
+    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap o-series at
+    # high and GPT-5 at xhigh unless the exact lane/model pair is allowlisted.
     if provider in {"openai-codex", "openai", "openai-api", "azure-foundry", "azure-openai", "azure"}:
         if bare.startswith(("o1", "o3", "o4")):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
-        if bare.startswith("gpt-5"):
+        max_models = (
+            _CODEX_MAX_REASONING_MODELS
+            if provider == "openai-codex"
+            else _OPENAI_MAX_REASONING_MODELS
+        )
+        if bare.startswith("gpt-5") and bare not in max_models:
             return [eff for eff in normalized if eff != "max"]
     # 'max' is a WebUI-level ceiling; providers whose native ladder tops out lower
     # must NOT advertise it, otherwise a stored/CLI 'max' degrades WORSE than the

--- a/api/config.py
+++ b/api/config.py
@@ -3204,15 +3204,10 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
 # Keep this WebUI-visible set aligned with hermes-agent#29248.
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
-# GPT-5-family model ids that DO accept 'max' on the OpenAI-family lanes.
-# The blanket `gpt-5*` -> strip-'max' rule below predates GPT-5.6, whose
-# published capabilities list 'max' explicitly (and whose Codex transport maps
-# the 'ultra' tier onto the 'max' wire value). Fail-closed: an unrecognised
-# future gpt-5.6-* id does NOT inherit 'max' until it is listed here.
 _OPENAI_MAX_REASONING_MODELS = frozenset({
-    "gpt-5.6-sol", "gpt-5.6-sol-pro",
-    "gpt-5.6-terra", "gpt-5.6-terra-pro",
-    "gpt-5.6-luna", "gpt-5.6-luna-pro",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
 })
 _CODEX_MAX_REASONING_MODELS = frozenset({
     "gpt-5.6-sol",
@@ -3543,8 +3538,12 @@ def _filter_reasoning_efforts_for_provider(
     normalized = list(dict.fromkeys(normalized))
     provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
     bare = _strip_provider_hint_for_reasoning(model_id).lower().rsplit("/", 1)[-1]
-    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap o-series at
-    # high and GPT-5 at xhigh unless the exact lane/model pair is allowlisted.
+    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap older GPT-5
+    # at xhigh and o-series at high. Only explicitly known GPT-5.6 Sol/Terra/Luna
+    # ids accept max; keep this exact-match allowlist fail-closed so an unknown
+    # future gpt-5.6-* id does not inherit the capability. The ChatGPT OAuth
+    # Codex backend rejects the public-API-style -pro slugs, so its allowlist is
+    # limited to the three live base ids.
     if provider in {"openai-codex", "openai", "openai-api", "azure-foundry", "azure-openai", "azure"}:
         if bare.startswith(("o1", "o3", "o4")):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
@@ -3903,8 +3902,9 @@ def resolve_model_reasoning_efforts(
     """Return supported reasoning-effort levels for *model_id*, or [] if none.
 
     Always passes the sourced list through _filter_reasoning_efforts_for_provider
-    so the hard provider ceilings (openai-codex/openai/azure GPT-5 cap at xhigh,
-    Gemini + pre-adaptive/cloud-hosted Claude cap at xhigh) are applied uniformly
+    so the hard provider ceilings (OpenAI-family GPT-5 except the known
+    GPT-5.6 Sol/Terra/Luna ids, with Codex limited to its three live base ids;
+    Gemini, and pre-adaptive/cloud-hosted Claude) are applied uniformly
     — the UI dropdown (which gates options on this list) and coercion therefore
     agree: 'max' is offered ONLY for models whose native ladder genuinely includes
     it, and is stripped everywhere it would be rejected/mishandled.

--- a/tests/test_gpt_5_6_max_reasoning.py
+++ b/tests/test_gpt_5_6_max_reasoning.py
@@ -6,24 +6,17 @@ from api import config as cfg
 from api.gateway_chat import _gateway_reasoning_effort_for_request
 
 
-KNOWN_GPT_5_6_MODELS = (
-    "gpt-5.6-sol",
-    "gpt-5.6-sol-pro",
-    "gpt-5.6-terra",
-    "gpt-5.6-terra-pro",
-    "gpt-5.6-luna",
-    "gpt-5.6-luna-pro",
-)
-CODEX_GPT_5_6_MODELS = (
+GPT_5_6_BASE_MODELS = (
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
 )
-CODEX_REJECTED_GPT_5_6_PRO_MODELS = (
+GPT_5_6_PRO_MODELS = (
     "gpt-5.6-sol-pro",
     "gpt-5.6-terra-pro",
     "gpt-5.6-luna-pro",
 )
+CODEX_GPT_5_6_MODELS = GPT_5_6_BASE_MODELS
 OPENAI_FAMILY_PROVIDERS = (
     "openai",
     "openai-api",
@@ -31,9 +24,10 @@ OPENAI_FAMILY_PROVIDERS = (
     "azure-openai",
     "azure",
 )
+ALL_OPENAI_FAMILY_PROVIDERS = ("openai-codex", *OPENAI_FAMILY_PROVIDERS)
 
 
-@pytest.mark.parametrize("model_id", KNOWN_GPT_5_6_MODELS)
+@pytest.mark.parametrize("model_id", GPT_5_6_BASE_MODELS)
 @pytest.mark.parametrize("provider_id", OPENAI_FAMILY_PROVIDERS)
 def test_known_gpt_5_6_models_advertise_max_on_openai_family(model_id, provider_id):
     assert "max" in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
@@ -46,21 +40,24 @@ def test_live_codex_gpt_5_6_models_advertise_max(model_id):
     )
 
 
-@pytest.mark.parametrize("model_id", CODEX_REJECTED_GPT_5_6_PRO_MODELS)
-def test_codex_rejected_gpt_5_6_pro_models_do_not_advertise_max(model_id):
-    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai-codex")
+@pytest.mark.parametrize("model_id", GPT_5_6_PRO_MODELS)
+@pytest.mark.parametrize("provider_id", ALL_OPENAI_FAMILY_PROVIDERS)
+def test_gpt_5_6_pro_models_fail_closed_on_every_openai_family_lane(
+    model_id, provider_id
+):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
     assert "max" not in efforts
     assert cfg.coerce_reasoning_effort_for_model(
-        "max", model_id, provider_id="openai-codex"
+        "max", model_id, provider_id=provider_id
     ) == "xhigh"
 
 
 @pytest.mark.parametrize(
     "model_id,provider_id",
     [
-        ("@openai:gpt-5.6-terra-pro", "openai"),
-        ("openai/gpt-5.6-luna", "openai-api"),
-        ("azure/gpt-5.6-luna-pro", "azure-foundry"),
+        ("@openai:gpt-5.6-sol", "openai"),
+        ("openai/gpt-5.6-terra", "openai-api"),
+        ("azure/gpt-5.6-luna", "azure-foundry"),
     ],
 )
 def test_known_gpt_5_6_prefixed_and_provider_hinted_ids_advertise_max(model_id, provider_id):
@@ -122,7 +119,7 @@ def test_status_metadata_advertises_and_preserves_max_for_known_gpt_5_6(monkeypa
 @pytest.mark.parametrize(
     "model_id,provider_id",
     [(model, "openai-codex") for model in CODEX_GPT_5_6_MODELS]
-    + [(model, "openai") for model in KNOWN_GPT_5_6_MODELS],
+    + [(model, "openai") for model in GPT_5_6_BASE_MODELS],
 )
 def test_max_is_preserved_by_coercion_and_gateway_streaming(model_id, provider_id):
     assert cfg.coerce_reasoning_effort_for_model(

--- a/tests/test_gpt_5_6_max_reasoning.py
+++ b/tests/test_gpt_5_6_max_reasoning.py
@@ -1,0 +1,148 @@
+"""Regression coverage for GPT-5.6 max-reasoning capability policy."""
+
+import pytest
+
+from api import config as cfg
+from api.gateway_chat import _gateway_reasoning_effort_for_request
+
+
+KNOWN_GPT_5_6_MODELS = (
+    "gpt-5.6-sol",
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra",
+    "gpt-5.6-terra-pro",
+    "gpt-5.6-luna",
+    "gpt-5.6-luna-pro",
+)
+CODEX_GPT_5_6_MODELS = (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+)
+CODEX_REJECTED_GPT_5_6_PRO_MODELS = (
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra-pro",
+    "gpt-5.6-luna-pro",
+)
+OPENAI_FAMILY_PROVIDERS = (
+    "openai",
+    "openai-api",
+    "azure-foundry",
+    "azure-openai",
+    "azure",
+)
+
+
+@pytest.mark.parametrize("model_id", KNOWN_GPT_5_6_MODELS)
+@pytest.mark.parametrize("provider_id", OPENAI_FAMILY_PROVIDERS)
+def test_known_gpt_5_6_models_advertise_max_on_openai_family(model_id, provider_id):
+    assert "max" in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+
+
+@pytest.mark.parametrize("model_id", CODEX_GPT_5_6_MODELS)
+def test_live_codex_gpt_5_6_models_advertise_max(model_id):
+    assert "max" in cfg.resolve_model_reasoning_efforts(
+        model_id, provider_id="openai-codex"
+    )
+
+
+@pytest.mark.parametrize("model_id", CODEX_REJECTED_GPT_5_6_PRO_MODELS)
+def test_codex_rejected_gpt_5_6_pro_models_do_not_advertise_max(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai-codex")
+    assert "max" not in efforts
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id="openai-codex"
+    ) == "xhigh"
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("@openai:gpt-5.6-terra-pro", "openai"),
+        ("openai/gpt-5.6-luna", "openai-api"),
+        ("azure/gpt-5.6-luna-pro", "azure-foundry"),
+    ],
+)
+def test_known_gpt_5_6_prefixed_and_provider_hinted_ids_advertise_max(model_id, provider_id):
+    assert "max" in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+
+
+@pytest.mark.parametrize("model_id", ["gpt-5", "gpt-5.1", "gpt-5.5", "gpt-5-pro"])
+def test_older_gpt_5_models_keep_xhigh_ceiling(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai")
+    assert "xhigh" in efforts
+    assert "max" not in efforts
+    assert cfg.coerce_reasoning_effort_for_model("max", model_id, provider_id="openai") == "xhigh"
+
+
+@pytest.mark.parametrize("model_id", ["o1", "o3-mini", "o4-mini"])
+def test_o_series_models_keep_high_ceiling(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai-codex")
+    assert efforts == ["low", "medium", "high"]
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id="openai-codex"
+    ) == "high"
+
+
+def test_unknown_gpt_5_6_variant_does_not_gain_max():
+    model_id = "gpt-5.6-nebula"
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai")
+    assert "max" not in efforts
+    assert cfg.coerce_reasoning_effort_for_model("max", model_id, provider_id="openai") == "xhigh"
+
+
+def test_configured_provider_effort_list_still_passes_through_model_ceiling(monkeypatch):
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {"openai": {"reasoning_efforts": ["none", "high", "xhigh", "max"]}},
+    )
+    assert cfg.resolve_model_reasoning_efforts(
+        "gpt-5.6-sol", provider_id="openai"
+    ) == ["none", "high", "xhigh", "max"]
+    assert cfg.resolve_model_reasoning_efforts(
+        "gpt-5.6-nebula", provider_id="openai"
+    ) == ["none", "high", "xhigh"]
+
+
+def test_status_metadata_advertises_and_preserves_max_for_known_gpt_5_6(monkeypatch):
+    monkeypatch.setattr(
+        cfg,
+        "_load_yaml_config_file",
+        lambda *_args, **_kwargs: {"agent": {"reasoning_effort": "max"}},
+    )
+    status = cfg.get_reasoning_status(
+        model_id="gpt-5.6-terra", provider_id="openai-codex"
+    )
+    assert "max" in status["supported_efforts"]
+    assert status["supports_reasoning_effort"] is True
+    assert status["reasoning_effort"] == "max"
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [(model, "openai-codex") for model in CODEX_GPT_5_6_MODELS]
+    + [(model, "openai") for model in KNOWN_GPT_5_6_MODELS],
+)
+def test_max_is_preserved_by_coercion_and_gateway_streaming(model_id, provider_id):
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id=provider_id
+    ) == "max"
+    gateway_cfg = {"agent": {"reasoning_effort": "max"}}
+    assert _gateway_reasoning_effort_for_request(
+        gateway_cfg, model=model_id, model_provider=provider_id
+    ) == "max"
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("gemini-3-pro", "gemini"),
+        ("claude-sonnet-4-5", "anthropic"),
+    ],
+)
+def test_other_existing_model_ceilings_remain_unchanged(model_id, provider_id):
+    assert "max" not in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id=provider_id
+    ) == "xhigh"


### PR DESCRIPTION
## Thinking Path

Hermes WebUI already recognizes `max`, but its OpenAI-family capability filter strips it from every GPT-5 model. GPT-5.6 Sol, Terra, and Luna support max reasoning, so the UI and gateway should preserve that level for those explicitly supported base IDs.

The policy is fail-closed: only the three documented GPT-5.6 base IDs gain `max` on the OpenAI-family lanes. The `-pro` model IDs are not a routable provider contract on any lane and remain capped at `xhigh`; if Pro-tier reasoning is exposed later, it should use the provider's `reasoning.mode` contract rather than a `-pro` model slug.

## What Changed

- Added explicit GPT-5.6 base-model allowlists for OpenAI-family and Codex lanes.
- Preserved `max` for GPT-5.6 Sol, Terra, and Luna on Codex and direct OpenAI/Azure-family routes.
- Kept all three `-pro` IDs fail-closed on Codex, OpenAI, OpenAI API, Azure Foundry, Azure OpenAI, and Azure lanes.
- Kept older GPT-5, o-series, unknown GPT-5.6 variants, Gemini, and pre-adaptive Claude at their existing ceilings.
- Added regression coverage for capability advertisement, provider-hinted IDs, configured effort lists, status metadata, coercion, gateway request handling, and fail-closed `-pro` IDs on every OpenAI-family lane.
- Updated the README to describe the base-only provider contract.

## Why It Matters

The WebUI should not silently downgrade a supported GPT-5.6 base-model request from `max` to `xhigh`. At the same time, unsupported or unknown model/provider combinations should not inherit a capability based only on a broad name prefix or an unroutable model slug.

## Contract Routing

Task type: reasoning capability-policy correction.

Touched contract family:
- Server-side model/provider reasoning capability filtering
- Reasoning status metadata
- Gateway effort coercion
- User-facing reasoning capability documentation in `README.md`

Scope boundaries:
- No new reasoning vocabulary.
- No model catalog changes.
- No frontend layout or interaction changes.
- No changes outside the existing OpenAI-family capability policy.

## Verification

- Focused GPT-5.6 regression suite: 57 passed.
- Neighboring reasoning-capability suites: 74 passed.
- Python compilation and `git diff --check`: passed.
- Red-before-green: the modified regression failed with 15 direct-lane `-pro` failures on the pre-fix head; it passed 57/57 after the allowlist and test fix.
- Ruff findings are pre-existing and outside the changed lines; no new finding was introduced by this follow-up.
- Remote CI for the exact pushed head is running; its final result is not claimed here.

No screenshots are included because this changes server-side capability policy and documentation only; it does not alter layout or interaction flow.

## Risks / Follow-ups

- The exact allowlists intentionally require future GPT-5.6 variants to be added explicitly.
- All GPT-5.6 `-pro` model IDs remain fail-closed. If a provider later exposes a valid Pro-tier route, implement it through the provider's documented reasoning-mode contract and update the allowlists, tests, and README together.
- This overlaps with draft #6353 and broader #6018. This PR is limited to the supported base-model capability policy and the fail-closed behavior for unroutable variants.

Release note: GPT-5.6 Sol, Terra, and Luna can use Max reasoning in Hermes WebUI on supported provider lanes.

## Model Used

AI-assisted with OpenAI Codex `gpt-5.6-sol`, using repository inspection, focused automated tests, and git/GitHub CLI verification.