### PR TITLE
fix(stream): avoid replaying active journal from zero

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2676,11 +2676,30 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _currentActivityBurstId=Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].currentActivityBurstId)||0)||0;
   let _currentLiveSegmentSeq=Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].currentLiveSegmentSeq)||0)||0;
   let _assistantSegmentSeq=Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].currentLiveSegmentSeq)||0)||0;
+  // A direct reload can discard the browser's INFLIGHT recovery cursor (for
+  // example after a prior journalReplayFromStart handoff). Reconnecting without
+  // a cursor would replay the entire active run journal into the browser,
+  // which is enough to freeze/crash a tab even when the settled transcript is
+  // small. The metadata-only session response carries a cheap authoritative
+  // journal cursor; use it as the cold-attach floor when no browser cursor is
+  // available. This intentionally starts at the current live point: the
+  // settled transcript remains the source for history, while future SSE events
+  // continue to update the active turn.
+  const _runtimeJournalCursor=(
+    reconnecting&&S.session&&S.session.session_id===activeSid&&
+    S.session.active_stream_id===streamId&&
+    S.session.runtime_journal&&
+    String(S.session.runtime_journal.run_id||'')===String(streamId)
+  ) ? S.session.runtime_journal : null;
+  const _storedRunJournalSeq=Number(INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalSeq)||0;
+  const _runtimeRunJournalSeq=Number(_runtimeJournalCursor&&_runtimeJournalCursor.last_seq)||0;
+  const _storedRunJournalEventId=String(INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalEventId||'');
+  const _runtimeRunJournalEventId=String(_runtimeJournalCursor&&_runtimeJournalCursor.last_event_id||'');
   let _lastRunJournalSeq=reconnecting
-    ? Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalSeq)||0)
+    ? Math.max(0,_storedRunJournalSeq||_runtimeRunJournalSeq)
     : 0;
   let _lastRunJournalEventId=reconnecting
-    ? String((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalEventId)||'')
+    ? (_storedRunJournalEventId||(_storedRunJournalSeq>0?'':_runtimeRunJournalEventId))
     : '';
   const _STREAM_FADE_MS=620;
   const _STREAM_FADE_MAX_MS=900;
@@ -5296,7 +5315,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // same run. `after_event_id` keeps that cursor run-aware so a stale cursor
     // from an earlier interrupted stream cannot suppress a newer stream whose
     // sequence numbers started over from 1.
-    return `&replay=1&after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}&after_event_id=${encodeURIComponent(_lastRunJournalEventId||'')}`;
+    const afterSeq=_runJournalReplayAfterSeq();
+    // Never request journal replay without a positive cursor. A missing cursor
+    // must not turn into a sequence-zero replay; for an active stream the bare
+    // SSE connection receives future events, and the replay-only path restores
+    // settled session state instead of asking the server for the full journal.
+    if(afterSeq<=0) return '';
+    return `&replay=1&after_seq=${encodeURIComponent(String(afterSeq))}&after_event_id=${encodeURIComponent(_lastRunJournalEventId||'')}`;
   }
 
   function _stableStringify(value){
@@ -7140,6 +7165,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){}
     }
     const replayParams=(reconnecting||replayOnly)?_runJournalReplayParams():'';
+    if(replayOnly&&!replayParams){
+      // Without a positive cursor, a dead stream must not fall through to the
+      // stream-not-found replay path, which would replay the journal from its
+      // beginning. Restore the settled transcript instead.
+      await _restoreSettledSession(null, {preserveVisibleOnShorterTerminalSnapshot:true});
+      return;
+    }
     _dispatchExtensionTurnLifecycle('turn:start',activeSid,streamId,{
       startedAt:_extensionTurnStartedAt,
     });

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -5,7 +5,10 @@ active pane. The owning session's persisted/runtime stream marker can be cleared
 but global pane state such as ``clearInflight()``, approval/clarify polling, and
 ``setBusy(false)`` must be gated to the session that owns the active pane/card.
 """
+import json
+import subprocess
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
 REPO_ROOT = Path(__file__).parent.parent
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
@@ -44,6 +47,112 @@ def _function_body(name: str) -> str:
     signature_end = MESSAGES_JS.find("){", start)
     assert signature_end >= 0, f"function body not found: {name}"
     return _body_from_brace(MESSAGES_JS, signature_end + 1, name)
+
+
+def _attach_live_stream_source(include_server_cursor=True):
+    """Execute the real attachLiveStream closure and return its EventSource URL."""
+    marker = "function attachLiveStream("
+    start = MESSAGES_JS.find(marker)
+    assert start >= 0, "attachLiveStream function not found"
+    signature_end = MESSAGES_JS.find("){", start)
+    assert signature_end >= 0, "attachLiveStream signature not found"
+    body = _body_from_brace(MESSAGES_JS, signature_end + 1, marker)
+    attach_source = MESSAGES_JS[start : signature_end + 2] + body + "}"
+    runtime_journal = (
+        "{run_id: streamId, last_seq: serverSeq, last_event_id: serverEventId}"
+        if include_server_cursor
+        else "undefined"
+    )
+    script = f"""
+import vm from 'node:vm';
+const captured = [];
+const sessionId = 'session-under-test';
+const streamId = 'stream-under-test';
+const serverSeq = 10491;
+const serverEventId = `${{streamId}}:${{serverSeq}}`;
+class FakeEventSource {{
+  constructor(url, options) {{
+    captured.push({{url: String(url), options}});
+    this.readyState = 0;
+  }}
+  addEventListener() {{}}
+  close() {{ this.readyState = 2; }}
+}}
+FakeEventSource.OPEN = 1;
+FakeEventSource.CONNECTING = 0;
+const noop = () => {{}};
+const sandbox = {{
+  console,
+  URL,
+  JSON,
+  Math,
+  Date,
+  encodeURIComponent,
+  setTimeout: () => 1,
+  clearTimeout: noop,
+  requestAnimationFrame: noop,
+  cancelAnimationFrame: noop,
+  EventSource: FakeEventSource,
+  location: {{href: 'https://webui.example.test/'}},
+  document: {{
+    hidden: false,
+    visibilityState: 'visible',
+    wasDiscarded: false,
+    baseURI: 'https://webui.example.test/',
+    addEventListener: noop,
+    removeEventListener: noop,
+  }},
+  S: {{
+    session: {{
+      session_id: sessionId,
+      active_stream_id: streamId,
+      pending_started_at: 1,
+      runtime_journal: {runtime_journal},
+    }},
+    activeStreamId: streamId,
+    messages: [],
+    busy: true,
+  }},
+  INFLIGHT: {{[sessionId]: {{
+    streamId,
+    messages: [],
+    toolCalls: [],
+    lastRunJournalSeq: 0,
+    lastRunJournalEventId: '',
+  }}}},
+  LIVE_STREAMS: {{}},
+  _STREAM_WAS_HIDDEN: {{}},
+  _STREAM_NOTIFICATION_BACKGROUND: {{}},
+  _streamHiddenTrackerBound: false,
+  _desktopBackgroundedForNotifications: false,
+  _bindStreamHiddenTracker: noop,
+  ensureLiveWorklogShell: noop,
+  closeOtherLiveStreams: noop,
+  closeLiveStream: noop,
+  resetTurnWorkspaceMutations: noop,
+  _resetStreamScrollFollow: noop,
+  _suspendSessionStreamForLiveChat: noop,
+  _dispatchExtensionTurnLifecycle: noop,
+  api: async () => ({{active: true}}),
+}};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+vm.runInContext({json.dumps(attach_source)}, sandbox);
+sandbox.attachLiveStream(sessionId, streamId, [], {{reconnecting: true}});
+await new Promise(resolve => setImmediate(resolve));
+if (captured.length !== 1) throw new Error(`expected one EventSource, got ${{captured.length}}`);
+process.stdout.write(JSON.stringify(captured[0]));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module"],
+        cwd=REPO_ROOT,
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
 
 
 def test_terminal_handlers_use_session_owned_cleanup_helpers():
@@ -185,6 +294,24 @@ def test_active_reconnect_uses_run_journal_replay_cursor():
     assert "${_runJournalReplayParams()}" in active_block
     assert "after_seq" in _function_body("_runJournalReplayParams")
     assert "after_event_id" in _function_body("_runJournalReplayParams")
+
+
+def test_cold_active_reconnect_uses_server_runtime_journal_cursor_when_inflight_cursor_is_missing():
+    """A direct reload must put the server's current cursor on EventSource."""
+    event_source = _attach_live_stream_source()
+    query = parse_qs(urlsplit(event_source["url"]).query)
+    assert query["stream_id"] == ["stream-under-test"]
+    assert query["after_seq"] == ["10491"]
+    assert query["after_event_id"] == ["stream-under-test:10491"]
+
+
+def test_cold_active_reconnect_without_server_cursor_does_not_request_zero_replay():
+    """A missing cursor must omit replay rather than fall back to sequence zero."""
+    event_source = _attach_live_stream_source(include_server_cursor=False)
+    query = parse_qs(urlsplit(event_source["url"]).query)
+    assert "after_seq" not in query
+    assert "after_event_id" not in query
+    assert "replay" not in query
 
 
 def test_attach_live_stream_registers_one_source_per_session_stream():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -1,6 +1,9 @@
 import json
 import subprocess
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+from tests.test_1694_terminal_cleanup_ownership import _attach_live_stream_source
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -421,8 +424,17 @@ def test_frontend_replay_cursor_uses_eventsource_last_event_id():
     assert "lastIndexOf(':')" in block
     assert "_lastRunJournalSeq=seq" in block
     assert "source.addEventListener(_runJournalEventName,_rememberRunJournalCursor)" in MESSAGES_SRC
-    assert "after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}" in MESSAGES_SRC
-    assert "after_seq=0" not in MESSAGES_SRC
+
+    event_source = _attach_live_stream_source()
+    query = parse_qs(urlsplit(event_source["url"]).query)
+    assert query["after_seq"] == ["10491"]
+    assert query["after_event_id"] == ["stream-under-test:10491"]
+
+    missing_cursor_source = _attach_live_stream_source(include_server_cursor=False)
+    missing_cursor_query = parse_qs(urlsplit(missing_cursor_source["url"]).query)
+    assert "after_seq" not in missing_cursor_query
+    assert "after_event_id" not in missing_cursor_query
+    assert "replay" not in missing_cursor_query
 
 
 def test_replayed_long_task_events_enter_the_same_live_timeline_handlers():


### PR DESCRIPTION
## Summary

- Use the metadata-only `runtime_journal.last_seq` / `last_event_id` as the cold reconnect cursor when browser-side INFLIGHT state has no usable cursor.
- Prevent direct reloads from reconnecting at `after_seq=0` and replaying an entire active run journal into the browser.
- Keep the settled transcript as the history source; future SSE events continue updating the active turn.

The reported session had a modest settled transcript but 9,773 active journal events. Replaying from sequence zero delivered 3.1 MB and more than 10,000 SSE events in five seconds, which could freeze or crash the browser tab.

## Verification

- `./scripts/test.sh tests/test_1694_terminal_cleanup_ownership.py tests/test_subpath_frontend_routes.py tests/test_inflight_stream_reuse.py -q` — 61 passed
- `node --check static/messages.js`
- `git diff --check`
- Live reproduction: `/api/session?messages=0` exposed a bounded runtime cursor; `after_seq=0` replayed the full active backlog.

## Risks / Follow-ups

- A cold attach starts at the current live cursor rather than reconstructing older live activity from the journal. The settled transcript remains available and the active response continues from the current point.
- The active stream is not cancelled or restarted by this change.

## AI Usage Disclosure

Provider/model: OpenAI Codex via Hermes Agent. The fix was isolated into a clean worktree based on the latest upstream `master`; the dirty deployment checkout was preserved.
