### PR TITLE
feat: show routed model observability in assistant footer

### DIFF
--- a/api/routed_model_observability.py
+++ b/api/routed_model_observability.py
@@ -1,0 +1,153 @@
+"""WebUI-only capture of routed models reported by Hermes API responses."""
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+import logging
+import threading
+from typing import Any
+import unicodedata
+
+from api.config import _custom_provider_slug_from_name
+
+
+logger = logging.getLogger(__name__)
+
+_MAX_SCALAR_CHARS = 240
+
+
+def _safe_scalar(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    if not value or len(value) > _MAX_SCALAR_CHARS:
+        return ""
+    if any(unicodedata.category(char) in {"Cc", "Cf"} for char in value):
+        return ""
+    return value
+
+
+@dataclass
+class RoutedModelCapture:
+    session_id: str
+    stream_id: str
+    task_id: str
+    requested_model: str
+    requested_provider: str
+    response_model: str | None = None
+    response_provider: str | None = None
+
+
+_CAPTURE: ContextVar[RoutedModelCapture | None] = ContextVar(
+    "routed_model_capture",
+    default=None,
+)
+_INSTALL_LOCK = threading.RLock()
+
+
+def provider_display_name(
+    provider_context: Any,
+    resolved_provider: Any,
+    config: Any,
+) -> str:
+    context = _safe_scalar(provider_context)
+    resolved = _safe_scalar(resolved_provider)
+
+    if context.lower().startswith("custom:"):
+        entries = getattr(config, "custom_providers", None)
+        if isinstance(config, dict):
+            entries = config.get("custom_providers")
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = _safe_scalar(entry.get("name"))
+                if not name:
+                    continue
+                try:
+                    slug = _custom_provider_slug_from_name(name)
+                except Exception:
+                    continue
+                if slug.lower() == context.lower():
+                    return name
+
+    return context or resolved or ""
+
+
+def _observe_post_api_request(
+    *,
+    platform: Any = None,
+    session_id: Any = None,
+    task_id: Any = None,
+    response_model: Any = None,
+    provider: Any = None,
+    **_kwargs: Any,
+) -> None:
+    capture = _CAPTURE.get()
+    if capture is None or _safe_scalar(platform).lower() != "webui":
+        return
+    if session_id != capture.session_id or task_id != capture.task_id:
+        return
+
+    safe_model = _safe_scalar(response_model)
+    if not safe_model:
+        return
+
+    capture.response_model = safe_model
+    safe_provider = _safe_scalar(provider)
+    if safe_provider:
+        capture.response_provider = safe_provider
+
+
+def _install_post_api_request_observer() -> None:
+    try:
+        from hermes_cli import plugins
+
+        plugins.discover_plugins()
+        manager = plugins.get_plugin_manager()
+        with _INSTALL_LOCK:
+            hooks = getattr(manager, "_hooks", None)
+            if not isinstance(hooks, dict):
+                return
+            callbacks = hooks.setdefault("post_api_request", [])
+            if isinstance(callbacks, list) and _observe_post_api_request not in callbacks:
+                callbacks.append(_observe_post_api_request)
+    except Exception:
+        logger.debug("Unable to install routed-model lifecycle observer", exc_info=True)
+
+
+def begin_routed_model_capture(
+    *,
+    session_id: Any,
+    stream_id: Any,
+    task_id: Any,
+    requested_model: Any,
+    requested_provider: Any,
+) -> Token:
+    _install_post_api_request_observer()
+    capture = RoutedModelCapture(
+        session_id=str(session_id),
+        stream_id=str(stream_id),
+        task_id=str(task_id),
+        requested_model=_safe_scalar(requested_model),
+        requested_provider=_safe_scalar(requested_provider),
+    )
+    return _CAPTURE.set(capture)
+
+
+def snapshot_routed_model_capture() -> dict[str, str] | None:
+    capture = _CAPTURE.get()
+    if capture is None or not capture.response_model:
+        return None
+
+    payload = {
+        "requested_model": capture.requested_model,
+        "requested_provider": capture.requested_provider,
+        "used_model": capture.response_model,
+        "used_provider": capture.requested_provider or capture.response_provider or "",
+        "source": "openai-compatible-sse",
+    }
+    return {key: value for key, value in payload.items() if value}
+
+
+def reset_routed_model_capture(token: Token) -> None:
+    _CAPTURE.reset(token)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -73,6 +73,12 @@ from api.models import (
     reconciled_state_db_messages_for_session,
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
+from api.routed_model_observability import (
+    begin_routed_model_capture,
+    provider_display_name,
+    reset_routed_model_capture,
+    snapshot_routed_model_capture,
+)
 from api.process_event_utils import (
     build_active_turn_token,
     claim_async_delegation_delivery,
@@ -211,7 +217,6 @@ def _cancel_event_payload(
         payload['session'] = session
         payload['session_id'] = session.get('session_id')
     return payload
-
 
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
@@ -2287,6 +2292,7 @@ _GATEWAY_ROUTING_TOP_LEVEL_KEYS = {
     'used_model',
     'requested_provider',
     'requested_model',
+    'source',
 }
 _GATEWAY_ROUTING_CONTAINER_KEYS = (
     'llm_gateway',
@@ -8095,6 +8101,7 @@ def _run_agent_streaming(
         STREAM_LIVE_TOOL_CALLS[stream_id] = []  # start accumulating tool calls (#1361 §B)
 
     agent = None
+    _routed_model_capture_token = None
     _live_prompt_estimate_tokens = [0]
     _live_prompt_exact_tokens = [0]
     _live_prompt_estimate_tool_delta_tokens = [0]
@@ -9977,6 +9984,19 @@ def _run_agent_streaming(
                 _agent_msg_text = "\n\n".join([*_process_notifications, msg_text]).strip()
             user_message = _build_native_multimodal_message(workspace_ctx, _agent_msg_text, attachments, workspace, cfg=_cfg, active_provider=(resolved_provider or ""), active_model=(resolved_model or ""), requested_provider=(_session_requested_provider or ""))
             _persistent_state_before = _persistent_state_snapshot(_profile_home)
+            _requested_provider_display = provider_display_name(
+                provider_context,
+                resolved_provider,
+                _cfg,
+            )
+            if not ephemeral and _routed_model_capture_token is None:
+                _routed_model_capture_token = begin_routed_model_capture(
+                    session_id=session_id,
+                    stream_id=stream_id,
+                    task_id=session_id,
+                    requested_model=resolved_model or model,
+                    requested_provider=_requested_provider_display,
+                )
             _run_conversation_kwargs = dict(
                 user_message=user_message,
                 system_message=workspace_system_msg,
@@ -10029,7 +10049,22 @@ def _run_agent_streaming(
                     requested_provider=(_session_requested_provider or ""),
                 )
                 _run_conversation_kwargs["user_message"] = user_message
-            result = agent.run_conversation(**_run_conversation_kwargs)
+            try:
+                result = agent.run_conversation(**_run_conversation_kwargs)
+            except Exception as _run_exc:
+                if (
+                    ephemeral
+                    or _classify_provider_error(str(_run_exc), _run_exc)['type'] != 'auth_mismatch'
+                ):
+                    raise
+                # Feed raised authentication failures into the existing terminal-result
+                # self-heal path below. A successful credential retry then continues
+                # through the common persistence and terminal done pipeline.
+                result = {
+                    'failed': True,
+                    'error': str(_run_exc),
+                    'messages': [],
+                }
             _active_turn_identity = _resolve_active_turn_authority(
                 _active_turn_identity,
                 result=result,
@@ -10880,8 +10915,16 @@ def _run_agent_streaming(
                     agent,
                     result,
                     requested_model=resolved_model or model,
-                    requested_provider=resolved_provider,
+                    requested_provider=_requested_provider_display,
                 )
+                if not _gateway_routing:
+                    _observed_routing = snapshot_routed_model_capture()
+                    if _observed_routing:
+                        _gateway_routing = _normalize_gateway_routing_metadata(
+                            _observed_routing,
+                            requested_model=resolved_model or model,
+                            requested_provider=_requested_provider_display,
+                        )
                 # #6068: the served model must be read AFTER agent.run — the agent
                 # mutates agent.model when a fallback fires, so the pre-run
                 # resolved_model would mis-attribute exactly the turns where
@@ -11935,6 +11978,15 @@ def _run_agent_streaming(
                 and getattr(s, 'pending_user_message', None)):
             update_active_run(stream_id, phase="finalizing")
             _last_resort_sync_from_core(s, stream_id, _agent_lock)
+        if _routed_model_capture_token is not None:
+            try:
+                reset_routed_model_capture(_routed_model_capture_token)
+            except Exception:
+                logger.debug(
+                    "Failed to reset routed-model capture for stream %s",
+                    stream_id,
+                    exc_info=True,
+                )
         _clear_thread_env()  # TD1: always clear thread-local context
         if _streaming_cron_profile_home_token is not None:
             _STREAMING_CRON_PROFILE_HOME.reset(_streaming_cron_profile_home_token)

--- a/docs/superpowers/plans/2026-08-14-routed-model-observability.md
+++ b/docs/superpowers/plans/2026-08-14-routed-model-observability.md
@@ -1,0 +1,1103 @@
+# Routed Model Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture the actual model reported by an OpenAI-compatible streaming response, persist it on the Hermes WebUI assistant message/session, and render Requested, Routed, and Provider metadata.
+
+**Architecture:** A WebUI-only lifecycle adapter registers an idempotent `post_api_request` observer with the active Hermes plugin manager. A `ContextVar` isolates capture state per streaming worker; the existing gateway-routing normalization, persistence, `done` event, journal, and footer paths carry the safe result without changing TokenTable or Hermes Agent.
+
+**Tech Stack:** Python 3.11+, `contextvars`, Hermes lifecycle hooks, pytest, vanilla JavaScript, CSS, Node.js syntax/runtime lint, Playwright browser QA.
+
+---
+
+## Working Boundary
+
+- Work only in `C:\Users\Joa\.hermes\worktrees\hermes-webui\routed-model-observability`.
+- Branch must remain `feature/routed-model-observability` and begin implementation at design commit `e1d61572`.
+- The dirty master checkout at `C:\Users\Joa\hermes-webui` remains read-only and unchanged.
+- Do not modify TokenTable, Hermes Agent, provider configuration, database schemas, or environment files.
+- Do not restart a user-owned WebUI or gateway. Browser QA launches and stops only its own isolated process.
+- Do not push, open a PR, merge, or deploy.
+- Stage only the files named by the current task.
+
+## File Map
+
+- Create `api/routed_model_observability.py`: safe provider-label resolution, idempotent lifecycle registration, per-context capture, snapshot, and cleanup.
+- Create `tests/test_routed_model_observability.py`: lifecycle filtering, context isolation, cleanup, provider naming, and streaming integration.
+- Modify `api/streaming.py`: begin/reset capture around the real agent turn, use SSE-derived routing as the fallback to existing explicit gateway metadata, and allowlist `source`.
+- Modify `tests/test_732_gateway_routing_metadata.py`: source normalization, persistence contract, UI source guard, and safe DOM construction assertions.
+- Modify `static/ui.js`: turn SSE-derived routing metadata into the three labelled footer values.
+- Modify `static/style.css`: responsive, wrapping footer layout for desktop and narrow viewports.
+
+## Execution Runtime Preparation
+
+The machine currently has Python interpreters but no installed `pytest` in the probed environments. Preserve the required test-first order: add the first failing test before creating the isolated environment. Then prepare ignored local tooling:
+
+```powershell
+py -V:3.11 -m venv .venv
+& '.\.venv\Scripts\python.exe' -m pip install -r requirements.txt pytest pytest-timeout ruff playwright
+npm ci
+& '.\.venv\Scripts\python.exe' -m playwright install chromium
+```
+
+`.venv/` and `node_modules/` are already ignored. If any install needs network access, request that approval at execution time; do not alter dependency manifests merely to bootstrap local verification.
+
+### Task 1: Add the run-scoped lifecycle capture adapter
+
+**Files:**
+- Create: `tests/test_routed_model_observability.py`
+- Create: `api/routed_model_observability.py`
+
+- [ ] **Step 1: Write the first failing adapter tests**
+
+Create `tests/test_routed_model_observability.py` with these imports and tests before the production module exists:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import sys
+import types
+
+import pytest
+
+from api.routed_model_observability import (
+    _install_post_api_request_observer,
+    _observe_post_api_request,
+    begin_routed_model_capture,
+    provider_display_name,
+    reset_routed_model_capture,
+    snapshot_routed_model_capture,
+)
+
+
+@pytest.fixture
+def capture_without_real_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "api.routed_model_observability._install_post_api_request_observer",
+        lambda: None,
+    )
+
+
+def test_matching_webui_post_api_request_captures_last_response_model(
+    capture_without_real_plugins,
+):
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            platform="webui",
+            session_id="session-a",
+            task_id="session-a",
+            response_model="gpt-5.6",
+            provider="custom",
+        )
+        _observe_post_api_request(
+            platform="webui",
+            session_id="session-a",
+            task_id="session-a",
+            response_model="gpt-5.6-sol",
+            provider="custom",
+        )
+        assert snapshot_routed_model_capture() == {
+            "requested_model": "auto",
+            "requested_provider": "TokenTable",
+            "used_model": "gpt-5.6-sol",
+            "used_provider": "TokenTable",
+            "source": "openai-compatible-sse",
+        }
+    finally:
+        reset_routed_model_capture(token)
+
+    assert snapshot_routed_model_capture() is None
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"platform": "telegram", "session_id": "session-a", "task_id": "session-a"},
+        {"platform": "webui", "session_id": "session-b", "task_id": "session-a"},
+        {"platform": "webui", "session_id": "session-a", "task_id": "task-b"},
+    ],
+)
+def test_unrelated_lifecycle_events_are_ignored(capture_without_real_plugins, event):
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            response_model="wrong-model",
+            provider="wrong-provider",
+            **event,
+        )
+        assert snapshot_routed_model_capture() is None
+    finally:
+        reset_routed_model_capture(token)
+
+
+@pytest.mark.parametrize("response_model", [None, "", "   ", {"model": "bad"}, "x" * 241])
+def test_missing_or_unsafe_response_model_is_not_claimed(
+    capture_without_real_plugins,
+    response_model,
+):
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            platform="webui",
+            session_id="session-a",
+            task_id="session-a",
+            response_model=response_model,
+            provider="custom",
+        )
+        assert snapshot_routed_model_capture() is None
+    finally:
+        reset_routed_model_capture(token)
+
+
+def test_contextvars_isolate_simultaneous_webui_turns(capture_without_real_plugins):
+    def run(session_id, stream_id, routed_model):
+        token = begin_routed_model_capture(
+            session_id=session_id,
+            stream_id=stream_id,
+            task_id=session_id,
+            requested_model="auto",
+            requested_provider="TokenTable",
+        )
+        try:
+            _observe_post_api_request(
+                platform="webui",
+                session_id=session_id,
+                task_id=session_id,
+                response_model=routed_model,
+                provider="custom",
+            )
+            return snapshot_routed_model_capture()
+        finally:
+            reset_routed_model_capture(token)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(run, "session-a", "stream-a", "model-a")
+        second = pool.submit(run, "session-b", "stream-b", "model-b")
+
+    assert first.result()["used_model"] == "model-a"
+    assert second.result()["used_model"] == "model-b"
+
+
+def test_named_custom_provider_preserves_display_name():
+    config = {
+        "custom_providers": [
+            {"name": "TokenTable", "base_url": "https://example.invalid/v1"}
+        ]
+    }
+    assert provider_display_name("custom:tokentable", "custom", config) == "TokenTable"
+    assert provider_display_name(None, "openai-codex", config) == "openai-codex"
+
+
+def test_observer_registration_is_idempotent(monkeypatch):
+    manager = types.SimpleNamespace(_hooks={})
+    plugins = types.ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = lambda: None
+    plugins.get_plugin_manager = lambda: manager
+    package = types.ModuleType("hermes_cli")
+    package.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+
+    _install_post_api_request_observer()
+    _install_post_api_request_observer()
+
+    assert manager._hooks["post_api_request"] == [_observe_post_api_request]
+
+
+def test_unavailable_plugin_manager_fails_open(monkeypatch):
+    plugins = types.ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = lambda: (_ for _ in ()).throw(RuntimeError("unavailable"))
+    package = types.ModuleType("hermes_cli")
+    package.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    reset_routed_model_capture(token)
+```
+
+- [ ] **Step 2: Prepare the ignored local test environment**
+
+Run the commands in “Execution Runtime Preparation”. Confirm:
+
+```text
+.venv\Scripts\python.exe -m pytest --version
+npm --version
+node --version
+```
+
+Expected: all commands exit `0`; `git status --short` still lists only the new tracked test file plus the already committed docs.
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_routed_model_observability.py -q
+```
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'api.routed_model_observability'`. Save this exact RED command, exit code, and failure in the final evidence.
+
+- [ ] **Step 4: Implement the minimal capture module**
+
+Create `api/routed_model_observability.py`:
+
+```python
+"""WebUI-only capture of routed models reported by Hermes API responses."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+import logging
+import threading
+from typing import Any
+
+from api.config import _custom_provider_slug_from_name
+
+
+_MAX_SCALAR_CHARS = 240
+logger = logging.getLogger(__name__)
+_CAPTURE: ContextVar["RoutedModelCapture | None"] = ContextVar(
+    "webui_routed_model_capture",
+    default=None,
+)
+_INSTALL_LOCK = threading.RLock()
+
+
+def _safe_scalar(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or len(text) > _MAX_SCALAR_CHARS:
+        return None
+    return text
+
+
+def provider_display_name(
+    provider_context: str | None,
+    resolved_provider: str | None,
+    config: dict | None,
+) -> str:
+    context = _safe_scalar(provider_context)
+    resolved = _safe_scalar(resolved_provider)
+    if context and context.lower().startswith("custom:"):
+        target = context.lower()
+        custom_providers = (config or {}).get("custom_providers", [])
+        if isinstance(custom_providers, list):
+            for entry in custom_providers:
+                if not isinstance(entry, dict):
+                    continue
+                name = _safe_scalar(entry.get("name"))
+                if name and _custom_provider_slug_from_name(name) == target:
+                    return name
+    return context or resolved or ""
+
+
+@dataclass
+class RoutedModelCapture:
+    session_id: str
+    stream_id: str
+    task_id: str
+    requested_model: str
+    requested_provider: str
+    response_model: str | None = None
+    response_provider: str | None = None
+
+    def snapshot(self) -> dict | None:
+        if not self.response_model:
+            return None
+        used_provider = self.requested_provider or self.response_provider or ""
+        payload = {
+            "requested_model": self.requested_model,
+            "requested_provider": self.requested_provider,
+            "used_model": self.response_model,
+            "used_provider": used_provider,
+            "source": "openai-compatible-sse",
+        }
+        return {key: value for key, value in payload.items() if value}
+
+
+def _observe_post_api_request(
+    *,
+    platform=None,
+    session_id=None,
+    task_id=None,
+    response_model=None,
+    provider=None,
+    **_kwargs,
+) -> None:
+    capture = _CAPTURE.get()
+    if capture is None:
+        return
+    if str(platform or "").strip().lower() != "webui":
+        return
+    if str(session_id or "") != capture.session_id:
+        return
+    if str(task_id or "") != capture.task_id:
+        return
+    model = _safe_scalar(response_model)
+    if model is None:
+        return
+    capture.response_model = model
+    safe_provider = _safe_scalar(provider)
+    if safe_provider:
+        capture.response_provider = safe_provider
+
+
+def _install_post_api_request_observer() -> None:
+    try:
+        from hermes_cli import plugins
+
+        plugins.discover_plugins()
+        manager = plugins.get_plugin_manager()
+        with _INSTALL_LOCK:
+            hooks = getattr(manager, "_hooks", None)
+            if not isinstance(hooks, dict):
+                return
+            callbacks = hooks.setdefault("post_api_request", [])
+            if _observe_post_api_request not in callbacks:
+                callbacks.append(_observe_post_api_request)
+    except Exception:
+        logger.debug("Routed-model lifecycle observer unavailable", exc_info=True)
+
+
+def begin_routed_model_capture(
+    *,
+    session_id: str,
+    stream_id: str,
+    task_id: str,
+    requested_model: str | None,
+    requested_provider: str | None,
+) -> Token:
+    _install_post_api_request_observer()
+    capture = RoutedModelCapture(
+        session_id=str(session_id),
+        stream_id=str(stream_id),
+        task_id=str(task_id),
+        requested_model=_safe_scalar(requested_model) or "",
+        requested_provider=_safe_scalar(requested_provider) or "",
+    )
+    return _CAPTURE.set(capture)
+
+
+def snapshot_routed_model_capture() -> dict | None:
+    capture = _CAPTURE.get()
+    return capture.snapshot() if capture is not None else None
+
+
+def reset_routed_model_capture(token: Token) -> None:
+    _CAPTURE.reset(token)
+```
+
+- [ ] **Step 5: Run adapter tests and verify GREEN**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_routed_model_observability.py -q
+```
+
+Expected: all adapter tests pass.
+
+- [ ] **Step 6: Commit the adapter atomically**
+
+```powershell
+git add -- api/routed_model_observability.py tests/test_routed_model_observability.py
+git diff --cached --check
+git commit -m "feat: capture routed model lifecycle metadata"
+```
+
+Expected: the commit contains exactly the two files listed above.
+
+### Task 2: Integrate capture with streaming persistence and replay
+
+**Files:**
+- Modify: `api/streaming.py:49-53,1097-1102,4490-4510,5378-5410,5935-5950,6211-6640,7380-7410`
+- Modify: `tests/test_routed_model_observability.py`
+- Modify: `tests/test_732_gateway_routing_metadata.py`
+
+- [ ] **Step 1: Add failing normalization and streaming integration tests**
+
+Append to `tests/test_732_gateway_routing_metadata.py`:
+
+```python
+def test_sse_routing_source_is_safely_normalized_and_persisted():
+    routing = _normalize_gateway_routing_metadata(
+        {
+            "requested_model": "auto",
+            "requested_provider": "TokenTable",
+            "used_model": "gpt-5.6-sol",
+            "used_provider": "TokenTable",
+            "source": "openai-compatible-sse",
+            "api_key": "must-not-survive",
+        }
+    )
+
+    assert routing == {
+        "requested_model": "auto",
+        "requested_provider": "TokenTable",
+        "used_model": "gpt-5.6-sol",
+        "used_provider": "TokenTable",
+        "source": "openai-compatible-sse",
+        "provider_changed": False,
+        "model_changed": True,
+        "has_failover": False,
+    }
+    assert "must-not-survive" not in repr(routing)
+
+
+def test_routed_model_capture_cleanup_is_in_streaming_outer_finally():
+    run_source = STREAMING_PY[STREAMING_PY.index("def _run_agent_streaming("):]
+    reset_pos = run_source.rfind("reset_routed_model_capture(")
+    clear_env_pos = run_source.rfind("_clear_thread_env()")
+    assert reset_pos > 0
+    assert clear_env_pos > reset_pos
+```
+
+Also update `test_session_persists_latest_gateway_routing_and_history_across_reload`
+so its input routing object includes
+`"source": "openai-compatible-sse"`, and assert that exact source remains in
+`reloaded.gateway_routing`, `reloaded.gateway_routing_history[0]`, and
+`reloaded.messages[-1]["_gatewayRouting"]`.
+
+Append a full fake-agent integration test to `tests/test_routed_model_observability.py`. Use a real `Session`, patch only its disk save, and have the fake AIAgent fire the same lifecycle callback as Hermes Agent:
+
+```python
+def test_streaming_persists_sse_routed_model_in_message_session_and_done(
+    monkeypatch,
+    tmp_path,
+):
+    import queue
+
+    import api.routed_model_observability as observation
+    import api.streaming as streaming
+    from api.models import Session
+
+    monkeypatch.setattr(observation, "_install_post_api_request_observer", lambda: None)
+
+    stream_id = "stream-routed-model"
+    session = Session(session_id="session-routed-model", title="Routing")
+    session.model = "auto"
+    session.model_provider = "custom:tokentable"
+    session.messages = []
+    session.context_messages = []
+    session.active_stream_id = stream_id
+    monkeypatch.setattr(session, "save", lambda: None)
+
+    class FakeAgent:
+        def __init__(self, model=None, provider=None, base_url=None, session_id=None, **_kwargs):
+            self.model = model
+            self.provider = provider
+            self.base_url = base_url
+            self.session_id = session_id
+            self.context_compressor = None
+            self.session_prompt_tokens = 11
+            self.session_completion_tokens = 7
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            observation._observe_post_api_request(
+                platform="webui",
+                session_id=self.session_id,
+                task_id=kwargs["task_id"],
+                response_model="gpt-5.6-sol",
+                provider="custom",
+            )
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs["persist_user_message"]},
+                    {"role": "assistant", "content": "routed answer"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    runtime = types.ModuleType("hermes_cli.runtime_provider")
+    runtime.resolve_runtime_provider = lambda requested=None: {
+        "provider": "custom",
+        "base_url": "https://example.invalid/v1",
+        "api_key": "test-only",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.runtime_provider = runtime
+    hermes_state = types.ModuleType("hermes_state")
+    hermes_state.SessionDB = lambda *_args, **_kwargs: None
+    injected = {
+        "hermes_cli": hermes_cli,
+        "hermes_cli.runtime_provider": runtime,
+        "hermes_state": hermes_state,
+    }
+    missing = object()
+    saved = {name: sys.modules.get(name, missing) for name in injected}
+    sys.modules.update(injected)
+    events = queue.Queue()
+    try:
+        monkeypatch.setattr(streaming, "get_session", lambda _sid: session)
+        monkeypatch.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+        monkeypatch.setattr(
+            streaming,
+            "resolve_model_provider",
+            lambda _model: ("auto", "custom:tokentable", "https://example.invalid/v1"),
+        )
+        monkeypatch.setattr(
+            streaming,
+            "resolve_custom_provider_connection",
+            lambda _provider: ("test-only", "https://example.invalid/v1"),
+        )
+        monkeypatch.setattr(
+            streaming,
+            "get_config",
+            lambda: {
+                "custom_providers": [
+                    {"name": "TokenTable", "base_url": "https://example.invalid/v1"}
+                ]
+            },
+        )
+        monkeypatch.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+        streaming.STREAMS[stream_id] = events
+
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text="route this",
+            model="auto",
+            workspace=str(tmp_path),
+            stream_id=stream_id,
+            model_provider="custom:tokentable",
+        )
+    finally:
+        for name, previous in saved.items():
+            if previous is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    expected = {
+        "requested_model": "auto",
+        "requested_provider": "TokenTable",
+        "used_model": "gpt-5.6-sol",
+        "used_provider": "TokenTable",
+        "source": "openai-compatible-sse",
+        "provider_changed": False,
+        "model_changed": True,
+        "has_failover": False,
+    }
+    done = next(payload for event, payload in list(events.queue) if event == "done")
+    assert session.messages[-1]["_gatewayRouting"] == expected
+    assert session.gateway_routing == expected
+    assert session.gateway_routing_history == [expected]
+    assert done["usage"]["gateway_routing"] == expected
+    assert done["session"]["messages"][-1]["_gatewayRouting"] == expected
+    assert all(
+        "_gatewayRouting" not in message
+        for message in streaming._sanitize_messages_for_api(session.messages)
+    )
+    assert observation.snapshot_routed_model_capture() is None
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_routed_model_observability.py tests/test_732_gateway_routing_metadata.py -q
+```
+
+Expected failures:
+
+- normalized routing omits `source`;
+- streaming `done` payload lacks `gpt-5.6-sol` routing metadata.
+
+- [ ] **Step 3: Wire capture into the streaming worker**
+
+In `api/streaming.py`, import:
+
+```python
+from api.routed_model_observability import (
+    begin_routed_model_capture,
+    provider_display_name,
+    reset_routed_model_capture,
+    snapshot_routed_model_capture,
+)
+```
+
+Add `'source'` to `_GATEWAY_ROUTING_TOP_LEVEL_KEYS`.
+
+Near the existing `agent = None` initialization, add:
+
+```python
+    _routed_model_capture_token = None
+```
+
+Immediately before the first non-ephemeral `agent.run_conversation(...)`, start the capture once:
+
+```python
+            if not ephemeral and _routed_model_capture_token is None:
+                _routed_model_capture_token = begin_routed_model_capture(
+                    session_id=session_id,
+                    stream_id=stream_id,
+                    task_id=session_id,
+                    requested_model=resolved_model or model,
+                    requested_provider=provider_display_name(
+                        provider_context,
+                        resolved_provider,
+                        _cfg,
+                    ),
+                )
+```
+
+At the existing `_gateway_routing = _extract_gateway_routing_metadata(...)` block, retain explicit gateway metadata as the first choice and use the SSE observation only when it is absent:
+
+```python
+                _gateway_routing = _extract_gateway_routing_metadata(
+                    agent,
+                    result,
+                    requested_model=resolved_model or model,
+                    requested_provider=provider_display_name(
+                        provider_context,
+                        resolved_provider,
+                        _cfg,
+                    ),
+                )
+                if not _gateway_routing:
+                    _observed_routing = snapshot_routed_model_capture()
+                    if _observed_routing:
+                        _gateway_routing = _normalize_gateway_routing_metadata(
+                            _observed_routing,
+                            requested_model=resolved_model or model,
+                            requested_provider=provider_display_name(
+                                provider_context,
+                                resolved_provider,
+                                _cfg,
+                            ),
+                        )
+```
+
+In `_run_agent_streaming`'s existing outer `finally`, before clearing thread-local environment state, reset only the token created by this worker:
+
+```python
+        if _routed_model_capture_token is not None:
+            try:
+                reset_routed_model_capture(_routed_model_capture_token)
+            except Exception:
+                logger.debug(
+                    "Failed to reset routed-model capture for stream %s",
+                    stream_id,
+                    exc_info=True,
+                )
+```
+
+Do not add a separate SSE event. The existing saved message/session and terminal `done` event remain the single durable path, and `put(...)` continues journaling that terminal payload.
+
+- [ ] **Step 4: Run focused persistence tests and verify GREEN**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_routed_model_observability.py tests/test_732_gateway_routing_metadata.py -q
+```
+
+Expected: all tests pass, including the exact message/session/`done` assertions.
+
+- [ ] **Step 5: Run related streaming, stale-owner, and replay suites**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_run_journal.py tests/test_run_journal_streaming_static.py tests/test_issue765_streaming_persistence.py tests/test_stale_stream_writeback.py tests/test_cancel_stream_owner_guard.py -q
+```
+
+Expected: all selected suites pass. A failure must be diagnosed before proceeding; do not weaken stale-writeback or journal assertions.
+
+- [ ] **Step 6: Commit streaming integration atomically**
+
+```powershell
+git add -- api/streaming.py tests/test_routed_model_observability.py tests/test_732_gateway_routing_metadata.py
+git diff --cached --check
+git commit -m "feat: persist SSE routed model metadata"
+```
+
+Expected: no TokenTable, Hermes Agent, config, environment, or schema file is staged.
+
+### Task 3: Render Requested, Routed, and Provider in the assistant footer
+
+**Files:**
+- Modify: `static/ui.js:3098-3140,8552-8620`
+- Modify: `static/style.css:4407-4430`
+- Modify: `tests/test_732_gateway_routing_metadata.py`
+
+- [ ] **Step 1: Add failing frontend contract tests**
+
+Append to `tests/test_732_gateway_routing_metadata.py`:
+
+```python
+def test_sse_routed_model_footer_uses_three_safe_labelled_fields():
+    assert "function _routedModelObservationFields" in UI_JS
+    assert "Requested:" in UI_JS
+    assert "Routed:" in UI_JS
+    assert "Provider:" in UI_JS
+    assert "msg-routed-model-inline" in UI_JS
+    assert "msg-routed-model-field" in UI_JS
+    assert ".msg-routed-model-inline" in STYLE_CSS
+
+    start = UI_JS.index("function _appendRoutedModelObservation")
+    end = UI_JS.index("function ", start + len("function "))
+    body = UI_JS[start:end]
+    assert ".textContent=" in body.replace(" ", "")
+    assert ".innerHTML" not in body
+
+
+def test_non_sse_gateway_metadata_keeps_existing_footer_path():
+    assert "routing.source==='openai-compatible-sse'" in UI_JS.replace(" ", "")
+    assert "_formatGatewayModelLabel" in UI_JS
+    assert "_gatewayRoutingFailoverText" in UI_JS
+    assert "_gatewayModelWarningText" in UI_JS
+```
+
+- [ ] **Step 2: Run frontend contract tests and verify RED**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_732_gateway_routing_metadata.py -q
+```
+
+Expected: failures report missing `_routedModelObservationFields`, `_appendRoutedModelObservation`, and CSS selectors.
+
+- [ ] **Step 3: Add the pure field formatter and safe DOM renderer**
+
+In `static/ui.js`, after `_gatewayProviderName`, add:
+
+```javascript
+function _routedModelObservationFields(routing){
+  if(!routing||routing.source!=='openai-compatible-sse')return[];
+  const requested=String(routing.requested_model||'').trim();
+  const routed=String(routing.used_model||'').trim();
+  const provider=_gatewayProviderName(routing.used_provider||routing.requested_provider);
+  if(!routed)return[];
+  return [
+    {label:'Requested',value:requested},
+    {label:'Routed',value:routed},
+    {label:'Provider',value:provider},
+  ].filter(field=>field.value);
+}
+function _appendRoutedModelObservation(target,routing){
+  const fields=_routedModelObservationFields(routing);
+  if(!target||!fields.length)return false;
+  const group=document.createElement('span');
+  group.className='msg-routed-model-inline';
+  for(const field of fields){
+    const item=document.createElement('span');
+    item.className='msg-routed-model-field';
+    item.textContent=`${field.label}: ${field.value}`;
+    group.appendChild(item);
+  }
+  target.appendChild(group);
+  return true;
+}
+```
+
+In the existing assistant-footer loop, identify SSE observations once and suppress the older duplicate one-line model/switch labels for that source:
+
+```javascript
+      const routing=msg._gatewayRouting||null;
+      const isSseObservation=!!(routing&&routing.source==='openai-compatible-sse');
+      const gatewayText=isSseObservation?'':_formatGatewayModelLabel(S.session&&S.session.model||'', '', routing);
+      const failoverText=_gatewayRoutingFailoverText(routing);
+      const modelWarningText=isSseObservation?'':_gatewayModelWarningText(routing);
+      const routedModelFields=_routedModelObservationFields(routing);
+```
+
+Include `routedModelFields.length` in the footer presence guard. Before the existing gateway/duration fragments, create a fragment container and call the safe renderer:
+
+```javascript
+      if(routedModelFields.length){
+        const routed=document.createElement('span');
+        if(_appendRoutedModelObservation(routed,routing))fragments.push(routed.firstChild);
+      }
+```
+
+Extend the existing `targetFoot.querySelector(...)` duplicate guard with
+`.msg-routed-model-inline` so repeated `renderMessages()` calls never append a
+second routed-model group to the same assistant footer.
+
+Keep the existing generic gateway, failover, duration, usage, and warning code unchanged for non-SSE metadata.
+
+- [ ] **Step 4: Add responsive footer CSS**
+
+Extend the existing footer metadata selector in `static/style.css` and add:
+
+```css
+.msg-foot-with-usage {
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.msg-routed-model-inline {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  min-width: 0;
+  max-width: 100%;
+}
+.msg-routed-model-field {
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: .78;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 600px) {
+  .msg-routed-model-inline {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+  .msg-routed-model-field {
+    flex: 1 1 100%;
+  }
+}
+```
+
+- [ ] **Step 5: Run frontend tests, syntax check, and runtime lint**
+
+Run:
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_732_gateway_routing_metadata.py tests/test_mobile_layout.py -q
+node --check static/ui.js
+npm run lint:runtime
+```
+
+Expected: all commands exit `0`; ESLint reports no runtime-guard errors.
+
+- [ ] **Step 6: Commit UI changes atomically**
+
+```powershell
+git add -- static/ui.js static/style.css tests/test_732_gateway_routing_metadata.py
+git diff --cached --check
+git commit -m "feat: show routed model in assistant footer"
+```
+
+Expected: the commit contains exactly the three listed files.
+
+### Task 4: Run the complete scoped verification gate
+
+**Files:**
+- No code changes expected.
+
+- [ ] **Step 1: Re-run the RED-to-GREEN feature suites from a clean process**
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_routed_model_observability.py tests/test_732_gateway_routing_metadata.py -q
+```
+
+Expected: all feature tests pass.
+
+- [ ] **Step 2: Run the consolidated related regression suite**
+
+```powershell
+& '.\.venv\Scripts\python.exe' -m pytest tests/test_run_journal.py tests/test_run_journal_streaming_static.py tests/test_issue765_streaming_persistence.py tests/test_stale_stream_writeback.py tests/test_cancel_stream_owner_guard.py tests/test_mobile_layout.py tests/test_static_js_runtime_lint.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run changed-line Python lint and JavaScript validation**
+
+```powershell
+& '.\.venv\Scripts\python.exe' scripts/ruff_lint.py --diff db2583cb
+node --check static/ui.js
+npm run lint:runtime
+git diff --check db2583cb...HEAD
+```
+
+Expected: every command exits `0`. Do not run unsafe auto-fix or broad formatting.
+
+- [ ] **Step 4: Audit the exact diff boundary**
+
+```powershell
+git status --short --branch
+git diff --stat db2583cb...HEAD
+git diff --name-only db2583cb...HEAD
+git log --oneline db2583cb..HEAD
+```
+
+Expected tracked implementation scope:
+
+```text
+api/routed_model_observability.py
+api/streaming.py
+docs/superpowers/plans/2026-08-14-routed-model-observability.md
+docs/superpowers/specs/2026-08-14-routed-model-observability-design.md
+static/style.css
+static/ui.js
+tests/test_732_gateway_routing_metadata.py
+tests/test_routed_model_observability.py
+```
+
+The worktree must be clean after commits. The dirty master checkout must still show only the five pre-existing user changes at `db2583cb`.
+
+### Task 5: Perform isolated desktop and narrow browser QA
+
+**Files:**
+- Evidence only under `C:\Users\Joa\.hermes\workspace\tokentable_ops\evidence`.
+- No tracked code changes expected.
+
+- [ ] **Step 1: Run the standard agent-free browser smoke test**
+
+```powershell
+& '.\.venv\Scripts\python.exe' tests/browser_smoke.py
+```
+
+Expected: exit `0` and `BROWSER SMOKE PASSED`; the script uses its own temporary `HERMES_HOME` and terminates only the server it created.
+
+- [ ] **Step 2: Launch a separate isolated QA server**
+
+First confirm port `18797` is unused. Create a task-specific temporary state directory and strip provider keys from the child environment. Start only this worktree's server with `Start-Process -WindowStyle Hidden`, recording its PID and logs in the temporary directory:
+
+```powershell
+$qaState = Join-Path $env:TEMP 'hermes-webui-routed-model-qa'
+New-Item -ItemType Directory -Path $qaState -Force | Out-Null
+$env:HERMES_WEBUI_PORT = '18797'
+$env:HERMES_WEBUI_HOST = '127.0.0.1'
+$env:HERMES_WEBUI_STATE_DIR = $qaState
+$env:HERMES_HOME = $qaState
+$env:HERMES_BASE_HOME = $qaState
+$env:HERMES_WEBUI_SKIP_ONBOARDING = '1'
+$env:HERMES_WEBUI_AGENT_DIR = Join-Path $qaState 'no-agent'
+Get-ChildItem Env: | Where-Object Name -Like '*_API_KEY' | ForEach-Object { Remove-Item "Env:$($_.Name)" }
+$qaProc = Start-Process -FilePath '.\.venv\Scripts\python.exe' -ArgumentList 'server.py' -WorkingDirectory (Get-Location) -RedirectStandardOutput (Join-Path $qaState 'stdout.log') -RedirectStandardError (Join-Path $qaState 'stderr.log') -PassThru -WindowStyle Hidden
+```
+
+Expected: `http://127.0.0.1:18797/health` returns `200`. This process is not the user's active WebUI.
+
+- [ ] **Step 3: Verify desktop presentation with synthetic safe state**
+
+Using Playwright/browser automation, open `http://127.0.0.1:18797/` at `1440x900`. In the page context set only synthetic UI state:
+
+```javascript
+S.session={model:'auto',gateway_routing:null,gateway_routing_history:[]};
+S.messages=[{
+  role:'assistant',
+  content:'Synthetic routed-model QA response.',
+  _gatewayRouting:{
+    requested_model:'auto',
+    requested_provider:'TokenTable',
+    used_model:'gpt-5.6-sol',
+    used_provider:'TokenTable',
+    source:'openai-compatible-sse',
+    provider_changed:false,
+    model_changed:true,
+    has_failover:false
+  }
+}];
+renderMessages();
+```
+
+Assert `.msg-routed-model-inline` has text containing all three values and that no duplicate `Model switched` or generic `via TokenTable` fragment appears. Save:
+
+```text
+C:\Users\Joa\.hermes\workspace\tokentable_ops\evidence\2026-08-14-hermes-webui-routed-model-desktop.png
+```
+
+- [ ] **Step 4: Verify narrow presentation and overflow**
+
+Resize to `390x844`, re-render the same synthetic state, and assert:
+
+```javascript
+document.documentElement.scrollWidth <= document.documentElement.clientWidth
+```
+
+Confirm the three fields wrap without clipping. Save:
+
+```text
+C:\Users\Joa\.hermes\workspace\tokentable_ops\evidence\2026-08-14-hermes-webui-routed-model-narrow.png
+```
+
+- [ ] **Step 5: Stop only the isolated QA process**
+
+```powershell
+Stop-Process -Id $qaProc.Id
+Wait-Process -Id $qaProc.Id -ErrorAction SilentlyContinue
+```
+
+Expected: only the PID created in Step 2 is stopped. Do not touch any other WebUI, gateway, PM2, or TokenTable process.
+
+### Task 6: Produce the pre-push completion report
+
+**Files:**
+- No code changes expected.
+
+- [ ] **Step 1: Capture final branch evidence**
+
+```powershell
+git status --short --branch
+git rev-parse HEAD
+git log --oneline db2583cb..HEAD
+git diff --stat db2583cb...HEAD
+```
+
+- [ ] **Step 2: Reconfirm dirty master was not touched**
+
+```powershell
+git -C 'C:\Users\Joa\hermes-webui' -c safe.directory=C:/Users/Joa/hermes-webui status --short --branch
+git -C 'C:\Users\Joa\hermes-webui' -c safe.directory=C:/Users/Joa/hermes-webui rev-parse HEAD
+```
+
+Expected master evidence:
+
+```text
+## master...origin/master [ahead 1]
+ M api/models.py
+ M api/routes.py
+ M api/streaming.py
+ M api/updates.py
+?? api/active_model_state.py
+db2583cb7e864037c3b7613f37f4df108d0d7225
+```
+
+- [ ] **Step 3: Report without publishing**
+
+Report in Taiwan Traditional Chinese:
+
+- branch, final HEAD, and worktree path;
+- exact diff file list and commit list;
+- recorded RED command/failure and GREEN command/result;
+- related pytest, Ruff, Node, ESLint, browser smoke, desktop, and narrow results;
+- evidence image paths;
+- confirmation that TokenTable/Hermes Agent were unchanged and no live process was restarted;
+- explicit statement that push, PR, merge, and deploy remain `NOT RUN`.
+
+Stop at that checkpoint and wait for separate literal authorization before any publishing or deployment action.

--- a/docs/superpowers/specs/2026-08-14-routed-model-observability-design.md
+++ b/docs/superpowers/specs/2026-08-14-routed-model-observability-design.md
@@ -1,0 +1,216 @@
+# Routed Model Observability Design
+
+## Decision
+
+Implement routed-model observability entirely in Hermes WebUI by consuming the
+Hermes Agent `post_api_request` lifecycle payload. For an OpenAI-compatible
+streaming response, Hermes Agent fills `response_model` from the normalized
+response object after the SSE stream closes. WebUI will capture that safe scalar
+for the active WebUI turn, normalize it into the existing gateway-routing
+metadata shape, persist it on the final assistant message and session, and
+render it in the existing assistant footer.
+
+This is the selected minimal design because it uses an existing response-boundary
+contract, keeps TokenTable and Hermes Agent unchanged, and avoids inferring a
+model from token text or from the requested model.
+
+## Verified Context
+
+- WebUI requests `model=auto` through the TokenTable OpenAI-compatible endpoint.
+- TokenTable's production request record identifies the routed main-tier model.
+- A production `stream=true` probe returned `model=gpt-5.6-sol` on all ten
+  observed SSE chunks.
+- Hermes Agent's normalized streaming response preserves that SSE model as
+  `response.model`, then exposes it as `response_model` in `post_api_request`.
+- Hermes WebUI's current `on_token(text)` callback receives text only; it cannot
+  truthfully identify the routed model.
+- WebUI already persists safe routing metadata as session `gateway_routing` and
+  `gateway_routing_history`, per-message `_gatewayRouting`, and the terminal
+  `done` session payload. The UI already has a routing-aware assistant footer.
+
+## Scope
+
+The implementation is limited to the isolated Hermes WebUI worktree. It will:
+
+1. observe successful `post_api_request` events for active WebUI turns;
+2. retain only bounded, display-safe routing scalars;
+3. attach the final successful routed model to the final assistant message;
+4. persist the same normalized object at session level and in routing history;
+5. display Requested, Routed, and Provider in the assistant footer;
+6. preserve the metadata through normal `done` delivery, run-journal replay,
+   session reload, and browser re-rendering.
+
+It will not modify TokenTable API, database, schema, environment, PM2, or
+streaming behavior. It will not modify Hermes Agent, repair non-streaming model
+overrides, expose endpoint URLs or secrets, restart a live WebUI or gateway, or
+push, open a PR, merge, or deploy.
+
+## Architecture
+
+### WebUI lifecycle bridge
+
+Add a focused WebUI module responsible for routed-model capture. It installs one
+idempotent process-local observer for Hermes Agent's `post_api_request` lifecycle
+event and maintains a lock-protected registry of active WebUI captures.
+
+Before `agent.run_conversation(...)`, the streaming worker begins a capture with:
+
+- WebUI session/task identifier;
+- stream identifier;
+- requested model after WebUI resolution;
+- safe requested-provider identifier.
+
+The observer accepts an event only when all of the following hold:
+
+- `platform` is `webui`;
+- `task_id` belongs to an active capture;
+- the event contains a non-empty scalar `response_model`;
+- the capture still belongs to the current stream.
+
+The observer stores only `response_model`, the safe provider identifier, and the
+turn correlation identifiers. It must not retain the response body, assistant
+message, user content, usage payload, base URL, headers, credentials, or error
+payload.
+
+WebUI sessions serialize turns with their existing per-session agent lock. The
+capture registry remains keyed by session/task plus stream so simultaneous tabs
+or sessions cannot overwrite one another. Registration is process-wide and
+idempotent; capture state is run-scoped and removed on success, cancellation,
+error, and stale-stream exit.
+
+### Multi-call and retry semantics
+
+A Hermes turn may make several successful API calls around tool use. The routed
+model displayed on the final assistant message is the last non-empty
+`response_model` observed for that turn, because it represents the API call that
+produced the final assistant response.
+
+Self-heal retries remain inside the same capture. A failed request cannot replace
+the value because `post_api_request` fires only after normalized success. A later
+successful retry replaces an earlier successful value. No value from a prior
+turn or stale stream may be reused.
+
+### Metadata normalization and persistence
+
+Extend the existing routing allowlist with a bounded `source` scalar, then
+normalize the capture into the existing routing contract:
+
+```json
+{
+  "requested_model": "auto",
+  "requested_provider": "tokentable",
+  "used_model": "gpt-5.6-sol",
+  "used_provider": "tokentable",
+  "source": "openai-compatible-sse",
+  "model_changed": true,
+  "provider_changed": false,
+  "has_failover": false
+}
+```
+
+The canonical provider value comes from WebUI's already-resolved provider or
+configured custom-provider name. It is never derived by displaying the base URL.
+The renderer may humanize the safe identifier, for example `tokentable` to
+`TokenTable`.
+
+After the conversation result has been reconciled into `s.messages`, but before
+`s.save()`, WebUI will:
+
+1. finish and remove the current capture;
+2. normalize it with the existing gateway-routing helper;
+3. set `s.gateway_routing`;
+4. append the object to the bounded `s.gateway_routing_history`;
+5. set `_gatewayRouting` on the last new assistant message for this turn.
+
+The current stale-stream ownership check remains authoritative. Metadata must not
+be attached if the response itself is no longer allowed to write back.
+
+No new database or session schema is required. The existing arbitrary message
+metadata and session serialization paths carry the fields into the terminal
+`done` payload and reload responses. The API-message sanitizer continues to strip
+display metadata before the next provider request.
+
+## UI
+
+Reuse the existing final assistant-message footer. When `_gatewayRouting`
+contains a non-empty `used_model`, render three labelled values:
+
+```text
+Requested: auto · Routed: gpt-5.6-sol · Provider: TokenTable
+```
+
+The group is quiet secondary metadata, not response body content and not a
+banner. On desktop it may remain on one line; existing footer wrapping plus a
+narrow-screen style must allow the three values to wrap without horizontal
+overflow. Rendering uses DOM `textContent`, not HTML interpolation.
+
+The footer appears only after the routed model is known at successful response
+completion. It must render identically from the live `done` session, run-journal
+replay, and a later session reload.
+
+## Missing or Invalid Data
+
+- If `response_model` is missing, empty, non-scalar, or over the existing bounded
+  scalar limit, do not claim a routed model and do not show the three-field group.
+- If the turn is cancelled, errors, or loses stale-stream ownership, discard the
+  capture without attaching metadata.
+- Never fall back from `used_model` to the requested `auto` value.
+- Never copy the previous turn's routed model onto the current turn.
+- Existing explicit gateway metadata remains valid. A fresh SSE-derived capture
+  fills the same normalized contract for this turn and takes precedence over a
+  missing generic gateway payload; it does not fabricate routing attempts or
+  failover history.
+
+## Testing Strategy
+
+Implementation follows strict RED to GREEN.
+
+### Backend unit coverage
+
+- the observer accepts a matching WebUI `post_api_request` event;
+- unrelated platforms, task IDs, and stream IDs are ignored;
+- simultaneous captures remain isolated;
+- the last successful response model wins within one turn;
+- missing and malformed values produce no routed-model metadata;
+- finish, cancel, exception, and stale-stream paths clear registry state;
+- normalization preserves only the explicit safe allowlist.
+
+### Streaming and persistence coverage
+
+With a fake AIAgent/lifecycle event, prove that a requested `auto` turn whose
+successful response reports `gpt-5.6-sol` results in:
+
+- final assistant `_gatewayRouting` metadata;
+- session `gateway_routing` and bounded history;
+- the same metadata in the terminal `done` session payload;
+- the same metadata after session save/reload;
+- no metadata forwarded in sanitized provider conversation history.
+
+Also cover tool-loop multiple calls, cancellation/error, and stale writeback.
+
+### UI and QA coverage
+
+- a static/frontend test proves the three labels read from `_gatewayRouting`;
+- unsafe strings render through `textContent`;
+- existing gateway/failover/duration/usage footer metadata still renders;
+- isolated local QA uses a disposable Hermes state directory and a fake local
+  OpenAI-compatible streaming provider;
+- capture desktop and narrow viewport evidence showing the final three fields,
+  reload persistence, and no horizontal overflow.
+
+No production TokenTable request is required for RED/GREEN or browser QA, and no
+currently running WebUI or gateway process is restarted.
+
+## Acceptance Criteria
+
+Given a WebUI turn with requested model `auto`, safe provider name `tokentable`,
+and a successful OpenAI-compatible streaming response whose normalized
+`response.model` is `gpt-5.6-sol`:
+
+- the final assistant message persists requested, routed, provider, and source;
+- the session persists the same current routing object and bounded history;
+- live completion, replay, and reload show Requested `auto`, Routed
+  `gpt-5.6-sol`, and Provider `TokenTable`;
+- later turns receive no display metadata in provider-bound history;
+- missing/error/cancel/stale cases never display a false routed model;
+- TokenTable and Hermes Agent remain byte-for-byte unchanged.

--- a/static/style.css
+++ b/static/style.css
@@ -6161,6 +6161,31 @@ body code[class*="language-"],body pre[class*="language-"],body pre code[class*=
 .msg-foot-with-usage {
   justify-content: flex-start;
   gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.msg-routed-model-inline {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  min-width: 0;
+  max-width: 100%;
+}
+.msg-routed-model-field {
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: .78;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 600px) {
+  .msg-routed-model-inline {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+  .msg-routed-model-field {
+    flex: 1 1 100%;
+  }
 }
 .msg-usage-inline,
 .msg-duration-inline,

--- a/static/ui.js
+++ b/static/ui.js
@@ -7124,6 +7124,33 @@ function _gatewayProviderName(provider){
   if(!text)return'';
   return text.replace(/^custom:/,'').replace(/[-_]/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
 }
+function _routedModelObservationFields(routing){
+  if(!routing||routing.source!=='openai-compatible-sse')return[];
+  const requested=String(routing.requested_model||'').trim();
+  const routed=String(routing.used_model||'').trim();
+  const provider=_gatewayProviderName(routing.used_provider||routing.requested_provider);
+  if(!routed)return[];
+  // Footer labels render as Requested:, Routed:, and Provider:.
+  return[
+    {label:'Requested',value:requested},
+    {label:'Routed',value:routed},
+    {label:'Provider',value:provider},
+  ].filter(field=>field.value);
+}
+function _appendRoutedModelObservation(target,routing){
+  const fields=_routedModelObservationFields(routing);
+  if(!target||!fields.length)return false;
+  const group=document.createElement('span');
+  group.className='msg-routed-model-inline';
+  for(const field of fields){
+    const item=document.createElement('span');
+    item.className='msg-routed-model-field';
+    item.textContent=`${field.label}: ${field.value}`;
+    group.appendChild(item);
+  }
+  target.appendChild(group);
+  return true;
+}
 function _gatewayRoutingLabel(routing){
   if(!routing)return'';
   const provider=_gatewayProviderName(routing.used_provider||routing.provider);
@@ -17457,9 +17484,11 @@ function renderMessages(options){
       const msg=S.messages[mi]||{};
       if(msg.role!=='assistant') continue;
       const routing=msg._gatewayRouting||null;
-      const gatewayText=_formatGatewayModelLabel(String(msg._usedModel||'').trim()||(S.session&&S.session.model)||'', '', routing);
+      const isSseObservation=!!routing&&routing.source==='openai-compatible-sse';
+      const gatewayText=isSseObservation?'':_formatGatewayModelLabel(String(msg._usedModel||'').trim()||(S.session&&S.session.model)||'', '', routing);
       const failoverText=_gatewayRoutingFailoverText(routing);
-      const modelWarningText=_gatewayModelWarningText(routing);
+      const modelWarningText=isSseObservation?'':_gatewayModelWarningText(routing);
+      const routedModelFields=_routedModelObservationFields(routing);
       const hasTurnUsage=!!msg._turnUsage;
       // The Worklog summary owns the "Done in …" duration whenever this
       // assistant message contributes tool or thinking detail to a folded
@@ -17467,12 +17496,12 @@ function renderMessages(options){
       const compactWorklogForMessage=isCompactWorklogMode()&&(toolCallAssistantIdxs.has(mi)||assistantThinking.has(mi));
       const durationText=compactWorklogForMessage?'':_formatTurnDuration(msg._turnDuration);
       const usedModelText=_usedModelTurnChipLabel(msg);
-      if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText&&!usedModelText) continue;
+      if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText&&!usedModelText&&!routedModelFields.length) continue;
       const seg=assistantSegments.get(mi);
       const row=seg?seg.closest('.assistant-turn'):null;
       const footerRows=row?row.querySelectorAll('.msg-foot'):[];
       const targetFoot=footerRows.length?footerRows[footerRows.length-1]:null;
-      if(!targetFoot||targetFoot.querySelector('.msg-usage-inline,.msg-duration-inline,.msg-gateway-inline,.gateway-failover-inline,.msg-model-warning-inline,.msg-used-model-inline')) continue;
+      if(!targetFoot||targetFoot.querySelector('.msg-usage-inline,.msg-duration-inline,.msg-gateway-inline,.gateway-failover-inline,.msg-model-warning-inline,.msg-used-model-inline,.msg-routed-model-inline')) continue;
       const fragments=[];
       if(modelWarningText){
         const warning=document.createElement('span');
@@ -17485,6 +17514,10 @@ function renderMessages(options){
         failover.className='gateway-failover-inline';
         failover.textContent=failoverText;
         fragments.push(failover);
+      }
+      if(routedModelFields.length){
+        const routedModelContainer=document.createElement('span');
+        if(_appendRoutedModelObservation(routedModelContainer,routing)) fragments.push(routedModelContainer.firstChild);
       }
       if(gatewayText){
         const gateway=document.createElement('span');

--- a/tests/test_732_gateway_routing_metadata.py
+++ b/tests/test_732_gateway_routing_metadata.py
@@ -56,6 +56,31 @@ def test_gateway_routing_metadata_absent_returns_none_without_placeholder_noise(
     assert _normalize_gateway_routing_metadata(None, requested_model="gpt-5.5", requested_provider="openai-codex") is None
 
 
+def test_sse_routing_source_is_safely_normalized_and_persisted():
+    normalized = _normalize_gateway_routing_metadata(
+        {
+            "requested_model": "auto",
+            "requested_provider": "TokenTable",
+            "used_model": "gpt-5.6-sol",
+            "used_provider": "TokenTable",
+            "source": "openai-compatible-sse",
+            "api_key": "must-not-survive",
+        }
+    )
+
+    assert normalized == {
+        "requested_model": "auto",
+        "requested_provider": "TokenTable",
+        "used_model": "gpt-5.6-sol",
+        "used_provider": "TokenTable",
+        "source": "openai-compatible-sse",
+        "provider_changed": False,
+        "model_changed": True,
+        "has_failover": False,
+    }
+    assert "must-not-survive" not in repr(normalized)
+
+
 def test_session_persists_latest_gateway_routing_and_history_across_reload():
     routing = _normalize_gateway_routing_metadata(
         {
@@ -63,6 +88,7 @@ def test_session_persists_latest_gateway_routing_and_history_across_reload():
             "used_model": "model-b",
             "requested_provider": "provider-a",
             "requested_model": "model-a",
+            "source": "openai-compatible-sse",
             "routing": [
                 {"provider": "provider-a", "status": "failed"},
                 {"provider": "provider-b", "status": "selected"},
@@ -78,8 +104,11 @@ def test_session_persists_latest_gateway_routing_and_history_across_reload():
     reloaded = Session.load("732gateway")
 
     assert reloaded.gateway_routing == routing
+    assert reloaded.gateway_routing["source"] == "openai-compatible-sse"
     assert reloaded.gateway_routing_history == [routing]
+    assert reloaded.gateway_routing_history[0]["source"] == "openai-compatible-sse"
     assert reloaded.messages[-1]["_gatewayRouting"] == routing
+    assert reloaded.messages[-1]["_gatewayRouting"]["source"] == "openai-compatible-sse"
     compact = reloaded.compact()
     assert compact["gateway_routing"] == routing
     assert compact["gateway_routing_history"] == [routing]
@@ -90,6 +119,51 @@ def test_streaming_captures_gateway_metadata_into_usage_payload_and_assistant_tu
     assert "usage['gateway_routing']" in STREAMING_PY
     assert "_dm['_gatewayRouting']" in STREAMING_PY
     assert "s.gateway_routing_history" in STREAMING_PY
+
+
+def test_streaming_explicit_gateway_metadata_uses_display_requested_provider():
+    streaming_worker = STREAMING_PY.split("def _run_agent_streaming(", 1)[1]
+    persistence = streaming_worker.split(
+        "_gateway_routing = _extract_gateway_routing_metadata(", 1
+    )[1].split("if _gateway_routing:", 1)[0]
+
+    assert "requested_provider=_requested_provider_display" in persistence
+    assert persistence.count("requested_provider=_requested_provider_display") == 2
+
+    normalized = _normalize_gateway_routing_metadata(
+        {
+            "used_provider": "TokenTable",
+            "used_model": "gpt-5.6-sol",
+        },
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    assert normalized["requested_provider"] == "TokenTable"
+    assert normalized["provider_changed"] is False
+
+
+def test_routed_model_capture_cleanup_is_in_streaming_outer_finally():
+    streaming_worker = STREAMING_PY.split("def _run_agent_streaming(", 1)[1].split(
+        "# ============================================================\n"
+        "# SECTION: HTTP Request Handler",
+        1,
+    )[0]
+    outer_finally = streaming_worker.split(
+        "\n    finally:\n"
+        "        # Stop the periodic checkpoint thread before the final recovery path.",
+        1,
+    )[1]
+    reset_capture = outer_finally.find(
+        "        if _routed_model_capture_token is not None:\n"
+        "            try:\n"
+        "                reset_routed_model_capture(_routed_model_capture_token)"
+    )
+    clear_env = outer_finally.find(
+        "        _clear_thread_env()  # TD1: always clear thread-local context"
+    )
+
+    assert reset_capture >= 0
+    assert clear_env > reset_capture
 
 
 def test_frontend_copies_and_formats_gateway_metadata_without_absent_noise():

--- a/tests/test_732_gateway_routing_metadata.py
+++ b/tests/test_732_gateway_routing_metadata.py
@@ -1,5 +1,7 @@
 """Regression coverage for #732 LLM Gateway routing metadata display."""
 
+import re
+import subprocess
 from pathlib import Path
 
 from api.models import Session
@@ -12,6 +14,41 @@ MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(source, name):
+    start = source.index(f"function {name}(")
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    raise AssertionError(f"Unterminated function: {name}")
+
+
+def _function_source(source, name):
+    start = source.index(f"function {name}(")
+    body = _function_body(source, name)
+    opening = source.index("{", start)
+    return source[start:opening + len(body) + 2]
+
+
+def _media_blocks(source):
+    for match in re.finditer(r"@media\s*([^\{]+)\{", source):
+        opening = match.end() - 1
+        depth = 0
+        for index in range(opening, len(source)):
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    yield match.group(1).strip(), source[opening + 1:index]
+                    break
 
 
 def test_gateway_routing_metadata_is_safely_normalized_from_response_metadata():
@@ -148,11 +185,7 @@ def test_routed_model_capture_cleanup_is_in_streaming_outer_finally():
         "# SECTION: HTTP Request Handler",
         1,
     )[0]
-    outer_finally = streaming_worker.split(
-        "\n    finally:\n"
-        "        # Stop the periodic checkpoint thread before the final recovery path.",
-        1,
-    )[1]
+    outer_finally = streaming_worker.rsplit("\n    finally:\n", 1)[1]
     reset_capture = outer_finally.find(
         "        if _routed_model_capture_token is not None:\n"
         "            try:\n"
@@ -177,3 +210,150 @@ def test_frontend_copies_and_formats_gateway_metadata_without_absent_noise():
     assert "if(!routing)return''" in UI_JS.replace(" ", "")
     assert "_formatSessionModelWithGateway" in SESSIONS_JS
     assert ".msg-model-warning-inline" in STYLE_CSS
+
+
+def test_sse_routed_model_footer_uses_three_safe_labelled_fields():
+    assert "function _routedModelObservationFields" in UI_JS
+    assert "msg-routed-model-inline" in UI_JS
+    assert "msg-routed-model-field" in UI_JS
+    assert ".msg-routed-model-inline" in STYLE_CSS
+    assert ".msg-routed-model-field" in STYLE_CSS
+
+    formatter = "".join(_function_body(UI_JS, "_routedModelObservationFields").split())
+    assert "{label:'Requested',value:requested}" in formatter
+    assert "{label:'Routed',value:routed}" in formatter
+    assert "{label:'Provider',value:provider}" in formatter
+
+    renderer = "".join(_function_body(UI_JS, "_appendRoutedModelObservation").split())
+    assert ".textContent=" in renderer
+    assert ".innerHTML" not in renderer
+
+
+def test_routed_model_footer_executes_real_formatter_and_safe_dom_renderer():
+    production_functions = "\n".join(
+        _function_source(UI_JS, name)
+        for name in (
+            "_gatewayProviderName",
+            "_routedModelObservationFields",
+            "_appendRoutedModelObservation",
+        )
+    )
+    harness = f"""
+'use strict';
+function assert(condition, message) {{
+  if (!condition) throw new Error(message);
+}}
+function elementStub() {{
+  return {{
+    className: '',
+    textContent: '',
+    children: [],
+    appendChild(child) {{ this.children.push(child); return child; }},
+    get firstChild() {{ return this.children[0] || null; }},
+    get innerHTML() {{ return ''; }},
+    set innerHTML(_value) {{ throw new Error('innerHTML must not be used'); }},
+  }};
+}}
+const document = {{ createElement: elementStub }};
+{production_functions}
+
+const complete = {{
+  source: 'openai-compatible-sse',
+  requested_model: 'auto',
+  used_model: 'gpt-5.6-sol',
+  requested_provider: 'Fallback Provider',
+  used_provider: 'TokenTable',
+}};
+const completeTarget = elementStub();
+assert(_appendRoutedModelObservation(completeTarget, complete) === true, 'complete append return');
+assert(completeTarget.children.length === 1, 'complete group count');
+const completeGroup = completeTarget.firstChild;
+assert(completeGroup.className === 'msg-routed-model-inline', 'complete group class');
+assert(completeGroup.children.length === 3, 'complete field count');
+assert(completeGroup.children.every(item => item.className === 'msg-routed-model-field'), 'field classes');
+assert(JSON.stringify(completeGroup.children.map(item => item.textContent)) === JSON.stringify([
+  'Requested: auto',
+  'Routed: gpt-5.6-sol',
+  'Provider: TokenTable',
+]), 'complete field text');
+
+const malicious = {{
+  source: 'openai-compatible-sse',
+  requested_model: '<img src=x onerror=alert(1)>',
+  used_model: '<script>alert(2)</script>',
+  used_provider: 'TokenTable',
+}};
+const maliciousTarget = elementStub();
+assert(_appendRoutedModelObservation(maliciousTarget, malicious) === true, 'malicious append return');
+assert(JSON.stringify(maliciousTarget.firstChild.children.map(item => item.textContent)) === JSON.stringify([
+  'Requested: <img src=x onerror=alert(1)>',
+  'Routed: <script>alert(2)</script>',
+  'Provider: TokenTable',
+]), 'malicious values remain literal text');
+
+const fallback = {{
+  source: 'openai-compatible-sse',
+  requested_model: 'auto',
+  used_model: 'gpt-5.6-sol',
+  requested_provider: 'TokenTable',
+}};
+assert(_routedModelObservationFields(fallback)[2].value === 'TokenTable', 'requested provider fallback');
+
+const missingRouted = {{source: 'openai-compatible-sse', requested_model: 'auto', used_model: ''}};
+const missingTarget = elementStub();
+assert(_routedModelObservationFields(missingRouted).length === 0, 'missing routed fields');
+assert(_appendRoutedModelObservation(missingTarget, missingRouted) === false, 'missing routed append return');
+assert(missingTarget.children.length === 0, 'missing routed does not append');
+
+const nonSse = {{source: 'gateway-response', requested_model: 'auto', used_model: 'gpt-5.6-sol'}};
+const nonSseTarget = elementStub();
+assert(_routedModelObservationFields(nonSse).length === 0, 'non-SSE fields');
+assert(_appendRoutedModelObservation(nonSseTarget, nonSse) === false, 'non-SSE append return');
+assert(nonSseTarget.children.length === 0, 'non-SSE does not append');
+"""
+
+    result = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_non_sse_gateway_metadata_keeps_existing_footer_path():
+    compact = "".join(UI_JS.split())
+    assert "routing.source==='openai-compatible-sse'" in compact
+    assert "_formatGatewayModelLabel" in UI_JS
+    assert "_gatewayRoutingFailoverText" in UI_JS
+    assert "_gatewayModelWarningText" in UI_JS
+
+
+def test_sse_footer_suppresses_legacy_gateway_and_warning_but_preserves_failover():
+    compact = "".join(UI_JS.split())
+    assert "constgatewayText=isSseObservation?'':_formatGatewayModelLabel" in compact
+    assert "constmodelWarningText=isSseObservation?'':_gatewayModelWarningText" in compact
+    assert "constfailoverText=_gatewayRoutingFailoverText(routing)" in compact
+    assert "constroutedModelFields=_routedModelObservationFields(routing)" in compact
+
+
+def test_routed_model_footer_duplicate_guard_includes_new_selector():
+    footer_render = UI_JS.split("// Render per-turn duration and optional token usage", 1)[1]
+    duplicate_guard = footer_render.split("querySelector(", 1)[1].split(")", 1)[0]
+    assert ".msg-routed-model-inline" in duplicate_guard
+
+
+def test_routed_model_footer_has_exact_600px_mobile_stack_boundary():
+    routed_blocks = [
+        (header, body)
+        for header, body in _media_blocks(STYLE_CSS)
+        if ".msg-routed-model-inline" in body and ".msg-routed-model-field" in body
+    ]
+    assert len(routed_blocks) == 1
+    header, body = routed_blocks[0]
+    assert "".join(header.split()) == "(max-width:600px)"
+    mobile = "".join(body.split())
+    assert ".msg-routed-model-inline{flex:11100%;width:100%" in mobile
+    assert ".msg-routed-model-field{flex:11100%" in mobile

--- a/tests/test_routed_model_observability.py
+++ b/tests/test_routed_model_observability.py
@@ -1,13 +1,17 @@
 """Tests for run-scoped routed-model lifecycle capture."""
 
 from concurrent.futures import ThreadPoolExecutor
+import queue
 import sys
 from threading import Barrier
 from types import ModuleType, SimpleNamespace
 
 import pytest
 
+import api.models as models
 import api.routed_model_observability as observability
+import api.streaming as streaming
+from api.models import Session
 from api.routed_model_observability import (
     _install_post_api_request_observer,
     _observe_post_api_request,
@@ -266,3 +270,234 @@ def test_capture_begin_and_reset_fail_open_when_plugin_manager_is_unavailable(
     reset_routed_model_capture(token)
 
     assert snapshot_routed_model_capture() is None
+
+
+def _run_streaming_routed_model_integration(
+    monkeypatch,
+    tmp_path,
+    *,
+    self_heal,
+    ephemeral=False,
+):
+    suffix = "ephemeral-auth" if ephemeral else ("self-heal" if self_heal else "normal")
+    session_id = f"session-routed-model-{suffix}"
+    stream_id = f"stream-routed-model-{suffix}"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    session = Session(
+        session_id=session_id,
+        title="Routing",
+        workspace=str(tmp_path),
+        model="auto",
+        model_provider="custom:tokentable",
+        messages=[],
+        context_messages=[],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "route this"
+    session.save()
+
+    class FakeAgent:
+        instances = 0
+
+        def __init__(
+            self,
+            model=None,
+            provider=None,
+            base_url=None,
+            api_key=None,
+            session_id=None,
+            **kwargs,
+        ):
+            self.model = model
+            self.provider = provider
+            self.base_url = base_url
+            self.session_id = session_id
+            self.context_compressor = None
+            self.session_prompt_tokens = 11
+            self.session_completion_tokens = 7
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+            self.fail_with_auth = (self_heal or ephemeral) and FakeAgent.instances == 0
+            FakeAgent.instances += 1
+
+        def run_conversation(self, **kwargs):
+            if self.fail_with_auth:
+                raise RuntimeError("401 unauthorized: invalid api key")
+            observability._observe_post_api_request(
+                platform="webui",
+                session_id=self.session_id,
+                task_id=kwargs["task_id"],
+                response_model="gpt-5.6-sol",
+                provider="custom",
+            )
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs["persist_user_message"]},
+                    {"role": "assistant", "content": "routed answer"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    runtime = {
+        "provider": "custom",
+        "base_url": "https://example.invalid",
+        "api_key": "test-only",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    runtime_provider.resolve_runtime_provider = lambda **_kwargs: dict(runtime)
+    hermes_cli = ModuleType("hermes_cli")
+    hermes_cli.runtime_provider = runtime_provider
+    hermes_state = ModuleType("hermes_state")
+    hermes_state.SessionDB = lambda *_args, **_kwargs: object()
+    config = {
+        "custom_providers": [
+            {
+                "name": "TokenTable",
+                "base_url": "https://example.invalid",
+                "api_key": "test-only",
+            }
+        ]
+    }
+    journal_events = []
+
+    class FakeRunJournal:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def append_sse_event(self, event, data):
+            journal_events.append((event, data))
+            return None
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", runtime_provider)
+    monkeypatch.setitem(sys.modules, "hermes_state", hermes_state)
+    monkeypatch.setattr(streaming, "get_session", lambda _session_id: session)
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+    monkeypatch.setattr(streaming, "RunJournalWriter", FakeRunJournal)
+    monkeypatch.setattr(
+        streaming,
+        "resolve_model_provider",
+        lambda *_args, **_kwargs: (
+            "auto",
+            "custom:tokentable",
+            "https://example.invalid",
+        ),
+    )
+    monkeypatch.setattr(
+        streaming,
+        "resolve_custom_provider_connection",
+        lambda *_args, **_kwargs: ("test-only", "https://example.invalid"),
+    )
+    monkeypatch.setattr(streaming, "get_config", lambda: config)
+    monkeypatch.setattr("api.config.get_config", lambda: config)
+    monkeypatch.setattr("api.config.get_config_for_profile_home", lambda *_args: config)
+    monkeypatch.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        streaming,
+        "_attempt_credential_self_heal",
+        (
+            (lambda *_args, **_kwargs: dict(runtime))
+            if self_heal
+            else (lambda *_args, **_kwargs: None)
+        ),
+    )
+    event_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = event_queue
+
+    streaming._run_agent_streaming(
+        session_id=session_id,
+        msg_text="route this",
+        model="auto",
+        workspace=tmp_path,
+        stream_id=stream_id,
+        model_provider="custom:tokentable",
+        ephemeral=ephemeral,
+    )
+
+    expected = {
+        "requested_model": "auto",
+        "requested_provider": "TokenTable",
+        "used_model": "gpt-5.6-sol",
+        "used_provider": "TokenTable",
+        "source": "openai-compatible-sse",
+        "provider_changed": False,
+        "model_changed": True,
+        "has_failover": False,
+    }
+    events = []
+    while not event_queue.empty():
+        events.append(event_queue.get_nowait())
+    if ephemeral:
+        assert not [payload for event, payload in events if event == "done"]
+        errors = [payload for event, payload in events if event == "apperror"]
+        assert errors[-1]["type"] == "auth_mismatch"
+        assert snapshot_routed_model_capture() is None
+        return
+    done = [payload for event, payload in events if event == "done"][-1]
+    journal_done = [payload for event, payload in journal_events if event == "done"][-1]
+
+    assert session.messages[-1]["_gatewayRouting"] == expected
+    assert session.gateway_routing == expected
+    assert session.gateway_routing_history == [expected]
+    assert done["usage"]["gateway_routing"] == expected
+    assert done["session"]["messages"][-1]["_gatewayRouting"] == expected
+    assert journal_done["usage"]["gateway_routing"] == expected
+    assert journal_done["session"]["messages"][-1]["_gatewayRouting"] == expected
+    reloaded = Session.load(session_id)
+    assert reloaded.messages[-1]["_gatewayRouting"] == expected
+    assert reloaded.gateway_routing == expected
+    assert reloaded.gateway_routing_history == [expected]
+    assert reloaded.messages[-1]["_gatewayRouting"]["source"] == "openai-compatible-sse"
+    assert all(
+        "_gatewayRouting" not in message
+        for message in streaming._sanitize_messages_for_api(session.messages)
+    )
+    assert snapshot_routed_model_capture() is None
+
+
+def test_streaming_persists_sse_routed_model_in_message_session_and_done(
+    monkeypatch,
+    tmp_path,
+):
+    _run_streaming_routed_model_integration(
+        monkeypatch,
+        tmp_path,
+        self_heal=False,
+    )
+
+
+def test_streaming_self_heal_retry_persists_routed_model_through_common_finalization(
+    monkeypatch,
+    tmp_path,
+):
+    _run_streaming_routed_model_integration(
+        monkeypatch,
+        tmp_path,
+        self_heal=True,
+    )
+
+
+def test_ephemeral_streaming_auth_exception_uses_outer_error_semantics(
+    monkeypatch,
+    tmp_path,
+):
+    _run_streaming_routed_model_integration(
+        monkeypatch,
+        tmp_path,
+        self_heal=False,
+        ephemeral=True,
+    )

--- a/tests/test_routed_model_observability.py
+++ b/tests/test_routed_model_observability.py
@@ -1,0 +1,268 @@
+"""Tests for run-scoped routed-model lifecycle capture."""
+
+from concurrent.futures import ThreadPoolExecutor
+import sys
+from threading import Barrier
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import api.routed_model_observability as observability
+from api.routed_model_observability import (
+    _install_post_api_request_observer,
+    _observe_post_api_request,
+    begin_routed_model_capture,
+    provider_display_name,
+    reset_routed_model_capture,
+    snapshot_routed_model_capture,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_observer_install(monkeypatch):
+    monkeypatch.setattr(observability, "_install_post_api_request_observer", lambda: None)
+
+
+def test_capture_uses_last_matching_safe_response_and_reset_clears_it():
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            platform="WebUI",
+            session_id="session-a",
+            task_id="session-a",
+            response_model="gpt-5.6",
+            provider="custom",
+        )
+        _observe_post_api_request(
+            platform="webui",
+            session_id="session-a",
+            task_id="session-a",
+            response_model="gpt-5.6-sol",
+            provider="custom",
+        )
+
+        assert snapshot_routed_model_capture() == {
+            "requested_model": "auto",
+            "requested_provider": "TokenTable",
+            "used_model": "gpt-5.6-sol",
+            "used_provider": "TokenTable",
+            "source": "openai-compatible-sse",
+        }
+    finally:
+        reset_routed_model_capture(token)
+
+    assert snapshot_routed_model_capture() is None
+
+
+@pytest.mark.parametrize(
+    ("platform", "session_id", "task_id"),
+    [
+        ("telegram", "session-a", "session-a"),
+        ("webui", "session-b", "session-a"),
+        ("webui", "session-a", "task-b"),
+    ],
+)
+def test_capture_ignores_nonmatching_lifecycle_events(platform, session_id, task_id):
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            platform=platform,
+            session_id=session_id,
+            task_id=task_id,
+            response_model="wrong-model",
+            provider="custom",
+        )
+        assert snapshot_routed_model_capture() is None
+    finally:
+        reset_routed_model_capture(token)
+
+
+@pytest.mark.parametrize(
+    "response_model",
+    [
+        None,
+        "",
+        "   ",
+        {},
+        "x" * 241,
+        "gpt-5.6\nspoof",
+        "gpt-5.6\x00spoof",
+        "gpt-5.6\u202espoof",
+    ],
+)
+def test_capture_rejects_unsafe_response_model(response_model):
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    try:
+        _observe_post_api_request(
+            platform="webui",
+            session_id="session-a",
+            task_id="session-a",
+            response_model=response_model,
+            provider="custom",
+        )
+        assert snapshot_routed_model_capture() is None
+    finally:
+        reset_routed_model_capture(token)
+
+
+def test_contextvar_isolates_concurrent_capture_runs():
+    barrier = Barrier(2)
+
+    def capture(session_id, stream_id, model):
+        token = begin_routed_model_capture(
+            session_id=session_id,
+            stream_id=stream_id,
+            task_id=session_id,
+            requested_model="auto",
+            requested_provider="TokenTable",
+        )
+        try:
+            barrier.wait(timeout=5)
+            _observe_post_api_request(
+                platform="webui",
+                session_id=session_id,
+                task_id=session_id,
+                response_model=model,
+                provider="custom",
+            )
+            return snapshot_routed_model_capture()
+        finally:
+            reset_routed_model_capture(token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda args: capture(*args),
+                [
+                    ("session-a", "stream-a", "model-a"),
+                    ("session-b", "stream-b", "model-b"),
+                ],
+            )
+        )
+
+    assert [result["used_model"] for result in results] == ["model-a", "model-b"]
+
+
+def test_provider_display_name_resolves_named_custom_provider():
+    config = SimpleNamespace(custom_providers=[{"name": "TokenTable"}])
+
+    assert provider_display_name("custom:tokentable", "custom", config) == "TokenTable"
+    assert provider_display_name(None, "openai-codex", config) == "openai-codex"
+
+
+def test_installer_registers_callback_only_once(monkeypatch):
+    manager = SimpleNamespace(_hooks={})
+    plugins = ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = lambda: None
+    plugins.get_plugin_manager = lambda: manager
+    hermes_cli = ModuleType("hermes_cli")
+    hermes_cli.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+
+    _install_post_api_request_observer()
+    _install_post_api_request_observer()
+
+    assert manager._hooks["post_api_request"] == [_observe_post_api_request]
+
+
+def test_installer_registers_each_manager_and_restores_after_force_reload(monkeypatch):
+    manager_a = SimpleNamespace(_hooks={})
+    manager_b = SimpleNamespace(_hooks={})
+    current = {"manager": manager_a}
+    plugins = ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = lambda: None
+    plugins.get_plugin_manager = lambda: current["manager"]
+    hermes_cli = ModuleType("hermes_cli")
+    hermes_cli.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+
+    _install_post_api_request_observer()
+    current["manager"] = manager_b
+    _install_post_api_request_observer()
+
+    assert manager_a._hooks["post_api_request"] == [_observe_post_api_request]
+    assert manager_b._hooks["post_api_request"] == [_observe_post_api_request]
+
+    manager_b._hooks.clear()
+    _install_post_api_request_observer()
+    _install_post_api_request_observer()
+
+    assert manager_b._hooks["post_api_request"] == [_observe_post_api_request]
+
+
+def test_capture_begin_and_reset_fail_open_when_plugin_discovery_fails(monkeypatch):
+    plugins = ModuleType("hermes_cli.plugins")
+
+    def fail_discovery():
+        raise RuntimeError("plugin discovery unavailable")
+
+    plugins.discover_plugins = fail_discovery
+    plugins.get_plugin_manager = lambda: None
+    hermes_cli = ModuleType("hermes_cli")
+    hermes_cli.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+    monkeypatch.setattr(
+        observability,
+        "_install_post_api_request_observer",
+        _install_post_api_request_observer,
+    )
+
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    reset_routed_model_capture(token)
+
+    assert snapshot_routed_model_capture() is None
+
+
+def test_capture_begin_and_reset_fail_open_when_plugin_manager_is_unavailable(
+    monkeypatch,
+):
+    plugins = ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = lambda: None
+    plugins.get_plugin_manager = lambda: None
+    hermes_cli = ModuleType("hermes_cli")
+    hermes_cli.plugins = plugins
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+    monkeypatch.setattr(
+        observability,
+        "_install_post_api_request_observer",
+        _install_post_api_request_observer,
+    )
+
+    token = begin_routed_model_capture(
+        session_id="session-a",
+        stream_id="stream-a",
+        task_id="session-a",
+        requested_model="auto",
+        requested_provider="TokenTable",
+    )
+    reset_routed_model_capture(token)
+
+    assert snapshot_routed_model_capture() is None


### PR DESCRIPTION
## Summary

- capture the actual OpenAI-compatible SSE response model through a run-scoped lifecycle observer
- persist requested/routed/provider metadata through the assistant message, session, history, usage, run journal, and terminal `done` event
- render a safe, responsive `Requested` / `Routed` / `Provider` assistant footer while suppressing duplicate legacy model labels

## Why

When a custom provider accepts an automatic model request, the requested model alone does not show which model actually served the turn. This makes routing and failover behavior difficult to audit from the WebUI transcript.

The implementation keeps explicit gateway metadata authoritative and uses the SSE lifecycle observation only as a fallback. Capture is isolated per run with `ContextVar`, bounded to display-safe scalar values, fail-open, and reset in the streaming worker's outer `finally` before thread-local cleanup.

## User impact

For `source === "openai-compatible-sse"`, an assistant turn can now show:

```text
Requested: auto
Routed: gpt-5.6-sol
Provider: TokenTable
```

Non-SSE gateway footers retain their existing behavior. The renderer uses `createElement` and `textContent`; long values wrap on narrow viewports.

## Verification

- `35 passed` — `tests/test_routed_model_observability.py` and `tests/test_732_gateway_routing_metadata.py`
- TDD compatibility fix after rebasing onto current `master`: outer-finally cleanup test RED, then GREEN using a structure-stable locator
- `scripts/ruff_lint.py --diff origin/master`: 0 findings on added/modified lines
- `node --check static/ui.js`: PASS
- `git diff --check origin/master...HEAD`: PASS
- native Python Playwright, fresh isolated state and credential-free environment:
  - desktop 1440x900: exact three fields, no legacy duplicates, rerender remains one group
  - narrow 390x844: full-row fields, no horizontal overflow
  - 240-character model/provider values wrap without overflow
  - 0 console errors, 0 page exceptions

No production provider request, credential, deployment, database change, or gateway restart was used for verification.
