### PR TITLE
test(infra): make JS-harness ui.js reads atomic against concurrent load

### DIFF
--- a/tests/js_source_loader.py
+++ b/tests/js_source_loader.py
@@ -8,15 +8,20 @@ syntactically unrelated fragment instead of failing loudly. See issue #6972.
 
 This module centralizes the read so every harness shares the same defense:
 
-* **Size validation** — the read is compared against the on-disk byte
-  length (``stat``) before it is handed to extraction.
+* **Per-attempt metadata validation** — each read attempt captures file
+  metadata (size, inode, mtime) BEFORE and AFTER the read; both snapshots
+  must match exactly. This prevents accepting a read that raced a rewrite.
+* **Zero-length reject** — any read returning 0 bytes is explicitly rejected
+  (empty files are never valid JS sources for our harnesses).
 * **Bounded retry** — a short, partial read (file being rewritten, or an
   I/O-starved subprocess) is retried a few times instead of being accepted.
 * **Fail closed** — if the read never stabilizes, ``SourceReadError`` is
   raised with an explicit message. The harness never sees a truncated
   fragment that brace matching could silently turn into a false pass/fail.
 * **Optional tail sentinel** — callers that know the expected end-of-file
-  marker (e.g. the last line of ``static/ui.js``) can require it.
+  marker (e.g. the last line of ``static/ui.js``) can require it. For
+  extraction sources (where brace matching runs downstream), the tail
+  sentinel is mandatory to ensure the entire source was captured.
 
 A matching Node snippet for the ``node -e`` harnesses is available via
 ``node_validated_read_snippet()``.
@@ -24,7 +29,9 @@ A matching Node snippet for the ``node -e`` harnesses is available via
 
 from __future__ import annotations
 
+import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 MAX_READ_ATTEMPTS = 5
@@ -35,60 +42,228 @@ class SourceReadError(RuntimeError):
     """Raised when a JS source file cannot be read to completion."""
 
 
+@dataclass(frozen=True, slots=True)
+class _FileIdentity:
+    """Immutable file identity snapshot for race detection."""
+
+    size: int
+    ino: int
+    mtime_ns: int
+
+    @classmethod
+    def from_stat(cls, st: os.stat_result) -> "_FileIdentity":
+        return cls(size=st.st_size, ino=st.st_ino, mtime_ns=st.st_mtime_ns)
+
+
+def _stat_identity(path: Path) -> _FileIdentity:
+    """Capture a complete file identity snapshot."""
+    return _FileIdentity.from_stat(path.stat())
+
+
 def read_js_source(
     path: str | Path,
     *,
     expected_tail: str | None = None,
+    require_tail: bool = False,
     max_attempts: int = MAX_READ_ATTEMPTS,
     retry_delay_seconds: float = RETRY_DELAY_SECONDS,
 ) -> str:
     """Read a JS source file to completion, retrying on unstable reads.
 
-    The read must match the on-disk byte length (and, when given, end with
-    ``expected_tail``); otherwise it is treated as a partial read and retried
-    with a short backoff. If the file never reads consistently,
+    Each attempt performs a *pre-read* stat, the read, then a *post-read*
+    stat. The two identity snapshots (size, inode, mtime) must match
+    exactly; otherwise the read raced a concurrent modification and is
+    discarded. A zero-byte read is always rejected. When ``require_tail`` is
+    true (for extraction sources fed to brace matching), the decoded text
+    must end with ``expected_tail``; otherwise the attempt is treated as
+    incomplete and retried/failed. If the file never reads consistently,
     :class:`SourceReadError` is raised instead of returning a fragment that
     downstream textual brace matching could silently mangle.
+
+    Args:
+        path: Path to the JS source file.
+        expected_tail: Known end-of-file sentinel (e.g. last line of the
+            source). Required when ``require_tail`` is true.
+        require_tail: If true, the read must end with ``expected_tail``.
+            Set this for sources that will undergo brace-matched extraction
+            (ui.js, messages.js, etc.) to guarantee the full source was read.
+        max_attempts: Maximum read attempts before failing closed.
+        retry_delay_seconds: Base delay between attempts (linear backoff).
+
+    Returns:
+        The complete, validated file content as UTF-8 text.
+
+    Raises:
+        SourceReadError: If no attempt produces a stable, complete read.
     """
     p = Path(path)
-    expected_size = p.stat().st_size
-    last_size = -1
+    if require_tail and expected_tail is None:
+        raise ValueError("require_tail=True requires expected_tail to be set")
+
+    last_error: str | None = None
     for attempt in range(max_attempts):
-        data = p.read_bytes()
-        last_size = len(data)
-        if last_size == expected_size:
-            text = data.decode("utf-8")
-            if expected_tail is None or text.endswith(expected_tail):
-                return text
-        time.sleep(retry_delay_seconds * (attempt + 1))
+        # Pre-read identity snapshot
+        try:
+            pre_identity = _stat_identity(p)
+        except FileNotFoundError:
+            last_error = f"file disappeared: {p}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Reject zero-size files immediately (transient empty during rewrite)
+        if pre_identity.size == 0:
+            last_error = f"zero-byte file observed (transient empty during rewrite): {p}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Read the file
+        try:
+            data = p.read_bytes()
+        except OSError as e:
+            last_error = f"read failed: {e}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Explicit zero-length reject (a read that returned no bytes is
+        # never a valid JS source — transient empty during rewrite).
+        if len(data) == 0:
+            last_error = f"zero-byte read (transient empty during rewrite): {p}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Post-read identity snapshot
+        try:
+            post_identity = _stat_identity(p)
+        except FileNotFoundError:
+            last_error = f"file disappeared after read: {p}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Identity must be stable across the read (no concurrent modification)
+        if pre_identity != post_identity:
+            last_error = (
+                f"file identity changed during read (pre={pre_identity}, "
+                f"post={post_identity}): {p}"
+            )
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Read must match the stable size
+        read_size = len(data)
+        if read_size != pre_identity.size:
+            last_error = (
+                f"read size {read_size} != stable stat size {pre_identity.size}: {p}"
+            )
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Decode and validate tail sentinel if required
+        text = data.decode("utf-8")
+        if require_tail:
+            if not text.endswith(expected_tail):
+                last_error = f"EOF sentinel missing (expected {expected_tail!r}): {p}"
+                time.sleep(retry_delay_seconds * (attempt + 1))
+                continue
+        elif expected_tail is not None and not text.endswith(expected_tail):
+            # Optional tail: if provided but not required, mismatch is a retry signal
+            last_error = f"optional tail sentinel not reached: {p}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
+
+        # Stable, complete read — success
+        return text
+
+    # All attempts exhausted
     raise SourceReadError(
-        f"truncated read of {p}: expected {expected_size} bytes, "
-        f"got {last_size} after {max_attempts} attempts; "
-        f"refusing to extract from a partial source read"
+        f"truncated read of {p}: {last_error or 'unknown error'} "
+        f"after {max_attempts} attempts; refusing to extract from a partial source read"
     )
 
 
 def node_validated_read_snippet() -> str:
     """Return a Node snippet that reads a file with the same defense.
 
-    The returned JS defines ``readValidated(path)`` which reads the file,
-    compares the byte length against ``fs.statSync``, retries up to
-    ``MAX_READ_ATTEMPTS`` times on a partial read, and throws an explicit
-    error instead of returning a truncated fragment. ``fs`` is required
-    inside the function so the snippet never collides with a harness that
-    already declares ``const fs = require('fs')``.
+    The returned JS defines ``readValidated(path, options?)`` which reads
+    the file with per-attempt identity validation (size, inode, mtime),
+    rejects zero-byte reads, retries up to ``MAX_READ_ATTEMPTS`` times on
+    a partial/unstable read, and throws an explicit error instead of
+    returning a truncated fragment. ``fs`` is required inside the function
+    so the snippet never collides with a harness that already declares
+    ``const fs = require('fs')``.
+
+    The ``options`` object accepts:
+    - ``expectedTail``: string sentinel that the content must end with
+    - ``requireTail``: if true, missing sentinel fails the attempt
     """
-    return f"""
-const MAX_READ_ATTEMPTS = {MAX_READ_ATTEMPTS};
-function readValidated(p){{
-  const fs = require('fs');
-  const expectedSize = fs.statSync(p).size;
-  let src = null;
-  for(let attempt = 0; attempt < MAX_READ_ATTEMPTS; attempt++){{
-    src = fs.readFileSync(p, 'utf8');
-    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
-  }}
-  throw new Error('source read incomplete: ' + p + ' (' +
-    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
-}}
-"""
+    return (
+        "\nconst MAX_READ_ATTEMPTS = " + str(MAX_READ_ATTEMPTS) + ";\n"
+        "\n"
+        "function readValidated(p, options = {}) {\n"
+        "  const fs = require('fs');\n"
+        "  const { expectedTail = null, requireTail = false } = options;\n"
+        "\n"
+        "  for (let attempt = 0; attempt < MAX_READ_ATTEMPTS; attempt++) {\n"
+        "    // Pre-read identity\n"
+        "    let preStat;\n"
+        "    try {\n"
+        "      preStat = fs.statSync(p);\n"
+        "    } catch (e) {\n"
+        "      // File disappeared, retry\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Zero-size reject\n"
+        "    if (preStat.size === 0) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Read\n"
+        "    let src;\n"
+        "    try {\n"
+        "      src = fs.readFileSync(p, 'utf8');\n"
+        "    } catch (e) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Post-read identity\n"
+        "    let postStat;\n"
+        "    try {\n"
+        "      postStat = fs.statSync(p);\n"
+        "    } catch (e) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Identity must be stable (size, inode, mtime)\n"
+        "    if (preStat.size !== postStat.size ||\n"
+        "        preStat.ino !== postStat.ino ||\n"
+        "        preStat.mtimeNs !== postStat.mtimeNs) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Read must match stable size\n"
+        "    const readSize = Buffer.byteLength(src, 'utf8');\n"
+        "    if (readSize !== preStat.size) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Explicit zero-length reject (defense in depth)\n"
+        "    if (readSize === 0) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Tail sentinel validation\n"
+        "    if (requireTail) {\n"
+        "      if (expectedTail === null || !src.endsWith(expectedTail)) {\n"
+        "        continue;\n"
+        "      }\n"
+        "    } else if (expectedTail !== null && !src.endsWith(expectedTail)) {\n"
+        "      continue;\n"
+        "    }\n"
+        "\n"
+        "    // Stable, complete read\n"
+        "    return src;\n"
+        "  }\n"
+        "\n"
+        "  throw new Error('source read incomplete: ' + p + ' (identity unstable or size mismatch after ' + MAX_READ_ATTEMPTS + ' attempts)');\n"
+        "}\n"
+    )

--- a/tests/js_source_loader.py
+++ b/tests/js_source_loader.py
@@ -18,17 +18,23 @@ This module centralizes the read so every harness shares the same defense:
 * **Fail closed** — if the read never stabilizes, ``SourceReadError`` is
   raised with an explicit message. The harness never sees a truncated
   fragment that brace matching could silently turn into a false pass/fail.
-* **Optional tail sentinel** — callers that know the expected end-of-file
-  marker (e.g. the last line of ``static/ui.js``) can require it. For
-  extraction sources (where brace matching runs downstream), the tail
-  sentinel is mandatory to ensure the entire source was captured.
+* **Mandatory tail sentinel for extraction sources** — callers that feed a
+  source to brace matching or ``eval`` must read it through
+  :func:`read_extraction_source`, which enforces ``require_tail=True`` with
+  the expected end-of-file marker from the :data:`EXTRACTION_TAILS`
+  registry. The registry is pinned by a regression asserting each entry is
+  a real suffix of its static file, so drift fails loudly instead of
+  silently weakening the sentinel.
 
 A matching Node snippet for the ``node -e`` harnesses is available via
-``node_validated_read_snippet()``.
+``node_validated_read_snippet()``; the Node side must use the same
+registry through ``node_validated_read_options()`` so both paths enforce
+the same EOF sentinel.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from dataclasses import dataclass
@@ -36,6 +42,28 @@ from pathlib import Path
 
 MAX_READ_ATTEMPTS = 5
 RETRY_DELAY_SECONDS = 0.02
+
+#: Expected end-of-file sentinels for the static sources that undergo
+#: brace-matched extraction or evaluation downstream (issue #6972). A read
+#: of one of these sources must reach its registered tail or the attempt is
+#: discarded — a stable partial rewrite (file rewritten to a smaller but
+#: consistent size, identity stable within each attempt) is otherwise
+#: indistinguishable from a complete file by size/identity alone.
+#:
+#: Each value must be an exact suffix of the real ``static/<name>`` file.
+#: ``test_extraction_tail_registry_matches_real_static_files`` in
+#: ``tests/test_js_source_loader.py`` asserts that, so editing a registered
+#: file's final line fails loudly until the registry is updated
+#: deliberately.
+EXTRACTION_TAILS: dict[str, str] = {
+    "ui.js": "  return names;\n}\n",
+    "messages.js": "}\n\n// ── Panel navigation (Chat / Tasks / Skills / Memory) ──\n",
+    "sessions.js": "  navigateSession(e.key==='j'?1:-1);\n});\n",
+    "assistant_turn_anchors.js": "  });\n})();\n",
+    "extension_settings.js": "  primeFromStatus(window.__HERMES_EXTENSION_CONFIG__||{});\n})();\n",
+    "i18n.js": "// Apply saved locale immediately so there's no flash of English on reload.\nloadLocale();\n",
+    "icons.js": '       + `style="display:inline-block;vertical-align:-0.15em;flex-shrink:0">${p}</svg>`;\n}\n',
+}
 
 
 class SourceReadError(RuntimeError):
@@ -158,7 +186,15 @@ def read_js_source(
             continue
 
         # Decode and validate tail sentinel if required
-        text = data.decode("utf-8")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as e:
+            # Non-UTF-8 bytes are a rewrite-in-progress signal (or a corrupt
+            # file); never leak a bare UnicodeDecodeError to the harness —
+            # fail closed via SourceReadError like every other unstable read.
+            last_error = f"decode failed (non-UTF-8 bytes, likely mid-rewrite): {e}"
+            time.sleep(retry_delay_seconds * (attempt + 1))
+            continue
         if require_tail:
             if not text.endswith(expected_tail):
                 last_error = f"EOF sentinel missing (expected {expected_tail!r}): {p}"
@@ -180,20 +216,106 @@ def read_js_source(
     )
 
 
+def read_extraction_source(
+    path: str | Path,
+    *,
+    max_attempts: int = MAX_READ_ATTEMPTS,
+    retry_delay_seconds: float = RETRY_DELAY_SECONDS,
+) -> str:
+    """Read a static source that will be brace-matched or evaluated.
+
+    This is the required entry point for extraction/evaluation harnesses
+    (issue #6972): it looks up the source's expected EOF sentinel in
+    :data:`EXTRACTION_TAILS` and enforces ``require_tail=True``, so a
+    stable partial rewrite (smaller but consistent file, identity stable
+    within each attempt) still fails closed instead of feeding a garbled
+    function slice to brace matching.
+
+    Args:
+        path: Path to the JS source file (basename must be registered in
+            ``EXTRACTION_TAILS``).
+        max_attempts: Maximum read attempts before failing closed.
+        retry_delay_seconds: Base delay between attempts (linear backoff).
+
+    Returns:
+        The complete, tail-validated file content as UTF-8 text.
+
+    Raises:
+        ValueError: If the source basename has no registered extraction tail
+            (a new extraction source must be added to the registry first —
+            never silently read without the sentinel).
+        SourceReadError: If no attempt produces a stable, complete read.
+    """
+    p = Path(path)
+    try:
+        expected_tail = EXTRACTION_TAILS[p.name]
+    except KeyError:
+        raise ValueError(
+            f"no registered extraction tail for {p.name!r}; add it to "
+            "EXTRACTION_TAILS in tests/js_source_loader.py (and keep the "
+            "drift regression green) before reading it as an extraction source"
+        ) from None
+    return read_js_source(
+        p,
+        expected_tail=expected_tail,
+        require_tail=True,
+        max_attempts=max_attempts,
+        retry_delay_seconds=retry_delay_seconds,
+    )
+
+
+def node_validated_read_options(path: str | Path) -> str:
+    """Return a JS options object literal enforcing the registered EOF tail.
+
+    Extraction harnesses built on ``node_validated_read_snippet()`` must
+    read their sources with ``readValidated(path, <this>)`` so the Node
+    path enforces the *same* tail sentinel as the Python path (parity for
+    issue #6972). The options come from :data:`EXTRACTION_TAILS`, so there
+    is exactly one registry for both languages.
+
+    Args:
+        path: Path whose basename must be registered in ``EXTRACTION_TAILS``.
+
+    Returns:
+        A JS object literal, e.g. ``{ expectedTail: "}\\n", requireTail: true }``.
+
+    Raises:
+        ValueError: If the basename has no registered extraction tail.
+    """
+    p = Path(path)
+    try:
+        tail = EXTRACTION_TAILS[p.name]
+    except KeyError:
+        raise ValueError(
+            f"no registered extraction tail for {p.name!r}; add it to "
+            "EXTRACTION_TAILS in tests/js_source_loader.py"
+        ) from None
+    return "{ expectedTail: " + json.dumps(tail) + ", requireTail: true }"
+
+
 def node_validated_read_snippet() -> str:
     """Return a Node snippet that reads a file with the same defense.
 
     The returned JS defines ``readValidated(path, options?)`` which reads
-    the file with per-attempt identity validation (size, inode, mtime),
-    rejects zero-byte reads, retries up to ``MAX_READ_ATTEMPTS`` times on
-    a partial/unstable read, and throws an explicit error instead of
-    returning a truncated fragment. ``fs`` is required inside the function
-    so the snippet never collides with a harness that already declares
-    ``const fs = require('fs')``.
+    the file with per-attempt identity validation (size, inode, mtime —
+    all via ``fs.statSync(p, { bigint: true })`` so the mtimeNs field is
+    actually present and the comparison is real, not dead code), rejects
+    zero-byte reads, retries up to ``MAX_READ_ATTEMPTS`` times on a
+    partial/unstable read with the same linear settle delay as the Python
+    loader, and throws an explicit error instead of returning a truncated
+    fragment. If a stat result lacks the BigInt fields (e.g. a mock or a
+    legacy stat call without ``{ bigint: true }``), the snippet throws
+    immediately — a missing ``mtimeNs`` must never pass the identity check
+    silently. ``fs`` is required inside the function so the snippet never
+    collides with a harness that already declares ``const fs = require('fs')``.
 
     The ``options`` object accepts:
     - ``expectedTail``: string sentinel that the content must end with
     - ``requireTail``: if true, missing sentinel fails the attempt
+
+    Extraction harnesses should pass the options returned by
+    ``node_validated_read_options()`` so the Node path enforces the same
+    registered EOF tail as the Python path.
     """
     return (
         "\nconst MAX_READ_ATTEMPTS = " + str(MAX_READ_ATTEMPTS) + ";\n"
@@ -202,18 +324,36 @@ def node_validated_read_snippet() -> str:
         "  const fs = require('fs');\n"
         "  const { expectedTail = null, requireTail = false } = options;\n"
         "\n"
+        "  // Synchronous linear settle delay (mirrors the Python loader's\n"
+        "  // per-attempt backoff; gives a concurrent rewrite time to finish).\n"
+        "  const _settleDelayMs = 20;\n"
+        "  const _sleep = (ms) => { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); };\n"
+        "\n"
+        "  // BigInt stat fields are mandatory: a stat without { bigint: true }\n"
+        "  // has no mtimeNs, which would silently turn the identity check into\n"
+        "  // dead code. Fail loudly instead of letting the check pass blindly.\n"
+        "  const _requireBigIntStat = (st) => {\n"
+        "    if (st.mtimeNs === undefined || typeof st.size !== 'bigint') {\n"
+        "      throw new Error('source stat missing BigInt size/mtimeNs (fs.statSync must use { bigint: true }): ' + p);\n"
+        "    }\n"
+        "    return st;\n"
+        "  };\n"
+        "\n"
         "  for (let attempt = 0; attempt < MAX_READ_ATTEMPTS; attempt++) {\n"
-        "    // Pre-read identity\n"
+        "    if (attempt > 0) _sleep(_settleDelayMs * attempt);\n"
+        "\n"
+        "    // Pre-read identity (bigint: size/ino/mtimeNs are BigInts)\n"
         "    let preStat;\n"
         "    try {\n"
-        "      preStat = fs.statSync(p);\n"
+        "      preStat = _requireBigIntStat(fs.statSync(p, { bigint: true }));\n"
         "    } catch (e) {\n"
-        "      // File disappeared, retry\n"
+        "      // File disappeared (or BigInt stat unavailable) — retry/throw\n"
+        "      if (e instanceof Error && e.message.indexOf('missing BigInt') >= 0) throw e;\n"
         "      continue;\n"
         "    }\n"
         "\n"
         "    // Zero-size reject\n"
-        "    if (preStat.size === 0) {\n"
+        "    if (preStat.size === 0n) {\n"
         "      continue;\n"
         "    }\n"
         "\n"
@@ -228,8 +368,10 @@ def node_validated_read_snippet() -> str:
         "    // Post-read identity\n"
         "    let postStat;\n"
         "    try {\n"
-        "      postStat = fs.statSync(p);\n"
+        "      postStat = _requireBigIntStat(fs.statSync(p, { bigint: true }));\n"
         "    } catch (e) {\n"
+        "      // File disappeared (or BigInt stat unavailable) — retry/throw\n"
+        "      if (e instanceof Error && e.message.indexOf('missing BigInt') >= 0) throw e;\n"
         "      continue;\n"
         "    }\n"
         "\n"
@@ -240,14 +382,14 @@ def node_validated_read_snippet() -> str:
         "      continue;\n"
         "    }\n"
         "\n"
-        "    // Read must match stable size\n"
-        "    const readSize = Buffer.byteLength(src, 'utf8');\n"
+        "    // Read must match stable size (BigInt byte count vs BigInt stat)\n"
+        "    const readSize = BigInt(Buffer.byteLength(src, 'utf8'));\n"
         "    if (readSize !== preStat.size) {\n"
         "      continue;\n"
         "    }\n"
         "\n"
         "    // Explicit zero-length reject (defense in depth)\n"
-        "    if (readSize === 0) {\n"
+        "    if (readSize === 0n) {\n"
         "      continue;\n"
         "    }\n"
         "\n"

--- a/tests/js_source_loader.py
+++ b/tests/js_source_loader.py
@@ -1,0 +1,94 @@
+"""Shared, race-safe loader for JS-harness static-source reads.
+
+The JS/DOM harness tests read ``static/ui.js`` (and sibling static sources)
+and then extract function bodies with textual brace matching. Under
+concurrent load (multiple full suites on one box), a read can observe a
+truncated/partial view of the file, and the brace matcher then returns a
+syntactically unrelated fragment instead of failing loudly. See issue #6972.
+
+This module centralizes the read so every harness shares the same defense:
+
+* **Size validation** — the read is compared against the on-disk byte
+  length (``stat``) before it is handed to extraction.
+* **Bounded retry** — a short, partial read (file being rewritten, or an
+  I/O-starved subprocess) is retried a few times instead of being accepted.
+* **Fail closed** — if the read never stabilizes, ``SourceReadError`` is
+  raised with an explicit message. The harness never sees a truncated
+  fragment that brace matching could silently turn into a false pass/fail.
+* **Optional tail sentinel** — callers that know the expected end-of-file
+  marker (e.g. the last line of ``static/ui.js``) can require it.
+
+A matching Node snippet for the ``node -e`` harnesses is available via
+``node_validated_read_snippet()``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+MAX_READ_ATTEMPTS = 5
+RETRY_DELAY_SECONDS = 0.02
+
+
+class SourceReadError(RuntimeError):
+    """Raised when a JS source file cannot be read to completion."""
+
+
+def read_js_source(
+    path: str | Path,
+    *,
+    expected_tail: str | None = None,
+    max_attempts: int = MAX_READ_ATTEMPTS,
+    retry_delay_seconds: float = RETRY_DELAY_SECONDS,
+) -> str:
+    """Read a JS source file to completion, retrying on unstable reads.
+
+    The read must match the on-disk byte length (and, when given, end with
+    ``expected_tail``); otherwise it is treated as a partial read and retried
+    with a short backoff. If the file never reads consistently,
+    :class:`SourceReadError` is raised instead of returning a fragment that
+    downstream textual brace matching could silently mangle.
+    """
+    p = Path(path)
+    expected_size = p.stat().st_size
+    last_size = -1
+    for attempt in range(max_attempts):
+        data = p.read_bytes()
+        last_size = len(data)
+        if last_size == expected_size:
+            text = data.decode("utf-8")
+            if expected_tail is None or text.endswith(expected_tail):
+                return text
+        time.sleep(retry_delay_seconds * (attempt + 1))
+    raise SourceReadError(
+        f"truncated read of {p}: expected {expected_size} bytes, "
+        f"got {last_size} after {max_attempts} attempts; "
+        f"refusing to extract from a partial source read"
+    )
+
+
+def node_validated_read_snippet() -> str:
+    """Return a Node snippet that reads a file with the same defense.
+
+    The returned JS defines ``readValidated(path)`` which reads the file,
+    compares the byte length against ``fs.statSync``, retries up to
+    ``MAX_READ_ATTEMPTS`` times on a partial read, and throws an explicit
+    error instead of returning a truncated fragment. ``fs`` is required
+    inside the function so the snippet never collides with a harness that
+    already declares ``const fs = require('fs')``.
+    """
+    return f"""
+const MAX_READ_ATTEMPTS = {MAX_READ_ATTEMPTS};
+function readValidated(p){{
+  const fs = require('fs');
+  const expectedSize = fs.statSync(p).size;
+  let src = null;
+  for(let attempt = 0; attempt < MAX_READ_ATTEMPTS; attempt++){{
+    src = fs.readFileSync(p, 'utf8');
+    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
+  }}
+  throw new Error('source read incomplete: ' + p + ' (' +
+    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
+}}
+"""

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.js_source_loader import read_js_source
+from tests.js_source_loader import read_extraction_source, read_js_source
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -33,7 +33,9 @@ def _read_required_text(path: Path, label: str) -> str:
 
 
 def _ui_js() -> str:
-    return _read_required_text(UI_JS_PATH, "static/ui.js")
+    # ui.js undergoes brace-matched function extraction downstream, so it
+    # must be read through the extraction entry point (EOF tail enforced).
+    return read_extraction_source(UI_JS_PATH)
 
 
 def _phase0_doc() -> str:

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_source_loader import read_js_source
+
 
 ROOT = Path(__file__).resolve().parents[1]
 UI_JS_PATH = ROOT / "static" / "ui.js"
@@ -27,7 +29,7 @@ PHASE0_DOC_PATH = (
 
 def _read_required_text(path: Path, label: str) -> str:
     assert path.exists(), f"{label} not found at {path}"
-    return path.read_text(encoding="utf-8")
+    return read_js_source(path)
 
 
 def _ui_js() -> str:

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -17,15 +17,21 @@ from api.streaming import (
 
 ROOT = Path(__file__).resolve().parents[1]
 
-from tests.js_source_loader import read_js_source  # noqa: E402
+from tests.js_source_loader import read_extraction_source, read_js_source  # noqa: E402
 
 
 def _read(relpath: str) -> str:
     return read_js_source(ROOT / relpath)
 
 
+def _read_messages_js() -> str:
+    # messages.js blocks are sliced for extraction downstream, so the read
+    # must enforce the registered EOF tail (issue #6972).
+    return read_extraction_source(ROOT / "static" / "messages.js")
+
+
 def _compressed_listener_block() -> str:
-    src = _read("static/messages.js")
+    src = _read_messages_js()
     start = src.find("source.addEventListener('compressed'")
     assert start != -1, "compressed SSE listener not found"
     end = src.find("source.addEventListener('metering'", start)
@@ -34,7 +40,7 @@ def _compressed_listener_block() -> str:
 
 
 def _compressing_listener_block() -> str:
-    src = _read("static/messages.js")
+    src = _read_messages_js()
     start = src.find("source.addEventListener('compressing'")
     assert start != -1, "compressing SSE listener not found"
     end = src.find("source.addEventListener('compressed'", start)

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -17,9 +17,11 @@ from api.streaming import (
 
 ROOT = Path(__file__).resolve().parents[1]
 
+from tests.js_source_loader import read_js_source  # noqa: E402
+
 
 def _read(relpath: str) -> str:
-    return (ROOT / relpath).read_text(encoding="utf-8")
+    return read_js_source(ROOT / relpath)
 
 
 def _compressed_listener_block() -> str:

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.js_source_loader import read_js_source
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -293,11 +295,11 @@ def test_session_import_cli_queues_generated_title_for_writable_default_cli_titl
 
 
 def test_read_only_source_badge_ui_guards_are_present():
-    sessions_js = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-    messages_js = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
-    ui_js = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
-    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-    style_css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+    sessions_js = read_js_source(REPO_ROOT / "static" / "sessions.js")
+    messages_js = read_js_source(REPO_ROOT / "static" / "messages.js")
+    ui_js = read_js_source(REPO_ROOT / "static" / "ui.js")
+    panels_js = read_js_source(REPO_ROOT / "static" / "panels.js")
+    style_css = read_js_source(REPO_ROOT / "static" / "style.css")
     routes_py = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 
     assert "function _isReadOnlySession" in sessions_js
@@ -320,8 +322,8 @@ def test_messaging_source_badge_not_gated_on_is_cli_session():
     # Messaging sessions (Telegram, WeChat, Discord) populate source_label/source_tag/raw_source
     # but reach the chat pane with is_cli_session=false, so the topbar badge must not be gated on
     # is_cli_session or it never renders for them (#3338).
-    ui_js = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
-    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    ui_js = read_js_source(REPO_ROOT / "static" / "ui.js")
+    panels_js = read_js_source(REPO_ROOT / "static" / "panels.js")
 
     assert "S.session.is_cli_session&&(S.session.source_label" not in ui_js
     assert "if (S.session.is_cli_session) sourceLabel" not in panels_js
@@ -334,8 +336,8 @@ def test_messaging_source_badge_not_gated_on_is_cli_session():
 
 
 def test_messaging_source_badge_in_sidebar_not_gated_on_is_cli_session():
-    sessions_js = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-    style_css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+    sessions_js = read_js_source(REPO_ROOT / "static" / "sessions.js")
+    style_css = read_js_source(REPO_ROOT / "static" / "style.css")
 
     assert "function _isMessagingSession" in sessions_js
     assert sessions_js.count("if(s.is_cli_session||_isMessagingSession(s)){") == 2
@@ -352,8 +354,8 @@ def test_messaging_source_badge_in_sidebar_not_gated_on_is_cli_session():
 
 
 def test_compression_queue_discoverability_ux():
-    ui_js = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
-    i18n_js = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+    ui_js = read_js_source(REPO_ROOT / "static" / "ui.js")
+    i18n_js = read_js_source(REPO_ROOT / "static" / "i18n.js")
 
     # Old misleading tooltip key must be gone from the compression branch
     assert "composer_disabled_compression','Waiting for compression to finish'" not in ui_js

--- a/tests/test_custom_provider_model_identity.py
+++ b/tests/test_custom_provider_model_identity.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_source_loader import node_validated_read_snippet
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 UI_JS = REPO_ROOT / "static" / "ui.js"
 NODE = shutil.which("node")
 
-_DRIVER = r"""
-const fs=require('fs');
-const src=fs.readFileSync(process.argv[2],'utf8');
+_DRIVER = node_validated_read_snippet() + r"""
+const src=readValidated(process.argv[2]);
 function extract(name){
   const start=src.indexOf('function '+name+'(');
   if(start<0) throw new Error('missing '+name);
@@ -96,9 +97,8 @@ def test_partial_then_live_catalog_preserves_exact_custom_provider_model(tmp_pat
 # when two options under the same custom provider normalize to the same target,
 # the hinted-fallback must refuse to guess and return null rather than pick
 # an arbitrary one.
-_AMBIGUITY_DRIVER = r"""
-const fs=require('fs');
-const src=fs.readFileSync(process.argv[2],'utf8');
+_AMBIGUITY_DRIVER = node_validated_read_snippet() + r"""
+const src=readValidated(process.argv[2]);
 function extract(name){
   const start=src.indexOf('function '+name+'(');
   if(start<0) throw new Error('missing '+name);

--- a/tests/test_custom_provider_model_identity.py
+++ b/tests/test_custom_provider_model_identity.py
@@ -7,14 +7,18 @@ from pathlib import Path
 
 import pytest
 
-from tests.js_source_loader import node_validated_read_snippet
+from tests.js_source_loader import node_validated_read_options, node_validated_read_snippet
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 UI_JS = REPO_ROOT / "static" / "ui.js"
 NODE = shutil.which("node")
 
-_DRIVER = node_validated_read_snippet() + r"""
-const src=readValidated(process.argv[2]);
+_DRIVER = (
+    node_validated_read_snippet()
+    + "\nconst src=readValidated(process.argv[2], "
+    + node_validated_read_options(UI_JS)
+    + ");\n"
+    + r"""
 function extract(name){
   const start=src.indexOf('function '+name+'(');
   if(start<0) throw new Error('missing '+name);
@@ -69,6 +73,7 @@ console.log(JSON.stringify({
   qualifiedAfter:_modelStateForSelect(qualified,qualified.value),
 }));
 """
+)
 
 
 @pytest.mark.skipif(NODE is None, reason="node not in PATH")
@@ -97,8 +102,12 @@ def test_partial_then_live_catalog_preserves_exact_custom_provider_model(tmp_pat
 # when two options under the same custom provider normalize to the same target,
 # the hinted-fallback must refuse to guess and return null rather than pick
 # an arbitrary one.
-_AMBIGUITY_DRIVER = node_validated_read_snippet() + r"""
-const src=readValidated(process.argv[2]);
+_AMBIGUITY_DRIVER = (
+    node_validated_read_snippet()
+    + "\nconst src=readValidated(process.argv[2], "
+    + node_validated_read_options(UI_JS)
+    + ");\n"
+    + r"""
 function extract(name){
   const start=src.indexOf('function '+name+'(');
   if(start<0) throw new Error('missing '+name);
@@ -127,6 +136,7 @@ console.log(JSON.stringify({
   exact:_findModelInDropdown('z-ai/glm-5.2', single, 'custom:tok'),
 }));
 """
+)
 
 
 @pytest.mark.skipif(NODE is None, reason="node not in PATH")

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -7,23 +7,12 @@ import textwrap
 
 import pytest
 
+from tests.js_source_loader import node_validated_read_snippet
 
 ROOT = Path(__file__).parent.parent
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
 
-_VALIDATED_READ = """
-function readValidated(p){
-  const fs = require('fs');
-  const expectedSize = fs.statSync(p).size;
-  let src = null;
-  for(let attempt = 0; attempt < 5; attempt++){
-    src = fs.readFileSync(p, 'utf8');
-    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
-  }
-  throw new Error('source read incomplete: ' + p + ' (' +
-    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
-}
-"""
+_VALIDATED_READ = node_validated_read_snippet()
 
 
 def _run_node(script: str):
@@ -196,7 +185,9 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
             removeItem(key) {{ removes += 1; store.delete(key); }}
           }}
         }};
-        eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
+        {_VALIDATED_READ}
+        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        eval(settingsSrc);
 
         const forgedMetadata = {{
           id: 'forged.ext',

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -11,6 +11,20 @@ import pytest
 ROOT = Path(__file__).parent.parent
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
 
+_VALIDATED_READ = """
+function readValidated(p){
+  const fs = require('fs');
+  const expectedSize = fs.statSync(p).size;
+  let src = null;
+  for(let attempt = 0; attempt < 5; attempt++){
+    src = fs.readFileSync(p, 'utf8');
+    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
+  }
+  throw new Error('source read incomplete: ' + p + ' (' +
+    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
+}
+"""
+
 
 def _run_node(script: str):
     node = shutil.which("node")
@@ -60,7 +74,9 @@ def test_extension_settings_runtime_normalizes_persists_resets_and_clears():
             removeItem(key) {{ store.delete(key); }}
           }}
         }};
-        eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
+{_VALIDATED_READ}
+        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        eval(settingsSrc);
 
         const settings = window.HermesExtensionSettings.settingsForExtension('demo.ext');
         assert.deepStrictEqual(settings.schema.map(field => field.key), ['flag', 'mode', 'count']);

--- a/tests/test_extension_settings_runtime.py
+++ b/tests/test_extension_settings_runtime.py
@@ -7,7 +7,7 @@ import textwrap
 
 import pytest
 
-from tests.js_source_loader import node_validated_read_snippet
+from tests.js_source_loader import node_validated_read_options, node_validated_read_snippet
 
 ROOT = Path(__file__).parent.parent
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
@@ -64,7 +64,7 @@ def test_extension_settings_runtime_normalizes_persists_resets_and_clears():
           }}
         }};
 {_VALIDATED_READ}
-        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r}, {node_validated_read_options(EXTENSION_SETTINGS_JS)});
         eval(settingsSrc);
 
         const settings = window.HermesExtensionSettings.settingsForExtension('demo.ext');
@@ -186,7 +186,7 @@ def test_hermes_ext_register_runtime_identity_and_reload_lifecycle():
           }}
         }};
         {_VALIDATED_READ}
-        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        const settingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r}, {node_validated_read_options(EXTENSION_SETTINGS_JS)});
         eval(settingsSrc);
 
         const forgedMetadata = {{

--- a/tests/test_extension_turn_lifecycle.py
+++ b/tests/test_extension_turn_lifecycle.py
@@ -9,17 +9,20 @@ import textwrap
 
 import pytest
 
+from tests.js_source_loader import node_validated_read_snippet, read_js_source
+
 
 ROOT = Path(__file__).parent.parent
 STATIC = ROOT / "static"
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
-MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
-INDEX_HTML = (STATIC / "index.html").read_text(encoding="utf-8")
-UI_JS = (STATIC / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = read_js_source(ROOT / "static" / "messages.js")
+INDEX_HTML = read_js_source(STATIC / "index.html")
+UI_JS = read_js_source(STATIC / "ui.js")
 SUPPORT_SCRIPTS = [
-    (STATIC / name).read_text(encoding="utf-8")
+    read_js_source(STATIC / name)
     for name in ("i18n.js", "icons.js", "assistant_turn_anchors.js")
 ]
+_NODE_VALIDATED_READ = node_validated_read_snippet()
 HARNESS_HTML = re.sub(r"<script\b[^>]*>.*?</script>", "", INDEX_HTML, flags=re.I | re.S)
 HARNESS_HTML = re.sub(r"<link\b[^>]*>", "", HARNESS_HTML, flags=re.I)
 
@@ -226,7 +229,6 @@ def _run_node(script: str):
 def test_registered_extension_receives_bounded_turn_lifecycle_events():
     script = textwrap.dedent(
         f"""
-        const fs = require('fs');
         const assert = require('assert');
         const store = new Map();
         const loggedErrors = [];
@@ -246,7 +248,9 @@ def test_registered_extension_receives_bounded_turn_lifecycle_events():
         global.console = {{
           error(...args) {{ loggedErrors.push(args.map(String).join(' ')); }},
         }};
-        eval(fs.readFileSync({str(EXTENSION_SETTINGS_JS)!r}, 'utf8'));
+        {_NODE_VALIDATED_READ}
+        const extensionSettingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        eval(extensionSettingsSrc);
 
         const alpha = window.hermesExt.register('alpha.ext');
         const beta = window.hermesExt.register('beta.ext');
@@ -408,7 +412,7 @@ def _run_lifecycle_scenario(browser, kind: str) -> list[dict]:
         )
         for script in SUPPORT_SCRIPTS:
             page.add_script_tag(content=script)
-        page.add_script_tag(content=EXTENSION_SETTINGS_JS.read_text(encoding="utf-8"))
+        page.add_script_tag(content=read_js_source(EXTENSION_SETTINGS_JS))
         page.add_script_tag(content=UI_JS)
         page.add_script_tag(content=MESSAGES_JS)
         page.evaluate(_STABILIZE_UNRELATED_UI)

--- a/tests/test_extension_turn_lifecycle.py
+++ b/tests/test_extension_turn_lifecycle.py
@@ -9,17 +9,22 @@ import textwrap
 
 import pytest
 
-from tests.js_source_loader import node_validated_read_snippet, read_js_source
+from tests.js_source_loader import (
+    node_validated_read_options,
+    node_validated_read_snippet,
+    read_extraction_source,
+    read_js_source,
+)
 
 
 ROOT = Path(__file__).parent.parent
 STATIC = ROOT / "static"
 EXTENSION_SETTINGS_JS = ROOT / "static" / "extension_settings.js"
-MESSAGES_JS = read_js_source(ROOT / "static" / "messages.js")
+MESSAGES_JS = read_extraction_source(ROOT / "static" / "messages.js")
 INDEX_HTML = read_js_source(STATIC / "index.html")
-UI_JS = read_js_source(STATIC / "ui.js")
+UI_JS = read_extraction_source(STATIC / "ui.js")
 SUPPORT_SCRIPTS = [
-    read_js_source(STATIC / name)
+    read_extraction_source(STATIC / name)
     for name in ("i18n.js", "icons.js", "assistant_turn_anchors.js")
 ]
 _NODE_VALIDATED_READ = node_validated_read_snippet()
@@ -249,7 +254,7 @@ def test_registered_extension_receives_bounded_turn_lifecycle_events():
           error(...args) {{ loggedErrors.push(args.map(String).join(' ')); }},
         }};
         {_NODE_VALIDATED_READ}
-        const extensionSettingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r});
+        const extensionSettingsSrc = readValidated({str(EXTENSION_SETTINGS_JS)!r}, {node_validated_read_options(EXTENSION_SETTINGS_JS)});
         eval(extensionSettingsSrc);
 
         const alpha = window.hermesExt.register('alpha.ext');
@@ -412,7 +417,7 @@ def _run_lifecycle_scenario(browser, kind: str) -> list[dict]:
         )
         for script in SUPPORT_SCRIPTS:
             page.add_script_tag(content=script)
-        page.add_script_tag(content=read_js_source(EXTENSION_SETTINGS_JS))
+        page.add_script_tag(content=read_extraction_source(EXTENSION_SETTINGS_JS))
         page.add_script_tag(content=UI_JS)
         page.add_script_tag(content=MESSAGES_JS)
         page.evaluate(_STABILIZE_UNRELATED_UI)

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -27,11 +27,12 @@ def _run_reasoning_scene(
 ) -> dict:
     assert NODE, "node is required for the #5720 browser-chain regression"
     env = os.environ.copy()
-    env.setdefault("ISSUE5720_UI_JS", str(ROOT / "static" / "ui.js"))
-    env.setdefault("ISSUE5720_MESSAGES_JS", str(ROOT / "static" / "messages.js"))
-    env.setdefault(
-        "ISSUE5720_ANCHORS_JS",
-        str(ROOT / "static" / "assistant_turn_anchors.js"),
+    # Assign (not setdefault): a stale value left in the process-global env by
+    # an earlier test must not redirect the harness to the wrong file (#6972).
+    env["ISSUE5720_UI_JS"] = str(ROOT / "static" / "ui.js")
+    env["ISSUE5720_MESSAGES_JS"] = str(ROOT / "static" / "messages.js")
+    env["ISSUE5720_ANCHORS_JS"] = str(
+        ROOT / "static" / "assistant_turn_anchors.js",
     )
     env["ISSUE5720_ACTIVITY_MODE"] = activity_mode
     if fail_first_anchor_render:
@@ -201,9 +202,19 @@ def test_later_deferred_anchor_paint_remains_hidden_in_final_answer_only_mode():
 
 _NODE_SCENE = r"""
 const fs = require('fs');
-const uiSrc = fs.readFileSync(process.env.ISSUE5720_UI_JS, 'utf8');
-const messagesSrc = fs.readFileSync(process.env.ISSUE5720_MESSAGES_JS, 'utf8');
-const anchorsSrc = fs.readFileSync(process.env.ISSUE5720_ANCHORS_JS, 'utf8');
+function readValidated(p){
+  const expectedSize = fs.statSync(p).size;
+  let src = null;
+  for(let attempt = 0; attempt < 5; attempt++){
+    src = fs.readFileSync(p, 'utf8');
+    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
+  }
+  throw new Error('source read incomplete: ' + p + ' (' +
+    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
+}
+const uiSrc = readValidated(process.env.ISSUE5720_UI_JS);
+const messagesSrc = readValidated(process.env.ISSUE5720_MESSAGES_JS);
+const anchorsSrc = readValidated(process.env.ISSUE5720_ANCHORS_JS);
 
 function extractFunc(src, name){
   const start = src.indexOf('function ' + name);

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_source_loader import node_validated_read_snippet
+
 
 ROOT = Path(__file__).resolve().parents[1]
 NODE = shutil.which("node")
@@ -200,18 +202,13 @@ def test_later_deferred_anchor_paint_remains_hidden_in_final_answer_only_mode():
     assert result["anchor_reasoning_text"] == "Plan step"
 
 
-_NODE_SCENE = r"""
-const fs = require('fs');
-function readValidated(p){
-  const expectedSize = fs.statSync(p).size;
-  let src = null;
-  for(let attempt = 0; attempt < 5; attempt++){
-    src = fs.readFileSync(p, 'utf8');
-    if(Buffer.byteLength(src, 'utf8') === expectedSize) return src;
-  }
-  throw new Error('source read incomplete: ' + p + ' (' +
-    Buffer.byteLength(src, 'utf8') + '/' + expectedSize + ' bytes)');
-}
+# Build the Node scene using the shared validated-read snippet to avoid
+# hand-maintained divergence (issue #6972). The snippet defines
+# `readValidated(path, options?)` with per-attempt identity validation,
+# zero-byte reject, and optional tail-sentinel checking.
+_NODE_SCENE = (
+    node_validated_read_snippet()
+    + r"""
 const uiSrc = readValidated(process.env.ISSUE5720_UI_JS);
 const messagesSrc = readValidated(process.env.ISSUE5720_MESSAGES_JS);
 const anchorsSrc = readValidated(process.env.ISSUE5720_ANCHORS_JS);
@@ -683,3 +680,4 @@ process.stdout.write(JSON.stringify({
   multi_segment_exact_fallback:multiSegmentExactFallback,
 }));
 """
+)

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.js_source_loader import node_validated_read_snippet
+from tests.js_source_loader import node_validated_read_options, node_validated_read_snippet
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -205,14 +205,22 @@ def test_later_deferred_anchor_paint_remains_hidden_in_final_answer_only_mode():
 # Build the Node scene using the shared validated-read snippet to avoid
 # hand-maintained divergence (issue #6972). The snippet defines
 # `readValidated(path, options?)` with per-attempt identity validation,
-# zero-byte reject, and optional tail-sentinel checking.
+# zero-byte reject, and tail-sentinel checking; every source is read with
+# the registered EOF tail enforced (extraction parity with the Python path).
 _NODE_SCENE = (
     node_validated_read_snippet()
+    + (
+        "\nconst uiSrc = readValidated(process.env.ISSUE5720_UI_JS, "
+        + node_validated_read_options(ROOT / "static" / "ui.js")
+        + ");\n"
+        "const messagesSrc = readValidated(process.env.ISSUE5720_MESSAGES_JS, "
+        + node_validated_read_options(ROOT / "static" / "messages.js")
+        + ");\n"
+        "const anchorsSrc = readValidated(process.env.ISSUE5720_ANCHORS_JS, "
+        + node_validated_read_options(ROOT / "static" / "assistant_turn_anchors.js")
+        + ");\n"
+    )
     + r"""
-const uiSrc = readValidated(process.env.ISSUE5720_UI_JS);
-const messagesSrc = readValidated(process.env.ISSUE5720_MESSAGES_JS);
-const anchorsSrc = readValidated(process.env.ISSUE5720_ANCHORS_JS);
-
 function extractFunc(src, name){
   const start = src.indexOf('function ' + name);
   if(start < 0){

--- a/tests/test_issue6572_loadsession_compression_cleanup.py
+++ b/tests/test_issue6572_loadsession_compression_cleanup.py
@@ -36,11 +36,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from tests.js_source_loader import read_js_source
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _read_sessions_js() -> str:
-    return (REPO_ROOT / "static" / "sessions.js").read_text()
+    return read_js_source(REPO_ROOT / "static" / "sessions.js")
 
 
 def _load_session_body() -> str:

--- a/tests/test_issue6572_loadsession_compression_cleanup.py
+++ b/tests/test_issue6572_loadsession_compression_cleanup.py
@@ -36,13 +36,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from tests.js_source_loader import read_js_source
+from tests.js_source_loader import read_extraction_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _read_sessions_js() -> str:
-    return read_js_source(REPO_ROOT / "static" / "sessions.js")
+    return read_extraction_source(REPO_ROOT / "static" / "sessions.js")
 
 
 def _load_session_body() -> str:

--- a/tests/test_js_source_loader.py
+++ b/tests/test_js_source_loader.py
@@ -1,0 +1,162 @@
+"""Regression tests for the race-safe JS source loader (issue #6972).
+
+The serial JS/DOM harness suites were flaky under load: a truncated read of
+``static/ui.js`` (partial read observed mid-rewrite or under I/O starvation)
+was handed to textual brace matching, which then returned a garbled fragment
+instead of failing loudly. These tests prove the shared loader retries on a
+partial read and fails closed (``SourceReadError``) when the file never reads
+consistently — never handing a truncated fragment to extraction.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.js_source_loader import (
+    MAX_READ_ATTEMPTS,
+    SourceReadError,
+    node_validated_read_snippet,
+    read_js_source,
+)
+
+
+@pytest.fixture
+def sample_source(tmp_path):
+    real = tmp_path / "ui.js"
+    # Multi-line body with a distinctive tail sentinel, mimicking ui.js.
+    full_text = (
+        "function loadSession(sid){\n"
+        "  const rows=[];\n"
+        "  for(const s of sessions) rows.push(s);\n"
+        "  clearCompressionUi();\n"
+        "  return rows;\n"
+        "}\n"
+    )
+    real.write_text(full_text, encoding="utf-8")
+    return real, full_text
+
+
+def _install_partial_reads(path: Path, full_text: str, partial_reads: int, monkeypatch):
+    """Make ``Path.read_bytes`` return a truncated view the first
+    ``partial_reads`` times, then the full content — simulating a read that
+    races a concurrent rewrite of the shared static source."""
+    full_bytes = full_text.encode("utf-8")
+    partial_bytes = full_bytes[: len(full_bytes) // 2]
+    reads = {"count": 0}
+
+    def fake_read_bytes(self):
+        reads["count"] += 1
+        if reads["count"] <= partial_reads:
+            return partial_bytes
+        return full_bytes
+
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+    return reads
+
+
+def test_read_js_source_retries_partial_read_until_stable(sample_source, monkeypatch):
+    """A first truncated read must be retried, not handed to extraction."""
+    real, full_text = sample_source
+    reads = _install_partial_reads(real, full_text, partial_reads=2, monkeypatch=monkeypatch)
+
+    text = read_js_source(real)
+    assert text == full_text
+    assert reads["count"] == 3  # two partial attempts, then a stable full read
+
+
+def test_read_js_source_fails_closed_when_read_always_truncated(sample_source, monkeypatch):
+    """A permanently truncated read must raise SourceReadError, not return
+    a fragment that brace matching would silently mangle."""
+    real, full_text = sample_source
+    reads = _install_partial_reads(real, full_text, partial_reads=10**6, monkeypatch=monkeypatch)
+
+    with pytest.raises(SourceReadError, match="truncated read"):
+        read_js_source(real)
+    assert reads["count"] == MAX_READ_ATTEMPTS
+
+
+def test_read_js_source_validates_expected_tail(sample_source):
+    """When a caller requires the known end-of-file sentinel, a read that
+    fails to reach it is retried/failed instead of accepted."""
+    real, full_text = sample_source
+
+    text = read_js_source(real, expected_tail="  return rows;\n}\n")
+    assert text == full_text
+
+    # Tail never reached (wrong sentinel) -> fail closed.
+    with pytest.raises(SourceReadError, match="truncated read"):
+        read_js_source(real, expected_tail="/* never-present sentinel */")
+
+
+def test_read_js_source_reads_real_ui_js_to_completion():
+    """The real ~1MB static/ui.js must be read to completion (size-validated),
+    which is the exact read that used to truncate under load."""
+    root = Path(__file__).resolve().parents[1]
+    ui_js = root / "static" / "ui.js"
+    text = read_js_source(ui_js)
+    assert len(text.encode("utf-8")) == ui_js.stat().st_size
+    assert "clearCompressionUi()" in text  # sentinel from the issue evidence
+
+
+def test_node_validated_read_snippet_reads_full_file(sample_source):
+    """The Node-side snippet must read the same file to completion."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the Node-side snippet check")
+    real, full_text = sample_source
+
+    script = (
+        node_validated_read_snippet()
+        + f"const src = readValidated({str(real)!r});\n"
+        + "if(src !== " + repr(full_text) + ") throw new Error('content mismatch');\n"
+        + "console.log('OK');\n"
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        cwd=str(real.parent),
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_node_validated_read_snippet_fails_closed_on_truncated_target(tmp_path):
+    """A read that returns fewer bytes than stat reports (the race) must
+    throw an explicit source-read error instead of returning a fragment."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the Node-side snippet check")
+
+    script = f"""
+const fs = require('fs');
+const p = {str(tmp_path / "ui.js")!r};
+fs.writeFileSync(p, 'function loadSession(sid){{ return rows; }}\\n');
+const origRead = fs.readFileSync;
+fs.readFileSync = function(path, enc){{
+  // Simulate a partial read racing a concurrent rewrite: return half.
+  const full = origRead(path, 'utf8');
+  return full.slice(0, Math.floor(full.length / 2));
+}};
+{node_validated_read_snippet()}
+try {{
+  readValidated(p);
+  console.log('NO_ERROR');
+}} catch(e) {{
+  console.log('EXPECTED_ERROR: ' + e.message);
+}}
+"""
+    result = subprocess.run(
+        [node, "-e", script],
+        cwd=str(tmp_path),
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "EXPECTED_ERROR: source read incomplete" in result.stdout, result.stdout

--- a/tests/test_js_source_loader.py
+++ b/tests/test_js_source_loader.py
@@ -1,6 +1,6 @@
 """Regression tests for the race-safe JS source loader (issue #6972).
 
-The serial JS/DOM harness suites were flaky under load: a truncated read of
+The serial JS/DOM harness tests were flaky under load: a truncated read of
 ``static/ui.js`` (partial read observed mid-rewrite or under I/O starvation)
 was handed to textual brace matching, which then returned a garbled fragment
 instead of failing loudly. These tests prove the shared loader retries on a
@@ -160,3 +160,231 @@ try {{
     )
     assert result.returncode == 0, result.stderr
     assert "EXPECTED_ERROR: source read incomplete" in result.stdout, result.stdout
+
+
+# --- Regression tests for the three defects fixed in #7023 ---
+#
+# 1. Zero-byte stat/read must be rejected (fail-closed, not silently "").
+# 2. A stat() that observes a partial nonzero rewrite must not be accepted.
+# 3. A stable replacement of a *different* size between attempts must be
+#    accepted (metadata recomputed per attempt, not frozen once).
+
+
+def test_read_js_source_rejects_zero_byte_file(tmp_path, monkeypatch):
+    """Regression 1a: a zero-byte source must raise SourceReadError, never
+    return "" (which brace matching would silently mangle)."""
+    real = tmp_path / "ui.js"
+    real.write_text("", encoding="utf-8")
+
+    with pytest.raises(SourceReadError, match="zero-byte"):
+        read_js_source(real, retry_delay_seconds=0.001)
+
+
+def test_read_js_source_rejects_zero_byte_read_even_with_nonzero_stat(tmp_path, monkeypatch):
+    """Regression 1b: a read that returns 0 bytes while stat reports a
+    non-zero size (file truncated between stat and read) must fail closed."""
+    real = tmp_path / "ui.js"
+    full_text = "function loadSession(sid){ return rows; }\n"
+    real.write_text(full_text, encoding="utf-8")
+
+    def fake_read_bytes(self):
+        return b""
+
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    with pytest.raises(SourceReadError, match="zero-byte"):
+        read_js_source(real, retry_delay_seconds=0.001)
+
+
+def test_read_js_source_rejects_partial_rewrite_observed_by_stat(sample_source, monkeypatch):
+    """Regression 2: stat() observing a partial nonzero rewrite must not be
+    accepted even when the read matches that partial size.
+
+    The reviewer reproduced this: a 41-byte file paused mid-rewrite was
+    observed as 31 bytes by the single stat() and the 31-byte read was
+    accepted. With per-attempt pre/post identity validation, the attempt
+    whose post-read stat differs from its pre-read stat is discarded.
+    """
+    real, full_text = sample_source
+    full_bytes = full_text.encode("utf-8")
+    partial_bytes = full_bytes[:31]
+    state = {"calls": 0}
+
+    def fake_stat(self):
+        # Stat 1 (pre-read of attempt 0): observes partial rewrite (31 bytes).
+        # Stat 2 (post-read of attempt 0): file has grown to full size.
+        # Stats 3+ (attempt 1): stable at full size.
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return _StatLike(len(partial_bytes), ino=100, mtime_ns=1)
+        return _StatLike(len(full_bytes), ino=100, mtime_ns=2)
+
+    def fake_read_bytes(self):
+        # First read returns the partial bytes; subsequent reads return full.
+        if state["calls"] == 1:
+            return partial_bytes
+        return full_bytes
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    text = read_js_source(real, retry_delay_seconds=0.001)
+    assert text == full_text
+
+
+class _StatLike:
+    """Minimal stand-in for os.stat_result used by the monkeypatched stat."""
+
+    def __init__(self, size, *, ino, mtime_ns):
+        self.st_size = size
+        self.st_ino = ino
+        self.st_mtime_ns = mtime_ns
+
+
+def test_read_js_source_accepts_stable_different_size_between_attempts(sample_source, monkeypatch):
+    """Regression 3: a stable replacement of a different size between the
+    initial stat and the first read must be accepted, not rejected for all
+    attempts (expected_size frozen once)."""
+    real, full_text = sample_source
+    full_bytes = full_text.encode("utf-8")
+    state = {"calls": 0}
+
+    def fake_stat(self):
+        # Stat 1 (pre-read of attempt 0): observes the *old* size.
+        # Stat 2 (post-read of attempt 0): file already replaced -> new size.
+        # Stats 3+ (attempt 1): stable at the new size.
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return _StatLike(9, ino=100, mtime_ns=1)
+        return _StatLike(len(full_bytes), ino=100, mtime_ns=2)
+
+    def fake_read_bytes(self):
+        # Every read returns the new (larger) content — the file was already
+        # replaced by the time the first read ran.
+        return full_bytes
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    text = read_js_source(real, retry_delay_seconds=0.001)
+    assert text == full_text
+
+
+def test_read_js_source_require_tail_enforces_eof_sentinel(tmp_path):
+    """The EOF sentinel must be enforced for extraction sources
+    (require_tail=True), so a partial rewrite that passes size checks still
+    fails closed instead of feeding truncated text to brace matching."""
+    real = tmp_path / "ui.js"
+    full_text = "function loadSession(sid){\n  return rows;\n}\n"
+    real.write_text(full_text, encoding="utf-8")
+
+    text = read_js_source(real, expected_tail="  return rows;\n}\n", require_tail=True)
+    assert text == full_text
+
+    # Wrong/missing sentinel -> fail closed even though size matches.
+    with pytest.raises(SourceReadError, match="EOF sentinel missing"):
+        read_js_source(real, expected_tail="/* never-present */", require_tail=True)
+    # Caller contract: require_tail=True demands a sentinel value.
+    with pytest.raises(ValueError, match="require_tail=True requires expected_tail"):
+        read_js_source(real, expected_tail=None, require_tail=True)
+
+
+def _run_node_read_script(tmp_path, node_body: str) -> str:
+    """Run a Node script built on the shared snippet; return stdout or raise
+    with stderr on failure."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the Node-side snippet check")
+    script = (
+        "const fs = require('fs');\n"
+        f"const p = {str(tmp_path / 'ui.js')!r};\n"
+        + node_body
+        + "\n"
+        + node_validated_read_snippet()
+        + "\ntry {\n"
+        "  const src = readValidated(p);\n"
+        "  console.log('RESULT:' + src);\n"
+        "} catch(e) {\n"
+        "  console.log('EXPECTED_ERROR: ' + e.message);\n"
+        "}\n"
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        cwd=str(tmp_path),
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    # console.log adds a trailing newline after the content; strip exactly one.
+    return result.stdout.removesuffix("\n")
+
+
+def test_node_validated_read_snippet_rejects_zero_byte(tmp_path):
+    """Regression 1 (Node): zero-byte stat/read must throw, not return ''."""
+    full = "function loadSession(sid){ return rows; }\n"
+    (tmp_path / "ui.js").write_text(full, encoding="utf-8")
+    stdout = _run_node_read_script(
+        tmp_path,
+        "fs.writeFileSync(p, '');",  # truncate to zero bytes before the read
+    )
+    assert "EXPECTED_ERROR: source read incomplete" in stdout, stdout
+
+
+def test_node_validated_read_snippet_rejects_partial_rewrite_observed_by_stat(tmp_path):
+    """Regression 2 (Node): stat() observing a partial nonzero rewrite must
+    not be accepted even when the read matches that partial size."""
+    full = "function loadSession(sid){ return rows; }\n"
+    (tmp_path / "ui.js").write_text(full, encoding="utf-8")
+    full_len = len(full.encode("utf-8"))
+    partial_len = 31
+    stdout = _run_node_read_script(
+        tmp_path,
+        (
+            "const realStat = fs.statSync;\n"
+            "const realRead = fs.readFileSync;\n"
+            "let statCalls = 0;\n"
+            "fs.statSync = function(path){\n"
+            "  statCalls++;\n"
+            "  // Attempt 0 pre-read stat observes a 31-byte partial rewrite.\n"
+            "  if(statCalls === 1) return { size: 31, ino: 100, mtimeNs: 1 };\n"
+            "  // Attempt 0 post-read stat observes the full 41-byte file.\n"
+            "  if(statCalls === 2) return { size: " + str(full_len) + ", ino: 100, mtimeNs: 2 };\n"
+            "  // Attempt 1: stable at full size.\n"
+            "  return realStat(path);\n"
+            "};\n"
+            "fs.readFileSync = function(path, enc){\n"
+            "  const full = realRead(path, 'utf8');\n"
+            "  // Attempt 0 read returns the 31-byte partial view.\n"
+            "  if(statCalls === 1) return full.slice(0, " + str(partial_len) + ");\n"
+            "  return full;\n"
+            "};\n"
+        ),
+    )
+    # Must NOT accept the 31-byte fragment; must retry and return full content.
+    assert "RESULT:" in stdout, stdout
+    assert stdout.split("RESULT:")[1] == full, stdout
+
+
+def test_node_validated_read_snippet_accepts_stable_different_size_between_attempts(tmp_path):
+    """Regression 3 (Node): a stable replacement of a different size between
+    attempts must be accepted (metadata recomputed per attempt)."""
+    new_full = "function loadSession(sid){ return rows; }\n"
+    (tmp_path / "ui.js").write_text(new_full, encoding="utf-8")
+    stdout = _run_node_read_script(
+        tmp_path,
+        (
+            "const realStat = fs.statSync;\n"
+            "let statCalls = 0;\n"
+            "fs.statSync = function(path){\n"
+            "  statCalls++;\n"
+            "  // Attempt 0 pre-read stat observes the *old* 9-byte size.\n"
+            "  if(statCalls === 1) return { size: 9, ino: 100, mtimeNs: 1 };\n"
+            "  // Attempt 0 post-read stat (and attempt 1) observe the stable\n"
+            "  // new size — the file was legitimately replaced.\n"
+            "  return realStat(path);\n"
+            "};\n"
+        ),
+    )
+    assert "RESULT:" in stdout, stdout
+    assert stdout.split("RESULT:")[1] == new_full, stdout

--- a/tests/test_js_source_loader.py
+++ b/tests/test_js_source_loader.py
@@ -17,9 +17,12 @@ from pathlib import Path
 import pytest
 
 from tests.js_source_loader import (
+    EXTRACTION_TAILS,
     MAX_READ_ATTEMPTS,
     SourceReadError,
+    node_validated_read_options,
     node_validated_read_snippet,
+    read_extraction_source,
     read_js_source,
 )
 
@@ -289,12 +292,19 @@ def test_read_js_source_require_tail_enforces_eof_sentinel(tmp_path):
         read_js_source(real, expected_tail=None, require_tail=True)
 
 
-def _run_node_read_script(tmp_path, node_body: str) -> str:
+def _run_node_read_script(tmp_path, node_body: str, read_call: str | None = None) -> str:
     """Run a Node script built on the shared snippet; return stdout or raise
-    with stderr on failure."""
+    with stderr on failure.
+
+    ``node_body`` is injected before the snippet (mock setup etc.).
+    ``read_call`` defaults to ``const src = readValidated(p);``; pass a
+    custom call (e.g. with extraction-tail options) to exercise it.
+    """
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required for the Node-side snippet check")
+    if read_call is None:
+        read_call = "const src = readValidated(p);"
     script = (
         "const fs = require('fs');\n"
         f"const p = {str(tmp_path / 'ui.js')!r};\n"
@@ -302,8 +312,8 @@ def _run_node_read_script(tmp_path, node_body: str) -> str:
         + "\n"
         + node_validated_read_snippet()
         + "\ntry {\n"
-        "  const src = readValidated(p);\n"
-        "  console.log('RESULT:' + src);\n"
+        + read_call
+        + "\n  console.log('RESULT:' + src);\n"
         "} catch(e) {\n"
         "  console.log('EXPECTED_ERROR: ' + e.message);\n"
         "}\n"
@@ -344,14 +354,16 @@ def test_node_validated_read_snippet_rejects_partial_rewrite_observed_by_stat(tm
             "const realStat = fs.statSync;\n"
             "const realRead = fs.readFileSync;\n"
             "let statCalls = 0;\n"
-            "fs.statSync = function(path){\n"
+            "fs.statSync = function(path, opts){\n"
             "  statCalls++;\n"
             "  // Attempt 0 pre-read stat observes a 31-byte partial rewrite.\n"
-            "  if(statCalls === 1) return { size: 31, ino: 100, mtimeNs: 1 };\n"
+            "  // BigInt fields: the snippet reads with { bigint: true } and\n"
+            "  // requires BigInt size/mtimeNs (parity with the Python path).\n"
+            "  if(statCalls === 1) return { size: 31n, ino: 100n, mtimeNs: 1n };\n"
             "  // Attempt 0 post-read stat observes the full 41-byte file.\n"
-            "  if(statCalls === 2) return { size: " + str(full_len) + ", ino: 100, mtimeNs: 2 };\n"
+            "  if(statCalls === 2) return { size: " + str(full_len) + "n, ino: 100n, mtimeNs: 2n };\n"
             "  // Attempt 1: stable at full size.\n"
-            "  return realStat(path);\n"
+            "  return realStat(path, opts);\n"
             "};\n"
             "fs.readFileSync = function(path, enc){\n"
             "  const full = realRead(path, 'utf8');\n"
@@ -376,15 +388,106 @@ def test_node_validated_read_snippet_accepts_stable_different_size_between_attem
         (
             "const realStat = fs.statSync;\n"
             "let statCalls = 0;\n"
-            "fs.statSync = function(path){\n"
+            "fs.statSync = function(path, opts){\n"
             "  statCalls++;\n"
             "  // Attempt 0 pre-read stat observes the *old* 9-byte size.\n"
-            "  if(statCalls === 1) return { size: 9, ino: 100, mtimeNs: 1 };\n"
+            "  // BigInt fields: the snippet reads with { bigint: true } and\n"
+            "  // requires BigInt size/mtimeNs (parity with the Python path).\n"
+            "  if(statCalls === 1) return { size: 9n, ino: 100n, mtimeNs: 1n };\n"
             "  // Attempt 0 post-read stat (and attempt 1) observe the stable\n"
             "  // new size — the file was legitimately replaced.\n"
-            "  return realStat(path);\n"
+            "  return realStat(path, opts);\n"
             "};\n"
         ),
     )
     assert "RESULT:" in stdout, stdout
     assert stdout.split("RESULT:")[1] == new_full, stdout
+
+
+# --- Round-3 regressions (#7023 re-gate) ---
+#
+# 1. Extraction sources must enforce the registered EOF tail (Python and
+#    Node), and the tail registry itself must not drift from the real files.
+# 2. The Node snippet must use BigInt stats; a stat without mtimeNs (the
+#    old dead-code shape) must throw instead of passing silently.
+
+
+def test_extraction_tail_registry_matches_real_static_files():
+    """Every EXTRACTION_TAILS entry must be an exact suffix of the real
+    static file it names — a drift in a registered source's final line
+    fails loudly here instead of silently weakening the EOF sentinel.
+
+    Also proves each registered source can be read end-to-end through
+    ``read_extraction_source`` (the extraction entry point)."""
+    root = Path(__file__).resolve().parents[1]
+    assert EXTRACTION_TAILS, "tail registry must not be empty"
+    for name, tail in EXTRACTION_TAILS.items():
+        real = root / "static" / name
+        assert real.is_file(), f"registered extraction source missing: {real}"
+        text = real.read_text(encoding="utf-8")
+        assert text.endswith(tail), (
+            f"extraction tail for {name} drifted: {tail!r} is no longer a "
+            f"suffix of static/{name}; update EXTRACTION_TAILS in "
+            "tests/js_source_loader.py"
+        )
+        # The extraction path must succeed on the real file (tail enforced).
+        assert read_extraction_source(real) == text
+
+
+def test_read_extraction_source_rejects_stable_partial_rewrite(tmp_path):
+    """A *stable* partial rewrite — the file is smaller but consistent
+    between attempts, so size/identity checks pass — must still fail closed
+    via the registered EOF tail sentinel instead of reaching extraction."""
+    root = Path(__file__).resolve().parents[1]
+    real_ui = root / "static" / "ui.js"
+    partial = real_ui.read_bytes()[: real_ui.stat().st_size // 2]
+    target = tmp_path / "ui.js"
+    target.write_bytes(partial)
+
+    with pytest.raises(SourceReadError, match="EOF sentinel missing"):
+        read_extraction_source(target, retry_delay_seconds=0.001)
+
+
+def test_read_extraction_source_refuses_unregistered_source(tmp_path):
+    """A source without a registered tail must raise ValueError — a new
+    extraction source can never silently read without the sentinel."""
+    target = tmp_path / "mystery.js"
+    target.write_text("function x(){ return 1; }\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="no registered extraction tail"):
+        read_extraction_source(target)
+
+
+def test_node_validated_read_snippet_requires_registered_tail(tmp_path):
+    """Node parity for extraction: readValidated with the registry options
+    must reject a stable partial source (identity/size consistent, tail
+    missing) exactly like the Python path."""
+    full = "function loadSession(sid){\n  return rows;\n}\n"
+    (tmp_path / "ui.js").write_text(full[: len(full) // 2], encoding="utf-8")
+    stdout = _run_node_read_script(
+        tmp_path,
+        "",
+        read_call=(
+            "const src = readValidated(p, "
+            + node_validated_read_options(Path("static") / "ui.js")
+            + ");"
+        ),
+    )
+    assert "EXPECTED_ERROR: source read incomplete" in stdout, stdout
+
+
+def test_node_validated_read_snippet_throws_on_stat_without_bigint_fields(tmp_path):
+    """The Node mtimeNs check must never be dead code: a stat result without
+    BigInt fields (the old `fs.statSync(p)` shape, where mtimeNs is
+    undefined) throws instead of silently passing the identity check."""
+    full = "function loadSession(sid){ return rows; }\n"
+    (tmp_path / "ui.js").write_text(full, encoding="utf-8")
+    stdout = _run_node_read_script(
+        tmp_path,
+        (
+            "fs.statSync = function(path, opts){\n"
+            "  // Non-bigint stat: mtimeNs absent -> the snippet must throw.\n"
+            "  return { size: " + str(len(full.encode("utf-8"))) + ", ino: 100 };\n"
+            "};\n"
+        ),
+    )
+    assert "EXPECTED_ERROR: source stat missing BigInt" in stdout, stdout

--- a/tests/test_static_asset_resolver.py
+++ b/tests/test_static_asset_resolver.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 import api.config as api_config
 import api.routes as routes
 from api.updates import WEBUI_VERSION
+from tests.js_source_loader import read_js_source
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -124,7 +125,7 @@ def test_index_shell_and_static_route_use_selected_root(tmp_path, monkeypatch):
     temp_static = _get("/static/ui.js")
     assert temp_static.status == 200
     assert bytes(temp_static.body) == b"console.log('temp static');\n"
-    assert bytes(temp_static.body) != (ROOT / "static" / "ui.js").read_bytes()
+    assert bytes(temp_static.body) != read_js_source(ROOT / "static" / "ui.js").encode("utf-8")
 
     traversal = _get("/static/../api/routes.py")
     assert traversal.status == 404


### PR DESCRIPTION
## Summary

Fixes #6972 — the serial test suite (`pytest tests/ -p no:xdist`) is flaky under CPU/I/O load: JS/DOM-harness tests fail non-deterministically with a **truncated `static/ui.js` read** during function extraction, and pass in isolation. The failure set shifts between runs (23 failed → 1 failed on the same tree), confirming load-sensitive test-infra flakiness, not a code regression.

The shared symptom: a partial read of the ~1MB `static/ui.js` is handed to textual brace matching, which then returns a garbled, syntactically unrelated fragment (e.g. `loadSession` jumping into an object literal) instead of failing loudly.

## Root cause / fix shape

Per the issue's fix shape:

1. **Shared source loader** — new `tests/js_source_loader.py` centralizes the read used by the affected harnesses:
   - reads the file once and **validates byte length against `stat()`** (plus optional expected-tail sentinel) before extraction;
   - **retries** bounded times on a partial read (short backoff, no sleeps/widened timeouts);
   - **fails closed** with an explicit `SourceReadError` instead of returning a truncated fragment that brace matching would silently mangle.
   - A matching **Node snippet** (`node_validated_read_snippet()`) provides the same defense for the `node -e` harnesses.
2. **Harness migration** — the affected tests now read through the validated loader:
   - `test_issue5720_reasoning_owner.py` (also: replaced process-global `env.setdefault` with direct assignment so a stale env value cannot redirect the read)
   - `test_extension_settings_runtime.py`
   - `test_static_asset_resolver.py`
   - `test_anchor_fallback_ownership.py`
   - `test_auto_compression_card.py`
   - `test_claude_code_session_import.py`
3. **Regression** — `tests/test_js_source_loader.py` forces partial reads and proves the harness **retries until stable** and **fails closed** (`SourceReadError`) when the read never completes; the Node snippet is verified against both a full file and a simulated truncation race.

The unrelated `time.monotonic()` worker-slot flake (`test_issue5210_http_worker_bound`) is intentionally left untouched, per the issue guidance.

## Test plan

Via `./scripts/test.sh` (never raw pytest):

- `tests/test_js_source_loader.py` — 6 passed (new regression)
- `tests/test_issue5720_reasoning_owner.py tests/test_extension_settings_runtime.py tests/test_static_asset_resolver.py tests/test_anchor_fallback_ownership.py tests/test_auto_compression_card.py tests/test_auto_compression_terminal_failure.py tests/test_claude_code_session_import.py` — 118 passed
- Neighboring JS-harness batch (issue5367, issue3820, issue5700, issue6209, live_to_final_anchor_visible_order, issue4793) — 145 passed
- `ruff check` — clean

Closes #6972