### PR TITLE
fix(async): atomic per-origin wakeup admission prevents delivery budget exhaustion

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1171,60 +1171,73 @@ def _process_async_delegation_event(
         )
         return
 
+    # Ownership-transfer guard (#6959 gate): the outer finally releases the
+    # per-origin reservation on EVERY exit below — claim exception, claim-None,
+    # formatting failure, dispatch failure, or any exception raised by the
+    # retry helpers themselves — UNLESS the wakeup thread successfully started,
+    # in which case the thread's own finally now owns the release. No raisable
+    # call can therefore strand the reservation (a stranded slot would defer
+    # every later completion for this origin forever, without delivery).
+    transfer_owned = False
     try:
-        claim = claim_async_delegation_delivery(evt, "webui-background")
-    except Exception:
-        _release_async_delegation_wakeup_admission(session_id)
-        _requeue_async_delegation_event(process_registry, evt)
-        return
-    if claim is None:
-        completion_queue = getattr(process_registry, "completion_queue", None)
-        schedule_async_delegation_claim_retry(evt, completion_queue)
-        _release_async_delegation_wakeup_admission(session_id)
-        return
+        try:
+            claim = claim_async_delegation_delivery(evt, "webui-background")
+        except Exception:
+            _requeue_async_delegation_event(process_registry, evt)
+            return
+        if claim is None:
+            completion_queue = getattr(process_registry, "completion_queue", None)
+            schedule_async_delegation_claim_retry(evt, completion_queue)
+            return
 
-    try:
-        wakeup_prompt_raw = format_wakeup_prompt(evt)
-        wakeup_prompt = wakeup_prompt_raw.strip() if wakeup_prompt_raw else ""
-        if not wakeup_prompt:
-            raise RuntimeError("async delegation completion could not be formatted")
-    except Exception:
-        # A formatting failure is a permanent, non-retryable defect (a malformed
-        # event will never format correctly), so it must stay on the bounded
-        # one-shot path — never keep_legacy_retrying, or it would loop forever.
-        release_async_delegation_delivery(evt, claim)
-        _retry_unclaimed_async_delegation_event(process_registry, evt)
-        _release_async_delegation_wakeup_admission(session_id)
-        logger.warning(
-            "async delegation completion could not be formatted for session %s",
-            session_id,
-            exc_info=True,
-        )
-        return
+        try:
+            wakeup_prompt_raw = format_wakeup_prompt(evt)
+            wakeup_prompt = wakeup_prompt_raw.strip() if wakeup_prompt_raw else ""
+            if not wakeup_prompt:
+                raise RuntimeError("async delegation completion could not be formatted")
+        except Exception:
+            # A formatting failure is a permanent, non-retryable defect (a malformed
+            # event will never format correctly), so it must stay on the bounded
+            # one-shot path — never keep_legacy_retrying, or it would loop forever.
+            release_async_delegation_delivery(evt, claim)
+            _retry_unclaimed_async_delegation_event(process_registry, evt)
+            logger.warning(
+                "async delegation completion could not be formatted for session %s",
+                session_id,
+                exc_info=True,
+            )
+            return
 
-    try:
-        _start_async_delegation_wakeup_turn(
-            session_id,
-            wakeup_prompt,
-            delegation_id=delegation_id,
-            evt=evt,
-            claim=claim,
-            process_registry=process_registry,
-        )
-    except Exception:
-        # A post-format dispatch failure against a resolved target is transient
-        # (the target may accept on a later pass), so keep the legacy completion
-        # retrying rather than dropping it after one bounded attempt.
-        release_async_delegation_delivery(evt, claim)
-        _retry_unclaimed_async_delegation_event(
-            process_registry, evt, keep_legacy_retrying=True
-        )
-        _release_async_delegation_wakeup_admission(session_id)
-        logger.warning(
-            "server-side async delegation dispatch failed for session %s",
-            session_id,
-            exc_info=True,
-        )
+        try:
+            _start_async_delegation_wakeup_turn(
+                session_id,
+                wakeup_prompt,
+                delegation_id=delegation_id,
+                evt=evt,
+                claim=claim,
+                process_registry=process_registry,
+            )
+        except Exception:
+            # A post-format dispatch failure against a resolved target is transient
+            # (the target may accept on a later pass), so keep the legacy completion
+            # retrying rather than dropping it after one bounded attempt.
+            release_async_delegation_delivery(evt, claim)
+            _retry_unclaimed_async_delegation_event(
+                process_registry, evt, keep_legacy_retrying=True
+            )
+            logger.warning(
+                "server-side async delegation dispatch failed for session %s",
+                session_id,
+                exc_info=True,
+            )
+            return
+        # The wakeup thread is running: its own finally owns the release from
+        # here on (set only after Thread.start() returns, so a mid-start
+        # failure still releases here).
+        transfer_owned = True
+    finally:
+        if not transfer_owned:
+            _release_async_delegation_wakeup_admission(session_id)
 
 
 def _resolve_completion_target(
@@ -1632,14 +1645,44 @@ def _session_has_active_turn(session_id: str) -> bool:
     ``_emit_to_session_streams``) to map a stream back to its owning session.
     ACTIVE_RUNS is registered at agent-worker start and removed in the worker's
     outer ``finally``, so it survives cancel/reconnect races better than
-    STREAMS. There is a brief window where ``_start_chat_stream_for_session``
-    has populated STREAMS but the worker thread has not yet called
-    ``register_active_run``; in that window this returns False and the
-    subsequent ``start_session_turn`` is rejected with a 409 by
-    ``_start_chat_stream_for_session``'s own active-stream guard — i.e. the
-    same lock /api/chat/start uses is the authoritative race backstop.
+    STREAMS. We ALSO count a same-session live STREAMS entry (via the
+    synchronously-populated STREAM_SESSION_OWNERS registry): the worker
+    publishes its stream BEFORE it registers in ACTIVE_RUNS, and that
+    pre-registration window must not look idle to a sibling completion
+    (#6959 gate — see the STREAMS check below). ``_start_chat_stream_for_session``'s
+    own active-stream guard remains the authoritative 409 backstop for any
+    residual race.
     """
-    return bool(_active_run_ids_for_session(session_id, attachable_only=False))
+    # ACTIVE_RUNS rows (including a bounded cancelling-run unwind window,
+    # per _active_run_ids_for_session).
+    if _active_run_ids_for_session(session_id, attachable_only=False):
+        return True
+
+    # Pre-ACTIVE_RUNS publication window (#6959 gate): the agent worker
+    # publishes its stream — register_stream_owner() first, then the live
+    # STREAMS channel — BEFORE it registers in ACTIVE_RUNS. In that window a
+    # same-session live STREAMS entry means a turn is already (or about to be)
+    # active, so it must count here: otherwise a sibling async-delegation
+    # completion would pass the busy pre-check, reserve the per-origin
+    # admission, claim, and then 409 against the already-published stream —
+    # burning the finite delivery-attempt budget on every retry round. The
+    # worker's teardown finally pops STREAMS (and unregisters the stream owner)
+    # before the turn-teardown idle-hook drain runs, so the just-ended turn
+    # does not keep the session busy.
+    from api import config as _cfg
+
+    try:
+        with _cfg.STREAMS_LOCK:
+            live_stream_ids = list((_cfg.STREAMS or {}).keys())
+        with _cfg.STREAM_SESSION_OWNERS_LOCK:
+            stream_owners = dict(_cfg.STREAM_SESSION_OWNERS or {})
+    except Exception:
+        logger.debug("STREAMS active-turn check failed", exc_info=True)
+        return False
+    for _stream_id in live_stream_ids:
+        if str(stream_owners.get(_stream_id) or "") == str(session_id or ""):
+            return True
+    return False
 
 
 def _start_server_side_wakeup_turn(

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1086,12 +1086,55 @@ def _start_async_delegation_wakeup_turn(
                 session_id,
                 exc_info=True,
             )
+        finally:
+            # The wakeup turn has resolved (accepted, rejected, or raised): the
+            # per-origin admission slot is free for the next backlogged
+            # completion. Never release earlier — the slot must stay reserved
+            # for the whole claim→turn window so siblings defer without
+            # consuming the finite delivery budget (#6959).
+            _release_async_delegation_wakeup_admission(session_id)
 
     threading.Thread(
         target=_runner,
         name=f"hermes-webui-delegation-wakeup-{str(session_id)[:8]}",
         daemon=True,
     ).start()
+
+
+# ── Per-origin wakeup admission reservation (#6959) ────────────────────────
+# A durable claim has a finite delivery-attempt budget, and the pre-claim busy
+# check is NOT atomic with turn publication: several completed delegations for
+# one idle origin can all pass it, each obtain a durable claim, then race for a
+# single ``start_session_turn`` admission slot. The losers' transient 409s
+# release already-counted claims, and repeated rounds can drive completed rows
+# to the terminal ``dropped`` state. Reserve the per-origin admission slot
+# ATOMICALLY before claiming so at most one async-delegation wakeup per session
+# is in flight at a time; siblings that lose the reservation defer WITHOUT
+# claiming (no delivery attempt consumed). The reservation is in-process only:
+# the wakeup thread releases it on every exit path and it vanishes on restart,
+# so it can never strand a durable claim.
+_ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK = threading.Lock()
+_ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT: set[str] = set()
+
+
+def _try_reserve_async_delegation_wakeup_admission(session_id: str) -> bool:
+    """Atomically reserve the single in-flight wakeup slot for *session_id*.
+
+    Returns False when another async-delegation wakeup for the same origin is
+    already in flight (claimed but not yet resolved), so the caller can defer
+    without touching the finite delivery budget.
+    """
+    with _ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+        if session_id in _ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT:
+            return False
+        _ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT.add(session_id)
+        return True
+
+
+def _release_async_delegation_wakeup_admission(session_id: str) -> None:
+    """Release the in-flight wakeup slot for *session_id* (idempotent)."""
+    with _ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+        _ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT.discard(session_id)
 
 
 def _process_async_delegation_event(
@@ -1114,14 +1157,30 @@ def _process_async_delegation_event(
         )
         return
 
+    # Atomic per-origin wakeup admission (#6959): the busy check above is a
+    # pre-check, not a reservation — several idle completions for one origin
+    # can all pass it together. Only one may own the in-flight wakeup slot; a
+    # sibling that loses this reservation must NOT claim, because a claim
+    # released by a transient 409 would count against the finite delivery
+    # budget. The admitted wakeup releases the slot when its turn resolves.
+    if not _try_reserve_async_delegation_wakeup_admission(session_id):
+        _retry_unclaimed_async_delegation_event(
+            process_registry,
+            evt,
+            keep_legacy_retrying=True,
+        )
+        return
+
     try:
         claim = claim_async_delegation_delivery(evt, "webui-background")
     except Exception:
+        _release_async_delegation_wakeup_admission(session_id)
         _requeue_async_delegation_event(process_registry, evt)
         return
     if claim is None:
         completion_queue = getattr(process_registry, "completion_queue", None)
         schedule_async_delegation_claim_retry(evt, completion_queue)
+        _release_async_delegation_wakeup_admission(session_id)
         return
 
     try:
@@ -1135,6 +1194,7 @@ def _process_async_delegation_event(
         # one-shot path — never keep_legacy_retrying, or it would loop forever.
         release_async_delegation_delivery(evt, claim)
         _retry_unclaimed_async_delegation_event(process_registry, evt)
+        _release_async_delegation_wakeup_admission(session_id)
         logger.warning(
             "async delegation completion could not be formatted for session %s",
             session_id,
@@ -1159,6 +1219,7 @@ def _process_async_delegation_event(
         _retry_unclaimed_async_delegation_event(
             process_registry, evt, keep_legacy_retrying=True
         )
+        _release_async_delegation_wakeup_admission(session_id)
         logger.warning(
             "server-side async delegation dispatch failed for session %s",
             session_id,

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -161,6 +161,10 @@ def _reset_wakeup_state() -> None:
     cfg.PENDING_BG_TASK_COMPLETIONS.clear()
     cfg.BG_TASK_COMPLETE_EVENTS_SEEN.clear()
     cfg.DEFERRED_PROCESS_WAKEUPS.clear()
+    # Clear any per-origin wakeup-admission reservations left by a test that
+    # monkeypatched the wakeup runner (which normally releases them).
+    with bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+        bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT.clear()
     reset = getattr(peu, "_reset_legacy_async_delivery_dedupe_for_tests", None)
     if reset is not None:
         reset()
@@ -1292,5 +1296,213 @@ def test_next_turn_drain_respects_origin_over_session_key_index(monkeypatch):
     assert [consumer for _evt, consumer in delivery["claim"]] == ["webui-next-turn"]
     assert len(delivery["complete"]) == 1
     assert delivery["release"] == []
+
+
+def test_concurrent_idle_wakeups_share_one_atomic_admission(monkeypatch):
+    """Issue #6959 regression: N simultaneous idle completions for one origin
+    must not each claim the durable delivery. The busy pre-check is not a
+    reservation — multiple completions can pass it together and race for a
+    single turn-admission slot; sibling 409s would then consume the finite
+    delivery-attempt budget. Only one completion may own the in-flight wakeup
+    admission; siblings defer WITHOUT claiming (zero attempts consumed)."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    turn_started = threading.Event()
+    allow_turn = threading.Event()
+    turn_calls: list[str] = []
+
+    def _start_turn(session_id, prompt, **_kwargs):
+        turn_calls.append(session_id)
+        turn_started.set()
+        assert allow_turn.wait(timeout=3), "first wakeup never unblocked"
+        return {"_status": 200, "stream_id": "stream-1"}
+
+    monkeypatch.setattr(routes, "start_session_turn", _start_turn)
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: False)
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 30.0)
+
+    events = [
+        _async_delegation_event(delegation_id=f"deleg_race_{i}")
+        for i in range(3)
+    ]
+    try:
+        # First completion reserves the per-origin admission and claims.
+        bp._process_async_delegation_event(
+            events[0],
+            session_id="webui-session-1",
+            delegation_id=events[0]["delegation_id"],
+            process_registry=registry,
+        )
+        assert _wait_until(turn_started.is_set), "first wakeup never started a turn"
+
+        # Siblings arrive while the first wakeup is still in flight: they must
+        # defer WITHOUT claiming (no delivery attempt consumed).
+        for evt in events[1:]:
+            bp._process_async_delegation_event(
+                evt,
+                session_id="webui-session-1",
+                delegation_id=evt["delegation_id"],
+                process_registry=registry,
+            )
+
+        assert len(turn_calls) == 1, "at most one wakeup turn per origin"
+        assert len(delivery["claim"]) == 1, (
+            "siblings must not claim while admission is held"
+        )
+        assert delivery["claim"][0][0]["delegation_id"] == "deleg_race_0"
+        assert delivery["delivery_attempts"] == 1
+        assert delivery["complete"] == []
+        assert delivery["release"] == []
+        assert delivery["delivery_state"] == "pending"
+
+        # Release admission: exactly the one admitted wakeup delivers once.
+        allow_turn.set()
+        assert _wait_until(lambda: len(delivery["complete"]) == 1)
+        assert delivery["delivery_attempts"] == 1
+        assert delivery["release"] == []
+        assert delivery["delivery_state"] == "delivered"
+        assert len(turn_calls) == 1
+        # Sibling deferrals armed a durable restore sweep (not dropped).
+        assert peu.async_delivery_retry_timer_count() >= 1
+    finally:
+        allow_turn.set()
+        _reset_wakeup_state()
+
+
+def test_idle_wakeup_admission_rotates_after_transient_rejection(monkeypatch):
+    """Issue #6959: when the admitted wakeup loses the turn (transient 409),
+    only ITS OWN claim is consumed; the per-origin admission slot rotates so
+    the next backlogged completion claims and delivers on the next
+    opportunity. No row reaches the terminal dropped state."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    turn_started = threading.Event()
+    allow_turn = threading.Event()
+    round_ = {"n": 0}
+
+    def _start_turn(session_id, prompt, **_kwargs):
+        turn_started.set()
+        assert allow_turn.wait(timeout=3), "wakeup never unblocked"
+        round_["n"] += 1
+        if round_["n"] == 1:
+            return {"_status": 409, "error": "busy"}  # lost turn admission
+        return {"_status": 200, "stream_id": "stream-1"}
+
+    monkeypatch.setattr(routes, "start_session_turn", _start_turn)
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: False)
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 30.0)
+
+    def _admission_empty() -> bool:
+        with bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+            return not bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT
+
+    evt_first = _async_delegation_event(delegation_id="deleg_rotate_0")
+    evt_second = _async_delegation_event(delegation_id="deleg_rotate_1")
+    try:
+        # Round 1: the admitted wakeup is transiently rejected. Its release
+        # must consume exactly one attempt and free the admission slot.
+        bp._process_async_delegation_event(
+            evt_first,
+            session_id="webui-session-1",
+            delegation_id=evt_first["delegation_id"],
+            process_registry=registry,
+        )
+        assert _wait_until(turn_started.is_set)
+        allow_turn.set()
+        assert _wait_until(lambda: len(delivery["release"]) == 1)
+        assert delivery["delivery_attempts"] == 1
+        assert delivery["delivery_state"] == "pending"
+        assert round_["n"] == 1
+        assert _wait_until(_admission_empty), "slot must rotate after rejection"
+
+        # Round 2: the next backlogged completion claims and is accepted.
+        turn_started.clear()
+        bp._process_async_delegation_event(
+            evt_second,
+            session_id="webui-session-1",
+            delegation_id=evt_second["delegation_id"],
+            process_registry=registry,
+        )
+        assert _wait_until(turn_started.is_set)
+        allow_turn.set()
+        assert _wait_until(lambda: len(delivery["complete"]) == 1)
+        assert delivery["delivery_state"] == "delivered"
+        assert delivery["delivery_attempts"] == 2
+        assert len(delivery["release"]) == 1
+        assert round_["n"] == 2
+        assert _wait_until(_admission_empty)
+    finally:
+        allow_turn.set()
+        _reset_wakeup_state()
+
+
+def test_admission_slot_released_on_claim_and_format_failures(monkeypatch):
+    """Issue #6959 guard: every pre-dispatch exit of the delivery path must
+    release the per-origin admission reservation, or a failed claim/format
+    would block all future wakeups for that session."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    accepted = []
+
+    monkeypatch.setattr(
+        routes,
+        "start_session_turn",
+        lambda *_args, **_kwargs: accepted.append(1)
+        or {"_status": 200, "stream_id": "stream-1"},
+    )
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: False)
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 30.0)
+
+    def _admission_empty() -> bool:
+        with bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+            return not bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT
+
+    try:
+        # Claim returns None (row already delivered): slot must be released.
+        delivery["delivery_state"] = "delivered"
+        bp._process_async_delegation_event(
+            _async_delegation_event(delegation_id="deleg_noclaim"),
+            session_id="webui-session-1",
+            delegation_id="deleg_noclaim",
+            process_registry=registry,
+        )
+        assert _admission_empty(), "claim-None exit must release the admission slot"
+
+        # Formatting failure (empty prompt): slot must be released.
+        delivery["delivery_state"] = "pending"
+        monkeypatch.setattr(bp, "format_wakeup_prompt", lambda _evt: "")
+        bp._process_async_delegation_event(
+            _async_delegation_event(delegation_id="deleg_badfmt"),
+            session_id="webui-session-1",
+            delegation_id="deleg_badfmt",
+            process_registry=registry,
+        )
+        assert _admission_empty(), "format-failure exit must release the admission slot"
+
+        # A normal wakeup for the same session still claims and delivers.
+        monkeypatch.setattr(bp, "format_wakeup_prompt", lambda _evt: "delegation result")
+        bp._process_async_delegation_event(
+            _async_delegation_event(delegation_id="deleg_ok"),
+            session_id="webui-session-1",
+            delegation_id="deleg_ok",
+            process_registry=registry,
+        )
+        assert _wait_until(lambda: len(delivery["complete"]) == 1)
+        assert delivery["delivery_state"] == "delivered"
+        assert accepted
+    finally:
+        _reset_wakeup_state()
 
 

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -1506,3 +1506,123 @@ def test_admission_slot_released_on_claim_and_format_failures(monkeypatch):
         _reset_wakeup_state()
 
 
+def test_busy_predicate_covers_stream_publication_window_before_active_runs(
+    monkeypatch,
+):
+    """#6959 gate (MUST-FIX 1 repro): a worker blocked *before* ACTIVE_RUNS
+    registration — stream already published (STREAMS + STREAM_SESSION_OWNERS
+    populated), worker thread not yet in ACTIVE_RUNS — must still count as an
+    active turn. Otherwise a sibling same-origin completion would pass the busy
+    pre-check, reserve, claim, and 409 against the already-published stream,
+    burning the finite delivery-attempt budget. With the fix, completions that
+    arrive in that window defer WITHOUT claiming (zero claims, zero attempts)."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    # ACTIVE_RUNS is empty: the worker has NOT yet registered — only the
+    # pre-registration stream publication is visible.
+    monkeypatch.setattr(cfg, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(cfg, "STREAMS", {"stream-preactive": object()})
+    monkeypatch.setattr(
+        cfg,
+        "STREAM_SESSION_OWNERS",
+        {"stream-preactive": "webui-session-1"},
+    )
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 30.0)
+
+    try:
+        # The real predicate (not monkeypatched) must see the published stream.
+        assert bp._session_has_active_turn("webui-session-1") is True
+        # Cross-origin isolation: another session is not blocked by it.
+        assert bp._session_has_active_turn("other-session") is False
+
+        # A completion for the origin arrives in the publication window: it
+        # must defer via the busy path — zero claims, zero delivery attempts.
+        bp._process_async_delegation_event(
+            _async_delegation_event(delegation_id="deleg_preactive"),
+            session_id="webui-session-1",
+            delegation_id="deleg_preactive",
+            process_registry=registry,
+        )
+        assert delivery["claim"] == [], (
+            "no claim may be taken while the pre-ACTIVE_RUNS stream is live"
+        )
+        assert delivery["delivery_attempts"] == 0
+        assert delivery["release"] == []
+        with bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+            assert bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT == set(), (
+                "busy-path exit must not leave a reservation behind"
+            )
+        assert delivery["delivery_state"] == "pending"
+    finally:
+        _reset_wakeup_state()
+
+
+def test_admission_slot_released_when_retry_helper_raises(monkeypatch):
+    """#6959 gate (MUST-FIX 2 repro): the post-reservation body must release
+    the per-origin admission even when a retry helper raises mid-path — the
+    old code released manually AFTER schedule_async_delegation_claim_retry, so
+    a raise there stranded the reservation permanently and every later
+    completion for the origin deferred forever without delivery."""
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: False)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 30.0)
+
+    def _admission_empty() -> bool:
+        with bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_LOCK:
+            return not bp._ASYNC_DELEGATION_WAKEUP_ADMISSION_INFLIGHT
+
+    try:
+        # Claim succeeds, then the claim-None retry scheduler raises: the
+        # exception must NOT strand the reservation.
+        delivery["delivery_state"] = "delivered"  # claim returns None
+        monkeypatch.setattr(
+            bp,
+            "schedule_async_delegation_claim_retry",
+            lambda *a, **k: (_ for _ in ()).throw(
+                RuntimeError("retry scheduler boom")
+            ),
+        )
+        with pytest.raises(RuntimeError):
+            bp._process_async_delegation_event(
+                _async_delegation_event(delegation_id="deleg_raise_claim"),
+                session_id="webui-session-1",
+                delegation_id="deleg_raise_claim",
+                process_registry=registry,
+            )
+        assert _admission_empty(), (
+            "reservation must be released even when the retry scheduler raises"
+        )
+
+        # The session is NOT bricked: a later completion still claims and
+        # delivers normally (real wakeup thread; its own finally releases).
+        from api import routes
+
+        delivery["delivery_state"] = "pending"
+        monkeypatch.setattr(
+            bp,
+            "schedule_async_delegation_claim_retry",
+            lambda *a, **k: False,
+        )
+        monkeypatch.setattr(bp, "format_wakeup_prompt", lambda _evt: "delegation result")
+        monkeypatch.setattr(
+            routes,
+            "start_session_turn",
+            lambda *_args, **_kwargs: {"_status": 200, "stream_id": "stream-1"},
+        )
+        bp._process_async_delegation_event(
+            _async_delegation_event(delegation_id="deleg_raise_ok"),
+            session_id="webui-session-1",
+            delegation_id="deleg_raise_ok",
+            process_registry=registry,
+        )
+        assert _wait_until(lambda: len(delivery["complete"]) == 1)
+        assert delivery["delivery_state"] == "delivered"
+        assert _wait_until(_admission_empty)
+    finally:
+        _reset_wakeup_state()
+
+


### PR DESCRIPTION
## Summary
Concurrent idle wakeups could still exhaust the async delegation delivery budget. The busy-origin fix from #6601/#6852 prevented consumption when the session was **already observed busy** before the durable claim — but a residual race remained when **multiple** completions idle-woke concurrently.

## Change (atomic per-origin admission — option 2 from the issue)
- `api/background_process.py`: new `_try_reserve_async_delegation_wakeup_admission` — test-and-set under `threading.Lock`.
- `_process_async_delegation_event`: after the busy pre-check (not a reservation), tries to reserve the slot; if another wakeup of the **same origin** is already in flight → **defer without claim** (zero budget consumption). Reservation released on every pre-dispatch exit (claim exception/None, formatting failure, dispatch failure).
- `_start_async_delegation_wakeup_turn`: `finally` releases the reservation on ALL exits (accepted / transient 409 / exception) — the slot stays reserved across the claim→turn window, blocking siblings from claiming.
- At most 1 admitted wakeup per origin at a time; a genuine 409 consumes only the admitted claim (bounded); siblings stay pending with `delivery_attempts=0`. Reservation is in-process → vanishes on restart, never pins a durable claim.

## Verification
- `tests/test_async_delegation_webui_bridge.py`: **43 passed**. Race proven pre-fix vs post-fix (RED: budget exhausted → GREEN: single delivery). `_reset_wakeup_state()` now clears the admission set for test isolation.

Closes #6959