### PR TITLE
Fix agent API unreachable in multiple containers

### DIFF
--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -60,6 +60,10 @@ services:
       # The agent's container detection (/.dockerenv) already auto-skips
       # credential chmod inside Docker, so HERMES_SKIP_CHMOD is redundant here.
       # - HERMES_HOME_MODE=0750
+      # Bind to 0.0.0.0 so that other services can reach the agent's api.
+      # We map the service to 127.0.0.1 with docker, so it won't be reachable
+      # outside the host
+      - API_SERVER_HOST=0.0.0.0
     restart: unless-stopped
     deploy:
       resources:

--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -76,6 +76,10 @@ services:
       # The agent's container detection (/.dockerenv) already auto-skips
       # credential chmod inside Docker, so HERMES_SKIP_CHMOD is redundant here.
       # - HERMES_HOME_MODE=0750
+      # Bind to 0.0.0.0 so that other services can reach the agent's api.
+      # We map the service to 127.0.0.1 with docker, so it won't be reachable
+      # outside the host
+      - API_SERVER_HOST=0.0.0.0
     restart: unless-stopped
     networks:
       - hermes-net


### PR DESCRIPTION
currently running the docker compose results in both dashboard and webui complaining about not reaching the gateway. it is confirmed by simple curl from within these services:

```
docker exec -ti hermes-webui /bin/bash

root@<id>:/apptoo# curl http://hermes-agent:8642/health
curl: (7) Failed to connect to hermes-agent port 8642 after 1 ms: Could not connect to server
```

this should fix the issue