### PR TITLE
fix(sessions): import subagent parent rows dropped by recency window

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -495,6 +495,275 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
     return projected
 
 
+# Safety belt for the ancestor walk below. Real delegation nests at most
+# ``max_spawn_depth`` (2) levels, so 8 hops is far beyond any legitimate chain;
+# it exists purely so a corrupt/cyclic ``parent_session_id`` chain in state.db
+# can never spin the sidebar request forever.
+_SUBAGENT_ANCESTOR_MAX_HOPS = 8
+
+
+def _rescue_row_source(row: dict) -> str:
+    """Return the raw source name used by the ancestor-rescue stop rules.
+
+    ``_with_normalized_source`` collapses unknown raws (including ``subagent``)
+    into ``session_source='other'``, so the coarse bucket cannot drive these
+    rules. Read the raw value the SQL filters also see, falling back to the
+    normalized copies for rows that only carry those.
+    """
+    for key in ('source', 'raw_source', 'session_source'):
+        name = _normalize_source_name(row.get(key))
+        if name:
+            return name
+    return ""
+
+
+def _rescue_row_passes_source_filters(
+    row: dict,
+    included: tuple[str, ...],
+    excluded: tuple[str, ...],
+) -> bool:
+    """Mirror this call's own ``include_sources``/``exclude_sources`` SQL filter.
+
+    An ancestor rescued from outside the candidate window must never smuggle a
+    source the caller explicitly filtered out (e.g. a cron/webhook parent) past
+    that filter. Compared exactly (case-sensitively) against the raw
+    ``sessions.source`` value, because that is precisely what the ``s.source IN
+    (...)`` / ``s.source NOT IN (...)`` clauses compare.
+    """
+    source = str(row.get('source') or '')
+    if included and source not in included:
+        return False
+    if excluded and source in excluded:
+        return False
+    return True
+
+
+def _index_rows_for_ancestor_lookup(rows: list[dict]) -> dict[str, dict]:
+    """Map every id a ``parent_session_id`` may point at to its projected row.
+
+    ``_project_agent_session_rows`` collapses a compression chain into ONE row
+    whose ``id`` is the latest importable segment, so a ``parent_session_id``
+    that names the chain head (or any middle segment) will not match any
+    projected ``id``. Index the lineage root/tip aliases as well so such a
+    parent resolves to the row that actually represents that conversation
+    instead of being re-fetched and emitted as a duplicate sidebar row.
+    Real ids win over aliases: fill them first, then alias with ``setdefault``.
+    """
+    index: dict[str, dict] = {}
+    for row in rows:
+        row_id = row.get('id')
+        if row_id:
+            index[str(row_id)] = row
+    for row in rows:
+        for alias in (row.get('_lineage_root_id'), row.get('_lineage_tip_id')):
+            if alias:
+                index.setdefault(str(alias), row)
+    return index
+
+
+def _fetch_ancestor_session_rows(
+    cur,
+    session_ids: list[str],
+    *,
+    select_sql: str,
+    join_clause: str,
+    group_by_clause: str,
+    log=None,
+) -> list[dict]:
+    """Read specific ancestor sessions with the main projection's columns.
+
+    Reuses the caller's already-open READ-ONLY cursor (#5455: the listing path
+    must not open a write-capable handle on the live WAL state.db) and the very
+    same ``select_sql``/join/group-by the main query built, so a rescued row
+    carries byte-identical columns to a row that made the window on its own.
+
+    Ids are bound as parameters, never interpolated (see
+    ``tests/test_issue3930_source_filter_pushdown.py``, which asserts the
+    listing path pushes filters down as bound parameters).
+
+    Any ``sqlite3.Error`` degrades to "no rescue" rather than propagating: this
+    function is the ONLY source of agent rows for the sidebar, so an exception
+    escaping here would empty the sidebar entirely — strictly worse than the
+    orphaned-child rendering this rescue exists to fix.
+    """
+    ids = [str(sid) for sid in session_ids if sid]
+    if not ids:
+        return []
+    placeholders = ", ".join("?" for _ in ids)
+    try:
+        cur.execute(
+            f"""
+            {select_sql}
+            FROM sessions s
+            {join_clause}
+            WHERE s.id IN ({placeholders})
+            {group_by_clause}
+            """,
+            ids,
+        )
+        return [dict(row) for row in cur.fetchall()]
+    except sqlite3.Error as exc:
+        (log or logger).warning(
+            "subagent ancestor rescue lookup failed (%s); listing %d subagent parent id(s) "
+            "un-rescued this pass",
+            exc,
+            len(ids),
+        )
+        return []
+
+
+def _rescue_missing_subagent_ancestors(
+    selected: list[dict],
+    projected: list[dict],
+    candidate_rows: list[dict],
+    cur,
+    *,
+    select_sql: str,
+    join_clause: str,
+    group_by_clause: str,
+    included: tuple[str, ...] = (),
+    excluded: tuple[str, ...] = (),
+    log=None,
+) -> list[dict]:
+    """Re-add the parent rows a visible ``subagent`` row needs to stay nested.
+
+    Why this exists: the sidebar window is recency-ordered and hard-sliced at
+    ``limit`` (20 for ``get_cli_sessions``). A frozen ``delegate_task``
+    orchestrator stops writing messages the moment its leaves take over, so the
+    still-streaming leaves keep the recency they inherited while the quiet
+    orchestrator parent sinks below the cut — recency-window eviction. The leaf
+    still carries ``relationship_type='child_session'`` + ``parent_session_id``,
+    but with the parent ROW gone from the payload
+    ``static/sessions.js::_attachChildSessionsToSidebarRows`` cannot resolve
+    ``visibleBySid.get(parentSid)`` and promotes the leaf to a contextless
+    top-level "Subagent Session" row with a branch icon.
+
+    Contract: if a ``source='subagent'`` row is returned, every ancestor on its
+    ``parent_session_id`` chain is returned too, unless the walk legitimately
+    stops (see the stop rules below). Ancestors are ADDED, never substituted:
+    a visible leaf is never evicted to make room for its parent, so the returned
+    list MAY exceed ``limit`` by the number of rescued ancestors. That is
+    intended — an over-long list renders correctly, a half-nested one does not.
+
+    Stop rules (break the walk, append nothing further):
+      * parent row missing/deleted, or not projectable (e.g. zero messages, so
+        ``_project_agent_session_rows`` drops it) — an unprojectable parent
+        leaves the leaf orphaned exactly as it is today (pre-existing
+        behaviour), and continuing to the grandparent would not help because the
+        client nests strictly by ``parent_session_id``.
+      * parent is a WebUI session — do NOT append. The WebUI parent chat is
+        already in the ``/api/sessions`` payload from its own JSON sidecar
+        (``all_sessions()``); a second state.db projection of it would render as
+        a ghost CLI duplicate (see ``represented_webui_ids`` /
+        ``_is_duplicate_webui_state_projection`` in ``api/routes.py``).
+      * parent's source is filtered out by this call's own
+        ``include_sources``/``exclude_sources``.
+      * parent fails ``is_cli_session_row_visible()``.
+      * parent already present in the result (contract already satisfied).
+      * the chain revisits an id (cycle) or exceeds ``_SUBAGENT_ANCESTOR_MAX_HOPS``.
+
+    No-op guarantee: when the selected window holds no ``subagent`` row, the
+    ORIGINAL ``selected`` list object is returned untouched and no extra SQL is
+    issued, so non-delegating deployments see byte-identical output and cost.
+    """
+    if not selected:
+        return selected
+
+    # Only walk parents of rows ALREADY selected — never import the whole
+    # subagent table. No subagent leaf in the window ⇒ nothing can be orphaned.
+    walks: list[tuple[str, set[str]]] = []
+    for row in selected:
+        if _rescue_row_source(row) != 'subagent':
+            continue
+        parent_id = row.get('parent_session_id')
+        row_id = row.get('id')
+        if parent_id:
+            walks.append((str(parent_id), {str(row_id)} if row_id else set()))
+    if not walks:
+        return selected
+
+    have = {str(row['id']) for row in selected if row.get('id')}
+    result = list(selected)
+    rescued_any = False
+    # Resolve from the limit*8 oversample first: the parent is usually just
+    # below the slice, already projected and normalized, so the common case
+    # costs one dict lookup and zero extra SQL.
+    rows_by_id = _index_rows_for_ancestor_lookup(projected)
+
+    for _hop in range(_SUBAGENT_ANCESTOR_MAX_HOPS):
+        if not walks:
+            break
+
+        # One targeted query per hop level for the ids the oversample missed.
+        unresolved = []
+        for parent_id, _seen in walks:
+            if parent_id not in rows_by_id and parent_id not in unresolved:
+                unresolved.append(parent_id)
+        if unresolved:
+            fetched = _fetch_ancestor_session_rows(
+                cur,
+                unresolved,
+                select_sql=select_sql,
+                join_clause=join_clause,
+                group_by_clause=group_by_clause,
+                log=log,
+            )
+            if fetched:
+                # Project the fetched ancestors ALONGSIDE the candidate rows so
+                # they pick up the same lineage/relationship metadata the main
+                # path would have given them had they made the window. Copies
+                # are projected so the candidate dicts stay untouched, and only
+                # the requested ancestor ids are harvested — the already
+                # selected rows are never re-derived.
+                reprojected = _project_agent_session_rows(
+                    [dict(row) for row in candidate_rows] + [dict(row) for row in fetched]
+                )
+                reprojected = [_with_normalized_source(row) for row in reprojected]
+                reprojected_by_id = _index_rows_for_ancestor_lookup(reprojected)
+                for parent_id in unresolved:
+                    resolved = reprojected_by_id.get(parent_id)
+                    if resolved is not None:
+                        rows_by_id.setdefault(parent_id, resolved)
+
+        next_walks: list[tuple[str, set[str]]] = []
+        for parent_id, seen in walks:
+            if parent_id in seen:
+                continue  # cycle in parent_session_id — stop this walk
+            parent = rows_by_id.get(parent_id)
+            if parent is None:
+                continue  # missing/deleted or unprojectable parent — stop
+            resolved_id = str(parent.get('id') or parent_id)
+            if resolved_id in have:
+                continue  # already satisfied
+            if _rescue_row_source(parent) == 'webui':
+                continue  # WebUI parent ships via its own sidecar — stop, no dup
+            if not _rescue_row_passes_source_filters(parent, included, excluded):
+                continue  # never smuggle a filtered-out source past the caller
+            if not is_cli_session_row_visible(parent):
+                continue  # hidden parent cannot host the child row anyway
+
+            result.append(parent)
+            have.add(resolved_id)
+            rescued_any = True
+
+            grandparent_id = parent.get('parent_session_id')
+            if grandparent_id:
+                next_walks.append((str(grandparent_id), seen | {parent_id, resolved_id}))
+        walks = next_walks
+
+    if not rescued_any:
+        return selected
+
+    # Keep the payload recency-ordered with the SAME key the projection used, so
+    # a rescued parent lands at its own last-activity position instead of being
+    # tacked onto the end of the sidebar.
+    result.sort(
+        key=lambda row: _as_score(row.get('last_activity'), row.get('started_at')),
+        reverse=True,
+    )
+    return result
+
+
 def read_importable_agent_session_rows(
     db_path: Path,
     limit: int | None = 200,
@@ -517,6 +786,15 @@ def read_importable_agent_session_rows(
     ``exclude_sources=None``. ``include_sources`` is an additional narrowing
     filter; callers that want an include-only query should explicitly pass
     ``exclude_sources=None`` so the default exclusions do not also apply.
+
+    ``limit`` bounds the recency window, but the returned list MAY exceed it:
+    when a visible ``source='subagent'`` row would otherwise be returned without
+    its ``parent_session_id`` ancestor (recency-window eviction of a frozen
+    delegate_task orchestrator), those ancestors are ADDED back so the client can
+    still nest the child instead of promoting it to a top-level orphan row. No
+    selected row is ever evicted to make room, and with no subagent rows in the
+    window the result is exactly ``projected[:limit]`` as before. See
+    ``_rescue_missing_subagent_ancestors`` for the walk's stop rules.
     """
     db_path = Path(db_path)
     if not db_path.exists():
@@ -637,6 +915,7 @@ def read_importable_agent_session_rows(
         where_clauses = ["s.source IS NOT NULL"]
         params: list[object] = []
         included = ()
+        excluded = ()
         if include_sources:
             included = tuple(str(source) for source in include_sources if source)
             if included:
@@ -761,12 +1040,35 @@ def read_importable_agent_session_rows(
                 """,
                 params,
             )
-        projected = _project_agent_session_rows([dict(row) for row in cur.fetchall()])
+        candidate_rows = [dict(row) for row in cur.fetchall()]
+        projected = _project_agent_session_rows([dict(row) for row in candidate_rows])
         projected = [_with_normalized_source(row) for row in projected]
         projected = [row for row in projected if is_cli_session_row_visible(row)]
         if limit is None:
             return projected
-        return projected[:max(0, int(limit))]
+        selected = projected[:max(0, int(limit))]
+        # A delegated ``subagent`` leaf is rendered NESTED under its parent row.
+        # The hard slice above is recency-ordered, and a frozen delegate_task
+        # orchestrator loses recency to its still-writing leaves — so the leaf
+        # survives the window while its parent is evicted, and the client
+        # (static/sessions.js::_attachChildSessionsToSidebarRows) promotes the
+        # parentless leaf to a contextless top-level "Subagent Session" row.
+        # Re-add (never substitute) the ancestors those visible leaves need.
+        # Runs inside the `with closing(conn):` block on purpose: ancestors that
+        # fell outside the oversampled candidate window need this same
+        # already-open READ-ONLY cursor (#5455).
+        return _rescue_missing_subagent_ancestors(
+            selected,
+            projected,
+            candidate_rows,
+            cur,
+            select_sql=select_sql,
+            join_clause=join_clause,
+            group_by_clause=group_by_clause,
+            included=included,
+            excluded=excluded,
+            log=log,
+        )
 
 
 

--- a/tests/test_subagent_sidebar_ancestor_import.py
+++ b/tests/test_subagent_sidebar_ancestor_import.py
@@ -1,0 +1,481 @@
+"""Regression tests: a visible subagent leaf must keep its orchestrator parent row.
+
+Mechanism being pinned (sidebar "orphan promotion"):
+
+``api/models.py: get_cli_sessions()`` builds the interactive sidebar window by
+calling ``agent_sessions.read_importable_agent_session_rows(..., limit=
+CLI_VISIBLE_SESSION_LIMIT)``. That projection orders rows by real recency
+(``MAX(messages.timestamp)``) and then HARD-SLICES the result to ``limit``.
+
+A ``delegate_task`` orchestrator is frozen while its delegated children run: the
+orchestrator's own last message is old, while its subagent leaves are still
+writing messages *right now*. So the leaves win the recency race, survive the
+slice, and the quieter orchestrator PARENT is evicted from the payload.
+
+The leaf row still carries ``relationship_type='child_session'`` and
+``parent_session_id=<orchestrator>``, but with no parent ROW in the payload the
+client (``static/sessions.js: _attachChildSessionsToSidebarRows()``) has nothing
+to nest it under, so it promotes the orphan to a TOP-LEVEL "Subagent Session"
+row in the sidebar. From the user's point of view a background delegation
+suddenly appears as a peer conversation next to their real chats.
+
+The contract these tests pin: after the recency slice, every selected
+``source='subagent'`` row's missing ancestors are ADDED back (never swapped in
+by evicting a selected row), walking ``parent_session_id`` upward and stopping
+at a ``webui`` ancestor, a missing parent, a cycle, or a source the caller's own
+filters exclude. Raising ``CLI_VISIBLE_SESSION_LIMIT`` is explicitly NOT the
+fix, so every test here runs at a small, deterministic limit.
+
+Black-box by construction: these tests only touch the public surface
+``read_importable_agent_session_rows()`` and ``get_cli_sessions()``.
+"""
+
+import sqlite3
+import time
+
+import pytest
+
+from api import models
+from api.agent_sessions import read_importable_agent_session_rows
+
+# Fixed epoch base so ordering is explicit and never depends on the real clock.
+T = 1_760_000_000.0
+
+# Mirrors the exclusions api/models.py uses for the interactive sidebar window,
+# i.e. background sources are handled by their own bounded passes while
+# ``webui`` rows stay eligible. Keeping webui eligible is what makes the
+# "do not force-import the webui ancestor" assertion in this file meaningful.
+SIDEBAR_EXCLUDES = ("cron", "webhook", "kanban")
+
+
+def _session(sid, source, last_activity, *, parent=None, title=None,
+             ended_at=None, end_reason=None, session_source=None):
+    """Describe one state.db session row plus the recency that ranks it."""
+    return {
+        "id": sid,
+        "source": source,
+        "session_source": session_source,
+        "title": title or f"{sid} title",
+        "started_at": last_activity - 100.0,
+        "parent_session_id": parent,
+        "ended_at": ended_at,
+        "end_reason": end_reason,
+        "last_activity": last_activity,
+    }
+
+
+def _make_state_db(db_path, rows):
+    """Create a state.db with the given session rows and real message rows.
+
+    Real ``messages`` rows are mandatory, not decoration: the projection drops
+    any row with ``actual_message_count <= 0``, and the recency window is
+    ordered by ``MAX(messages.timestamp)``. A session with no messages is
+    silently invisible and would quietly void these tests.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO sessions
+                (id, source, session_source, title, model, started_at,
+                 message_count, parent_session_id, ended_at, end_reason)
+            VALUES (?, ?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?)
+            """,
+            (
+                row["id"], row["source"], row["session_source"], row["title"],
+                row["started_at"], row["parent_session_id"], row["ended_at"],
+                row["end_reason"],
+            ),
+        )
+        # One user + one assistant turn. The user turn matters: CLI-classified
+        # rows need a user turn to stay visible in the sidebar projection.
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', 'hi', ?)",
+            (row["id"], row["last_activity"] - 1.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'assistant', 'ok', ?)",
+            (row["id"], row["last_activity"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ids(rows):
+    return [row["id"] for row in rows]
+
+
+def _by_id(rows):
+    return {row["id"]: row for row in rows}
+
+
+def _hot_leaf_orchestrator_rows(leaf_count=4, orchestrator="orch-frozen"):
+    """The bug shape: one quiet orchestrator, N leaves with the newest activity.
+
+    The orchestrator's last message is far older than every leaf's, so the
+    recency slice keeps the leaves and evicts the parent.
+    """
+    rows = [_session(orchestrator, "subagent", T + 100.0, title="Delegated run")]
+    rows += [
+        _session(f"leaf-{i}", "subagent", T + 900.0 + i,
+                 parent=orchestrator, title=f"Subagent leaf {i}")
+        for i in range(leaf_count)
+    ]
+    return rows
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    """Point get_cli_sessions() at a temporary HERMES_HOME (see #3172 tests)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    import api.config as cfg
+    import api.profiles as profiles
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: None)
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+
+    # The CLI sessions projection is TTL-cached; drop anything a previous test
+    # left behind so this test observes its own fixture.
+    if hasattr(models, "clear_cli_sessions_cache"):
+        models.clear_cli_sessions_cache()
+
+    return home
+
+
+def test_orchestrator_parent_rescued_when_recency_window_evicts_it(tmp_path):
+    """4 hot leaves + 1 quiet orchestrator at limit=4: the parent must come back.
+
+    Unfixed, ``projected[:limit]`` keeps exactly the 4 leaves and drops the
+    orchestrator, which is what turns the leaves into top-level sidebar rows.
+    """
+    db = tmp_path / "state.db"
+    rows = _hot_leaf_orchestrator_rows(leaf_count=4)
+    # An older, unrelated CLI row that must not be dragged in by the rescue.
+    rows.append(_session("cli-old", "cli", T + 50.0, title="Old CLI chat"))
+    _make_state_db(db, rows)
+
+    result = read_importable_agent_session_rows(
+        db, limit=4, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+    leaves = [f"leaf-{i}" for i in range(4)]
+
+    # add-not-evict: the rescue must not buy room for the parent by dropping a
+    # leaf the recency window legitimately selected.
+    missing_leaves = [leaf for leaf in leaves if leaf not in got]
+    assert not missing_leaves, (
+        f"Recency-selected subagent leaves {missing_leaves} disappeared from the payload; "
+        f"the ancestor rescue must ADD the parent, never evict a selected child to make "
+        f"room for it. Returned ids: {got}"
+    )
+    assert "orch-frozen" in got, (
+        "The delegate_task orchestrator 'orch-frozen' was evicted by the recency window "
+        f"(limit=4) and never restored. Returned ids: {got}. Without the parent row in the "
+        "payload, static/sessions.js _attachChildSessionsToSidebarRows() cannot nest the "
+        "leaves and promotes them to top-level 'Subagent Session' rows in the sidebar."
+    )
+    assert "cli-old" not in got, (
+        "Unrelated older CLI row 'cli-old' was pulled into the window. The rescue must add "
+        f"ancestors of selected subagent rows only, not widen the window. Returned ids: {got}"
+    )
+
+
+def test_rescued_parent_preserves_child_relationship(tmp_path):
+    """The leaf keeps its lineage metadata AND its parent id resolves in-payload.
+
+    This pair is the exact precondition the client needs to nest the row:
+    ``relationship_type == 'child_session'`` plus a ``parent_session_id`` that
+    is present in the returned id set.
+    """
+    db = tmp_path / "state.db"
+    _make_state_db(db, _hot_leaf_orchestrator_rows(leaf_count=4))
+
+    result = read_importable_agent_session_rows(
+        db, limit=4, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+    rows_by_id = _by_id(result)
+
+    leaf = rows_by_id.get("leaf-3")
+    assert leaf is not None, (
+        f"Hot leaf 'leaf-3' should always be inside the recency window. Returned ids: {got}"
+    )
+    assert leaf.get("relationship_type") == "child_session", (
+        "Leaf lost its child_session relationship_type; the client keys nesting off this "
+        f"field. Got relationship_type={leaf.get('relationship_type')!r}"
+    )
+    assert leaf.get("parent_session_id") == "orch-frozen", (
+        "Leaf lost its parent_session_id pointer to the orchestrator. Got "
+        f"{leaf.get('parent_session_id')!r}"
+    )
+    assert leaf["parent_session_id"] in got, (
+        f"Leaf 'leaf-3' points at parent {leaf['parent_session_id']!r}, but that parent row is "
+        f"NOT in the payload (ids: {got}). A child row whose parent id does not resolve inside "
+        "the same payload is rendered as an orphan top-level sidebar row."
+    )
+
+
+def test_unrelated_rows_are_not_bulk_imported(tmp_path):
+    """The rescue must stay surgical: only ancestors of selected subagent rows.
+
+    Guards against the lazy fix of widening the query / dumping the table.
+    """
+    db = tmp_path / "state.db"
+    rows = _hot_leaf_orchestrator_rows(leaf_count=3)
+    rows.append(_session("subagent-unrelated", "subagent", T + 60.0,
+                         title="Unrelated old subagent"))
+    rows.append(_session("cli-unrelated", "cli", T + 40.0, title="Unrelated old CLI"))
+    _make_state_db(db, rows)
+
+    result = read_importable_agent_session_rows(
+        db, limit=3, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+
+    assert "subagent-unrelated" not in got, (
+        "An old subagent row that is NOT an ancestor of any selected row was imported. The "
+        f"rescue must walk parent_session_id only, not re-admit every subagent row. Ids: {got}"
+    )
+    assert "cli-unrelated" not in got, (
+        "An old unrelated CLI row was imported into a limit=3 window. The rescue must not "
+        f"widen the recency window for non-ancestors. Ids: {got}"
+    )
+
+
+def test_missing_parent_does_not_break_listing(tmp_path):
+    """A dangling parent_session_id must degrade quietly, not raise.
+
+    Subagent rows can outlive their orchestrator row (pruned/rotated state.db),
+    so the ancestor walk has to tolerate an id that resolves to nothing.
+    """
+    db = tmp_path / "state.db"
+    rows = [
+        _session("leaf-orphan", "subagent", T + 900.0,
+                 parent="orchestrator-that-was-deleted", title="Orphan leaf"),
+        _session("cli-live", "cli", T + 800.0, title="Live CLI chat"),
+    ]
+    _make_state_db(db, rows)
+
+    result = read_importable_agent_session_rows(
+        db, limit=3, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+
+    assert "leaf-orphan" in got, (
+        "A subagent leaf whose parent row does not exist was dropped from the payload. A "
+        f"dangling parent_session_id must never hide the child itself. Ids: {got}"
+    )
+    assert "orchestrator-that-was-deleted" not in got, (
+        "A parent id that has no row in sessions must not be synthesised into the payload. "
+        f"Ids: {got}"
+    )
+    assert "cli-live" in got, (
+        f"Unrelated visible rows must keep listing normally alongside the orphan. Ids: {got}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_parent_cycle_does_not_hang(tmp_path):
+    """a -> b -> a lineage must terminate; the ancestor walk needs cycle protection.
+
+    A naive `while parent_id:` walk over a corrupt/cyclic lineage spins forever
+    and hangs the whole /api/sessions request, so this asserts both liveness
+    (pytest-timeout) and a small wall-clock bound.
+    """
+    db = tmp_path / "state.db"
+    rows = [
+        _session("cycle-a", "subagent", T + 900.0, parent="cycle-b", title="Cycle A"),
+        _session("cycle-b", "subagent", T + 890.0, parent="cycle-a", title="Cycle B"),
+    ]
+    _make_state_db(db, rows)
+
+    started = time.monotonic()
+    result = read_importable_agent_session_rows(
+        db, limit=1, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 10.0, (
+        f"Listing a cyclic parent_session_id chain took {elapsed:.2f}s; the ancestor walk is "
+        "not breaking the cycle and would stall the sidebar request."
+    )
+    got = _ids(result)
+    assert "cycle-a" in got, (
+        f"The recency-selected row 'cycle-a' vanished while resolving a cyclic lineage. Ids: {got}"
+    )
+    assert len(got) == len(set(got)), (
+        f"Cyclic lineage produced duplicate rows in the payload: {got}"
+    )
+    assert len(got) <= 2, (
+        f"Cyclic lineage over 2 rows returned {len(got)} rows ({got}); the walk is re-adding "
+        "rows it already visited."
+    )
+
+
+def test_webui_ancestor_not_force_imported(tmp_path):
+    """Depth-2: webui root -> orchestrator -> leaf. Rescue the orchestrator only.
+
+    Rationale for stopping at the webui ancestor: the WebUI parent chat already
+    reaches /api/sessions from its own JSON sidecar, so importing the state.db
+    copy of it here would render a duplicate ghost row for the same
+    conversation (see ``represented_webui_ids`` in api/routes.py). One hop is
+    all the nesting contract needs.
+    """
+    db = tmp_path / "state.db"
+    rows = [
+        _session("webui-root", "webui", T + 50.0, title="Planning chat"),
+        _session("orch-frozen", "subagent", T + 120.0,
+                 parent="webui-root", title="Delegated run"),
+    ]
+    rows += [
+        _session(f"leaf-{i}", "subagent", T + 900.0 + i,
+                 parent="orch-frozen", title=f"Subagent leaf {i}")
+        for i in range(3)
+    ]
+    _make_state_db(db, rows)
+
+    # webui is deliberately NOT excluded here, so "webui-root is absent" proves
+    # the walk stopped rather than proving the SQL filter removed it.
+    result = read_importable_agent_session_rows(
+        db, limit=3, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+
+    assert "orch-frozen" in got, (
+        "The subagent orchestrator was not rescued in a depth-2 lineage "
+        f"(webui-root -> orch-frozen -> leaf-*). Returned ids: {got}"
+    )
+    assert "webui-root" not in got, (
+        "The webui ancestor was force-imported from state.db. The WebUI chat already reaches "
+        "/api/sessions from its own JSON sidecar, so this creates a duplicate ghost row "
+        f"(see represented_webui_ids in api/routes.py). Returned ids: {got}"
+    )
+
+
+def test_no_subagent_rows_leaves_window_unchanged(tmp_path):
+    """With no subagent rows at all, the rescue is a strict no-op.
+
+    Pins that the limit itself is not being quietly raised: exactly K rows, in
+    unchanged recency order.
+    """
+    db = tmp_path / "state.db"
+    rows = [
+        _session(f"cli-{i}", "cli", T + 500.0 + i, title=f"CLI chat {i}")
+        for i in range(6)
+    ]
+    _make_state_db(db, rows)
+
+    result = read_importable_agent_session_rows(
+        db, limit=4, exclude_sources=SIDEBAR_EXCLUDES
+    )
+    got = _ids(result)
+
+    assert len(got) == 4, (
+        f"limit=4 over a subagent-free db returned {len(got)} rows ({got}). The ancestor "
+        "rescue must not change the window size when there is nothing to rescue."
+    )
+    assert got == ["cli-5", "cli-4", "cli-3", "cli-2"], (
+        f"Recency order changed: expected newest-first ['cli-5','cli-4','cli-3','cli-2'], got {got}. "
+        "The rescue must not reorder the normally-selected window."
+    )
+
+
+def test_get_cli_sessions_ships_parent_row_for_visible_subagent_child(
+    fake_hermes_home, monkeypatch
+):
+    """END-TO-END sidebar contract through get_cli_sessions().
+
+    Every visible subagent child must have its parent addressable in the SAME
+    payload, unless the parent is a webui chat (delivered by its own sidecar)
+    or is absent from state.db entirely. Anything else is an orphan the client
+    promotes to a top-level sidebar row.
+
+    Fixture is the real depth-2 delegation shape: webui root -> frozen
+    orchestrator -> hot leaves.
+    """
+    monkeypatch.setattr(models, "CLI_VISIBLE_SESSION_LIMIT", 4)
+
+    db = fake_hermes_home / "state.db"
+    rows = [
+        _session("webui-root", "webui", T + 50.0, title="Planning chat"),
+        _session("orch-frozen", "subagent", T + 120.0,
+                 parent="webui-root", title="Delegated run"),
+        _session("cli-old", "cli", T + 70.0, title="Old CLI chat"),
+    ]
+    rows += [
+        _session(f"leaf-{i}", "subagent", T + 900.0 + i,
+                 parent="orch-frozen", title=f"Subagent leaf {i}")
+        for i in range(4)
+    ]
+    _make_state_db(db, rows)
+    source_by_id = {row["id"]: row["source"] for row in rows}
+
+    # include_claude_code=False keeps the payload dependent on the fixture only.
+    sessions = models.get_cli_sessions(include_claude_code=False)
+    returned_ids = {s["session_id"] for s in sessions}
+
+    subagent_children = [
+        s for s in sessions
+        if s.get("source_tag") == "subagent" and s.get("parent_session_id")
+    ]
+    assert subagent_children, (
+        "Fixture failure: no visible subagent child rows came back from get_cli_sessions(), "
+        f"so the sidebar contract was never exercised. Returned ids: {sorted(returned_ids)}"
+    )
+
+    for child in subagent_children:
+        parent_id = child["parent_session_id"]
+        parent_source = source_by_id.get(parent_id)
+        allowed = (
+            parent_id in returned_ids            # nestable: parent row shipped
+            or parent_source == "webui"          # webui chat ships via its own sidecar
+            or parent_source is None             # parent no longer exists in state.db
+        )
+        assert allowed, (
+            f"Subagent session {child['session_id']!r} references parent {parent_id!r} "
+            f"(source={parent_source!r}) which is NOT in the /api/sessions payload. "
+            f"Allowed exceptions are ONLY: parent source == 'webui', or parent missing from "
+            f"state.db. Returned ids: {sorted(returned_ids)}. Without the parent row the client "
+            f"cannot nest this child and renders it as a top-level 'Subagent Session'."
+        )
+
+    assert "orch-frozen" in returned_ids, (
+        "The frozen orchestrator is missing from the end-to-end sidebar payload at "
+        f"CLI_VISIBLE_SESSION_LIMIT=4. Returned ids: {sorted(returned_ids)}"
+    )
+    assert "webui-root" not in returned_ids, (
+        "The webui ancestor was force-imported from state.db into the sidebar payload, which "
+        f"duplicates the sidecar-backed WebUI chat. Returned ids: {sorted(returned_ids)}"
+    )


### PR DESCRIPTION
## Summary

A delegated `source='subagent'` child is rendered **nested** under its parent row. But some subagent rows were showing up as **top-level sidebar rows** with a branch icon instead of nesting under the session that spawned them.

The `state.db` lineage was correct the whole time — `parent_session_id` and `source='subagent'` were set properly on every row. The bug is that the **parent row never reached the payload**.

## Mechanism

1. `get_cli_sessions()` calls `read_importable_agent_session_rows(..., limit=CLI_VISIBLE_SESSION_LIMIT)` (20).
2. That projection is recency-ordered by `MAX(messages.timestamp)` and ends in a hard slice: `return projected[:max(0, int(limit))]`.
3. A frozen `delegate_task` orchestrator **stops writing messages** the moment its leaves take over. The still-streaming leaves keep their recency and survive the slice; the quiet orchestrator parent sinks below the cut and is evicted.
4. The leaf still carries `relationship_type='child_session'` + `parent_session_id` (lineage enrichment works), but the parent **row** is gone from the payload.
5. `static/sessions.js::_attachChildSessionsToSidebarRows()` only nests when the parent is present in the payload. No parent row → the leaf is promoted to a contextless top-level "Subagent Session".

Note the client-side suppression added in #5305 does **not** cover this: it only fires when `_cross_surface_child_session && _isChildSession`, and that flag is set only when `parent.source != child.source`. `webui→subagent` gets marked, but **`subagent→subagent` does not** — so leaves of a dropped orchestrator fall straight through to the top level. The server now supplies the parent row instead, which is what the client needs to nest.

## What the fix does

After the recency slice, walk the `parent_session_id` chain of every selected `subagent` row and re-add the missing ancestors.

- **Adds, never substitutes.** No visible leaf is evicted to make room for its parent. The returned list may exceed `limit` by the number of rescued ancestors — an over-long list renders correctly, a half-nested one does not.
- **`CLI_VISIBLE_SESSION_LIMIT` stays at 20.** Raising the cap was explicitly not the fix.
- **Bounded.** Only parents of already-selected rows are walked — never a table dump. Resolution hits the existing `limit*8` oversample first (common case = one dict lookup, zero extra SQL), then one targeted query per hop for anything outside that window.
- **Read-only.** The ancestor query reuses the already-open read-only cursor and the same `select_sql`/join/group-by, so rescued rows carry byte-identical columns (preserves the #5455 contract). `sqlite3.Error` degrades to "no rescue" rather than propagating — this function is the only source of agent rows for the sidebar, so an escaping exception would empty it entirely.
- **Leaf metadata untouched.** No invented `relationship_type` / `_cross_surface_child_session`, and the leaf is never hidden server-side.

### What it does not do — stop rules

The walk stops and appends nothing further when the parent is:

- **a WebUI session** — it already ships via its own JSON sidecar (`all_sessions()`); a second `state.db` projection would render as a ghost CLI duplicate of the user's own chat (see `represented_webui_ids` / `_is_duplicate_webui_state_projection`).
- **missing / deleted / unprojectable** (e.g. zero messages) — leaves the leaf orphaned exactly as today; a grandparent would not help since the client nests strictly by `parent_session_id`.
- **filtered out by the caller's own `include_sources`/`exclude_sources`** — never smuggles a cron/webhook parent past the caller's filter.
- **already present**, a **cycle**, or beyond the **hop cap** (8; real delegation nests at most `max_spawn_depth`=2).

**No-op guarantee:** when the window holds no `subagent` rows, the original list is returned untouched and no extra SQL is issued — non-delegating deployments see byte-identical output and cost.

## Test evidence

New: `tests/test_subagent_sidebar_ancestor_import.py` (8 cases, black-box through `read_importable_agent_session_rows()` / `get_cli_sessions()`, no private helpers asserted on).

Reverting **only** `api/agent_sessions.py` to its pristine `HEAD` state and re-running the new file reproduces the bug — 4 fail, 4 pass:

```
$ git show HEAD:api/agent_sessions.py > api/agent_sessions.py
$ python -m pytest tests/test_subagent_sidebar_ancestor_import.py -q
FAILED tests/test_subagent_sidebar_ancestor_import.py::test_orchestrator_parent_rescued_when_recency_window_evicts_it
FAILED tests/test_subagent_sidebar_ancestor_import.py::test_rescued_parent_preserves_child_relationship
FAILED tests/test_subagent_sidebar_ancestor_import.py::test_webui_ancestor_not_force_imported
FAILED tests/test_subagent_sidebar_ancestor_import.py::test_get_cli_sessions_ships_parent_row_for_visible_subagent_child
4 failed, 4 passed in 2.13s
```

Representative pre-fix assertion (end-to-end through `get_cli_sessions()` at `CLI_VISIBLE_SESSION_LIMIT=4`):

```
AssertionError: Subagent session 'leaf-3' references parent 'orch-frozen'
(source='subagent') which is NOT in the /api/sessions payload. Allowed exceptions
are ONLY: parent source == 'webui', or parent missing from state.db.
Returned ids: ['leaf-0', 'leaf-1', 'leaf-2', 'leaf-3'].
```

At `limit=4` the hot leaves consumed the entire window — orchestrator, webui root and the CLI chat were all evicted. That is the user-visible symptom.

With the fix, plus the closest existing projection/lineage suites:

```
$ python -m pytest tests/test_subagent_sidebar_ancestor_import.py \
    tests/test_issue2628_cli_sessions_perf.py \
    tests/test_issue5455_listing_readonly_connection.py \
    tests/test_issue3930_source_filter_pushdown.py \
    tests/test_issue3172_cron_session_limit.py \
    tests/test_pr1370_lineage_metadata_perf_and_orphan.py \
    tests/test_session_lineage_metadata_api.py \
    tests/test_5306_subagent_sidebar_flicker.py \
    tests/test_5307_subagent_child_transcript.py \
    tests/test_issue4638_lineage_top_n_cap.py -q
81 passed in 4.96s
```

Wider sweep, `-k "session or sidebar or lineage or subagent or cli"` (3130 passed, 34 skipped). The 2 failures + 11 errors in that selection were diffed against a `git stash` baseline run on pristine `origin/master` and the failure sets are **identical** — all pre-existing (`test_bootstrap_discover_agent`, `test_xsession_wakeup_misroute`, and `test_mcp_server` errors), none introduced here. `tests/test_compression_phantom_barrier.py` is excluded from the sweep: it fails to import because `playwright` is not installed in this environment (also pre-existing).

`ruff check api/agent_sessions.py tests/test_subagent_sidebar_ancestor_import.py` → clean.

## Scope

Two files: `api/agent_sessions.py` and the new test. Server-side only — no client changes, no schema changes, no config changes.