### PR TITLE
fix(models): preserve custom provider model identity

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3205,11 +3205,22 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
         if(routed.toLowerCase().startsWith(prefix)) routed=routed.slice(prefix.length);
         return routed.toLowerCase().replace(/-/g,'.');
       };
-      const providerMatch=options.find(o=>
-        _getOptionProviderId(o).toLowerCase()===preferred
-        &&routeNorm(o.value)===routeNorm(rawModel)
-      );
-      return providerMatch?providerMatch.value:null;
+      const providerOptions=options.filter(o=>_getOptionProviderId(o).toLowerCase()===preferred);
+      const providerMatch=providerOptions.find(o=>routeNorm(o.value)===routeNorm(rawModel));
+      if(providerMatch) return providerMatch.value;
+      // Legacy sessions may store only the bare suffix of a routed custom
+      // option. Preserve #6195's provider-hinted repair, but only for an
+      // explicit @provider: row; an unwrapped slash ID belongs to the active
+      // endpoint and must not substitute for a distinct bare model.
+      if(!rawModel.includes('/')&&!rawModel.startsWith('@')){
+        const prefix=`@${preferred}:`;
+        const suffixMatches=providerOptions.filter(o=>
+          String(o.value||'').toLowerCase().startsWith(prefix)
+          &&norm(o.value)===target
+        );
+        if(suffixMatches.length===1) return suffixMatches[0].value;
+      }
+      return null;
     }
     const providerMatch=options.find(o=>norm(o.value)===target&&_getOptionProviderId(o).toLowerCase()===preferred);
     if(providerMatch) return providerMatch.value;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3195,7 +3195,23 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
   }
   const preferred=String(preferredProviderId||explicitProvider||'').toLowerCase();
   if(preferred){
-    const providerMatch=options.find(o=>norm(o.value)===target && _getOptionProviderId(o).toLowerCase()===preferred);
+    if(preferred==='custom'||preferred.startsWith('custom:')){
+      // A slash is part of a custom endpoint's upstream model ID, not a
+      // provider namespace. Match the exact routed ID (allowing only the
+      // WebUI's @provider: wrapper and dash/dot spelling compatibility).
+      const routeNorm=value=>{
+        let routed=String(value||'');
+        const prefix=`@${preferred}:`;
+        if(routed.toLowerCase().startsWith(prefix)) routed=routed.slice(prefix.length);
+        return routed.toLowerCase().replace(/-/g,'.');
+      };
+      const providerMatch=options.find(o=>
+        _getOptionProviderId(o).toLowerCase()===preferred
+        &&routeNorm(o.value)===routeNorm(rawModel)
+      );
+      return providerMatch?providerMatch.value:null;
+    }
+    const providerMatch=options.find(o=>norm(o.value)===target&&_getOptionProviderId(o).toLowerCase()===preferred);
     if(providerMatch) return providerMatch.value;
   }
   // 2. Normalized match — but ONLY when unambiguous. If the bare id

--- a/tests/test_custom_provider_model_identity.py
+++ b/tests/test_custom_provider_model_identity.py
@@ -1,0 +1,90 @@
+"""Regression coverage for exact custom-provider model identity during catalog refresh."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+_DRIVER = r"""
+const fs=require('fs');
+const src=fs.readFileSync(process.argv[2],'utf8');
+function extract(name){
+  const start=src.indexOf('function '+name+'(');
+  if(start<0) throw new Error('missing '+name);
+  let i=src.indexOf('{',start), depth=0;
+  for(;i<src.length;i++){
+    if(src[i]==='{') depth++;
+    else if(src[i]==='}'&&--depth===0) return src.slice(start,i+1);
+  }
+  throw new Error('unterminated '+name);
+}
+class Node {
+  constructor(tag){this.tagName=tag.toUpperCase();this.children=[];this.dataset={};this.parentElement=null;this._value='';this.textContent='';this.id='';}
+  appendChild(child){child.parentElement=this;this.children.push(child);return child;}
+  removeChild(child){this.children=this.children.filter(x=>x!==child);child.parentElement=null;}
+  querySelectorAll(selector){
+    if(selector==='optgroup') return this.children.filter(x=>x.tagName==='OPTGROUP');
+    return [];
+  }
+  get options(){
+    if(this.tagName!=='SELECT') return [];
+    return this.children.flatMap(x=>x.tagName==='OPTGROUP'?x.children:[x]).filter(x=>x.tagName==='OPTION');
+  }
+  get value(){return this._value;}
+  set value(value){this._value=String(value||'');}
+  get selectedOptions(){const hit=this.options.find(x=>x.value===this._value);return hit?[hit]:[];}
+}
+const document={createElement:tag=>new Node(tag)};
+const window={_configuredModelBadges:{},_activeProvider:'custom:cpa'};
+const S={session:null};
+const _dynamicModelLabels={};
+const _liveModelFetchPending=new Set();
+const $=()=>null;
+const getModelLabel=value=>value;
+const syncModelChip=()=>{};
+for(const name of ['_getOptionProviderId','_providerFromModelValue','_modelPickerOptionIdentity','_deduplicateModelPickerOptions','_modelStateForSelect','_findModelInDropdown','_refreshOpenModelDropdown','_applyModelToDropdown','_ensureModelOptionInDropdown','_addLiveModelsToSelect']) eval(extract(name));
+function makeSelect(selected){
+  const sel=new Node('select');sel.id='modelSelect';
+  const group=new Node('optgroup');group.dataset.provider='custom:cpa';sel.appendChild(group);
+  for(const id of ['jb/gpt-5.6-sol']){const opt=new Node('option');opt.value=id;opt.dataset.provider='custom:cpa';group.appendChild(opt);}
+  sel.value=selected||'jb/gpt-5.6-sol';return sel;
+}
+const bare=makeSelect();
+const appliedBare=_ensureModelOptionInDropdown('gpt-5.6-sol',bare,'custom:cpa');
+const beforeLive=_modelStateForSelect(bare,bare.value);
+_addLiveModelsToSelect('custom:cpa',[{id:'gpt-5.6-sol'},{id:'jb/gpt-5.6-sol'}],bare);
+const afterLive=_modelStateForSelect(bare,bare.value);
+const qualified=makeSelect('jb/gpt-5.6-sol');
+_addLiveModelsToSelect('custom:cpa',[{id:'gpt-5.6-sol'}],qualified);
+console.log(JSON.stringify({
+  appliedBare,beforeLive,afterLive,
+  bareOptions:bare.options.map(x=>x.value),
+  qualifiedAfter:_modelStateForSelect(qualified,qualified.value),
+}));
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not in PATH")
+def test_partial_then_live_catalog_preserves_exact_custom_provider_model(tmp_path):
+    driver = tmp_path / "driver.js"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    result = subprocess.run(
+        [NODE, str(driver), str(UI_JS)], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    expected = {"model": "gpt-5.6-sol", "model_provider": "custom:cpa"}
+    assert payload["beforeLive"] == expected
+    assert payload["afterLive"] == expected
+    assert payload["appliedBare"] == "@custom:cpa:gpt-5.6-sol"
+    assert payload["qualifiedAfter"] == {
+        "model": "jb/gpt-5.6-sol",
+        "model_provider": "custom:cpa",
+    }

--- a/tests/test_custom_provider_model_identity.py
+++ b/tests/test_custom_provider_model_identity.py
@@ -84,6 +84,8 @@ def test_partial_then_live_catalog_preserves_exact_custom_provider_model(tmp_pat
     assert payload["beforeLive"] == expected
     assert payload["afterLive"] == expected
     assert payload["appliedBare"] == "@custom:cpa:gpt-5.6-sol"
+    assert "@custom:cpa:gpt-5.6-sol" in payload["bareOptions"]
+    assert "@custom:cpa:jb/gpt-5.6-sol" in payload["bareOptions"]
     assert payload["qualifiedAfter"] == {
         "model": "jb/gpt-5.6-sol",
         "model_provider": "custom:cpa",


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI loads cached/static models first and merges live provider models afterward.
- A configured or session model must survive those refreshes independently of catalog arrival order.
- Custom OpenAI-compatible endpoints may expose both a bare ID such as `gpt-5.6-sol` and a distinct upstream ID such as `jb/gpt-5.6-sol`.
- The restore matcher stripped the first slash segment, making those distinct IDs equivalent under the same named custom provider.
- This change keeps the exact custom-provider route authoritative while preserving the existing compatibility matcher for non-custom providers.
- The result is that partial/live catalog refreshes no longer move a custom-provider selection to a suffix-sharing sibling.

## What Changed

- Updated `_findModelInDropdown()` so named custom providers compare the exact upstream model ID, allowing only the WebUI's `@provider:` routing wrapper and existing dash/dot spelling compatibility.
- Added an executable Node regression using the live frontend functions and the reported shape:
  - provider: `custom:cpa`
  - configured model: `gpt-5.6-sol`
  - sibling model: `jb/gpt-5.6-sol`
  - partial catalog followed by live-model arrival
- Verified the reverse selection remains `jb/gpt-5.6-sol` when the bare model arrives later.

## Why It Matters

Without exact custom-provider identity, catalog refresh timing could make the picker display or persist a different upstream model even though the provider remained the same. This is particularly risky for proxies where slash prefixes are part of the model ID rather than a provider namespace.

## Siblings Checked

- Same model IDs across multiple providers
- Named custom-provider routing wrappers
- OpenRouter slash-prefix compatibility
- Multi-slash custom model IDs
- Colon-suffixed model IDs
- Session model refresh persistence
- Profile/default boot precedence
- Deferred session model resolution
- Partial and late live-model catalog refreshes

## Verification

The new regression was run against the previous matcher first and failed because the bare request resolved to `jb/gpt-5.6-sol`. It passes with this change.

```text
./scripts/test.sh tests/test_custom_provider_model_identity.py ...neighboring model tests... -q
105 passed

./scripts/test.sh tests/test_static_js_runtime_lint.py -q
1 passed

git diff --check
passed
```

No provider credentials or live proxy endpoint were used; the executable regression drives the repository's real frontend picker functions with the exact reported model IDs.

## Risks / Follow-ups

- The behavior change is intentionally limited to `custom` and `custom:*` providers.
- Non-custom provider compatibility matching, including OpenRouter-style `provider/model` restoration, remains unchanged.
- No cache policy, endpoint, loading sequence, persistence schema, or UI appearance changed.
- Full manual validation against the reporter's private proxy was not possible; that endpoint owns the live catalog truth.

## Release-note wording

Fixed custom-provider model selection so distinct upstream IDs with the same suffix no longer replace each other during model catalog refreshes.

## Model Used

AI-assisted:

- Investigation and final review: OpenAI Codex, `gpt-5.6-sol`
- Initial implementation assistance: xAI Grok Build, `grok-4.5`, high-reasoning configuration
