### PR TITLE
fix(ui): workspace panel unopenable at 641-900px viewports

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2997,10 +2997,27 @@
 
   @media(max-width:900px){
     .workspace-panel-edge-toggle{display:none!important;}
-    .rightpanel{display:none}
     .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
     .app-titlebar{justify-content:space-between;}
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
+  }
+
+  /* 641–900px viewports (phone landscape / large phones / narrow windows):
+     previously the compact breakpoint forced `display:none` on `.rightpanel`,
+     leaving the workspace panel impossible to open. Add the slide-in overlay
+     used below 640px for this band too.
+     position:fixed needs !important to survive the @media(min-width:641px)
+     `.rightpanel{position:relative}` rule later in the file. */
+  @media(max-width:900px) and (min-width:641px){
+    .rightpanel{display:flex!important;position:fixed!important;
+      --mobile-rightpanel-width:min(300px, 100vw);
+      right:calc(-1 * var(--mobile-rightpanel-width))!important;
+      top:0;bottom:0;width:var(--mobile-rightpanel-width)!important;max-width:100vw!important;z-index:200;padding-top:var(--app-titlebar-safe-top);box-sizing:border-box;transition:right .25s ease;
+      box-shadow:none!important;}
+    .rightpanel.mobile-open{right:0!important;box-shadow:-4px 0 24px rgba(0,0,0,.4)!important;}
+    .rightpanel .resize-handle{display:none;}
+    .rightpanel .panel-header{row-gap:8px;}
+    .rightpanel .panel-actions{align-items:center;gap:8px;}
   }
 
   /* Fit-based composer footer collapse. ui.js measures actual overflow on

--- a/tests/test_issue5545_three_panel_layout.py
+++ b/tests/test_issue5545_three_panel_layout.py
@@ -96,17 +96,21 @@ def test_desktop_side_rails_can_shrink_to_resize_minima():
     assert collapsed_rightpanel.get("min-width") == "0 !important"
 
 
-def test_compact_breakpoint_900px_remains_hidden_right_panel_boundary():
+def test_compact_breakpoint_900px_keeps_panel_openable():
     assert "@media(max-width:900px)" in CSS or "@media (max-width: 900px)" in CSS
 
-    compact = _media_block("max-width", 900, ".rightpanel{display:none}")
-    rightpanel = _declarations(_rule_body(compact, ".rightpanel"))
+    compact = _media_block("max-width", 900, ".workspace-toggle-btn")
     workspace_toggle = _declarations(_rule_body(compact, ".workspace-toggle-btn"))
     mobile_files = _declarations(_rule_body(compact, ".mobile-files-btn"))
 
-    assert rightpanel.get("display") == "none"
     assert workspace_toggle.get("display") == "inline-flex!important"
     assert mobile_files.get("display") == "inline-flex!important"
+    # The compact 900px breakpoint must NOT force .rightpanel{display:none}:
+    # the 641-900px band uses the off-canvas slide-over instead (see
+    # tests/test_workspace_panel_641_900.py).
+    assert ".rightpanel{display:none}" not in _normalize_css(compact), (
+        ".rightpanel must NOT be display:none at max-width:900px — the 641-900px band uses the slide-over"
+    )
 
 
 def test_mobile_slide_over_breakpoint_640px_remains_intact():
@@ -130,5 +134,7 @@ def test_no_unmatched_desktop_hide_breakpoint_above_900():
         if re.search(r"\.rightpanel\s*\{\s*display\s*:\s*none", block):
             hidden_widths.append(width_px)
 
-    assert 900 in hidden_widths
-    assert all(width_px <= 900 for width_px in hidden_widths)
+    # The workspace panel is never hard-hidden by a breakpoint anymore:
+    # the 641-900px band uses the off-canvas slide-over and 640px-and-below
+    # uses the drawer, so no display:none breakpoint may remain.
+    assert hidden_widths == [], f"unexpected display:none breakpoints: {hidden_widths}"

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -170,13 +170,17 @@ class _ComposerLeftDropdownParser(HTMLParser):
 # ── Mobile breakpoint rules ───────────────────────────────────────────────────
 
 def test_mobile_breakpoint_900px_present():
-    """@media(max-width:900px) must hide the right panel and show mobile-files-btn."""
+    """@media(max-width:900px) must switch to compact mode and show mobile-files-btn."""
     assert "@media(max-width:900px)" in CSS or "@media (max-width: 900px)" in CSS, \
         "Missing @media(max-width:900px) breakpoint in style.css"
-    # Right panel should be hidden at 900px, replaced by slide-over
-    assert ".rightpanel{display:none" in CSS or ".rightpanel {display:none" in CSS or \
-           re.search(r'max-width:900px\).*?\.rightpanel\{display:none', CSS, re.DOTALL), \
-        ".rightpanel must be display:none at max-width:900px (slide-over replaces it)"
+    # The 900px compact breakpoint must NOT hard-hide the right panel: the
+    # 641-900px band uses the off-canvas slide-over instead (see
+    # tests/test_workspace_panel_641_900.py).
+    idx = CSS.find("@media(max-width:900px){")
+    assert idx > 0, "@media(max-width:900px) block not found"
+    body = CSS[idx:idx + 400]
+    assert ".rightpanel{display:none}" not in body, \
+        ".rightpanel must NOT be display:none at max-width:900px — the 641-900px band uses the slide-over"
 
 
 def test_mobile_breakpoint_640px_present():
@@ -579,8 +583,10 @@ def test_compact_titlebar_keeps_hamburger_available():
     assert re.search(r'\.app-titlebar-hamburger,\s*\.app-titlebar-spacer\{[^}]*display:\s*flex', compact_css), (
         "Compact titlebar should expose the hamburger before true phone width"
     )
-    assert ".rightpanel{display:none}" in compact_css.replace(" ", ""), (
-        "The compact titlebar breakpoint should match the hidden workspace-panel breakpoint"
+    assert ".rightpanel{display:none}" not in compact_css.replace(" ", ""), (
+        "The compact breakpoint must not hide the workspace panel: the "
+        "641-900px band uses the slide-in overlay instead (see "
+        "tests/test_workspace_panel_641_900.py)"
     )
 
 

--- a/tests/test_workspace_panel_641_900.py
+++ b/tests/test_workspace_panel_641_900.py
@@ -1,0 +1,66 @@
+"""
+Regression tests: the workspace panel must be openable at 641-900px viewports.
+
+`@media(max-width:900px)` used to set `.rightpanel{display:none}` while the
+slide-in overlay only existed in the max-width:640px block. That left the
+641-900px band (phone landscape / large phones / narrow desktop windows) with
+no way to open the workspace panel at all.
+
+The fix:
+  1. Removes `.rightpanel{display:none}` from the 900px block.
+  2. Adds an equivalent slide-in overlay for the 641-900px band, with
+     `position:fixed!important` so it survives the later
+     `@media(min-width:641px) .rightpanel{position:relative}` rule.
+
+Tests below are static-source assertions following the pattern used by the
+other workspace-panel regression tests in this directory.
+"""
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+class TestNoDisplayNoneBlindSpot:
+    def test_900px_block_does_not_hide_rightpanel(self):
+        """The @media(max-width:900px) block must not force .rightpanel
+        display:none — that hid the panel for every viewport between 641 and
+        900px where the 640px-and-below drawer does not apply."""
+        idx = STYLE_CSS.find("@media(max-width:900px){")
+        assert idx > 0, "@media(max-width:900px) block not found"
+        body = STYLE_CSS[idx:idx + 300]
+        assert ".rightpanel{display:none}" not in body, (
+            "max-width:900px block must not set .rightpanel{display:none}: "
+            "that makes the workspace panel impossible to open at 641-900px"
+        )
+
+
+class TestSlideInOverlayFor641To900:
+    def test_overlay_media_query_exists(self):
+        """A dedicated 641-900px overlay block must exist."""
+        assert "@media(max-width:900px) and (min-width:641px)" in STYLE_CSS, (
+            "missing @media(max-width:900px) and (min-width:641px) overlay block"
+        )
+
+    def test_overlay_uses_mobile_open_slide_in(self):
+        """The 641-900px overlay must slide in via .mobile-open, same as the
+        max-width:640px drawer."""
+        idx = STYLE_CSS.find("@media(max-width:900px) and (min-width:641px)")
+        assert idx > 0, "641-900px overlay block not found"
+        block = STYLE_CSS[idx:idx + 700]
+        assert "--mobile-rightpanel-width" in block
+        assert ".rightpanel.mobile-open{right:0!important" in block, (
+            "641-900px overlay must include .rightpanel.mobile-open{right:0!important}"
+        )
+
+    def test_position_fixed_is_important(self):
+        """position:fixed must carry !important so the later
+        @media(min-width:641px) .rightpanel{position:relative} rule (which is
+        scoped to the same band) cannot pull the panel back into the document
+        flow and squeeze the chat pane."""
+        idx = STYLE_CSS.find("@media(max-width:900px) and (min-width:641px)")
+        assert idx > 0, "641-900px overlay block not found"
+        block = STYLE_CSS[idx:idx + 700]
+        assert "position:fixed!important" in block, (
+            "641-900px overlay .rightpanel must use position:fixed!important"
+        )


### PR DESCRIPTION
## Problem

`@media(max-width:900px)` sets `.rightpanel{display:none}`, but the slide-in overlay only exists in the `max-width:640px` block. On 641–900px viewports (phone landscape / large phones / narrow desktop windows) the workspace panel can never be opened — the toggle button does nothing.

## Fix

- Remove `.rightpanel{display:none}` from the `max-width:900px` block.
- Add a dedicated `@media(max-width:900px) and (min-width:641px)` block with the same slide-in overlay used below 640px (`.mobile-open`), using `position:fixed!important` so it survives the later `@media(min-width:641px) .rightpanel{position:relative}` rule — without `!important` that rule pulls the panel back into the document flow and squeezes the chat pane (verified while testing).

## Tests

- New `tests/test_workspace_panel_641_900.py` (4 static-source assertions): the 900px block must not hide `.rightpanel`, the 641–900px overlay block must exist, it must slide in via `.mobile-open`, and `position:fixed` must carry `!important`. **Fails 4/4 before the fix, passes 4/4 after.**
- Updated `test_compact_titlebar_keeps_hamburger_available` and `test_mobile_breakpoint_900px_present` in `tests/test_mobile_layout.py`: the previous assertions encoded the bug (they required the compact breakpoint to hide the panel); they now require the panel not be hidden, matching the new overlay behavior.
- Updated `test_compact_breakpoint_900px_remains_hidden_right_panel_boundary` (now `test_compact_breakpoint_900px_keeps_panel_openable`) and `test_no_unmatched_desktop_hide_breakpoint_above_900` in `tests/test_issue5545_three_panel_layout.py`: same contract flip — no breakpoint may hard-hide the workspace panel anymore.
- All 206 tests that read `static/style.css` pass (2881 passed), and the mobile-layout + workspace-panel group passes (113 tests). Ruff clean.

## Reproduction

Set viewport width between 641 and 900px, click the workspace panel toggle — nothing happens before this fix; the panel slides in from the right after it.
