### PR TITLE
fix(webui): follow compressed sessions before new turns

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -9870,6 +9870,60 @@ def _pre_compression_continuation_session_id(session) -> str | None:
     rows.extend(_child_rows_from_sidecars(memory_seen_ids))
     return _resolve_from_rows(rows)
 
+
+def _resolve_writable_compression_tip(session):
+    """Return the live WebUI sidecar for a stale compressed session id.
+
+    A server-side process wakeup can rotate the Agent session while no browser is
+    attached to consume the ``compressed`` SSE handoff. The browser then posts
+    its still-open root id on the next human turn. state.db is authoritative for
+    repeated compression rotations, including an intermediate sidecar that
+    missed its snapshot marker.
+
+    Fail closed to the requested sidecar on lookup errors. Accept a continuation
+    only when it has a persisted WebUI sidecar in the same profile.
+    """
+    requested_sid = _safe_first(getattr(session, "session_id", None))
+    profile = getattr(session, "profile", None)
+    if not requested_sid:
+        return session
+    db = None
+    try:
+        from api.profiles import get_hermes_home_for_profile
+        from hermes_state import SessionDB
+
+        db_path = Path(get_hermes_home_for_profile(str(profile or "default"))) / "state.db"
+        if not db_path.exists():
+            return session
+        db = SessionDB(db_path=db_path)
+        tip_sid = _safe_first(db.resolve_resume_session_id(requested_sid))
+        if not tip_sid or tip_sid == requested_sid or not is_safe_session_id(tip_sid):
+            return session
+        tip = get_session(tip_sid)
+        if not _profiles_match(getattr(tip, "profile", None), profile):
+            return session
+        if not (SESSION_DIR / f"{tip_sid}.json").exists():
+            return session
+        logger.info(
+            "Resolved stale compressed WebUI session %s to live continuation %s",
+            requested_sid,
+            tip_sid,
+        )
+        return tip
+    except Exception:
+        logger.debug(
+            "Failed to resolve writable compression continuation for %s",
+            requested_sid,
+            exc_info=True,
+        )
+        return session
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                logger.debug("Failed to close compression-tip SessionDB", exc_info=True)
+
 from api.workspace import (
     load_workspaces,
     save_workspaces,
@@ -22355,23 +22409,6 @@ def _start_chat_stream_for_session(
         stale_response["_status"] = 409
         return stale_response
     attachments = attachments or []
-    # Prevent duplicate runs in the same session while a stream is still active.
-    # This commonly happens after page refresh/reconnect races and can produce
-    # duplicated clarify cards for what appears to be a single user request.
-    diag.stage("active_stream_check") if diag else None
-    current_stream_id = getattr(s, "active_stream_id", None)
-    if current_stream_id:
-        if _active_stream_blocks_chat_start(s, current_stream_id):
-            diag.stage("response_write") if diag else None
-            return {
-                "error": "session already has an active stream",
-                "active_stream_id": current_stream_id,
-                "_status": 409,
-            }
-        # Stale stream id from a previous run; clear and continue.
-        diag.stage("stale_stream_cleanup") if diag else None
-        _clear_stale_stream_state(s)
-
     # #1932: check if this session has a pending goal continuation flag.
     # The streaming hook sets PENDING_GOAL_CONTINUATION when goal_continue fires,
     # so the next chat/start for this session is automatically treated as goal-related.
@@ -22391,6 +22428,18 @@ def _start_chat_stream_for_session(
     diag.stage("session_lock_wait") if diag else None
     while True:
         with session_lock:
+            writable = _resolve_writable_compression_tip(s)
+            if writable.session_id != s.session_id:
+                # Compression won after the caller derived workspace/model state.
+                # Do not start the continuation with values owned by its parent;
+                # return the canonical id and let the caller retry resolution.
+                return {
+                    "error": "session rotated during chat start; retry on continuation",
+                    "type": "session_continuation_changed",
+                    "session_id": writable.session_id,
+                    "retryable": True,
+                    "_status": 409,
+                }
             locked_stream_id = getattr(s, "active_stream_id", None)
             if locked_stream_id:
                 if _active_stream_blocks_chat_start(s, locked_stream_id):
@@ -22787,6 +22836,8 @@ def start_session_turn(
         s = get_session(session_id)
     except KeyError:
         return {"error": "Session not found", "_status": 404}
+    s = _resolve_writable_compression_tip(s)
+    session_id = s.session_id
 
     try:
         workspace = _resolve_chat_workspace_with_recovery(s, None)
@@ -23414,6 +23465,7 @@ def _handle_chat_start(handler, body, diag=None):
                 pass
         except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
+        s = _resolve_writable_compression_tip(s)
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
         active_profile = _get_active_profile_name()

--- a/api/routes.py
+++ b/api/routes.py
@@ -22605,6 +22605,8 @@ def _chat_start_response_from_run_start(result):
         "effective_model_provider",
         "error",
         "code",
+        "type",
+        "retryable",
         "active_stream_id",
         "_status",
     ):

--- a/static/messages.js
+++ b/static/messages.js
@@ -1879,6 +1879,19 @@ async function send(){
   }
 
   const startData = postStartData || {};
+  // A server-side wakeup may have compressed this conversation while the tab
+  // was detached. Adopt /api/chat/start's canonical continuation before binding
+  // the live stream, or the tab would subscribe to the closed parent.
+  const runSid=String((startData&&startData.session_id)||activeSid);
+  if(runSid!==activeSid&&S.session&&S.session.session_id===activeSid){
+    S.session.session_id=runSid;
+    if(INFLIGHT[activeSid]&&!INFLIGHT[runSid]) INFLIGHT[runSid]=INFLIGHT[activeSid];
+    delete INFLIGHT[activeSid];
+    try{localStorage.setItem('hermes-webui-session',runSid);}catch(_){}
+    if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(runSid);
+    stopApprovalPolling();startApprovalPolling(runSid);
+    stopClarifyPolling();startClarifyPolling(runSid);
+  }
   streamId = postStartData ? postStartData.stream_id : null;
   S.activeStreamId = streamId;
   // setBusy(true) already ran with activeStreamId=null; refresh now that we
@@ -1888,7 +1901,7 @@ async function send(){
   _runOptionalPostStartUiStep('post-start ui/bookkeeping', ()=>{
     const _modelState=modelStateForPostStart || _chatPayloadModelState();
     const _explicitPick=explicitPickForPostStart;
-    if(startData&&startData.title) applySessionTitleUpdate(activeSid, startData.title, {provisionalText:displayText.slice(0,64), rememberProvisional:true});
+    if(startData&&startData.title) applySessionTitleUpdate(runSid, startData.title, {provisionalText:displayText.slice(0,64), rememberProvisional:true});
 
     if(startData&&startData.effective_model && S.session){
       const _sentModel=_modelState&&_modelState.model;
@@ -1918,27 +1931,27 @@ async function send(){
     // have a stream id so the primary button can switch to Stop (see
     // getComposerPrimaryAction).
     if(typeof updateSendBtn==='function') updateSendBtn();
-    if(S.session&&S.session.session_id===activeSid){
+    if(S.session&&S.session.session_id===runSid){
       S.session.active_stream_id = streamId;
     }
-    if(S.session&&S.session.session_id===activeSid&&typeof showLiveRunStatus==='function'){
+    if(S.session&&S.session.session_id===runSid&&typeof showLiveRunStatus==='function'){
       const _startedAt=typeof startData?.pending_started_at==='number'
         ? startData.pending_started_at
         : (S.session.pending_started_at||Date.now()/1000);
-      showLiveRunStatus(activeSid,{startedAt:_startedAt});
+      showLiveRunStatus(runSid,{startedAt:_startedAt});
     }
     if(typeof upsertActiveSessionForLocalTurn==='function'){
       // Third optimistic pass: stream_id is now known, so the row can reconcile
       // against real active-stream metadata before the background refresh lands.
       upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
-    if(!INFLIGHT[activeSid]){
-      INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+    if(!INFLIGHT[runSid]){
+      INFLIGHT[runSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
     }
-    const currentInflight=INFLIGHT[activeSid];
-    markInflight(activeSid, streamId);
+    const currentInflight=INFLIGHT[runSid];
+    markInflight(runSid, streamId);
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[]});
+      saveInflightState(runSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[]});
     }
     // Refresh session list so background streaming indicators appear immediately for the
     // session that was just started and any others that may already be running.
@@ -1948,7 +1961,7 @@ async function send(){
   });
 
   // Open SSE stream and render tokens live
-  attachLiveStream(activeSid, streamId, uploadedNames);
+  attachLiveStream(runSid, streamId, uploadedNames);
 
   }finally{ _sendInProgress=false; _sendInProgressSid=null; }
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1347,6 +1347,20 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
   return restoredVisible;
 }
 
+function _chatStartErrorPayload(err){
+  if(!err) return null;
+  const raw=err.body;
+  if(raw && typeof raw==='object') return raw;
+  try{return JSON.parse(String(raw||''));}catch(_){return null;}
+}
+
+function _continuationChangedSessionId(err){
+  if(!err || Number(err.status)!==409) return '';
+  const body=_chatStartErrorPayload(err);
+  if(!body || body.type!=='session_continuation_changed' || body.retryable!==true) return '';
+  return String(body.session_id||'').trim();
+}
+
 async function send(){
   // Static guards expect _defaultMessageMode to stay near send() while the actual
   // read remains in the S.busy branch below.
@@ -1811,6 +1825,26 @@ async function send(){
     _pendingMoaConfig=null;
     postStartData = startData;
   }catch(e){
+    const nextSid=_continuationChangedSessionId(e);
+    if(nextSid && nextSid!==String(activeSid||'')){
+      try{
+        const _retryModel=modelStateForPostStart||((typeof _chatPayloadModelState==='function')?_chatPayloadModelState():{});
+        const retryData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
+          session_id:nextSid,message:msgText,
+          model:_retryModel.model,workspace:S.session&&S.session.workspace,
+          model_provider:_retryModel.model_provider,
+          profile:S.activeProfile||(S.session&&S.session.profile)||'default',
+          explicit_model_pick:explicitPickForPostStart||undefined,
+          attachments:uploaded.length?uploaded:undefined,
+          moa_config:_pendingMoaConfig?true:undefined
+        })});
+        _pendingMoaConfig=null;
+        postStartData=retryData;
+      }catch(retryErr){
+        e=retryErr;
+      }
+    }
+    if(!postStartData){
     const errMsg=String((e&&e.message)||'');
     // If /api/chat/start returns 404, the session was deleted server-side
     // (its sidecar is gone) while GET kept returning a CLI stub (#2782). Strip
@@ -1876,6 +1910,7 @@ async function send(){
     // Reconcile with server truth after immediately clearing the optimistic spinner.
     if(typeof renderSessionList==='function') void renderSessionList();
     return;
+    }
   }
 
   const startData = postStartData || {};

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -266,7 +266,7 @@ class TestBusySendButton:
         assert update_idx > apos, (
             "send() should call updateSendBtn() after S.activeStreamId is assigned"
         )
-        attach_idx = send_body.find("attachLiveStream(activeSid, streamId, uploadedNames);")
+        attach_idx = send_body.find("attachLiveStream(runSid, streamId, uploadedNames);")
         assert attach_idx > update_idx, (
             "send() should refresh primary button before opening SSE stream attach"
         )

--- a/tests/test_compression_recovery_action.py
+++ b/tests/test_compression_recovery_action.py
@@ -1,6 +1,10 @@
 import io
 import json
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from api import models, routes
 from api.compression_recovery import (
@@ -239,6 +243,296 @@ def test_chat_start_race_returns_canonical_retry_without_writing_parent_config(m
     assert tip.model_provider == "tip-provider"
     assert tip.pending_user_message is None
     assert stale_cleanup_calls == []
+
+
+def _install_noop_chat_start_workers(monkeypatch):
+    class ImmediateThread:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(routes, "ensure_agent_runtime_current", lambda: None)
+    monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: object())
+    monkeypatch.setattr(routes, "_run_agent_streaming", lambda *a, **k: None)
+    monkeypatch.setattr(routes.threading, "Thread", ImmediateThread)
+
+
+def test_chat_start_continuation_409_survives_legacy_adapter_and_retries(monkeypatch, tmp_path):
+    """Production /api/chat/start path: lock-time rotation 409 through the
+    legacy-journal adapter, then a retry on the returned session_id starts the tip.
+    """
+    _isolate_sessions(monkeypatch, tmp_path)
+    monkeypatch.setattr(routes, "SESSION_DIR", models.SESSION_DIR)
+    monkeypatch.setenv("HERMES_WEBUI_RUNTIME_ADAPTER", "legacy-journal")
+    parent = Session(
+        session_id="adapterraceparent",
+        title="Parent",
+        workspace=str(tmp_path / "parent"),
+        model="parent-model",
+        model_provider="parent-provider",
+        profile="default",
+        messages=[{"role": "user", "content": "start"}],
+    )
+    tip = Session(
+        session_id="adapterracetip",
+        title="Tip",
+        workspace=str(tmp_path / "tip"),
+        model="tip-model",
+        model_provider="tip-provider",
+        profile="default",
+        messages=[{"role": "assistant", "content": "compressed"}],
+        parent_session_id=parent.session_id,
+    )
+    for session in (parent, tip):
+        session.save()
+        models.SESSIONS[session.session_id] = session
+        routes.SESSIONS[session.session_id] = session
+
+    resolve_calls = []
+
+    def _resolve(session):
+        resolve_calls.append(session.session_id)
+        if len(resolve_calls) == 2 and session.session_id == parent.session_id:
+            return tip
+        return session
+
+    monkeypatch.setattr(routes, "_resolve_writable_compression_tip", _resolve)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_session_visible_to_active_profile", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda session, *_args, **_kwargs: session.workspace)
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda *_args, **_kwargs: (None, None, {}))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda requested_model, requested_provider, **_kwargs: (
+            requested_model or "tip-model",
+            requested_provider or "tip-provider",
+            False,
+        ),
+    )
+    monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _config: False)
+    _install_noop_chat_start_workers(monkeypatch)
+
+    first = _JSONHandler()
+    routes._handle_chat_start(first, {"session_id": parent.session_id, "message": "rank them"})
+    first_payload = _payload(first)
+
+    assert first.status == 409
+    assert first_payload["type"] == "session_continuation_changed"
+    assert first_payload["retryable"] is True
+    assert first_payload["session_id"] == tip.session_id
+    assert tip.pending_user_message is None
+    assert tip.active_stream_id in (None, "")
+
+    retry = _JSONHandler()
+    routes._handle_chat_start(
+        retry,
+        {"session_id": first_payload["session_id"], "message": "rank them"},
+    )
+    retry_payload = _payload(retry)
+
+    assert retry.status == 200
+    assert retry_payload["session_id"] == tip.session_id
+    assert retry_payload.get("stream_id")
+    try:
+        routes.STREAMS.pop(retry_payload["stream_id"], None)
+    except Exception:
+        pass
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required for send() retry/adopt behavior")
+def test_send_retries_session_continuation_changed_409_and_adopts_tip():
+    """send() must parse api()'s 409, retry the returned session_id, then adopt it."""
+    driver = r'''
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2] || process.argv[1], 'utf8');
+
+function extractFunction(source, name){
+  const marker = 'function ' + name + '(';
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('not found: ' + name);
+  const brace = source.indexOf('{', source.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error('unterminated: ' + name);
+}
+
+function extractAdoptBlock(source){
+  const start = source.indexOf('const runSid=String((startData&&startData.session_id)||activeSid);');
+  const end = source.indexOf('attachLiveStream(runSid, streamId, uploadedNames);', start);
+  if (start < 0 || end < 0) throw new Error('adopt block not found');
+  return source.slice(start, end + 'attachLiveStream(runSid, streamId, uploadedNames);'.length);
+}
+
+eval(extractFunction(src, '_chatStartErrorPayload'));
+eval(extractFunction(src, '_continuationChangedSessionId'));
+const adoptBlock = extractAdoptBlock(src);
+
+function makeApi(script){
+  return async function api(path, opts){
+    const payload = JSON.parse(opts.body);
+    const step = script.calls.length;
+    script.calls.push({path, session_id: payload.session_id, message: payload.message});
+    const planned = script.responses[step];
+    if (!planned) throw new Error('unexpected extra /api/chat/start call');
+    if (planned.status && planned.status >= 400) {
+      const err = new Error(planned.body.error || 'http error');
+      err.status = planned.status;
+      err.statusText = 'Conflict';
+      err.body = JSON.stringify(planned.body);
+      throw err;
+    }
+    return planned.body;
+  };
+}
+
+async function runCase(script){
+  const storage = {};
+  const attached = [];
+  const optimisticMessages = [{role:'user',content:'rank them'}];
+  const uploadedNames = [];
+  const INFLIGHT = {parent: {messages:optimisticMessages, uploaded:uploadedNames, toolCalls:[]}};
+  const S = {session:{session_id:'parent', workspace:'/tmp/ws', profile:'default'}, messages:optimisticMessages.slice()};
+  const activeSid = 'parent';
+  const msgText = 'rank them';
+  const uploaded = [];
+  let modelStateForPostStart = {model:'gpt-4o', model_provider:'openai'};
+  let explicitPickForPostStart = false;
+  let _pendingMoaConfig = null;
+  let postStartData;
+  const api = makeApi(script);
+  try {
+    const startData = await api('/api/chat/start', {method:'POST', body:JSON.stringify({
+      session_id:activeSid, message:msgText,
+      model:modelStateForPostStart.model, workspace:S.session.workspace,
+      model_provider:modelStateForPostStart.model_provider,
+      profile:S.activeProfile||S.session.profile||'default',
+      explicit_model_pick:explicitPickForPostStart||undefined,
+      attachments:uploaded.length?uploaded:undefined,
+      moa_config:_pendingMoaConfig?true:undefined
+    })});
+    postStartData = startData;
+  } catch (e) {
+    const nextSid = _continuationChangedSessionId(e);
+    if (nextSid && nextSid !== String(activeSid || '')) {
+      try {
+        const retryData = await api('/api/chat/start', {method:'POST', body:JSON.stringify({
+          session_id:nextSid, message:msgText,
+          model:modelStateForPostStart.model, workspace:S.session && S.session.workspace,
+          model_provider:modelStateForPostStart.model_provider,
+          profile:S.activeProfile||(S.session&&S.session.profile)||'default',
+          explicit_model_pick:explicitPickForPostStart||undefined,
+          attachments:uploaded.length?uploaded:undefined,
+          moa_config:_pendingMoaConfig?true:undefined
+        })});
+        postStartData = retryData;
+      } catch (retryErr) {
+        e = retryErr;
+      }
+    }
+    if (!postStartData) {
+      return {ok:false, error:String((e && e.message) || ''), calls:script.calls, storage, attached, inflight:Object.keys(INFLIGHT), sessionId:S.session && S.session.session_id};
+    }
+  }
+  const startData = postStartData || {};
+  let streamId;
+  const localStorage = {setItem(k,v){ storage[k]=v; }};
+  function _setActiveSessionUrl(sid){ storage.url = sid; }
+  function stopApprovalPolling(){}
+  function startApprovalPolling(sid){ storage.approval = sid; }
+  function stopClarifyPolling(){}
+  function startClarifyPolling(sid){ storage.clarify = sid; }
+  function updateSendBtn(){}
+  function _runOptionalPostStartUiStep(_name, fn){ if (typeof fn === 'function') fn(); }
+  function applySessionTitleUpdate(){}
+  function _writePersistedModelState(){}
+  function _applyModelToDropdown(){}
+  function syncTopbar(){}
+  function syncModelChip(){}
+  function ensureLiveWorklogShell(){}
+  function showLiveRunStatus(){}
+  function upsertActiveSessionForLocalTurn(){}
+  function markInflight(){}
+  function saveInflightState(){}
+  function renderSessionList(){}
+  function $(id){ return id === 'modelSelect' ? null : null; }
+  function attachLiveStream(sid, liveStreamId){ attached.push({sid, streamId: liveStreamId}); }
+  eval(adoptBlock);
+  return {
+    ok:true,
+    calls:script.calls,
+    storage,
+    attached,
+    inflight:Object.keys(INFLIGHT),
+    sessionId:S.session.session_id,
+    runSid:String((startData && startData.session_id) || activeSid)
+  };
+}
+
+(async () => {
+  const continuation = await runCase({
+    calls: [],
+    responses: [
+      {status:409, body:{
+        error:'session rotated during chat start; retry on continuation',
+        type:'session_continuation_changed',
+        session_id:'tip',
+        retryable:true
+      }},
+      {body:{session_id:'tip', stream_id:'stream-tip'}}
+    ]
+  });
+  const hardConflict = await runCase({
+    calls: [],
+    responses: [
+      {status:409, body:{error:'session already has an active stream', active_stream_id:'live'}}
+    ]
+  });
+  const staleRuntime = await runCase({
+    calls: [],
+    responses: [
+      {status:409, body:{error:'agent runtime changed', type:'agent_runtime_stale', retryable:true}}
+    ]
+  });
+  console.log(JSON.stringify({continuation, hardConflict, staleRuntime}));
+})().catch((err) => {
+  console.error(err && err.stack || err);
+  process.exit(1);
+});
+'''
+    result = subprocess.run(
+        ["node", "-e", driver, str(ROOT / "static" / "messages.js")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    continuation = payload["continuation"]
+    assert continuation["ok"] is True
+    assert [call["session_id"] for call in continuation["calls"]] == ["parent", "tip"]
+    assert continuation["sessionId"] == "tip"
+    assert continuation["runSid"] == "tip"
+    assert continuation["storage"]["hermes-webui-session"] == "tip"
+    assert continuation["storage"]["url"] == "tip"
+    assert continuation["attached"] == [{"sid": "tip", "streamId": "stream-tip"}]
+    assert "tip" in continuation["inflight"]
+    assert "parent" not in continuation["inflight"]
+
+    assert payload["hardConflict"]["ok"] is False
+    assert [call["session_id"] for call in payload["hardConflict"]["calls"]] == ["parent"]
+    assert payload["staleRuntime"]["ok"] is False
+    assert [call["session_id"] for call in payload["staleRuntime"]["calls"]] == ["parent"]
 
 
 def test_chat_start_keeps_recovery_when_substantive_prompt_fails_validation(monkeypatch, tmp_path):

--- a/tests/test_compression_recovery_action.py
+++ b/tests/test_compression_recovery_action.py
@@ -87,6 +87,7 @@ def test_chat_start_blocks_generic_continue_after_compression_exhausted(monkeypa
 
 def test_chat_start_resolves_stale_snapshot_to_live_state_db_tip(monkeypatch, tmp_path):
     """A closed-tab follow-up must not append to a parent closed by compression."""
+    pytest.importorskip("hermes_state")
     _isolate_sessions(monkeypatch, tmp_path)
     monkeypatch.setattr(routes, "SESSION_DIR", models.SESSION_DIR)
     monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "browser-agent")
@@ -345,11 +346,11 @@ def test_chat_start_continuation_409_survives_legacy_adapter_and_retries(monkeyp
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required for send() retry/adopt behavior")
-def test_send_retries_session_continuation_changed_409_and_adopts_tip():
+def test_send_retries_session_continuation_changed_409_and_adopts_tip(tmp_path):
     """send() must parse api()'s 409, retry the returned session_id, then adopt it."""
     driver = r'''
 const fs = require('fs');
-const src = fs.readFileSync(process.argv[2] || process.argv[1], 'utf8');
+const src = fs.readFileSync(process.argv[process.argv.length - 1], 'utf8');
 
 function extractFunction(source, name){
   const marker = 'function ' + name + '(';
@@ -445,6 +446,7 @@ async function runCase(script){
     }
   }
   const startData = postStartData || {};
+  const displayText = msgText;
   let streamId;
   const localStorage = {setItem(k,v){ storage[k]=v; }};
   function _setActiveSessionUrl(sid){ storage.url = sid; }
@@ -510,12 +512,14 @@ async function runCase(script){
   process.exit(1);
 });
 '''
+    driver_path = tmp_path / "send_continuation_retry.js"
+    driver_path.write_text(driver, encoding="utf-8")
     result = subprocess.run(
-        ["node", "-e", driver, str(ROOT / "static" / "messages.js")],
-        check=True,
+        ["node", str(driver_path), str(ROOT / "static" / "messages.js")],
         capture_output=True,
         text=True,
     )
+    assert result.returncode == 0, result.stderr or result.stdout
     payload = json.loads(result.stdout)
 
     continuation = payload["continuation"]

--- a/tests/test_compression_recovery_action.py
+++ b/tests/test_compression_recovery_action.py
@@ -81,6 +81,166 @@ def test_chat_start_blocks_generic_continue_after_compression_exhausted(monkeypa
     assert payload["compression_recovery"]["terminal_state"] == "compression_exhausted"
 
 
+def test_chat_start_resolves_stale_snapshot_to_live_state_db_tip(monkeypatch, tmp_path):
+    """A closed-tab follow-up must not append to a parent closed by compression."""
+    _isolate_sessions(monkeypatch, tmp_path)
+    monkeypatch.setattr(routes, "SESSION_DIR", models.SESSION_DIR)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "browser-agent")
+    root_sid = "stalecompressionroot"
+    middle_sid = "stalecompressionmiddle"
+    tip_sid = "stalecompressiontip"
+    profile_home = tmp_path / "profiles" / "browser-agent"
+    profile_home.mkdir(parents=True)
+
+    root = Session(
+        session_id=root_sid,
+        title="Compressed task",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        model_provider="openai",
+        profile="browser-agent",
+        messages=[{"role": "user", "content": "start"}],
+        pre_compression_snapshot=True,
+    )
+    # Reproduce the real incident: the intermediate sidecar missed its snapshot
+    # marker even though state.db records that it ended by compression.
+    middle = Session(
+        session_id=middle_sid,
+        title="Compressed task",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        model_provider="openai",
+        profile="browser-agent",
+        messages=[{"role": "user", "content": "background wakeup"}],
+        parent_session_id=root_sid,
+        pre_compression_snapshot=False,
+    )
+    tip = Session(
+        session_id=tip_sid,
+        title="Compressed task",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        model_provider="openai",
+        profile="browser-agent",
+        messages=[{"role": "assistant", "content": "background work finished"}],
+        parent_session_id=middle_sid,
+    )
+    for session in (root, middle, tip):
+        session.save()
+        models.SESSIONS[session.session_id] = session
+        routes.SESSIONS[session.session_id] = session
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(root_sid, source="webui", profile_name="browser-agent")
+        db.append_message(root_sid, "user", "start")
+        db.end_session(root_sid, "compression")
+        db.create_session(
+            middle_sid,
+            source="webui",
+            parent_session_id=root_sid,
+            profile_name="browser-agent",
+        )
+        db.append_message(middle_sid, "user", "background wakeup")
+        db.end_session(middle_sid, "compression")
+        db.create_session(
+            tip_sid,
+            source="webui",
+            parent_session_id=middle_sid,
+            profile_name="browser-agent",
+        )
+        db.append_message(tip_sid, "assistant", "background work finished")
+    finally:
+        db.close()
+
+    monkeypatch.setattr(
+        "api.profiles.get_hermes_home_for_profile",
+        lambda _profile: profile_home,
+    )
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda *_args, **_kwargs: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda *_args, **_kwargs: (None, None, {}))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda requested_model, requested_provider, **_kwargs: (requested_model or "gpt-4o", requested_provider or "openai", False),
+    )
+    monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _config: False)
+    captured = {}
+
+    def _fake_start_run(run_session, **_kwargs):
+        captured["session_id"] = run_session.session_id
+        return {"session_id": run_session.session_id, "stream_id": "stream-tip", "_status": 200}
+
+    monkeypatch.setattr(routes, "_start_run", _fake_start_run)
+
+    handler = _JSONHandler()
+    routes._handle_chat_start(
+        handler,
+        {"session_id": root_sid, "message": "rank them by follower count"},
+    )
+    payload = _payload(handler)
+
+    assert handler.status == 200
+    assert captured["session_id"] == tip_sid
+    assert payload["session_id"] == tip_sid
+
+
+def test_browser_adopts_chat_start_continuation_before_opening_stream():
+    """The UI must subscribe with the canonical id returned by chat/start."""
+    messages_js = (
+        Path(__file__).resolve().parent.parent / "static" / "messages.js"
+    ).read_text(encoding="utf-8")
+    start = messages_js.index("const startData = postStartData || {};")
+    end = messages_js.index("// Open SSE stream and render tokens live", start)
+    block = messages_js[start:end + 200]
+
+    assert "const runSid=String((startData&&startData.session_id)||activeSid);" in block
+    assert "localStorage.setItem('hermes-webui-session',runSid)" in block
+    assert "_setActiveSessionUrl(runSid)" in block
+    assert "attachLiveStream(runSid, streamId, uploadedNames);" in block
+
+
+def test_chat_start_race_returns_canonical_retry_without_writing_parent_config(monkeypatch, tmp_path):
+    """A post-resolution rotation must retry, not overwrite the continuation."""
+    parent = Session(
+        session_id="compressionraceparent",
+        workspace=str(tmp_path / "parent"),
+        model="parent-model",
+        model_provider="parent-provider",
+        active_stream_id="stale-parent-stream",
+    )
+    tip = Session(
+        session_id="compressionracetip",
+        workspace=str(tmp_path / "tip"),
+        model="tip-model",
+        model_provider="tip-provider",
+        parent_session_id=parent.session_id,
+    )
+    monkeypatch.setattr(routes, "_resolve_writable_compression_tip", lambda _session: tip)
+    monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _config: False)
+    stale_cleanup_calls = []
+    monkeypatch.setattr(routes, "_clear_stale_stream_state", lambda session: stale_cleanup_calls.append(session.session_id))
+
+    result = routes._start_chat_stream_for_session(
+        parent,
+        msg="continue",
+        workspace=parent.workspace,
+        model=parent.model,
+        model_provider=parent.model_provider,
+    )
+
+    assert result["_status"] == 409
+    assert result["type"] == "session_continuation_changed"
+    assert result["session_id"] == tip.session_id
+    assert tip.workspace == str(tmp_path / "tip")
+    assert tip.model == "tip-model"
+    assert tip.model_provider == "tip-provider"
+    assert tip.pending_user_message is None
+    assert stale_cleanup_calls == []
+
+
 def test_chat_start_keeps_recovery_when_substantive_prompt_fails_validation(monkeypatch, tmp_path):
     session_dir = _isolate_sessions(monkeypatch, tmp_path)
     sid = "recoverychat2"

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -27,11 +27,11 @@ def test_send_preserves_optimistic_messages_across_chat_start_await():
     setup_idx = body.index("optimisticMessages=[...S.messages];")
     inflight_idx = body.index("INFLIGHT[activeSid]={messages:optimisticMessages")
     await_idx = body.index("const startData=await api('/api/chat/start'")
-    save_idx = body.index("saveInflightState(activeSid,{streamId", await_idx)
+    save_idx = body.index("saveInflightState(runSid,{streamId", await_idx)
 
     assert setup_idx < inflight_idx < await_idx < save_idx
     post_await = body[await_idx:save_idx]
-    assert "if(!INFLIGHT[activeSid])" in post_await, (
+    assert "if(!INFLIGHT[runSid])" in post_await, (
         "send() should recreate the INFLIGHT entry if a session-list refresh pruned it"
     )
     assert "messages:INFLIGHT[activeSid].messages" not in body[save_idx : save_idx + 220], (
@@ -152,7 +152,7 @@ def test_post_start_bookkeeping_errors_cannot_block_live_attach():
     catch_idx = body.index("}catch(e){", chat_start_idx)
     optional_idx = body.index("_runOptionalPostStartUiStep('post-start ui/bookkeeping'", catch_idx)
     stream_id_idx = body.index("streamId = postStartData ? postStartData.stream_id : null;", catch_idx)
-    attach_idx = body.index("attachLiveStream(activeSid, streamId, uploadedNames);")
+    attach_idx = body.index("attachLiveStream(runSid, streamId, uploadedNames);")
     assert catch_idx < stream_id_idx < optional_idx < attach_idx, (
         "stream-id setup, post-start UI/bookkeeping, and attach must run after successful API catch"
     )

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -476,6 +476,8 @@ def test_chat_start_adapter_path_preserves_legacy_response_shape():
 
     assert '"stream_id",' in helper_body
     assert '"session_id",' in helper_body
+    assert '"type",' in helper_body
+    assert '"retryable",' in helper_body
     assert 'response.setdefault("stream_id", result.stream_id)' in helper_body
     assert 'response.setdefault("session_id", result.session_id)' in helper_body
     assert '"run_id",' not in helper_body
@@ -518,6 +520,39 @@ def test_chat_start_response_from_run_start_filters_adapter_internal_fields():
         "effective_model": "gpt-5.5",
         "effective_model_provider": "openai-codex",
     }
+
+
+def test_chat_start_response_from_run_start_forwards_continuation_retry_fields():
+    """Legacy-journal must keep type/retryable so the browser can retry a 409."""
+    routes = importlib.import_module("api.routes")
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    response = routes._chat_start_response_from_run_start(
+        runtime.RunStartResult(
+            run_id="",
+            session_id="compression-tip",
+            stream_id="",
+            status="started",
+            payload={
+                "error": "session rotated during chat start; retry on continuation",
+                "type": "session_continuation_changed",
+                "session_id": "compression-tip",
+                "retryable": True,
+                "_status": 409,
+                "run_id": "runner-internal-1",
+                "status": "started",
+                "active_controls": ["cancel"],
+            },
+        )
+    )
+
+    assert response["type"] == "session_continuation_changed"
+    assert response["retryable"] is True
+    assert response["session_id"] == "compression-tip"
+    assert response["_status"] == 409
+    assert "run_id" not in response
+    assert "status" not in response
+    assert "active_controls" not in response
 
 
 def test_rfc_distinguishes_goal_routing_from_queue_route_staging():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI can rotate an active Agent session during automatic context compression.
- A server-side process wakeup can trigger that rotation while no browser tab is attached to consume the `compressed` SSE handoff.
- The browser can therefore retain a stale root session ID even though `state.db` has a live descendant.
- Posting the next human turn to that closed root makes Hermes reject persistence (`closed by compression; adopt its live continuation`) and the browser shows no reply.
- The fix resolves the authoritative lineage before turn admission, rechecks it at the mutation boundary, and makes the browser adopt the server-returned continuation before attaching the stream.

## What Changed

- Added `_resolve_writable_compression_tip()` to resolve a stale WebUI sidecar through the active profile's `state.db` lineage.
- Accepts a continuation only when it is a safe ID, belongs to the same profile, and has a persisted WebUI sidecar.
- Applied resolution to both browser-originated and server-originated turn entrypoints.
- Rechecks lineage under the per-session lock before any stream-state mutation. If compression wins after workspace/model derivation, returns a typed retryable `409` with the canonical continuation ID instead of writing parent-derived configuration to the tip.
- Removed the redundant eager stale-stream cleanup so canonical validation is the first session mutation at admission.
- Updated the browser to adopt `/api/chat/start`'s returned `session_id` in localStorage, URL state, inflight ownership, polling, and SSE attachment.
- Added regressions for a two-hop compression lineage, browser stream adoption, and the lock-time rotation race with stale parent stream state.

## Review follow-up (nesquena-hermes CHANGES_REQUESTED, exact-head `50d6d9c13790`)

The 409 was already the correct server signal; the production caller did not follow it.

- `send()` now parses `api()`'s 409 body. If `type === "session_continuation_changed"` and `retryable === true`, it retries `/api/chat/start` once against the returned `session_id`, then uses the existing `runSid` adoption block.
- Hard 409s (active stream) and other retryable types (`agent_runtime_stale`) still do not take this branch.
- `_chat_start_response_from_run_start` now forwards `type` and `retryable` so the legacy-journal lane keeps the discriminator. Adapter-internal fields (`run_id`, `status`, `active_controls`) stay filtered.
- Added a production-path regression: `_handle_chat_start` through `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` returns the typed 409, and a second start on the returned id admits the tip. A Node test executes the send() retry/adopt helpers plus the production adopt block against a workspace.js-shaped `api()` throw.
- Rebased onto current `nesquena/master` (collision-safe; replayed the original commit cleanly, then added this follow-up).

Out of scope (named, not churned): pending goal/background marker ownership on the pre-admission 409, `start_session_turn` server-side retry, hydration of the tip transcript before attach, and session-switch-during-start ownership. Those were earlier comments, not the 2026-08-14 exact-head blocker.

## Why It Matters

A detached browser tab can now continue a conversation after one or more automatic compression rotations without silently losing the next response. The state owner is explicit: Agent `state.db` owns compression lineage; WebUI sidecars own browser-visible session state; `/api/chat/start` returns the canonical stream owner that the browser must adopt. If compression wins between caller derivation and locked admission, the browser retries once on the canonical id instead of showing a hard error.

## Contract Routing

Task type: runtime/session recovery bug fix

Touched areas:
- chat turn admission
- compression lineage resolution
- per-session locking
- browser SSE ownership
- legacy-journal chat-start response filter
- `/api/chat/start` 409 retry

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/canonical-session-resolution.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

Scope boundaries:
- No general boot/sidebar canonicalization changes.
- No schema or migration changes.
- No visible layout changes.
- No marker-ownership rewrite on the 409 exit.

Evidence needed before claiming done:
- stale root resolves through repeated compression descendants
- profile/sidecar checks prevent cross-profile or foreign-session adoption
- lock-time rotation causes a retry before mutation
- legacy-journal 409 keeps `type` and `retryable`
- browser retries the returned session id and attaches SSE using the canonical id

## Verification

- Review blocker reproduced on `50d6d9c13790`: `send()` had no continuation-409 branch; `_chat_start_response_from_run_start` omitted `type`/`retryable`.
- Rebase onto current `nesquena/master` completed with no conflicts.
- `./scripts/test.sh tests/test_compression_recovery_action.py tests/test_runtime_adapter_seam.py tests/test_1062_busy_input_modes.py tests/test_stale_empty_session_restore.py tests/test_inflight_send_start_race.py tests/test_issue5472_preserve_draft_on_failed_send.py tests/test_chat_start_provider_fallback.py -q`
  - `128 passed, 2 skipped`
  - skipped: `hermes_state` not installed in this trial environment (state.db lineage test); one other optional skip
- `node --check static/messages.js` passed
- New production-path tests passed: `test_chat_start_continuation_409_survives_legacy_adapter_and_retries`, `test_send_retries_session_continuation_changed_409_and_adopts_tip`, `test_chat_start_response_from_run_start_forwards_continuation_retry_fields`

Could not verify: real browser tab against a live compression rotation; `start_session_turn` wakeup retry (out of scope); pending marker ownership on the 409 exit (out of scope).

## Risks / Follow-ups

- The resolver intentionally fails closed to the requested sidecar when `state.db` cannot be read or the candidate lacks a same-profile WebUI sidecar.
- Continuation retry is once per send. A second rotation during the retry still surfaces as a normal start error.
- `start_session_turn` still surfaces the typed 409 to its caller; this follow-up does not add a server-side wakeup retry.
- No screenshots are included because this changes routing/recovery behavior, not visual layout.

Release-note wording: Fixed browser conversations showing no reply when a detached tab sent a message after automatic context compression rotated the session. A lock-time rotation 409 is now retried against the live continuation.

## Model Used

OpenAI `gpt-5.6-sol` via Hermes Agent for the original change; this review follow-up is the Cursor cloud agent on `fix/canonical-compression-tip`.