### PR TITLE
fix(docker): probe the configured state dir before /workspace for UID/GID detection (#7027)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -87,6 +87,176 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # Startup-health gate for UID/GID auto-detection (#7027).
+  #
+  # The compose variants above all mount a hermes-home volume, so they never
+  # exercise the plain single-container shape from the issue: a state directory
+  # bind-mounted from a host directory owned by a non-1024 user, /workspace left
+  # as the image's own build-time 1024, and no explicit WANTED_UID/WANTED_GID.
+  # Before the fix the auto-detector read /workspace, remapped to 1024, failed
+  # its own state-dir writability check and restart-looped. Source-level
+  # invariants can't catch that — only actually booting the container can.
+  state-dir-uid:
+    name: State-dir UID detection (#7027)
+    runs-on: ubuntu-latest
+    needs: [compose-config, build-image]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker image from cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/nesquena/hermes-webui:latest
+          cache-from: type=gha
+
+      - name: Boot on a host-owned state mount with no explicit IDs
+        run: |
+          set -euo pipefail
+
+          CONTAINER="hermes-smoke-uid-${{ github.run_id }}-${{ github.run_attempt }}"
+          HOST_UID=1001
+          STATE_DIR="$(mktemp -d -t hermes-smoke-uidstate-XXXXXX)"
+          sudo chown -R "$HOST_UID:$HOST_UID" "$STATE_DIR"
+
+          cleanup() {
+            local rc=$?
+            echo "::group::Cleanup (rc=$rc)"
+            docker logs "$CONTAINER" 2>&1 | tail -200 || true
+            docker rm -f "$CONTAINER" || true
+            sudo rm -rf "$STATE_DIR" || true
+            echo "::endgroup::"
+            return $rc
+          }
+          trap cleanup EXIT
+
+          # Deliberately NOT mounting /workspace: the point of this gate is that
+          # the stock image's own /workspace (owned 1024:1024) must not win over
+          # the host-owned state mount.
+          echo "::group::docker run"
+          docker run -d --name "$CONTAINER" \
+            -p 127.0.0.1:8788:8787 \
+            -e HERMES_WEBUI_STATE_DIR=/app/data \
+            -v "$STATE_DIR":/app/data \
+            ghcr.io/nesquena/hermes-webui:latest
+          echo "::endgroup::"
+
+          # ----- The product gate: the container must reach /health -----
+          echo "::group::Probe /health"
+          attempts=0
+          max_attempts=60
+          until curl --fail --silent --max-time 5 http://127.0.0.1:8788/health > /dev/null; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "❌ WebUI /health never returned 200 after $max_attempts attempts (~5m)"
+              echo "   Startup logs follow in the cleanup group below."
+              exit 1
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER")" != "true" ]; then
+              echo "❌ Container exited before /health came up — this is the #7027 restart loop"
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "✅ /health = 200 after $attempts attempts"
+          echo "::endgroup::"
+
+          echo "::group::Verify the detected identity"
+          LOGS="$(docker logs "$CONTAINER" 2>&1)"
+
+          # The identity must have been detected from the state dir, not /workspace.
+          if ! echo "$LOGS" | grep -qE -- "-- Auto-detected UID: ${HOST_UID} \(from /app/data\)"; then
+            echo "❌ UID was not auto-detected from the state directory (#7027)"
+            echo "$LOGS" | grep -E -- "-- (Auto-detected|WANTED_)" || true
+            exit 1
+          fi
+          if ! echo "$LOGS" | grep -qE -- "-- Auto-detected GID: ${HOST_UID} \(from /app/data\)"; then
+            echo "❌ GID was not auto-detected from the state directory (#7027)"
+            echo "$LOGS" | grep -E -- "-- (Auto-detected|WANTED_)" || true
+            exit 1
+          fi
+
+          # And the runtime user must really carry it.
+          ACTUAL_UID="$(docker exec "$CONTAINER" id -u hermeswebui)"
+          ACTUAL_GID="$(docker exec "$CONTAINER" id -g hermeswebui)"
+          if [ "$ACTUAL_UID" != "$HOST_UID" ] || [ "$ACTUAL_GID" != "$HOST_UID" ]; then
+            echo "❌ hermeswebui runs as ${ACTUAL_UID}:${ACTUAL_GID}, expected ${HOST_UID}:${HOST_UID}"
+            exit 1
+          fi
+          echo "✅ hermeswebui runs as ${ACTUAL_UID}:${ACTUAL_GID}, detected from the state mount"
+          echo "::endgroup::"
+
+          echo "::group::Startup log scan"
+          BAD_PATTERNS='!! ERROR|!! Exiting script|Failed to verify state directory|Permission denied'
+          if echo "$LOGS" | grep -E -i "$BAD_PATTERNS"; then
+            echo "❌ Startup logs contain known-bad pattern (see above)"
+            exit 1
+          fi
+          echo "✅ No known-bad patterns in startup logs"
+          echo "::endgroup::"
+
+      - name: Explicit WANTED_UID=1024 must survive auto-detection
+        run: |
+          set -euo pipefail
+
+          CONTAINER="hermes-smoke-uid1024-${{ github.run_id }}-${{ github.run_attempt }}"
+          STATE_DIR="$(mktemp -d -t hermes-smoke-uid1024-XXXXXX)"
+          HERMES_DIR="$(mktemp -d -t hermes-smoke-uid1024home-XXXXXX)"
+          # Both mounts are owned by a *different* UID than the one requested.
+          # The hermes-home mount is what makes this discriminating: it is a
+          # probe candidate the pre-fix script already read, so if the explicit
+          # 1024 is still treated as "unset" the container remaps to 1001 and
+          # the assertion below fails. World-writable state dir so the only
+          # thing under test is which identity wins, not mount permissions.
+          sudo chown -R 1001:1001 "$STATE_DIR" "$HERMES_DIR"
+          sudo chmod 0777 "$STATE_DIR"
+
+          cleanup() {
+            local rc=$?
+            echo "::group::Cleanup (rc=$rc)"
+            docker logs "$CONTAINER" 2>&1 | tail -100 || true
+            docker rm -f "$CONTAINER" || true
+            sudo rm -rf "$STATE_DIR" "$HERMES_DIR" || true
+            echo "::endgroup::"
+            return $rc
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "$CONTAINER" \
+            -p 127.0.0.1:8789:8787 \
+            -e HERMES_WEBUI_STATE_DIR=/app/data \
+            -e WANTED_UID=1024 \
+            -e WANTED_GID=1024 \
+            -v "$STATE_DIR":/app/data \
+            -v "$HERMES_DIR":/home/hermeswebui/.hermes \
+            ghcr.io/nesquena/hermes-webui:latest
+
+          attempts=0
+          max_attempts=60
+          until curl --fail --silent --max-time 5 http://127.0.0.1:8789/health > /dev/null; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "❌ WebUI /health never returned 200 with explicit WANTED_UID=1024"
+              exit 1
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER")" != "true" ]; then
+              echo "❌ Container exited before /health came up"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          ACTUAL_UID="$(docker exec "$CONTAINER" id -u hermeswebui)"
+          if [ "$ACTUAL_UID" != "1024" ]; then
+            echo "❌ explicit WANTED_UID=1024 was overwritten by auto-detection — got ${ACTUAL_UID} (#7027)"
+            exit 1
+          fi
+          echo "✅ explicit WANTED_UID=1024 preserved (sentinel no longer shadows the valid value)"
+
   smoke:
     name: Smoke ${{ matrix.variant }}
     runs-on: ubuntu-latest

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -57,17 +57,31 @@ if [ ! -d "$itdir" ]; then error_exit "Failed to create $itdir"; fi
 # logic: if not set and file exists, use file value, else use default. Create file for persistence when the container is re-run
 # reasoning: needed when using docker compose as the file will exist in the stopped container, and changing the value from environment variables or configuration file must be propagated from the root init phase to the hermeswebui runtime phase
 it=$itdir/hermeswebui_user_uid
-if [ -z "${WANTED_UID+x}" ]; then
-  if [ -f $it ]; then WANTED_UID=$(cat $it); fi
+# Remember where the value came from. Auto-detection must never overwrite an
+# identity the operator chose explicitly — including the legitimate value 1024,
+# which is also the built-in default and was therefore indistinguishable from
+# "unset" (#7027). The source is persisted next to the value because `su` drops
+# the environment when this script re-enters as the runtime user, so an explicit
+# choice would otherwise look like a detected one on the second pass.
+it_source=$itdir/hermeswebui_user_uid_source
+_wanted_uid_source=""
+if [ -n "${WANTED_UID+x}" ]; then
+  _wanted_uid_source=explicit
+elif [ -f $it ]; then
+  WANTED_UID=$(cat $it)
+  if [ -f $it_source ]; then _wanted_uid_source=$(cat $it_source); fi
 fi
-# Auto-detect from mounted volumes if still unset (#569, #668).
+# Auto-detect from mounted volumes if still unset (#569, #668, #7027).
 # On macOS, host UIDs start at 501. Using the wrong UID means the container
 # user cannot read the bind-mounted files, making the workspace appear empty.
 # In two-container setups (hermes-agent + hermes-webui), the shared hermes-home
 # volume may be owned by the agent container's UID — detect from there first.
-if [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; then
-  # Priority 1: hermes-home shared volume — covers two-container Zeabur/Compose setups (#668)
-  for _probe_dir in "/home/hermeswebui/.hermes" "$HERMES_HOME" "/opt/data"; do
+if [ "$_wanted_uid_source" != "explicit" ] && { [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; }; then
+  # Priority 1: the configured state dir first (#7027) — in a single-container
+  # deploy it is a bind mount by definition, so its owner is the host identity
+  # the container has to match — then the hermes-home shared volume, which
+  # covers two-container Zeabur/Compose setups (#668)
+  for _probe_dir in "${HERMES_WEBUI_STATE_DIR:-/app/data}" "/home/hermeswebui/.hermes" "$HERMES_HOME" "/opt/data"; do
     if [ -d "$_probe_dir" ]; then
       _detected_uid=$(stat -c '%u' "$_probe_dir" 2>/dev/null || echo "")
       if [ -n "$_detected_uid" ] && [ "$_detected_uid" != "0" ]; then
@@ -78,8 +92,10 @@ if [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; then
     fi
   done
 fi
-if [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; then
-  # Priority 2: /workspace bind-mount — the standard single-container mount point
+if [ "$_wanted_uid_source" != "explicit" ] && { [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; }; then
+  # Priority 2: /workspace bind-mount — a useful signal when it is actually
+  # bind-mounted, but a stock image ships /workspace owned by the build-time
+  # 1024, which says nothing about the host, so it stays below the state dir (#7027)
   if [ -d "/workspace" ]; then
     _detected_uid=$(stat -c '%u' "/workspace" 2>/dev/null || echo "")
     if [ -n "$_detected_uid" ] && [ "$_detected_uid" != "0" ]; then
@@ -90,16 +106,22 @@ if [ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]; then
 fi
 WANTED_UID=${WANTED_UID:-1024}
 write_privtmpfile $it "$WANTED_UID"
+write_privtmpfile $it_source "${_wanted_uid_source:-detected}"
 echo "-- WANTED_UID: \"${WANTED_UID}\""
 
 it=$itdir/hermeswebui_user_gid
-if [ -z "${WANTED_GID+x}" ]; then
-  if [ -f $it ]; then WANTED_GID=$(cat $it); fi
+it_source=$itdir/hermeswebui_user_gid_source
+_wanted_gid_source=""
+if [ -n "${WANTED_GID+x}" ]; then
+  _wanted_gid_source=explicit
+elif [ -f $it ]; then
+  WANTED_GID=$(cat $it)
+  if [ -f $it_source ]; then _wanted_gid_source=$(cat $it_source); fi
 fi
-# Auto-detect GID from mounted volumes to match (#569, #668)
-if [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; then
-  # Priority 1: hermes-home shared volume
-  for _probe_dir in "/home/hermeswebui/.hermes" "$HERMES_HOME" "/opt/data"; do
+# Auto-detect GID from mounted volumes to match (#569, #668, #7027)
+if [ "$_wanted_gid_source" != "explicit" ] && { [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; }; then
+  # Priority 1: configured state dir first, then the hermes-home shared volume
+  for _probe_dir in "${HERMES_WEBUI_STATE_DIR:-/app/data}" "/home/hermeswebui/.hermes" "$HERMES_HOME" "/opt/data"; do
     if [ -d "$_probe_dir" ]; then
       _detected_gid=$(stat -c '%g' "$_probe_dir" 2>/dev/null || echo "")
       if [ -n "$_detected_gid" ] && [ "$_detected_gid" != "0" ]; then
@@ -110,8 +132,8 @@ if [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; then
     fi
   done
 fi
-if [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; then
-  # Priority 2: /workspace bind-mount
+if [ "$_wanted_gid_source" != "explicit" ] && { [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; }; then
+  # Priority 2: /workspace bind-mount — lower priority for the same reason as UID (#7027)
   if [ -d "/workspace" ]; then
     _detected_gid=$(stat -c '%g' "/workspace" 2>/dev/null || echo "")
     if [ -n "$_detected_gid" ] && [ "$_detected_gid" != "0" ]; then
@@ -122,6 +144,7 @@ if [ -z "${WANTED_GID+x}" ] || [ "${WANTED_GID}" = "1024" ]; then
 fi
 WANTED_GID=${WANTED_GID:-1024}
 write_privtmpfile $it "$WANTED_GID"
+write_privtmpfile $it_source "${_wanted_gid_source:-detected}"
 echo "-- WANTED_GID: \"${WANTED_GID}\""
 
 echo "== Most Environment variables set"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -468,6 +468,44 @@ services:
 
 Then configure the URL as `http://host.docker.internal:<port>`. Also ensure the host service binds to an address reachable from containers (not only a loopback interface the Docker bridge cannot reach) and that your host firewall allows the connection.
 
+### 9. "Failed to verify state directory" / restart loop on a bind-mounted state dir (#7027)
+
+**Symptom**: Single-container deploy with the state directory bind-mounted from a
+host directory, no `WANTED_UID` set. The container exits 1 and restart-loops:
+
+```
+-- Auto-detected workspace UID: 1024 (from /workspace)
+touch: cannot touch '/app/data/.testfile': Permission denied
+!! ERROR: Failed to verify state directory at /app/data
+```
+
+**Cause**: UID auto-detection used to read `/workspace` before the configured
+state directory. In a stock image `/workspace` exists and is owned by the
+image's own build-time `1024:1024`, so detection returned a value that carries
+no information about the host — and because `1024` is also the fallback default,
+the log read as if detection had found nothing.
+
+**Fix**: Fixed in the init script — the configured `HERMES_WEBUI_STATE_DIR` is
+now probed first. The full order is:
+
+1. `$HERMES_WEBUI_STATE_DIR` (default `/app/data`) — a bind mount by definition
+   in a single-container deploy, so its owner is the host identity to match
+2. `/home/hermeswebui/.hermes`, `$HERMES_HOME`, `/opt/data` — the hermes-home
+   shared volume in two-container setups (#668)
+3. `/workspace` — used only when nothing above resolves
+4. `1024` — fallback default
+
+Root-owned candidates (UID 0, e.g. a freshly created named volume) are skipped
+at every step. An explicitly supplied `WANTED_UID`/`WANTED_GID` always wins and
+is never overwritten by detection — including the value `1024`, which earlier
+versions treated as "unset".
+
+If you are on an older image, the workaround is to set the IDs explicitly:
+
+```bash
+docker run -e WANTED_UID=$(id -u) -e WANTED_GID=$(id -g) ...
+```
+
 ## Multi-container architecture
 
 The two- and three-container setups use **named Docker volumes** (not bind mounts) by default for a reason: named volumes solve the UID/GID problem by construction. Docker creates the volume's root directory with the correct ownership, all containers reading/writing to it see the same files, no host-side permission setup required.
@@ -588,6 +626,7 @@ volumes:
 - #681 — tools running in WebUI container, not agent container (architectural)
 - #668 — auto-detect UID/GID from mounted volume
 - #569 — UID/GID detection priority order
+- #7027 — state dir probed before `/workspace` in UID/GID detection (see [#9 above](#9-failed-to-verify-state-directory--restart-loop-on-a-bind-mounted-state-dir-7027))
 
 If you hit a new failure mode not covered here, please [open an issue](https://github.com/nesquena/hermes-webui/issues/new) with:
 

--- a/tests/test_7027_state_dir_uid_probe.py
+++ b/tests/test_7027_state_dir_uid_probe.py
@@ -1,0 +1,406 @@
+"""Regression tests for #7027 — UID/GID auto-detection probe order.
+
+Background: ``docker_init.bash`` auto-detects the UID/GID to remap the
+``hermeswebui`` user to, by stat-ing mounted directories. Before this fix the
+probe list was:
+
+    priority 1: /home/hermeswebui/.hermes, $HERMES_HOME, /opt/data
+    priority 2: /workspace
+    fallback:   1024
+
+In a stock single-container image none of the priority-1 candidates exist, but
+``/workspace`` *does* — owned by the image's build-time ``1024:1024``. Detection
+therefore returned the image's own owner, which carries no information about the
+host, while the one directory that carries the host UID by definition — the
+state-dir bind mount — was never probed. With a host-owned state mount and no
+explicit ``WANTED_UID``, the container remapped to 1024, failed its own
+writability check on the state dir, and restart-looped:
+
+    touch: cannot touch '/app/data/.testfile': Permission denied
+    !! ERROR: Failed to verify state directory at /app/data
+
+The second half of the bug: ``1024`` was both the fallback sentinel and a
+legitimate UID, so ``WANTED_UID=1024`` supplied explicitly by an operator was
+overwritten by detection anyway.
+
+The behavioural tests below extract the UID/GID resolution block from
+``docker_init.bash`` and run it under real bash, with ``stat`` stubbed so
+ownership can be simulated without root. Source-level assertions alone cannot
+catch shell-quoting or ordering regressions inside the block (the pattern
+mirrors ``tests/test_docker_env_readonly_vars.py``).
+
+The startup-health half of this contract — a real container coming up on a
+host-owned state mount — is covered by the ``state-dir-uid`` job in
+``.github/workflows/docker-smoke.yml``.
+"""
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INIT_SH = (REPO_ROOT / "docker_init.bash").read_text(encoding="utf-8")
+
+# Logical probe name -> path basename used inside the sandbox. The extracted
+# block's absolute paths are rewritten to these so the test can create/own them.
+PROBE_PATHS = {
+    "state": "state",
+    "app_data": "app-data",
+    "hermes_home": "hermes-home",
+    "opt_data": "opt-data",
+    "workspace": "workspace",
+}
+
+_BLOCK_START = "it=$itdir/hermeswebui_user_uid\n"
+_BLOCK_END = 'echo "-- WANTED_GID: \\"${WANTED_GID}\\""'
+
+
+# ── source-level invariants ───────────────────────────────────────────────────
+
+def _probe_loop_lines():
+    """Both `for _probe_dir in ...` lines (UID block, then GID block)."""
+    return [ln for ln in INIT_SH.splitlines() if "for _probe_dir in" in ln]
+
+
+def test_7027_both_probe_loops_include_the_state_dir():
+    """UID *and* GID detection must probe the configured state directory."""
+    loops = _probe_loop_lines()
+    assert len(loops) == 2, f"expected one probe loop for UID and one for GID, found {len(loops)}"
+    for line in loops:
+        assert "HERMES_WEBUI_STATE_DIR" in line, (
+            "probe loop must include the configured state dir — it is the only "
+            f"path that is a bind mount by definition (#7027): {line.strip()!r}"
+        )
+
+
+def test_7027_state_dir_is_probed_first_in_both_loops():
+    """The state dir must be the first candidate, ahead of hermes-home/workspace."""
+    for line in _probe_loop_lines():
+        candidates = line.split("for _probe_dir in", 1)[1].rstrip("; do").strip()
+        first = candidates.split()[0]
+        assert "HERMES_WEBUI_STATE_DIR" in first, (
+            "the state dir must be probed before any image-owned path, otherwise "
+            f"a stock /workspace wins with the build-time 1024 (#7027): {first!r}"
+        )
+
+
+def test_7027_workspace_probe_still_exists_as_lower_priority():
+    """/workspace stays as a fallback signal — it is not removed (#569, #668)."""
+    assert 'if [ -d "/workspace" ]' in INIT_SH, (
+        "/workspace must remain a lower-priority probe for setups that bind-mount it"
+    )
+    state_pos = INIT_SH.find("HERMES_WEBUI_STATE_DIR:-/app/data")
+    workspace_pos = INIT_SH.find('if [ -d "/workspace" ]')
+    assert state_pos != -1 and workspace_pos != -1
+    assert state_pos < workspace_pos, "state-dir probe must precede the /workspace probe"
+
+
+def test_7027_explicit_value_guard_present_on_every_detection_branch():
+    """Each detection branch must be gated on the value not being explicit.
+
+    Without this, `WANTED_UID=1024` set deliberately by an operator is
+    indistinguishable from the unset fallback and gets overwritten.
+    """
+    uid_guards = INIT_SH.count('[ "$_wanted_uid_source" != "explicit" ]')
+    gid_guards = INIT_SH.count('[ "$_wanted_gid_source" != "explicit" ]')
+    assert uid_guards == 2, f"both UID detection branches must be guarded, found {uid_guards}"
+    assert gid_guards == 2, f"both GID detection branches must be guarded, found {gid_guards}"
+
+
+def test_7027_id_source_is_persisted_for_the_runtime_pass():
+    """The explicit/detected origin must be persisted next to the value.
+
+    `su` drops the environment when the script re-enters as the runtime user,
+    so without persistence the second pass cannot tell an operator's explicit
+    1024 from the fallback.
+    """
+    assert "hermeswebui_user_uid_source" in INIT_SH
+    assert "hermeswebui_user_gid_source" in INIT_SH
+    assert INIT_SH.count('write_privtmpfile $it_source') == 2, (
+        "both the UID and GID source markers must be written to $itdir"
+    )
+
+
+def test_7027_fallback_default_preserved():
+    """The 1024 fallback must survive (guard shared with #569)."""
+    assert "WANTED_UID=${WANTED_UID:-1024}" in INIT_SH
+    assert "WANTED_GID=${WANTED_GID:-1024}" in INIT_SH
+
+
+# ── behavioural harness ───────────────────────────────────────────────────────
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+class TestIdResolutionBehaviour:
+    """Run the real resolution block under bash against simulated mounts."""
+
+    @staticmethod
+    def _extract_block(init_sh: str) -> str:
+        start = init_sh.find(_BLOCK_START)
+        assert start != -1, "UID/GID resolution block not found in docker_init.bash"
+        end = init_sh.find(_BLOCK_END, start)
+        assert end != -1, "end of the UID/GID resolution block not found"
+        return init_sh[start:end + len(_BLOCK_END)]
+
+    def _run(self, tmp_path, *, owners, env=None, itdir=None, state_dir_env=True):
+        """Execute the resolution block.
+
+        owners: {logical name: (uid, gid)} — each named directory is created and
+                its simulated ownership is returned by the stubbed `stat`.
+                Directories not listed are simply absent.
+        state_dir_env: when False, HERMES_WEBUI_STATE_DIR is left unset so the
+                block falls back to its built-in default path.
+        """
+        sandbox = tmp_path / "sandbox"
+        sandbox.mkdir(exist_ok=True)
+        itdir = itdir or (tmp_path / "itdir")
+        Path(itdir).mkdir(exist_ok=True)
+
+        paths = {name: sandbox / base for name, base in PROBE_PATHS.items()}
+        for name in owners:
+            paths[name].mkdir(parents=True, exist_ok=True)
+
+        block = self._extract_block(INIT_SH)
+        # Rewrite the block's absolute probe paths into the sandbox. Longest
+        # first so /app/data is not clipped by a shorter prefix.
+        for absolute, name in (
+            ("/home/hermeswebui/.hermes", "hermes_home"),
+            ("/opt/data", "opt_data"),
+            ("/app/data", "app_data"),
+            ("/workspace", "workspace"),
+        ):
+            block = block.replace(absolute, str(paths[name]))
+
+        # `stat -c FMT PATH` stub: $2 is the format, $3 the path. Unknown paths
+        # exit nonzero so the block's `|| echo ""` yields an empty detection.
+        cases = []
+        for name, (uid, gid) in owners.items():
+            cases.append(
+                f'    {str(paths[name])!r}) '
+                f'if [ "$_fmt" = "%u" ]; then echo "{uid}"; else echo "{gid}"; fi; return 0 ;;'
+            )
+        stat_cases = "\n".join(cases) if cases else "    __never__) return 1 ;;"
+
+        script = textwrap.dedent("""\
+            set -e
+            itdir={itdir}
+            write_privtmpfile() {{
+              tmpfile=$1
+              if [ -f "$tmpfile" ]; then rm -f "$tmpfile"; fi
+              printf '%s' "$2" > "$tmpfile"
+              chmod 600 "$tmpfile"
+            }}
+            error_exit() {{ echo "!! ERROR: $*"; exit 1; }}
+            stat() {{
+              _fmt=$2
+              _path=$3
+            case "$_path" in
+            {stat_cases}
+              esac
+              return 1
+            }}
+            {block}
+            echo "RESULT_UID=${{WANTED_UID}}"
+            echo "RESULT_GID=${{WANTED_GID}}"
+            echo "RESULT_UID_SOURCE=$(cat "$itdir/hermeswebui_user_uid_source" 2>/dev/null || echo missing)"
+            echo "RESULT_GID_SOURCE=$(cat "$itdir/hermeswebui_user_gid_source" 2>/dev/null || echo missing)"
+        """).format(
+            itdir=str(itdir),
+            stat_cases=stat_cases,
+            block=block,
+        )
+
+        run_env = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"}
+        if state_dir_env:
+            run_env["HERMES_WEBUI_STATE_DIR"] = str(paths["state"])
+        run_env.update(env or {})
+
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=run_env,
+        )
+        assert result.returncode == 0, (
+            f"resolution block failed: rc={result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        parsed = dict(
+            line.split("=", 1)
+            for line in result.stdout.splitlines()
+            if line.startswith("RESULT_")
+        )
+        parsed["_stdout"] = result.stdout
+        parsed["_state_dir"] = str(paths["state"])
+        return parsed
+
+    # ── the reported bug ──────────────────────────────────────────────────────
+
+    def test_7027_state_mount_beats_stock_workspace(self, tmp_path):
+        """The reproduction from the issue: host-owned state dir, stock /workspace.
+
+        Host directory owned by 1001:1001 bind-mounted as the state dir, no
+        explicit IDs, and an image-owned /workspace at 1024:1024. Detection must
+        return 1001 — the identity that makes the state dir writable.
+        """
+        out = self._run(
+            tmp_path,
+            owners={"state": (1001, 1001), "workspace": (1024, 1024)},
+        )
+        assert out["RESULT_UID"] == "1001", (
+            "UID must be detected from the state bind mount, not from the "
+            f"image-owned /workspace (#7027). stdout:\n{out['_stdout']}"
+        )
+        assert out["RESULT_GID"] == "1001", (
+            f"GID must be detected from the state bind mount too. stdout:\n{out['_stdout']}"
+        )
+        assert f"(from {out['_state_dir']})" in out["_stdout"], (
+            "the log line must name the state dir as the detection source so the "
+            "operator can see which path decided the identity"
+        )
+
+    def test_7027_non_1024_state_mount_with_no_workspace_at_all(self, tmp_path):
+        """Same, in the single-container shape where /workspace is not mounted."""
+        out = self._run(tmp_path, owners={"state": (501, 20)})
+        assert out["RESULT_UID"] == "501", "macOS-style host UID must be detected"
+        assert out["RESULT_GID"] == "20"
+
+    def test_7027_default_state_path_probed_when_env_unset(self, tmp_path):
+        """With HERMES_WEBUI_STATE_DIR unset, the built-in default is still probed."""
+        out = self._run(
+            tmp_path,
+            owners={"app_data": (1001, 1001), "workspace": (1024, 1024)},
+            state_dir_env=False,
+        )
+        assert out["RESULT_UID"] == "1001"
+        assert out["RESULT_GID"] == "1001"
+
+    # ── explicit operator values ──────────────────────────────────────────────
+
+    def test_7027_explicit_1024_is_not_overwritten(self, tmp_path):
+        """`WANTED_UID=1024` set deliberately must survive detection.
+
+        1024 is both the fallback default and a legitimate UID; before the fix
+        the two were indistinguishable and detection clobbered the explicit value.
+        """
+        out = self._run(
+            tmp_path,
+            owners={"state": (1001, 1001), "workspace": (1001, 1001)},
+            env={"WANTED_UID": "1024", "WANTED_GID": "1024"},
+        )
+        assert out["RESULT_UID"] == "1024", (
+            "an explicitly supplied 1024 must be preserved, not treated as unset (#7027)"
+        )
+        assert out["RESULT_GID"] == "1024"
+        assert out["RESULT_UID_SOURCE"] == "explicit"
+        assert out["RESULT_GID_SOURCE"] == "explicit"
+
+    def test_7027_explicit_non_default_still_wins(self, tmp_path):
+        """The pre-existing contract: any explicit value beats detection."""
+        out = self._run(
+            tmp_path,
+            owners={"state": (1001, 1001)},
+            env={"WANTED_UID": "1500", "WANTED_GID": "1500"},
+        )
+        assert out["RESULT_UID"] == "1500"
+        assert out["RESULT_GID"] == "1500"
+
+    def test_7027_explicit_choice_survives_the_privilege_drop(self, tmp_path):
+        """Second pass (as the runtime user) must not re-detect over an explicit 1024.
+
+        docker_init.bash runs twice: once as root, then `exec su` re-enters it as
+        hermeswebui with the environment dropped. The second pass reads the value
+        back from $itdir — so the *origin* has to persist too, or the explicit
+        1024 gets auto-detected away and the UID no longer matches the running
+        user, which is a hard startup failure.
+        """
+        itdir = tmp_path / "itdir-shared"
+        first = self._run(
+            tmp_path,
+            owners={"state": (1001, 1001)},
+            env={"WANTED_UID": "1024", "WANTED_GID": "1024"},
+            itdir=itdir,
+        )
+        assert first["RESULT_UID"] == "1024"
+
+        second = self._run(  # no WANTED_* in env — `su` dropped it
+            tmp_path,
+            owners={"state": (1001, 1001)},
+            itdir=itdir,
+        )
+        assert second["RESULT_UID"] == "1024", (
+            "the runtime pass must honour the persisted explicit choice; "
+            "re-detecting here would make WANTED_UID disagree with the user the "
+            "script is already running as"
+        )
+        assert second["RESULT_GID"] == "1024"
+
+    def test_7027_persisted_default_is_still_re_detected(self, tmp_path):
+        """A *detected*/fallback 1024 stays re-detectable on a later run.
+
+        This is what the `= 1024` sentinel was for: a container that fell back to
+        1024 with nothing mounted must pick up the right identity once a state
+        volume appears. Only explicit values are frozen.
+        """
+        itdir = tmp_path / "itdir-shared"
+        first = self._run(tmp_path, owners={}, itdir=itdir)
+        assert first["RESULT_UID"] == "1024", "nothing mounted -> fallback"
+        assert first["RESULT_UID_SOURCE"] == "detected"
+
+        second = self._run(tmp_path, owners={"state": (1001, 1001)}, itdir=itdir)
+        assert second["RESULT_UID"] == "1001", (
+            "a persisted fallback 1024 must not freeze detection for later runs"
+        )
+        assert second["RESULT_GID"] == "1001"
+
+    # ── previously shipped behaviour that must not regress ────────────────────
+
+    def test_7027_workspace_fallback_preserved(self, tmp_path):
+        """With no state mount, /workspace still decides (#569)."""
+        out = self._run(tmp_path, owners={"workspace": (501, 20)})
+        assert out["RESULT_UID"] == "501"
+        assert out["RESULT_GID"] == "20"
+        assert "from /workspace" in out["_stdout"] or "workspace UID" in out["_stdout"]
+
+    def test_7027_hermes_home_still_beats_workspace(self, tmp_path):
+        """Two-container setups keep detecting from the shared hermes-home (#668)."""
+        out = self._run(
+            tmp_path,
+            owners={"hermes_home": (1001, 1001), "workspace": (1024, 1024)},
+        )
+        assert out["RESULT_UID"] == "1001"
+        assert out["RESULT_GID"] == "1001"
+
+    def test_7027_hermes_home_env_probe_preserved(self, tmp_path):
+        """$HERMES_HOME remains a probe candidate (#668)."""
+        sandbox = tmp_path / "sandbox"
+        sandbox.mkdir(exist_ok=True)
+        hermes_home = sandbox / "hermes-home"
+        out = self._run(
+            tmp_path,
+            owners={"hermes_home": (1001, 1001)},
+            env={"HERMES_HOME": str(hermes_home)},
+        )
+        assert out["RESULT_UID"] == "1001"
+
+    def test_7027_root_owned_state_dir_is_skipped(self, tmp_path):
+        """A root-owned state dir (fresh named volume) is not a host signal.
+
+        Docker creates a brand-new named volume owned by 0:0. Detection must skip
+        it — as it already does for every probe — and fall through.
+        """
+        out = self._run(
+            tmp_path,
+            owners={"state": (0, 0), "workspace": (501, 20)},
+        )
+        assert out["RESULT_UID"] == "501", "root-owned probes must be ignored"
+        assert out["RESULT_GID"] == "20"
+
+    def test_7027_nothing_mounted_falls_back_to_1024(self, tmp_path):
+        """No probe resolves -> the documented 1024 default."""
+        out = self._run(tmp_path, owners={})
+        assert out["RESULT_UID"] == "1024"
+        assert out["RESULT_GID"] == "1024"


### PR DESCRIPTION
Fixes #7027.

Implements the fix shape agreed in https://github.com/nesquena/hermes-webui/issues/7027#issuecomment-5297089216.

## Thinking Path

- Hermes WebUI's single-container Docker deploy is the setup users are pointed at first, so its startup path has to be forgiving of ordinary host layouts
- The container aligns its runtime user with the host by auto-detecting a UID/GID from mounted directories before `usermod`
- Detection is only as good as the paths it probes: a probe that resolves against something the *image* owns produces a confident answer with no host information in it
- The bug was that `/workspace` — present and owned `1024:1024` in every stock image — was probed while the configured state directory, which is a bind mount by definition, was not
- This PR probes the state directory first and stops treating an explicitly supplied `1024` as "unset"
- The result is that the documented single-container command comes up healthy on a host-owned state mount instead of restart-looping

## What Changed

`docker_init.bash`

- The UID and GID probe loops now start with `${HERMES_WEBUI_STATE_DIR:-/app/data}`, ahead of the hermes-home candidates.
- `/workspace` stays exactly where it was, as the priority-2 signal, for setups that genuinely bind-mount it. The hermes-home probes from #668 are untouched.
- Every detection branch is now gated on the value not having been supplied explicitly. Previously the guard was `[ -z "${WANTED_UID+x}" ] || [ "${WANTED_UID}" = "1024" ]`, so the fallback sentinel and a legitimate UID were the same number and an operator's explicit `1024` was overwritten by detection.
- The origin of the value (`explicit` / `detected`) is persisted to `$itdir` next to the value itself. `docker_init.bash` runs twice — once as root, then `exec su` re-enters it as `hermeswebui` with the environment dropped — so without persisting the origin, the second pass reads `1024` back from the file and cannot tell an operator's explicit choice from the fallback. Re-detecting there would leave `WANTED_UID` disagreeing with the user the script is already running as, which is a hard startup failure. A *detected* `1024` stays re-detectable on later runs, which is what the sentinel was for.

`tests/test_7027_state_dir_uid_probe.py` (new) — 18 tests, described under Verification.

`.github/workflows/docker-smoke.yml` — new `state-dir-uid` job, described under Verification.

`docs/docker.md` — new troubleshooting entry #9 with the symptom, the cause, and the full probe order; `#7027` added to Related issues.

## Why It Matters

The failure is a restart loop with an error that names the consequence rather than the cause:

```
touch: cannot touch '/app/data/.testfile': Permission denied
!! ERROR: Failed to verify state directory at /app/data
```

Nothing in it points at UID detection, and because `1024` is also the fallback, the preceding `Auto-detected workspace UID: 1024` line reads as though detection had found nothing — so the natural next step is to investigate why detection found nothing, when in fact it succeeded and picked the wrong source. The state directory is the one path that is a bind mount by definition in a single-container deploy, so its owner is always the host identity the container needs to match.

## Verification

**Behavioural tests** — `tests/test_7027_state_dir_uid_probe.py` extracts the real UID/GID resolution block from `docker_init.bash` and runs it under bash with `stat` stubbed, so ownership can be simulated without root. This follows the existing pattern in `tests/test_docker_env_readonly_vars.py`; source-level assertions alone cannot catch ordering or shell-quoting regressions inside the block.

The reproduction test is bound to the shape pinned in the issue — host directory owned `1001:1001` bind-mounted as the state dir, stock `/workspace` at `1024:1024`, no explicit IDs — rather than a fixture rebuilt from my reading of it. Coverage:

| Scenario | Expected |
|---|---|
| non-1024 state mount + stock `/workspace` (the issue) | 1001, detected from the state dir |
| macOS-style state mount, no `/workspace` | 501:20 |
| `HERMES_WEBUI_STATE_DIR` unset → default path | probed |
| explicit `WANTED_UID=1024` + 1001-owned mounts | stays 1024 |
| explicit `1024` across the `su` privilege drop | stays 1024 |
| persisted *fallback* 1024, state volume appears later | re-detects 1001 |
| explicit non-default (1500) | stays 1500 |
| no state mount, `/workspace` owned 501 | 501 (#569 path intact) |
| hermes-home owned 1001 vs `/workspace` 1024 | 1001 (#668 path intact) |
| `$HERMES_HOME` probe | intact |
| root-owned state dir (fresh named volume) | skipped, falls through |
| nothing mounted | 1024 fallback |

Reverting `docker_init.bash` alone turns 10 of the 18 red, including both behavioural anchors (`state_mount_beats_stock_workspace`, `explicit_1024_is_not_overwritten`). The 8 that still pass without the fix are the ones pinning previously shipped behaviour — that is the intended split.

```
$ ./scripts/test.sh tests/test_7027_state_dir_uid_probe.py -q
18 passed

$ git stash -- docker_init.bash && ./scripts/test.sh tests/test_7027_state_dir_uid_probe.py -q
10 failed, 8 passed
```

**Full suite** — `./scripts/test.sh` on Python 3.11, run twice: once on this branch, once on `master` with an otherwise identical environment. The failure sets are byte-identical (319 failing ids on both), so this branch introduces no regressions; it adds exactly 18 passes (12903 vs 12885).

```
branch: 312 failed, 12903 passed, 1444 skipped, 7 errors
master: 312 failed, 12885 passed, 1444 skipped, 7 errors
comm -23 branch_failures master_failures  ->  (empty)
```

Those 312 are environmental on my machine, not pre-existing repo breakage: 224 of them are `FileNotFoundError: [Errno 2] No such file or directory: 'node'` — I have no Node installed, and the JS-evaluating tests need it. CI has it. `tests/test_compression_phantom_barrier.py` was excluded from both runs because `playwright` is not in my local venv; it is unrelated to this change.

Docker-adjacent suites specifically (`test_issue569_579.py`, `test_docker_docs_and_readonly.py`, `test_issue2237_docker_chown_git_objects.py`, `test_issue1908_docker_hardening.py`, `test_docker_env_readonly_vars.py`, and the rest that read `docker_init.bash`): 108 passed.

`scripts/ruff_lint.py` clean, `scripts/critical_markdown_check.py` clean on `docs/docker.md`, `bash -n docker_init.bash` clean, and every `run:` block in the modified workflow parses under `bash -n`.

**Startup health** — the product gate named in the issue comment is `/health`, which no source-level invariant can prove, so it is a new `state-dir-uid` job in `docker-smoke.yml` rather than a pytest assertion. It boots a real container the way the issue does — `HERMES_WEBUI_STATE_DIR` bind-mounted from a host directory `chown`ed to `1001:1001`, no `WANTED_UID`, and deliberately **no** `/workspace` mount so the image's own `1024`-owned `/workspace` is the competing signal — then requires `/health` to return 200, the log to name the state dir as the detection source, `id -u hermeswebui` to actually be 1001, and the startup log to be free of the error signatures. A second step covers the explicit-`1024` half; it additionally mounts a 1001-owned hermes-home, because without that the pre-fix script would land on 1024 anyway via `/workspace` and the step would pass for the wrong reason.

**What I could not verify myself**: I have no Docker daemon on this machine, so that job has never executed on my side — it is verified by syntax only. Docker is owned by the runner, not by this repo's test suite, so please treat the CI run on this PR as the authoritative evidence for it, and I will iterate on the job if it comes back red.

## Contract Routing

Task type: bug fix in container startup, with a public-doc update
Touched areas: `docker_init.bash` UID/GID resolution, `docs/docker.md`, Docker smoke workflow
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/docker.md`
Scope boundaries: probe order and explicit-value handling only. No change to `usermod`/`groupmod`, the chown walk, the read-only-root branch, or any compose file.
Evidence needed before claiming done: bash-level regressions for the reported shape plus the pre-existing fallbacks, and a real container reaching `/health` on a host-owned state mount.

## Contract Change

- **Previous**: `WANTED_UID`/`WANTED_GID` equal to `1024` were treated as unset and re-derived by auto-detection, regardless of whether an operator had set them; detection ranked `/workspace` above the configured state directory.
- **New**: an explicitly supplied value always wins, including `1024`; the configured state directory ranks first, `/workspace` remains the next signal.
- **Affected docs and tests**: `docs/docker.md` (new §9 documenting the full order), `tests/test_7027_state_dir_uid_probe.py`. `tests/test_issue569_579.py` still passes unmodified — the `/workspace` and hermes-home probes it pins are unchanged.
- **Reason**: `1024` was simultaneously the sentinel and a valid identity, and the pre-fix order let an image-owned path outrank a host-owned one. Deployments that set IDs explicitly, or that rely on `/workspace`/hermes-home detection, keep their current behaviour.

## Risks / Follow-ups

- Deploys where the state dir and `/workspace` are owned by *different* non-root UIDs now follow the state dir instead of `/workspace`. That is the intended change, and it is the ownership that startup actually validates, but it is a behaviour change for anyone who was relying on the old precedence.
- `$itdir` gains two small marker files (`hermeswebui_user_{uid,gid}_source`). They are covered by the existing `chown -R "$itdir"` and written through `write_privtmpfile`, so they inherit the same 600 mode and ownership as the value files. A container carrying an old `$itdir` with no marker files reads them as absent and behaves exactly as before.
- Not addressed here: the state dir is probed before it is known to be writable, so a mounted-but-unwritable state dir still surfaces as the same "Failed to verify state directory" error, just with the right UID in it. That is a separate diagnostics improvement.
- Not addressed here either (raised by the Greptile review): the UID and GID loops are independent and each skips `0`, so a probe owned `1001:0` can hand the UID to one directory and the GID to a later one, yielding a pair that matches neither mount. That behaviour predates this PR — the two loops have always been separate with the same `!= "0"` guard — and this change extends both lists identically, so it adds a candidate rather than the divergence itself. Coupling the two loops would change detection semantics for the #569/#668 paths as well, which is past the scope agreed on the issue; happy to open a sibling issue for it, or to fold it in here if you would rather have it in one go.
- The new job reuses the same mutable action tags as the existing jobs in this workflow (`actions/checkout@v4`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v6`). Also flagged by Greptile. I kept them consistent with the rest of the file rather than SHA-pinning only my steps; pinning the workflow is a worthwhile change but belongs in its own PR.

## Release notes

**Docker: fix UID/GID auto-detection selecting the image's `1024` owner (#7027)** — single-container deploys with a bind-mounted `HERMES_WEBUI_STATE_DIR` owned by a non-`1024` host user no longer restart-loop with `Failed to verify state directory`. The configured state directory is now probed before `/workspace`, whose owner in a stock image is a build-time artifact rather than a host signal. An explicitly supplied `WANTED_UID`/`WANTED_GID` of `1024` is also no longer overwritten by auto-detection.

## Model Used

AI-assisted.

- Provider: Anthropic
- Model: Claude Opus 5 (1M context) — `claude-opus-5[1m]`, via Claude Code
- Notable mode/tool use: the assistant read the repo's Docker init, test, and contract docs, wrote the patch and tests, and ran the suites listed under Verification. The Docker smoke job is the one piece it could not execute locally, as noted above.
