### PR TITLE
fix(ui): strip provider prefix from OpenRouter @preset model ids in picker

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2990,6 +2990,8 @@ function _providerFromModelValue(modelId){
 }
 function _modelPickerOptionIdentity(modelId, providerId){
   let value=String(modelId||'');
+  const presetRest=(typeof _providerQualifiedPresetRest==='function')?_providerQualifiedPresetRest(value,providerId):null;
+  if(presetRest) value=presetRest;
   const provider=String(providerId||'').trim();
   if(value.startsWith('@')&&value.includes(':')){
     const exactPrefix=provider ? `@${provider}:` : '';
@@ -3004,6 +3006,37 @@ function _modelPickerOptionIdentity(modelId, providerId){
     }
   }
   return value.replace(/-/g,'.').toLowerCase();
+}
+// Provider-qualified "@"-qualified remainder (e.g. "openrouter/@preset/<name>"
+// → "@preset/<name>") when the value's first-slash prefix matches its option's
+// own provider group and the remainder is "@"-qualified. Returns null otherwise,
+// so vendor-prefixed model ids (e.g. "kilo/minimax/minimax-m3") are left
+// untouched: their group provider is not their first-slash prefix and their
+// remainder is not "@"-qualified. Shared by the outgoing normalization
+// (_modelStateForSelect) and the canonical identity below so the OpenRouter
+// @preset round-trip stays closed (#6936).
+function _providerQualifiedPresetRest(modelId, providerId){
+  const value=String(modelId||'');
+  const provider=String(providerId||'').trim();
+  if(!value||!provider) return null;
+  const slashAt=value.indexOf('/');
+  if(slashAt<=0) return null;
+  const valuePrefix=value.slice(0,slashAt);
+  const valueRest=value.slice(slashAt+1);
+  if(!valuePrefix||!valueRest.startsWith('@')) return null;
+  if(valuePrefix.toLowerCase()!==provider.toLowerCase()) return null;
+  return valueRest;
+}
+// Canonical identity used by the model-picker lookup, dedup and selected-row
+// paths: the catalog option value "openrouter/@preset/<name>" and the normalized
+// send/session form "@preset/<name>" (with provider "openrouter") resolve to the
+// SAME key, so a restored preset re-finds its existing option instead of
+// injecting a duplicate row and losing the selection (#6936 round-trip).
+function _modelPickerCanonicalIdentity(modelId, providerId){
+  let value=String(modelId||'');
+  const presetRest=(typeof _providerQualifiedPresetRest==='function')?_providerQualifiedPresetRest(value,providerId):null;
+  if(presetRest) value=presetRest;
+  return _modelPickerOptionIdentity(value,providerId);
 }
 function _deduplicateModelPickerOptions(sel,selectedValue){
   if(!sel||!sel.querySelectorAll) return 0;
@@ -3082,19 +3115,14 @@ function _modelStateForSelect(sel, modelId){
   // into their value ("openrouter/@preset/<name>") but never set data-model
   // (that attribute is only set by the fallback injection path
   // _ensureModelOptionInDropdown), so the raw value would otherwise be sent as
-  // the model id. Split a "<provider>/<qualified-id>" value on its FIRST slash
-  // when the prefix matches the option's own provider group and the remainder
-  // is a qualified id (e.g. "@preset/<name>") — send the qualified id as model
-  // with the provider split out (#6936). Vendor-prefixed model ids (e.g.
-  // "kilo/minimax/minimax-m3") are left untouched: their group provider does
-  // not equal their first-slash prefix, and their remainder is not '@'-qualified.
-  let resolvedModel=value;
-  const slashAt=value.indexOf('/');
-  const valuePrefix=slashAt>0?value.slice(0,slashAt):'';
-  const valueRest=slashAt>0?value.slice(slashAt+1):'';
-  if(valuePrefix&&valueRest.startsWith('@')&&provider&&valuePrefix.toLowerCase()===provider.toLowerCase()){
-    resolvedModel=valueRest;
-  }
+  // the model id. Send the "@"-qualified remainder as model with the provider
+  // split out, via the same shared helper the reverse/restore paths use — the
+  // session then stores "@preset/<name>" + model_provider "openrouter", which
+  // the canonical identity round-trips back to the original catalog option
+  // (#6936). Vendor-prefixed model ids (e.g. "kilo/minimax/minimax-m3") are
+  // left untouched: their group provider is not their first-slash prefix.
+  const presetRest=(typeof _providerQualifiedPresetRest==='function')?_providerQualifiedPresetRest(value,provider):null;
+  const resolvedModel=presetRest||value;
   return {model:resolvedModel,model_provider:(provider&&provider!=='default')?provider:null};
 }
 function _captureModelDropdownSelection(sel){

--- a/static/ui.js
+++ b/static/ui.js
@@ -3078,7 +3078,24 @@ function _modelStateForSelect(sel, modelId){
     opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
   }
   const provider=String(_getOptionProviderId(opt)||'').trim();
-  return {model:value,model_provider:(provider&&provider!=='default')?provider:null};
+  // Catalog-rendered OpenRouter preset options carry the provider prefix baked
+  // into their value ("openrouter/@preset/<name>") but never set data-model
+  // (that attribute is only set by the fallback injection path
+  // _ensureModelOptionInDropdown), so the raw value would otherwise be sent as
+  // the model id. Split a "<provider>/<qualified-id>" value on its FIRST slash
+  // when the prefix matches the option's own provider group and the remainder
+  // is a qualified id (e.g. "@preset/<name>") — send the qualified id as model
+  // with the provider split out (#6936). Vendor-prefixed model ids (e.g.
+  // "kilo/minimax/minimax-m3") are left untouched: their group provider does
+  // not equal their first-slash prefix, and their remainder is not '@'-qualified.
+  let resolvedModel=value;
+  const slashAt=value.indexOf('/');
+  const valuePrefix=slashAt>0?value.slice(0,slashAt):'';
+  const valueRest=slashAt>0?value.slice(slashAt+1):'';
+  if(valuePrefix&&valueRest.startsWith('@')&&provider&&valuePrefix.toLowerCase()===provider.toLowerCase()){
+    resolvedModel=valueRest;
+  }
+  return {model:resolvedModel,model_provider:(provider&&provider!=='default')?provider:null};
 }
 function _captureModelDropdownSelection(sel){
   if(!sel||!sel.value) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3077,14 +3077,20 @@ function _deduplicateModelPickerOptions(sel,selectedValue){
   // orphan so "one option remains" after reconcile (#6936 round-trip).
   const orphans=Array.from(sel.children||[]).filter(opt=>opt&&opt.tagName==='OPTION'&&opt.dataset&&opt.dataset.custom==='1');
   for(const orphan of orphans){
+    const orphanProvider=_getOptionProviderId(orphan)||'';
     const identity=typeof _modelPickerCanonicalIdentity==='function'
-      ?_modelPickerCanonicalIdentity(orphan.value,_getOptionProviderId(orphan)||'')
-      :_modelPickerOptionIdentity(orphan.value,_getOptionProviderId(orphan));
+      ?_modelPickerCanonicalIdentity(orphan.value,orphanProvider)
+      :_modelPickerOptionIdentity(orphan.value,orphanProvider);
     if(!identity) continue;
     const realTwin=(()=>{
       for(const group of sel.querySelectorAll('optgroup')){
         const twin=Array.from(group.children||[]).find(opt=>opt&&opt.tagName==='OPTION'
           &&!(opt.dataset&&opt.dataset.custom==='1')
+          // #6946 re-gate: the canonical identity is model-only, so a real
+          // option from ANOTHER provider must never retire a synthetic,
+          // routable selection owned by this provider (provider equality
+          // required before treating it as a twin).
+          &&(_getOptionProviderId(opt)||'')===orphanProvider
           &&_modelPickerOptionIdentity(opt.value,_getOptionProviderId(opt))===identity);
         if(twin) return twin;
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -3053,13 +3053,46 @@ function _deduplicateModelPickerOptions(sel,selectedValue){
     for(const candidates of byIdentity.values()){
       if(candidates.length<2) continue;
       const selected=candidates.find(opt=>opt.value===selectedValue);
+      // Prefer the REAL catalog row (no data-custom) over any synthetic
+      // injected duplicate: a restored OpenRouter preset must collapse back
+      // onto "openrouter/@preset/<name>", not onto the injected
+      // "@openrouter:@preset/<name>" row (#6936 round-trip). Only when a
+      // synthetic row is actually present: live-model custom proxies
+      // ("@custom:llm-proxy:x-ai/grok-4.5") carry no data-custom and must
+      // keep the routable-survivor rule (#5989).
+      const synthetic=candidates.find(opt=>opt.dataset&&opt.dataset.custom==='1');
+      const realRow=synthetic?candidates.find(opt=>!(opt.dataset&&opt.dataset.custom==='1')):null;
       const routable=candidates.find(opt=>String(opt.value||'').startsWith('@'));
-      const survivor=selected||routable||candidates[0];
+      const survivor=selected||realRow||routable||candidates[0];
       for(const opt of candidates){
         if(opt===survivor) continue;
         group.removeChild(opt);
         removed++;
       }
+    }
+  }
+  // Synthetic rows injected by _ensureModelOptionInDropdown are appended
+  // directly to the <select> (outside any optgroup). If the real catalog row
+  // with the same canonical identity exists inside an optgroup, drop the
+  // orphan so "one option remains" after reconcile (#6936 round-trip).
+  const orphans=Array.from(sel.children||[]).filter(opt=>opt&&opt.tagName==='OPTION'&&opt.dataset&&opt.dataset.custom==='1');
+  for(const orphan of orphans){
+    const identity=typeof _modelPickerCanonicalIdentity==='function'
+      ?_modelPickerCanonicalIdentity(orphan.value,_getOptionProviderId(orphan)||'')
+      :_modelPickerOptionIdentity(orphan.value,_getOptionProviderId(orphan));
+    if(!identity) continue;
+    const realTwin=(()=>{
+      for(const group of sel.querySelectorAll('optgroup')){
+        const twin=Array.from(group.children||[]).find(opt=>opt&&opt.tagName==='OPTION'
+          &&!(opt.dataset&&opt.dataset.custom==='1')
+          &&_modelPickerOptionIdentity(opt.value,_getOptionProviderId(opt))===identity);
+        if(twin) return twin;
+      }
+      return null;
+    })();
+    if(realTwin){
+      if(sel.removeChild) sel.removeChild(orphan);
+      removed++;
     }
   }
   return removed;
@@ -3388,6 +3421,30 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
     explicitProvider=rawModel.slice(1,rawModel.lastIndexOf(':'));
   }
   const preferred=String(preferredProviderId||explicitProvider||'').toLowerCase();
+  // 0.5 Provider-aware canonical (model, provider) identity — the SAME key the
+  // outgoing path (_modelStateForSelect), dedup and the selected-row check use.
+  // A restored preset "@preset/<name>" (provider "openrouter") and the real
+  // catalog option "openrouter/@preset/<name>" (provider "openrouter") resolve
+  // to ONE identity, so reverse lookup re-finds the catalog row instead of
+  // falling through to synthetic injection (@openrouter:@preset/<name>).
+  // Prefer the real catalog row (no data-custom) when it exists (#6936).
+  if(typeof _modelPickerCanonicalIdentity==='function'){
+    const canonicalTarget=_modelPickerCanonicalIdentity(modelId,preferredProviderId||explicitProvider||'');
+    if(canonicalTarget){
+      const canonicalMatches=options.filter(o=>{
+        const oProv=String(_getOptionProviderId(o)||'').toLowerCase();
+        if(preferred && oProv && oProv!==preferred) return false;
+        return _modelPickerCanonicalIdentity(o.value,oProv||'')===canonicalTarget;
+      });
+      if(canonicalMatches.length){
+        const distinctProviders=new Set(canonicalMatches.map(o=>String(_getOptionProviderId(o)||'').toLowerCase()));
+        if(preferred || distinctProviders.size===1){
+          const realRow=canonicalMatches.find(o=>!(o.dataset&&o.dataset.custom==='1'));
+          return (realRow||canonicalMatches[0]).value;
+        }
+      }
+    }
+  }
   if(preferred){
     if(preferred==='custom'||preferred.startsWith('custom:')){
       // A slash is part of a custom endpoint's upstream model ID, not a
@@ -4458,7 +4515,23 @@ function renderModelDropdown(){
     const _provider=String((m&&m.providerId)||(m&&m.badge&&m.badge.provider)||((typeof _providerFromModelValue==='function')?_providerFromModelValue(m&&m.value):'')||'').trim();
     return (_provider&&_provider!=='default')?_provider:null;
   };
-  const _isSelectedModelRow=(m)=>String((m&&m.value)||'')===String((_selectedModelState&&_selectedModelState.model)||(sel&&sel.value)||'')&&String(_modelProviderForSelectedBadge(m)||'')===String((_selectedModelState&&_selectedModelState.model_provider)||'');
+  // Same provider-aware semantic (model, provider) identity the outgoing,
+  // reverse and dedup paths use: the real catalog row
+  // "openrouter/@preset/<name>" matches a selected state of
+  // "@preset/<name>" + provider "openrouter", so it is marked active and gets
+  // the Selected badge instead of staying unhighlighted (#6936 round-trip).
+  const _isSelectedModelRow=(m)=>{
+    const rowValue=String((m&&m.value)||'');
+    const rowProvider=String(_modelProviderForSelectedBadge(m)||'');
+    const selModel=String((_selectedModelState&&_selectedModelState.model)||(sel&&sel.value)||'');
+    const selProvider=String((_selectedModelState&&_selectedModelState.model_provider)||'');
+    if(typeof _modelPickerCanonicalIdentity==='function'&&rowProvider.toLowerCase()===selProvider.toLowerCase()){
+      try{
+        if(_modelPickerCanonicalIdentity(rowValue,rowProvider||null)===_modelPickerCanonicalIdentity(selModel,selProvider||null)) return true;
+      }catch(_e){}
+    }
+    return rowValue===selModel&&rowProvider.toLowerCase()===selProvider.toLowerCase();
+  };
   const _selectedModelBadge=(m)=>_isSelectedModelRow(m)
     ?`<span class="model-opt-badge model-opt-badge--selected">${esc(t('model_badge_selected')||'Selected')}</span>`
     :'';

--- a/tests/test_configured_model_picker_provider_routing.py
+++ b/tests/test_configured_model_picker_provider_routing.py
@@ -190,6 +190,7 @@ function extractFunction(source, name) {
 eval([
   '_getOptionProviderId',
   '_providerFromModelValue',
+  '_providerQualifiedPresetRest',
   '_modelStateForSelect',
 ].map(name => extractFunction(uiSrc, name)).join('\n'));
 
@@ -273,6 +274,295 @@ def test_openrouter_preset_entry_strips_provider_prefix_from_model_id():
         "model": "kilo/minimax/minimax-m3",
         "model_provider": "kilo/minimax",
     }
+
+
+# Full #6936 round-trip (production-shaped): the user selects the RAW catalog
+# preset option ("openrouter/@preset/<name>" — the value the backend would
+# reject), the outgoing state persists "@preset/<name>" + provider "openrouter",
+# and after a catalog rebuild/reconcile the SAME provider-aware semantic
+# identity is used by the reverse lookup, the dedup survivor rule and the
+# selected-row check. One option must remain (the REAL catalog row), it must be
+# the row that gets the Selected badge / active state, and the outgoing state
+# must stay canonical. The vendor-prefixed non-strip control (kilo/minimax) is
+# kept so the preset stripping never leaks into ordinary vendor ids.
+_ROUNDTRIP_DRIVER = r"""
+const fs = require('fs');
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+
+function extractFunc(name) {
+  const marker = 'function ' + name + '(';
+  const start = uiSrc.indexOf(marker);
+  if (start < 0) throw new Error('not found: ' + name);
+  const brace = uiSrc.indexOf('{', uiSrc.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < uiSrc.length; i++) {
+    if (uiSrc[i] === '{') depth += 1;
+    else if (uiSrc[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return uiSrc.slice(start, i + 1);
+    }
+  }
+  throw new Error('unterminated: ' + name);
+}
+
+function makeClassList(initial) {
+  const _set = new Set(initial || []);
+  return {
+    _set,
+    add(...names) { names.forEach(n => _set.add(n)); },
+    remove(...names) { names.forEach(n => _set.delete(n)); },
+    contains(name) { return _set.has(name); },
+    toggle(name, force) {
+      if (force === undefined) { _set.has(name) ? _set.delete(name) : _set.add(name); }
+      else { force ? _set.add(name) : _set.delete(name); }
+    },
+  };
+}
+function defineClassName(node) {
+  Object.defineProperty(node, 'className', {
+    get() { return [...node.classList._set].join(' '); },
+    set(v) { node.classList = makeClassList(String(v || '').split(/\s+/).filter(Boolean)); },
+  });
+}
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag || '').toUpperCase(),
+    children: [],
+    dataset: {},
+    style: {},
+    parentElement: null,
+    textContent: '',
+    value: '',
+    tabIndex: 0,
+    onclick: null,
+    _listeners: {},
+    _innerHTML: '',
+    appendChild(child) {
+      child.parentElement = this;
+      this.children.push(child);
+      if (this.tagName === 'OPTGROUP' && this._ownerSelect && child.tagName === 'OPTION') {
+        this._ownerSelect.options.push(child);
+      }
+      return child;
+    },
+    addEventListener(type, handler) { this._listeners[type] = handler; },
+    querySelector(selector) { return this._qs ? this._qs[selector] || null : null; },
+    setAttribute(name, value) { this[name] = value; },
+    focus() { this._focused = true; },
+  };
+  node.classList = makeClassList();
+  defineClassName(node);
+  Object.defineProperty(node, 'innerHTML', {
+    get() { return this._innerHTML; },
+    set(v) {
+      this._innerHTML = String(v || '');
+      this.children = [];
+      this._qs = {};
+      if (this.tagName === 'DIV' && this._innerHTML.includes('model-search-input')) {
+        const input = makeNode('input');
+        input.className = 'model-search-input';
+        const clear = makeNode('button');
+        clear.className = 'model-search-clear';
+        this._qs['.model-search-input'] = input;
+        this._qs['.model-search-clear'] = clear;
+      } else if (this.tagName === 'DIV' && this._innerHTML.includes('model-custom-input')) {
+        const input = makeNode('input');
+        input.className = 'model-custom-input';
+        const btn = makeNode('button');
+        btn.className = 'model-custom-btn';
+        this._qs['.model-custom-input'] = input;
+        this._qs['.model-custom-btn'] = btn;
+      }
+    },
+  });
+  return node;
+}
+function makeOption(value, label, parent) {
+  const opt = makeNode('option');
+  opt.value = value;
+  opt.textContent = label || value;
+  opt.parentElement = parent || null;
+  return opt;
+}
+function makeSelect(groups, selectedValue) {
+  const sel = { id: 'modelSelect', children: [], options: [], _value: selectedValue || '' };
+  Object.defineProperty(sel, 'value', {get(){return sel._value;}, set(v){sel._value=String(v||'');}});
+  Object.defineProperty(sel, 'selectedOptions', {get(){const o=sel.options.find(x=>x.value===sel._value);return o?[o]:[];}});
+  sel.appendChild=function(option){option.parentElement=null;sel.children.push(option);sel.options.push(option);};
+  sel.querySelectorAll=function(){return sel.children.filter(c=>c.tagName==='OPTGROUP');};
+  sel.removeChild=function(option){const i=sel.children.indexOf(option);if(i>=0)sel.children.splice(i,1);const j=sel.options.indexOf(option);if(j>=0)sel.options.splice(j,1);};
+  for (const group of groups || []) {
+    const og = makeNode('optgroup');
+    og.label = group.provider || '';
+    og.dataset.provider = group.provider_id || '';
+    for (const model of group.models || []) og.appendChild(makeOption(model.id, model.label || model.id, og));
+    sel.children.push(og);
+    sel.options.push(...og.children);
+  }
+  return sel;
+}
+function findInTree(dd, pred) {
+  const stack = [...(dd.children || [])];
+  while (stack.length) {
+    const n = stack.shift();
+    if (pred(n)) return n;
+    if (n.children && n.children.length) stack.push(...n.children);
+  }
+  return null;
+}
+
+const dropdown = makeNode('div');
+dropdown.classList.add('open');
+function $(id) {
+  if (id === 'composerModelDropdown') return dropdown;
+  if (id === 'modelSelect') return modelSelect;
+  return null;
+}
+const window = { _configuredModelBadges: {} };
+const document = { createElement(tag) { return makeNode(tag); } };
+function esc(v) { return String(v || ''); }
+function t(key, ...args) {
+  if (key === 'model_show_all_models') return `Show all ${args[0]} models`;
+  return key;
+}
+function li() { return 'x'; }
+function getModelLabel(v) { return String(v || ''); }
+function _providerFromModelValue(v) {
+  const value = String(v || '');
+  if (value.startsWith('@') && value.includes(':')) return value.slice(1, value.lastIndexOf(':'));
+  return '';
+}
+function _normalizeConfiguredModelKey(v) { return String(v || '').toLowerCase(); }
+function _getConfiguredModelBadge(value, badgeMap) { return badgeMap[value] || null; }
+function closeModelDropdown() {}
+function syncModelChip() {}
+function _refreshOpenModelDropdown() {}
+async function selectModelFromDropdown(value, provider) {
+  _ensureModelOptionInDropdown(value, modelSelect, provider);
+  window.__picked=_modelStateForSelect(modelSelect,modelSelect.value);
+}
+
+for (const name of [
+  '_providerQualifiedPresetRest',
+  '_modelPickerOptionIdentity',
+  '_modelPickerCanonicalIdentity',
+  '_getOptionProviderId',
+  '_modelStateForSelect',
+  '_findModelInDropdown',
+  '_applyModelToDropdown',
+  '_ensureModelOptionInDropdown',
+  '_deduplicateModelPickerOptions',
+  '_readModelOverflowData',
+  '_appendOverflowOptionsToGroup',
+  '_isEquivalentConfiguredModelEntry',
+  'renderModelDropdown',
+]) {
+  eval(extractFunc(name));
+}
+
+// ---- Catalog renders the RAW preset option under the openrouter group ----
+const groups = [{
+  provider: 'OpenRouter',
+  provider_id: 'openrouter',
+  models: [{id: 'openrouter/@preset/deepseek-v4-flash', label: '@preset/deepseek-v4-flash'}],
+}];
+
+// 1) Select the raw catalog preset -> outgoing canonical state.
+let modelSelect = makeSelect(groups, 'openrouter/@preset/deepseek-v4-flash');
+const outgoing = _modelStateForSelect(modelSelect, modelSelect.value);
+
+// 2) Rebuild/reconcile the catalog: a fresh select with the same real row and
+//    a leftover synthetic @openrouter: row injected by an earlier failed
+//    apply (dataset.custom, orphaned outside the optgroup, like the real
+//    _ensureModelOptionInDropdown appendChild path).
+modelSelect = makeSelect(groups, '');
+const synthetic = makeOption('@openrouter:@preset/deepseek-v4-flash', '@preset/deepseek-v4-flash');
+synthetic.dataset.custom = '1';
+synthetic.dataset.provider = 'openrouter';
+synthetic.dataset.model = '@preset/deepseek-v4-flash';
+modelSelect.appendChild(synthetic);
+
+// Reverse lookup of the persisted canonical state must hit the REAL catalog row.
+const resolved = _findModelInDropdown('@preset/deepseek-v4-flash', modelSelect, 'openrouter');
+// Dedup must prefer the real row over the synthetic one: exactly one option
+// remains and it is the catalog row.
+const dedupRemoved = _deduplicateModelPickerOptions(modelSelect, resolved || '');
+const remainingOptions = modelSelect.options.map(o => o.value);
+// Applying the persisted state must reselect the real row.
+const applied = _ensureModelOptionInDropdown('@preset/deepseek-v4-flash', modelSelect, 'openrouter');
+const appliedState = _modelStateForSelect(modelSelect, modelSelect.value);
+
+// 3) Rich picker: the real row must be active and carry the Selected badge.
+renderModelDropdown();
+const realRow = findInTree(dropdown, node =>
+  String(node._innerHTML || '').includes('openrouter/@preset/deepseek-v4-flash'));
+const badgeHtml = realRow ? realRow._innerHTML : '';
+const active = realRow && realRow.classList && realRow.classList.contains('active');
+// The synthetic orphan must NOT appear as a rendered row.
+const synthRow = findInTree(dropdown, node =>
+  String(node._innerHTML || '').includes('@openrouter:@preset/deepseek-v4-flash'));
+
+// 4) Vendor-prefixed control: kilo/minimax stays untouched end-to-end.
+const kiloGroup = {provider: 'Kilo/MiniMax', provider_id: 'kilo/minimax', models: [{id: 'kilo/minimax/minimax-m3', label: 'kilo/minimax/minimax-m3'}]};
+const kiloSelect = makeSelect([kiloGroup], 'kilo/minimax/minimax-m3');
+const kiloOutgoing = _modelStateForSelect(kiloSelect, kiloSelect.value);
+const kiloResolved = _findModelInDropdown('kilo/minimax/minimax-m3', kiloSelect, 'kilo/minimax');
+
+process.stdout.write(JSON.stringify({
+  outgoing,
+  resolved,
+  dedupRemoved,
+  remainingOptions,
+  applied,
+  appliedState,
+  active,
+  selectedBadge: badgeHtml.includes('model-opt-badge--selected'),
+  synthRowRendered: !!synthRow,
+  kiloOutgoing,
+  kiloResolved,
+}));
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_openrouter_preset_round_trip_uses_one_semantic_identity():
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, "-e", _ROUNDTRIP_DRIVER, str(UI_JS)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    # Outgoing stays canonical: @preset/<name> + openrouter, never the raw value.
+    assert payload["outgoing"] == {
+        "model": "@preset/deepseek-v4-flash",
+        "model_provider": "openrouter",
+    }
+    # Reverse lookup of the persisted state hits the REAL catalog row.
+    assert payload["resolved"] == "openrouter/@preset/deepseek-v4-flash"
+    # Dedup collapses the synthetic duplicate; one option remains (the real row).
+    assert payload["dedupRemoved"] >= 1
+    assert payload["remainingOptions"] == ["openrouter/@preset/deepseek-v4-flash"]
+    # Reconcile reselects the real row; outgoing state stays canonical.
+    assert payload["applied"] == "openrouter/@preset/deepseek-v4-flash"
+    assert payload["appliedState"] == {
+        "model": "@preset/deepseek-v4-flash",
+        "model_provider": "openrouter",
+    }
+    # The real row is active and carries the Selected badge; the synthetic
+    # orphan is gone from the rendered picker.
+    assert payload["active"] is True
+    assert payload["selectedBadge"] is True
+    assert payload["synthRowRendered"] is False
+    # Vendor-prefixed control: kilo/minimax is never stripped.
+    assert payload["kiloOutgoing"] == {
+        "model": "kilo/minimax/minimax-m3",
+        "model_provider": "kilo/minimax",
+    }
+    assert payload["kiloResolved"] == "kilo/minimax/minimax-m3"
 
 
 _RENDERED_CLICK_DRIVER = r"""

--- a/tests/test_configured_model_picker_provider_routing.py
+++ b/tests/test_configured_model_picker_provider_routing.py
@@ -160,6 +160,121 @@ def test_colon_bearing_missing_fallback_keeps_authoritative_provider():
     }
 
 
+# OpenRouter preset dropdown entries are rendered by the catalog with the
+# provider prefix baked into the option value ("openrouter/@preset/<name>") and
+# NEVER set data-model (that attribute is only set by the fallback injection
+# path _ensureModelOptionInDropdown). Regression for #6936: the model id sent
+# must be the qualified "@preset/<name>" with model_provider "openrouter" — NOT
+# the raw "openrouter/@preset/<name>" value (which the backend rejects with
+# HTTP 400 'openrouter/ is not a valid model ID').
+_OPENROUTER_PRESET_DRIVER = r"""
+const fs = require('fs');
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+
+function extractFunction(source, name) {
+  const marker = 'function ' + name + '(';
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('not found: ' + name);
+  const brace = source.indexOf('{', source.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error('unterminated: ' + name);
+}
+
+eval([
+  '_getOptionProviderId',
+  '_providerFromModelValue',
+  '_modelStateForSelect',
+].map(name => extractFunction(uiSrc, name)).join('\n'));
+
+globalThis.document = {
+  createElement(tag) {
+    return {
+      tagName: String(tag).toUpperCase(),
+      value: '',
+      textContent: '',
+      dataset: {},
+      parentElement: null,
+    };
+  },
+};
+globalThis.getModelLabel = value => String(value || '');
+globalThis.window = { _configuredModelBadges: {} };
+
+const openrouterGroup = {tagName: 'OPTGROUP', dataset: {provider: 'openrouter'}};
+const preset = {
+  value: 'openrouter/@preset/deepseek-v4-flash',
+  textContent: '@preset/deepseek-v4-flash',
+  dataset: {},  // no data-model — normal catalog render path
+  parentElement: openrouterGroup,
+};
+const select = {
+  id: 'modelSelect',
+  options: [preset],
+  querySelectorAll() { return []; },
+  get selectedOptions() { return [preset]; },
+  get value() { return preset.value; },
+  set value(value) {},
+};
+
+// Sanity: a vendor-prefixed model id under a slash-bearing provider group must
+// NOT be stripped — its first-slash prefix ('kilo') does not match the group
+// provider ('kilo/minimax') and the remainder is not '@'-qualified.
+const kiloGroup = {tagName: 'OPTGROUP', dataset: {provider: 'kilo/minimax'}};
+const kilo = {
+  value: 'kilo/minimax/minimax-m3',
+  textContent: 'kilo/minimax/minimax-m3',
+  dataset: {},
+  parentElement: kiloGroup,
+};
+const kiloSelect = {
+  id: 'modelSelect',
+  options: [kilo],
+  querySelectorAll() { return []; },
+  get selectedOptions() { return [kilo]; },
+  get value() { return kilo.value; },
+  set value(value) {},
+};
+
+process.stdout.write(JSON.stringify({
+  preset: _modelStateForSelect(select, 'openrouter/@preset/deepseek-v4-flash'),
+  vendorPrefixed: _modelStateForSelect(kiloSelect, 'kilo/minimax/minimax-m3'),
+}));
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_openrouter_preset_entry_strips_provider_prefix_from_model_id():
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, "-e", _OPENROUTER_PRESET_DRIVER, str(UI_JS)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    # #6936: the catalog-rendered preset option carries "openrouter/" baked into
+    # its value, so the model id must be the qualified "@preset/<name>" with the
+    # provider split out — not the raw "openrouter/@preset/<name>" value.
+    assert payload["preset"] == {
+        "model": "@preset/deepseek-v4-flash",
+        "model_provider": "openrouter",
+    }
+    # Sanity: vendor-prefixed model ids must keep their full value untouched.
+    assert payload["vendorPrefixed"] == {
+        "model": "kilo/minimax/minimax-m3",
+        "model_provider": "kilo/minimax",
+    }
+
+
 _RENDERED_CLICK_DRIVER = r"""
 
 const fs = require('fs');

--- a/tests/test_issue6946_cross_provider_orphan.py
+++ b/tests/test_issue6946_cross_provider_orphan.py
@@ -1,5 +1,14 @@
 """#6946 re-gate: a real option from provider A must never retire a synthetic,
-routable selection owned by provider B (cross-provider orphan dedup)."""
+routable selection owned by provider B (cross-provider orphan dedup).
+
+Two production shapes (per maintainer review #4):
+(a) Provider A has a real catalog `shared-model`; a restored provider B
+    selection is represented by the synthetic `@provider-b:shared-model` row
+    because provider B's catalog entry is not hydrated. Dedup must preserve B.
+(b) A provider B real twin is added to the catalog. Only the B
+    synthetic/real pair collapses, the B real row becomes the reverse-lookup
+    target, and the provider-A row remains.
+"""
 
 from __future__ import annotations
 
@@ -19,6 +28,7 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 def _function(src: str, name: str) -> str:
     import re
+
     match = re.search(rf"function\s+{re.escape(name)}\s*\(", src)
     assert match, f"{name} not found"
     start = match.start()
@@ -34,7 +44,7 @@ def _function(src: str, name: str) -> str:
     return src[start:i]
 
 
-def _run_harness(tmp_path, case: str) -> dict:
+def _run_harness(tmp_path, case: str, with_twin_b: bool) -> dict:
     src = UI_JS_PATH.read_text(encoding="utf-8")
     parts = [
         _function(src, "_getOptionProviderId"),
@@ -42,13 +52,14 @@ def _run_harness(tmp_path, case: str) -> dict:
         _function(src, "_modelPickerCanonicalIdentity"),
         _function(src, "_providerQualifiedPresetRest"),
         _function(src, "_deduplicateModelPickerOptions"),
+        _function(src, "_findModelInDropdown"),
     ]
     driver = tmp_path / f"driver_{case}.js"
     driver.write_text(
         "\n".join(parts)
         + r"""
 class Node {
-  constructor(tag) { this.tagName=tag.toUpperCase(); this.children=[]; this.dataset={}; this.parentElement=null; this.value=''; }
+  constructor(tag) { this.tagName=tag.toUpperCase(); this.children=[]; this.dataset={}; this.parentElement=null; this.value=''; this.textContent=''; }
   appendChild(child) { child.parentElement=this; this.children.push(child); return child; }
   removeChild(child) { this.children=this.children.filter(item=>item!==child); child.parentElement=null; }
   querySelectorAll(selector) {
@@ -67,19 +78,34 @@ globalThis._dynamicModelLabels={};
 globalThis._modelStateForSelect=()=>({model:'',model_provider:null});
 globalThis._applyModelToDropdown=()=>null;
 globalThis.S={session:null};
-function makeSelect() {
+function makeSelect(withTwinB) {
   const select=new Node('select');
   const groupA=new Node('optgroup'); groupA.dataset.provider='provider-a'; select.appendChild(groupA);
-  const real=new Node('option'); real.value='shared-model'; real.textContent='shared-model'; groupA.appendChild(real);
-  const orphan=new Node('option'); orphan.value='@provider-b:shared-model'; orphan.dataset.custom='1'; select.appendChild(orphan);
+  const realA=new Node('option'); realA.value='shared-model'; realA.textContent='shared-model'; groupA.appendChild(realA);
+  if(withTwinB){
+    const groupB=new Node('optgroup'); groupB.dataset.provider='provider-b'; select.appendChild(groupB);
+    const realB=new Node('option'); realB.value='shared-model'; realB.textContent='shared-model'; groupB.appendChild(realB);
+  }
+  // Synthetic orphan shaped exactly like _ensureModelOptionInDropdown creates
+  // it: dataset.custom='1' AND dataset.provider set (ui.js:3464-3471).
+  const orphan=new Node('option'); orphan.value='@provider-b:shared-model'; orphan.textContent='@provider-b:shared-model';
+  orphan.dataset.custom='1'; orphan.dataset.provider='provider-b';
+  select.appendChild(orphan);
   return select;
 }
-const select=makeSelect();
+const WITH_TWIN_B = __WITH_TWIN_B__;
+const select=makeSelect(WITH_TWIN_B);
 const removed=_deduplicateModelPickerOptions(select,select.value);
 const groups=select.querySelectorAll('optgroup').map(item=>item.children.map(option=>option.value));
 const orphans=select.children.filter(child=>child.tagName==='OPTION').map(option=>option.value);
-process.stdout.write(JSON.stringify({removed,groups,orphans}));
-""",
+const found=_findModelInDropdown('@provider-b:shared-model',select,'provider-b');
+// The reverse-lookup result must resolve to a row owned by provider B (the
+// provider-aware canonical match filters the provider-A row out).
+const foundHasProviderBRow=select.options.some(o=>o.value===found&&(_getOptionProviderId(o)||'')==='provider-b');
+process.stdout.write(JSON.stringify({removed,groups,orphans,found,foundHasProviderBRow}));
+""".replace(
+            "__WITH_TWIN_B__", "true" if with_twin_b else "false"
+        ),
         encoding="utf-8",
     )
     result = subprocess.run(
@@ -91,10 +117,34 @@ process.stdout.write(JSON.stringify({removed,groups,orphans}));
 
 def test_cross_provider_orphan_not_retired_by_other_provider_twin(tmp_path):
     """Provider A's real `shared-model` option must NOT retire provider B's
-    synthetic `@provider-b:shared-model` orphan (#6946 re-gate)."""
-    out = _run_harness(tmp_path, "cross")
+    synthetic `@provider-b:shared-model` orphan while provider B has no
+    catalog twin (#6946 re-gate)."""
+    out = _run_harness(tmp_path, "cross", with_twin_b=False)
+    assert out["removed"] == 0, str(out)
     assert out["orphans"] == ["@provider-b:shared-model"], (
         "orphan owned by provider B must survive dedup (provider mismatch): "
         + str(out)
     )
     assert out["groups"] == [["shared-model"]], str(out)
+
+
+def test_cross_provider_orphan_collapses_onto_real_twin(tmp_path):
+    """Once a provider B real twin exists, only the B synthetic/real pair
+    collapses; the B real row becomes the reverse-lookup target and the
+    provider-A row remains (#6946 re-gate)."""
+    out = _run_harness(tmp_path, "twin", with_twin_b=True)
+    assert out["removed"] == 1, (
+        "only the provider-B orphan must collapse onto its real twin: " + str(out)
+    )
+    assert out["orphans"] == [], (
+        "provider-B synthetic row must be removed once the real twin exists: "
+        + str(out)
+    )
+    assert out["groups"] == [["shared-model"], ["shared-model"]], (
+        "provider-A row and provider-B real row must both remain: " + str(out)
+    )
+    assert out["found"] == "shared-model", str(out)
+    assert out["foundHasProviderBRow"] is True, (
+        "reverse lookup of @provider-b:shared-model must resolve to the "
+        "provider-B real row (provider equality): " + str(out)
+    )

--- a/tests/test_issue6946_cross_provider_orphan.py
+++ b/tests/test_issue6946_cross_provider_orphan.py
@@ -1,0 +1,100 @@
+"""#6946 re-gate: a real option from provider A must never retire a synthetic,
+routable selection owned by provider B (cross-provider orphan dedup)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _function(src: str, name: str) -> str:
+    import re
+    match = re.search(rf"function\s+{re.escape(name)}\s*\(", src)
+    assert match, f"{name} not found"
+    start = match.start()
+    i = src.index("{", match.end())
+    depth = 1
+    i += 1
+    while depth > 0 and i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    return src[start:i]
+
+
+def _run_harness(tmp_path, case: str) -> dict:
+    src = UI_JS_PATH.read_text(encoding="utf-8")
+    parts = [
+        _function(src, "_getOptionProviderId"),
+        _function(src, "_modelPickerOptionIdentity"),
+        _function(src, "_modelPickerCanonicalIdentity"),
+        _function(src, "_providerQualifiedPresetRest"),
+        _function(src, "_deduplicateModelPickerOptions"),
+    ]
+    driver = tmp_path / f"driver_{case}.js"
+    driver.write_text(
+        "\n".join(parts)
+        + r"""
+class Node {
+  constructor(tag) { this.tagName=tag.toUpperCase(); this.children=[]; this.dataset={}; this.parentElement=null; this.value=''; }
+  appendChild(child) { child.parentElement=this; this.children.push(child); return child; }
+  removeChild(child) { this.children=this.children.filter(item=>item!==child); child.parentElement=null; }
+  querySelectorAll(selector) {
+    if(selector==='optgroup') return this.children.filter(child=>child.tagName==='OPTGROUP');
+    return [];
+  }
+  get options() {
+    return this.tagName==='SELECT'
+      ? this.children.flatMap(child=>child.tagName==='OPTGROUP'?child.children:[child])
+      : undefined;
+  }
+}
+globalThis.window={_activeProvider:null};
+globalThis.document={createElement:tag=>new Node(tag)};
+globalThis._dynamicModelLabels={};
+globalThis._modelStateForSelect=()=>({model:'',model_provider:null});
+globalThis._applyModelToDropdown=()=>null;
+globalThis.S={session:null};
+function makeSelect() {
+  const select=new Node('select');
+  const groupA=new Node('optgroup'); groupA.dataset.provider='provider-a'; select.appendChild(groupA);
+  const real=new Node('option'); real.value='shared-model'; real.textContent='shared-model'; groupA.appendChild(real);
+  const orphan=new Node('option'); orphan.value='@provider-b:shared-model'; orphan.dataset.custom='1'; select.appendChild(orphan);
+  return select;
+}
+const select=makeSelect();
+const removed=_deduplicateModelPickerOptions(select,select.value);
+const groups=select.querySelectorAll('optgroup').map(item=>item.children.map(option=>option.value));
+const orphans=select.children.filter(child=>child.tagName==='OPTION').map(option=>option.value);
+process.stdout.write(JSON.stringify({removed,groups,orphans}));
+""",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [NODE, str(driver)], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_cross_provider_orphan_not_retired_by_other_provider_twin(tmp_path):
+    """Provider A's real `shared-model` option must NOT retire provider B's
+    synthetic `@provider-b:shared-model` orphan (#6946 re-gate)."""
+    out = _run_harness(tmp_path, "cross")
+    assert out["orphans"] == ["@provider-b:shared-model"], (
+        "orphan owned by provider B must survive dedup (provider mismatch): "
+        + str(out)
+    )
+    assert out["groups"] == [["shared-model"]], str(out)


### PR DESCRIPTION
## Summary

Fixes #6936 — the model picker sends a malformed `openrouter/@preset/<name>` model id for OpenRouter preset dropdown entries, which OpenRouter's API rejects with `HTTP 400: openrouter/ is not a valid model ID`.

## Root Cause

`_modelStateForSelect()` in `static/ui.js` only strips a provider prefix from the dropdown value when the matched `<option>` carries a `data-model` attribute — which, as established in #6884 / PR #6895, is only set by the fallback injection path `_ensureModelOptionInDropdown()`. Normally-rendered catalog options (including the OpenRouter preset group) never set `data-model`, so the function falls back to the raw option `value`. For OpenRouter preset entries that raw value already carries the `provider/` prefix baked in by the catalog renderer (`openrouter/@preset/<name>`), so the doubled, malformed string is sent as `model` and the backend rejects it (`HTTP 400 'openrouter/ is not a valid model ID'`).

PR #6895 fixes the same fallback branch for the `@custom:<slug>:<model>` **colon** format, but its `@<provider>:` stripping does not cover the `provider/model` **slash** format OpenRouter preset entries use.

## Change

In the fallback branch of `_modelStateForSelect()` (`static/ui.js`), generalize the resolution to also handle slash-joined values: when the value is a `<provider>/<qualified-id>` pair whose first-slash prefix matches the option's own provider group and the remainder is a qualified id (e.g. `@preset/<name>`), return the qualified id as `model` with the provider split out into `model_provider`.

The change is deliberately conservative and isolated:

- Vendor-prefixed model ids (e.g. `kilo/minimax/minimax-m3`) are left untouched — their group provider does not equal their first-slash prefix and their remainder is not `@`-qualified.
- The colon-format handling from PR #6895 lives in the upper `explicitProvider` branch of the same function; this change touches only the lower fallback branch, so both PRs apply independently to `master` without conflict.
- Adds a regression test in `tests/test_configured_model_picker_provider_routing.py` covering the exact scenario from the issue: configured `model.default '@preset/<preset-name>'` with provider `openrouter` → the picker entry resolves to `model: "@preset/<preset-name>"`, `model_provider: "openrouter"` (never `"openrouter/@preset/..."`).

## Verification

```
pytest tests/test_configured_model_picker_provider_routing.py -q
4 passed in 4.30s
```

## Closes

Closes #6936
