### PR TITLE
fix(upload): expose chat attachment paths inside docker terminal sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Thinking/reasoning display -- collapsible gold-themed cards for Claude extended thinking and o3 reasoning blocks
 - Approval card for dangerous shell commands (allow once / session / always / deny)
 - SSE auto-reconnect on network blips (SSH tunnel resilience)
-- File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured)
+- File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured). With a remote terminal backend (`terminal.backend: docker`, ssh, ...) the default inbox moves to the active profile's sandbox-visible cache subtree (`~/.hermes/cache/documents/webui-attachments/<session_id>/`), which hermes-agent auto-mounts into sandboxes, and the agent-facing path is translated to its container form. If you set `HERMES_WEBUI_ATTACHMENT_DIR` with a remote backend, point it at a directory that is actually bind-mounted into the sandbox (e.g. under `~/.hermes/attachments` or `~/.hermes/cache/...`).
 - Message timestamps (HH:MM next to each message, full date on hover)
 - Code block copy button with "Copied!" feedback
 - Syntax highlighting via Prism.js (Python, JS, bash, JSON, SQL, and more)

--- a/api/routes.py
+++ b/api/routes.py
@@ -15945,9 +15945,9 @@ def handle_post(handler, parsed) -> bool:
         from api.config import _evict_session_agent
         _evict_session_agent(sid)
         try:
-            from api.upload import _session_attachment_dir
+            from api.upload import remove_session_attachments
 
-            shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
+            remove_session_attachments(sid)
         except Exception:
             logger.debug("Failed to clean attachment dir for deleted session %s", sid)
         # Remove the turn-journal shards and the run-journal directory so a
@@ -20719,16 +20719,19 @@ def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:
 
     # Chat uploads now live in a per-session attachment inbox outside the
     # workspace. Keep the public URL stable while scoping fallback lookup to
-    # the requesting session's own attachment directory.
+    # the requesting session's own attachment directories. The write root
+    # follows the active terminal backend (legacy STATE_DIR/attachments for
+    # local/ssh-style backends, sandbox cache/documents/webui-attachments for
+    # docker/modal), so reads consider BOTH compatible roots: a backend switch
+    # or an upgrade must not orphan previously uploaded attachments.
     try:
-        from api.upload import _session_attachment_dir
+        from api.upload import resolve_session_attachment
 
-        attachment_root = _session_attachment_dir(sid)
-        attachment_target = safe_resolve(attachment_root, rel)
+        resolved = resolve_session_attachment(sid, rel)
+        if resolved is not None:
+            return resolved
     except Exception:
         return None
-    if attachment_target.exists() and attachment_target.is_file():
-        return attachment_root, attachment_target
     return None
 
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -210,11 +210,19 @@ def _agent_visible_attachment_path(host_path) -> str:
         container_base = '/root/.hermes'
     try:
         from api.profiles import get_active_hermes_home
-        from hermes_constants import get_hermes_dir
 
-        host_root = Path(
-            get_hermes_dir('cache/documents', 'document_cache', home=get_active_hermes_home())
-        ).resolve()
+        host_root = Path(get_active_hermes_home()).resolve() / 'cache' / 'documents'
+        # Prefer the agent's canonical resolver when available (it honors
+        # operator-configured document-cache overrides), falling back to the
+        # WebUI-local default under the active profile home.
+        try:
+            from hermes_constants import get_hermes_dir
+
+            host_root = Path(
+                get_hermes_dir('cache/documents', 'document_cache', home=get_active_hermes_home())
+            ).resolve()
+        except Exception:
+            pass
         candidate = Path(host_path).resolve()
         try:
             rel = candidate.relative_to(host_root)

--- a/api/upload.py
+++ b/api/upload.py
@@ -1,15 +1,17 @@
 """
 Hermes Web UI -- File upload: multipart parser and upload handler.
 """
+import json
 import mimetypes
 import os
 import posixpath
 import re as _re
+import shutil
 import tempfile
 from pathlib import Path
 
 from api.config import MAX_UPLOAD_BYTES, STATE_DIR
-from api.helpers import j
+from api.helpers import j, safe_resolve
 from api.models import get_session
 from api.profiles import _profiles_match, get_active_profile_name as _get_active_profile_name
 from api.workspace import (
@@ -111,23 +113,28 @@ def _sanitize_upload_name(filename: str) -> str:
 
 
 def _attachment_root() -> Path:
-    """Return the configured upload inbox root.
+    """Return the configured upload inbox root (the WRITE root).
 
     Plain chat attachments are transient context for the agent, not project
     source files.  Keep them out of the active workspace by default while still
     allowing operators to move the inbox with HERMES_WEBUI_ATTACHMENT_DIR.
 
-    When a remote terminal backend (``terminal.backend: docker``/modal/ssh/...)
-    is active, the default root moves under the active profile's Hermes cache
-    subtree (``cache/documents/webui-attachments``). hermes-agent auto-mounts
-    those cache directories into remote sandboxes, so a file staged there can
-    be translated to its sandbox-visible path (see _agent_visible_attachment_path)
-    instead of dangling as an unreachable host path inside the container.
+    Sandbox staging is scoped to container backends that auto-mount the
+    agent's cache directories at a fixed host path (``terminal.backend:
+    docker``/``modal``): the default root then moves under the active profile's
+    Hermes cache subtree (``cache/documents/webui-attachments``) so a file
+    staged there can be translated to its sandbox-visible path (see
+    _agent_visible_attachment_path). ssh/daytona/vercel sync files under the
+    REMOTE user's home with no fixed mount point — translating to a
+    host-expanded ``~/.hermes`` would point the agent at the WebUI host's home,
+    so those backends keep the legacy ``STATE_DIR/attachments`` root (and the
+    untranslated host path). Reads/cleanup must still consider BOTH roots (see
+    _attachment_read_roots) because switching backends orphans files.
     """
     override = os.getenv('HERMES_WEBUI_ATTACHMENT_DIR', '').strip()
     if override:
         return Path(override).expanduser().resolve()
-    if _remote_terminal_backend_active():
+    if _terminal_backend_name() in ('docker', 'modal'):
         return _sandbox_attachment_root()
     return (STATE_DIR / 'attachments').resolve()
 
@@ -163,7 +170,7 @@ def _terminal_backend_name() -> str:
 
 
 def _sandbox_attachment_root() -> Path:
-    """Return the profile-scoped staging root that remote sandboxes see.
+    """Return the profile-scoped staging root that container sandboxes see.
 
     hermes-agent's remote backends bind-mount (or file-sync) its cache
     directories — ``cache/documents`` among them — into every sandbox it
@@ -173,14 +180,15 @@ def _sandbox_attachment_root() -> Path:
     host path translatable to its sandbox-visible form. ``get_hermes_dir`` is
     used (with an explicit home) so a legacy ``document_cache`` layout is
     honored exactly the way hermes-agent resolves it when building mounts.
-    """
-    try:
-        from api.profiles import get_active_hermes_home
 
-        home = get_active_hermes_home()
-    except Exception:
-        _env_home = os.getenv('HERMES_HOME', '').strip()
-        home = Path(_env_home).expanduser() if _env_home else STATE_DIR.parent
+    FAIL-CLOSED: if the active profile home cannot be resolved, the exception
+    propagates to the caller (the upload fails) instead of silently falling
+    back to the process-global HERMES_HOME / STATE_DIR.parent — a fallback
+    that crossed profile boundaries and staged files inside the wrong profile.
+    """
+    from api.profiles import get_active_hermes_home
+
+    home = get_active_hermes_home()
     try:
         from hermes_constants import get_hermes_dir
 
@@ -193,21 +201,25 @@ def _sandbox_attachment_root() -> Path:
 def _agent_visible_attachment_path(host_path) -> str:
     """Return the form of *host_path* that tool calls inside the sandbox see.
 
-    For remote terminal backends, hermes-agent mounts its cache directories
-    into the sandbox; chat attachments are staged under
-    ``cache/documents/webui-attachments`` (see _attachment_root), so the host
-    path maps to the container path (``/root/.hermes/cache/documents/...`` for
-    docker/modal, ``~/.hermes/cache/documents/...`` for ssh-style backends).
-    Returns the host path unchanged for local backends, paths outside the
-    staged subtree, or when translation is unavailable (older agent builds).
+    Translation is scoped to container backends that auto-mount the agent's
+    cache directories at a fixed path (docker/modal): chat attachments staged
+    under ``cache/documents/webui-attachments`` (see _attachment_root) map to
+    the container path ``/root/.hermes/cache/documents/...``.
+
+    ssh/daytona/vercel deliberately keep the HOST path: those backends sync
+    files under the REMOTE user's home, and the agent's read_file resolver
+    expands ``~`` on the WebUI host before remote dispatch — a translated
+    ``~/.hermes/...`` would resolve to the WebUI host's home, not the remote
+    user's, so no translation is attempted (pre-#6939 behavior).
+
+    Also returns the host path unchanged for local backends, paths outside
+    the staged subtree, or when translation is unavailable (older agent
+    builds).
     """
     backend = _terminal_backend_name()
-    if backend in ('', 'local', 'singularity'):
+    if backend not in ('docker', 'modal'):
         return str(host_path)
-    if backend in ('ssh', 'daytona', 'vercel_sandbox'):
-        container_base = '~/.hermes'
-    else:  # docker, modal, and any other container/remote backend
-        container_base = '/root/.hermes'
+    container_base = '/root/.hermes'
     try:
         from api.profiles import get_active_hermes_home
 
@@ -273,6 +285,139 @@ def _session_attachment_dir(session_id: str, *, root: Path | None = None) -> Pat
     if not dest_dir.is_relative_to(root):
         raise ValueError('Invalid attachment directory')
     return dest_dir
+
+
+def _attachment_metadata_path(session_id: str) -> Path:
+    """Stable per-session metadata sidecar recording where each attachment was written.
+
+    Lives under the legacy STATE_DIR/attachments tree (always present on the
+    WebUI host) so it survives backend switches that move the write root.
+    """
+    safe_sid = _re.sub(r'[^\w.\-]', '_', str(session_id or 'session'))[:120]
+    return (STATE_DIR / 'attachments' / '.meta').resolve() / f'{safe_sid}.json'
+
+
+def _read_attachment_metadata(session_id: str) -> dict:
+    try:
+        data = json.loads(_attachment_metadata_path(session_id).read_text(encoding='utf-8'))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _record_attachment_metadata(session_id: str, filename: str, host_path: Path, agent_path: str) -> None:
+    """Persist write-root provenance for *filename* (best effort).
+
+    Lets later reads disambiguate duplicate filenames that exist in both the
+    legacy STATE_DIR/attachments/<sid> root and the sandbox staging root after
+    a backend switch or an upgrade from a pre-#6939 build. Written atomically
+    via os.replace; failures are swallowed (the attachment itself is already
+    stored — metadata is an index, never the source of truth).
+    """
+    try:
+        meta_path = _attachment_metadata_path(session_id)
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        data = _read_attachment_metadata(session_id)
+        data[filename] = {'path': str(host_path), 'agent_path': agent_path}
+        tmp = meta_path.with_name(meta_path.name + '.tmp')
+        tmp.write_text(json.dumps(data, indent=2), encoding='utf-8')
+        os.replace(tmp, meta_path)
+    except Exception:
+        pass
+
+
+def _attachment_read_roots(session_id: str) -> list:
+    """Return the deduplicated set of per-session attachment roots for reads/cleanup.
+
+    The write root follows the active terminal backend. Switching backends (or
+    upgrading from a build that predates sandbox staging) orphans files under
+    the other root, so reads and deletion must consider the legacy
+    STATE_DIR/attachments/<sid> root AND the sandbox
+    cache/documents/webui-attachments/<sid> root in addition to the current
+    write root. Ordered current-write-root first. The sandbox root is included
+    best-effort: if the active-profile resolver is unavailable the sandbox
+    root is skipped rather than aborting the read/cleanup.
+    """
+    roots: list = []
+    seen: set = set()
+
+    def _add(root) -> None:
+        if root is None:
+            return
+        try:
+            resolved = root.resolve()
+        except Exception:
+            return
+        key = str(resolved)
+        if key in seen:
+            return
+        seen.add(key)
+        roots.append(resolved)
+
+    try:
+        _add(_session_attachment_dir(session_id))  # current write root
+    except Exception:
+        pass
+    _add(_session_attachment_dir(session_id, root=STATE_DIR / 'attachments'))  # legacy root
+    try:
+        _add(_session_attachment_dir(session_id, root=_sandbox_attachment_root()))
+    except Exception:
+        pass  # sandbox root unresolvable: skip it, legacy/current roots still serve
+    return roots
+
+
+def resolve_session_attachment(session_id: str, rel: str):
+    """Resolve *rel* inside any compatible session attachment root (read path).
+
+    Returns ``(root, target)`` for the first match, or None. Metadata-recorded
+    provenance (see _record_attachment_metadata) is preferred so duplicate
+    filenames across the legacy and sandbox roots stay unambiguous; otherwise
+    the compatible roots are scanned in write-root-first order (pre-metadata
+    uploads).
+    """
+    roots = _attachment_read_roots(session_id)
+    if not roots:
+        return None
+    recorded = _read_attachment_metadata(session_id).get(rel)
+    if isinstance(recorded, dict):
+        try:
+            recorded_path = Path(str(recorded.get('path') or '')).resolve()
+        except Exception:
+            recorded_path = None
+        if recorded_path is not None:
+            for root in roots:
+                try:
+                    if recorded_path.is_relative_to(root):
+                        if recorded_path.exists() and recorded_path.is_file():
+                            return root, recorded_path
+                        break  # provenance says this root owns the name; file gone = 404
+                except ValueError:
+                    continue
+    for root in roots:
+        try:
+            target = safe_resolve(root, rel)
+        except Exception:
+            continue
+        if target.exists() and target.is_file():
+            return root, target
+    return None
+
+
+def remove_session_attachments(session_id: str) -> None:
+    """Remove every per-session attachment root plus the metadata sidecar.
+
+    Called on session deletion so files staged under the legacy root, the
+    sandbox root, or an operator-override root are all cleaned up.
+    """
+    for root in _attachment_read_roots(session_id):
+        try:
+            shutil.rmtree(root, ignore_errors=True)
+        except Exception:
+            pass
+    try:
+        _attachment_metadata_path(session_id).unlink(missing_ok=True)
+    except Exception:
+        pass
 
 
 def _session_visible_to_active_profile(session) -> bool:
@@ -353,6 +498,10 @@ def handle_upload(handler):
         dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
         mime = mimetypes.guess_type(safe_name)[0] or 'application/octet-stream'
+        # Persist write-root provenance so reads can disambiguate duplicate
+        # filenames across the legacy and sandbox roots after a backend switch
+        # (#7022 re-gate gap 1).
+        _record_attachment_metadata(session_id, dest.name, dest, _agent_visible_attachment_path(dest))
         return j(handler, {
             'filename': dest.name,
             'path': str(dest),

--- a/api/upload.py
+++ b/api/upload.py
@@ -3,6 +3,7 @@ Hermes Web UI -- File upload: multipart parser and upload handler.
 """
 import mimetypes
 import os
+import posixpath
 import re as _re
 import tempfile
 from pathlib import Path
@@ -115,11 +116,128 @@ def _attachment_root() -> Path:
     Plain chat attachments are transient context for the agent, not project
     source files.  Keep them out of the active workspace by default while still
     allowing operators to move the inbox with HERMES_WEBUI_ATTACHMENT_DIR.
+
+    When a remote terminal backend (``terminal.backend: docker``/modal/ssh/...)
+    is active, the default root moves under the active profile's Hermes cache
+    subtree (``cache/documents/webui-attachments``). hermes-agent auto-mounts
+    those cache directories into remote sandboxes, so a file staged there can
+    be translated to its sandbox-visible path (see _agent_visible_attachment_path)
+    instead of dangling as an unreachable host path inside the container.
     """
     override = os.getenv('HERMES_WEBUI_ATTACHMENT_DIR', '').strip()
     if override:
         return Path(override).expanduser().resolve()
+    if _remote_terminal_backend_active():
+        return _sandbox_attachment_root()
     return (STATE_DIR / 'attachments').resolve()
+
+
+def _remote_terminal_backend_active() -> bool:
+    """Return True when tool execution runs inside a remote/container sandbox.
+
+    Mirrors api.workspace._is_remote_terminal_backend: any ``terminal.backend``
+    other than ''/local means the agent's tool calls (read_file, ...) execute
+    inside a sandbox (docker, modal, ssh, daytona, vercel_sandbox, ...) that
+    does not share the WebUI host's filesystem.
+    """
+    try:
+        from api.config import get_config
+        from api.workspace import _is_remote_terminal_backend
+
+        return _is_remote_terminal_backend(get_config().get('terminal', {}))
+    except Exception:
+        return False
+
+
+def _terminal_backend_name() -> str:
+    """Return the active ``terminal.backend`` value, lowercased ('' = local)."""
+    try:
+        from api.config import get_config
+
+        terminal_cfg = get_config().get('terminal', {})
+        if not isinstance(terminal_cfg, dict):
+            return ''
+        return str(terminal_cfg.get('backend') or '').strip().lower()
+    except Exception:
+        return ''
+
+
+def _sandbox_attachment_root() -> Path:
+    """Return the profile-scoped staging root that remote sandboxes see.
+
+    hermes-agent's remote backends bind-mount (or file-sync) its cache
+    directories — ``cache/documents`` among them — into every sandbox it
+    creates. Staging chat uploads under the active profile's
+    ``cache/documents/webui-attachments`` subtree keeps them out of the
+    workspace, keeps them per-profile and per-session, and makes the staged
+    host path translatable to its sandbox-visible form. ``get_hermes_dir`` is
+    used (with an explicit home) so a legacy ``document_cache`` layout is
+    honored exactly the way hermes-agent resolves it when building mounts.
+    """
+    try:
+        from api.profiles import get_active_hermes_home
+
+        home = get_active_hermes_home()
+    except Exception:
+        _env_home = os.getenv('HERMES_HOME', '').strip()
+        home = Path(_env_home).expanduser() if _env_home else STATE_DIR.parent
+    try:
+        from hermes_constants import get_hermes_dir
+
+        root = get_hermes_dir('cache/documents', 'document_cache', home=home)
+    except Exception:
+        root = Path(home) / 'cache' / 'documents'
+    return (Path(root).resolve() / 'webui-attachments').resolve()
+
+
+def _agent_visible_attachment_path(host_path) -> str:
+    """Return the form of *host_path* that tool calls inside the sandbox see.
+
+    For remote terminal backends, hermes-agent mounts its cache directories
+    into the sandbox; chat attachments are staged under
+    ``cache/documents/webui-attachments`` (see _attachment_root), so the host
+    path maps to the container path (``/root/.hermes/cache/documents/...`` for
+    docker/modal, ``~/.hermes/cache/documents/...`` for ssh-style backends).
+    Returns the host path unchanged for local backends, paths outside the
+    staged subtree, or when translation is unavailable (older agent builds).
+    """
+    backend = _terminal_backend_name()
+    if backend in ('', 'local', 'singularity'):
+        return str(host_path)
+    if backend in ('ssh', 'daytona', 'vercel_sandbox'):
+        container_base = '~/.hermes'
+    else:  # docker, modal, and any other container/remote backend
+        container_base = '/root/.hermes'
+    try:
+        from api.profiles import get_active_hermes_home
+        from hermes_constants import get_hermes_dir
+
+        host_root = Path(
+            get_hermes_dir('cache/documents', 'document_cache', home=get_active_hermes_home())
+        ).resolve()
+        candidate = Path(host_path).resolve()
+        try:
+            rel = candidate.relative_to(host_root)
+        except ValueError:
+            rel = None
+        if rel is not None:
+            return posixpath.join(f'{container_base.rstrip("/")}/cache/documents', rel.as_posix())
+    except Exception:
+        pass
+    # Fall back to the agent's own cache-path translator for roots that live
+    # under any other auto-mounted cache directory (e.g. an operator-configured
+    # HERMES_WEBUI_ATTACHMENT_DIR pointing into ~/.hermes/attachments). Best
+    # effort only — older agent builds without the helper degrade to the host
+    # path, which is exactly today's behavior.
+    try:
+        from tools.credential_files import map_cache_path_to_container
+
+        mapped = map_cache_path_to_container(str(host_path), container_base=container_base)
+        if mapped is not None:
+            return mapped
+    except Exception:
+        pass
+    return str(host_path)
 
 
 def _upload_destination(session_id: str, safe_name: str) -> Path:
@@ -230,6 +348,11 @@ def handle_upload(handler):
         return j(handler, {
             'filename': dest.name,
             'path': str(dest),
+            # Sandbox-visible path for remote terminal backends (docker/...);
+            # equals 'path' on local backends. The frontend embeds this in the
+            # agent-facing [Attached files: ...] marker so tool calls inside
+            # the sandbox can actually open the file (#6939).
+            'agent_path': _agent_visible_attachment_path(dest),
             'size': dest.stat().st_size,
             'mime': mime,
             'is_image': mime.startswith('image/'),
@@ -404,7 +527,12 @@ def handle_upload_extract(handler):
         session_dir = _session_attachment_dir(session_id)
         session_dir.mkdir(parents=True, exist_ok=True)
         result = extract_archive(file_bytes, filename, session_dir)
-        return j(handler, {'ok': True, **result})
+        return j(handler, {
+            'ok': True,
+            **result,
+            # Sandbox-visible destination for remote terminal backends (#6939).
+            'agent_path': _agent_visible_attachment_path(result.get('dest') or session_dir),
+        })
     except ValueError as e:
         return j(handler, {'error': str(e)}, status=400)
     except Exception:

--- a/static/messages.js
+++ b/static/messages.js
@@ -1656,7 +1656,7 @@ async function send(){
   setComposerStatus('');
 
   const uploadedNames=uploaded.map(u=>u.name||u);
-  const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
+  const uploadedPaths=uploaded.map(u=>u&&(u.agent_path||u.path)?(u.agent_path||u.path):(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
   let msgText=text;
   if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
   else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;

--- a/static/ui.js
+++ b/static/ui.js
@@ -21637,10 +21637,10 @@ async function uploadPendingFiles(options={}){
       const data=await res.json();
       if(data.error)throw new Error(data.error);
       if(isArchive){
-        names.push({name: data.dest, path: data.dest, extracted: data.extracted});
+        names.push({name: data.dest, path: data.dest, agent_path: data.agent_path||data.dest, extracted: data.extracted});
         if(typeof loadDir==='function'&&_uploadPendingFilesCurrentSession(sessionId))loadDir(S.currentDir||'.');
       }else{
-        names.push({name: data.filename, path: data.path, mime: data.mime, size: data.size, is_image: !!data.is_image});
+        names.push({name: data.filename, path: data.path, agent_path: data.agent_path||data.path, mime: data.mime, size: data.size, is_image: !!data.is_image});
       }
     }catch(e){failures++;setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);}
     _uploadPendingFilesUpdateProgress(sessionId,Math.round((i+1)/total*100));

--- a/tests/test_chat_upload_attachment_paths.py
+++ b/tests/test_chat_upload_attachment_paths.py
@@ -19,7 +19,10 @@ def test_image_uploads_use_server_path_in_attached_files_context():
     src = MESSAGES_JS.read_text(encoding="utf-8")
 
     assert "uploadedPaths=uploaded.map(u=>u&&u.is_image?" not in src
-    assert "uploadedPaths=uploaded.map(u=>u&&u.path?u.path" in src
+    # The marker prefers the server-provided sandbox-visible path (agent_path)
+    # and falls back to the host path, which is what local backends see (#6939).
+    assert "uploadedPaths=uploaded.map(u=>u&&(u.agent_path||u.path)" in src
+    assert "u.agent_path||u.path" in src
 
 
 def test_attached_files_context_is_hidden_from_user_message_display():

--- a/tests/test_issue6939_attachment_docker_paths.py
+++ b/tests/test_issue6939_attachment_docker_paths.py
@@ -1,12 +1,20 @@
 """Regression coverage for #6939: chat-composer attachment paths must be
-visible inside remote terminal sandboxes (terminal.backend: docker, ssh, ...).
+visible inside remote terminal sandboxes (terminal.backend: docker, ...).
 
 hermes-agent auto-mounts its cache directories (cache/documents, ...) into
-remote sandboxes. The WebUI stages chat uploads under
-``cache/documents/webui-attachments`` when a remote backend is active and
+container sandboxes (docker/modal). The WebUI stages chat uploads under
+``cache/documents/webui-attachments`` when such a backend is active and
 translates the host path to its sandbox-visible form (agent_path) so the
 ``[Attached files: ...]`` marker handed to the model contains a path tool
 calls (read_file) can actually open inside the container.
+
+Re-gate coverage (#7022): staging/translation is scoped to docker/modal only
+(ssh-style backends keep the legacy root and the host path — a translated
+``~/.hermes`` would be host-expanded on the WebUI side), reads/deletion
+consider BOTH the legacy STATE_DIR/attachments/<sid> root and the sandbox
+root so backend switches don't orphan files, duplicate filenames across roots
+are disambiguated via persisted metadata, and active-profile resolution
+failures fail CLOSED instead of falling back to the process-global home.
 """
 from pathlib import Path
 
@@ -16,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = ROOT / "static" / "messages.js"
 UI_JS = ROOT / "static" / "ui.js"
 UPLOAD_PY = ROOT / "api" / "upload.py"
+ROUTES_PY = ROOT / "api" / "routes.py"
 
 
 @pytest.fixture
@@ -59,13 +68,26 @@ def test_attachment_root_docker_backend_stages_under_cache_subtree(monkeypatch, 
     assert root.is_relative_to(fake_home / "cache" / "documents")
 
 
-def test_attachment_root_ssh_backend_stages_under_cache_subtree(monkeypatch, fake_home):
-    _set_terminal_backend(monkeypatch, "ssh")
+def test_attachment_root_modal_backend_stages_under_cache_subtree(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "modal")
     monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
 
     from api.upload import _attachment_root
 
     assert _attachment_root() == (fake_home / "cache" / "documents" / "webui-attachments").resolve()
+
+
+def test_attachment_root_ssh_backend_keeps_state_dir(monkeypatch, fake_home):
+    """ssh-style backends keep the legacy root: a ``~/.hermes``-based staged
+    path would be host-expanded by the agent's read_file resolver on the WebUI
+    host, not the remote user's home (#7022 re-gate gap 2)."""
+    _set_terminal_backend(monkeypatch, "ssh")
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
+
+    from api.config import STATE_DIR
+    from api.upload import _attachment_root
+
+    assert _attachment_root() == (STATE_DIR / "attachments").resolve()
 
 
 def test_attachment_root_env_override_wins_over_sandbox_staging(monkeypatch, fake_home, tmp_path):
@@ -103,15 +125,18 @@ def test_translate_modal_staged_path_to_container(monkeypatch, fake_home):
     )
 
 
-def test_translate_ssh_staged_path_uses_remote_home(monkeypatch, fake_home):
-    _set_terminal_backend(monkeypatch, "ssh")
+@pytest.mark.parametrize("backend", ["ssh", "daytona", "vercel_sandbox"])
+def test_translate_ssh_style_backends_return_host_path(monkeypatch, fake_home, backend):
+    """ssh/daytona/vercel keep the host path unchanged: a translated
+    ``~/.hermes/...`` would be host-expanded to the WebUI host's home before
+    remote dispatch and point the agent at a nonexistent path
+    (#7022 re-gate gap 2)."""
+    _set_terminal_backend(monkeypatch, backend)
 
     from api.upload import _agent_visible_attachment_path
 
     staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "doc.pdf"
-    assert _agent_visible_attachment_path(staged) == (
-        "~/.hermes/cache/documents/webui-attachments/s/doc.pdf"
-    )
+    assert _agent_visible_attachment_path(staged) == str(staged)
 
 
 def test_translate_local_backend_passthrough(monkeypatch, fake_home):
@@ -157,6 +182,178 @@ def test_translate_survives_missing_agent_translation_api(monkeypatch, fake_home
     assert _agent_visible_attachment_path(staged) == (
         "/root/.hermes/cache/documents/webui-attachments/s/photo.jpg"
     )
+
+
+# ── Dual read/cleanup roots: backend switches must not orphan files ─────────
+# (#7022 re-gate gap 1)
+
+
+def test_legacy_attachment_readable_after_switch_to_docker(monkeypatch, fake_home, tmp_path):
+    """Files written under the legacy STATE_DIR root stay readable after the
+    backend switches to docker (write root moves to the sandbox subtree)."""
+    from api.upload import _session_attachment_dir, resolve_session_attachment
+
+    _set_terminal_backend(monkeypatch, "local")
+    legacy = _session_attachment_dir("sess-1")
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "old.txt").write_text("legacy bytes")
+
+    _set_terminal_backend(monkeypatch, "docker")
+    resolved = resolve_session_attachment("sess-1", "old.txt")
+    assert resolved is not None
+    root, target = resolved
+    assert target == (legacy / "old.txt").resolve()
+    assert target.read_text() == "legacy bytes"
+
+
+def test_sandbox_attachment_readable_after_switch_back_to_local(monkeypatch, fake_home, tmp_path):
+    """Files staged under the sandbox root stay readable after switching back
+    to a local backend."""
+    from api.upload import _session_attachment_dir, resolve_session_attachment
+
+    _set_terminal_backend(monkeypatch, "docker")
+    sandbox = _session_attachment_dir("sess-1")
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "new.txt").write_text("sandbox bytes")
+
+    _set_terminal_backend(monkeypatch, "local")
+    resolved = resolve_session_attachment("sess-1", "new.txt")
+    assert resolved is not None
+    root, target = resolved
+    assert target == (sandbox / "new.txt").resolve()
+    assert target.read_text() == "sandbox bytes"
+
+
+def test_duplicate_filename_disambiguated_by_metadata(monkeypatch, fake_home, tmp_path):
+    """Same filename in both roots: persisted provenance picks the recorded
+    copy instead of the first root in scan order."""
+    from api.upload import (
+        _record_attachment_metadata,
+        _session_attachment_dir,
+        resolve_session_attachment,
+    )
+
+    _set_terminal_backend(monkeypatch, "local")
+    legacy = _session_attachment_dir("sess-1")
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "dup.txt").write_text("legacy copy")
+    _record_attachment_metadata("sess-1", "dup.txt", legacy / "dup.txt", str(legacy / "dup.txt"))
+
+    _set_terminal_backend(monkeypatch, "docker")
+    sandbox = _session_attachment_dir("sess-1")
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "dup.txt").write_text("sandbox copy")
+
+    resolved = resolve_session_attachment("sess-1", "dup.txt")
+    assert resolved is not None
+    root, target = resolved
+    assert target == (legacy / "dup.txt").resolve()
+    assert target.read_text() == "legacy copy"
+
+
+def test_upload_records_attachment_metadata():
+    """handle_upload persists write-root provenance for the stored filename.
+
+    Source-level contract (this file's established style for handler bodies):
+    the recorder is invoked with the exact stored destination so reads can
+    disambiguate duplicates across roots after a backend switch.
+    """
+    src = UPLOAD_PY.read_text(encoding="utf-8")
+    handle_body = src[src.index("def handle_upload"): src.index("def extract_archive", src.index("def handle_upload"))]
+    assert "_record_attachment_metadata(session_id, dest.name, dest, _agent_visible_attachment_path(dest))" in handle_body
+
+
+def test_delete_removes_all_roots_and_metadata(monkeypatch, fake_home, tmp_path):
+    """Session deletion must clean the legacy root, the sandbox root, and the
+    metadata sidecar."""
+    from api.upload import (
+        _attachment_metadata_path,
+        _record_attachment_metadata,
+        _session_attachment_dir,
+        remove_session_attachments,
+    )
+
+    _set_terminal_backend(monkeypatch, "local")
+    legacy = _session_attachment_dir("sess-9")
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "a.txt").write_text("a")
+    _record_attachment_metadata("sess-9", "a.txt", legacy / "a.txt", str(legacy / "a.txt"))
+
+    _set_terminal_backend(monkeypatch, "docker")
+    sandbox = _session_attachment_dir("sess-9")
+    sandbox.mkdir(parents=True, exist_ok=True)
+    (sandbox / "b.txt").write_text("b")
+
+    remove_session_attachments("sess-9")
+    assert not legacy.exists()
+    assert not sandbox.exists()
+    assert not _attachment_metadata_path("sess-9").exists()
+
+
+def test_routes_read_path_considers_all_roots():
+    """/api/file/raw lookup delegates to the dual-root resolver."""
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "from api.upload import resolve_session_attachment" in src
+    assert "resolve_session_attachment(sid, rel)" in src
+
+
+def test_routes_delete_path_removes_all_roots():
+    """Session deletion delegates to the all-roots cleanup helper."""
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "from api.upload import remove_session_attachments" in src
+    assert "remove_session_attachments(sid)" in src
+
+
+# ── Fail-closed profile resolution (#7022 re-gate gap 3) ────────────────────
+
+
+def test_profile_resolution_failure_fails_closed(monkeypatch):
+    """Resolver failure must propagate (fail-closed), never fall back to the
+    process-global HERMES_HOME / STATE_DIR.parent — the fallback silently
+    staged files inside the WRONG profile."""
+    import api.profiles as profiles
+
+    def _boom():
+        raise RuntimeError("resolver unavailable")
+
+    monkeypatch.setattr(profiles, "get_active_hermes_home", _boom)
+    monkeypatch.setenv("HERMES_HOME", str(Path("/somewhere/else/beta")))
+    _set_terminal_backend(monkeypatch, "docker")
+
+    from api.upload import _attachment_root, _sandbox_attachment_root
+
+    with pytest.raises(RuntimeError):
+        _sandbox_attachment_root()
+    with pytest.raises(RuntimeError):
+        _attachment_root()
+
+
+# ── Real remote file-tool consumer shape (#7022 re-gate coverage) ───────────
+
+
+def test_marker_path_is_readable_by_remote_file_consumer(monkeypatch, fake_home, tmp_path):
+    """End-to-end shape of the real consumer: an upload staged under the
+    sandbox root yields an agent_path that, joined to the container mount
+    root, resolves to the exact staged bytes — the path the agent's read_file
+    will open inside the container."""
+    _set_terminal_backend(monkeypatch, "docker")
+
+    from api.upload import _agent_visible_attachment_path, _session_attachment_dir
+
+    staged = _session_attachment_dir("sess-1")
+    staged.mkdir(parents=True, exist_ok=True)
+    payload = b"attached payload"
+    (staged / "report.txt").write_bytes(payload)
+
+    agent_path = _agent_visible_attachment_path(staged / "report.txt")
+    assert agent_path == "/root/.hermes/cache/documents/webui-attachments/sess-1/report.txt"
+    # The container-visible path is the staged host file under the
+    # /root/.hermes mount: resolving the suffix back under the real host root
+    # must yield the exact bytes the agent will read.
+    container_suffix = agent_path.removeprefix("/root/.hermes/")
+    host_back = (fake_home / container_suffix).resolve()
+    assert host_back == (staged / "report.txt").resolve()
+    assert host_back.read_bytes() == payload
 
 
 # ── Upload/extract responses carry agent_path ───────────────────────────────

--- a/tests/test_issue6939_attachment_docker_paths.py
+++ b/tests/test_issue6939_attachment_docker_paths.py
@@ -1,0 +1,179 @@
+"""Regression coverage for #6939: chat-composer attachment paths must be
+visible inside remote terminal sandboxes (terminal.backend: docker, ssh, ...).
+
+hermes-agent auto-mounts its cache directories (cache/documents, ...) into
+remote sandboxes. The WebUI stages chat uploads under
+``cache/documents/webui-attachments`` when a remote backend is active and
+translates the host path to its sandbox-visible form (agent_path) so the
+``[Attached files: ...]`` marker handed to the model contains a path tool
+calls (read_file) can actually open inside the container.
+"""
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = ROOT / "static" / "messages.js"
+UI_JS = ROOT / "static" / "ui.js"
+UPLOAD_PY = ROOT / "api" / "upload.py"
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Pin the active profile's Hermes home to a temp dir."""
+    home = tmp_path / "hermes-home"
+    monkeypatch.setattr("api.profiles.get_active_hermes_home", lambda: home)
+    return home
+
+
+def _set_terminal_backend(monkeypatch, backend):
+    """Rebind the in-memory config so get_config() reports *backend*."""
+    import api.config as config
+
+    monkeypatch.setattr(config, "cfg", {"terminal": {"backend": backend}})
+
+
+# ── _attachment_root(): sandbox-aware default inbox ─────────────────────────
+
+
+def test_attachment_root_local_backend_keeps_state_dir(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "local")
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
+
+    from api.config import STATE_DIR
+    from api.upload import _attachment_root
+
+    root = _attachment_root()
+    assert root == (STATE_DIR / "attachments").resolve()
+
+
+def test_attachment_root_docker_backend_stages_under_cache_subtree(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "docker")
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
+
+    from api.upload import _attachment_root
+
+    root = _attachment_root()
+    assert root == (fake_home / "cache" / "documents" / "webui-attachments").resolve()
+    # The staged root must stay under the auto-mounted cache/documents dir.
+    assert root.is_relative_to(fake_home / "cache" / "documents")
+
+
+def test_attachment_root_ssh_backend_stages_under_cache_subtree(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "ssh")
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
+
+    from api.upload import _attachment_root
+
+    assert _attachment_root() == (fake_home / "cache" / "documents" / "webui-attachments").resolve()
+
+
+def test_attachment_root_env_override_wins_over_sandbox_staging(monkeypatch, fake_home, tmp_path):
+    _set_terminal_backend(monkeypatch, "docker")
+    inbox = tmp_path / "operator-inbox"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(inbox))
+
+    from api.upload import _attachment_root
+
+    assert _attachment_root() == inbox.resolve()
+
+
+# ── _agent_visible_attachment_path(): host → sandbox translation ────────────
+
+
+def test_translate_docker_staged_path_to_container(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "docker")
+    staged = fake_home / "cache" / "documents" / "webui-attachments" / "sess-1" / "photo.jpg"
+
+    from api.upload import _agent_visible_attachment_path
+
+    assert _agent_visible_attachment_path(staged) == (
+        "/root/.hermes/cache/documents/webui-attachments/sess-1/photo.jpg"
+    )
+
+
+def test_translate_modal_staged_path_to_container(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "modal")
+
+    from api.upload import _agent_visible_attachment_path
+
+    staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "doc.pdf"
+    assert _agent_visible_attachment_path(staged) == (
+        "/root/.hermes/cache/documents/webui-attachments/s/doc.pdf"
+    )
+
+
+def test_translate_ssh_staged_path_uses_remote_home(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "ssh")
+
+    from api.upload import _agent_visible_attachment_path
+
+    staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "doc.pdf"
+    assert _agent_visible_attachment_path(staged) == (
+        "~/.hermes/cache/documents/webui-attachments/s/doc.pdf"
+    )
+
+
+def test_translate_local_backend_passthrough(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "local")
+
+    from api.upload import _agent_visible_attachment_path
+
+    staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "doc.pdf"
+    assert _agent_visible_attachment_path(staged) == str(staged)
+
+
+def test_translate_path_outside_cache_subtree_unchanged(monkeypatch, fake_home):
+    _set_terminal_backend(monkeypatch, "docker")
+
+    from api.upload import _agent_visible_attachment_path
+
+    elsewhere = fake_home / "webui" / "attachments" / "s" / "photo.jpg"
+    assert _agent_visible_attachment_path(elsewhere) == str(elsewhere)
+
+
+def test_translate_survives_missing_agent_translation_api(monkeypatch, fake_home):
+    """Older agent builds without the translation helpers degrade to host path."""
+    _set_terminal_backend(monkeypatch, "docker")
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "get_hermes_dir", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("old agent"))
+    )
+
+    from api.upload import _agent_visible_attachment_path
+
+    staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "photo.jpg"
+    assert _agent_visible_attachment_path(staged) == str(staged)
+
+
+# ── Upload/extract responses carry agent_path ───────────────────────────────
+
+
+def test_upload_response_includes_agent_path():
+    src = UPLOAD_PY.read_text(encoding="utf-8")
+    handle_body = src[src.index("def handle_upload"): src.index("def extract_archive", src.index("def handle_upload"))]
+    assert "'path': str(dest)" in handle_body
+    assert "'agent_path': _agent_visible_attachment_path(dest)" in handle_body
+
+
+def test_extract_response_includes_agent_path():
+    src = UPLOAD_PY.read_text(encoding="utf-8")
+    assert "'agent_path': _agent_visible_attachment_path(result.get('dest') or session_dir)" in src
+
+
+# ── Frontend marker composition prefers the sandbox-visible path ─────────────
+
+
+def test_messages_js_prefers_agent_path_in_marker():
+    src = MESSAGES_JS.read_text(encoding="utf-8")
+    assert "uploadedPaths=uploaded.map(u=>u&&(u.agent_path||u.path)" in src
+    # Host path stays as the fallback so local backends behave exactly as before.
+    assert "u.agent_path||u.path):(u&&u.name?u.name:(u&&u.filename?u.filename:u))" in src
+
+
+def test_ui_js_forwards_agent_path_from_upload_responses():
+    src = UI_JS.read_text(encoding="utf-8")
+    assert "agent_path: data.agent_path||data.path" in src
+    assert "agent_path: data.agent_path||data.dest" in src

--- a/tests/test_issue6939_attachment_docker_paths.py
+++ b/tests/test_issue6939_attachment_docker_paths.py
@@ -136,16 +136,27 @@ def test_translate_survives_missing_agent_translation_api(monkeypatch, fake_home
     """Older agent builds without the translation helpers degrade to host path."""
     _set_terminal_backend(monkeypatch, "docker")
 
-    import hermes_constants
+    # Simulate an older agent build: the canonical resolver raises, so the
+    # function must fall back to the WebUI-local home-derived root and still
+    # translate (not crash). hermes_constants lives in hermes-agent, not in
+    # the WebUI tree, so this test must not import it directly.
+    import builtins
 
-    monkeypatch.setattr(
-        hermes_constants, "get_hermes_dir", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("old agent"))
-    )
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "hermes_constants":
+            raise ImportError("No module named 'hermes_constants'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
 
     from api.upload import _agent_visible_attachment_path
 
     staged = fake_home / "cache" / "documents" / "webui-attachments" / "s" / "photo.jpg"
-    assert _agent_visible_attachment_path(staged) == str(staged)
+    assert _agent_visible_attachment_path(staged) == (
+        "/root/.hermes/cache/documents/webui-attachments/s/photo.jpg"
+    )
 
 
 # ── Upload/extract responses carry agent_path ───────────────────────────────


### PR DESCRIPTION
## Problem

`api/upload.py`'s `handle_upload()` saves chat-composer attachments to `_attachment_root()` (`HERMES_WEBUI_STATE_DIR/attachments/<session_id>/<filename>`), and the frontend embeds that literal absolute **host** path into the user message via `[Attached files: <path>]` (static/messages.js).

When hermes-agent runs with `terminal.backend: docker`, tool calls (`read_file`, ...) execute **inside the sandbox container** via `docker exec`. The container never has `STATE_DIR/attachments` bind-mounted, so the host path dangles — the model is handed a real, correct host path that cannot exist inside the sandbox, and has no way to ask for a different one.

## Root cause

hermes-agent's remote backends auto-mount a fixed set of cache directories (`cache/documents`, `cache/images`, `attachments`, ...) into every sandbox it creates (`tools/credential_files.py::_CACHE_DIRS` / `get_cache_directory_mounts()`), and translate host→container paths with `map_cache_path_to_container()` / `to_agent_visible_cache_path()`. The WebUI's `/api/upload` inbox lives under `HERMES_HOME/webui/attachments/`, which is **not** in that auto-mount list.

## Fix

1. **Stage under the sandbox-visible cache subtree** — when a remote terminal backend is active (`terminal.backend` other than `local`), `_attachment_root()` now returns the active profile's `cache/documents/webui-attachments/<session>/` (resolved via the same `hermes_constants.get_hermes_dir("cache/documents", "document_cache", home=...)` the agent uses when building mounts, so legacy `document_cache` layouts stay consistent). `HERMES_WEBUI_ATTACHMENT_DIR` keeps full precedence; local backends keep the exact current `STATE_DIR/attachments` behavior.
2. **Translate host → container** — `_agent_visible_attachment_path()` maps the staged host path to its sandbox form (`/root/.hermes/cache/documents/...` for docker/modal, `~/.hermes/...` for ssh/daytona/vercel_sandbox), mirroring the agent's own translator (verified to produce identical output), with a best-effort fallback to the agent's `map_cache_path_to_container` and graceful degradation to the host path for local/unknown/older-agent cases.
3. **Return both paths** — `/api/upload` and `/api/upload/extract` now return `agent_path` (sandbox-visible) alongside the unchanged host `path` (UI/display/download, e.g. `/api/file/raw`).
4. **Marker uses the sandbox path** — the composer's `[Attached files: ...]` marker prefers `agent_path`, falling back to `path` (which is what local backends see — full parity).

No whole-`STATE_DIR` mount, no container-path guessing: the fix rides the exact mount list hermes-agent already maintains.

## Verification

- New regression suite `tests/test_issue6939_attachment_docker_paths.py`: local-path parity, docker/modal/ssh translation, paths outside the staged subtree unchanged, env-override precedence, missing-agent-API degradation, upload/extract responses carrying `agent_path`, and frontend marker composition.
- Cross-checked against hermes-agent's own `to_agent_visible_cache_path()` — identical container paths — and against `get_cache_directory_mounts()`, which confirms `cache/documents` (host) → `/root/.hermes/cache/documents` (container) is in the docker mount list, so the staged file is readable inside the sandbox.
- `pytest`: 119 affected upload/attachment tests + 153 marker/regression tests pass; `ruff check` clean.

Note: a live `read_file`-inside-container test requires a docker daemon, which this environment doesn't have; the mount-list + translator cross-check covers the same contract.

## Files changed

- `api/upload.py` — sandbox-aware `_attachment_root()`, `_agent_visible_attachment_path()`, `agent_path` in upload/extract responses
- `static/messages.js` — marker prefers `agent_path`
- `static/ui.js` — forwards `agent_path` from upload responses
- `tests/test_issue6939_attachment_docker_paths.py` — new regression suite
- `tests/test_chat_upload_attachment_paths.py` — updated marker assertion
- `README.md` — documents sandbox staging + `HERMES_WEBUI_ATTACHMENT_DIR` caveat

Closes #6939