### PR TITLE
fix(workspace): do not block root load on expanded dirs

### DIFF
--- a/static/workspace.js
+++ b/static/workspace.js
@@ -720,6 +720,29 @@ function clearWorkspaceTreeSkeleton(){
   if(tree.querySelector('.skeleton-tree')) tree.innerHTML = '';
 }
 
+const _WORKSPACE_PREFETCH_CONCURRENCY=6;
+const _WORKSPACE_PREFETCH_TIMEOUT_MS=8000;
+
+async function _prefetchExpandedWorkspaceDirs(sessionId, treeGen, pending){
+  for(let offset=0;offset<pending.length;offset+=_WORKSPACE_PREFETCH_CONCURRENCY){
+    const batch=pending.slice(offset,offset+_WORKSPACE_PREFETCH_CONCURRENCY);
+    const results=await Promise.all(batch.map(dirPath=>{
+      const route=_workspaceRouteForPath(dirPath,'list');
+      if(!route) return Promise.resolve({dirPath,entries:[]});
+      return api(route,{
+        timeoutMs:_WORKSPACE_PREFETCH_TIMEOUT_MS,
+        timeoutToast:false,
+        retries:0,
+      })
+        .then(dc=>({dirPath,entries:dc.entries||[]}))
+        .catch(()=>({dirPath,entries:[]}));
+    }));
+    if(!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
+    for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
+    if(typeof renderFileTree==='function') renderFileTree();
+  }
+}
+
 async function loadDir(path, opts={}){
   const preservePreview=!!(opts&&opts.preservePreview);
   const refreshExpanded=!!(opts&&opts.refreshExpanded);
@@ -758,15 +781,7 @@ async function loadDir(path, opts={}){
     if(!path||path==='.'||refreshExpanded){
       const expanded=S._expandedDirs||new Set();
       const pending=[...expanded].filter(dirPath=>!S._dirCache[dirPath]);
-      if(pending.length){
-        const results=await Promise.all(pending.map(dirPath=>
-          api(_workspaceRouteForPath(dirPath, 'list'))
-            .then(dc=>({dirPath,entries:dc.entries||[]}))
-            .catch(()=>({dirPath,entries:[]}))
-        ));
-        if(!S.session||S.session.session_id!==sessionId||treeGen!==_wsTreeGen)return;
-        for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
-      }
+      if(pending.length) void _prefetchExpandedWorkspaceDirs(sessionId,treeGen,pending);
       if(expanded.size>0)renderFileTree();
     }
     if(!preservePreview&&typeof clearPreview==='function'){

--- a/tests/test_workspace_load_dir_resilience.py
+++ b/tests/test_workspace_load_dir_resilience.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_JS = (REPO_ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+
+
+def test_root_load_does_not_wait_for_restored_expanded_directory_prefetch():
+    """A slow restored child directory must not block the root workspace view."""
+    load_start = WORKSPACE_JS.index("async function loadDir(path, opts={})")
+    load_end = WORKSPACE_JS.index("function refreshWorkspacePanel", load_start)
+    load_body = WORKSPACE_JS[load_start:load_end]
+
+    assert "void _prefetchExpandedWorkspaceDirs" in load_body
+    assert "await Promise.all(pending.map(dirPath=>" not in load_body
+
+
+def test_restored_directory_prefetch_is_bounded_and_silent_on_timeout():
+    """Background tree hydration must use a bounded, non-toast API request."""
+    start = WORKSPACE_JS.index("async function _prefetchExpandedWorkspaceDirs")
+    end = WORKSPACE_JS.index("async function loadDir", start)
+    body = WORKSPACE_JS[start:end]
+
+    assert "const _WORKSPACE_PREFETCH_TIMEOUT_MS=8000" in WORKSPACE_JS
+    assert "timeoutToast:false" in body
+    assert "retries:0" in body
+    assert "Promise.all" in body


### PR DESCRIPTION
## Summary

- Render the workspace root immediately instead of awaiting every restored expanded-directory listing.
- Hydrate restored child directories in bounded background batches with an 8-second timeout and no per-child timeout toast.
- Ignore stale hydration results after a session/profile tree generation changes.

This prevents one slow or stale nested `/api/list` request from making `loadDir('.')` appear to time out.

## Verification

- `./scripts/test.sh tests/test_workspace_load_dir_resilience.py tests/test_sprint9.py tests/test_subpath_frontend_routes.py tests/test_issue3337_workspace_preview_highlight.py -q` — 22 passed
- `node --check static/workspace.js`
- `git diff --check`
- Live root `/api/list` timing before submission: approximately 4 ms

## Risks / Follow-ups

- Background hydration may complete after the root tree is first rendered; the tree is refreshed as each bounded batch completes.
- Nested directory errors remain non-fatal and are represented as an empty cache result.

## AI Usage Disclosure

Provider/model: OpenAI Codex via Hermes Agent. The change was isolated from a dirty deployment checkout into a clean worktree based on the latest upstream `master` before testing, committing, and pushing.
