### PR TITLE
fix: keep WebUI context ring aligned after a model switch

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -14581,6 +14581,12 @@ def handle_post(handler, parsed) -> bool:
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,
         )
+        _new_cl = _resolve_context_length_for_session_model(
+            getattr(s, "model", None),
+            getattr(s, "model_provider", None),
+        )
+        if _new_cl:
+            s.context_length = _new_cl
         if worktree_info:
             publish_session_list_changed(
                 "session_new",

--- a/static/boot.js
+++ b/static/boot.js
@@ -2234,6 +2234,11 @@ function _applySessionContextMetadataUpdate(data){
   S.session.threshold_tokens=data.session.threshold_tokens||0;
   S.session.last_prompt_tokens=data.session.last_prompt_tokens||0;
   S.session.post_compression_context_tokens_estimate=data.session.post_compression_context_tokens_estimate||null;
+  if(S.lastUsage&&typeof S.lastUsage==='object'){
+    if(Number(S.session.context_length)>0) S.lastUsage.context_length=S.session.context_length;
+    S.lastUsage.threshold_tokens=S.session.threshold_tokens||0;
+    if(S.session.last_prompt_tokens!=null) S.lastUsage.last_prompt_tokens=S.session.last_prompt_tokens;
+  }
   if(typeof _syncCtxIndicator==='function'){
     const u=S.lastUsage||{};
     const _pick=(latest,stored,dflt=0)=>latest!=null?latest:(stored!=null?stored:dflt);

--- a/static/commands.js
+++ b/static/commands.js
@@ -738,6 +738,12 @@ async function cmdModel(args){
         if(resp.ok){
           S.session.model=q;
           S.session.model_provider=provider;
+          try{
+            const payload=await resp.json();
+            if(typeof _applySessionContextMetadataUpdate==='function'){
+              _applySessionContextMetadataUpdate(payload);
+            }
+          }catch(_){}
           if(typeof syncTopbar==='function') syncTopbar();
           showToast(t('switched_to')+q);
           return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2968,6 +2968,10 @@ function _resolveSessionModelForDisplaySoon(sid){
       S.session.threshold_tokens=data.session.threshold_tokens||0;
       S.session.last_prompt_tokens=data.session.last_prompt_tokens||0;
       S.session.post_compression_context_tokens_estimate=data.session.post_compression_context_tokens_estimate||null;
+      if(S.lastUsage&&typeof S.lastUsage==='object'&&Number(resolvedContextLength)>0){
+        S.lastUsage.context_length=resolvedContextLength;
+        S.lastUsage.threshold_tokens=S.session.threshold_tokens||0;
+      }
       S.session._modelResolutionDeferred=false;
       syncTopbar();
       if(typeof _syncCtxIndicator==='function'){

--- a/tests/test_issue_grok46_context_window_mismatch.py
+++ b/tests/test_issue_grok46_context_window_mismatch.py
@@ -11,9 +11,18 @@ knows the Grok window. The leftover 272k came from:
    prefers a positive lastUsage value, so the ring snapped back to 272k.
 """
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+
+import api.helpers as helpers
+import api.models as models
+import api.routes as routes
+from api.models import SESSIONS
 
 from tests.test_issue3256_context_length_default_only_guard import (
     _install_fake_get_model_context_length,
+    _stub_route_session,
 )
 
 
@@ -23,15 +32,17 @@ SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 
 
-def _session_get_block():
-    import api.routes as routes
+def _capture_json(monkeypatch, captured):
+    def _j(handler, payload, status=200, extra_headers=None):
+        captured.update(payload=payload, status=status)
+        return True
 
-    return Path(routes.__file__).read_text(encoding="utf-8")
+    monkeypatch.setattr(routes, "j", _j)
+    monkeypatch.setattr(helpers, "j", _j)
 
 
 def test_resolver_returns_grok46_window_not_codex_272k(monkeypatch):
     import api.config as config
-    import api.routes as routes
 
     rec = {}
     _install_fake_get_model_context_length(monkeypatch, rec, default_context=500_000)
@@ -51,16 +62,102 @@ def test_resolver_returns_grok46_window_not_codex_272k(monkeypatch):
     assert rec["config_context_length"] is None
 
 
-def test_new_session_resolves_context_length_for_selected_model():
-    src = _session_get_block()
-    new_start = src.find('if parsed.path == "/api/session/new":')
-    assert new_start != -1
-    new_end = src.find('if parsed.path == "/api/session/compression-recovery/start":', new_start)
-    block = src[new_start:new_end]
-    assert "_resolve_context_length_for_session_model" in block, (
-        "POST /api/session/new must resolve the selected model's context window "
-        "instead of leaving context_length unset"
+def test_new_session_persists_grok46_window(tmp_path, monkeypatch):
+    import api.config as config
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    SESSIONS.clear()
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=500_000)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+            }
+        },
     )
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda handler: {
+            "workspace": str(tmp_path),
+            "profile": "default",
+            "model": "grok-4.6",
+            "model_provider": "xai-oauth",
+            "worktree": False,
+        },
+    )
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda raw: tmp_path)
+    monkeypatch.setattr(routes, "_worktree_default_from_config", lambda profile: False)
+
+    captured = {}
+    _capture_json(monkeypatch, captured)
+    try:
+        assert routes.handle_post(object(), SimpleNamespace(path="/api/session/new")) is True
+        session = captured["payload"]["session"]
+        assert captured["status"] == 200
+        assert rec["model"] == "grok-4.6"
+        assert session["context_length"] == 500_000
+        assert session["model"] in {"grok-4.6", "@xai-oauth:grok-4.6"}
+    finally:
+        SESSIONS.clear()
+
+
+def test_session_update_replaces_codex_272k_with_grok46_window(monkeypatch):
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=500_000)
+
+    s = _stub_route_session(context_length=272_000, threshold_tokens=190_400, model="gpt-5.6-sol")
+    s.model_provider = "openai-codex"
+    s.workspace = "/tmp"
+    s.save = MagicMock()
+    s.compact.return_value = {
+        **s.compact.return_value,
+        "model": "grok-4.6",
+        "model_provider": "xai-oauth",
+        "context_length": 500_000,
+        "threshold_tokens": 0,
+        "last_prompt_tokens": 0,
+        "messages": [],
+    }
+
+    captured = {}
+
+    def fake_j(h, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return True
+
+    body = {
+        "session_id": "test-4248",
+        "workspace": "/tmp",
+        "model": "grok-4.6",
+        "model_provider": "xai-oauth",
+    }
+    with patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes._get_or_materialize_session", return_value=s), \
+         patch("api.routes.resolve_trusted_workspace", return_value="/tmp"), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes._get_session_agent_lock", return_value=MagicMock()):
+        assert routes.handle_post(object(), urlparse("/api/session/update")) is True
+
+    assert s.model == "grok-4.6"
+    assert s.model_provider == "xai-oauth"
+    assert rec["model"] == "grok-4.6"
+    assert s.context_length == 500_000
+    assert s.threshold_tokens == 0
+    assert s.last_prompt_tokens == 0
+    s.save.assert_called_once()
+    assert captured["data"]["session"]["context_length"] == 500_000
 
 
 def test_model_switch_updates_last_usage_context_window():

--- a/tests/test_issue_grok46_context_window_mismatch.py
+++ b/tests/test_issue_grok46_context_window_mismatch.py
@@ -1,0 +1,95 @@
+"""Grok 4.6 session switches must not keep the Codex 272k context window.
+
+A default Codex route (272,000) leftover in S.lastUsage used to win after the
+user switched the chat to xai-oauth/grok-4.6 (500,000). The resolver already
+knows the Grok window. The leftover 272k came from:
+
+1. POST /api/session/new never resolved context_length, so a new Grok chat
+   started at 0 and the UI merged the previous session's 272k.
+2. After /api/session/update, the frontend updated S.session.context_length
+   but left S.lastUsage.context_length at 272k. The next indicator sync
+   prefers a positive lastUsage value, so the ring snapped back to 272k.
+"""
+from pathlib import Path
+
+from tests.test_issue3256_context_length_default_only_guard import (
+    _install_fake_get_model_context_length,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+
+
+def _session_get_block():
+    import api.routes as routes
+
+    return Path(routes.__file__).read_text(encoding="utf-8")
+
+
+def test_resolver_returns_grok46_window_not_codex_272k(monkeypatch):
+    import api.config as config
+    import api.routes as routes
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=500_000)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+            }
+        },
+    )
+
+    assert routes._resolve_context_length_for_session_model("grok-4.6", "xai-oauth") == 500_000
+    assert rec["model"] == "grok-4.6"
+    assert rec["config_context_length"] is None
+
+
+def test_new_session_resolves_context_length_for_selected_model():
+    src = _session_get_block()
+    new_start = src.find('if parsed.path == "/api/session/new":')
+    assert new_start != -1
+    new_end = src.find('if parsed.path == "/api/session/compression-recovery/start":', new_start)
+    block = src[new_start:new_end]
+    assert "_resolve_context_length_for_session_model" in block, (
+        "POST /api/session/new must resolve the selected model's context window "
+        "instead of leaving context_length unset"
+    )
+
+
+def test_model_switch_updates_last_usage_context_window():
+    start = BOOT_JS.find("function _applySessionContextMetadataUpdate")
+    assert start != -1
+    end = BOOT_JS.find("$('modelSelect').onchange", start)
+    block = BOOT_JS[start:end]
+    assert "S.lastUsage" in block
+    assert "S.lastUsage.context_length" in block, (
+        "model switch must overwrite lastUsage.context_length so the next "
+        "indicator sync cannot prefer the previous model's 272k window"
+    )
+
+
+def test_deferred_model_resolve_overwrites_stale_last_usage_window():
+    start = SESSIONS_JS.find("function _resolveSessionModelForDisplaySoon")
+    assert start != -1
+    end = SESSIONS_JS.find("\nfunction ", start + 1)
+    if end == -1 or end < start:
+        end = start + 1200
+    block = SESSIONS_JS[start:end]
+    assert "S.lastUsage" in block and "context_length" in block
+    assert "S.lastUsage.context_length" in block or "lastUsage.context_length" in block, (
+        "deferred resolve_model=1 must also replace lastUsage.context_length"
+    )
+
+
+def test_slash_model_switch_applies_session_context_metadata():
+    assert "_applySessionContextMetadataUpdate" in COMMANDS_JS, (
+        "slash /model updates that POST /api/session/update must apply the "
+        "returned context_length instead of leaving the Codex 272k ring in place"
+    )


### PR DESCRIPTION
## Bug Description

Switching a live WebUI chat from Codex GPT-5.6 Sol (272k) to Grok 4.6 left the composer context ring on **272k**. The model change itself was real. Hermes already resolves `xai-oauth/grok-4.6` to **500,000**. The UI kept the previous Codex snapshot.

## Root Cause

Two display/persist paths mixed the old window with the new model label:

1. `POST /api/session/new` never set `context_length`, so a new Grok chat started at `0` and the frontend could merge the previous session's 272k.
2. After `POST /api/session/update`, the frontend updated `S.session.context_length` but left `S.lastUsage.context_length` at 272k. The next indicator sync prefers a positive `lastUsage` value, so the ring snapped back to the Codex window.

The slash `/model` path had the same lastUsage gap: it updated the model label and ignored the update response's context metadata.

## Fix

- Resolve the selected model's context window when creating a new session.
- On model switch, copy the new `context_length` / threshold onto `S.lastUsage` so later syncs cannot prefer the old 272k snapshot.
- Do the same on the deferred `resolve_model=1` hydration path.
- Apply the `/api/session/update` payload in the slash `/model` cross-provider path.

## How to Verify

1. Open a WebUI chat that has already used Codex GPT-5.6 Sol so the ring shows 272k.
2. Switch the session model to `xai-oauth/grok-4.6`.
3. Confirm the context ring / tooltip now shows **500k**, not 272k.
4. Start a new chat with Grok 4.6 already selected and confirm the new session's `context_length` is 500k rather than empty/0.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing related context-window tests still pass (`61 passed`, including #1436 / #3256 / #3660)
- [ ] Manual verification of the fix (needs a WebUI restart + hard refresh)

## Risk Assessment

Low. The GET `resolve_model=0` fast path is unchanged, so first-paint still uses the persisted window. The change only writes a resolved window on new sessions and keeps `lastUsage` aligned after an explicit model switch. Compression still uses the live agent compressor, not this display snapshot.

## Contract Routing

Not contract-affecting. No RFC / CONTRACTS.md / product-semantics docs were changed. This is display/persist alignment for existing session `context_length` metadata.
