### PR TITLE
fix(updates): prevent mixed-revision static assets under immutable version URLs

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -17745,42 +17745,58 @@ def _serve_static(handler, parsed):
     # being applied we refuse to serve static bytes (503 + no-store); the
     # client's post-update reload lands after the restart, on the new coherent
     # revision.
-    from api.updates import update_in_progress
+    #
+    # Read-ticket lifecycle (drain): every request that may touch the served
+    # tree takes a read ticket via begin_static_read(); the updater's freeze
+    # (api.updates.freeze_static_serving) sets the flag and then waits for all
+    # in-flight tickets to be released before running its first mutating git
+    # command. A request admitted just before the freeze therefore always
+    # finishes reading the OLD revision's bytes — it can never observe bytes
+    # written by the updater under the old version token (TOCTOU). The ticket
+    # is released as soon as the file bytes are in memory; the response write
+    # below only sends already-read bytes, so a slow client cannot stall an
+    # update's drain.
+    from api.updates import begin_static_read, end_static_read
 
-    if update_in_progress():
+    if not begin_static_read():
         return j(handler, {"error": "server is updating; retry shortly"}, status=503)
-    # Strip the leading '/static/' prefix, then resolve and sandbox
-    rel = parsed.path[len("/static/") :]
-    static_file = (static_root / rel).resolve()
     try:
-        static_file.relative_to(static_root)
-    except ValueError:
-        return j(handler, {"error": "not found"}, status=404)
-    if not static_file.exists() or not static_file.is_file():
-        return j(handler, {"error": "not found"}, status=404)
-    ext = static_file.suffix.lower()
-    ct = _STATIC_MIME.get(ext.lstrip("."), "text/plain")
-    ct_header = f"{ct}; charset=utf-8" if ct in _TEXT_MIME_TYPES else ct
+        # Strip the leading '/static/' prefix, then resolve and sandbox
+        rel = parsed.path[len("/static/") :]
+        static_file = (static_root / rel).resolve()
+        try:
+            static_file.relative_to(static_root)
+        except ValueError:
+            return j(handler, {"error": "not found"}, status=404)
+        if not static_file.exists() or not static_file.is_file():
+            return j(handler, {"error": "not found"}, status=404)
+        ext = static_file.suffix.lower()
+        ct = _STATIC_MIME.get(ext.lstrip("."), "text/plain")
+        ct_header = f"{ct}; charset=utf-8" if ct in _TEXT_MIME_TYPES else ct
 
-    # Look up or populate the per-file cache (raw, optional gzip, ETag).
-    # Keyed by absolute path; invalidated by (size, nanosecond mtime).
-    st = static_file.stat()
-    sig = (st.st_size, st.st_mtime_ns)
-    cache_key = str(static_file)
-    raw = gz = etag = None
-    with _STATIC_CACHE_LOCK:
-        cached = _STATIC_CACHE.get(cache_key)
-        if cached and cached[0] == sig:
-            _, raw, gz, etag = cached
-    if raw is None:
-        raw = static_file.read_bytes()
-        # Weak ETag: equality semantics, derived from filesystem identity.
-        etag = f'W/"{sig[0]:x}-{sig[1]:x}"'
-        gz = (gzip.compress(raw, compresslevel=6)
-              if ct in _COMPRESSIBLE_MIME and len(raw) > 1024
-              else None)
+        # Look up or populate the per-file cache (raw, optional gzip, ETag).
+        # Keyed by absolute path; invalidated by (size, nanosecond mtime).
+        st = static_file.stat()
+        sig = (st.st_size, st.st_mtime_ns)
+        cache_key = str(static_file)
+        raw = gz = etag = None
         with _STATIC_CACHE_LOCK:
-            _STATIC_CACHE[cache_key] = (sig, raw, gz, etag)
+            cached = _STATIC_CACHE.get(cache_key)
+            if cached and cached[0] == sig:
+                _, raw, gz, etag = cached
+        if raw is None:
+            raw = static_file.read_bytes()
+            # Weak ETag: equality semantics, derived from filesystem identity.
+            etag = f'W/"{sig[0]:x}-{sig[1]:x}"'
+            gz = (gzip.compress(raw, compresslevel=6)
+                  if ct in _COMPRESSIBLE_MIME and len(raw) > 1024
+                  else None)
+            with _STATIC_CACHE_LOCK:
+                _STATIC_CACHE[cache_key] = (sig, raw, gz, etag)
+    finally:
+        # Tree access is done — release the read ticket so an update freeze
+        # can drain. Everything below only touches in-memory bytes.
+        end_static_read()
 
     # The page template substitutes __WEBUI_VERSION__ at request time (see the
     # `/`/`/index.html`/`/session/` branch above), and static/sw.js's

--- a/api/routes.py
+++ b/api/routes.py
@@ -17737,6 +17737,18 @@ _STATIC_CACHE_LOCK = threading.Lock()
 
 def _serve_static(handler, parsed):
     static_root = api_config.get_static_root().resolve()
+    # Issue #6992: an in-place self-update mutates the working tree this
+    # process serves /static/* from. During that window a request could receive
+    # bytes from two different revisions under one versioned URL, and the old
+    # code marked every non-empty ?v= response immutable for a year — caching a
+    # mixed bundle (e.g. new JS + old CSS) indefinitely. While an update is
+    # being applied we refuse to serve static bytes (503 + no-store); the
+    # client's post-update reload lands after the restart, on the new coherent
+    # revision.
+    from api.updates import update_in_progress
+
+    if update_in_progress():
+        return j(handler, {"error": "server is updating; retry shortly"}, status=503)
     # Strip the leading '/static/' prefix, then resolve and sandbox
     rel = parsed.path[len("/static/") :]
     static_file = (static_root / rel).resolve()
@@ -17773,9 +17785,18 @@ def _serve_static(handler, parsed):
     # The page template substitutes __WEBUI_VERSION__ at request time (see the
     # `/`/`/index.html`/`/session/` branch above), and static/sw.js's
     # SHELL_ASSETS list relies on the same convention. So a fingerprinted URL
-    # is safe to cache aggressively: any redeploy changes the URL.
+    # is safe to cache aggressively — but ONLY when this process can prove the
+    # token→bytes binding: the token must equal WEBUI_VERSION, the revision
+    # this server was started on (resolved once at import). Any other non-empty
+    # token — e.g. HTML stamped by a different revision mid-update, a stale
+    # service worker, or a hand-crafted URL — cannot be verified against the
+    # bytes being served, so keep it short-lived instead of immutable for a
+    # year (issue #6992).
     version_values = parse_qs(parsed.query, keep_blank_values=True).get("v", [""])
-    has_fingerprint = bool(version_values[0])
+    from api.updates import WEBUI_VERSION
+
+    version_token = version_values[0]
+    has_fingerprint = bool(version_token) and version_token == WEBUI_VERSION
     cache_control = (
         "public, max-age=31536000, immutable" if has_fingerprint
         else "public, max-age=300"

--- a/api/updates.py
+++ b/api/updates.py
@@ -82,8 +82,14 @@ _frozen = False
 _freeze_generation = 0
 _active_readers = 0
 # Bounded drain: a pathological reader (e.g. a client stalling mid-download
-# while we hold a ticket) must not hang the update forever. After the bound we
-# proceed with a warning — mirroring _wait_until_restart_safe()'s policy.
+# while we hold a ticket) must not hang the update forever. When the bound is
+# reached the update FAILS CLOSED: freeze_static_serving() raises
+# StaticFreezeDrainTimeoutError instead of returning mutation authority, so
+# no git command ever runs while a reader could still serve the OLD revision's
+# bytes under an immutable version URL (mixed-revision cache poisoning, #6992).
+# The caller releases only its own freeze generation and returns a retryable
+# non-success; the reader finishes serving the old bytes and a later update
+# retries cleanly.
 _FREEZE_DRAIN_MAX_WAIT_S = 30.0
 CACHE_TTL = 1800  # 30 minutes
 _AGENT_GATEWAY_RESTART_RETRY_DELAY_S = 1.0
@@ -1983,12 +1989,29 @@ def _discard_local_changes(path: Path, reset_ref: str) -> bool:
     return ok
 
 
-def freeze_static_serving(max_drain_wait_s: float = _FREEZE_DRAIN_MAX_WAIT_S) -> int:
+class StaticFreezeDrainTimeoutError(Exception):
+    """The freeze drain reached its bound while static readers were still active.
+
+    Raised by :func:`freeze_static_serving` INSTEAD of returning mutation
+    authority: while any reader can still serve the OLD revision's bytes, the
+    updater must not run a single mutating git command (issue #6992 —
+    mixed-revision immutable cache). The caller — still under the update lock —
+    must release exactly this freeze generation via ``unfreeze_static_serving``
+    (``token``) and return a retryable non-success response.
+    """
+
+    def __init__(self, message: str, token: int):
+        super().__init__(message)
+        self.token = token
+
+
+def freeze_static_serving(max_drain_wait_s: float | None = None) -> int:
     """Freeze /static/* serving and drain in-flight readers (issue #6992).
 
     Sets the freeze flag (new requests get 503 from _serve_static), bumps the
     generation and returns the new generation as an ownership token, then
-    waits — bounded by *max_drain_wait_s* — until every reader admitted before
+    waits — bounded by *max_drain_wait_s* (default
+    ``_FREEZE_DRAIN_MAX_WAIT_S``) — until every reader admitted before
     the freeze has released its read ticket. Only after the drain returns is
     it safe for the caller to run the first mutating git command: no request
     can read bytes written by the updater under the old version token.
@@ -1997,11 +2020,20 @@ def freeze_static_serving(max_drain_wait_s: float = _FREEZE_DRAIN_MAX_WAIT_S) ->
     is cleared only while the token is still the current generation, so a
     stale owner can never clear a newer update's freeze.
 
+    FAIL-CLOSED drain bound: if *max_drain_wait_s* elapses while readers are
+    still active, raises :class:`StaticFreezeDrainTimeoutError` (carrying the
+    generation token) instead of returning — mutation authority is NEVER
+    granted while a reader could still serve the old revision's bytes. The
+    caller must not run any git command; it should release its own freeze
+    generation and return a retryable non-success.
+
     On a SUCCESSFUL update the caller must NOT unfreeze — the freeze persists
     until the scheduled ``os.execv`` replaces the process. Callers should
     unfreeze only when the attempt failed or was a no-op (no restart
     scheduled), i.e. when the working tree is coherent again.
     """
+    if max_drain_wait_s is None:
+        max_drain_wait_s = _FREEZE_DRAIN_MAX_WAIT_S
     global _freeze_generation, _frozen
     with _UPDATE_FREEZE_LOCK:
         _freeze_generation += 1
@@ -2011,12 +2043,17 @@ def freeze_static_serving(max_drain_wait_s: float = _FREEZE_DRAIN_MAX_WAIT_S) ->
         while _active_readers > 0:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                logger.warning(
-                    "update freeze drain timed out after %.0fs with %d active "
-                    "static reader(s); proceeding with mutation",
-                    max_drain_wait_s, _active_readers,
+                # Fail-closed: never hand out mutation authority while an
+                # active reader can still read the old revision's bytes. Raise
+                # (with the caller's own token) so no mutating git command
+                # ever runs; the caller unfreezes exactly this generation.
+                raise StaticFreezeDrainTimeoutError(
+                    'update freeze drain timed out after %.1fs with %d active '
+                    'static reader(s); aborting before any mutation — retry '
+                    'once the reader(s) release'
+                    % (max_drain_wait_s, _active_readers),
+                    token,
                 )
-                break
             _UPDATE_FREEZE_DRAINED.wait(remaining)
     return token
 
@@ -2220,7 +2257,23 @@ def apply_force_update(target: str, channel=None) -> dict:
         # the first mutating git command, so a request admitted just before
         # the freeze can never read bytes written by the updater.
         if target == 'webui':
-            freeze_token = freeze_static_serving()
+            try:
+                freeze_token = freeze_static_serving()
+            except StaticFreezeDrainTimeoutError as exc:
+                # Fail-closed (issue #6992): a reader that did not drain within
+                # the bound means we MUST NOT mutate — the old process could
+                # otherwise serve the new bytes under the old immutable version
+                # URL. Still under the update lock: release ONLY this caller's
+                # freeze generation (a newer update's freeze stays intact) and
+                # return a retryable non-success; no git command has run.
+                unfreeze_static_serving(exc.token)
+                return {
+                    'ok': False,
+                    'message': str(exc),
+                    'target': target,
+                    'drain_timeout': True,
+                    'retryable': True,
+                }
         response = _locked(channel)
         # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
         # scheduled restart replaces this process (static stays 503 through
@@ -2252,7 +2305,23 @@ def apply_update(target, channel=None):
         # the first mutating git command, so a request admitted just before
         # the freeze can never read bytes written by the updater.
         if target == 'webui':
-            freeze_token = freeze_static_serving()
+            try:
+                freeze_token = freeze_static_serving()
+            except StaticFreezeDrainTimeoutError as exc:
+                # Fail-closed (issue #6992): a reader that did not drain within
+                # the bound means we MUST NOT mutate — the old process could
+                # otherwise serve the new bytes under the old immutable version
+                # URL. Still under the update lock: release ONLY this caller's
+                # freeze generation (a newer update's freeze stays intact) and
+                # return a retryable non-success; no git command has run.
+                unfreeze_static_serving(exc.token)
+                return {
+                    'ok': False,
+                    'message': str(exc),
+                    'target': target,
+                    'drain_timeout': True,
+                    'retryable': True,
+                }
         response = _apply_update_inner(target, channel)
         # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
         # scheduled restart replaces this process (static stays 503 through

--- a/api/updates.py
+++ b/api/updates.py
@@ -44,13 +44,47 @@ _summary_cache: OrderedDict = OrderedDict()
 _cache_lock = threading.Lock()
 _check_in_progress = False
 _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same repo
-# Issue #6992: set while an in-place WebUI update is mutating the checkout this
-# process serves from. `_serve_static()` in api/routes.py refuses to serve
-# /static/* bytes while it is set, so a request can never receive a
-# mixed-revision bundle (new JS + old CSS) under one versioned URL and have it
-# cached immutable for a year. Plain bool: reads/writes are GIL-atomic, and
-# this is checked on the hot static-serving path.
-_UPDATE_IN_PROGRESS = False
+# Issue #6992: freeze model for in-place WebUI updates.
+#
+# An in-place self-update mutates the working tree this process serves
+# /static/* from (git stash/pull/pop for apply_update, checkout/clean/reset
+# for apply_force_update). During that window a request could receive bytes
+# from two different revisions under one versioned URL and cache them
+# immutable for a year. The freeze state below coordinates the update
+# lifecycle with the static-serving path in api/routes._serve_static():
+#
+#   * frozen flag — while set, _serve_static() refuses to serve any /static/*
+#     bytes (503 + no-store), so a request that arrives after the freeze can
+#     never observe a tree mid-mutation.
+#   * reader count — every _serve_static() call that may touch the tree takes
+#     a read ticket (begin_static_read/end_static_read). freeze_static_serving()
+#     sets the flag and then DRAINS: it waits until every in-flight reader has
+#     released its ticket, so a request admitted just before the freeze always
+#     finishes serving the OLD revision's bytes before the updater's first
+#     mutating git command runs (TOCTOU hole #1).
+#   * generation token — each freeze bumps a generation; the caller receives
+#     the generation as an ownership token and unfreeze_static_serving() only
+#     clears the flag while that token is still current. A stale owner (an
+#     update that finished or failed while a newer one was starting) can never
+#     clear the newer update's freeze (handoff hole #2).
+#   * persist-until-replacement — on a SUCCESSFUL update the freeze is NOT
+#     cleared: static stays 503 through the scheduled-restart delay until the
+#     os.execv replaces the process (the new process starts with a fresh,
+#     unfrozen state). Only failure / no-op (no restart scheduled) clears the
+#     freeze, because only then is the working tree coherent again
+#     (restart-delay hole #3).
+#
+# All freeze state is process-local; the restart (or the OS supervisor after
+# os._exit) clears it by replacing the process image.
+_UPDATE_FREEZE_LOCK = threading.Lock()
+_UPDATE_FREEZE_DRAINED = threading.Condition(_UPDATE_FREEZE_LOCK)
+_frozen = False
+_freeze_generation = 0
+_active_readers = 0
+# Bounded drain: a pathological reader (e.g. a client stalling mid-download
+# while we hold a ticket) must not hang the update forever. After the bound we
+# proceed with a warning — mirroring _wait_until_restart_safe()'s policy.
+_FREEZE_DRAIN_MAX_WAIT_S = 30.0
 CACHE_TTL = 1800  # 30 minutes
 _AGENT_GATEWAY_RESTART_RETRY_DELAY_S = 1.0
 _FORCE_DIRTY_PROBE_TIMEOUT = 5
@@ -1949,31 +1983,104 @@ def _discard_local_changes(path: Path, reset_ref: str) -> bool:
     return ok
 
 
-def set_update_in_progress() -> None:
-    """Freeze versioned static serving while an in-place update mutates the WebUI checkout.
+def freeze_static_serving(max_drain_wait_s: float = _FREEZE_DRAIN_MAX_WAIT_S) -> int:
+    """Freeze /static/* serving and drain in-flight readers (issue #6992).
 
-    Called (for ``target == 'webui'``) under ``_apply_lock`` before any git
-    command that can change the working tree this process serves /static/*
-    from. Cleared by :func:`clear_update_in_progress` once the working tree is
-    coherent again — the scheduled ``os.execv`` restart then serves the new
-    revision (issue #6992).
+    Sets the freeze flag (new requests get 503 from _serve_static), bumps the
+    generation and returns the new generation as an ownership token, then
+    waits — bounded by *max_drain_wait_s* — until every reader admitted before
+    the freeze has released its read ticket. Only after the drain returns is
+    it safe for the caller to run the first mutating git command: no request
+    can read bytes written by the updater under the old version token.
+
+    The token must be handed to :func:`unfreeze_static_serving`; the freeze
+    is cleared only while the token is still the current generation, so a
+    stale owner can never clear a newer update's freeze.
+
+    On a SUCCESSFUL update the caller must NOT unfreeze — the freeze persists
+    until the scheduled ``os.execv`` replaces the process. Callers should
+    unfreeze only when the attempt failed or was a no-op (no restart
+    scheduled), i.e. when the working tree is coherent again.
     """
-    global _UPDATE_IN_PROGRESS
-    _UPDATE_IN_PROGRESS = True
+    global _freeze_generation, _frozen
+    with _UPDATE_FREEZE_LOCK:
+        _freeze_generation += 1
+        token = _freeze_generation
+        _frozen = True
+        deadline = time.monotonic() + max(0.0, max_drain_wait_s)
+        while _active_readers > 0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    "update freeze drain timed out after %.0fs with %d active "
+                    "static reader(s); proceeding with mutation",
+                    max_drain_wait_s, _active_readers,
+                )
+                break
+            _UPDATE_FREEZE_DRAINED.wait(remaining)
+    return token
 
 
-def clear_update_in_progress() -> None:
-    """Resume normal static serving after an update attempt finishes.
+def unfreeze_static_serving(token: int) -> bool:
+    """Clear the freeze, but only while *token* still owns it (current generation).
 
-    Safe to call even when the flag was never set (agent-target updates).
+    Returns True if this call cleared the freeze. Returns False — leaving the
+    freeze untouched — when a newer update has taken over ownership (stale
+    handoff) or the freeze was already cleared; in either case the caller must
+    not assume the freeze state changed.
     """
-    global _UPDATE_IN_PROGRESS
-    _UPDATE_IN_PROGRESS = False
+    global _frozen
+    with _UPDATE_FREEZE_LOCK:
+        if token != _freeze_generation or not _frozen:
+            return False
+        _frozen = False
+        return True
+
+
+def reset_update_freeze() -> None:
+    """Force-clear the freeze regardless of ownership.
+
+    Test/teardown helper only. Production code uses freeze/unfreeze with
+    generation tokens; a real replacement (os.execv) clears the flag simply
+    by starting a fresh process.
+    """
+    global _frozen
+    with _UPDATE_FREEZE_LOCK:
+        _frozen = False
 
 
 def update_in_progress() -> bool:
     """True while an in-place WebUI update may be mutating the served checkout."""
-    return _UPDATE_IN_PROGRESS
+    return _frozen
+
+
+def begin_static_read() -> bool:
+    """Take a read ticket before touching the served tree in _serve_static().
+
+    Returns False when a freeze is active — the caller must refuse to serve
+    (503 + no-store) without touching any file. Returns True with the reader
+    counted; the caller MUST pair it with :func:`end_static_read` (finally),
+    otherwise the update drain can block forever.
+    """
+    with _UPDATE_FREEZE_LOCK:
+        if _frozen:
+            return False
+        global _active_readers
+        _active_readers += 1
+        return True
+
+
+def end_static_read() -> None:
+    """Release a read ticket taken by :func:`begin_static_read`.
+
+    Wakes any freeze drain waiting for readers to finish.
+    """
+    with _UPDATE_FREEZE_LOCK:
+        global _active_readers
+        _active_readers -= 1
+        if _active_readers < 0:
+            _active_readers = 0
+        _UPDATE_FREEZE_DRAINED.notify_all()
 
 
 def apply_force_update(target: str, channel=None) -> dict:
@@ -2003,12 +2110,9 @@ def apply_force_update(target: str, channel=None) -> dict:
 
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
-    try:
-        # Freeze /static/* serving while this checkout is being mutated in
-        # place (issue #6992) — cleared in the finally below once the working
-        # tree is coherent again.
-        if target == 'webui':
-            set_update_in_progress()
+    freeze_token = None
+
+    def _locked(channel: str) -> dict:
         if target == 'webui':
             path = REPO_ROOT
         elif target == 'agent':
@@ -2109,10 +2213,25 @@ def apply_force_update(target: str, channel=None) -> dict:
         if target == 'agent':
             response['gateway_restart'] = gateway_result.get('status')
         return response
+
+    try:
+        # Freeze /static/* serving while this checkout is being mutated in
+        # place (issue #6992): set the flag and DRAIN in-flight readers before
+        # the first mutating git command, so a request admitted just before
+        # the freeze can never read bytes written by the updater.
+        if target == 'webui':
+            freeze_token = freeze_static_serving()
+        response = _locked(channel)
+        # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
+        # scheduled restart replaces this process (static stays 503 through
+        # the restart-delay window); failure / no-op lifts it here — BEFORE
+        # releasing _apply_lock, so a waiting handoff update can never observe
+        # our unfreeze racing with its own freeze.
+        if freeze_token is not None and not response.get('restart_scheduled'):
+            unfreeze_static_serving(freeze_token)
+        return response
     finally:
         _apply_lock.release()
-        if target == 'webui':
-            clear_update_in_progress()
 
 
 def apply_update(target, channel=None):
@@ -2126,18 +2245,25 @@ def apply_update(target, channel=None):
 
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
+    freeze_token = None
     try:
         # Freeze /static/* serving while this checkout is being mutated in
-        # place (issue #6992) — cleared in the finally below once the working
-        # tree is coherent again (the scheduled restart then serves the new
-        # revision).
+        # place (issue #6992): set the flag and DRAIN in-flight readers before
+        # the first mutating git command, so a request admitted just before
+        # the freeze can never read bytes written by the updater.
         if target == 'webui':
-            set_update_in_progress()
-        return _apply_update_inner(target, channel)
+            freeze_token = freeze_static_serving()
+        response = _apply_update_inner(target, channel)
+        # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
+        # scheduled restart replaces this process (static stays 503 through
+        # the restart-delay window); failure / no-op lifts it here — BEFORE
+        # releasing _apply_lock, so a waiting handoff update can never observe
+        # our unfreeze racing with its own freeze.
+        if freeze_token is not None and not response.get('restart_scheduled'):
+            unfreeze_static_serving(freeze_token)
+        return response
     finally:
         _apply_lock.release()
-        if target == 'webui':
-            clear_update_in_progress()
 
 
 def _restore_stash_after_pull_failure(

--- a/api/updates.py
+++ b/api/updates.py
@@ -81,14 +81,43 @@ _UPDATE_FREEZE_DRAINED = threading.Condition(_UPDATE_FREEZE_LOCK)
 _frozen = False
 _freeze_generation = 0
 _active_readers = 0
-# Exception-safety tracker (issue #6992 re-gate): set by the apply internals
-# immediately before the first working-tree-mutating git command. The apply
-# wrappers consult it on the exception path — if no mutation may have started
-# the served tree is still coherent and the freeze can be released; once
-# mutation may have started the freeze must persist (or the process must be
-# replaced) so mixed-revision bytes are never exposed. Reset at each wrapper
-# entry; updates are serialized by _apply_lock.
-_update_mutation_may_have_started = False
+# Per-attempt mutation lifecycle authority (issue #6992 re-gate).
+#
+# Replaces the earlier global-boolean tracker with a structured per-attempt
+# lifecycle owned by the exact freeze generation token. Both update wrappers
+# (and the WebUI-mutating clear-lock retry) share ONE authority for
+# exceptions and ordinary failure returns: `_settle_update_lifecycle()`.
+#
+# States (transitions all under ``_apply_lock``, reset at each wrapper entry):
+#   IDLE              — no update attempt in flight (or freeze never acquired)
+#   FROZEN            — freeze acquired + drain complete; NO mutating git
+#                       command has run yet (pre-mutation)
+#   MUTATION_STARTED  — at least one tree-mutating git command has run
+#                       (checkout/clean/reset, stash/pull/restore); the served
+#                       tree may be mixed-revision
+#   COHERENT_RECOVERY — mutation started but the tree was VERIFIED coherent
+#                       again (stash restored, or reset --hard completed)
+#   REPLACEMENT_OWNED — a bounded replacement (restart) is scheduled or
+#                       guaranteed; the freeze is owned by the replacement
+#
+# Unfreeze rules (do NOT infer coherence from the absence of restart_scheduled):
+#   pre-mutation (IDLE/FROZEN)  → generation-unfreeze, tree untouched
+#   COHERENT_RECOVERY           → generation-unfreeze, rollback verified
+#   MUTATION_STARTED, no verify → NEVER unfreeze into a possibly-mixed tree:
+#                                 transfer ownership to a bounded replacement
+#                                 (_schedule_restart) or keep the freeze
+#                                 (fail-closed terminal outcome)
+#   REPLACEMENT_OWNED           → freeze persists until the replacement runs
+class _MutationLifecycle:
+    IDLE = 0
+    FROZEN = 1
+    MUTATION_STARTED = 2
+    COHERENT_RECOVERY = 3
+    REPLACEMENT_OWNED = 4
+
+
+_mutation_state = _MutationLifecycle.IDLE
+_mutation_token = 0  # freeze generation that owns the current attempt
 # Bounded drain: a pathological reader (e.g. a client stalling mid-download
 # while we hold a ticket) must not hang the update forever. When the bound is
 # reached the update FAILS CLOSED: freeze_static_serving() raises
@@ -398,7 +427,41 @@ def apply_clear_lock(target: str) -> dict:
             # to stable (Codex gate: _apply_update_inner defaults to stable).
             with _cache_lock:
                 _update_cache['checked_at'] = 0
-            retry_result = _apply_update_inner(target, _read_update_channel())
+            # The retry re-runs the WebUI-mutating apply path, so it gets the
+            # same per-attempt freeze lifecycle authority as apply_update()
+            # (issue #6992 re-gate): freeze before the first mutating git
+            # command, settle on every exception AND ordinary failure return.
+            freeze_token = None
+            if target == 'webui':
+                _reset_mutation_lifecycle()
+                try:
+                    try:
+                        freeze_token = freeze_static_serving()
+                        _mark_freeze_acquired(freeze_token)
+                    except StaticFreezeDrainTimeoutError as exc:
+                        unfreeze_static_serving(exc.token)
+                        _reset_mutation_lifecycle()
+                        retry_result = {
+                            'ok': False,
+                            'message': str(exc),
+                            'target': target,
+                            'drain_timeout': True,
+                            'retryable': True,
+                        }
+                        retry_result = dict(retry_result)
+                        retry_result['lock_recovery'] = {
+                            'action': 'no-lock-found',
+                            'manual_command': manual_command,
+                            'other_locks': inv['other_locks'],
+                        }
+                        return retry_result
+                    retry_result = _apply_update_inner(target, _read_update_channel())
+                    _settle_update_lifecycle(freeze_token, retry_result)
+                except Exception:
+                    _settle_update_lifecycle(freeze_token)
+                    raise
+            else:
+                retry_result = _apply_update_inner(target, _read_update_channel())
             retry_result = dict(retry_result)
             retry_result['lock_recovery'] = {
                 'action': 'no-lock-found',
@@ -2159,6 +2222,129 @@ def end_static_read() -> None:
         _UPDATE_FREEZE_DRAINED.notify_all()
 
 
+# ── Per-attempt mutation lifecycle authority (issue #6992 re-gate) ──────────
+#
+# Shared by apply_force_update(), apply_update() and the WebUI-mutating
+# clear-lock retry. All calls below happen under ``_apply_lock`` (updates are
+# serialized), so the module-level state is safe. The lifecycle is reset at
+# each wrapper entry and transitions as the apply internals run mutating git
+# commands or verify a coherent rollback.
+
+
+def _reset_mutation_lifecycle() -> None:
+    """Start a fresh per-attempt lifecycle (call at wrapper entry)."""
+    global _mutation_state, _mutation_token
+    _mutation_state = _MutationLifecycle.IDLE
+    _mutation_token = 0
+
+
+def _mark_freeze_acquired(freeze_token: int) -> None:
+    """Record that the freeze was acquired and the drain completed.
+
+    Pre-mutation: from here until the first mutating git command the served
+    tree is still untouched, so a failure may generation-unfreeze.
+    """
+    global _mutation_state, _mutation_token
+    _mutation_state = _MutationLifecycle.FROZEN
+    _mutation_token = freeze_token
+
+
+def _mark_mutation_started() -> None:
+    """Transition FROZEN → MUTATION_STARTED (first tree-mutating git command).
+
+    Idempotent — only the first transition matters; agent-only attempts
+    (never frozen) stay IDLE and are unaffected.
+    """
+    global _mutation_state
+    if _mutation_state == _MutationLifecycle.FROZEN:
+        _mutation_state = _MutationLifecycle.MUTATION_STARTED
+
+
+def _mark_coherent_recovery() -> None:
+    """Record a VERIFIED clean rollback (tree coherent again).
+
+    Called only when the tree has been verified coherent (e.g. stash
+    restored, or reset --hard completed). After this a failure may
+    generation-unfreeze; without it the freeze must persist or be replaced.
+    """
+    global _mutation_state
+    if _mutation_state == _MutationLifecycle.MUTATION_STARTED:
+        _mutation_state = _MutationLifecycle.COHERENT_RECOVERY
+
+
+def _mark_replacement_owned() -> None:
+    """Record that a bounded replacement (restart) is scheduled/guaranteed.
+
+    The freeze is owned by the replacement process from here on; this attempt
+    must never unfreeze it.
+    """
+    global _mutation_state
+    if _mutation_state in (
+        _MutationLifecycle.FROZEN,
+        _MutationLifecycle.MUTATION_STARTED,
+        _MutationLifecycle.COHERENT_RECOVERY,
+    ):
+        _mutation_state = _MutationLifecycle.REPLACEMENT_OWNED
+
+
+def _settle_update_lifecycle(freeze_token, response=None) -> None:
+    """Shared exception/failure authority for the update wrappers.
+
+    Called under ``_apply_lock`` on BOTH ordinary failure returns (with the
+    response) and exceptions (``response=None``), with this attempt's freeze
+    token. Decides whether the freeze may be released:
+
+    * ``freeze_token is None`` — no freeze was acquired (agent target or
+      no-op before freeze); nothing to do.
+    * Success (``restart_scheduled``) — freeze persists until the scheduled
+      replacement; ownership transfers to it.
+    * Pre-mutation (IDLE/FROZEN) — tree untouched, generation-unfreeze.
+    * COHERENT_RECOVERY — rollback verified, generation-unfreeze.
+    * MUTATION_STARTED without verified recovery — NEVER unfreeze into a
+      possibly-mixed tree: transfer ownership to a bounded replacement
+      (``_schedule_restart``). If even that fails, keep the freeze
+      (fail-closed terminal outcome: 503 until a later update or manual
+      restart).
+    * REPLACEMENT_OWNED — freeze persists; nothing to do.
+
+    Coherence is NEVER inferred from the absence of ``restart_scheduled``:
+    a returned partial-mutation failure keeps the freeze unless a verified
+    rollback was recorded.
+    """
+    if freeze_token is None:
+        return
+    if response is not None and response.get('restart_scheduled'):
+        _mark_replacement_owned()
+        return
+    if _mutation_state in (
+        _MutationLifecycle.IDLE,
+        _MutationLifecycle.FROZEN,
+        _MutationLifecycle.COHERENT_RECOVERY,
+    ):
+        unfreeze_static_serving(freeze_token)
+        _reset_mutation_lifecycle()
+        return
+    if _mutation_state == _MutationLifecycle.MUTATION_STARTED:
+        # Mutation may have started with no verified rollback: the served
+        # tree may be mixed-revision. Never unfreeze into it — guarantee a
+        # process replacement (restart thread, or synchronous fallback that
+        # replaces the process and never returns).
+        try:
+            _schedule_restart()
+            _mark_replacement_owned()
+        except Exception:
+            # Both the thread start and the synchronous fallback failed:
+            # keep the freeze (fail-closed — 503 rather than mixed immutable
+            # bytes). A later update or manual restart clears it.
+            logger.exception(
+                'update: failed to schedule replacement after mutation error; '
+                'freeze persists (fail-closed)'
+            )
+        return
+    # REPLACEMENT_OWNED: freeze persists until the replacement process starts.
+
+
+
 def apply_force_update(target: str, channel=None) -> dict:
     """Discard local changes for the requested update target.
 
@@ -2187,11 +2373,10 @@ def apply_force_update(target: str, channel=None) -> dict:
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     freeze_token = None
-    # Fresh per-invocation mutation tracking (issue #6992 re-gate): set by
-    # _locked() right before the first mutating git command; read by the
-    # exception handler below to decide whether the freeze may be released.
-    global _update_mutation_may_have_started
-    _update_mutation_may_have_started = False
+    # Fresh per-attempt mutation lifecycle (issue #6992 re-gate): reset at
+    # wrapper entry; transitions are made by the apply internals at the exact
+    # points the tree mutates or is verified coherent.
+    _reset_mutation_lifecycle()
 
     def _locked(channel: str) -> dict:
         if target == 'webui':
@@ -2268,10 +2453,10 @@ def apply_force_update(target: str, channel=None) -> dict:
                 'refused_rewind': True,
             }
         # From here on the served checkout may be mutated in place
-        # (checkout ./ clean / reset --hard) — mark it so an exception on
-        # this path can never unfreeze into a possibly-mixed tree (issue
-        # #6992).
-        _mark_update_mutation_started()
+        # (checkout ./ clean / reset --hard) — mark it so an exception or
+        # returned partial-mutation failure on this path can never unfreeze
+        # into a possibly-mixed tree (issue #6992).
+        _mark_mutation_started()
         if not _discard_local_changes(path, compare_ref):
             return {'ok': False, 'message': f'Force reset to {compare_ref} failed'}
 
@@ -2289,6 +2474,10 @@ def apply_force_update(target: str, channel=None) -> dict:
                 }
 
         _schedule_restart()
+        # Ownership of the freeze transfers to the scheduled replacement
+        # (issue #6992): a later exception in this attempt must never unfreeze
+        # or re-schedule.
+        _mark_replacement_owned()
 
         response = {
             'ok': True,
@@ -2308,6 +2497,7 @@ def apply_force_update(target: str, channel=None) -> dict:
         if target == 'webui':
             try:
                 freeze_token = freeze_static_serving()
+                _mark_freeze_acquired(freeze_token)
             except StaticFreezeDrainTimeoutError as exc:
                 # Fail-closed (issue #6992): a reader that did not drain within
                 # the bound means we MUST NOT mutate — the old process could
@@ -2316,6 +2506,7 @@ def apply_force_update(target: str, channel=None) -> dict:
                 # freeze generation (a newer update's freeze stays intact) and
                 # return a retryable non-success; no git command has run.
                 unfreeze_static_serving(exc.token)
+                _reset_mutation_lifecycle()
                 return {
                     'ok': False,
                     'message': str(exc),
@@ -2326,11 +2517,13 @@ def apply_force_update(target: str, channel=None) -> dict:
         response = _locked(channel)
         # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
         # scheduled restart replaces this process (static stays 503 through
-        # the restart-delay window); failure / no-op lifts it here — BEFORE
+        # the restart-delay window). Failures and no-ops are settled by the
+        # shared authority — it generation-unfreezes pre-mutation/verified-
+        # rollback attempts and keeps the freeze (or transfers ownership to a
+        # bounded replacement) when mutation may have started. Runs BEFORE
         # releasing _apply_lock, so a waiting handoff update can never observe
         # our unfreeze racing with its own freeze.
-        if freeze_token is not None and not response.get('restart_scheduled'):
-            unfreeze_static_serving(freeze_token)
+        _settle_update_lifecycle(freeze_token, response)
         return response
     except Exception:
         # Exception-safety for the freeze lifecycle (issue #6992 re-gate):
@@ -2339,30 +2532,11 @@ def apply_force_update(target: str, channel=None) -> dict:
         # _schedule_restart's restart thread failing to start, after the
         # checkout was already updated) would leave /static/* frozen at 503
         # until a restart or another successful update — server.py keeps the
-        # process alive on the 500. Decide by mutation state:
-        if freeze_token is not None:
-            if not _update_mutation_may_have_started:
-                # Pre-mutation failure: the served tree is untouched, so
-                # release ONLY this caller's freeze generation and let
-                # static serving resume (the request surfaces the 500).
-                unfreeze_static_serving(freeze_token)
-            else:
-                # Mutation may already have started: NEVER unfreeze into a
-                # possibly-mixed tree. Guarantee process replacement before
-                # static assets are exposed again. _schedule_restart either
-                # starts the restart thread or — if that fails — replaces the
-                # process synchronously; it does not return without a
-                # replacement being guaranteed.
-                try:
-                    _schedule_restart()
-                except Exception:
-                    # Both the thread start and the synchronous fallback
-                    # failed: keep the freeze (fail-closed — 503 rather than
-                    # mixed immutable bytes). A later update or manual
-                    # restart clears it.
-                    logger.exception(
-                        'force_update: failed to schedule restart after update error'
-                    )
+        # process alive on the 500. The shared authority decides by the
+        # per-attempt lifecycle state (pre-mutation / coherent rollback →
+        # generation-unfreeze; mutation may have started → bounded
+        # replacement or fail-closed freeze).
+        _settle_update_lifecycle(freeze_token)
         raise
     finally:
         _apply_lock.release()
@@ -2380,6 +2554,10 @@ def apply_update(target, channel=None):
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     freeze_token = None
+    # Fresh per-attempt mutation lifecycle (issue #6992 re-gate); transitions
+    # are made by _apply_update_inner at the exact points the tree mutates or
+    # is verified coherent.
+    _reset_mutation_lifecycle()
     try:
         # Freeze /static/* serving while this checkout is being mutated in
         # place (issue #6992): set the flag and DRAIN in-flight readers before
@@ -2388,6 +2566,7 @@ def apply_update(target, channel=None):
         if target == 'webui':
             try:
                 freeze_token = freeze_static_serving()
+                _mark_freeze_acquired(freeze_token)
             except StaticFreezeDrainTimeoutError as exc:
                 # Fail-closed (issue #6992): a reader that did not drain within
                 # the bound means we MUST NOT mutate — the old process could
@@ -2396,6 +2575,7 @@ def apply_update(target, channel=None):
                 # freeze generation (a newer update's freeze stays intact) and
                 # return a retryable non-success; no git command has run.
                 unfreeze_static_serving(exc.token)
+                _reset_mutation_lifecycle()
                 return {
                     'ok': False,
                     'message': str(exc),
@@ -2406,12 +2586,23 @@ def apply_update(target, channel=None):
         response = _apply_update_inner(target, channel)
         # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
         # scheduled restart replaces this process (static stays 503 through
-        # the restart-delay window); failure / no-op lifts it here — BEFORE
+        # the restart-delay window). Failures and no-ops are settled by the
+        # shared authority — it generation-unfreezes pre-mutation/verified-
+        # rollback attempts and keeps the freeze (or transfers ownership to a
+        # bounded replacement) when mutation may have started. Runs BEFORE
         # releasing _apply_lock, so a waiting handoff update can never observe
         # our unfreeze racing with its own freeze.
-        if freeze_token is not None and not response.get('restart_scheduled'):
-            unfreeze_static_serving(freeze_token)
+        _settle_update_lifecycle(freeze_token, response)
         return response
+    except Exception:
+        # Exception-safety for the freeze lifecycle (issue #6992 re-gate): an
+        # unexpected exception after freeze_static_serving() must never leave
+        # static serving permanently 503. The shared authority decides by the
+        # per-attempt lifecycle state (pre-mutation / coherent rollback →
+        # generation-unfreeze; mutation may have started → bounded replacement
+        # or fail-closed freeze).
+        _settle_update_lifecycle(freeze_token)
+        raise
     finally:
         _apply_lock.release()
 
@@ -2433,6 +2624,9 @@ def _restore_stash_after_pull_failure(
     """
     _, pop_ok = _run_git(['stash', 'pop'], path)
     if pop_ok:
+        # Stash restored — the served tree is back to the pre-update state
+        # (verified rollback), so a failure may generation-unfreeze.
+        _mark_coherent_recovery()
         return ('Local modifications were restored from the temporary stash.')
 
     # `git stash pop` failed -- could be that the working tree changed under
@@ -2440,6 +2634,7 @@ def _restore_stash_after_pull_failure(
     _, apply_ok = _run_git(['stash', 'apply'], path)
     if apply_ok:
         _, _ = _run_git(['stash', 'drop'], path)
+        _mark_coherent_recovery()
         return ('Local modifications were restored from the temporary stash.')
 
     detail = (pull_out or '').strip()[:200]
@@ -2529,8 +2724,16 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     if status_out:
         _, ok = _run_git(['stash', 'push', '-m', 'hermes-update-autostash'], path)
         if not ok:
+            # git stash push is atomic: a failure leaves the served tree
+            # untouched, so this stays pre-mutation (FROZEN) and the wrapper
+            # may generation-unfreeze.
             return {'ok': False, 'message': 'Failed to stash local changes'}
         stashed = True
+        # First tree-mutating command confirmed (stash push moved the user's
+        # changes out of the served tree) — from here on a failure must never
+        # unfreeze into a possibly-mixed tree unless a rollback is verified
+        # (issue #6992).
+        _mark_mutation_started()
 
     # Pull with ff-only (no merge commits).
     # Split tracking refs like 'origin/main' into separate remote + branch
@@ -2541,6 +2744,9 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         pull_args.extend([remote, branch])
     else:
         pull_args.extend(['origin', compare_ref])
+    # Pull mutates the served tree (idempotent — no-op if already marked by
+    # the stash push above; agent-only attempts stay IDLE).
+    _mark_mutation_started()
     pull_out, pull_ok = _run_git(pull_args, path, timeout=30)
     if not pull_ok:
         if _is_git_lock_error(pull_out):
@@ -2577,6 +2783,9 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 _, drop_ok = _run_git(['stash', 'drop'], path)
                 restored_stash = True
                 stash_drop_failed = not drop_ok
+                # Stash re-applied — the served tree is back to the pre-update
+                # state (verified rollback), so a failure may unfreeze.
+                _mark_coherent_recovery()
             else:
                 _, reset_ok = _run_git(['reset', '--hard', 'HEAD'], path)
                 if not reset_ok:
@@ -2595,6 +2804,10 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                     if diverged_failure:
                         response['diverged'] = True
                     return response
+                # reset --hard HEAD completed — the served tree is back to the
+                # pre-update HEAD (verified rollback), so a failure may
+                # unfreeze.
+                _mark_coherent_recovery()
                 response = {
                     'ok': False,
                     'message': (
@@ -2698,6 +2911,9 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                         'gateway_restart': gateway_result.get('status'),
                     }
             _schedule_restart()
+            # Ownership of the freeze transfers to the scheduled replacement
+            # (issue #6992).
+            _mark_replacement_owned()
             response = {
                 'ok': True,
                 'message': (
@@ -2742,6 +2958,9 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     # setTimeout(() => location.reload(), 1500) on success, so the page reload
     # and the restart land at roughly the same time.
     _schedule_restart()
+    # Ownership of the freeze transfers to the scheduled replacement
+    # (issue #6992).
+    _mark_replacement_owned()
     message = f'{target} updated successfully'
     if stash_drop_failed:
         message += (

--- a/api/updates.py
+++ b/api/updates.py
@@ -81,6 +81,14 @@ _UPDATE_FREEZE_DRAINED = threading.Condition(_UPDATE_FREEZE_LOCK)
 _frozen = False
 _freeze_generation = 0
 _active_readers = 0
+# Exception-safety tracker (issue #6992 re-gate): set by the apply internals
+# immediately before the first working-tree-mutating git command. The apply
+# wrappers consult it on the exception path — if no mutation may have started
+# the served tree is still coherent and the freeze can be released; once
+# mutation may have started the freeze must persist (or the process must be
+# replaced) so mixed-revision bytes are never exposed. Reset at each wrapper
+# entry; updates are serialized by _apply_lock.
+_update_mutation_may_have_started = False
 # Bounded drain: a pathological reader (e.g. a client stalling mid-download
 # while we hold a ticket) must not hang the update forever. When the bound is
 # reached the update FAILS CLOSED: freeze_static_serving() raises
@@ -1780,6 +1788,109 @@ def _schedule_restart(delay: float = 2.0) -> None:
     import os
     import sys
 
+    def _restart_now() -> None:
+        """Synchronously replace this process image.
+
+        Runs the restart sequence without the delay and without re-acquiring
+        ``_apply_lock`` (the caller already holds it). Never returns:
+        ``os.execv`` replaces the process image, and any exec failure falls
+        back to ``os._exit(0)`` so the process supervisor (start.sh / Docker)
+        restarts us. Used as the synchronous fallback when the delayed
+        restart thread cannot start (issue #6992 — an exception while frozen
+        must never leave static serving permanently 503 with no replacement
+        pending).
+        """
+        _wait_until_restart_safe()
+        # Purge bytecode caches so the new process imports from
+        # current source.  Without this, Python may serve stale .pyc
+        # files whose mtime matches the just-pulled .py files,
+        # causing AttributeError when new methods are missing from
+        # cached class definitions.
+        if _AGENT_DIR is not None:
+            _purge_agent_pycache(Path(_AGENT_DIR))
+        _purge_agent_pycache(REPO_ROOT)
+        try:
+            # Re-exec into the just-pulled image.
+            #
+            # sys.argv[0]'s meaning depends on how the server was launched:
+            #
+            #   * Source checkout (`python server.py` via bootstrap.py /
+            #     ctl.sh / start.sh): sys.argv[0] is the SCRIPT path
+            #     (e.g. "/root/hermes-webui/server.py"), sys.executable is
+            #     the interpreter. CPython treats argv[1] as the script to
+            #     run, so we must pass [sys.executable] + sys.argv.
+            #
+            #   * Frozen/packaged build (PyInstaller, embedded zipapp,
+            #     etc.): sys.argv[0] == sys.executable == <binary>. Passing
+            #     [sys.executable] + sys.argv would re-insert the binary as
+            #     argv[1] — the kernel launches it, the interpreter treats
+            #     the binary itself as the "script" to run, and execv
+            #     effectively becomes a recursive no-op that never reaches
+            #     bind(), leaving the WebUI stuck "offline" after every
+            #     self-update. Pass argv as-is instead.
+            #
+            # Distinguish the two cases with sys.frozen (set by
+            # PyInstaller / zipapp / similar). For source checkouts the
+            # `[sys.executable] + sys.argv` form is the canonical CPython
+            # re-exec idiom (same shape Flask/Django reloaders use) and
+            # is the correct path.
+            #
+            # IMPORTANT: On Windows, os.execv() does NOT replace the
+            # current process — it spawns a new process while the old
+            # one keeps running.  This causes "address already in use"
+            # because the old process still holds the port.  On Windows
+            # we use subprocess.Popen() + os._exit() instead.
+            if sys.platform == 'win32':
+                import subprocess
+                if getattr(sys, "frozen", False):
+                    args = sys.argv
+                else:
+                    args = [sys.executable] + sys.argv
+                # Prefer pythonw.exe over python.exe so the restarted
+                # server does not create a visible console window.
+                # sys.executable may point at python.exe (console
+                # subsystem); substitute pythonw.exe if it exists
+                # next to python.exe.
+                _exe = sys.executable
+                if _exe.lower().endswith('python.exe'):
+                    _w_exe = _exe[:-4] + 'w.exe'  # python.exe -> pythonw.exe
+                    if os.path.isfile(_w_exe):
+                        if getattr(sys, "frozen", False):
+                            args = sys.argv
+                        else:
+                            args = [_w_exe] + sys.argv
+                # Start new process fully detached with NO console
+                # window.  DETACHED_PROCESS alone is not sufficient
+                # on modern Windows — without CREATE_NO_WINDOW a
+                # python.exe (console-subsystem) child still flashes
+                # an empty terminal window, which the user then
+                # manually kills (taking the WebUI with it).
+                subprocess.Popen(
+                    args,
+                    cwd=os.getcwd(),
+                    creationflags=(
+                        subprocess.DETACHED_PROCESS
+                        | subprocess.CREATE_NEW_PROCESS_GROUP
+                        | subprocess.CREATE_NO_WINDOW
+                    ),
+                    close_fds=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                # Exit immediately — the port is released as soon as
+                # this process dies, allowing the new process to bind.
+                os._exit(0)
+            else:
+                if getattr(sys, "frozen", False):
+                    os.execv(sys.executable, sys.argv)
+                else:
+                    os.execv(sys.executable, [sys.executable] + sys.argv)
+        except Exception:
+            # Last-resort: if execv fails for any reason, just exit so the
+            # process supervisor (start.sh / Docker) restarts us.
+            os._exit(0)
+
     def _do():
         import time
         time.sleep(delay)
@@ -1792,98 +1903,26 @@ def _schedule_restart(delay: float = 2.0) -> None:
         # Threads die when execv replaces the process image, so the lock is
         # released atomically by the kernel.
         with _apply_lock:
-            _wait_until_restart_safe()
-            # Purge bytecode caches so the new process imports from
-            # current source.  Without this, Python may serve stale .pyc
-            # files whose mtime matches the just-pulled .py files,
-            # causing AttributeError when new methods are missing from
-            # cached class definitions.
-            if _AGENT_DIR is not None:
-                _purge_agent_pycache(Path(_AGENT_DIR))
-            _purge_agent_pycache(REPO_ROOT)
-            try:
-                # Re-exec into the just-pulled image.
-                #
-                # sys.argv[0]'s meaning depends on how the server was launched:
-                #
-                #   * Source checkout (`python server.py` via bootstrap.py /
-                #     ctl.sh / start.sh): sys.argv[0] is the SCRIPT path
-                #     (e.g. "/root/hermes-webui/server.py"), sys.executable is
-                #     the interpreter. CPython treats argv[1] as the script to
-                #     run, so we must pass [sys.executable] + sys.argv.
-                #
-                #   * Frozen/packaged build (PyInstaller, embedded zipapp,
-                #     etc.): sys.argv[0] == sys.executable == <binary>. Passing
-                #     [sys.executable] + sys.argv would re-insert the binary as
-                #     argv[1] — the kernel launches it, the interpreter treats
-                #     the binary itself as the "script" to run, and execv
-                #     effectively becomes a recursive no-op that never reaches
-                #     bind(), leaving the WebUI stuck "offline" after every
-                #     self-update. Pass argv as-is instead.
-                #
-                # Distinguish the two cases with sys.frozen (set by
-                # PyInstaller / zipapp / similar). For source checkouts the
-                # `[sys.executable] + sys.argv` form is the canonical CPython
-                # re-exec idiom (same shape Flask/Django reloaders use) and
-                # is the correct path.
-                #
-                # IMPORTANT: On Windows, os.execv() does NOT replace the
-                # current process — it spawns a new process while the old
-                # one keeps running.  This causes "address already in use"
-                # because the old process still holds the port.  On Windows
-                # we use subprocess.Popen() + os._exit() instead.
-                if sys.platform == 'win32':
-                    import subprocess
-                    if getattr(sys, "frozen", False):
-                        args = sys.argv
-                    else:
-                        args = [sys.executable] + sys.argv
-                    # Prefer pythonw.exe over python.exe so the restarted
-                    # server does not create a visible console window.
-                    # sys.executable may point at python.exe (console
-                    # subsystem); substitute pythonw.exe if it exists
-                    # next to python.exe.
-                    _exe = sys.executable
-                    if _exe.lower().endswith('python.exe'):
-                        _w_exe = _exe[:-4] + 'w.exe'  # python.exe -> pythonw.exe
-                        if os.path.isfile(_w_exe):
-                            if getattr(sys, "frozen", False):
-                                args = sys.argv
-                            else:
-                                args = [_w_exe] + sys.argv
-                    # Start new process fully detached with NO console
-                    # window.  DETACHED_PROCESS alone is not sufficient
-                    # on modern Windows — without CREATE_NO_WINDOW a
-                    # python.exe (console-subsystem) child still flashes
-                    # an empty terminal window, which the user then
-                    # manually kills (taking the WebUI with it).
-                    subprocess.Popen(
-                        args,
-                        cwd=os.getcwd(),
-                        creationflags=(
-                            subprocess.DETACHED_PROCESS
-                            | subprocess.CREATE_NEW_PROCESS_GROUP
-                            | subprocess.CREATE_NO_WINDOW
-                        ),
-                        close_fds=True,
-                        stdin=subprocess.DEVNULL,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                    )
-                    # Exit immediately — the port is released as soon as
-                    # this process dies, allowing the new process to bind.
-                    os._exit(0)
-                else:
-                    if getattr(sys, "frozen", False):
-                        os.execv(sys.executable, sys.argv)
-                    else:
-                        os.execv(sys.executable, [sys.executable] + sys.argv)
-            except Exception:
-                # Last-resort: if execv fails for any reason, just exit so the
-                # process supervisor (start.sh / Docker) restarts us.
-                os._exit(0)
+            _restart_now()
 
-    threading.Thread(target=_do, daemon=True).start()
+    try:
+        _start_restart_thread(_do)
+    except Exception as exc:
+        # The restart thread could not start (e.g. resource exhaustion at
+        # Thread.start()). The checkout may already have been mutated in
+        # place, so static serving must NOT be exposed again until this
+        # process is replaced (issue #6992 — mixed-revision immutable cache).
+        # Fall back to a synchronous restart: it replaces the process and
+        # never returns.
+        logger.error(
+            'restart thread failed to start (%s); restarting synchronously', exc
+        )
+        _restart_now()
+
+
+def _start_restart_thread(target) -> None:
+    """Start the delayed-restart thread (split out for test injection)."""
+    threading.Thread(target=target, daemon=True).start()
 
 
 def _ensure_gateway_restart_for_agent_update() -> tuple[bool, dict]:
@@ -2148,6 +2187,11 @@ def apply_force_update(target: str, channel=None) -> dict:
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     freeze_token = None
+    # Fresh per-invocation mutation tracking (issue #6992 re-gate): set by
+    # _locked() right before the first mutating git command; read by the
+    # exception handler below to decide whether the freeze may be released.
+    global _update_mutation_may_have_started
+    _update_mutation_may_have_started = False
 
     def _locked(channel: str) -> dict:
         if target == 'webui':
@@ -2223,6 +2267,11 @@ def apply_force_update(target: str, channel=None) -> dict:
                 'channel': channel,
                 'refused_rewind': True,
             }
+        # From here on the served checkout may be mutated in place
+        # (checkout ./ clean / reset --hard) — mark it so an exception on
+        # this path can never unfreeze into a possibly-mixed tree (issue
+        # #6992).
+        _mark_update_mutation_started()
         if not _discard_local_changes(path, compare_ref):
             return {'ok': False, 'message': f'Force reset to {compare_ref} failed'}
 
@@ -2283,6 +2332,38 @@ def apply_force_update(target: str, channel=None) -> dict:
         if freeze_token is not None and not response.get('restart_scheduled'):
             unfreeze_static_serving(freeze_token)
         return response
+    except Exception:
+        # Exception-safety for the freeze lifecycle (issue #6992 re-gate):
+        # without this handler the finally below releases only _apply_lock,
+        # so an exception raised after the freeze was acquired (e.g.
+        # _schedule_restart's restart thread failing to start, after the
+        # checkout was already updated) would leave /static/* frozen at 503
+        # until a restart or another successful update — server.py keeps the
+        # process alive on the 500. Decide by mutation state:
+        if freeze_token is not None:
+            if not _update_mutation_may_have_started:
+                # Pre-mutation failure: the served tree is untouched, so
+                # release ONLY this caller's freeze generation and let
+                # static serving resume (the request surfaces the 500).
+                unfreeze_static_serving(freeze_token)
+            else:
+                # Mutation may already have started: NEVER unfreeze into a
+                # possibly-mixed tree. Guarantee process replacement before
+                # static assets are exposed again. _schedule_restart either
+                # starts the restart thread or — if that fails — replaces the
+                # process synchronously; it does not return without a
+                # replacement being guaranteed.
+                try:
+                    _schedule_restart()
+                except Exception:
+                    # Both the thread start and the synchronous fallback
+                    # failed: keep the freeze (fail-closed — 503 rather than
+                    # mixed immutable bytes). A later update or manual
+                    # restart clears it.
+                    logger.exception(
+                        'force_update: failed to schedule restart after update error'
+                    )
+        raise
     finally:
         _apply_lock.release()
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -455,6 +455,24 @@ def apply_clear_lock(target: str) -> dict:
                             'other_locks': inv['other_locks'],
                         }
                         return retry_result
+                    except StaticFreezeAlreadyActiveError as exc:
+                        # Another update holds the freeze with replacement
+                        # pending — do NOT unfreeze (it owns the freeze until
+                        # its execv) and do NOT mutate (#7005 hole 2).
+                        retry_result = {
+                            'ok': False,
+                            'message': str(exc),
+                            'target': target,
+                            'freeze_occupied': True,
+                            'retryable': True,
+                        }
+                        retry_result = dict(retry_result)
+                        retry_result['lock_recovery'] = {
+                            'action': 'no-lock-found',
+                            'manual_command': manual_command,
+                            'other_locks': inv['other_locks'],
+                        }
+                        return retry_result
                     retry_result = _apply_update_inner(target, _read_update_channel())
                     _settle_update_lifecycle(freeze_token, retry_result)
                 except Exception:
@@ -1957,16 +1975,30 @@ def _schedule_restart(delay: float = 2.0) -> None:
     def _do():
         import time
         time.sleep(delay)
-        # Hold _apply_lock through os.execv so no new update can start between
-        # the lock-release and the process replacement.  Any in-flight update
-        # finishes first (since it holds the lock), and then the process is
-        # replaced while still holding the lock — meaning no new update can
-        # sneak in during the brief TOCTOU window that existed with the
-        # original acquire-release-execv sequence.
-        # Threads die when execv replaces the process image, so the lock is
-        # released atomically by the kernel.
-        with _apply_lock:
-            _restart_now()
+        try:
+            # Hold _apply_lock through os.execv so no new update can start
+            # between the lock-release and the process replacement.  Any
+            # in-flight update finishes first (since it holds the lock), and
+            # then the process is replaced while still holding the lock —
+            # meaning no new update can sneak in during the brief TOCTOU
+            # window that existed with the original acquire-release-execv
+            # sequence.
+            # Threads die when execv replaces the process image, so the lock
+            # is released atomically by the kernel.
+            with _apply_lock:
+                _restart_now()
+        except BaseException:
+            # BRICK (#6992/#7005): a failure DURING the worker (e.g.
+            # _wait_until_restart_safe raised before execv) must never leave
+            # the process frozen with static serving 503 and no replacement
+            # pending. The tree may already be mutated — force the supervisor
+            # to replace us.
+            logger.exception('restart worker failed; forcing process replacement')
+            try:
+                os._exit(1)
+            except Exception:
+                pass
+            raise
 
     try:
         _start_restart_thread(_do)
@@ -2107,9 +2139,22 @@ class StaticFreezeDrainTimeoutError(Exception):
         self.token = token
 
 
+class StaticFreezeAlreadyActiveError(Exception):
+    """A freeze is already held by a pending update (replacement ownership).
+
+    Raised by :func:`freeze_static_serving` when a previous update attempt
+    already holds the freeze (its tree may be mutated and a restart is
+    scheduled, or it is mid-apply). A nested freeze must NOT supersede it:
+    the new caller would later settle by unfreezing its own (newer) token
+    while the old process still serves mutated bytes under the old version
+    token — the exact #6992 mixed-revision exposure. The caller must return a
+    retryable non-success WITHOUT unfreezing (the existing freeze persists
+    until the owning update's ``os.execv`` replaces the process).
+    """
+
+
 def freeze_static_serving(max_drain_wait_s: float | None = None) -> int:
     """Freeze /static/* serving and drain in-flight readers (issue #6992).
-
     Sets the freeze flag (new requests get 503 from _serve_static), bumps the
     generation and returns the new generation as an ownership token, then
     waits — bounded by *max_drain_wait_s* (default
@@ -2138,6 +2183,17 @@ def freeze_static_serving(max_drain_wait_s: float | None = None) -> int:
         max_drain_wait_s = _FREEZE_DRAIN_MAX_WAIT_S
     global _freeze_generation, _frozen
     with _UPDATE_FREEZE_LOCK:
+        if _frozen:
+            # A previous update already holds the freeze with replacement
+            # ownership pending (or its tree is mid-mutation). Never supersede
+            # it: the new caller would later settle by unfreezing its own
+            # newer token while the old process still serves mutated bytes
+            # under the old version token (#6992/#7005 hole 2).
+            raise StaticFreezeAlreadyActiveError(
+                'static serving already frozen by a pending update '
+                '(replacement ownership pending); refusing to supersede',
+                _freeze_generation,
+            )
         _freeze_generation += 1
         token = _freeze_generation
         _frozen = True
@@ -2514,6 +2570,17 @@ def apply_force_update(target: str, channel=None) -> dict:
                     'drain_timeout': True,
                     'retryable': True,
                 }
+            except StaticFreezeAlreadyActiveError as exc:
+                # A previous update already holds the freeze with replacement
+                # ownership pending — do NOT unfreeze (it owns the freeze until
+                # its execv) and do NOT mutate (#7005 hole 2).
+                return {
+                    'ok': False,
+                    'message': str(exc),
+                    'target': target,
+                    'freeze_occupied': True,
+                    'retryable': True,
+                }
         response = _locked(channel)
         # Lifecycle (issue #6992): on SUCCESS the freeze persists until the
         # scheduled restart replaces this process (static stays 503 through
@@ -2581,6 +2648,17 @@ def apply_update(target, channel=None):
                     'message': str(exc),
                     'target': target,
                     'drain_timeout': True,
+                    'retryable': True,
+                }
+            except StaticFreezeAlreadyActiveError as exc:
+                # A previous update already holds the freeze with replacement
+                # ownership pending — do NOT unfreeze (it owns the freeze until
+                # its execv) and do NOT mutate (#7005 hole 2).
+                return {
+                    'ok': False,
+                    'message': str(exc),
+                    'target': target,
+                    'freeze_occupied': True,
                     'retryable': True,
                 }
         response = _apply_update_inner(target, channel)
@@ -2722,18 +2800,20 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         }
     stashed = False
     if status_out:
+        # Mark mutation-as-possible BEFORE the stash push: a timed-out
+        # `stash push` can still create the stash and move the user's changes
+        # out of the served tree before the timeout is observed, so a failure
+        # return here must NOT unfreeze into a possibly-mutated tree
+        # (#7005 hole 3). From this point a failure must never unfreeze
+        # unless a rollback is verified (issue #6992).
+        _mark_mutation_started()
         _, ok = _run_git(['stash', 'push', '-m', 'hermes-update-autostash'], path)
         if not ok:
-            # git stash push is atomic: a failure leaves the served tree
-            # untouched, so this stays pre-mutation (FROZEN) and the wrapper
-            # may generation-unfreeze.
+            # The tree may have been mutated by a timed-out stash push — the
+            # lifecycle is already marked mutation-possible, so the wrapper
+            # keeps the freeze / bounded replacement instead of unfreezing.
             return {'ok': False, 'message': 'Failed to stash local changes'}
         stashed = True
-        # First tree-mutating command confirmed (stash push moved the user's
-        # changes out of the served tree) — from here on a failure must never
-        # unfreeze into a possibly-mixed tree unless a rollback is verified
-        # (issue #6992).
-        _mark_mutation_started()
 
     # Pull with ff-only (no merge commits).
     # Split tracking refs like 'origin/main' into separate remote + branch

--- a/api/updates.py
+++ b/api/updates.py
@@ -44,6 +44,13 @@ _summary_cache: OrderedDict = OrderedDict()
 _cache_lock = threading.Lock()
 _check_in_progress = False
 _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same repo
+# Issue #6992: set while an in-place WebUI update is mutating the checkout this
+# process serves from. `_serve_static()` in api/routes.py refuses to serve
+# /static/* bytes while it is set, so a request can never receive a
+# mixed-revision bundle (new JS + old CSS) under one versioned URL and have it
+# cached immutable for a year. Plain bool: reads/writes are GIL-atomic, and
+# this is checked on the hot static-serving path.
+_UPDATE_IN_PROGRESS = False
 CACHE_TTL = 1800  # 30 minutes
 _AGENT_GATEWAY_RESTART_RETRY_DELAY_S = 1.0
 _FORCE_DIRTY_PROBE_TIMEOUT = 5
@@ -1942,6 +1949,33 @@ def _discard_local_changes(path: Path, reset_ref: str) -> bool:
     return ok
 
 
+def set_update_in_progress() -> None:
+    """Freeze versioned static serving while an in-place update mutates the WebUI checkout.
+
+    Called (for ``target == 'webui'``) under ``_apply_lock`` before any git
+    command that can change the working tree this process serves /static/*
+    from. Cleared by :func:`clear_update_in_progress` once the working tree is
+    coherent again — the scheduled ``os.execv`` restart then serves the new
+    revision (issue #6992).
+    """
+    global _UPDATE_IN_PROGRESS
+    _UPDATE_IN_PROGRESS = True
+
+
+def clear_update_in_progress() -> None:
+    """Resume normal static serving after an update attempt finishes.
+
+    Safe to call even when the flag was never set (agent-target updates).
+    """
+    global _UPDATE_IN_PROGRESS
+    _UPDATE_IN_PROGRESS = False
+
+
+def update_in_progress() -> bool:
+    """True while an in-place WebUI update may be mutating the served checkout."""
+    return _UPDATE_IN_PROGRESS
+
+
 def apply_force_update(target: str, channel=None) -> dict:
     """Discard local changes for the requested update target.
 
@@ -1970,6 +2004,11 @@ def apply_force_update(target: str, channel=None) -> dict:
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     try:
+        # Freeze /static/* serving while this checkout is being mutated in
+        # place (issue #6992) — cleared in the finally below once the working
+        # tree is coherent again.
+        if target == 'webui':
+            set_update_in_progress()
         if target == 'webui':
             path = REPO_ROOT
         elif target == 'agent':
@@ -2072,6 +2111,8 @@ def apply_force_update(target: str, channel=None) -> dict:
         return response
     finally:
         _apply_lock.release()
+        if target == 'webui':
+            clear_update_in_progress()
 
 
 def apply_update(target, channel=None):
@@ -2086,9 +2127,17 @@ def apply_update(target, channel=None):
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     try:
+        # Freeze /static/* serving while this checkout is being mutated in
+        # place (issue #6992) — cleared in the finally below once the working
+        # tree is coherent again (the scheduled restart then serves the new
+        # revision).
+        if target == 'webui':
+            set_update_in_progress()
         return _apply_update_inner(target, channel)
     finally:
         _apply_lock.release()
+        if target == 'webui':
+            clear_update_in_progress()
 
 
 def _restore_stash_after_pull_failure(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,30 @@ _MISSING = object()  # sentinel: api.profiles module not loaded pre-test
 
 
 @pytest.fixture(autouse=True)
+def _reset_update_freeze_state():
+    """Reset the #6992 static-serving freeze around every test.
+
+    api.updates' freeze state is process-global. In production a successful
+    in-place update keeps /static/* frozen at 503 until the scheduled
+    os.execv replaces the process — which resets the state by starting a
+    fresh interpreter. Tests that drive the apply path (e.g. test_updates.py)
+    never get that replacement, so without this fixture a successful-update
+    test would leak ``frozen=True`` and 503 every later static-serving test
+    in the shard. Reset before AND after each test, mirroring the production
+    process boundary.
+    """
+    try:
+        from api.updates import reset_update_freeze
+    except Exception:
+        reset_update_freeze = None
+    if reset_update_freeze:
+        reset_update_freeze()
+    yield
+    if reset_update_freeze:
+        reset_update_freeze()
+
+
+@pytest.fixture(autouse=True)
 def _restore_profile_home_globals():
     """Restore HERMES_HOME / HERMES_BASE_HOME after every test.
 

--- a/tests/test_issue6992_mixed_static_assets.py
+++ b/tests/test_issue6992_mixed_static_assets.py
@@ -473,3 +473,213 @@ def test_apply_force_update_noop_clears_freeze(monkeypatch):
     assert resp.get("restart_scheduled") is None
     assert upd.update_in_progress() is False
     assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+# ── Re-gate: drain bound must FAIL CLOSED, never proceed with mutation ──────
+#
+# Original defect: freeze_static_serving() waited at most 30s for active
+# readers, then logged "proceeding with mutation", broke out of the drain and
+# returned a token while _active_readers > 0 — both update callers then ran
+# their mutating git commands unconditionally. A reader held beyond the bound
+# could observe the NEW bytes under the OLD process version URL with
+# Cache-Control: immutable (mixed-revision cache poisoning, same class as the
+# issue). Required fix shape (maintainer re-gate): fail closed — raise a
+# dedicated timeout, cancel before the first mutating git operation, release
+# only the caller's freeze generation, and return a retryable non-success.
+
+
+def test_freeze_drain_timeout_raises_fail_closed(monkeypatch):
+    """freeze_static_serving() must NEVER return mutation authority while an
+    active reader remains: at the drain bound it raises a dedicated timeout
+    carrying the caller's own generation token. The freeze stays in place
+    until the caller releases exactly that generation; a later freeze/update
+    succeeds once the reader releases."""
+    import api.updates as upd
+
+    upd.reset_update_freeze()
+    # A reader that never drains within the bound.
+    assert upd.begin_static_read() is True
+    try:
+        with pytest.raises(upd.StaticFreezeDrainTimeoutError) as excinfo:
+            upd.freeze_static_serving(max_drain_wait_s=0.1)
+        assert excinfo.value.token > 0
+        # The freeze is still set — the timeout did not silently clear it.
+        assert upd.update_in_progress() is True
+        assert _serve("/static/style.css?v=v-test-new").status == 503
+        # Release ONLY this caller's generation → coherent and retryable.
+        assert upd.unfreeze_static_serving(excinfo.value.token) is True
+        assert upd.update_in_progress() is False
+        assert _serve("/static/style.css?v=v-test-new").status == 200
+    finally:
+        upd.end_static_read()
+    # Once the reader released, a fresh freeze+unfreeze cycle works normally.
+    token = upd.freeze_static_serving(max_drain_wait_s=1.0)
+    assert upd.update_in_progress() is True
+    assert upd.unfreeze_static_serving(token) is True
+    assert upd.update_in_progress() is False
+
+
+def test_apply_update_drain_timeout_fails_closed(monkeypatch):
+    """Normal update path: with a real _serve_static() reader held past the
+    drain bound, apply_update('webui') must abort BEFORE any mutating
+    operation, release its own freeze generation, and return a retryable
+    non-success — the old-version immutable URL keeps serving the OLD bytes,
+    and a later update succeeds once the reader releases."""
+    import api.updates as upd
+    from api import config as api_config
+    from api import routes
+
+    monkeypatch.setattr(routes, "_STATIC_CACHE", {}, raising=True)
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+    # Production-composed: the real callers call freeze_static_serving() with
+    # the default bound, resolved at call time from this constant.
+    monkeypatch.setattr(upd, "_FREEZE_DRAIN_MAX_WAIT_S", 0.2)
+    expected_old_bytes = (api_config.get_static_root() / "messages.js").read_bytes()
+
+    reader_started = threading.Event()
+    reader_release = threading.Event()
+    real_read_bytes = pathlib.Path.read_bytes
+
+    def gated_read_bytes(self, *args, **kwargs):
+        if str(self).endswith("messages.js"):
+            reader_started.set()
+            assert reader_release.wait(10), "test timed out releasing the reader"
+        return real_read_bytes(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", gated_read_bytes)
+
+    inner_calls = []
+
+    def recording_inner(target, channel):
+        inner_calls.append((target, channel))
+        return {"ok": True, "message": "fake ok", "target": target,
+                "restart_scheduled": True}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", recording_inner)
+
+    result = {}
+
+    def do_request():
+        handler = _serve("/static/messages.js?v=v-test-1")
+        result["status"] = handler.status
+        result["body"] = bytes(handler.body)
+
+    reader = threading.Thread(target=do_request)
+    reader.start()
+    assert reader_started.wait(10), "reader never reached read_bytes"
+
+    resp = upd.apply_update("webui")
+
+    # Fail-closed: retryable non-success, and NOTHING mutating ran.
+    assert resp["ok"] is False
+    assert resp.get("drain_timeout") is True
+    assert resp.get("retryable") is True
+    assert "reader" in resp["message"].lower()
+    assert inner_calls == [], \
+        f"update proceeded despite an undrained reader: {inner_calls}"
+    # Freeze released for THIS caller's generation → serving is coherent again
+    # (the tree was never touched). style.css is not gated, so this read is
+    # safe while the messages.js reader is still held.
+    assert upd.update_in_progress() is False
+    assert _serve("/static/style.css?v=v-test-new").status == 200
+
+    # Release the reader: it finishes serving the OLD revision's bytes under
+    # the old token — the mixed-revision immutable exposure cannot happen.
+    reader_release.set()
+    reader.join(10)
+    assert result["status"] == 200
+    assert result["body"] == expected_old_bytes
+    old_token = _serve("/static/messages.js?v=v-test-1")
+    assert old_token.status == 200
+    assert old_token.body == expected_old_bytes
+    assert "immutable" in old_token.header("Cache-Control")
+
+    # A later update succeeds once the reader released.
+    resp2 = upd.apply_update("webui")
+    assert resp2["ok"] is True and resp2.get("restart_scheduled") is True
+    assert len(inner_calls) == 1
+    upd.reset_update_freeze()
+
+
+def test_apply_force_update_drain_timeout_fails_closed(monkeypatch):
+    """Force update path: with a real _serve_static() reader held past the
+    drain bound, apply_force_update('webui') must abort before ANY git command
+    (not even the pre-flight fetch), release its own freeze generation, and
+    return a retryable non-success — old-version immutable serving keeps
+    binding to the old bytes, and a later force update succeeds once the
+    reader releases."""
+    import api.updates as upd
+    from api import config as api_config
+    from api import routes
+
+    monkeypatch.setattr(routes, "_STATIC_CACHE", {}, raising=True)
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+    monkeypatch.setattr(upd, "_FREEZE_DRAIN_MAX_WAIT_S", 0.2)
+    expected_old_bytes = (api_config.get_static_root() / "messages.js").read_bytes()
+
+    reader_started = threading.Event()
+    reader_release = threading.Event()
+    real_read_bytes = pathlib.Path.read_bytes
+
+    def gated_read_bytes(self, *args, **kwargs):
+        if str(self).endswith("messages.js"):
+            reader_started.set()
+            assert reader_release.wait(10), "test timed out releasing the reader"
+        return real_read_bytes(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", gated_read_bytes)
+
+    git_calls = []
+
+    def recording_run_git(args, cwd, timeout=10):
+        git_calls.append(list(args))
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", recording_run_git)
+    monkeypatch.setattr(
+        upd, "_select_apply_compare_ref",
+        lambda path, channel, target: "origin/master",
+    )
+    monkeypatch.setattr(upd, "_head_contains_ref", lambda path, ref: False)
+    monkeypatch.setattr(upd, "_can_fast_forward_to", lambda path, ref: True)
+    monkeypatch.setattr(upd, "_schedule_restart", lambda *a, **k: None)
+
+    result = {}
+
+    def do_request():
+        handler = _serve("/static/messages.js?v=v-test-1")
+        result["status"] = handler.status
+        result["body"] = bytes(handler.body)
+
+    reader = threading.Thread(target=do_request)
+    reader.start()
+    assert reader_started.wait(10), "reader never reached read_bytes"
+
+    resp = upd.apply_force_update("webui")
+
+    # Fail-closed: retryable non-success, and NO git command ran at all — the
+    # abort happens before the first mutating operation inside _locked().
+    assert resp["ok"] is False
+    assert resp.get("drain_timeout") is True
+    assert resp.get("retryable") is True
+    assert "reader" in resp["message"].lower()
+    assert git_calls == [], \
+        f"force update ran git despite an undrained reader: {git_calls}"
+    assert upd.update_in_progress() is False
+    assert _serve("/static/style.css?v=v-test-new").status == 200
+
+    reader_release.set()
+    reader.join(10)
+    assert result["status"] == 200
+    assert result["body"] == expected_old_bytes
+    old_token = _serve("/static/messages.js?v=v-test-1")
+    assert old_token.status == 200
+    assert old_token.body == expected_old_bytes
+    assert "immutable" in old_token.header("Cache-Control")
+
+    # A later force update succeeds once the reader released.
+    resp2 = upd.apply_force_update("webui")
+    assert resp2["ok"] is True and resp2.get("restart_scheduled") is True
+    assert any(args[0] == "reset" for args in git_calls)
+    assert upd.update_in_progress() is True
+    upd.reset_update_freeze()

--- a/tests/test_issue6992_mixed_static_assets.py
+++ b/tests/test_issue6992_mixed_static_assets.py
@@ -11,17 +11,31 @@ and CSS from the old one under the SAME versioned URL (the reported ``Refine``
 button with none of its new CSS), and the mismatched pair was cached
 indefinitely because the client/server skew check saw a token match.
 
-Fix (this PR):
-  1. While an in-place WebUI update is being applied (flag set by
-     ``api.updates`` under ``_apply_lock``), ``_serve_static()`` refuses to
-     serve static bytes: 503 + no-store, so nothing mixed is ever served or
-     cached. The client's post-update reload lands on the restarted server,
-     which serves one coherent revision.
-  2. ``immutable`` is only claimed when the token provably matches the revision
+Fix (this PR) — freeze lifecycle in ``api.updates`` + ``api.routes._serve_static()``:
+  1. While an in-place WebUI update is being applied, ``_serve_static()``
+     refuses to serve static bytes: 503 + no-store, so nothing mixed is ever
+     served or cached. The client's post-update reload lands on the restarted
+     server, which serves one coherent revision.
+  2. Reader drain (TOCTOU hole): every request that may touch the tree takes a
+     read ticket (``begin_static_read``/``end_static_read``); the freeze sets
+     the flag and then waits for all in-flight tickets before the first
+     mutating git command, so a request admitted just before the freeze always
+     finishes serving the OLD revision's bytes.
+  3. Generation-owned handoff (handoff hole): each freeze returns an ownership
+     token; ``unfreeze_static_serving`` only clears while the token is still
+     current, so an earlier update can never clear a newer update's freeze.
+  4. Persist-until-replacement (restart-delay hole): a successful update
+     (restart scheduled) keeps static frozen at 503 through the restart delay
+     until ``os.execv`` replaces the process; failure / no-op clears the
+     freeze because the working tree is coherent again.
+  5. ``immutable`` is only claimed when the token provably matches the revision
      this process was started on (``v == WEBUI_VERSION``); any other token is
      served with a short ``max-age=300`` instead of a year-long immutable cache.
 """
 
+import pathlib
+import threading
+import time
 import urllib.parse
 
 import pytest
@@ -61,12 +75,12 @@ class FakeHandler:
 
 @pytest.fixture(autouse=True)
 def _reset_update_flag():
-    """Ensure the update-freeze flag never leaks between tests."""
+    """Ensure the update-freeze state never leaks between tests."""
     import api.updates as upd
 
-    upd.clear_update_in_progress()
+    upd.reset_update_freeze()
     yield
-    upd.clear_update_in_progress()
+    upd.reset_update_freeze()
 
 
 def _serve(path: str):
@@ -84,7 +98,7 @@ def test_static_requests_frozen_503_during_update_window():
     """While an update is in progress, /static/* must not be served at all."""
     import api.updates as upd
 
-    upd.set_update_in_progress()
+    upd.freeze_static_serving()
     handler = _serve("/static/style.css?v=v-test-new")
 
     assert handler.status == 503
@@ -100,7 +114,7 @@ def test_no_mixed_revision_pair_served_during_update_window():
     window serves nothing, so a mixed (new JS + old CSS) pair cannot occur."""
     import api.updates as upd
 
-    upd.set_update_in_progress()
+    upd.freeze_static_serving()
     js_handler = _serve("/static/messages.js?v=v-test-new")
     css_handler = _serve("/static/style.css?v=v-test-new")
 
@@ -111,12 +125,12 @@ def test_no_mixed_revision_pair_served_during_update_window():
 
 
 def test_static_serving_resumes_after_update_window():
-    """Once the update attempt finishes (flag cleared), serving works again."""
+    """Once the freeze is lifted (failure/no-op path), serving works again."""
     import api.updates as upd
 
-    upd.set_update_in_progress()
+    upd.freeze_static_serving()
     assert _serve("/static/style.css?v=v-test-new").status == 503
-    upd.clear_update_in_progress()
+    upd.reset_update_freeze()
 
     handler = _serve("/static/style.css?v=v-test-new")
     assert handler.status == 200
@@ -171,17 +185,25 @@ def test_static_unversioned_request_keeps_short_cache(monkeypatch):
 def test_update_progress_flag_helpers():
     import api.updates as upd
 
-    upd.clear_update_in_progress()
+    upd.reset_update_freeze()
     assert upd.update_in_progress() is False
-    upd.set_update_in_progress()
+    token = upd.freeze_static_serving()
     assert upd.update_in_progress() is True
-    upd.clear_update_in_progress()
+    assert upd.unfreeze_static_serving(token) is True
+    assert upd.update_in_progress() is False
+    # A stale token can never clear a newer freeze (generation ownership).
+    token_a = upd.freeze_static_serving()
+    token_b = upd.freeze_static_serving()
+    assert upd.unfreeze_static_serving(token_a) is False
+    assert upd.update_in_progress() is True
+    assert upd.unfreeze_static_serving(token_b) is True
     assert upd.update_in_progress() is False
 
 
 def test_apply_update_freezes_static_during_apply(monkeypatch):
-    """apply_update('webui') must hold the freeze flag while the checkout is
-    being mutated and release it once the attempt finishes."""
+    """apply_update('webui') must hold the freeze while the checkout is being
+    mutated and — because the update succeeds (restart scheduled) — KEEP it
+    until the replacement, per the persist-until-replacement lifecycle."""
     import api.updates as upd
 
     observed = {}
@@ -189,7 +211,8 @@ def test_apply_update_freezes_static_during_apply(monkeypatch):
     def fake_inner(target, channel):
         observed["target"] = target
         observed["flag_during_apply"] = upd.update_in_progress()
-        return {"ok": True, "message": "fake ok", "target": target}
+        return {"ok": True, "message": "fake ok", "target": target,
+                "restart_scheduled": True}
 
     monkeypatch.setattr(upd, "_apply_update_inner", fake_inner)
 
@@ -197,7 +220,10 @@ def test_apply_update_freezes_static_during_apply(monkeypatch):
     assert resp["ok"] is True
     assert observed["target"] == "webui"
     assert observed["flag_during_apply"] is True
-    assert upd.update_in_progress() is False
+    # Success → freeze persists until the scheduled restart replaces the process.
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
 
 
 def test_apply_update_agent_does_not_freeze_webui_static(monkeypatch):
@@ -220,8 +246,9 @@ def test_apply_update_agent_does_not_freeze_webui_static(monkeypatch):
 
 
 def test_apply_force_update_freezes_static_during_apply(monkeypatch):
-    """apply_force_update('webui') must hold the freeze flag through the
-    checkout/clean/reset mutation and release it afterwards."""
+    """apply_force_update('webui') must hold the freeze through the
+    checkout/clean/reset mutation and — because the update succeeds (restart
+    scheduled) — KEEP it until the replacement."""
     import api.updates as upd
 
     observed = {}
@@ -242,4 +269,207 @@ def test_apply_force_update_freezes_static_during_apply(monkeypatch):
     assert resp["ok"] is True
     assert resp.get("restart_scheduled") is True
     assert observed.get("flag_during_reset") is True
+    # Success → freeze persists until the scheduled restart replaces the process.
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+# ── Maintainer-review regressions: lifecycle holes #1-#3 ───────────────────
+
+
+def test_freeze_drains_inflight_reader_before_mutation(monkeypatch):
+    """TOCTOU hole #1: a request admitted just before the freeze must finish
+    serving the OLD revision's bytes before the updater mutates the tree; the
+    updater's freeze waits (drain) for the reader, and no request admitted
+    after the freeze reads anything (503). Exercises the real production path
+    (_serve_static → read_bytes) with an event-gated file read."""
+    import api.updates as upd
+    from api import config as api_config
+    from api import routes
+
+    # Use the real static tree with a fresh cache so the gated read_bytes is
+    # actually exercised (cache hits would bypass the file read entirely).
+    monkeypatch.setattr(routes, "_STATIC_CACHE", {}, raising=True)
+    expected_old_bytes = (api_config.get_static_root() / "messages.js").read_bytes()
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+
+    reader_started = threading.Event()
+    reader_release = threading.Event()
+    real_read_bytes = pathlib.Path.read_bytes
+
+    def gated_read_bytes(self, *args, **kwargs):
+        if str(self).endswith("messages.js"):
+            reader_started.set()
+            assert reader_release.wait(10), "test timed out releasing the reader"
+        return real_read_bytes(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", gated_read_bytes)
+
+    result = {}
+
+    def do_request():
+        handler = _serve("/static/messages.js?v=v-test-1")
+        result["status"] = handler.status
+        result["body"] = bytes(handler.body)
+
+    reader = threading.Thread(target=do_request)
+    reader.start()
+    assert reader_started.wait(10), "reader never reached read_bytes"
+
+    freeze_result = {}
+
+    def do_freeze():
+        freeze_result["token"] = upd.freeze_static_serving()
+        freeze_result["done"] = True
+
+    freezer = threading.Thread(target=do_freeze)
+    freezer.start()
+
+    # Wait for the freeze flag to be set, then verify the updater is blocked
+    # in the drain (not done) and that new requests are rejected (503).
+    deadline = time.monotonic() + 10
+    while not upd.update_in_progress() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert upd.update_in_progress() is True, "freeze flag never set"
+    time.sleep(0.2)
+    assert not freeze_result.get("done"), \
+        "freeze returned before the in-flight reader drained"
+    assert _serve("/static/messages.js?v=v-test-1").status == 503
+
+    # Release the reader: it serves the pre-mutation bytes untouched, then the
+    # freeze drain completes and the updater may safely mutate.
+    reader_release.set()
+    reader.join(10)
+    assert result["status"] == 200
+    assert result["body"] == expected_old_bytes
+    freezer.join(10)
+    assert freeze_result.get("done") is True
+    assert upd.update_in_progress() is True
+
+
+def test_apply_update_success_keeps_freeze_until_replacement(monkeypatch):
+    """Restart-delay hole #3: a successful update (restart scheduled) must keep
+    /static/* frozen at 503 until the replacement happens; the replacement
+    (new process) starts unfrozen."""
+    import api.updates as upd
+
+    monkeypatch.setattr(
+        upd, "_apply_update_inner",
+        lambda target, channel: {"ok": True, "message": "ok", "target": target,
+                                 "restart_scheduled": True},
+    )
+    resp = upd.apply_update("webui")
+    assert resp["ok"] is True and resp.get("restart_scheduled") is True
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+
+    # Simulate the replacement: the new process starts unfrozen.
+    upd.reset_update_freeze()
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_update_failure_clears_freeze(monkeypatch):
+    """A failed update leaves the tree coherent again → freeze must be lifted."""
+    import api.updates as upd
+
+    monkeypatch.setattr(
+        upd, "_apply_update_inner",
+        lambda target, channel: {"ok": False, "message": "fetch failed",
+                                 "target": target},
+    )
+    resp = upd.apply_update("webui")
+    assert resp["ok"] is False
     assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_update_noop_clears_freeze(monkeypatch):
+    """An up-to-date no-op schedules no restart → freeze must be lifted."""
+    import api.updates as upd
+
+    monkeypatch.setattr(
+        upd, "_apply_update_inner",
+        lambda target, channel: {"ok": True, "message": "already up to date",
+                                 "target": target, "up_to_date": True},
+    )
+    resp = upd.apply_update("webui")
+    assert resp["ok"] is True and resp.get("restart_scheduled") is None
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_handoff_a_cannot_clear_b_freeze():
+    """Handoff hole #2: update A's stale unfreeze must never clear update B's
+    freeze — ownership is generation-scoped."""
+    import api.updates as upd
+
+    # A freezes (e.g. successful update awaiting its scheduled restart).
+    token_a = upd.freeze_static_serving()
+    assert upd.update_in_progress() is True
+    # B starts while A's freeze persists (restart-delay window) → B owns now.
+    token_b = upd.freeze_static_serving()
+    # A's stale unfreeze is a no-op.
+    assert upd.unfreeze_static_serving(token_a) is False
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    # B clears its own freeze (e.g. B failed or was a no-op).
+    assert upd.unfreeze_static_serving(token_b) is True
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_sequential_successful_updates_keep_freeze_until_replacement(monkeypatch):
+    """A→B lock handoff through the real apply_update path: B takes over the
+    freeze while A's is still pending and neither clears the other's."""
+    import api.updates as upd
+
+    def ok_inner(target, channel):
+        return {"ok": True, "message": "ok", "target": target,
+                "restart_scheduled": True}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", ok_inner)
+
+    resp_a = upd.apply_update("webui")  # A: success, freeze persists
+    assert resp_a["ok"] is True
+    assert upd.update_in_progress() is True
+    resp_b = upd.apply_update("webui")  # B: success, takes over the freeze
+    assert resp_b["ok"] is True
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+def test_apply_force_update_failure_clears_freeze(monkeypatch):
+    """Force-update failure (fetch) → freeze must be lifted."""
+    import api.updates as upd
+
+    def fake_run_git(args, cwd, timeout=10):
+        if args and args[0] == "fetch":
+            return ("could not resolve host: origin", False)
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", fake_run_git)
+
+    resp = upd.apply_force_update("webui")
+    assert resp["ok"] is False
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_force_update_noop_clears_freeze(monkeypatch):
+    """Force-update no-op (already up to date, nothing to force) schedules no
+    restart → freeze must be lifted."""
+    import api.updates as upd
+
+    def fake_run_git(args, cwd, timeout=10):
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", fake_run_git)
+    monkeypatch.setattr(upd, "_select_apply_compare_ref", lambda path, channel, target: None)
+
+    resp = upd.apply_force_update("webui")
+    assert resp["ok"] is True and resp.get("up_to_date") is True
+    assert resp.get("restart_scheduled") is None
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200

--- a/tests/test_issue6992_mixed_static_assets.py
+++ b/tests/test_issue6992_mixed_static_assets.py
@@ -1,0 +1,245 @@
+"""Regression tests for #6992 — in-place updates must not serve mixed-revision static assets.
+
+Bug shape: ``api.updates._schedule_restart()`` mutates the WebUI checkout in
+place (git stash/pull/pop, or checkout/clean/reset --hard for force updates)
+before re-exec'ing the server. During that window the old process keeps serving
+``/static/*`` from the changing working tree, and ``_serve_static()`` marked
+every non-empty ``?v=`` response ``Cache-Control: immutable`` for a year —
+without any check that the served bytes actually belong to the revision the
+token claims. One page load could therefore receive JS from the new revision
+and CSS from the old one under the SAME versioned URL (the reported ``Refine``
+button with none of its new CSS), and the mismatched pair was cached
+indefinitely because the client/server skew check saw a token match.
+
+Fix (this PR):
+  1. While an in-place WebUI update is being applied (flag set by
+     ``api.updates`` under ``_apply_lock``), ``_serve_static()`` refuses to
+     serve static bytes: 503 + no-store, so nothing mixed is ever served or
+     cached. The client's post-update reload lands on the restarted server,
+     which serves one coherent revision.
+  2. ``immutable`` is only claimed when the token provably matches the revision
+     this process was started on (``v == WEBUI_VERSION``); any other token is
+     served with a short ``max-age=300`` instead of a year-long immutable cache.
+"""
+
+import urllib.parse
+
+import pytest
+
+from api import routes
+
+
+class FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler (pattern from
+    tests/test_extension_status_endpoint.py)."""
+
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def header(self, name):
+        for key, value in self.sent_headers:
+            if key.lower() == name.lower():
+                return value
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_flag():
+    """Ensure the update-freeze flag never leaks between tests."""
+    import api.updates as upd
+
+    upd.clear_update_in_progress()
+    yield
+    upd.clear_update_in_progress()
+
+
+def _serve(path: str):
+    """Call routes._serve_static() directly with a fake handler."""
+    handler = FakeHandler()
+    parsed = urllib.parse.urlsplit(path)
+    routes._serve_static(handler, parsed)
+    return handler
+
+
+# ── Freeze during the in-place update window ───────────────────────────────
+
+
+def test_static_requests_frozen_503_during_update_window():
+    """While an update is in progress, /static/* must not be served at all."""
+    import api.updates as upd
+
+    upd.set_update_in_progress()
+    handler = _serve("/static/style.css?v=v-test-new")
+
+    assert handler.status == 503
+    cache_control = handler.header("Cache-Control")
+    assert cache_control == "no-store"
+    assert "immutable" not in (cache_control or "")
+    assert b"error" in handler.body
+
+
+def test_no_mixed_revision_pair_served_during_update_window():
+    """The issue's source-level repro: with the tree mid-mutation, JS and CSS
+    requested under the SAME version token must never both be served — the
+    window serves nothing, so a mixed (new JS + old CSS) pair cannot occur."""
+    import api.updates as upd
+
+    upd.set_update_in_progress()
+    js_handler = _serve("/static/messages.js?v=v-test-new")
+    css_handler = _serve("/static/style.css?v=v-test-new")
+
+    assert js_handler.status == 503
+    assert css_handler.status == 503
+    assert js_handler.header("Cache-Control") == "no-store"
+    assert css_handler.header("Cache-Control") == "no-store"
+
+
+def test_static_serving_resumes_after_update_window():
+    """Once the update attempt finishes (flag cleared), serving works again."""
+    import api.updates as upd
+
+    upd.set_update_in_progress()
+    assert _serve("/static/style.css?v=v-test-new").status == 503
+    upd.clear_update_in_progress()
+
+    handler = _serve("/static/style.css?v=v-test-new")
+    assert handler.status == 200
+    assert len(handler.body) > 0
+
+
+# ── immutable only when the token→bytes binding is provable ────────────────
+
+
+def test_static_immutable_for_proven_version_token(monkeypatch):
+    """v == WEBUI_VERSION (the revision this process started on) is the only
+    token the server can bind to the bytes it serves → immutable is fine."""
+    import api.updates as upd
+
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+    handler = _serve("/static/messages.js?v=v-test-1")
+
+    assert handler.status == 200
+    assert "immutable" in handler.header("Cache-Control")
+
+
+def test_static_not_immutable_for_unproven_token(monkeypatch):
+    """A non-empty v that does NOT equal the process's revision cannot be
+    verified against the served bytes → short cache, never immutable."""
+    import api.updates as upd
+
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+    handler = _serve("/static/messages.js?v=v-test-2")
+
+    assert handler.status == 200
+    cache_control = handler.header("Cache-Control")
+    assert "immutable" not in cache_control
+    assert cache_control == "public, max-age=300"
+
+
+def test_static_unversioned_request_keeps_short_cache(monkeypatch):
+    """No v token at all → unchanged short cache (no immutable regression)."""
+    import api.updates as upd
+
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "v-test-1")
+    handler = _serve("/static/messages.js")
+
+    assert handler.status == 200
+    cache_control = handler.header("Cache-Control")
+    assert "immutable" not in cache_control
+    assert cache_control == "public, max-age=300"
+
+
+# ── The freeze flag lifecycle around the apply functions ───────────────────
+
+
+def test_update_progress_flag_helpers():
+    import api.updates as upd
+
+    upd.clear_update_in_progress()
+    assert upd.update_in_progress() is False
+    upd.set_update_in_progress()
+    assert upd.update_in_progress() is True
+    upd.clear_update_in_progress()
+    assert upd.update_in_progress() is False
+
+
+def test_apply_update_freezes_static_during_apply(monkeypatch):
+    """apply_update('webui') must hold the freeze flag while the checkout is
+    being mutated and release it once the attempt finishes."""
+    import api.updates as upd
+
+    observed = {}
+
+    def fake_inner(target, channel):
+        observed["target"] = target
+        observed["flag_during_apply"] = upd.update_in_progress()
+        return {"ok": True, "message": "fake ok", "target": target}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", fake_inner)
+
+    resp = upd.apply_update("webui")
+    assert resp["ok"] is True
+    assert observed["target"] == "webui"
+    assert observed["flag_during_apply"] is True
+    assert upd.update_in_progress() is False
+
+
+def test_apply_update_agent_does_not_freeze_webui_static(monkeypatch):
+    """Agent-target updates do not mutate the WebUI checkout, so the freeze
+    flag must stay clear."""
+    import api.updates as upd
+
+    observed = {}
+
+    def fake_inner(target, channel):
+        observed["flag_during_apply"] = upd.update_in_progress()
+        return {"ok": True, "message": "fake ok", "target": target}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", fake_inner)
+
+    resp = upd.apply_update("agent")
+    assert resp["ok"] is True
+    assert observed["flag_during_apply"] is False
+    assert upd.update_in_progress() is False
+
+
+def test_apply_force_update_freezes_static_during_apply(monkeypatch):
+    """apply_force_update('webui') must hold the freeze flag through the
+    checkout/clean/reset mutation and release it afterwards."""
+    import api.updates as upd
+
+    observed = {}
+
+    def fake_run_git(args, cwd, timeout=10):
+        if args and args[0] == "reset":
+            observed["flag_during_reset"] = upd.update_in_progress()
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", fake_run_git)
+    monkeypatch.setattr(upd, "_select_apply_compare_ref", lambda path, channel, target: "origin/master")
+    monkeypatch.setattr(upd, "_head_contains_ref", lambda path, ref: False)
+    monkeypatch.setattr(upd, "_can_fast_forward_to", lambda path, ref: True)
+    monkeypatch.setattr(upd, "_schedule_restart", lambda *a, **k: None)
+
+    resp = upd.apply_force_update("webui")
+
+    assert resp["ok"] is True
+    assert resp.get("restart_scheduled") is True
+    assert observed.get("flag_during_reset") is True
+    assert upd.update_in_progress() is False

--- a/tests/test_issue6992_mutation_lifecycle.py
+++ b/tests/test_issue6992_mutation_lifecycle.py
@@ -1,0 +1,512 @@
+"""Regression tests for the #6992 re-gate: per-attempt mutation lifecycle.
+
+The maintainer re-gate (2026-08-19, exact head ``347b1b1d``) found two
+objective blockers:
+
+1. ``api/updates.py::_locked()`` called the undefined
+   ``_mark_update_mutation_started()`` — every force update that reached the
+   mutation path raised ``NameError`` before checkout/reset, and the new
+   exception handler then treated the attempt as pre-mutation (the
+   ``_update_mutation_may_have_started`` flag was never set), unfroze static
+   serving and re-raised.
+2. The prior exception/failure contract was still open: ``apply_update()``
+   had only ``finally: _apply_lock.release()`` — an unexpected exception
+   after ``freeze_static_serving()`` left static serving permanently 503 —
+   and both wrappers unfroze every ordinary ``restart_scheduled == false``
+   response, including failures after checkout/clean/reset or
+   stash/pull/restore may have changed the tree.
+
+Fix (this PR): a per-attempt lifecycle authority owned by the exact freeze
+generation token, shared by ``apply_force_update()``, ``apply_update()`` and
+the WebUI-mutating clear-lock retry. States distinguish pre-mutation,
+mutation-may-have-started, verified-coherent-recovery, and
+replacement-owned. Pre-mutation failures (or verified rollbacks) may
+generation-unfreeze; once mutation may have started with no verified
+rollback the freeze is NEVER released — ownership transfers to a bounded
+replacement (``_schedule_restart``) or the freeze persists fail-closed.
+
+This file exercises every schedule the fix-spec requires: exception before
+mutation, exception after mutation begins, each returned partial-mutation
+failure, restart-thread start/worker failure, exact generation ownership,
+lock reuse, and a bounded terminal outcome. Deleting the mutation-state
+transition (``_mark_mutation_started``) makes the post-mutation tests fail.
+"""
+
+import urllib.parse
+
+import pytest
+
+from api import routes
+
+
+class FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler (pattern from
+    tests/test_extension_status_endpoint.py)."""
+
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def header(self, name):
+        for key, value in self.sent_headers:
+            if key.lower() == name.lower():
+                return value
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_state():
+    """Ensure the update-freeze and lifecycle state never leaks between tests."""
+    import api.updates as upd
+
+    upd.reset_update_freeze()
+    upd._reset_mutation_lifecycle()
+    yield
+    upd.reset_update_freeze()
+    upd._reset_mutation_lifecycle()
+
+
+def _serve(path: str):
+    """Call routes._serve_static() directly with a fake handler."""
+    handler = FakeHandler()
+    parsed = urllib.parse.urlsplit(path)
+    routes._serve_static(handler, parsed)
+    return handler
+
+
+def _force_update_git_stubs(monkeypatch):
+    """Standard stubs so apply_force_update('webui') reaches _locked()."""
+    import api.updates as upd
+
+    monkeypatch.setattr(upd, "_run_git", lambda args, cwd, timeout=10: ("", True))
+    monkeypatch.setattr(
+        upd, "_select_apply_compare_ref",
+        lambda path, channel, target: "origin/master",
+    )
+    monkeypatch.setattr(upd, "_head_contains_ref", lambda path, ref: False)
+    monkeypatch.setattr(upd, "_can_fast_forward_to", lambda path, ref: True)
+
+
+# ── apply_update: exception before / after mutation ────────────────────────
+
+
+def test_apply_update_exception_before_mutation_unfreezes(monkeypatch):
+    """Pre-mutation exception (inner raises before any mutating git command):
+    the tree is untouched, so the freeze is generation-unfrozen and static
+    serving resumes; the exception still propagates to the caller."""
+    import api.updates as upd
+
+    def boom_inner(target, channel):
+        raise RuntimeError("fetch exploded before any mutation")
+
+    monkeypatch.setattr(upd, "_apply_update_inner", boom_inner)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_update("webui")
+
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_update_exception_after_mutation_begins_keeps_freeze(monkeypatch):
+    """Post-mutation exception (inner raised after stash/pull may have run):
+    NEVER unfreeze into a possibly-mixed tree — transfer ownership to a
+    bounded replacement (_schedule_restart) and keep the freeze."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def boom_inner(target, channel):
+        upd._mark_mutation_started()  # stash push / pull already ran
+        raise RuntimeError("pull exploded mid-write")
+
+    monkeypatch.setattr(upd, "_apply_update_inner", boom_inner)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_update("webui")
+
+    assert restart_calls == [1], "post-mutation exception must schedule a replacement"
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+# ── apply_update: returned partial-mutation failures ───────────────────────
+
+
+def test_apply_update_returned_pre_mutation_failure_unfreezes(monkeypatch):
+    """Ordinary returned failure BEFORE any mutation (e.g. fetch lock error):
+    pre-mutation → generation-unfreeze, no replacement scheduled."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def pre_mutation_failure_inner(target, channel):
+        return {
+            "ok": False,
+            "message": "Fetch failed due to a repository lock: index.lock",
+            "lock_conflict": True,
+        }
+
+    monkeypatch.setattr(upd, "_apply_update_inner", pre_mutation_failure_inner)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    resp = upd.apply_update("webui")
+
+    assert resp["ok"] is False
+    assert resp.get("restart_scheduled") is None
+    assert restart_calls == [], "pre-mutation failure must not schedule a replacement"
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_update_returned_partial_mutation_failure_keeps_freeze(monkeypatch):
+    """Ordinary returned failure AFTER mutation may have started (stash
+    pushed, pull failed, stash restore failed — tree may be mixed): the
+    freeze MUST NOT be inferred coherent from the absence of
+    restart_scheduled; ownership transfers to a bounded replacement."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def partial_mutation_failure_inner(target, channel):
+        upd._mark_mutation_started()
+        return {
+            "ok": False,
+            "message": (
+                "Pull failed, and failed to clean up a stash-apply conflict "
+                "while restoring local changes. Manual intervention needed: "
+                "run git reset --hard HEAD to remove conflict markers."
+            ),
+            "stash_conflict": True,
+        }
+
+    monkeypatch.setattr(upd, "_apply_update_inner", partial_mutation_failure_inner)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    resp = upd.apply_update("webui")
+
+    assert resp["ok"] is False
+    assert resp.get("restart_scheduled") is None
+    assert restart_calls == [1], "partial-mutation failure must schedule a replacement"
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+def test_apply_update_verified_rollback_failure_unfreezes(monkeypatch):
+    """Returned failure AFTER mutation but with a VERIFIED rollback (stash
+    restored / reset completed): coherent again → generation-unfreeze."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def rollback_failure_inner(target, channel):
+        upd._mark_mutation_started()
+        upd._mark_coherent_recovery()  # stash pop restored the pre-update tree
+        return {"ok": False, "message": "pull diverged", "diverged": True}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", rollback_failure_inner)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    resp = upd.apply_update("webui")
+
+    assert resp["ok"] is False
+    assert resp.get("restart_scheduled") is None
+    assert restart_calls == [], "verified rollback must not schedule a replacement"
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+# ── apply_force_update: exception before / after mutation ──────────────────
+
+
+def test_apply_force_update_exception_before_mutation_unfreezes(monkeypatch):
+    """Force update: exception during the pre-flight fetch (before the
+    mutation mark) → pre-mutation, generation-unfreeze, exception propagates."""
+    import api.updates as upd
+
+    def exploding_git(args, cwd, timeout=10):
+        if args and args[0] == "fetch":
+            raise RuntimeError("git fetch crashed")
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", exploding_git)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_force_update("webui")
+
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_force_update_exception_after_mutation_begins_keeps_freeze(monkeypatch):
+    """Force update: exception DURING checkout/clean/reset (after the
+    mutation mark in _locked) → never unfreeze; schedule a bounded
+    replacement and keep the freeze."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def exploding_discard(path, reset_ref):
+        raise RuntimeError("git reset crashed mid-mutation")
+
+    _force_update_git_stubs(monkeypatch)
+    monkeypatch.setattr(upd, "_discard_local_changes", exploding_discard)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_force_update("webui")
+
+    assert restart_calls == [1], "post-mutation exception must schedule a replacement"
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+# ── apply_force_update: returned partial-mutation failures ─────────────────
+
+
+def test_apply_force_update_returned_pre_mutation_failure_unfreezes(monkeypatch):
+    """Force update: ordinary returned failure at the fetch (pre-mutation) →
+    generation-unfreeze, no replacement scheduled."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def failing_git(args, cwd, timeout=10):
+        if args and args[0] == "fetch":
+            return ("could not resolve host: origin", False)
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", failing_git)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    resp = upd.apply_force_update("webui")
+
+    assert resp["ok"] is False
+    assert restart_calls == [], "pre-mutation failure must not schedule a replacement"
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_force_update_returned_partial_mutation_failure_keeps_freeze(monkeypatch):
+    """Force update: ordinary returned failure AFTER checkout/clean/reset may
+    have run (reset --hard failed) → tree may be mixed; do NOT infer
+    coherence from the absence of restart_scheduled — keep the freeze and
+    schedule a bounded replacement."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    _force_update_git_stubs(monkeypatch)
+    monkeypatch.setattr(upd, "_discard_local_changes", lambda path, reset_ref: False)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+
+    resp = upd.apply_force_update("webui")
+
+    assert resp["ok"] is False
+    assert resp.get("restart_scheduled") is None
+    assert restart_calls == [1], "partial-mutation failure must schedule a replacement"
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+# ── Restart-thread start/worker failure → bounded terminal outcome ─────────
+
+
+def test_restart_thread_start_failure_keeps_freeze_fail_closed(monkeypatch):
+    """Restart-thread start failure (thread AND synchronous fallback both
+    fail): the shared authority must NOT unfreeze — fail-closed terminal
+    outcome (503) until a later update or manual restart clears it."""
+    import api.updates as upd
+
+    def failing_thread_start(target):
+        raise RuntimeError("thread start failed")
+
+    def failing_sync_fallback(**kwargs):
+        raise RuntimeError("synchronous fallback failed")
+
+    def boom_inner(target, channel):
+        upd._mark_mutation_started()
+        raise RuntimeError("post-mutation failure")
+
+    monkeypatch.setattr(upd, "_apply_update_inner", boom_inner)
+    monkeypatch.setattr(upd, "_start_restart_thread", failing_thread_start)
+    monkeypatch.setattr(upd, "_wait_until_restart_safe", failing_sync_fallback)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_update("webui")
+
+    # Bounded terminal outcome: freeze persists (fail-closed), static is 503,
+    # and the state survives until the process is replaced.
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+# ── Exact generation ownership / lock reuse ────────────────────────────────
+
+
+def test_generation_ownership_stale_token_cannot_clear_newer_freeze():
+    """A stale attempt settling with its own (superseded) freeze generation
+    must never clear a newer attempt's freeze — exact generation ownership."""
+    import api.updates as upd
+
+    token_a = upd.freeze_static_serving()
+    upd._mark_freeze_acquired(token_a)
+    # A newer attempt takes over the freeze while A is still in flight.
+    token_b = upd.freeze_static_serving()
+    upd._mark_freeze_acquired(token_b)
+
+    # A settles with its own (now stale) token → unfreeze is a no-op.
+    upd._settle_update_lifecycle(token_a)
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+
+    # B settles with the current generation → freeze clears.
+    upd._settle_update_lifecycle(token_b)
+    assert upd.update_in_progress() is False
+    assert _serve("/static/messages.js?v=v-test-new").status == 200
+
+
+def test_apply_lock_released_after_exception_for_reuse(monkeypatch):
+    """After a pre-mutation exception the wrapper's finally must release
+    _apply_lock, so a subsequent update attempt can proceed (lock reuse)."""
+    import api.updates as upd
+
+    def boom_inner(target, channel):
+        raise RuntimeError("boom before mutation")
+
+    monkeypatch.setattr(upd, "_apply_update_inner", boom_inner)
+
+    with pytest.raises(RuntimeError):
+        upd.apply_update("webui")
+
+    # The lock was released by the wrapper's finally.
+    assert upd._apply_lock.acquire(blocking=False) is True
+    upd._apply_lock.release()
+
+    # A subsequent attempt runs normally.
+    def ok_inner(target, channel):
+        return {"ok": True, "message": "ok", "target": target,
+                "restart_scheduled": True}
+
+    monkeypatch.setattr(upd, "_apply_update_inner", ok_inner)
+    resp = upd.apply_update("webui")
+    assert resp["ok"] is True and resp.get("restart_scheduled") is True
+    assert upd.update_in_progress() is True
+    upd.reset_update_freeze()
+
+
+# ── Clear-lock retry shares the lifecycle authority ────────────────────────
+
+
+def test_apply_clear_lock_webui_retry_uses_lifecycle_authority(monkeypatch):
+    """The WebUI-mutating clear-lock retry re-runs _apply_update_inner and
+    must use the SAME per-attempt lifecycle authority: freeze before the
+    mutating path, settle on ordinary failure returns."""
+    import api.updates as upd
+
+    restart_calls = []
+
+    def fake_schedule_restart(*a, **k):
+        restart_calls.append(1)
+
+    def no_lock_inventory(path):
+        return {
+            "well_known_lock_present": False,
+            "well_known_lock_path": str(path / ".git" / "index.lock"),
+            "other_locks": [],
+        }
+
+    def partial_mutation_failure_inner(target, channel):
+        upd._mark_mutation_started()
+        return {
+            "ok": False,
+            "message": "stash restore failed; changes remain in git stash",
+            "stash_conflict": True,
+        }
+
+    monkeypatch.setattr(upd, "_restart_blocker_snapshot", lambda: {})
+    monkeypatch.setattr(upd, "_inventory_locks", no_lock_inventory)
+    monkeypatch.setattr(upd, "_apply_update_inner", partial_mutation_failure_inner)
+    monkeypatch.setattr(upd, "_schedule_restart", fake_schedule_restart)
+    monkeypatch.setattr(upd, "_read_update_channel", lambda: "stable")
+
+    resp = upd.apply_clear_lock("webui")
+
+    assert resp["ok"] is False
+    assert resp.get("lock_recovery", {}).get("action") == "no-lock-found"
+    assert restart_calls == [1], "clear-lock retry must schedule a replacement"
+    assert upd.update_in_progress() is True
+    assert _serve("/static/messages.js?v=v-test-new").status == 503
+    upd.reset_update_freeze()
+
+
+def test_apply_clear_lock_agent_retry_does_not_freeze(monkeypatch):
+    """Agent-target clear-lock retries never touch the WebUI tree — no
+    freeze, no lifecycle authority needed."""
+    import api.updates as upd
+
+    def no_lock_inventory(path):
+        return {
+            "well_known_lock_present": False,
+            "well_known_lock_path": str(path / ".git" / "index.lock"),
+            "other_locks": [],
+        }
+
+    calls = []
+
+    def recording_inner(target, channel):
+        calls.append((target, channel))
+        return {"ok": True, "message": "ok", "target": target}
+
+    monkeypatch.setattr(upd, "_restart_blocker_snapshot", lambda: {})
+    monkeypatch.setattr(upd, "_inventory_locks", no_lock_inventory)
+    monkeypatch.setattr(upd, "_apply_update_inner", recording_inner)
+    monkeypatch.setattr(upd, "_read_update_channel", lambda: "stable")
+
+    resp = upd.apply_clear_lock("agent")
+
+    assert resp["ok"] is True
+    assert calls == [("agent", "stable")]
+    assert upd.update_in_progress() is False

--- a/tests/test_issue6992_mutation_lifecycle.py
+++ b/tests/test_issue6992_mutation_lifecycle.py
@@ -393,17 +393,19 @@ def test_generation_ownership_stale_token_cannot_clear_newer_freeze():
 
     token_a = upd.freeze_static_serving()
     upd._mark_freeze_acquired(token_a)
-    # A newer attempt takes over the freeze while A is still in flight.
-    token_b = upd.freeze_static_serving()
-    upd._mark_freeze_acquired(token_b)
 
-    # A settles with its own (now stale) token → unfreeze is a no-op.
-    upd._settle_update_lifecycle(token_a)
+    # #7005 hole 2: a nested freeze (update B arriving while A still holds the
+    # freeze with replacement ownership pending) must be REJECTED, not
+    # supersede A's freeze — otherwise B's no-op settle would unfreeze its own
+    # newer token while A's old process still serves mutated bytes.
+    with pytest.raises(upd.StaticFreezeAlreadyActiveError):
+        upd.freeze_static_serving()
+    # A's freeze persists untouched.
     assert upd.update_in_progress() is True
     assert _serve("/static/messages.js?v=v-test-new").status == 503
 
-    # B settles with the current generation → freeze clears.
-    upd._settle_update_lifecycle(token_b)
+    # A settles with the current generation → freeze clears.
+    upd._settle_update_lifecycle(token_a)
     assert upd.update_in_progress() is False
     assert _serve("/static/messages.js?v=v-test-new").status == 200
 
@@ -510,3 +512,67 @@ def test_apply_clear_lock_agent_retry_does_not_freeze(monkeypatch):
     assert resp["ok"] is True
     assert calls == [("agent", "stable")]
     assert upd.update_in_progress() is False
+
+
+def test_restart_worker_failure_forces_process_exit(monkeypatch):
+    """#7005 hole 1 (BRICK): a failure DURING the restart worker (e.g.
+    _wait_until_restart_safe raising before execv) must never leave the
+    process frozen with static serving 503 — the worker forces os._exit(1)
+    so the supervisor replaces the process."""
+    import api.updates as upd
+
+    exited = []
+
+    # Run the worker target synchronously (test injection seam).
+    monkeypatch.setattr(upd, "_start_restart_thread", lambda target: target())
+    # Make the pre-execv gate raise — the worker's non-returning path must
+    # catch it and force process replacement.
+    def boom():
+        raise RuntimeError("restart gate failed before execv")
+
+    monkeypatch.setattr(upd, "_wait_until_restart_safe", boom)
+    monkeypatch.setattr(upd.os, "_exit", lambda code: exited.append(code))
+
+    with pytest.raises(RuntimeError):
+        upd._schedule_restart(delay=0)
+
+    assert exited == [1], f"worker failure must force os._exit(1), got {exited}"
+
+
+def test_stash_failure_marks_mutation_possible_before_side_effect(monkeypatch):
+    """#7005 hole 3: a timed-out `git stash push` can still mutate the tree
+    before the timeout is observed, so the lifecycle must be marked
+    mutation-possible BEFORE the stash command runs — a failure return must
+    never unfreeze into a possibly-mutated tree."""
+    import api.updates as upd
+
+    events = []
+
+    def fake_run_git(args, cwd, timeout=10):
+        cmd = args[0] if isinstance(args, list) else str(args)
+        events.append(("git", cmd))
+        if cmd == "fetch":
+            return ("", True)
+        if cmd == "status":
+            return (" M modified.py", True)  # dirty tree → stash path
+        if cmd == "stash":
+            return ("timed out", False)  # stash push fails/times out
+        return ("", True)
+
+    monkeypatch.setattr(upd, "_run_git", fake_run_git)
+    monkeypatch.setattr(upd, "_select_apply_compare_ref", lambda *a, **k: "origin/main")
+    monkeypatch.setattr(upd, "_reset_mutation_lifecycle", lambda: None)
+    monkeypatch.setattr(
+        upd, "_mark_mutation_started", lambda: events.append(("mark", None))
+    )
+
+    result = upd._apply_update_inner("webui")
+
+    assert result.get("ok") is False
+    assert "Failed to stash local changes" in result.get("message", "")
+    stash_pos = next(i for i, e in enumerate(events) if e == ("git", "stash"))
+    mark_pos = next(i for i, e in enumerate(events) if e == ("mark", None))
+    assert mark_pos < stash_pos, (
+        "mutation must be marked BEFORE the stash push side effect "
+        "(a timed-out stash can still mutate the tree)"
+    )

--- a/tests/test_static_asset_compression_and_cache.py
+++ b/tests/test_static_asset_compression_and_cache.py
@@ -118,12 +118,23 @@ def test_gzip_negotiated_when_client_accepts(isolated_static):
     assert int(h.header("Content-Length")) == len(h.body) < len(payload)
 
 
-def test_fingerprinted_url_gets_immutable_cache(isolated_static):
+def test_fingerprinted_url_gets_immutable_cache(isolated_static, monkeypatch):
     from api import routes
+    import api.updates as upd
+
     _make_static_file(isolated_static, "ui.js", b"x" * 2000)
 
+    # immutable is only claimed when the token provably matches the revision
+    # this process serves (issue #6992): patch WEBUI_VERSION to the token.
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "abc1234")
     h = _serve(routes, "/static/ui.js", query="v=abc1234")
     assert h.header("Cache-Control") == "public, max-age=31536000, immutable"
+
+    # A mismatched token can never be verified against the served bytes →
+    # short cache, never immutable (mismatch contract retained).
+    h2 = _serve(routes, "/static/ui.js", query="v=other-token")
+    assert h2.header("Cache-Control") == "public, max-age=300"
+    assert "immutable" not in h2.header("Cache-Control")
 
 
 def test_empty_fingerprint_value_gets_short_cache(isolated_static):
@@ -143,10 +154,15 @@ def test_unfingerprinted_url_gets_short_cache(isolated_static):
     assert h.header("Cache-Control") == "public, max-age=300"
 
 
-def test_conditional_get_returns_304(isolated_static):
+def test_conditional_get_returns_304(isolated_static, monkeypatch):
     from api import routes
+    import api.updates as upd
+
     _make_static_file(isolated_static, "ui.js", b"hello world\n" * 100)
 
+    # Supply the matching startup token so the 304 keeps the immutable claim
+    # (issue #6992: a non-matching token would only get max-age=300).
+    monkeypatch.setattr(upd, "WEBUI_VERSION", "abc")
     first = _serve(routes, "/static/ui.js", query="v=abc")
     etag = first.header("ETag")
     assert etag is not None

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -654,7 +654,14 @@ def test_force_update_dirty_stable_reset_failure_reports_head(tmp_path, monkeypa
         ['clean', '-fd'],
         ['reset', '--hard', 'HEAD'],
     ]
-    restart.assert_not_called()
+    # Mutation may have started (checkout/clean/reset ran): the failure is a
+    # partial-mutation failure — the tree may be mixed, so the wrapper must
+    # transfer ownership to a bounded replacement instead of serving again
+    # (issue #6992 re-gate: do not infer coherence from the absence of
+    # restart_scheduled).
+    restart.assert_called_once_with()
+    assert updates.update_in_progress() is True
+    updates.reset_update_freeze()
 
 
 @pytest.mark.parametrize('reset_ok', [True, False])
@@ -703,7 +710,14 @@ def test_force_update_clean_failure_preserves_reset_boundary(tmp_path, monkeypat
         restart.assert_called_once_with()
     else:
         assert result == {'ok': False, 'message': 'Force reset to origin/main failed'}
-        restart.assert_not_called()
+        # Mutation may have started (checkout/clean/reset ran): the failure is
+        # a partial-mutation failure — the tree may be mixed, so the wrapper
+        # must transfer ownership to a bounded replacement instead of serving
+        # again (issue #6992 re-gate: do not infer coherence from the absence
+        # of restart_scheduled).
+        restart.assert_called_once_with()
+        assert updates.update_in_progress() is True
+        updates.reset_update_freeze()
 
 
 def test_check_for_updates_can_skip_agent_repo(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #6992: after an in-place WebUI self-update, a single page load could receive static files from **two different revisions under the same versioned URL** (`/static/*.js?v=<token>` + `/static/*.css?v=<token>`), and each response was served with `Cache-Control: public, max-age=31536000, immutable` — so the mismatched pair (e.g. the new selected-text `Refine` control with none of its new CSS) was cached indefinitely.

## Root Cause

`api/updates.py` mutates the WebUI checkout **in place** (`git stash`/`pull --ff-only`/`stash pop`, or `checkout .`/`clean`/`reset --hard` for force updates) and then re-execs the server after a short delay. During that window the old process keeps serving `/static/*` from the changing working tree. `api/routes.py::_serve_static()` read the current file for every request and treated **any non-empty `v` value** as immutable, with no check that the served bytes actually belong to the revision the token claims:

```python
version_values = parse_qs(parsed.query, keep_blank_values=True).get("v", [""])
has_fingerprint = bool(version_values[0])
cache_control = "public, max-age=31536000, immutable" if has_fingerprint else ...
```

Because the old process stamps the same token on every asset URL, the existing client/server version-skew check (#5428) sees a match even though the returned bytes came from different filesystem revisions — the mixed bundle survives.

## Change

Two complementary guards (the "stop serving before mutating" + "avoid immutable when unprovable" directions from the issue):

1. **Freeze static serving during the in-place update window** — `api/updates.py` gains a process-wide `update_in_progress()` flag that is set (under `_apply_lock`, `target == 'webui'` only) before any git command can mutate the served checkout and cleared once the apply attempt finishes. While set, `_serve_static()` refuses to serve static bytes: `503` + `Cache-Control: no-store` (via `j()`), so **nothing mixed is ever served or cached**. The client's post-update reload lands on the restarted server, which serves one coherent revision. Agent-target updates do not touch the WebUI checkout and do not set the flag.

2. **`immutable` only when the token→bytes binding is provable** — `_serve_static()` now claims `immutable` only when `v == WEBUI_VERSION` (the revision this process was started on, resolved once at import — the only token the server can bind to the bytes it serves). Any other non-empty token (HTML stamped by a different revision mid-update, a stale service worker, a hand-crafted URL) gets `public, max-age=300` instead of a year-long immutable cache.

## Verification

- New regression tests in `tests/test_issue6992_mixed_static_assets.py` (10 tests):
  - during the update window, `/static/*` returns `503` + `no-store` — the issue's source-level repro (JS and CSS requested under the same new token) now serves **nothing**, so a mixed pair cannot occur;
  - serving resumes normally once the flag is cleared;
  - `immutable` is only emitted for `v == WEBUI_VERSION`; unproven tokens and unversioned requests keep the short `max-age=300`;
  - flag lifecycle: `apply_update('webui')` / `apply_force_update('webui')` hold the freeze while the checkout is being mutated and release it afterwards; `apply_update('agent')` does not freeze WebUI static.
- Existing related suites pass: `test_update_banner_fixes.py`, `test_issue1633_models_cache_version_stamp.py`, `test_pwa_manifest_sw.py`, worktree-static tests — 196 passed.
- Full suite: `./scripts/test.sh` (see run results).

Closes #6992
