### PR TITLE
fix: assign projects across canonical session lineages

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1,4 +1,5 @@
 """Shared helpers for reading Hermes Agent sessions from state.db."""
+import json
 import logging
 import sqlite3
 from contextlib import closing
@@ -937,6 +938,196 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
         'children': [_lineage_report_row(row, 'child_session') for row in child_rows],
         'manual_review': manual_review,
     }
+
+
+def resolve_writable_compression_lineage(
+    db_path: Path,
+    session_id: str | None,
+    *,
+    max_hops: int = 20,
+    max_segments: int = 500,
+    compression_edge_validator=None,
+) -> dict:
+    """Resolve every segment in one writable compression lineage.
+
+    Unlike the sidebar projection, a metadata mutation cannot safely degrade to
+    a partial graph: doing so would let the next authoritative refresh select a
+    different segment's stale value.  Return ``complete=False`` for missing
+    parents, cycles, depth/size overflow, malformed schemas, or read failures.
+    Explicit forks and other child-session edges are never included. Callers
+    that own stronger durable rotation evidence may supply
+    ``compression_edge_validator``; a rejected compression edge stays outside
+    the writable lineage.
+    """
+    sid = str(session_id or '').strip()
+    result = {
+        "found": False,
+        "complete": False,
+        "error": False,
+        "root_id": None,
+        "segment_ids": [],
+    }
+    if not sid:
+        return result
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return result
+
+    try:
+        with closing(open_state_db_readonly(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            cols = {row[1] for row in cur.fetchall()}
+            if 'id' not in cols:
+                return result
+            cur.execute("SELECT 1 FROM sessions WHERE id = ?", (sid,))
+            if cur.fetchone() is None:
+                return result
+            required = {'id', 'parent_session_id', 'end_reason'}
+            if not required.issubset(cols):
+                # Legacy state.db schemas predate compression lineage entirely.
+                # They cannot encode a partial lineage, so preserve the existing
+                # standalone-sidecar mutation path. Once the lineage columns
+                # exist, missing/cyclic graph rows below fail closed.
+                return result
+
+            source_expr = _optional_col('source', cols)
+            session_source_expr = _optional_col('session_source', cols)
+            model_config_expr = _optional_col('model_config', cols)
+            started_expr = _optional_col('started_at', cols, '0')
+            ended_expr = _optional_col('ended_at', cols)
+
+            def fetch_one(row_id: str | None) -> dict | None:
+                if not row_id:
+                    return None
+                cur.execute(
+                    f"""SELECT s.id, {source_expr}, {session_source_expr},
+                               {model_config_expr}, {started_expr}, s.parent_session_id,
+                               {ended_expr}, s.end_reason
+                        FROM sessions s WHERE s.id = ?""",
+                    (row_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+            def is_writable_continuation(parent: dict, child: dict) -> bool:
+                child_is_fork = str(child.get('session_source') or '').strip().lower() == 'fork'
+                parent_is_fork = str(parent.get('session_source') or '').strip().lower() == 'fork'
+                # Compression rotates the existing Session object, so a fork's
+                # continuation inherits session_source="fork". Keep the initial
+                # branch edge independent, but allow durable compression edges
+                # once both sides already belong to that fork lineage.
+                if child_is_fork and not parent_is_fork:
+                    return False
+
+                def branch_markers(row: dict) -> tuple:
+                    raw_model_config = row.get('model_config')
+                    if raw_model_config in (None, ''):
+                        return (None, None)
+                    try:
+                        model_config = json.loads(raw_model_config)
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError("ambiguous lineage model_config") from exc
+                    if not isinstance(model_config, dict):
+                        raise ValueError("ambiguous lineage model_config")
+                    branched_from = model_config.get('_branched_from')
+                    delegate_from = model_config.get('_delegate_from')
+                    markers = [value for value in (branched_from, delegate_from) if value is not None]
+                    if len(markers) > 1 or any(not isinstance(value, str) or not value.strip() for value in markers):
+                        raise ValueError("ambiguous lineage model_config")
+                    return branched_from, delegate_from
+
+                parent_markers = branch_markers(parent)
+                child_markers = branch_markers(child)
+                if parent_markers != child_markers and (
+                    parent_markers != (None, None) or child_markers != (None, None)
+                ):
+                    # Compression preserves model_config. An unchanged marker
+                    # identifies the fork/delegate lineage we are already in;
+                    # a new or changed marker starts an independent branch.
+                    return False
+                if parent.get('end_reason') == 'compression' and compression_edge_validator is not None:
+                    # The mutation caller's durable sidecar proof is authoritative
+                    # for WebUI rotations even when historical state.db source
+                    # labels drift between webui/cli across old segments.
+                    return bool(compression_edge_validator(parent, child))
+                if child_is_fork:
+                    return False
+                return _is_continuation_session(parent, child)
+
+            target = fetch_one(sid)
+            if not target:
+                return result
+            result["found"] = True
+
+            root = target
+            seen_ancestors = {sid}
+            for _hop in range(max(0, int(max_hops))):
+                parent_id = root.get('parent_session_id')
+                if not parent_id:
+                    break
+                parent_id = str(parent_id)
+                parent = fetch_one(parent_id)
+                if parent is None or parent_id in seen_ancestors:
+                    return result
+                if not is_writable_continuation(parent, root):
+                    break
+                seen_ancestors.add(parent_id)
+                root = parent
+            else:
+                if root.get('parent_session_id'):
+                    return result
+
+            root_id = str(root['id'])
+            segment_ids: list[str] = []
+            seen: set[str] = set()
+            frontier: list[tuple[dict, int]] = [(root, 0)]
+            while frontier:
+                current, depth = frontier.pop(0)
+                current_id = str(current['id'])
+                if current_id in seen or depth > max_hops:
+                    return result
+                seen.add(current_id)
+                segment_ids.append(current_id)
+                if len(segment_ids) > max_segments:
+                    return result
+                cur.execute(
+                    f"""SELECT s.id, {source_expr}, {session_source_expr},
+                               {model_config_expr}, {started_expr}, s.parent_session_id,
+                               {ended_expr}, s.end_reason
+                        FROM sessions s WHERE s.parent_session_id = ?""",
+                    (current_id,),
+                )
+                writable_children = []
+                for row in cur.fetchall():
+                    child = dict(row)
+                    if is_writable_continuation(current, child):
+                        writable_children.append(child)
+                # Two sidecar-backed children with the same compression parent
+                # are indistinguishable from a continuation plus an unmarked
+                # ordinary child. Never guess which branch owns lineage-wide
+                # metadata; require repair/manual disambiguation before writing.
+                if len(writable_children) > 1:
+                    return result
+                for child in writable_children:
+                    frontier.append((child, depth + 1))
+
+            if sid not in seen:
+                return result
+            return {
+                "found": True,
+                "complete": True,
+                "error": False,
+                "root_id": root_id,
+                "segment_ids": segment_ids,
+            }
+    except Exception:
+        # The path existed when resolution started. Any open/schema/read failure
+        # is uncertainty, not proof that this is a standalone sidecar. Metadata
+        # mutations must fail closed while their authority store is unreadable.
+        result["error"] = True
+        return result
 
 
 def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[str]) -> dict[str, dict]:

--- a/api/models.py
+++ b/api/models.py
@@ -4799,6 +4799,81 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
     raise KeyError(sid)
 
 
+_PROJECT_MOVE_JOURNAL_LOCK = threading.RLock()
+
+
+def _project_move_journal_dir() -> Path:
+    return Path(_cfg.STATE_DIR) / "project-move-journal"
+
+
+def _write_project_move_journal(payload: dict) -> Path:
+    """Durably replace one project-move journal before sidecar mutation."""
+    journal_dir = _project_move_journal_dir()
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    txid = str(payload["txid"])
+    path = journal_dir / f"{txid}.json"
+    tmp = journal_dir / f".{txid}.{uuid.uuid4().hex}.tmp"
+    try:
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        try:
+            dir_fd = os.open(journal_dir, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+        return path
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def recover_project_move_journals() -> bool:
+    """Recover interrupted lineage project moves before sidebar projection.
+
+    Prepared transactions roll back to their exact original metadata. Committed
+    transactions finish applying one shared target timestamp. A journal is kept
+    when any sidecar cannot be recovered so the next poll/startup retries.
+    """
+    with _PROJECT_MOVE_JOURNAL_LOCK:
+        journal_dir = _project_move_journal_dir()
+        if not journal_dir.exists():
+            return True
+        recovered_all = True
+        for path in sorted(journal_dir.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                committed = payload.get("state") == "committed"
+                entries = payload.get("entries") or []
+                for entry in entries:
+                    session = Session.load(str(entry["session_id"]))
+                    if session is None or getattr(session, "read_only", False):
+                        raise RuntimeError(f"missing writable sidecar {entry.get('session_id')}")
+                    session.project_id = (
+                        payload.get("target_project_id")
+                        if committed
+                        else entry.get("project_id")
+                    )
+                    session.updated_at = (
+                        payload.get("target_updated_at")
+                        if committed
+                        else entry.get("updated_at")
+                    )
+                    session.save(touch_updated_at=False)
+                path.unlink()
+            except Exception:
+                recovered_all = False
+                logger.error("project move journal recovery failed for %s", path, exc_info=True)
+        return recovered_all
+
+
 def get_session(sid, metadata_only=False):
     """Load a session, optionally with metadata only (skipping messages)."""
     return _resolve_session(sid, metadata_only=metadata_only)
@@ -6133,6 +6208,10 @@ def _diag_stage(diag, name: str) -> None:
 
 
 def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
+    # Resolve any interrupted multi-sidecar project transaction before exposing
+    # sidebar metadata after a process restart.
+    if not recover_project_move_journals():
+        raise RuntimeError("project assignment journal recovery is incomplete")
     _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
     # Phase C: try index first for O(1) read; fall back to full scan

--- a/api/routes.py
+++ b/api/routes.py
@@ -45,6 +45,7 @@ from api.agent_sessions import (
     is_cli_session_row,
     is_cli_session_row_visible,
     read_session_lineage_report,
+    resolve_writable_compression_lineage,
 )
 from api.compression_anchor import visible_messages_for_anchor
 from api.compression_recovery import (
@@ -5290,6 +5291,83 @@ def _get_or_materialize_session(sid: str, *, refresh_cli_messages: bool = False)
     return s
 
 
+def _project_assignment_compression_edge(parent, child):
+    """Confirm a WebUI rotation edge from both durable sidecars."""
+    parent_sid = str(parent.get("id") or "")
+    child_sid = str(child.get("id") or "")
+    parent_sidecar = Session.load_metadata_only(parent_sid)
+    child_sidecar = Session.load_metadata_only(child_sid)
+    return bool(
+        parent_sidecar
+        and child_sidecar
+        and getattr(parent_sidecar, "pre_compression_snapshot", False)
+        and str(getattr(child_sidecar, "parent_session_id", "") or "") == parent_sid
+    )
+
+
+def _resolve_project_assignment_sessions(requested_session):
+    """Return the complete writable compression lineage for a project move."""
+    requested_sid = str(getattr(requested_session, "session_id", "") or "")
+
+    lineage = resolve_writable_compression_lineage(
+        _active_state_db_path(),
+        requested_sid,
+        compression_edge_validator=_project_assignment_compression_edge,
+    )
+    if lineage.get("error"):
+        raise ValueError("Session compression lineage could not be verified; project assignment was not changed")
+    if not lineage.get("found"):
+        return [requested_session], lineage
+    if not lineage.get("complete"):
+        raise ValueError("Session compression lineage is incomplete; project assignment was not changed")
+
+    sessions = []
+    requested_profile = getattr(requested_session, "profile", None) or get_active_profile_name()
+    for sid in lineage.get("segment_ids") or []:
+        try:
+            segment = _get_or_materialize_session(str(sid))
+        except (KeyError, PermissionError) as exc:
+            raise ValueError(
+                "Session compression lineage is not fully writable; project assignment was not changed"
+            ) from exc
+        segment_profile = getattr(segment, "profile", None) or get_active_profile_name()
+        if not _profiles_match(segment_profile, requested_profile):
+            raise ValueError(
+                "Session compression lineage crosses profiles; project assignment was not changed"
+            )
+        sessions.append(segment)
+    if not sessions or requested_sid not in {
+        str(getattr(segment, "session_id", "") or "") for segment in sessions
+    }:
+        raise ValueError("Session compression lineage is incomplete; project assignment was not changed")
+    return sessions, lineage
+
+
+def _acquire_project_assignment_locks(sessions, *, timeout: float = 5.0):
+    """Acquire unique lineage locks in deterministic session-id order."""
+    def session_id(item):
+        if isinstance(item, str):
+            return item
+        return str(getattr(item, "session_id", "") or "")
+
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    locks = []
+    seen_lock_ids = set()
+    for session in sorted(sessions, key=session_id):
+        lock = _get_session_agent_lock(session_id(session))
+        lock_identity = id(lock)
+        if lock_identity in seen_lock_ids:
+            continue
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not lock.acquire(timeout=remaining):
+            for acquired in reversed(locks):
+                acquired.release()
+            return []
+        locks.append(lock)
+        seen_lock_ids.add(lock_identity)
+    return locks
+
+
 def _share_snapshot_messages_for_session(session, *, cli_meta: dict | None = None) -> list:
     """Return the visible transcript that a public share should snapshot.
 
@@ -9612,6 +9690,9 @@ from api.models import (
     all_sessions,
     title_from,
     _write_session_index,
+    _PROJECT_MOVE_JOURNAL_LOCK,
+    _write_project_move_journal,
+    recover_project_move_journals,
     SESSION_INDEX_FILE,
     _active_state_db_path,
     load_projects,
@@ -16347,12 +16428,56 @@ def handle_post(handler, parsed) -> bool:
             require(body, "session_id")
         except ValueError as e:
             return bad(handler, str(e))
+        requested_sid = str(body["session_id"])
+        state_only_tip = False
         try:
-            s = _get_or_materialize_session(body["session_id"])
+            s = _get_or_materialize_session(requested_sid)
         except KeyError:
-            return bad(handler, "Session not found", 404)
+            def state_only_edge_validator(parent, child):
+                return (
+                    str(child.get("id") or "") == requested_sid
+                    or _project_assignment_compression_edge(parent, child)
+                )
+
+            initial_lineage = resolve_writable_compression_lineage(
+                _active_state_db_path(),
+                requested_sid,
+                compression_edge_validator=state_only_edge_validator,
+            )
+            if not initial_lineage.get("found"):
+                return bad(handler, "Session not found", 404)
+            if not initial_lineage.get("complete"):
+                return bad(
+                    handler,
+                    "Session compression lineage is incomplete; project assignment was not changed",
+                    409,
+                )
+            assignment_sessions = [
+                loaded
+                for sid in initial_lineage.get("segment_ids") or []
+                if (loaded := Session.load(str(sid))) is not None
+            ]
+            if not assignment_sessions:
+                return bad(handler, "Session not found", 404)
+            lineage_profiles = {
+                getattr(segment, "profile", None) or get_active_profile_name()
+                for segment in assignment_sessions
+            }
+            if len(lineage_profiles) != 1:
+                return bad(
+                    handler,
+                    "Session compression lineage crosses profiles; project assignment was not changed",
+                    409,
+                )
+            s = assignment_sessions[-1]
+            state_only_tip = True
         except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be moved from WebUI", 403)
+        if not state_only_tip:
+            try:
+                assignment_sessions, initial_lineage = _resolve_project_assignment_sessions(s)
+            except ValueError as e:
+                return bad(handler, str(e), 409)
         # #1614: refuse moves into a project owned by another profile.
         target_pid = body.get("project_id") or None
         if target_pid:
@@ -16379,22 +16504,162 @@ def handle_post(handler, parsed) -> bool:
         # the wait converts that into an actionable HTTP 503 the client can retry.
         # We keep the lock (rather than dropping it for this metadata-only write)
         # because s.save() still races the streaming thread's atomic writer.
-        _move_lock = _get_session_agent_lock(body["session_id"])
-        if not _move_lock.acquire(timeout=5):
+        # The helper performs a bounded ``lock.acquire(timeout=remaining)`` for
+        # every distinct lineage lock, preserving the #3746 non-blocking gate.
+        lock_owners = (
+            initial_lineage.get("segment_ids") or assignment_sessions
+            if initial_lineage.get("found")
+            else assignment_sessions
+        )
+        _move_locks = _acquire_project_assignment_locks(lock_owners, timeout=5)
+        if not _move_locks:
             return j(
                 handler,
                 {"error": "Session is busy (streaming). Please try again in a moment."},
                 status=503,
             )
         try:
-            s.project_id = target_pid
-            s.save()
+            locked_lineage = resolve_writable_compression_lineage(
+                _active_state_db_path(),
+                requested_sid,
+                compression_edge_validator=(
+                    state_only_edge_validator
+                    if state_only_tip
+                    else _project_assignment_compression_edge
+                ),
+            )
+            expected_ids = {
+                str(getattr(segment, "session_id", "") or "")
+                for segment in assignment_sessions
+            }
+            initial_ids = set(initial_lineage.get("segment_ids") or [])
+            if (
+                locked_lineage.get("error")
+                or (
+                    initial_lineage.get("found")
+                    and not locked_lineage.get("found")
+                )
+                or (
+                    locked_lineage.get("found")
+                    and (
+                        not locked_lineage.get("complete")
+                        or set(locked_lineage.get("segment_ids") or [])
+                        != (initial_ids if initial_lineage.get("found") else expected_ids)
+                    )
+                )
+                or (not locked_lineage.get("found") and len(expected_ids) != 1)
+            ):
+                return bad(
+                    handler,
+                    "Session compression lineage changed while moving; project assignment was not changed",
+                    409,
+                )
+            # Reload while holding every lineage lock so stale pre-lock Session
+            # objects cannot overwrite newer transcript checkpoints.
+            locked_sessions = []
+            for segment in assignment_sessions:
+                sid = str(getattr(segment, "session_id", "") or "")
+                locked = Session.load(sid)
+                if locked is None and len(assignment_sessions) == 1:
+                    # New empty sessions live only in SESSIONS until their first
+                    # write. Preserve that existing single-row move behavior;
+                    # multi-segment lineage mutations still require every
+                    # durable sidecar to be present before any write begins.
+                    locked = segment
+                if locked is None or getattr(locked, "read_only", False):
+                    return bad(
+                        handler,
+                        "Session compression lineage changed while moving; project assignment was not changed",
+                        409,
+                    )
+                locked_sessions.append(locked)
+            with _PROJECT_MOVE_JOURNAL_LOCK:
+                if not recover_project_move_journals():
+                    return bad(
+                        handler,
+                        "A previous project assignment is still recovering; refresh before retrying",
+                        503,
+                    )
+                original_project_ids = {
+                    locked.session_id: locked.project_id for locked in locked_sessions
+                }
+                original_updated_at = {
+                    locked.session_id: locked.updated_at for locked in locked_sessions
+                }
+                transaction_updated_at = time.time()
+                journal = {
+                    "txid": uuid.uuid4().hex,
+                    "state": "prepared",
+                    "target_project_id": target_pid,
+                    "target_updated_at": transaction_updated_at,
+                    "entries": [
+                        {
+                            "session_id": locked.session_id,
+                            "project_id": original_project_ids[locked.session_id],
+                            "updated_at": original_updated_at[locked.session_id],
+                        }
+                        for locked in locked_sessions
+                    ],
+                }
+                journal_path = _write_project_move_journal(journal)
+                for locked in locked_sessions:
+                    locked.project_id = target_pid
+                    locked.updated_at = transaction_updated_at
+                attempted_sessions = []
+                try:
+                    for locked in locked_sessions:
+                        # save() replaces the sidecar before it updates the index.
+                        # Record the attempt first so an index failure rolls back a
+                        # sidecar that was already durably replaced.
+                        attempted_sessions.append(locked)
+                        locked.save(touch_updated_at=False)
+                except Exception:
+                    rollback_failed = False
+                    for saved in reversed(attempted_sessions):
+                        saved.project_id = original_project_ids[saved.session_id]
+                        saved.updated_at = original_updated_at[saved.session_id]
+                        try:
+                            saved.save(touch_updated_at=False)
+                        except Exception:
+                            rollback_failed = True
+                            logger.error(
+                                "session/move rollback failed for %s",
+                                saved.session_id,
+                                exc_info=True,
+                            )
+                    if not rollback_failed:
+                        journal_path.unlink(missing_ok=True)
+                    message = "Project assignment could not be persisted; no sessions were changed"
+                    if rollback_failed:
+                        message = "Project assignment failed and rollback was incomplete; refresh before retrying"
+                    return bad(handler, message, 500)
+                journal["state"] = "committed"
+                _write_project_move_journal(journal)
+                journal_path.unlink(missing_ok=True)
+            with LOCK:
+                for locked in locked_sessions:
+                    if locked.session_id in SESSIONS:
+                        SESSIONS[locked.session_id] = locked
+            s = next(
+                (
+                    locked for locked in locked_sessions
+                    if locked.session_id == requested_sid
+                ),
+                locked_sessions[-1] if state_only_tip else None,
+            )
+            if s is None:
+                return bad(
+                    handler,
+                    "Session compression lineage changed while moving; project assignment was not changed",
+                    409,
+                )
         finally:
-            _move_lock.release()
+            for _move_lock in reversed(_move_locks):
+                _move_lock.release()
         publish_session_list_changed(
             "session_move",
             profile=getattr(s, "profile", None),
-            session_id=getattr(s, "session_id", body["session_id"]),
+            session_id=requested_sid,
         )
         return j(handler, {"ok": True, "session": s.compact()})
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6662,22 +6662,49 @@ function _isForkWithResolvableParent(s, sessionIdsInList){
 }
 
 function _sessionLineageKey(s, sessionIdsInList, sessionsById){
+  const isCompressionEdge=(parent,child)=>{
+    if(!(
+      parent&&child&&parent.session_id&&child.parent_session_id===parent.session_id&&
+      parent.pre_compression_snapshot===true&&(
+        child.session_source!=='fork'||parent.session_source==='fork'
+      )
+    )) return false;
+    let candidateCount=0;
+    const childIsFork=child.session_source==='fork';
+    for(const candidate of (sessionsById?sessionsById.values():[])){
+      if(
+        candidate&&candidate.parent_session_id===parent.session_id&&
+        (candidate.session_source==='fork')===childIsFork
+      ) candidateCount++;
+      if(candidateCount>1) return false;
+    }
+    return candidateCount===1;
+  };
   if(!s||!s.session_id) return null;
-  if(_isChildSession(s)) return null;
-  if(s.session_source==='fork') return null;
+  const parent=s.parent_session_id&&sessionsById?sessionsById.get(s.parent_session_id):null;
+  // Compression rotates the existing Session object, so descendants of a fork
+  // retain session_source='fork'. Collapse only fork→fork snapshot edges; the
+  // original non-fork→fork branch remains an independent conversation.
+  if(s.session_source==='fork'&&!(parent&&parent.session_source==='fork'&&isCompressionEdge(parent,s))){
+    return s.pre_compression_snapshot===true?s.session_id:null;
+  }
+  // Sidecar compression provenance is stronger than state.db's conservative
+  // child-session projection. A continuation can therefore arrive labelled as
+  // a child while its exact parent is a durable pre-compression snapshot.
+  if(_isChildSession(s)&&!isCompressionEdge(parent,s)) return null;
   const lineageKey=s._lineage_root_id||s.lineage_root_id||null;
   if(lineageKey) return lineageKey;
   // WebUI-native context compression may only persist parent_session_id:
   // the preserved parent snapshot is marked pre_compression_snapshot while
   // the new continuation points at it.  When both rows are in the sidebar
   // payload, still collapse them into one conversation (#2489).
-  const parent=s.parent_session_id&&sessionsById?sessionsById.get(s.parent_session_id):null;
   if(s.pre_compression_snapshot||parent&&parent.pre_compression_snapshot){
     let root=s;
     const seen=new Set();
     while(root&&root.parent_session_id&&sessionsById&&sessionsById.has(root.parent_session_id)&&!seen.has(root.parent_session_id)){
       const next=sessionsById.get(root.parent_session_id);
-      if(!next||_isChildSession(next)||next.session_source==='fork'||!(root.pre_compression_snapshot||next.pre_compression_snapshot)) break;
+      if(!next||!isCompressionEdge(next,root)) break;
+      if(root.session_source==='fork'&&next.session_source!=='fork') break;
       seen.add(root.session_id);
       root=next;
     }
@@ -7023,6 +7050,10 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawRefere
   for(const child of attachQueue){
     const childRenderable=!!(child&&child.session_id&&renderableChildIds.has(child.session_id));
     if(child&&child.session_id&&visibleBySid.has(child.session_id)) continue;
+    // A raw segment already represented by the collapsed lineage is a prior
+    // turn, never a child row. This prevents one session from appearing in both
+    // expansion lists when state.db conservatively labelled it as a child.
+    if(child&&child.session_id&&visibleBySegmentSid.has(child.session_id)) continue;
     const isForkChild=_isForkWithResolvableParent(child, sessionIdsInList)&&!(child&&child.pinned);
     const childLineageKey=child&&(child._lineage_root_id||child.lineage_root_id||child.parent_session_id);
     const isHiddenLineageReferenceChild=!!(child&&child.archived&&child.parent_session_id&&childLineageKey&&!child.pinned&&!childRenderable);
@@ -7114,6 +7145,10 @@ function _syncSidebarExpansionForActiveSession(rows, activeSid){
   }
 }
 
+async function _openSidebarLineageSegment(segment){
+  return _openSidebarSession(segment, {skipLineageResolve:true});
+}
+
 function _collapseSessionLineageForSidebar(sessions){
   const result=[];
   const sessionIdsInList=new Set((sessions||[]).map(s=>s.session_id));
@@ -7146,7 +7181,18 @@ function _collapseSessionLineageForSidebar(sessions){
       ? _authoritativeLineageTipId(item)
       : item&&(item._lineage_tip_id||item._parent_lineage_tip_id)||null).filter(Boolean));
     const chosen=sorted.find(item=>tipIds.has(item&&item.session_id))||sorted[0];
-    result.push({...chosen,_lineage_key:key,_lineage_collapsed_count:items.length,_lineage_segments:sorted});
+    const collapsed={...chosen,_lineage_key:key,_lineage_collapsed_count:items.length,_lineage_segments:sorted};
+    // A canonical tip can exist only in state.db while older materialized
+    // sidecars own the lineage metadata. Inherit their agreed project value so
+    // a refresh cannot resurrect the tip's absent/stale assignment.
+    if(collapsed.project_id==null){
+      const projectOwner=sorted.find(item=>item&&item.project_id!=null);
+      if(projectOwner) collapsed.project_id=projectOwner.project_id;
+    }
+    // A state.db fallback may conservatively call the proven continuation a
+    // child. Once collapsed from sidecar snapshot edges it is the lineage tip.
+    if(items.length>1&&collapsed.relationship_type==='child_session') delete collapsed.relationship_type;
+    result.push(collapsed);
   }
   return result;
 }
@@ -8204,7 +8250,7 @@ function renderSessionListFromCache(){
         row.title=t('session_lineage_segment_open');
         row.onclick=async(e)=>{
           e.stopPropagation();
-          await _openSidebarSession(seg, {skipLineageResolve:true});
+          await _openSidebarLineageSegment(seg);
         };
         lineageList.appendChild(row);
       }

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -308,14 +308,15 @@ def test_branch_marks_explicit_forks_as_fork_sessions():
 
 
 def test_branch_fork_sessions_do_not_collapse_into_parent_lineage():
-    """Fork sessions are not collapsed into compression-lineage; guard must remain in _sessionLineageKey."""
+    """The initial fork edge stays independent while compressed fork tips may collapse."""
     src = _read('static/sessions.js')
     fn = re.search(r'function _sessionLineageKey\(.*?\n\}', src, re.DOTALL)
     assert fn, "Could not find _sessionLineageKey"
     block = fn.group(0)
-    assert "if(s.session_source==='fork') return null;" in block, \
-        "Fork guard must remain in _sessionLineageKey to prevent compression-lineage merging"
-    assert block.index("if(s.session_source==='fork') return null;") < block.index('return s.parent_session_id || null')
+    guard = "if(s.session_source==='fork'&&!(parent&&parent.session_source==='fork'&&isCompressionEdge(parent,s)))"
+    assert guard in block, \
+        "Fork guard must reject the initial non-fork→fork edge while allowing fork compression"
+    assert block.index(guard) < block.index('return s.parent_session_id || null')
 
 
 def test_branch_fork_sessions_nest_under_parent():

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -205,7 +205,8 @@ def test_static_sessions_js_switches_profile_before_opening_all_profiles_row():
     assert "_profileSwitchOpeningExistingSession=true;" in ensure_body
     assert open_body.index("await _ensureSidebarSessionProfile(session);") < open_body.index("await loadSession(session.session_id,")
     assert "await _openSidebarSession(s);" in src
-    assert "await _openSidebarSession(seg, {skipLineageResolve:true});" in src
+    assert "await _openSidebarLineageSegment(seg);" in src
+    assert "return _openSidebarSession(segment, {skipLineageResolve:true});" in src
     assert "await _openSidebarSession(childSession, {skipLineageResolve:true});" in src
 
 

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -279,7 +279,9 @@ def test_session_move_uses_session_profile():
 
     move_idx = src.find('"/api/session/move"')
     assert move_idx > 0
-    move_block = src[move_idx:move_idx + 2000]
+    next_route_idx = src.find('\n    if parsed.path == ', move_idx + 1)
+    assert next_route_idx > move_idx
+    move_block = src[move_idx:next_route_idx]
     assert '_profiles_match(target.get("profile"), _session_profile)' in move_block, (
         "session/move must use session-scoped profile (not active_profile) for authorization"
     )

--- a/tests/test_issue3603_external_session_import_gate.py
+++ b/tests/test_issue3603_external_session_import_gate.py
@@ -81,7 +81,8 @@ def test_lineage_open_uses_is_external_session():
         r'if\s*\(\s*_isExternalSession\s*\(\s*session\s*\)\s*\)',
         body,
     ), 'Shared sidebar helper must keep _isExternalSession(session) import gate'
-    assert "await _openSidebarSession(seg, {skipLineageResolve:true});" in js
+    assert "await _openSidebarLineageSegment(seg);" in js
+    assert "return _openSidebarSession(segment, {skipLineageResolve:true});" in js
 
 
 def test_child_session_open_uses_is_external_session():

--- a/tests/test_project_assignment_compression_lineage.py
+++ b/tests/test_project_assignment_compression_lineage.py
@@ -1,0 +1,665 @@
+"""Project assignment is durable metadata of one compression lineage.
+
+The production regression was a successful ``POST /api/session/move`` followed by
+an authoritative ``GET /api/sessions`` replacing the optimistic project chip with
+``null``.  These tests use real sidecars plus a real state.db compression graph so
+they exercise the server mutation and sidebar-authority seams together.
+"""
+
+from collections import OrderedDict
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = "20260812_101401_f002bb"
+MIDDLE = "20260812_102343_19117b"
+TIP = "20260812_113743_e99b89"
+FORK = "20260812_114500_fork001"
+FORK_TIP = "20260812_114550_forktip"
+ORDINARY_CHILD = "20260812_114600_child01"
+PROJECT = "proj-lineage"
+
+
+def _make_state_db(path, *, malformed=False):
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT,
+            model_config TEXT
+        );
+        CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    rows = [
+        (ROOT, "webui", None, "Production lineage", 100.0, 1, None, 150.0, "compression"),
+        (MIDDLE, "webui", None, "Production lineage #2", 151.0, 1, ROOT, 200.0, "compression"),
+        (TIP, "webui", None, "Production lineage #3", 201.0, 1, MIDDLE, None, None),
+        (FORK, "webui", "fork", "Independent fork", 202.0, 1, MIDDLE, None, None),
+        # A physical parent edge is not proof that WebUI's compression rotation
+        # carried the parent's sidecar lineage into this ordinary child.
+        (ORDINARY_CHILD, "webui", None, "Ordinary child", 203.0, 1, MIDDLE, None, None),
+    ]
+    if malformed:
+        rows[1] = (MIDDLE, "webui", None, "Production lineage #2", 151.0, 1, "missing-parent", 200.0, "compression")
+    conn.executemany(
+        "INSERT INTO sessions "
+        "(id, source, session_source, title, started_at, message_count, "
+        "parent_session_id, ended_at, end_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    for idx, sid in enumerate((ROOT, MIDDLE, TIP, FORK, ORDINARY_CHILD), start=1):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', ?, ?)",
+            (sid, f"message {sid}", float(100 + idx * 50)),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def lineage_store(monkeypatch, tmp_path):
+    import api.config as config
+    import api.models as models
+    import api.profiles as profiles
+    import api.routes as routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(
+        json.dumps([
+            {
+                "project_id": PROJECT,
+                "name": "Lineage project",
+                "profile": "default",
+                "color": "#123456",
+                "created_at": 1.0,
+            }
+        ]),
+        encoding="utf-8",
+    )
+    state_db = tmp_path / "state.db"
+    _make_state_db(state_db)
+
+    sessions = OrderedDict()
+    # The ordinary child exists only in Agent state.db. It has no WebUI sidecar
+    # and must not be materialized merely because a project mutation traverses
+    # the compression-ended parent row.
+    for idx, sid in enumerate((ROOT, MIDDLE, TIP, FORK), start=1):
+        session = models.Session(
+            session_id=sid,
+            title=(
+                "Independent fork" if sid == FORK
+                else "Ordinary child" if sid == ORDINARY_CHILD
+                else "Production lineage"
+            ),
+            workspace=str(tmp_path),
+            model="test-model",
+            messages=[{"role": "user", "content": f"message {sid}", "timestamp": float(100 + idx * 50)}],
+            created_at=float(90 + idx),
+            updated_at=float(100 + idx),
+            profile="default",
+            parent_session_id=(
+                MIDDLE if sid in {TIP, FORK}
+                else ROOT if sid == MIDDLE
+                else None
+            ),
+            pre_compression_snapshot=sid in {ROOT, MIDDLE},
+            session_source="fork" if sid == FORK else None,
+        )
+        sessions[sid] = session
+
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(config, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "SESSIONS", sessions, raising=False)
+    monkeypatch.setattr(routes, "SESSIONS", sessions, raising=False)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(routes, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default", raising=False)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: state_db, raising=False)
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: state_db, raising=False)
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "default", raising=False)
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+
+    for session in sessions.values():
+        session.save(touch_updated_at=False)
+
+    def post_move(session_id, project_id):
+        captured = {}
+        monkeypatch.setattr(
+            routes,
+            "read_body",
+            lambda _handler: {"session_id": session_id, "project_id": project_id},
+        )
+        monkeypatch.setattr(
+            routes,
+            "j",
+            lambda _handler, payload, status=200, extra_headers=None: captured.update(
+                payload=payload, status=status
+            ) or True,
+        )
+        monkeypatch.setattr(
+            routes,
+            "bad",
+            lambda _handler, message, status=400: captured.update(
+                payload={"error": message}, status=status
+            ) or True,
+        )
+        assert routes.handle_post(object(), SimpleNamespace(path="/api/session/move")) is True
+        return captured
+
+    def sidebar_rows():
+        payload = routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            show_claude_code_sessions=False,
+            include_archived=True,
+            show_webhook_sessions=False,
+        )
+        return routes._session_list_payload_to_response(payload)["sessions"]
+
+    return SimpleNamespace(
+        routes=routes,
+        models=models,
+        sessions=sessions,
+        state_db=state_db,
+        post_move=post_move,
+        sidebar_rows=sidebar_rows,
+    )
+
+
+def _projects_by_id(rows):
+    return {row["session_id"]: row.get("project_id") for row in rows}
+
+
+def test_move_stale_segment_survives_authoritative_refresh_and_reload(lineage_store):
+    result = lineage_store.post_move(MIDDLE, PROJECT)
+
+    assert result["status"] == 200
+    assert result["payload"]["session"]["project_id"] == PROJECT
+    projects = _projects_by_id(lineage_store.sidebar_rows())
+    assert projects[TIP] == PROJECT
+    assert projects[FORK] is None
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+    # Simulate a process reload: discard every in-memory Session and rebuild the
+    # authoritative sidebar rows from sidecars + state.db.
+    lineage_store.sessions.clear()
+    reloaded = _projects_by_id(lineage_store.sidebar_rows())
+    assert reloaded[TIP] == PROJECT
+    assert reloaded[FORK] is None
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+
+def test_move_state_db_only_tip_updates_every_existing_lineage_sidecar(lineage_store):
+    """A canonical URL may advance before WebUI persists the tip sidecar."""
+    lineage_store.models.Session.load(TIP).path.unlink()
+    lineage_store.sessions.pop(TIP, None)
+
+    result = lineage_store.post_move(TIP, PROJECT)
+
+    assert result["status"] == 200, result
+    assert result["payload"]["session"]["project_id"] == PROJECT
+    assert lineage_store.models.Session.load(TIP) is None
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE)
+    )
+    assert lineage_store.models.Session.load(FORK).project_id is None
+
+
+def test_existing_corrupt_state_db_fails_closed_without_partial_move(lineage_store):
+    lineage_store.state_db.write_bytes(b"not a sqlite database")
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 409
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    )
+
+
+def test_state_db_only_tip_rejects_cross_profile_materialized_lineage(lineage_store):
+    lineage_store.models.Session.load(TIP).path.unlink()
+    lineage_store.sessions.pop(TIP, None)
+    root = lineage_store.models.Session.load(ROOT)
+    root.profile = "other-profile"
+    root.save(touch_updated_at=False)
+
+    result = lineage_store.post_move(TIP, PROJECT)
+
+    assert result["status"] == 409
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, FORK)
+    )
+
+
+def test_move_stale_visible_segment_crosses_mixed_historical_source_tags(lineage_store):
+    """Durable WebUI rotation markers outrank historical state.db source drift."""
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute("UPDATE sessions SET source = 'cli' WHERE id = ?", (ROOT,))
+    conn.execute("UPDATE sessions SET source = 'webui' WHERE id = ?", (MIDDLE,))
+    conn.execute("UPDATE sessions SET source = 'cli' WHERE id = ?", (TIP,))
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(MIDDLE, PROJECT)
+
+    assert result["status"] == 200
+    assert result["payload"]["session"]["project_id"] == PROJECT
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+    lineage_store.sessions.clear()
+    assert _projects_by_id(lineage_store.sidebar_rows())[TIP] == PROJECT
+
+
+def test_move_tip_then_unassign_root_updates_whole_lineage(lineage_store):
+    assigned = lineage_store.post_move(TIP, PROJECT)
+    assert assigned["status"] == 200
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+    unassigned = lineage_store.post_move(ROOT, None)
+    assert unassigned["status"] == 200
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+    assert lineage_store.models.Session.load(FORK).project_id is None
+
+
+def test_move_fork_does_not_mutate_parent_compression_lineage(lineage_store):
+    result = lineage_store.post_move(FORK, PROJECT)
+
+    assert result["status"] == 200
+    assert lineage_store.models.Session.load(FORK).project_id == PROJECT
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+
+def test_move_compressed_fork_updates_only_that_fork_lineage(lineage_store):
+    """Compression descendants inherit a fork's lineage, not its original parent."""
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute(
+        "UPDATE sessions SET ended_at = 210, end_reason = 'compression' WHERE id = ?",
+        (FORK,),
+    )
+    inherited_branch_marker = json.dumps({"_branched_from": MIDDLE})
+    conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = ?",
+        (inherited_branch_marker, FORK),
+    )
+    conn.execute(
+        "INSERT INTO sessions "
+        "(id, source, session_source, title, started_at, message_count, parent_session_id, model_config) "
+        "VALUES (?, 'webui', 'fork', 'Compressed fork', 211, 1, ?, ?)",
+        (FORK_TIP, FORK, inherited_branch_marker),
+    )
+    conn.commit()
+    conn.close()
+    fork = lineage_store.models.Session.load(FORK)
+    fork.pre_compression_snapshot = True
+    fork.save(touch_updated_at=False)
+    fork_tip = lineage_store.models.Session(
+        session_id=FORK_TIP,
+        title="Compressed fork",
+        workspace=str(lineage_store.state_db.parent),
+        model="test-model",
+        messages=[{"role": "user", "content": "fork tip", "timestamp": 211.0}],
+        created_at=211.0,
+        updated_at=211.0,
+        profile="default",
+        parent_session_id=FORK,
+        session_source="fork",
+    )
+    fork_tip.save(touch_updated_at=False)
+    lineage_store.sessions[FORK] = fork
+    lineage_store.sessions[FORK_TIP] = fork_tip
+
+    result = lineage_store.post_move(FORK_TIP, PROJECT)
+
+    assert result["status"] == 200
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (FORK, FORK_TIP)
+    )
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+
+def test_move_lineage_does_not_mutate_ordinary_parent_linked_child(lineage_store):
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 200
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+    assert lineage_store.models.Session.load(ORDINARY_CHILD) is None
+    assert ORDINARY_CHILD not in lineage_store.sessions
+
+
+def test_ambiguous_sidecar_backed_ordinary_child_fails_closed(lineage_store):
+    ordinary = lineage_store.models.Session(
+        session_id=ORDINARY_CHILD,
+        title="Production lineage",
+        workspace=str(lineage_store.state_db.parent),
+        model="test-model",
+        messages=[{"role": "user", "content": "ordinary child", "timestamp": 203.0}],
+        created_at=90.0,
+        updated_at=203.0,
+        profile="default",
+        parent_session_id=MIDDLE,
+        pre_compression_snapshot=False,
+    )
+    ordinary.save(touch_updated_at=False)
+    lineage_store.sessions[ORDINARY_CHILD] = ordinary
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 409
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP, FORK, ORDINARY_CHILD)
+    )
+
+
+def test_model_config_branch_marker_stays_independent(lineage_store):
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute(
+        "UPDATE sessions SET session_source = NULL, model_config = ? WHERE id = ?",
+        (json.dumps({"_branched_from": MIDDLE}), FORK),
+    )
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 200
+    assert lineage_store.models.Session.load(FORK).project_id is None
+
+
+def test_model_config_delegate_marker_stays_independent(lineage_store):
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute(
+        "UPDATE sessions SET session_source = NULL, model_config = ? WHERE id = ?",
+        (json.dumps({"_delegate_from": MIDDLE}), FORK),
+    )
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 200
+    assert lineage_store.models.Session.load(FORK).project_id is None
+
+
+def test_dropped_inherited_branch_marker_starts_new_independent_lineage(lineage_store):
+    marker = json.dumps({"_branched_from": ROOT})
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute("UPDATE sessions SET model_config = ? WHERE id = ?", (marker, MIDDLE))
+    conn.execute("UPDATE sessions SET model_config = NULL WHERE id = ?", (TIP,))
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(TIP, PROJECT)
+
+    assert result["status"] == 200
+    assert lineage_store.models.Session.load(TIP).project_id == PROJECT
+    assert lineage_store.models.Session.load(MIDDLE).project_id is None
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"_branched_from": ROOT, "_delegate_from": ROOT},
+        {"_branched_from": [ROOT]},
+    ],
+)
+def test_malformed_branch_markers_fail_closed(lineage_store, malformed):
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = ?",
+        (json.dumps(malformed), TIP),
+    )
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(TIP, PROJECT)
+
+    assert result["status"] == 409
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+
+def test_malformed_lineage_fails_closed_without_partial_writes(lineage_store):
+    conn = sqlite3.connect(lineage_store.state_db)
+    conn.execute(
+        "UPDATE sessions SET parent_session_id = 'missing-parent' WHERE id = ?",
+        (MIDDLE,),
+    )
+    conn.commit()
+    conn.close()
+
+    result = lineage_store.post_move(MIDDLE, PROJECT)
+
+    assert result["status"] == 409
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    )
+
+
+def test_contended_lineage_lock_returns_busy_without_partial_writes(lineage_store):
+    lock = lineage_store.routes._get_session_agent_lock(TIP)
+    assert lock.acquire(timeout=0.1)
+    try:
+        result = lineage_store.post_move(ROOT, PROJECT)
+    finally:
+        lock.release()
+
+    assert result["status"] == 503
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    )
+
+
+def test_lineage_authority_disappearing_under_lock_fails_closed(lineage_store, monkeypatch):
+    original_resolve = lineage_store.routes.resolve_writable_compression_lineage
+    calls = 0
+
+    def disappear_after_lock(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return {
+                "found": False,
+                "complete": False,
+                "error": False,
+                "root_id": None,
+                "segment_ids": [],
+            }
+        return original_resolve(*args, **kwargs)
+
+    monkeypatch.setattr(
+        lineage_store.routes,
+        "resolve_writable_compression_lineage",
+        disappear_after_lock,
+    )
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 409
+    assert lineage_store.models.Session.load(ROOT).project_id is None
+
+
+def test_save_failure_rolls_back_already_written_segments(lineage_store, monkeypatch):
+    original_save = lineage_store.models.Session.save
+    original_updated_at = {
+        sid: lineage_store.models.Session.load(sid).updated_at
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    }
+
+    def fail_middle_assignment(session, *args, **kwargs):
+        if session.session_id == MIDDLE and session.project_id == PROJECT:
+            raise OSError("injected sidecar write failure")
+        return original_save(session, *args, **kwargs)
+
+    monkeypatch.setattr(lineage_store.models.Session, "save", fail_middle_assignment)
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 500
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    )
+    assert all(
+        lineage_store.models.Session.load(sid).updated_at == original_updated_at[sid]
+        for sid in (ROOT, MIDDLE, TIP, FORK)
+    )
+
+
+def test_index_failure_rolls_back_sidecar_already_replaced(lineage_store, monkeypatch):
+    original_save = lineage_store.models.Session.save
+    original_updated_at = lineage_store.models.Session.load(ROOT).updated_at
+
+    def fail_after_root_sidecar_replace(session, *args, **kwargs):
+        if session.session_id == ROOT and session.project_id == PROJECT:
+            original_write_index = lineage_store.models._write_session_index
+
+            def fail_index(*_args, **_kwargs):
+                raise OSError("injected index failure")
+
+            monkeypatch.setattr(lineage_store.models, "_write_session_index", fail_index)
+            try:
+                return original_save(session, *args, **kwargs)
+            finally:
+                monkeypatch.setattr(
+                    lineage_store.models,
+                    "_write_session_index",
+                    original_write_index,
+                )
+        return original_save(session, *args, **kwargs)
+
+    monkeypatch.setattr(lineage_store.models.Session, "save", fail_after_root_sidecar_replace)
+
+    result = lineage_store.post_move(ROOT, PROJECT)
+
+    assert result["status"] == 500
+    assert lineage_store.models.Session.load(ROOT).project_id is None
+    assert lineage_store.models.Session.load(ROOT).updated_at == original_updated_at
+
+
+def test_prepared_project_move_journal_rolls_back_partial_crash(lineage_store):
+    originals = {
+        sid: lineage_store.models.Session.load(sid).updated_at
+        for sid in (ROOT, MIDDLE, TIP)
+    }
+    journal = {
+        "txid": "prepared-crash",
+        "state": "prepared",
+        "target_project_id": PROJECT,
+        "target_updated_at": 999.0,
+        "entries": [
+            {"session_id": sid, "project_id": None, "updated_at": originals[sid]}
+            for sid in (ROOT, MIDDLE, TIP)
+        ],
+    }
+    lineage_store.models._write_project_move_journal(journal)
+    for sid in (ROOT, MIDDLE):
+        session = lineage_store.models.Session.load(sid)
+        session.project_id = PROJECT
+        session.updated_at = 999.0
+        session.save(touch_updated_at=False)
+
+    assert lineage_store.models.recover_project_move_journals() is True
+    assert all(
+        lineage_store.models.Session.load(sid).project_id is None
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+    assert all(
+        lineage_store.models.Session.load(sid).updated_at == originals[sid]
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+
+
+def test_committed_project_move_journal_finishes_partial_crash(lineage_store):
+    journal = {
+        "txid": "committed-crash",
+        "state": "committed",
+        "target_project_id": PROJECT,
+        "target_updated_at": 999.0,
+        "entries": [
+            {
+                "session_id": sid,
+                "project_id": None,
+                "updated_at": lineage_store.models.Session.load(sid).updated_at,
+            }
+            for sid in (ROOT, MIDDLE, TIP)
+        ],
+    }
+    lineage_store.models._write_project_move_journal(journal)
+    root = lineage_store.models.Session.load(ROOT)
+    root.project_id = PROJECT
+    root.updated_at = 999.0
+    root.save(touch_updated_at=False)
+
+    assert lineage_store.models.recover_project_move_journals() is True
+    assert all(
+        lineage_store.models.Session.load(sid).project_id == PROJECT
+        for sid in (ROOT, MIDDLE, TIP)
+    )
+    assert all(
+        lineage_store.models.Session.load(sid).updated_at == 999.0
+        for sid in (ROOT, MIDDLE, TIP)
+    )

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -67,6 +67,239 @@ console.log(JSON.stringify(collapsed));
     assert [seg["session_id"] for seg in by_sid["tip"]["_lineage_segments"]] == ["tip", "root"]
 
 
+def test_state_db_only_tip_inherits_materialized_lineage_project():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const rows = _collapseSessionLineageForSidebar([
+  {{session_id:'tip', project_id:null, updated_at:20, _lineage_root_id:'root', _lineage_tip_id:'tip'}},
+  {{session_id:'root', project_id:'project-a', updated_at:10, _lineage_root_id:'root', _lineage_tip_id:'tip'}},
+]);
+console.log(JSON.stringify(rows));
+"""
+    collapsed = json.loads(_run_node(source))
+    assert len(collapsed) == 1
+    assert collapsed[0]["session_id"] == "tip"
+    assert collapsed[0]["project_id"] == "project-a"
+
+
+def test_mixed_source_production_compression_lineage_is_prior_turns_not_children():
+    """The production ten-segment chain must project as one conversation.
+
+    state.db can conservatively label these rows ``child_session`` while each
+    WebUI sidecar carries the stronger compression evidence: the parent is a
+    pre-compression snapshot and the child points to that exact parent.
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function _isExternalSession() {{ return false; }}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const ids = [
+  '54b6067d50d3',
+  '20260811_111854_014d12',
+  '20260811_134525_f2d39c',
+  '20260811_190249_c207a3',
+  '20260812_034723_084cc9',
+  '20260812_101401_f002bb',
+  '20260812_102343_19117b',
+  '20260812_113743_e99b89',
+  '20260812_120205_592085',
+  '20260812_120834_e64cd8',
+];
+const raw = ids.map((session_id, index) => ({{
+  session_id,
+  parent_session_id:index ? ids[index-1] : null,
+  relationship_type:index ? 'child_session' : null,
+  pre_compression_snapshot:index < ids.length-1,
+  raw_source:index%2 ? 'cli' : 'webui',
+  title:'fix WebUI project assignment across compressed session lineage',
+  created_at:1,
+  updated_at:index+1,
+  last_message_at:index+1,
+  message_count:2,
+}}));
+const rows = _attachChildSessionsToSidebarRows(
+  _collapseSessionLineageForSidebar(raw), raw
+);
+const row = rows[0];
+console.log(JSON.stringify({{
+  rowCount:rows.length,
+  sid:row.session_id,
+  staleVisibleSid:row._lineage_segments.find(segment=>segment.session_id==='20260812_120205_592085').session_id,
+  childSids:(row._child_sessions||[]).map(child=>child.session_id),
+  priorSids:(row._lineage_segments||[])
+    .filter(segment=>segment.session_id!==row.session_id)
+    .map(segment=>segment.session_id),
+}}));
+"""
+    result = json.loads(_run_node(source))
+    assert result == {
+        "rowCount": 1,
+        "sid": "20260812_120834_e64cd8",
+        "staleVisibleSid": "20260812_120205_592085",
+        "childSids": [],
+        "priorSids": [
+            "20260812_120205_592085",
+            "20260812_113743_e99b89",
+            "20260812_102343_19117b",
+            "20260812_101401_f002bb",
+            "20260812_034723_084cc9",
+            "20260811_190249_c207a3",
+            "20260811_134525_f2d39c",
+            "20260811_111854_014d12",
+            "54b6067d50d3",
+        ],
+    }
+
+
+def test_explicit_prior_turn_open_preserves_each_requested_segment_id():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('(?:async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+const opened=[];
+async function _openSidebarSession(session, opts) {{
+  opened.push({{sid:session.session_id, skipLineageResolve:opts.skipLineageResolve}});
+}}
+eval(extractFunc('_openSidebarLineageSegment'));
+(async()=>{{
+  for(const sid of ['snapshot-a','snapshot-b','snapshot-c']){{
+    await _openSidebarLineageSegment({{session_id:sid}});
+  }}
+  console.log(JSON.stringify(opened));
+}})().catch(error=>{{ console.error(error); process.exit(1); }});
+"""
+    assert json.loads(_run_node(source)) == [
+        {"sid": "snapshot-a", "skipLineageResolve": True},
+        {"sid": "snapshot-b", "skipLineageResolve": True},
+        {"sid": "snapshot-c", "skipLineageResolve": True},
+    ]
+
+
+def test_compressed_fork_collapses_within_fork_without_absorbing_original_parent():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const raw=[
+  {{session_id:'original', pre_compression_snapshot:true, updated_at:1}},
+  {{session_id:'fork-root', parent_session_id:'original', session_source:'fork', pre_compression_snapshot:true, updated_at:2}},
+  {{session_id:'fork-tip', parent_session_id:'fork-root', session_source:'fork', relationship_type:'child_session', updated_at:3}},
+];
+console.log(JSON.stringify(Object.fromEntries(_collapseSessionLineageForSidebar(raw).map(row=>[
+  row.session_id,
+  (row._lineage_segments||[]).map(segment=>segment.session_id),
+]))));
+"""
+    assert json.loads(_run_node(source)) == {
+        "fork-tip": ["fork-tip", "fork-root"],
+        "original": [],
+    }
+
+
+def test_unmarked_ordinary_sibling_keeps_compression_parent_ambiguous():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const raw=[
+  {{session_id:'parent', title:'Same title', pre_compression_snapshot:true, created_at:1, updated_at:1}},
+  {{session_id:'tip', title:'Same title', parent_session_id:'parent', relationship_type:'child_session', created_at:1, updated_at:2}},
+  {{session_id:'ordinary', title:'Same title', parent_session_id:'parent', relationship_type:'child_session', created_at:1, updated_at:3}},
+];
+console.log(JSON.stringify(_collapseSessionLineageForSidebar(raw).map(row=>({{
+  sid:row.session_id,
+  segments:(row._lineage_segments||[]).map(segment=>segment.session_id),
+}}))));
+"""
+    assert json.loads(_run_node(source)) == [
+        {"sid": "tip", "segments": []},
+        {"sid": "ordinary", "segments": []},
+        {"sid": "parent", "segments": []},
+    ]
+
+
 def test_sidebar_active_state_can_fall_back_to_url_session_during_boot():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
@@ -1596,7 +1829,8 @@ def test_lineage_segment_expansion_static_contract():
     assert "className='session-lineage-segment'" in js
     assert "const segTitle=_sessionDisplayTitle(seg)||t('session_lineage_segment_untitled');" in js
     assert "row.title=t('session_lineage_segment_open');" in js
-    assert "await _openSidebarSession(seg, {skipLineageResolve:true});" in js
+    assert "await _openSidebarLineageSegment(seg);" in js
+    assert "return _openSidebarSession(segment, {skipLineageResolve:true});" in js
     assert "const openChildSession=async(childSession)=>{" in js
     assert "await _openSidebarSession(childSession, {skipLineageResolve:true});" in js
     assert "if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){" in js


### PR DESCRIPTION
## Summary

- resolve one writable compression lineage before changing project metadata
- fail closed when an existing state.db is unreadable or corrupt
- enforce one profile across every materialized segment, including state.db-only canonical tips
- lock and update every materialized segment as one crash-recoverable journaled transaction
- preserve exact project and updated_at metadata on rollback
- inherit project metadata onto state-only canonical tips in sidebar projection
- keep forks/delegates and same-title conversations separate

## Test plan

- focused project/lineage/import suite: 136 passed
- `python3 -m py_compile api/routes.py api/models.py api/agent_sessions.py`
- `node --check static/sessions.js`
- `python3 scripts/ruff_lint.py --diff upstream/master`
- `git diff --check`
- adversarial regressions: corrupt existing state.db and cross-profile state-only lineage both fail closed without writes