### PR TITLE
fix(sessions): dedup title on collision instead of leaving blank

### DIFF
--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -210,6 +210,10 @@ def sync_session_title(session_id: str, title: str, profile: Optional[str] = Non
     title refreshes (where state.db already holds the initial auto-title) are
     effectively no-ops at the state.db layer -- acceptable because the primary
     goal is ensuring ``hermes sessions list`` is not blank.
+
+    On a title collision (two sessions with the same auto-title), the title is
+    de-duplicated via ``get_next_title_in_lineage`` (e.g. "My Session" ->
+    "My Session #2") and retried, so the second session is never left blank.
     """
     if not title:
         return
@@ -219,7 +223,16 @@ def sync_session_title(session_id: str, title: str, profile: Optional[str] = Non
     try:
         # Ensure the session row exists (idempotent) so the UPDATE has a target.
         db.ensure_session(session_id=session_id, source='webui')
-        db.set_auto_title_if_empty(session_id, title)
+        try:
+            db.set_auto_title_if_empty(session_id, title)
+        except ValueError:
+            # state.db enforces uniqueness on sessions.title, so a byte-identical
+            # auto-title generated for two sessions raises ValueError here. Derive
+            # a de-duplicated variant (e.g. "My Session" -> "My Session #2") and
+            # retry instead of leaving the second row blank (#6964).
+            alt = db.get_next_title_in_lineage(title)
+            if alt and alt != title:
+                db.set_auto_title_if_empty(session_id, alt)
     except Exception:
         logger.debug("Failed to sync session title to state.db for %s", session_id)
     finally:

--- a/tests/test_issue6964_title_dedup.py
+++ b/tests/test_issue6964_title_dedup.py
@@ -1,0 +1,95 @@
+"""Regression tests for state.db title de-dup on collision (#6964).
+
+Follow-up to #6892 (sync auto-generated session titles to state.db).
+When two WebUI sessions generate the SAME auto-title, hermes-agent's
+state.db uniqueness rule makes the second ``set_auto_title_if_empty``
+raise ValueError, which ``sync_session_title`` used to swallow at debug
+level -- leaving the second row blank in ``hermes sessions list``.
+These tests prove the collision path now de-duplicates (suffix variant)
+instead of leaving the row untitled, and that unique titles are unchanged.
+"""
+
+import pytest
+
+
+def _make_db(tmp_path):
+    hermes_state = pytest.importorskip("hermes_state")
+    SessionDB = hermes_state.SessionDB
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+@pytest.mark.requires_agent_modules
+def test_sync_session_title_dedups_second_session_on_collision(tmp_path, monkeypatch):
+    """Two sessions with the same auto-title: the 2nd gets a de-duplicated
+    variant instead of being left blank in state.db."""
+    from api import state_sync
+
+    db = _make_db(tmp_path)
+    try:
+        # Route sync_session_title at the real temp DB (a fresh handle each call,
+        # mirroring production, but pointed at our tmp state.db).
+        monkeypatch.setattr(
+            state_sync,
+            "_get_state_db",
+            lambda profile=None: _make_db(tmp_path),
+        )
+
+        state_sync.sync_session_title("sess-1", "Same Title", profile="default")
+        state_sync.sync_session_title("sess-2", "Same Title", profile="default")
+
+        t1 = db.get_session_title("sess-1")
+        t2 = db.get_session_title("sess-2")
+        assert t1 == "Same Title"
+        # De-duplicated with a lineage suffix -- never left blank.
+        assert t2 == "Same Title #2"
+        assert t1 != t2
+    finally:
+        db.close()
+
+
+@pytest.mark.requires_agent_modules
+def test_sync_session_title_dedup_handles_numbered_base(tmp_path, monkeypatch):
+    """A colliding title that already carries a '#N' suffix keeps incrementing
+    deterministically (e.g. 'Same Title #2' -> 'Same Title #3')."""
+    from api import state_sync
+
+    db = _make_db(tmp_path)
+    try:
+        monkeypatch.setattr(
+            state_sync,
+            "_get_state_db",
+            lambda profile=None: _make_db(tmp_path),
+        )
+
+        state_sync.sync_session_title("sess-1", "Same Title #2", profile="default")
+        state_sync.sync_session_title("sess-2", "Same Title #2", profile="default")
+
+        t1 = db.get_session_title("sess-1")
+        t2 = db.get_session_title("sess-2")
+        assert t1 == "Same Title #2"
+        assert t2 == "Same Title #3"
+        assert t1 != t2
+    finally:
+        db.close()
+
+
+@pytest.mark.requires_agent_modules
+def test_sync_session_title_unique_titles_unchanged(tmp_path, monkeypatch):
+    """Non-colliding titles keep their exact value (no suffix added)."""
+    from api import state_sync
+
+    db = _make_db(tmp_path)
+    try:
+        monkeypatch.setattr(
+            state_sync,
+            "_get_state_db",
+            lambda profile=None: _make_db(tmp_path),
+        )
+
+        state_sync.sync_session_title("sess-a", "Alpha Title", profile="default")
+        state_sync.sync_session_title("sess-b", "Beta Title", profile="default")
+
+        assert db.get_session_title("sess-a") == "Alpha Title"
+        assert db.get_session_title("sess-b") == "Beta Title"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
Follow-up to #6892: when two sessions would have the same auto-generated title, the state.db title sync left the 2nd session blank instead of de-duplicating.

## Change
- `api/state_sync.py::sync_session_title()`: now catches `ValueError` specifically (raised by the SessionDB uniqueness rule on `sessions.title`) and retries with `db.get_next_title_in_lineage(title)` (existing SessionDB helper, confirmed `hermes_state.py:5441`) — generates `" #N"` suffix (`"My Session"` → `"My Session #2"`), with guard `alt and alt != title`. Deterministic.
- `tests/test_issue6964_title_dedup.py` (new, 3 tests): collision → 2nd session gets `" #2"`, both non-blank; collision with already-numbered base (`"X #2"` → `"X #3"`); unique titles unchanged.

## Verification
- RED without fix (2 dedup tests fail — 2nd session blank); GREEN with fix: **3 passed** + neighbor suite. The 2 failures in the affected suite are pre-existing (`test_issue6892_sync_title_coverage.py` expects a newer hermes_state API — unrelated to this change).

Closes #6964