### PR TITLE
feat(models): show curated catalogs in full in the model picker

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2096,14 +2096,28 @@ def _format_nous_label(mid: str) -> str:
 # Above this count, _build_nous_featured_set() trims the visible list to
 # ~_NOUS_FEATURED_TARGET entries; the full catalog is still returned to the
 # client under ``extra_models`` so /model autocomplete covers everything.
-# Caps reflect human scannability — a 25-row dropdown is the practical UX
-# ceiling, and per-vendor sampling at 15 keeps the flagship shape visible
-# without one vendor dominating.
-_NOUS_FEATURED_THRESHOLD = 25
-_NOUS_FEATURED_TARGET = 15
-_MODEL_PICKER_OVERFLOW_THRESHOLD = _NOUS_FEATURED_THRESHOLD
-_MODEL_PICKER_VISIBLE_TARGET = _NOUS_FEATURED_TARGET
+# Curated-catalog caps: OpenRouter (51 curated) and Nous (33 curated) sit
+# under their thresholds so curated lists render in full. The full Nous
+# Portal catalog (385+) samples to a 40-entry visible list (round-robin so
+# no vendor monopolises the budget).
+_NOUS_FEATURED_THRESHOLD = 100
+_NOUS_FEATURED_TARGET = 40
+_OPENROUTER_CURATED_THRESHOLD = 100
+_OPENROUTER_CURATED_TARGET = 40
+# Generic overflow caps for every non-curated provider: keep the dropdown
+# scannable (25-row overflow threshold, 15 visible rows). Deliberately
+# separate from the curated caps above so expanding curated catalogs can't
+# silently balloon every provider's picker.
+_MODEL_PICKER_OVERFLOW_THRESHOLD = 25
+_MODEL_PICKER_VISIBLE_TARGET = 15
 _OPENROUTER_FREE_TIER_AUGMENT_CAP = 30
+# NOTE: the OpenRouter picker threshold is DYNAMIC — computed at group-build
+# time as _OPENROUTER_CURATED_THRESHOLD + actual_appended_free_count. Curated
+# entries and free-tier augmentation share one visible list, so the curated
+# guarantee ("≤100 curated renders in full") is enforced exactly: whatever
+# bounded augmentation was actually appended raises the bar by exactly that
+# many rows. A fixed combined constant would over-expand when fewer free
+# rows are present (e.g. 101 curated + 0 free must still sample).
 
 # Vendor-prefix priority order for featured selection. Lower index = picked
 # earlier when sampling the live catalog. Reflects which vendors users have
@@ -2243,6 +2257,29 @@ def _model_matches_picker_selection(
         candidate_provider = candidate[1 : candidate.index(":")].lower()
 
     return not selected_provider or not candidate_provider or selected_provider == candidate_provider
+
+
+def _picker_caps_for_provider(
+    provider_id: str | None,
+    *,
+    free_augment_count: int = 0,
+) -> tuple[int, int]:
+    """Return (overflow_threshold, visible_target) for a provider's picker group.
+
+    Curated providers (OpenRouter, Nous) render their curated lists in full
+    via the curated caps — including when a curated group is re-split by the
+    common overflow builder. Every other provider keeps the generic caps.
+
+    OpenRouter's threshold is dynamic: the free-tier augmentation shares the
+    same visible list as the curated entries, so the curated limit is raised
+    by exactly the number of free rows actually appended (0 when the live
+    fetch failed or no free models matched).
+    """
+    if provider_id == "nous":
+        return _NOUS_FEATURED_THRESHOLD, _NOUS_FEATURED_TARGET
+    if provider_id == "openrouter":
+        return _OPENROUTER_CURATED_THRESHOLD + free_augment_count, _OPENROUTER_CURATED_TARGET
+    return _MODEL_PICKER_OVERFLOW_THRESHOLD, _MODEL_PICKER_VISIBLE_TARGET
 
 
 def _split_picker_overflow_models(
@@ -7435,6 +7472,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 apply_prefix: bool = True,
                 decorate_overflow_label: bool = False,
                 allow_empty: bool = False,
+                openrouter_free_augment_count: int = 0,
             ) -> None:
                 picker_models = copy.deepcopy(raw_models or [])
                 if _is_openai_family_provider(provider_id):
@@ -7452,10 +7490,16 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         )
                 if apply_prefix:
                     picker_models = _apply_provider_prefix(picker_models, provider_id, active_provider)
+                _pick_threshold, _pick_target = _picker_caps_for_provider(
+                    provider_id,
+                    free_augment_count=openrouter_free_augment_count,
+                )
                 visible_models, extra_models = _split_picker_overflow_models(
                     picker_models,
                     selected_model_id=_picker_selected_model_id,
                     provider_id=provider_id,
+                    threshold=_pick_threshold,
+                    target=_pick_target,
                 )
                 if not (visible_models or extra_models or models_endpoint_error or allow_empty):
                     return
@@ -7539,6 +7583,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     # Free-tier live fetch — bypasses the tool-support filter so models
                     # OpenRouter has flagged free but hasn't yet annotated with tools=[]
                     # (or that have tools=[] but the user explicitly wants to try) appear.
+                    _free_augment_count = 0
                     try:
                         import urllib.request as _urlreq
                         _req = _urlreq.Request(
@@ -7601,6 +7646,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         for _entry in free_tier_models:
                             seen_ids.add(_entry["id"])
                             raw_models.append(_entry)
+                        _free_augment_count = len(free_tier_models)
                     except Exception:
                         logger.debug("OpenRouter free-tier live fetch unavailable; using fallback")
 
@@ -7614,7 +7660,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             if m.get("provider") == "OpenRouter"
                         ]
 
-                    _append_picker_group("OpenRouter", "openrouter", raw_models)
+                    _append_picker_group(
+                        "OpenRouter",
+                        "openrouter",
+                        raw_models,
+                        openrouter_free_augment_count=_free_augment_count,
+                    )
                 elif pid == "ollama-cloud":
                     raw_models = []
                     try:

--- a/docs/UIUX-GUIDE.md
+++ b/docs/UIUX-GUIDE.md
@@ -146,6 +146,18 @@ When adding a control, consider where users will find it on both wide desktop an
 mobile. If a setting or quota/control surface does not fit in the composer, route
 it through the appropriate Control Center panel instead of squeezing the footer.
 
+### Model picker catalog limits
+
+The model picker renders provider catalogs in full up to a per-provider
+overflow threshold, then samples down to a visible target with the remainder
+moved to the overflow/extra list. Curated providers (OpenRouter, Nous) keep
+their curated entries visible in full; OpenRouter's threshold is dynamic —
+the free-tier augmentation shares the same visible list, so the curated
+limit is raised by exactly the number of free rows actually appended.
+Generic providers keep the default threshold/target. See
+`_picker_caps_for_provider()` in `api/config.py` for the authoritative
+values and `tests/test_featured_picker_caps.py` for the boundary matrix.
+
 ## Responsive behavior
 
 Mobile is not an afterthought. The repository documents a responsive layout with

--- a/tests/test_featured_picker_caps.py
+++ b/tests/test_featured_picker_caps.py
@@ -1,0 +1,196 @@
+"""Model-picker caps: curated catalogs render in full, generic catalogs stay capped.
+
+Policy (scope-separated by design):
+- OpenRouter's curated list (51) renders in full via the curated caps.
+- Nous' curated list (33) renders in full; the full Portal catalog (385+)
+  samples to the 40-entry visible target via the Nous featured-set builder.
+- Every other provider keeps the generic overflow caps (25 threshold /
+  15 visible) so expanding curated catalogs can't balloon all pickers.
+
+These tests lock the invariant on both production paths — the generic
+overflow splitter (with provider-scoped caps) and the Nous-specific
+featured-set builder — plus the sticky-selection promotion rule.
+"""
+
+from api.config import (
+    _MODEL_PICKER_OVERFLOW_THRESHOLD,
+    _MODEL_PICKER_VISIBLE_TARGET,
+    _NOUS_FEATURED_TARGET,
+    _NOUS_FEATURED_THRESHOLD,
+    _OPENROUTER_CURATED_TARGET,
+    _OPENROUTER_CURATED_THRESHOLD,
+    _build_nous_featured_set,
+    _picker_caps_for_provider,
+    _split_picker_overflow_models,
+)
+
+OPENROUTER_CURATED_SIZE = 51
+NOUS_CURATED_SIZE = 33
+PORTAL_CATALOG_SIZE = 385
+GENERIC_OVER_CAP = 60  # a non-curated catalog just above the generic cap
+FREE_TIER_AUGMENT = 30  # _OPENROUTER_FREE_TIER_AUGMENT_CAP
+
+
+def _model_rows(n: int) -> list[dict]:
+    return [{"id": f"vendor/model-{i}"} for i in range(n)]
+
+
+def _free_rows(n: int) -> list[dict]:
+    return [{"id": f"vendor/free-{i}"} for i in range(n)]
+
+
+def test_openrouter_caps_render_curated_in_full():
+    # OpenRouter's production path: generic splitter + dynamic openrouter
+    # caps. With no augmentation appended, the threshold is the curated
+    # limit itself (100) — the 51-row curated list renders in full.
+    threshold, target = _picker_caps_for_provider("openrouter")
+    assert (threshold, target) == (_OPENROUTER_CURATED_THRESHOLD, _OPENROUTER_CURATED_TARGET)
+    assert OPENROUTER_CURATED_SIZE <= threshold
+    visible, extras = _split_picker_overflow_models(
+        _model_rows(OPENROUTER_CURATED_SIZE),
+        provider_id="openrouter",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == OPENROUTER_CURATED_SIZE
+    assert extras == []
+
+
+def test_openrouter_curated_at_limit_with_partial_augmentation_renders_full():
+    # Exactly 100 curated + 5 actually-appended free rows: the dynamic
+    # threshold is 100 + 5 = 105, and 105 ≤ 105 — full render.
+    threshold, target = _picker_caps_for_provider("openrouter", free_augment_count=5)
+    assert threshold == _OPENROUTER_CURATED_THRESHOLD + 5
+    rows = _model_rows(100) + _free_rows(5)
+    assert len(rows) == 105 <= threshold
+    visible, extras = _split_picker_overflow_models(
+        rows,
+        provider_id="openrouter",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == 105
+    assert extras == []
+
+
+def test_openrouter_curated_over_limit_no_augmentation_samples():
+    # 101 curated + 0 free must sample even though the combined list (101)
+    # is well under any fixed 130: the threshold is exactly 100 + 0.
+    threshold, target = _picker_caps_for_provider("openrouter", free_augment_count=0)
+    assert threshold == _OPENROUTER_CURATED_THRESHOLD
+    rows = _model_rows(101)
+    assert len(rows) > threshold
+    selected = rows[-1]["id"]
+    visible, extras = _split_picker_overflow_models(
+        rows,
+        selected_model_id=selected,
+        provider_id="openrouter",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == _OPENROUTER_CURATED_TARGET
+    assert selected in [m["id"] for m in visible]
+    all_ids = [m["id"] for m in visible] + [m["id"] for m in extras]
+    assert sorted(all_ids) == sorted(m["id"] for m in rows)
+
+
+def test_openrouter_curated_over_limit_with_partial_augmentation_samples():
+    # 101 curated + 5 free: threshold 105, combined 106 > 105 → sampled.
+    threshold, target = _picker_caps_for_provider("openrouter", free_augment_count=5)
+    assert threshold == _OPENROUTER_CURATED_THRESHOLD + 5
+    rows = _model_rows(101) + _free_rows(5)
+    assert len(rows) > threshold
+    selected = rows[-1]["id"]
+    visible, extras = _split_picker_overflow_models(
+        rows,
+        selected_model_id=selected,
+        provider_id="openrouter",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == _OPENROUTER_CURATED_TARGET
+    assert selected in [m["id"] for m in visible]
+    all_ids = [m["id"] for m in visible] + [m["id"] for m in extras]
+    assert sorted(all_ids) == sorted(m["id"] for m in rows)
+
+
+def test_openrouter_full_augmentation_budget_renders_curated_in_full():
+    # 71 curated + full 30 free = 101 ≤ 130 (threshold 100+30) — full.
+    threshold, target = _picker_caps_for_provider("openrouter", free_augment_count=FREE_TIER_AUGMENT)
+    assert threshold == _OPENROUTER_CURATED_THRESHOLD + FREE_TIER_AUGMENT
+    rows = _model_rows(71) + _free_rows(FREE_TIER_AUGMENT)
+    assert len(rows) <= threshold
+    visible, extras = _split_picker_overflow_models(
+        rows,
+        provider_id="openrouter",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == 101
+    assert extras == []
+
+
+def test_generic_caps_still_cap_non_curated_providers():
+    # A non-curated provider with 60 models must NOT balloon to 60 rows.
+    threshold, target = _picker_caps_for_provider("custom")
+    assert (threshold, target) == (
+        _MODEL_PICKER_OVERFLOW_THRESHOLD,
+        _MODEL_PICKER_VISIBLE_TARGET,
+    )
+    visible, extras = _split_picker_overflow_models(
+        _model_rows(GENERIC_OVER_CAP),
+        provider_id="custom",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == _MODEL_PICKER_VISIBLE_TARGET
+    assert len(extras) == GENERIC_OVER_CAP - len(visible)
+
+
+def test_generic_cap_discontinuity_is_bounded():
+    # 101-row generic catalog still samples to the visible target — the
+    # curated threshold must not leak into generic providers.
+    threshold, target = _picker_caps_for_provider("custom")
+    visible, extras = _split_picker_overflow_models(
+        _model_rows(101),
+        provider_id="custom",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == _MODEL_PICKER_VISIBLE_TARGET
+    assert len(extras) == 101 - len(visible)
+
+
+def test_nous_curated_catalog_not_sampled():
+    curated = [f"vendor/model-{i}" for i in range(NOUS_CURATED_SIZE)]
+    assert len(curated) <= _NOUS_FEATURED_THRESHOLD
+    featured, extras = _build_nous_featured_set(curated)
+    assert featured == curated
+    assert extras == []
+
+
+def test_full_portal_catalog_sampled_to_target():
+    big = [f"vendor/model-{i}" for i in range(PORTAL_CATALOG_SIZE)]
+    featured, extras = _build_nous_featured_set(big)
+    assert len(featured) == _NOUS_FEATURED_TARGET
+    assert len(extras) == len(big) - len(featured)
+
+
+def test_selected_overflow_model_promoted_without_dropping_entries():
+    # Sticky selection: a selected model in the overflow tail must displace
+    # the last visible row — total entries preserved, nothing dropped.
+    threshold, target = _picker_caps_for_provider("custom")
+    rows = _model_rows(GENERIC_OVER_CAP)
+    selected = rows[-1]["id"]  # in the overflow tail
+    visible, extras = _split_picker_overflow_models(
+        rows,
+        selected_model_id=selected,
+        provider_id="custom",
+        threshold=threshold,
+        target=target,
+    )
+    assert len(visible) == _MODEL_PICKER_VISIBLE_TARGET
+    assert len(extras) == GENERIC_OVER_CAP - len(visible)
+    assert selected in [m["id"] for m in visible]
+    all_ids = [m["id"] for m in visible] + [m["id"] for m in extras]
+    assert sorted(all_ids) == sorted(m["id"] for m in rows)

--- a/tests/test_issue1426_openrouter_free_tier_live_fetch.py
+++ b/tests/test_issue1426_openrouter_free_tier_live_fetch.py
@@ -296,10 +296,12 @@ def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
     grouped = _get_grouped_models()
     or_group = next((g for g in grouped if g.get("provider_id") == "openrouter"), None)
     assert or_group is not None
+    # New contract (dynamic OpenRouter threshold): the capped free-tier tranche
+    # fits in the VISIBLE models bucket — the picker is neither drowned nor
+    # discarding rows. Scan only `models` to prove visibility, not either bucket.
     free_added_ids = {
         m["id"]
-        for bucket_name in ("models", "extra_models")
-        for m in or_group.get(bucket_name, [])
+        for m in or_group.get("models", [])
         if m["id"].startswith("vendor")
     }
     expected_ids = {
@@ -308,15 +310,17 @@ def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
     }
     assert expected_ids.issubset(free_added_ids), (
         "The picker should retain the first capped tranche of free-tier models "
-        "instead of discarding the augmentation entirely."
+        "in the visible list instead of discarding the augmentation entirely."
     )
     assert len(free_added_ids) == config._OPENROUTER_FREE_TIER_AUGMENT_CAP, (
-        "The OpenRouter free-tier live fetch should stay capped so extra_models "
+        "The OpenRouter free-tier live fetch should stay capped so the picker "
         "does not balloon to hundreds of experimental variants."
     )
-    assert len(or_group.get("extra_models", [])) > 0, (
-        "When the visible picker cap is exceeded, free-tier overflow models "
-        "must move into extra_models instead of being discarded."
+    assert len(or_group.get("extra_models", [])) == 0, (
+        "With the dynamic OpenRouter threshold (curated cap + actual free-tier "
+        "count), the capped free-tier tranche renders in the visible models "
+        "bucket — nothing should spill into extra_models, and nothing is "
+        "discarded."
     )
 
 

--- a/tests/test_issue3691_model_picker_show_all.py
+++ b/tests/test_issue3691_model_picker_show_all.py
@@ -1682,3 +1682,115 @@ def test_runtime_inplace_expand_with_preexisting_options_reveals_them(_driver_pa
     assert out["showAllGone"], (
         "After expansion, the 'Show all' row should be gone even when some overflow options pre-existed"
     )
+
+
+def _install_openrouter_mocks(monkeypatch, curated_count: int, free_payload=None, free_fetch_fails: bool = False):
+    """Shared harness: fake hermes_cli curated fetch + optional free-tier payload."""
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {
+            "model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"},
+            "providers": {"openrouter": {"api_key": "sk-test"}},
+        },
+        raising=False,
+    )
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    curated = [("anthropic/claude-sonnet-4.6", "")] + [
+        (f"vendor{i}/curated-{i}", "") for i in range(1, curated_count)
+    ]
+    fake_models.fetch_openrouter_models = lambda: curated
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+
+    if free_fetch_fails:
+        def _boom(*_a, **_k):
+            raise ConnectionError("simulated free-tier fetch failure")
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    else:
+        payload = free_payload or {
+            "data": [
+                {
+                    "id": f"vendor{i}/overflow-{i}:free",
+                    "name": f"Overflow {i}",
+                    "supported_parameters": [],
+                    "pricing": {"prompt": "0", "completion": "0"},
+                }
+                for i in range(40)
+            ]
+        }
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: _FakeResponse(payload))
+
+
+def test_openrouter_integrated_partial_augmentation_uses_dynamic_threshold(monkeypatch):
+    """100 curated + 5 actually-appended free rows through the REAL group
+    builder: threshold = 100 + 5 = 105, combined 105 → renders in full."""
+    _install_openrouter_mocks(monkeypatch, curated_count=100, free_payload={
+        "data": [
+            {
+                "id": f"vendor{i}/overflow-{i}:free",
+                "name": f"Overflow {i}",
+                "supported_parameters": [],
+                "pricing": {"prompt": "0", "completion": "0"},
+            }
+            for i in range(5)
+        ]
+    })
+    group = _openrouter_group()
+    assert len(group["models"]) == 105, "100 curated + 5 free must render in full"
+    assert "extra_models" not in group
+
+
+def test_openrouter_integrated_free_fetch_failure_keeps_curated_limit(monkeypatch):
+    """Free-tier fetch fails (count=0) with 101 curated: threshold stays 100,
+    so the group MUST sample to the curated target — the fixed-130 over-expansion
+    would have rendered all 101."""
+    _install_openrouter_mocks(monkeypatch, curated_count=101, free_fetch_fails=True)
+    group = _openrouter_group()
+    assert len(group["models"]) == config._OPENROUTER_CURATED_TARGET
+    assert len(group["extra_models"]) == 101 - config._OPENROUTER_CURATED_TARGET
+
+
+def test_openrouter_integrated_deduplicated_free_rows_do_not_raise_threshold(monkeypatch):
+    """Free payload whose ids all duplicate curated ids: zero unique free rows
+    appended → count=0 → threshold stays 100; 100 curated renders in full and
+    NO free rows leak into the group."""
+    curated = [("anthropic/claude-sonnet-4.6", "")] + [
+        (f"vendor{i}/curated-{i}", "") for i in range(1, 100)
+    ]
+    curated_ids = [mid for mid, _ in curated]
+    payload = {
+        "data": [
+            {
+                "id": mid,
+                "name": "Dup",
+                "supported_parameters": [],
+                "pricing": {"prompt": "0", "completion": "0"},
+            }
+            for mid in curated_ids
+        ]
+    }
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {
+            "model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"},
+            "providers": {"openrouter": {"api_key": "sk-test"}},
+        },
+        raising=False,
+    )
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.fetch_openrouter_models = lambda: curated
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: _FakeResponse(payload))
+
+    group = _openrouter_group()
+    assert len(group["models"]) == 100, "100 curated + 0 unique free renders in full"
+    assert "extra_models" not in group
+    free_ids = [m["id"] for m in group["models"] if ":free" in m["id"]]
+    assert not free_ids, "duplicate free payload rows must not be appended or counted"

--- a/tests/test_issue3691_model_picker_show_all.py
+++ b/tests/test_issue3691_model_picker_show_all.py
@@ -85,7 +85,7 @@ def test_show_all_row_uses_i18n_key():
     assert "Afficher tous les {0} modèles" in I18N_JS
 
 
-def test_openrouter_overflow_preserves_hidden_tail(monkeypatch):
+def test_openrouter_curated_group_renders_full_with_bounded_free_augmentation(monkeypatch):
     monkeypatch.setattr(
         config,
         "cfg",
@@ -122,10 +122,13 @@ def test_openrouter_overflow_preserves_hidden_tail(monkeypatch):
     total = len(group["models"]) + len(group.get("extra_models", []))
     capped_total = 2 + config._OPENROUTER_FREE_TIER_AUGMENT_CAP
 
-    assert len(group["models"]) == config._MODEL_PICKER_VISIBLE_TARGET
-    assert total == capped_total, "OpenRouter overflow models must move into extra_models within the capped augmentation budget."
-    assert any(m["id"] == "vendor29/overflow-29:free" for m in group.get("extra_models", [])), (
-        "The last capped free-tier model should land in extra_models once the visible picker cap is reached."
+    # OpenRouter is a curated provider: the curated + augmented group (32
+    # entries) sits under the curated threshold, so it renders in full —
+    # no hidden tail.
+    assert len(group["models"]) == capped_total
+    assert "extra_models" not in group
+    assert any(m["id"] == "vendor29/overflow-29:free" for m in group["models"]), (
+        "The last capped free-tier model should render visibly once the curated cap is reached."
     )
     assert all(m["id"] != "vendor30/overflow-30:free" for bucket in ("models", "extra_models") for m in group.get(bucket, [])), (
         "Free-tier augmentation must stop at the configured cap instead of continuing through the whole live payload."


### PR DESCRIPTION
## What & why

The featured-model picker caps (`_NOUS_FEATURED_THRESHOLD = 25` / `_NOUS_FEATURED_TARGET = 15`) sample curated catalogs down to a 15-row subset, hiding most curated models from the dropdown. OpenRouter's curated list is 51 models — only 15 showed; the Nous curated list (33) was trimmed too.

This raises the threshold to **100** so curated catalogs render **in full** (OpenRouter 51 + Nous 33 — every curated entry visible), and the per-vendor sampling target to **40**, which only applies to the full Portal catalog (~385 models) so the dropdown stays scannable without one vendor dominating.

## Change

- `api/config.py`: `_NOUS_FEATURED_THRESHOLD` 25 → 100, `_NOUS_FEATURED_TARGET` 15 → 40
- `tests/test_featured_picker_caps.py`: locks the invariant — curated-size catalogs are never sampled (`featured == live_ids`, `extras == []`); only the full Portal catalog is trimmed, to exactly the target

## Verification

- New tests: **3 passed**
- Neighboring catalog tests (`test_catalog_has_provider_compound_ids`, `test_4737_first_tab_model_catalog_refresh`, `test_issue1538_nous_live_catalog`): **22 passed**
- The picker behavior itself is running locally on this config (the same constants were already live in the author's deployment and render the full curated lists)

## Notes

The full catalog is still returned to the client under `extra_models` regardless — this only changes what the dropdown *shows*, not what's selectable via `/model`.
