### PR TITLE
fix(media): deny base/sibling profile webui state dirs when named profile active

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -19434,16 +19434,18 @@ def _open_verified_leaf_fd(target: Path) -> int | None:
     ancestor — including the immediate parent — between the grant decision and
     the serve open is refused (ELOOP). The returned leaf fd is retained and the
     response is served from it, so later pathname changes cannot redirect the
-    serve. Returns None on any failure (fail closed). On platforms without
-    dir_fd support (Windows, where creating symlinks requires admin) falls back
-    to a plain O_NOFOLLOW open of the resolved leaf — no new race protection
-    but no regression vs the prior path-based behaviour.
+    serve. Returns None on any failure (fail closed).
+
+    Round 3: on platforms without dir_fd support (Windows — Python's os
+    module has no openat/dir_fd there), there is no stable-handle equivalent
+    to anchor the walk, and a plain pathname open of the resolved leaf would
+    silently re-expose the authorization-to-open race this route exists to
+    close (Windows reparse points are not an acceptable trust primitive).
+    The route therefore FAILS CLOSED (403 via the caller) instead of falling
+    back to a pathname open.
     """
     if not _DIR_FD_OK:
-        try:
-            return os.open(str(target), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-        except OSError:
-            return None
+        return None
     try:
         anchor = Path(target.anchor)
         rel = target.relative_to(anchor)
@@ -20795,9 +20797,14 @@ def _handle_media(handler, parsed):
     #   - exact-token grant: retain an already-verified LEAF fd (walked with
     #     O_NOFOLLOW from the filesystem anchor) instead of the mutable
     #     target.parent pathname.
+    # Round 3: the route REQUIRES a genuinely secure handle capability
+    # (dir_fd + per-component no-follow). Platforms without dir_fd (Windows —
+    # Python's os module has no openat equivalent there) have no stable-handle
+    # equivalent for this walk, so the request FAILS CLOSED (403) rather than
+    # re-resolving/opening the authorizing root, target, or target.parent by
+    # pathname after the decision — the known-vulnerable path is never used.
     # Fail closed (403) when the authority fd cannot be retained — the serve
     # path must never fall through to an unanchored pathname open. (#6988.)
-    serve_anchor = None
     media_anchor_fd = None      # retained authority fd (opened at authorization)
     media_rel_parts = None      # pre-computed relative components under the fd
     if session_media_allowed:
@@ -20813,23 +20820,22 @@ def _handle_media(handler, parsed):
         ]
         if matching_roots:
             root = max(matching_roots, key=lambda r: len(r.parts))
-            if _DIR_FD_OK:
-                try:
-                    media_rel_parts = target.relative_to(root).parts
-                except ValueError:
-                    media_rel_parts = None
-                media_anchor_fd = _open_allowed_root_fd(root)
-                if media_anchor_fd is None or not media_rel_parts:
-                    # Authority fd could not be retained, or the relative
-                    # components could not be computed: fail closed — never
-                    # fall through to a pathname open or serve a directory fd.
-                    return bad(handler, "Path not in allowed location", 403)
-            else:
-                # Windows / no openat: keep the round-1 pathname anchor (no
-                # new race protection, but symlink creation needs admin there).
-                serve_anchor = root
-        if media_anchor_fd is None and serve_anchor is None:
-            return bad(handler, "Path not in allowed location", 403)
+            if not _DIR_FD_OK:
+                # No secure anchored-open capability on this platform: fail
+                # closed instead of re-resolving root/target by pathname.
+                return bad(handler, "Path not in allowed location", 403)
+            try:
+                media_rel_parts = target.relative_to(root).parts
+            except ValueError:
+                media_rel_parts = None
+            media_anchor_fd = _open_allowed_root_fd(root)
+            if media_anchor_fd is None or not media_rel_parts:
+                # Authority fd could not be retained, or the relative
+                # components could not be computed: fail closed — never
+                # fall through to a pathname open or serve a directory fd.
+                return bad(handler, "Path not in allowed location", 403)
+    if media_anchor_fd is None:
+        return bad(handler, "Path not in allowed location", 403)
     # HTML inline previews change frequently (agent edits + re-renders).
     # Use no-store so the browser always fetches fresh content, avoiding stale
     # previews that require a manual full-page refresh to update.
@@ -20845,8 +20851,7 @@ def _handle_media(handler, parsed):
         cache_control = "private, no-cache"
     return _serve_file_bytes(
         handler, target, mime, disposition, cache_control, csp=csp,
-        anchor_root=serve_anchor, anchor_fd=media_anchor_fd,
-        rel_parts=media_rel_parts,
+        anchor_fd=media_anchor_fd, rel_parts=media_rel_parts,
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -10509,6 +10509,7 @@ from api.workspace import (
     resolve_trusted_workspace,
     resolve_implicit_workspace_with_recovery,
     open_anchored_fd,
+    open_anchored_fd_from_root,
     open_anchored_create_fd,
     open_anchored_write_fd,
     unlink_anchored,
@@ -10518,6 +10519,7 @@ from api.workspace import (
     validate_workspace_to_add,
     _is_blocked_system_path,
     _home_path,
+    _DIR_FD_OK,
     _is_within,
     _strip_surrounding_quotes,
     _is_remote_terminal_backend,
@@ -19404,6 +19406,63 @@ def _open_file_read_fd(target: Path, anchor_root: Path | None = None) -> int:
     return open_anchored_fd(anchor_root, target.resolve(), want_dir=False)
 
 
+def _open_allowed_root_fd(root: Path) -> int | None:
+    """Open an allowed-root directory fd AT AUTHORIZATION time (#6988 round 2).
+
+    The O_DIRECTORY | O_NOFOLLOW open binds the authority to the DIRECTORY the
+    (already resolved) root pathname currently names, and the fd is RETAINED:
+    the serve-time walk starts from this fd, so replacing the root pathname
+    with a symlink after authorization cannot rebind the walk into the
+    replacement tree. Returns None when the root cannot be opened as a real
+    directory (fail closed — never fall through to a pathname open).
+    """
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        return os.open(str(root), flags)
+    except OSError:
+        return None
+
+
+def _open_verified_leaf_fd(target: Path) -> int | None:
+    """Retain an already-verified LEAF fd for an exact-token MEDIA grant (#6988).
+
+    Session MEDIA tokens are exact-path grants. The grant authority must NOT be
+    the mutable ``target.parent`` pathname (a swapped parent would rebind the
+    open into the replacement tree), so we walk every component from the
+    filesystem anchor (``/`` on POSIX) with O_NOFOLLOW: ``target`` is already
+    symlink-resolved, every component is a real directory, and a swap of ANY
+    ancestor — including the immediate parent — between the grant decision and
+    the serve open is refused (ELOOP). The returned leaf fd is retained and the
+    response is served from it, so later pathname changes cannot redirect the
+    serve. Returns None on any failure (fail closed). On platforms without
+    dir_fd support (Windows, where creating symlinks requires admin) falls back
+    to a plain O_NOFOLLOW open of the resolved leaf — no new race protection
+    but no regression vs the prior path-based behaviour.
+    """
+    if not _DIR_FD_OK:
+        try:
+            return os.open(str(target), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError:
+            return None
+    try:
+        anchor = Path(target.anchor)
+        rel = target.relative_to(anchor)
+    except (ValueError, OSError):
+        return None
+    if not rel.parts:
+        return None
+    try:
+        root_fd = os.open(
+            str(anchor), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        )
+    except OSError:
+        return None
+    try:
+        return open_anchored_fd_from_root(root_fd, rel.parts, want_dir=False)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
 def _close_fd_quietly(fd: int | None) -> None:
     if fd is None:
         return
@@ -19470,21 +19529,36 @@ def _etag_and_snapshot(fd, *, file_size: int) -> tuple[str | None, bytes | None,
     return _bytes_etag(data), data, actual_size
 
 
-def _serve_file_bytes(handler, target: Path, mime: str, disposition: str, cache_control: str, *, csp: str | None = None, anchor_root: Path | None = None, download_name: str | None = None):
+def _serve_file_bytes(handler, target: Path, mime: str, disposition: str, cache_control: str, *, csp: str | None = None, anchor_root: Path | None = None, anchor_fd: int | None = None, rel_parts=None, download_name: str | None = None):
     """Serve a file with correct MIME/disposition and optional byte-range support.
 
     Supports conditional GET via If-None-Match (ETag) — when the ETag matches,
     the request is short-circuited with 304 so revalidating clients (e.g.
     `no-cache` responses) do not re-download unchanged files.
 
+    ``anchor_fd`` (with ``rel_parts``) is the #6988 fd-based authority: an
+    allowed-root directory fd (or an already-verified leaf fd) retained at
+    authorization time. When ``anchor_fd`` is a root fd, ``rel_parts`` are the
+    pre-computed relative components of ``target`` under that root and the
+    serve open walks them from the retained fd with O_NOFOLLOW (never
+    re-resolving the root/target pathnames). When ``rel_parts`` is None,
+    ``anchor_fd`` IS the verified leaf fd and the bytes are served from it
+    directly. ``anchor_root`` remains the pathname-anchored fallback used by
+    the other file routes.
+
     ``download_name`` overrides the Content-Disposition filename (used when
     serving an immutable media snapshot whose on-disk name is a content digest).
     """
     fd = None
     try:
-        fd = _open_file_read_fd(target, anchor_root)
-        st = os.fstat(fd)
-        file_size = st.st_size
+        if anchor_fd is not None:
+            if rel_parts is None:
+                fd = anchor_fd
+            else:
+                fd = open_anchored_fd_from_root(anchor_fd, rel_parts, want_dir=False)
+        else:
+            fd = _open_file_read_fd(target, anchor_root)
+        file_size = os.fstat(fd).st_size
     except PermissionError:
         _close_fd_quietly(fd)
         return bad(handler, "Permission denied", 403)
@@ -20709,14 +20783,27 @@ def _handle_media(handler, parsed):
     # swap an ancestor (e.g. an `alias` dir) for a symlink to a denied
     # base/sibling webui state dir BETWEEN the checks and os.open — the same
     # already-authorized pathname would then open the denied object (TOCTOU).
-    # Retain the root that authorized `target` and pass it as anchor_root so
-    # the final open is component-anchored (openat + O_NOFOLLOW): any
-    # component swapped to a symlink after the checks is refused. (#6988.)
+    # Round 1 anchored the open with anchor_root, but that anchor was itself a
+    # PATHNAME re-resolved at open time, so replacing the selected allowed-root
+    # pathname (or the exact-token target parent) after authorization rebound
+    # root and target together into the replacement tree. Round 2 therefore
+    # retains the authority as an OPENED FD at authorization time:
+    #   - allowed-root grant: open the root dir fd (O_DIRECTORY|O_NOFOLLOW)
+    #     NOW and compute the target's relative components ONCE; the serve
+    #     open walks those components from the retained fd, so no later
+    #     pathname re-resolution can redirect it.
+    #   - exact-token grant: retain an already-verified LEAF fd (walked with
+    #     O_NOFOLLOW from the filesystem anchor) instead of the mutable
+    #     target.parent pathname.
+    # Fail closed (403) when the authority fd cannot be retained — the serve
+    # path must never fall through to an unanchored pathname open. (#6988.)
     serve_anchor = None
+    media_anchor_fd = None      # retained authority fd (opened at authorization)
+    media_rel_parts = None      # pre-computed relative components under the fd
     if session_media_allowed:
-        # Session MEDIA: tokens are exact-path grants; anchor at the parent so
-        # a swapped parent component cannot redirect the open either.
-        serve_anchor = target.parent
+        media_anchor_fd = _open_verified_leaf_fd(target)
+        if media_anchor_fd is None:
+            return bad(handler, "Path not in allowed location", 403)
     elif within_allowed:
         # Narrowest matching allowed root -> smallest open scope (the active
         # workspace root when the file lives there, HERMES_HOME otherwise).
@@ -20725,7 +20812,24 @@ def _handle_media(handler, parsed):
             if r.exists() and _path_is_within_root(target, r)
         ]
         if matching_roots:
-            serve_anchor = max(matching_roots, key=lambda r: len(r.parts))
+            root = max(matching_roots, key=lambda r: len(r.parts))
+            if _DIR_FD_OK:
+                try:
+                    media_rel_parts = target.relative_to(root).parts
+                except ValueError:
+                    media_rel_parts = None
+                media_anchor_fd = _open_allowed_root_fd(root)
+                if media_anchor_fd is None or not media_rel_parts:
+                    # Authority fd could not be retained, or the relative
+                    # components could not be computed: fail closed — never
+                    # fall through to a pathname open or serve a directory fd.
+                    return bad(handler, "Path not in allowed location", 403)
+            else:
+                # Windows / no openat: keep the round-1 pathname anchor (no
+                # new race protection, but symlink creation needs admin there).
+                serve_anchor = root
+        if media_anchor_fd is None and serve_anchor is None:
+            return bad(handler, "Path not in allowed location", 403)
     # HTML inline previews change frequently (agent edits + re-renders).
     # Use no-store so the browser always fetches fresh content, avoiding stale
     # previews that require a manual full-page refresh to update.
@@ -20741,7 +20845,8 @@ def _handle_media(handler, parsed):
         cache_control = "private, no-cache"
     return _serve_file_bytes(
         handler, target, mime, disposition, cache_control, csp=csp,
-        anchor_root=serve_anchor,
+        anchor_root=serve_anchor, anchor_fd=media_anchor_fd,
+        rel_parts=media_rel_parts,
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -20702,6 +20702,30 @@ def _handle_media(handler, parsed):
     if not target.exists() or not target.is_file():
         return j(handler, {"error": "not found"}, status=404)
 
+    # ── #6988: bind authorization to the object actually opened ──────────────
+    # All allow/deny checks above authorize the RESOLVED pathname, but
+    # _serve_file_bytes() would otherwise re-traverse it by NAME at open time:
+    # an attacker able to mutate an allowed tree (/tmp or the workspace) could
+    # swap an ancestor (e.g. an `alias` dir) for a symlink to a denied
+    # base/sibling webui state dir BETWEEN the checks and os.open — the same
+    # already-authorized pathname would then open the denied object (TOCTOU).
+    # Retain the root that authorized `target` and pass it as anchor_root so
+    # the final open is component-anchored (openat + O_NOFOLLOW): any
+    # component swapped to a symlink after the checks is refused. (#6988.)
+    serve_anchor = None
+    if session_media_allowed:
+        # Session MEDIA: tokens are exact-path grants; anchor at the parent so
+        # a swapped parent component cannot redirect the open either.
+        serve_anchor = target.parent
+    elif within_allowed:
+        # Narrowest matching allowed root -> smallest open scope (the active
+        # workspace root when the file lives there, HERMES_HOME otherwise).
+        matching_roots = [
+            r for r in allowed_roots
+            if r.exists() and _path_is_within_root(target, r)
+        ]
+        if matching_roots:
+            serve_anchor = max(matching_roots, key=lambda r: len(r.parts))
     # HTML inline previews change frequently (agent edits + re-renders).
     # Use no-store so the browser always fetches fresh content, avoiding stale
     # previews that require a manual full-page refresh to update.
@@ -20715,7 +20739,10 @@ def _handle_media(handler, parsed):
         cache_control = "no-store"
     else:
         cache_control = "private, no-cache"
-    return _serve_file_bytes(handler, target, mime, disposition, cache_control, csp=csp)
+    return _serve_file_bytes(
+        handler, target, mime, disposition, cache_control, csp=csp,
+        anchor_root=serve_anchor,
+    )
 
 
 def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -20428,6 +20428,17 @@ def _media_deny_reason(target: Path) -> str | None:
         _ws_state = (_root / "webui_state")
         for _sub in _DENY_SUBDIRS:
             _deny_dirs.append((_ws_state / _sub).resolve())
+        # The default WebUI STATE_DIR is <root>/webui (api/config.py) — the base
+        # profile's state dir, and <root>/profiles/<name>/webui for each named
+        # profile. Only the ACTIVE STATE_DIR was previously denied (as a root
+        # above), so a base/sibling profile's <root>/webui state was servable
+        # through /api/media whenever a named profile was active (#6982). Deny
+        # its state subdirs for every enumerated root/profile-root too. The
+        # `webui` container itself is NOT denied: STATE_DIR/workspace is the
+        # legitimate default workspace and must keep serving. (Fail-closed.)
+        _webui_state = (_root / "webui")
+        for _sub in _DENY_SUBDIRS:
+            _deny_dirs.append((_webui_state / _sub).resolve())
     # The configured media-snapshot store root itself: blobs are internal and
     # only reachable through the validated `snap=` parameter on an authorized
     # path, so a bare `path=` request at or below the store is rejected

--- a/api/routes.py
+++ b/api/routes.py
@@ -19417,7 +19417,18 @@ def _open_allowed_root_fd(root: Path) -> int | None:
     directory (fail closed — never fall through to a pathname open).
     """
     try:
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        # Retained root descriptor: used only as a dir_fd anchor for the
+        # serve-time walk, never read. O_PATH | O_DIRECTORY | O_NOFOLLOW when
+        # O_PATH is available — opening the directory with O_RDONLY would
+        # require READ permission on the root directory itself, regressing a
+        # valid search-only (0111) allowed root from HTTP 200 (pre-change
+        # direct leaf open needed only search on ancestors) to HTTP 403.
+        # Falls back to O_RDONLY on platforms without O_PATH. (#6988 round 4.)
+        flags = (
+            (getattr(os, "O_PATH", 0) or os.O_RDONLY)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
         return os.open(str(root), flags)
     except OSError:
         return None
@@ -19454,8 +19465,16 @@ def _open_verified_leaf_fd(target: Path) -> int | None:
     if not rel.parts:
         return None
     try:
+        # Filesystem anchor (e.g. "/" on POSIX): retained and used only as a
+        # dir_fd for the component walk, never read. O_PATH when available —
+        # no read permission needed on the anchor directory itself, and the
+        # walk stays identical (openat + O_NOFOLLOW). O_RDONLY fallback on
+        # platforms without O_PATH. (#6988 round 4.)
         root_fd = os.open(
-            str(anchor), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            str(anchor),
+            (getattr(os, "O_PATH", 0) or os.O_RDONLY)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
         )
     except OSError:
         return None

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1092,6 +1092,50 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
         raise
 
 
+def open_anchored_fd_from_root(root_fd: int, rel_parts, *, want_dir: bool) -> int:
+    """Walk ``rel_parts`` from an already-open, already-trusted root directory fd.
+
+    Unlike open_anchored_fd(), this NEVER re-resolves the root pathname: the
+    root fd was opened (and authorized) BEFORE this call, so a later swap of
+    the root pathname for a symlink (TOCTOU on the anchor itself) cannot rebind
+    the walk into the replacement tree. ``rel_parts`` must be the relative
+    components of the already-symlink-resolved target under the resolved root
+    (computed ONCE at authorization time); every component is opened with
+    O_NOFOLLOW (and O_DIRECTORY on parents), so a component swapped to a
+    symlink mid-walk is refused (ELOOP -> FileNotFoundError). Ownership of
+    ``root_fd`` transfers to this function: it is closed on success (after the
+    walk) and on failure. Caller owns and must close the returned leaf fd.
+    """
+    if not _DIR_FD_OK:
+        raise ValueError("open_anchored_fd_from_root requires dir_fd support")
+    if not rel_parts:
+        try:
+            os.close(root_fd)
+        except OSError:
+            pass
+        raise ValueError("Invalid destination: empty relative components")
+    fd = root_fd
+    try:
+        for i, part in enumerate(rel_parts):
+            is_last = i == len(rel_parts) - 1
+            want_directory = (not is_last) or want_dir
+            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0)
+            try:
+                nfd = os.open(part, flags, dir_fd=fd)
+            except OSError:
+                # ELOOP (component is a symlink — swapped in) or missing/wrong type.
+                raise FileNotFoundError(f"Not found: {part}") from None
+            os.close(fd)
+            fd = nfd
+        return fd
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+
+
 def open_anchored_create_fd(root: Path, dest: Path) -> int:
     """Create ``dest`` for exclusive writing race-safely, anchored under ``root``.
 

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1030,6 +1030,10 @@ def safe_resolve_ws(root: Path, requested: str) -> Path:
 _DIR_FD_OK = os.open in getattr(os, "supports_dir_fd", set())
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+# Windows opens files in TEXT mode by default (CRLF translation); every leaf
+# fd that reaches os.read / response serving must be opened in BINARY mode so
+# media bytes, ETag digests and Content-Lengths are never corrupted. No-op
+# (0) on POSIX. (#6988 round 3.)
 _O_BINARY = getattr(os, "O_BINARY", 0)
 
 
@@ -1051,12 +1055,9 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
     if not _DIR_FD_OK:
         # Windows / no openat: fall back to a plain pathname open. No new race
         # protection, but no regression vs the prior path-based behaviour, and
-        # symlink creation needs admin on Windows anyway.
-        flags = (
-            os.O_RDONLY
-            | (_O_DIRECTORY if want_dir else _O_BINARY)
-            | _O_NOFOLLOW
-        )
+        # symlink creation needs admin on Windows anyway. O_BINARY is required
+        # so the returned leaf fd reads raw bytes (no CRLF translation).
+        flags = os.O_RDONLY | (_O_DIRECTORY if want_dir else 0) | _O_NOFOLLOW | _O_BINARY
         try:
             return os.open(str(target), flags)
         except OSError:
@@ -1071,17 +1072,22 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
         for i, part in enumerate(rel_parts):
             is_last = i == len(rel_parts) - 1
             want_directory = (not is_last) or want_dir
-            flags = (
-                os.O_RDONLY
-                | _O_NOFOLLOW
-                | (_O_DIRECTORY if want_directory else _O_BINARY)
-            )
+            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
             try:
                 nfd = os.open(part, flags, dir_fd=fd)
             except OSError:
                 # ELOOP (component is a symlink — swapped in) or missing/wrong type.
                 raise FileNotFoundError(f"Not found: {target}") from None
-            os.close(fd)
+            try:
+                os.close(fd)
+            except BaseException:
+                # Never orphan the freshly-opened descriptor: close nfd before
+                # propagating the close failure. (#6988 round 3.)
+                try:
+                    os.close(nfd)
+                except OSError:
+                    pass
+                raise
             fd = nfd
         return fd
     except BaseException:
@@ -1119,13 +1125,22 @@ def open_anchored_fd_from_root(root_fd: int, rel_parts, *, want_dir: bool) -> in
         for i, part in enumerate(rel_parts):
             is_last = i == len(rel_parts) - 1
             want_directory = (not is_last) or want_dir
-            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0)
+            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
             try:
                 nfd = os.open(part, flags, dir_fd=fd)
             except OSError:
                 # ELOOP (component is a symlink — swapped in) or missing/wrong type.
                 raise FileNotFoundError(f"Not found: {part}") from None
-            os.close(fd)
+            try:
+                os.close(fd)
+            except BaseException:
+                # Never orphan the freshly-opened descriptor: close nfd before
+                # propagating the close failure. (#6988 round 3.)
+                try:
+                    os.close(nfd)
+                except OSError:
+                    pass
+                raise
             fd = nfd
         return fd
     except BaseException:
@@ -1160,7 +1175,7 @@ def open_anchored_create_fd(root: Path, dest: Path) -> int:
     if not _DIR_FD_OK:
         # Windows / no openat: create parent dirs then exclusively create the leaf.
         dest.parent.mkdir(parents=True, exist_ok=True)
-        return os.open(str(dest), os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW, 0o644)
+        return os.open(str(dest), os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW | _O_BINARY, 0o644)
 
     fd = os.open(str(root_resolved), os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
     try:
@@ -1173,11 +1188,20 @@ def open_anchored_create_fd(root: Path, dest: Path) -> int:
             except OSError:
                 # ELOOP — component swapped to a symlink (escape attempt).
                 raise FileNotFoundError(f"Not found: {dest}") from None
-            os.close(fd)
+            try:
+                os.close(fd)
+            except BaseException:
+                # Never orphan the freshly-opened descriptor: close nfd before
+                # propagating the close failure. (#6988 round 3.)
+                try:
+                    os.close(nfd)
+                except OSError:
+                    pass
+                raise
             fd = nfd
         return os.open(
             rel_parts[-1],
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW | _O_BINARY,
             0o644,
             dir_fd=fd,
         )

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1030,11 +1030,44 @@ def safe_resolve_ws(root: Path, requested: str) -> Path:
 _DIR_FD_OK = os.open in getattr(os, "supports_dir_fd", set())
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+# O_PATH opens a directory fd WITHOUT requiring read permission on the
+# directory itself (only search on its parents). Retained root/intermediate
+# directory fds are used purely as openat anchors, never read, so O_PATH is
+# both sufficient and required to keep a valid 0111 (search-only) allowed
+# root / intermediate servable: the pre-change direct leaf open needed only
+# search on ancestors, and an O_RDONLY open of such a directory would fail
+# with EACCES (403). Falls back to 0 on platforms without O_PATH, where the
+# callers use O_RDONLY instead. (#6988 round 4.)
+_O_PATH = getattr(os, "O_PATH", 0)
 # Windows opens files in TEXT mode by default (CRLF translation); every leaf
 # fd that reaches os.read / response serving must be opened in BINARY mode so
 # media bytes, ETag digests and Content-Lengths are never corrupted. No-op
 # (0) on POSIX. (#6988 round 3.)
 _O_BINARY = getattr(os, "O_BINARY", 0)
+
+
+def _dir_component_flags() -> int:
+    """Flags for retained root/intermediate DIRECTORY descriptors.
+
+    O_PATH | O_DIRECTORY | O_NOFOLLOW when O_PATH is available (no read
+    permission needed on the directory itself), falling back to
+    O_RDONLY | O_DIRECTORY | O_NOFOLLOW on platforms without O_PATH. The
+    returned fd is only ever used as a dir_fd anchor for the openat walk,
+    never read directly.
+    """
+    base = _O_PATH if _O_PATH else os.O_RDONLY
+    return base | _O_DIRECTORY | _O_NOFOLLOW
+
+
+def _leaf_flags(*, want_directory: bool) -> int:
+    """Flags for the FINAL (leaf) component: always readable.
+
+    O_RDONLY | O_NOFOLLOW | O_BINARY (+ O_DIRECTORY when the leaf is a
+    directory). O_PATH is never used for the leaf — the fd is returned to
+    callers that read/scan it (file bytes, os.scandir), and an O_PATH fd
+    cannot be read.
+    """
+    return os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
 
 
 def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
@@ -1067,12 +1100,25 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
     # collapsed any symlinks to REACH it, e.g. macOS /tmp -> /private/tmp), so its
     # final component is legitimately a real directory — O_NOFOLLOW here only fires
     # if the root itself was raced into a symlink after resolve() (escape attempt).
-    fd = os.open(str(root_resolved), os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
+    # When the target IS the root (empty rel_parts), the root fd is the returned
+    # LEAF the caller reads (e.g. os.scandir in list_dir) — keep it O_RDONLY.
+    # Otherwise it is a retained anchor used only as dir_fd: O_PATH when
+    # available, so a search-only (0111) allowed root stays openable.
+    if rel_parts:
+        fd = os.open(str(root_resolved), _dir_component_flags())
+    else:
+        fd = os.open(str(root_resolved), os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
     try:
         for i, part in enumerate(rel_parts):
             is_last = i == len(rel_parts) - 1
             want_directory = (not is_last) or want_dir
-            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
+            # Intermediate components are retained anchors (dir_fd only):
+            # O_PATH when available. The FINAL component is the readable leaf
+            # (file bytes, or the directory the caller scans) — never O_PATH.
+            if is_last:
+                flags = _leaf_flags(want_directory=want_directory)
+            else:
+                flags = _dir_component_flags()
             try:
                 nfd = os.open(part, flags, dir_fd=fd)
             except OSError:
@@ -1125,7 +1171,14 @@ def open_anchored_fd_from_root(root_fd: int, rel_parts, *, want_dir: bool) -> in
         for i, part in enumerate(rel_parts):
             is_last = i == len(rel_parts) - 1
             want_directory = (not is_last) or want_dir
-            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
+            # Intermediate components are retained anchors (dir_fd only):
+            # O_PATH when available, so a search-only (0111) intermediate
+            # stays traversable. The FINAL component is the readable leaf
+            # (file bytes, or the directory the caller scans) — never O_PATH.
+            if is_last:
+                flags = _leaf_flags(want_directory=want_directory)
+            else:
+                flags = _dir_component_flags()
             try:
                 nfd = os.open(part, flags, dir_fd=fd)
             except OSError:

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1067,7 +1067,7 @@ def _leaf_flags(*, want_directory: bool) -> int:
     callers that read/scan it (file bytes, os.scandir), and an O_PATH fd
     cannot be read.
     """
-    return os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | _O_BINARY
+    return os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0) | (_O_BINARY if not want_directory else 0)
 
 
 def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
@@ -1090,7 +1090,7 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
         # protection, but no regression vs the prior path-based behaviour, and
         # symlink creation needs admin on Windows anyway. O_BINARY is required
         # so the returned leaf fd reads raw bytes (no CRLF translation).
-        flags = os.O_RDONLY | (_O_DIRECTORY if want_dir else 0) | _O_NOFOLLOW | _O_BINARY
+        flags = os.O_RDONLY | (_O_DIRECTORY if want_dir else 0) | _O_NOFOLLOW | (_O_BINARY if not want_dir else 0)
         try:
             return os.open(str(target), flags)
         except OSError:

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -651,6 +651,115 @@ class TestMediaEndpointUnit(unittest.TestCase):
                     h5.status, 403,
                     "active profile's webui/workspace/shot.png must NOT be blocked")
 
+    def test_media_serve_binds_authorization_to_opened_object_swap_toctou(self):
+        """#6988 review: authorization must be bound to the object actually
+        opened. /api/media resolves + allow/deny-checks `target` first, then
+        serves it; if an ancestor is swapped for a symlink to a denied webui
+        state dir between the check and the final open, the SAME
+        already-authorized pathname must NOT open the denied object.
+
+        (a) A plain file under an allowed tree serves normally (200 + body).
+        (b) After swapping an ancestor (`alias`) for a symlink to the denied
+        active-profile <root>/webui/sessions dir, the same pathname must be
+        refused at open time (component-anchored openat + O_NOFOLLOW) — the
+        denied state content must never reach the response, even though the
+        path was authorized before the swap.
+        """
+        import shutil
+        from api import routes
+
+        class _CaptureHandler:
+            def __init__(self):
+                self.status = None
+                self.headers = {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as home:
+            base = pathlib.Path(home) / ".hermes"
+            # Active named profile (HERMES_HOME) with its WebUI state dir and
+            # the default workspace under it (STATE_DIR/workspace).
+            active = base / "profiles" / "webui"
+            active_webui = active / "webui"
+            denied_sessions = active_webui / "sessions"
+            ws = active_webui / "workspace"
+            denied_sessions.mkdir(parents=True)
+            ws.mkdir(parents=True)
+            # Denied state object with the SAME relative name the request uses.
+            denied_state = denied_sessions / "payload.json"
+            denied_state.write_text(
+                '{"top-secret-session":"do-not-leak","messages":[]}',
+                encoding="utf-8")
+            # Allowed, attacker-mutable tree inside the active workspace.
+            alias_dir = ws / "media_swap" / "alias"
+            alias_dir.mkdir(parents=True)
+            innocent = alias_dir / "payload.json"
+            innocent.write_text('{"ok":true,"payload":"innocent"}', encoding="utf-8")
+
+            env = {
+                "HERMES_HOME": str(active),
+                "HERMES_WEBUI_STATE_DIR": str(active_webui),
+            }
+            with mock.patch.dict(os.environ, env), \
+                 mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                 mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                 mock.patch("api.config.STATE_DIR", active_webui), \
+                 mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                request_path = (
+                    "path="
+                    + urllib.parse.quote(str((alias_dir / "payload.json").resolve()))
+                )
+
+                # (a) Pre-swap: the same pathname serves the innocent file.
+                h1 = _CaptureHandler()
+                routes._handle_media(h1, SimpleNamespace(
+                    query=request_path, path="/api/media"))
+                self.assertEqual(
+                    h1.status, 200,
+                    "innocent file under the allowed workspace must serve (200)")
+                self.assertIn(
+                    b"innocent", h1.body,
+                    "pre-swap body must be the innocent file content")
+
+                # (b) Swap the ancestor for a symlink to the denied webui
+                # state dir between check and open (simulated inside the first
+                # os.open call, i.e. after allow/deny evaluation). With the
+                # anchor_root binding the open is component-anchored and the
+                # swapped component is refused; without it, the same pathname
+                # re-traversed by name would open the denied state object.
+                real_open = os.open
+                swapped = {"done": False}
+
+                def _swap_on_first_open(path, *args, **kwargs):
+                    if not swapped["done"]:
+                        swapped["done"] = True
+                        shutil.rmtree(str(alias_dir))
+                        os.symlink(str(denied_sessions), str(alias_dir))
+                    return real_open(path, *args, **kwargs)
+
+                h2 = _CaptureHandler()
+                with mock.patch.object(os, "open", autospec=True,
+                                       side_effect=_swap_on_first_open):
+                    routes._handle_media(h2, SimpleNamespace(
+                        query=request_path, path="/api/media"))
+                self.assertNotEqual(
+                    h2.status, 200,
+                    "swapped-ancestor open must not serve the denied state object")
+                self.assertNotIn(
+                    b"top-secret-session", h2.body,
+                    "denied webui state content must never reach the response "
+                    "(authorization must be bound to the opened object)")
+
     def test_media_allowed_roots_env_var_serves_outside_hermes_root(self):
         """MEDIA_ALLOWED_ROOTS must still allow legitimate outside-root media."""
         from api import routes

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -760,6 +760,303 @@ class TestMediaEndpointUnit(unittest.TestCase):
                     "denied webui state content must never reach the response "
                     "(authorization must be bound to the opened object)")
 
+    def test_media_serve_swapped_allowed_root_pathname_fails_closed(self):
+        """#6988 round 2: replacing the SELECTED ALLOWED-ROOT pathname between
+        authorization and open must never serve replacement state bytes.
+
+        Round 1 anchored the open with ``anchor_root``, but that anchor was
+        itself a PATHNAME re-resolved at open time (open_anchored_fd calls
+        workspace.resolve() again), so replacing the allowed-root pathname for
+        a symlink to a denied webui state dir made root and target rebound
+        together into the replacement tree. Round 2 retains the root DIRECTORY
+        FD at authorization time (O_DIRECTORY|O_NOFOLLOW) and walks
+        pre-computed relative components from that fd:
+
+        - swap BEFORE the retention open (inside the first os.open call, after
+          all stat-based checks): the O_NOFOLLOW root open refuses the swapped
+          pathname (fail closed);
+        - swap AFTER the retention open (inside the second os.open call, i.e.
+          at the first serve-walk component): the walk from the RETAINED fd
+          stays in the original tree and serves the original object — a
+          pathname re-open would have rebound into the replacement tree.
+
+        Neither schedule can return denied bytes, for full or range requests.
+        """
+        import shutil
+        from api import routes
+
+        class _CaptureHandler:
+            def __init__(self, headers=None):
+                self.status = None
+                self.headers = headers or {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as home:
+            base = pathlib.Path(home) / ".hermes"
+            active = base / "profiles" / "webui"
+            active_webui = active / "webui"
+            denied_sessions = active_webui / "sessions"
+            ws = active_webui / "workspace"
+            denied_sessions.mkdir(parents=True)
+            ws.mkdir(parents=True)
+            # Denied state object with the SAME relative name the request uses.
+            denied_state = denied_sessions / "payload.json"
+            denied_state.write_text(
+                '{"top-secret-session":"do-not-leak","messages":[]}',
+                encoding="utf-8")
+            # Innocent file served directly from the workspace root (the
+            # SELECTED allowed root for this request).
+            innocent = ws / "payload.json"
+            innocent.write_text('{"ok":true,"payload":"innocent"}', encoding="utf-8")
+            moved = ws.parent / (ws.name + "_moved")
+
+            env = {
+                "HERMES_HOME": str(active),
+                "HERMES_WEBUI_STATE_DIR": str(active_webui),
+            }
+            with mock.patch.dict(os.environ, env), \
+                 mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                 mock.patch("api.workspace.get_last_workspace", lambda: str(ws)), \
+                 mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                 mock.patch("api.config.STATE_DIR", active_webui), \
+                 mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                request_path = (
+                    "path=" + urllib.parse.quote(str((ws / "payload.json").resolve()))
+                )
+
+                # Baseline: the same pathname serves the innocent file.
+                h1 = _CaptureHandler()
+                routes._handle_media(h1, SimpleNamespace(
+                    query=request_path, path="/api/media"))
+                self.assertEqual(
+                    h1.status, 200,
+                    "innocent file at the selected root must serve (200)")
+                self.assertIn(b"innocent", h1.body)
+
+                def _restore():
+                    if ws.is_symlink():
+                        ws.unlink()
+                        if moved.exists():
+                            os.rename(str(moved), str(ws))
+                        else:
+                            ws.mkdir(parents=True)
+                            innocent.write_text(
+                                '{"ok":true,"payload":"innocent"}', encoding="utf-8")
+
+                for trigger in ("before_retention", "after_retention"):
+                    for range_header in (None, {"Range": "bytes=0-100"}):
+                        _restore()
+                        real_open = os.open
+                        swapped = {"done": False}
+                        calls = {"n": 0}
+
+                        def _swap_root(path, *args, **kwargs):
+                            # Rename the real root dir aside, then put a
+                            # symlink to the denied tree at the root pathname.
+                            if not swapped["done"]:
+                                swapped["done"] = True
+                                shutil.rmtree(str(moved), ignore_errors=True)
+                                os.rename(str(ws), str(moved))
+                                os.symlink(str(denied_sessions), str(ws))
+                            return real_open(path, *args, **kwargs)
+
+                        def _swap_root_after_retention(path, *args, **kwargs):
+                            calls["n"] += 1
+                            if calls["n"] == 2 and not swapped["done"]:
+                                swapped["done"] = True
+                                shutil.rmtree(str(moved), ignore_errors=True)
+                                os.rename(str(ws), str(moved))
+                                os.symlink(str(denied_sessions), str(ws))
+                            return real_open(path, *args, **kwargs)
+
+                        side_effect = (
+                            _swap_root if trigger == "before_retention"
+                            else _swap_root_after_retention
+                        )
+                        h2 = _CaptureHandler(range_header)
+                        with mock.patch.object(os, "open", autospec=True,
+                                               side_effect=side_effect):
+                            routes._handle_media(h2, SimpleNamespace(
+                                query=request_path, path="/api/media"))
+                        self.assertNotIn(
+                            b"top-secret-session", h2.body,
+                            "denied webui state bytes must never reach the "
+                            "response (swapped allowed-root pathname) "
+                            f"[trigger={trigger}, range={bool(range_header)}]")
+                        if trigger == "before_retention":
+                            self.assertNotEqual(
+                                h2.status, 200,
+                                "swapped allowed-root open must be refused "
+                                "(O_NOFOLLOW on the retained root open)")
+                        else:
+                            self.assertIn(
+                                h2.status, (200, 206),
+                                "walk from the RETAINED root fd must keep "
+                                "serving the original tree")
+                            self.assertIn(
+                                b"innocent", h2.body,
+                                "retained-fd walk must serve the ORIGINAL "
+                                "object, not the replacement tree")
+
+    def test_media_serve_swapped_exact_token_parent_fails_closed(self):
+        """#6988 round 2: the exact-token MEDIA grant must not use mutable
+        target.parent as its anchor authority.
+
+        The grant retains an already-verified LEAF fd (walked with O_NOFOLLOW
+        from the filesystem anchor), so replacing the token target's parent
+        with a symlink to a denied webui state dir — before or during the
+        retention walk — is refused, and neither full nor range responses can
+        return the replacement state bytes.
+        """
+        import shutil
+        from api import routes
+
+        class _CaptureHandler:
+            def __init__(self, headers=None):
+                self.status = None
+                self.headers = headers or {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        token_dir = None
+        try:
+            # Token-granted file OUTSIDE every allowed root (the real home is
+            # not an allowed root; only $HOME/.hermes is), so the request
+            # exercises the exact-token grant branch, not the /tmp allow root.
+            token_dir = pathlib.Path(tempfile.mkdtemp(
+                prefix="hermes_media_token_", dir=str(pathlib.Path.home())))
+            moved = pathlib.Path(str(token_dir) + "_moved")
+            with tempfile.TemporaryDirectory() as home:
+                base = pathlib.Path(home) / ".hermes"
+                active = base / "profiles" / "webui"
+                active_webui = active / "webui"
+                denied_sessions = active_webui / "sessions"
+                ws = active_webui / "workspace"
+                denied_sessions.mkdir(parents=True)
+                ws.mkdir(parents=True)
+                # Denied state object with the SAME relative name the request
+                # uses, so a redirected open would return these bytes.
+                denied_state = denied_sessions / "report.html"
+                denied_state.write_text(
+                    "<!doctype html><title>top-secret-session</title>",
+                    encoding="utf-8")
+                innocent = token_dir / "report.html"
+                innocent.write_text(
+                    "<!doctype html><title>innocent</title>", encoding="utf-8")
+                session = SimpleNamespace(messages=[
+                    {"role": "assistant", "content": f"MEDIA:{innocent}"}])
+
+                env = {
+                    "HERMES_HOME": str(active),
+                    "HERMES_WEBUI_STATE_DIR": str(active_webui),
+                }
+                with mock.patch.dict(os.environ, env), \
+                     mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                     mock.patch.object(routes, "get_session", return_value=session), \
+                     mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                     mock.patch("api.config.STATE_DIR", active_webui), \
+                     mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                    request_path = (
+                        "path=" + urllib.parse.quote(str(innocent.resolve()))
+                        + "&session_id=s-media&inline=1"
+                    )
+
+                    # Baseline: the token-granted file serves normally.
+                    h1 = _CaptureHandler()
+                    routes._handle_media(h1, SimpleNamespace(
+                        query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h1.status, 200,
+                        "token-granted file must serve (200)")
+                    self.assertIn(b"innocent", h1.body)
+
+                    def _restore():
+                        if token_dir.is_symlink():
+                            token_dir.unlink()
+                            if moved.exists():
+                                os.rename(str(moved), str(token_dir))
+                            else:
+                                token_dir.mkdir(parents=True)
+                                innocent.write_text(
+                                    "<!doctype html><title>innocent</title>",
+                                    encoding="utf-8")
+
+                    for trigger in ("before_retention", "after_retention"):
+                        for range_header in (None, {"Range": "bytes=0-100"}):
+                            _restore()
+                            real_open = os.open
+                            swapped = {"done": False}
+                            calls = {"n": 0}
+
+                            def _swap_parent(path, *args, **kwargs):
+                                # Rename the token parent dir aside, then put a
+                                # symlink to the denied webui state dir at the
+                                # parent pathname.
+                                if not swapped["done"]:
+                                    swapped["done"] = True
+                                    shutil.rmtree(str(moved), ignore_errors=True)
+                                    os.rename(str(token_dir), str(moved))
+                                    os.symlink(str(denied_sessions), str(token_dir))
+                                return real_open(path, *args, **kwargs)
+
+                            def _swap_parent_midwalk(path, *args, **kwargs):
+                                calls["n"] += 1
+                                if calls["n"] == 2 and not swapped["done"]:
+                                    swapped["done"] = True
+                                    shutil.rmtree(str(moved), ignore_errors=True)
+                                    os.rename(str(token_dir), str(moved))
+                                    os.symlink(str(denied_sessions), str(token_dir))
+                                return real_open(path, *args, **kwargs)
+
+                            side_effect = (
+                                _swap_parent if trigger == "before_retention"
+                                else _swap_parent_midwalk
+                            )
+                            h2 = _CaptureHandler(range_header)
+                            with mock.patch.object(os, "open", autospec=True,
+                                                   side_effect=side_effect):
+                                routes._handle_media(h2, SimpleNamespace(
+                                    query=request_path, path="/api/media"))
+                            self.assertNotEqual(
+                                h2.status, 200,
+                                "swapped exact-token parent must not serve "
+                                "(the grant authority is the retained leaf fd, "
+                                "not target.parent) "
+                                f"[trigger={trigger}, range={bool(range_header)}]")
+                            self.assertNotIn(
+                                b"top-secret-session", h2.body,
+                                "denied webui state bytes must never reach the "
+                                "response (swapped exact-token target parent) "
+                                f"[trigger={trigger}, range={bool(range_header)}]")
+        finally:
+            if token_dir is not None:
+                if token_dir.is_symlink():
+                    token_dir.unlink()
+                shutil.rmtree(str(token_dir), ignore_errors=True)
+                shutil.rmtree(str(pathlib.Path(str(token_dir) + "_moved")),
+                              ignore_errors=True)
+
     def test_media_allowed_roots_env_var_serves_outside_hermes_root(self):
         """MEDIA_ALLOWED_ROOTS must still allow legitimate outside-root media."""
         from api import routes

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -1401,6 +1401,120 @@ class TestMediaEndpointUnit(unittest.TestCase):
                 "MEDIA_ALLOWED_ROOTS media outside Hermes roots must still serve",
             )
 
+    def test_media_serves_readable_leaf_under_0111_search_only_root(self):
+        """#6988 review round 4: retained root/intermediate DIRECTORY fds must
+        open with O_PATH | O_DIRECTORY | O_NOFOLLOW (no READ permission needed
+        on the directory itself — only search on its parents). The pre-change
+        direct leaf open needed only search on ancestors, so a readable media
+        file beneath a valid 0111 (search-only) allowed root and nested
+        intermediate must keep serving HTTP 200 with the exact bytes (and 206
+        for Range), never regress to 403.
+
+        An O_RDONLY open of the 0111 root/intermediate fails with EACCES for
+        non-root users, which is exactly the regression this test guards:
+        with the retained root fd opened O_RDONLY, the authorization-time
+        retention open itself fails and the route returns 403.
+
+        Permissions are restored in ``finally`` so the TemporaryDirectory
+        cleanup can traverse and remove the tree.
+        """
+        from api import routes
+
+        if not hasattr(os, "O_PATH"):
+            self.skipTest("O_PATH unavailable on this platform")
+        if os.name == "nt":
+            self.skipTest("POSIX mode bits unavailable on Windows")
+
+        class _CaptureHandler:
+            def __init__(self, headers=None):
+                self.status = None
+                self.headers = headers or {}
+                self.sent_headers = {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, name, value):
+                self.sent_headers[name] = value
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        png_bytes = (
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+            b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00'
+            b'\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82'
+        )
+        with tempfile.TemporaryDirectory() as home:
+            # Traversable by the testing user AND by a non-root drop (the
+            # 0111 search-only bits on the allowed root/intermediate are the
+            # point of this test; the parent must not add an unrelated
+            # EACCES). TemporaryDirectory creates 0700 by default.
+            home_path = pathlib.Path(home)
+            home_path.chmod(0o755)
+            hermes_home = home_path / ".hermes"
+            hermes_home.mkdir(parents=True)
+            ws = hermes_home / "workspace"
+            ws.mkdir(parents=True)
+            state_dir = hermes_home / "webui-state"
+            state_dir.mkdir(parents=True)
+            # Valid allowed root via MEDIA_ALLOWED_ROOTS, with a NESTED
+            # intermediate — both search-only (0111), leaf readable (0644).
+            allowed_root = home_path / "media_0111"
+            intermediate = allowed_root / "nested"
+            intermediate.mkdir(parents=True)
+            leaf = intermediate / "shot.png"
+            leaf.write_bytes(png_bytes)
+            leaf.chmod(0o644)
+            try:
+                allowed_root.chmod(0o111)
+                intermediate.chmod(0o111)
+
+                env = {
+                    "HERMES_HOME": str(hermes_home),
+                    "MEDIA_ALLOWED_ROOTS": str(allowed_root),
+                }
+                request_path = (
+                    "path=" + urllib.parse.quote(str(leaf.resolve())) + "&inline=1"
+                )
+                with mock.patch.dict(os.environ, env), \
+                     mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                     mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                     mock.patch("api.config.STATE_DIR", state_dir), \
+                     mock.patch("api.profiles._DEFAULT_HERMES_HOME", hermes_home):
+                    # Full request: HTTP 200 with the exact bytes.
+                    h1 = _CaptureHandler()
+                    routes._handle_media(h1, SimpleNamespace(
+                        query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h1.status, 200,
+                        "readable leaf below 0111 search-only root+intermediate "
+                        "must serve full HTTP 200 (O_PATH on retained dir fds)")
+                    self.assertEqual(
+                        bytes(h1.body), png_bytes,
+                        "full response body must be the exact media bytes")
+                    # Range request: HTTP 206 with the exact slice.
+                    h2 = _CaptureHandler({"Range": "bytes=4-11"})
+                    routes._handle_media(h2, SimpleNamespace(
+                        query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h2.status, 206,
+                        "Range on a leaf below 0111 dirs must serve HTTP 206")
+                    self.assertEqual(
+                        bytes(h2.body), png_bytes[4:12],
+                        "206 body must be the exact requested byte slice")
+                    self.assertEqual(
+                        h2.sent_headers.get("Content-Range"),
+                        f"bytes 4-11/{len(png_bytes)}",
+                        "206 must carry the exact Content-Range")
+            finally:
+                # Restore permissions so TemporaryDirectory cleanup works.
+                allowed_root.chmod(0o755)
+                intermediate.chmod(0o755)
+
     def test_media_endpoints_advertise_byte_range_support(self):
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
         self.assertIn("Accept-Ranges", routes_src)

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -740,12 +740,12 @@ class TestMediaEndpointUnit(unittest.TestCase):
                 real_open = os.open
                 swapped = {"done": False}
 
-                def _swap_on_first_open(path, *args, **kwargs):
-                    if not swapped["done"]:
-                        swapped["done"] = True
-                        shutil.rmtree(str(alias_dir))
-                        os.symlink(str(denied_sessions), str(alias_dir))
-                    return real_open(path, *args, **kwargs)
+                def _swap_on_first_open(path, *args, _real_open=real_open, _swapped=swapped, _alias_dir=alias_dir, _denied_sessions=denied_sessions, **kwargs):
+                    if not _swapped["done"]:
+                        _swapped["done"] = True
+                        shutil.rmtree(str(_alias_dir))
+                        os.symlink(str(_denied_sessions), str(_alias_dir))
+                    return _real_open(path, *args, **kwargs)
 
                 h2 = _CaptureHandler()
                 with mock.patch.object(os, "open", autospec=True,
@@ -861,24 +861,24 @@ class TestMediaEndpointUnit(unittest.TestCase):
                         swapped = {"done": False}
                         calls = {"n": 0}
 
-                        def _swap_root(path, *args, **kwargs):
+                        def _swap_root(path, *args, _real_open=real_open, _swapped=swapped, _moved=moved, _ws=ws, _denied_sessions=denied_sessions, **kwargs):
                             # Rename the real root dir aside, then put a
                             # symlink to the denied tree at the root pathname.
-                            if not swapped["done"]:
-                                swapped["done"] = True
-                                shutil.rmtree(str(moved), ignore_errors=True)
-                                os.rename(str(ws), str(moved))
-                                os.symlink(str(denied_sessions), str(ws))
-                            return real_open(path, *args, **kwargs)
+                            if not _swapped["done"]:
+                                _swapped["done"] = True
+                                shutil.rmtree(str(_moved), ignore_errors=True)
+                                os.rename(str(_ws), str(_moved))
+                                os.symlink(str(_denied_sessions), str(_ws))
+                            return _real_open(path, *args, **kwargs)
 
-                        def _swap_root_after_retention(path, *args, **kwargs):
-                            calls["n"] += 1
-                            if calls["n"] == 2 and not swapped["done"]:
-                                swapped["done"] = True
-                                shutil.rmtree(str(moved), ignore_errors=True)
-                                os.rename(str(ws), str(moved))
-                                os.symlink(str(denied_sessions), str(ws))
-                            return real_open(path, *args, **kwargs)
+                        def _swap_root_after_retention(path, *args, _real_open=real_open, _swapped=swapped, _calls=calls, _moved=moved, _ws=ws, _denied_sessions=denied_sessions, **kwargs):
+                            _calls["n"] += 1
+                            if _calls["n"] == 2 and not _swapped["done"]:
+                                _swapped["done"] = True
+                                shutil.rmtree(str(_moved), ignore_errors=True)
+                                os.rename(str(_ws), str(_moved))
+                                os.symlink(str(_denied_sessions), str(_ws))
+                            return _real_open(path, *args, **kwargs)
 
                         side_effect = (
                             _swap_root if trigger == "before_retention"
@@ -1009,25 +1009,25 @@ class TestMediaEndpointUnit(unittest.TestCase):
                             swapped = {"done": False}
                             calls = {"n": 0}
 
-                            def _swap_parent(path, *args, **kwargs):
+                            def _swap_parent(path, *args, _real_open=real_open, _swapped=swapped, _moved=moved, _token_dir=token_dir, _denied_sessions=denied_sessions, **kwargs):
                                 # Rename the token parent dir aside, then put a
                                 # symlink to the denied webui state dir at the
                                 # parent pathname.
-                                if not swapped["done"]:
-                                    swapped["done"] = True
-                                    shutil.rmtree(str(moved), ignore_errors=True)
-                                    os.rename(str(token_dir), str(moved))
-                                    os.symlink(str(denied_sessions), str(token_dir))
-                                return real_open(path, *args, **kwargs)
+                                if not _swapped["done"]:
+                                    _swapped["done"] = True
+                                    shutil.rmtree(str(_moved), ignore_errors=True)
+                                    os.rename(str(_token_dir), str(_moved))
+                                    os.symlink(str(_denied_sessions), str(_token_dir))
+                                return _real_open(path, *args, **kwargs)
 
-                            def _swap_parent_midwalk(path, *args, **kwargs):
-                                calls["n"] += 1
-                                if calls["n"] == 2 and not swapped["done"]:
-                                    swapped["done"] = True
-                                    shutil.rmtree(str(moved), ignore_errors=True)
-                                    os.rename(str(token_dir), str(moved))
-                                    os.symlink(str(denied_sessions), str(token_dir))
-                                return real_open(path, *args, **kwargs)
+                            def _swap_parent_midwalk(path, *args, _real_open=real_open, _swapped=swapped, _calls=calls, _moved=moved, _token_dir=token_dir, _denied_sessions=denied_sessions, **kwargs):
+                                _calls["n"] += 1
+                                if _calls["n"] == 2 and not _swapped["done"]:
+                                    _swapped["done"] = True
+                                    shutil.rmtree(str(_moved), ignore_errors=True)
+                                    os.rename(str(_token_dir), str(_moved))
+                                    os.symlink(str(_denied_sessions), str(_token_dir))
+                                return _real_open(path, *args, **kwargs)
 
                             side_effect = (
                                 _swap_parent if trigger == "before_retention"

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -43,6 +43,37 @@ def _media_fixture_dir() -> pathlib.Path:
     return fixture_dir
 
 
+def _media_token_fixture_dir() -> pathlib.Path:
+    """A writable directory that is NOT an /api/media allowed root.
+
+    ``_handle_media`` hardcodes /tmp as an allowed root (screenshots land
+    there), and the review sandbox sets HOME=/tmp, so an exact-token fixture
+    under the OS temp dir would be authorized by the ALLOWED-ROOT branch and
+    the request would never exercise the token grant (it would only reach it
+    by precedence). The OS temp dir is used only when it lives OUTSIDE the
+    /tmp root — macOS (/var/folders) and Windows (%TEMP%; ``Path('/tmp')``
+    does not exist there). On Linux the /dev/shm tmpfs is used instead, which
+    is outside every allowed root. Falls back to the OS temp dir when no
+    outside-/tmp location is available.
+    """
+    tmp_root = pathlib.Path("/tmp").resolve()
+    for cand in (
+        pathlib.Path(tempfile.gettempdir()).resolve(),
+        pathlib.Path("/dev/shm"),
+    ):
+        if cand == tmp_root or tmp_root in cand.parents:
+            continue
+        try:
+            probe = pathlib.Path(
+                tempfile.mkdtemp(prefix="hermes_media_token_probe_", dir=str(cand))
+            )
+            probe.rmdir()
+            return cand
+        except OSError:
+            continue
+    return pathlib.Path(tempfile.gettempdir())
+
+
 # ── Static analysis: renderMd MEDIA stash ────────────────────────────────────
 
 class TestMediaRenderMdStash(unittest.TestCase):
@@ -941,11 +972,14 @@ class TestMediaEndpointUnit(unittest.TestCase):
 
         token_dir = None
         try:
-            # Token-granted file OUTSIDE every allowed root (the real home is
-            # not an allowed root; only $HOME/.hermes is), so the request
-            # exercises the exact-token grant branch, not the /tmp allow root.
+            # Token-granted file OUTSIDE every allowed root (the OS temp dir
+            # is itself an allowed /api/media root — /tmp is hardcoded, and
+            # the review sandbox sets HOME=/tmp — so a fixture there would be
+            # authorized by the allowed-root branch and only reach the token
+            # branch by precedence). The fixture root is chosen outside /tmp
+            # so the exact-token grant is the ONLY thing that can serve it.
             token_dir = pathlib.Path(tempfile.mkdtemp(
-                prefix="hermes_media_token_", dir=str(pathlib.Path.home())))
+                prefix="hermes_media_token_", dir=str(_media_token_fixture_dir())))
             moved = pathlib.Path(str(token_dir) + "_moved")
             with tempfile.TemporaryDirectory() as home:
                 base = pathlib.Path(home) / ".hermes"
@@ -1049,6 +1083,258 @@ class TestMediaEndpointUnit(unittest.TestCase):
                                 "denied webui state bytes must never reach the "
                                 "response (swapped exact-token target parent) "
                                 f"[trigger={trigger}, range={bool(range_header)}]")
+        finally:
+            if token_dir is not None:
+                if token_dir.is_symlink():
+                    token_dir.unlink()
+                shutil.rmtree(str(token_dir), ignore_errors=True)
+                shutil.rmtree(str(pathlib.Path(str(token_dir) + "_moved")),
+                              ignore_errors=True)
+
+    def test_media_fails_closed_without_dir_fd_allowed_root_grant(self):
+        """#6988 round 3: on platforms without dir_fd (no secure anchored-open
+        capability — Windows), /api/media must FAIL CLOSED (403) for
+        allowed-root grants instead of silently re-resolving/opening the
+        authorizing root/target pathnames (the known-vulnerable path). Covers
+        full and Range responses, and proves replacement state bytes cannot be
+        returned even when the allowed-root pathname is swapped to a secret
+        location BEFORE the request — a pathname re-open would have served it.
+        """
+        import shutil
+        from api import routes
+
+        class _CaptureHandler:
+            def __init__(self, headers=None):
+                self.status = None
+                self.headers = headers or {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as home:
+            base = pathlib.Path(home) / ".hermes"
+            active = base / "profiles" / "webui"
+            active_webui = active / "webui"
+            ws = active_webui / "workspace"
+            ws.mkdir(parents=True)
+            innocent = ws / "payload.json"
+            innocent.write_text('{"ok":true,"payload":"innocent"}', encoding="utf-8")
+            # Secret location that is NOT deny-listed (so the deny gate cannot
+            # mask the fail-closed): a plain pathname open through the swapped
+            # symlink would serve these bytes on the pre-round-3 fallback.
+            secret_stash = active_webui / "workspace_secret_stash"
+            secret_stash.mkdir(parents=True)
+            secret = secret_stash / "payload.json"
+            secret.write_text(
+                '{"top-secret-session":"do-not-leak","messages":[]}',
+                encoding="utf-8")
+            moved = ws.parent / (ws.name + "_moved")
+
+            env = {
+                "HERMES_HOME": str(active),
+                "HERMES_WEBUI_STATE_DIR": str(active_webui),
+            }
+            with mock.patch.dict(os.environ, env), \
+                 mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                 mock.patch("api.workspace.get_last_workspace", lambda: str(ws)), \
+                 mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                 mock.patch("api.config.STATE_DIR", active_webui), \
+                 mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                request_path = (
+                    "path=" + urllib.parse.quote(str((ws / "payload.json").resolve()))
+                )
+
+                # Control: with dir_fd the same request serves the innocent file.
+                h1 = _CaptureHandler()
+                routes._handle_media(h1, SimpleNamespace(
+                    query=request_path, path="/api/media"))
+                self.assertEqual(
+                    h1.status, 200,
+                    "control: allowed-root request must serve with dir_fd")
+                self.assertIn(b"innocent", h1.body)
+
+                def _restore():
+                    if ws.is_symlink():
+                        ws.unlink()
+                        if moved.exists():
+                            os.rename(str(moved), str(ws))
+                        else:
+                            ws.mkdir(parents=True)
+                            innocent.write_text(
+                                '{"ok":true,"payload":"innocent"}', encoding="utf-8")
+
+                # Fail-closed on the no-dir_fd platform: full and Range.
+                for range_header in (None, {"Range": "bytes=0-100"}):
+                    _restore()
+                    with mock.patch("api.routes._DIR_FD_OK", False):
+                        h2 = _CaptureHandler(range_header)
+                        routes._handle_media(h2, SimpleNamespace(
+                            query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h2.status, 403,
+                        "no-dir_fd platform must fail closed for allowed-root "
+                        f"grants [range={bool(range_header)}]")
+                    self.assertNotIn(
+                        b"top-secret-session", h2.body,
+                        "denied bytes must never reach the response")
+                    self.assertNotIn(
+                        b"innocent", h2.body,
+                        "fail-closed must not serve the file either")
+
+                # Replacement-bytes proof: swap the allowed-root pathname for a
+                # symlink to the secret location BEFORE the request. Without
+                # dir_fd the authority fd cannot be retained, so the route must
+                # fail closed — never open the swapped pathname by name.
+                for range_header in (None, {"Range": "bytes=0-100"}):
+                    _restore()
+                    os.rename(str(ws), str(moved))
+                    os.symlink(str(secret_stash), str(ws))
+                    with mock.patch("api.routes._DIR_FD_OK", False):
+                        h3 = _CaptureHandler(range_header)
+                        routes._handle_media(h3, SimpleNamespace(
+                            query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h3.status, 403,
+                        "swapped allowed-root pathname must fail closed without "
+                        f"dir_fd [range={bool(range_header)}]")
+                    self.assertNotIn(
+                        b"top-secret-session", h3.body,
+                        "replacement state bytes must never be returned "
+                        f"[range={bool(range_header)}]")
+                _restore()
+
+    def test_media_fails_closed_without_dir_fd_exact_token_grant(self):
+        """#6988 round 3: without dir_fd the exact-token MEDIA grant must also
+        FAIL CLOSED (403) — the verified leaf fd cannot be retained without
+        openat, and a plain pathname open of the resolved leaf would re-expose
+        the authorization-to-open race. The token fixture lives OUTSIDE every
+        allowed root, so the token is the ONLY grantor (not /tmp precedence).
+        Covers full and Range responses, and proves replacement state bytes
+        cannot be returned even when the token target's parent is swapped to a
+        secret location BEFORE the request.
+        """
+        import shutil
+        from api import routes
+
+        class _CaptureHandler:
+            def __init__(self, headers=None):
+                self.status = None
+                self.headers = headers or {}
+                self.body = bytearray()
+                self.wfile = self
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            def write(self, b):
+                self.body.extend(b)
+            def flush(self):
+                pass
+
+        token_dir = None
+        try:
+            token_dir = pathlib.Path(tempfile.mkdtemp(
+                prefix="hermes_media_token_", dir=str(_media_token_fixture_dir())))
+            moved = pathlib.Path(str(token_dir) + "_moved")
+            with tempfile.TemporaryDirectory() as home:
+                base = pathlib.Path(home) / ".hermes"
+                active = base / "profiles" / "webui"
+                active_webui = active / "webui"
+                ws = active_webui / "workspace"
+                ws.mkdir(parents=True)
+                # Non-deny-listed secret location under an allowed root (the
+                # deny gate cannot mask the fail-closed for the swapped case).
+                secret_stash = active_webui / "workspace_secret_stash"
+                secret_stash.mkdir(parents=True)
+                secret = secret_stash / "report.html"
+                secret.write_text(
+                    "<!doctype html><title>top-secret-session</title>",
+                    encoding="utf-8")
+                innocent = token_dir / "report.html"
+                innocent.write_text(
+                    "<!doctype html><title>innocent</title>", encoding="utf-8")
+                session = SimpleNamespace(messages=[
+                    {"role": "assistant", "content": f"MEDIA:{innocent}"}])
+
+                env = {
+                    "HERMES_HOME": str(active),
+                    "HERMES_WEBUI_STATE_DIR": str(active_webui),
+                }
+                with mock.patch.dict(os.environ, env), \
+                     mock.patch.object(routes, "get_last_workspace", lambda: str(ws)), \
+                     mock.patch("api.workspace.get_last_workspace", lambda: str(ws)), \
+                     mock.patch.object(routes, "get_session", return_value=session), \
+                     mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                     mock.patch("api.config.STATE_DIR", active_webui), \
+                     mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                    request_path = (
+                        "path=" + urllib.parse.quote(str(innocent.resolve()))
+                        + "&session_id=s-media&inline=1"
+                    )
+
+                    # Control: with dir_fd the token-granted file serves.
+                    h1 = _CaptureHandler()
+                    routes._handle_media(h1, SimpleNamespace(
+                        query=request_path, path="/api/media"))
+                    self.assertEqual(
+                        h1.status, 200,
+                        "control: token-granted file must serve with dir_fd")
+                    self.assertIn(b"innocent", h1.body)
+
+                    # Fail-closed on the no-dir_fd platform: full and Range.
+                    for range_header in (None, {"Range": "bytes=0-100"}):
+                        with mock.patch("api.routes._DIR_FD_OK", False):
+                            h2 = _CaptureHandler(range_header)
+                            routes._handle_media(h2, SimpleNamespace(
+                                query=request_path, path="/api/media"))
+                        self.assertEqual(
+                            h2.status, 403,
+                            "no-dir_fd platform must fail closed for exact-token "
+                            f"grants [range={bool(range_header)}]")
+                        self.assertNotIn(
+                            b"top-secret-session", h2.body,
+                            "denied bytes must never reach the response")
+                        self.assertNotIn(
+                            b"innocent", h2.body,
+                            "fail-closed must not serve the file either")
+
+                    # Replacement-bytes proof: swap the token target's parent
+                    # for a symlink to the secret location BEFORE the request.
+                    # The token still resolves (pathname-based), but without
+                    # dir_fd the leaf fd cannot be retained, so the route must
+                    # fail closed — never open the swapped pathname by name.
+                    for range_header in (None, {"Range": "bytes=0-100"}):
+                        # Restore the real dir at token_dir first (a previous
+                        # iteration left it renamed aside at `moved`).
+                        if token_dir.is_symlink():
+                            token_dir.unlink()
+                        if moved.exists():
+                            os.rename(str(moved), str(token_dir))
+                        os.rename(str(token_dir), str(moved))
+                        os.symlink(str(secret_stash), str(token_dir))
+                        with mock.patch("api.routes._DIR_FD_OK", False):
+                            h3 = _CaptureHandler(range_header)
+                            routes._handle_media(h3, SimpleNamespace(
+                                query=request_path, path="/api/media"))
+                        self.assertEqual(
+                            h3.status, 403,
+                            "swapped exact-token parent must fail closed without "
+                            f"dir_fd [range={bool(range_header)}]")
+                        self.assertNotIn(
+                            b"top-secret-session", h3.body,
+                            "replacement state bytes must never be returned "
+                            f"[range={bool(range_header)}]")
         finally:
             if token_dir is not None:
                 if token_dir.is_symlink():

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -536,6 +536,121 @@ class TestMediaEndpointUnit(unittest.TestCase):
                     h4.status, 403,
                     "profile webui_state/sessions/*.json must be denied")
 
+    def test_sibling_base_profile_webui_state_dir_denied_when_named_profile_active(self):
+        """#6982: /api/media must NOT serve a base/sibling profile's WebUI state
+        dir (<root>/webui — the default STATE_DIR) when a NAMED profile is
+        active. Only the active STATE_DIR was previously denied (as a root), so
+        base `~/.hermes/webui/sessions/...` and sibling
+        `<root>/profiles/<other>/webui/sessions/...` were served with a 200.
+        Fail-closed: deny every enumerated root/profile-root's `<root>/webui`
+        state subtree, while `<root>/webui/workspace` media stays servable.
+        """
+        from api import routes
+
+        class _Handler:
+            def __init__(self):
+                self.status = None
+                self.headers = {}
+            def send_response(self, code):
+                self.status = code
+            def send_header(self, *a, **k):
+                pass
+            def end_headers(self):
+                pass
+            class _W:
+                def write(self_inner, b):
+                    pass
+                def flush(self_inner):
+                    pass
+            wfile = _W()
+
+        png_bytes = (
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+            b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00'
+            b'\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82'
+        )
+        with tempfile.TemporaryDirectory() as home:
+            base = pathlib.Path(home) / ".hermes"
+            # Base profile's WebUI state dir (~/.hermes/webui) and its workspace.
+            base_webui = base / "webui"
+            base_sessions = base_webui / "sessions"
+            base_ws = base_webui / "workspace"
+            base_sessions.mkdir(parents=True)
+            base_ws.mkdir(parents=True)
+            base_index = base_sessions / "_index.json"
+            base_index.write_text('{"sessions":[]}', encoding="utf-8")
+            base_shot = base_ws / "shot.png"
+            base_shot.write_bytes(png_bytes)
+            # Sibling named profile's WebUI state dir.
+            sibling = base / "profiles" / "other"
+            sibling_webui = sibling / "webui"
+            sibling_sessions = sibling_webui / "sessions"
+            sibling_sessions.mkdir(parents=True)
+            sibling_sess = sibling_sessions / "s1.json"
+            sibling_sess.write_text('{"messages":[]}', encoding="utf-8")
+            # Active named profile's own state dir + workspace.
+            active = base / "profiles" / "webui"
+            active_webui = active / "webui"
+            active_sessions = active_webui / "sessions"
+            active_ws = active_webui / "workspace"
+            active_sessions.mkdir(parents=True)
+            active_ws.mkdir(parents=True)
+            active_sess = active_sessions / "s2.json"
+            active_sess.write_text('{"messages":[]}', encoding="utf-8")
+            active_shot = active_ws / "shot.png"
+            active_shot.write_bytes(png_bytes)
+
+            env = {
+                "HERMES_HOME": str(active),
+                "HERMES_WEBUI_STATE_DIR": str(active_webui),
+            }
+            with mock.patch.dict(os.environ, env), \
+                 mock.patch.object(routes, "get_last_workspace", lambda: str(active_ws)), \
+                 mock.patch("api.auth.is_auth_enabled", lambda: False), \
+                 mock.patch("api.config.STATE_DIR", active_webui), \
+                 mock.patch("api.profiles._DEFAULT_HERMES_HOME", base):
+                # Base profile's WebUI session index → DENIED (was 200, #6982)
+                h1 = _Handler()
+                routes._handle_media(h1, SimpleNamespace(
+                    query=f"path={urllib.parse.quote(str(base_index.resolve()))}",
+                    path="/api/media"))
+                self.assertEqual(
+                    h1.status, 403,
+                    "base profile <root>/webui/sessions/_index.json must be denied "
+                    "when a named profile is active (#6982)")
+                # Sibling named profile's WebUI session file → DENIED
+                h2 = _Handler()
+                routes._handle_media(h2, SimpleNamespace(
+                    query=f"path={urllib.parse.quote(str(sibling_sess.resolve()))}",
+                    path="/api/media"))
+                self.assertEqual(
+                    h2.status, 403,
+                    "sibling profile <root>/profiles/other/webui/sessions must be denied")
+                # Active named profile's own state → still denied
+                h3 = _Handler()
+                routes._handle_media(h3, SimpleNamespace(
+                    query=f"path={urllib.parse.quote(str(active_sess.resolve()))}",
+                    path="/api/media"))
+                self.assertEqual(
+                    h3.status, 403,
+                    "active named profile's own webui/sessions must stay denied")
+                # Base profile's <root>/webui/workspace media → still servable
+                h4 = _Handler()
+                routes._handle_media(h4, SimpleNamespace(
+                    query=f"path={urllib.parse.quote(str(base_shot.resolve()))}&inline=1",
+                    path="/api/media"))
+                self.assertNotEqual(
+                    h4.status, 403,
+                    "base <root>/webui/workspace/shot.png must NOT be blocked (legit media)")
+                # Active profile's workspace media → still servable
+                h5 = _Handler()
+                routes._handle_media(h5, SimpleNamespace(
+                    query=f"path={urllib.parse.quote(str(active_shot.resolve()))}&inline=1",
+                    path="/api/media"))
+                self.assertNotEqual(
+                    h5.status, 403,
+                    "active profile's webui/workspace/shot.png must NOT be blocked")
+
     def test_media_allowed_roots_env_var_serves_outside_hermes_root(self):
         """MEDIA_ALLOWED_ROOTS must still allow legitimate outside-root media."""
         from api import routes

--- a/tests/test_workspace_symlink_containment.py
+++ b/tests/test_workspace_symlink_containment.py
@@ -475,3 +475,89 @@ def test_list_dir_escape_symlink_read_still_blocked(tmp_path):
     # But reading through it is still blocked
     with pytest.raises(ValueError, match="Path traversal blocked"):
         read_file_content(workspace, "escape.txt")
+
+
+def test_open_anchored_fd_no_dir_fd_fallback_preserves_o_binary(tmp_path, monkeypatch):
+    """#6988 round 3: the no-dir_fd portability fallback (Windows path) must
+    pass O_BINARY on the leaf open so the returned fd reads raw bytes — text
+    mode would CRLF-translate media bytes, ETag digests and Content-Lengths."""
+    import os
+    from unittest import mock
+
+    import api.workspace as w
+
+    monkeypatch.setattr(w, "_DIR_FD_OK", False)
+    # 0x8000 is the Windows O_BINARY bit; on POSIX the constant is 0, so patch
+    # it to a sentinel and assert it reaches os.open's flags.
+    monkeypatch.setattr(w, "_O_BINARY", 0x8000)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "a.bin").write_bytes(b"\x00\x01\x02")
+
+    real_open = os.open
+    seen = {}
+
+    def capture_open(path, *args, **kwargs):
+        seen["flags"] = args[0] if args else kwargs.get("flags")
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch.object(w.os, "open", autospec=True, side_effect=capture_open):
+        fd = w.open_anchored_fd(workspace, (workspace / "a.bin").resolve(), want_dir=False)
+        try:
+            assert seen.get("flags") is not None, "fallback os.open must have run"
+            assert seen["flags"] & 0x8000, \
+                "no-dir_fd fallback must preserve O_BINARY on the leaf open"
+            assert os.read(fd, 3) == b"\x00\x01\x02"
+        finally:
+            os.close(fd)
+
+
+def test_open_anchored_fd_from_root_handoff_closes_nfd_when_prior_close_fails(tmp_path):
+    """#6988 round 3: if closing the prior per-component fd raises during the
+    anchored walk, the freshly-opened nfd must be closed before the exception
+    propagates — the old code assigned ``fd = nfd`` only AFTER ``os.close(fd)``,
+    so a close failure orphaned the new descriptor."""
+    import os
+    from unittest import mock
+
+    import api.workspace as w
+
+    if not w._DIR_FD_OK:
+        pytest.skip("anchored walk requires dir_fd support")
+
+    root = tmp_path / "root"
+    sub = root / "sub"
+    sub.mkdir(parents=True)
+    (sub / "f.txt").write_text("x", encoding="utf-8")
+
+    root_fd = os.open(str(root), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        real_close = os.close
+        real_open = os.open
+        closed = []
+        nfd_seen = []
+
+        def flaky_close(fd):
+            closed.append(fd)
+            # Fail ONLY when closing the root fd — the first per-component
+            # handoff, exactly the window where the old code orphaned nfd.
+            if fd == root_fd:
+                raise OSError("injected close failure")
+            return real_close(fd)
+
+        def capture_open(*args, **kwargs):
+            nfd = real_open(*args, **kwargs)
+            nfd_seen.append(nfd)
+            return nfd
+
+        with mock.patch.object(w.os, "open", autospec=True, side_effect=capture_open), \
+             mock.patch.object(w.os, "close", autospec=True, side_effect=flaky_close):
+            with pytest.raises(OSError, match="injected close failure"):
+                w.open_anchored_fd_from_root(root_fd, ("sub", "f.txt"), want_dir=False)
+    finally:
+        real_close(root_fd)
+
+    assert nfd_seen, "the walk must have opened the sub component"
+    assert nfd_seen[0] in closed, \
+        "nfd must be closed when closing the prior fd fails (no fd leak)"


### PR DESCRIPTION
## Summary
`/api/media` served a **base/sibling profile's** WebUI state dir when a *named* profile was the active one (deny-model gap, #3234). The deny vocabulary enumerated `<root>/<sub>` and `<root>/webui_state/<sub>` per Hermes root — but the default `STATE_DIR` `<root>/webui` (base `~/.hermes/webui` and `~/.hermes/profiles/<name>/webui`) fell **outside** the deny vocabulary when a named profile was active. Result: base/sibling `webui/sessions/*` served with 200.

## Change (`api/routes.py`, +11)
- In the `_deny_dirs` loop, also deny `<root>/webui/<sub>` for every sub in `_DENY_SUBDIRS`, for **every** root/profile-root enumerated — covering base + all siblings, not just the active `STATE_DIR`.
- The `webui/` container itself is **not** denied: `STATE_DIR/workspace` (legit default workspace) stays servable.
- Single shared predicate → deny applies to both serve and snapshot-capture paths.

## Verification
- `tests/test_media_inline.py`: **66 passed** (new case reproduced RED `200 != 403` pre-fix → 403 post-fix).

Closes #6982