### PR TITLE
fix: defer teardown of live cached agents

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -9135,60 +9135,45 @@ SESSION_AGENT_CACHE_LOCK = threading.Lock()
 
 
 def _evict_session_agent(session_id: str) -> None:
-    """Remove a cached agent for a session (on delete, clear, or model switch).
+    """Remove and safely tear down a cached agent at a session boundary.
 
-    Attempts a lifecycle commit before dropping the agent handle so that
-    batch-extraction memory providers can extract any pending work.  If the
-    commit fails or there is uncommitted work with no successful commit, the
-    lifecycle entry is preserved (not unregistered) so a future commit can
-    retry.
+    Teardown is delegated to streaming's shared lifecycle path. If the agent is
+    still owned by a live worker, that path defers provider and SessionDB cleanup
+    until the worker releases its run registries.
     """
-    agent = None
+    requested_session_id = str(session_id or "").strip()
+    if not requested_session_id:
+        return
+
     with SESSION_AGENT_CACHE_LOCK:
-        entry = SESSION_AGENT_CACHE.pop(session_id, None)
-        if entry is not None:
-            agent = entry[0] if isinstance(entry, tuple) else None
-    if agent is None:
+        popped_entry = SESSION_AGENT_CACHE.pop(requested_session_id, None)
+    if popped_entry is None:
         return
-    # A live run for this session may still hold this agent's _session_db (the
-    # worker assigns agent._session_db at run start). Never close it out from
-    # under an in-flight turn — ACTIVE_RUNS is the authoritative liveness signal
-    # (mirrors the worker's own LRU-eviction guard in streaming.py). When a run
-    # is live we still drop the cache handle above (harmless — the worker holds
-    # a local ref), but skip the lifecycle commit + _session_db.close() so the
-    # running turn can finish persisting. Hardens /clear + model-switch eviction
-    # too, not just truncate (#5096 Bug D).
-    _run_active = False
+
     try:
-        with ACTIVE_RUNS_LOCK:
-            for _entry in (ACTIVE_RUNS or {}).values():
-                if (_entry or {}).get("session_id") == session_id:
-                    _run_active = True
-                    break
+        from api import streaming as _streaming
     except Exception:
-        _run_active = False
-    if _run_active:
+        logger.debug(
+            "Could not load cached-agent teardown while evicting session %s",
+            requested_session_id,
+            exc_info=True,
+        )
+        # Fail safe: if teardown could not even be scheduled, restore ownership
+        # unless another worker has already installed a successor entry.
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE.setdefault(requested_session_id, popped_entry)
         return
-    should_close = True
+
     try:
-        from api.session_lifecycle import commit_session_memory, discard_session, has_uncommitted_work, unregister_agent
-        if has_uncommitted_work(session_id):
-            commit_session_memory(session_id, agent=agent, wait=True)
-        if not has_uncommitted_work(session_id):
-            unregister_agent(session_id)
-            # Bound the lifecycle dict: drop the entry now that the session has
-            # no uncommitted work and the agent handle is gone (issue #3506).
-            discard_session(session_id)
-        else:
-            should_close = False
+        _streaming._close_cached_agent_entry_at_session_boundary(requested_session_id, popped_entry)
     except Exception:
-        should_close = False
-        logger.debug("Lifecycle commit on eviction failed for %s", session_id, exc_info=True)
-    if should_close and getattr(agent, '_session_db', None) is not None:
-        try:
-            agent._session_db.close()
-        except Exception:
-            logger.debug("Failed to close _session_db on eviction for %s", session_id, exc_info=True)
+        # The shared helper owns deferred tracking and may have partially
+        # completed teardown. Do not re-cache an entry in an unknown state.
+        logger.debug(
+            "Could not tear down cached agent while evicting session %s",
+            requested_session_id,
+            exc_info=True,
+        )
 
 # ── Thread-local env context ─────────────────────────────────────────────────
 # (_thread_ctx + _thread_local_env_value are defined near the top of this module,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7747,22 +7747,45 @@ def _close_evicted_agent_at_session_boundary(session_id: str, agent) -> bool:
     if agent is None:
         return True
 
+    requested_session_id = str(session_id or "").strip()
+    teardown_session_id = _evicted_agent_teardown_session_id(requested_session_id, agent) or requested_session_id
+    if _evicted_agent_has_cache_owner(agent):
+        _clear_deferred_evicted_agent_teardown(agent)
+        return False
+    if _evicted_agent_teardown_is_live_blocked(requested_session_id, agent):
+        _mark_deferred_evicted_agent_teardown(requested_session_id, agent)
+        try:
+            _drain_deferred_evicted_agent_teardowns()
+        except Exception:
+            logger.debug(
+                "Immediate deferred evicted-agent teardown drain failed for session %s",
+                teardown_session_id,
+                exc_info=True,
+            )
+        return False
+
     should_close_evicted_agent = True
     try:
-        _lifecycle_commit_session_memory(session_id, agent=agent, wait=True)
-        if not _lifecycle_has_uncommitted_work(session_id):
-            _lifecycle_unregister_agent(session_id)
+        _lifecycle_commit_session_memory(teardown_session_id, agent=agent, wait=True)
+        if not _lifecycle_has_uncommitted_work(teardown_session_id):
+            _lifecycle_unregister_agent(teardown_session_id)
             # Drop the lifecycle dict entry now that the LRU-evicted agent is
             # gone and no uncommitted work remains, so the dict tracks only live
             # sessions instead of growing unbounded (issue #3506).
-            _lifecycle_discard_session(session_id)
+            _lifecycle_discard_session(teardown_session_id)
         else:
             should_close_evicted_agent = False
     except Exception:
         should_close_evicted_agent = False
-        logger.debug("Lifecycle commit on eviction failed for %s", session_id, exc_info=True)
+        logger.debug("Lifecycle commit on eviction failed for %s", teardown_session_id, exc_info=True)
 
     if not should_close_evicted_agent:
+        # Keep an uncached dirty/failed agent reachable for a later worker-end
+        # drain and schedule an idle retry. Without both, pending memory work and
+        # its open SessionDB could be orphaned after the cache entry was popped
+        # when no later stream happens to finish.
+        _mark_deferred_evicted_agent_teardown(teardown_session_id, agent)
+        _schedule_deferred_evicted_agent_teardown_retry()
         return False
 
     try:
@@ -7771,14 +7794,15 @@ def _close_evicted_agent_at_session_boundary(session_id: str, agent) -> bool:
             session_messages = vars(agent).get('_session_messages', [])
             shutdown_memory_provider(session_messages)
     except Exception:
-        logger.debug("Failed to shut down evicted agent memory provider for session %s", session_id, exc_info=True)
+        logger.debug("Failed to shut down evicted agent memory provider for session %s", teardown_session_id, exc_info=True)
 
     try:
         session_db = getattr(agent, '_session_db', None)
         if session_db is not None:
             session_db.close()
     except Exception:
-        logger.debug("Failed to close evicted agent session DB for session %s", session_id, exc_info=True)
+        logger.debug("Failed to close evicted agent session DB for session %s", teardown_session_id, exc_info=True)
+    _clear_deferred_evicted_agent_teardown(agent)
     return True
 
 
@@ -7889,6 +7913,262 @@ def _cached_agent_session_identity(agent) -> str | None:
 def _cached_agent_matches_session(agent, session_id: str) -> bool:
     identity = _cached_agent_session_identity(agent)
     return identity is None or identity == str(session_id)
+
+
+_DEFERRED_EVICTION_TEARDOWN_SESSION_ATTR = "_webui_deferred_eviction_teardown_session_id"
+_DEFERRED_EVICTION_TEARDOWN_SESSION_IDS_ATTR = "_webui_deferred_eviction_teardown_session_ids"
+_DEFERRED_EVICTION_TEARDOWN_LOCK = threading.Lock()
+_DEFERRED_EVICTION_TEARDOWNS = {}
+_DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS = set()
+_DEFERRED_EVICTION_RETRY_TIMER = None
+_DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS = 1.0
+_DEFERRED_EVICTION_RETRY_MAX_DELAY_SECONDS = 60.0
+_DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS = _DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS
+
+
+def _normalize_evicted_agent_session_id(session_id: str | None) -> str | None:
+    normalized = str(session_id or "").strip()
+    return normalized or None
+
+
+def _evicted_agent_teardown_session_id(session_id: str | None, agent) -> str | None:
+    identity = _cached_agent_session_identity(agent)
+    if identity:
+        return identity
+    return _normalize_evicted_agent_session_id(session_id)
+
+
+def _deferred_evicted_agent_teardown_session_ids(agent) -> tuple[str, ...]:
+    if agent is None:
+        return ()
+    try:
+        values = getattr(agent, _DEFERRED_EVICTION_TEARDOWN_SESSION_IDS_ATTR, ())
+    except Exception:
+        values = ()
+    if isinstance(values, str):
+        values = (values,)
+    aliases = []
+    if isinstance(values, (tuple, list, set, frozenset)):
+        for value in values:
+            normalized = _normalize_evicted_agent_session_id(value)
+            if normalized and normalized not in aliases:
+                aliases.append(normalized)
+    marker = _deferred_evicted_agent_teardown_session_id(agent)
+    if marker and marker not in aliases:
+        aliases.append(marker)
+    return tuple(aliases)
+
+
+def _evicted_agent_liveness_session_ids(session_id: str | None, agent) -> tuple[str, ...]:
+    identities = []
+    for value in (
+        _normalize_evicted_agent_session_id(session_id),
+        _cached_agent_session_identity(agent),
+        _deferred_evicted_agent_teardown_session_id(agent),
+    ):
+        normalized = _normalize_evicted_agent_session_id(value)
+        if normalized and normalized not in identities:
+            identities.append(normalized)
+    for value in _deferred_evicted_agent_teardown_session_ids(agent):
+        if value not in identities:
+            identities.append(value)
+    return tuple(identities)
+
+
+def _mark_deferred_evicted_agent_teardown(session_id: str | None, agent) -> None:
+    teardown_session_id = _evicted_agent_teardown_session_id(session_id, agent)
+    if agent is None or not teardown_session_id:
+        return
+    try:
+        with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+            aliases = _evicted_agent_liveness_session_ids(session_id, agent)
+            if teardown_session_id not in aliases:
+                aliases = (teardown_session_id, *aliases)
+            setattr(agent, _DEFERRED_EVICTION_TEARDOWN_SESSION_ATTR, teardown_session_id)
+            setattr(agent, _DEFERRED_EVICTION_TEARDOWN_SESSION_IDS_ATTR, tuple(aliases))
+            _DEFERRED_EVICTION_TEARDOWNS[id(agent)] = agent
+    except Exception:
+        logger.debug(
+            "Failed to mark deferred evicted-agent teardown for session %s",
+            teardown_session_id,
+            exc_info=True,
+        )
+
+
+def _clear_deferred_evicted_agent_teardown(agent) -> None:
+    if agent is None:
+        return
+    agent_id = id(agent)
+    try:
+        with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+            if _DEFERRED_EVICTION_TEARDOWNS.get(agent_id) is agent:
+                _DEFERRED_EVICTION_TEARDOWNS.pop(agent_id, None)
+            _DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.discard(agent_id)
+            for attr, fallback in (
+                (_DEFERRED_EVICTION_TEARDOWN_SESSION_ATTR, None),
+                (_DEFERRED_EVICTION_TEARDOWN_SESSION_IDS_ATTR, ()),
+            ):
+                try:
+                    if hasattr(agent, attr):
+                        delattr(agent, attr)
+                except Exception:
+                    try:
+                        setattr(agent, attr, fallback)
+                    except Exception:
+                        pass
+    except Exception:
+        logger.debug("Failed to clear deferred evicted-agent teardown marker", exc_info=True)
+
+
+def _deferred_evicted_agent_teardown_session_id(agent) -> str | None:
+    if agent is None:
+        return None
+    try:
+        value = getattr(agent, _DEFERRED_EVICTION_TEARDOWN_SESSION_ATTR, None)
+    except Exception:
+        return None
+    if not isinstance(value, str):
+        return None
+    value = str(value or "").strip()
+    return value or None
+
+
+def _evicted_agent_is_live_instance(agent) -> bool:
+    if agent is None:
+        return False
+    from api import config as _live_config
+
+    with _live_config.STREAMS_LOCK:
+        return any(live_agent is agent for live_agent in _live_config.AGENT_INSTANCES.values())
+
+
+def _evicted_agent_session_has_active_run(session_id: str | None) -> bool:
+    session_id = _normalize_evicted_agent_session_id(session_id)
+    if not session_id:
+        return False
+    from api import config as _live_config
+
+    with _live_config.ACTIVE_RUNS_LOCK:
+        for entry in (_live_config.ACTIVE_RUNS or {}).values():
+            if str((entry or {}).get("session_id") or "").strip() == session_id:
+                return True
+    return False
+
+
+def _evicted_agent_has_cache_owner(agent) -> bool:
+    if agent is None:
+        return False
+    from api import config as _live_config
+
+    with _live_config.SESSION_AGENT_CACHE_LOCK:
+        for entry in (_live_config.SESSION_AGENT_CACHE or {}).values():
+            cached_agent = entry[0] if isinstance(entry, tuple) else entry
+            if cached_agent is agent:
+                return True
+    return False
+
+
+def _evicted_agent_teardown_is_live_blocked(session_id: str | None, agent) -> bool:
+    session_ids = _evicted_agent_liveness_session_ids(session_id, agent)
+    return (
+        _evicted_agent_is_live_instance(agent)
+        or any(_evicted_agent_session_has_active_run(live_session_id) for live_session_id in session_ids)
+    )
+
+
+def _claim_deferred_evicted_agent_teardowns() -> list:
+    claimed = []
+    with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+        for agent_id, agent in list(_DEFERRED_EVICTION_TEARDOWNS.items()):
+            if agent_id in _DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS:
+                continue
+            if agent is None:
+                _DEFERRED_EVICTION_TEARDOWNS.pop(agent_id, None)
+                continue
+            _DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.add(agent_id)
+            claimed.append(agent)
+    return claimed
+
+
+def _release_deferred_evicted_agent_teardown_claim(agent) -> None:
+    if agent is None:
+        return
+    with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+        _DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.discard(id(agent))
+
+
+def _schedule_deferred_evicted_agent_teardown_retry() -> None:
+    """Ensure one backoff timer will retry dirty/failed idle teardowns."""
+    global _DEFERRED_EVICTION_RETRY_TIMER
+
+    with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+        timer = _DEFERRED_EVICTION_RETRY_TIMER
+        if timer is not None and timer.is_alive():
+            return
+        timer = threading.Timer(
+            _DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS,
+            _run_deferred_evicted_agent_teardown_retry,
+        )
+        timer.daemon = True
+        _DEFERRED_EVICTION_RETRY_TIMER = timer
+        # Start before releasing the registry lock so another scheduler cannot
+        # observe the stored timer in its pre-start state and create a duplicate.
+        timer.start()
+
+
+def _run_deferred_evicted_agent_teardown_retry() -> None:
+    """Drain deferred teardowns, backing off while dirty work remains."""
+    global _DEFERRED_EVICTION_RETRY_TIMER, _DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS
+
+    try:
+        _drain_deferred_evicted_agent_teardowns()
+    except Exception:
+        logger.debug("Scheduled deferred evicted-agent teardown retry failed", exc_info=True)
+
+    with _DEFERRED_EVICTION_TEARDOWN_LOCK:
+        _DEFERRED_EVICTION_RETRY_TIMER = None
+        pending = bool(_DEFERRED_EVICTION_TEARDOWNS)
+        if pending:
+            _DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS = min(
+                max(
+                    _DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS,
+                    _DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS * 2,
+                ),
+                _DEFERRED_EVICTION_RETRY_MAX_DELAY_SECONDS,
+            )
+        else:
+            _DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS = _DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS
+    if pending:
+        _schedule_deferred_evicted_agent_teardown_retry()
+
+
+def _drain_deferred_evicted_agent_teardowns() -> int:
+    """Drain globally deferred evicted-agent teardowns.
+
+    Registry ownership is protected by a private lock, but all stream/cache
+    probes and lifecycle/provider/DB cleanup run outside it. Concurrent drainers
+    claim each agent id once; blocked agents stay pending after the claim is
+    released so a later worker completion can retry them.
+    """
+    closed_count = 0
+    for agent in _claim_deferred_evicted_agent_teardowns():
+        try:
+            teardown_session_id = _deferred_evicted_agent_teardown_session_id(agent)
+            if not teardown_session_id:
+                _clear_deferred_evicted_agent_teardown(agent)
+                continue
+            if _evicted_agent_has_cache_owner(agent):
+                _clear_deferred_evicted_agent_teardown(agent)
+                continue
+            if _evicted_agent_teardown_is_live_blocked(teardown_session_id, agent):
+                continue
+            if _close_evicted_agent_at_session_boundary(teardown_session_id, agent):
+                closed_count += 1
+        except Exception:
+            logger.debug("Deferred evicted-agent teardown drain failed", exc_info=True)
+        finally:
+            _release_deferred_evicted_agent_teardown_claim(agent)
+    return closed_count
 
 
 def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
@@ -11909,6 +12189,16 @@ def _run_agent_streaming(
             # POST /api/chat/start round-trip and erase the marker before
             # the next stream can read it, breaking the goal-continuation
             # chain. Stage-326 critical fix per Opus advisor review.
+
+        try:
+            _drain_deferred_evicted_agent_teardowns()
+        except Exception:
+            logger.debug(
+                "Deferred evicted-agent teardown drain failed after stream %s for session %s",
+                stream_id,
+                session_id,
+                exc_info=True,
+            )
 
         # ── Defer-path fix: turn-teardown idle-hook ────────────────────────
         # The session has just transitioned active→idle: unregister_active_run

--- a/tests/test_evict_session_agent_active_run_guard.py
+++ b/tests/test_evict_session_agent_active_run_guard.py
@@ -10,20 +10,50 @@ client / direct API; the UI gates it behind S.busy) closes the SessionDB the
 running worker is still persisting through.
 """
 
+from unittest.mock import MagicMock
+
+import pytest
+
 import api.config as config
+
+
+@pytest.fixture(autouse=True)
+def clear_agent_liveness_registries():
+    import api.streaming as streaming
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE.clear()
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        streaming._DEFERRED_EVICTION_TEARDOWNS.clear()
+        streaming._DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.clear()
+    yield
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE.clear()
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        streaming._DEFERRED_EVICTION_TEARDOWNS.clear()
+        streaming._DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.clear()
 
 
 class _FakeSessionDB:
     def __init__(self):
         self.closed = False
+        self.close_count = 0
 
     def close(self):
+        self.close_count += 1
         self.closed = True
 
 
 class _FakeAgent:
-    def __init__(self):
+    def __init__(self, session_id="live-session-evict-guard"):
+        self.session_id = session_id
         self._session_db = _FakeSessionDB()
+        self._session_messages = [{"role": "user", "content": "hello"}]
+        self.shutdown_memory_provider = MagicMock()
 
 
 def _seed_cache(session_id, agent):
@@ -36,21 +66,38 @@ def _clear_active_runs():
         config.ACTIVE_RUNS.clear()
 
 
-def test_evict_skips_session_db_close_when_run_active(monkeypatch):
-    """A live run on the session => the cache handle drops but the DB stays open."""
+def _patch_streaming_lifecycle(monkeypatch, streaming, *, dirty=False):
+    lifecycle_commit = MagicMock(return_value=True)
+    lifecycle_has_uncommitted_work = MagicMock(return_value=dirty)
+    lifecycle_unregister = MagicMock()
+    lifecycle_discard = MagicMock()
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", lifecycle_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", lifecycle_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", lifecycle_unregister)
+    monkeypatch.setattr(streaming, "_lifecycle_discard_session", lifecycle_discard)
+    return lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard
+
+
+def test_evict_defers_session_db_close_when_run_active(monkeypatch):
+    """A live run may lose the cache handle, but its DB stays open until idle."""
+    import api.streaming as streaming
+
     sid = "live-session-evict-guard"
-    agent = _FakeAgent()
+    agent = _FakeAgent(sid)
     _seed_cache(sid, agent)
     _clear_active_runs()
+    _patch_streaming_lifecycle(monkeypatch, streaming)
     config.register_active_run("stream-xyz", session_id=sid)
     try:
         config._evict_session_agent(sid)
-        # The agent handle is removed from the cache (harmless — the worker
-        # holds its own local ref) ...
         with config.SESSION_AGENT_CACHE_LOCK:
             assert sid not in config.SESSION_AGENT_CACHE
-        # ... but the live worker's SessionDB must NOT be closed.
+        assert agent._webui_deferred_eviction_teardown_session_id == sid
         assert agent._session_db.closed is False
+
+        _clear_active_runs()
+        assert streaming._drain_deferred_evicted_agent_teardowns() == 1
+        assert agent._session_db.close_count == 1
     finally:
         _clear_active_runs()
         with config.SESSION_AGENT_CACHE_LOCK:
@@ -59,22 +106,134 @@ def test_evict_skips_session_db_close_when_run_active(monkeypatch):
 
 def test_evict_closes_session_db_when_no_run_active(monkeypatch):
     """No live run => normal eviction closes the SessionDB (idle path unchanged)."""
+    import api.streaming as streaming
+
     sid = "idle-session-evict-guard"
-    agent = _FakeAgent()
+    agent = _FakeAgent(sid)
     _seed_cache(sid, agent)
     _clear_active_runs()
 
-    # Neutralize the lifecycle commit machinery so the test isolates the
-    # ACTIVE_RUNS guard + close decision (no uncommitted work => should_close).
-    monkeypatch.setattr("api.session_lifecycle.has_uncommitted_work", lambda *_a, **_k: False)
-    monkeypatch.setattr("api.session_lifecycle.unregister_agent", lambda *_a, **_k: None)
-    monkeypatch.setattr("api.session_lifecycle.discard_session", lambda *_a, **_k: None)
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_streaming_lifecycle(monkeypatch, streaming)
+    )
+    closed_entries = []
+    original_close = streaming._close_cached_agent_entry_at_session_boundary
+
+    def spy_close(closed_sid, cache_entry):
+        closed_entries.append((closed_sid, cache_entry))
+        return original_close(closed_sid, cache_entry)
+
+    monkeypatch.setattr(streaming, "_close_cached_agent_entry_at_session_boundary", spy_close)
     try:
         config._evict_session_agent(sid)
         with config.SESSION_AGENT_CACHE_LOCK:
             assert sid not in config.SESSION_AGENT_CACHE
+        assert closed_entries == [(sid, (agent, "sig"))]
+        lifecycle_commit.assert_called_once_with(sid, agent=agent, wait=True)
+        lifecycle_has_uncommitted_work.assert_called_once_with(sid)
+        lifecycle_unregister.assert_called_once_with(sid)
+        lifecycle_discard.assert_called_once_with(sid)
+        agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
         assert agent._session_db.closed is True
     finally:
         _clear_active_runs()
         with config.SESSION_AGENT_CACHE_LOCK:
             config.SESSION_AGENT_CACHE.pop(sid, None)
+
+
+def test_evict_defers_wrong_key_entry_when_agent_actual_identity_has_active_run(monkeypatch):
+    import api.streaming as streaming
+
+    old_sid = "old-cache-key"
+    new_sid = "actual-live-session"
+    agent = _FakeAgent(new_sid)
+    _seed_cache(old_sid, agent)
+    _patch_streaming_lifecycle(monkeypatch, streaming)
+    config.register_active_run("stream-actual", session_id=new_sid)
+
+    config._evict_session_agent(old_sid)
+
+    with config.SESSION_AGENT_CACHE_LOCK:
+        assert old_sid not in config.SESSION_AGENT_CACHE
+    assert set(agent._webui_deferred_eviction_teardown_session_ids) == {old_sid, new_sid}
+    assert agent._session_db.closed is False
+
+
+def test_evict_pop_race_defers_to_shared_streaming_teardown(monkeypatch):
+    import api.streaming as streaming
+
+    old_sid = "stale-cache-key"
+    new_sid = "actual-session-after-compression"
+    agent = _FakeAgent(new_sid)
+    _seed_cache(old_sid, agent)
+    _clear_active_runs()
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_streaming_lifecycle(monkeypatch, streaming)
+    )
+
+    original_has_cache_owner = streaming._evicted_agent_has_cache_owner
+    injected_active_run = False
+
+    def register_run_after_config_precheck(checked_agent):
+        nonlocal injected_active_run
+        if checked_agent is agent and not injected_active_run:
+            injected_active_run = True
+            config.register_active_run("stream-after-precheck", session_id=new_sid)
+        return original_has_cache_owner(checked_agent)
+
+    monkeypatch.setattr(streaming, "_evicted_agent_has_cache_owner", register_run_after_config_precheck)
+
+    config._evict_session_agent(old_sid)
+
+    with config.SESSION_AGENT_CACHE_LOCK:
+        assert old_sid not in config.SESSION_AGENT_CACHE
+    assert injected_active_run is True
+    assert agent._webui_deferred_eviction_teardown_session_id == new_sid
+    assert set(agent._webui_deferred_eviction_teardown_session_ids) == {old_sid, new_sid}
+    assert agent._session_db.closed is False
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+
+    _clear_active_runs()
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 1
+    lifecycle_commit.assert_called_once_with(new_sid, agent=agent, wait=True)
+    lifecycle_has_uncommitted_work.assert_called_once_with(new_sid)
+    lifecycle_unregister.assert_called_once_with(new_sid)
+    lifecycle_discard.assert_called_once_with(new_sid)
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    assert agent._session_db.close_count == 1
+
+
+def test_evict_idle_matching_entry_uses_shared_streaming_teardown(monkeypatch):
+    import api.streaming as streaming
+
+    sid = "idle-matching-session"
+    agent = _FakeAgent(sid)
+    _seed_cache(sid, agent)
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_streaming_lifecycle(monkeypatch, streaming)
+    )
+    closed_entries = []
+    original_close = streaming._close_cached_agent_entry_at_session_boundary
+
+    def spy_close(closed_sid, cache_entry):
+        closed_entries.append((closed_sid, cache_entry))
+        return original_close(closed_sid, cache_entry)
+
+    monkeypatch.setattr(streaming, "_close_cached_agent_entry_at_session_boundary", spy_close)
+
+    config._evict_session_agent(sid)
+
+    with config.SESSION_AGENT_CACHE_LOCK:
+        assert sid not in config.SESSION_AGENT_CACHE
+    assert closed_entries == [(sid, (agent, "sig"))]
+    lifecycle_commit.assert_called_once_with(sid, agent=agent, wait=True)
+    lifecycle_has_uncommitted_work.assert_called_once_with(sid)
+    lifecycle_unregister.assert_called_once_with(sid)
+    lifecycle_discard.assert_called_once_with(sid)
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    assert agent._session_db.close_count == 1

--- a/tests/test_streaming_agent_cache_lifecycle.py
+++ b/tests/test_streaming_agent_cache_lifecycle.py
@@ -1,4 +1,367 @@
+import threading
 from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_agent_lifecycle_registries():
+    import api.config as config
+    import api.streaming as streaming
+
+    def reset_deferred_teardowns():
+        with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+            retry_timer = streaming._DEFERRED_EVICTION_RETRY_TIMER
+        if retry_timer is not None:
+            retry_timer.cancel()
+            retry_timer.join(timeout=1)
+        with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+            streaming._DEFERRED_EVICTION_TEARDOWNS.clear()
+            streaming._DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS.clear()
+            streaming._DEFERRED_EVICTION_RETRY_TIMER = None
+            streaming._DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS = (
+                streaming._DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS
+            )
+
+    def reset_runtime_registries():
+        with config.STREAMS_LOCK:
+            config.STREAMS.clear()
+            config.CANCEL_FLAGS.clear()
+            config.AGENT_INSTANCES.clear()
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+        with config.SESSION_AGENT_CACHE_LOCK:
+            config.SESSION_AGENT_CACHE.clear()
+
+    reset_runtime_registries()
+    reset_deferred_teardowns()
+    yield
+    reset_runtime_registries()
+    reset_deferred_teardowns()
+
+
+def _patch_lifecycle(monkeypatch, streaming, *, dirty=False):
+    lifecycle_commit = MagicMock(return_value=True)
+    lifecycle_has_uncommitted_work = MagicMock(return_value=dirty)
+    lifecycle_unregister = MagicMock()
+    lifecycle_discard = MagicMock()
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", lifecycle_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", lifecycle_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", lifecycle_unregister)
+    monkeypatch.setattr(streaming, "_lifecycle_discard_session", lifecycle_discard)
+    return lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard
+
+
+def _agent(session_id="real-session"):
+    session_db = MagicMock()
+    agent = MagicMock()
+    agent.session_id = session_id
+    agent._session_db = session_db
+    agent._session_messages = [{"role": "user", "content": "still running"}]
+    return agent
+
+
+def test_evicted_agent_lifecycle_defers_teardown_when_exact_agent_is_live(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+
+    live_stream_id = "live-stream-for-real-session"
+    with config.STREAMS_LOCK:
+        config.AGENT_INSTANCES[live_stream_id] = agent
+
+    assert streaming._close_evicted_agent_at_session_boundary("wrong-cache-key", agent) is False
+    assert agent._webui_deferred_eviction_teardown_session_id == "real-session"
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
+
+
+def test_evicted_agent_lifecycle_defers_when_cancel_detached_active_run_owns_session(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS["detached-stream"] = {
+            "stream_id": "detached-stream",
+            "session_id": "real-session",
+            "phase": "cancelling",
+        }
+
+    assert streaming._close_evicted_agent_at_session_boundary("wrong-cache-key", agent) is False
+    assert agent._webui_deferred_eviction_teardown_session_id == "real-session"
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
+
+
+def test_blocked_evicted_agent_drains_if_worker_clears_liveness_before_mark(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+    with config.STREAMS_LOCK:
+        config.AGENT_INSTANCES["live-stream"] = agent
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS["live-stream"] = {
+            "stream_id": "live-stream",
+            "session_id": "real-session",
+            "phase": "running",
+        }
+
+    original_mark = streaming._mark_deferred_evicted_agent_teardown
+
+    def clear_liveness_then_mark(session_id, marked_agent):
+        with config.STREAMS_LOCK:
+            config.AGENT_INSTANCES.clear()
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+        original_mark(session_id, marked_agent)
+
+    monkeypatch.setattr(streaming, "_mark_deferred_evicted_agent_teardown", clear_liveness_then_mark)
+
+    assert streaming._close_evicted_agent_at_session_boundary("stale-cache-key", agent) is False
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_id")
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        assert id(agent) not in streaming._DEFERRED_EVICTION_TEARDOWNS
+        assert id(agent) not in streaming._DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS
+    lifecycle_commit.assert_called_once_with("real-session", agent=agent, wait=True)
+    lifecycle_has_uncommitted_work.assert_called_once_with("real-session")
+    lifecycle_unregister.assert_called_once_with("real-session")
+    lifecycle_discard.assert_called_once_with("real-session")
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    agent._session_db.close.assert_called_once()
+
+
+def test_evicted_agent_defers_when_requested_key_alias_is_active_after_identity_rotation(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    old_sid = "pre-compression-session"
+    new_sid = "post-compression-session"
+    agent = _agent(new_sid)
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS["compressing-stream"] = {
+            "stream_id": "compressing-stream",
+            "session_id": old_sid,
+            "phase": "cancelling",
+        }
+
+    assert streaming._close_evicted_agent_at_session_boundary(old_sid, agent) is False
+
+    assert agent._webui_deferred_eviction_teardown_session_id == new_sid
+    assert set(agent._webui_deferred_eviction_teardown_session_ids) == {old_sid, new_sid}
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 1
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_id")
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_ids")
+    lifecycle_commit.assert_called_once_with(new_sid, agent=agent, wait=True)
+    lifecycle_has_uncommitted_work.assert_called_once_with(new_sid)
+    lifecycle_unregister.assert_called_once_with(new_sid)
+    lifecycle_discard.assert_called_once_with(new_sid)
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    agent._session_db.close.assert_called_once()
+
+
+def test_global_deferred_evicted_agent_drain_closes_orphan_after_successor_finishes(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    old_agent = _agent("real-session")
+    successor_agent = _agent("real-session")
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS["successor-stream"] = {
+            "stream_id": "successor-stream",
+            "session_id": "real-session",
+            "phase": "running",
+        }
+
+    assert streaming._close_evicted_agent_at_session_boundary("stale-cache-key", old_agent) is False
+    assert old_agent._webui_deferred_eviction_teardown_session_id == "real-session"
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 0
+    assert old_agent._webui_deferred_eviction_teardown_session_id == "real-session"
+    lifecycle_commit.assert_not_called()
+    old_agent.shutdown_memory_provider.assert_not_called()
+    old_agent._session_db.close.assert_not_called()
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 1
+    assert not hasattr(old_agent, "_webui_deferred_eviction_teardown_session_id")
+    lifecycle_commit.assert_called_once_with("real-session", agent=old_agent, wait=True)
+    lifecycle_has_uncommitted_work.assert_called_once_with("real-session")
+    lifecycle_unregister.assert_called_once_with("real-session")
+    lifecycle_discard.assert_called_once_with("real-session")
+    old_agent.shutdown_memory_provider.assert_called_once_with(old_agent._session_messages)
+    old_agent._session_db.close.assert_called_once()
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 0
+    lifecycle_commit.assert_called_once()
+    old_agent.shutdown_memory_provider.assert_called_once()
+    old_agent._session_db.close.assert_called_once()
+    successor_agent.shutdown_memory_provider.assert_not_called()
+
+
+def test_global_deferred_evicted_agent_drain_claims_once_under_concurrency(monkeypatch):
+    import api.streaming as streaming
+
+    agent = _agent("idle-session")
+    commit_started = threading.Event()
+    release_commit = threading.Event()
+    commit_calls = []
+    commit_lock = threading.Lock()
+
+    def fake_commit(session_id, *, agent=None, wait=False):
+        with commit_lock:
+            commit_calls.append((session_id, agent, wait))
+        commit_started.set()
+        assert release_commit.wait(timeout=5)
+        return True
+
+    lifecycle_has_uncommitted_work = MagicMock(return_value=False)
+    lifecycle_unregister = MagicMock()
+    lifecycle_discard = MagicMock()
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", fake_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", lifecycle_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", lifecycle_unregister)
+    monkeypatch.setattr(streaming, "_lifecycle_discard_session", lifecycle_discard)
+
+    streaming._mark_deferred_evicted_agent_teardown("idle-session", agent)
+    results = []
+
+    def drain():
+        results.append(streaming._drain_deferred_evicted_agent_teardowns())
+
+    first = threading.Thread(target=drain)
+    first.start()
+    assert commit_started.wait(timeout=5)
+
+    second = threading.Thread(target=drain)
+    second.start()
+    second.join(timeout=5)
+    assert not second.is_alive()
+
+    release_commit.set()
+    first.join(timeout=5)
+    assert not first.is_alive()
+
+    assert sorted(results) == [0, 1]
+    assert commit_calls == [("idle-session", agent, True)]
+    lifecycle_has_uncommitted_work.assert_called_once_with("idle-session")
+    lifecycle_unregister.assert_called_once_with("idle-session")
+    lifecycle_discard.assert_called_once_with("idle-session")
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    agent._session_db.close.assert_called_once()
+
+
+def test_global_deferred_drain_does_not_reclaim_when_close_recheck_blocks(monkeypatch):
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+    liveness_checks = []
+
+    def fake_live_blocked(session_id, checked_agent):
+        liveness_checks.append((session_id, checked_agent))
+        return len(liveness_checks) >= 2
+
+    monkeypatch.setattr(streaming, "_evicted_agent_teardown_is_live_blocked", fake_live_blocked)
+
+    streaming._mark_deferred_evicted_agent_teardown("real-session", agent)
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 0
+    assert liveness_checks == [("real-session", agent), ("real-session", agent)]
+    assert agent._webui_deferred_eviction_teardown_session_id == "real-session"
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        assert streaming._DEFERRED_EVICTION_TEARDOWNS[id(agent)] is agent
+        assert id(agent) not in streaming._DEFERRED_EVICTION_TEARDOWN_IN_PROGRESS
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
+
+
+def test_deferred_evicted_agent_teardown_does_not_close_cache_owned_duplicate(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+    streaming._mark_deferred_evicted_agent_teardown("real-session", agent)
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE["real-session"] = (agent, "sig")
+
+    assert streaming._drain_deferred_evicted_agent_teardowns() == 0
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_id")
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
+
+
+def test_evicted_agent_lifecycle_does_not_close_when_same_agent_is_still_cache_owned(monkeypatch):
+    import api.config as config
+    import api.streaming as streaming
+
+    lifecycle_commit, lifecycle_has_uncommitted_work, lifecycle_unregister, lifecycle_discard = (
+        _patch_lifecycle(monkeypatch, streaming)
+    )
+    agent = _agent("real-session")
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE["real-session"] = (agent, "sig")
+
+    assert streaming._close_evicted_agent_at_session_boundary("old-cache-key", agent) is False
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_id")
+    lifecycle_commit.assert_not_called()
+    lifecycle_has_uncommitted_work.assert_not_called()
+    lifecycle_unregister.assert_not_called()
+    lifecycle_discard.assert_not_called()
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()
 
 
 def test_evicted_agent_lifecycle_commits_unregisters_and_shutdowns(monkeypatch):
@@ -67,26 +430,47 @@ def test_cached_agent_entry_lifecycle_extracts_agent_from_cache_tuple(monkeypatc
     assert closed == [("old-session", agent)]
 
 
-def test_evicted_agent_lifecycle_keeps_provider_alive_when_commit_still_dirty(monkeypatch):
+def test_evicted_agent_lifecycle_retries_until_commit_is_clean(monkeypatch):
     import api.streaming as streaming
 
-    def fake_commit(session_id, *, agent=None, wait=False):
-        return True
+    lifecycle_commit = MagicMock(return_value=True)
+    lifecycle_has_uncommitted_work = MagicMock(side_effect=[True, False])
+    lifecycle_unregister = MagicMock()
+    lifecycle_discard = MagicMock()
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", lifecycle_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", lifecycle_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", lifecycle_unregister)
+    monkeypatch.setattr(streaming, "_lifecycle_discard_session", lifecycle_discard)
+    monkeypatch.setattr(streaming, "_DEFERRED_EVICTION_RETRY_BASE_DELAY_SECONDS", 0.01)
+    monkeypatch.setattr(streaming, "_DEFERRED_EVICTION_RETRY_MAX_DELAY_SECONDS", 0.02)
+    monkeypatch.setattr(streaming, "_DEFERRED_EVICTION_RETRY_NEXT_DELAY_SECONDS", 0.01)
 
-    def fake_has_uncommitted_work(session_id):
-        return True
+    agent = _agent("dirty-session")
 
-    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", fake_commit)
-    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", fake_has_uncommitted_work)
-    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", MagicMock())
+    assert streaming._close_evicted_agent_at_session_boundary("dirty-session", agent) is False
 
-    agent = MagicMock()
-    agent._session_db = MagicMock()
-
-    streaming._close_evicted_agent_at_session_boundary("dirty-session", agent)
-
+    assert agent._webui_deferred_eviction_teardown_session_id == "dirty-session"
     agent.shutdown_memory_provider.assert_not_called()
     agent._session_db.close.assert_not_called()
+
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        retry_timer = streaming._DEFERRED_EVICTION_RETRY_TIMER
+    assert retry_timer is not None
+    retry_timer.join(timeout=2)
+    assert not retry_timer.is_alive()
+    assert not hasattr(agent, "_webui_deferred_eviction_teardown_session_id")
+    assert lifecycle_commit.call_count == 2
+    assert lifecycle_has_uncommitted_work.call_count == 2
+    lifecycle_unregister.assert_called_once_with("dirty-session")
+    lifecycle_discard.assert_called_once_with("dirty-session")
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    agent._session_db.close.assert_called_once()
+
+    with streaming._DEFERRED_EVICTION_TEARDOWN_LOCK:
+        assert streaming._DEFERRED_EVICTION_RETRY_TIMER is None
+        assert not streaming._DEFERRED_EVICTION_TEARDOWNS
+    assert lifecycle_commit.call_count == 2
+    agent._session_db.close.assert_called_once()
 
 
 def test_identity_mismatch_cache_evictions_close_entries_outside_cache_lock():
@@ -121,3 +505,35 @@ def test_identity_mismatch_cache_evictions_close_entries_outside_cache_lock():
             and len(line) - len(line.lstrip()) <= lock_indent
             for line in between
         ), f"{marker} still appears inside the SESSION_AGENT_CACHE_LOCK block"
+
+
+def test_worker_finally_keeps_run_unregisters_inside_streams_lock_before_global_deferred_drain():
+    lines = open("api/streaming.py", encoding="utf-8").read().splitlines()
+    reset_idx = next(i for i, line in enumerate(lines) if "_reset_turn_session_identity(_turn_session_identity_tokens)" in line)
+    lock_idx = next(i for i in range(reset_idx, len(lines)) if "with STREAMS_LOCK:" in lines[i])
+    lock_indent = len(lines[lock_idx]) - len(lines[lock_idx].lstrip())
+
+    block_end = next(
+        i
+        for i in range(lock_idx + 1, len(lines))
+        if lines[i].strip()
+        and not lines[i].lstrip().startswith("#")
+        and len(lines[i]) - len(lines[i].lstrip()) <= lock_indent
+    )
+
+    ordered_markers = [
+        "AGENT_INSTANCES.pop(stream_id, None)",
+        "unregister_active_run(stream_id)",
+        "unregister_stream_owner(stream_id)",
+        "clear_session_writeback_owner_if_owned(session_id, stream_id)",
+    ]
+    marker_indexes = []
+    for marker in ordered_markers:
+        marker_idx = next(i for i in range(lock_idx, block_end) if marker in lines[i])
+        marker_indexes.append(marker_idx)
+        assert len(lines[marker_idx]) - len(lines[marker_idx].lstrip()) > lock_indent
+
+    assert marker_indexes == sorted(marker_indexes)
+    drain_idx = next(i for i in range(block_end, len(lines)) if "_drain_deferred_evicted_agent_teardowns()" in lines[i])
+    assert drain_idx > block_end
+    assert len(lines[drain_idx]) - len(lines[drain_idx].lstrip()) <= lock_indent + 4


### PR DESCRIPTION
## Thinking Path

WebUI could evict a cached `AIAgent` and close its `SessionDB` while a streaming worker still held the same object. The worker would later attempt transcript persistence through the closed handle, producing `NoneType.execute` and the user-facing `session_persistence_failed` / “No reply” error.

The fix centralizes cached-agent teardown and treats stream ownership as a lifecycle boundary:

1. Pop cache ownership under `SESSION_AGENT_CACHE_LOCK`, but perform lifecycle/provider/DB work outside the lock.
2. Before teardown, check the exact agent instance, active-run ownership, cache ownership, and both requested/actual session IDs.
3. If any owner is live, retain the agent in a deferred teardown registry.
4. Drain deferred entries only after worker registries are cleared.
5. If memory commit remains dirty or fails during an idle eviction, keep the agent reachable and retry through one shared daemon timer with bounded exponential backoff.
6. Claim deferred entries under a private lock so concurrent drainers cannot close the same agent twice.

## What Changed

- Routed `api.config._evict_session_agent()` through the same lifecycle-safe teardown helper used by streaming cache eviction.
- Added liveness checks for:
  - exact live `AIAgent` instances
  - `ACTIVE_RUNS`
  - replacement cache ownership
  - requested and actual session-ID aliases after compression/identity rotation
- Added a deferred teardown registry with exact-once claims.
- Added a worker-finally drain after stream/run ownership is removed.
- Added a single shared retry timer for dirty/failed idle lifecycle commits, backing off from 1s to 60s.
- Added regression coverage for active streams, detached cancellation, compression identity rotation, mark-after-finish races, successor agents, concurrent drainers, dirty idle retries, and idle teardown behavior.

## Why It Matters

A successful model response must not be discarded because an unrelated cache-eviction path closed the live transcript database. This preserves durable transcript writes while still ensuring evicted providers and database handles are eventually cleaned up.

## Contract Routing

Related contract: `docs/rfcs/webui-run-state-consistency-contract.md`.

This is not an intentional contract change. It restores the existing invariant that live-run ownership must outlive durable turn persistence, while keeping session teardown outside shared cache/stream locks.

## Verification

- Focused concurrency/lifecycle suite: **56 passed**
- Dirty idle scheduled-retry regression: **1 passed**
- Python compilation: passed
- `git diff --check`: passed
- Ruff on changed lines: **0 findings**
- Independent staged concurrency review: **PASS, no merge blockers**
- Full suite: **14,289 passed, 106 skipped, 1 xfailed, 2 xpassed, 34 subtests passed**

The full suite has 7 unrelated baseline/environment failures, reproduced independently before the final patch:

- `test_5774b_atomic_config_writes.py::test_atomic_write_preserves_existing_permissions` (macOS setgid mode behavior)
- `test_issue2929_settings_max_tokens.py::test_post_settings_does_not_write_max_tokens_before_auth_failures`
- Three `test_issue803.py` profile-cookie tests affected by auth-enabled local configuration
- Two `test_sprint23.py` tests that construct an unescaped skill name containing spaces

None touch the changed teardown paths.

## Risks / Follow-ups

- Deferred dirty agents retain a strong reference until lifecycle work commits successfully. The shared retry timer bounds retry frequency and resets after the registry drains.
- The registry remains process-local; existing shutdown lifecycle draining remains the final process-exit safeguard.

## Model Used

OpenAI Codex GPT-5.4 for implementation and independent review, orchestrated through Hermes Agent.
