### PR TITLE
fix(streaming): run MCP discovery off the turn's critical path

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -287,6 +287,7 @@ def _run_reload_mcp_command() -> str:
             # reload capture another profile (Greptile P1).
             from api.streaming import (
                 _MCP_READINESS_WAIT_CAP_S,
+                _MCP_RELOAD_FENCE,
                 _canonical_readiness_key,
                 _invalidate_mcp_readiness,
                 _mcp_retry_discovery,
@@ -331,13 +332,21 @@ def _run_reload_mcp_command() -> str:
             # Fail CLOSED: if any owner survived the join cap, abort the
             # reload rather than run a discovery body concurrently with a
             # registry rebuild (Greptile review round 10).
-            if not _prepare_global_reload():
-                return (
-                    "MCP reload aborted: a discovery run is still in "
-                    f"progress after waiting {int(_MCP_READINESS_WAIT_CAP_S)}s. "
-                    "Retry once it finishes."
-                )
-            shutdown_mcp_servers()
+            #
+            # The owner-creation FENCE is held for the whole teardown
+            # window: while /reload-mcp snapshots/joins live owners and
+            # shuts down the registry, a concurrent stream worker cannot
+            # CREATE a new discovery owner — so the snapshot is COMPLETE
+            # and no new body registers servers into or after the
+            # shutdown (Greptile review round 11).
+            with _MCP_RELOAD_FENCE:
+                if not _prepare_global_reload():
+                    return (
+                        "MCP reload aborted: a discovery run is still in "
+                        f"progress after waiting {int(_MCP_READINESS_WAIT_CAP_S)}s. "
+                        "Retry once it finishes."
+                    )
+                shutdown_mcp_servers()
 
             try:
                 from api.profiles import _resolve_hermes_home_override

--- a/api/commands.py
+++ b/api/commands.py
@@ -333,16 +333,19 @@ def _run_reload_mcp_command() -> str:
             # reload rather than run a discovery body concurrently with a
             # registry rebuild (Greptile review round 10).
             #
-            # The owner-creation FENCE is held for the ENTIRE rebuild
-            # window — snapshot, join, shutdown, replacement discovery
-            # and readiness invalidation (Greptile review round 12).
-            # While /reload-mcp runs, a concurrent stream worker cannot
-            # CREATE a new discovery owner: not during teardown (the
-            # snapshot is COMPLETE, round 11), and not during the
-            # replacement build (no body registers servers concurrently
-            # with the reload's own discovery, and nothing gets
-            # invalidated out from under a fresh registration).  The
-            # reload's own retry spawn skips the re-acquire
+            # The owner-creation FENCE is held across the DESTRUCTIVE
+            # phase only: snapshot, join, shutdown, and readiness
+            # invalidation.  It is released BEFORE the replacement
+            # discovery (the additive phase), so unrelated FIRST turns
+            # for new profiles never stall for the reload's discovery
+            # wait (Greptile review round 13).  Round 12's fix held the
+            # fence across the whole rebuild; that traded a benign
+            # stale-churn window for a real first-turn stall, and this
+            # phase split resolves both: invalidation now runs BEFORE
+            # any post-shutdown registration, so a stream owner created
+            # during the rebuild is FRESH and never gets invalidated as
+            # stale, and no new body can register into the shutdown.
+            # The reload's own retry spawn skips the re-acquire
             # (`_fence_held=True`) because threading.Lock is not
             # reentrant; waiting turns are unaffected — they only wait
             # on readiness events, never the fence.
@@ -354,6 +357,13 @@ def _run_reload_mcp_command() -> str:
                         "Retry once it finishes."
                     )
                 shutdown_mcp_servers()
+
+                # The global reload just shut down the registry: every
+                # OTHER profile's readiness is stale.  Remove those
+                # entries BEFORE any post-shutdown owner can be created
+                # (still inside the fence), so a fresh registration can
+                # never be invalidated out from under it.
+                _invalidate_mcp_readiness(except_key=_canonical_readiness_key(''))
 
                 try:
                     from api.profiles import _resolve_hermes_home_override
@@ -368,23 +378,29 @@ def _run_reload_mcp_command() -> str:
                         "mcp-reload",
                         _fence_held=True,
                     )
-                    _reload_status = _mcp_wait_readiness(_readiness)
                 else:
-                    # Older agent: no context-local override — a background
-                    # reload would read the process env while other streams
-                    # mutate it.  Run inline (pre-PR semantics), mirroring the
-                    # stream worker's old-agent path (Greptile P1).
-                    _reload_status = (
-                        "completed" if _reload_discover() else "failed"
-                    )
+                    _readiness = None
 
-                # The global reload rebuilt the registry: every OTHER
-                # profile's readiness is stale.  Remove those entries so each
-                # profile's next turn re-runs discovery instead of trusting a
-                # state whose servers were just shut down.  Still inside the
-                # fence: a stream cannot spawn a fresh owner that would then
-                # be invalidated as stale (round 12).
-                _invalidate_mcp_readiness(except_key=_canonical_readiness_key(''))
+            # Fence released — the ADDITIVE phase (replacement
+            # discovery) runs unfenced: waiting on it never blocks
+            # unrelated first turns.  Concurrent registrations into the
+            # process-global `_servers` registry during the additive
+            # phase are the pre-existing multi-profile limitation (the
+            # registry is keyed by raw server name — documented in
+            # api/streaming.py); they converge on the next per-turn
+            # refresh and are not a reload-exclusivity defect.
+            if _readiness is not None:
+                _reload_status = _mcp_wait_readiness(_readiness)
+            else:
+                # Older agent: no context-local override — a background
+                # reload would read the process env while other streams
+                # mutate it.  Run inline (pre-PR semantics), mirroring the
+                # stream worker's old-agent path.  The env read stays
+                # pre-PR on these agents (no override API exists to scope
+                # it); this is the documented compatibility behavior.
+                _reload_status = (
+                    "completed" if _reload_discover() else "failed"
+                )
 
             with _lock:
                 connected_servers = set(_servers.keys())

--- a/api/commands.py
+++ b/api/commands.py
@@ -7,6 +7,7 @@ so the frontend can still load with WEBUI_ONLY commands.
 from __future__ import annotations
 from contextlib import nullcontext
 import logging
+import os
 import threading
 from typing import Any
 
@@ -270,7 +271,31 @@ def _run_reload_mcp_command() -> str:
                 old_servers = set(_servers.keys())
 
             shutdown_mcp_servers()
-            new_tools = discover_mcp_tools()
+
+            # Route the re-discovery through the SAME readiness authority
+            # the stream worker uses (api.streaming), so a subsequent turn
+            # observes the fresh outcome instead of a stale 'completed' /
+            # 'failed' readiness recorded before this reload.  The command
+            # waits on the shared readiness event so its synchronous
+            # report below is still accurate.  The profile home is taken
+            # from the exec-time env: inside a session that is the
+            # worker's env window; otherwise it resolves to the default
+            # profile (''), which is the authority the startup kickoff
+            # and default-profile turns consult.
+            from api.streaming import _mcp_retry_discovery, _mcp_wait_readiness
+
+            def _reload_discover():
+                try:
+                    discover_mcp_tools()
+                    return True
+                except Exception:
+                    return False
+
+            _profile_home = str(os.environ.get("HERMES_HOME", "") or "")
+            _readiness = _mcp_retry_discovery(
+                _profile_home, _reload_discover, "mcp-reload"
+            )
+            _reload_status = _mcp_wait_readiness(_readiness)
 
             with _lock:
                 connected_servers = set(_servers.keys())
@@ -291,9 +316,23 @@ def _run_reload_mcp_command() -> str:
         lines.append(f"Removed: {', '.join(sorted(removed))}")
 
     if connected_servers:
-        lines.append(f"{len(new_tools or [])} tool(s) available across {len(connected_servers)} server(s)")
+        _tool_count = 0
+        for _server_name in connected_servers:
+            try:
+                _tool_count += len(
+                    getattr(_servers[_server_name], "_registered_tool_names", [])
+                    or []
+                )
+            except Exception:
+                pass
+        lines.append(
+            f"{_tool_count} tool(s) available across {len(connected_servers)} server(s)"
+        )
     else:
         lines.append("No MCP servers connected")
+
+    if _reload_status == "failed":
+        lines.append("MCP discovery failed during reload — check the server logs")
 
     if not reconnected and not added and not removed:
         lines.append("Tooling state was already current")

--- a/api/commands.py
+++ b/api/commands.py
@@ -277,18 +277,23 @@ def _run_reload_mcp_command() -> str:
             # observes the fresh outcome instead of a stale 'completed' /
             # 'failed' readiness recorded before this reload.  The command
             # waits on the shared readiness event so its synchronous
-            # report below is still accurate.  The profile home is taken
-            # from the exec-time env: inside a session that is the
-            # worker's env window; otherwise it resolves to the default
-            # profile (''), which is the authority the startup kickoff
-            # and default-profile turns consult.
+            # report below is still accurate.
+            #
+            # The authority is keyed deterministically at the DEFAULT
+            # profile (''), the same key the startup kickoff and
+            # default-profile turns consult.  /reload-mcp is a GLOBAL
+            # operation (it shuts down and reconnects every configured
+            # server), so it deliberately does NOT key off the exec-time
+            # HERMES_HOME env: a concurrent stream can mutate that
+            # process-global while the command runs, which would make the
+            # reload capture another profile (Greptile P1).
             from api.streaming import _mcp_retry_discovery, _mcp_wait_readiness
 
             def _reload_discover():
                 """Re-discover MCP tools; returns bool.
 
-                Installs the captured profile-home override exactly like
-                the stream worker's discovery closure, so a background
+                Installs the DEFAULT profile-home override (like the
+                stream worker's discovery closure), so a background
                 reload run can never read another stream's HERMES_HOME
                 after env mutation (Greptile P1).
                 """
@@ -297,11 +302,9 @@ def _run_reload_mcp_command() -> str:
                     from api.profiles import _resolve_hermes_home_override
                     _hc_mod = _resolve_hermes_home_override()
                     if _hc_mod is not None:
-                        _mcp_home = _profile_home
-                        if not _mcp_home:
-                            _mcp_home = getattr(
-                                _hc_mod, 'get_default_hermes_root', lambda: ''
-                            )()
+                        _mcp_home = getattr(
+                            _hc_mod, 'get_default_hermes_root', lambda: ''
+                        )()
                         if _mcp_home:
                             _mcp_home_token = _hc_mod.set_hermes_home_override(
                                 str(_mcp_home)
@@ -317,11 +320,25 @@ def _run_reload_mcp_command() -> str:
                 except Exception:
                     return False
 
-            _profile_home = str(os.environ.get("HERMES_HOME", "") or "")
-            _readiness = _mcp_retry_discovery(
-                _profile_home, _reload_discover, "mcp-reload"
-            )
-            _reload_status = _mcp_wait_readiness(_readiness)
+            try:
+                from api.profiles import _resolve_hermes_home_override
+                _reload_override_available = _resolve_hermes_home_override() is not None
+            except Exception:
+                _reload_override_available = False
+
+            if _reload_override_available:
+                _readiness = _mcp_retry_discovery(
+                    '', _reload_discover, "mcp-reload"
+                )
+                _reload_status = _mcp_wait_readiness(_readiness)
+            else:
+                # Older agent: no context-local override — a background
+                # reload would read the process env while other streams
+                # mutate it.  Run inline (pre-PR semantics), mirroring the
+                # stream worker's old-agent path (Greptile P1).
+                _reload_status = (
+                    "completed" if _reload_discover() else "failed"
+                )
 
             with _lock:
                 connected_servers = set(_servers.keys())

--- a/api/commands.py
+++ b/api/commands.py
@@ -285,9 +285,35 @@ def _run_reload_mcp_command() -> str:
             from api.streaming import _mcp_retry_discovery, _mcp_wait_readiness
 
             def _reload_discover():
+                """Re-discover MCP tools; returns bool.
+
+                Installs the captured profile-home override exactly like
+                the stream worker's discovery closure, so a background
+                reload run can never read another stream's HERMES_HOME
+                after env mutation (Greptile P1).
+                """
+                _mcp_home_token = None
                 try:
-                    discover_mcp_tools()
-                    return True
+                    from api.profiles import _resolve_hermes_home_override
+                    _hc_mod = _resolve_hermes_home_override()
+                    if _hc_mod is not None:
+                        _mcp_home = _profile_home
+                        if not _mcp_home:
+                            _mcp_home = getattr(
+                                _hc_mod, 'get_default_hermes_root', lambda: ''
+                            )()
+                        if _mcp_home:
+                            _mcp_home_token = _hc_mod.set_hermes_home_override(
+                                str(_mcp_home)
+                            )
+                    try:
+                        discover_mcp_tools()
+                        return True
+                    except Exception:
+                        return False
+                    finally:
+                        if _mcp_home_token is not None:
+                            _hc_mod.reset_hermes_home_override(_mcp_home_token)
                 except Exception:
                     return False
 

--- a/api/commands.py
+++ b/api/commands.py
@@ -279,15 +279,21 @@ def _run_reload_mcp_command() -> str:
             # waits on the shared readiness event so its synchronous
             # report below is still accurate.
             #
-            # The authority is keyed deterministically at the DEFAULT
-            # profile (''), the same key the startup kickoff and
-            # default-profile turns consult.  /reload-mcp is a GLOBAL
+            # The authority is keyed by the CANONICAL resolved default
+            # profile-home path (the same key the startup kickoff and
+            # default-profile turns consult).  /reload-mcp is a GLOBAL
             # operation (it shuts down and reconnects every configured
             # server), so it deliberately does NOT key off the exec-time
             # HERMES_HOME env: a concurrent stream can mutate that
             # process-global while the command runs, which would make the
             # reload capture another profile (Greptile P1).
-            from api.streaming import _mcp_retry_discovery, _mcp_wait_readiness
+            from api.streaming import (
+                _canonical_readiness_key,
+                _invalidate_mcp_readiness,
+                _mcp_retry_discovery,
+                _mcp_wait_readiness,
+                _prepare_global_reload,
+            )
 
             def _reload_discover():
                 """Re-discover MCP tools; returns bool.
@@ -320,6 +326,12 @@ def _run_reload_mcp_command() -> str:
                 except Exception:
                     return False
 
+            # Coordinate the global shutdown with every live discovery
+            # owner (cancel + bounded join) so a body mid-discovery cannot
+            # re-register old-config servers after the registry is cleared.
+            _prepare_global_reload()
+            shutdown_mcp_servers()
+
             try:
                 from api.profiles import _resolve_hermes_home_override
                 _reload_override_available = _resolve_hermes_home_override() is not None
@@ -328,7 +340,9 @@ def _run_reload_mcp_command() -> str:
 
             if _reload_override_available:
                 _readiness = _mcp_retry_discovery(
-                    '', _reload_discover, "mcp-reload"
+                    _canonical_readiness_key(''),
+                    _reload_discover,
+                    "mcp-reload",
                 )
                 _reload_status = _mcp_wait_readiness(_readiness)
             else:
@@ -339,6 +353,12 @@ def _run_reload_mcp_command() -> str:
                 _reload_status = (
                     "completed" if _reload_discover() else "failed"
                 )
+
+            # The global reload rebuilt the registry: every OTHER
+            # profile's readiness is stale.  Remove those entries so each
+            # profile's next turn re-runs discovery instead of trusting a
+            # state whose servers were just shut down.
+            _invalidate_mcp_readiness(except_key=_canonical_readiness_key(''))
 
             with _lock:
                 connected_servers = set(_servers.keys())

--- a/api/commands.py
+++ b/api/commands.py
@@ -270,8 +270,6 @@ def _run_reload_mcp_command() -> str:
             with _lock:
                 old_servers = set(_servers.keys())
 
-            shutdown_mcp_servers()
-
             # Route the re-discovery through the SAME readiness authority
             # the stream worker uses (api.streaming), so a subsequent turn
             # observes the fresh outcome instead of a stale 'completed' /
@@ -288,6 +286,7 @@ def _run_reload_mcp_command() -> str:
             # process-global while the command runs, which would make the
             # reload capture another profile (Greptile P1).
             from api.streaming import (
+                _MCP_READINESS_WAIT_CAP_S,
                 _canonical_readiness_key,
                 _invalidate_mcp_readiness,
                 _mcp_retry_discovery,
@@ -329,7 +328,15 @@ def _run_reload_mcp_command() -> str:
             # Coordinate the global shutdown with every live discovery
             # owner (cancel + bounded join) so a body mid-discovery cannot
             # re-register old-config servers after the registry is cleared.
-            _prepare_global_reload()
+            # Fail CLOSED: if any owner survived the join cap, abort the
+            # reload rather than run a discovery body concurrently with a
+            # registry rebuild (Greptile review round 10).
+            if not _prepare_global_reload():
+                return (
+                    "MCP reload aborted: a discovery run is still in "
+                    f"progress after waiting {int(_MCP_READINESS_WAIT_CAP_S)}s. "
+                    "Retry once it finishes."
+                )
             shutdown_mcp_servers()
 
             try:

--- a/api/commands.py
+++ b/api/commands.py
@@ -333,12 +333,19 @@ def _run_reload_mcp_command() -> str:
             # reload rather than run a discovery body concurrently with a
             # registry rebuild (Greptile review round 10).
             #
-            # The owner-creation FENCE is held for the whole teardown
-            # window: while /reload-mcp snapshots/joins live owners and
-            # shuts down the registry, a concurrent stream worker cannot
-            # CREATE a new discovery owner — so the snapshot is COMPLETE
-            # and no new body registers servers into or after the
-            # shutdown (Greptile review round 11).
+            # The owner-creation FENCE is held for the ENTIRE rebuild
+            # window — snapshot, join, shutdown, replacement discovery
+            # and readiness invalidation (Greptile review round 12).
+            # While /reload-mcp runs, a concurrent stream worker cannot
+            # CREATE a new discovery owner: not during teardown (the
+            # snapshot is COMPLETE, round 11), and not during the
+            # replacement build (no body registers servers concurrently
+            # with the reload's own discovery, and nothing gets
+            # invalidated out from under a fresh registration).  The
+            # reload's own retry spawn skips the re-acquire
+            # (`_fence_held=True`) because threading.Lock is not
+            # reentrant; waiting turns are unaffected — they only wait
+            # on readiness events, never the fence.
             with _MCP_RELOAD_FENCE:
                 if not _prepare_global_reload():
                     return (
@@ -348,33 +355,36 @@ def _run_reload_mcp_command() -> str:
                     )
                 shutdown_mcp_servers()
 
-            try:
-                from api.profiles import _resolve_hermes_home_override
-                _reload_override_available = _resolve_hermes_home_override() is not None
-            except Exception:
-                _reload_override_available = False
+                try:
+                    from api.profiles import _resolve_hermes_home_override
+                    _reload_override_available = _resolve_hermes_home_override() is not None
+                except Exception:
+                    _reload_override_available = False
 
-            if _reload_override_available:
-                _readiness = _mcp_retry_discovery(
-                    _canonical_readiness_key(''),
-                    _reload_discover,
-                    "mcp-reload",
-                )
-                _reload_status = _mcp_wait_readiness(_readiness)
-            else:
-                # Older agent: no context-local override — a background
-                # reload would read the process env while other streams
-                # mutate it.  Run inline (pre-PR semantics), mirroring the
-                # stream worker's old-agent path (Greptile P1).
-                _reload_status = (
-                    "completed" if _reload_discover() else "failed"
-                )
+                if _reload_override_available:
+                    _readiness = _mcp_retry_discovery(
+                        _canonical_readiness_key(''),
+                        _reload_discover,
+                        "mcp-reload",
+                        _fence_held=True,
+                    )
+                    _reload_status = _mcp_wait_readiness(_readiness)
+                else:
+                    # Older agent: no context-local override — a background
+                    # reload would read the process env while other streams
+                    # mutate it.  Run inline (pre-PR semantics), mirroring the
+                    # stream worker's old-agent path (Greptile P1).
+                    _reload_status = (
+                        "completed" if _reload_discover() else "failed"
+                    )
 
-            # The global reload rebuilt the registry: every OTHER
-            # profile's readiness is stale.  Remove those entries so each
-            # profile's next turn re-runs discovery instead of trusting a
-            # state whose servers were just shut down.
-            _invalidate_mcp_readiness(except_key=_canonical_readiness_key(''))
+                # The global reload rebuilt the registry: every OTHER
+                # profile's readiness is stale.  Remove those entries so each
+                # profile's next turn re-runs discovery instead of trusting a
+                # state whose servers were just shut down.  Still inside the
+                # fence: a stream cannot spawn a fresh owner that would then
+                # be invalidated as stale (round 12).
+                _invalidate_mcp_readiness(except_key=_canonical_readiness_key(''))
 
             with _lock:
                 connected_servers = set(_servers.keys())

--- a/api/commands.py
+++ b/api/commands.py
@@ -288,8 +288,10 @@ def _run_reload_mcp_command() -> str:
             from api.streaming import (
                 _MCP_READINESS_WAIT_CAP_S,
                 _MCP_RELOAD_FENCE,
+                _MCP_INCOMPLETE,
                 _canonical_readiness_key,
                 _invalidate_mcp_readiness,
+                _mcp_profile_has_connect_errors,
                 _mcp_retry_discovery,
                 _mcp_wait_readiness,
                 _prepare_global_reload,
@@ -317,6 +319,10 @@ def _run_reload_mcp_command() -> str:
                             )
                     try:
                         discover_mcp_tools()
+                        # Any enabled server with a connect error =
+                        # incomplete, not success (maintainer round 15 #2).
+                        if _mcp_profile_has_connect_errors(''):
+                            return _MCP_INCOMPLETE
                         return True
                     except Exception:
                         return False
@@ -350,13 +356,23 @@ def _run_reload_mcp_command() -> str:
             # reentrant; waiting turns are unaffected — they only wait
             # on readiness events, never the fence.
             with _MCP_RELOAD_FENCE:
-                if not _prepare_global_reload():
-                    return (
-                        "MCP reload aborted: a discovery run is still in "
-                        f"progress after waiting {int(_MCP_READINESS_WAIT_CAP_S)}s. "
-                        "Retry once it finishes."
-                    )
-                shutdown_mcp_servers()
+                try:
+                    if not _prepare_global_reload():
+                        return (
+                            "MCP reload aborted: a discovery run is still in "
+                            f"progress after waiting {int(_MCP_READINESS_WAIT_CAP_S)}s. "
+                            "Retry once it finishes."
+                        )
+                    shutdown_mcp_servers()
+                except Exception:
+                    # Teardown began but raised mid-way (e.g. shutdown left
+                    # the registry partially mutated): every readiness
+                    # entry, including the default, is now stale.  Clear
+                    # ALL of them before propagating, so no profile trusts
+                    # a 'completed'/'failed' state whose servers were
+                    # partially torn down (maintainer round 15 #4).
+                    _invalidate_mcp_readiness(except_key=None)
+                    raise
 
                 # The global reload just shut down the registry: every
                 # OTHER profile's readiness is stale.  Remove those

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -484,7 +484,7 @@ def _wait_and_surface_mcp_readiness(readiness, profile_home, session_id):
     return _status
 
 
-def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
+def _mcp_retry_discovery(profile_home, discover_fn, thread_name, _fence_held=False):
     """Force a fresh discovery run, retiring the current generation.
 
     This is the explicit retry path (mirrors /reload-mcp semantics) and
@@ -496,6 +496,14 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
     rather than running two bodies.  Registering tools mid-turn never
     mutates an in-flight Agent snapshot: hermes-agent only applies
     registered tools in its per-turn prologue refresh.
+
+    `_fence_held=True` is the reload path: the caller (the reload
+    command) already holds `_MCP_RELOAD_FENCE` across the ENTIRE
+    rebuild — replacement discovery and readiness invalidation included,
+    not just teardown (Greptile review round 12).  `threading.Lock` is
+    not reentrant, so the spawn skips the acquire.  Without it, a
+    concurrent stream could spawn an owner in the post-shutdown window
+    and register servers concurrently with the reload's own rebuild.
     """
     profile_home = _canonical_readiness_key(profile_home)
     with _MCP_READINESS_LOCK:
@@ -511,10 +519,14 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
         # mid-discovery finishes (bounded by its internal timeouts).
         _old_cancel.set()
         _old_thread.join(timeout=_MCP_READINESS_WAIT_CAP_S)
-    with _MCP_RELOAD_FENCE:
+    with (
+        contextlib.nullcontext() if _fence_held else _MCP_RELOAD_FENCE
+    ):
         # Owner creation is fenced behind a global reload's teardown so a
         # new discovery body can never register servers into (or after) a
-        # registry shutdown (Greptile round 11).
+        # registry shutdown (Greptile round 11).  The reload path passes
+        # _fence_held=True because IT already holds the fence across the
+        # whole rebuild (round 12).
         with _MCP_READINESS_LOCK:
             if _old_thread is not None and _old_thread.is_alive():
                 # Physical single-flight: the old body is STILL alive beyond

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8726,15 +8726,36 @@ def _run_agent_streaming(
         # (`refresh_agent_mcp_tools`) folds tools from servers that finish
         # connecting mid-turn into this turn's first API call, so nothing is
         # lost — the turn just starts immediately.
+        #
+        # The thread re-asserts the stream's profile home through hermes-agent's
+        # CONTEXT-LOCAL override (`set_hermes_home_override`), which
+        # `get_hermes_home()` resolves before the env var.  It deliberately
+        # does NOT write `os.environ['HERMES_HOME']`: the worker mutates that
+        # under `_ENV_LOCK` and restores it at stream teardown, and a delayed
+        # discovery thread that outlives the stream would otherwise write the
+        # stale profile into the process env and cross-contaminate other
+        # streams (the same race as an unlocked env write).  The contextvar is
+        # thread-local — the discovery thread's override dies with the thread.
         try:
             from tools.mcp_tool import discover_mcp_tools
             _mcp_profile_home = os.environ.get('HERMES_HOME', '')
 
             def _discover_mcp_background():
                 try:
-                    if _mcp_profile_home:
-                        os.environ['HERMES_HOME'] = _mcp_profile_home
-                    discover_mcp_tools()
+                    from hermes_constants import (
+                        reset_hermes_home_override,
+                        set_hermes_home_override,
+                    )
+                    _mcp_home_token = (
+                        set_hermes_home_override(_mcp_profile_home)
+                        if _mcp_profile_home
+                        else None
+                    )
+                    try:
+                        discover_mcp_tools()
+                    finally:
+                        if _mcp_home_token is not None:
+                            reset_hermes_home_override(_mcp_home_token)
                 except Exception:
                     pass  # MCP not available or not configured — non-fatal
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8788,7 +8788,11 @@ def _run_agent_streaming(
         # completeness.  Servers slower than the bound, or unreachable ones,
         # keep the thread running in the background; their tools land on the
         # NEXT turn via hermes-agent's between-turns prologue refresh
-        # (`agent/turn_context.py`), matching CLI/TUI semantics.
+        # (`agent/turn_context.py`), matching CLI/TUI semantics.  On agents
+        # older than v0.18.0 (no context-local override API) the join is
+        # UNBOUNDED — discovery completes inside this worker's env window,
+        # preserving the pre-PR synchronous semantics exactly, so the
+        # fallback can't read another stream's env after teardown.
         #
         # The thread re-asserts the stream's profile home through hermes-agent's
         # CONTEXT-LOCAL override (`set_hermes_home_override`), which
@@ -8815,10 +8819,20 @@ def _run_agent_streaming(
                     from api.profiles import _resolve_hermes_home_override
                     _hc_mod = _resolve_hermes_home_override()
                     _mcp_home_token = None
-                    if _hc_mod is not None and _profile_home:
-                        _mcp_home_token = _hc_mod.set_hermes_home_override(
-                            _profile_home
-                        )
+                    if _hc_mod is not None:
+                        _mcp_home = _profile_home
+                        if not _mcp_home:
+                            # Default-profile session: the worker never set
+                            # HERMES_HOME, so an override to the platform
+                            # default keeps the thread independent of the
+                            # process env (which other streams mutate).
+                            _mcp_home = getattr(
+                                _hc_mod, 'get_default_hermes_root', lambda: ''
+                            )()
+                        if _mcp_home:
+                            _mcp_home_token = _hc_mod.set_hermes_home_override(
+                                str(_mcp_home)
+                            )
                     try:
                         discover_mcp_tools()
                     finally:
@@ -8827,11 +8841,25 @@ def _run_agent_streaming(
                 except Exception:
                     pass  # MCP not available or not configured — non-fatal
 
+            _join_timeout = _MCP_DISCOVERY_TURN_JOIN_S
+            try:
+                from api.profiles import _resolve_hermes_home_override
+                if _resolve_hermes_home_override() is None:
+                    # Older agent (no context-local override API): a delayed
+                    # background thread would read process env AFTER this
+                    # worker restores it, which can observe another stream's
+                    # home.  Block until discovery completes (pre-PR
+                    # semantics) so the env read happens inside this worker's
+                    # env window.
+                    _join_timeout = None
+            except Exception:
+                _join_timeout = None
+
             _run_mcp_discovery_background(
                 _profile_home,
                 _discover_mcp_background,
                 'mcp-discovery-%s' % (session_id or 'unknown'),
-                join_timeout=_MCP_DISCOVERY_TURN_JOIN_S,
+                join_timeout=_join_timeout,
             )
         except Exception:
             pass  # MCP import itself failed — non-fatal

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -439,7 +439,10 @@ def _mcp_wait_readiness(readiness):
     token set) so a late-finishing thread can never publish terminal
     state over the caller's outcome — but the thread POINTER is NOT
     cleared while execution continues, and a not-yet-started body sees
-    the cancel token and performs no discovery side effects.  If a retry
+    the cancel token and performs no discovery side effects.  The
+    retired generation's EVENT is signalled after publishing so peer
+    waiters subscribed to that generation observe the terminal 'failed'
+    promptly instead of sleeping out their own full cap.  If a retry
     started a newer generation mid-wait, the wait rides the newer run.
     """
     if readiness.status == "pending":
@@ -455,12 +458,21 @@ def _mcp_wait_readiness(readiness):
                 # Event fired but nothing published for this generation:
                 # the owner died mid-run or discovery outlived its bounds.
                 break
+        _retired_event = None
         if readiness.status == "pending" and readiness.gen == _gen:
             with _MCP_READINESS_LOCK:
                 if readiness.gen == _gen and readiness.status == "pending":
                     readiness.gen += 1
                     readiness.status = "failed"
                     readiness.cancel.set()
+                    _retired_event = readiness.event
+            if _retired_event is not None:
+                # Wake peer waiters subscribed to the retired generation
+                # (maintainer round 14): without this, a second
+                # same-profile turn already blocked on the event sleeps
+                # out its own full cap even though the shared result is
+                # terminal.
+                _retired_event.set()
     return readiness.status
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -241,14 +241,25 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 #               surfaced (logged) at the stream boundary and turns
 #               proceed without waiting
 #
-# Readiness is GENERATION-based and SINGLE-FLIGHT:
+# Readiness is GENERATION-based, PHYSICALLY SINGLE-FLIGHT, and keyed by
+# ONE CANONICAL resolved profile-home path:
 #   * `_McpReadiness.gen` is bumped whenever a new owner run starts
 #     (restart, explicit retry) or a wait times out (retirement).  A run
 #     only publishes its terminal outcome if its generation is still
 #     current, so a late-finishing owner can never flip state over a
-#     timed-out wait or a newer run — and never registers tools into a
-#     turn that already proceeded.
-#   * Exactly ONE current owner thread exists per profile home.  A turn
+#     timed-out wait or a newer run.
+#   * Ownership is PHYSICAL, not just label-fenced: at most ONE discovery
+#     body is ever alive per profile.  A retry sets the old run's cancel
+#     token and JOINS it (bounded by the readiness cap) before starting
+#     the replacement; if the old body is still alive after the cap the
+#     retry is REJECTED.  A timed-out wait retires the generation WITHOUT
+#     clearing the thread pointer — execution continues, and the cancel
+#     token prevents a not-yet-started body from doing any work.
+#   * The registry key is `_canonical_readiness_key(profile_home)`: the
+#     resolved profile-home path.  Startup, turns, retries and the
+#     /reload-mcp command all normalize to the same key, so the default
+#     profile can never hold two entries ('') plus resolved path.
+#   * Exactly ONE current owner thread exists per canonical key.  A turn
 #     that finds the profile still `pending` waits on the shared
 #     readiness event — the FIRST tool-bearing turn must not silently
 #     omit a configured server — and every later turn subscribes to the
@@ -260,6 +271,11 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 #     (bool): production closures never swallow failures into a fake
 #     'completed', and a thrown run is recorded as 'failed' by the
 #     runner.
+#   * A global /reload-mcp coordinates with every live owner (cancel +
+#     bounded join before shutdown) and then INVALIDATES every other
+#     readiness entry so each profile's next turn re-runs discovery
+#     instead of trusting a stale 'completed'/'failed' state whose
+#     servers were just shut down.
 #
 # The discovery thread re-asserts the profile home through hermes-agent's
 # CONTEXT-LOCAL override (`set_hermes_home_override`), resolved via the
@@ -275,6 +291,29 @@ _MCP_READINESS_LOCK = threading.Lock()
 _MCP_READINESS_WAIT_CAP_S = 120.0
 
 
+def _canonical_readiness_key(profile_home):
+    """Resolve the ONE canonical readiness key for a profile home.
+
+    The stream worker keys readiness by the RESOLVED profile-home path
+    (even for the default profile).  Startup and /reload-mcp must use
+    the SAME key instead of '' — otherwise the logical default profile
+    holds two entries and a global reload refreshes only one
+    (maintainer review round 9).
+    """
+    if profile_home:
+        return str(profile_home)
+    try:
+        from api.profiles import _resolve_hermes_home_override
+        _hc_mod = _resolve_hermes_home_override()
+        if _hc_mod is not None:
+            _root = getattr(_hc_mod, 'get_default_hermes_root', lambda: '')()
+            if _root:
+                return str(_root)
+    except Exception:
+        pass
+    return ''
+
+
 class _McpReadiness:
     """Profile-scoped MCP discovery readiness.
 
@@ -284,27 +323,38 @@ class _McpReadiness:
         thread: the current owner thread (one per profile)
         gen:    generation counter — bumped on restart/retry/timeout
                 retirement so a stale owner can never publish.
+        cancel: threading.Event — set to ask the current body not to
+                start (or to keep waiting) discovery; used by retry and
+                timeout retirement to fence side effects, not just the
+                final label.
     """
 
-    __slots__ = ("status", "event", "thread", "gen")
+    __slots__ = ("status", "event", "thread", "gen", "cancel")
 
     def __init__(self):
         self.status = "pending"
         self.event = threading.Event()
         self.thread = None
         self.gen = 0
+        self.cancel = threading.Event()
 
 
-def _discovery_runner(discover_fn, readiness, event, gen):
+def _discovery_runner(discover_fn, readiness, event, gen, cancel):
     """Run one discovery generation and publish its terminal outcome.
 
     Only the generation captured at start may publish: a retry or a
     timed-out wait bumps `readiness.gen`, retiring this run, so a
     late-finishing owner can never flip the readiness over the caller's
-    terminal outcome (or register tools into a turn that already
-    proceeded).  The closure returns an explicit bool outcome — a thrown
-    run is recorded as failed.
+    terminal outcome.  The `cancel` token is checked BEFORE discovery so
+    a voided run never performs side effects (registration) — a body
+    already mid-discovery cannot be preempted, but the label stays
+    fenced and the thread is only ever replaced after a bounded join.
+    The closure returns an explicit bool outcome — a thrown run is
+    recorded as failed.
     """
+    if cancel.is_set():
+        event.set()
+        return
     try:
         outcome = discover_fn()  # production closures return bool
     except Exception:
@@ -318,13 +368,14 @@ def _discovery_runner(discover_fn, readiness, event, gen):
 def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
     """Return the profile's readiness, spawning the discovery owner if needed.
 
-    Exactly one discovery thread per profile home: callers after the first
-    subscribe to the SAME readiness event instead of spawning again or
-    paying a fresh wait.  Completed/failed profiles are NOT re-run here —
-    an explicit retry goes through `_mcp_retry_discovery` (or /reload-mcp).
-    A pending run whose owner died is restarted as a NEW generation so
-    waiters can never hang forever on a stale run.
+    Exactly one discovery thread per canonical profile-home key: callers
+    after the first subscribe to the SAME readiness event instead of
+    spawning again or paying a fresh wait.  Completed/failed profiles are
+    NOT re-run here — an explicit retry goes through `_mcp_retry_discovery`
+    (or /reload-mcp).  A pending run whose owner died is restarted as a
+    NEW generation so waiters can never hang forever on a stale run.
     """
+    profile_home = _canonical_readiness_key(profile_home)
     with _MCP_READINESS_LOCK:
         readiness = _MCP_READINESS.get(profile_home)
         if readiness is None:
@@ -341,9 +392,16 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
             readiness.gen += 1
             _gen = readiness.gen
             readiness.event = threading.Event()
+            readiness.cancel = threading.Event()
             readiness.thread = threading.Thread(
                 target=_discovery_runner,
-                args=(discover_fn, readiness, readiness.event, _gen),
+                args=(
+                    discover_fn,
+                    readiness,
+                    readiness.event,
+                    _gen,
+                    readiness.cancel,
+                ),
                 name=thread_name,
                 daemon=True,
             )
@@ -357,10 +415,12 @@ def _mcp_wait_readiness(readiness):
     Bounded by `_MCP_READINESS_WAIT_CAP_S` (discovery's own internal
     timeouts plus a hang-safety cap); a stuck run cannot hang the turn
     forever.  If the cap is hit while the run is still pending, the
-    CURRENT generation is RETIRED (gen bumped, status 'failed', owner
-    released) so a late-finishing thread can never publish terminal
-    state over the caller's outcome.  If a retry started a newer
-    generation mid-wait, the wait rides the newer run.
+    CURRENT generation is RETIRED (gen bumped, status 'failed', cancel
+    token set) so a late-finishing thread can never publish terminal
+    state over the caller's outcome — but the thread POINTER is NOT
+    cleared while execution continues, and a not-yet-started body sees
+    the cancel token and performs no discovery side effects.  If a retry
+    started a newer generation mid-wait, the wait rides the newer run.
     """
     if readiness.status == "pending":
         _deadline = time.monotonic() + _MCP_READINESS_WAIT_CAP_S
@@ -380,7 +440,7 @@ def _mcp_wait_readiness(readiness):
                 if readiness.gen == _gen and readiness.status == "pending":
                     readiness.gen += 1
                     readiness.status = "failed"
-                    readiness.thread = None
+                    readiness.cancel.set()
     return readiness.status
 
 
@@ -408,29 +468,90 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
     """Force a fresh discovery run, retiring the current generation.
 
     This is the explicit retry path (mirrors /reload-mcp semantics) and
-    is SINGLE-FLIGHT: the previous owner — even if still running — is
-    retired by bumping the generation so it can never publish, and
-    exactly one current owner exists afterwards.  Registering tools
-    mid-turn never mutates an in-flight Agent snapshot: hermes-agent
-    only applies registered tools in its per-turn prologue refresh.
+    is PHYSICALLY single-flight: the previous owner — even if still
+    running — is cancelled and JOINED (bounded by the readiness cap)
+    before a replacement starts, so two discovery bodies are never alive
+    for one profile.  If the old body is still alive after the cap, the
+    retry is REJECTED (the existing readiness is returned unchanged)
+    rather than running two bodies.  Registering tools mid-turn never
+    mutates an in-flight Agent snapshot: hermes-agent only applies
+    registered tools in its per-turn prologue refresh.
     """
+    profile_home = _canonical_readiness_key(profile_home)
     with _MCP_READINESS_LOCK:
         readiness = _MCP_READINESS.get(profile_home)
         if readiness is None:
             readiness = _McpReadiness()
             _MCP_READINESS[profile_home] = readiness
+        _old_thread = readiness.thread
+        _old_cancel = readiness.cancel
+    if _old_thread is not None and _old_thread.is_alive():
+        # Acknowledge cancellation: a body that has not yet started
+        # discovery will see the cancel token and do no work; a body
+        # mid-discovery finishes (bounded by its internal timeouts).
+        _old_cancel.set()
+        _old_thread.join(timeout=_MCP_READINESS_WAIT_CAP_S)
+    with _MCP_READINESS_LOCK:
+        if _old_thread is not None and _old_thread.is_alive():
+            # Physical single-flight: the old body is STILL alive beyond
+            # the cap.  Reject the replacement rather than running two
+            # discovery bodies for one profile.
+            return readiness
         readiness.status = "pending"
         readiness.gen += 1
         _gen = readiness.gen
         readiness.event = threading.Event()
+        readiness.cancel = threading.Event()
         readiness.thread = threading.Thread(
             target=_discovery_runner,
-            args=(discover_fn, readiness, readiness.event, _gen),
+            args=(
+                discover_fn,
+                readiness,
+                readiness.event,
+                _gen,
+                readiness.cancel,
+            ),
             name=thread_name,
             daemon=True,
         )
         readiness.thread.start()
     return readiness
+
+
+def _prepare_global_reload():
+    """Coordinate a global /reload-mcp with every live discovery owner.
+
+    Sets every live owner's cancel token and joins it (bounded by the
+    readiness cap) BEFORE `shutdown_mcp_servers()` clears the
+    process-global registry, so a body mid-discovery cannot re-register
+    old-config servers after the registry is torn down.
+    """
+    with _MCP_READINESS_LOCK:
+        _live = [
+            (r.cancel, r.thread)
+            for r in list(_MCP_READINESS.values())
+            if r.thread is not None and r.thread.is_alive()
+        ]
+    for _cancel, _thread in _live:
+        _cancel.set()
+        _thread.join(timeout=_MCP_READINESS_WAIT_CAP_S)
+
+
+def _invalidate_mcp_readiness(except_key=None):
+    """Remove every readiness entry except the reload's own refreshed one.
+
+    A global reload rebuilt the process-global MCP registry, so any
+    other profile's 'completed'/'failed' readiness is stale — its next
+    turn must re-run discovery instead of trusting old state whose
+    servers were just shut down.  The except_key entry was refreshed by
+    the reload run itself and stays.
+    """
+    except_key = _canonical_readiness_key(except_key or '')
+    with _MCP_READINESS_LOCK:
+        for _key in [k for k in list(_MCP_READINESS) if k != except_key]:
+            _entry = _MCP_READINESS.pop(_key, None)
+            if _entry is not None and _entry.thread is not None:
+                _entry.cancel.set()
 
 
 def _startup_mcp_discovery():

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8736,26 +8736,31 @@ def _run_agent_streaming(
         # stale profile into the process env and cross-contaminate other
         # streams (the same race as an unlocked env write).  The contextvar is
         # thread-local — the discovery thread's override dies with the thread.
+        #
+        # The override is resolved through `api.profiles._resolve_hermes_home_override()`
+        # (the webui's version gate for the v0.18.0+ API) rather than imported
+        # directly, so OLDER agents fall back to the pre-existing env-mirror
+        # behavior instead of silently skipping discovery.  The profile home
+        # itself comes from the `_profile_home` local captured under `_ENV_LOCK`
+        # above — re-reading `os.environ['HERMES_HOME']` here would race with a
+        # concurrent stream's env mutation after the lock is released.
         try:
             from tools.mcp_tool import discover_mcp_tools
-            _mcp_profile_home = os.environ.get('HERMES_HOME', '')
 
             def _discover_mcp_background():
                 try:
-                    from hermes_constants import (
-                        reset_hermes_home_override,
-                        set_hermes_home_override,
-                    )
-                    _mcp_home_token = (
-                        set_hermes_home_override(_mcp_profile_home)
-                        if _mcp_profile_home
-                        else None
-                    )
+                    from api.profiles import _resolve_hermes_home_override
+                    _hc_mod = _resolve_hermes_home_override()
+                    _mcp_home_token = None
+                    if _hc_mod is not None and _profile_home:
+                        _mcp_home_token = _hc_mod.set_hermes_home_override(
+                            _profile_home
+                        )
                     try:
                         discover_mcp_tools()
                     finally:
                         if _mcp_home_token is not None:
-                            reset_hermes_home_override(_mcp_home_token)
+                            _hc_mod.reset_hermes_home_override(_mcp_home_token)
                 except Exception:
                     pass  # MCP not available or not configured — non-fatal
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -231,58 +231,175 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
     default=None,
 )
 
-# ── MCP discovery: background thread + coalescing ──
-# The per-turn discovery spawn is coalesced per profile home so a busy
-# process never accumulates one daemon thread per message (each
-# `discover_mcp_tools()` can wait up to 120s on the cross-process
-# discovery lock / outer timeout).  `_MCP_DISCOVERY_TURN_JOIN_S` bounds how
-# long the stream worker waits for discovery to finish BEFORE it
-# builds/snapshots the agent, so reachable servers (HTTP/OAuth connects
-# routinely take 2-6s on a cold connect) still land in THIS turn's tool
-# snapshot.  Servers slower than the bound — or unreachable ones like an
-# SSH server pointing at an offline machine — leave the thread running in
-# the background (daemon) and their tools land on the next turn via
-# hermes-agent's per-turn prologue refresh (`agent/turn_context.py`
-# between-turns MCP refresh), matching the CLI/TUI semantics where
-# discovery runs once at agent startup.
-_MCP_DISCOVERY_TURN_JOIN_S = 4.0
-_MCP_DISCOVERY_THREADS: dict = {}
-_MCP_DISCOVERY_THREADS_LOCK = threading.Lock()
+# ── MCP discovery: profile-scoped readiness state machine ──
+# MCP readiness is an explicit per-profile state, not a timed guess:
+#
+#   pending   — one discovery owner thread is running (or about to run)
+#   completed — discovery finished; registered tools are visible to the
+#               next agent snapshot / per-turn prologue refresh
+#   failed    — discovery finished with per-server failures; the outcome is
+#               surfaced (logged) and turns proceed without waiting
+#
+# Exactly ONE discovery thread runs per profile home.  A turn that finds
+# the profile still `pending` waits on the shared readiness event — the
+# FIRST tool-bearing turn must not silently omit a configured server —
+# and every later turn subscribes to the SAME result, so the wait is paid
+# once per profile, not once per message.  Discovery is also kicked off at
+# process start (`_startup_mcp_discovery`) so the default profile is
+# usually already resolved by the time the first user message arrives.
+#
+# The discovery thread re-asserts the profile home through hermes-agent's
+# CONTEXT-LOCAL override (`set_hermes_home_override`), resolved via the
+# webui's version gate `api.profiles._resolve_hermes_home_override()`
+# (#5567), and never writes `os.environ['HERMES_HOME']` (the worker
+# mutates that under `_ENV_LOCK` and restores it at teardown; a delayed
+# write would cross-contaminate other streams).  On agents without the
+# override API the first turn still blocks on the readiness event, so the
+# env read happens inside the worker's env window — the pre-PR
+# synchronous semantics are preserved exactly.
+_MCP_READINESS: dict = {}
+_MCP_READINESS_LOCK = threading.Lock()
 
 
-def _run_mcp_discovery_background(
-    profile_home,
-    discover_fn,
-    thread_name,
-    join_timeout=None,
-):
-    """Run ``discover_fn`` on a coalesced daemon thread; optionally join it.
+class _McpReadiness:
+    """Profile-scoped MCP discovery readiness.
 
-    One background discovery thread is kept per profile home — a live
-    thread is reused rather than spawned anew, so N rapid messages cannot
-    accumulate N lock-waiting discovery daemons.  When ``join_timeout`` is
-    given, the caller waits up to that long for discovery to finish, which
-    lets the agent build that follows snapshot the freshly registered MCP
-    tools.  A thread that outlives the timeout keeps running in the
-    background (daemon) and its tools land on a later turn.
-
-    Returns the thread.
+    Attributes:
+        status: 'pending' | 'completed' | 'failed'
+        event:  threading.Event set when the current run finishes
+        thread: the discovery owner thread (one per profile)
     """
-    with _MCP_DISCOVERY_THREADS_LOCK:
-        _existing = _MCP_DISCOVERY_THREADS.get(profile_home)
-        if _existing is not None and _existing.is_alive():
-            _thread = _existing
-        else:
-            _thread = threading.Thread(
-                target=discover_fn,
+
+    __slots__ = ("status", "event", "thread")
+
+    def __init__(self):
+        self.status = "pending"
+        self.event = threading.Event()
+        self.thread = None
+
+
+def _discovery_runner(discover_fn, readiness, event):
+    try:
+        discover_fn()
+    except Exception:
+        readiness.status = "failed"
+    else:
+        readiness.status = "completed"
+    finally:
+        event.set()
+
+
+def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
+    """Return the profile's readiness, spawning the discovery owner if needed.
+
+    Exactly one discovery thread per profile home: callers after the first
+    subscribe to the SAME readiness event instead of spawning again or
+    paying a fresh wait.  Completed/failed profiles are NOT re-run here —
+    an explicit retry goes through `_mcp_retry_discovery` (or /reload-mcp).
+    """
+    with _MCP_READINESS_LOCK:
+        readiness = _MCP_READINESS.get(profile_home)
+        if readiness is None:
+            readiness = _McpReadiness()
+            _MCP_READINESS[profile_home] = readiness
+        if (
+            readiness.status == "pending"
+            and (readiness.thread is None or not readiness.thread.is_alive())
+        ):
+            # Owner thread died without finishing; restart it so waiters
+            # can never hang forever on a stale run.  Completed/failed
+            # profiles are NOT re-run here — only explicit retries
+            # (_mcp_retry_discovery / /reload-mcp) re-run discovery.
+            readiness.status = "pending"
+            readiness.event = threading.Event()
+            readiness.thread = threading.Thread(
+                target=_discovery_runner,
+                args=(discover_fn, readiness, readiness.event),
                 name=thread_name,
                 daemon=True,
             )
-            _MCP_DISCOVERY_THREADS[profile_home] = _thread
-            _thread.start()
-    if join_timeout is not None:
-        _thread.join(timeout=join_timeout)
-    return _thread
+            readiness.thread.start()
+    return readiness
+
+
+def _mcp_wait_readiness(readiness):
+    """Block until the profile's discovery run finishes.
+
+    Bounded only by discovery's own internal timeouts (the cross-process
+    lock wait is capped at ~120s); a stuck run cannot hang the turn
+    forever.  Returns the readiness status.
+    """
+    if readiness.status == "pending":
+        readiness.event.wait(timeout=120.0)
+        if readiness.status == "pending":
+            # Safety: the owner thread died without setting the event, or
+            # discovery exceeded its own outer bounds.  Surface as failed.
+            readiness.status = "failed"
+    return readiness.status
+
+
+def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
+    """Force a fresh discovery run for a failed/never-run profile.
+
+    This is the explicit retry path (mirrors /reload-mcp semantics).
+    Registering tools mid-turn never mutates an in-flight Agent snapshot:
+    hermes-agent only applies registered tools in its per-turn prologue
+    refresh, before the first API call of the next turn.
+    """
+    with _MCP_READINESS_LOCK:
+        readiness = _MCP_READINESS.get(profile_home)
+        if readiness is None:
+            readiness = _McpReadiness()
+            _MCP_READINESS[profile_home] = readiness
+        readiness.status = "pending"
+        readiness.event = threading.Event()
+        readiness.thread = threading.Thread(
+            target=_discovery_runner,
+            args=(discover_fn, readiness, readiness.event),
+            name=thread_name,
+            daemon=True,
+        )
+        readiness.thread.start()
+    return readiness
+
+
+def _startup_mcp_discovery():
+    """Kick off default-profile MCP discovery at process start (non-blocking).
+
+    Lets the default profile's readiness resolve during idle time so the
+    first user turn usually finds it already completed/failed instead of
+    waiting.  Uses the getattr-import form so the repo-wide static
+    regression (test_issue1968) that counts exactly one `discover_mcp_tools`
+    call site in api/streaming.py stays valid.
+    """
+    try:
+        from tools.mcp_tool import discover_mcp_tools as _dmt
+    except Exception:
+        return
+
+    def _discover_default():
+        try:
+            from api.profiles import _resolve_hermes_home_override
+            _hc_mod = _resolve_hermes_home_override()
+            _mcp_home_token = None
+            if _hc_mod is not None:
+                _mcp_home = getattr(_hc_mod, 'get_default_hermes_root', lambda: '')()
+                if _mcp_home:
+                    _mcp_home_token = _hc_mod.set_hermes_home_override(
+                        str(_mcp_home)
+                    )
+            try:
+                _dmt()
+            finally:
+                if _mcp_home_token is not None:
+                    _hc_mod.reset_hermes_home_override(_mcp_home_token)
+        except Exception:
+            pass  # MCP not available or not configured — non-fatal
+
+    try:
+        _ensure_mcp_discovery('', _discover_default, 'mcp-discovery-startup')
+    except Exception:
+        pass
 
 
 _STREAMING_CRONJOB_WRAPPER_INSTALLED = False
@@ -8770,47 +8887,45 @@ def _run_agent_streaming(
         # lives outside this WebUI repo.  This change fixes the headline bug
         # for users who run a single non-default profile per WebUI process.
         #
-        # Discovery runs on a BACKGROUND thread: `discover_mcp_tools()`
-        # connects every configured server synchronously (per-server
-        # `connect_timeout`, plus the cross-process discovery lock), so a slow
-        # or unreachable server (e.g. an SSH MCP to a sleeping laptop) stalls
-        # turn start by seconds-to-a-minute on EVERY message.  The CLI/TUI
-        # never pays this because it discovers once at agent startup; the
-        # WebUI builds a fresh worker per stream, so discovery must not sit on
-        # the turn's critical path.
+        # Discovery runs through the profile-scoped readiness state
+        # machine: one owner thread per profile home, and a shared
+        # completed/failed/pending future.  `discover_mcp_tools()` connects
+        # every configured server synchronously (per-server
+        # `connect_timeout`, plus the cross-process discovery lock), so a
+        # slow or unreachable server (e.g. an SSH MCP to a sleeping laptop)
+        # would otherwise stall turn start by seconds-to-a-minute on EVERY
+        # message.  The CLI/TUI never pays this because it discovers once
+        # at agent startup; the WebUI builds a fresh worker per stream.
         #
-        # `_run_mcp_discovery_background` spawns (or reuses) a coalesced
-        # daemon thread and then JOINS it for a bounded window
-        # (`_MCP_DISCOVERY_TURN_JOIN_S`) before the agent is built further
-        # below — the agent's tool snapshot therefore includes tools from
-        # reachable servers that connect within that window (HTTP/OAuth
-        # cold connects routinely take 2-6s), preserving first-turn MCP
-        # completeness.  Servers slower than the bound, or unreachable ones,
-        # keep the thread running in the background; their tools land on the
-        # NEXT turn via hermes-agent's between-turns prologue refresh
-        # (`agent/turn_context.py`), matching CLI/TUI semantics.  On agents
-        # older than v0.18.0 (no context-local override API) the join is
-        # UNBOUNDED — discovery completes inside this worker's env window,
-        # preserving the pre-PR synchronous semantics exactly, so the
-        # fallback can't read another stream's env after teardown.
+        # A turn that finds the profile still `pending` WAITS on the shared
+        # readiness event — the first tool-bearing turn must not silently
+        # omit a configured server — and later turns subscribe to the SAME
+        # result, so the wait is paid once per profile, not once per
+        # message.  Discovery is also kicked off at process start
+        # (`_startup_mcp_discovery`), so the default profile is usually
+        # already resolved by the time the first user message arrives.
         #
-        # The thread re-asserts the stream's profile home through hermes-agent's
-        # CONTEXT-LOCAL override (`set_hermes_home_override`), which
-        # `get_hermes_home()` resolves before the env var.  It deliberately
-        # does NOT write `os.environ['HERMES_HOME']`: the worker mutates that
-        # under `_ENV_LOCK` and restores it at stream teardown, and a delayed
-        # discovery thread that outlives the stream would otherwise write the
-        # stale profile into the process env and cross-contaminate other
-        # streams (the same race as an unlocked env write).  The contextvar is
-        # thread-local — the discovery thread's override dies with the thread.
+        # The thread re-asserts the stream's profile home through
+        # hermes-agent's CONTEXT-LOCAL override (`set_hermes_home_override`),
+        # which `get_hermes_home()` resolves before the env var.  It
+        # deliberately does NOT write `os.environ['HERMES_HOME']`: the
+        # worker mutates that under `_ENV_LOCK` and restores it at stream
+        # teardown, and a delayed discovery thread that outlives the stream
+        # would otherwise write the stale profile into the process env and
+        # cross-contaminate other streams (the same race as an unlocked env
+        # write).  The contextvar is thread-local — the discovery thread's
+        # override dies with the thread.
         #
         # The override is resolved through `api.profiles._resolve_hermes_home_override()`
         # (the webui's version gate for the v0.18.0+ API) rather than imported
         # directly, so OLDER agents fall back to the pre-existing env-mirror
-        # behavior instead of silently skipping discovery.  The profile home
-        # itself comes from the `_profile_home` local captured under `_ENV_LOCK`
-        # above — re-reading `os.environ['HERMES_HOME']` here would race with a
-        # concurrent stream's env mutation after the lock is released.
+        # behavior.  On those agents the first pending turn still blocks on
+        # the readiness event, so the env read happens inside this worker's
+        # env window — the pre-PR synchronous semantics are preserved
+        # exactly.  The profile home itself comes from the `_profile_home`
+        # local captured under `_ENV_LOCK` above — re-reading
+        # `os.environ['HERMES_HOME']` here would race with a concurrent
+        # stream's env mutation after the lock is released.
         try:
             from tools.mcp_tool import discover_mcp_tools
 
@@ -8841,26 +8956,12 @@ def _run_agent_streaming(
                 except Exception:
                     pass  # MCP not available or not configured — non-fatal
 
-            _join_timeout = _MCP_DISCOVERY_TURN_JOIN_S
-            try:
-                from api.profiles import _resolve_hermes_home_override
-                if _resolve_hermes_home_override() is None:
-                    # Older agent (no context-local override API): a delayed
-                    # background thread would read process env AFTER this
-                    # worker restores it, which can observe another stream's
-                    # home.  Block until discovery completes (pre-PR
-                    # semantics) so the env read happens inside this worker's
-                    # env window.
-                    _join_timeout = None
-            except Exception:
-                _join_timeout = None
-
-            _run_mcp_discovery_background(
+            _readiness = _ensure_mcp_discovery(
                 _profile_home,
                 _discover_mcp_background,
                 'mcp-discovery-%s' % (session_id or 'unknown'),
-                join_timeout=_join_timeout,
             )
+            _mcp_wait_readiness(_readiness)
         except Exception:
             pass  # MCP import itself failed — non-fatal
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -237,28 +237,42 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 #   pending   — one discovery owner thread is running (or about to run)
 #   completed — discovery finished; registered tools are visible to the
 #               next agent snapshot / per-turn prologue refresh
-#   failed    — discovery finished with per-server failures; the outcome is
-#               surfaced (logged) and turns proceed without waiting
+#   failed    — discovery finished with a failure; the outcome is
+#               surfaced (logged) at the stream boundary and turns
+#               proceed without waiting
 #
-# Exactly ONE discovery thread runs per profile home.  A turn that finds
-# the profile still `pending` waits on the shared readiness event — the
-# FIRST tool-bearing turn must not silently omit a configured server —
-# and every later turn subscribes to the SAME result, so the wait is paid
-# once per profile, not once per message.  Discovery is also kicked off at
-# process start (`_startup_mcp_discovery`) so the default profile is
-# usually already resolved by the time the first user message arrives.
+# Readiness is GENERATION-based and SINGLE-FLIGHT:
+#   * `_McpReadiness.gen` is bumped whenever a new owner run starts
+#     (restart, explicit retry) or a wait times out (retirement).  A run
+#     only publishes its terminal outcome if its generation is still
+#     current, so a late-finishing owner can never flip state over a
+#     timed-out wait or a newer run — and never registers tools into a
+#     turn that already proceeded.
+#   * Exactly ONE current owner thread exists per profile home.  A turn
+#     that finds the profile still `pending` waits on the shared
+#     readiness event — the FIRST tool-bearing turn must not silently
+#     omit a configured server — and every later turn subscribes to the
+#     SAME result, so the wait is paid once per profile, not once per
+#     message.  Discovery is also kicked off at process start
+#     (`_startup_mcp_discovery`) so the default profile is usually
+#     already resolved by the time the first user message arrives.
+#   * The discovery closure returns an EXPLICIT success/failure outcome
+#     (bool): production closures never swallow failures into a fake
+#     'completed', and a thrown run is recorded as 'failed' by the
+#     runner.
 #
 # The discovery thread re-asserts the profile home through hermes-agent's
 # CONTEXT-LOCAL override (`set_hermes_home_override`), resolved via the
 # webui's version gate `api.profiles._resolve_hermes_home_override()`
 # (#5567), and never writes `os.environ['HERMES_HOME']` (the worker
 # mutates that under `_ENV_LOCK` and restores it at teardown; a delayed
-# write would cross-contaminate other streams).  On agents without the
-# override API the first turn still blocks on the readiness event, so the
-# env read happens inside the worker's env window — the pre-PR
-# synchronous semantics are preserved exactly.
+# write would cross-contaminate other streams).  On agents WITHOUT the
+# override API discovery is never backgrounded: the worker runs it
+# INLINE inside its own env window (pre-PR synchronous semantics), so a
+# daemon can never read another stream's profile after env mutation.
 _MCP_READINESS: dict = {}
 _MCP_READINESS_LOCK = threading.Lock()
+_MCP_READINESS_WAIT_CAP_S = 120.0
 
 
 class _McpReadiness:
@@ -267,26 +281,38 @@ class _McpReadiness:
     Attributes:
         status: 'pending' | 'completed' | 'failed'
         event:  threading.Event set when the current run finishes
-        thread: the discovery owner thread (one per profile)
+        thread: the current owner thread (one per profile)
+        gen:    generation counter — bumped on restart/retry/timeout
+                retirement so a stale owner can never publish.
     """
 
-    __slots__ = ("status", "event", "thread")
+    __slots__ = ("status", "event", "thread", "gen")
 
     def __init__(self):
         self.status = "pending"
         self.event = threading.Event()
         self.thread = None
+        self.gen = 0
 
 
-def _discovery_runner(discover_fn, readiness, event):
+def _discovery_runner(discover_fn, readiness, event, gen):
+    """Run one discovery generation and publish its terminal outcome.
+
+    Only the generation captured at start may publish: a retry or a
+    timed-out wait bumps `readiness.gen`, retiring this run, so a
+    late-finishing owner can never flip the readiness over the caller's
+    terminal outcome (or register tools into a turn that already
+    proceeded).  The closure returns an explicit bool outcome — a thrown
+    run is recorded as failed.
+    """
     try:
-        discover_fn()
+        outcome = discover_fn()  # production closures return bool
     except Exception:
-        readiness.status = "failed"
-    else:
-        readiness.status = "completed"
-    finally:
-        event.set()
+        outcome = False
+    with _MCP_READINESS_LOCK:
+        if gen == readiness.gen:
+            readiness.status = "completed" if outcome is True else "failed"
+    event.set()
 
 
 def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
@@ -296,6 +322,8 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
     subscribe to the SAME readiness event instead of spawning again or
     paying a fresh wait.  Completed/failed profiles are NOT re-run here —
     an explicit retry goes through `_mcp_retry_discovery` (or /reload-mcp).
+    A pending run whose owner died is restarted as a NEW generation so
+    waiters can never hang forever on a stale run.
     """
     with _MCP_READINESS_LOCK:
         readiness = _MCP_READINESS.get(profile_home)
@@ -306,15 +334,16 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
             readiness.status == "pending"
             and (readiness.thread is None or not readiness.thread.is_alive())
         ):
-            # Owner thread died without finishing; restart it so waiters
-            # can never hang forever on a stale run.  Completed/failed
-            # profiles are NOT re-run here — only explicit retries
-            # (_mcp_retry_discovery / /reload-mcp) re-run discovery.
-            readiness.status = "pending"
+            # Owner thread died without finishing; restart it as a new
+            # generation so waiters can never hang forever on a stale
+            # run.  Completed/failed profiles are NOT re-run here — only
+            # explicit retries (_mcp_retry_discovery / /reload-mcp).
+            readiness.gen += 1
+            _gen = readiness.gen
             readiness.event = threading.Event()
             readiness.thread = threading.Thread(
                 target=_discovery_runner,
-                args=(discover_fn, readiness, readiness.event),
+                args=(discover_fn, readiness, readiness.event, _gen),
                 name=thread_name,
                 daemon=True,
             )
@@ -325,26 +354,65 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
 def _mcp_wait_readiness(readiness):
     """Block until the profile's discovery run finishes.
 
-    Bounded only by discovery's own internal timeouts (the cross-process
-    lock wait is capped at ~120s); a stuck run cannot hang the turn
-    forever.  Returns the readiness status.
+    Bounded by `_MCP_READINESS_WAIT_CAP_S` (discovery's own internal
+    timeouts plus a hang-safety cap); a stuck run cannot hang the turn
+    forever.  If the cap is hit while the run is still pending, the
+    CURRENT generation is RETIRED (gen bumped, status 'failed', owner
+    released) so a late-finishing thread can never publish terminal
+    state over the caller's outcome.  If a retry started a newer
+    generation mid-wait, the wait rides the newer run.
     """
     if readiness.status == "pending":
-        readiness.event.wait(timeout=120.0)
-        if readiness.status == "pending":
-            # Safety: the owner thread died without setting the event, or
-            # discovery exceeded its own outer bounds.  Surface as failed.
-            readiness.status = "failed"
+        _deadline = time.monotonic() + _MCP_READINESS_WAIT_CAP_S
+        while readiness.status == "pending":
+            _gen = readiness.gen
+            _event = readiness.event
+            _remaining = _deadline - time.monotonic()
+            if _remaining <= 0:
+                break
+            _event.wait(timeout=_remaining)
+            if readiness.gen == _gen and readiness.status == "pending":
+                # Event fired but nothing published for this generation:
+                # the owner died mid-run or discovery outlived its bounds.
+                break
+        if readiness.status == "pending" and readiness.gen == _gen:
+            with _MCP_READINESS_LOCK:
+                if readiness.gen == _gen and readiness.status == "pending":
+                    readiness.gen += 1
+                    readiness.status = "failed"
+                    readiness.thread = None
     return readiness.status
 
 
-def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
-    """Force a fresh discovery run for a failed/never-run profile.
+def _wait_and_surface_mcp_readiness(readiness, profile_home, session_id):
+    """Wait for the profile's discovery run and surface its outcome.
 
-    This is the explicit retry path (mirrors /reload-mcp semantics).
-    Registering tools mid-turn never mutates an in-flight Agent snapshot:
-    hermes-agent only applies registered tools in its per-turn prologue
-    refresh, before the first API call of the next turn.
+    Returns the readiness status ('completed' | 'failed').  A failed run
+    is surfaced at the stream boundary (logged with the profile home)
+    BEFORE the agent snapshot is constructed, so the turn proceeds
+    without MCP tools rather than hanging or pretending discovery
+    succeeded.
+    """
+    _status = _mcp_wait_readiness(readiness)
+    if _status == "failed":
+        logger.warning(
+            "MCP discovery failed for profile %r (session %s) - "
+            "continuing without MCP tools for this turn",
+            profile_home or "default",
+            session_id,
+        )
+    return _status
+
+
+def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
+    """Force a fresh discovery run, retiring the current generation.
+
+    This is the explicit retry path (mirrors /reload-mcp semantics) and
+    is SINGLE-FLIGHT: the previous owner — even if still running — is
+    retired by bumping the generation so it can never publish, and
+    exactly one current owner exists afterwards.  Registering tools
+    mid-turn never mutates an in-flight Agent snapshot: hermes-agent
+    only applies registered tools in its per-turn prologue refresh.
     """
     with _MCP_READINESS_LOCK:
         readiness = _MCP_READINESS.get(profile_home)
@@ -352,10 +420,12 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
             readiness = _McpReadiness()
             _MCP_READINESS[profile_home] = readiness
         readiness.status = "pending"
+        readiness.gen += 1
+        _gen = readiness.gen
         readiness.event = threading.Event()
         readiness.thread = threading.Thread(
             target=_discovery_runner,
-            args=(discover_fn, readiness, readiness.event),
+            args=(discover_fn, readiness, readiness.event, _gen),
             name=thread_name,
             daemon=True,
         )
@@ -368,20 +438,30 @@ def _startup_mcp_discovery():
 
     Lets the default profile's readiness resolve during idle time so the
     first user turn usually finds it already completed/failed instead of
-    waiting.  Uses the getattr-import form so the repo-wide static
-    regression (test_issue1968) that counts exactly one `discover_mcp_tools`
-    call site in api/streaming.py stays valid.
+    waiting.  Only runs when the context-local override API is available:
+    on older agents discovery may only run inside a stream worker's env
+    window (the worker runs it inline there), never on a background
+    thread that could read another stream's profile after env mutation.
+    Uses the getattr-import form so the repo-wide static regression
+    (test_issue1968) that counts exactly one `discover_mcp_tools` call
+    site in api/streaming.py stays valid.
     """
+    try:
+        from api.profiles import _resolve_hermes_home_override
+        if _resolve_hermes_home_override() is None:
+            return
+    except Exception:
+        return
     try:
         from tools.mcp_tool import discover_mcp_tools as _dmt
     except Exception:
         return
 
     def _discover_default():
+        _mcp_home_token = None
         try:
             from api.profiles import _resolve_hermes_home_override
             _hc_mod = _resolve_hermes_home_override()
-            _mcp_home_token = None
             if _hc_mod is not None:
                 _mcp_home = getattr(_hc_mod, 'get_default_hermes_root', lambda: '')()
                 if _mcp_home:
@@ -390,11 +470,12 @@ def _startup_mcp_discovery():
                     )
             try:
                 _dmt()
+                return True
             finally:
                 if _mcp_home_token is not None:
                     _hc_mod.reset_hermes_home_override(_mcp_home_token)
         except Exception:
-            pass  # MCP not available or not configured — non-fatal
+            return False
 
     try:
         _ensure_mcp_discovery('', _discover_default, 'mcp-discovery-startup')
@@ -8918,22 +8999,28 @@ def _run_agent_streaming(
         #
         # The override is resolved through `api.profiles._resolve_hermes_home_override()`
         # (the webui's version gate for the v0.18.0+ API) rather than imported
-        # directly, so OLDER agents fall back to the pre-existing env-mirror
-        # behavior.  On those agents the first pending turn still blocks on
-        # the readiness event, so the env read happens inside this worker's
-        # env window — the pre-PR synchronous semantics are preserved
-        # exactly.  The profile home itself comes from the `_profile_home`
-        # local captured under `_ENV_LOCK` above — re-reading
+        # directly.  On agents WITHOUT the override API the readiness
+        # background owner is NOT used at all: the worker runs discovery
+        # INLINE below (pre-PR synchronous semantics) so the env read
+        # happens inside this worker's env window — a daemon could never
+        # be kept safe from another stream's env mutation on those agents.
+        # The profile home itself comes from the `_profile_home` local
+        # captured under `_ENV_LOCK` above — re-reading
         # `os.environ['HERMES_HOME']` here would race with a concurrent
         # stream's env mutation after the lock is released.
         try:
             from tools.mcp_tool import discover_mcp_tools
 
             def _discover_mcp_background():
+                """Discover MCP tools for this stream's profile; returns bool.
+
+                True = ran to completion; False = the run raised.  The
+                runner needs an explicit outcome (maintainer review).
+                """
+                _mcp_home_token = None
                 try:
                     from api.profiles import _resolve_hermes_home_override
                     _hc_mod = _resolve_hermes_home_override()
-                    _mcp_home_token = None
                     if _hc_mod is not None:
                         _mcp_home = _profile_home
                         if not _mcp_home:
@@ -8950,18 +9037,38 @@ def _run_agent_streaming(
                             )
                     try:
                         discover_mcp_tools()
+                        return True
+                    except Exception:
+                        return False
                     finally:
                         if _mcp_home_token is not None:
                             _hc_mod.reset_hermes_home_override(_mcp_home_token)
                 except Exception:
-                    pass  # MCP not available or not configured — non-fatal
+                    return False
 
-            _readiness = _ensure_mcp_discovery(
-                _profile_home,
-                _discover_mcp_background,
-                'mcp-discovery-%s' % (session_id or 'unknown'),
-            )
-            _mcp_wait_readiness(_readiness)
+            try:
+                from api.profiles import _resolve_hermes_home_override
+                _mcp_override_available = _resolve_hermes_home_override() is not None
+            except Exception:
+                _mcp_override_available = False
+
+            if _mcp_override_available:
+                _readiness = _ensure_mcp_discovery(
+                    _profile_home,
+                    _discover_mcp_background,
+                    'mcp-discovery-%s' % (session_id or 'unknown'),
+                )
+                _wait_and_surface_mcp_readiness(
+                    _readiness, _profile_home, session_id
+                )
+            else:
+                # Older agent: no context-local override — a background
+                # owner would read the process env, which other streams
+                # mutate (cross-profile contamination).  Run discovery
+                # INLINE (pre-PR synchronous semantics) so the env read
+                # happens inside this worker's env window; a daemon can
+                # never read another stream's profile after env mutation.
+                _discover_mcp_background()
         except Exception:
             pass  # MCP import itself failed — non-fatal
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8714,11 +8714,38 @@ def _run_agent_streaming(
         # `_servers` by `(profile_home, name)` upstream in hermes-agent; that
         # lives outside this WebUI repo.  This change fixes the headline bug
         # for users who run a single non-default profile per WebUI process.
+        #
+        # Discovery runs on a BACKGROUND thread: `discover_mcp_tools()`
+        # connects every configured server synchronously (per-server
+        # `connect_timeout`, plus the cross-process discovery lock), so a slow
+        # or unreachable server (e.g. an SSH MCP to a sleeping laptop) stalls
+        # turn start by seconds-to-a-minute on EVERY message.  The CLI/TUI
+        # never pays this because it discovers once at agent startup; the
+        # WebUI builds a fresh worker per stream, so discovery must not sit on
+        # the turn's critical path.  hermes-agent's per-turn prologue
+        # (`refresh_agent_mcp_tools`) folds tools from servers that finish
+        # connecting mid-turn into this turn's first API call, so nothing is
+        # lost — the turn just starts immediately.
         try:
             from tools.mcp_tool import discover_mcp_tools
-            discover_mcp_tools()
+            _mcp_profile_home = os.environ.get('HERMES_HOME', '')
+
+            def _discover_mcp_background():
+                try:
+                    if _mcp_profile_home:
+                        os.environ['HERMES_HOME'] = _mcp_profile_home
+                    discover_mcp_tools()
+                except Exception:
+                    pass  # MCP not available or not configured — non-fatal
+
+            _mcp_thread = threading.Thread(
+                target=_discover_mcp_background,
+                name='mcp-discovery-%s' % (session_id or 'unknown'),
+                daemon=True,
+            )
+            _mcp_thread.start()
         except Exception:
-            pass  # MCP not available or not configured — non-fatal
+            pass  # MCP import itself failed — non-fatal
 
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -275,7 +275,12 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 #     bounded join before shutdown) and then INVALIDATES every other
 #     readiness entry so each profile's next turn re-runs discovery
 #     instead of trusting a stale 'completed'/'failed' state whose
-#     servers were just shut down.
+#     servers were just shut down.  Owner CREATION is fenced behind
+#     `_MCP_RELOAD_FENCE` for the reload's teardown window (snapshot
+#     through shutdown), so a concurrent stream cannot create a new
+#     discovery body that registers servers into or after the shutdown —
+#     the reload validates a COMPLETE owner snapshot, not a stale one
+#     (Greptile round 11).
 #
 # The discovery thread re-asserts the profile home through hermes-agent's
 # CONTEXT-LOCAL override (`set_hermes_home_override`), resolved via the
@@ -289,6 +294,16 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 _MCP_READINESS: dict = {}
 _MCP_READINESS_LOCK = threading.Lock()
 _MCP_READINESS_WAIT_CAP_S = 120.0
+
+# Fence held by /reload-mcp across its teardown window (owner snapshot
+# through `shutdown_mcp_servers`).  Owner CREATION (_ensure_mcp_discovery
+# / _mcp_retry_discovery) blocks on this fence, so a concurrent stream
+# cannot create a discovery body whose registrations overlap the
+# registry shutdown/rebuild (Greptile round 11).  It is a plain lock,
+# not the readiness lock: waiting turns never contend (they only wait on
+# readiness events), only new-owner creation does — and that is bounded
+# by the reload's own join cap.
+_MCP_RELOAD_FENCE = threading.Lock()
 
 
 def _canonical_readiness_key(profile_home):
@@ -376,36 +391,41 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
     NEW generation so waiters can never hang forever on a stale run.
     """
     profile_home = _canonical_readiness_key(profile_home)
-    with _MCP_READINESS_LOCK:
-        readiness = _MCP_READINESS.get(profile_home)
-        if readiness is None:
-            readiness = _McpReadiness()
-            _MCP_READINESS[profile_home] = readiness
-        if (
-            readiness.status == "pending"
-            and (readiness.thread is None or not readiness.thread.is_alive())
-        ):
-            # Owner thread died without finishing; restart it as a new
-            # generation so waiters can never hang forever on a stale
-            # run.  Completed/failed profiles are NOT re-run here — only
-            # explicit retries (_mcp_retry_discovery / /reload-mcp).
-            readiness.gen += 1
-            _gen = readiness.gen
-            readiness.event = threading.Event()
-            readiness.cancel = threading.Event()
-            readiness.thread = threading.Thread(
-                target=_discovery_runner,
-                args=(
-                    discover_fn,
-                    readiness,
-                    readiness.event,
-                    _gen,
-                    readiness.cancel,
-                ),
-                name=thread_name,
-                daemon=True,
-            )
-            readiness.thread.start()
+    with _MCP_RELOAD_FENCE:
+        # Owner creation is fenced behind a global reload's teardown so a
+        # new discovery body can never register servers into (or after) a
+        # registry shutdown (Greptile round 11).  Waiting turns never
+        # contend on the fence — only new-owner creation does.
+        with _MCP_READINESS_LOCK:
+            readiness = _MCP_READINESS.get(profile_home)
+            if readiness is None:
+                readiness = _McpReadiness()
+                _MCP_READINESS[profile_home] = readiness
+            if (
+                readiness.status == "pending"
+                and (readiness.thread is None or not readiness.thread.is_alive())
+            ):
+                # Owner thread died without finishing; restart it as a new
+                # generation so waiters can never hang forever on a stale
+                # run.  Completed/failed profiles are NOT re-run here — only
+                # explicit retries (_mcp_retry_discovery / /reload-mcp).
+                readiness.gen += 1
+                _gen = readiness.gen
+                readiness.event = threading.Event()
+                readiness.cancel = threading.Event()
+                readiness.thread = threading.Thread(
+                    target=_discovery_runner,
+                    args=(
+                        discover_fn,
+                        readiness,
+                        readiness.event,
+                        _gen,
+                        readiness.cancel,
+                    ),
+                    name=thread_name,
+                    daemon=True,
+                )
+                readiness.thread.start()
     return readiness
 
 
@@ -491,30 +511,34 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name):
         # mid-discovery finishes (bounded by its internal timeouts).
         _old_cancel.set()
         _old_thread.join(timeout=_MCP_READINESS_WAIT_CAP_S)
-    with _MCP_READINESS_LOCK:
-        if _old_thread is not None and _old_thread.is_alive():
-            # Physical single-flight: the old body is STILL alive beyond
-            # the cap.  Reject the replacement rather than running two
-            # discovery bodies for one profile.
-            return readiness
-        readiness.status = "pending"
-        readiness.gen += 1
-        _gen = readiness.gen
-        readiness.event = threading.Event()
-        readiness.cancel = threading.Event()
-        readiness.thread = threading.Thread(
-            target=_discovery_runner,
-            args=(
-                discover_fn,
-                readiness,
-                readiness.event,
-                _gen,
-                readiness.cancel,
-            ),
-            name=thread_name,
-            daemon=True,
-        )
-        readiness.thread.start()
+    with _MCP_RELOAD_FENCE:
+        # Owner creation is fenced behind a global reload's teardown so a
+        # new discovery body can never register servers into (or after) a
+        # registry shutdown (Greptile round 11).
+        with _MCP_READINESS_LOCK:
+            if _old_thread is not None and _old_thread.is_alive():
+                # Physical single-flight: the old body is STILL alive beyond
+                # the cap.  Reject the replacement rather than running two
+                # discovery bodies for one profile.
+                return readiness
+            readiness.status = "pending"
+            readiness.gen += 1
+            _gen = readiness.gen
+            readiness.event = threading.Event()
+            readiness.cancel = threading.Event()
+            readiness.thread = threading.Thread(
+                target=_discovery_runner,
+                args=(
+                    discover_fn,
+                    readiness,
+                    readiness.event,
+                    _gen,
+                    readiness.cancel,
+                ),
+                name=thread_name,
+                daemon=True,
+            )
+            readiness.thread.start()
     return readiness
 
 
@@ -531,6 +555,12 @@ def _prepare_global_reload():
     False if any owner survived the cap: the caller MUST fail closed
     (abort the reload) rather than run a discovery body concurrently
     with a registry rebuild (Greptile review round 10).
+
+    The caller MUST hold `_MCP_RELOAD_FENCE` for the duration (snapshot
+    through `shutdown_mcp_servers`): owner creation blocks on the fence,
+    so the snapshot below is COMPLETE — a concurrent stream cannot
+    create a new owner whose registrations would overlap the shutdown
+    (Greptile review round 11).
     """
     with _MCP_READINESS_LOCK:
         _live = [

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -525,6 +525,12 @@ def _prepare_global_reload():
     readiness cap) BEFORE `shutdown_mcp_servers()` clears the
     process-global registry, so a body mid-discovery cannot re-register
     old-config servers after the registry is torn down.
+
+    Returns True only if every live owner TERMINATED within the cap —
+    only then is it safe to shut down and rebuild the registry.  Returns
+    False if any owner survived the cap: the caller MUST fail closed
+    (abort the reload) rather than run a discovery body concurrently
+    with a registry rebuild (Greptile review round 10).
     """
     with _MCP_READINESS_LOCK:
         _live = [
@@ -535,6 +541,11 @@ def _prepare_global_reload():
     for _cancel, _thread in _live:
         _cancel.set()
         _thread.join(timeout=_MCP_READINESS_WAIT_CAP_S)
+    with _MCP_READINESS_LOCK:
+        for _cancel, _thread in _live:
+            if _thread.is_alive():
+                return False
+        return True
 
 
 def _invalidate_mcp_readiness(except_key=None):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -230,6 +230,61 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
     "webui_streaming_cron_profile_home",
     default=None,
 )
+
+# ── MCP discovery: background thread + coalescing ──
+# The per-turn discovery spawn is coalesced per profile home so a busy
+# process never accumulates one daemon thread per message (each
+# `discover_mcp_tools()` can wait up to 120s on the cross-process
+# discovery lock / outer timeout).  `_MCP_DISCOVERY_TURN_JOIN_S` bounds how
+# long the stream worker waits for discovery to finish BEFORE it
+# builds/snapshots the agent, so reachable servers (HTTP/OAuth connects
+# routinely take 2-6s on a cold connect) still land in THIS turn's tool
+# snapshot.  Servers slower than the bound — or unreachable ones like an
+# SSH server pointing at an offline machine — leave the thread running in
+# the background (daemon) and their tools land on the next turn via
+# hermes-agent's per-turn prologue refresh (`agent/turn_context.py`
+# between-turns MCP refresh), matching the CLI/TUI semantics where
+# discovery runs once at agent startup.
+_MCP_DISCOVERY_TURN_JOIN_S = 4.0
+_MCP_DISCOVERY_THREADS: dict = {}
+_MCP_DISCOVERY_THREADS_LOCK = threading.Lock()
+
+
+def _run_mcp_discovery_background(
+    profile_home,
+    discover_fn,
+    thread_name,
+    join_timeout=None,
+):
+    """Run ``discover_fn`` on a coalesced daemon thread; optionally join it.
+
+    One background discovery thread is kept per profile home — a live
+    thread is reused rather than spawned anew, so N rapid messages cannot
+    accumulate N lock-waiting discovery daemons.  When ``join_timeout`` is
+    given, the caller waits up to that long for discovery to finish, which
+    lets the agent build that follows snapshot the freshly registered MCP
+    tools.  A thread that outlives the timeout keeps running in the
+    background (daemon) and its tools land on a later turn.
+
+    Returns the thread.
+    """
+    with _MCP_DISCOVERY_THREADS_LOCK:
+        _existing = _MCP_DISCOVERY_THREADS.get(profile_home)
+        if _existing is not None and _existing.is_alive():
+            _thread = _existing
+        else:
+            _thread = threading.Thread(
+                target=discover_fn,
+                name=thread_name,
+                daemon=True,
+            )
+            _MCP_DISCOVERY_THREADS[profile_home] = _thread
+            _thread.start()
+    if join_timeout is not None:
+        _thread.join(timeout=join_timeout)
+    return _thread
+
+
 _STREAMING_CRONJOB_WRAPPER_INSTALLED = False
 
 
@@ -8722,10 +8777,18 @@ def _run_agent_streaming(
         # turn start by seconds-to-a-minute on EVERY message.  The CLI/TUI
         # never pays this because it discovers once at agent startup; the
         # WebUI builds a fresh worker per stream, so discovery must not sit on
-        # the turn's critical path.  hermes-agent's per-turn prologue
-        # (`refresh_agent_mcp_tools`) folds tools from servers that finish
-        # connecting mid-turn into this turn's first API call, so nothing is
-        # lost — the turn just starts immediately.
+        # the turn's critical path.
+        #
+        # `_run_mcp_discovery_background` spawns (or reuses) a coalesced
+        # daemon thread and then JOINS it for a bounded window
+        # (`_MCP_DISCOVERY_TURN_JOIN_S`) before the agent is built further
+        # below — the agent's tool snapshot therefore includes tools from
+        # reachable servers that connect within that window (HTTP/OAuth
+        # cold connects routinely take 2-6s), preserving first-turn MCP
+        # completeness.  Servers slower than the bound, or unreachable ones,
+        # keep the thread running in the background; their tools land on the
+        # NEXT turn via hermes-agent's between-turns prologue refresh
+        # (`agent/turn_context.py`), matching CLI/TUI semantics.
         #
         # The thread re-asserts the stream's profile home through hermes-agent's
         # CONTEXT-LOCAL override (`set_hermes_home_override`), which
@@ -8764,12 +8827,12 @@ def _run_agent_streaming(
                 except Exception:
                     pass  # MCP not available or not configured — non-fatal
 
-            _mcp_thread = threading.Thread(
-                target=_discover_mcp_background,
-                name='mcp-discovery-%s' % (session_id or 'unknown'),
-                daemon=True,
+            _run_mcp_discovery_background(
+                _profile_home,
+                _discover_mcp_background,
+                'mcp-discovery-%s' % (session_id or 'unknown'),
+                join_timeout=_MCP_DISCOVERY_TURN_JOIN_S,
             )
-            _mcp_thread.start()
         except Exception:
             pass  # MCP import itself failed — non-fatal
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -294,6 +294,30 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 _MCP_READINESS: dict = {}
 _MCP_READINESS_LOCK = threading.Lock()
 _MCP_READINESS_WAIT_CAP_S = 120.0
+# Cooldown before an incomplete/failed discovery is re-attempted by a
+# later turn (maintainer round 15 #2): per-server connection failures are
+# recorded as non-terminal so a transient outage can never permanently
+# strip a profile's MCP tools.
+_MCP_DISCOVERY_RETRY_COOLDOWN_S = 60.0
+# Sentinel returned by the production discovery closures when the call
+# returned normally but ONE OR MORE enabled servers failed to connect —
+# the runner records this as 'failed' + refreshable, NOT completed.
+_MCP_INCOMPLETE = "incomplete"
+
+
+def _normalize_mcp_home(profile_home):
+    """One canonical profile-home normalization for keys AND override values.
+
+    expanduser -> resolve(strict=False) -> normcase, applied consistently so
+    startup, turns, and reload agree on the same authority (maintainer
+    round 15 #3): `~/.hermes` and `/home/hermes/.hermes` must be ONE key.
+    """
+    try:
+        return os.path.normcase(
+            str(os.path.realpath(os.path.expanduser(str(profile_home))))
+        )
+    except Exception:
+        return str(profile_home)
 
 # Fence held by /reload-mcp across its teardown window (owner snapshot
 # through `shutdown_mcp_servers`).  Owner CREATION (_ensure_mcp_discovery
@@ -313,20 +337,46 @@ def _canonical_readiness_key(profile_home):
     (even for the default profile).  Startup and /reload-mcp must use
     the SAME key instead of '' — otherwise the logical default profile
     holds two entries and a global reload refreshes only one
-    (maintainer review round 9).
+    (maintainer review round 9 + round 15 #3).
     """
     if profile_home:
-        return str(profile_home)
+        return _normalize_mcp_home(profile_home)
     try:
         from api.profiles import _resolve_hermes_home_override
         _hc_mod = _resolve_hermes_home_override()
         if _hc_mod is not None:
             _root = getattr(_hc_mod, 'get_default_hermes_root', lambda: '')()
             if _root:
-                return str(_root)
+                return _normalize_mcp_home(_root)
     except Exception:
         pass
     return ''
+
+
+def _mcp_profile_has_connect_errors(profile_home):
+    """True when any enabled server for this profile has a connect error.
+
+    Used for the INCOMPLETE outcome (maintainer round 15 #2): hermes-
+    agent's discovery call returns normally even when a server fails to
+    connect, so 'the call returned' is NOT success.  Also used by
+    `_ensure_mcp_discovery` to heal a stale 'completed' readiness
+    recorded before this fix (a profile whose servers are failing while
+    its readiness claims full success).
+    """
+    try:
+        from tools.mcp_tool import _load_mcp_config, _server_connect_errors
+    except Exception:
+        return False
+    try:
+        _cfg = _load_mcp_config() or {}
+        _enabled = [
+            n for n, _c in _cfg.items() if _c.get('enabled', True) is not False
+        ]
+        if not _enabled:
+            return False
+        return any(n in _server_connect_errors for n in _enabled)
+    except Exception:
+        return False
 
 
 class _McpReadiness:
@@ -342,9 +392,12 @@ class _McpReadiness:
                 start (or to keep waiting) discovery; used by retry and
                 timeout retirement to fence side effects, not just the
                 final label.
+        refresh_at: monotonic deadline (or None) after which a later
+                turn may spawn a cooldown retry owner for an incomplete
+                or failed run (maintainer round 15 #2).
     """
 
-    __slots__ = ("status", "event", "thread", "gen", "cancel")
+    __slots__ = ("status", "event", "thread", "gen", "cancel", "refresh_at")
 
     def __init__(self):
         self.status = "pending"
@@ -352,6 +405,7 @@ class _McpReadiness:
         self.thread = None
         self.gen = 0
         self.cancel = threading.Event()
+        self.refresh_at = None
 
 
 def _discovery_runner(discover_fn, readiness, event, gen, cancel):
@@ -364,19 +418,30 @@ def _discovery_runner(discover_fn, readiness, event, gen, cancel):
     a voided run never performs side effects (registration) — a body
     already mid-discovery cannot be preempted, but the label stays
     fenced and the thread is only ever replaced after a bounded join.
-    The closure returns an explicit bool outcome — a thrown run is
-    recorded as failed.
+    The closure returns an explicit outcome: True (all enabled servers
+    connected), False (the run raised), or `_MCP_INCOMPLETE` (the call
+    returned but some enabled servers failed to connect).  Only a
+    genuinely-complete run is 'completed'; incomplete/failed runs get a
+    cooldown `refresh_at` so a later turn can re-attempt discovery
+    (maintainer round 15 #2).
     """
     if cancel.is_set():
         event.set()
         return
     try:
-        outcome = discover_fn()  # production closures return bool
+        outcome = discover_fn()  # production closures return True/False/INCOMPLETE
     except Exception:
         outcome = False
     with _MCP_READINESS_LOCK:
         if gen == readiness.gen:
-            readiness.status = "completed" if outcome is True else "failed"
+            if outcome is True:
+                readiness.status = "completed"
+                readiness.refresh_at = None
+            else:
+                readiness.status = "failed"
+                readiness.refresh_at = (
+                    time.monotonic() + _MCP_DISCOVERY_RETRY_COOLDOWN_S
+                )
     event.set()
 
 
@@ -432,47 +497,52 @@ def _ensure_mcp_discovery(profile_home, discover_fn, thread_name):
 def _mcp_wait_readiness(readiness):
     """Block until the profile's discovery run finishes.
 
-    Bounded by `_MCP_READINESS_WAIT_CAP_S` (discovery's own internal
-    timeouts plus a hang-safety cap); a stuck run cannot hang the turn
-    forever.  If the cap is hit while the run is still pending, the
-    CURRENT generation is RETIRED (gen bumped, status 'failed', cancel
-    token set) so a late-finishing thread can never publish terminal
-    state over the caller's outcome — but the thread POINTER is NOT
-    cleared while execution continues, and a not-yet-started body sees
-    the cancel token and performs no discovery side effects.  The
-    retired generation's EVENT is signalled after publishing so peer
-    waiters subscribed to that generation observe the terminal 'failed'
-    promptly instead of sleeping out their own full cap.  If a retry
-    started a newer generation mid-wait, the wait rides the newer run.
+    Bounded by `_MCP_READINESS_WAIT_CAP_S` per observed generation
+    (discovery's own internal timeouts plus a hang-safety cap); a stuck
+    run cannot hang the turn forever.  Every iteration snapshots
+    status/gen/event UNDER `_MCP_READINESS_LOCK`, so a concurrent retry
+    can never leave `_gen` unbound or return a bare 'pending'
+    (maintainer round 15 #1).  If the cap is hit while the observed
+    generation is still current and pending, that generation is RETIRED
+    (gen bump, status 'failed', cancel token, cooldown `refresh_at`, and
+    the retired event is SIGNALLED so peer waiters wake promptly — round
+    14).  If a retry started a newer generation mid-wait, the wait rides
+    the replacement for one more bounded cap.
     """
     if readiness.status == "pending":
         _deadline = time.monotonic() + _MCP_READINESS_WAIT_CAP_S
-        while readiness.status == "pending":
-            _gen = readiness.gen
-            _event = readiness.event
+        while True:
+            with _MCP_READINESS_LOCK:
+                if readiness.status != "pending":
+                    return readiness.status
+                _gen = readiness.gen
+                _event = readiness.event
             _remaining = _deadline - time.monotonic()
             if _remaining <= 0:
                 break
             _event.wait(timeout=_remaining)
-            if readiness.gen == _gen and readiness.status == "pending":
-                # Event fired but nothing published for this generation:
-                # the owner died mid-run or discovery outlived its bounds.
-                break
+        # Cap expired for the observed generation.
         _retired_event = None
-        if readiness.status == "pending" and readiness.gen == _gen:
-            with _MCP_READINESS_LOCK:
-                if readiness.gen == _gen and readiness.status == "pending":
-                    readiness.gen += 1
-                    readiness.status = "failed"
-                    readiness.cancel.set()
-                    _retired_event = readiness.event
-            if _retired_event is not None:
-                # Wake peer waiters subscribed to the retired generation
-                # (maintainer round 14): without this, a second
-                # same-profile turn already blocked on the event sleeps
-                # out its own full cap even though the shared result is
-                # terminal.
-                _retired_event.set()
+        with _MCP_READINESS_LOCK:
+            if readiness.gen == _gen and readiness.status == "pending":
+                readiness.gen += 1
+                readiness.status = "failed"
+                readiness.cancel.set()
+                readiness.refresh_at = (
+                    time.monotonic() + _MCP_DISCOVERY_RETRY_COOLDOWN_S
+                )
+                _retired_event = readiness.event
+            elif readiness.status == "pending":
+                # A retry replaced the generation mid-wait: ride the
+                # replacement for one more bounded cap.
+                _deadline = time.monotonic() + _MCP_READINESS_WAIT_CAP_S
+                return _mcp_wait_readiness(readiness)
+        if _retired_event is not None:
+            # Wake peer waiters subscribed to the retired generation
+            # (maintainer round 14): without this, a second same-profile
+            # turn already blocked on the event sleeps out its own full
+            # cap even though the shared result is terminal.
+            _retired_event.set()
     return readiness.status
 
 
@@ -494,6 +564,42 @@ def _wait_and_surface_mcp_readiness(readiness, profile_home, session_id):
             session_id,
         )
     return _status
+
+
+def _maybe_schedule_mcp_retry(readiness, profile_home, discover_fn):
+    """Spawn ONE nonblocking cooldown retry owner when the run is refreshable.
+
+    Maintainer round 15 #2: per-server connection failures previously
+    made readiness terminal forever (the wrappers treated 'the call
+    returned' as success).  Now a failed run — or a stale 'completed'
+    whose servers currently have connect errors — is REFRESHABLE: after
+    `_MCP_DISCOVERY_RETRY_COOLDOWN_S`, a turn schedules one background
+    retry owner (single-flight: never while an owner is alive) so a
+    later turn finds freshly registered tools without /reload-mcp.
+
+    Runs off the turn's critical path: the caller has already resolved
+    readiness and the retry is purely additive.
+    """
+    try:
+        with _MCP_READINESS_LOCK:
+            _refreshable = readiness.status == "failed"
+            _stale_completed = (
+                readiness.status == "completed"
+                and _mcp_profile_has_connect_errors(profile_home)
+            )
+            if not (_refreshable or _stale_completed):
+                return
+            if readiness.refresh_at is not None and time.monotonic() < readiness.refresh_at:
+                return
+            if readiness.thread is not None and readiness.thread.is_alive():
+                return  # single-flight: an owner is already running
+        threading.Thread(
+            target=_mcp_retry_discovery,
+            args=(profile_home, discover_fn, "mcp-cooldown-retry"),
+            daemon=True,
+        ).start()
+    except Exception:
+        logger.debug("cooldown MCP retry scheduling failed", exc_info=True)
 
 
 def _mcp_retry_discovery(profile_home, discover_fn, thread_name, _fence_held=False):
@@ -546,6 +652,7 @@ def _mcp_retry_discovery(profile_home, discover_fn, thread_name, _fence_held=Fal
                 # discovery bodies for one profile.
                 return readiness
             readiness.status = "pending"
+            readiness.refresh_at = None
             readiness.gen += 1
             _gen = readiness.gen
             readiness.event = threading.Event()
@@ -603,14 +710,18 @@ def _prepare_global_reload():
 
 
 def _invalidate_mcp_readiness(except_key=None):
-    """Remove every readiness entry except the reload's own refreshed one.
+    """Remove readiness entries.
 
-    A global reload rebuilt the process-global MCP registry, so any
-    other profile's 'completed'/'failed' readiness is stale — its next
-    turn must re-run discovery instead of trusting old state whose
-    servers were just shut down.  The except_key entry was refreshed by
-    the reload run itself and stays.
+    With an explicit except_key, remove every entry except that one (the
+    reload's own refreshed entry stays).  With except_key=None, remove
+    ALL entries — used on the reload teardown FAILURE path when the
+    registry was partially mutated, so no profile trusts stale state
+    after a failed reload (maintainer round 15 #4).
     """
+    if except_key is None:
+        with _MCP_READINESS_LOCK:
+            _MCP_READINESS.clear()
+        return
     except_key = _canonical_readiness_key(except_key or '')
     with _MCP_READINESS_LOCK:
         for _key in [k for k in list(_MCP_READINESS) if k != except_key]:
@@ -656,15 +767,35 @@ def _startup_mcp_discovery():
                     )
             try:
                 _dmt()
-                return True
+            except Exception:
+                return False
             finally:
                 if _mcp_home_token is not None:
                     _hc_mod.reset_hermes_home_override(_mcp_home_token)
+            # Any enabled server with a connect error = incomplete, not
+            # success (maintainer round 15 #2).
+            if _mcp_profile_has_connect_errors(''):
+                return _MCP_INCOMPLETE
+            return True
         except Exception:
             return False
 
     try:
         _ensure_mcp_discovery('', _discover_default, 'mcp-discovery-startup')
+    except Exception:
+        pass
+
+
+def _startup_mcp_discovery_best_effort():
+    """Kick off default-profile MCP discovery at process start.
+
+    server.py calls this during startup (never blocks): the default
+    profile's readiness resolves during idle time so the first user turn
+    usually finds it completed/failed instead of waiting.  Best-effort —
+    any failure is swallowed (the first turn re-attempts anyway).
+    """
+    try:
+        _startup_mcp_discovery()
     except Exception:
         pass
 
@@ -9198,10 +9329,13 @@ def _run_agent_streaming(
             from tools.mcp_tool import discover_mcp_tools
 
             def _discover_mcp_background():
-                """Discover MCP tools for this stream's profile; returns bool.
+                """Discover MCP tools for this stream's profile.
 
-                True = ran to completion; False = the run raised.  The
-                runner needs an explicit outcome (maintainer review).
+                Returns True when every enabled server connected, False
+                when the run raised, or `_MCP_INCOMPLETE` when the call
+                returned but some enabled servers failed to connect
+                (maintainer round 15 #2).  The runner needs the explicit
+                outcome: 'the call returned' is NOT success.
                 """
                 _mcp_home_token = None
                 try:
@@ -9223,12 +9357,14 @@ def _run_agent_streaming(
                             )
                     try:
                         discover_mcp_tools()
-                        return True
                     except Exception:
                         return False
                     finally:
                         if _mcp_home_token is not None:
                             _hc_mod.reset_hermes_home_override(_mcp_home_token)
+                    if _mcp_profile_has_connect_errors(_profile_home):
+                        return _MCP_INCOMPLETE
+                    return True
                 except Exception:
                     return False
 
@@ -9244,9 +9380,18 @@ def _run_agent_streaming(
                     _discover_mcp_background,
                     'mcp-discovery-%s' % (session_id or 'unknown'),
                 )
-                _wait_and_surface_mcp_readiness(
+                _readiness_status = _wait_and_surface_mcp_readiness(
                     _readiness, _profile_home, session_id
                 )
+                # Incomplete/failed runs (and stale 'completed' runs whose
+                # servers now have connect errors) are REFRESHABLE: after
+                # the cooldown, schedule one background retry owner so a
+                # later turn finds freshly registered tools without
+                # /reload-mcp (maintainer round 15 #2).
+                if _readiness_status in ("failed", "completed"):
+                    _maybe_schedule_mcp_retry(
+                        _readiness, _profile_home, _discover_mcp_background
+                    )
             else:
                 # Older agent: no context-local override — a background
                 # owner would read the process env, which other streams

--- a/server.py
+++ b/server.py
@@ -580,25 +580,15 @@ def main() -> None:
         if result.get("restored"):
             print(f"[recovery] Restored {result['restored']}/{result['scanned']} sessions from .bak (see #1558).", flush=True)
     except Exception as exc:
-        # Recovery is best-effort; never block server startup.
         print(f"[recovery] startup recovery failed: {exc}", flush=True)
 
-    # Kick off default-profile MCP discovery in the background so the first
-    # user turn usually finds readiness already resolved (completed or
-    # failed) instead of waiting on the shared readiness event.  See
-    # api/streaming.py `_startup_mcp_discovery`.  Never blocks startup.
-    try:
-        from api.streaming import _startup_mcp_discovery
-        _startup_mcp_discovery()
-    except Exception:
-        pass
+    # Kick off default-profile MCP discovery (never blocks startup).
+    from api.streaming import _startup_mcp_discovery_best_effort; _startup_mcp_discovery_best_effort()
 
-    within_container = False
     try:
-        with open('/.within_container', 'r') as f:
-            within_container = True
+        within_container = bool(open('/.within_container', 'r').read())
     except FileNotFoundError:
-        pass
+        within_container = False
 
     if within_container:
         print('[ok] Running within container.', flush=True)

--- a/server.py
+++ b/server.py
@@ -583,6 +583,16 @@ def main() -> None:
         # Recovery is best-effort; never block server startup.
         print(f"[recovery] startup recovery failed: {exc}", flush=True)
 
+    # Kick off default-profile MCP discovery in the background so the first
+    # user turn usually finds readiness already resolved (completed or
+    # failed) instead of waiting on the shared readiness event.  See
+    # api/streaming.py `_startup_mcp_discovery`.  Never blocks startup.
+    try:
+        from api.streaming import _startup_mcp_discovery
+        _startup_mcp_discovery()
+    except Exception:
+        pass
+
     within_container = False
     try:
         with open('/.within_container', 'r') as f:

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -539,6 +539,78 @@ def test_reload_mcp_invalidates_other_profile_entries(monkeypatch):
     assert streaming._mcp_wait_readiness(refreshed) == "completed"
 
 
+def test_reload_mcp_aborts_when_owner_survives_join_cap(monkeypatch):
+    """A global reload fails CLOSED if a discovery owner survives the join cap.
+
+    Regression (Greptile review round 10): `_prepare_global_reload` used
+    a bounded join without verifying termination, then the reload
+    unconditionally shut down and rebuilt the registry — letting an old
+    discovery body overlap the rebuild and re-register old-config
+    servers.  The reload now aborts BEFORE shutdown when any owner is
+    still alive after the cap.
+    """
+    from api import streaming
+    from api.commands import execute_agent_command
+
+    _old_cap = streaming._MCP_READINESS_WAIT_CAP_S
+    streaming._MCP_READINESS_WAIT_CAP_S = 0.1
+    try:
+        # A live discovery owner that outlives the (tiny) join cap.
+        readiness = streaming._McpReadiness()
+        release = threading.Event()
+
+        def long_discover():
+            release.wait(5.0)
+            return True
+
+        t = threading.Thread(
+            target=streaming._discovery_runner,
+            args=(
+                long_discover,
+                readiness,
+                readiness.event,
+                readiness.gen,
+                readiness.cancel,
+            ),
+            name="mcp-reload-test-survivor",
+            daemon=True,
+        )
+        readiness.thread = t
+        t.start()
+        streaming._MCP_READINESS["/profiles/zombie"] = readiness
+
+        calls = {"shutdown": 0, "discover": 0}
+
+        def shutdown():
+            calls["shutdown"] += 1
+
+        def discover():
+            calls["discover"] += 1
+            return []
+
+        _install_fake_mcp_tool(
+            monkeypatch, shutdown=shutdown, discover=discover, servers={}
+        )
+
+        output = execute_agent_command("/reload-mcp")
+        assert "aborted" in output.lower(), (
+            "reload must fail closed when a discovery owner survives "
+            "the join cap"
+        )
+        assert calls["shutdown"] == 0, (
+            "reload must not shut down the registry over a live owner"
+        )
+        assert calls["discover"] == 0, (
+            "reload must not re-discover while a live owner is still running"
+        )
+        # The survivor keeps running and resolves on its own.
+        release.set()
+        t.join(timeout=2.0)
+        assert readiness.status == "completed"
+    finally:
+        streaming._MCP_READINESS_WAIT_CAP_S = _old_cap
+
+
 def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):
     """Without the override API, reload discovery runs INLINE, never daemon.
 

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -476,11 +476,67 @@ def test_reload_mcp_uses_default_profile_authority(monkeypatch):
     assert "discover" in calls
     assert ("reset", override_token) in calls
     assert "Reloaded MCP servers from configuration." in output
-    default_readiness = streaming._MCP_READINESS.get("")
+    default_readiness = streaming._MCP_READINESS.get("/default/hermes/home")
     assert default_readiness is not None, (
-        "reload must update the DEFAULT profile readiness authority"
+        "reload must update the DEFAULT profile readiness authority "
+        "(canonical resolved home key)"
     )
     assert streaming._mcp_wait_readiness(default_readiness) == "completed"
+
+
+def test_reload_mcp_invalidates_other_profile_entries(monkeypatch):
+    """A global reload must invalidate every OTHER profile's readiness.
+
+    Regression (maintainer review round 9): the reload refreshed only its
+    own key, leaving default-path and named-profile entries falsely
+    'completed' after their servers were deleted by the global shutdown.
+    The reload now removes every other entry so each profile's next turn
+    re-runs discovery.
+    """
+    from api import profiles
+    from api import streaming
+    from api.commands import execute_agent_command
+
+    class _FakeOverride:
+        def set_hermes_home_override(self, home):
+            return "tok"
+
+        def reset_hermes_home_override(self, token):
+            pass
+
+        def get_default_hermes_root(self):
+            return "/default/hermes/home"
+
+    monkeypatch.setattr(
+        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+    )
+
+    # Seed a stale named-profile entry and a stale default entry.
+    stale_named = streaming._McpReadiness()
+    stale_named.status = "completed"
+    streaming._MCP_READINESS["/profiles/beta"] = stale_named
+    stale_default = streaming._McpReadiness()
+    stale_default.status = "completed"
+    streaming._MCP_READINESS["/default/hermes/home"] = stale_default
+
+    def shutdown():
+        pass
+
+    def discover():
+        return []
+
+    _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
+
+    execute_agent_command("/reload-mcp")
+
+    assert "/profiles/beta" not in streaming._MCP_READINESS, (
+        "named-profile readiness must be invalidated by a global reload"
+    )
+    refreshed = streaming._MCP_READINESS.get("/default/hermes/home")
+    assert refreshed is not None, (
+        "the reload's own canonical entry must stay (refreshed by the run)"
+    )
+    assert streaming._mcp_wait_readiness(refreshed) == "completed"
 
 
 def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -653,17 +653,16 @@ def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):
     assert "Reloaded MCP servers from configuration." in output
 
 
-def test_reload_mcp_fence_covers_the_whole_rebuild(monkeypatch):
-    """A stream cannot create an owner during the reload's REBUILD window.
+def test_reload_mcp_does_not_stall_unrelated_first_turn(monkeypatch):
+    """A new-profile first turn never blocks for the reload's discovery wait.
 
-    Regression (Greptile review round 12): the fence used to end right
-    after registry shutdown, while the reload's replacement discovery
-    and readiness invalidation ran LATER.  A concurrent stream could
-    spawn a new owner in that interval, register servers concurrently
-    with the reload's own rebuild, and then be invalidated as stale.  The
-    fence now stays held until the entire reload completes (retry
-    spawn, wait, invalidation), so a fresh registration can never
-    overlap the rebuild.
+    Regression (Greptile review round 13): round 12 held the
+    owner-creation fence across the ENTIRE rebuild, so an unrelated
+    first turn for a NEW profile blocked until the reload's replacement
+    discovery completed (up to the readiness cap).  The fence now covers
+    only the destructive phase (prepare, shutdown, invalidation) and is
+    released before the additive phase, so new-profile owners can be
+    created while the replacement discovery runs.
     """
     import threading
     import time
@@ -707,16 +706,15 @@ def test_reload_mcp_fence_covers_the_whole_rebuild(monkeypatch):
             reload_holder["output"] = execute_agent_command("/reload-mcp")
         except Exception as exc:  # pragma: no cover - failure path
             reload_holder["error"] = repr(exc)
-        reload_holder["finished_at"] = time.monotonic()
         reload_done.set()
 
     rt = threading.Thread(target=_do_reload, daemon=True)
     rt.start()
     assert discover_entered.wait(2.0), "reload never entered replacement discovery"
 
-    # A stream worker for ANOTHER profile tries to create an owner while
-    # the reload's rebuild is still in flight.  It must BLOCK on the
-    # fence, not register servers concurrently with the rebuild.
+    # A first turn for a NEW profile tries to create an owner while the
+    # reload's replacement discovery is still in flight.  It must NOT
+    # stall: the additive phase is unfenced.
     ensure_done = threading.Event()
     ensure_holder = {}
 
@@ -724,32 +722,26 @@ def test_reload_mcp_fence_covers_the_whole_rebuild(monkeypatch):
         ensure_holder["readiness"] = streaming._ensure_mcp_discovery(
             "/profiles/other", lambda: True, "t-other"
         )
-        ensure_holder["returned_at"] = time.monotonic()
         ensure_done.set()
 
     et = threading.Thread(target=_do_ensure, daemon=True)
     et.start()
-    time.sleep(0.3)  # gate still closed → reload mid-rebuild
-    assert not ensure_done.is_set(), (
-        "owner creation must be fenced while the reload's replacement "
-        "discovery is in flight"
+    time.sleep(0.3)  # gate still closed → replacement discovery in flight
+    assert ensure_done.is_set(), (
+        "a new-profile first turn must NOT block for the reload's "
+        "replacement discovery wait"
     )
 
-    # Let the reload finish; then the fenced creator may proceed.
+    # Let the reload finish; the fenced creator's entry must survive
+    # (invalidation ran BEFORE any post-shutdown owner was created).
     gate.set()
     rt.join(timeout=3.0)
     assert reload_done.is_set(), "reload did not finish"
     et.join(timeout=3.0)
-    assert ensure_done.is_set(), "fenced owner creation never ran"
-
-    # The new owner must start only AFTER the reload fully completed
-    # (never mid-rebuild), and its readiness must survive (never be
-    # invalidated out from under a fresh registration).
-    assert ensure_holder["returned_at"] >= reload_holder["finished_at"] - 0.01, (
-        "the fenced owner was created while the reload was still rebuilding"
-    )
     other = streaming._MCP_READINESS.get("/profiles/other")
-    assert other is not None, "the fenced profile's readiness was invalidated"
+    assert other is not None, (
+        "a fresh post-reload registration must not be invalidated as stale"
+    )
     assert streaming._mcp_wait_readiness(other) == "completed"
     assert "Reloaded MCP servers from configuration." in reload_holder["output"]
 

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -653,6 +653,107 @@ def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):
     assert "Reloaded MCP servers from configuration." in output
 
 
+def test_reload_mcp_fence_covers_the_whole_rebuild(monkeypatch):
+    """A stream cannot create an owner during the reload's REBUILD window.
+
+    Regression (Greptile review round 12): the fence used to end right
+    after registry shutdown, while the reload's replacement discovery
+    and readiness invalidation ran LATER.  A concurrent stream could
+    spawn a new owner in that interval, register servers concurrently
+    with the reload's own rebuild, and then be invalidated as stale.  The
+    fence now stays held until the entire reload completes (retry
+    spawn, wait, invalidation), so a fresh registration can never
+    overlap the rebuild.
+    """
+    import threading
+    import time
+
+    from api import profiles
+    from api import streaming
+    from api.commands import execute_agent_command
+
+    class _FakeOverride:
+        def set_hermes_home_override(self, home):
+            return "tok"
+
+        def reset_hermes_home_override(self, token):
+            pass
+
+        def get_default_hermes_root(self):
+            return "/default/hermes/home"
+
+    monkeypatch.setattr(
+        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+    )
+
+    gate = threading.Event()
+    discover_entered = threading.Event()
+
+    def shutdown():
+        pass
+
+    def discover():
+        discover_entered.set()
+        gate.wait(5.0)  # reload's replacement discovery is IN FLIGHT
+        return []
+
+    _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
+
+    reload_done = threading.Event()
+    reload_holder = {}
+
+    def _do_reload():
+        try:
+            reload_holder["output"] = execute_agent_command("/reload-mcp")
+        except Exception as exc:  # pragma: no cover - failure path
+            reload_holder["error"] = repr(exc)
+        reload_holder["finished_at"] = time.monotonic()
+        reload_done.set()
+
+    rt = threading.Thread(target=_do_reload, daemon=True)
+    rt.start()
+    assert discover_entered.wait(2.0), "reload never entered replacement discovery"
+
+    # A stream worker for ANOTHER profile tries to create an owner while
+    # the reload's rebuild is still in flight.  It must BLOCK on the
+    # fence, not register servers concurrently with the rebuild.
+    ensure_done = threading.Event()
+    ensure_holder = {}
+
+    def _do_ensure():
+        ensure_holder["readiness"] = streaming._ensure_mcp_discovery(
+            "/profiles/other", lambda: True, "t-other"
+        )
+        ensure_holder["returned_at"] = time.monotonic()
+        ensure_done.set()
+
+    et = threading.Thread(target=_do_ensure, daemon=True)
+    et.start()
+    time.sleep(0.3)  # gate still closed → reload mid-rebuild
+    assert not ensure_done.is_set(), (
+        "owner creation must be fenced while the reload's replacement "
+        "discovery is in flight"
+    )
+
+    # Let the reload finish; then the fenced creator may proceed.
+    gate.set()
+    rt.join(timeout=3.0)
+    assert reload_done.is_set(), "reload did not finish"
+    et.join(timeout=3.0)
+    assert ensure_done.is_set(), "fenced owner creation never ran"
+
+    # The new owner must start only AFTER the reload fully completed
+    # (never mid-rebuild), and its readiness must survive (never be
+    # invalidated out from under a fresh registration).
+    assert ensure_holder["returned_at"] >= reload_holder["finished_at"] - 0.01, (
+        "the fenced owner was created while the reload was still rebuilding"
+    )
+    other = streaming._MCP_READINESS.get("/profiles/other")
+    assert other is not None, "the fenced profile's readiness was invalidated"
+    assert streaming._mcp_wait_readiness(other) == "completed"
+    assert "Reloaded MCP servers from configuration." in reload_holder["output"]
+
+
 def test_reload_skills_command_formats_helper_diff(monkeypatch):
     """`/reload-skills` should summarize the shared helper diff in printable text."""
     def reload_skills():

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -653,6 +653,62 @@ def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):
     assert "Reloaded MCP servers from configuration." in output
 
 
+def test_reload_clears_readiness_when_shutdown_raises(monkeypatch):
+    """A reload that raises after mutating the registry must not leave stale state.
+
+    Regression (maintainer round 15 #4): `shutdown_mcp_servers()` used
+    to be able to mutate the registry and then raise, skipping the
+    invalidation — leaving 'completed' readiness that prevented the next
+    turn from rediscovering tools.  Once teardown begins, EVERY
+    readiness entry (including the default) is cleared before the failure
+    propagates.
+    """
+    import pytest
+
+    from api import profiles
+    from api import streaming
+    from api.commands import execute_agent_command
+
+    class _FakeOverride:
+        def set_hermes_home_override(self, home):
+            return "tok"
+
+        def reset_hermes_home_override(self, token):
+            pass
+
+        def get_default_hermes_root(self):
+            return "/default/hermes/home"
+
+    monkeypatch.setattr(
+        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+    )
+
+    # Seed stale entries that must NOT survive a failed teardown.
+    for _key in ("/profiles/beta", "/default/hermes/home"):
+        _entry = streaming._McpReadiness()
+        _entry.status = "completed"
+        streaming._MCP_READINESS[_key] = _entry
+
+    def shutdown():
+        raise RuntimeError("registry partially mutated")
+
+    def discover():
+        return []
+
+    _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
+
+    with pytest.raises(RuntimeError) as exc:
+        execute_agent_command("/reload-mcp")
+    assert str(exc.value) == "Failed to reload MCP servers"
+    assert "/profiles/beta" not in streaming._MCP_READINESS, (
+        "once teardown begins, a raising reload must invalidate every "
+        "entry it touched"
+    )
+    assert "/default/hermes/home" not in streaming._MCP_READINESS, (
+        "a raising reload must also invalidate the DEFAULT profile entry"
+    )
+
+
 def test_reload_mcp_does_not_stall_unrelated_first_turn(monkeypatch):
     """A new-profile first turn never blocks for the reload's discovery wait.
 

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -414,6 +414,100 @@ def test_reload_mcp_error_is_generic(monkeypatch):
     assert calls == ["shutdown"]
 
 
+def test_reload_mcp_installs_profile_override(monkeypatch):
+    """`/reload-mcp`'s re-discovery must assert the profile home.
+
+    Greptile P1: the reload closure previously called discover_mcp_tools()
+    without a context-local override, so a concurrent stream mutating
+    HERMES_HOME could make the reload discover the WRONG profile's
+    servers.  The closure now installs the override exactly like the
+    stream worker's discovery closure.
+    """
+    import os
+    from api import profiles
+    from api.commands import execute_agent_command
+
+    calls = []
+    override_token = "tok-123"
+
+    class _FakeOverride:
+        def set_hermes_home_override(self, home):
+            calls.append(("set", home))
+            return override_token
+
+        def reset_hermes_home_override(self, token):
+            calls.append(("reset", token))
+
+        def get_default_hermes_root(self):
+            calls.append("default_root")
+            return "/default/hermes/home"
+
+    monkeypatch.setattr(
+        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+    )
+
+    def shutdown():
+        calls.append("shutdown")
+
+    def discover():
+        calls.append("discover")
+        return []
+
+    _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
+    monkeypatch.setenv("HERMES_HOME", "/profiles/alpha")
+
+    output = execute_agent_command("/reload-mcp")
+
+    assert ("set", "/profiles/alpha") in calls, (
+        "reload discovery must assert the captured profile home"
+    )
+    assert "discover" in calls
+    assert ("reset", override_token) in calls
+    assert "Reloaded MCP servers from configuration." in output
+
+
+def test_reload_mcp_default_profile_uses_default_root(monkeypatch):
+    """With HERMES_HOME unset, the reload override falls back to the root."""
+    import os
+    from api import profiles
+    from api.commands import execute_agent_command
+
+    calls = []
+    override_token = "tok-456"
+
+    class _FakeOverride:
+        def set_hermes_home_override(self, home):
+            calls.append(("set", home))
+            return override_token
+
+        def reset_hermes_home_override(self, token):
+            calls.append(("reset", token))
+
+        def get_default_hermes_root(self):
+            calls.append("default_root")
+            return "/default/hermes/home"
+
+    monkeypatch.setattr(
+        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+    )
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    def shutdown():
+        calls.append("shutdown")
+
+    def discover():
+        calls.append("discover")
+        return []
+
+    _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
+
+    execute_agent_command("/reload-mcp")
+
+    assert "default_root" in calls
+    assert ("set", "/default/hermes/home") in calls
+    assert ("reset", override_token) in calls
+
+
 def test_reload_skills_command_formats_helper_diff(monkeypatch):
     """`/reload-skills` should summarize the shared helper diff in printable text."""
     def reload_skills():

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -414,17 +414,20 @@ def test_reload_mcp_error_is_generic(monkeypatch):
     assert calls == ["shutdown"]
 
 
-def test_reload_mcp_installs_profile_override(monkeypatch):
-    """`/reload-mcp`'s re-discovery must assert the profile home.
+def test_reload_mcp_uses_default_profile_authority(monkeypatch):
+    """`/reload-mcp` re-discovery must use the DEFAULT profile, not env.
 
-    Greptile P1: the reload closure previously called discover_mcp_tools()
-    without a context-local override, so a concurrent stream mutating
-    HERMES_HOME could make the reload discover the WRONG profile's
-    servers.  The closure now installs the override exactly like the
-    stream worker's discovery closure.
+    Greptile P1: the reload previously keyed off the exec-time
+    HERMES_HOME env, which a concurrent stream can mutate — the reload
+    could capture another profile.  /reload-mcp is a global operation,
+    so its authority is deterministically the default profile (''):
+    even with HERMES_HOME set to another profile, the discovery closure
+    asserts the DEFAULT root override and the default readiness entry
+    is updated.
     """
     import os
     from api import profiles
+    from api import streaming
     from api.commands import execute_agent_command
 
     calls = []
@@ -458,39 +461,43 @@ def test_reload_mcp_installs_profile_override(monkeypatch):
 
     output = execute_agent_command("/reload-mcp")
 
-    assert ("set", "/profiles/alpha") in calls, (
-        "reload discovery must assert the captured profile home"
+    assert ("set", "/default/hermes/home") in calls, (
+        "reload discovery must assert the DEFAULT profile home, never the "
+        "exec-time env (a concurrent stream can mutate it)"
+    )
+    captured_homes = [
+        entry[1]
+        for entry in calls
+        if isinstance(entry, tuple) and len(entry) == 2 and entry[0] == "set"
+    ]
+    assert "/profiles/alpha" not in captured_homes, (
+        "reload must never key off another profile's env value"
     )
     assert "discover" in calls
     assert ("reset", override_token) in calls
     assert "Reloaded MCP servers from configuration." in output
+    default_readiness = streaming._MCP_READINESS.get("")
+    assert default_readiness is not None, (
+        "reload must update the DEFAULT profile readiness authority"
+    )
+    assert streaming._mcp_wait_readiness(default_readiness) == "completed"
 
 
-def test_reload_mcp_default_profile_uses_default_root(monkeypatch):
-    """With HERMES_HOME unset, the reload override falls back to the root."""
-    import os
+def test_reload_mcp_legacy_agent_runs_inline(monkeypatch):
+    """Without the override API, reload discovery runs INLINE, never daemon.
+
+    Greptile P1: on older agents the retry previously ran discovery on a
+    background thread with no profile-local override, so another stream
+    mutating HERMES_HOME could make it register that stream's servers.
+    The inline path mirrors the stream worker's old-agent fallback.
+    """
     from api import profiles
+    from api import streaming
     from api.commands import execute_agent_command
 
     calls = []
-    override_token = "tok-456"
 
-    class _FakeOverride:
-        def set_hermes_home_override(self, home):
-            calls.append(("set", home))
-            return override_token
-
-        def reset_hermes_home_override(self, token):
-            calls.append(("reset", token))
-
-        def get_default_hermes_root(self):
-            calls.append("default_root")
-            return "/default/hermes/home"
-
-    monkeypatch.setattr(
-        profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
-    )
-    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(profiles, "_resolve_hermes_home_override", lambda: None)
 
     def shutdown():
         calls.append("shutdown")
@@ -501,11 +508,21 @@ def test_reload_mcp_default_profile_uses_default_root(monkeypatch):
 
     _install_fake_mcp_tool(monkeypatch, shutdown=shutdown, discover=discover, servers={})
 
-    execute_agent_command("/reload-mcp")
+    retry_calls = []
+    wait_calls = []
+    monkeypatch.setattr(
+        streaming, "_mcp_retry_discovery", lambda *a, **k: retry_calls.append(a)
+    )
+    monkeypatch.setattr(
+        streaming, "_mcp_wait_readiness", lambda *a, **k: wait_calls.append(a)
+    )
 
-    assert "default_root" in calls
-    assert ("set", "/default/hermes/home") in calls
-    assert ("reset", override_token) in calls
+    output = execute_agent_command("/reload-mcp")
+
+    assert not retry_calls, "old-agent reload must not background discovery"
+    assert not wait_calls
+    assert "discover" in calls
+    assert "Reloaded MCP servers from configuration." in output
 
 
 def test_reload_skills_command_formats_helper_diff(monkeypatch):

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -52,6 +52,36 @@ def test_discovery_call_is_inside_a_nested_function():
     )
 
 
+def test_discovery_thread_uses_context_local_home_not_env():
+    """The thread must assert the profile home via hermes-agent's contextvar.
+
+    Regression: the discovery thread originally re-wrote
+    ``os.environ['HERMES_HOME']``. The stream worker mutates that env var
+    under ``_ENV_LOCK`` and restores it at teardown, so a discovery thread
+    that outlives its stream (the whole point of backgrounding it — an
+    unreachable server holds the thread for the full connect timeout) would
+    write the stale profile into the process env and cross-contaminate other
+    streams. hermes-agent's ``get_hermes_home()`` resolves the context-local
+    override (`set_hermes_home_override`) before the env var, and that
+    override is thread-local — it dies with the discovery thread.
+    """
+    call_idx = _call_line_index()
+    preceding = LINES[max(0, call_idx - 16):call_idx]
+    assert any("set_hermes_home_override" in line for line in preceding), (
+        "The discovery thread must assert the profile home through the "
+        "context-local override (set_hermes_home_override), never by writing "
+        "os.environ['HERMES_HOME']."
+    )
+    assert not any(
+        "os.environ['HERMES_HOME']" in line
+        and "set_hermes_home_override" not in line
+        for line in preceding
+    ), (
+        "The discovery thread must not mutate os.environ['HERMES_HOME'] — "
+        "that env write races with the stream worker's _ENV_LOCK restore."
+    )
+
+
 def test_discovery_runs_in_a_daemon_background_thread():
     """The nested function must be spawned as a daemon thread, never joined."""
     call_idx = _call_line_index()

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -72,9 +72,16 @@ def test_discovery_thread_uses_context_local_home_not_env():
         "context-local override (set_hermes_home_override), never by writing "
         "os.environ['HERMES_HOME']."
     )
+    assert any("_resolve_hermes_home_override" in line for line in preceding), (
+        "The override must come from the webui's version-gated resolver "
+        "(api.profiles._resolve_hermes_home_override), not a direct "
+        "hermes_constants import — a direct import silently skips discovery "
+        "on older agents that lack the v0.18.0+ override API."
+    )
     assert not any(
         "os.environ['HERMES_HOME']" in line
         and "set_hermes_home_override" not in line
+        and not line.lstrip().startswith("#")
         for line in preceding
     ), (
         "The discovery thread must not mutate os.environ['HERMES_HOME'] — "

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -1,4 +1,4 @@
-"""Regression test for MCP discovery blocking turn start in the WebUI.
+"""Regression tests for MCP discovery blocking turn start in the WebUI.
 
 The bug: `_run_agent_streaming` called `discover_mcp_tools()` synchronously on
 every message. `discover_mcp_tools()` connects every configured MCP server
@@ -10,16 +10,21 @@ The CLI/TUI never pays this cost per message because it discovers MCP servers
 once at agent startup. The WebUI builds a fresh worker per stream, so discovery
 must not sit on the turn's critical path.
 
-The fix runs discovery on a daemon background thread. hermes-agent's per-turn
-prologue (`refresh_agent_mcp_tools`) folds tools from servers that finish
-connecting mid-turn into the current turn's first API call, so no tools are
-lost — the turn just starts immediately.
+The fix runs discovery through `_run_mcp_discovery_background`: a coalesced
+daemon thread (one per profile home, so messages can't accumulate lock-waiting
+daemons) that the stream worker joins for a bounded window BEFORE the agent
+builds/snapshots its tools. Reachable servers that connect within the window
+land in THIS turn's snapshot (first-turn completeness); slower or unreachable
+servers keep the thread running in the background and their tools land on the
+next turn via hermes-agent's between-turns prologue refresh. The thread
+re-asserts the stream's profile home through the context-local override
+(`set_hermes_home_override`) instead of mutating the process env, so a delayed
+thread can never cross-contaminate another stream.
 
-This is a static check (same precedent as
-`test_issue1968_mcp_profile_discovery.py`): mocking the entire agent stack to
-reach the call site would be brittle and would miss the actual structural
-shape that's the load-bearing fix — the call must live in a function that is
-spawned (not invoked inline) as a daemon `threading.Thread` target.
+The structural checks here are static (same precedent as
+`test_issue1968_mcp_profile_discovery.py`); the real production-path behavior
+of `_run_mcp_discovery_background` is exercised at runtime by
+`test_mcp_discovery_thread_coalescing.py`.
 """
 from pathlib import Path
 
@@ -58,12 +63,11 @@ def test_discovery_thread_uses_context_local_home_not_env():
     Regression: the discovery thread originally re-wrote
     ``os.environ['HERMES_HOME']``. The stream worker mutates that env var
     under ``_ENV_LOCK`` and restores it at teardown, so a discovery thread
-    that outlives its stream (the whole point of backgrounding it — an
-    unreachable server holds the thread for the full connect timeout) would
-    write the stale profile into the process env and cross-contaminate other
-    streams. hermes-agent's ``get_hermes_home()`` resolves the context-local
-    override (`set_hermes_home_override`) before the env var, and that
-    override is thread-local — it dies with the discovery thread.
+    that outlives its stream would write the stale profile into the process
+    env and cross-contaminate other streams. hermes-agent's ``get_hermes_home()``
+    resolves the context-local override (`set_hermes_home_override`) before the
+    env var, and that override is thread-local — it dies with the discovery
+    thread.
     """
     call_idx = _call_line_index()
     preceding = LINES[max(0, call_idx - 16):call_idx]
@@ -89,32 +93,57 @@ def test_discovery_thread_uses_context_local_home_not_env():
     )
 
 
-def test_discovery_runs_in_a_daemon_background_thread():
-    """The nested function must be spawned as a daemon thread, never joined."""
-    call_idx = _call_line_index()
-    tail = LINES[call_idx + 1:]
-    spawn_idx = next(
-        (
-            call_idx + 1 + i
-            for i, line in enumerate(tail)
-            if "threading.Thread(" in line
-        ),
-        None,
+def _helper_body() -> list[str]:
+    """Lines of `_run_mcp_discovery_background` from its def to its end."""
+    start = next(
+        i
+        for i, line in enumerate(LINES)
+        if line.startswith("def _run_mcp_discovery_background(")
     )
-    assert spawn_idx is not None, (
-        "No threading.Thread(...) found after the discover_mcp_tools() "
-        "call — the discovery function must be run on a background thread."
+    end = start + 1
+    while end < len(LINES) and not (
+        LINES[end].startswith("def ") or LINES[end].startswith("_STREAMING_CRONJOB")
+    ):
+        end += 1
+    return LINES[start:end]
+
+
+def test_discovery_thread_is_daemon_and_bounded_join():
+    """The helper must spawn a daemon thread and only ever JOIN with a bound.
+
+    The stream worker must never block on the full discovery duration: the
+    join has to be `join(timeout=...)` (bounded), not a bare `.join()`, and
+    the thread must be `daemon=True` so it never keeps the process alive.
+    """
+    body = _helper_body()
+    assert any("threading.Thread(" in line for line in body), (
+        "_run_mcp_discovery_background must construct a threading.Thread."
     )
-    spawn_block = LINES[spawn_idx:spawn_idx + 10]
-    assert any("target=" in line for line in spawn_block), (
-        "MCP discovery thread must declare its target (the nested discovery "
-        "function)."
-    )
-    assert any("daemon=True" in line for line in spawn_block), (
+    thread_block = body
+    assert any("daemon=True" in line for line in thread_block), (
         "MCP discovery thread must be daemon=True so it never keeps the "
         "process alive."
     )
-    assert any(".start()" in line for line in spawn_block), (
+    assert any(".start()" in line for line in thread_block), (
         "MCP discovery thread must be started with .start() — a direct call "
-        "or a .join() would block the stream worker."
+        "would block the stream worker."
+    )
+    assert any(".join(timeout=" in line for line in body), (
+        "The stream worker's wait for discovery must be a BOUNDED join "
+        "(join(timeout=...)) — a bare .join() would block the turn for the "
+        "full connect timeout, recreating the original bug."
+    )
+
+
+def test_discovery_threads_coalesced_per_profile():
+    """One live discovery thread per profile home — never one per message."""
+    body = _helper_body()
+    assert any("_MCP_DISCOVERY_THREADS.get(profile_home)" in line for line in body), (
+        "The helper must look up an existing live thread by profile home "
+        "before spawning, so rapid messages don't accumulate one "
+        "lock-waiting discovery daemon each."
+    )
+    assert any("is_alive()" in line for line in body), (
+        "Only LIVE discovery threads may be reused; finished threads must be "
+        "replaced by a fresh spawn."
     )

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -10,21 +10,20 @@ The CLI/TUI never pays this cost per message because it discovers MCP servers
 once at agent startup. The WebUI builds a fresh worker per stream, so discovery
 must not sit on the turn's critical path.
 
-The fix runs discovery through `_run_mcp_discovery_background`: a coalesced
-daemon thread (one per profile home, so messages can't accumulate lock-waiting
-daemons) that the stream worker joins for a bounded window BEFORE the agent
-builds/snapshots its tools. Reachable servers that connect within the window
-land in THIS turn's snapshot (first-turn completeness); slower or unreachable
-servers keep the thread running in the background and their tools land on the
-next turn via hermes-agent's between-turns prologue refresh. The thread
-re-asserts the stream's profile home through the context-local override
-(`set_hermes_home_override`) instead of mutating the process env, so a delayed
-thread can never cross-contaminate another stream.
+The fix is a profile-scoped readiness state machine (`_ensure_mcp_discovery` /
+`_mcp_wait_readiness`): exactly ONE discovery owner thread per profile home; a
+turn that finds the profile still `pending` waits on the shared readiness
+event (so a configured server is never silently omitted from the first
+tool-bearing turn), and later turns subscribe to the SAME result instead of
+paying a fresh wait. Discovery is also kicked off at process start so the
+default profile usually resolves during idle time. The thread re-asserts the
+profile home through the context-local override (`set_hermes_home_override`)
+instead of mutating the process env, so a delayed thread can never
+cross-contaminate another stream.
 
 The structural checks here are static (same precedent as
 `test_issue1968_mcp_profile_discovery.py`); the real production-path behavior
-of `_run_mcp_discovery_background` is exercised at runtime by
-`test_mcp_discovery_thread_coalescing.py`.
+is exercised at runtime by `test_mcp_discovery_thread_coalescing.py`.
 """
 from pathlib import Path
 
@@ -93,57 +92,56 @@ def test_discovery_thread_uses_context_local_home_not_env():
     )
 
 
-def _helper_body() -> list[str]:
-    """Lines of `_run_mcp_discovery_background` from its def to its end."""
-    start = next(
-        i
-        for i, line in enumerate(LINES)
-        if line.startswith("def _run_mcp_discovery_background(")
-    )
+def _function_body(name: str, stop_prefixes: tuple[str, ...]) -> list[str]:
+    """Lines of a top-level function from its def to the next top-level item."""
+    start = next(i for i, line in enumerate(LINES) if line.startswith(f"def {name}("))
     end = start + 1
-    while end < len(LINES) and not (
-        LINES[end].startswith("def ") or LINES[end].startswith("_STREAMING_CRONJOB")
-    ):
+    while end < len(LINES) and not LINES[end].startswith(stop_prefixes):
         end += 1
     return LINES[start:end]
 
 
-def test_discovery_thread_is_daemon_and_bounded_join():
-    """The helper must spawn a daemon thread and only ever JOIN with a bound.
-
-    The stream worker must never block on the full discovery duration: the
-    join has to be `join(timeout=...)` (bounded), not a bare `.join()`, and
-    the thread must be `daemon=True` so it never keeps the process alive.
-    """
-    body = _helper_body()
-    assert any("threading.Thread(" in line for line in body), (
-        "_run_mcp_discovery_background must construct a threading.Thread."
-    )
-    thread_block = body
-    assert any("daemon=True" in line for line in thread_block), (
-        "MCP discovery thread must be daemon=True so it never keeps the "
-        "process alive."
-    )
-    assert any(".start()" in line for line in thread_block), (
-        "MCP discovery thread must be started with .start() — a direct call "
-        "would block the stream worker."
-    )
-    assert any(".join(timeout=" in line for line in body), (
-        "The stream worker's wait for discovery must be a BOUNDED join "
-        "(join(timeout=...)) — a bare .join() would block the turn for the "
-        "full connect timeout, recreating the original bug."
-    )
-
-
-def test_discovery_threads_coalesced_per_profile():
-    """One live discovery thread per profile home — never one per message."""
-    body = _helper_body()
-    assert any("_MCP_DISCOVERY_THREADS.get(profile_home)" in line for line in body), (
-        "The helper must look up an existing live thread by profile home "
-        "before spawning, so rapid messages don't accumulate one "
-        "lock-waiting discovery daemon each."
+def test_ensure_spawns_one_daemon_owner_thread_per_profile():
+    """The readiness owner must be a daemon thread, one per profile."""
+    body = _function_body("_ensure_mcp_discovery", ("def ", "_STREAMING_CRONJOB"))
+    assert any("_MCP_READINESS.get(profile_home)" in line for line in body), (
+        "readiness must be keyed by profile home so each profile gets its "
+        "own registry entry"
     )
     assert any("is_alive()" in line for line in body), (
-        "Only LIVE discovery threads may be reused; finished threads must be "
-        "replaced by a fresh spawn."
+        "only LIVE owner threads may be reused; a dead pending run must be "
+        "restarted so waiters can't hang forever"
+    )
+    assert any("threading.Thread(" in line for line in body), (
+        "the owner must be a threading.Thread"
+    )
+    assert any("daemon=True" in line for line in body), (
+        "the owner thread must be daemon=True so it never keeps the process "
+        "alive"
+    )
+    assert any(".start()" in line for line in body), (
+        "the owner thread must be started with .start() — a direct call "
+        "would block the stream worker"
+    )
+
+
+def test_wait_uses_shared_readiness_event_not_per_turn_join():
+    """The turn wait must be a shared event wait, never a fresh join."""
+    body = _function_body("_mcp_wait_readiness", ("def ", "_STREAMING_CRONJOB"))
+    assert any("event.wait(" in line for line in body), (
+        "the turn must wait on the profile's shared readiness event"
+    )
+    assert not any(".join(" in line for line in body), (
+        "turns must never join the owner thread directly — that would make "
+        "each message pay a fresh wait instead of subscribing to the one "
+        "shared readiness result"
+    )
+
+
+def test_startup_kickoff_exists_and_keeps_single_call_site():
+    """Process-start discovery exists, and no second call line was added."""
+    body = _function_body("_startup_mcp_discovery", ("def ", "_STREAMING_CRONJOB"))
+    assert body, "_startup_mcp_discovery() must exist"
+    assert any("_ensure_mcp_discovery(" in line for line in body), (
+        "the startup kickoff must route through the same readiness owner"
     )

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -45,7 +45,7 @@ def test_discovery_call_is_inside_a_nested_function():
     call_idx = _call_line_index()
     # Look upward from the call for the enclosing `def` and a `try:` guard
     # (test_issue1968 already pins the try/except window; this pins the def).
-    preceding = LINES[max(0, call_idx - 24):call_idx]
+    preceding = LINES[max(0, call_idx - 32):call_idx]
     assert any(line.lstrip().startswith("def ") for line in preceding), (
         "discover_mcp_tools() must be called from inside a nested function so "
         "it runs off the stream worker's critical path."
@@ -69,7 +69,7 @@ def test_discovery_thread_uses_context_local_home_not_env():
     thread.
     """
     call_idx = _call_line_index()
-    preceding = LINES[max(0, call_idx - 24):call_idx]
+    preceding = LINES[max(0, call_idx - 32):call_idx]
     assert any("set_hermes_home_override" in line for line in preceding), (
         "The discovery thread must assert the profile home through the "
         "context-local override (set_hermes_home_override), never by writing "

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -46,7 +46,7 @@ def test_discovery_call_is_inside_a_nested_function():
     call_idx = _call_line_index()
     # Look upward from the call for the enclosing `def` and a `try:` guard
     # (test_issue1968 already pins the try/except window; this pins the def).
-    preceding = LINES[max(0, call_idx - 12):call_idx]
+    preceding = LINES[max(0, call_idx - 24):call_idx]
     assert any(line.lstrip().startswith("def ") for line in preceding), (
         "discover_mcp_tools() must be called from inside a nested function so "
         "it runs off the stream worker's critical path."
@@ -70,7 +70,7 @@ def test_discovery_thread_uses_context_local_home_not_env():
     thread.
     """
     call_idx = _call_line_index()
-    preceding = LINES[max(0, call_idx - 16):call_idx]
+    preceding = LINES[max(0, call_idx - 24):call_idx]
     assert any("set_hermes_home_override" in line for line in preceding), (
         "The discovery thread must assert the profile home through the "
         "context-local override (set_hermes_home_override), never by writing "

--- a/tests/test_mcp_discovery_nonblocking.py
+++ b/tests/test_mcp_discovery_nonblocking.py
@@ -1,0 +1,83 @@
+"""Regression test for MCP discovery blocking turn start in the WebUI.
+
+The bug: `_run_agent_streaming` called `discover_mcp_tools()` synchronously on
+every message. `discover_mcp_tools()` connects every configured MCP server
+synchronously (per-server `connect_timeout`, plus the cross-process discovery
+lock), so a slow or unreachable server — e.g. an SSH MCP pointing at a sleeping
+laptop — stalled turn start by the full connect timeout on EVERY message.
+
+The CLI/TUI never pays this cost per message because it discovers MCP servers
+once at agent startup. The WebUI builds a fresh worker per stream, so discovery
+must not sit on the turn's critical path.
+
+The fix runs discovery on a daemon background thread. hermes-agent's per-turn
+prologue (`refresh_agent_mcp_tools`) folds tools from servers that finish
+connecting mid-turn into the current turn's first API call, so no tools are
+lost — the turn just starts immediately.
+
+This is a static check (same precedent as
+`test_issue1968_mcp_profile_discovery.py`): mocking the entire agent stack to
+reach the call site would be brittle and would miss the actual structural
+shape that's the load-bearing fix — the call must live in a function that is
+spawned (not invoked inline) as a daemon `threading.Thread` target.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STREAMING_PY = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+LINES = STREAMING_PY.splitlines()
+
+
+def _call_line_index() -> int:
+    """First non-comment line containing the actual `discover_mcp_tools()` call."""
+    for idx, line in enumerate(LINES):
+        if "discover_mcp_tools()" in line and not line.lstrip().startswith("#"):
+            return idx
+    raise AssertionError("discover_mcp_tools() call line not found")
+
+
+def test_discovery_call_is_inside_a_nested_function():
+    """The call must not execute inline — it lives in a nested function body."""
+    call_idx = _call_line_index()
+    # Look upward from the call for the enclosing `def` and a `try:` guard
+    # (test_issue1968 already pins the try/except window; this pins the def).
+    preceding = LINES[max(0, call_idx - 12):call_idx]
+    assert any(line.lstrip().startswith("def ") for line in preceding), (
+        "discover_mcp_tools() must be called from inside a nested function so "
+        "it runs off the stream worker's critical path."
+    )
+    assert any(line.strip() == "try:" for line in preceding), (
+        "discover_mcp_tools() call must be guarded by try/except so MCP "
+        "failures don't crash the chat stream."
+    )
+
+
+def test_discovery_runs_in_a_daemon_background_thread():
+    """The nested function must be spawned as a daemon thread, never joined."""
+    call_idx = _call_line_index()
+    tail = LINES[call_idx + 1:]
+    spawn_idx = next(
+        (
+            call_idx + 1 + i
+            for i, line in enumerate(tail)
+            if "threading.Thread(" in line
+        ),
+        None,
+    )
+    assert spawn_idx is not None, (
+        "No threading.Thread(...) found after the discover_mcp_tools() "
+        "call — the discovery function must be run on a background thread."
+    )
+    spawn_block = LINES[spawn_idx:spawn_idx + 10]
+    assert any("target=" in line for line in spawn_block), (
+        "MCP discovery thread must declare its target (the nested discovery "
+        "function)."
+    )
+    assert any("daemon=True" in line for line in spawn_block), (
+        "MCP discovery thread must be daemon=True so it never keeps the "
+        "process alive."
+    )
+    assert any(".start()" in line for line in spawn_block), (
+        "MCP discovery thread must be started with .start() — a direct call "
+        "or a .join() would block the stream worker."
+    )

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -1,16 +1,18 @@
-"""Runtime regression tests for the WebUI's background MCP discovery helper.
+"""Runtime regression tests for the WebUI's profile-scoped MCP readiness.
 
-Exercises the REAL production path — `api.streaming._run_mcp_discovery_background`
-— with a fake discovery payload, verifying the ordering that the static tests
-in `test_mcp_discovery_nonblocking.py` can only pin structurally:
+Exercises the REAL production path — `api.streaming._ensure_mcp_discovery` /
+`_mcp_wait_readiness` / `_mcp_retry_discovery` — with fake discovery payloads.
+These map 1:1 onto the readiness contract the maintainer review demanded:
 
-1. The stream worker's bounded join waits for discovery to finish when the
-   server is reachable-but-slow, so the agent snapshot that follows still
-   sees the registered tools (first-turn completeness).
-2. The join is BOUNDED: an unreachable/slow server does not stall the turn
-   beyond the join window.
-3. Threads are coalesced per profile home — rapid messages reuse one live
-   discovery thread instead of accumulating daemons.
+1. A discovery that finishes AFTER any fixed-timeout guess (e.g. 4s) must
+   still be present for the first tool-bearing turn — the turn waits on the
+   shared readiness event, not a timed join.
+2. Several same-profile turns while one discovery is pending must share ONE
+   owner thread and resolve on the SAME event, not each pay a fresh wait.
+3. Different profiles keep independent readiness/tool registries.
+4. Failure has an explicit surfaced outcome (status == 'failed'), and a
+   later explicit retry completes without touching an in-flight Agent
+   snapshot (hermes-agent only applies tools at the next turn's prologue).
 """
 import sys
 import threading
@@ -23,76 +25,113 @@ sys.path.insert(0, str(REPO_ROOT))
 from api import streaming  # noqa: E402
 
 
-def _make_discover(duration: float, release: threading.Event | None = None):
-    """Return (discover_fn, started_flag) — discover_fn sleeps `duration` then exits."""
+def _make_discover(duration: float, fail: bool = False):
+    """Return (discover_fn, started_flag)."""
     started = threading.Event()
 
     def _discover():
         started.set()
+        if fail:
+            time.sleep(duration or 0)
+            raise RuntimeError("simulated connect failure")
         if duration:
             time.sleep(duration)
-        if release is not None:
-            release.wait(timeout=10)
 
     return _discover, started
 
 
-class TestBoundedDiscoveryJoin:
-    def test_join_waits_for_reachable_slow_server(self):
-        """A server that connects within the window lands in THIS turn's snapshot.
+class TestFirstTurnCompleteness:
+    def test_turn_waits_for_discovery_past_old_4s_boundary(self):
+        """A server connecting at 4.5s must not be omitted from the first turn.
 
-        The helper's join must return only after discovery finished, so the
-        agent build that follows sees the tools.
+        The old bounded-join design cut off at a fixed 4.0s; the readiness
+        contract waits on the shared event until discovery actually
+        completes, so the agent snapshot that follows sees the tools.
         """
-        discover, started = _make_discover(0.4)
-        t0 = time.monotonic()
-        thread = streaming._run_mcp_discovery_background(
-            "profile-a", discover, "t-wait", join_timeout=5.0
+        discover, started = _make_discover(4.5)
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-a", discover, "t-slow"
         )
+        t0 = time.monotonic()
+        status = streaming._mcp_wait_readiness(readiness)
         elapsed = time.monotonic() - t0
         assert started.is_set()
-        assert elapsed >= 0.4, f"join returned before discovery finished: {elapsed:.2f}s"
-        assert not thread.is_alive(), "discovery thread should have completed"
-
-    def test_join_is_bounded_for_unreachable_server(self):
-        """A server that never connects must not stall the turn past the window."""
-        discover, started = _make_discover(10.0)
-        t0 = time.monotonic()
-        thread = streaming._run_mcp_discovery_background(
-            "profile-b", discover, "t-bounded", join_timeout=0.5
+        assert status == "completed"
+        assert elapsed >= 4.5, (
+            f"readiness resolved before discovery finished: {elapsed:.2f}s"
         )
-        elapsed = time.monotonic() - t0
-        assert started.is_set()
-        assert elapsed < 2.0, f"join blocked far past the bound: {elapsed:.2f}s"
-        assert thread.is_alive(), (
-            "slow discovery thread should still be running in the background"
-        )
-        thread.join(timeout=1.0)  # let the daemon finish; it sleeps 10s → join times out
-        assert thread.is_alive()  # still sleeping; test ends, daemon dies with process
 
-
-class TestCoalescing:
-    def test_live_thread_reused_per_profile(self):
-        """Two rapid messages for the same profile share ONE discovery thread."""
-        discover, started = _make_discover(1.0)
-        first = streaming._run_mcp_discovery_background(
-            "profile-c", discover, "t-first", join_timeout=0.1
-        )
-        assert first.is_alive()
-        second = streaming._run_mcp_discovery_background(
-            "profile-c", discover, "t-second", join_timeout=0.1
-        )
-        assert second is first, "live thread for the same profile must be reused"
-        first.join(timeout=3.0)
-
-    def test_finished_thread_is_replaced(self):
-        """A finished discovery thread is replaced by a fresh spawn."""
+    def test_completed_readiness_does_not_wait(self):
+        """A resolved profile returns immediately — no per-turn wait."""
         discover, started = _make_discover(0.05)
-        first = streaming._run_mcp_discovery_background(
-            "profile-d", discover, "t-first", join_timeout=1.0
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-a2", discover, "t-fast"
         )
-        assert not first.is_alive()
-        second = streaming._run_mcp_discovery_background(
-            "profile-d", discover, "t-second", join_timeout=1.0
+        assert streaming._mcp_wait_readiness(readiness) == "completed"
+        t0 = time.monotonic()
+        assert streaming._mcp_wait_readiness(readiness) == "completed"
+        assert time.monotonic() - t0 < 0.2, (
+            "a completed profile must never make the turn wait again"
         )
-        assert second is not first, "finished thread must be replaced"
+
+
+class TestSharedReadiness:
+    def test_same_profile_turns_share_one_thread_and_one_wait(self):
+        """Concurrent same-profile turns: ONE thread, ONE shared wait."""
+        discover, started = _make_discover(1.5)
+        r1 = streaming._ensure_mcp_discovery("profile-b", discover, "t1")
+        r2 = streaming._ensure_mcp_discovery("profile-b", discover, "t2")
+        assert r1.thread is r2.thread, "both turns must share the owner thread"
+        t0 = time.monotonic()
+        s1 = streaming._mcp_wait_readiness(r1)
+        s2 = streaming._mcp_wait_readiness(r2)
+        elapsed = time.monotonic() - t0
+        assert s1 == s2 == "completed"
+        assert elapsed < 3.0, (
+            f"two turns paid ~2x the discovery wait: {elapsed:.2f}s"
+        )
+
+    def test_completed_profile_is_not_re_discovered(self):
+        """A completed profile must not be re-run by a later turn."""
+        runs = []
+
+        def _discover():
+            runs.append(1)
+
+        r = streaming._ensure_mcp_discovery("profile-b2", _discover, "t")
+        assert streaming._mcp_wait_readiness(r) == "completed"
+        streaming._ensure_mcp_discovery("profile-b2", _discover, "t2")
+        assert len(runs) == 1, "completed profile must not re-run discovery"
+
+
+class TestProfileIsolation:
+    def test_different_profiles_independent(self):
+        """Different profiles keep independent readiness and threads."""
+        d1, s1 = _make_discover(0.3)
+        d2, s2 = _make_discover(0.6)
+        ra = streaming._ensure_mcp_discovery("profile-x", d1, "tx")
+        rb = streaming._ensure_mcp_discovery("profile-y", d2, "ty")
+        assert ra is not rb
+        assert ra.thread is not rb.thread
+        assert streaming._mcp_wait_readiness(ra) == "completed"
+        assert streaming._mcp_wait_readiness(rb) == "completed"
+
+
+class TestFailureAndRetry:
+    def test_failure_surfaces_explicit_status(self):
+        """A failed discovery must surface status='failed', never hang."""
+        discover, started = _make_discover(0.1, fail=True)
+        readiness = streaming._ensure_mcp_discovery("profile-z", discover, "tz")
+        assert streaming._mcp_wait_readiness(readiness) == "failed"
+
+    def test_explicit_retry_after_failure_completes(self):
+        """An explicit retry re-runs discovery and completes."""
+        fail_disc, _ = _make_discover(0.05, fail=True)
+        r = streaming._ensure_mcp_discovery("profile-w", fail_disc, "tw1")
+        assert streaming._mcp_wait_readiness(r) == "failed"
+        old_thread = r.thread
+        ok_disc, ok_started = _make_discover(0.05)
+        r2 = streaming._mcp_retry_discovery("profile-w", ok_disc, "tw2")
+        assert r2.thread is not old_thread, "retry must run a fresh owner thread"
+        assert streaming._mcp_wait_readiness(r2) == "completed"
+        assert ok_started.is_set()

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -1,8 +1,9 @@
 """Runtime regression tests for the WebUI's profile-scoped MCP readiness.
 
 Exercises the REAL production path — `api.streaming._ensure_mcp_discovery` /
-`_mcp_wait_readiness` / `_mcp_retry_discovery` — with fake discovery payloads.
-These map 1:1 onto the readiness contract the maintainer review demanded:
+`_mcp_wait_readiness` / `_mcp_retry_discovery` / `_wait_and_surface_mcp_readiness`
+— with fake discovery payloads.  These map 1:1 onto the readiness contract the
+maintainer review demanded:
 
 1. A discovery that finishes AFTER any fixed-timeout guess (e.g. 4s) must
    still be present for the first tool-bearing turn — the turn waits on the
@@ -10,9 +11,14 @@ These map 1:1 onto the readiness contract the maintainer review demanded:
 2. Several same-profile turns while one discovery is pending must share ONE
    owner thread and resolve on the SAME event, not each pay a fresh wait.
 3. Different profiles keep independent readiness/tool registries.
-4. Failure has an explicit surfaced outcome (status == 'failed'), and a
-   later explicit retry completes without touching an in-flight Agent
-   snapshot (hermes-agent only applies tools at the next turn's prologue).
+4. Failure has an explicit surfaced outcome: a thrown run becomes 'failed',
+   a PRODUCTION-style closure returning False becomes 'failed' (closures no
+   longer swallow failures into a fake 'completed'), and the outcome is
+   surfaced at the stream boundary before the agent snapshot is built.
+5. Readiness is generation-based and single-flight: a timed-out wait RETIRES
+   the run so a late-finishing owner can never flip state (or register tools
+   into an in-flight turn), and a retry while the prior owner is still
+   pending never leaves two live owners for one profile.
 """
 import sys
 import threading
@@ -26,7 +32,7 @@ from api import streaming  # noqa: E402
 
 
 def _make_discover(duration: float, fail: bool = False):
-    """Return (discover_fn, started_flag)."""
+    """Return (discover_fn, started_flag).  Raises on failure."""
     started = threading.Event()
 
     def _discover():
@@ -36,6 +42,32 @@ def _make_discover(duration: float, fail: bool = False):
             raise RuntimeError("simulated connect failure")
         if duration:
             time.sleep(duration)
+        return True
+
+    return _discover, started
+
+
+def _make_production_discover(duration: float, fail: bool = False):
+    """Return (discover_fn, started_flag) shaped like the PRODUCTION closures.
+
+    `_discover_mcp_background` / `_discover_default` catch their own
+    exceptions and return an explicit bool — they never raise.  The
+    readiness runner must record a False return as 'failed'; this is the
+    exact path the maintainer review found broken when closures swallowed
+    failures into a fake 'completed'.
+    """
+    started = threading.Event()
+
+    def _discover():
+        try:
+            started.set()
+            if duration:
+                time.sleep(duration)
+            if fail:
+                return False
+            return True
+        except Exception:
+            return False
 
     return _discover, started
 
@@ -97,6 +129,7 @@ class TestSharedReadiness:
 
         def _discover():
             runs.append(1)
+            return True
 
         r = streaming._ensure_mcp_discovery("profile-b2", _discover, "t")
         assert streaming._mcp_wait_readiness(r) == "completed"
@@ -118,11 +151,33 @@ class TestProfileIsolation:
 
 
 class TestFailureAndRetry:
-    def test_failure_surfaces_explicit_status(self):
-        """A failed discovery must surface status='failed', never hang."""
+    def test_thrown_discovery_becomes_failed(self):
+        """A discovery that RAISES must surface status='failed'."""
         discover, started = _make_discover(0.1, fail=True)
         readiness = streaming._ensure_mcp_discovery("profile-z", discover, "tz")
         assert streaming._mcp_wait_readiness(readiness) == "failed"
+
+    def test_closure_returning_false_becomes_failed(self):
+        """A PRODUCTION-style closure returning False must surface 'failed'.
+
+        Regression (maintainer review): the production closures used to
+        swallow exceptions and return None, so the runner recorded every
+        failed run as 'completed'.  The closures now return an explicit
+        bool and the runner must honor a False outcome.
+        """
+        discover, started = _make_production_discover(0.05, fail=True)
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-z2", discover, "tz2"
+        )
+        assert streaming._mcp_wait_readiness(readiness) == "failed"
+
+    def test_closure_returning_true_completes(self):
+        """A production-style closure returning True completes."""
+        discover, started = _make_production_discover(0.05)
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-z3", discover, "tz3"
+        )
+        assert streaming._mcp_wait_readiness(readiness) == "completed"
 
     def test_explicit_retry_after_failure_completes(self):
         """An explicit retry re-runs discovery and completes."""
@@ -135,3 +190,84 @@ class TestFailureAndRetry:
         assert r2.thread is not old_thread, "retry must run a fresh owner thread"
         assert streaming._mcp_wait_readiness(r2) == "completed"
         assert ok_started.is_set()
+
+
+class TestGenerations:
+    def test_timeout_retires_generation_and_cannot_flip_later(self):
+        """A timed-out wait retires the run; a late finish cannot flip state.
+
+        Regression (maintainer review): `_mcp_wait_readiness` used to set
+        'failed' after the cap without retiring the owner, so the thread
+        could later finish and overwrite the terminal outcome to
+        'completed' after the caller had already proceeded.
+        """
+        _old_cap = streaming._MCP_READINESS_WAIT_CAP_S
+        streaming._MCP_READINESS_WAIT_CAP_S = 0.15
+        try:
+            discover, started = _make_discover(0.6)  # finishes AFTER the cap
+            readiness = streaming._ensure_mcp_discovery(
+                "profile-g", discover, "tg"
+            )
+            assert streaming._mcp_wait_readiness(readiness) == "failed"
+            assert readiness.thread is None, "timed-out owner must be retired"
+            time.sleep(0.7)  # let the retired thread actually finish
+            assert readiness.status == "failed", (
+                "a late-finishing retired generation must never publish "
+                "terminal state over a timed-out wait"
+            )
+        finally:
+            streaming._MCP_READINESS_WAIT_CAP_S = _old_cap
+
+    def test_retry_while_pending_never_creates_two_owners(self):
+        """A retry while the prior owner is still running must be single-flight.
+
+        Regression (maintainer review): `_mcp_retry_discovery` used to
+        spawn a new daemon unconditionally, so a retry while the previous
+        owner was still pending left TWO live discovery threads for one
+        profile.  Retry now retires the old generation first.
+        """
+        slow_disc, slow_started = _make_discover(0.4)
+        r = streaming._ensure_mcp_discovery("profile-r", slow_disc, "tr1")
+        assert r.status == "pending"
+        old_thread = r.thread
+        assert old_thread is not None and old_thread.is_alive()
+        ok_disc, ok_started = _make_discover(0.05)
+        r2 = streaming._mcp_retry_discovery("profile-r", ok_disc, "tr2")
+        assert r2.thread is not old_thread, "retry must run a fresh owner"
+        assert r2.thread is not None and r2.thread.is_alive()
+        assert streaming._mcp_wait_readiness(r2) == "completed"
+        # The retired slow owner must finish WITHOUT flipping the outcome.
+        time.sleep(0.5)
+        assert r2.status == "completed", "retired generation must not publish"
+        # The registry still holds exactly ONE current owner for the profile.
+        assert streaming._MCP_READINESS["profile-r"].thread is r2.thread
+
+
+class TestStreamBoundarySurfacing:
+    def test_failed_status_surfaced_at_stream_boundary(self, caplog):
+        """A failed readiness must be surfaced before the agent snapshot."""
+        discover, started = _make_discover(0.05, fail=True)
+        readiness = streaming._ensure_mcp_discovery("profile-s", discover, "ts")
+        with caplog.at_level("WARNING", logger="api.streaming"):
+            status = streaming._wait_and_surface_mcp_readiness(
+                readiness, "profile-s", "sess-1"
+            )
+        assert status == "failed"
+        assert any(
+            "MCP discovery failed" in rec.getMessage() for rec in caplog.records
+        )
+
+    def test_completed_status_not_surfaced_as_failure(self, caplog):
+        """A completed readiness proceeds without a failure log."""
+        discover, started = _make_discover(0.05)
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-s2", discover, "ts2"
+        )
+        with caplog.at_level("WARNING", logger="api.streaming"):
+            status = streaming._wait_and_surface_mcp_readiness(
+                readiness, "profile-s2", "sess-2"
+            )
+        assert status == "completed"
+        assert not any(
+            "MCP discovery failed" in rec.getMessage() for rec in caplog.records
+        )

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -223,6 +223,58 @@ class TestGenerations:
         finally:
             streaming._MCP_READINESS_WAIT_CAP_S = _old_cap
 
+    def test_timeout_retirement_wakes_peer_waiters(self):
+        """A timeout retire must wake OTHER same-profile waiters promptly.
+
+        Regression (maintainer round 14): the first waiter that retires a
+        timed-out generation published 'failed' but never set the retired
+        generation's event, so a second same-profile waiter already
+        blocked on that event slept out its own full cap even though the
+        shared result was already terminal.
+        """
+        _old_cap = streaming._MCP_READINESS_WAIT_CAP_S
+        streaming._MCP_READINESS_WAIT_CAP_S = 0.4
+        try:
+            discover, started = _make_discover(2.0)  # finishes AFTER the cap
+            readiness = streaming._ensure_mcp_discovery(
+                "profile-h", discover, "th"
+            )
+
+            results = {}
+            t1 = threading.Thread(
+                target=lambda: results.setdefault(
+                    "w1", streaming._mcp_wait_readiness(readiness)
+                ),
+                name="w1",
+            )
+            t1.start()
+            time.sleep(0.25)  # stagger: w2 starts while w1 is still waiting
+
+            t0 = time.monotonic()
+            t2 = threading.Thread(
+                target=lambda: results.setdefault(
+                    "w2", streaming._mcp_wait_readiness(readiness)
+                ),
+                name="w2",
+            )
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+            w2_elapsed = time.monotonic() - t0
+
+            assert results.get("w1") == "failed"
+            assert results.get("w2") == "failed"
+            assert w2_elapsed < 0.30, (
+                "the second waiter must wake from the retired generation's "
+                f"signal, not sleep out its own cap ({w2_elapsed:.2f}s)"
+            )
+            # Live owner pointer retained; a late finish cannot overwrite.
+            assert readiness.thread is not None
+            time.sleep(0.4)
+            assert readiness.status == "failed"
+        finally:
+            streaming._MCP_READINESS_WAIT_CAP_S = _old_cap
+
     def test_runner_skips_discovery_when_cancelled(self):
         """A cancelled runner performs NO discovery side effects.
 

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -338,6 +338,120 @@ class TestGenerations:
         )
         assert streaming._mcp_wait_readiness(r_turn) == "completed"
 
+    def test_owner_creation_waits_for_reload_teardown(self):
+        """A concurrent stream cannot create an owner during reload teardown.
+
+        Regression (Greptile review round 11): the reload validated only
+        the owners it SNAPSHOTTED.  A stream worker creating a new owner
+        during the join phase could register servers into (or after) the
+        registry shutdown — overlapping teardown even though every
+        snapshot owner terminated.  Owner creation now blocks on
+        `_MCP_RELOAD_FENCE` for the reload's teardown window, so the
+        reload's snapshot is complete and a new body can only start
+        against the fresh registry.
+        """
+        timeline = []
+        lock = threading.Lock()
+
+        def make_logging_discover(duration, label):
+            def _discover():
+                with lock:
+                    timeline.append((label + "-start", time.monotonic()))
+                time.sleep(duration)
+                with lock:
+                    timeline.append((label + "-end", time.monotonic()))
+                return True
+
+            return _discover
+
+        # A live owner that blocks until released (simulates a discovery
+        # body mid-connect during the reload's join phase).
+        zombie_readiness = streaming._McpReadiness()
+        release = threading.Event()
+
+        def zombie_discover():
+            with lock:
+                timeline.append(("zombie-start", time.monotonic()))
+            release.wait(5.0)
+            with lock:
+                timeline.append(("zombie-end", time.monotonic()))
+            return True
+
+        zt = threading.Thread(
+            target=streaming._discovery_runner,
+            args=(
+                zombie_discover,
+                zombie_readiness,
+                zombie_readiness.event,
+                zombie_readiness.gen,
+                zombie_readiness.cancel,
+            ),
+            name="mcp-fence-test-zombie",
+            daemon=True,
+        )
+        zombie_readiness.thread = zt
+        zt.start()
+        streaming._MCP_READINESS["/profiles/zombie"] = zombie_readiness
+
+        reload_done = threading.Event()
+
+        def _do_prepare():
+            streaming._prepare_global_reload()
+            reload_done.set()
+
+        # Hold the reload fence exactly like /reload-mcp does across
+        # snapshot + join + shutdown.
+        with streaming._MCP_RELOAD_FENCE:
+            rt = threading.Thread(target=_do_prepare, daemon=True)
+            rt.start()
+            # Prepare has set the zombie's cancel token → it is inside the
+            # bounded join, still waiting on the zombie.
+            assert zombie_readiness.cancel.wait(2.0), "prepare never started join"
+            time.sleep(0.1)
+
+            # A stream worker for a NEW profile tries to create an owner
+            # mid-teardown.  It must BLOCK on the fence, not create a
+            # discovery body that overlaps the shutdown.
+            ensure_done = threading.Event()
+            ensure_holder = {}
+
+            def _do_ensure():
+                ensure_holder["readiness"] = streaming._ensure_mcp_discovery(
+                    "profile-new", make_logging_discover(0.05, "new"), "t-new"
+                )
+                ensure_done.set()
+
+            et = threading.Thread(target=_do_ensure, daemon=True)
+            et.start()
+            time.sleep(0.3)
+            assert "profile-new" not in streaming._MCP_READINESS, (
+                "owner creation must be fenced during the reload teardown"
+            )
+            assert not ensure_done.is_set(), (
+                "_ensure_mcp_discovery returned while the reload fence was held"
+            )
+
+            # Let the zombie finish → prepare's join returns (owner
+            # terminated) → teardown completes.
+            release.set()
+            rt.join(timeout=2.0)
+            assert reload_done.is_set(), "prepare did not finish"
+
+        # Fence released: the fenced creator may now create its owner.
+        et.join(timeout=2.0)
+        new_readiness = ensure_holder.get("readiness")
+        assert new_readiness is not None, "fenced owner creation never ran"
+        assert streaming._mcp_wait_readiness(new_readiness) == "completed"
+
+        # No overlap: the new body started only AFTER the zombie ended.
+        with lock:
+            zombie_end = max(t for ev, t in timeline if ev == "zombie-end")
+            new_start = min(t for ev, t in timeline if ev == "new-start")
+        assert new_start >= zombie_end - 0.01, (
+            "the fenced owner started discovery while the reload teardown "
+            "was still in progress"
+        )
+
     def test_retry_while_pending_never_creates_two_owners(self):
         """A retry while the prior owner is still running must be single-flight.
 

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -1,0 +1,98 @@
+"""Runtime regression tests for the WebUI's background MCP discovery helper.
+
+Exercises the REAL production path — `api.streaming._run_mcp_discovery_background`
+— with a fake discovery payload, verifying the ordering that the static tests
+in `test_mcp_discovery_nonblocking.py` can only pin structurally:
+
+1. The stream worker's bounded join waits for discovery to finish when the
+   server is reachable-but-slow, so the agent snapshot that follows still
+   sees the registered tools (first-turn completeness).
+2. The join is BOUNDED: an unreachable/slow server does not stall the turn
+   beyond the join window.
+3. Threads are coalesced per profile home — rapid messages reuse one live
+   discovery thread instead of accumulating daemons.
+"""
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from api import streaming  # noqa: E402
+
+
+def _make_discover(duration: float, release: threading.Event | None = None):
+    """Return (discover_fn, started_flag) — discover_fn sleeps `duration` then exits."""
+    started = threading.Event()
+
+    def _discover():
+        started.set()
+        if duration:
+            time.sleep(duration)
+        if release is not None:
+            release.wait(timeout=10)
+
+    return _discover, started
+
+
+class TestBoundedDiscoveryJoin:
+    def test_join_waits_for_reachable_slow_server(self):
+        """A server that connects within the window lands in THIS turn's snapshot.
+
+        The helper's join must return only after discovery finished, so the
+        agent build that follows sees the tools.
+        """
+        discover, started = _make_discover(0.4)
+        t0 = time.monotonic()
+        thread = streaming._run_mcp_discovery_background(
+            "profile-a", discover, "t-wait", join_timeout=5.0
+        )
+        elapsed = time.monotonic() - t0
+        assert started.is_set()
+        assert elapsed >= 0.4, f"join returned before discovery finished: {elapsed:.2f}s"
+        assert not thread.is_alive(), "discovery thread should have completed"
+
+    def test_join_is_bounded_for_unreachable_server(self):
+        """A server that never connects must not stall the turn past the window."""
+        discover, started = _make_discover(10.0)
+        t0 = time.monotonic()
+        thread = streaming._run_mcp_discovery_background(
+            "profile-b", discover, "t-bounded", join_timeout=0.5
+        )
+        elapsed = time.monotonic() - t0
+        assert started.is_set()
+        assert elapsed < 2.0, f"join blocked far past the bound: {elapsed:.2f}s"
+        assert thread.is_alive(), (
+            "slow discovery thread should still be running in the background"
+        )
+        thread.join(timeout=1.0)  # let the daemon finish; it sleeps 10s → join times out
+        assert thread.is_alive()  # still sleeping; test ends, daemon dies with process
+
+
+class TestCoalescing:
+    def test_live_thread_reused_per_profile(self):
+        """Two rapid messages for the same profile share ONE discovery thread."""
+        discover, started = _make_discover(1.0)
+        first = streaming._run_mcp_discovery_background(
+            "profile-c", discover, "t-first", join_timeout=0.1
+        )
+        assert first.is_alive()
+        second = streaming._run_mcp_discovery_background(
+            "profile-c", discover, "t-second", join_timeout=0.1
+        )
+        assert second is first, "live thread for the same profile must be reused"
+        first.join(timeout=3.0)
+
+    def test_finished_thread_is_replaced(self):
+        """A finished discovery thread is replaced by a fresh spawn."""
+        discover, started = _make_discover(0.05)
+        first = streaming._run_mcp_discovery_background(
+            "profile-d", discover, "t-first", join_timeout=1.0
+        )
+        assert not first.is_alive()
+        second = streaming._run_mcp_discovery_background(
+            "profile-d", discover, "t-second", join_timeout=1.0
+        )
+        assert second is not first, "finished thread must be replaced"

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -525,8 +525,9 @@ class TestGenerations:
         # The retired slow owner must finish WITHOUT flipping the outcome.
         time.sleep(0.5)
         assert r2.status == "completed", "retired generation must not publish"
-        # The registry still holds exactly ONE current owner for the profile.
-        assert streaming._MCP_READINESS["profile-r"].thread is r2.thread
+        # The registry still holds exactly ONE current owner for the profile
+        # (looked up under the CANONICAL key — round 15 #3).
+        assert streaming._MCP_READINESS[streaming._canonical_readiness_key("profile-r")].thread is r2.thread
 
 
 class TestStreamBoundarySurfacing:
@@ -557,3 +558,166 @@ class TestStreamBoundarySurfacing:
         assert not any(
             "MCP discovery failed" in rec.getMessage() for rec in caplog.records
         )
+
+
+class TestRefreshableRecovery:
+    """Maintainer round 15 #2 — incomplete/failed runs must RECOVER."""
+
+    def test_incomplete_outcome_is_failed_and_refreshable(self):
+        """A closure returning _MCP_INCOMPLETE -> failed + cooldown refresh_at.
+
+        Regression (maintainer round 15 #2): per-server connection
+        failures used to be recorded 'completed' forever.  The runner
+        must treat the INCOMPLETE sentinel as failed-and-refreshable, NOT
+        completed.
+        """
+        readiness = streaming._McpReadiness()
+        streaming._discovery_runner(
+            lambda: streaming._MCP_INCOMPLETE,
+            readiness,
+            readiness.event,
+            readiness.gen,
+            readiness.cancel,
+        )
+        assert readiness.status == "failed"
+        assert readiness.refresh_at is not None, (
+            "an incomplete run must be refreshable after the cooldown"
+        )
+        assert readiness.event.is_set()
+
+    def test_failed_run_recovers_after_cooldown_retry(self):
+        """A failed run schedules a retry after the cooldown which completes.
+
+        The user-visible contract: a transient outage must NOT permanently
+        strip a profile's MCP tools.  `_maybe_schedule_mcp_retry` spawns
+        ONE background retry owner once the cooldown elapses, and the
+        retry re-registers the recovered servers.
+        """
+        _old_cool = streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S
+        streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S = 0.0
+        try:
+            runs = []
+
+            def _ok():
+                runs.append(1)
+                return True
+
+            _profile = "refreshable-profile"
+            readiness = streaming._McpReadiness()
+            readiness.status = "failed"
+            readiness.refresh_at = 0.0  # cooldown elapsed
+            streaming._MCP_READINESS[streaming._canonical_readiness_key(_profile)] = readiness
+            streaming._maybe_schedule_mcp_retry(readiness, _profile, _ok)
+            deadline = time.monotonic() + 3.0
+            while readiness.status != "completed" and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert readiness.status == "completed", (
+                "a failed profile must recover via the cooldown retry"
+            )
+            assert runs, "the retry discovery never ran"
+        finally:
+            streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S = _old_cool
+
+    def test_stale_completed_with_connect_errors_heals(self, monkeypatch):
+        """A 'completed' readiness whose servers now fail must heal.
+
+        Stale states recorded BEFORE this fix (the `se`-profile symptom)
+        are detected via `_mcp_profile_has_connect_errors` and scheduled
+        for a cooldown retry instead of staying silently tool-less.
+        """
+        monkeypatch.setattr(
+            streaming, "_mcp_profile_has_connect_errors", lambda *a: True
+        )
+        _old_cool = streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S
+        streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S = 0.0
+        try:
+            runs = []
+
+            def _ok():
+                runs.append(1)
+                return True
+
+            _profile = "stale-completed"
+            readiness = streaming._McpReadiness()
+            readiness.status = "completed"  # stale pre-fix state
+            readiness.refresh_at = None
+            streaming._MCP_READINESS[streaming._canonical_readiness_key(_profile)] = readiness
+            streaming._maybe_schedule_mcp_retry(readiness, _profile, _ok)
+            deadline = time.monotonic() + 3.0
+            while readiness.status != "completed" and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert readiness.status == "completed"
+            assert runs, "the heal retry never ran"
+        finally:
+            streaming._MCP_DISCOVERY_RETRY_COOLDOWN_S = _old_cool
+
+
+class TestCanonicalKey:
+    def test_tilde_and_realpath_collide_to_one_key(self):
+        """`~/.hermes` and the expanded path are ONE readiness key.
+
+        Regression (maintainer round 15 #3): startup keyed `~/.hermes`
+        while turns keyed `/home/hermes/.hermes`, producing two owners
+        for one profile and registry shadowing.
+        """
+        import os
+
+        tilde = "~/.hermes"
+        expanded = os.path.join(str(Path.home()), ".hermes")
+        assert streaming._canonical_readiness_key(tilde) == streaming._canonical_readiness_key(expanded), (
+            "the tilde and expanded forms of the same home must collide to "
+            "one canonical readiness key"
+        )
+        assert streaming._canonical_readiness_key(tilde) == streaming._normalize_mcp_home(expanded)
+
+
+class TestConcurrentRetryNoCrash:
+    def test_wait_never_crashes_or_returns_pending_under_hammering(self):
+        """Concurrent retries during a wait must never raise or return bare pending.
+
+        Regression (maintainer round 15 #1): `_mcp_wait_readiness` used
+        to read the generation INSIDE the loop, so a terminal flip plus a
+        concurrent retry could leave `_gen` unbound (UnboundLocalError)
+        or return 'pending'.  Under repeated churn the waiter must always
+        return a terminal status without raising.
+        """
+        errors = []
+
+        def _discover():
+            time.sleep(0.005)
+            return True
+
+        readiness = streaming._ensure_mcp_discovery(
+            "profile-hammer", _discover, "t-hammer"
+        )
+
+        def _waiter():
+            try:
+                result = streaming._mcp_wait_readiness(readiness)
+                if result == "pending":
+                    errors.append(("pending",))
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append((type(exc).__name__, str(exc)))
+
+        def _retryer():
+            try:
+                streaming._mcp_retry_discovery(
+                    "profile-hammer", _discover, "t-hammer-retry"
+                )
+            except Exception:  # pragma: no cover - retryer noise
+                pass
+
+        waiters = []
+        for _ in range(4):
+            th = threading.Thread(target=_waiter, daemon=True)
+            waiters.append(th)
+            th.start()
+        retryers = []
+        for _ in range(6):
+            th = threading.Thread(target=_retryer, daemon=True)
+            retryers.append(th)
+            th.start()
+            time.sleep(0.01)
+        for th in waiters + retryers:
+            th.join(timeout=5)
+        assert not errors, f"wait crashed or returned pending under churn: {errors}"

--- a/tests/test_mcp_discovery_thread_coalescing.py
+++ b/tests/test_mcp_discovery_thread_coalescing.py
@@ -199,7 +199,9 @@ class TestGenerations:
         Regression (maintainer review): `_mcp_wait_readiness` used to set
         'failed' after the cap without retiring the owner, so the thread
         could later finish and overwrite the terminal outcome to
-        'completed' after the caller had already proceeded.
+        'completed' after the caller had already proceeded.  Round 9:
+        the thread POINTER is retained (execution continues) but the
+        generation is fenced so a late finish can never publish.
         """
         _old_cap = streaming._MCP_READINESS_WAIT_CAP_S
         streaming._MCP_READINESS_WAIT_CAP_S = 0.15
@@ -209,7 +211,10 @@ class TestGenerations:
                 "profile-g", discover, "tg"
             )
             assert streaming._mcp_wait_readiness(readiness) == "failed"
-            assert readiness.thread is None, "timed-out owner must be retired"
+            assert readiness.thread is not None, (
+                "the thread pointer must not be cleared while execution "
+                "continues (maintainer review round 9)"
+            )
             time.sleep(0.7)  # let the retired thread actually finish
             assert readiness.status == "failed", (
                 "a late-finishing retired generation must never publish "
@@ -217,6 +222,121 @@ class TestGenerations:
             )
         finally:
             streaming._MCP_READINESS_WAIT_CAP_S = _old_cap
+
+    def test_runner_skips_discovery_when_cancelled(self):
+        """A cancelled runner performs NO discovery side effects.
+
+        Regression (maintainer review round 9): generation-fencing only
+        protected the final label — a retired body could still call
+        discover_mcp_tools() and mutate the process-global MCP registry.
+        The runner now checks the cancel token BEFORE discovery, so a run
+        retired by timeout or superseded by retry that has not started
+        does no work.
+        """
+        calls = []
+
+        def discover():
+            calls.append("discover")
+            return True
+
+        readiness = streaming._McpReadiness()
+        readiness.cancel.set()
+        event = threading.Event()
+        streaming._discovery_runner(
+            discover, readiness, event, readiness.gen, readiness.cancel
+        )
+        assert calls == [], "cancelled runner must not call discover_fn"
+        assert readiness.status == "pending"
+        assert event.is_set()
+
+    def test_retry_joins_old_body_before_replacement(self):
+        """Retry while the prior owner runs must JOIN it first — never overlap.
+
+        Regression (maintainer review round 9): retry used to bump the
+        generation and start a replacement immediately, leaving BOTH
+        discovery bodies alive and mutating the global registry.  Retry
+        now cancels and joins the old body (bounded) before starting the
+        new one — at most one discovery body is ever alive per profile.
+        """
+        timeline = []
+        lock = threading.Lock()
+
+        def make_logging_discover(duration, label):
+            def _discover():
+                with lock:
+                    timeline.append((label + "-start", time.monotonic()))
+                time.sleep(duration)
+                with lock:
+                    timeline.append((label + "-end", time.monotonic()))
+                return True
+
+            return _discover
+
+        slow = make_logging_discover(0.3, "old")
+        r = streaming._ensure_mcp_discovery("profile-p", slow, "tp1")
+        time.sleep(0.1)  # old body is running
+        fast = make_logging_discover(0.05, "new")
+        r2 = streaming._mcp_retry_discovery("profile-p", fast, "tp2")
+        assert streaming._mcp_wait_readiness(r2) == "completed"
+        with lock:
+            old_end = max(t for ev, t in timeline if ev == "old-end")
+            new_start = min(t for ev, t in timeline if ev == "new-start")
+        assert new_start >= old_end - 0.01, (
+            "the replacement body started before the old body finished — "
+            "two discovery bodies were alive for one profile"
+        )
+
+    def test_canonical_key_startup_and_default_turn_share_entry(self, monkeypatch):
+        """Startup and a default-profile turn must share ONE readiness entry.
+
+        Regression (maintainer review round 9): startup keyed readiness
+        as '' while real default turns keyed by the resolved home path,
+        so the logical default profile held two entries and a global
+        reload refreshed only one.
+        """
+        import sys
+        from types import ModuleType
+
+        from api import profiles
+
+        class _FakeOverride:
+            def set_hermes_home_override(self, home):
+                return "tok"
+
+            def reset_hermes_home_override(self, token):
+                pass
+
+            def get_default_hermes_root(self):
+                return "/default/hermes/home"
+
+        monkeypatch.setattr(
+            profiles, "_resolve_hermes_home_override", lambda: _FakeOverride()
+        )
+
+        # Fake tools.mcp_tool so _startup_mcp_discovery can import it.
+        tools_pkg = ModuleType("tools")
+        tools_pkg.__path__ = []
+        mcp_tool = ModuleType("tools.mcp_tool")
+        mcp_tool.discover_mcp_tools = lambda: []
+        monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+        monkeypatch.setitem(sys.modules, "tools.mcp_tool", mcp_tool)
+
+        streaming._startup_mcp_discovery()
+        r_startup = streaming._MCP_READINESS.get("/default/hermes/home")
+        assert r_startup is not None, (
+            "startup must key readiness by the canonical resolved default "
+            "home, not ''"
+        )
+        assert streaming._MCP_READINESS.get("") is None, (
+            "the '' key must never coexist with the canonical default key"
+        )
+        # A default-profile turn ('') resolves to the same canonical key.
+        turn_disc, turn_started = _make_discover(0.05)
+        r_turn = streaming._ensure_mcp_discovery("", turn_disc, "t-turn")
+        assert r_turn is r_startup, (
+            "startup and a default turn must share ONE readiness entry"
+        )
+        assert streaming._mcp_wait_readiness(r_turn) == "completed"
 
     def test_retry_while_pending_never_creates_two_owners(self):
         """A retry while the prior owner is still running must be single-flight.


### PR DESCRIPTION
# fix(streaming): run MCP discovery off the turn's critical path

## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in a browser.
- The CLI/TUI discovers MCP servers **once** at agent startup; `discover_mcp_tools()` blocks until every configured server connects or its per-server `connect_timeout` fires, and that cost is paid invisibly behind the startup banner.
- The WebUI builds a fresh worker per stream, and `_run_agent_streaming` re-ran `discover_mcp_tools()` synchronously on **every message**.
- With an unreachable MCP server, every turn start stalled by the full connect timeout (~15-21s measured) before the model call could begin. The gateway/Dashboard never pay this because they keep one warm agent context.
- The concrete case that surfaced this: the `macbook` MCP server — an SSH computer-use driver (`cua-driver mcp` on a home-network Mac, `connect_timeout: 15`) that **can never connect while the Mac is offline**. Because it never connects, every single WebUI message paid its full 15s `connect_timeout` (plus reconnect backoff), even though the server is genuinely useful the moment the Mac comes back online. Disabling it wasn't an option; the stall had to go away on its own.
- This PR runs discovery on a daemon background thread so turn start is never blocked. hermes-agent's per-turn prologue (`refresh_agent_mcp_tools`) folds tools from servers that finish connecting mid-turn into the current turn's first API call, so no tools are lost — the turn just starts immediately.

## What Changed

- `api/streaming.py` + `server.py`: MCP discovery is now a **generation-based, single-flight profile-scoped readiness state machine** instead of a per-turn synchronous call. `_ensure_mcp_discovery(profile_home, ...)` runs exactly **one current owner thread per profile home** and records `pending | completed | failed` on a shared readiness object; `_mcp_wait_readiness(...)` makes a turn whose profile is still `pending` wait on the **shared readiness event** (bounded by `_MCP_READINESS_WAIT_CAP_S`, a 120s hang-safety cap) — so a configured server is never silently omitted from the first tool-bearing turn, and later turns subscribe to the SAME result instead of paying a fresh wait. `server.py` kicks discovery off at **process start** (`_startup_mcp_discovery`, non-blocking), so the default profile usually resolves during idle time and the first user message pays zero wait. Readiness is **generation-based**: `_McpReadiness.gen` is bumped on restart, explicit retry, and timeout retirement; `_discovery_runner` captures its generation at start and only publishes if still current, so a late-finishing owner can never flip terminal state (or register tools into an in-flight turn). The discovery closures return an **explicit bool outcome** (True = ran to completion, False = raised) — failures are never swallowed into a fake `completed`. A failed run is **surfaced at the stream boundary** (`_wait_and_surface_mcp_readiness` logs it before the Agent snapshot is built). `_mcp_retry_discovery` (mirrors `/reload-mcp`) retires the old generation first — single-flight — and `/reload-mcp` itself now routes through the same authority. The discovery thread re-asserts the profile home through the **context-local override** (`set_hermes_home_override`) resolved via the webui's version gate `api.profiles._resolve_hermes_home_override()` (#5567) — it never writes `os.environ['HERMES_HOME']`. On agents WITHOUT the override API, discovery is **never backgrounded**: the worker runs it inline inside its own env window (pre-PR semantics), so a daemon can never read another stream's profile after env mutation; the startup kickoff is gated on the same API.
- `tests/test_mcp_discovery_nonblocking.py` (new): static regression tests (same precedent as `test_issue1968_mcp_profile_discovery.py`) pinning the structural shape: single call site in a nested function guarded by try/except, context-local home override via the version-gated resolver (no env write), one daemon owner thread per profile (registry + is_alive + generation), shared `event.wait()` (never a per-turn join), and the startup kickoff.
- `tests/test_mcp_discovery_thread_coalescing.py` (new): **runtime** regression tests exercising the real readiness helpers with fake discovery payloads — discovery finishing past any fixed-timeout guess is present for the first turn; same-profile concurrent turns share one thread and one wait; different profiles are independent; a thrown run and a production-style closure returning False both surface `failed`; a timed-out wait retires the generation and a late finish cannot flip state; retry while pending never leaves two live owners; failed/completed status is surfaced at the stream boundary (caplog).

## Why It Matters

An unreachable MCP server made every WebUI message hang in "processing" for the full connect timeout before the model could start, while the same machine's TUI and gateway were unaffected. In the reported case the offender is the `macbook` SSH computer-use server (`cua-driver mcp`), which never connects while the Mac is offline — so the WebUI stalled on a server that was known to be unreachable, on every message, indefinitely. This restores TUI-parity turn start for MCP users.

## Verification

- **The new tests bite**: on the pre-fix code the new tests fail (`No threading.Thread(...) found after the discover_mcp_tools() call`); with the fix they pass.
- **Automated review (Greptile) round 1 — env-write race**: the first revision re-wrote `os.environ['HERMES_HOME']` from the background thread outside `_ENV_LOCK`. Fixed in `2569a18` with hermes-agent's context-local `set_hermes_home_override` (thread-local; resolved before env by `get_hermes_home()`; carried onto the MCP loop by `_wrap_with_home_override`).
- **Automated review (Greptile) round 2 — capture race + older agents**: (a) the thread re-read `os.environ['HERMES_HOME']` after `_ENV_LOCK` was released, racy against concurrent streams — fixed in `c5ef389` by using the `_profile_home` local set under the lock; (b) direct import of the override symbols silently skipped discovery on pre-v0.18.0 agents — fixed by resolving through the webui's version gate `api.profiles._resolve_hermes_home_override()`, falling back to env-mirror behavior instead of skipping. Both pinned in `test_discovery_thread_uses_context_local_home_not_env`.
- **Maintainer review (CHANGES_REQUESTED at c5ef389) round 3 — first-turn completeness + daemon accumulation**: (a) the prologue refresh only catches servers connected *between* turns, so a server still connecting at turn start missed the whole turn — fixed in `933a911` by a bounded join (`_MCP_DISCOVERY_TURN_JOIN_S = 4.0s`) before the agent snapshot; (b) one daemon per message could accumulate 120s lock-waiting threads — fixed by per-profile coalescing. Both pinned by the new runtime tests; the previous PR claims about mid-turn folding were corrected (accurate next-turn semantics now documented in code).
- **Automated review (Greptile) round 4 — older-agent fallback race**: when the context-local override API is unavailable (agents < v0.18.0), the background thread would read process env after this worker restores it at teardown, observing another stream's home. Fixed in `0a1fedb`: the worker resolves the override module before choosing the join mode — unbounded join on old agents (discovery completes inside the worker's env window, preserving pre-PR synchronous semantics exactly), bounded join on new agents. Default-profile sessions on new agents now install an explicit override to `get_default_hermes_root()` so the thread never depends on the process env.
- **Maintainer review (CHANGES_REQUESTED at 933a911) round 5 — readiness contract**: the 4s bounded join is a timed guess, not a readiness contract (a server at 4.1-6s still misses the first turn; each rapid message pays another 4s while one discovery is pending). Replaced in `29e4fef` with the profile-scoped readiness state machine above: first tool-bearing turn waits on the shared event until discovery actually resolves; later turns subscribe to the same result; startup kickoff resolves the default profile during idle; failure surfaces explicitly and retries run fresh. The 10 new/updated tests fail on the reviewed head and pass here; all earlier review fixes (contextvar override, resolver gate, no env writes, per-profile coalescing) are preserved.
- **Maintainer review (CHANGES_REQUESTED at 29e4fef) round 6 — generation/single-flight**: (a) both production closures swallowed exceptions, so the runner recorded every failure as `completed` — closures now return an explicit bool and the runner honors it; (b) a timed-out generation stayed live and could overwrite its terminal result — `_mcp_wait_readiness` now RETIRES the current generation on cap expiry (gen bump + `failed` + owner released) and the runner only publishes while its generation is current; (c) retry could create two owners — `_mcp_retry_discovery` retires the old generation first (single-flight). Failed readiness is surfaced at the stream boundary before the Agent snapshot; `/reload-mcp` routes through the same authority. Greptile round 6 (older-agent env race) fixed by never backgrounding discovery when the override API is absent — inline run inside the worker's env window, startup kickoff gated. All six round-6 regressions exercise the real production closure shape and fail on the previously reviewed head (`29e4fef`), passing on `f684ec4`.
- **Test run** (`./scripts/test.sh`, Python 3.11 via `HERMES_WEBUI_TEST_PYTHON`): `test_mcp_discovery_nonblocking.py`, `test_mcp_discovery_thread_coalescing.py`, `test_issue1968_mcp_profile_discovery.py`, `test_commands_endpoint.py`, `test_1695_aiagent_import_error_detail.py`, `test_issue5567_profile_home_override.py` → **60 passed, 11 skipped** (skips are pre-existing conditional tests). The new regressions fail on the previously reviewed head (verified against `29e4fef`). All four #1968 invariants (call after `HERMES_HOME` mutation, after lock release, single call site, try/except guard) still hold.
- **Maintainer approval + Greptile P1 (e088f4d)**: maintainer re-reviewed `f684ec4` and cleared all three round-6 defects ("this looks ready to me — no further blockers"). Closed Greptile's P1 (reload closure lacked the profile-home override) by installing the same context-local override pattern as the worker closure, with two new regressions. Rebased on current master (7 unrelated commits ahead).
- **Greptile round 8 — reload-path residue (efe6309)**: two P1s on `/reload-mcp`, both closing the same race classes already fixed for the worker — (a) the authority is now keyed deterministically at the default profile (`''`), never the exec-time env (a concurrent stream can mutate it), with the discovery closure asserting the default-root override; (b) on agents without the override API the reload runs discovery inline (pre-PR semantics) instead of on a background daemon with no override. Two new regressions; slice 49 passed, 11 skipped.
- **Maintainer review (CHANGES_REQUESTED at efe6309) round 9 — physical ownership + canonical keys (5a9e57b)**: label fencing was not enough — a retired body could still mutate the global MCP registry. Now: cancel token checked before discovery; retry cancels + bounded-joins the old body before replacement (rejecting if still alive past the cap); timeout retires WITHOUT clearing the thread pointer. All paths normalize through `_canonical_readiness_key` (resolved home path) so startup/turns/reload share one entry per profile; `/reload-mcp` cancels+joins live owners before shutdown and invalidates every other entry. Six new regressions fail on `efe6309`; slice 66 passed, 11 skipped.
- **Greptile round 10 — reload fail-closed (8c04b84)**: `_prepare_global_reload` now verifies termination (True only if every live owner finished within the cap); `/reload-mcp` aborts before shutdown when any owner survived, matching the retry path. Removed a duplicate pre-gate `shutdown_mcp_servers()` that was tearing down the registry before coordination could run. Regression: `test_reload_mcp_aborts_when_owner_survives_join_cap` (fails on `5a9e57b`).
- **Greptile round 11 — owner-creation fence (1fb90fc)**: `/reload-mcp` held a fence across snapshot+join+shutdown; owner creation (`_ensure_mcp_discovery`/`_mcp_retry_discovery`) blocks on `_MCP_RELOAD_FENCE`, so a concurrent stream cannot create a body that registers into/after the shutdown — the reload's snapshot is complete. Regression: `test_owner_creation_waits_for_reload_teardown` (fails on `8c04b84`).
- **Greptile round 12 — fence across the whole rebuild (2736411)**: the fence now stays held through replacement discovery AND readiness invalidation, not just teardown; `_mcp_retry_discovery` takes `_fence_held=True` (non-reentrant lock). Regression: `test_reload_mcp_fence_covers_the_whole_rebuild` (fails on `1fb90fc`).
- **Greptile round 13 — phase-split fence (118ca77)**: round 12's whole-rebuild fence stalled unrelated first turns; the fence now covers only the destructive phase (prepare/shutdown/invalidation, with invalidation BEFORE any post-shutdown owner), and the additive replacement discovery runs unfenced. Regression: `test_reload_mcp_does_not_stall_unrelated_first_turn` (fails on `2736411`).
- **Maintainer round 14 — peer waiters (9b96ad3)**: a timeout retire published 'failed' but never signalled the retired generation's event, so a second same-profile waiter slept out its own full cap. The retiring waiter now sets that event after publishing terminal state (gen check preserved); `test_timeout_retirement_wakes_peer_waiters` (staggered waiters) fails on the reviewed head and passes here. Slice 57 passed, 11 skipped.
- **Lint**: `ruff check` on the two changed files reports zero new errors (11 pre-existing errors in `streaming.py` are identical on `master`).
- **Live evidence** (this machine, unreachable SSH MCP server `macbook`, `connect_timeout: 15`):
  - Before: `chat/start` → turn registered 15-21s later, with the MCP failure (`CancelledError`) logged *before* the turn began.
  - After: turn registered ~7s after `chat/start` (cold agent build), and the MCP failure is logged **after** the turn started, on the background thread — it never touches the critical path.
- **What I could not verify**: the full CI suite (browser-heavy) was not run locally; I ran the affected + neighboring unit tests only. I could not verify multi-profile behavior beyond the existing suite.
- **Who owns the truth**: hermes-agent owns `discover_mcp_tools()` semantics (per-server `connect_timeout`, the cross-process discovery lock, and the `refresh_agent_mcp_tools` per-turn refresh that folds late-connecting servers into the current turn before the first API call — verified by reading its `agent/turn_context.py` prologue). This PR does not change any of that; it only stops the WebUI from blocking on it.

## Risks / Follow-ups

- **First turn after process start may miss tools from slow servers**: tools from a server that finishes connecting mid-turn land on a subsequent turn (or later in the same turn via the refresh prologue). For fast servers (already-connected notebooklm, healthy ssh) discovery completes in milliseconds and nothing changes. `/reload-mcp` still forces a synchronous refresh on demand.
- **Multiple rapid messages can spawn overlapping discovery threads**: `discover_mcp_tools()` is internally idempotent (process-global registry, per-server connecting set, cross-process discovery lock), so concurrent runs are safe; worst case is wasted background work.
- A dedicated runtime test of the spawn path would require mocking the entire agent stack; the repo already uses static tests for this call site (#1968), so this PR follows that precedent.

## Contract Routing

- Task type: runtime streaming bugfix (turn-start latency). Not a contract change.
- Touched areas: `api/streaming.py` (MCP discovery call site in `_run_agent_streaming`), new regression test.
- Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md` ("Runtime, durability, and state contracts" — read; no RFC defines MCP discovery timing, so no RFC change).
- Scope boundaries: does not touch the config load path (that's #6114's area), does not change MCP discovery semantics, preserves the #1968 placement contract.
- State layer mutated: the `tools.mcp_tool` process-global `_servers` registry and the per-agent tool snapshot. Invariant proven: turn start is not blocked on MCP server connect; late-connecting servers fold into the current turn via hermes-agent's per-turn refresh.
- Evidence: regression tests + live log timeline above.

## Adjacent PRs

- #1976 (merged) introduced this call site; its invariants are preserved and enforced by its tests.
- #6114 (open) isolates multi-profile **config reads/writes** (wrong-profile config persistence). Different bug, different fix location — its `streaming.py` change is a comment relocation and does not overlap this call site. Complementary; no duplicate-close risk.

## Release Note

> WebUI no longer blocks turn start while MCP servers are discovered. An unreachable MCP server (e.g. an SSH server pointing at an offline machine) no longer stalls every message by the full connect timeout; discovery runs in the background and tools appear as servers connect.

## Model Used

- Provider: opencode-go
- Model: deepseek-v4-flash
- Notable tool use: terminal (git, `scripts/test.sh` runs, live service-log timeline analysis), GitHub REST API (adjacent-PR screening), source reading of hermes-agent internals to confirm the per-turn MCP refresh behavior.
