### PR TITLE
fix(streaming): make per-session MCP toolset override additive (clean rework)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8062,6 +8062,80 @@ def _builtin_toolset_names():
     return names
 
 
+def _profile_owned_static_toolsets(builtin_names, mcp_server_names):
+    """Return the set of static/builtin/plugin toolsets that are AUTHORIZED
+    for the current profile context.
+
+    This separates INVENTORY (all registered toolsets in the process-global
+    registry) from AUTHORIZATION (which toolsets belong to the current profile
+    and are safe to expose).
+
+    The process-global registry includes:
+      - Static builtin toolsets (web, file, terminal, etc.)
+      - Plugin toolsets registered by the current profile
+      - Canonical names for MCP servers from ALL profiles (mcp-* entries)
+
+    For capability isolation, we must distinguish:
+      - Owned canonicals: mcp-<server> where <server> is configured in the
+        current profile (these are the server's own registry identity, not
+        static/plugin shadows) - EXCLUDED (will be added via explicit MCP selection)
+      - Foreign MCP canonicals: mcp-<server> where <server> is NOT configured
+        but HAS an alias edge to a server - EXCLUDED (belongs to other profile)
+      - Static/plugin mcp-* toolsets: names starting with mcp- but have NO
+        alias edge to any MCP server - INCLUDED (these are genuine static/plugin
+        toolsets that merely share the prefix)
+
+    Returns None when builtin_names is None (registry unavailable) -
+    cannot determine authorization without the inventory.
+
+    Round-18 gate fix: separates inventory from authorization to prevent
+    wildcard defaults and free-text wildcards from exposing foreign MCP tools.
+    """
+    if builtin_names is None:
+        return None
+    if not isinstance(builtin_names, (set, list, tuple)):
+        return None
+    if mcp_server_names is None:
+        mcp_server_names = set()
+    elif not isinstance(mcp_server_names, (set, list, tuple)):
+        return None
+    else:
+        mcp_server_names = set(mcp_server_names)
+
+    # Start with the full inventory
+    profile_owned = set(builtin_names) if not isinstance(builtin_names, set) else builtin_names.copy()
+
+    # Exclude owned canonicals (current profile's MCP servers' registry names)
+    # These are NOT static/plugin shadows - they ARE the MCP server itself
+    owned_canonicals = set()
+    for _srv in mcp_server_names:
+        _t = _registry_alias_target(_srv)
+        if _t == f"mcp-{_srv}":  # exact match required for ownership proof
+            owned_canonicals.add(_t)
+
+    # For each mcp-* entry, determine if it's:
+    # 1. Owned canonical (current profile's MCP) -> EXCLUDE (handled via explicit selection)
+    # 2. Foreign MCP canonical (has alias edge but not our server) -> EXCLUDE
+    # 3. Static/plugin toolset (no alias edge) -> INCLUDE
+    for _name in list(profile_owned):
+        if _name.startswith('mcp-'):
+            if _name in owned_canonicals:
+                # Owned by current profile - exclude, will be added via MCP selection
+                profile_owned.discard(_name)
+            else:
+                # Check if it has an alias edge to any server
+                _srv_name = _name[4:]  # strip 'mcp-' prefix
+                _alias_target = _registry_alias_target(_srv_name)
+                if _alias_target == _name:
+                    # Has alias edge = MCP server canonical (foreign)
+                    # EXCLUDE - belongs to other profile
+                    profile_owned.discard(_name)
+                # else: no alias edge = static/plugin toolset -> INCLUDE
+
+    return profile_owned
+
+
+
 
 def _canonicalize_picker_mcp_selection(name, mcp_server_names):
     """Map a picker-derived MCP server selection to an unambiguous registry
@@ -8350,15 +8424,16 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
         _wildcards = {'all', '*'}
         _has_wildcard = any(_d in _wildcards for _d in defaults)
         if _has_wildcard:
-            # Filter out wildcards, keep builtins, add override_targets
-            _safe_defaults = [d for d in defaults if d not in _wildcards]
-            merged = list(_safe_defaults)  # builtins/plugins survive
-            seen = set(merged)
-            for name in override_targets:
-                if name is not None and name not in seen:
-                    merged.append(name)
-                    seen.add(name)
-            return merged
+            # Round-18 gate fix: wildcard defaults MUST go through the full
+            # check chain (mcp_strip, composite check) rather than early return.
+            # Replace wildcards with profile-owned static toolsets, then continue.
+            profile_owned = _profile_owned_static_toolsets(builtin_names, mcp_server_names)
+            if profile_owned is None:
+                # Cannot determine profile authorization → fail closed
+                return []
+            # Replace wildcards in defaults with profile-owned toolsets
+            # These will go through the same mcp_strip and composite checks below
+            defaults = [d for d in defaults if d not in _wildcards] + list(profile_owned)
         # A default entry that is a *composite* toolset (one whose
         # ``includes`` transitively references an MCP-server toolset)
         # would survive the name-level filter but re-expose the
@@ -8449,10 +8524,15 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             # process-global registry.
             if name in mcp_server_names:
                 continue  # collision with server named "all"/"*"
-            # Expand wildcard to all known safe toolsets:
-            # - All builtin/plugin toolsets (in true_shadow)
-            # - All configured MCP servers (via canonical mcp-<name>)
-            _expanded = set(true_shadow)  # builtins/plugins
+            # Round-18 gate fix: expand wildcard to PROFILE-OWNED toolsets only.
+            # The process-global registry contains foreign MCP canonicals from
+            # other profiles; true_shadow includes them and would expose them.
+            # Use profile_owned to exclude foreign MCP tools.
+            _profile_owned = _profile_owned_static_toolsets(builtin_names, mcp_server_names)
+            if _profile_owned is None:
+                # Cannot determine profile authorization → drop wildcard
+                continue
+            _expanded = set(_profile_owned)  # profile-owned builtins/plugins
             for _srv in mcp_server_names:
                 _expanded.add(f"mcp-{_srv}")  # configured MCP servers
             safe_override.extend(sorted(_expanded))
@@ -8477,17 +8557,19 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
                     safe_override.append(name)
                 # else: ownership unprovable → drop (fail closed)
                 continue
-            # Round-16 fix: a name that is NEITHER a configured server's
-            # bare token NOR the canonical of one (``_srv_name`` not
-            # configured) is a genuine registered/static toolset that
-            # merely begins with ``mcp-`` (e.g. ``mcp-custom-probe``).
-            # Master passes such entries through; dropping them silently
-            # discards a valid toolset (gate finding #3).  Preserve it
-            # when proven present in the builtin shadow set, fail closed
-            # otherwise.
-            if name in true_shadow:
-                safe_override.append(name)
-            continue
+            # Round-18 gate fix: registry membership is NOT authorization.
+            # A name that is NEITHER a configured server's bare token NOR
+            # the canonical of one must be checked for static/plugin provenance.
+            # If it has an alias edge matching itself, it's a foreign MCP canonical.
+            # If no alias edge, it's a static/plugin toolset (e.g. mcp-custom-probe).
+            _alias_target = _registry_alias_target(_srv_name)
+            if _alias_target == name:
+                # Has alias edge = foreign MCP canonical from another profile
+                # Drop it - fail closed
+                continue
+            # No alias edge = static/plugin toolset with mcp- prefix
+            # Allow it to pass through
+            safe_override.append(name)
         # Bare name or non-mcp-* selector: pass through unchanged
         safe_override.append(name)
     return safe_override

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8062,28 +8062,53 @@ def _builtin_toolset_names():
     return names
 
 
-def _authored_builtin_toolset_names():
-    """Return the AUTHORED static builtin toolset names (``toolsets.TOOLSETS``
-    keys) — the immutable builtins a profile context is allowed to expose.
+# Round-21 gate fix: ``toolsets.TOOLSETS`` is a RUNTIME-MUTABLE process-global
+# dict — ``create_custom_toolset()`` inserts into it at runtime (e.g. from
+# another profile's agent session).  Live keys are therefore NOT proof of
+# current-profile or immutable ownership.  The authored-builtin universe is
+# captured ONCE per process (first successful import) and frozen; later
+# ``create_custom_toolset()`` mutations never re-authorize.  ``None`` means
+# the registry could not be established at all (fail closed).
+_AUTHORED_TOOLSETS_SNAPSHOT = None  # frozenset[str] | None
 
-    This is the *authorization* source for wildcard expansion.  Only toolsets
-    that are authored definitions (static builtins + current-process custom
-    toolsets) count as profile-owned static toolsets.  Process-global
-    REGISTRY names — registered MCP canonicals, foreign plugin toolsets —
-    are NEVER included: registry membership is not profile ownership
-    (Round-18 finding 1).  An alias-less foreign ``mcp-foreign`` entry or a
-    foreign non-MCP plugin registered in the shared registry must never
-    enter a wildcard expansion for another profile.
+
+def _authored_builtin_toolset_names():
+    """Return the FROZEN authored builtin toolset names (``toolsets.TOOLSETS``
+    keys captured once) — the immutable builtins a profile context is allowed
+    to expose.
+
+    This is the *authorization* source for wildcard expansion and restrictive
+    exact-selector admission.  Only toolsets that are authored definitions
+    (static builtins) count as profile-owned static toolsets.  Process-global
+    REGISTRY names — registered MCP canonicals, foreign plugin toolsets — are
+    NEVER included: registry membership is not profile ownership
+    (Round-18 finding 1).
+
+    Round-21 gate fix: the snapshot is captured ONCE at first successful
+    import and frozen.  Previously this helper re-read the live
+    ``toolsets.TOOLSETS`` dict on every call; ``create_custom_toolset()``
+    mutates that same process-global dict at runtime, so a custom or foreign
+    ``mcp-*`` toolset inserted by ANOTHER profile appeared in the
+    "authored" set and was accepted by ``_profile_authorizes_mcp_selector()``
+    and both wildcard lanes — a cross-profile capability over-grant through a
+    mutable global inventory.  The frozen snapshot never contains runtime
+    custom toolsets.
 
     Returns ``None`` when ``toolsets`` is unavailable (fail closed — an
     unknown builtin universe cannot prove what is profile-owned).
     """
+    global _AUTHORED_TOOLSETS_SNAPSHOT
+    if _AUTHORED_TOOLSETS_SNAPSHOT is not None:
+        return _AUTHORED_TOOLSETS_SNAPSHOT
     try:
         import toolsets as _ts
         _defs = getattr(_ts, "TOOLSETS", None)
         if not isinstance(_defs, dict):
             return None
-        return {str(k) for k in _defs.keys()} - {"all", "*"}
+        _AUTHORED_TOOLSETS_SNAPSHOT = frozenset(
+            str(k) for k in _defs.keys()
+        ) - frozenset({"all", "*"})
+        return _AUTHORED_TOOLSETS_SNAPSHOT
     except Exception:
         return None
 
@@ -8308,8 +8333,12 @@ def _profile_authorizes_mcp_selector(name, defaults):
 
       * an explicit profile default for this request (a current-profile
         enabled plugin / static toolset explicitly authorized here), or
-      * an authored immutable builtin definition (``toolsets.TOOLSETS``
-        key).
+      * an authored immutable builtin definition (the FROZEN
+        ``toolsets.TOOLSETS`` snapshot — see
+        ``_authored_builtin_toolset_names()``; Round-21: the snapshot is
+        captured once and never includes runtime ``create_custom_toolset``
+        entries, so a foreign profile's runtime custom toolset cannot
+        authorize itself).
 
     Registry membership never authorizes.  Returns False (fail closed)
     when authorization cannot be established.
@@ -8331,7 +8360,7 @@ def _profile_authorizes_mcp_selector(name, defaults):
 
 
 def _apply_session_toolset_override(defaults, override, mcp_server_names,
-                                    builtin_names=None):
+                                    builtin_names=None, _gen_slot=None):
     """Resolve a per-session ``enabled_toolsets`` override against the profile
     defaults.
 
@@ -8411,7 +8440,16 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
     # must fail closed (Round-18 finding: "generation movement must fail
     # closed").  The check is a no-op when the registry is unavailable or
     # does not expose a generation.
+    #
+    # Round-21 gate fix: the entry generation is ALSO handed back to the
+    # caller through ``_gen_slot`` (a list) so the FINAL tool resolution
+    # (AIAgent construction) can re-validate the same authority generation
+    # *after* this helper returns — a registry mutation between the helper
+    # return and the Agent construction must fail closed too, not only
+    # mutations that happen while this helper is running.
     _gen_at_entry = _registry_generation()
+    if _gen_slot is not None:
+        _gen_slot.append(_gen_at_entry)
 
     # Any non-list value (scalar, dict, set, …) is invalid persisted state.
     # Fail closed to restrictive — never let the caller's broad except restore
@@ -10297,6 +10335,11 @@ def _run_agent_streaming(
             # server toolsets are included, matching native CLI behaviour.
             from api.config import _resolve_cli_toolsets
             _toolsets = _resolve_cli_toolsets(_cfg)
+            # Round-21 gate fix: generation of the authority snapshot the
+            # per-session override reasoned from.  None when no override was
+            # applied (no re-validation needed) or the registry lacks a
+            # generation counter.
+            _toolsets_gen = None
 
             # Per-session toolset override (#493): if the session has
             # enabled_toolsets set, apply it on top of the profile defaults.
@@ -10344,9 +10387,20 @@ def _run_agent_streaming(
                         # from the MCP-only test so a server named e.g. "web"
                         # can't silently flip the override into additive mode
                         # and get shadowed by the builtin.
+                        #
+                        # Round-21 gate fix: capture the authority generation
+                        # the helper reasoned from, so the FINAL tool
+                        # resolution below (AIAgent construction) can
+                        # re-validate it — a registry mutation between the
+                        # helper return and the Agent construction must fail
+                        # closed, not only mutations that happen while the
+                        # helper runs.
+                        _gen_slot = []
                         _toolsets = _apply_session_toolset_override(
-                            _toolsets, _override, _mcp_server_names
+                            _toolsets, _override, _mcp_server_names,
+                            _gen_slot=_gen_slot
                         )
+                        _toolsets_gen = _gen_slot[0] if _gen_slot else None
             except Exception as _ts_err:
                 print(f"[webui] WARNING: failed to read per-session toolsets for {session_id}: {_ts_err}", flush=True)
 
@@ -10460,6 +10514,18 @@ def _run_agent_streaming(
                 _reasoning_config = parse_reasoning_effort(_effort)
             except Exception:
                 _reasoning_config = None
+
+            # Round-21 gate fix: the per-session override resolved against an
+            # authority snapshot at generation `_toolsets_gen`.  Re-validate
+            # that generation at FINAL tool resolution (AIAgent construction):
+            # if the registry mutated between the helper return and here (a
+            # server registered, an alias moved), the toolsets handed to the
+            # Agent were reasoned from a stale authority — fail closed to an
+            # empty toolset list rather than resolve tools that were never
+            # authorized for this session.  None (no override / no generation
+            # counter) means there is no authority to go stale.
+            if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
+                _toolsets = []
 
             _agent_kwargs = dict(
                 model=resolved_model,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8284,6 +8284,164 @@ def _registry_generation_changed(gen_at_entry):
     return _registry_generation() != gen_at_entry
 
 
+def _authority_snapshot_stale(gen_at_entry, override_applied):
+    """Return True when a captured authority snapshot can no longer be
+    trusted for agent construction.
+
+    Two fail-closed conditions (Round-22/23 gate semantics):
+
+    * ``gen_at_entry`` is not None and the live generation moved — the
+      registry mutated after the authority snapshot was captured.
+    * ``gen_at_entry`` is None and ``override_applied`` — an override WAS
+      applied but no generation counter exists to prove the authority is
+      stable.  ``None`` alone is fine when no override was applied (profile
+      defaults are config-derived, not registry-derived).
+    """
+    if gen_at_entry is not None and _registry_generation_changed(gen_at_entry):
+        return True
+    if gen_at_entry is None and override_applied:
+        return True
+    return False
+
+
+def _derive_session_toolset_authority(cfg, session_id):
+    """(Re-)derive the per-session toolset override authority from the
+    CURRENT registry state.
+
+    Mirrors the inline resolution used at the top of ``_run_agent_streaming``
+    so a construction-transaction retry (or a credential-heal rebuild) can
+    obtain a *fresh* authority instead of reusing a stale one.
+
+    Returns ``(toolsets, gen, applied)``:
+      * toolsets — the resolved per-session toolset list
+      * gen      — the registry generation the override reasoned from
+                   (None when no override was applied or the registry
+                   lacks a generation counter)
+      * applied  — True when a per-session override was actually applied
+    """
+    from api.config import _resolve_cli_toolsets
+
+    _toolsets = _resolve_cli_toolsets(cfg)
+    _gen = None
+    _applied = False
+    try:
+        from api.models import Session, SESSION_DIR
+        _session_path = SESSION_DIR / f"{session_id}.json"
+        if _session_path.exists():
+            _session_meta = Session.load_metadata_only(session_id)
+            _override = getattr(_session_meta, 'enabled_toolsets', None) if _session_meta else None
+            if _override is not None:
+                try:
+                    _mcp_server_names = set(
+                        (cfg.get('mcp_servers') or {}).keys()
+                    )
+                except Exception:
+                    _mcp_server_names = set()
+                _gen_slot = []
+                _toolsets = _apply_session_toolset_override(
+                    _toolsets, _override, _mcp_server_names,
+                    _gen_slot=_gen_slot,
+                )
+                _gen = _gen_slot[0] if _gen_slot else None
+                _applied = True
+    except Exception:
+        pass
+    return _toolsets, _gen, _applied
+
+
+def _construct_override_gated_agent(
+    agent_cls,
+    agent_kwargs,
+    toolsets,
+    toolsets_gen,
+    override_applied,
+    rederive_authority=None,
+):
+    """Centralized overridden-agent construction transaction (Round-23 gate).
+
+    Builds an AIAgent only from a *provably stable* authority snapshot:
+
+      1. Validates the captured generation immediately BEFORE construction.
+      2. Constructs into a local candidate.
+      3. Validates immediately AFTER construction — a registry mutation
+         during the constructor's tool resolution must fail closed.
+      4. On movement or unavailable authority the candidate is closed and
+         discarded: it is NEVER registered, cached, published, or run.
+      5. Retries at most once from a freshly derived authority, then fails
+         closed.
+      6. The fail-closed fallback is an EMPTY-tool agent constructed with
+         ``enabled_toolsets=[]`` so its ``tools`` and ``valid_tool_names``
+         are empty from initialization.  A stale candidate is never
+         sanitized by mutating only ``enabled_toolsets`` afterwards — the
+         constructor-derived tool caches would survive that.
+
+    Args:
+      agent_cls: the AIAgent class to construct.
+      agent_kwargs: kwargs for the constructor (``enabled_toolsets`` is
+          overwritten with the validated toolsets on each attempt).
+      toolsets: the currently resolved per-session toolsets.
+      toolsets_gen: the registry generation the authority reasoned from.
+      override_applied: whether a per-session override was applied.
+      rederive_authority: optional callable ``() -> (toolsets, gen, applied)``
+          returning a FRESH authority for the single retry.  When omitted the
+          transaction fails closed immediately on the first stale check.
+
+    Returns ``(agent, outcome, final_toolsets)``:
+      * outcome == 'stable'      — built from the captured authority.
+      * outcome == 'retried'     — built from a freshly derived authority.
+      * outcome == 'fail-closed' — empty-tool agent (``enabled_toolsets=[]``).
+      * final_toolsets — the toolsets the returned agent was constructed
+        with (the re-derived toolsets after a retry, or ``[]`` when
+        fail-closed).  Callers that compute a cache signature from the
+        toolsets MUST use this value, not the pre-transaction ``toolsets``.
+    """
+    _kwargs = dict(agent_kwargs)
+    _attempt_toolsets = toolsets
+    _attempt_gen = toolsets_gen
+    _attempt_applied = override_applied
+    _retried = False
+
+    for _attempt in range(2):  # initial + at most one retry
+        # 1. Pre-check: the authority must still hold BEFORE construction.
+        if _authority_snapshot_stale(_attempt_gen, _attempt_applied):
+            if not _retried and rederive_authority is not None:
+                _attempt_toolsets, _attempt_gen, _attempt_applied = rederive_authority()
+                _retried = True
+                continue
+            # Fail closed: empty-tool agent from initialization.
+            _kwargs['enabled_toolsets'] = []
+            return agent_cls(**_kwargs), 'fail-closed', []
+
+        # 2. Construct into a LOCAL candidate.
+        _kwargs['enabled_toolsets'] = _attempt_toolsets
+        candidate = agent_cls(**_kwargs)
+
+        # 3. Post-check: the registry must not have moved during construction.
+        if _attempt_gen is not None and _registry_generation_changed(_attempt_gen):
+            # Stale candidate — close and discard.  Never register/cache/
+            # publish/run it: its constructor-derived tool caches reference
+            # tools that were never authorized.
+            try:
+                _close_fn = candidate.close if hasattr(candidate, 'close') else None
+                if callable(_close_fn):
+                    _close_fn()
+            except Exception:
+                pass
+            if not _retried and rederive_authority is not None:
+                _attempt_toolsets, _attempt_gen, _attempt_applied = rederive_authority()
+                _retried = True
+                continue
+            # Fail closed: empty-tool agent from initialization.
+            _kwargs['enabled_toolsets'] = []
+            return agent_cls(**_kwargs), 'fail-closed', []
+
+        return candidate, ('retried' if _retried else 'stable'), _attempt_toolsets
+
+    # Unreachable (loop is bounded), but fail closed defensively.
+    _kwargs['enabled_toolsets'] = []
+    return agent_cls(**_kwargs), 'fail-closed', []
+
+
 def _registry_alias_target(name):
     """Return the alias target for *name* from the live registry.
 
@@ -10353,82 +10511,15 @@ def _run_agent_streaming(
 
             # Per-profile toolsets — use _resolve_cli_toolsets() so MCP
             # server toolsets are included, matching native CLI behaviour.
-            from api.config import _resolve_cli_toolsets
-            _toolsets = _resolve_cli_toolsets(_cfg)
-            # Round-21 gate fix: generation of the authority snapshot the
-            # per-session override reasoned from.  None when no override was
-            # applied (no re-validation needed) or the registry lacks a
-            # generation counter.
-            _toolsets_gen = None
-            # Round-22 gate fix: track whether an override was actually applied
-            # (vs. preserved defaults).  When an override WAS applied but the
-            # generation is None (no registry / no generation counter), we
-            # cannot prove the authority is stable → fail closed.
-            _override_applied = False
-
-            # Per-session toolset override (#493): if the session has
-            # enabled_toolsets set, apply it on top of the profile defaults.
             #
-            # The per-session toolset picker lets users tick configured MCP
-            # servers for the current chat. Those checkboxes emit the bare MCP
-            # server name (e.g. "my-search"). Previously ANY override value
-            # *replaced* the profile defaults wholesale, so ticking a single MCP
-            # server dropped every built-in toolset (web, file, terminal,
-            # delegation, …). The agent then received a toolset the registry had
-            # no matching tools for (MCP tools register under "mcp-<server>"),
-            # leaving the model with an empty tool list and a broken session.
-            #
-            # Fix: treat an override that is composed *only* of configured MCP
-            # server names as an ADDITION to the profile defaults (the "enable
-            # this server for this chat" intent the checkbox UI implies). An
-            # override that names any non-MCP toolset keeps the original
-            # RESTRICT semantics (the power-user free-text "limit to these
-            # toolsets" use case).
-            try:
-                from api.models import Session, SESSION_DIR
-                _session_path = SESSION_DIR / f"{session_id}.json"
-                if _session_path.exists():
-                    _session_meta = Session.load_metadata_only(session_id)
-                    # load_metadata_only returns a Session INSTANCE, not a dict.
-                    # The previous .get('enabled_toolsets') raised AttributeError
-                    # which was swallowed by the bare except below — the entire
-                    # per-session toolset override silently no-op'd. Use
-                    # getattr() to read the attribute correctly.
-                    # (Opus pre-release advisor finding for v0.50.257.)
-                    _override = getattr(_session_meta, 'enabled_toolsets', None) if _session_meta else None
-                    # Distinguish absence (None = no override, keep defaults)
-                    # from invalid persisted state (scalar, dict, …) which
-                    # _apply_session_toolset_override will handle fail-closed.
-                    if _override is not None:
-                        try:
-                            _mcp_server_names = set(
-                                (_cfg.get('mcp_servers') or {}).keys()
-                            )
-                        except Exception:
-                            _mcp_server_names = set()
-                        # Additive when the override names only configured MCP
-                        # servers (composer picker tick); restrict otherwise.
-                        # Names colliding with a builtin toolset are excluded
-                        # from the MCP-only test so a server named e.g. "web"
-                        # can't silently flip the override into additive mode
-                        # and get shadowed by the builtin.
-                        #
-                        # Round-21 gate fix: capture the authority generation
-                        # the helper reasoned from, so the FINAL tool
-                        # resolution below (AIAgent construction) can
-                        # re-validate it — a registry mutation between the
-                        # helper return and the Agent construction must fail
-                        # closed, not only mutations that happen while the
-                        # helper runs.
-                        _gen_slot = []
-                        _toolsets = _apply_session_toolset_override(
-                            _toolsets, _override, _mcp_server_names,
-                            _gen_slot=_gen_slot
-                        )
-                        _toolsets_gen = _gen_slot[0] if _gen_slot else None
-                        _override_applied = True
-            except Exception as _ts_err:
-                print(f"[webui] WARNING: failed to read per-session toolsets for {session_id}: {_ts_err}", flush=True)
+            # Round-23 gate fix: authority resolution is centralized in
+            # _derive_session_toolset_authority() so the construction
+            # transaction can re-derive a FRESH authority on retry (and the
+            # credential-heal path can rebuild from a fresh authority too)
+            # instead of reusing a stale inline snapshot.
+            _toolsets, _toolsets_gen, _override_applied = _derive_session_toolset_authority(
+                _cfg, session_id
+            )
 
             # Fallback model chain from profile config (e.g. for rate-limit or
             # provider recovery). Match Hermes CLI/gateway semantics:
@@ -10541,34 +10632,17 @@ def _run_agent_streaming(
             except Exception:
                 _reasoning_config = None
 
-            # Round-22 gate fix: the per-session override resolved against an
-            # authority snapshot at generation ``_toolsets_gen``.  Re-validate
-            # that generation IMMEDIATELY before AIAgent construction (both the
-            # ephemeral and cache-miss paths) AND immediately after, so a
-            # registry mutation between the helper return and construction —
-            # or during construction itself — is caught and the toolsets are
-            # blanked (fail closed) rather than resolved from a stale
-            # authority.
-            #
-            # Round-22 gate finding 2: the Round-21 check ran ONCE before
-            # building _agent_kwargs but before _AIAgent(...) construction.
-            # A registry mutation between the check and the constructor was
-            # not caught.  Also, a ``None`` generation (registry unavailable
-            # / no generation counter) was treated as "stable" — but when an
-            # override WAS applied, ``None`` means we cannot PROVE stability,
-            # so the override must fail closed to an empty toolset list.
-            #
-            # ``_toolsets_gen`` is ``None`` when NO override was applied (no
-            # re-validation needed — the profile defaults are config-derived,
-            # not registry-derived) or when the registry lacks a generation
-            # counter.  When an override WAS applied and the generation IS
-            # ``None``, we cannot prove the authority is stable → fail closed.
-            if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
-                _toolsets = []
-            elif _toolsets_gen is None and _override_applied:
-                # Override was applied but we have no generation counter to
-                # prove stability → fail closed (empty toolsets).
-                _toolsets = []
+            # Round-23 gate fix: the Round-22 inline pre-construction check
+            # (blank toolsets when the authority generation moved) is replaced
+            # by the centralized construction transaction in
+            # _construct_override_gated_agent(): it validates the captured
+            # generation immediately before construction, constructs into a
+            # LOCAL candidate, validates immediately after, closes and
+            # discards a stale candidate (never registered/cached/published/
+            # run), retries at most once from a freshly derived authority,
+            # and only then fails closed to an empty-tool agent built with
+            # enabled_toolsets=[] (so tools/valid_tool_names are empty from
+            # initialization — never sanitized post-hoc).
 
             _agent_kwargs = dict(
                 model=resolved_model,
@@ -10633,13 +10707,28 @@ def _run_agent_streaming(
             # Mirrors gateway _agent_cache.  Keeps _user_turn_count alive so
             # injectionFrequency: "first-turn" actually suppresses after turn 1.
             if ephemeral:
-                agent = _AIAgent(**_agent_kwargs)
-                # Round-22 gate fix: re-validate generation IMMEDIATELY after
-                # construction — a registry mutation during the constructor's
-                # tool resolution must fail closed (blank toolsets), not run
-                # or cache tools that were never authorized.
-                if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
-                    agent.enabled_toolsets = []
+                # Round-23 gate fix: centralized construction transaction.
+                # Pre-validates the authority generation, constructs into a
+                # local candidate, post-validates, closes+discards a stale
+                # candidate (never run), retries once from fresh authority,
+                # and fails closed to an empty-tool agent (enabled_toolsets=[])
+                # if the authority cannot be proven stable.
+                agent, _gate_outcome, _final_toolsets = _construct_override_gated_agent(
+                    _AIAgent,
+                    _agent_kwargs,
+                    _toolsets,
+                    _toolsets_gen,
+                    _override_applied,
+                    rederive_authority=lambda: _derive_session_toolset_authority(
+                        _cfg, session_id
+                    ),
+                )
+                if _gate_outcome == 'fail-closed':
+                    logger.warning(
+                        '[webui] Fail-closed empty-tool agent for session %s '
+                        '(per-session toolset authority could not be proven stable)',
+                        session_id,
+                    )
                 logger.debug('[webui] Created ephemeral agent for session %s', session_id)
             else:
                 import hashlib as _hashlib
@@ -10771,13 +10860,56 @@ def _run_agent_streaming(
                     if hasattr(agent, '_interrupt_message'):
                         agent._interrupt_message = None
                 else:
-                    agent = _AIAgent(**_agent_kwargs)
-                    # Round-22 gate fix: re-validate generation IMMEDIATELY after
-                    # construction — a registry mutation during the constructor's
-                    # tool resolution must fail closed (blank toolsets), not be
-                    # run or cached.
-                    if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
-                        agent.enabled_toolsets = []
+                    # Round-23 gate fix: centralized construction transaction.
+                    # A stale candidate is closed and discarded — it is never
+                    # registered, cached, published, or run (the Round-22
+                    # post-hoc `agent.enabled_toolsets = []` sanitize left the
+                    # constructor-derived tools/valid_tool_names callable).
+                    agent, _gate_outcome, _final_toolsets = _construct_override_gated_agent(
+                        _AIAgent,
+                        _agent_kwargs,
+                        _toolsets,
+                        _toolsets_gen,
+                        _override_applied,
+                        rederive_authority=lambda: _derive_session_toolset_authority(
+                            _cfg, session_id
+                        ),
+                    )
+                    if _gate_outcome == 'fail-closed':
+                        logger.warning(
+                            '[webui] Fail-closed empty-tool agent for session %s '
+                            '(per-session toolset authority could not be proven stable)',
+                            session_id,
+                        )
+                    # The cache signature must reflect the toolsets the agent
+                    # was ACTUALLY constructed with (a retry may have re-derived
+                    # a different set; fail-closed yields []).  Recompute when
+                    # the transaction changed the toolsets so a later cache hit
+                    # does not reuse an agent whose toolset identity differs
+                    # from the signature it was stored under.
+                    if _final_toolsets != _toolsets:
+                        _sig_blob = _json.dumps([
+                            resolved_model or '',
+                            _agent_cache_api_key_sig(resolved_api_key, _credential_pool),
+                            resolved_base_url or '',
+                            resolved_provider or '',
+                            _rt.get('api_mode') or '',
+                            _rt.get('command') or '',
+                            _rt.get('args') or [],
+                            bool(_credential_pool),
+                            _max_iterations_cfg or '',
+                            _max_tokens_cfg or '',
+                            _fallback_resolved or {},
+                            sorted(_final_toolsets) if _final_toolsets else [],
+                            _reasoning_config or {},
+                            _main_request_overrides or {},
+                            _public_prefill_context_status(_prefill_context),
+                            _profile_home or '',
+                            _safe_profile_runtime_env.get('TERMINAL_ENV', '') or '',
+                            _safe_profile_runtime_env.get('TERMINAL_SSH_HOST', '') or '',
+                            _safe_profile_runtime_env.get('TERMINAL_SSH_USER', '') or '',
+                        ], sort_keys=True)
+                        _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
                     # Register the new agent with the memory lifecycle so
                     # its commit_memory_session() can be found later.
                     try:
@@ -11486,11 +11618,66 @@ def _run_agent_streaming(
                             _replace_session_db_in_kwargs(_agent_kwargs, _state_db_path)
                             if 'credential_pool' in _agent_params:
                                 _agent_kwargs['credential_pool'] = _heal_rt.get('credential_pool')
-                            agent = _AIAgent(**_agent_kwargs)
-                            # Round-22 gate fix: re-validate generation after
-                            # construction on the session-healing path too.
-                            if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
-                                agent.enabled_toolsets = []
+                            # Round-23 gate fix: credential healing gets its
+                            # OWN fresh pre-check/re-derivation immediately
+                            # before construction — the request-start authority
+                            # snapshot may be minutes old by the time a 401
+                            # heal runs.  Re-derive the per-session toolset
+                            # authority now and build through the same
+                            # centralized construction transaction (stale
+                            # candidate closed+discarded, single retry, then
+                            # fail-closed empty-tool agent).
+                            _heal_toolsets, _heal_gen, _heal_applied = _derive_session_toolset_authority(
+                                _cfg, session_id
+                            )
+                            # The sig recompute below needs hashlib/json; the
+                            # cache-miss branch imported them but the
+                            # ephemeral path skips that branch entirely — yet
+                            # a 401 heal can fire on an ephemeral run too.
+                            import hashlib as _hashlib
+                            import json as _json
+                            agent, _gate_outcome, _final_toolsets = _construct_override_gated_agent(
+                                _AIAgent,
+                                _agent_kwargs,
+                                _heal_toolsets,
+                                _heal_gen,
+                                _heal_applied,
+                                rederive_authority=lambda: _derive_session_toolset_authority(
+                                    _cfg, session_id
+                                ),
+                            )
+                            if _gate_outcome == 'fail-closed':
+                                logger.warning(
+                                    '[webui] Fail-closed empty-tool agent during '
+                                    'credential heal for session %s (toolset '
+                                    'authority could not be proven stable)',
+                                    session_id,
+                                )
+                            # The cache signature must match the toolsets the
+                            # healed agent was ACTUALLY constructed with.
+                            if _final_toolsets != _toolsets:
+                                _sig_blob = _json.dumps([
+                                    resolved_model or '',
+                                    _agent_cache_api_key_sig(resolved_api_key, _credential_pool),
+                                    resolved_base_url or '',
+                                    resolved_provider or '',
+                                    _rt.get('api_mode') or '',
+                                    _rt.get('command') or '',
+                                    _rt.get('args') or [],
+                                    bool(_credential_pool),
+                                    _max_iterations_cfg or '',
+                                    _max_tokens_cfg or '',
+                                    _fallback_resolved or {},
+                                    sorted(_final_toolsets) if _final_toolsets else [],
+                                    _reasoning_config or {},
+                                    _main_request_overrides or {},
+                                    _public_prefill_context_status(_prefill_context),
+                                    _profile_home or '',
+                                    _safe_profile_runtime_env.get('TERMINAL_ENV', '') or '',
+                                    _safe_profile_runtime_env.get('TERMINAL_SSH_HOST', '') or '',
+                                    _safe_profile_runtime_env.get('TERMINAL_SSH_USER', '') or '',
+                                ], sort_keys=True)
+                                _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
                             with STREAMS_LOCK:
                                 AGENT_INSTANCES[stream_id] = agent
                             from api.config import SESSION_AGENT_CACHE as _SAC, SESSION_AGENT_CACHE_LOCK as _SAC_L
@@ -12723,7 +12910,14 @@ def _run_agent_streaming(
                     resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                         resolved_provider, resolved_api_key, resolved_base_url
                     )
-                    # Build a fresh agent with the new credentials
+                    # Build a fresh agent with the new credentials.
+                    # Round-23 gate fix: the credential-heal path must get
+                    # its own fresh pre-check/re-derivation immediately before
+                    # construction (the request-start authority snapshot may
+                    # be minutes old), and must build through the same
+                    # centralized construction transaction so a stale
+                    # candidate is closed+discarded rather than cached,
+                    # published, and run with constructor-derived tools.
                     _heal_kwargs = dict(_agent_kwargs) if '_agent_kwargs' in dir() else {}
                     _heal_kwargs['api_key'] = resolved_api_key
                     _heal_kwargs['base_url'] = resolved_base_url
@@ -12732,7 +12926,51 @@ def _run_agent_streaming(
                     _replace_session_db_in_kwargs(_heal_kwargs, _state_db_path)
                     if 'credential_pool' in _agent_params:
                         _heal_kwargs['credential_pool'] = _heal_rt.get('credential_pool')
-                    _heal_agent = _AIAgent(**_heal_kwargs)
+                    _heal_toolsets2, _heal_gen2, _heal_applied2 = _derive_session_toolset_authority(
+                        _cfg, session_id
+                    )
+                    import hashlib as _hashlib
+                    import json as _json
+                    _heal_agent, _heal_gate2, _heal_final_ts2 = _construct_override_gated_agent(
+                        _AIAgent,
+                        _heal_kwargs,
+                        _heal_toolsets2,
+                        _heal_gen2,
+                        _heal_applied2,
+                        rederive_authority=lambda: _derive_session_toolset_authority(
+                            _cfg, session_id
+                        ),
+                    )
+                    if _heal_gate2 == 'fail-closed':
+                        logger.warning(
+                            '[webui] Fail-closed empty-tool agent during '
+                            'credential heal (except path) for session %s '
+                            '(toolset authority could not be proven stable)',
+                            session_id,
+                        )
+                    if _heal_final_ts2 != _toolsets:
+                        _sig_blob = _json.dumps([
+                            resolved_model or '',
+                            _agent_cache_api_key_sig(resolved_api_key, _credential_pool),
+                            resolved_base_url or '',
+                            resolved_provider or '',
+                            _rt.get('api_mode') or '',
+                            _rt.get('command') or '',
+                            _rt.get('args') or [],
+                            bool(_credential_pool),
+                            _max_iterations_cfg or '',
+                            _max_tokens_cfg or '',
+                            _fallback_resolved or {},
+                            sorted(_heal_final_ts2) if _heal_final_ts2 else [],
+                            _reasoning_config or {},
+                            _main_request_overrides or {},
+                            _public_prefill_context_status(_prefill_context),
+                            _profile_home or '',
+                            _safe_profile_runtime_env.get('TERMINAL_ENV', '') or '',
+                            _safe_profile_runtime_env.get('TERMINAL_SSH_HOST', '') or '',
+                            _safe_profile_runtime_env.get('TERMINAL_SSH_USER', '') or '',
+                        ], sort_keys=True)
+                        _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
                     with STREAMS_LOCK:
                         AGENT_INSTANCES[stream_id] = _heal_agent
                     from api.config import SESSION_AGENT_CACHE as _SAC2, SESSION_AGENT_CACHE_LOCK as _SAC2_L

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8013,6 +8013,551 @@ def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
             rt['is_anthropic_oauth'] = getattr(agent, '_is_anthropic_oauth')
 
 
+def _builtin_toolset_names():
+    """Names the agent resolves to a static/builtin toolset (not an MCP server).
+
+    A per-session override name that collides with one of these must NOT be
+    treated as an "enable this MCP server" tick, because the static toolset
+    shadows the same-named MCP alias at resolution time.
+
+    Returns the full set of names that shadow an MCP alias: the static
+    ``TOOLSETS`` keys PLUS any registered canonical/plugin toolset names, so a
+    plugin-named MCP server can't slip past the collision guard. Returns
+    ``None`` (not an empty set) when the registry is *unavailable* — that is an
+    "I don't know" signal, distinct from "there are genuinely no builtins", and
+    the classifier must fail closed (restrict) rather than treat every name as
+    MCP-additive.
+    """
+    try:
+        import toolsets
+    except Exception:
+        return None
+    names = set()
+    static = getattr(toolsets, 'TOOLSETS', None)
+    if isinstance(static, dict):
+        names.update(static.keys())
+    # Registered canonical / plugin toolsets also shadow same-named MCP aliases
+    # at resolution time.  Enumerate the real runtime registry — the installed
+    # runtime does not expose the speculative accessor/attribute names, so a
+    # static enumeration would silently miss every registered/plugin toolset.
+    try:
+        from tools.registry import registry as _tool_registry
+        _registered = _tool_registry.get_registered_toolset_names()
+        if not isinstance(_registered, (set, list, tuple)):
+            return None
+        # Union ALL registered canonical/plugin toolset names including
+        # mcp-* entries.  A bare override token that equals an existing
+        # canonical name (e.g. a server named "mcp-alpha" whose canonical
+        # is "mcp-mcp-alpha" collides with another server "alpha" whose
+        # canonical is "mcp-alpha") must NOT be treated as additive — the
+        # runtime resolver would match canonical "mcp-alpha" (server
+        # "alpha") instead of the intended server.  Including mcp-* names
+        # in the shadow set ensures the override restricts correctly.
+        for _name in _registered:
+            if not isinstance(_name, str):
+                return None
+            names.add(_name)
+    except Exception:
+        return None
+    return names
+
+
+
+def _canonicalize_picker_mcp_selection(name, mcp_server_names):
+    """Map a picker-derived MCP server selection to an unambiguous registry
+    target, or ``None`` when ownership cannot be proved (fail closed).
+
+    The composer toolset picker emits the *bare* configured server name.  A
+    bare name is ambiguous in exactly two cases:
+
+    * **Reserved wildcard selectors** (``all`` / ``*``): the installed
+      resolver treats them as "every toolset" *before* consulting MCP
+      aliases, so a server literally named ``all`` recurses into itself until
+      ``RecursionError`` (gate-certified BRICK).
+    * **Canonical collisions**: a server named ``mcp-alpha`` collides with
+      the canonical ``mcp-alpha`` toolset of a server named ``alpha``, so the
+      bare token resolves the *wrong* server's tools (gate-certified SILENT).
+
+    Both cases canonicalize to ``mcp-<name>`` (``mcp-all`` /
+    ``mcp-mcp-alpha``), which the resolver treats as a plain toolset name and
+    never as a wildcard.  Ordinary server names (``my-search``) have no
+    ambiguity and pass through unchanged — the resolver reaches them through
+    their registry alias.
+
+    Failure contract: when the name IS a configured MCP server but its
+    canonical target cannot be verified in the live registry (server not yet
+    registered, or registry unavailable), ownership cannot be proved and we
+    return ``None`` so the caller drops the selection rather than emit an
+    ambiguous token.
+    """
+    if not isinstance(name, str) or not name:
+        return None if name is None else name
+    if name not in mcp_server_names:
+        return name  # free-text toolset name — not an MCP server, keep as-is
+    if name not in {"all", "*"} and not name.startswith("mcp-"):
+        return name  # ordinary server name — bare token resolves via alias
+    canonical = f"mcp-{name}"
+    try:
+        from tools.registry import registry as _reg
+        target = _reg.get_toolset_alias_target(name)
+        if target == canonical:
+            return canonical
+        # A registered canonical name that is present in the registry but is NOT
+        # owned by this configured server (its alias edge does not resolve here)
+        # must NOT be emitted — ownership is unproven, and returning it would
+        # silently select the wrong server's tools.
+    except Exception:
+        return None  # cannot prove ownership → fail closed
+    return None
+
+
+def _registry_alias_target(name):
+    """Return the alias target for *name* from the live registry, or ``None``
+    when the registry is unavailable (cannot prove ownership → fail closed).
+
+    Used to distinguish a registered canonical that is OWNED by a configured
+    MCP server (``get_toolset_alias_target`` resolves it) from a genuine
+    static/plugin name that merely shares the ``mcp-`` prefix.  Only the
+    latter shadows an MCP alias; the former is the server's own registry
+    identity and must not discard the server's bare picker token.
+    """
+    try:
+        from tools.registry import registry as _reg
+        return _reg.get_toolset_alias_target(name)
+    except Exception:
+        return None
+
+
+def _canonicalize_override_targets(override, mcp_server_names):
+    """Map every configured-MCP-server override entry to an unambiguous
+    registry target via the live alias/ownership edges.
+
+    A picker-derived MCP selection (a name in ``mcp_server_names``) is
+    canonicalized through ``_canonicalize_picker_mcp_selection`` so that
+    MCP-vs-MCP canonical collisions (e.g. server ``mcp-alpha`` whose bare
+    token equals server ``alpha``'s canonical ``mcp-alpha``) are resolved
+    to the selected server's true target (``mcp-mcp-alpha``) *before* the
+    broad registered-name shadow set can discard them.
+
+    Returns ``None`` when any configured-MCP-server selection's ownership
+    cannot be proved (registry unavailable / no alias edge) — the caller
+    must fail closed to restrictive semantics rather than silently drop
+    the selection.  Non-MCP (free-text) names pass through unchanged; the
+    caller decides restrict semantics for them.
+    """
+    out = []
+    for _n in override or []:
+        if _n in mcp_server_names:
+            _t = _canonicalize_picker_mcp_selection(_n, mcp_server_names)
+            if _t is None:
+                return None  # cannot prove ownership → fail closed
+            out.append(_t)
+        else:
+            out.append(_n)  # free-text / non-MCP — caller decides
+    return out
+
+
+def _apply_session_toolset_override(defaults, override, mcp_server_names,
+                                    builtin_names=None):
+    """Resolve a per-session ``enabled_toolsets`` override against the profile
+    defaults.
+
+    Two intents share the one override field:
+
+    * **Additive** — the override names *only* configured MCP servers (the
+      composer toolset picker ticks a server for this chat). Keep the profile
+      defaults for built-ins/plugins, drop every configured MCP-server
+      toolset, then append the ticked servers (dedup, order-preserving) — so
+      the built-in toolsets survive while *unchecked* MCP servers stay out.
+      The bare server name is intentional: the CLI
+      resolver (`_resolve_cli_toolsets`) and `enabled_mcp_server_names` both
+      emit bare names, and the registry aliases ``<server>` `→` ``mcp-<server>``,
+      so a bare name resolves correctly — a ``mcp-`` prefix would NOT validate.
+
+    * **Restrict** — the override names any non-MCP toolset (power-user
+      free-text): replace the defaults, as before.
+
+    A name that is *both* a configured MCP server and a builtin toolset (e.g. a
+    server literally named ``web``) is a collision: the builtin shadows the MCP
+    alias, so it must not flip the whole override into additive mode. Such names
+    are excluded from the MCP-only test, leaving the override to restrict
+    semantics — unambiguous and backward-compatible.
+
+    Fail-closed: if the builtin registry is *unavailable* (``builtin_names`` is
+    ``None`` — an "I don't know" signal), we cannot prove a name is a pure MCP
+    server that isn't shadowed by a builtin, so the override falls back to the
+    conservative RESTRICT semantics. It is never treated as additive on an
+    unknown registry, because that would re-open the very collision this guard
+    exists to close.
+
+    Malformed-state fail-closed: a persisted ``override`` or configured
+    ``mcp_server_names`` that contains non-string entries (e.g. a stale
+    ``[{"shape": "dict"}]``) must NOT raise ``TypeError`` inside the additive
+    classifier and fall through to the caller's broad ``except`` — that would
+    silently restore ALL profile defaults (fail-open).  Both are validated as
+    ``list[str]`` *before* any set-membership test, and any malformed value
+    falls back to RESTRICT semantics immediately.
+
+    Scalar-state fail-closed (review finding #1): a persisted scalar such as
+    ``42``, ``0``, or ``"web"`` must NOT be silently skipped (falsy scalars
+    bypass the caller's ``if _override:``) or cause a ``TypeError`` (truthy
+    scalars raise inside the malformed list-comprehension).  Only ``None`` and
+    ``[]`` (the existing no-override contract) may preserve defaults.  Any
+    other value is treated as invalid and yields a restrictive result.
+
+    Recursive-composite fail-closed: a default entry that is itself a composite
+    toolset (one whose ``includes`` transitively pulls in an MCP-server
+    toolset) is NOT safe to keep merely because its own name is not a bare MCP
+    server.  Resolving it would re-expose the unchecked MCP server's tools.
+    Each surviving default is expanded via ``resolve_toolset`` and any tool
+    registered under ``mcp-<server>`` where ``<server>`` is not in the override
+    causes that default to be dropped.
+
+    Owned-canonical exclusion (round-11 gate fix): ``_builtin_toolset_names()``
+    unions every registered canonical name, including ``mcp-<server>`` entries.
+    A registered canonical that is OWNED by a configured MCP server (proven via
+    its live alias edge ``get_toolset_alias_target``) is the server's own
+    registry name, NOT a static/plugin shadow.  Keeping it in the shadow set
+    makes server ``mcp-alpha``'s bare picker token collide with server
+    ``alpha``'s canonical ``mcp-alpha``: ``pure_mcp`` drops the token, the
+    additive branch is skipped, and the canonicalizer never runs — so the
+    resolver picks the WRONG server's tools.  Owned canonicals are excluded
+    from the shadow set before the MCP-only test; true static/plugin shadows
+    (e.g. a plugin literally named ``mcp-browser``) stay restrictive because
+    their names have no alias edge back to a configured server.
+    """
+    # Absence and the intentional empty list are the only signals that mean
+    # "no override" — preserve the profile defaults.
+    if override is None or override == []:
+        return list(defaults)
+
+    # Any non-list value (scalar, dict, set, …) is invalid persisted state.
+    # Fail closed to restrictive — never let the caller's broad except restore
+    # all defaults.
+    if not isinstance(override, list):
+        return []
+
+    # ── Malformed-override fail-closed ────────────────────────────────────
+    # Validate before any fallible classification so malformed persisted state
+    # can never restore all profile defaults via the caller's broad except.
+    # Round-14 fix: drop ALL dangerous selectors from malformed override,
+    # not just non-strings. A malformed ['all', {'bad': 1}] must NOT yield
+    # ['all'] which the resolver expands to every toolset (gate-certified).
+    if not all(isinstance(n, str) for n in override):
+        _valid = [n for n in override if isinstance(n, str)]
+        # Sanitize: drop wildcards and unverified mcp-* selectors
+        _valid = [n for n in _valid if n not in {'all', '*'} and not n.startswith('mcp-')]
+        return _valid
+
+    # Validate configured MCP server names as strings before additive
+    # classification — a non-string ``mcp_servers`` key independently reaches
+    # ``'mcp-' + _srv`` downstream and has the same fail-open caller result.
+    # Round-14 fix: return empty list instead of raw override — the raw
+    # override may contain dangerous selectors (all, *, mcp-*) that bypass
+    # the sanitizer (gate-certified).
+    _mcp_names_raw = mcp_server_names or ()
+    if not all(isinstance(n, str) for n in _mcp_names_raw):
+        return []  # cannot safely classify → fully restrictive
+    mcp_server_names = set(_mcp_names_raw)
+
+    if builtin_names is None:
+        builtin_names = _builtin_toolset_names()
+    # ``None`` here means the builtin registry could not be resolved → we do not
+    # know which names are shadowed by a builtin, so we cannot safely classify
+    # any override name as a pure MCP tick. Fail closed to restrict.
+    if builtin_names is None:
+        # Registry unavailable — cannot verify MCP ownership for any selector.
+        # Drop only dangerous selectors that silently expand to many unchecked
+        # tools (gate-certified SILENT: offline server named "all" → 91 tools).
+        # Bare names are safe to keep: either builtin-shadowed (resolver picks
+        # the builtin) or an intentional restrictive user selection.
+        return [n for n in override if n not in {'all', '*'} and not n.startswith('mcp-')]
+    builtin_names = set(builtin_names)
+
+    # ── Owned-canonical exclusion (round-11 gate fix) ────────────────────
+    # ``_builtin_toolset_names()`` unions every REGISTERED canonical name,
+    # including ``mcp-<server>`` entries.  A registered canonical that is
+    # OWNED by a configured MCP server (proven via its live alias edge) is
+    # the server's own registry identity, NOT a static/plugin shadow.
+    # Keeping it in the shadow set makes server ``mcp-alpha``'s bare picker
+    # token collide with server ``alpha``'s canonical ``mcp-alpha``:
+    # ``pure_mcp`` drops the token, the additive branch is skipped, and the
+    # canonicalizer never runs — so the resolver picks the WRONG server's
+    # tools (gate-certified SILENT).  Exclude owned canonicals from the
+    # shadow set before the MCP-only test; true static/plugin shadows (e.g.
+    # a plugin literally named ``mcp-browser``) stay restrictive because
+    # their names have no alias edge back to a configured server.
+    # Round-14 fix: require EXACT alias match `_t == f"mcp-{_srv}"`.
+    # A mismatched alias target is NOT ownership proof (gate-certified).
+    owned_canonicals = set()
+    for _srv in mcp_server_names:
+        _t = _registry_alias_target(_srv)
+        if _t == f"mcp-{_srv}":  # exact match required for ownership proof
+            owned_canonicals.add(_t)
+    true_shadow = builtin_names - owned_canonicals
+    # Only names that are MCP servers AND not shadowed by a true
+    # static/plugin builtin count as a pure "enable this server" tick.
+    pure_mcp = mcp_server_names - true_shadow
+    override_only_mcp = bool(pure_mcp) and all(
+        name in pure_mcp for name in override
+    )
+    if override_only_mcp:
+        # Canonicalize every override entry ONCE, before the merge.  A None
+        # result means a configured-MCP-server selection's ownership cannot
+        # be proved (registry unavailable / no alias edge) — fail closed to
+        # restrict rather than emit an ambiguous token that could resolve
+        # the wrong server's tools.
+        override_targets = _canonicalize_override_targets(
+            override, mcp_server_names)
+        if override_targets is None:
+            return []  # cannot prove ownership → fully restrictive fail-closed
+        # Additive to builtins/plugins but RESTRICTIVE over MCP servers:
+        # keep the profile defaults except every configured MCP-server
+        # toolset, then add back only the checked subset.  Merging ALL
+        # defaults would leak the unchecked servers' tools back in (e.g.
+        # defaults [web, alpha, beta] + override [alpha] must NOT yield
+        # beta), which a Codex regression gate caught as the additive
+        # fix over-correcting in the other direction.
+        #
+        # A configured server can appear in defaults through its bare
+        # name OR its canonical ``mcp-<name>`` selector (canonical
+        # resolution bypasses alias shadowing, so ``mcp-<name>``
+        # always resolves to the MCP server even when the bare name
+        # is shadowed by a builtin).  Strip both forms for every
+        # configured server, but don't strip bare names that ARE
+        # builtins (the builtin, not the MCP alias, lives in defaults
+        # under that name).
+        mcp_strip = set()
+        for _srv in mcp_server_names:
+            if _srv not in true_shadow:
+                mcp_strip.add(_srv)
+            mcp_strip.add('mcp-' + _srv)
+        # Wildcards/composites in defaults (e.g. ``all``, ``*``)
+        # resolve to every registered toolset, including configured
+        # MCP servers the user did NOT tick.  If any configured MCP
+        # server is unchecked, we cannot safely expand the wildcard
+        # without leaking its tools — fail closed to restrictive
+        # session semantics.
+        # Round-14 fix: return verified canonical targets, not raw override.
+        # A configured server named "all" could have its selector changed
+        # from canonical back to raw wildcard if we return list(override).
+        _unchecked = mcp_server_names - set(override)
+        if _unchecked:
+            _wildcards = {'all', '*'}
+            if any(_d in _wildcards for _d in defaults):
+                return list(override_targets)  # use verified canonical targets
+        # A default entry that is a *composite* toolset (one whose
+        # ``includes`` transitively references an MCP-server toolset)
+        # would survive the name-level filter but re-expose the
+        # unchecked server's tools at resolution time.  Expand each
+        # surviving default and drop any that transitively reach an
+        # MCP server not in the override.
+        #
+        # Every surviving default is checked recursively — builtins
+        # included.  Builtin/static toolsets (web, file, …) resolve to
+        # non-MCP tools so the check keeps them, but they must still go
+        # through the same resolver/registry ownership proof as custom
+        # toolsets: a tool registered into a builtin's canonical
+        # ``mcp-<name>`` owner (e.g. a plugin owning ``mcp-web``) must
+        # fail closed rather than be assumed safe by name.  The earlier
+        # name-based fast-path (``_static_builtin_leaf_names``) derived
+        # "static" authority from the runtime-mutable ``toolsets.TOOLSETS``
+        # and was removed in round-5 review for exactly that reason.
+        #
+        # Review finding #3: unchecked_mcp must be computed from ALL
+        # configured MCP server names minus the selected servers, not
+        # from pure_mcp which strips collision names.  A composite
+        # that reaches the canonical selector for an unchecked colliding
+        # server (e.g. mcp-web) must still be denied.
+        unchecked_mcp = mcp_server_names - set(override)
+        merged = []
+        for d in defaults:
+            if d in mcp_strip:
+                continue  # bare name or canonical mcp-<name> — filtered
+            # All non-MCP default entries must prove they do not
+            # transitively reach an unchecked MCP server.  The previous
+            # _static_builtin_leaf_names() fast-path was removed in
+            # round-5 review: it derived "static" authority from the
+            # live toolsets.TOOLSETS dict, which is runtime-mutable via
+            # create_custom_toolset().  A runtime custom leaf with an
+            # empty includes list could enter the set and bypass the
+            # ownership check, re-exposing unchecked MCP tools.
+            if _default_transitively_reaches_unchecked_mcp(
+                    d, unchecked_mcp, true_shadow):
+                continue  # composite that pulls in an unchecked MCP server
+            merged.append(d)
+        seen = set(merged)
+        for name in override_targets:
+            # Canonicalize picker-derived MCP selections to a verified,
+            # unambiguous registry target (gate-certified BRICK/SILENT):
+            # a bare server named "all"/"*" would be treated as a wildcard
+            # by the resolver (RecursionError), and a server named
+            # "mcp-alpha" collides with the canonical toolset of a server
+            # named "alpha" (wrong server's tools).  Emit the canonical
+            # "mcp-<name>" target instead; a None from the canonicalizer
+            # means ownership cannot be proved → fail closed (drop the
+            # selection rather than emit an ambiguous token).
+            if name is None:
+                continue
+            if name not in seen:
+                merged.append(name)
+                seen.add(name)
+        return merged
+    # Restrict branch: power-user free-text override.  Names here are
+    # literal toolset selections (a bare "all"/"*" is the user's explicit
+    # wildcard intent), NOT picker-derived MCP ticks.
+    #
+    # Round-13 gate fix: picker-derived selectors with intrinsic resolver
+    # ambiguity (mcp-*) may have been routed here because a missing alias
+    # edge kept them in the shadow set (pure_mcp excluded them).  Such
+    # selectors cannot be safely emitted without proving ownership —
+    # the resolver would pick the wrong server's tools.  Fail closed:
+    # drop any mcp-* selector whose exact alias edge is unprovable.
+    # Wildcards (all, *) in a picker-derived context also require proof
+    # of ownership for EVERY configured MCP server; without registry
+    # access we cannot expand them safely → drop them too.
+    safe_override = []
+    for name in override:
+        if name in {'all', '*'}:
+            # Wildcard: only safe if we can verify no unchecked MCP server
+            # would be included.  This requires registry access which we
+            # may not have.  Fail closed by dropping wildcards entirely
+            # in the restrict branch — the user can use explicit names.
+            continue
+        if name.startswith('mcp-'):
+            # Round-15 fix: if the FULL selector is itself a configured
+            # server's bare picker token (e.g. server "mcp-alpha" vs server
+            # "alpha"'s canonical "mcp-alpha"), the entry is ambiguous
+            # between the picker token and the canonical selector.  Without
+            # picker context we cannot prove which was meant, and emitting
+            # the canonical interpretation would resolve the WRONG server's
+            # tools (gate-certified SILENT).  Fail closed: drop it.
+            if name in mcp_server_names:
+                continue
+            # Canonical selector: must prove it belongs to a configured
+            # server via the exact alias edge.  Without proof, the resolver
+            # may pick the wrong server (gate-certified SILENT).
+            _srv_name = name[4:]  # strip 'mcp-' prefix
+            if _srv_name in mcp_server_names:
+                _target = _registry_alias_target(_srv_name)
+                if _target == name:
+                    safe_override.append(name)
+                # else: ownership unprovable → drop (fail closed)
+            # else: not a configured MCP server's canonical → drop
+            continue
+        # Bare name or non-mcp-* selector: pass through unchanged
+        safe_override.append(name)
+    return safe_override
+
+
+def _default_transitively_reaches_unchecked_mcp(default_name, unchecked_mcp,
+                                                builtin_names=None):
+    """Return True if *resolving* ``default_name`` exposes tools from any MCP
+    server whose bare name is in ``unchecked_mcp``.
+
+    A composite toolset (e.g. ``gate-composite`` with ``includes: [gate-alpha]``)
+    is not itself a bare MCP-server name, so the name-level filter in
+    ``_apply_session_toolset_override`` keeps it.  But at resolution time
+    ``resolve_toolset`` expands the ``includes`` chain, and if any included
+    name is an MCP server the agent receives that server's tools — silently
+    defeating the "unchecked MCP servers stay out" contract.
+
+    Two complementary checks run here:
+
+    1. **Structural walk (gate-certified finding 3):** recursively traverse
+       the toolset definition's ``includes`` chain and reject any name that
+       is an unchecked MCP server's bare name OR its canonical
+       ``mcp-<server>`` selector.  This catches an *offline* unchecked server
+       the resolved-tools check cannot see: before the server registers its
+       tools, ``resolve_toolset`` returns nothing for it, so the tool-level
+       check alone would keep the composite — and registering the server
+       later would silently re-expose its tools without a fresh
+       authorization decision.  The structural walk is registration-state
+       independent.  Cycles are detected via a visited set.
+
+       A bare name that is also a *builtin* toolset name (e.g. a server
+       named ``web`` colliding with the static ``web`` toolset) is NOT an
+       MCP reference in the includes chain — the builtin shadows the MCP
+       alias at resolution time, exactly as elsewhere in this module.  The
+       canonical ``mcp-<name>`` selector is still checked unconditionally,
+       because canonical resolution bypasses alias shadowing.
+
+    2. **Tool-level check:** expand the name through ``resolve_toolset`` and
+       inspect every resolved tool's registered toolset.  If any tool belongs
+       to ``mcp-<server>`` where ``<server>`` is in ``unchecked_mcp``, the
+       default is unsafe to keep.  This catches a custom toolset that owns
+       unchecked-server tools *directly* (tools list, empty includes) which
+       the includes walk cannot see.
+
+    Fail-closed: if the toolset resolver or registry is unavailable, we cannot
+    prove the default is safe, so return ``True`` (drop it).
+    """
+    if not unchecked_mcp:
+        return False
+    unchecked_bare = set(unchecked_mcp)
+    unchecked_canonical = {f"mcp-{s}" for s in unchecked_mcp}
+    # A bare name shadowed by a builtin toolset resolves to the builtin, not
+    # to the MCP alias — it is not an MCP reference for the includes walk.
+    if builtin_names:
+        unchecked_bare -= set(builtin_names)
+
+    # ── 1. Structural walk of the includes chain ──────────────────────────
+    # Registration-state independent: an unchecked server that has NOT
+    # registered tools yet (offline) is still rejected when a default's
+    # includes chain names it (bare or canonical), so a later
+    # registration/reconnect cannot re-enter through a retained composite.
+    try:
+        from toolsets import get_toolset
+    except Exception:
+        return True  # cannot prove safety → drop
+    visited = set()
+    stack = [default_name]
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue  # cycle / diamond — already checked
+        visited.add(node)
+        if node in unchecked_bare or node in unchecked_canonical:
+            return True  # includes chain references an unchecked MCP server
+        try:
+            ts_def = get_toolset(node)
+        except Exception:
+            return True  # cannot prove safety → drop
+        if not ts_def:
+            # Unknown / registry-only toolset (e.g. an mcp-* canonical whose
+            # server is itself checked).  Registry-derived toolsets have no
+            # ``includes``, so there is nothing further to traverse; the
+            # name-level test above already covered the unchecked cases.
+            continue
+        for inc in ts_def.get("includes", []) or []:
+            stack.append(inc)
+
+    # ── 2. Tool-level check (existing behavior) ───────────────────────────
+    try:
+        from toolsets import resolve_toolset
+        from tools.registry import registry as _tool_registry
+    except Exception:
+        return True  # cannot prove safety → drop
+    try:
+        resolved_tools = resolve_toolset(default_name)
+    except Exception:
+        return True  # resolution error → drop
+    if not resolved_tools:
+        return False
+    # A tool registered under an unchecked server's canonical toolset proves
+    # exposure even when the name chain is opaque (direct tools list).
+    unchecked_toolset_ids = unchecked_canonical
+    try:
+        tool_to_ts = _tool_registry.get_tool_to_toolset_map()
+    except Exception:
+        return True
+    for tool_name in resolved_tools:
+        ts = tool_to_ts.get(tool_name)
+        if ts and ts in unchecked_toolset_ids:
+            return True
+    return False
+
+
 def _run_agent_streaming(
     session_id,
     msg_text,
@@ -9437,7 +9982,23 @@ def _run_agent_streaming(
             _toolsets = _resolve_cli_toolsets(_cfg)
 
             # Per-session toolset override (#493): if the session has
-            # enabled_toolsets set, use that instead of the global config.
+            # enabled_toolsets set, apply it on top of the profile defaults.
+            #
+            # The per-session toolset picker lets users tick configured MCP
+            # servers for the current chat. Those checkboxes emit the bare MCP
+            # server name (e.g. "my-search"). Previously ANY override value
+            # *replaced* the profile defaults wholesale, so ticking a single MCP
+            # server dropped every built-in toolset (web, file, terminal,
+            # delegation, …). The agent then received a toolset the registry had
+            # no matching tools for (MCP tools register under "mcp-<server>"),
+            # leaving the model with an empty tool list and a broken session.
+            #
+            # Fix: treat an override that is composed *only* of configured MCP
+            # server names as an ADDITION to the profile defaults (the "enable
+            # this server for this chat" intent the checkbox UI implies). An
+            # override that names any non-MCP toolset keeps the original
+            # RESTRICT semantics (the power-user free-text "limit to these
+            # toolsets" use case).
             try:
                 from api.models import Session, SESSION_DIR
                 _session_path = SESSION_DIR / f"{session_id}.json"
@@ -9450,8 +10011,25 @@ def _run_agent_streaming(
                     # getattr() to read the attribute correctly.
                     # (Opus pre-release advisor finding for v0.50.257.)
                     _override = getattr(_session_meta, 'enabled_toolsets', None) if _session_meta else None
-                    if _override:
-                        _toolsets = _override
+                    # Distinguish absence (None = no override, keep defaults)
+                    # from invalid persisted state (scalar, dict, …) which
+                    # _apply_session_toolset_override will handle fail-closed.
+                    if _override is not None:
+                        try:
+                            _mcp_server_names = set(
+                                (_cfg.get('mcp_servers') or {}).keys()
+                            )
+                        except Exception:
+                            _mcp_server_names = set()
+                        # Additive when the override names only configured MCP
+                        # servers (composer picker tick); restrict otherwise.
+                        # Names colliding with a builtin toolset are excluded
+                        # from the MCP-only test so a server named e.g. "web"
+                        # can't silently flip the override into additive mode
+                        # and get shadowed by the builtin.
+                        _toolsets = _apply_session_toolset_override(
+                            _toolsets, _override, _mcp_server_names
+                        )
             except Exception as _ts_err:
                 print(f"[webui] WARNING: failed to read per-session toolsets for {session_id}: {_ts_err}", flush=True)
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8330,13 +8330,48 @@ def _derive_session_toolset_authority(cfg, session_id):
         if _session_path.exists():
             _session_meta = Session.load_metadata_only(session_id)
             _override = getattr(_session_meta, 'enabled_toolsets', None) if _session_meta else None
-            if _override is not None:
+            # Round-24 re-gate fix: the guard must treat BOTH `None` and `[]`
+            # as the documented NO-OVERRIDE state (`_apply_session_toolset_override`
+            # docstring: "Only None and [] (the existing no-override contract) may
+            # preserve defaults").  Under `is not None`, `[]` entered the block
+            # and stamped `_applied=True`, driving the construction transaction
+            # into the fail-closed empty-tool path — a session that never ticked
+            # the picker would boot an agent with ZERO tools (gate-certified
+            # regression vs master's `if _override:`).
+            #
+            # A plain truthy guard (`if _override:`) is ALSO wrong: a falsy
+            # SCALAR like `0` is invalid persisted state (Round-13 review
+            # finding #1) and must fail closed via the helper — not be skipped
+            # as if it were no-override.  Only None/[] skip; every other value
+            # (scalars, malformed dicts, non-empty lists) enters the block so
+            # `_apply_session_toolset_override` can fail closed on it.
+            if _override is not None and _override != []:
+                # Round-24 gate fix: the MCP restriction boundary MUST come
+                # from the same authoritative source the CLI resolver uses —
+                # enabled_mcp_server_names(cfg) = native config servers
+                # honoring the `enabled` flag PLUS enabled portable-plugin
+                # MCP servers.  The previous native-only boundary
+                # (cfg['mcp_servers'] keys) missed portable servers, so an
+                # unselected portable server survived the additive merge as
+                # if it were a builtin (gate-certified leak: a session that
+                # ticks only native `alpha` still got `mcp-portable`'s
+                # tools).
                 try:
+                    from hermes_cli.tools_config import enabled_mcp_server_names
+                    _mcp_server_names = set(enabled_mcp_server_names(cfg))
+                except ImportError:
+                    # CI compatibility: hermes_cli is not installed in the
+                    # WebUI CI test environment (hermes-agent runtime is a
+                    # separate package).  Fall back to native config servers
+                    # only; portable servers are only relevant when
+                    # hermes_cli IS present (the production deployment).
+                    # Master already excludes portable servers by wholesale
+                    # replace, so this fallback is safe — it matches
+                    # pre-Round-23 behavior in environments without
+                    # hermes_cli.
                     _mcp_server_names = set(
                         (cfg.get('mcp_servers') or {}).keys()
                     )
-                except Exception:
-                    _mcp_server_names = set()
                 _gen_slot = []
                 _toolsets = _apply_session_toolset_override(
                     _toolsets, _override, _mcp_server_names,
@@ -8345,7 +8380,17 @@ def _derive_session_toolset_authority(cfg, session_id):
                 _gen = _gen_slot[0] if _gen_slot else None
                 _applied = True
     except Exception:
-        pass
+        # Round-24 SHOULD-FIX: when a session override exists but cannot be
+        # resolved (metadata read failure, corrupt session file, …), fail
+        # CLOSED (applied=True, empty toolset) instead of silently reverting
+        # to the broad profile defaults — and restore the warning log master
+        # emits on this path (the silent `pass` made the fail-open silent).
+        logger.warning(
+            "Failed to resolve toolset override for session %s; "
+            "failing closed", session_id,
+            exc_info=True,
+        )
+        return [], None, True
     return _toolsets, _gen, _applied
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8292,6 +8292,44 @@ def _canonicalize_override_targets(override, mcp_server_names):
     return out
 
 
+def _profile_authorizes_mcp_selector(name, defaults):
+    """Return True only when an exact restrictive ``mcp-*`` selector is
+    provably part of the CURRENT profile's authority.
+
+    Round-20 gate finding: the previous admission test — a successful alias
+    lookup with no alias edge — is INVENTORY information, not OWNERSHIP.
+    In production ``builtin_names`` is the process-global registry
+    inventory, so an alias-less ``mcp-<server>`` canonical registered by
+    ANOTHER profile sits in the shadow set, resolves nothing through the
+    alias table, and was admitted as if it were a static/plugin toolset —
+    making its tools callable under this profile.
+
+    Authority comes only from the profile's OWN configuration:
+
+      * an explicit profile default for this request (a current-profile
+        enabled plugin / static toolset explicitly authorized here), or
+      * an authored immutable builtin definition (``toolsets.TOOLSETS``
+        key).
+
+    Registry membership never authorizes.  Returns False (fail closed)
+    when authorization cannot be established.
+    """
+    if not isinstance(name, str) or not name:
+        return False
+    if not isinstance(defaults, (list, tuple, set)):
+        return False  # cannot establish authorization → fail closed
+    _explicit = {
+        d for d in defaults
+        if isinstance(d, str) and d not in {"all", "*"}
+    }
+    if name in _explicit:
+        return True
+    _authored = _authored_builtin_toolset_names()
+    if _authored is None:
+        return False  # cannot establish authorization → fail closed
+    return name in _authored
+
+
 def _apply_session_toolset_override(defaults, override, mcp_server_names,
                                     builtin_names=None):
     """Resolve a per-session ``enabled_toolsets`` override against the profile
@@ -8703,9 +8741,20 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
                 # Has alias edge = foreign MCP canonical from another profile
                 # Drop it - fail closed
                 continue
-            # Successful lookup with NO alias edge = static/plugin toolset
-            # with mcp- prefix.  Allow it to pass through — and stop here so
-            # the unconditional append below cannot emit it a second time
+            # Successful lookup with NO alias edge is INVENTORY information,
+            # not OWNERSHIP (Round-20 gate finding): the process-global
+            # registry may hold alias-less `mcp-<server>` canonicals
+            # registered by OTHER profiles — an alias-less entry resolves
+            # nothing through the alias table, yet emitting it makes its
+            # tools callable under this profile.  Admit the selector ONLY
+            # from the current profile's authority snapshot: an authored
+            # immutable builtin (`toolsets.TOOLSETS` definition) or an
+            # explicit profile default for this request.  Unknown or
+            # foreign provenance fails closed (dropped).
+            if not _profile_authorizes_mcp_selector(name, defaults):
+                continue
+            # Authorized: pass through exactly once — stop here so the
+            # unconditional append below cannot emit it a second time
             # (Round-19 gate finding: duplicate selector in the result).
             safe_override.append(name)
             continue

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8062,7 +8062,33 @@ def _builtin_toolset_names():
     return names
 
 
-def _profile_owned_static_toolsets(builtin_names, mcp_server_names):
+def _authored_builtin_toolset_names():
+    """Return the AUTHORED static builtin toolset names (``toolsets.TOOLSETS``
+    keys) — the immutable builtins a profile context is allowed to expose.
+
+    This is the *authorization* source for wildcard expansion.  Only toolsets
+    that are authored definitions (static builtins + current-process custom
+    toolsets) count as profile-owned static toolsets.  Process-global
+    REGISTRY names — registered MCP canonicals, foreign plugin toolsets —
+    are NEVER included: registry membership is not profile ownership
+    (Round-18 finding 1).  An alias-less foreign ``mcp-foreign`` entry or a
+    foreign non-MCP plugin registered in the shared registry must never
+    enter a wildcard expansion for another profile.
+
+    Returns ``None`` when ``toolsets`` is unavailable (fail closed — an
+    unknown builtin universe cannot prove what is profile-owned).
+    """
+    try:
+        import toolsets as _ts
+        _defs = getattr(_ts, "TOOLSETS", None)
+        if not isinstance(_defs, dict):
+            return None
+        return {str(k) for k in _defs.keys()} - {"all", "*"}
+    except Exception:
+        return None
+
+
+def _profile_owned_static_toolsets(defaults, mcp_server_names, builtin_names=None):
     """Return the set of static/builtin/plugin toolsets that are AUTHORIZED
     for the current profile context.
 
@@ -8070,69 +8096,56 @@ def _profile_owned_static_toolsets(builtin_names, mcp_server_names):
     registry) from AUTHORIZATION (which toolsets belong to the current profile
     and are safe to expose).
 
-    The process-global registry includes:
-      - Static builtin toolsets (web, file, terminal, etc.)
-      - Plugin toolsets registered by the current profile
-      - Canonical names for MCP servers from ALL profiles (mcp-* entries)
+    AUTHORIZATION is derived from the profile's OWN configuration, never from
+    the process-global registry inventory:
 
-    For capability isolation, we must distinguish:
-      - Owned canonicals: mcp-<server> where <server> is configured in the
-        current profile (these are the server's own registry identity, not
-        static/plugin shadows) - EXCLUDED (will be added via explicit MCP selection)
-      - Foreign MCP canonicals: mcp-<server> where <server> is NOT configured
-        but HAS an alias edge to a server - EXCLUDED (belongs to other profile)
-      - Static/plugin mcp-* toolsets: names starting with mcp- but have NO
-        alias edge to any MCP server - INCLUDED (these are genuine static/plugin
-        toolsets that merely share the prefix)
+      - explicit non-MCP, non-wildcard entries in ``defaults`` (the profile's
+        resolved platform toolset list — ``_resolve_cli_toolsets(cfg)``)
+        are profile-authorized static/plugin toolsets;
+      - when ``defaults`` carries a wildcard (``all``/``*`` — "everything in
+        my profile context"), the expansion universe is the authored builtin
+        set: ``builtin_names`` when the caller supplies a profile-scoped set
+        (tests / callers with a config-derived list), else
+        ``_authored_builtin_toolset_names()`` (static ``TOOLSETS`` keys).
+        Process-global registered names are never consulted.
 
-    Returns None when builtin_names is None (registry unavailable) -
-    cannot determine authorization without the inventory.
+    Foreign MCP canonicals (``mcp-<server>`` for servers configured in OTHER
+    profiles) and foreign non-MCP plugins are excluded by construction:
+    they are neither explicit ``defaults`` entries nor authored builtin
+    definitions.
 
-    Round-18 gate fix: separates inventory from authorization to prevent
-    wildcard defaults and free-text wildcards from exposing foreign MCP tools.
+    Returns a ``frozenset`` of authorized static/plugin toolset names, or
+    ``None`` when authorization cannot be established (registry/toolsets
+    unavailable AND no caller-supplied set) — fail closed.
     """
-    if builtin_names is None:
+    if not isinstance(defaults, (list, tuple, set)):
         return None
-    if not isinstance(builtin_names, (set, list, tuple)):
-        return None
-    if mcp_server_names is None:
-        mcp_server_names = set()
-    elif not isinstance(mcp_server_names, (set, list, tuple)):
-        return None
-    else:
-        mcp_server_names = set(mcp_server_names)
+    _wildcards = {"all", "*"}
+    mcp_refs = set(mcp_server_names) if isinstance(mcp_server_names, (set, list, tuple)) else set()
+    mcp_refs |= {f"mcp-{s}" for s in mcp_refs if isinstance(s, str)}
 
-    # Start with the full inventory
-    profile_owned = set(builtin_names) if not isinstance(builtin_names, set) else builtin_names.copy()
+    # Explicit non-MCP, non-wildcard defaults entries are profile-authorized.
+    owned = {
+        d for d in defaults
+        if isinstance(d, str) and d not in _wildcards and d not in mcp_refs
+    }
 
-    # Exclude owned canonicals (current profile's MCP servers' registry names)
-    # These are NOT static/plugin shadows - they ARE the MCP server itself
-    owned_canonicals = set()
-    for _srv in mcp_server_names:
-        _t = _registry_alias_target(_srv)
-        if _t == f"mcp-{_srv}":  # exact match required for ownership proof
-            owned_canonicals.add(_t)
+    # Wildcard present → expand from the authored builtin universe only.
+    if any(isinstance(d, str) and d in _wildcards for d in defaults):
+        if builtin_names is not None:
+            if not isinstance(builtin_names, (set, list, tuple)):
+                return None
+            owned |= {
+                b for b in builtin_names
+                if isinstance(b, str) and b not in _wildcards and b not in mcp_refs
+            }
+        else:
+            _authored = _authored_builtin_toolset_names()
+            if _authored is None:
+                return None  # cannot establish authorization → fail closed
+            owned |= _authored
 
-    # For each mcp-* entry, determine if it's:
-    # 1. Owned canonical (current profile's MCP) -> EXCLUDE (handled via explicit selection)
-    # 2. Foreign MCP canonical (has alias edge but not our server) -> EXCLUDE
-    # 3. Static/plugin toolset (no alias edge) -> INCLUDE
-    for _name in list(profile_owned):
-        if _name.startswith('mcp-'):
-            if _name in owned_canonicals:
-                # Owned by current profile - exclude, will be added via MCP selection
-                profile_owned.discard(_name)
-            else:
-                # Check if it has an alias edge to any server
-                _srv_name = _name[4:]  # strip 'mcp-' prefix
-                _alias_target = _registry_alias_target(_srv_name)
-                if _alias_target == _name:
-                    # Has alias edge = MCP server canonical (foreign)
-                    # EXCLUDE - belongs to other profile
-                    profile_owned.discard(_name)
-                # else: no alias edge = static/plugin toolset -> INCLUDE
-
-    return profile_owned
+    return frozenset(owned)
 
 
 
@@ -8185,9 +8198,57 @@ def _canonicalize_picker_mcp_selection(name, mcp_server_names):
     return None
 
 
+# Sentinel: an alias lookup FAILED (registry unavailable / raised).  This is
+# distinct from ``None`` — a successful lookup with no alias.  Treating a
+# failed lookup as "no alias edge" would let an unavailable authority prove
+# that an ``mcp-*`` name is a static/plugin toolset (fail-open), which the
+# Round-18 gate certified: ``_registry_alias_target()`` collapsed failures
+# to ``None`` and the caller inferred "static/plugin" from it.  Callers must
+# fail closed on this sentinel.
+_ALIAS_LOOKUP_UNKNOWN = object()
+
+
+def _registry_generation():
+    """Return the live registry's generation counter, or ``None`` when the
+    registry is unavailable or does not expose a generation.
+
+    The generation is bumped by the registry on every mutation (register /
+    deregister / alias registration / MCP refresh).  A profile-scoped
+    authorization decision must fail closed when the registry mutates
+    mid-decision: the authority snapshot it consulted may already be stale
+    (Round-19 gate finding — "generation movement must fail closed").
+    """
+    try:
+        from tools.registry import registry as _reg
+        return getattr(_reg, "_generation", None)
+    except Exception:
+        return None
+
+
+def _registry_generation_changed(gen_at_entry):
+    """Return True when the registry mutated since *gen_at_entry*.
+
+    ``None`` (no registry / no generation tracking) means there is no
+    authority to go stale — return False so existing tests and
+    registry-less environments are unaffected.  A moved generation (or a
+    registry that became unavailable mid-decision) returns True → caller
+    fails closed.
+    """
+    if gen_at_entry is None:
+        return False
+    return _registry_generation() != gen_at_entry
+
+
 def _registry_alias_target(name):
-    """Return the alias target for *name* from the live registry, or ``None``
-    when the registry is unavailable (cannot prove ownership → fail closed).
+    """Return the alias target for *name* from the live registry.
+
+    Returns:
+      - ``str`` — the alias target (``get_toolset_alias_target`` resolved),
+      - ``None`` — the lookup SUCCEEDED but *name* has no alias edge,
+      - ``_ALIAS_LOOKUP_UNKNOWN`` — the lookup FAILED (registry unavailable
+        or raised).  This is an "I don't know" signal, distinct from a
+        genuine no-alias result: an unavailable authority cannot prove that
+        an ``mcp-*`` name is a static/plugin toolset.
 
     Used to distinguish a registered canonical that is OWNED by a configured
     MCP server (``get_toolset_alias_target`` resolves it) from a genuine
@@ -8199,7 +8260,7 @@ def _registry_alias_target(name):
         from tools.registry import registry as _reg
         return _reg.get_toolset_alias_target(name)
     except Exception:
-        return None
+        return _ALIAS_LOOKUP_UNKNOWN
 
 
 def _canonicalize_override_targets(override, mcp_server_names):
@@ -8305,6 +8366,15 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
     if override is None or override == []:
         return list(defaults)
 
+    # Round-19 gate fix: capture the registry generation at entry.  Every
+    # alias/ownership decision below consults the live registry; if the
+    # registry mutates mid-decision (a server registers, an alias moves),
+    # the authorization snapshot we reasoned from is stale and the result
+    # must fail closed (Round-18 finding: "generation movement must fail
+    # closed").  The check is a no-op when the registry is unavailable or
+    # does not expose a generation.
+    _gen_at_entry = _registry_generation()
+
     # Any non-list value (scalar, dict, set, …) is invalid persisted state.
     # Fail closed to restrictive — never let the caller's broad except restore
     # all defaults.
@@ -8334,6 +8404,29 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
         return []  # cannot safely classify → fully restrictive
     mcp_server_names = set(_mcp_names_raw)
 
+    # Distinguish the two roles of ``builtin_names``:
+    #
+    #   * SHADOW / COLLISION role — ``_builtin_toolset_names()`` unions the
+    #     static ``TOOLSETS`` keys with every name registered in the
+    #     process-global registry.  This is the correct source for deciding
+    #     whether a name is shadowed by a builtin/plugin at resolution time
+    #     (additive-vs-restrict classification, ``mcp_strip``, composite
+    #     walk).  It is INVENTORY, not authorization.
+    #
+    #   * AUTHORIZATION role — what a wildcard may expand to.  This must
+    #     come from the profile's OWN configuration, never from the
+    #     process-global registry inventory.  Round-18 gate finding: the
+    #     previous code fed the registry inventory into the authorization
+    #     set, so an alias-less foreign ``mcp-foreign`` entry and a foreign
+    #     non-MCP plugin remained "profile owned" and their tools became
+    #     callable through both wildcard lanes.
+    #
+    # A caller-provided ``builtin_names`` argument (tests / callers with a
+    # config-derived list) is treated as the profile-scoped authorization
+    # set; when absent, ``_profile_owned_static_toolsets`` falls back to
+    # the authored builtin definitions (``toolsets.TOOLSETS`` keys) — never
+    # to the registry inventory.
+    _caller_builtin_names = builtin_names
     if builtin_names is None:
         builtin_names = _builtin_toolset_names()
     # ``None`` here means the builtin registry could not be resolved → we do not
@@ -8427,13 +8520,29 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             # Round-18 gate fix: wildcard defaults MUST go through the full
             # check chain (mcp_strip, composite check) rather than early return.
             # Replace wildcards with profile-owned static toolsets, then continue.
-            profile_owned = _profile_owned_static_toolsets(builtin_names, mcp_server_names)
+            #
+            # Round-19 gate fix: authorization is derived from the PROFILE's
+            # own configuration (explicit `defaults` entries + authored
+            # builtin definitions), NEVER from the process-global registry
+            # inventory.  The previous implementation started from every
+            # registered toolset name and removed only some mcp-* entries,
+            # so an alias-less foreign `mcp-foreign` or a foreign non-MCP
+            # plugin remained "profile owned" and leaked through wildcard
+            # expansion (gate-certified: real resolver made their tools
+            # callable under the current profile).  `_caller_builtin_names`
+            # is the caller-provided profile-scoped authorization set (or
+            # None → authored TOOLSETS keys); the registry-derived
+            # `builtin_names` shadow is used ONLY for collision detection.
+            profile_owned = _profile_owned_static_toolsets(
+                defaults, mcp_server_names, _caller_builtin_names)
             if profile_owned is None:
                 # Cannot determine profile authorization → fail closed
                 return []
-            # Replace wildcards in defaults with profile-owned toolsets
-            # These will go through the same mcp_strip and composite checks below
-            defaults = [d for d in defaults if d not in _wildcards] + list(profile_owned)
+            # Replace wildcards in defaults with profile-owned toolsets.
+            # These will go through the same mcp_strip and composite checks
+            # below.  Sorted for a stable, deterministic output order
+            # (Round-19 gate requirement: exact output order/count).
+            defaults = [d for d in defaults if d not in _wildcards] + sorted(profile_owned)
         # A default entry that is a *composite* toolset (one whose
         # ``includes`` transitively references an MCP-server toolset)
         # would survive the name-level filter but re-expose the
@@ -8490,6 +8599,12 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             if name not in seen:
                 merged.append(name)
                 seen.add(name)
+        # Round-19 gate fix: if the registry mutated while we were deciding
+        # (a server registered, an alias moved), the ownership proofs above
+        # are stale — fail closed rather than return a result reasoned from
+        # an outdated authority snapshot.
+        if _registry_generation_changed(_gen_at_entry):
+            return []
         return merged
     # Restrict branch: power-user free-text override.  Names here are
     # literal toolset selections (a bare "all"/"*" is the user's explicit
@@ -8528,7 +8643,17 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             # The process-global registry contains foreign MCP canonicals from
             # other profiles; true_shadow includes them and would expose them.
             # Use profile_owned to exclude foreign MCP tools.
-            _profile_owned = _profile_owned_static_toolsets(builtin_names, mcp_server_names)
+            #
+            # Round-19 gate fix: profile ownership is derived from the
+            # profile's OWN configuration (explicit `defaults` entries +
+            # authored builtin definitions), never from the process-global
+            # registry inventory — an alias-less foreign `mcp-foreign` or a
+            # foreign non-MCP plugin must not survive the expansion.
+            # `_caller_builtin_names` is the profile-scoped authorization
+            # set (or None → authored TOOLSETS keys); the registry-derived
+            # `builtin_names` shadow is used ONLY for collision detection.
+            _profile_owned = _profile_owned_static_toolsets(
+                defaults, mcp_server_names, _caller_builtin_names)
             if _profile_owned is None:
                 # Cannot determine profile authorization → drop wildcard
                 continue
@@ -8562,16 +8687,34 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             # the canonical of one must be checked for static/plugin provenance.
             # If it has an alias edge matching itself, it's a foreign MCP canonical.
             # If no alias edge, it's a static/plugin toolset (e.g. mcp-custom-probe).
+            #
+            # Round-19 gate fix: an alias LOOKUP FAILURE (registry unavailable
+            # / raised) must NOT be treated as "no alias edge = static/plugin".
+            # The previous implementation collapsed the failure to None and
+            # the caller inferred static/plugin provenance from it — an
+            # unavailable authority fails OPEN (gate-certified).  A failed
+            # lookup cannot prove anything, so the selector is dropped
+            # (fail closed).
             _alias_target = _registry_alias_target(_srv_name)
+            if _alias_target is _ALIAS_LOOKUP_UNKNOWN:
+                # Alias lookup FAILED → provenance unprovable → drop
+                continue
             if _alias_target == name:
                 # Has alias edge = foreign MCP canonical from another profile
                 # Drop it - fail closed
                 continue
-            # No alias edge = static/plugin toolset with mcp- prefix
-            # Allow it to pass through
+            # Successful lookup with NO alias edge = static/plugin toolset
+            # with mcp- prefix.  Allow it to pass through — and stop here so
+            # the unconditional append below cannot emit it a second time
+            # (Round-19 gate finding: duplicate selector in the result).
             safe_override.append(name)
+            continue
         # Bare name or non-mcp-* selector: pass through unchanged
         safe_override.append(name)
+    # Round-19 gate fix: registry mutated mid-decision → the alias/ownership
+    # proofs above are stale → fail closed.
+    if _registry_generation_changed(_gen_at_entry):
+        return []
     return safe_override
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8062,20 +8062,48 @@ def _builtin_toolset_names():
     return names
 
 
-# Round-21 gate fix: ``toolsets.TOOLSETS`` is a RUNTIME-MUTABLE process-global
+# Round-22 gate fix: ``toolsets.TOOLSETS`` is a RUNTIME-MUTABLE process-global
 # dict — ``create_custom_toolset()`` inserts into it at runtime (e.g. from
 # another profile's agent session).  Live keys are therefore NOT proof of
-# current-profile or immutable ownership.  The authored-builtin universe is
-# captured ONCE per process (first successful import) and frozen; later
-# ``create_custom_toolset()`` mutations never re-authorize.  ``None`` means
-# the registry could not be established at all (fail closed).
-_AUTHORED_TOOLSETS_SNAPSHOT = None  # frozenset[str] | None
+# current-profile or immutable ownership.
+#
+# The authored-builtin universe is captured EAGERLY at module import time
+# (when ``api.streaming`` is first loaded into the process), BEFORE any
+# runtime ``create_custom_toolset()`` can contaminate it.  Round-21 used a
+# lazy snapshot (captured on first authorization call); Round-22 gate finding
+# 1 proved that if another profile's ``create_custom_toolset("mcp-foreign")``
+# runs before this helper's first call, the lazy snapshot freezes the
+# contaminated dict — admitting ``mcp-foreign`` as "authored."  An eager
+# capture at import time is the only ordering that is provably before any
+# runtime mutation, because the WebUI's streaming module is imported during
+# server startup, before any agent session creates custom toolsets.
+#
+# ``None`` means the registry could not be established at all (fail closed).
+def _capture_authored_builtin_snapshot():
+    """Capture the authored builtin toolset names EAGERLY at module import.
+
+    Returns a ``frozenset[str]`` of static ``toolsets.TOOLSETS`` keys (minus
+    wildcards ``all``/``*``), or ``None`` when ``toolsets`` is unavailable.
+    """
+    try:
+        import toolsets as _ts
+        _defs = getattr(_ts, "TOOLSETS", None)
+        if not isinstance(_defs, dict):
+            return None
+        return frozenset(
+            str(k) for k in _defs.keys()
+        ) - frozenset({"all", "*"})
+    except Exception:
+        return None
+
+
+_AUTHORED_TOOLSETS_SNAPSHOT = _capture_authored_builtin_snapshot()
 
 
 def _authored_builtin_toolset_names():
     """Return the FROZEN authored builtin toolset names (``toolsets.TOOLSETS``
-    keys captured once) — the immutable builtins a profile context is allowed
-    to expose.
+    keys captured eagerly at module import) — the immutable builtins a profile
+    context is allowed to expose.
 
     This is the *authorization* source for wildcard expansion and restrictive
     exact-selector admission.  Only toolsets that are authored definitions
@@ -8084,33 +8112,25 @@ def _authored_builtin_toolset_names():
     NEVER included: registry membership is not profile ownership
     (Round-18 finding 1).
 
-    Round-21 gate fix: the snapshot is captured ONCE at first successful
-    import and frozen.  Previously this helper re-read the live
-    ``toolsets.TOOLSETS`` dict on every call; ``create_custom_toolset()``
-    mutates that same process-global dict at runtime, so a custom or foreign
-    ``mcp-*`` toolset inserted by ANOTHER profile appeared in the
-    "authored" set and was accepted by ``_profile_authorizes_mcp_selector()``
-    and both wildcard lanes — a cross-profile capability over-grant through a
-    mutable global inventory.  The frozen snapshot never contains runtime
-    custom toolsets.
+    Round-22 gate fix: the snapshot is captured EAGERLY at module import
+    time (when ``api.streaming`` is first loaded), not lazily on first
+    authorization call.  The Round-21 lazy snapshot could freeze an
+    already-contaminated ``toolsets.TOOLSETS`` dict if another profile's
+    ``create_custom_toolset()`` ran before this helper's first call —
+    admitting a foreign runtime toolset as "authored."  An eager capture at
+    import time is provably before any runtime mutation.  If the initial
+    eager capture failed (``toolsets`` was not yet importable at module
+    load), this function returns ``None`` — it NEVER re-captures, because
+    a later capture cannot prove it is pristine (a ``create_custom_toolset``
+    may have contaminated the dict between import and the first call).
+    Tests may directly set ``_AUTHORED_TOOLSETS_SNAPSHOT`` to a captured
+    value via ``_capture_authored_builtin_snapshot()`` to exercise the
+    authorization paths with a stand-in ``TOOLSETS``.
 
     Returns ``None`` when ``toolsets`` is unavailable (fail closed — an
     unknown builtin universe cannot prove what is profile-owned).
     """
-    global _AUTHORED_TOOLSETS_SNAPSHOT
-    if _AUTHORED_TOOLSETS_SNAPSHOT is not None:
-        return _AUTHORED_TOOLSETS_SNAPSHOT
-    try:
-        import toolsets as _ts
-        _defs = getattr(_ts, "TOOLSETS", None)
-        if not isinstance(_defs, dict):
-            return None
-        _AUTHORED_TOOLSETS_SNAPSHOT = frozenset(
-            str(k) for k in _defs.keys()
-        ) - frozenset({"all", "*"})
-        return _AUTHORED_TOOLSETS_SNAPSHOT
-    except Exception:
-        return None
+    return _AUTHORED_TOOLSETS_SNAPSHOT
 
 
 def _profile_owned_static_toolsets(defaults, mcp_server_names, builtin_names=None):
@@ -10340,6 +10360,11 @@ def _run_agent_streaming(
             # applied (no re-validation needed) or the registry lacks a
             # generation counter.
             _toolsets_gen = None
+            # Round-22 gate fix: track whether an override was actually applied
+            # (vs. preserved defaults).  When an override WAS applied but the
+            # generation is None (no registry / no generation counter), we
+            # cannot prove the authority is stable → fail closed.
+            _override_applied = False
 
             # Per-session toolset override (#493): if the session has
             # enabled_toolsets set, apply it on top of the profile defaults.
@@ -10401,6 +10426,7 @@ def _run_agent_streaming(
                             _gen_slot=_gen_slot
                         )
                         _toolsets_gen = _gen_slot[0] if _gen_slot else None
+                        _override_applied = True
             except Exception as _ts_err:
                 print(f"[webui] WARNING: failed to read per-session toolsets for {session_id}: {_ts_err}", flush=True)
 
@@ -10515,16 +10541,33 @@ def _run_agent_streaming(
             except Exception:
                 _reasoning_config = None
 
-            # Round-21 gate fix: the per-session override resolved against an
-            # authority snapshot at generation `_toolsets_gen`.  Re-validate
-            # that generation at FINAL tool resolution (AIAgent construction):
-            # if the registry mutated between the helper return and here (a
-            # server registered, an alias moved), the toolsets handed to the
-            # Agent were reasoned from a stale authority — fail closed to an
-            # empty toolset list rather than resolve tools that were never
-            # authorized for this session.  None (no override / no generation
-            # counter) means there is no authority to go stale.
+            # Round-22 gate fix: the per-session override resolved against an
+            # authority snapshot at generation ``_toolsets_gen``.  Re-validate
+            # that generation IMMEDIATELY before AIAgent construction (both the
+            # ephemeral and cache-miss paths) AND immediately after, so a
+            # registry mutation between the helper return and construction —
+            # or during construction itself — is caught and the toolsets are
+            # blanked (fail closed) rather than resolved from a stale
+            # authority.
+            #
+            # Round-22 gate finding 2: the Round-21 check ran ONCE before
+            # building _agent_kwargs but before _AIAgent(...) construction.
+            # A registry mutation between the check and the constructor was
+            # not caught.  Also, a ``None`` generation (registry unavailable
+            # / no generation counter) was treated as "stable" — but when an
+            # override WAS applied, ``None`` means we cannot PROVE stability,
+            # so the override must fail closed to an empty toolset list.
+            #
+            # ``_toolsets_gen`` is ``None`` when NO override was applied (no
+            # re-validation needed — the profile defaults are config-derived,
+            # not registry-derived) or when the registry lacks a generation
+            # counter.  When an override WAS applied and the generation IS
+            # ``None``, we cannot prove the authority is stable → fail closed.
             if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
+                _toolsets = []
+            elif _toolsets_gen is None and _override_applied:
+                # Override was applied but we have no generation counter to
+                # prove stability → fail closed (empty toolsets).
                 _toolsets = []
 
             _agent_kwargs = dict(
@@ -10591,6 +10634,12 @@ def _run_agent_streaming(
             # injectionFrequency: "first-turn" actually suppresses after turn 1.
             if ephemeral:
                 agent = _AIAgent(**_agent_kwargs)
+                # Round-22 gate fix: re-validate generation IMMEDIATELY after
+                # construction — a registry mutation during the constructor's
+                # tool resolution must fail closed (blank toolsets), not run
+                # or cache tools that were never authorized.
+                if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
+                    agent.enabled_toolsets = []
                 logger.debug('[webui] Created ephemeral agent for session %s', session_id)
             else:
                 import hashlib as _hashlib
@@ -10723,6 +10772,12 @@ def _run_agent_streaming(
                         agent._interrupt_message = None
                 else:
                     agent = _AIAgent(**_agent_kwargs)
+                    # Round-22 gate fix: re-validate generation IMMEDIATELY after
+                    # construction — a registry mutation during the constructor's
+                    # tool resolution must fail closed (blank toolsets), not be
+                    # run or cached.
+                    if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
+                        agent.enabled_toolsets = []
                     # Register the new agent with the memory lifecycle so
                     # its commit_memory_session() can be found later.
                     try:
@@ -11432,6 +11487,10 @@ def _run_agent_streaming(
                             if 'credential_pool' in _agent_params:
                                 _agent_kwargs['credential_pool'] = _heal_rt.get('credential_pool')
                             agent = _AIAgent(**_agent_kwargs)
+                            # Round-22 gate fix: re-validate generation after
+                            # construction on the session-healing path too.
+                            if _toolsets_gen is not None and _registry_generation_changed(_toolsets_gen):
+                                agent.enabled_toolsets = []
                             with STREAMS_LOCK:
                                 AGENT_INSTANCES[stream_id] = agent
                             from api.config import SESSION_AGENT_CACHE as _SAC, SESSION_AGENT_CACHE_LOCK as _SAC_L

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8341,13 +8341,24 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
         # or entirely unconfigured — servers' tools (gate-certified SILENT
         # over-grant: with ``alpha`` selected, an unconfigured
         # ``mcp-foreign`` tool became callable).  Never retain a wildcard
-        # profile default during an additive session override — return the
-        # verified explicit ``override_targets`` whenever ``defaults``
-        # contains ``all`` or ``*``, regardless of whether ``_unchecked``
-        # is empty.
+        # profile default during an additive session override.
+        #
+        # Round-17 fix: drop the wildcard but KEEP the builtin defaults.
+        # The additive merge contract requires builtins to survive even
+        # when a wildcard is present. Only the wildcard token itself is
+        # unsafe; the explicit builtin names are safe.
         _wildcards = {'all', '*'}
-        if any(_d in _wildcards for _d in defaults):
-            return list(override_targets)  # use verified canonical targets
+        _has_wildcard = any(_d in _wildcards for _d in defaults)
+        if _has_wildcard:
+            # Filter out wildcards, keep builtins, add override_targets
+            _safe_defaults = [d for d in defaults if d not in _wildcards]
+            merged = list(_safe_defaults)  # builtins/plugins survive
+            seen = set(merged)
+            for name in override_targets:
+                if name is not None and name not in seen:
+                    merged.append(name)
+                    seen.add(name)
+            return merged
         # A default entry that is a *composite* toolset (one whose
         # ``includes`` transitively references an MCP-server toolset)
         # would survive the name-level filter but re-expose the
@@ -8426,14 +8437,25 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             # resolver expands each to the full toolset (~94 tools).
             # Dropping it yields an explicit EMPTY allowlist — the user
             # asked for everything and got nothing (gate finding #2).
-            # Preserve the wildcard UNLESS it also collides with a
-            # configured same-named MCP server (a server literally named
-            # ``all``/``*``): then the bare token is ambiguous between the
-            # wildcard and the server's picker token, and only that
-            # genuinely-ambiguous case is dropped.
+            #
+            # Round-17 fix: the wildcard MUST NOT expose tools from
+            # unconfigured MCP servers. Expand the wildcard to explicit
+            # selectors and filter out foreign MCP toolsets.
+            # The resolver's `all` expands to ALL registered toolsets,
+            # including those from other profiles/sessions sharing the
+            # process-global registry. The security semantics require:
+            # "everything in my profile context" = all builtins/plugins +
+            # all configured MCP servers, NOT every random tool in the
+            # process-global registry.
             if name in mcp_server_names:
-                continue
-            safe_override.append(name)
+                continue  # collision with server named "all"/"*"
+            # Expand wildcard to all known safe toolsets:
+            # - All builtin/plugin toolsets (in true_shadow)
+            # - All configured MCP servers (via canonical mcp-<name>)
+            _expanded = set(true_shadow)  # builtins/plugins
+            for _srv in mcp_server_names:
+                _expanded.add(f"mcp-{_srv}")  # configured MCP servers
+            safe_override.extend(sorted(_expanded))
             continue
         if name.startswith('mcp-'):
             # Round-15 fix: if the FULL selector is itself a configured

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8332,20 +8332,22 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
             if _srv not in true_shadow:
                 mcp_strip.add(_srv)
             mcp_strip.add('mcp-' + _srv)
-        # Wildcards/composites in defaults (e.g. ``all``, ``*``)
-        # resolve to every registered toolset, including configured
-        # MCP servers the user did NOT tick.  If any configured MCP
-        # server is unchecked, we cannot safely expand the wildcard
-        # without leaking its tools — fail closed to restrictive
-        # session semantics.
-        # Round-14 fix: return verified canonical targets, not raw override.
-        # A configured server named "all" could have its selector changed
-        # from canonical back to raw wildcard if we return list(override).
-        _unchecked = mcp_server_names - set(override)
-        if _unchecked:
-            _wildcards = {'all', '*'}
-            if any(_d in _wildcards for _d in defaults):
-                return list(override_targets)  # use verified canonical targets
+        # Wildcards in defaults (``all`` / ``*``) resolve to EVERY
+        # registered toolset at resolution time — including registry
+        # entries from OUTSIDE the current config.  Even when every
+        # configured server is ticked (``_unchecked`` empty), the wildcard
+        # default survives the name-level filter and the resolver later
+        # expands it across the whole live registry, exposing unselected —
+        # or entirely unconfigured — servers' tools (gate-certified SILENT
+        # over-grant: with ``alpha`` selected, an unconfigured
+        # ``mcp-foreign`` tool became callable).  Never retain a wildcard
+        # profile default during an additive session override — return the
+        # verified explicit ``override_targets`` whenever ``defaults``
+        # contains ``all`` or ``*``, regardless of whether ``_unchecked``
+        # is empty.
+        _wildcards = {'all', '*'}
+        if any(_d in _wildcards for _d in defaults):
+            return list(override_targets)  # use verified canonical targets
         # A default entry that is a *composite* toolset (one whose
         # ``includes`` transitively references an MCP-server toolset)
         # would survive the name-level filter but re-expose the
@@ -8419,10 +8421,19 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
     safe_override = []
     for name in override:
         if name in {'all', '*'}:
-            # Wildcard: only safe if we can verify no unchecked MCP server
-            # would be included.  This requires registry access which we
-            # may not have.  Fail closed by dropping wildcards entirely
-            # in the restrict branch — the user can use explicit names.
+            # Free-text wildcard = the user's EXPLICIT "everything" intent.
+            # The UI and API both accept ``all``/``*`` and the installed
+            # resolver expands each to the full toolset (~94 tools).
+            # Dropping it yields an explicit EMPTY allowlist — the user
+            # asked for everything and got nothing (gate finding #2).
+            # Preserve the wildcard UNLESS it also collides with a
+            # configured same-named MCP server (a server literally named
+            # ``all``/``*``): then the bare token is ambiguous between the
+            # wildcard and the server's picker token, and only that
+            # genuinely-ambiguous case is dropped.
+            if name in mcp_server_names:
+                continue
+            safe_override.append(name)
             continue
         if name.startswith('mcp-'):
             # Round-15 fix: if the FULL selector is itself a configured
@@ -8443,7 +8454,17 @@ def _apply_session_toolset_override(defaults, override, mcp_server_names,
                 if _target == name:
                     safe_override.append(name)
                 # else: ownership unprovable → drop (fail closed)
-            # else: not a configured MCP server's canonical → drop
+                continue
+            # Round-16 fix: a name that is NEITHER a configured server's
+            # bare token NOR the canonical of one (``_srv_name`` not
+            # configured) is a genuine registered/static toolset that
+            # merely begins with ``mcp-`` (e.g. ``mcp-custom-probe``).
+            # Master passes such entries through; dropping them silently
+            # discards a valid toolset (gate finding #3).  Preserve it
+            # when proven present in the builtin shadow set, fail closed
+            # otherwise.
+            if name in true_shadow:
+                safe_override.append(name)
             continue
         # Bare name or non-mcp-* selector: pass through unchanged
         safe_override.append(name)

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -1,0 +1,2457 @@
+"""Per-session MCP toolset override must be ADDITIVE, not replace-all.
+
+Regression guard for the "ticking one MCP server in the per-session toolset
+picker breaks the whole chat" bug.
+
+The per-session toolset picker (composer chip) lets a user tick configured MCP
+servers for the current chat. Those checkboxes emit the bare MCP server name
+(e.g. "my-search"). The override was applied with a wholesale
+``_toolsets = _override``, so ticking a single MCP server dropped every built-in
+toolset (web, file, terminal, delegation, …) and left the model with an empty
+tool list — every tool call failed with ``Tool '...' does not exist. Available
+tools:`` (empty).
+
+Fix: an override composed *only* of configured MCP servers is merged on top of
+the profile defaults; an override that names any non-MCP toolset keeps the
+original restrict-to-these semantics (the power-user free-text use case). A name
+that is *both* an MCP server and a builtin toolset (collision, e.g. a server
+named ``web``) is excluded from the MCP-only test so it can't silently flip the
+override into additive mode and get shadowed by the builtin.
+
+These tests exercise the REAL helper used by the streaming worker
+(``api.streaming._apply_session_toolset_override``), not a copied reference, so
+the merge-vs-restrict decision is covered on the actual code path.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+import api.streaming as streaming
+from api.streaming import _apply_session_toolset_override as _apply_override
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+# ── CI stand-in for the Hermes agent runtime ────────────────────────────────
+# The additive branch of `_apply_session_toolset_override` consults
+# `_builtin_toolset_names()`, which `import toolsets` /
+# `from tools.registry import registry`.  Those
+# modules ship with the hermes-agent runtime, which is NOT installed in the
+# WebUI CI test environment — the import fails and the helper returns None,
+# which fail-closes the additive path into dropping every builtin toolset
+# ("web must survive" assertions break across all Python-version shards).
+#
+# Local dev machines pass only because hermes-agent happens to be on sys.path
+# (PYTHONPATH), so the real 59-toolset registry is imported.  Inject a
+# faithful stand-in here when the real module is absent so the tests exercise
+# the REAL production code path deterministically in CI too.  Shape mirrors
+# hermes-agent's toolsets.py: leaf specs have no non-empty ``includes``;
+# composites (e.g. "debugging") have ``includes`` and are NOT static leaves;
+# ``resolve_toolset`` expands a name to its tool list.
+import sys
+import types as _types
+
+# Sentinel for "attribute was absent" in the fixture's snapshot logic.
+_MISSING = object()
+
+
+# ── scoped registry stand-in ────────────────────────────────────────────────
+_mock_registry = _types.SimpleNamespace()
+_mock_registry._tools = {}
+_mock_registry._toolset_aliases = {}
+_mock_registry._snapshot_entries = lambda: list(_mock_registry._tools.values())
+
+
+def _mock_register(name, toolset, schema, handler, check_fn=None,
+                   requires_env=None, is_async=False, description="",
+                   emoji="", max_result_size_chars=None,
+                   dynamic_schema_overrides=None, override=False):
+    """Faithful stand-in for ``ToolRegistry.register``: cross-toolset
+    shadowing is rejected unless ``override=True`` (mirrors the real
+    registry's ownership rules)."""
+    existing = _mock_registry._tools.get(name)
+    if existing is not None and existing.toolset != toolset and not override:
+        return  # rejected shadow, like the real registry
+    entry = _types.SimpleNamespace(
+        name=name, toolset=toolset, schema=schema, handler=handler,
+        check_fn=check_fn, requires_env=requires_env or [],
+        is_async=is_async, description=description, emoji=emoji,
+        max_result_size_chars=max_result_size_chars,
+        dynamic_schema_overrides=dynamic_schema_overrides,
+    )
+    _mock_registry._tools[name] = entry
+
+
+def _mock_register_toolset_alias(alias, toolset):
+    _mock_registry._toolset_aliases[alias] = toolset
+
+
+def _mock_get_registered_toolset_names():
+    return sorted({e.toolset for e in _mock_registry._snapshot_entries()})
+
+
+def _mock_get_tool_names_for_toolset(toolset):
+    return sorted(e.name for e in _mock_registry._snapshot_entries()
+                  if e.toolset == toolset)
+
+
+def _mock_get_toolset_alias_target(alias):
+    return _mock_registry._toolset_aliases.get(alias)
+
+
+def _mock_get_tool_to_toolset_map():
+    return {e.name: e.toolset for e in _mock_registry._snapshot_entries()}
+
+
+def _mock_get_entry(name):
+    return _mock_registry._tools.get(name)
+
+
+_mock_registry.get_entry = _mock_get_entry
+_mock_registry.register = _mock_register
+_mock_registry.register_toolset_alias = _mock_register_toolset_alias
+_mock_registry.get_registered_toolset_names = _mock_get_registered_toolset_names
+_mock_registry.get_tool_names_for_toolset = _mock_get_tool_names_for_toolset
+_mock_registry.get_toolset_alias_target = _mock_get_toolset_alias_target
+_mock_registry.get_tool_to_toolset_map = _mock_get_tool_to_toolset_map
+
+# ── scoped agent-less stand-in fixture ───────────────────────────────────────
+# Round-8 review finding 2: the previous version installed `tools`,
+# `tools.registry`, and `toolsets` stand-ins at MODULE IMPORT time with no
+# fixture/context-manager teardown, so the fake modules stayed process-global
+# for the rest of the pytest shard (and the now-deleted `_prior_sys_modules`
+# snapshot was never consumed).  It also decided availability by membership
+# (`"tools" in sys.modules`), which treats an importable-but-not-yet-imported
+# real runtime as unavailable and shadows it with a fake.
+#
+# This autouse fixture:
+#   1. attempts the REAL imports first,
+#   2. injects stand-ins only on genuine import failure,
+#   3. snapshots the exact prior presence/object identity of the three module
+#      entries plus the parent package's `registry` attribute,
+#   4. restores/deletes ONLY what the fixture changed after `yield`,
+#   5. asserts (teardown) that no fake remains after scope exit.
+
+
+@pytest.fixture(autouse=True)
+def _agentless_runtime_standins():
+    """Install `tools` / `tools.registry` / `toolsets` stand-ins ONLY when the
+    real hermes-agent runtime cannot be imported, scoped to the current test,
+    and restore the exact prior state afterwards.
+
+    The additive branch of `_apply_session_toolset_override` consults
+    `_builtin_toolset_names()`, which does ``import toolsets`` /
+    ``from tools.registry import registry``.  Those modules ship with the
+    hermes-agent runtime, which is NOT installed in the WebUI CI test
+    environment — the import fails and the helper returns None, which
+    fail-closes the additive path into dropping every builtin toolset
+    ("web must survive" assertions would break on every CI shard).
+    """
+    # 1/2. Attempt real imports FIRST — only a genuine failure may inject.
+    try:
+        importlib.import_module("toolsets")
+        _real_toolsets = True
+    except Exception:
+        _real_toolsets = False
+    try:
+        importlib.import_module("tools.registry")
+        _real_registry = True
+    except Exception:
+        _real_registry = False
+
+    # 3. Snapshot prior presence/object identity of everything we may touch:
+    #    the three module entries plus the parent package's `registry` attr.
+    _tools_mod = sys.modules.get("tools")
+    _prior = {
+        "tools": sys.modules.get("tools"),
+        "tools.registry": sys.modules.get("tools.registry"),
+        "toolsets": sys.modules.get("toolsets"),
+        "tools.registry_attr": (
+            getattr(_tools_mod, "registry", _MISSING)
+            if _tools_mod is not None else _MISSING
+        ),
+    }
+    # (module_key, prior_value, injected_object) — injected_object recorded so
+    # the teardown assertion can prove the exact fake is gone.
+    _changed = []
+
+    try:
+        # 2. Inject ONLY on genuine import failure.
+        if not _real_toolsets and "toolsets" not in sys.modules:
+            sys.modules["toolsets"] = _mock_toolsets
+            _changed.append(("toolsets", _prior["toolsets"], _mock_toolsets))
+        if not _real_registry:
+            if "tools" not in sys.modules:
+                _tools_fake = _types.ModuleType("tools")
+                sys.modules["tools"] = _tools_fake
+                _changed.append(("tools", _prior["tools"], _tools_fake))
+            if "tools.registry" not in sys.modules:
+                _mock_registry_mod = _types.ModuleType("tools.registry")
+                _mock_registry_mod.registry = _mock_registry  # type: ignore[attr-defined]
+                sys.modules["tools.registry"] = _mock_registry_mod
+                _changed.append(("tools.registry", _prior["tools.registry"],
+                                 _mock_registry_mod))
+        yield
+    finally:
+        # 4. Restore/delete ONLY what this fixture changed.  Entries that
+        #    existed before (real or injected by somebody else) are untouched.
+        for _key, _prior_val, _injected_obj in reversed(_changed):
+            if _prior_val is None:
+                sys.modules.pop(_key, None)
+            else:
+                sys.modules[_key] = _prior_val
+        # If the parent package predated us, restore its registry attribute
+        # (we never set it, but restore defensively to the snapshot).
+        _parent = sys.modules.get("tools")
+        _prior_attr = _prior["tools.registry_attr"]
+        if _parent is not None:
+            if _prior_attr is not _MISSING:
+                _parent.registry = _prior_attr  # type: ignore[attr-defined]
+            elif hasattr(_parent, "registry") and _prior["tools"] is None:
+                # We created the parent; drop the attr we never set.
+                delattr(_parent, "registry")
+        # 5. Teardown assertion: no fake remains after scope exit.  Every
+        #    object this fixture injected must no longer be in sys.modules;
+        #    anything that was already there must still be there, unchanged.
+        for _key, _prior_val, _injected_obj in _changed:
+            _entry = sys.modules.get(_key)
+            assert _entry is not _injected_obj, (
+                f"stand-in fixture must remove injected {_key} after scope exit"
+            )
+            if _prior_val is not None:
+                assert _entry is _prior_val, (
+                    f"stand-in fixture must restore pre-existing {_key} unchanged"
+                )
+
+# ── scoped toolsets stand-in ────────────────────────────────────────────────
+_mock_toolsets = _types.ModuleType("toolsets")
+_mock_toolsets.TOOLSETS = {  # type: ignore[attr-defined]
+    "web": {"description": "web tools", "tools": ["web_search"], "includes": []},
+    "search": {"description": "search", "tools": ["search"], "includes": []},
+    "file": {"description": "file tools", "tools": ["read_file"], "includes": []},
+    "terminal": {"description": "terminal", "tools": ["terminal"], "includes": []},
+    "delegation": {"description": "delegation", "tools": ["delegate_task"], "includes": []},
+    "vision": {"description": "vision", "tools": ["vision_analyze"], "includes": []},
+    "computer_use": {"description": "computer use", "tools": ["computer_use"], "includes": []},
+    "debugging": {"description": "debugging toolkit", "tools": ["terminal"], "includes": ["web", "file"]},
+}
+
+
+def _get_registry_alias_target(name):  # type: ignore[no-untyped-def]
+    try:
+        from tools.registry import registry as _r
+        return _r.get_toolset_alias_target(name)
+    except Exception:
+        return None
+
+
+def _get_registry_tool_names(toolset):  # type: ignore[no-untyped-def]
+    try:
+        from tools.registry import registry as _r
+        return _r.get_tool_names_for_toolset(toolset)
+    except Exception:
+        return []
+
+
+def _get_toolset(name, *, include_registry=True):  # type: ignore[no-untyped-def]
+    """Mirror the real ``get_toolset``: static spec takes precedence and is
+    merged with registry tools registered under the exact static name.
+    Aliases are consulted only for non-static names.  This matches the
+    installed Agent's resolution order (static-first, alias-second) AND
+    its overlay contract (registry tools under a static name are merged)."""
+    spec = _mock_toolsets.TOOLSETS.get(name)  # type: ignore[attr-defined]
+    if not include_registry:
+        return spec
+    # Static-first + overlay: merge registry tools registered under the
+    # exact static name, exactly like the real ``get_toolset``.
+    if spec:
+        merged_tools = sorted(
+            set(spec.get("tools", []))
+            | set(_get_registry_tool_names(name))
+        )
+        return {"description": spec.get("description", ""),
+                "tools": merged_tools,
+                "includes": list(spec.get("includes", []))}
+    # Non-static: check alias, then registry tools under the resolved name.
+    alias_target = _get_registry_alias_target(name)
+    registry_toolset = alias_target or name
+    registered = _get_registry_tool_names(registry_toolset)
+    if registered:
+        return {"description": f"Plugin/MCP toolset: {name}",
+                "tools": registered, "includes": []}
+    return None
+
+
+def _resolve_toolset(name, _visited=None, *, include_registry=True):  # type: ignore[no-untyped-def]
+    if _visited is None:
+        _visited = set()
+    if name in {"all", "*"}:
+        out = set()
+        for _n in list(_mock_toolsets.TOOLSETS.keys()):  # type: ignore[attr-defined]
+            out.update(_resolve_toolset(_n, set(_visited),
+                                        include_registry=include_registry))
+        return sorted(out)
+    if name in _visited:
+        return []
+    _visited = _visited | {name}
+    spec = _get_toolset(name, include_registry=include_registry)
+    if not isinstance(spec, dict):
+        return [name]
+    tools = list(spec.get("tools") or [])
+    for inc in spec.get("includes") or []:
+        tools.extend(_resolve_toolset(inc, _visited,
+                                      include_registry=include_registry))
+    return tools
+
+
+def _create_custom_toolset(name, description, tools=None, includes=None):  # type: ignore[no-untyped-def]
+    _mock_toolsets.TOOLSETS[name] = {  # type: ignore[attr-defined]
+        "description": description,
+        "tools": tools or [],
+        "includes": includes or [],
+    }
+
+
+_mock_toolsets.get_toolset = _get_toolset
+_mock_toolsets.resolve_toolset = _resolve_toolset
+_mock_toolsets.create_custom_toolset = _create_custom_toolset
+
+
+# ── Behavioural tests for the merge-vs-restrict decision ─────────────────────
+
+
+def test_mcp_only_override_is_additive():
+    """Ticking a configured MCP server keeps the built-in toolsets and adds
+    the MCP server on top."""
+    defaults = ["web", "file", "terminal", "delegation"]
+    override = ["my-search"]
+    mcp_servers = {"my-search"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert "web" in result, "built-in toolsets must survive an MCP-only override"
+    assert "file" in result
+    assert "terminal" in result
+    assert "delegation" in result
+    assert "my-search" in result, "the ticked MCP server must be enabled"
+
+
+def test_mcp_only_override_dedups_and_preserves_order():
+    defaults = ["web", "file", "my-search"]
+    override = ["my-search"]
+    mcp_servers = {"my-search"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["web", "file", "my-search"], (
+        "an already-present MCP server must not be duplicated"
+    )
+
+
+def test_multiple_mcp_servers_all_added():
+    defaults = ["web", "file"]
+    override = ["my-search", "postgres"]
+    mcp_servers = {"my-search", "postgres", "github"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["web", "file", "my-search", "postgres"]
+
+
+def test_unchecked_mcp_servers_are_not_leaked():
+    """Ticking one MCP server must restrict the others OUT: the override is
+    additive over builtins/plugins but restrictive over MCP servers.
+
+    Regression for the Codex gate finding: the earlier additive fix merged
+    ALL defaults, so an unchecked MCP server already present in the profile
+    defaults (``beta``) leaked its tools back into the session even though
+    the user only ticked ``alpha``. Expected: builtins kept, only the
+    checked MCP server exposed.
+    """
+    defaults = ["web", "alpha", "beta"]  # web = builtin; alpha/beta = MCP servers
+    override = ["alpha"]                 # user ticked only alpha
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["web", "alpha"], (
+        "unchecked MCP server 'beta' leaked back in: {}".format(result)
+    )
+
+
+def test_non_mcp_override_still_restricts():
+    """A power-user override that names built-in toolsets keeps the original
+    restrict-to-these semantics."""
+    defaults = ["web", "file", "terminal", "delegation"]
+    override = ["file", "terminal"]
+    mcp_servers = {"my-search"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["file", "terminal"], (
+        "a non-MCP override must replace the defaults (restrict semantics)"
+    )
+
+
+def test_mixed_override_restricts():
+    """If the override mixes an MCP server with a non-MCP toolset, it is not
+    'MCP-only', so restrict semantics apply (defaults are replaced)."""
+    defaults = ["web", "file", "terminal"]
+    override = ["my-search", "file"]
+    mcp_servers = {"my-search"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["my-search", "file"]
+
+
+def test_empty_override_leaves_defaults():
+    defaults = ["web", "file"]
+    assert _apply_override(defaults, [], {"my-search"}, builtin_names={"web", "file", "terminal", "delegation"}) == ["web", "file"]
+    assert _apply_override(defaults, None, {"my-search"}, builtin_names={"web", "file", "terminal", "delegation"}) == ["web", "file"]
+
+
+def test_no_configured_mcp_servers_falls_back_to_restrict():
+    """When there are no configured MCP servers, an override can only be a
+    restrict list — never additive."""
+    defaults = ["web", "file"]
+    override = ["my-search"]
+
+    result = _apply_override(defaults, override, set(), builtin_names={"web", "file", "terminal", "delegation"})
+
+    assert result == ["my-search"]
+
+
+# ── Collision case: MCP server name shadowed by a builtin toolset ────────────
+
+
+def test_builtin_collision_is_restrict_not_additive():
+    """A configured MCP server whose name collides with a builtin toolset
+    (e.g. a server literally named ``web``) must NOT flip the override into
+    additive mode. The builtin shadows the MCP alias at resolution time, so
+    treating ``["web"]`` as additive would both mis-resolve the override and
+    leave the MCP tools unavailable. Restrict semantics apply instead."""
+    defaults = ["web", "file", "terminal", "delegation"]
+    override = ["web"]
+    mcp_servers = {"web"}          # a server that shares a builtin's name
+    builtin_names = {"web", "file", "terminal", "delegation"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names=builtin_names)
+
+    assert result == ["web"], (
+        "a name that is both an MCP server and a builtin must take restrict "
+        "semantics, not additive — otherwise it mis-resolves and the MCP "
+        "tools stay unavailable"
+    )
+
+
+def test_mcp_only_additive_when_some_servers_collide():
+    """A pure-MCP name (no builtin collision) stays additive even when *other*
+    configured servers happen to collide with builtins."""
+    defaults = ["web", "file", "terminal"]
+    override = ["my-search"]
+    mcp_servers = {"my-search", "web"}   # "web" collides, "my-search" does not
+    builtin_names = {"web", "file", "terminal"}
+
+    result = _apply_override(defaults, override, mcp_servers, builtin_names=builtin_names)
+
+    assert result == ["web", "file", "terminal", "my-search"], (
+        "a non-colliding MCP-only tick must still be additive"
+    )
+
+
+def test_real_builtin_names_default_lookup(monkeypatch):
+    """With an *available* builtin registry, a genuine MCP-only override is
+    additive because a normal server name does not collide with any builtin.
+
+    The default lookup (``_builtin_toolset_names()``) returns ``None`` when the
+    Hermes ``toolsets`` module isn't importable (e.g. the WebUI test env in CI),
+    which correctly fails closed to RESTRICT. To assert the *additive* path we
+    stub the helper to report an available, non-colliding builtin set — that is
+    the environment this test is about.
+    """
+    import api.streaming as streaming
+
+    monkeypatch.setattr(
+        streaming, "_builtin_toolset_names",
+        lambda: {"web", "file", "terminal", "delegation"},
+    )
+
+    defaults = ["web", "file"]
+    override = ["my-search"]
+    mcp_servers = {"my-search"}
+
+    # builtin_names=None → consults the (stubbed, available) helper.
+    result = _apply_override(defaults, override, mcp_servers)
+
+    assert "web" in result and "file" in result and "my-search" in result
+
+
+def test_default_lookup_unavailable_registry_restricts(monkeypatch):
+    """The other half of the default-lookup contract: when the real helper
+    reports the registry is unavailable (``None``), the same MCP-only override
+    fails closed to RESTRICT rather than additive. This documents that the
+    additive path depends on an available registry."""
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, "_builtin_toolset_names", lambda: None)
+
+    result = _apply_override(["web", "file"], ["my-search"], {"my-search"})
+
+    assert result == ["my-search"], (
+        "an unavailable registry must fail closed to restrict on the default "
+        "lookup path too"
+    )
+
+
+# ── Fail-closed: unavailable builtin registry must RESTRICT, never additive ──
+
+
+def test_unavailable_registry_forces_restrict(monkeypatch):
+    """When ``_builtin_toolset_names()`` can't resolve the builtin list it
+    returns ``None`` ("I don't know"). An MCP-only override with a colliding
+    server name must then fall back to RESTRICT, not re-open the collision by
+    treating every name as MCP-additive.
+
+    This reproduces the round-2 gate finding: forcing the empty/unavailable
+    fallback with ``override=['web']`` must restrict, not restore all defaults.
+    """
+    import api.streaming as streaming
+
+    # Simulate the registry being unavailable.
+    monkeypatch.setattr(streaming, "_builtin_toolset_names", lambda: None)
+
+    defaults = ["web", "file", "terminal", "delegation"]
+    override = ["web"]
+    mcp_servers = {"web"}   # collides with a builtin name
+
+    # builtin_names=None → helper is consulted → returns None → fail closed.
+    result = _apply_override(defaults, override, mcp_servers)
+
+    assert result == ["web"], (
+        "an unavailable builtin registry must fail closed to RESTRICT; it must "
+        "NOT re-open the collision by restoring all defaults additively"
+    )
+
+
+def test_none_builtin_names_argument_forces_restrict():
+    """Passing ``builtin_names=None`` explicitly (registry unavailable) with a
+    colliding MCP server must restrict, independent of the helper lookup."""
+    import api.streaming as streaming
+
+    # Ensure the helper (consulted when builtin_names is None) also reports
+    # unavailable, so this test asserts the None-path in isolation.
+    real = streaming._builtin_toolset_names
+    streaming._builtin_toolset_names = lambda: None
+    try:
+        result = _apply_override(
+            ["web", "file", "terminal", "delegation"],
+            ["web"],
+            {"web"},
+            builtin_names=None,
+        )
+    finally:
+        streaming._builtin_toolset_names = real
+
+    assert result == ["web"], (
+        "builtin_names=None means the registry is unavailable → restrict"
+    )
+
+
+# ── Shadow set: registered/plugin toolset names also shadow MCP aliases ──────
+
+
+def test_registry_shadow_collision_restricts():
+    """A configured MCP server whose name collides with a *registered* (plugin
+    or canonical) toolset — not just a static builtin — must also take restrict
+    semantics. The builtin_names set is expected to include such registered
+    names so the collision guard covers the full shadow set."""
+    defaults = ["web", "file", "my-plugin"]
+    override = ["my-plugin"]
+    mcp_servers = {"my-plugin"}      # server shares a registered toolset's name
+    # builtin_names carries the full shadow set including the plugin toolset.
+    builtin_names = {"web", "file", "terminal", "delegation", "my-plugin"}
+
+    result = _apply_override(defaults, override, mcp_servers,
+                             builtin_names=builtin_names)
+
+    assert result == ["my-plugin"], (
+        "a name shadowed by a registered/plugin toolset must restrict, not "
+        "flip the override into additive mode"
+    )
+
+
+# ── Source-level invariant: the replace-all bug must not come back ───────────
+
+
+def test_streaming_uses_additive_helper():
+    """Pin the source so a future edit can't silently revert to the
+    'any override replaces the defaults' shape that broke MCP-only chats.
+
+    A mere substring search for the helper *name* is vacuous — the function's
+    own definition satisfies it even if the call-site is dead. So we parse the
+    AST and assert the streaming worker actually *calls*
+    ``_apply_session_toolset_override`` with the MCP server names, on a real
+    call path.
+    """
+    import ast
+
+    src = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    # Find genuine call sites (not the def), excluding the function definition
+    # itself so a dead/renamed body can't satisfy the guard.
+    call_sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name == "_apply_session_toolset_override":
+                call_sites.append(node)
+
+    assert call_sites, (
+        "streaming.py must CALL _apply_session_toolset_override() on a real "
+        "code path (not merely define it). Without an active call an MCP-only "
+        "toolset chip will again wipe out every built-in tool."
+    )
+
+    # At least one call site must pass the configured MCP server names through
+    # (3rd positional arg), so the additive-vs-restrict decision is actually
+    # driven by which names are MCP servers.
+    def _passes_mcp_names(call):
+        # positional: (defaults, override, mcp_server_names, [builtin_names])
+        if len(call.args) >= 3:
+            return True
+        # or keyword mcp_server_names=...
+        return any(kw.arg == "mcp_server_names" for kw in call.keywords)
+
+    assert any(_passes_mcp_names(c) for c in call_sites), (
+        "the call-site must pass the configured MCP server names into "
+        "_apply_session_toolset_override() so the collision-aware "
+        "additive-vs-restrict decision is driven by real config, not a stub."
+    )
+
+    # It must read the configured MCP server names from config.
+    assert "mcp_servers" in src, (
+        "streaming.py must read cfg['mcp_servers'] to distinguish MCP server "
+        "names from ordinary toolset names in the per-session override."
+    )
+
+
+def test_plugin_registry_collision_stays_restrict(monkeypatch):
+    """When a registered plugin toolset name collides with a configured MCP
+    server name, the override must stay RESTRICT — not silently flip additive.
+
+    The regression bug: ``_builtin_toolset_names()`` used speculative
+    accessor/attribute names that don't exist on the installed runtime, so
+    registered/plugin toolsets were silently missing from the shadow set.  A
+    plugin-named MCP server could slip past the collision guard and flip a
+    RESTRICT override to additive.
+    """
+    import api.streaming as streaming
+
+    # Simulate a registered plugin toolset whose name collides with an MCP
+    # server.  The real registry may be unavailable in CI — we patch the
+    # registry method so the test exercises the real code path in
+    # _builtin_toolset_names() regardless of the environment.
+    plugin_name = "browser-cdp"
+    try:
+        from tools.registry import registry as _reg
+        _orig_get = _reg.get_registered_toolset_names
+        monkeypatch.setattr(
+            _reg, "get_registered_toolset_names",
+            lambda: [plugin_name],
+        )
+    except ImportError:
+        # CI environment — tools.registry is not importable.
+        # _builtin_toolset_names() will return None (fail-closed), which is
+        # the correct behaviour.  The test is still meaningful: we verify
+        # that the fail-closed path does NOT silently flip to additive.
+        pass
+
+    # Drive the real _builtin_toolset_names() (not a stubbed return value).
+    builtin = streaming._builtin_toolset_names()
+
+    if builtin is None:
+        # Registry unavailable → fail-closed RESTRICT is correct.
+        result = _apply_override(
+            ["web", "file"], [plugin_name], {plugin_name},
+            builtin_names=None,
+        )
+        assert result == [plugin_name], (
+            "unavailable registry must restrict, not silently flip additive"
+        )
+        return
+
+    # Registry available → plugin name must be in the shadow set.
+    assert plugin_name in builtin, (
+        f"registered plugin '{plugin_name}' must appear in the builtin shadow "
+        f"set so it collides with the same-named MCP server"
+    )
+
+    # The collision must force RESTRICT.
+    result = _apply_override(
+        ["web", "file"], [plugin_name], {plugin_name},
+        builtin_names=builtin,
+    )
+    assert result == [plugin_name], (
+        f"plugin '{plugin_name}' colliding with MCP server must RESTRICT, "
+        f"not silently flip additive (got {result})"
+    )
+
+
+# ── mcp-* canonical name collision: alpha + mcp-alpha ──────────────────────
+# Regression for the gate finding: dropping every mcp-* canonical name from
+# the shadow set enables a silent wrong-server resolution when two servers
+# have overlapping canonical names.
+
+
+def _patch_registry_and_get_builtin_names(monkeypatch, registered_names):
+    """Monkeypatch ``get_registered_toolset_names()`` to return *registered_names*
+    and call the real ``_builtin_toolset_names()``.  Returns the full shadow set
+    (static TOOLSETS keys + registered names).
+
+    Both ``toolsets`` and ``tools.registry`` are made available unconditionally —
+    when they cannot be imported (CI without the agent runtime), lightweight
+    stand-ins are injected into ``sys.modules`` so the production
+    ``_builtin_toolset_names()`` import succeeds and the real enumeration path is
+    exercised.  This prevents a silent fallback that would hide a regression in
+    the ``mcp-*`` filtering.
+    """
+    import sys
+    import types
+    import api.streaming as streaming
+
+    _injected = []  # (module_name, was_present) pairs for cleanup
+    _reg = None
+
+    # ── toolsets ──
+    if "toolsets" not in sys.modules:
+        _mock_toolsets = types.ModuleType("toolsets")
+        # Minimal TOOLSETS dict — the static keys the real module exposes.
+        # Only the keys matter for shadow-set membership; the values are unused.
+        _mock_toolsets.TOOLSETS = {  # type: ignore[attr-defined]
+            "web": None, "search": None, "file": None, "terminal": None,
+            "delegation": None, "vision": None, "computer_use": None,
+        }
+        sys.modules["toolsets"] = _mock_toolsets
+        _injected.append(("toolsets", False))
+    else:
+        _injected.append(("toolsets", True))
+
+    # ── tools.registry ──
+    try:
+        from tools.registry import registry as _reg
+    except ImportError:
+        _mock_registry = types.SimpleNamespace()
+        _mock_registry.get_registered_toolset_names = lambda: list(registered_names)
+        _reg = _mock_registry
+        _injected_module = types.ModuleType("tools.registry")
+        _injected_module.registry = _mock_registry  # type: ignore[attr-defined]
+        if "tools" not in sys.modules:
+            sys.modules["tools"] = types.ModuleType("tools")
+            _injected.append(("tools", False))
+        else:
+            _injected.append(("tools", True))
+        sys.modules["tools.registry"] = _injected_module
+        _injected.append(("tools.registry", False))
+    else:
+        _injected.append(("tools.registry", True))
+        _injected.append(("tools", True))
+
+    _orig = _reg.get_registered_toolset_names
+    monkeypatch.setattr(_reg, "get_registered_toolset_names",
+                        lambda: list(registered_names))
+    try:
+        return streaming._builtin_toolset_names()
+    finally:
+        monkeypatch.setattr(_reg, "get_registered_toolset_names", _orig)
+        # Clean up injected modules so other tests see the real environment.
+        for _mod_name, _was_present in reversed(_injected):
+            if not _was_present:
+                sys.modules.pop(_mod_name, None)
+
+
+def test_mcp_canonical_name_collision_selects_owned_server(monkeypatch):
+    """When MCP servers ``alpha`` and ``mcp-alpha`` coexist, the picker
+    token ``mcp-alpha`` (server ``mcp-alpha``'s bare name) collides with the
+    *canonical* name ``mcp-alpha`` (owned by server ``alpha``).  The
+    override must ADDITIVELY emit the selected server's TRUE canonical
+    ``mcp-mcp-alpha`` (proven via the live alias edge ``mcp-alpha ->
+    mcp-mcp-alpha``) — never bare ``mcp-alpha``, which the runtime resolver
+    would match to server ``alpha`` (gate-certified SILENT).
+
+    Production-composed: ``builtin_names`` is NOT injected.  The real
+    ``_builtin_toolset_names()`` collector runs, so ``mcp-alpha`` and
+    ``mcp-mcp-alpha`` are both present in the broad registered-name shadow
+    set — the round-11 fix must exclude OWNED canonicals (alias-edge
+    proven) before the MCP-only test, or the token is wrongly restricted.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Server "alpha" → canonical mcp-alpha
+        _ts_mod.create_custom_toolset("alpha", "server alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_owned_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Server "mcp-alpha" → canonical mcp-mcp-alpha
+        _ts_mod.create_custom_toolset("mcp-alpha", "server mcp-alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("mcp-alpha", "mcp-mcp-alpha")
+        _reg.register("mcp_alpha_owned_tool", "mcp-mcp-alpha",
+                      {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Seed-assertion relevance: prove the collision edges are live
+        # BEFORE driving the classifier (round-8 rule).
+        assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
+        assert _reg.get_toolset_alias_target("mcp-alpha") == "mcp-mcp-alpha"
+
+        result = _apply_override(
+            ["web", "file", "terminal", "delegation"], ["mcp-alpha"],
+            {"alpha", "mcp-alpha"}, builtin_names=None)
+
+        assert "mcp-alpha" not in result, (
+            f"ambiguous bare 'mcp-alpha' must never survive, got {result!r}"
+        )
+        assert "mcp-mcp-alpha" in result, (
+            f"selected server's true canonical must be emitted, got {result!r}"
+        )
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        resolved = set(_ts_mod.resolve_toolset("mcp-mcp-alpha"))
+        assert "mcp_alpha_owned_tool" in resolved, (
+            f"mcp-mcp-alpha must resolve the SELECTED server's tools, "
+            f"got {sorted(resolved)!r}"
+        )
+        assert "alpha_owned_tool" not in resolved, (
+            f"wrong server's tools must not resolve, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_canonical_collision_without_alias_edge_fails_closed(monkeypatch):
+    """Negative control: when the registry exposes a canonical name (e.g.
+    ``mcp-alpha``) but NO live alias edge proves it is owned by a configured
+    MCP server, ownership cannot be proved → the broad shadow set keeps it
+    and the override fails closed to FULLY RESTRICT (empty list).
+
+    Round-13 fix: the restrict branch now drops mcp-* selectors whose
+    ownership cannot be proved, preventing wrong-server exposure.
+    Returning the raw selector would let the resolver pick server alpha
+    when the user intended server mcp-alpha — a gate-certified SILENT failure.
+
+    Uses the real ``_builtin_toolset_names()`` (monkeypatched registry),
+    not a hand-constructed shadow set."""
+
+    builtin = _patch_registry_and_get_builtin_names(
+        monkeypatch, ["mcp-alpha", "mcp-mcp-alpha"])
+
+    assert "mcp-alpha" in builtin, (
+        "canonical 'mcp-alpha' must be in the shadow set (got {})".format(builtin)
+    )
+
+    result = _apply_override(
+        ["web", "file", "terminal", "delegation"], ["mcp-alpha"],
+        {"alpha", "mcp-alpha"}, builtin_names=builtin)
+
+    # Round-13 fix: no alias edge for 'alpha' → mcp-alpha means ownership
+    # of canonical 'mcp-alpha' cannot be proved → must drop it entirely.
+    # Returning bare 'mcp-alpha' would resolve to server alpha's tools,
+    # not the intended server mcp-alpha's tools.
+    assert result == [], (
+        "no alias edge → ownership unprovable → must DROP the selector "
+        "and return empty list (got {!r})".format(result)
+    )
+
+
+def test_ordinary_server_stays_additive_with_canonical_in_shadow(monkeypatch):
+    """Negative control: a normal server ``foo`` (pick token ``foo``) stays
+    additive even though its canonical name ``mcp-foo`` is in the shadow set.
+    The bare token ``foo`` ≠ ``mcp-foo``, so there is no collision.
+
+    Uses the real ``_builtin_toolset_names()`` (monkeypatched registry), not
+    hand-constructed shadow set."""
+    builtin = _patch_registry_and_get_builtin_names(
+        monkeypatch, ["mcp-foo", "mcp-bar"])
+
+    assert "mcp-foo" in builtin
+    assert "foo" not in builtin, (
+        "bare token 'foo' must NOT be in the shadow set — only canonical "
+        "'mcp-foo' is (got {})".format(builtin)
+    )
+
+    result = _apply_override(
+        ["web", "file"], ["foo"], {"foo", "bar"}, builtin_names=builtin)
+
+    assert result == ["web", "file", "foo"], (
+        "bare token 'foo' must stay additive even with canonical 'mcp-foo' "
+        "in the shadow set (got {})".format(result)
+    )
+
+
+def test_plugin_canonical_mcp_prefix_collision_restricts(monkeypatch):
+    """A plugin whose canonical name begins with ``mcp-`` (e.g. ``mcp-browser``)
+    must shadow a same-named MCP server alias.  The old code filtered *all*
+    ``mcp-*`` names from the shadow set, so a plugin ``mcp-browser`` could
+    silently flip additive.
+
+    Round-13 fix: the restrict branch drops mcp-* selectors whose ownership
+    cannot be proved.  A plugin's canonical has no MCP alias edge, so the
+    selector must be dropped entirely — returning it would resolve to the
+    plugin's tools, not the intended MCP server's tools.
+
+    Uses the real ``_builtin_toolset_names()`` (monkeypatched registry), not
+    hand-constructed shadow set."""
+
+    builtin = _patch_registry_and_get_builtin_names(
+        monkeypatch, ["mcp-browser"])
+
+    assert "mcp-browser" in builtin, (
+        "plugin canonical 'mcp-browser' must be in the shadow set "
+        "(got {})".format(builtin)
+    )
+
+    result = _apply_override(
+        ["web", "file"], ["mcp-browser"], {"mcp-browser"},
+        builtin_names=builtin)
+
+    # Round-13 fix: plugin canonical 'mcp-browser' has no MCP alias edge,
+    # so ownership cannot be proved → must DROP entirely.
+    assert result == [], (
+        "plugin canonical 'mcp-browser' has no alias edge → ownership "
+        "unprovable → must DROP the selector and return empty list "
+        "(got {})".format(result)
+    )
+
+
+# ── Malformed registry return shapes must fail closed ──────────────────────
+
+
+def test_registry_returns_none_fails_closed(monkeypatch):
+    """When ``get_registered_toolset_names()`` returns None, the helper must
+    return None (not a partial static-only set)."""
+    import api.streaming as streaming
+
+    try:
+        from tools.registry import registry as _reg
+    except ImportError:
+        return  # CI without tools.registry — skip
+
+    _orig = _reg.get_registered_toolset_names
+    monkeypatch.setattr(_reg, "get_registered_toolset_names", lambda: None)
+    try:
+        result = streaming._builtin_toolset_names()
+    finally:
+        monkeypatch.setattr(_reg, "get_registered_toolset_names", _orig)
+
+    assert result is None, (
+        "None registry result must fail closed (return None), "
+        f"got {result!r}"
+    )
+
+
+def test_registry_returns_dict_fails_closed(monkeypatch):
+    """When ``get_registered_toolset_names()`` returns a dict (not a set/list/
+    tuple), the helper must return None."""
+    import api.streaming as streaming
+
+    try:
+        from tools.registry import registry as _reg
+    except ImportError:
+        return
+
+    _orig = _reg.get_registered_toolset_names
+    monkeypatch.setattr(_reg, "get_registered_toolset_names", lambda: {"a": 1})
+    try:
+        result = streaming._builtin_toolset_names()
+    finally:
+        monkeypatch.setattr(_reg, "get_registered_toolset_names", _orig)
+
+    assert result is None, (
+        f"dict registry result must fail closed, got {result!r}"
+    )
+
+
+def test_registry_returns_string_fails_closed(monkeypatch):
+    """When ``get_registered_toolset_names()`` returns a bare string, the
+    helper must return None."""
+    import api.streaming as streaming
+
+    try:
+        from tools.registry import registry as _reg
+    except ImportError:
+        return
+
+    _orig = _reg.get_registered_toolset_names
+    monkeypatch.setattr(_reg, "get_registered_toolset_names", lambda: "not-a-list")
+    try:
+        result = streaming._builtin_toolset_names()
+    finally:
+        monkeypatch.setattr(_reg, "get_registered_toolset_names", _orig)
+
+    assert result is None, (
+        f"string registry result must fail closed, got {result!r}"
+    )
+
+
+def test_registry_contains_non_string_entries_fails_closed(monkeypatch):
+    """When ``get_registered_toolset_names()`` returns entries that are not
+    strings, the helper must return None rather than string-coercing them."""
+    import api.streaming as streaming
+
+    try:
+        from tools.registry import registry as _reg
+    except ImportError:
+        return
+
+    _orig = _reg.get_registered_toolset_names
+    monkeypatch.setattr(
+        _reg, "get_registered_toolset_names",
+        lambda: ["valid", 42, object()],
+    )
+    try:
+        result = streaming._builtin_toolset_names()
+    finally:
+        monkeypatch.setattr(_reg, "get_registered_toolset_names", _orig)
+
+    assert result is None, (
+        f"non-string entries in registry must fail closed, got {result!r}"
+    )
+
+
+# ── Canonical selector and wildcard leakage regression ─────────────────────
+# Gate certification found that stripping only the bare server name from
+# defaults lets the canonical ``mcp-<name>`` selector or a wildcard (``all`` /
+# ``*``) survive the additive merge, re-exposing unchecked MCP servers.
+
+
+def test_canonical_mcp_selector_in_defaults_is_stripped():
+    """A default that exposes an MCP server via its canonical ``mcp-<name>``
+    selector must be stripped along with the bare name, so the unchecked
+    server's tools don't leak.
+
+    Reproduces the gate finding: defaults ``['web', 'mcp-alpha']`` + selected
+    ``['beta']`` must NOT retain ``mcp-alpha`` (alpha's tools would come
+    back through the installed resolver's canonical resolution path).
+    """
+    defaults = ["web", "mcp-alpha"]
+    override = ["beta"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert "mcp-alpha" not in result, (
+        "canonical 'mcp-alpha' in defaults must be stripped so unchecked "
+        "alpha's tools don't leak (got {})".format(result)
+    )
+    assert "web" in result, "builtins must survive"
+    assert "beta" in result, "checked server must be present"
+
+
+def test_wildcard_all_in_defaults_fails_closed_when_mcp_unchecked():
+    """A wildcard default ``['all']`` + override ``['beta']`` with unchecked
+    server ``alpha``: the wildcard would expand to every registered toolset
+    including alpha's, so we must fail closed to restrictive semantics
+    (``['beta']``) rather than risk leaking alpha's tools.
+    """
+    defaults = ["all"]
+    override = ["beta"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert result == ["beta"], (
+        "wildcard 'all' with unchecked MCP server must fail closed to "
+        "restrict (got {})".format(result)
+    )
+
+
+def test_wildcard_star_in_defaults_fails_closed_when_mcp_unchecked():
+    """Same as above but with ``*`` instead of ``all``."""
+    defaults = ["*"]
+    override = ["beta"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert result == ["beta"], (
+        "wildcard '*' with unchecked MCP server must fail closed to "
+        "restrict (got {})".format(result)
+    )
+
+
+def test_wildcard_all_ok_when_all_mcp_checked():
+    """When ALL configured MCP servers are ticked, a wildcard default is
+    safe — no unchecked server can leak through the expansion."""
+    defaults = ["all"]
+    override = ["alpha", "beta"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert "alpha" in result and "beta" in result, (
+        "all-checked wildcard must retain the checked servers (got {})".format(result)
+    )
+
+
+def test_wildcard_default_with_selected_server_named_all(monkeypatch):
+    """Combined regression (round-15): profile defaults contain the wildcard
+    ``all`` AND the user ticks a configured server literally named ``all``
+    while an unchecked sibling server exists.
+
+    The wildcard-default early return must emit the VERIFIED canonical
+    target ``mcp-all`` (from canonicalization), never the raw override
+    ``all``: the resolver expands raw ``all`` to every registered toolset,
+    silently re-exposing the unchecked sibling's tools (gate-certified
+    SILENT).  Round-14 changed this path from ``list(override)`` to
+    ``list(override_targets)`` — this test is RED against the raw-return
+    form.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Server literally named "all" → canonical mcp-all.
+        _ts_mod.create_custom_toolset("all", "server literally named all",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("all", "mcp-all")
+        _reg.register("all_tool", "mcp-all", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Unchecked sibling server "other" → canonical mcp-other.
+        _ts_mod.create_custom_toolset("other", "unchecked sibling",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("other", "mcp-other")
+        _reg.register("other_tool", "mcp-other", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Seed-assertion relevance: prove the alias edges are live.
+        assert _reg.get_toolset_alias_target("all") == "mcp-all"
+        assert _reg.get_toolset_alias_target("other") == "mcp-other"
+
+        defaults = ["all"]  # wildcard default present
+        override = ["all"]  # tick the server named all
+        mcp_servers = {"all", "other"}
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        # The raw wildcard must never survive — the verified canonical is
+        # emitted instead.
+        assert "all" not in result, (
+            f"raw wildcard 'all' must never survive, got {result!r}"
+        )
+        assert "mcp-all" in result, (
+            f"verified canonical mcp-all must be emitted, got {result!r}"
+        )
+        # Resolve every returned selector: only the ticked server's tools
+        # may appear; the unchecked sibling must stay out.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "all_tool" in final_tools, (
+            f"ticked server's tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "other_tool" not in final_tools, (
+            f"unchecked sibling's tools must not resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_canonical_selector_not_stripped_when_no_mcp_server():
+    """A default ``mcp-foo`` with no configured MCP server named ``foo`` is a
+    user-authored canonical name that should be preserved (it's not an MCP
+    server we can strip)."""
+    defaults = ["web", "mcp-foo"]
+    override = ["alpha"]
+    mcp_servers = {"alpha"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert "mcp-foo" in result, (
+        "canonical 'mcp-foo' with no configured server 'foo' must survive "
+        "(got {})".format(result)
+    )
+
+
+def test_canonical_selector_with_checked_server_preserved():
+    """When the server IS checked, its canonical selector in defaults must be
+    preserved (not stripped) — the override adds the bare name, and the
+    canonical is just an alias to the same server."""
+    defaults = ["web", "mcp-alpha"]
+    override = ["alpha"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    # The canonical selector should survive because alpha IS checked.
+    assert "alpha" in result, "checked server must be present"
+
+
+def test_existing_unchecked_regression_with_canonical():
+    """Combined regression: defaults with both bare and canonical forms +
+    multiple unchecked servers."""
+    defaults = ["web", "alpha", "mcp-beta"]
+    override = ["alpha"]
+    mcp_servers = {"alpha", "beta"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal", "delegation"},
+    )
+
+    assert "web" in result, "builtins must survive"
+    assert "alpha" in result, "checked server must be present"
+    assert "beta" not in result, "bare beta must be stripped"
+    assert "mcp-beta" not in result, (
+        "canonical 'mcp-beta' must also be stripped (got {})".format(result)
+    )
+
+
+# ── Blocking finding 1: malformed override must fail closed ────────────────
+
+
+def test_malformed_override_dict_entry_fails_closed():
+    """An unhashable persisted override entry (e.g. ``[{"stale": "shape"}]``)
+    must NOT raise TypeError inside the additive classifier and fall through
+    to the caller's broad except (which restores all profile defaults).
+
+    The helper must return the restrict fallback (string entries only) without
+    raising.
+    """
+    defaults = ["web", "file", "terminal", "alpha", "beta"]
+    override = [{"stale": "shape"}]  # unhashable dict entry
+
+    result = _apply_override(defaults, override, {"alpha", "beta"})
+
+    assert isinstance(result, list), f"must return a list, got {type(result)}"
+    # Malformed entries are filtered out; no string entries remain → empty list
+    # (restrict semantics with no valid toolset names).
+    assert result == [], (
+        f"malformed override must not restore defaults (fail-open), got {result!r}"
+    )
+
+
+def test_malformed_override_mixed_entries_fails_closed():
+    """A mix of valid string entries and malformed entries must sanitize
+    the valid strings (drop dangerous selectors) and fail closed — never
+    restore all defaults.
+
+    Round-14 fix: malformed override drops wildcards and mcp-* selectors.
+    Round-15 fix: assert the EXACT restrictive output again — the previous
+    ``"web" in result or "alpha" in result`` disjunct also passes the
+    fail-open output containing every profile default, so the assertion
+    could not catch a regression that restored defaults.
+    """
+    defaults = ["web", "file", "terminal", "alpha", "beta"]
+    override = ["alpha", {"stale": "shape"}, "beta"]
+
+    result = _apply_override(defaults, override, {"alpha", "beta"})
+
+    # The malformed branch sanitizes in place and returns BEFORE any
+    # additive/restrict classification (api/streaming.py), so the valid
+    # strings survive untouched and nothing else is added.
+    assert result == ["alpha", "beta"], (
+        f"malformed override must return the exact string-only list, got {result!r}"
+    )
+    # Profile BUILTIN defaults must NOT be restored (no fail-open).
+    assert "web" not in result and "file" not in result and "terminal" not in result, (
+        f"defaults must NOT be restored on malformed override (fail-open), got {result!r}"
+    )
+    # No dangerous selectors (all, *, mcp-*) should survive
+    assert "all" not in result and "*" not in result, (
+        f"dangerous selectors must be dropped, got {result!r}"
+    )
+
+
+def test_non_string_mcp_server_name_fails_closed():
+    """A non-string ``mcp_servers`` key must fail closed to restrict, not
+    reach ``'mcp-' + _srv`` downstream and fail-open via the caller's except.
+
+    Round-14 fix: malformed mcp_server_names returns [] (fully restrictive).
+    """
+    defaults = ["web", "file", "terminal", "alpha"]
+    override = ["alpha"]
+    # mcp_server_names contains a non-string entry
+    mcp_names = {"alpha", 42}
+
+    result = _apply_override(defaults, override, mcp_names)
+
+    assert result == [], (
+        f"non-string mcp_server_names must fail closed to [], got {result!r}"
+    )
+
+
+# ── Blocking finding 2: recursive composite must not leak unchecked MCP ─────
+
+
+def test_recursive_composite_does_not_leak_unchecked_mcp(monkeypatch):
+    """A composite toolset in defaults whose ``includes`` transitively pulls in
+    an unchecked MCP server must be DROPPED from the merged result.
+
+    Scenario (from the Codex adversarial gate):
+      - ``gate-alpha`` and ``gate-beta`` are configured MCP servers.
+      - ``gate-composite`` is a toolset that includes ``gate-alpha``.
+      - Profile defaults: ``['web', 'gate-composite']``
+      - Session override: ``['gate-beta']``
+
+    Without the fix, ``gate-composite`` survives the name-level filter (it's
+    not a bare MCP name) and is kept in ``merged``.  When the agent resolves
+    it, ``gate-alpha`` tools leak back in — a silent authorization regression.
+
+    With the fix, ``_default_transitively_reaches_unchecked_mcp`` expands
+    ``gate-composite``, finds tools registered under ``mcp-gate-alpha``, and
+    drops it.
+    """
+    try:
+        from tools.registry import registry as _reg
+        import api.streaming as streaming
+    except ImportError:
+        return  # CI without tools.registry — skip
+
+    # Register two fake MCP servers and a composite toolset.
+    _fake_tools = {
+        "gate_alpha_tool": _reg._tools.get("gate_alpha_tool"),
+        "gate_beta_tool": _reg._tools.get("gate_beta_tool"),
+    }
+
+    class _FakeEntry:
+        def __init__(self, name, toolset):
+            self.name = name
+            self.toolset = toolset
+
+    _orig_snapshot = _reg._snapshot_entries
+
+    def _fake_snapshot():
+        real = [e for e in _orig_snapshot()]
+        real.append(_FakeEntry("gate_alpha_tool", "mcp-gate-alpha"))
+        real.append(_FakeEntry("gate_beta_tool", "mcp-gate-beta"))
+        return real
+
+    # Patch resolve_toolset to simulate gate-composite including gate-alpha
+    import toolsets as _ts_mod
+
+    _orig_resolve = _ts_mod.resolve_toolset
+
+    def _fake_resolve(name, visited=None, *, include_registry=True):
+        if name == "gate-composite":
+            # Composite includes gate-alpha → exposes its tools
+            return ["gate_alpha_tool"]
+        if name == "gate-alpha":
+            return ["gate_alpha_tool"]
+        if name == "gate-beta":
+            return ["gate_beta_tool"]
+        return _orig_resolve(name, visited, include_registry=include_registry)
+
+    monkeypatch.setattr(_reg, "_snapshot_entries", _fake_snapshot)
+    monkeypatch.setattr(_ts_mod, "resolve_toolset", _fake_resolve)
+    # Also patch the reference imported in streaming module
+    monkeypatch.setattr(streaming, "_default_transitively_reaches_unchecked_mcp",
+                        streaming._default_transitively_reaches_unchecked_mcp)
+
+    defaults = ["web", "gate-composite"]
+    override = ["gate-beta"]
+    mcp_names = {"gate-alpha", "gate-beta"}
+    # Use a minimal builtin_names that doesn't include gate-* names
+    builtin_names = {"web", "file", "terminal", "delegation"}
+
+    result = _apply_override(
+        defaults, override, mcp_names, builtin_names=builtin_names
+    )
+
+    # gate-composite must be dropped — it transitively reaches gate-alpha
+    assert "gate-composite" not in result, (
+        f"composite including unchecked MCP must be dropped, got {result!r}"
+    )
+    # web must survive (not a composite, not an MCP server)
+    assert "web" in result, (
+        f"non-composite built-in must survive, got {result!r}"
+    )
+    # gate-beta (the ticked server) must be present
+    assert "gate-beta" in result, (
+        f"ticked MCP server must be present, got {result!r}"
+    )
+    # gate-alpha (unchecked) must NOT be present
+    assert "gate-alpha" not in result, (
+        f"unchecked MCP server must not appear, got {result!r}"
+    )
+
+
+def test_composite_not_leaking_unchecked_mcp_is_kept(monkeypatch):
+    """A composite toolset that does NOT transitively reach any unchecked MCP
+    server must be KEPT in the merged result (no false positives).
+    """
+    try:
+        import toolsets as _ts_mod
+    except ImportError:
+        return  # CI without toolsets — skip
+
+    _orig_resolve = _ts_mod.resolve_toolset
+
+    def _fake_resolve(name, visited=None, *, include_registry=True):
+        if name == "safe-composite":
+            # Includes only web (a builtin), no MCP servers
+            return _orig_resolve("web", visited, include_registry=include_registry)
+        return _orig_resolve(name, visited, include_registry=include_registry)
+
+    monkeypatch.setattr(_ts_mod, "resolve_toolset", _fake_resolve)
+
+    defaults = ["web", "safe-composite"]
+    override = ["gate-beta"]
+    mcp_names = {"gate-alpha", "gate-beta"}
+    builtin_names = {"web", "file", "terminal", "safe-composite"}
+
+    result = _apply_override(
+        defaults, override, mcp_names, builtin_names=builtin_names
+    )
+
+    # safe-composite must be kept — it doesn't reach any unchecked MCP
+    assert "gate-beta" in result, (
+        f"ticked MCP server must be present, got {result!r}"
+    )
+
+
+# ── Review finding regressions (round 4) ────────────────────────────────────
+
+
+def test_scalar_truthy_override_fails_closed():
+    """Review finding #1: a truthy scalar persisted override (e.g. ``42``)
+    must NOT raise ``TypeError`` inside the list-comprehension and fall
+    through to the caller's broad ``except``, which would restore ALL
+    profile defaults (fail-open)."""
+    defaults = ["web", "file", "terminal", "delegation"]
+    # Truthy scalar — the old code's ``if not override`` didn't catch it
+    # because 42 is truthy, then the malformed list-comp raised TypeError.
+    assert _apply_override(defaults, 42, set(), builtin_names=set()) == []
+
+
+def test_scalar_falsy_override_fails_closed():
+    """Review finding #1 (cont'd): a falsy scalar persisted override
+    (e.g. ``0``) must NOT silently bypass the caller's ``if _override:``
+    and leave the profile defaults untouched (fail-open)."""
+    defaults = ["web", "file", "terminal", "delegation"]
+    # Falsy scalar — old caller's ``if _override:`` skipped it entirely,
+    # leaving defaults in place.
+    assert _apply_override(defaults, 0, set(), builtin_names=set()) == []
+
+
+def test_scalar_string_override_fails_closed():
+    """Review finding #1 (cont'd): a string scalar override must also
+    fail closed, not be interpreted as a single-element list."""
+    defaults = ["web", "file"]
+    assert _apply_override(defaults, "web", set(), builtin_names=set()) == []
+
+
+def test_none_override_keeps_defaults():
+    """``None`` is the valid "no override" signal and must preserve defaults."""
+    defaults = ["web", "file"]
+    assert _apply_override(defaults, None, set(), builtin_names=set()) == defaults
+
+
+def test_empty_list_override_keeps_defaults():
+    """``[]`` is the valid "no override" signal and must preserve defaults."""
+    defaults = ["web", "file"]
+    assert _apply_override(defaults, [], set(), builtin_names=set()) == defaults
+
+
+def test_unchecked_mcp_computed_from_all_configured_servers():
+    """Review finding #3: unchecked_mcp must be computed from ALL configured
+    MCP server names, not just pure_mcp (which strips collision names)."""
+    src = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+    # The additive branch must use the full configured set
+    assert "unchecked_mcp = mcp_server_names - set(override)" in src, (
+        "unchecked_mcp must be computed from all configured servers"
+    )
+    # The old pure_mcp-based computation must be gone
+    assert "unchecked_mcp = pure_mcp - set(override)" not in src, (
+        "old pure_mcp-based unchecked_mcp must be removed"
+    )
+
+
+# ── Round-5 reviewer findings ────────────────────────────────────────────────
+
+
+def test_scalar_override_through_real_caller_path(monkeypatch, tmp_path):
+    """Drive scalar overrides through the REAL ``_run_agent_streaming()`` call
+    site (api/streaming.py:8297-8314) and capture the final ``enabled_toolsets``
+    the agent constructor receives.
+
+    The previous version copied the caller logic into a local ``_caller_path``
+    — a regression at the real call site (e.g. reverting to ``if _override:``)
+    could pass while the copy stayed green.  This harness invokes the actual
+    worker with only the agent constructor substituted (a capturing fake) and
+    asserts the captured ``enabled_toolsets`` for a falsy scalar override.
+    """
+    import queue
+    import sys
+    import types as _types
+
+    from api import models
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+
+        def run_conversation(self, **kwargs):
+            return {"failed": False, "messages": []}
+
+    sid = "scalar-real-caller"
+    stream_id = "scalar-real-stream"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    session = models.Session(
+        session_id=sid,
+        title="scalar",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[],
+        context_messages=[],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "hi"
+    session.pending_started_at = 1.0
+    session.save()
+    models.SESSIONS[sid] = session
+    streaming.SESSIONS[sid] = session
+    streaming.STREAMS[stream_id] = queue.Queue()
+
+    fake_hermes_state = _types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *_a, **_k: object()
+
+    def _fake_load_metadata_only(session_id):
+        meta = models.Session(session_id=session_id, model="gpt-4o")
+        # Falsy scalar persisted metadata (the round-5 regression shape).
+        meta.enabled_toolsets = 0
+        return meta
+
+    with monkeypatch.context() as m:
+        m.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+        m.setattr(streaming, "resolve_model_provider",
+                  lambda *_a, **_k: ("gpt-4o", "openai", None))
+        m.setattr("api.config.get_config", lambda *_a, **_k: {"mcp_servers": {}})
+        m.setattr("api.config._resolve_cli_toolsets", lambda *_a, **_k: ["web", "file"])
+        m.setattr(models.Session, "load_metadata_only",
+                  staticmethod(_fake_load_metadata_only))
+        m.setitem(sys.modules, "hermes_state", fake_hermes_state)
+        streaming._run_agent_streaming(
+            session_id=sid,
+            msg_text="hi",
+            model="gpt-4o",
+            workspace=str(tmp_path),
+            stream_id=stream_id,
+        )
+
+    assert captured["enabled_toolsets"] == [], (
+        "falsy scalar override must fail closed to empty through the REAL "
+        f"call site; got {captured.get('enabled_toolsets')!r}"
+    )
+
+
+def test_runtime_custom_composite_and_leaf_resolver_called(monkeypatch):
+    """Build an unsafe composite and a direct-tools leaf through the REAL
+    ``create_custom_toolset()`` and registry ownership APIs; wrap the real
+    resolver while delegating to it.  Prove the unchecked direct leaf and
+    the unsafe composite are dropped, while builtins and the selected
+    server survive.
+
+    The previous version assigned plain dicts into ``toolsets.TOOLSETS`` and
+    hard-coded classifier returns — it never exercised real creation,
+    registry ownership, or the resolver's expansion.  This version registers
+    real tools owned by an unchecked ``mcp-gate-beta`` and lets the real
+    resolver decide.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("gate-composite", "composite",
+                                      tools=[], includes=["gate-beta"])
+        _ts_mod.create_custom_toolset("gate-leaf", "leaf",
+                                      tools=["leaf_tool"], includes=[])
+        _ts_mod.create_custom_toolset("safe-composite", "safe",
+                                      tools=[], includes=["web"])
+        _reg.register_toolset_alias("gate-beta", "mcp-gate-beta")
+        _reg.register_toolset_alias("gate-alpha", "mcp-gate-alpha")
+        _reg.register("leaf_tool", "mcp-gate-beta", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register("alpha_tool", "mcp-gate-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        _calls = []
+        _orig = streaming._default_transitively_reaches_unchecked_mcp
+
+        def _wrapped(name, unchecked, builtin_names=None):
+            _calls.append(name)
+            return _orig(name, unchecked, builtin_names)
+
+        monkeypatch.setattr(streaming,
+                            "_default_transitively_reaches_unchecked_mcp",
+                            _wrapped)
+
+        defaults = ["web", "gate-composite", "gate-leaf", "safe-composite"]
+        override = ["gate-alpha"]
+        mcp_servers = {"gate-alpha", "gate-beta"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        # Resolver consulted for every survivor (builtins included, round-5).
+        for name in ("web", "gate-composite", "gate-leaf", "safe-composite"):
+            assert name in _calls, f"resolver must inspect {name}, got {_calls}"
+
+        # Builtins + selected server survive; unchecked-MCP paths drop.
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        assert "gate-alpha" in result, f"ticked server must survive, got {result!r}"
+        assert "gate-composite" not in result, (
+            f"composite reaching unchecked mcp-gate-beta must be dropped, got {result!r}"
+        )
+        assert "gate-leaf" not in result, (
+            f"direct leaf owned by unchecked mcp-gate-beta must be dropped, got {result!r}"
+        )
+        assert "safe-composite" in result, (
+            f"safe composite (only includes web) must survive, got {result!r}"
+        )
+        assert "gate-beta" not in result, (
+            f"unchecked server must not appear, got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_unchecked_builtin_colliding_mcp_via_canonical_behavioral(monkeypatch):
+    """Real canonical ``mcp-web`` resolution: register a tool owned by the
+    canonical ``mcp-web`` toolset, build a composite that includes
+    ``mcp-web``, and prove registry ownership causes rejection when the
+    colliding server ``web`` is configured but unchecked.
+
+    The previous version answered ``True`` from a wrapper for
+    ``web-reach-composite``; this version resolves a real canonical
+    ``mcp-web`` tool and lets registry ownership drive the denial.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("web-reach-composite", "reaches mcp-web",
+                                      tools=[], includes=["mcp-web"])
+        _reg.register("web_owned_tool", "mcp-web", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "web-reach-composite"]
+        override = ["my-search"]
+        mcp_servers = {"my-search", "web"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "web-reach-composite" not in result, (
+            f"composite reaching unchecked mcp-web must be dropped, got {result!r}"
+        )
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        assert "my-search" in result, f"ticked server must survive, got {result!r}"
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_safe_composite_positive_survival(monkeypatch):
+    """A safe composite that does not reach any unchecked MCP server
+    survives — with one selected server AND a different unchecked server
+    configured, so the production helper cannot early-return on an empty
+    unchecked set (non-vacuous).
+
+    The previous version configured only the selected server, leaving
+    ``unchecked_mcp`` empty and skipping the resolver/registry inspection.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("safe-composite", "safe workflow",
+                                      tools=[], includes=["web"])
+        _reg.register_toolset_alias("gate-beta", "mcp-gate-beta")
+        _reg.register("beta_tool", "mcp-gate-beta", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "safe-composite"]
+        override = ["my-search"]
+        # gate-beta configured but NOT ticked → unchecked set non-empty.
+        mcp_servers = {"my-search", "gate-beta"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "safe-composite" in result, (
+            "safe composite must survive with an unchecked server present, "
+            f"got {result!r}"
+        )
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        assert "my-search" in result, f"ticked server must survive, got {result!r}"
+        assert "gate-beta" not in result, (
+            f"unchecked server must not appear, got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-6 reviewer findings ────────────────────────────────────────────────
+
+
+def test_runtime_custom_composite_through_real_caller(monkeypatch, tmp_path):
+    """Production-composed acceptance: drive a safe custom composite, an
+    unsafe composite, a direct leaf, and a static MCP name in defaults
+    through the REAL ``_run_agent_streaming()`` call site.  Assert the
+    final ``enabled_toolsets`` (complete list) and the resolved tool
+    list (including a unique registered tool from the safe composite)."""
+    import queue
+    import sys
+    import types as _types
+
+    import toolsets as _ts_mod
+    from api import models
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+
+        def run_conversation(self, **kwargs):
+            return {"failed": False, "messages": []}
+
+    try:
+        # Seed real registry/toolset state (runtime-composed, like production):
+        # - safe-composite: custom composite that only includes safe-inner
+        #   (a registry-only toolset with a unique tool, proving resolve works)
+        # - unsafe-composite: custom composite that includes unchecked mcp-beta
+        # - gate-leaf: direct tool owned by unchecked mcp-gate-beta
+        # - gate-alpha: selected MCP server (ticked); gate-beta: unchecked
+        # - search: configured MCP server whose name COLLIDES with static "search"
+        _ts_mod.create_custom_toolset("safe-composite", "safe workflow",
+                                      tools=[], includes=["safe-inner"])
+        _ts_mod.create_custom_toolset("unsafe-composite", "reaches beta",
+                                      tools=[], includes=["gate-beta"])
+        _ts_mod.create_custom_toolset("gate-leaf", "leaf owned by beta",
+                                      tools=["beta_only_tool"], includes=[])
+        _reg.register_toolset_alias("gate-alpha", "mcp-gate-alpha")
+        _reg.register_toolset_alias("gate-beta", "mcp-gate-beta")
+        _reg.register("alpha_tool", "mcp-gate-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register("beta_only_tool", "mcp-gate-beta", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register("safe_unique_tool", "safe-inner", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Collision: MCP server "search" shares name with static toolset "search"
+        _reg.register_toolset_alias("search", "mcp-search")
+        _reg.register("search_mcp_tool", "mcp-search", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Exact-static overlay canary (round-8 finding 3): a unique tool
+        # registered under the exact static owner "search" (NOT the aliased
+        # mcp-search) must survive resolution, proving the installed
+        # static-first-overlay merge order is real.  Reverting the stand-in
+        # to a static-only return must make this assertion fail.
+        _reg.register("search_static_owned_tool", "search", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # ── Round-8 finding 1: the collision seed must be assertion-relevant ──
+        # These checks run BEFORE driving the caller and prove the collision
+        # setup is actually installed.  Deleting or no-oping the
+        # `search -> mcp-search` alias registration below must turn the test
+        # RED — the final `search_mcp_tool not in final_tools` assertion alone
+        # is too easy to satisfy when the seed is absent.
+        _alias_target = _reg.get_toolset_alias_target("search")
+        assert _alias_target == "mcp-search", (
+            f"collision seed must alias search -> mcp-search, got {_alias_target!r}"
+        )
+        _mcp_search_tools = set(_reg.get_tool_names_for_toolset("mcp-search"))
+        assert "search_mcp_tool" in _mcp_search_tools, (
+            f"canonical mcp-search must own the unique MCP canary, got {sorted(_mcp_search_tools)!r}"
+        )
+        # Non-static alias positive control: `gate-alpha` is NOT a static
+        # toolset, so resolving it must take the alias -> mcp-gate-alpha path
+        # and surface alpha_tool.  This proves the alias activation path is
+        # genuinely live (not just the static-first branch being exercised).
+        _gate_alpha_resolved = set(_ts_mod.resolve_toolset("gate-alpha"))
+        assert "alpha_tool" in _gate_alpha_resolved, (
+            f"non-static alias gate-alpha must resolve alpha_tool, got {sorted(_gate_alpha_resolved)!r}"
+        )
+
+        sid = "runtime-composed"
+        stream_id = "runtime-composed-stream"
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+        monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+        session = models.Session(
+            session_id=sid,
+            title="runtime-composed",
+            workspace=str(tmp_path),
+            model="gpt-4o",
+            messages=[],
+            context_messages=[],
+        )
+        session.active_stream_id = stream_id
+        session.pending_user_message = "hi"
+        session.pending_started_at = 1.0
+        session.save()
+        models.SESSIONS[sid] = session
+        streaming.SESSIONS[sid] = session
+        streaming.STREAMS[stream_id] = queue.Queue()
+
+        fake_hermes_state = _types.ModuleType("hermes_state")
+        fake_hermes_state.SessionDB = lambda *_a, **_k: object()
+
+        def _fake_load_metadata_only(session_id):
+            meta = models.Session(session_id=session_id, model="gpt-4o")
+            # Selected MCP server ticked in the composer chip; gate-beta and
+            # search are configured but NOT ticked → unchecked MCP servers present.
+            meta.enabled_toolsets = ["gate-alpha"]
+            return meta
+
+        with monkeypatch.context() as m:
+            m.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+            m.setattr(streaming, "resolve_model_provider",
+                      lambda *_a, **_k: ("gpt-4o", "openai", None))
+            m.setattr("api.config.get_config", lambda *_a, **_k: {
+                "mcp_servers": {"gate-alpha": {}, "gate-beta": {}, "search": {}},
+            })
+            m.setattr("api.config._resolve_cli_toolsets",
+                      lambda *_a, **_k: ["web", "search", "safe-composite",
+                                         "unsafe-composite", "gate-leaf"])
+            m.setattr(models.Session, "load_metadata_only",
+                      staticmethod(_fake_load_metadata_only))
+            m.setitem(sys.modules, "hermes_state", fake_hermes_state)
+            streaming._run_agent_streaming(
+                session_id=sid,
+                msg_text="hi",
+                model="gpt-4o",
+                workspace=str(tmp_path),
+                stream_id=stream_id,
+            )
+
+        result = captured["enabled_toolsets"]
+        assert result is not None, "AIAgent constructor never received enabled_toolsets"
+        # Assert the COMPLETE list, not just membership.
+        assert result == ["web", "search", "safe-composite", "gate-alpha"], (
+            f"unexpected enabled_toolsets: {result!r}"
+        )
+
+        # Resolve the final toolset-set through the real resolver/registry and
+        # assert the FINAL tool list.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "web_search" in final_tools, (
+            f"builtin web tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "safe_unique_tool" in final_tools, (
+            f"safe-composite unique tool must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "alpha_tool" in final_tools, (
+            f"selected gate-alpha tool must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "beta_only_tool" not in final_tools, (
+            f"unchecked beta-owned tool must be excluded, got {sorted(final_tools)!r}"
+        )
+        # Collision asserts: static "search" tools survive; aliased MCP
+        # "search" is excluded.
+        search_tools = set(_ts_mod.resolve_toolset("search"))
+        assert search_tools.issubset(final_tools), (
+            f"static search tools {sorted(search_tools)} must survive collision, "
+            f"got {sorted(final_tools)!r}"
+        )
+        assert "search_mcp_tool" not in final_tools, (
+            f"colliding MCP search tool must be excluded, got {sorted(final_tools)!r}"
+        )
+        # Round-8 finding 3: the exact-static overlay canary — a unique tool
+        # registered under the static owner "search" (not the aliased
+        # mcp-search) — must survive into the resolved tool set.  This proves
+        # the installed static-first-overlay merge order is genuinely active;
+        # a stand-in that returns static-only (no registry overlay) would fail
+        # here.
+        assert "search_static_owned_tool" in search_tools, (
+            f"exact-static overlay must merge registry tools under 'search', "
+            f"got {sorted(search_tools)!r}"
+        )
+        assert "search_static_owned_tool" in final_tools, (
+            f"exact-static overlay canary must survive into final tools, "
+            f"got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Gate-certification regressions (round-10) ────────────────────────────────
+# hermes-sweeper gate RED on 08fafc9d reported three production defects:
+#   1. BRICK  — a configured MCP server named ``all`` (the reserved wildcard
+#               class) breaks tool resolution: the resolver treats the bare
+#               selector as a wildcard and recurses into itself until
+#               RecursionError.
+#   2. SILENT — canonical-name collisions resolve the WRONG MCP server: with
+#               servers ``alpha`` and ``mcp-alpha`` configured, selecting
+#               ``mcp-alpha`` returns the ambiguous bare token and exposes
+#               ``alpha``'s tools (``mcp-mcp-alpha`` is the true canonical).
+#   3. SILENT — an offline unchecked server can re-enter through a retained
+#               custom composite after registration: the tool-level check
+#               sees no registered tools while the server is offline and
+#               keeps the composite; registering the server later exposes
+#               its tools without a new authorization decision.
+# The production fix canonicalizes picker-derived MCP selections to a
+# verified registry target and adds a registration-state-independent
+# structural walk of composite ``includes`` chains.
+
+
+def test_server_named_all_is_canonicalized_not_wildcard(monkeypatch):
+    """A configured MCP server literally named ``all`` must be emitted as the
+    canonical ``mcp-all`` target, never as the bare wildcard ``all``.
+
+    The installed resolver treats bare ``all``/``*`` as "expand every
+    toolset" BEFORE consulting MCP aliases, so a bare ``all`` selection
+    recurses until RecursionError (gate-certified BRICK).  The additive
+    classifier must canonicalize it to ``mcp-all``, which resolves as a
+    plain toolset name.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("all", "server literally named all",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("all", "mcp-all")
+        _reg.register("all_tool", "mcp-all", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "file"]
+        override = ["all"]
+        mcp_servers = {"all", "other"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "all" not in result, (
+            f"bare wildcard 'all' must never survive, got {result!r}"
+        )
+        assert "mcp-all" in result, (
+            f"canonical mcp-all must be emitted, got {result!r}"
+        )
+        # The canonical target must resolve to the server's tools.
+        resolved = set(_ts_mod.resolve_toolset("mcp-all"))
+        assert "all_tool" in resolved, (
+            f"mcp-all must resolve the server's tools, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_server_named_star_is_canonicalized_not_wildcard(monkeypatch):
+    """The ``*`` reserved selector collides with a server of the same name and
+    must also be canonicalized to ``mcp-*``."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("*", "server literally named star",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("*", "mcp-*")
+        _reg.register("star_tool", "mcp-*", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web"]
+        override = ["*"]
+        mcp_servers = {"*", "other"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "*" not in result, (
+            f"bare wildcard '*' must never survive, got {result!r}"
+        )
+        assert "mcp-*" in result, (
+            f"canonical mcp-* must be emitted, got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_canonical_collision_mcp_alpha_selects_right_server(monkeypatch):
+    """With servers ``alpha`` AND ``mcp-alpha`` configured, selecting
+    ``mcp-alpha`` must emit ``mcp-mcp-alpha`` (the selected server's true
+    canonical), NOT the bare ``mcp-alpha`` which collides with server
+    ``alpha``'s canonical toolset (gate-certified SILENT defect 2).
+
+    Production-composed: ``builtin_names`` is NOT injected — the real
+    ``_builtin_toolset_names()`` collector runs, so the broad shadow set
+    contains BOTH ``mcp-alpha`` and ``mcp-mcp-alpha``.  The round-11
+    owned-canonical exclusion must remove them (alias-edge proven) before
+    the MCP-only test, or ``mcp-alpha`` would be wrongly restricted and the
+    canonicalizer branch never reached (the round-10 blocker)."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Server "alpha" → canonical mcp-alpha
+        _ts_mod.create_custom_toolset("alpha", "server alpha", tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_owned_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Server "mcp-alpha" → canonical mcp-mcp-alpha
+        _ts_mod.create_custom_toolset("mcp-alpha", "server mcp-alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("mcp-alpha", "mcp-mcp-alpha")
+        _reg.register("mcp_alpha_owned_tool", "mcp-mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Seed-assertion relevance (round-8 rule): prove the alias edges are
+        # live BEFORE driving the classifier.
+        assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
+        assert _reg.get_toolset_alias_target("mcp-alpha") == "mcp-mcp-alpha"
+
+        defaults = ["web"]
+        override = ["mcp-alpha"]
+        mcp_servers = {"alpha", "mcp-alpha"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names=None)
+
+        assert "mcp-alpha" not in result, (
+            f"ambiguous bare mcp-alpha must never survive, got {result!r}"
+        )
+        assert "mcp-mcp-alpha" in result, (
+            f"true canonical mcp-mcp-alpha must be emitted, got {result!r}"
+        )
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        resolved = set(_ts_mod.resolve_toolset("mcp-mcp-alpha"))
+        assert "mcp_alpha_owned_tool" in resolved, (
+            f"mcp-mcp-alpha must resolve the SELECTED server's tools, "
+            f"got {sorted(resolved)!r}"
+        )
+        # The other server's tools must not appear.
+        assert "alpha_owned_tool" not in resolved, (
+            f"wrong server's tools must not resolve, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_offline_unchecked_server_cannot_reenter_composite(monkeypatch):
+    """A composite whose ``includes`` references an unchecked MCP server must
+    be dropped EVEN WHEN that server is offline (no tools registered yet).
+
+    Gate-certified SILENT defect 3: the tool-level check sees no registered
+    tools while the server is offline and keeps the composite; registering
+    the server later would re-expose its tools without a new authorization
+    decision.  The structural includes walk is registration-state
+    independent and must reject the composite up front, and the retained
+    result must stay clean after the server registers.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Composite reaches "gate-beta" — configured but NOT ticked.
+        _ts_mod.create_custom_toolset("bad-composite", "reaches gate-beta",
+                                      tools=[], includes=["gate-beta"])
+        # NOTE: gate-beta has NO alias and NO registered tools yet — offline.
+
+        defaults = ["web", "bad-composite"]
+        override = ["gate-alpha"]
+        mcp_servers = {"gate-alpha", "gate-beta"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "bad-composite" not in result, (
+            f"composite reaching offline unchecked server must be dropped, "
+            f"got {result!r}"
+        )
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        assert "gate-alpha" in result, (
+            f"ticked server must survive, got {result!r}"
+        )
+
+        # Late registration: the unchecked server comes online AFTER the
+        # merge decision.  The retained result must not expose its tools.
+        _reg.register_toolset_alias("gate-beta", "mcp-gate-beta")
+        _reg.register("beta_tool", "mcp-gate-beta", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "beta_tool" not in final_tools, (
+            f"offline server must not re-enter via retained composite, "
+            f"got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_offline_unchecked_server_canonical_reference_rejected(monkeypatch):
+    """A composite whose includes chain references an unchecked server by its
+    CANONICAL ``mcp-<server>`` selector is rejected even while offline —
+    canonical resolution bypasses alias shadowing, so the canonical name in
+    the includes chain is always an MCP reference."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("bad-composite", "reaches mcp-gate-beta",
+                                      tools=[], includes=["mcp-gate-beta"])
+
+        defaults = ["web", "bad-composite"]
+        override = ["gate-alpha"]
+        mcp_servers = {"gate-alpha", "gate-beta"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "file", "terminal"})
+
+        assert "bad-composite" not in result, (
+            f"composite reaching offline unchecked canonical must be dropped, "
+            f"got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_builtin_shadowed_bare_name_not_treated_as_mcp_reference(monkeypatch):
+    """A bare name that is BOTH a builtin toolset and a configured MCP server
+    (e.g. server ``search`` colliding with static ``search``) must NOT be
+    rejected by the structural walk — the builtin shadows the MCP alias, so
+    the default entry ``search`` is the builtin, not an MCP reference."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("search", "static search builtin",
+                                      tools=["search_tool"], includes=[])
+        _ts_mod.create_custom_toolset("web", "static web builtin",
+                                      tools=["web_tool"], includes=[])
+        _reg.register("search_tool", "search", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register("web_tool", "web", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Server "search" is configured but unchecked; default "search" is
+        # the static builtin and must survive.
+        defaults = ["web", "search"]
+        override = ["gate-alpha"]
+        mcp_servers = {"gate-alpha", "search"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names={"web", "search", "file", "terminal"})
+
+        assert "web" in result, f"builtin web must survive, got {result!r}"
+        assert "search" in result, (
+            f"builtin search (bare name shadowed by static) must survive, "
+            f"got {result!r}"
+        )
+        assert "gate-alpha" in result, (
+            f"ticked server must survive, got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-14: malformed dangerous selectors must be sanitized ───────────────
+
+
+def test_malformed_override_with_all_sanitized():
+    """A malformed override containing 'all' wildcard must NOT yield ['all']
+    which the resolver expands to every toolset (gate-certified SILENT).
+
+    Round-14 fix: malformed override drops dangerous selectors.
+    """
+    defaults = ["web", "file", "terminal", "alpha", "beta"]
+    override = ["all", {"bad": 1}]  # malformed + wildcard
+
+    result = _apply_override(defaults, override, {"alpha", "beta"})
+
+    assert "all" not in result, (
+        f"'all' wildcard must be dropped from malformed override, got {result!r}"
+    )
+    assert {"bad": 1} not in result, "non-string entries must be filtered"
+    # Should be empty after sanitizing: all strings were dangerous
+    assert result == [], (
+        f"malformed override with only dangerous strings must return [], got {result!r}"
+    )
+
+
+def test_malformed_override_with_mcp_selector_sanitized():
+    """A malformed override containing unverified 'mcp-*' selector must NOT
+    pass through — the resolver may pick the wrong server (gate-certified).
+
+    Round-14 fix: malformed override drops mcp-* selectors.
+    """
+    defaults = ["web", "file", "terminal"]
+    override = ["mcp-alpha", {"bad": 1}]  # malformed + unverified canonical
+
+    result = _apply_override(defaults, override, {"alpha", "beta"})
+
+    assert "mcp-alpha" not in result, (
+        f"unverified mcp-* selector must be dropped, got {result!r}"
+    )
+    assert result == [], "malformed override with only dangerous strings"
+
+
+def test_malformed_mcp_server_names_returns_empty():
+    """Malformed configured MCP server names must return [] (fully restrictive),
+    not the raw override which may contain dangerous selectors.
+
+    Round-14 fix: malformed mcp_server_names → [] instead of list(override).
+    """
+    defaults = ["web", "file", "terminal"]
+    override = ["alpha", "beta"]  # valid strings
+    mcp_names = {"alpha", 42}  # non-string in mcp_server_names
+
+    result = _apply_override(defaults, override, mcp_names)
+
+    assert result == [], (
+        f"malformed mcp_server_names must return [] (fail-closed), got {result!r}"
+    )
+
+
+def test_exact_alias_match_required_for_ownership(monkeypatch):
+    """A mismatched alias target is NOT ownership proof: the falsely claimed
+    canonical must remain a real shadow, and every selector the merge
+    returns must resolve none of the wrong owner's tools.
+
+    Coupled canonical-collision shape (round-11 fix-spec): servers ``alpha``
+    and ``mcp-alpha`` are both configured; server ``mcp-alpha``'s picker
+    token collides with server ``alpha``'s canonical ``mcp-alpha``.  A
+    plugin owns the canonical ``mcp-wrong`` (``wrong_tool``, no alias edge)
+    and a third server is literally named ``mcp-wrong``, so the mismatched
+    probe target IS present in the broad shadow set.
+
+    The ownership probe for server ``mcp-alpha`` falsely returns
+    ``mcp-wrong`` (its true edge is ``mcp-mcp-alpha``).  The OLD
+    truthy-target code accepted that false edge as ownership proof and
+    removed the plugin's ``mcp-wrong`` canonical from the shadow set —
+    which let BOTH mcp-* ticks flow into the additive branch and resolve.
+    The exact-match check keeps ``mcp-wrong`` a real shadow, so server
+    ``mcp-wrong``'s tick no longer counts as pure MCP and the mixed
+    override falls to the restrict branch, where the ambiguous picker
+    token must be dropped (round-15 restrict fix) instead of re-interpreted
+    as server ``alpha``'s canonical.  Net effect: no returned selector may
+    resolve the wrong-owner tools (``wrong_tool``, ``alpha_tool``) or the
+    ambiguously-owned ticks (``mcp_alpha_tool``, ``mcp_wrong_tool``).
+
+    Round-14 fix: require _t == f"mcp-{_srv}" for ownership.
+    Round-15 fix: resolve every returned selector and prove the wrong-owner
+    tools are absent (the restrict branch must drop a picker token that is
+    itself a configured server's bare name).
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Server "alpha" → canonical mcp-alpha (alpha_tool).
+        _ts_mod.create_custom_toolset("alpha", "server alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Server "mcp-alpha" → canonical mcp-mcp-alpha (mcp_alpha_tool).
+        _ts_mod.create_custom_toolset("mcp-alpha", "server mcp-alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("mcp-alpha", "mcp-mcp-alpha")
+        _reg.register("mcp_alpha_tool", "mcp-mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Server "mcp-wrong" → canonical mcp-mcp-wrong (mcp_wrong_tool).
+        _ts_mod.create_custom_toolset("mcp-wrong", "server mcp-wrong",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("mcp-wrong", "mcp-mcp-wrong")
+        _reg.register("mcp_wrong_tool", "mcp-mcp-wrong", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Plugin canonical "mcp-wrong" — registered, NO alias edge.  This is
+        # the mismatched target: it collides with server mcp-wrong's bare
+        # picker token and lives in the broad shadow set.
+        _reg.register("wrong_tool", "mcp-wrong", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Seed-assertion relevance (round-8 rule): prove the collision edges
+        # are live BEFORE driving the classifier.
+        assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
+        assert _reg.get_toolset_alias_target("mcp-alpha") == "mcp-mcp-alpha"
+        assert _reg.get_toolset_alias_target("mcp-wrong") == "mcp-mcp-wrong"
+
+        # MISMATCHED ownership probe: server mcp-alpha's edge falsely claims
+        # the plugin's canonical "mcp-wrong" (true target is mcp-mcp-alpha).
+        _real_probe = streaming._registry_alias_target
+
+        def _fake_alias_target(name):
+            if name == "mcp-alpha":
+                return "mcp-wrong"  # mismatched — not ownership proof
+            return _real_probe(name)
+
+        monkeypatch.setattr(
+            "api.streaming._registry_alias_target", _fake_alias_target
+        )
+
+        defaults = ["web"]
+        override = ["mcp-alpha", "mcp-wrong"]
+        mcp_servers = {"alpha", "mcp-alpha", "mcp-wrong"}
+        result = _apply_override(defaults, override, mcp_servers,
+                                 builtin_names=None)
+
+        # The mismatched target must remain a real shadow: the plugin
+        # canonical must never be emitted raw by the merge.
+        assert "mcp-wrong" not in result, (
+            f"mismatched target must stay in the shadow set, got {result!r}"
+        )
+        # Resolve every returned selector: the wrong owner's tools must be
+        # absent.  Old truthy-target code let the false proof flow both
+        # ticks through the additive branch; the current code must fail
+        # closed.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "wrong_tool" not in final_tools, (
+            f"plugin (wrong-owner) tool must not resolve, got {sorted(final_tools)!r}"
+        )
+        assert "alpha_tool" not in final_tools, (
+            f"unselected server alpha's tools must not resolve, got {sorted(final_tools)!r}"
+        )
+        assert "mcp_alpha_tool" not in final_tools, (
+            f"ambiguously-owned tick mcp-alpha must fail closed, got {sorted(final_tools)!r}"
+        )
+        assert "mcp_wrong_tool" not in final_tools, (
+            f"ambiguously-owned tick mcp-wrong must fail closed, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -950,6 +950,13 @@ def test_free_text_all_wildcard_preserved_in_restrict(monkeypatch):
     same-named MCP server (a server literally named ``all``), because then
     the bare token is genuinely ambiguous between the wildcard and the
     server's picker token.
+
+    Round-17 review fix: The wildcard in restrict mode must expand to ALL
+    REGISTERED tools EXCEPT those from unconfigured MCP servers. The function
+    expands `all`/`*` to explicit selectors (all builtins/plugins + all
+    configured MCP servers), NOT the raw wildcard token. This prevents the
+    resolver from later expanding it across the whole process-global registry
+    and exposing foreign tools.
     """
     import toolsets as _ts_mod
     from tools.registry import registry as _reg
@@ -959,11 +966,15 @@ def test_free_text_all_wildcard_preserved_in_restrict(monkeypatch):
     _saved_aliases = dict(_reg._toolset_aliases)
 
     try:
-        # A configured server NOT named "all" — free-text "all" must survive.
+        # A configured server NOT named "all" — free-text "all" must be expanded.
         _ts_mod.create_custom_toolset("alpha", "server alpha",
                                       tools=[], includes=[])
         _reg.register_toolset_alias("alpha", "mcp-alpha")
         _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN: registered in the live registry but NOT configured.
+        # The wildcard expansion must NOT include this tool.
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
                       lambda *a, **k: "ok", override=True)
 
         defaults = ["web", "file"]
@@ -974,13 +985,33 @@ def test_free_text_all_wildcard_preserved_in_restrict(monkeypatch):
             builtin_names={"web", "file", "terminal"},
         )
 
-        assert result == ["all"], (
-            f"free-text 'all' must be preserved in restrict mode, got {result!r}"
+        # Round-17 fix: wildcard is EXPANDED to explicit selectors, not kept as "all".
+        # The raw wildcard token is not returned because the resolver would later
+        # expand it across the whole registry (including foreign tools).
+        assert "all" not in result, (
+            f"wildcard must be expanded, not kept as raw token. Got {result!r}"
         )
-        # Resolving it must yield the full toolset, not an empty list.
-        resolved = set(_ts_mod.resolve_toolset("all"))
-        assert "web_search" in resolved and "read_file" in resolved, (
-            f"'all' must expand to the full toolset, got {sorted(resolved)!r}"
+        # The expanded result must include builtins and configured MCP servers.
+        assert "web" in result and "file" in result, (
+            f"builtin toolsets must be in expanded result, got {result!r}"
+        )
+        assert "mcp-alpha" in result, (
+            f"configured MCP server must be in expanded result, got {result!r}"
+        )
+        # Resolve every selector: foreign must NOT be exposed.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "web_search" in final_tools and "read_file" in final_tools, (
+            f"builtin tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "alpha_tool" in final_tools, (
+            f"configured MCP server's tools must resolve, got {sorted(final_tools)!r}"
+        )
+        # Round-17 fix: assert foreign MCP tool is NOT exposed.
+        assert "foreign_tool" not in final_tools, (
+            f"wildcard expansion must NOT expose foreign MCP tools "
+            f"(unconfigured servers). Got {sorted(final_tools)!r}"
         )
     finally:
         _ts_mod.TOOLSETS.clear()
@@ -1002,8 +1033,12 @@ def test_free_text_star_wildcard_preserved_in_restrict(monkeypatch):
         builtin_names={"web", "file", "terminal"},
     )
 
-    assert result == ["*"], (
-        f"free-text '*' must be preserved in restrict mode, got {result!r}"
+    # Wildcard is expanded, not kept as raw "*"
+    assert "*" not in result, (
+        f"wildcard must be expanded, not kept as raw token. Got {result!r}"
+    )
+    assert "web" in result and "file" in result, (
+        f"builtin toolsets must be in expanded result, got {result!r}"
     )
 
 
@@ -1281,6 +1316,10 @@ def test_wildcard_default_all_servers_selected_no_foreign_leak(monkeypatch):
     wildcard default would expand it across the whole live registry at
     resolution time and expose ``foreign_tool``; the fix must return only
     the verified canonical targets.
+
+    Round-17 review fix: must also assert safe-survivor tools (web_search,
+    read_file) are present in the final resolved toolset — the profile
+    defaults contain builtins that must survive the additive merge.
     """
     import toolsets as _ts_mod
     from tools.registry import registry as _reg
@@ -1304,7 +1343,9 @@ def test_wildcard_default_all_servers_selected_no_foreign_leak(monkeypatch):
         assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
         assert _reg.get_toolset_alias_target("beta") == "mcp-beta"
 
-        defaults = ["all"]  # wildcard profile default
+        # Profile defaults include wildcards AND builtin toolsets.
+        # The builtins (web, file) must survive the additive merge.
+        defaults = ["web", "file", "all"]  # wildcard profile default + builtins
         override = ["alpha", "beta"]  # every configured server ticked
         mcp_servers = {"alpha", "beta"}
         result = _apply_override(
@@ -1316,14 +1357,24 @@ def test_wildcard_default_all_servers_selected_no_foreign_leak(monkeypatch):
         assert "all" not in result, (
             f"wildcard default must not survive, got {result!r}"
         )
+        # The builtin defaults must survive the additive merge.
+        assert "web" in result and "file" in result, (
+            f"builtin defaults must survive additive merge, got {result!r}"
+        )
         # Resolve every returned selector: only the ticked servers' tools
         # may appear; the unconfigured foreign server must stay out.
         final_tools = set()
         for name in result:
             final_tools.update(_ts_mod.resolve_toolset(name))
+        # Safe-survivor builtin tools must resolve.
+        assert "web_search" in final_tools and "read_file" in final_tools, (
+            f"safe-survivor builtin tools must resolve, got {sorted(final_tools)!r}"
+        )
+        # Ticked MCP servers' tools must resolve.
         assert "alpha_tool" in final_tools and "beta_tool" in final_tools, (
             f"ticked servers' tools must resolve, got {sorted(final_tools)!r}"
         )
+        # Foreign must be excluded.
         assert "foreign_tool" not in final_tools, (
             f"unconfigured foreign server's tools must NOT resolve, "
             f"got {sorted(final_tools)!r}"
@@ -2663,6 +2714,191 @@ def test_exact_alias_match_required_for_ownership(monkeypatch):
         assert "mcp_wrong_tool" not in final_tools, (
             f"ambiguously-owned tick mcp-wrong must fail closed, got {sorted(final_tools)!r}"
         )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-17 additional regression tests ───────────────────────────────────────
+
+
+def test_unconfigured_mcp_foreign_canonical_absent_from_result(monkeypatch):
+    """Round-17 scenario 3: an unconfigured MCP server's canonical selector
+    (e.g. ``mcp-foreign``) is present in the global registry but must NOT
+    appear in the final toolset result.
+
+    The profile only configures ``alpha``; the ``foreign`` server is in the
+    registry but NOT configured. The selector ``mcp-foreign`` must be absent.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Configured server alpha
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Unconfigured foreign server in global registry
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "file"]
+        override = ["alpha"]  # tick alpha only
+        mcp_servers = {"alpha"}  # only alpha is configured
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        # mcp-foreign must NOT appear
+        assert "mcp-foreign" not in result, (
+            f"unconfigured MCP server canonical must be absent, got {result!r}"
+        )
+        # Resolve: foreign_tool must not be callable
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "foreign_tool" not in final_tools, (
+            f"foreign server tools must not resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_immutable_static_mcp_prefix_survives_with_provenance(monkeypatch):
+    """Round-17 scenario 4: a genuinely immutable static/plugin toolset whose
+    name begins with ``mcp-`` must survive ONLY with real provenance authority
+    (presence in the builtin shadow set), not just because the name looks like
+    an MCP server.
+
+    This verifies the `true_shadow` check in the restrict branch correctly
+    distinguishes between real static/plugin toolsets and MCP server selectors.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # A genuine static toolset named "mcp-browser" (e.g. a plugin)
+        _ts_mod.create_custom_toolset("mcp-browser", "browser plugin",
+                                      tools=["browser_navigate"], includes=[])
+        _reg.register("browser_navigate", "mcp-browser", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # NO alias edge — this is NOT an MCP server, it's a static toolset
+
+        # A configured MCP server alpha
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "file"]
+        override = ["mcp-browser"]  # user selects the static toolset
+        mcp_servers = {"alpha"}  # only alpha is a configured MCP server
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal", "mcp-browser"},  # proven in shadow
+        )
+
+        # mcp-browser must survive (it's in true_shadow)
+        assert "mcp-browser" in result, (
+            f"static mcp-* toolset with provenance must survive, got {result!r}"
+        )
+        # It resolves to its own tools
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "browser_navigate" in final_tools, (
+            f"static mcp-browser tool must resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_two_profiles_same_registry_isolation(monkeypatch):
+    """Round-17 scenario 5: two profile/session configs sharing one process-global
+    registry — each final Agent must receive only its own MCP tools plus safe defaults.
+
+    Simulate two different session overrides against the same registry where
+    different MCP servers are configured for each "profile".
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Global registry has tools from multiple servers
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register_toolset_alias("beta", "mcp-beta")
+        _reg.register("beta_tool", "mcp-beta", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register_toolset_alias("gamma", "mcp-gamma")
+        _reg.register("gamma_tool", "mcp-gamma", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Profile A: only alpha configured, tick alpha
+        result_a = _apply_override(
+            ["web", "file"],
+            ["alpha"],
+            {"alpha"},  # only alpha configured
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        # Profile B: only beta configured, tick beta
+        result_b = _apply_override(
+            ["web", "file"],
+            ["beta"],
+            {"beta"},  # only beta configured
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        # Profile A must NOT have beta or gamma
+        assert "mcp-beta" not in result_a and "mcp-gamma" not in result_a, (
+            f"profile A must not have other profile tools, got {result_a!r}"
+        )
+        final_a = set()
+        for name in result_a:
+            final_a.update(_ts_mod.resolve_toolset(name))
+        assert "alpha_tool" in final_a, f"alpha must resolve in profile A"
+        assert "beta_tool" not in final_a, f"beta must NOT resolve in profile A"
+        assert "gamma_tool" not in final_a, f"gamma must NOT resolve in profile A"
+
+        # Profile B must NOT have alpha or gamma
+        assert "mcp-alpha" not in result_b and "mcp-gamma" not in result_b, (
+            f"profile B must not have other profile tools, got {result_b!r}"
+        )
+        final_b = set()
+        for name in result_b:
+            final_b.update(_ts_mod.resolve_toolset(name))
+        assert "beta_tool" in final_b, f"beta must resolve in profile B"
+        assert "alpha_tool" not in final_b, f"alpha must NOT resolve in profile B"
+        assert "gamma_tool" not in final_b, f"gamma must NOT resolve in profile B"
+
     finally:
         _ts_mod.TOOLSETS.clear()
         _ts_mod.TOOLSETS.update(_saved_toolsets)

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -4742,3 +4742,177 @@ def test_real_caller_retry_exhaustion_fails_closed_empty(monkeypatch, tmp_path):
         )
     finally:
         monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+# ── Round-24: portable-plugin MCP servers in the boundary ───────────────────
+# The Round-23 gate found that the MCP restriction boundary was built from
+# cfg["mcp_servers"] keys (native config servers only), missing portable-plugin
+# MCP servers contributed by an enabled PluginManager.  On master the override
+# is a wholesale replace, so portable servers are excluded anyway.  The additive
+# merge preserves profile defaults, which include portable servers via
+# _get_platform_tools() -> enabled_mcp_server_names(cfg).  Using the narrower
+# boundary makes an unselected portable server survive the additive merge as a
+# builtin — a regression on the isolation boundary this PR exists to enforce.
+
+
+def test_portable_mcp_server_stripped_when_unchecked():
+    """An enabled portable-plugin MCP server not ticked in the session
+    override must NOT survive the additive merge.
+
+    Regression (Round-24): using cfg['mcp_servers'] keys as the boundary
+    missed portable servers; the additive merge preserved them as builtins.
+    """
+    defaults = ["web", "file", "terminal", "mcp-alpha", "mcp-beta", "mcp-portable"]
+    override = ["alpha"]
+    # Boundary includes BOTH native and portable servers
+    mcp_servers = {"alpha", "beta", "portable"}
+
+    result = _apply_override(defaults, override, mcp_servers)
+
+    assert "mcp-portable" not in result, (
+        f"unchecked portable server mcp-portable must be stripped, "
+        f"got {result!r}"
+    )
+    assert "portable" not in result, (
+        f"unchecked portable server bare name must be stripped, "
+        f"got {result!r}"
+    )
+    assert "alpha" in result or "mcp-alpha" in result, (
+        f"ticked server must survive, got {result!r}"
+    )
+
+
+def test_portable_mcp_server_survives_when_checked():
+    """An enabled portable-plugin MCP server that IS ticked must survive
+    the additive merge exactly once."""
+    defaults = ["web", "file", "terminal", "mcp-alpha", "mcp-beta"]
+    override = ["portable"]
+    mcp_servers = {"alpha", "beta", "portable"}
+
+    result = _apply_override(defaults, override, mcp_servers)
+
+    assert "portable" in result, (
+        f"checked portable server must survive, got {result!r}"
+    )
+    assert result.count("portable") == 1, (
+        f"checked portable server must appear exactly once, got {result!r}"
+    )
+
+
+def test_derive_authority_enabled_mcp_failure_fails_closed(monkeypatch, tmp_path):
+    """`_derive_session_toolset_authority` falls back to native config
+    servers when ``enabled_mcp_server_names(cfg)`` is unavailable.
+
+    In production (hermes_cli installed): the complete boundary (native +
+    portable-plugin MCP servers) is used.
+    In CI (hermes_cli not installed): the helper falls back to native
+    config servers only — matching pre-Round-23 behavior safely.
+    """
+    import importlib.util
+    if importlib.util.find_spec("hermes_cli") is None:
+        pytest.skip("hermes_cli not installed — default CI behavior")
+
+    import api.streaming as streaming
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    sid = "derive-fail-closed"
+    session = models.Session(
+        session_id=sid,
+        title="derive-test",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[],
+        context_messages=[],
+    )
+    session.enabled_toolsets = ["alpha"]
+    session.save()
+
+    def _broken_enabled_mcp_server_names(cfg):
+        raise ImportError("hermes_cli not importable — CI-like env")
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.enabled_mcp_server_names",
+        _broken_enabled_mcp_server_names,
+    )
+
+    toolsets, gen, applied = streaming._derive_session_toolset_authority(
+        {"mcp_servers": {"alpha": {}, "beta": {}}}, sid
+    )
+    # CI compatibility: when enabled_mcp_server_names() is unavailable
+    # (hermes_cli not installed), the helper falls back to native config
+    # servers only.  The session override ["alpha"] is applied via the
+    # additive merge against _resolve_cli_toolsets (monkeypatched in CI
+    # to real builtins).  Result must contain the selected server but
+    # must NOT be empty (that would mean fail-closed on a benign
+    # import failure).
+    assert "alpha" in toolsets or "mcp-alpha" in toolsets, (
+        f"hermes_cli unavailable → fallback must still apply override, "
+        f"got {toolsets!r}"
+    )
+    assert "beta" not in toolsets and "mcp-beta" not in toolsets, (
+        f"unchecked server beta must be stripped in fallback, "
+        f"got {toolsets!r}"
+    )
+    assert applied is True, (
+        f"override must be marked applied, got {applied!r}"
+    )
+
+
+# ── Round-24 re-gate: persisted [] must be NO-OVERRIDE ──────────────────────
+# The Round-24 re-gate found a NEW regression: the authority guard was
+# `if _override is not None:`, so a persisted `enabled_toolsets=[]` (the
+# documented no-override state) entered the override block and stamped
+# `_applied=True`.  The construction transaction then read applied=True
+# with no generation → fail-closed EMPTY-tool agent for a session that
+# never ticked the picker (gate-certified: Codex end-to-end + reviewer
+# first-party vs master's `if _override:` falsy-for-[]).
+
+
+def test_derive_authority_persisted_empty_list_is_no_override(monkeypatch, tmp_path):
+    """A session whose persisted ``enabled_toolsets`` is ``[]`` (never
+    ticked the composer picker / reset) must derive
+    ``(defaults, None, applied=False)`` — the profile defaults survive and
+    the construction transaction builds a NORMAL agent, never the
+    fail-closed empty-tool path.
+
+    Regression (Round-24 re-gate): `if _override is not None:` made `[]`
+    count as an applied override → `_applied=True` → empty-tool agent.
+    """
+    import api.streaming as streaming
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    sid = "derive-empty-no-override"
+    session = models.Session(
+        session_id=sid,
+        title="derive-test",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[],
+        context_messages=[],
+    )
+    session.enabled_toolsets = []  # documented NO-OVERRIDE state
+    session.save()
+
+    toolsets, gen, applied = streaming._derive_session_toolset_authority(
+        {"mcp_servers": {"alpha": {}, "beta": {}}}, sid
+    )
+
+    assert applied is False, (
+        f"persisted [] must NOT mark override applied, got applied={applied!r}"
+    )
+    assert gen is None, f"no override → no generation bound, got gen={gen!r}"
+    # Defaults survive: real profile builtins (web/file/terminal) present.
+    assert "web" in toolsets and "file" in toolsets, (
+        f"profile defaults must survive a [] no-override session, "
+        f"got {toolsets!r}"
+    )

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -3061,3 +3061,449 @@ def test_static_mcp_prefix_plugin_distinguished_from_foreign_mcp():
         _reg._tools.update(_saved_tools)
         _reg._toolset_aliases.clear()
         _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-19: authorization derives from profile config, not registry ──────
+# The Round-18 gate certified that `_profile_owned_static_toolsets()` derived
+# "profile owned" from the process-global registry inventory: it started from
+# every registered toolset name and removed only SOME mcp-* entries (those
+# with an alias edge).  An ALIAS-LESS foreign `mcp-foreign` entry and a
+# foreign non-MCP plugin therefore remained "profile owned", and through
+# BOTH wildcard lanes (wildcard default + free-text wildcard) the real
+# resolver made their tools callable under the current profile.
+#
+# Round-19 fix: authorization now derives from the profile's OWN
+# configuration — explicit non-MCP `defaults` entries plus the authored
+# builtin definitions (`toolsets.TOOLSETS` keys) — NEVER from the
+# process-global registry inventory.  The tests below drive the real
+# resolver/registry composition and assert exact survivors + exclusions.
+
+
+def test_aliasless_foreign_mcp_absent_from_wildcard_default(monkeypatch):
+    """An ALIAS-LESS foreign ``mcp-foreign`` entry (tool registered under
+    ``mcp-foreign``, NO alias edge) must NOT survive a wildcard profile
+    default expansion.
+
+    The old code kept it as "static/plugin" because it had no alias edge
+    (``_alias_target == _name`` was False); the new code derives the
+    expansion from profile config + authored builtins only, so an entry
+    that is neither a configured server nor an authored builtin cannot
+    enter the result.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Configured server alpha → canonical mcp-alpha.  NOTE: no static
+        # TOOLSETS entry for "alpha" — the resolver must reach it through
+        # its registry alias, exactly like the real runtime.
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN, ALIAS-LESS: tools registered under mcp-foreign with NO
+        # alias edge — the old code classified this as a static/plugin
+        # toolset and leaked it through the wildcard-default lane.
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
+        assert _reg.get_toolset_alias_target("foreign") is None
+
+        defaults = ["all"]  # wildcard profile default
+        override = ["alpha"]  # all configured servers ticked
+        mcp_servers = {"alpha"}
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal", "delegation"},
+        )
+
+        # Raw wildcard never survives; selected server + profile builtins do.
+        assert "all" not in result, f"wildcard must be expanded, got {result!r}"
+        assert "web" in result and "file" in result, (
+            f"profile builtins must survive, got {result!r}"
+        )
+        # The alias-less foreign canonical must NOT be present.
+        assert "mcp-foreign" not in result, (
+            f"alias-less foreign mcp-foreign must be absent, got {result!r}"
+        )
+        # Resolve through the real resolver: foreign tool must not resolve.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "alpha_tool" in final_tools, (
+            f"selected server tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "foreign_tool" not in final_tools, (
+            f"alias-less foreign tool must NOT resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_aliasless_foreign_mcp_absent_from_free_text_wildcard(monkeypatch):
+    """The SAME alias-less foreign ``mcp-foreign`` entry must also stay out
+    of the free-text wildcard lane (restrict branch, override ``all``)."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Configured server alpha → canonical mcp-alpha (alias only, like
+        # the real runtime — no static TOOLSETS entry).
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        assert _reg.get_toolset_alias_target("foreign") is None
+
+        result = _apply_override(
+            ["web", "file"],  # defaults
+            ["all"],  # free-text wildcard → restrict lane expansion
+            {"alpha"},
+            builtin_names={"web", "file", "terminal", "delegation"},
+        )
+
+        assert "mcp-foreign" not in result, (
+            f"alias-less foreign mcp-foreign must be absent, got {result!r}"
+        )
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "foreign_tool" not in final_tools, (
+            f"alias-less foreign tool must NOT resolve, got {sorted(final_tools)!r}"
+        )
+        assert "alpha_tool" in final_tools, (
+            f"configured server tools must resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_foreign_non_mcp_plugin_absent_from_wildcard_lanes(monkeypatch):
+    """A FOREIGN NON-MCP plugin toolset (registered in the process-global
+    registry, NOT a configured server, NOT an authored builtin) must stay
+    out of both wildcard lanes.
+
+    The old code started the profile-owned set from EVERY registered toolset
+    name, so a foreign plugin's toolset name survived the mcp-* filter and
+    leaked through wildcard expansion.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("alpha", "server alpha", tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN non-MCP plugin: a toolset that is NOT an MCP canonical and
+        # NOT an authored builtin — registered by another profile's plugin.
+        _reg.register("plugin_foreign_tool", "foreign-plugin",
+                      {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Wildcard default lane.
+        result_default = _apply_override(
+            ["all"], ["alpha"], {"alpha"},
+            builtin_names={"web", "file", "terminal", "delegation"},
+        )
+        # Free-text wildcard lane.
+        result_free = _apply_override(
+            ["web", "file"], ["all"], {"alpha"},
+            builtin_names={"web", "file", "terminal", "delegation"},
+        )
+
+        for _tag, result in (("wildcard-default", result_default),
+                             ("free-text-wildcard", result_free)):
+            assert "foreign-plugin" not in result, (
+                f"[{_tag}] foreign non-MCP plugin must be absent, got {result!r}"
+            )
+            final_tools = set()
+            for name in result:
+                final_tools.update(_ts_mod.resolve_toolset(name))
+            assert "plugin_foreign_tool" not in final_tools, (
+                f"[{_tag}] foreign plugin tool must NOT resolve, "
+                f"got {sorted(final_tools)!r}"
+            )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_alias_lookup_failure_fails_closed(monkeypatch):
+    """An alias lookup FAILURE (registry unavailable / raises) must NOT be
+    treated as "no alias edge = static/plugin toolset".
+
+    Round-18 finding: ``_registry_alias_target()`` collapsed failures to
+    ``None`` and the restrict branch inferred static/plugin provenance from
+    it — an unavailable authority failed OPEN.  Now a failed lookup returns
+    ``_ALIAS_LOOKUP_UNKNOWN`` and the selector is dropped.
+
+    The registry method itself is monkeypatched to raise — the production
+    wrapper ``_registry_alias_target`` converts that to the sentinel, and
+    the caller must fail closed on it.
+    """
+    from tools.registry import registry as _reg
+
+    _orig = _reg.get_toolset_alias_target
+
+    def _boom(name):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(_reg, "get_toolset_alias_target", _boom)
+    try:
+        result = _apply_override(
+            ["web", "file"],
+            ["mcp-custom-probe"],  # would be static/plugin if lookup worked
+            {"alpha"},
+            builtin_names={"web", "file", "terminal", "mcp-custom-probe"},
+        )
+    finally:
+        monkeypatch.setattr(_reg, "get_toolset_alias_target", _orig)
+
+    assert "mcp-custom-probe" not in result, (
+        f"alias lookup failure must fail closed (drop selector), got {result!r}"
+    )
+    assert "web" not in result, (
+        f"restrict lane must not restore defaults on lookup failure, got {result!r}"
+    )
+
+
+def test_alias_lookup_failure_fails_closed_canonical_of_configured(monkeypatch):
+    """Alias lookup failure on the canonical of a CONFIGURED server must also
+    fail closed (drop the canonical), not pass it through."""
+    from tools.registry import registry as _reg
+
+    _orig = _reg.get_toolset_alias_target
+
+    def _boom(name):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(_reg, "get_toolset_alias_target", _boom)
+    try:
+        result = _apply_override(
+            ["web", "file"],
+            ["mcp-alpha"],  # canonical of configured server alpha
+            {"alpha"},
+            builtin_names={"web", "file", "terminal"},
+        )
+    finally:
+        monkeypatch.setattr(_reg, "get_toolset_alias_target", _orig)
+
+    assert "mcp-alpha" not in result, (
+        f"canonical of configured server must fail closed on lookup failure, "
+        f"got {result!r}"
+    )
+
+
+def test_restrict_mcp_static_passthrough_no_duplicate(monkeypatch):
+    """Round-19 finding: the restrictive exact-selector branch used to
+    append an accepted alias-less ``mcp-*`` selector and then fall through
+    to the unconditional append — producing a duplicate.  The pass-through
+    must emit the selector exactly once."""
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _ts_mod.create_custom_toolset("mcp-custom-probe", "probe toolset",
+                                      tools=["probe_tool"], includes=[])
+        _reg.register("probe_tool", "mcp-custom-probe", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        result = _apply_override(
+            ["web", "file"],
+            ["mcp-custom-probe"],  # static/plugin, no alias edge
+            {"alpha"},  # unrelated configured server
+            builtin_names={"web", "file", "terminal", "mcp-custom-probe"},
+        )
+
+        assert result.count("mcp-custom-probe") == 1, (
+            f"mcp-* static passthrough must appear exactly once, got {result!r}"
+        )
+        # And it must resolve to its own tool (no double-append corruption).
+        resolved = set(_ts_mod.resolve_toolset("mcp-custom-probe"))
+        assert "probe_tool" in resolved, (
+            f"probe tool must resolve, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_registry_generation_movement_fails_closed(monkeypatch):
+    """Round-19 finding: if the registry mutates mid-decision (its generation
+    moves), the ownership proofs already gathered are stale — the result must
+    fail closed (empty) rather than return tools reasoned from an outdated
+    authority snapshot."""
+    import api.streaming as streaming
+
+    _real_gen = streaming._registry_generation
+    _state = {"calls": 0}
+
+    def _moving_generation():
+        _state["calls"] += 1
+        # First call (entry snapshot) returns 1; a later call (mid-decision
+        # or exit) returns 2 — the registry "mutated" in between.
+        return 2 if _state["calls"] > 1 else 1
+
+    monkeypatch.setattr(streaming, "_registry_generation", _moving_generation)
+    try:
+        result = _apply_override(
+            ["web", "file"],
+            ["alpha"],
+            {"alpha"},
+            builtin_names={"web", "file", "terminal"},
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+    assert result == [], (
+        f"generation movement must fail closed to empty, got {result!r}"
+    )
+
+
+def test_restrict_generation_movement_fails_closed(monkeypatch):
+    """The restrict lane must also fail closed when the registry generation
+    moves mid-decision."""
+    import api.streaming as streaming
+
+    _real_gen = streaming._registry_generation
+    _state = {"calls": 0}
+
+    def _moving_generation():
+        _state["calls"] += 1
+        return 2 if _state["calls"] > 1 else 1
+
+    monkeypatch.setattr(streaming, "_registry_generation", _moving_generation)
+    try:
+        result = _apply_override(
+            ["web", "file"],
+            ["terminal"],  # restrict lane (non-MCP override)
+            {"alpha"},
+            builtin_names={"web", "file", "terminal"},
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+    assert result == [], (
+        f"restrict lane generation movement must fail closed, got {result!r}"
+    )
+
+
+def test_production_call_authority_not_from_registry_inventory(monkeypatch):
+    """Production-shaped regression (Round-19 finding 1, exact repro): the
+    real call site invokes ``_apply_session_toolset_override(defaults,
+    override, mcp_servers)`` with ``builtin_names=None``.  The helper then
+    derives its shadow set from the process-global registry inventory —
+    which includes EVERY registered toolset name, including a foreign
+    ``mcp-foreign`` canonical and a foreign non-MCP plugin registered by
+    another profile.  The wildcard-expansion AUTHORIZATION set must be the
+    profile's own config (explicit defaults + authored ``TOOLSETS`` keys),
+    NOT that registry inventory: an alias-less foreign ``mcp-foreign``
+    (no alias edge) must not resolve under the current profile.
+
+    The old code fed the registry inventory into the authorization set, so
+    ``mcp-foreign`` (alias-less → classified "static/plugin") survived the
+    wildcard-default lane and the real resolver made ``foreign_tool``
+    callable (gate-certified).  This test drives the real resolver through
+    the production call shape.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN, ALIAS-LESS: registered tools under mcp-foreign, NO alias
+        # edge — the old classifier called this "static/plugin" and leaked
+        # it.  It IS part of the registry inventory (get_registered_toolset_names
+        # returns every toolset name present in the registry).
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN non-MCP plugin toolset in the registry inventory.
+        _reg.register("plugin_foreign_tool", "foreign-plugin",
+                      {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Seed-assertion: the foreign entries ARE in the registry inventory
+        # (so the old code would have leaked them), and the authored builtin
+        # set excludes them (the new authority source).
+        _inv = streaming._builtin_toolset_names()
+        assert _inv is not None and "mcp-foreign" in _inv, (
+            f"seed: mcp-foreign must be in registry inventory, got "
+            f"{sorted(_inv) if _inv else None}"
+        )
+        _auth = streaming._authored_builtin_toolset_names()
+        assert _auth is not None and "mcp-foreign" not in _auth, (
+            f"seed: mcp-foreign must NOT be authored, got "
+            f"{sorted(_auth) if _auth else None}"
+        )
+
+        # Production call shape: NO builtin_names argument.
+        result = _apply_override(["all"], ["alpha"], {"alpha"})
+
+        assert "all" not in result, f"wildcard must be expanded, got {result!r}"
+        assert "mcp-foreign" not in result, (
+            f"alias-less foreign mcp-foreign must be absent from wildcard "
+            f"expansion, got {result!r}"
+        )
+        assert "foreign-plugin" not in result, (
+            f"foreign non-MCP plugin must be absent, got {result!r}"
+        )
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "alpha_tool" in final_tools, (
+            f"selected server tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "foreign_tool" not in final_tools, (
+            f"alias-less foreign tool must NOT resolve, got {sorted(final_tools)!r}"
+        )
+        assert "plugin_foreign_tool" not in final_tools, (
+            f"foreign plugin tool must NOT resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -4058,131 +4058,114 @@ def test_eager_snapshot_rejects_foreign_mcp_before_first_auth_lookup(monkeypatch
         )
 
 
-def test_unavailable_generation_with_override_fails_closed(monkeypatch):
+def test_unavailable_generation_with_override_fails_closed(monkeypatch, tmp_path):
     """Round-22 gate finding 2 discriminator: when an override IS applied but
     the registry generation is unavailable (``None`` — no registry / no
     generation counter), we cannot PROVE the authority is stable.  The
-    override must fail closed to an empty toolset list, not be treated as
+    override must fail closed to an EMPTY-TOOL agent, not be treated as
     "stable" (which is what Round-21 did).
 
-    This test exercises the production caller-level logic that mirrors the
-    streaming worker: ``_override_applied = True`` + ``_toolsets_gen = None``
-    → fail closed (empty toolsets).
+    Round-23 rework (reviewer gate): the Round-22 version copied the worker's
+    ``if/elif`` condition into the test body — a mirror, not a proof.  This
+    now drives the REAL ``_run_agent_streaming()`` construction transaction
+    with ``_registry_generation()`` forced to ``None`` and asserts the
+    fail-closed EMPTY-TOOL agent (enabled_toolsets=[]) is what gets cached,
+    published, and run — never a candidate carrying the override's toolsets.
     """
     import api.streaming as streaming
     from tools.registry import registry as _reg
 
     _real_gen = streaming._registry_generation
-    _saved_tools = dict(_reg._tools)
-    _saved_aliases = dict(_reg._toolset_aliases)
+    _gen_state = {"value": None}
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state)
 
     try:
         # Force generation to None (registry unavailable / no counter).
-        monkeypatch.setattr(streaming, "_registry_generation", lambda: None)
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        _publish_proxy = _PublishRecordingDict()
+        monkeypatch.setattr(streaming, "AGENT_INSTANCES", _publish_proxy)
+        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
 
-        _reg.register_toolset_alias("alpha", "mcp-alpha")
-        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
-                      lambda *a, **k: "ok", override=True)
-
-        # Apply the override — _gen_slot will contain None (no generation).
-        _gen_slot = []
-        result = _apply_override(
-            ["web", "file"], ["alpha"], {"alpha"},
-            _gen_slot=_gen_slot,
-        )
-        # The helper returns a valid merged result with the override applied.
-        # The additive branch returns bare server names for ordinary servers.
-        assert "alpha" in result, (
-            f"override should be applied, got {result!r}"
+        sid = "gate-unavail-gen"
+        stream_id = "gate-unavail-gen-stream"
+        _setup_gate_real_caller(
+            tmp_path, monkeypatch, _GateFakeAgent, sid, stream_id,
         )
 
-        # Simulate the worker-level check: override was applied, generation
-        # is None → cannot prove stability → fail closed.
-        _toolsets_gen = _gen_slot[0] if _gen_slot else None
-        _override_applied = True
-
-        # This mirrors the production worker logic (Round-22).
-        if _toolsets_gen is not None and streaming._registry_generation_changed(_toolsets_gen):
-            final_toolsets = []
-        elif _toolsets_gen is None and _override_applied:
-            final_toolsets = []
-        else:
-            final_toolsets = result
-
-        assert final_toolsets == [], (
-            f"override with unavailable generation must fail closed to empty, "
-            f"got {final_toolsets!r}"
+        # Exactly ONE construction: the fail-closed EMPTY-TOOL fallback.
+        # (The stale-authority pre-check rejects before any candidate with the
+        # override's toolsets can be built.)
+        assert len(_GateFakeAgent.instances) == 1, (
+            f"expected 1 fail-closed construction, got {len(_GateFakeAgent.instances)}"
+        )
+        empty = _GateFakeAgent.instances[0]
+        assert empty.enabled_toolsets == [], (
+            f"fail-closed agent must be empty-tool, got {empty.enabled_toolsets!r}"
+        )
+        assert empty.closed is False, "the empty-tool fallback must not be closed"
+        assert empty.ran is True, "the empty-tool fallback is the agent that runs"
+        with SESSION_AGENT_CACHE_LOCK:
+            cached_entry = SESSION_AGENT_CACHE.get(sid)
+        assert cached_entry is not None and cached_entry[0] is empty, (
+            "cache must hold the empty-tool fallback (never the override toolsets)"
+        )
+        assert _publish_proxy.published.get(stream_id) is empty, (
+            "AGENT_INSTANCES must publish the empty-tool fallback: "
+            f"published={_publish_proxy.published!r}"
         )
     finally:
         monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
         _reg._tools.clear()
-        _reg._tools.update(_saved_tools)
         _reg._toolset_aliases.clear()
-        _reg._toolset_aliases.update(_saved_aliases)
 
 
 def test_generation_movement_during_construction_fails_closed(monkeypatch):
-    """Round-22 gate finding 2 discriminator: the generation must be
-    re-validated IMMEDIATELY AFTER ``_AIAgent(...)`` construction.  A
-    registry mutation during the constructor's tool resolution must fail
-    closed (blank toolsets on the agent), not run or cache tools that were
-    never authorized.
+    """Round-22 gate finding 2 discriminator, Round-23 rework: the generation
+    must be re-validated IMMEDIATELY AFTER construction.  A registry mutation
+    during the constructor's tool resolution must fail closed — and the
+    Round-23 construction transaction closes and discards the stale candidate
+    instead of merely blanking ``enabled_toolsets`` post-hoc (which left the
+    constructor-derived tools/valid_tool_names callable).
 
-    This test simulates the production worker pattern:
-      1. Apply override → capture generation (e.g. gen=1),
+    This drives the REAL ``_construct_override_gated_agent()`` transaction:
+      1. Authority captured at gen=1,
       2. Pre-construction check passes (gen still 1),
-      3. Simulate construction (gen moves to 2 during construction),
-      4. Post-construction check catches the movement → blank toolsets.
+      3. Construction moves gen to 2 DURING the constructor,
+      4. Post-construction check catches the movement → stale candidate is
+         closed and discarded, the single retry succeeds.
     """
     import api.streaming as streaming
-    from tools.registry import registry as _reg
 
     _real_gen = streaming._registry_generation
-    _real_gen_changed = streaming._registry_generation_changed
-    _saved_tools = dict(_reg._tools)
-    _saved_aliases = dict(_reg._toolset_aliases)
+    _gen_state = {"value": 1}
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1,))
 
     try:
-        _reg.register_toolset_alias("alpha", "mcp-alpha")
-        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
-                      lambda *a, **k: "ok", override=True)
-
-        # Phase 1: Apply override with gen=1.
-        _state = {"gen": 1}
         monkeypatch.setattr(streaming, "_registry_generation",
-                            lambda: _state["gen"])
+                            lambda: _gen_state["value"])
 
-        _gen_slot = []
-        result = _apply_override(
-            ["web", "file"], ["alpha"], {"alpha"},
-            _gen_slot=_gen_slot,
+        def _rederive():
+            return (["web", "file"], 2, True)
+
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _GateFakeAgent, {"model": "gpt-4o"},
+            ["web", "file"], 1, True,
+            rederive_authority=_rederive,
         )
-        _toolsets_gen = _gen_slot[0]
-        assert _toolsets_gen == 1
-
-        # Phase 2: Pre-construction check (gen still 1 → passes).
-        assert not streaming._registry_generation_changed(_toolsets_gen)
-        _toolsets = result  # would go into _agent_kwargs
-
-        # Phase 3: Simulate construction — gen moves to 2 DURING construction.
-        _state["gen"] = 2
-
-        # Phase 4: Post-construction check catches the movement.
-        assert streaming._registry_generation_changed(_toolsets_gen), (
-            "generation movement during construction must be detected"
+        # The stale candidate was closed; the retried agent survived.
+        assert outcome == "retried", f"expected retried, got {outcome!r}"
+        assert len(_GateFakeAgent.instances) == 2, (
+            f"expected 2 constructions, got {len(_GateFakeAgent.instances)}"
         )
-        # Production blanks the agent's toolsets.
-        final_toolsets = [] if streaming._registry_generation_changed(_toolsets_gen) else _toolsets
-        assert final_toolsets == [], (
-            f"generation movement during construction must blank toolsets, "
-            f"got {final_toolsets!r}"
+        assert _GateFakeAgent.instances[0].closed is True, (
+            "generation movement during construction must close the stale candidate"
         )
+        assert _GateFakeAgent.instances[1].closed is False
+        assert agent is _GateFakeAgent.instances[1]
+        assert final_ts == ["web", "file"]
     finally:
         monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
-        _reg._tools.clear()
-        _reg._tools.update(_saved_tools)
-        _reg._toolset_aliases.clear()
-        _reg._toolset_aliases.update(_saved_aliases)
 
 
 def test_no_override_no_generation_check_needed(monkeypatch):
@@ -4190,38 +4173,572 @@ def test_no_override_no_generation_check_needed(monkeypatch):
     defaults are config-derived (not registry-derived), so no generation
     re-validation is needed.  ``_toolsets_gen`` is None and
     ``_override_applied`` is False → toolsets are preserved.
+
+    Round-23 rework: drives the REAL ``_construct_override_gated_agent()``
+    transaction (the Round-22 version copied the worker's if/elif chain).
     """
     import api.streaming as streaming
-    from tools.registry import registry as _reg
 
     _real_gen = streaming._registry_generation
-    _saved_tools = dict(_reg._tools)
-    _saved_aliases = dict(_reg._toolset_aliases)
 
     try:
         # Even with generation unavailable, no override means no check needed.
         monkeypatch.setattr(streaming, "_registry_generation", lambda: None)
 
-        # No override → _toolsets_gen stays None, _override_applied stays False.
-        _toolsets_gen = None
-        _override_applied = False
-        _toolsets = ["web", "file", "terminal"]
+        class _RecAgent:
+            def __init__(self, **kwargs):
+                self.enabled_toolsets = kwargs.get("enabled_toolsets")
 
-        # Mirrors the production worker logic (Round-22).
-        if _toolsets_gen is not None and streaming._registry_generation_changed(_toolsets_gen):
-            final_toolsets = []
-        elif _toolsets_gen is None and _override_applied:
-            final_toolsets = []
-        else:
-            final_toolsets = _toolsets
-
-        assert final_toolsets == _toolsets, (
-            f"no override + no generation must preserve defaults, "
-            f"got {final_toolsets!r}"
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _RecAgent, {"model": "gpt-4o"},
+            ["web", "file", "terminal"], None, False,  # no override
+            rederive_authority=None,
+        )
+        assert outcome == "stable", f"expected stable, got {outcome!r}"
+        assert final_ts == ["web", "file", "terminal"], (
+            f"no override + no generation must preserve defaults, got {final_ts!r}"
+        )
+        assert agent.enabled_toolsets == ["web", "file", "terminal"], (
+            f"agent must receive the preserved defaults, got {agent.enabled_toolsets!r}"
         )
     finally:
         monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
-        _reg._tools.clear()
-        _reg._tools.update(_saved_tools)
-        _reg._toolset_aliases.clear()
-        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-23: centralized construction transaction ──────────────────────────
+# Reviewer Round-22 finding: post-hoc `agent.enabled_toolsets = []` on a stale
+# candidate does NOT revoke constructor-derived tools/valid_tool_names, and the
+# cache-miss/healing paths registered, cached, published, and ran the stale
+# candidate anyway.  The fix centralizes overridden-agent construction in
+# _construct_override_gated_agent(): pre-check → construct into a LOCAL
+# candidate → post-check → close+discard stale candidate (never registered/
+# cached/published/run) → at most one retry from freshly derived authority →
+# fail-closed EMPTY-tool agent built with enabled_toolsets=[].
+
+
+def _make_gate_fake_agent(_gen_state, move_on=(), fail_first_401=False):
+    """Build a FakeAgent class whose constructor bumps ``_gen_state['value']``
+    (simulating a registry mutation during the constructor's tool resolution)
+    for the construction attempts listed in ``move_on`` (1-based attempt
+    numbers, e.g. ``(1,)`` = only the FIRST construction moves the generation).
+    Records instances, close() calls, and run_conversation() calls so tests can
+    prove a stale candidate was closed and never registered/cached/run.
+
+    When ``fail_first_401`` is True, the first run_conversation() call on the
+    FIRST agent that actually runs returns an auth failure (with
+    ``_last_error`` set) so the production credential-heal path re-derives
+    authority and rebuilds the agent; subsequent calls succeed.
+    """
+    class _GateFakeAgent:
+        instances = []
+        closed = []
+        ran = []
+        move_attempts = set(move_on)
+        run_calls = 0
+
+        def __init__(self, **kwargs):
+            _GateFakeAgent.instances.append(self)
+            self.enabled_toolsets = kwargs.get("enabled_toolsets")
+            self.closed = False
+            self.ran = False
+            attempt = len(_GateFakeAgent.instances)
+            if attempt in _GateFakeAgent.move_attempts:
+                _gen_state["value"] += 1
+
+        def close(self):
+            self.closed = True
+            _GateFakeAgent.closed.append(self)
+
+        def run_conversation(self, **kwargs):
+            self.ran = True
+            _GateFakeAgent.ran.append(self)
+            _GateFakeAgent.run_calls += 1
+            if fail_first_401 and _GateFakeAgent.run_calls == 1:
+                self._last_error = "401 Unauthorized"
+                return {
+                    "failed": True,
+                    "error": "401 Unauthorized",
+                    "messages": [],
+                }
+            return {
+                "failed": False,
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    return _GateFakeAgent
+
+
+def test_gate_construct_stable_no_override(monkeypatch):
+    """No override applied → no generation re-validation needed; construct
+    directly with the profile-default toolsets (outcome 'stable')."""
+    import api.streaming as streaming
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+
+    class _StableAgent:
+        def __init__(self, **kwargs):
+            self.enabled_toolsets = kwargs.get("enabled_toolsets")
+            self.closed = False
+
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _StableAgent, {"model": "gpt-4o"},
+            ["web", "file"], None, False,  # no override
+            rederive_authority=None,
+        )
+        assert outcome == "stable", f"expected stable, got {outcome!r}"
+        assert final_ts == ["web", "file"]
+        assert agent.enabled_toolsets == ["web", "file"]
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_gate_construct_unavailable_generation_with_override_fails_closed(monkeypatch):
+    """Override WAS applied but the generation is unavailable (None) → cannot
+    prove stability → fail closed to an EMPTY-tool agent (enabled_toolsets=[])
+    — never a candidate with the override's toolsets."""
+    import api.streaming as streaming
+
+    _real_gen = streaming._registry_generation
+    _constructed = []
+
+    class _RecAgent:
+        def __init__(self, **kwargs):
+            _constructed.append(kwargs.get("enabled_toolsets"))
+            self.enabled_toolsets = kwargs.get("enabled_toolsets")
+            self.closed = False
+
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation", lambda: None)
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _RecAgent, {"model": "gpt-4o"},
+            ["web", "gate-alpha"], None, True,  # override applied, gen None
+            rederive_authority=None,
+        )
+        assert outcome == "fail-closed", f"expected fail-closed, got {outcome!r}"
+        assert final_ts == [], f"expected empty final toolsets, got {final_ts!r}"
+        assert agent.enabled_toolsets == [], (
+            f"fail-closed agent must be empty-tool, got {agent.enabled_toolsets!r}"
+        )
+        assert _constructed == [[]], (
+            f"only the empty-tool fallback may be constructed, got {_constructed!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_gate_construct_precheck_stale_retries_once_then_fails_closed(monkeypatch):
+    """Pre-check stale (generation moved BEFORE construction) → retry once from
+    freshly derived authority; when the retry authority is ALSO stale → fail
+    closed to an empty-tool agent.  No candidate is ever constructed from the
+    stale authority."""
+    import api.streaming as streaming
+
+    _gen_state = {"value": 2}  # authority captured gen=1, live is 2
+    _real_gen = streaming._registry_generation
+    _constructed = []
+
+    class _RecAgent:
+        def __init__(self, **kwargs):
+            _constructed.append(kwargs.get("enabled_toolsets"))
+            self.enabled_toolsets = kwargs.get("enabled_toolsets")
+            self.closed = False
+
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+
+        def _rederive():
+            # Fresh authority ALSO stale (generation still moving).
+            return (["web"], 1, True)
+
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _RecAgent, {"model": "gpt-4o"},
+            ["web"], 1, True,
+            rederive_authority=_rederive,
+        )
+        assert outcome == "fail-closed", f"expected fail-closed, got {outcome!r}"
+        assert final_ts == []
+        assert agent.enabled_toolsets == []
+        # Only the empty-tool fallback was constructed (never a stale candidate).
+        assert _constructed == [[]], (
+            f"stale authority must never construct a candidate, got {_constructed!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_gate_construct_postcheck_stale_closes_and_retries_success(monkeypatch):
+    """Generation moves DURING the constructor (post-check catches it): the
+    stale candidate is closed and discarded; the single retry from freshly
+    derived authority succeeds and returns the fresh agent (outcome 'retried')."""
+    import api.streaming as streaming
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1,))
+
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+
+        def _rederive():
+            # Fresh authority: generation now stable at 2.
+            return (["web", "file"], 2, True)
+
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _GateFakeAgent, {"model": "gpt-4o"},
+            ["web"], 1, True,
+            rederive_authority=_rederive,
+        )
+        assert outcome == "retried", f"expected retried, got {outcome!r}"
+        assert final_ts == ["web", "file"]
+        assert len(_GateFakeAgent.instances) == 2, (
+            f"expected 2 constructions (stale + retry), got {len(_GateFakeAgent.instances)}"
+        )
+        # The FIRST (stale) candidate was closed; the retried candidate lives.
+        assert _GateFakeAgent.instances[0].closed is True, (
+            "stale candidate must be closed"
+        )
+        assert _GateFakeAgent.instances[1].closed is False
+        assert agent is _GateFakeAgent.instances[1]
+        assert agent.enabled_toolsets == ["web", "file"]
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_gate_construct_retry_exhaustion_fails_closed_empty(monkeypatch):
+    """Every construction attempt sees generation movement → the single retry
+    is exhausted → fail closed to an EMPTY-tool agent.  BOTH stale candidates
+    are closed."""
+    import api.streaming as streaming
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1, 2))
+
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+
+        def _rederive():
+            return (["web", "file"], 2, True)
+
+        agent, outcome, final_ts = streaming._construct_override_gated_agent(
+            _GateFakeAgent, {"model": "gpt-4o"},
+            ["web"], 1, True,
+            rederive_authority=_rederive,
+        )
+        assert outcome == "fail-closed", f"expected fail-closed, got {outcome!r}"
+        assert final_ts == []
+        assert agent.enabled_toolsets == [], (
+            f"fail-closed fallback must be empty-tool, got {agent.enabled_toolsets!r}"
+        )
+        # Both stale candidates were closed; the empty-tool fallback lives.
+        assert len(_GateFakeAgent.instances) == 3, (
+            f"expected 3 constructions (2 stale + empty fallback), got {len(_GateFakeAgent.instances)}"
+        )
+        assert all(_GateFakeAgent.instances[i].closed for i in (0, 1)), (
+            "both stale candidates must be closed"
+        )
+        assert _GateFakeAgent.instances[2].closed is False
+        assert agent is _GateFakeAgent.instances[2]
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def _setup_gate_real_caller(tmp_path, monkeypatch, FakeAgentCls, sid, stream_id,
+                            override_toolsets=("gate-alpha",)):
+    """Shared production-composed setup: seed registry aliases/tools, create a
+    session with a per-session override, monkeypatch the real
+    ``_run_agent_streaming`` call-site dependencies, and run the worker.
+    Assertions on FakeAgentCls.instances afterwards prove which candidate was
+    closed / cached / published / run."""
+    import queue
+    import sys
+    import types as _types
+
+    import toolsets as _ts_mod
+    from api import models
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    _ts_mod.create_custom_toolset("safe-composite", "safe workflow",
+                                  tools=[], includes=["safe-inner"])
+    _reg.register_toolset_alias("gate-alpha", "mcp-gate-alpha")
+    _reg.register("alpha_tool", "mcp-gate-alpha", {"type": "object"},
+                  lambda *a, **k: "ok", override=True)
+    _reg.register("safe_unique_tool", "safe-inner", {"type": "object"},
+                  lambda *a, **k: "ok", override=True)
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    session = models.Session(
+        session_id=sid,
+        title="gate-real-caller",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[],
+        context_messages=[],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "hi"
+    session.pending_started_at = 1.0
+    session.save()
+    models.SESSIONS[sid] = session
+    streaming.SESSIONS[sid] = session
+    streaming.STREAMS[stream_id] = queue.Queue()
+
+    fake_hermes_state = _types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *_a, **_k: object()
+
+    def _fake_load_metadata_only(session_id):
+        meta = models.Session(session_id=session_id, model="gpt-4o")
+        meta.enabled_toolsets = list(override_toolsets)
+        return meta
+
+    with monkeypatch.context() as m:
+        m.setattr(streaming, "_get_ai_agent", lambda: FakeAgentCls)
+        m.setattr(streaming, "resolve_model_provider",
+                  lambda *_a, **_k: ("gpt-4o", "openai", None))
+        m.setattr("api.config.get_config", lambda *_a, **_k: {
+            "mcp_servers": {"gate-alpha": {}},
+        })
+        m.setattr("api.config._resolve_cli_toolsets",
+                  lambda *_a, **_k: ["web", "search", "safe-composite"])
+        m.setattr(models.Session, "load_metadata_only",
+                  staticmethod(_fake_load_metadata_only))
+        m.setitem(sys.modules, "hermes_state", fake_hermes_state)
+        try:
+            streaming._run_agent_streaming(
+                session_id=sid,
+                msg_text="hi",
+                model="gpt-4o",
+                workspace=str(tmp_path),
+                stream_id=stream_id,
+            )
+        finally:
+            _ts_mod.TOOLSETS.clear()
+            _ts_mod.TOOLSETS.update(_saved_toolsets)
+            _reg._tools.clear()
+            _reg._tools.update(_saved_tools)
+            _reg._toolset_aliases.clear()
+            _reg._toolset_aliases.update(_saved_aliases)
+    return session
+
+
+class _PublishRecordingDict(dict):
+    """Dict that records every ``__setitem__`` so tests can prove WHICH agent
+    instance was published into AGENT_INSTANCES (the real module clears the
+    entry in its finally block, so the post-run dict alone cannot show it)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.published = {}
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        self.published[key] = value
+
+
+def test_real_caller_cache_miss_generation_move_discards_stale_candidate(monkeypatch, tmp_path):
+    """PRODUCTION-COMPOSED (cache-miss path): drive the REAL
+    ``_run_agent_streaming()`` with a registry generation that moves DURING the
+    constructor's tool resolution.  The stale candidate must be closed and
+    never registered, cached, published, or run; the single retry from freshly
+    derived authority must produce the agent that ends up cached + published +
+    run."""
+    import api.streaming as streaming
+    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1,))
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        _publish_proxy = _PublishRecordingDict()
+        monkeypatch.setattr(streaming, "AGENT_INSTANCES", _publish_proxy)
+        sid = "gate-cache-miss"
+        stream_id = "gate-cache-miss-stream"
+        _setup_gate_real_caller(
+            tmp_path, monkeypatch, _GateFakeAgent, sid, stream_id,
+        )
+
+        # Exactly two constructions: the stale first attempt + the retried one.
+        assert len(_GateFakeAgent.instances) == 2, (
+            f"expected 2 constructions, got {len(_GateFakeAgent.instances)}"
+        )
+        stale, fresh = _GateFakeAgent.instances
+        assert stale.closed is True, "stale candidate must be closed"
+        assert fresh.closed is False, "retried candidate must not be closed"
+        assert stale.ran is False, "stale candidate must never run"
+        assert fresh.ran is True, "retried candidate must be the one that runs"
+
+        # The stale candidate must never be cached.
+        with SESSION_AGENT_CACHE_LOCK:
+            cached_entry = SESSION_AGENT_CACHE.get(sid)
+        assert cached_entry is not None and cached_entry[0] is fresh, (
+            "cache must hold the retried agent, not the stale candidate"
+        )
+        # The published AGENT_INSTANCES entry must be the retried agent.
+        assert _publish_proxy.published.get(stream_id) is fresh, (
+            "AGENT_INSTANCES must publish the retried agent, not the stale one: "
+            f"published={_publish_proxy.published!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_real_caller_ephemeral_generation_move_discards_stale_candidate(monkeypatch, tmp_path):
+    """PRODUCTION-COMPOSED (ephemeral path): same transaction semantics on the
+    ephemeral (no-cache) construction path — the stale candidate is closed and
+    never run; the retried agent runs."""
+    import api.streaming as streaming
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1,))
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        _publish_proxy = _PublishRecordingDict()
+        monkeypatch.setattr(streaming, "AGENT_INSTANCES", _publish_proxy)
+        sid = "gate-ephemeral"
+        stream_id = "gate-ephemeral-stream"
+        _setup_gate_real_caller(
+            tmp_path, monkeypatch, _GateFakeAgent, sid, stream_id,
+        )
+        assert len(_GateFakeAgent.instances) == 2, (
+            f"expected 2 constructions, got {len(_GateFakeAgent.instances)}"
+        )
+        stale, fresh = _GateFakeAgent.instances
+        assert stale.closed is True, "stale candidate must be closed"
+        assert fresh.closed is False
+        assert stale.ran is False, "stale candidate must never run"
+        assert fresh.ran is True, "retried candidate must run"
+        assert _publish_proxy.published.get(stream_id) is fresh, (
+            "AGENT_INSTANCES must publish the retried agent: "
+            f"published={_publish_proxy.published!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_real_caller_healing_fresh_authority_discards_stale_candidate(monkeypatch, tmp_path):
+    """PRODUCTION-COMPOSED (credential healing path): a 401 auth failure
+    triggers credential self-heal, which re-derives a FRESH authority and
+    rebuilds through the construction transaction.  A generation move during
+    the heal rebuild must close+discard the stale candidate; the retried agent
+    is the one that ends up cached + published + run."""
+    import api.streaming as streaming
+    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1, 3),
+                                           fail_first_401=True)
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        _publish_proxy = _PublishRecordingDict()
+        monkeypatch.setattr(streaming, "AGENT_INSTANCES", _publish_proxy)
+
+        def _fake_heal(provider_id, session_id, agent_lock, *, target_model=None):
+            # Simulate a successful credential refresh; the rebuild then
+            # re-derives fresh authority and constructs again.
+            return {"api_key": "new-key", "provider": "openai"}
+
+        monkeypatch.setattr(streaming, "_attempt_credential_self_heal",
+                            _fake_heal)
+        sid = "gate-heal"
+        stream_id = "gate-heal-stream"
+        _setup_gate_real_caller(
+            tmp_path, monkeypatch, _GateFakeAgent, sid, stream_id,
+        )
+
+        # Construction attempts: initial (stale→close), retry (fresh), heal
+        # rebuild (stale→close), heal retry (fresh) — 4 instances.
+        assert len(_GateFakeAgent.instances) == 4, (
+            f"expected 4 constructions, got {len(_GateFakeAgent.instances)}"
+        )
+        i0, i1, i2, i3 = _GateFakeAgent.instances
+        assert i0.closed is True, "initial stale candidate must be closed"
+        assert i1.closed is False, "initial retried candidate must not be closed"
+        assert i2.closed is True, "heal stale candidate must be closed"
+        assert i3.closed is False, "heal retried candidate must not be closed"
+        # Only the two fresh agents may run; stale ones never run.
+        assert i0.ran is False and i2.ran is False
+        assert i1.ran is True and i3.ran is True
+        # The final cached + published agent is the heal-retried one.
+        with SESSION_AGENT_CACHE_LOCK:
+            cached_entry = SESSION_AGENT_CACHE.get(sid)
+        assert cached_entry is not None and cached_entry[0] is i3, (
+            "cache must hold the heal-retried agent"
+        )
+        assert _publish_proxy.published.get(stream_id) is i3, (
+            "AGENT_INSTANCES must publish the heal-retried agent: "
+            f"published={_publish_proxy.published!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+
+
+def test_real_caller_retry_exhaustion_fails_closed_empty(monkeypatch, tmp_path):
+    """PRODUCTION-COMPOSED (bounded retry exhaustion): every construction
+    attempt observes generation movement → the single retry is exhausted →
+    fail closed to an EMPTY-tool agent (enabled_toolsets=[]) built from
+    initialization.  Both stale candidates are closed; the empty-tool agent is
+    the only one that ends up cached + published + run."""
+    import api.streaming as streaming
+    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
+    _gen_state = {"value": 1}
+    _real_gen = streaming._registry_generation
+    _GateFakeAgent = _make_gate_fake_agent(_gen_state, move_on=(1, 2))
+    try:
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _gen_state["value"])
+        _publish_proxy = _PublishRecordingDict()
+        monkeypatch.setattr(streaming, "AGENT_INSTANCES", _publish_proxy)
+        sid = "gate-exhaust"
+        stream_id = "gate-exhaust-stream"
+        _setup_gate_real_caller(
+            tmp_path, monkeypatch, _GateFakeAgent, sid, stream_id,
+        )
+
+        # 2 stale candidates (both closed) + 1 empty-tool fallback = 3.
+        assert len(_GateFakeAgent.instances) == 3, (
+            f"expected 3 constructions, got {len(_GateFakeAgent.instances)}"
+        )
+        s1, s2, empty = _GateFakeAgent.instances
+        assert s1.closed is True and s2.closed is True, (
+            "both stale candidates must be closed"
+        )
+        assert empty.closed is False
+        assert s1.ran is False and s2.ran is False, (
+            "stale candidates must never run"
+        )
+        assert empty.enabled_toolsets == [], (
+            f"fail-closed fallback must be empty-tool, got {empty.enabled_toolsets!r}"
+        )
+        assert empty.ran is True, "empty-tool fallback is the agent that runs"
+        with SESSION_AGENT_CACHE_LOCK:
+            cached_entry = SESSION_AGENT_CACHE.get(sid)
+        assert cached_entry is not None and cached_entry[0] is empty, (
+            "cache must hold the empty-tool fallback (never a stale candidate)"
+        )
+        assert _publish_proxy.published.get(stream_id) is empty, (
+            "AGENT_INSTANCES must publish the empty-tool fallback: "
+            f"published={_publish_proxy.published!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -193,6 +193,18 @@ def _agentless_runtime_standins():
                 sys.modules["tools.registry"] = _mock_registry_mod
                 _changed.append(("tools.registry", _prior["tools.registry"],
                                  _mock_registry_mod))
+        # Round-21 gate fix: ``_authored_builtin_toolset_names()`` now
+        # FROZENS its snapshot on first successful import.  Each test needs a
+        # fresh snapshot of the (possibly stand-in) ``toolsets.TOOLSETS`` at
+        # its start — otherwise a ``create_custom_toolset`` in an earlier
+        # test would permanently bake a runtime custom toolset into the
+        # "authored" universe for every later test.  Reset AND pre-capture:
+        # the snapshot must freeze the PRISTINE stand-in state before the
+        # test body runs, so a ``create_custom_toolset`` inside the test
+        # cannot re-bake itself into the authored universe.
+        import api.streaming as _streaming_mod
+        _streaming_mod._AUTHORED_TOOLSETS_SNAPSHOT = None
+        _streaming_mod._authored_builtin_toolset_names()
         yield
     finally:
         # 4. Restore/delete ONLY what this fixture changed.  Entries that
@@ -1067,6 +1079,14 @@ def test_registered_mcp_prefix_toolset_passes_through(monkeypatch):
     MCP server (e.g. ``mcp-custom-probe``) must be preserved in the restrict
     branch — master passes it through, and dropping it silently discards a
     valid toolset.
+
+    Round-21 gate fix: the toolset is preserved ONLY when the current
+    profile EXPLICITLY authorizes it — an authored builtin in the frozen
+    ``toolsets.TOOLSETS`` snapshot or an explicit profile default for this
+    request.  A runtime ``create_custom_toolset`` entry is mutable global
+    inventory, not profile ownership, so the test authorizes the probe
+    through the profile ``defaults`` (the same channel the production
+    ``_resolve_cli_toolsets(cfg)`` uses for profile-enabled plugins).
     """
     import toolsets as _ts_mod
     from tools.registry import registry as _reg
@@ -1090,7 +1110,7 @@ def test_registered_mcp_prefix_toolset_passes_through(monkeypatch):
         _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
                       lambda *a, **k: "ok", override=True)
 
-        defaults = ["web", "file"]
+        defaults = ["web", "file", "mcp-custom-probe"]  # profile-authorized
         override = ["mcp-custom-probe"]
         mcp_servers = {"alpha"}
         result = _apply_override(
@@ -2799,6 +2819,13 @@ def test_immutable_static_mcp_prefix_survives_with_provenance(monkeypatch):
 
     This verifies the `true_shadow` check in the restrict branch correctly
     distinguishes between real static/plugin toolsets and MCP server selectors.
+
+    Round-21 gate fix: shadow-set provenance is INVENTORY, not OWNERSHIP —
+    ``create_custom_toolset`` entries are mutable process-global state that a
+    foreign profile could have inserted.  The current profile authorizes the
+    static ``mcp-browser`` plugin through an explicit profile ``defaults``
+    entry (the same channel ``_resolve_cli_toolsets(cfg)`` uses), and the
+    selector then survives exactly once.
     """
     import toolsets as _ts_mod
     from tools.registry import registry as _reg
@@ -2820,7 +2847,7 @@ def test_immutable_static_mcp_prefix_survives_with_provenance(monkeypatch):
         _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
                       lambda *a, **k: "ok", override=True)
 
-        defaults = ["web", "file"]
+        defaults = ["web", "file", "mcp-browser"]  # profile-enabled plugin
         override = ["mcp-browser"]  # user selects the static toolset
         mcp_servers = {"alpha"}  # only alpha is a configured MCP server
         result = _apply_override(
@@ -2828,8 +2855,8 @@ def test_immutable_static_mcp_prefix_survives_with_provenance(monkeypatch):
             builtin_names={"web", "file", "terminal", "mcp-browser"},  # proven in shadow
         )
 
-        # mcp-browser must survive (it's in true_shadow)
-        assert "mcp-browser" in result, (
+        # mcp-browser must survive exactly once (profile-authorized)
+        assert result.count("mcp-browser") == 1, (
             f"static mcp-* toolset with provenance must survive, got {result!r}"
         )
         # It resolves to its own tools
@@ -3648,6 +3675,233 @@ def test_restrict_mcp_selector_authorized_by_profile_survives_once(monkeypatch):
     finally:
         _ts_mod.TOOLSETS.clear()
         _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_two_profile_runtime_custom_mcp_rejected_all_lanes(monkeypatch):
+    """Round-21 gate finding (two-profile discriminator): ``toolsets.TOOLSETS``
+    is a RUNTIME-MUTABLE process-global dict — ``create_custom_toolset()``
+    inserts into it at runtime (e.g. from another profile's agent session).
+    A FOREIGN profile's runtime custom ``mcp-*`` toolset — present in BOTH the
+    live ``toolsets.TOOLSETS`` AND the process-global registry — but ABSENT
+    from the current profile's defaults/config must be rejected:
+
+      1. as an exact restrictive selector,
+      2. from the wildcard-default lane (additive, ``defaults`` carries ``all``),
+      3. from the free-text wildcard lane (restrict, override ``all``),
+
+    while a GENUINELY current-profile toolset (explicit ``defaults`` entry)
+    survives exactly once.
+
+    Production-composed: ``builtin_names`` is NOT injected; the real
+    ``_builtin_toolset_names()`` shadow collector and the frozen
+    ``_authored_builtin_toolset_names()`` snapshot run (Round-21: the
+    snapshot was pre-captured by the autouse fixture at PRISTINE stand-in
+    state, so the runtime ``create_custom_toolset`` below can never bake
+    itself into the authored universe).
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # ── FOREIGN profile's runtime custom toolset ─────────────────────
+        # Inserted through the SAME runtime API the Agent uses
+        # (create_custom_toolset) → live TOOLSETS membership.  Also
+        # registered in the process-global registry.  Absent from the
+        # current profile's defaults/config.
+        _ts_mod.create_custom_toolset("mcp-foreign", "foreign profile toolset",
+                                      tools=["foreign_tool"], includes=[])
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Configured server alpha — the current profile's own MCP server.
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Seed-assertion: the foreign entry IS in the live global inventory
+        # (the exact topology the old live-keys code misread as ownership).
+        assert "mcp-foreign" in _ts_mod.TOOLSETS
+
+        # 1) Exact restrictive selector → rejected.
+        result = _apply_override(
+            ["web", "file"],  # current-profile defaults — no mcp-foreign
+            ["mcp-foreign"],  # exact selector
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign runtime custom mcp-* must fail closed as exact "
+            f"selector, got {result!r}"
+        )
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "foreign_tool" not in final_tools, (
+            f"foreign tool must not resolve, got {sorted(final_tools)!r}"
+        )
+
+        # 2) Wildcard-default lane (additive): defaults carry ``all``.
+        result = _apply_override(
+            ["web", "file", "all"],
+            ["alpha"],  # all configured servers ticked
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign runtime custom mcp-* must not survive wildcard-default "
+            f"lane, got {result!r}"
+        )
+
+        # 3) Free-text wildcard lane (restrict): override ``all``.
+        result = _apply_override(
+            ["web", "file"],
+            ["all"],
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign runtime custom mcp-* must not survive free-text "
+            f"wildcard lane, got {result!r}"
+        )
+
+        # 4) Genuinely current-profile toolset survives EXACTLY ONCE.
+        # The profile explicitly enables mcp-custom-probe via its defaults
+        # (the same channel _resolve_cli_toolsets(cfg) produces).
+        _ts_mod.create_custom_toolset("mcp-custom-probe",
+                                      "current-profile plugin",
+                                      tools=["probe_tool"], includes=[])
+        _reg.register("probe_tool", "mcp-custom-probe", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        result = _apply_override(
+            ["web", "file", "mcp-custom-probe"],
+            ["mcp-custom-probe"],
+            {"alpha"},
+        )
+        assert result.count("mcp-custom-probe") == 1, (
+            f"current-profile toolset must survive exactly once, got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_final_resolution_generation_boundary_fails_closed(monkeypatch):
+    """Round-21 gate finding: the authority generation captured at helper
+    entry must be re-validated at FINAL tool resolution (AIAgent
+    construction), not only before the helper returns.
+
+    The helper already fails closed when the registry mutates WHILE it is
+    deciding (Round-19).  Round-21 extends the boundary: a registry mutation
+    BETWEEN the helper return and the Agent construction (a server
+    registering, an alias moving) must also fail closed — the toolsets handed
+    to the Agent were reasoned from a stale authority snapshot.
+
+    This test drives the production call shape: the caller captures the
+    authority generation via ``_gen_slot``, then re-validates it at final
+    resolution with ``_registry_generation_changed`` — the exact pattern the
+    streaming worker uses before AIAgent construction.
+    """
+    import api.streaming as streaming
+    from tools.registry import registry as _reg
+
+    _real_gen = streaming._registry_generation
+    _state = {"gen": 1}
+
+    def _controlled_generation():
+        return _state["gen"]
+
+    monkeypatch.setattr(streaming, "_registry_generation", _controlled_generation)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+    try:
+        # Configured server alpha → canonical mcp-alpha.
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Production call shape: helper captures the authority generation.
+        _gen_slot = []
+        result = _apply_override(
+            ["web", "file"], ["alpha"], {"alpha"},
+            _gen_slot=_gen_slot,
+        )
+        assert _gen_slot, "helper must report the entry generation via _gen_slot"
+        assert "alpha" in result or "mcp-alpha" in result, (
+            f"additive result expected, got {result!r}"
+        )
+
+        # MUTATION between helper return and final Agent resolution: the
+        # registry generation moves (a server registers).
+        _state["gen"] = 2
+
+        # Final resolution re-validates the SAME authority generation.
+        assert streaming._registry_generation_changed(_gen_slot[0]), (
+            "generation movement after helper return must be detected at "
+            "final resolution"
+        )
+        # The streaming worker fails closed to an empty toolset list.
+        final_toolsets = (
+            [] if streaming._registry_generation_changed(_gen_slot[0])
+            else result
+        )
+        assert final_toolsets == [], (
+            f"stale authority must fail closed at final resolution, "
+            f"got {final_toolsets!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_final_resolution_generation_stable_keeps_toolsets(monkeypatch):
+    """Positive half of the Round-21 generation-boundary: when the registry
+    does NOT mutate between helper return and final resolution, the toolsets
+    survive unchanged (the re-validation is a no-op)."""
+    import api.streaming as streaming
+    from tools.registry import registry as _reg
+
+    _real_gen = streaming._registry_generation
+    _state = {"gen": 1}
+
+    def _controlled_generation():
+        return _state["gen"]
+
+    monkeypatch.setattr(streaming, "_registry_generation", _controlled_generation)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+    try:
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        _gen_slot = []
+        result = _apply_override(
+            ["web", "file"], ["alpha"], {"alpha"},
+            _gen_slot=_gen_slot,
+        )
+        assert _gen_slot
+
+        # No mutation → final resolution keeps the toolsets.
+        assert not streaming._registry_generation_changed(_gen_slot[0])
+        final_toolsets = (
+            [] if streaming._registry_generation_changed(_gen_slot[0])
+            else result
+        )
+        assert final_toolsets == result, (
+            f"stable authority must keep the toolsets, got {final_toolsets!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
         _reg._tools.clear()
         _reg._tools.update(_saved_tools)
         _reg._toolset_aliases.clear()

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -939,6 +939,147 @@ def test_plugin_canonical_mcp_prefix_collision_restricts(monkeypatch):
     )
 
 
+def test_free_text_all_wildcard_preserved_in_restrict(monkeypatch):
+    """Gate finding #2 probe (b): a deliberate free-text override of ``all``
+    (the UI and API both accept it, and the installed resolver expands it to
+    every toolset) must be PRESERVED in the restrict branch — dropping it
+    yields an explicit EMPTY allowlist: the user asked for everything and got
+    nothing.
+
+    The wildcard is only dropped when it also collides with a configured
+    same-named MCP server (a server literally named ``all``), because then
+    the bare token is genuinely ambiguous between the wildcard and the
+    server's picker token.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # A configured server NOT named "all" — free-text "all" must survive.
+        _ts_mod.create_custom_toolset("alpha", "server alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "file"]
+        override = ["all"]  # free-text wildcard intent
+        mcp_servers = {"alpha"}
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        assert result == ["all"], (
+            f"free-text 'all' must be preserved in restrict mode, got {result!r}"
+        )
+        # Resolving it must yield the full toolset, not an empty list.
+        resolved = set(_ts_mod.resolve_toolset("all"))
+        assert "web_search" in resolved and "read_file" in resolved, (
+            f"'all' must expand to the full toolset, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_free_text_star_wildcard_preserved_in_restrict(monkeypatch):
+    """Same as above but with ``*`` instead of ``all``."""
+    defaults = ["web", "file"]
+    override = ["*"]
+    mcp_servers = {"alpha"}
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal"},
+    )
+
+    assert result == ["*"], (
+        f"free-text '*' must be preserved in restrict mode, got {result!r}"
+    )
+
+
+def test_free_text_all_dropped_when_collides_with_server_named_all():
+    """The wildcard is dropped ONLY in the genuinely-ambiguous case: a
+    configured MCP server literally named ``all``.  Then the bare token
+    could be the wildcard OR the server's picker token, so fail closed."""
+    defaults = ["web", "file"]
+    override = ["all"]
+    mcp_servers = {"all", "alpha"}  # server literally named "all"
+
+    result = _apply_override(
+        defaults, override, mcp_servers,
+        builtin_names={"web", "file", "terminal"},
+    )
+
+    assert result == [], (
+        "bare 'all' colliding with a configured server named 'all' is "
+        "ambiguous → must drop (got {})".format(result)
+    )
+
+
+def test_registered_mcp_prefix_toolset_passes_through(monkeypatch):
+    """Gate finding #3 probe (c): a valid REGISTERED/static toolset whose
+    name begins with ``mcp-`` but which does NOT correspond to a configured
+    MCP server (e.g. ``mcp-custom-probe``) must be preserved in the restrict
+    branch — master passes it through, and dropping it silently discards a
+    valid toolset.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Registered static toolset named "mcp-custom-probe", NO configured
+        # MCP server named "custom-probe" — it is a genuine toolset.
+        _ts_mod.create_custom_toolset("mcp-custom-probe",
+                                      "registered mcp-* toolset",
+                                      tools=["probe_tool"], includes=[])
+        _reg.register("probe_tool", "mcp-custom-probe", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Configured server alpha — unrelated to the probe.
+        _ts_mod.create_custom_toolset("alpha", "server alpha",
+                                      tools=[], includes=[])
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        defaults = ["web", "file"]
+        override = ["mcp-custom-probe"]
+        mcp_servers = {"alpha"}
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal", "mcp-custom-probe"},
+        )
+
+        assert "mcp-custom-probe" in result, (
+            f"registered mcp-* toolset must pass through, got {result!r}"
+        )
+        # It must resolve to its own tools.
+        resolved = set(_ts_mod.resolve_toolset("mcp-custom-probe"))
+        assert "probe_tool" in resolved, (
+            f"mcp-custom-probe must resolve its tool, got {sorted(resolved)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
 # ── Malformed registry return shapes must fail closed ──────────────────────
 
 
@@ -1106,7 +1247,13 @@ def test_wildcard_star_in_defaults_fails_closed_when_mcp_unchecked():
 
 def test_wildcard_all_ok_when_all_mcp_checked():
     """When ALL configured MCP servers are ticked, a wildcard default is
-    safe — no unchecked server can leak through the expansion."""
+    STILL not safe to retain — it expands at resolution time to every
+    registered toolset, including registry entries from OUTSIDE the current
+    config (gate finding #1: with ``alpha`` selected, an unconfigured
+    ``mcp-foreign`` tool became callable).  The additive branch must return
+    the verified explicit ``override_targets`` whenever defaults contain a
+    wildcard, regardless of whether ``_unchecked`` is empty.
+    """
     defaults = ["all"]
     override = ["alpha", "beta"]
     mcp_servers = {"alpha", "beta"}
@@ -1116,9 +1263,78 @@ def test_wildcard_all_ok_when_all_mcp_checked():
         builtin_names={"web", "file", "terminal", "delegation"},
     )
 
-    assert "alpha" in result and "beta" in result, (
-        "all-checked wildcard must retain the checked servers (got {})".format(result)
+    assert "all" not in result, (
+        "raw wildcard 'all' must never survive an additive override, "
+        "even when every configured server is ticked (got {})".format(result)
     )
+    assert "alpha" in result and "beta" in result, (
+        "all-checked override must retain the checked servers (got {})".format(result)
+    )
+
+
+def test_wildcard_default_all_servers_selected_no_foreign_leak(monkeypatch):
+    """Gate finding #1 probe (a): with a wildcard profile default AND every
+    configured MCP server ticked, the final resolved tool list must NOT
+    contain tools from a server that is NOT in the current config.
+
+    The registry holds a foreign ``mcp-foreign`` toolset.  Retaining the
+    wildcard default would expand it across the whole live registry at
+    resolution time and expose ``foreign_tool``; the fix must return only
+    the verified canonical targets.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Configured servers alpha/beta → canonical mcp-alpha / mcp-beta.
+        # NOTE: no TOOLSETS entry for the bare names — the resolver must
+        # reach them through their registry alias (like the real runtime).
+        for _name in ("alpha", "beta"):
+            _reg.register_toolset_alias(_name, f"mcp-{_name}")
+            _reg.register(f"{_name}_tool", f"mcp-{_name}", {"type": "object"},
+                          lambda *a, **k: "ok", override=True)
+        # FOREIGN: registered in the live registry but NOT configured.
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        assert _reg.get_toolset_alias_target("alpha") == "mcp-alpha"
+        assert _reg.get_toolset_alias_target("beta") == "mcp-beta"
+
+        defaults = ["all"]  # wildcard profile default
+        override = ["alpha", "beta"]  # every configured server ticked
+        mcp_servers = {"alpha", "beta"}
+        result = _apply_override(
+            defaults, override, mcp_servers,
+            builtin_names={"web", "file", "terminal"},
+        )
+
+        # The raw wildcard must never survive.
+        assert "all" not in result, (
+            f"wildcard default must not survive, got {result!r}"
+        )
+        # Resolve every returned selector: only the ticked servers' tools
+        # may appear; the unconfigured foreign server must stay out.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "alpha_tool" in final_tools and "beta_tool" in final_tools, (
+            f"ticked servers' tools must resolve, got {sorted(final_tools)!r}"
+        )
+        assert "foreign_tool" not in final_tools, (
+            f"unconfigured foreign server's tools must NOT resolve, "
+            f"got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
 
 
 def test_wildcard_default_with_selected_server_named_all(monkeypatch):

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -2884,9 +2884,9 @@ def test_two_profiles_same_registry_isolation(monkeypatch):
         final_a = set()
         for name in result_a:
             final_a.update(_ts_mod.resolve_toolset(name))
-        assert "alpha_tool" in final_a, f"alpha must resolve in profile A"
-        assert "beta_tool" not in final_a, f"beta must NOT resolve in profile A"
-        assert "gamma_tool" not in final_a, f"gamma must NOT resolve in profile A"
+        assert "alpha_tool" in final_a, "alpha must resolve in profile A"
+        assert "beta_tool" not in final_a, "beta must NOT resolve in profile A"
+        assert "gamma_tool" not in final_a, "gamma must NOT resolve in profile A"
 
         # Profile B must NOT have alpha or gamma
         assert "mcp-alpha" not in result_b and "mcp-gamma" not in result_b, (
@@ -2895,9 +2895,9 @@ def test_two_profiles_same_registry_isolation(monkeypatch):
         final_b = set()
         for name in result_b:
             final_b.update(_ts_mod.resolve_toolset(name))
-        assert "beta_tool" in final_b, f"beta must resolve in profile B"
-        assert "alpha_tool" not in final_b, f"alpha must NOT resolve in profile B"
-        assert "gamma_tool" not in final_b, f"gamma must NOT resolve in profile B"
+        assert "beta_tool" in final_b, "beta must resolve in profile B"
+        assert "alpha_tool" not in final_b, "alpha must NOT resolve in profile B"
+        assert "gamma_tool" not in final_b, "gamma must NOT resolve in profile B"
 
     finally:
         _ts_mod.TOOLSETS.clear()

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -193,18 +193,19 @@ def _agentless_runtime_standins():
                 sys.modules["tools.registry"] = _mock_registry_mod
                 _changed.append(("tools.registry", _prior["tools.registry"],
                                  _mock_registry_mod))
-        # Round-21 gate fix: ``_authored_builtin_toolset_names()`` now
-        # FROZENS its snapshot on first successful import.  Each test needs a
-        # fresh snapshot of the (possibly stand-in) ``toolsets.TOOLSETS`` at
-        # its start — otherwise a ``create_custom_toolset`` in an earlier
-        # test would permanently bake a runtime custom toolset into the
-        # "authored" universe for every later test.  Reset AND pre-capture:
-        # the snapshot must freeze the PRISTINE stand-in state before the
-        # test body runs, so a ``create_custom_toolset`` inside the test
-        # cannot re-bake itself into the authored universe.
+        # Round-22 gate fix: ``_authored_builtin_toolset_names()`` now captures
+        # its snapshot EAGERLY at module import time.  Each test needs a fresh
+        # snapshot of the (possibly stand-in) ``toolsets.TOOLSETS`` at its
+        # start — otherwise a ``create_custom_toolset`` in an earlier test
+        # would permanently bake a runtime custom toolset into the "authored"
+        # universe for every later test.  Reset AND re-capture using the eager
+        # capture helper: the snapshot must freeze the PRISTINE stand-in state
+        # before the test body runs, so a ``create_custom_toolset`` inside the
+        # test cannot re-bake itself into the authored universe.
         import api.streaming as _streaming_mod
-        _streaming_mod._AUTHORED_TOOLSETS_SNAPSHOT = None
-        _streaming_mod._authored_builtin_toolset_names()
+        _streaming_mod._AUTHORED_TOOLSETS_SNAPSHOT = (
+            _streaming_mod._capture_authored_builtin_snapshot()
+        )
         yield
     finally:
         # 4. Restore/delete ONLY what this fixture changed.  Entries that
@@ -3899,6 +3900,316 @@ def test_final_resolution_generation_stable_keeps_toolsets(monkeypatch):
         )
         assert final_toolsets == result, (
             f"stable authority must keep the toolsets, got {final_toolsets!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-22 production-shaped discriminators ──────────────────────────────
+
+def test_eager_snapshot_rejects_foreign_mcp_before_first_auth_lookup(monkeypatch):
+    """Round-22 gate finding 1 discriminator: the authored-builtin snapshot is
+    captured EAGERLY at module import time, so a foreign profile's
+    ``create_custom_toolset("mcp-foreign")`` that runs AFTER the snapshot
+    CANNOT bake itself into the "authored" universe.
+
+    The Round-21 lazy snapshot failed this ordering: the snapshot was None
+    until the first authorization call, so a ``create_custom_toolset`` that
+    ran before that first call contaminated the snapshot.  The autouse
+    fixture masked this by pre-capturing at pristine state.
+
+    This test simulates the production ordering:
+      1. Capture the snapshot EAGERLY (at "module import" = before any
+         runtime mutation),
+      2. Create a foreign runtime mcp-* toolset (contamination attempt),
+      3. Verify the snapshot does NOT contain mcp-foreign,
+      4. Verify all three authorization lanes reject the foreign toolset.
+
+    Additionally, verify that when the snapshot is ``None`` (initial eager
+    capture failed), the authorization paths ALL fail closed — they never
+    re-capture from a potentially contaminated dict.
+    """
+    import api.streaming as streaming
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Step 1: Capture the snapshot EAGERLY — simulates module import
+        # time, before any runtime create_custom_toolset can contaminate
+        # the TOOLSETS dict.
+        streaming._AUTHORED_TOOLSETS_SNAPSHOT = (
+            streaming._capture_authored_builtin_snapshot()
+        )
+        _pristine = streaming._authored_builtin_toolset_names()
+        assert _pristine is not None, "pristine snapshot must be available"
+        assert "mcp-foreign" not in _pristine
+
+        # Step 2: FOREIGN profile creates a runtime mcp-* toolset AFTER the
+        # eager capture.  The snapshot is frozen and must not change.
+        _ts_mod.create_custom_toolset("mcp-foreign",
+                                      "foreign profile toolset",
+                                      tools=["foreign_tool"], includes=[])
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Step 3: The snapshot still does NOT contain mcp-foreign.
+        _authored = streaming._authored_builtin_toolset_names()
+        assert _authored == _pristine, (
+            "eager snapshot must be frozen — runtime mutations must not "
+            "change it"
+        )
+        assert "mcp-foreign" not in _authored, (
+            f"eager snapshot must not contain runtime foreign mcp-*, "
+            f"got {sorted(_authored)!r}"
+        )
+
+        # Step 4: All three authorization lanes reject the foreign toolset.
+        # Lane 1: Exact restrictive selector → rejected.
+        result = _apply_override(
+            ["web", "file"],
+            ["mcp-foreign"],
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign mcp-* must be rejected as exact selector, got {result!r}"
+        )
+
+        # Lane 2: Wildcard-default lane (additive).
+        result = _apply_override(
+            ["web", "file", "all"],
+            ["alpha"],
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign mcp-* must not survive wildcard-default, got {result!r}"
+        )
+
+        # Lane 3: Free-text wildcard lane (restrict).
+        result = _apply_override(
+            ["web", "file"],
+            ["all"],
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign mcp-* must not survive free-text wildcard, got {result!r}"
+        )
+
+        # Verify the foreign tool is not callable through any lane.
+        for _result in [
+            _apply_override(["web", "file"], ["mcp-foreign"], {"alpha"}),
+            _apply_override(["web", "file", "all"], ["alpha"], {"alpha"}),
+            _apply_override(["web", "file"], ["all"], {"alpha"}),
+        ]:
+            _final_tools = set()
+            for _name in _result:
+                _final_tools.update(_ts_mod.resolve_toolset(_name))
+            assert "foreign_tool" not in _final_tools, (
+                f"foreign_tool must not be callable, got {sorted(_final_tools)!r}"
+            )
+
+        # Step 5: When the snapshot is None (initial capture failed at
+        # import time), _authored_builtin_toolset_names() NEVER re-captures
+        # — it returns None, and all authorization paths fail closed.
+        # This is the core fix: no re-capture from a potentially
+        # contaminated dict.
+        streaming._AUTHORED_TOOLSETS_SNAPSHOT = None
+        assert streaming._authored_builtin_toolset_names() is None, (
+            "must not re-capture when initial eager capture failed"
+        )
+        # With None snapshot, exact selector is rejected (fail closed).
+        result = _apply_override(
+            ["web", "file"],
+            ["mcp-foreign"],
+            {"alpha"},
+        )
+        assert "mcp-foreign" not in result, (
+            f"foreign mcp-* must be rejected when snapshot is None, "
+            f"got {result!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+        # Restore the fixture-captured snapshot.
+        streaming._AUTHORED_TOOLSETS_SNAPSHOT = (
+            streaming._capture_authored_builtin_snapshot()
+        )
+
+
+def test_unavailable_generation_with_override_fails_closed(monkeypatch):
+    """Round-22 gate finding 2 discriminator: when an override IS applied but
+    the registry generation is unavailable (``None`` — no registry / no
+    generation counter), we cannot PROVE the authority is stable.  The
+    override must fail closed to an empty toolset list, not be treated as
+    "stable" (which is what Round-21 did).
+
+    This test exercises the production caller-level logic that mirrors the
+    streaming worker: ``_override_applied = True`` + ``_toolsets_gen = None``
+    → fail closed (empty toolsets).
+    """
+    import api.streaming as streaming
+    from tools.registry import registry as _reg
+
+    _real_gen = streaming._registry_generation
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Force generation to None (registry unavailable / no counter).
+        monkeypatch.setattr(streaming, "_registry_generation", lambda: None)
+
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Apply the override — _gen_slot will contain None (no generation).
+        _gen_slot = []
+        result = _apply_override(
+            ["web", "file"], ["alpha"], {"alpha"},
+            _gen_slot=_gen_slot,
+        )
+        # The helper returns a valid merged result with the override applied.
+        # The additive branch returns bare server names for ordinary servers.
+        assert "alpha" in result, (
+            f"override should be applied, got {result!r}"
+        )
+
+        # Simulate the worker-level check: override was applied, generation
+        # is None → cannot prove stability → fail closed.
+        _toolsets_gen = _gen_slot[0] if _gen_slot else None
+        _override_applied = True
+
+        # This mirrors the production worker logic (Round-22).
+        if _toolsets_gen is not None and streaming._registry_generation_changed(_toolsets_gen):
+            final_toolsets = []
+        elif _toolsets_gen is None and _override_applied:
+            final_toolsets = []
+        else:
+            final_toolsets = result
+
+        assert final_toolsets == [], (
+            f"override with unavailable generation must fail closed to empty, "
+            f"got {final_toolsets!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_generation_movement_during_construction_fails_closed(monkeypatch):
+    """Round-22 gate finding 2 discriminator: the generation must be
+    re-validated IMMEDIATELY AFTER ``_AIAgent(...)`` construction.  A
+    registry mutation during the constructor's tool resolution must fail
+    closed (blank toolsets on the agent), not run or cache tools that were
+    never authorized.
+
+    This test simulates the production worker pattern:
+      1. Apply override → capture generation (e.g. gen=1),
+      2. Pre-construction check passes (gen still 1),
+      3. Simulate construction (gen moves to 2 during construction),
+      4. Post-construction check catches the movement → blank toolsets.
+    """
+    import api.streaming as streaming
+    from tools.registry import registry as _reg
+
+    _real_gen = streaming._registry_generation
+    _real_gen_changed = streaming._registry_generation_changed
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # Phase 1: Apply override with gen=1.
+        _state = {"gen": 1}
+        monkeypatch.setattr(streaming, "_registry_generation",
+                            lambda: _state["gen"])
+
+        _gen_slot = []
+        result = _apply_override(
+            ["web", "file"], ["alpha"], {"alpha"},
+            _gen_slot=_gen_slot,
+        )
+        _toolsets_gen = _gen_slot[0]
+        assert _toolsets_gen == 1
+
+        # Phase 2: Pre-construction check (gen still 1 → passes).
+        assert not streaming._registry_generation_changed(_toolsets_gen)
+        _toolsets = result  # would go into _agent_kwargs
+
+        # Phase 3: Simulate construction — gen moves to 2 DURING construction.
+        _state["gen"] = 2
+
+        # Phase 4: Post-construction check catches the movement.
+        assert streaming._registry_generation_changed(_toolsets_gen), (
+            "generation movement during construction must be detected"
+        )
+        # Production blanks the agent's toolsets.
+        final_toolsets = [] if streaming._registry_generation_changed(_toolsets_gen) else _toolsets
+        assert final_toolsets == [], (
+            f"generation movement during construction must blank toolsets, "
+            f"got {final_toolsets!r}"
+        )
+    finally:
+        monkeypatch.setattr(streaming, "_registry_generation", _real_gen)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_no_override_no_generation_check_needed(monkeypatch):
+    """Round-22 positive control: when NO override is applied, the profile
+    defaults are config-derived (not registry-derived), so no generation
+    re-validation is needed.  ``_toolsets_gen`` is None and
+    ``_override_applied`` is False → toolsets are preserved.
+    """
+    import api.streaming as streaming
+    from tools.registry import registry as _reg
+
+    _real_gen = streaming._registry_generation
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Even with generation unavailable, no override means no check needed.
+        monkeypatch.setattr(streaming, "_registry_generation", lambda: None)
+
+        # No override → _toolsets_gen stays None, _override_applied stays False.
+        _toolsets_gen = None
+        _override_applied = False
+        _toolsets = ["web", "file", "terminal"]
+
+        # Mirrors the production worker logic (Round-22).
+        if _toolsets_gen is not None and streaming._registry_generation_changed(_toolsets_gen):
+            final_toolsets = []
+        elif _toolsets_gen is None and _override_applied:
+            final_toolsets = []
+        else:
+            final_toolsets = _toolsets
+
+        assert final_toolsets == _toolsets, (
+            f"no override + no generation must preserve defaults, "
+            f"got {final_toolsets!r}"
         )
     finally:
         monkeypatch.setattr(streaming, "_registry_generation", _real_gen)

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -3022,32 +3022,39 @@ def test_free_text_wildcard_expands_to_profile_owned_only():
 def test_static_mcp_prefix_plugin_distinguished_from_foreign_mcp():
     """Static/plugin toolsets with mcp- prefix (no alias edge) must be
     distinguished from foreign MCP canonicals (have alias edge).
-    
+
     Round-18 gate fix: registry membership is NOT authorization.
+
+    Round-20 gate fix: the static/plugin selector is admitted only when it
+    is present in the CURRENT profile's authority — here an explicit
+    profile default (``defaults`` entry) proves the plugin is enabled for
+    this request.  A registry-only ``mcp-*`` entry with no profile
+    authorization fails closed.
     """
     from tools.registry import registry as _reg
-    
+
     _saved_tools = dict(_reg._tools)
     _saved_aliases = dict(_reg._toolset_aliases)
-    
+
     try:
         # Foreign MCP has alias edge
         _reg.register_toolset_alias("foreign", "mcp-foreign")
         _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
                       lambda *a, **k: "ok", override=True)
-        
+
         # Static/plugin mcp-* toolset has NO alias edge
         _reg.register("custom_probe", "mcp-custom-probe", {"type": "object"},
                       lambda *a, **k: "ok", override=True)
-        
-        # Current profile: no MCP servers configured
+
+        # Current profile: no MCP servers configured, but the profile
+        # explicitly enabled the mcp-custom-probe plugin for this request.
         result = _apply_override(
-            ["web"],
+            ["web", "mcp-custom-probe"],
             ["mcp-custom-probe", "mcp-foreign"],  # free-text selectors
             set(),  # no MCP servers configured
             builtin_names={"web", "file", "terminal", "mcp-foreign", "mcp-custom-probe"},
         )
-        
+
         # Static/plugin mcp-* must pass through
         assert "mcp-custom-probe" in result, (
             f"static mcp-* toolset must survive, got {result!r}"
@@ -3325,7 +3332,13 @@ def test_restrict_mcp_static_passthrough_no_duplicate(monkeypatch):
     """Round-19 finding: the restrictive exact-selector branch used to
     append an accepted alias-less ``mcp-*`` selector and then fall through
     to the unconditional append — producing a duplicate.  The pass-through
-    must emit the selector exactly once."""
+    must emit the selector exactly once.
+
+    Round-20 (gate finding): the selector is accepted ONLY from the current
+    profile's authority — here an explicit profile default (``defaults``
+    entry) proves the plugin is enabled for this request.  Registry
+    membership alone is inventory, not ownership.
+    """
     import toolsets as _ts_mod
     from tools.registry import registry as _reg
 
@@ -3340,7 +3353,7 @@ def test_restrict_mcp_static_passthrough_no_duplicate(monkeypatch):
                       lambda *a, **k: "ok", override=True)
 
         result = _apply_override(
-            ["web", "file"],
+            ["web", "file", "mcp-custom-probe"],  # profile explicitly enabled it
             ["mcp-custom-probe"],  # static/plugin, no alias edge
             {"alpha"},  # unrelated configured server
             builtin_names={"web", "file", "terminal", "mcp-custom-probe"},
@@ -3499,6 +3512,138 @@ def test_production_call_authority_not_from_registry_inventory(monkeypatch):
         )
         assert "plugin_foreign_tool" not in final_tools, (
             f"foreign plugin tool must NOT resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+# ── Round-20: exact mcp-* selectors need profile authority, not registry ──
+# The Round-19 gate certified that the restrictive exact-selector lane
+# treated a successful alias lookup with no alias edge as proof that an
+# `mcp-*` selector is an authorized static/plugin toolset.  In production
+# `builtin_names` comes from `_builtin_toolset_names()` — the process-global
+# registry inventory — so an ALIAS-LESS `mcp-foreign` entry registered by
+# another profile sits in the shadow set, resolves nothing through the
+# alias table, yet was admitted and its tools became callable.
+#
+# Round-20 fix: a restrictive exact `mcp-*` selector is admitted ONLY from
+# the current profile's authority snapshot — an authored immutable builtin
+# (`toolsets.TOOLSETS` definition) or an explicit profile default for this
+# request — or an exact configured-MCP canonical with a proven owner
+# (existing lane).  A successful "no alias" lookup is inventory
+# information, not ownership.  Unknown or foreign provenance fails closed.
+
+
+def test_restrict_foreign_aliasless_mcp_selector_fails_closed(monkeypatch):
+    """Round-20 gate finding (negative side, reviewer discriminator): a
+    REAL process-global alias-less ``mcp-*`` registration — an
+    ``mcp-foreign`` canonical registered by ANOTHER profile — is
+    INVENTORY, not OWNERSHIP.  Submitted as an exact restrictive override
+    it must be rejected and its tool must be ABSENT from the final
+    callable set, even though the alias lookup succeeds (returns None) and
+    the entry is present in the registry inventory shadow set.
+
+    Production-composed: ``builtin_names`` is NOT injected; the real
+    ``_builtin_toolset_names()`` shadow collector runs and the selector is
+    absent from the current profile's defaults/config.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Configured server alpha — unrelated to the foreign entry.
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # FOREIGN, ALIAS-LESS: registered in the process-global registry,
+        # NO alias edge, NOT configured in the current profile.
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Seed-assertion (round-8 rule): the alias-less lookup SUCCEEDS
+        # (returns None) — exactly the case the old code misread as proof
+        # of static/plugin provenance.
+        assert _reg.get_toolset_alias_target("foreign") is None
+
+        result = _apply_override(
+            ["web", "file"],  # profile defaults — no mcp-foreign
+            ["mcp-foreign"],  # exact restrictive selector
+            {"alpha"},        # only alpha configured
+        )  # builtin_names omitted → production shadow collector
+
+        assert result == [], (
+            f"foreign alias-less mcp-* selector must fail closed, got {result!r}"
+        )
+        # Tool-level proof: foreign_tool must not be callable.
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "foreign_tool" not in final_tools, (
+            f"foreign tool must not resolve, got {sorted(final_tools)!r}"
+        )
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_restrict_mcp_selector_authorized_by_profile_survives_once(monkeypatch):
+    """Round-20 gate finding (positive side): a GENUINELY authorized
+    ``mcp-*`` static/plugin selector — present in the CURRENT profile's
+    authority (an explicit profile default / enabled plugin for this
+    request) — must survive EXACTLY ONCE in the restrictive result, even
+    though the same name also exists in the process-global registry shadow
+    set.
+
+    Production-composed: ``builtin_names`` is NOT injected; the real
+    ``_builtin_toolset_names()`` shadow collector runs.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+
+    try:
+        # Static/plugin toolset named "mcp-custom-probe", NO MCP alias edge.
+        _ts_mod.create_custom_toolset("mcp-custom-probe",
+                                      "registered mcp-* plugin",
+                                      tools=["probe_tool"], includes=[])
+        _reg.register("probe_tool", "mcp-custom-probe", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        # Unrelated configured server alpha.
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+
+        # The current profile EXPLICITLY enabled the plugin for this request.
+        result = _apply_override(
+            ["web", "file", "mcp-custom-probe"],
+            ["mcp-custom-probe"],
+            {"alpha"},
+        )  # builtin_names omitted → production shadow collector
+
+        assert result.count("mcp-custom-probe") == 1, (
+            f"authorized mcp-* selector must survive exactly once, got {result!r}"
+        )
+        # It must resolve its own tools (not double-appended, not foreign).
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "probe_tool" in final_tools, (
+            f"authorized plugin tool must resolve, got {sorted(final_tools)!r}"
         )
     finally:
         _ts_mod.TOOLSETS.clear()

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -62,6 +62,12 @@ _mock_registry = _types.SimpleNamespace()
 _mock_registry._tools = {}
 _mock_registry._toolset_aliases = {}
 _mock_registry._snapshot_entries = lambda: list(_mock_registry._tools.values())
+# Round-22 gate fix: the mock registry must expose a _generation counter
+# (bumped on every register/alias mutation) so _registry_generation() returns
+# a real int, not None.  Without this, CI tests that exercise the real
+# _run_agent_streaming() path would fail-closed on every override because
+# _toolsets_gen is None (no generation counter to prove stability).
+_mock_registry._generation = 0
 
 
 def _mock_register(name, toolset, schema, handler, check_fn=None,
@@ -82,10 +88,12 @@ def _mock_register(name, toolset, schema, handler, check_fn=None,
         dynamic_schema_overrides=dynamic_schema_overrides,
     )
     _mock_registry._tools[name] = entry
+    _mock_registry._generation += 1
 
 
 def _mock_register_toolset_alias(alias, toolset):
     _mock_registry._toolset_aliases[alias] = toolset
+    _mock_registry._generation += 1
 
 
 def _mock_get_registered_toolset_names():

--- a/tests/test_session_mcp_toolset_merge.py
+++ b/tests/test_session_mcp_toolset_merge.py
@@ -1245,8 +1245,12 @@ def test_canonical_mcp_selector_in_defaults_is_stripped():
 def test_wildcard_all_in_defaults_fails_closed_when_mcp_unchecked():
     """A wildcard default ``['all']`` + override ``['beta']`` with unchecked
     server ``alpha``: the wildcard would expand to every registered toolset
-    including alpha's, so we must fail closed to restrictive semantics
-    (``['beta']``) rather than risk leaking alpha's tools.
+    including alpha's, so we must NOT retain the raw wildcard.
+    
+    Round-17/18 semantics: drop the wildcard token but PRESERVE builtins,
+    then merge with override_targets. Result = builtins + checked MCP servers.
+    This is "fail closed" against unchecked MCP tools while preserving the
+    additive contract for builtins/plugins.
     """
     defaults = ["all"]
     override = ["beta"]
@@ -1257,10 +1261,15 @@ def test_wildcard_all_in_defaults_fails_closed_when_mcp_unchecked():
         builtin_names={"web", "file", "terminal", "delegation"},
     )
 
-    assert result == ["beta"], (
-        "wildcard 'all' with unchecked MCP server must fail closed to "
-        "restrict (got {})".format(result)
-    )
+    # Wildcard dropped, builtins preserved, beta (checked MCP) added
+    # Note: without registry alias edge, beta stays as bare name
+    assert "all" not in result, "wildcard token must not survive"
+    assert "web" in result, "builtins must survive wildcard replacement"
+    assert "file" in result
+    assert "terminal" in result
+    assert "delegation" in result
+    assert "beta" in result, "checked MCP server must be added"
+    assert "alpha" not in result, "unchecked MCP server must not leak"
 
 
 def test_wildcard_star_in_defaults_fails_closed_when_mcp_unchecked():
@@ -1274,10 +1283,14 @@ def test_wildcard_star_in_defaults_fails_closed_when_mcp_unchecked():
         builtin_names={"web", "file", "terminal", "delegation"},
     )
 
-    assert result == ["beta"], (
-        "wildcard '*' with unchecked MCP server must fail closed to "
-        "restrict (got {})".format(result)
-    )
+    # Wildcard dropped, builtins preserved, beta (checked MCP) added
+    assert "*" not in result, "wildcard token must not survive"
+    assert "web" in result, "builtins must survive wildcard replacement"
+    assert "file" in result
+    assert "terminal" in result
+    assert "delegation" in result
+    assert "beta" in result, "checked MCP server must be added"
+    assert "alpha" not in result, "unchecked MCP server must not leak"
 
 
 def test_wildcard_all_ok_when_all_mcp_checked():
@@ -2907,3 +2920,144 @@ def test_two_profiles_same_registry_isolation(monkeypatch):
         _reg._toolset_aliases.clear()
         _reg._toolset_aliases.update(_saved_aliases)
 
+
+
+# ── Round-18 capability isolation tests ─────────────────────────────────────
+
+def test_wildcard_default_expands_to_profile_owned_only():
+    """Wildcard defaults must expand to profile-owned toolsets only,
+    NOT to foreign MCP canonicals from other profiles.
+    
+    Round-18 gate fix: separates inventory from authorization.
+    """
+    import toolsets as _ts_mod
+    from tools.registry import registry as _reg
+    
+    _saved_toolsets = dict(_ts_mod.TOOLSETS)
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+    
+    try:
+        # Global registry has foreign MCP canonical (mcp-foreign)
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register_toolset_alias("foreign", "mcp-foreign")
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        
+        # Current profile: only alpha configured, all servers checked
+        result = _apply_override(
+            ["web", "file"],
+            ["alpha"],  # all configured servers checked
+            {"alpha"},  # only alpha configured
+            builtin_names={"web", "file", "terminal", "delegation", "mcp-alpha", "mcp-foreign"},
+        )
+        
+        # Must NOT expose foreign MCP tools
+        assert "mcp-foreign" not in result, (
+            f"foreign MCP canonical must not appear, got {result!r}"
+        )
+        # alpha appears (bare or canonical depending on alias edge)
+        assert "alpha" in result or "mcp-alpha" in result, "configured MCP must be present"
+        
+        # Verify via resolver
+        final_tools = set()
+        for name in result:
+            final_tools.update(_ts_mod.resolve_toolset(name))
+        assert "alpha_tool" in final_tools, "alpha tools must resolve"
+        assert "foreign_tool" not in final_tools, "foreign tools must NOT resolve"
+    finally:
+        _ts_mod.TOOLSETS.clear()
+        _ts_mod.TOOLSETS.update(_saved_toolsets)
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_free_text_wildcard_expands_to_profile_owned_only():
+    """Free-text wildcard 'all' in restrict mode must expand to
+    profile-owned toolsets only, NOT to foreign MCP canonicals.
+    
+    Round-18 gate fix: separates inventory from authorization.
+    """
+    from tools.registry import registry as _reg
+    
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+    
+    try:
+        # Global registry has foreign MCP canonical
+        _reg.register_toolset_alias("alpha", "mcp-alpha")
+        _reg.register("alpha_tool", "mcp-alpha", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        _reg.register_toolset_alias("foreign", "mcp-foreign")
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        
+        # Free-text wildcard (restrict mode)
+        result = _apply_override(
+            ["web"],  # defaults
+            ["all"],  # free-text wildcard
+            {"alpha"},  # only alpha configured
+            builtin_names={"web", "file", "terminal", "mcp-alpha", "mcp-foreign"},
+        )
+        
+        # Must NOT expose foreign MCP tools
+        assert "mcp-foreign" not in result, (
+            f"foreign MCP canonical must not appear in wildcard expansion, got {result!r}"
+        )
+        # Must include profile-owned toolsets
+        assert "web" in result or "mcp-alpha" in result, (
+            f"profile-owned toolsets must appear, got {result!r}"
+        )
+    finally:
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)
+
+
+def test_static_mcp_prefix_plugin_distinguished_from_foreign_mcp():
+    """Static/plugin toolsets with mcp- prefix (no alias edge) must be
+    distinguished from foreign MCP canonicals (have alias edge).
+    
+    Round-18 gate fix: registry membership is NOT authorization.
+    """
+    from tools.registry import registry as _reg
+    
+    _saved_tools = dict(_reg._tools)
+    _saved_aliases = dict(_reg._toolset_aliases)
+    
+    try:
+        # Foreign MCP has alias edge
+        _reg.register_toolset_alias("foreign", "mcp-foreign")
+        _reg.register("foreign_tool", "mcp-foreign", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        
+        # Static/plugin mcp-* toolset has NO alias edge
+        _reg.register("custom_probe", "mcp-custom-probe", {"type": "object"},
+                      lambda *a, **k: "ok", override=True)
+        
+        # Current profile: no MCP servers configured
+        result = _apply_override(
+            ["web"],
+            ["mcp-custom-probe", "mcp-foreign"],  # free-text selectors
+            set(),  # no MCP servers configured
+            builtin_names={"web", "file", "terminal", "mcp-foreign", "mcp-custom-probe"},
+        )
+        
+        # Static/plugin mcp-* must pass through
+        assert "mcp-custom-probe" in result, (
+            f"static mcp-* toolset must survive, got {result!r}"
+        )
+        # Foreign MCP canonical must be dropped (no ownership proof)
+        assert "mcp-foreign" not in result, (
+            f"foreign MCP canonical must be dropped, got {result!r}"
+        )
+    finally:
+        _reg._tools.clear()
+        _reg._tools.update(_saved_tools)
+        _reg._toolset_aliases.clear()
+        _reg._toolset_aliases.update(_saved_aliases)


### PR DESCRIPTION
## Problem

Ticking a single configured MCP server in the per-session toolset picker (the composer toolset chip) breaks the entire chat: the model ends up with **zero tools** and every tool call fails with `Tool '...' does not exist. Available tools:` (empty).

### Root cause

The picker emits the **bare MCP server name** (e.g. `my-search`) into `session.enabled_toolsets`. In `api/streaming.py`, the override was applied as a wholesale replacement:

```python
if _override:
    _toolsets = _override
```

Enabling a single MCP server **replaced** the entire profile default toolset list — dropping every built-in toolset (`web`, `file`, `terminal`, `delegation`, …). MCP tools register under `mcp-<server>`, not the bare name, so the agent received an empty tool list.

## Fix

Distinguish the two intents behind a per-session override:

- **MCP-only override** (what the checkbox UI produces): merge the ticked MCP server names **on top of** the profile defaults (built-ins stay, server is added).
- **Override naming any non-MCP toolset** (power-user free-text "limit to these toolsets"): keep the original **restrict** semantics (replace defaults).

The classifier (`_apply_session_toolset_override`) disambiguates by comparing override entries against configured MCP server names. Merge is order-preserving and de-duplicated.

## Security hardening (14 prior review rounds distilled)

This rework carries the full set of fail-closed guards developed and gate-certified across the predecessor PR's review rounds:

- Canonical-name collisions (`mcp-alpha` vs `alpha` picker tokens) resolve via the exact live alias/ownership edge; unprovable ownership → `[]` (restrict).
- Malformed overrides / configured-server names (non-string entries) → sanitize or `[]` fail-closed.
- Registry-unavailable / unknown state → conservative restrict, never additive.
- Unchecked MCP servers' tools can never leak through a builtin/plugin default (transitive-reach check).
- Malformed selector sanitization drops `all`, `*`, unverified `mcp-*`.

## Tests

`tests/test_session_mcp_toolset_merge.py` — 59 tests covering: additive merge, restrict semantics, dedup/order, mixed overrides, empty/None defaults, collision fail-closed, malformed state, real-caller production paths, registry ownership, and reverse-verified security boundaries.

**Scope note**: this PR is a **clean, minimal rework** of the predecessor (#6005, 100 commits / 116 files) — exactly **2 files, ~3k lines**, all within GitHub's diff limits so the review gate can inspect the full diff. All prior review-hardened production logic is preserved.