### PR TITLE
Harden offline repair for oversized session replays

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,6 +233,85 @@ Session is a plain Python class (not a dataclass, not SQLAlchemy):
     With 10 sessions: negligible. With 1000+: will be slow.
     See Architecture Phase C for the index file fix.
 
+#### Offline replay repair for very large sidecars
+
+Loading a session normally repairs known replay duplicates before returning the
+mutable `Session`. For a sidecar larger than 128 MiB, that inline path would
+create several full-size copies inside an HTTP request. `Session.load()` instead
+performs an allocation-free adjacent-partial check: only a large projection that
+actually needs that repair is marked `_replay_repair_deferred` and blocked from
+save. A large valid projection remains writable, and full session-index rebuilds
+use a bounded streaming top-level metadata scanner that skips transcript and
+scene bodies, accepts metadata before or after those arrays, and refuses files
+without a valid persisted session ID matching the sidecar filename rather than
+constructing a default or phantom ID. Skipped values are still fully checked
+against JSON grammar; if legacy JSON repeats `messages` and omits an explicit
+`message_count`, the last array supplies the count, matching `json.loads`.
+
+`Session.save()` and the tool share an exclusive per-session sidecar lock.
+Every normal save, compact, and restore advances `_sidecar_generation_v1` from
+the durable value observed under that lock. New sidecars receive a durable
+`_sidecar_epoch_v1`, and the first mutating compaction bootstraps one for a
+legacy sidecar; restore retains that epoch. A loaded mutable `Session` records
+epoch, generation, the digest of the exact bytes read, and the session ID that
+owns that observation; save compares that complete revision under the lock and
+records the digest of the bytes actually published, including platform newline
+behavior. It fails stale instead of republishing history loaded before
+maintenance. A freshly constructed replacement has no prior observation: its
+first save adopts an existing target epoch under the lock, while a session-ID
+rotation with no target sidecar starts a new epoch. Any authoritative in-place
+refresh that copies newer durable state also transfers the matching revision.
+After that first save or refresh, the object is revision-bound again. The epoch
+changes on delete/recreate, preventing generation-counter ABA.
+
+The command remains strictly offline: always drain and stop every WebUI process
+before running it, then restart from fresh durable state after maintenance,
+because older, direct, or non-WebUI writers may not acquire this maintenance
+lock. Even `--dry-run` acquires the cooperative lock and may create its private
+`.sidecar-locks/<sid>.lock` metadata:
+
+```bash
+python scripts/compact_session_replays.py --dry-run ~/.hermes/webui/sessions/<session-id>.json
+python scripts/compact_session_replays.py ~/.hermes/webui/sessions/<session-id>.json
+```
+
+The maintenance command is POSIX/WSL-only; on Windows, run it inside WSL rather
+than invoking it from native Python.
+
+The tool performs separate analysis and write passes, validates every copied
+JSON value with RFC 8259's exact whitespace set, incrementally validates and
+copies non-target strings with fixed-size buffers, limits one decoded target
+message to 64 MiB, and transforms only top-level `messages` and
+`context_messages`.
+Exact replay membership is tracked
+in a temporary SQLite
+index with a bounded page cache, so RAM does not grow with the number of unique
+message identities; operators must provide temporary-disk headroom proportional
+to that unique-key count. It publishes only while the source inode/stat
+signature, SHA-256, and generation still match. Ambiguous or non-JSON-stable
+rows are retained. A content-addressed byte-exact backup and hidden checksum
+manifest are fsynced, including the manifest directory entry, before the
+compacted sidecar is atomically installed. A non-crash source-install failure
+removes and fsyncs the unpublished manifest; the
+source mode is preserved on source, backup, manifest, and restore output. Every
+sensitive artifact is created as `0600` before its final mode is applied. The
+source must be a regular non-symlink sidecar whose safe embedded `session_id`
+matches its filename and is at most 150 characters. The hidden manifest is
+excluded from session discovery and index rebuilds, and WebUI session deletion
+removes that session's replay-v10 backups, manifests, and stale temporaries.
+
+Rollback is explicit and also fail-closed:
+
+```bash
+python scripts/compact_session_replays.py --restore <manifest-path>
+```
+
+Restore refuses if either the current compacted sidecar or immutable backup no
+longer matches the manifest. It opens the backup without following symlinks and
+hashes/transforms one regular-file descriptor, closing the check/use gap. The
+archive remains byte-exact; only the restored sidecar receives the newer
+generation required to order later writes.
+
 title_from(): takes messages list, finds first user message, returns first 64 chars.
 Called after run_conversation() completes to set the session title retroactively.
 

--- a/api/config.py
+++ b/api/config.py
@@ -874,7 +874,7 @@ DEFAULT_MODEL = os.getenv("HERMES_WEBUI_DEFAULT_MODEL", "")  # Empty = use provi
 def _warn_state_dir_divergence(warn_prefix: str) -> None:
     """Check if SESSION_DIR is empty but a sibling state directory has session data.
 
-    If the session store looks empty (no *.json files besides _index.json in SESSION_DIR,
+    If the session store looks empty (no non-hidden *.json files in SESSION_DIR,
     or SESSION_INDEX_FILE is absent/empty/contains only {}|[]|null), scan STATE_DIR.parent
     for sibling directories with a sessions/ child that has .json files.
 
@@ -885,9 +885,13 @@ def _warn_state_dir_divergence(warn_prefix: str) -> None:
         # Check if session store is empty
         session_dir_empty = False
 
-        # Check for .json files in SESSION_DIR (excluding _index.json)
+        # Hidden JSON files are indexes, manifests, or maintenance artifacts,
+        # not user sessions.
         if SESSION_DIR.exists():
-            json_files = [f for f in SESSION_DIR.glob("*.json") if f.name != "_index.json"]
+            json_files = [
+                f for f in SESSION_DIR.glob("*.json")
+                if not f.name.startswith("_")
+            ]
             session_dir_empty = len(json_files) == 0
         else:
             session_dir_empty = True
@@ -912,7 +916,10 @@ def _warn_state_dir_divergence(warn_prefix: str) -> None:
                         continue
                     sibling_sessions = sibling / "sessions"
                     if sibling_sessions.exists():
-                        json_files = [f for f in sibling_sessions.glob("*.json") if f.name != "_index.json"]
+                        json_files = [
+                            f for f in sibling_sessions.glob("*.json")
+                            if not f.name.startswith("_")
+                        ]
                         if json_files:
                             # Found a sibling with session data
                             print(

--- a/api/models.py
+++ b/api/models.py
@@ -2,6 +2,7 @@
 import collections
 import copy
 import datetime
+import errno
 import hashlib
 import inspect
 import json
@@ -9,9 +10,11 @@ import logging
 import math
 import os
 import re
+import stat as stat_module
 import threading
 import time
 import uuid
+import weakref
 from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -182,12 +185,166 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+def _set_file_descriptor_mode(descriptor: int, mode: int) -> None:
+    """Apply a POSIX mode where supported; Windows relies on its ACL."""
+    fchmod = getattr(os, 'fchmod', None)
+    if fchmod is not None:
+        fchmod(descriptor, mode)
+
+
+def _fsync_sidecar_directory(directory: Path) -> None:
+    """Durably publish sidecar directory entry changes where supported."""
+    if os.name == 'nt':
+        return
+    flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
+    descriptor = os.open(Path(directory), flags)
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as exc:
+            if exc.errno not in {errno.EINVAL, errno.ENOTSUP}:
+                raise
+    finally:
+        os.close(descriptor)
+
+
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
+_INLINE_REPLAY_REPAIR_MAX_BYTES = 128 * 1024 * 1024
+_SESSION_SAVE_AUTHORITIES_LOCK = threading.Lock()
+_SESSION_SAVE_AUTHORITIES: "weakref.WeakValueDictionary[str, threading.RLock]" = weakref.WeakValueDictionary()
+_WORKSPACE_BINDING_REVISION_RECEIPTS_LOCK = threading.Lock()
+_WORKSPACE_BINDING_REVISION_RECEIPTS: "collections.OrderedDict[tuple, tuple]" = collections.OrderedDict()
+_WORKSPACE_BINDING_REVISION_RECEIPTS_MAX = 2000
 _SESSION_INDEX_REBUILD_LOCK = threading.Lock()
 _SESSION_INDEX_REBUILD_THREAD = None
 _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
+
+
+def _session_save_authority(authority_id: str) -> threading.RLock:
+    """Return one process-local reentrant mutation authority."""
+    with _SESSION_SAVE_AUTHORITIES_LOCK:
+        authority = _SESSION_SAVE_AUTHORITIES.get(authority_id)
+        if authority is None:
+            authority = threading.RLock()
+            _SESSION_SAVE_AUTHORITIES[authority_id] = authority
+        return authority
+
+
+def _record_workspace_binding_revision_receipt(
+    session_id: str,
+    revision_before,
+    revision_after,
+    workspace: str,
+    *,
+    session_dir: Path | None = None,
+) -> None:
+    """Remember one trusted metadata-only revision for same-process rebasing."""
+    if revision_before is None or revision_after is None:
+        return
+    key = (
+        str(Path(session_dir or SESSION_DIR).resolve()),
+        session_id,
+        tuple(revision_after),
+    )
+    value = (tuple(revision_before), str(workspace))
+    with _WORKSPACE_BINDING_REVISION_RECEIPTS_LOCK:
+        _WORKSPACE_BINDING_REVISION_RECEIPTS[key] = value
+        _WORKSPACE_BINDING_REVISION_RECEIPTS.move_to_end(key)
+        while (
+            len(_WORKSPACE_BINDING_REVISION_RECEIPTS)
+            > _WORKSPACE_BINDING_REVISION_RECEIPTS_MAX
+        ):
+            _WORKSPACE_BINDING_REVISION_RECEIPTS.popitem(last=False)
+
+
+def _trusted_workspace_binding_rebase(
+    session_id: str,
+    expected_revision,
+    durable_revision,
+    *,
+    session_dir: Path | None = None,
+):
+    """Return the trusted workspace for exactly one metadata-only revision."""
+    if expected_revision is None or durable_revision is None:
+        return None
+    key = (
+        str(Path(session_dir or SESSION_DIR).resolve()),
+        session_id,
+        tuple(durable_revision),
+    )
+    with _WORKSPACE_BINDING_REVISION_RECEIPTS_LOCK:
+        receipt = _WORKSPACE_BINDING_REVISION_RECEIPTS.get(key)
+    if receipt is None or receipt[0] != tuple(expected_revision):
+        return None
+    return receipt[1]
+
+
+@contextmanager
+def _cross_process_sidecar_file_authority(
+    lock_id: str,
+    *,
+    session_dir: Path | None = None,
+    lock_domain: str = 'session',
+):
+    """Serialize one sidecar-store mutation key across threads and processes."""
+    if not is_safe_session_id(lock_id):
+        raise ValueError(f"Unsafe sidecar lock id {lock_id!r}")
+    directory = Path(session_dir or SESSION_DIR)
+    if lock_domain == 'session':
+        authority_id = f"session:{directory.resolve()}:{lock_id}"
+        lock_dir = directory / '.sidecar-locks'
+    elif lock_domain == 'deleted-session-tombstone':
+        # Keep the global tombstone namespace disjoint from valid session SIDs.
+        authority_id = f"deleted-tombstone:{directory.resolve()}:{lock_id}"
+        lock_dir = directory / '.sidecar-locks' / '.deleted-session-tombstone'
+    else:
+        raise ValueError(f"Unknown sidecar lock domain {lock_domain!r}")
+    with _session_save_authority(authority_id):
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = lock_dir / f'{lock_id}.lock'
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        with os.fdopen(fd, 'r+b', buffering=0) as lock_file:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+                return
+            if _msvcrt is not None:  # pragma: no cover - Windows only.
+                if os.fstat(lock_file.fileno()).st_size == 0:
+                    lock_file.write(b'\0')
+                lock_file.seek(0)
+                _msvcrt.locking(  # type: ignore[attr-defined]
+                    lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
+                )
+                try:
+                    yield
+                finally:
+                    lock_file.seek(0)
+                    _msvcrt.locking(  # type: ignore[attr-defined]
+                        lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+                    )
+                return
+            raise RuntimeError('cross-process sidecar locking is unavailable')
+
+
+@contextmanager
+def _session_sidecar_authority(
+    session_id: str,
+    *,
+    session_dir: Path | None = None,
+):
+    """Serialize compliant sidecar writers for one SID across processes."""
+    if not is_safe_session_id(session_id):
+        raise ValueError(f"Unsafe session_id {session_id!r}")
+    with _cross_process_sidecar_file_authority(
+        session_id,
+        session_dir=session_dir,
+    ):
+        yield
 
 # Serializes ``_record_webui_zero_message_orphan_tombstone`` /
 # ``_clear_webui_zero_message_orphan_tombstone`` so two concurrent sidebar
@@ -201,7 +358,17 @@ _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
 # WebUI sidebar polling path is single-process) but must wrap the WHOLE
 # load-modify-write/unlink sequence in both helpers.
 _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK = threading.Lock()
-_WEBUI_DELETED_SESSION_TOMBSTONE_LOCK = threading.Lock()
+_WEBUI_DELETED_SESSION_TOMBSTONE_LOCK_SID = '_webui_deleted_sessions_global'
+
+
+@contextmanager
+def _webui_deleted_session_tombstone_authority():
+    """Serialize the deleted-session tombstone RMW across processes."""
+    with _cross_process_sidecar_file_authority(
+        _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK_SID,
+        lock_domain='deleted-session-tombstone',
+    ):
+        yield
 
 # Path-safety contract for session IDs.  Accept alphanumerics, underscore, and
 # hyphen so API/gateway-issued ids (``api-*``, ``reachy-voice-*``) round-trip
@@ -225,6 +392,192 @@ def is_safe_session_id(sid) -> bool:
     if not sid or not isinstance(sid, str):
         return False
     return all(c in _SAFE_SID_CHARS for c in sid)
+
+
+def _offline_replay_artifact_paths(sidecar: Path):
+    """Yield replay-v10 artifacts owned by one safe session sidecar."""
+    sidecar = Path(sidecar)
+    if sidecar.suffix != '.json' or not is_safe_session_id(sidecar.stem):
+        raise ValueError(f'Unsafe session sidecar path: {sidecar}')
+    name = sidecar.name
+    patterns = (
+        f'{name}.replay-v10.*.bak',
+        f'_replay-v10.{name}.*.manifest.json',
+        f'.{name}.replay-v10.tmp.*',
+        f'.{name}.replay-v10.restore.*',
+        f'._replay-v10.{name}.*.manifest.json.tmp.*',
+    )
+    seen = set()
+    for pattern in patterns:
+        for candidate in sidecar.parent.glob(pattern):
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if candidate.is_file() or candidate.is_symlink():
+                yield candidate
+
+
+def _delete_offline_replay_artifacts(sidecar: Path) -> int:
+    """Remove all plaintext replay artifacts owned by one sidecar."""
+    removed = 0
+    first_error = None
+    for candidate in _offline_replay_artifact_paths(sidecar):
+        try:
+            candidate.unlink()
+            removed += 1
+        except OSError as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+    return removed
+
+
+def _invalidate_cached_session_generation(session_id: str) -> None:
+    """Evict and poison a cached alias after an out-of-band mutation."""
+    with LOCK:
+        cached = SESSIONS.pop(session_id, None)
+        if cached is not None:
+            cached._sidecar_revision_session_id_v1 = session_id
+            cached._sidecar_revision_v1 = (-1, None, None)
+
+
+def _delete_session_recovery_artifacts_locked(
+    sid: str,
+    *,
+    session_dir: Path | None = None,
+    expected_live_revision=None,
+) -> bool:
+    """Delete backup/manifest/temp artifacts without deleting the live sidecar."""
+    if not is_safe_session_id(sid):
+        raise ValueError(f"Unsafe session_id {sid!r}")
+    directory = Path(session_dir or SESSION_DIR)
+    sidecar = directory / f'{sid}.json'
+    if (
+        expected_live_revision is not None
+        and _read_sidecar_revision(sidecar) != expected_live_revision
+    ):
+        return False
+    failures = []
+    backup = sidecar.with_suffix('.json.bak')
+    recovery_paths = [backup]
+    recovery_paths.extend(directory.glob(f'{sidecar.name}.bak.archive-*'))
+    for artifact in recovery_paths:
+        try:
+            artifact.unlink(missing_ok=True)
+        except Exception as exc:
+            failures.append(exc)
+    try:
+        _delete_offline_replay_artifacts(sidecar)
+    except Exception as exc:
+        failures.append(exc)
+    remaining = any(path.exists() for path in recovery_paths)
+    remaining = remaining or any(_offline_replay_artifact_paths(sidecar))
+    remaining = remaining or any(directory.glob(f'{sidecar.name}.bak.archive-*'))
+    _fsync_sidecar_directory(directory)
+    if failures or remaining:
+        cause = failures[0] if failures else None
+        raise RuntimeError(
+            f"Failed to delete required recovery artifacts for {sid!r}"
+        ) from cause
+    return True
+
+
+class SessionDeleteTombstoneError(RuntimeError):
+    """A sidecar delete could not durably fence stale writers."""
+
+
+def _delete_session_sidecar_artifacts_locked(
+    sid: str,
+    *,
+    session_dir: Path | None = None,
+    expected_revision=None,
+    record_tombstone: bool = True,
+) -> bool:
+    """Delete one SID's complete sidecar family while its authority is held."""
+    if not is_safe_session_id(sid):
+        raise ValueError(f"Unsafe session_id {sid!r}")
+    directory = Path(session_dir or SESSION_DIR)
+    sidecar = directory / f'{sid}.json'
+    if expected_revision is not None:
+        if _read_sidecar_revision(sidecar) != expected_revision:
+            return False
+    if record_tombstone:
+        try:
+            _record_webui_deleted_session_tombstone(sid)
+        except Exception as exc:
+            raise SessionDeleteTombstoneError(
+                f"Failed to durably tombstone deleted WebUI session {sid!r}"
+            ) from exc
+
+    _invalidate_cached_session_generation(sid)
+    failures = []
+    required = [sidecar, sidecar.with_suffix('.json.bak')]
+    required.extend(directory.glob(f'{sidecar.name}.bak.archive-*'))
+    for artifact in required:
+        try:
+            artifact.unlink(missing_ok=True)
+        except Exception as exc:
+            failures.append(exc)
+    try:
+        _delete_offline_replay_artifacts(sidecar)
+    except Exception as exc:
+        failures.append(exc)
+
+    remaining = any(path.exists() for path in required)
+    remaining = remaining or any(_offline_replay_artifact_paths(sidecar))
+    remaining = remaining or any(directory.glob(f'{sidecar.name}.bak.archive-*'))
+    _fsync_sidecar_directory(directory)
+    if failures or remaining:
+        cause = failures[0] if failures else None
+        raise RuntimeError(
+            f"Failed to delete required sidecar artifacts for {sid!r}"
+        ) from cause
+    return True
+
+
+def _file_contains_bytes(path: Path, needle: bytes) -> bool:
+    """Return whether a byte marker exists using bounded streaming reads."""
+    overlap = b''
+    overlap_size = max(len(needle) - 1, 0)
+    with path.open('rb') as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b''):
+            candidate = overlap + chunk
+            if needle in candidate:
+                return True
+            overlap = candidate[-overlap_size:] if overlap_size else b''
+    return False
+
+
+def _read_sidecar_generation(path: Path) -> int:
+    """Read the persisted offline-maintenance generation, failing closed."""
+    if not path.exists():
+        return 0
+    try:
+        prefix = _read_metadata_json_prefix(path)
+        if prefix is not None:
+            payload = json.loads(prefix)
+            if (
+                '_sidecar_generation_v1' not in payload
+                and _file_contains_bytes(path, b'"_sidecar_generation_v1"')
+            ):
+                payload = json.loads(path.read_text(encoding='utf-8'))
+        elif path.stat().st_size <= _INLINE_REPLAY_REPAIR_MAX_BYTES:
+            payload = json.loads(path.read_text(encoding='utf-8'))
+        else:
+            raise RuntimeError(
+                f'Cannot read bounded sidecar generation for {path.name!r}'
+            )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(
+            f'Cannot verify sidecar generation for {path.name!r}'
+        ) from exc
+    generation = payload.get('_sidecar_generation_v1', 0)
+    if type(generation) is not int or generation < 0:
+        raise RuntimeError(
+            f'Invalid sidecar generation for {path.name!r}: {generation!r}'
+        )
+    return generation
 
 
 def _cleanup_stale_tmp_files() -> None:
@@ -720,46 +1073,85 @@ def _clear_webui_zero_message_orphan_tombstone(sid: str) -> None:
             )
 
 
-def _webui_deleted_session_tombstone_file() -> "Path":
-    return SESSION_DIR / "_deleted_webui_sessions.json"
+def _webui_deleted_session_tombstone_file(
+    session_dir: Path | None = None,
+) -> "Path":
+    return Path(session_dir or SESSION_DIR) / "_deleted_webui_sessions.json"
 
 
-def _load_webui_deleted_session_tombstone() -> frozenset[str]:
-    p = _webui_deleted_session_tombstone_file()
+def _load_webui_deleted_session_tombstone_ids(
+    *,
+    session_dir: Path | None = None,
+    strict: bool = False,
+) -> list[str]:
+    p = _webui_deleted_session_tombstone_file(session_dir)
     if not p.exists():
-        return frozenset()
+        return []
     try:
         raw = json.loads(p.read_text(encoding='utf-8'))
+        if not isinstance(raw, dict):
+            raise ValueError('deleted-session tombstone must be an object')
+        if int(raw.get('version', 0)) != WEBUI_DELETED_SESSION_TOMBSTONE_VERSION:
+            raise ValueError('unsupported deleted-session tombstone version')
+        ids = raw.get('ids', [])
+        if not isinstance(ids, list):
+            raise ValueError('deleted-session tombstone ids must be a list')
     except Exception:
+        if strict:
+            raise
         logger.debug("Failed to load webui deleted-session tombstone", exc_info=True)
-        return frozenset()
-    if not isinstance(raw, dict):
-        return frozenset()
-    try:
-        if int(raw.get("version", 0)) != WEBUI_DELETED_SESSION_TOMBSTONE_VERSION:
-            return frozenset()
-    except (TypeError, ValueError):
-        return frozenset()
-    ids = raw.get("ids", [])
-    if not isinstance(ids, list):
-        return frozenset()
+        return []
+    ordered = []
+    seen = set()
+    for value in ids:
+        sid = str(value or '').strip()
+        if sid and sid not in seen:
+            seen.add(sid)
+            ordered.append(sid)
+    return ordered
+
+
+def _load_webui_deleted_session_tombstone(
+    *,
+    session_dir: Path | None = None,
+    strict: bool = False,
+) -> frozenset[str]:
     return frozenset(
-        str(sid).strip() for sid in ids if str(sid or "").strip()
+        _load_webui_deleted_session_tombstone_ids(
+            session_dir=session_dir,
+            strict=strict,
+        )
+    )
+
+
+def _webui_deleted_session_is_tombstoned(
+    sid: str,
+    *,
+    session_dir: Path | None = None,
+    strict: bool = False,
+) -> bool:
+    return sid in _load_webui_deleted_session_tombstone_ids(
+        session_dir=session_dir,
+        strict=strict,
     )
 
 
 def _save_webui_deleted_session_tombstone(ids) -> None:
     try:
-        sorted_ids = sorted(set(
-            str(sid).strip() for sid in (ids or []) if str(sid or "").strip()
-        ))
-    except TypeError:
-        return
-    if len(sorted_ids) > WEBUI_DELETED_SESSION_TOMBSTONE_CAP:
-        sorted_ids = sorted_ids[-WEBUI_DELETED_SESSION_TOMBSTONE_CAP:]
+        ordered_ids = []
+        seen = set()
+        for value in ids or []:
+            sid = str(value or '').strip()
+            if sid and sid not in seen:
+                seen.add(sid)
+                ordered_ids.append(sid)
+    except TypeError as exc:
+        raise ValueError('deleted-session tombstone ids are not iterable') from exc
+    if len(ordered_ids) > WEBUI_DELETED_SESSION_TOMBSTONE_CAP:
+        ordered_ids = ordered_ids[-WEBUI_DELETED_SESSION_TOMBSTONE_CAP:]
     payload = {
         "version": WEBUI_DELETED_SESSION_TOMBSTONE_VERSION,
-        "ids": sorted_ids,
+        "ids": ordered_ids,
     }
     p = _webui_deleted_session_tombstone_file()
     _tmp = None
@@ -769,10 +1161,12 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
             f'.tmp.{os.getpid()}.{threading.current_thread().ident}'
         )
         with open(_tmp, 'w', encoding='utf-8') as f:
+            _set_file_descriptor_mode(f.fileno(), 0o600)
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
         os.replace(_tmp, p)
+        _fsync_sidecar_directory(p.parent)
     except Exception:
         logger.debug("Failed to save webui deleted-session tombstone", exc_info=True)
         if _tmp is not None:
@@ -780,34 +1174,47 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
                 _tmp.unlink(missing_ok=True)
             except Exception:
                 pass
+        raise
 
 
 def _record_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
-        current = set(_load_webui_deleted_session_tombstone())
+    with _webui_deleted_session_tombstone_authority():
+        # Keep this public load in the RMW path: tests and diagnostics can gate
+        # the exact read while the persisted order remains independently retained.
+        current = _load_webui_deleted_session_tombstone(strict=True)
         if sid in current:
+            _fsync_sidecar_directory(SESSION_DIR)
             return
-        current.add(sid)
-        _save_webui_deleted_session_tombstone(current)
+        ordered = _load_webui_deleted_session_tombstone_ids(strict=True)
+        ordered.append(sid)
+        _save_webui_deleted_session_tombstone(ordered)
+        if sid not in _load_webui_deleted_session_tombstone(strict=True):
+            raise RuntimeError(f"Deleted-session tombstone dropped new SID {sid!r}")
 
 
 def _clear_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
-        current = set(_load_webui_deleted_session_tombstone())
+    with _webui_deleted_session_tombstone_authority():
+        current = _load_webui_deleted_session_tombstone(strict=True)
         if sid not in current:
             return
-        current.discard(sid)
-        if current:
-            _save_webui_deleted_session_tombstone(current)
+        ordered = [
+            current_sid
+            for current_sid in _load_webui_deleted_session_tombstone_ids(strict=True)
+            if current_sid != sid
+        ]
+        if ordered:
+            _save_webui_deleted_session_tombstone(ordered)
             return
         try:
-            _webui_deleted_session_tombstone_file().unlink(missing_ok=True)
+            p = _webui_deleted_session_tombstone_file()
+            p.unlink(missing_ok=True)
+            _fsync_sidecar_directory(p.parent)
         except Exception:
             logger.debug("Failed to remove empty webui deleted-session tombstone", exc_info=True)
 
@@ -1034,6 +1441,354 @@ def _message_role(message):
     return str(message.get('role', '')).strip().lower()
 
 
+_SESSION_METADATA_FIELDS = [
+    'session_id', 'title', 'workspace', 'created_workspace', 'model',
+    'model_provider', 'model_explicit_pick_signature', 'created_at',
+    'updated_at', 'pinned', 'archived', 'project_id', 'profile',
+    'input_tokens', 'output_tokens', 'estimated_cost', 'cache_read_tokens',
+    'cache_write_tokens', 'personality', 'active_stream_id',
+    'pending_user_message', 'pending_attachments', 'pending_started_at',
+    'pending_user_source', 'compression_anchor_visible_idx',
+    'compression_anchor_message_key', 'compression_anchor_summary',
+    'pre_compression_snapshot', 'context_engine',
+    'compression_anchor_engine', 'compression_anchor_mode',
+    'compression_anchor_details', 'context_engine_state', 'context_length',
+    'threshold_tokens', 'last_prompt_tokens',
+    'post_compression_context_tokens_estimate', 'compression_recovery',
+    'recommended_recovery_action', 'compression_recovery_source_session_id',
+    'compression_recovery_action', 'truncation_watermark',
+    'truncation_boundary', 'clear_generation',
+    'intentional_shrink_generation', 'gateway_routing',
+    'gateway_routing_history', 'llm_title_generated', 'manual_title',
+    'parent_session_id', 'worktree_path', 'worktree_branch',
+    'worktree_repo_root', 'worktree_created_at', 'is_cli_session',
+    'source_tag', 'raw_source', 'session_source', 'source_label', 'read_only',
+    'enabled_toolsets', 'composer_draft', 'process_wakeup_pause',
+    'share_token', 'share_created_at',
+]
+_BOUNDED_SESSION_METADATA_FIELDS = frozenset((
+    *_SESSION_METADATA_FIELDS,
+    'message_count',
+    'anchor_scene_index',
+    '_sidecar_epoch_v1',
+    '_sidecar_generation_v1',
+))
+_BOUNDED_METADATA_VALUE_CHARS = 65_536
+_JSON_STRING_SPECIAL_RE = re.compile(r'["\\\x00-\x1f]')
+_JSON_SCALAR_END_RE = re.compile(r'[ \t\r\n,}\]]')
+
+
+class _StreamingTopLevelJSONReader:
+    """Scan one JSON object with memory independent of skipped value size."""
+
+    def initialize(self, handle, chunk_chars=65_536):
+        self.handle = handle
+        self.chunk_chars = chunk_chars
+        self.buffer = ''
+        self.pos = 0
+        self.eof = False
+        self._capture = None
+
+    def _fill(self):
+        if self.pos:
+            self.buffer = self.buffer[self.pos:]
+            self.pos = 0
+        if self.eof:
+            return False
+        chunk = self.handle.read(self.chunk_chars)
+        if chunk:
+            self.buffer += chunk
+            return True
+        self.eof = True
+        return False
+
+    def ensure(self):
+        while self.pos >= len(self.buffer):
+            if not self._fill():
+                return False
+        return True
+
+    def peek(self):
+        return self.buffer[self.pos] if self.ensure() else ''
+
+    def take(self):
+        char = self.peek()
+        if not char:
+            raise ValueError('unexpected end of session JSON')
+        self.pos += 1
+        if self._capture is not None:
+            self._capture(char)
+        return char
+
+    def skip_ws(self):
+        while self.peek() and self.peek() in ' \t\r\n':
+            if self._capture is None:
+                self.pos += 1
+            else:
+                self.take()
+
+    def expect(self, expected):
+        self.skip_ws()
+        actual = self.take()
+        if actual != expected:
+            raise ValueError(f'expected {expected!r}, got {actual!r}')
+
+    def _skip_string_body(self):
+        if self._capture is not None:
+            while True:
+                char = self.take()
+                if char == '"':
+                    return
+                if char == '\\':
+                    self._consume_string_escape()
+                elif ord(char) < 0x20:
+                    raise ValueError('unescaped control character in session JSON string')
+        while True:
+            if not self.ensure():
+                raise ValueError('unexpected end of session JSON string')
+            match = _JSON_STRING_SPECIAL_RE.search(self.buffer, self.pos)
+            if match is None:
+                self.pos = len(self.buffer)
+                continue
+            self.pos = match.end()
+            if match.group() == '"':
+                return
+            if match.group() == '\\':
+                self._consume_string_escape()
+            else:
+                raise ValueError('unescaped control character in session JSON string')
+
+    def _consume_string_escape(self):
+        escape = self.take()
+        if escape == 'u':
+            for _ in range(4):
+                digit = self.take()
+                if digit not in '0123456789abcdefABCDEF':
+                    raise ValueError('malformed unicode escape in session JSON string')
+        elif escape not in '"\\/bfnrt':
+            raise ValueError(f'invalid session JSON string escape: {escape!r}')
+
+    def _skip_container_body(self, first, depth):
+        if depth >= 512:
+            raise ValueError('session JSON nesting exceeds 512 levels')
+        closing = ']' if first == '[' else '}'
+        self.skip_ws()
+        if self.peek() == closing:
+            self.take()
+            return
+        while True:
+            if first == '{':
+                if self.take() != '"':
+                    raise ValueError('session JSON object key must be a string')
+                self._skip_string_body()
+                self.expect(':')
+            self._consume_value(depth + 1)
+            self.skip_ws()
+            delimiter = self.take()
+            if delimiter == closing:
+                return
+            if delimiter != ',':
+                raise ValueError(
+                    f'expected session JSON container delimiter, got {delimiter!r}'
+                )
+            self.skip_ws()
+
+    def _skip_scalar_body(self, first):
+        token = [first]
+        token_size = len(first)
+        if self._capture is not None:
+            while True:
+                char = self.peek()
+                if not char or char in ' \t\r\n,}]':
+                    break
+                token.append(self.take())
+                if len(token) > _BOUNDED_METADATA_VALUE_CHARS:
+                    raise ValueError('session JSON scalar exceeds bounded limit')
+            raw = ''.join(token)
+            try:
+                value = json.loads(
+                    raw,
+                    parse_constant=_reject_bounded_metadata_constant,
+                )
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise ValueError(f'invalid session JSON scalar: {exc}') from exc
+            if isinstance(value, (dict, list, str)):
+                raise ValueError('invalid session JSON scalar')
+            return
+        while self.ensure():
+            match = _JSON_SCALAR_END_RE.search(self.buffer, self.pos)
+            if match is not None:
+                piece = self.buffer[self.pos:match.start()]
+                token.append(piece)
+                token_size += len(piece)
+                if token_size > _BOUNDED_METADATA_VALUE_CHARS:
+                    raise ValueError('session JSON scalar exceeds bounded limit')
+                self.pos = match.start()
+                break
+            piece = self.buffer[self.pos:]
+            token.append(piece)
+            token_size += len(piece)
+            if token_size > _BOUNDED_METADATA_VALUE_CHARS:
+                raise ValueError('session JSON scalar exceeds bounded limit')
+            self.pos = len(self.buffer)
+        raw = ''.join(token)
+        try:
+            value = json.loads(raw, parse_constant=_reject_bounded_metadata_constant)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(f'invalid session JSON scalar: {exc}') from exc
+        if isinstance(value, (dict, list, str)):
+            raise ValueError('invalid session JSON scalar')
+
+    def _consume_value(self, depth=0):
+        self.skip_ws()
+        first = self.take()
+        if first in ',}]':
+            raise ValueError('missing JSON value')
+        if first == '"':
+            self._skip_string_body()
+        elif first in '[{':
+            self._skip_container_body(first, depth)
+        else:
+            self._skip_scalar_body(first)
+
+    def consume_value(self, max_capture_chars=0):
+        """Consume one JSON-shaped value and optionally retain a bounded copy."""
+        self.skip_ws()
+        captured = []
+        capture_size = 0
+        truncated = False
+        previous_capture = self._capture
+
+        def capture(char):
+            nonlocal capture_size, truncated
+            if truncated:
+                return
+            capture_size += len(char)
+            if capture_size > max_capture_chars:
+                captured.clear()
+                truncated = True
+                self._capture = None
+                return
+            captured.append(char)
+        try:
+            self._capture = capture if max_capture_chars > 0 else None
+            self._consume_value()
+            return None if truncated or max_capture_chars <= 0 else ''.join(captured)
+        finally:
+            self._capture = previous_capture
+
+    def consume_array_count(self):
+        """Consume one top-level array and count items without retaining them."""
+        self.expect('[')
+        self.skip_ws()
+        if self.peek() == ']':
+            self.take()
+            return 0
+        count = 0
+        while True:
+            self.consume_value()
+            count += 1
+            self.skip_ws()
+            delimiter = self.take()
+            if delimiter == ']':
+                return count
+            if delimiter != ',':
+                raise ValueError(f'expected array delimiter, got {delimiter!r}')
+
+
+def _reject_bounded_metadata_constant(value):
+    raise ValueError(f'invalid JSON constant: {value}')
+
+
+def _decode_bounded_metadata_value(raw):
+    return json.loads(
+        raw,
+        parse_constant=_reject_bounded_metadata_constant,
+    )
+
+
+def _read_bounded_session_metadata(path):
+    """Extract fixed session/index metadata while streaming past large arrays."""
+    data = {}
+    inferred_message_count = None
+    with open(path, 'r', encoding='utf-8') as handle:
+        reader = _StreamingTopLevelJSONReader()
+        reader.initialize(handle)
+        reader.expect('{')
+        reader.skip_ws()
+        if reader.peek() == '}':
+            reader.take()
+            return data
+        while True:
+            if reader.peek() != '"':
+                raise ValueError('session JSON key must be a string')
+            raw_key = reader.consume_value(max_capture_chars=4096)
+            key = _decode_bounded_metadata_value(raw_key) if raw_key else None
+            if key is not None and type(key) is not str:
+                raise ValueError('session JSON key must be a string')
+            reader.expect(':')
+            reader.skip_ws()
+            if key == 'messages' and reader.peek() == '[':
+                inferred_message_count = reader.consume_array_count()
+            else:
+                raw_value = reader.consume_value(
+                    max_capture_chars=(
+                        _BOUNDED_METADATA_VALUE_CHARS
+                        if key in _BOUNDED_SESSION_METADATA_FIELDS
+                        else 0
+                    )
+                )
+                if key in _BOUNDED_SESSION_METADATA_FIELDS and raw_value is not None:
+                    data[key] = _decode_bounded_metadata_value(raw_value)
+            reader.skip_ws()
+            delimiter = reader.take()
+            if delimiter == '}':
+                break
+            if delimiter != ',':
+                raise ValueError(
+                    f'expected top-level delimiter, got {delimiter!r}'
+                )
+            reader.skip_ws()
+        reader.skip_ws()
+        if reader.peek():
+            raise ValueError('trailing data after session object')
+    if 'message_count' not in data and inferred_message_count is not None:
+        data['message_count'] = inferred_message_count
+    return data
+
+
+def _validated_sidecar_epoch(value):
+    if value is None:
+        return None
+    if type(value) is not str or re.fullmatch(r'[0-9a-f]{32}', value) is None:
+        raise RuntimeError(f'Invalid sidecar epoch: {value!r}')
+    return value
+
+
+def _sidecar_content_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as handle:
+        for chunk in iter(lambda: handle.read(4 << 20), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_sidecar_revision(path: Path):
+    if not path.exists():
+        return None
+    try:
+        metadata = _read_bounded_session_metadata(path)
+        generation = metadata.get('_sidecar_generation_v1', 0)
+        if type(generation) is not int or generation < 0:
+            raise RuntimeError(f'Invalid sidecar generation: {generation!r}')
+        epoch = _validated_sidecar_epoch(metadata.get('_sidecar_epoch_v1'))
+        return (generation, epoch, _sidecar_content_digest(path))
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise RuntimeError(
+            f'Cannot verify sidecar revision for {path.name!r}'
+        ) from exc
+
+
 def _find_top_level_json_key(text, key):
     """Return the byte offset of a top-level JSON object key, if present."""
     depth = 0
@@ -1120,8 +1875,37 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
 def _load_session_from_path(path: Path) -> "Session | None":
     """Load a session from an explicit JSON path without consulting SESSION_DIR."""
     try:
+        is_large = path.stat().st_size > _INLINE_REPLAY_REPAIR_MAX_BYTES
+    except OSError:
+        return None
+    if is_large:
+        try:
+            data = _read_bounded_session_metadata(path)
+            session_id = data.get('session_id') if isinstance(data, dict) else None
+            if (
+                type(session_id) is not str
+                or not is_safe_session_id(session_id)
+                or session_id != path.stem
+            ):
+                return None
+            data['messages'] = []
+            session = Session(**data)
+            session._metadata_message_count = _parse_nonnegative_int(
+                data.get('message_count')
+            )
+            return session
+        except Exception:
+            return None
+    try:
         data = json.loads(path.read_text(encoding='utf-8'))
     except Exception:
+        return None
+    session_id = data.get('session_id') if isinstance(data, dict) else None
+    if (
+        type(session_id) is not str
+        or not is_safe_session_id(session_id)
+        or session_id != path.stem
+    ):
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
     return Session(**data)
@@ -1362,12 +2146,38 @@ class Session:
             except (TypeError, ValueError):
                 parsed_message_count = None
         self._metadata_message_count = parsed_message_count if parsed_message_count is not None and parsed_message_count >= 0 else None
+        self._replay_repair_deferred = False
+        raw_sidecar_generation = kwargs.get('_sidecar_generation_v1', 0)
+        self._sidecar_generation_v1 = (
+            raw_sidecar_generation
+            if type(raw_sidecar_generation) is int and raw_sidecar_generation >= 0
+            else 0
+        )
+        raw_sidecar_epoch = kwargs.get('_sidecar_epoch_v1')
+        self._sidecar_epoch_v1 = (
+            _validated_sidecar_epoch(raw_sidecar_epoch)
+            if raw_sidecar_epoch is not None
+            else uuid.uuid4().hex
+        )
+        self._sidecar_revision_v1 = None
+        self._sidecar_revision_session_id_v1 = None
 
     @property
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        with _session_sidecar_authority(self.session_id):
+            return self._save_with_sidecar_authority(
+                touch_updated_at=touch_updated_at,
+                skip_index=skip_index,
+            )
+
+    def _save_with_sidecar_authority(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+    ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1387,39 +2197,83 @@ class Session:
                 f"Reload with metadata_only=False before mutating state. "
                 f"See #1558."
             )
+        if getattr(self, '_replay_repair_deferred', False):
+            raise RuntimeError(
+                f"Session {self.session_id!r} requires offline replay repair before saving"
+            )
+        if (
+            not self.messages
+            and (self.active_stream_id or self.pending_user_message)
+            and self.path.exists()
+        ):
+            try:
+                durable_payload = json.loads(self.path.read_text(encoding='utf-8'))
+            except (OSError, json.JSONDecodeError, ValueError):
+                durable_payload = None
+            if isinstance(durable_payload, dict) and durable_payload.get('messages'):
+                logger.warning(
+                    "refusing to overwrite session %s messages with empty active/pending snapshot",
+                    self.session_id,
+                )
+                return
+        durable_revision = _read_sidecar_revision(self.path)
+        expected_revision = getattr(self, '_sidecar_revision_v1', None)
+        expected_revision_sid = getattr(
+            self,
+            '_sidecar_revision_session_id_v1',
+            None,
+        )
+        if (
+            expected_revision_sid == self.session_id
+            and durable_revision != expected_revision
+        ):
+            rebased_workspace = _trusted_workspace_binding_rebase(
+                self.session_id,
+                expected_revision,
+                durable_revision,
+                session_dir=self.path.parent,
+            )
+            if rebased_workspace is None:
+                raise RuntimeError(
+                    f'stale sidecar revision for session {self.session_id!r}; '
+                    'reload before saving'
+                )
+            # A same-process workspace recovery patched metadata only while this
+            # canonical save waited for sidecar authority. Preserve that trusted
+            # binding, then publish this session's transcript as the next CAS
+            # generation instead of discarding it as a generic stale writer.
+            self.workspace = rebased_workspace
+            expected_revision = durable_revision
+        if (
+            durable_revision is not None
+            and _webui_deleted_session_is_tombstoned(
+                self.session_id,
+                strict=True,
+            )
+        ):
+            raise RuntimeError(
+                f'deleted sidecar generation for session {self.session_id!r}; '
+                'explicit recreation is required'
+            )
+        if expected_revision_sid != self.session_id:
+            durable_epoch = durable_revision[1] if durable_revision else None
+            if durable_epoch is not None:
+                self._sidecar_epoch_v1 = durable_epoch
+            elif expected_revision_sid is not None:
+                self._sidecar_epoch_v1 = uuid.uuid4().hex
+        persisted_generation = durable_revision[0] if durable_revision else 0
+        output_generation = persisted_generation + 1
+        source_mode = (
+            stat_module.S_IMODE(self.path.stat().st_mode)
+            if self.path.exists()
+            else 0o600
+        )
         if touch_updated_at:
             self.updated_at = time.time()
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
-        METADATA_FIELDS = [
-            'session_id', 'title', 'workspace', 'created_workspace', 'model', 'model_provider', 'model_explicit_pick_signature', 'created_at', 'updated_at',
-            'pinned', 'archived', 'project_id', 'profile',
-            'input_tokens', 'output_tokens', 'estimated_cost',
-            'cache_read_tokens', 'cache_write_tokens',
-            'personality', 'active_stream_id',
-            'pending_user_message', 'pending_attachments', 'pending_started_at', 'pending_user_source',
-            'compression_anchor_visible_idx', 'compression_anchor_message_key',
-            'compression_anchor_summary', 'pre_compression_snapshot',
-            'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',
-            'compression_anchor_details', 'context_engine_state',
-            'context_length', 'threshold_tokens', 'last_prompt_tokens',
-            'post_compression_context_tokens_estimate',
-            'compression_recovery', 'recommended_recovery_action',
-            'compression_recovery_source_session_id', 'compression_recovery_action',
-            'truncation_watermark',
-            'truncation_boundary',
-            'clear_generation',
-            'intentional_shrink_generation',
-            'gateway_routing', 'gateway_routing_history', 'llm_title_generated', 'manual_title',
-            'parent_session_id',
-            'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
-            'is_cli_session', 'source_tag', 'raw_source', 'session_source', 'source_label', 'read_only',
-            'enabled_toolsets', 'composer_draft',
-            'process_wakeup_pause',
-            'share_token', 'share_created_at',
-        ]
-        meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
+        meta = {k: getattr(self, k, None) for k in _SESSION_METADATA_FIELDS}
         # #5854: message_count and a compact anchor-scene fingerprint go in the
         # metadata prefix (BEFORE messages) so load_metadata_only() and the
         # sidebar-poll freshness check never have to parse the full (250-480KB)
@@ -1428,6 +2282,8 @@ class Session:
         # The full anchor_activity_scenes bodies serialize AFTER messages.
         meta['message_count'] = len(self.messages or [])
         meta['anchor_scene_index'] = _anchor_scene_index_from_records(self.anchor_activity_scenes)
+        meta['_sidecar_epoch_v1'] = self._sidecar_epoch_v1
+        meta['_sidecar_generation_v1'] = output_generation
         # Keep the in-memory fingerprint aligned with what we just persisted, so a
         # later metadata-only reload of THIS object (or any fingerprint reader)
         # sees the current value rather than a stale load-time snapshot (#5854
@@ -1437,11 +2293,19 @@ class Session:
         meta['messages'] = self.messages
         meta['tool_calls'] = self.tool_calls
         meta['anchor_activity_scenes'] = self.anchor_activity_scenes if isinstance(self.anchor_activity_scenes, dict) else {}
-        # Fields not in METADATA_FIELDS (e.g. last_usage) go at the end. Exclude
+        # Fields not in _SESSION_METADATA_FIELDS (e.g. last_usage) go at the end. Exclude
         # the keys we placed explicitly above so they aren't emitted twice.
-        _placed = {'message_count', 'anchor_scene_index', 'messages', 'tool_calls', 'anchor_activity_scenes'}
+        _placed = {
+            'message_count',
+            'anchor_scene_index',
+            '_sidecar_epoch_v1',
+            '_sidecar_generation_v1',
+            'messages',
+            'tool_calls',
+            'anchor_activity_scenes',
+        }
         extra = {k: v for k, v in self.__dict__.items()
-                 if k not in METADATA_FIELDS and k not in _placed
+                 if k not in _SESSION_METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
         payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
@@ -1495,10 +2359,12 @@ class Session:
                             f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
                         )
                         with open(bak_tmp, 'w', encoding='utf-8') as bf:
+                            _set_file_descriptor_mode(bf.fileno(), source_mode)
                             bf.write(existing_text)
                             bf.flush()
                             os.fsync(bf.fileno())
                         _safe_replace(bak_tmp, bak_path)
+                        _fsync_sidecar_directory(bak_path.parent)
                     except OSError:
                         # Backup is best-effort; main save proceeds regardless.
                         try:
@@ -1511,16 +2377,25 @@ class Session:
         tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
             with open(tmp, 'w', encoding='utf-8') as f:
+                _set_file_descriptor_mode(f.fileno(), source_mode)
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())
             _safe_replace(tmp, self.path)
+            _fsync_sidecar_directory(self.path.parent)
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)
             except Exception:
                 pass
             raise
+        self._sidecar_generation_v1 = output_generation
+        self._sidecar_revision_v1 = (
+            output_generation,
+            self._sidecar_epoch_v1,
+            _sidecar_content_digest(self.path),
+        )
+        self._sidecar_revision_session_id_v1 = self.session_id
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1558,13 +2433,39 @@ class Session:
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
             return None
+        inline_repair = p.stat().st_size <= _INLINE_REPLAY_REPAIR_MAX_BYTES
         # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
         # cache write is only committed if the file didn't change under us
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
-        data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        source_bytes = p.read_bytes()
+        data = json.loads(source_bytes.decode('utf-8'))
+        if inline_repair:
+            data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(
+                data.get('messages')
+            )
+        else:
+            _collapsed_partials = False
         session = cls(**data)
+        loaded_generation = data.get('_sidecar_generation_v1', 0)
+        if type(loaded_generation) is not int or loaded_generation < 0:
+            raise RuntimeError(
+                f'Invalid sidecar generation for {p.name!r}: {loaded_generation!r}'
+            )
+        loaded_epoch = _validated_sidecar_epoch(data.get('_sidecar_epoch_v1'))
+        session._sidecar_revision_v1 = (
+            loaded_generation,
+            loaded_epoch,
+            hashlib.sha256(source_bytes).hexdigest(),
+        )
+        session._sidecar_revision_session_id_v1 = session.session_id
+        session._replay_repair_deferred = bool(
+            not inline_repair
+            and (
+                _has_adjacent_duplicate_partials(data.get('messages'))
+                or _has_adjacent_duplicate_partials(data.get('context_messages'))
+            )
+        )
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching
@@ -2373,6 +3274,22 @@ def _partial_message_signature(message: dict) -> tuple:
         str(message.get('reasoning') or '').strip(),
         tuple(tool_sig),
     )
+
+
+def _has_adjacent_duplicate_partials(messages) -> bool:
+    """Detect the inline-repair case without allocating a collapsed copy."""
+    if not isinstance(messages, list):
+        return False
+    previous_partial_sig = None
+    for message in messages:
+        if isinstance(message, dict) and message.get('_partial'):
+            signature = _partial_message_signature(message)
+            if previous_partial_sig == signature:
+                return True
+            previous_partial_sig = signature
+        else:
+            previous_partial_sig = None
+    return False
 
 
 def _collapse_adjacent_duplicate_partials(messages) -> tuple[list, bool]:
@@ -3931,6 +4848,16 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
 
         # Durable write succeeded — reflect the reconciled state on the caller's
         # shared/cached object so the in-flight read returns the recovered data.
+        # This is an authoritative in-place refresh, so transfer the exact CAS
+        # observation made by the locked writer as well as its public fields.
+        # Otherwise the caller would carry the new transcript with the old byte
+        # revision and its next legitimate save would be rejected as stale.
+        session._sidecar_generation_v1 = locked._sidecar_generation_v1
+        session._sidecar_epoch_v1 = locked._sidecar_epoch_v1
+        session._sidecar_revision_v1 = locked._sidecar_revision_v1
+        session._sidecar_revision_session_id_v1 = (
+            locked._sidecar_revision_session_id_v1
+        )
         session.messages = merged_messages
         session.context_messages = merged_context
         session.active_stream_id = None
@@ -5617,14 +6544,7 @@ def persist_recovered_workspace_binding(
     *,
     expected_workspace=_EXPECTED_WORKSPACE_UNSET,
 ):
-    """Atomically persist only a recovered session's workspace binding.
-
-    Existing sidecars are patched as raw JSON so metadata-only callers never
-    reserialize (or otherwise clobber) the transcript. Missing sidecars fail
-    closed so recovery cannot resurrect a concurrently deleted session. The
-    per-session mutation lock keeps compare-and-replace ordered with other
-    compliant session writers.
-    """
+    """CAS-patch a recovered workspace without reserializing a stale Session."""
     sid = str(getattr(session, "session_id", "") or "").strip()
     if not sid or not is_safe_session_id(sid):
         raise WorkspaceBindingPersistenceError(
@@ -5638,65 +6558,132 @@ def persist_recovered_workspace_binding(
     )
     expected = str(expected_value or "")
     path = SESSION_DIR / f"{sid}.json"
-    lock = _get_session_agent_lock(sid)
-    with lock:
-        if not path.exists():
-            # Recovery only repairs an existing WebUI sidecar. Creating a new
-            # sidecar here can resurrect a session that was deleted after the
-            # recovery decision but before this lock was acquired.
-            raise WorkspaceBindingPersistenceError(
-                "Failed to persist recovered workspace: session sidecar is missing"
-            )
-
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            raise WorkspaceBindingPersistenceError(
-                "Failed to persist recovered workspace: unreadable session sidecar"
-            ) from exc
-        if not isinstance(payload, dict):
-            raise WorkspaceBindingPersistenceError(
-                "Failed to persist recovered workspace: invalid session sidecar"
-            )
-        current = str(payload.get("workspace") or "")
-        if current != resolved:
-            if current != expected:
+    with _get_session_agent_lock(sid):
+        with _session_sidecar_authority(sid):
+            revision_before = _read_sidecar_revision(path)
+            if revision_before is None:
                 raise WorkspaceBindingPersistenceError(
-                    "Failed to persist recovered workspace: session workspace changed"
+                    "Failed to persist recovered workspace: session sidecar is missing"
                 )
-            payload["workspace"] = resolved
-            tmp = path.with_suffix(
-                f".tmp.{os.getpid()}.{threading.current_thread().ident}"
-            )
-            try:
-                with open(tmp, "w", encoding="utf-8") as handle:
-                    json.dump(payload, handle, ensure_ascii=False, indent=2)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                _safe_replace(tmp, path)
-            except Exception as exc:
-                try:
-                    tmp.unlink(missing_ok=True)
-                except Exception:
-                    pass
+            if _webui_deleted_session_is_tombstoned(sid, strict=True):
                 raise WorkspaceBindingPersistenceError(
-                    "Failed to persist recovered workspace"
+                    "Failed to persist recovered workspace: session was deleted"
+                )
+            try:
+                raw = path.read_bytes()
+                payload = json.loads(raw)
+            except Exception as exc:
+                raise WorkspaceBindingPersistenceError(
+                    "Failed to persist recovered workspace: unreadable session sidecar"
                 ) from exc
+            if not isinstance(payload, dict) or payload.get('session_id') != sid:
+                raise WorkspaceBindingPersistenceError(
+                    "Failed to persist recovered workspace: invalid session sidecar"
+                )
+            if hashlib.sha256(raw).hexdigest() != revision_before[2]:
+                raise WorkspaceBindingPersistenceError(
+                    "Failed to persist recovered workspace: session changed"
+                )
+            current = str(payload.get("workspace") or "")
+            revision_after = revision_before
+            if current != resolved:
+                if current != expected:
+                    raise WorkspaceBindingPersistenceError(
+                        "Failed to persist recovered workspace: session workspace changed"
+                    )
+                payload["workspace"] = resolved
+                payload['_sidecar_generation_v1'] = revision_before[0] + 1
+                payload['_sidecar_epoch_v1'] = revision_before[1] or uuid.uuid4().hex
+                serialized = json.dumps(payload, ensure_ascii=False, indent=2).encode(
+                    'utf-8'
+                )
+                tmp = path.with_suffix(
+                    f".tmp.{os.getpid()}.{threading.current_thread().ident}"
+                )
+                try:
+                    with open(tmp, "xb") as handle:
+                        _set_file_descriptor_mode(handle.fileno(), 0o600)
+                        handle.write(serialized)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    if _read_sidecar_revision(path) != revision_before:
+                        raise RuntimeError(
+                            f"Session {sid!r} changed during workspace recovery"
+                        )
+                    if _webui_deleted_session_is_tombstoned(sid, strict=True):
+                        raise RuntimeError(
+                            f"Session {sid!r} was deleted during workspace recovery"
+                        )
+                    _safe_replace(tmp, path)
+                    _fsync_sidecar_directory(path.parent)
+                    revision_after = _read_sidecar_revision(path)
+                    if revision_after is None or revision_after[0] <= revision_before[0]:
+                        raise RuntimeError(
+                            f"Session {sid!r} generation did not advance"
+                        )
+                    _record_workspace_binding_revision_receipt(
+                        sid,
+                        revision_before,
+                        revision_after,
+                        resolved,
+                        session_dir=path.parent,
+                    )
+                except Exception as exc:
+                    try:
+                        tmp.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+                    raise WorkspaceBindingPersistenceError(
+                        "Failed to persist recovered workspace"
+                    ) from exc
 
-        session.workspace = resolved
+        def owns_revision(candidate) -> bool:
+            return bool(
+                candidate is not None
+                and getattr(candidate, '_sidecar_revision_session_id_v1', None) == sid
+                and getattr(candidate, '_sidecar_revision_v1', None) == revision_before
+            )
+
+        session_owned = owns_revision(session)
+        metadata_view = not hasattr(session, '_sidecar_revision_v1')
+        if session_owned or metadata_view:
+            session.workspace = resolved
+            if session_owned:
+                session._sidecar_revision_v1 = revision_after
+        cached_owned = False
         with LOCK:
             cached = SESSIONS.get(sid)
-            if cached is not None:
+            cached_owned = owns_revision(cached)
+            if cached_owned and cached is not None:
                 cached.workspace = resolved
+                cached._sidecar_revision_v1 = revision_after
+            elif cached is not None:
+                SESSIONS.pop(sid, None)
+                cached._sidecar_revision_session_id_v1 = sid
+                cached._sidecar_revision_v1 = (-1, None, None)
+        result = (
+            cached
+            if cached_owned
+            else (session if session_owned or metadata_view else None)
+        )
+        if result is None:
+            result = Session.load(sid)
+            if result is None:
+                raise WorkspaceBindingPersistenceError(
+                    "Failed to reload session after workspace recovery"
+                )
+            with LOCK:
+                SESSIONS[sid] = result
+                SESSIONS.move_to_end(sid)
         try:
-            _write_session_index(updates=[cached or session])
+            _write_session_index(updates=[result])
         except Exception:
             logger.debug(
                 "Failed to refresh session index after workspace recovery for %s",
                 sid,
                 exc_info=True,
             )
-        return cached or session
+        return result
 
 
 def get_session_for_file_ops(sid: str):

--- a/api/routes.py
+++ b/api/routes.py
@@ -10301,7 +10301,11 @@ from api.models import (
     _record_webui_zero_message_orphan_tombstone,
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
-    _record_webui_deleted_session_tombstone,
+    _delete_session_recovery_artifacts_locked,
+    _delete_session_sidecar_artifacts_locked,
+    _read_bounded_session_metadata,
+    _read_sidecar_revision,
+    _session_sidecar_authority,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -15912,32 +15916,28 @@ def handle_post(handler, parsed) -> bool:
         if not session_lock.acquire(timeout=5):
             return bad(handler, "Session busy, try again", 503)
         try:
-            with LOCK:
-                SESSIONS.pop(sid, None)
             try:
                 p = (SESSION_DIR / f"{sid}.json").resolve()
                 p.relative_to(SESSION_DIR.resolve())
             except Exception:
                 return bad(handler, "Invalid session_id", 400)
-            sidecar_deleted = False
             try:
-                p.unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session file %s", p)
-            sidecar_deleted = not p.exists()
+                with _session_sidecar_authority(sid):
+                    _delete_session_sidecar_artifacts_locked(
+                        sid,
+                        record_tombstone=not is_messaging_session,
+                    )
+            except Exception as exc:
+                logger.exception("Failed to durably delete session sidecar %s", sid)
+                return bad(
+                    handler,
+                    f"Session deletion failed; retry is required: {_sanitize_error(exc)}",
+                    500,
+                )
             try:
                 prune_session_from_index(sid)
             except Exception:
                 logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-            try:
-                p.with_suffix('.json.bak').unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
-            if sidecar_deleted and not is_messaging_session:
-                try:
-                    _record_webui_deleted_session_tombstone(sid)
-                except Exception:
-                    logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         finally:
             session_lock.release()
         # Evict outside the mutation lock: lifecycle commit may perform provider
@@ -16084,11 +16084,41 @@ def handle_post(handler, parsed) -> bool:
                 )
             except (OSError, json.JSONDecodeError, ValueError):
                 logger.warning("session clear could not verify persisted empty state for %s", sid, exc_info=True)
-            if had_sidecar_messages and persisted_clear:
+            # Clearing an already-empty live session is not a destructive
+            # transition. Keep any older, still-recoverable backup: it may be
+            # the only durable copy after an earlier live-sidecar loss. When
+            # this request actually removed messages, however, the pre-clear
+            # backup must be retired so startup recovery cannot resurrect the
+            # history the user just cleared.
+            if persisted_clear and had_sidecar_messages:
+                live_revision = (
+                    s._sidecar_revision_v1
+                    if getattr(s, '_sidecar_revision_session_id_v1', None) == sid
+                    else _read_sidecar_revision(s.path)
+                )
                 try:
-                    s.path.with_suffix('.json.bak').unlink(missing_ok=True)
-                except OSError:
-                    logger.warning("session clear could not remove stale backup for %s", sid, exc_info=True)
+                    with _session_sidecar_authority(sid):
+                        retired = _delete_session_recovery_artifacts_locked(
+                            sid,
+                            expected_live_revision=live_revision,
+                        )
+                    if not retired:
+                        return bad(
+                            handler,
+                            "Session changed while retiring clear recovery artifacts; retry",
+                            409,
+                        )
+                except Exception as exc:
+                    logger.exception(
+                        "session clear could not remove recovery artifacts for %s",
+                        sid,
+                    )
+                    return bad(
+                        handler,
+                        f"Session clear recovery cleanup failed; retry is required: "
+                        f"{_sanitize_error(exc)}",
+                        500,
+                    )
         # Evict cached agent outside the per-session lock.  Eviction may run a
         # boundary memory commit for batch-extraction providers, and provider
         # I/O must not hold the session mutation lock.
@@ -22206,25 +22236,64 @@ def _handle_memory_read(handler, parsed=None):
 def _handle_sessions_cleanup(handler, body, zero_only=False):
     cleaned = 0
     phase1_removed_ids = set()
+    cleanup_failures = []
 
-    # Phase 1: Clean orphan session files (existing behavior).
+    # Phase 1: classify and delete under the same SID authority as writers.
     for p in SESSION_DIR.glob("*.json"):
-        if p.name.startswith("_"):
+        if p.name.startswith("_") or not is_safe_session_id(p.stem):
             continue
+        sid = p.stem
         try:
-            s = Session.load(p.stem)
-            if zero_only:
-                should_delete = s and len(s.messages) == 0
-            else:
-                should_delete = s and s.title == "Untitled" and len(s.messages) == 0
-            if should_delete:
-                with LOCK:
-                    SESSIONS.pop(p.stem, None)
-                p.unlink(missing_ok=True)
-                cleaned += 1
-                phase1_removed_ids.add(p.stem)
-        except Exception:
-            logger.debug("Failed to clean up session file %s", p)
+            with _get_session_agent_lock(sid):
+                with _session_sidecar_authority(sid):
+                    revision = _read_sidecar_revision(p)
+                    if revision is None:
+                        continue
+                    metadata = _read_bounded_session_metadata(p)
+                    if metadata.get('session_id') != sid:
+                        continue
+                    message_count = metadata.get('message_count')
+                    if type(message_count) is not int:
+                        # Legacy/minimal sidecars can omit both messages and the
+                        # derived count. Keep the fallback hard-bounded and fail
+                        # closed for malformed or large unknown shapes.
+                        if p.stat().st_size > 1024 * 1024:
+                            continue
+                        legacy_payload = json.loads(p.read_text(encoding='utf-8'))
+                        if not isinstance(legacy_payload, dict):
+                            continue
+                        legacy_messages = legacy_payload.get('messages', [])
+                        if not isinstance(legacy_messages, list):
+                            continue
+                        message_count = len(legacy_messages)
+                    if zero_only:
+                        should_delete = message_count == 0
+                    else:
+                        should_delete = (
+                            metadata.get('title') == "Untitled"
+                            and message_count == 0
+                        )
+                    if not should_delete:
+                        continue
+                    if not _delete_session_sidecar_artifacts_locked(
+                        sid,
+                        expected_revision=revision,
+                    ):
+                        continue
+                    cleaned += 1
+                    phase1_removed_ids.add(sid)
+        except Exception as exc:
+            cleanup_failures.append((sid, exc))
+            logger.exception("Failed to durably clean up session file %s", p)
+
+    if cleanup_failures:
+        failed_sid, failed_exc = cleanup_failures[0]
+        return bad(
+            handler,
+            f"Session cleanup failed for {failed_sid}; retry is required: "
+            f"{_sanitize_error(failed_exc)}",
+            500,
+        )
 
     phase1_touched = bool(cleaned)
     phase2_rewrote_index = False
@@ -22369,6 +22438,18 @@ def _handle_btw(handler, body):
     return j(handler, {"stream_id": stream_id, "session_id": ephemeral.session_id, "parent_session_id": body["session_id"]})
 
 
+def _delete_hidden_background_session_sidecar(sid: str) -> bool:
+    """Durably remove a hidden background sidecar and every recovery artifact."""
+    with _get_session_agent_lock(sid):
+        with _session_sidecar_authority(sid):
+            sidecar = SESSION_DIR / f'{sid}.json'
+            revision = _read_sidecar_revision(sidecar)
+            return _delete_session_sidecar_artifacts_locked(
+                sid,
+                expected_revision=revision,
+            )
+
+
 def _handle_background(handler, body):
     """POST /api/background — run prompt in parallel background agent.
 
@@ -22431,10 +22512,10 @@ def _handle_background(handler, body):
                 model_provider=model_provider,
             )
             # Reload the bg session from disk and extract the final assistant reply.
+            _answer = ""
             try:
                 from api.models import Session as _Session
                 reloaded = _Session.load(bg_sid)
-                _answer = ""
                 for _m in reversed((reloaded.messages if reloaded else None) or []):
                     if not isinstance(_m, dict) or _m.get("role") != "assistant":
                         continue
@@ -22444,16 +22525,25 @@ def _handle_background(handler, body):
                     if _content:
                         _answer = _content
                         break
-                complete_background(parent_sid, task_id, _answer or "(no answer produced)")
             except Exception:
-                complete_background(parent_sid, task_id, "(background task failed)")
-            # Best-effort cleanup of the hidden bg session file so it doesn't
-            # clutter the sidebar or SESSION_DIR. The index is pruned on the
-            # next rebuild via _index_entry_exists().
+                _answer = "(background task failed)"
+            # Do not acknowledge success until the hidden transcript and every
+            # recovery artifact are durably fenced and removed.
             try:
-                (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                _delete_hidden_background_session_sidecar(bg_sid)
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to durably delete hidden background session %s",
+                    bg_sid,
+                    exc_info=True,
+                )
+                complete_background(
+                    parent_sid,
+                    task_id,
+                    "(background task cleanup failed)",
+                )
+                return
+            complete_background(parent_sid, task_id, _answer or "(no answer produced)")
         except Exception:
             try:
                 complete_background(parent_sid, task_id, "(background task failed)")
@@ -27186,11 +27276,36 @@ def _handle_session_compress(handler, body):
             s.compression_anchor_mode = "manual"
             s.last_prompt_tokens = new_tokens
             s.save()
-            # Drop stale backups that would undo an intentional manual compress.
+            # Retire every stale recovery copy only if this live revision still owns
+            # the SID; otherwise a concurrent writer's backup must survive.
+            live_revision = (
+                s._sidecar_revision_v1
+                if getattr(s, '_sidecar_revision_session_id_v1', None) == sid
+                else _read_sidecar_revision(s.path)
+            )
             try:
-                s.path.with_suffix(".json.bak").unlink(missing_ok=True)
-            except OSError:
-                pass
+                with _session_sidecar_authority(sid):
+                    retired = _delete_session_recovery_artifacts_locked(
+                        sid,
+                        expected_live_revision=live_revision,
+                    )
+                if not retired:
+                    return bad(
+                        handler,
+                        "Session changed while retiring compression artifacts; retry",
+                        409,
+                    )
+            except Exception as exc:
+                logger.exception(
+                    "Manual compression could not remove recovery artifacts for %s",
+                    sid,
+                )
+                return bad(
+                    handler,
+                    f"Compression recovery cleanup failed; retry is required: "
+                    f"{_sanitize_error(exc)}",
+                    500,
+                )
 
         session_payload = redact_session_data(
             s.compact() | {

--- a/api/session_discoverability.py
+++ b/api/session_discoverability.py
@@ -16,6 +16,7 @@ import os
 import threading
 import shutil
 import sqlite3
+import uuid
 from collections import Counter
 from contextlib import closing
 from pathlib import Path
@@ -398,13 +399,18 @@ def _atomic_write_json(path: Path, payload) -> None:
     # (umask default) since the plain open() respects the umask.
     text = json.dumps(payload, ensure_ascii=False, indent=2)
     tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    descriptor = None
     try:
-        with open(tmp, "w", encoding="utf-8") as f:
+        descriptor = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as f:
+            descriptor = None
             f.write(text)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp, path)
     except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
         try:
             os.unlink(tmp)
         except OSError:
@@ -448,18 +454,39 @@ def _plan_discoverability_repairs(report: dict) -> list[dict]:
 
 
 def _clear_sidecar_cli_flag(session_dir: Path, sid: str, backup_dir: Path, backed_up: dict[Path, str]) -> dict:
+    from api import models
+
+    action = "clear_sidecar_cli_flag"
+    if not models.is_safe_session_id(sid):
+        return {"session_id": sid, "action": action, "applied": False, "error": "invalid_session_id"}
     path = session_dir / f"{sid}.json"
-    payload = _read_json(path)
-    if not isinstance(payload, dict):
-        return {"session_id": sid, "action": "clear_sidecar_cli_flag", "applied": False, "error": "sidecar_unreadable"}
-    if not _webui_origin(payload):
-        return {"session_id": sid, "action": "clear_sidecar_cli_flag", "applied": False, "skipped": "not_webui_origin"}
-    if payload.get("is_cli_session") is not True:
-        return {"session_id": sid, "action": "clear_sidecar_cli_flag", "applied": False, "skipped": "already_clear"}
-    backup = _backup_file(path, backup_dir, backed_up)
-    payload["is_cli_session"] = False
-    _atomic_write_json(path, payload)
-    return {"session_id": sid, "action": "clear_sidecar_cli_flag", "applied": True, "backup": backup}
+    with models._session_sidecar_authority(sid, session_dir=session_dir):
+        revision = models._read_sidecar_revision(path)
+        if revision is None:
+            return {"session_id": sid, "action": action, "applied": False, "error": "sidecar_unreadable"}
+        if models._webui_deleted_session_is_tombstoned(
+            sid,
+            session_dir=session_dir,
+            strict=True,
+        ):
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "deleted_session_tombstone"}
+        payload = _read_json(path)
+        if not isinstance(payload, dict) or payload.get('session_id') not in (None, sid):
+            return {"session_id": sid, "action": action, "applied": False, "error": "sidecar_unreadable"}
+        if not _webui_origin(payload):
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "not_webui_origin"}
+        if payload.get("is_cli_session") is not True:
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "already_clear"}
+        backup = _backup_file(path, backup_dir, backed_up)
+        payload["is_cli_session"] = False
+        payload['_sidecar_generation_v1'] = revision[0] + 1
+        payload['_sidecar_epoch_v1'] = revision[1] or uuid.uuid4().hex
+        if models._read_sidecar_revision(path) != revision:
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "sidecar_changed_during_repair"}
+        _atomic_write_json(path, payload)
+        models._fsync_sidecar_directory(session_dir)
+        models._invalidate_cached_session_generation(sid)
+    return {"session_id": sid, "action": action, "applied": True, "backup": backup}
 
 
 def _clear_index_cli_flag(session_dir: Path, sid: str, backup_dir: Path, backed_up: dict[Path, str]) -> dict:
@@ -486,33 +513,61 @@ def _clear_index_cli_flag(session_dir: Path, sid: str, backup_dir: Path, backed_
 
 
 def _materialize_sidecar_from_state_db(session_dir: Path, state_db_path: Path | None, sid: str, backup_dir: Path, backed_up: dict[Path, str]) -> dict:
+    from api import models
+
+    action = "materialize_sidecar_from_state_db"
     if state_db_path is None:
-        return {"session_id": sid, "action": "materialize_sidecar_from_state_db", "applied": False, "error": "state_db_required"}
+        return {"session_id": sid, "action": action, "applied": False, "error": "state_db_required"}
+    if not models.is_safe_session_id(sid):
+        return {"session_id": sid, "action": action, "applied": False, "error": "invalid_session_id"}
     target = session_dir / f"{sid}.json"
-    if target.exists():
-        return {"session_id": sid, "action": "materialize_sidecar_from_state_db", "applied": False, "skipped": "sidecar_exists"}
     try:
         from api.session_recovery import _read_state_db_missing_sidecar_rows, _state_db_row_to_sidecar
     except Exception as exc:
-        return {"session_id": sid, "action": "materialize_sidecar_from_state_db", "applied": False, "error": f"recovery_import_failed:{exc}"}
+        return {"session_id": sid, "action": action, "applied": False, "error": f"recovery_import_failed:{exc}"}
     rows = {str(row.get("id") or ""): row for row in _read_state_db_missing_sidecar_rows(session_dir, state_db_path)}
     row = rows.get(sid)
     if not row:
-        return {"session_id": sid, "action": "materialize_sidecar_from_state_db", "applied": False, "skipped": "state_row_not_repairable"}
+        return {"session_id": sid, "action": action, "applied": False, "skipped": "state_row_not_repairable"}
     payload = _state_db_row_to_sidecar(row)
+    payload['_sidecar_generation_v1'] = 1
+    payload['_sidecar_epoch_v1'] = uuid.uuid4().hex
     _backup_file(state_db_path, backup_dir, backed_up)
     session_dir.mkdir(parents=True, exist_ok=True)
     tmp = target.with_suffix(target.suffix + f".tmp.{os.getpid()}.{threading.get_ident()}")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    try:
-        os.link(str(tmp), str(target))
-    except FileExistsError:
-        return {"session_id": sid, "action": "materialize_sidecar_from_state_db", "applied": False, "skipped": "sidecar_appeared_during_repair"}
-    finally:
+    with models._session_sidecar_authority(sid, session_dir=session_dir):
+        if target.exists():
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "sidecar_exists"}
+        if models._webui_deleted_session_is_tombstoned(
+            sid,
+            session_dir=session_dir,
+            strict=True,
+        ):
+            return {"session_id": sid, "action": action, "applied": False, "skipped": "deleted_session_tombstone"}
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2).encode('utf-8')
         try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
+            with open(tmp, 'xb') as handle:
+                models._set_file_descriptor_mode(handle.fileno(), 0o600)
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            if models._webui_deleted_session_is_tombstoned(
+                sid,
+                session_dir=session_dir,
+                strict=True,
+            ):
+                return {"session_id": sid, "action": action, "applied": False, "skipped": "deleted_session_tombstone"}
+            try:
+                os.link(str(tmp), str(target))
+                models._fsync_sidecar_directory(session_dir)
+                models._invalidate_cached_session_generation(sid)
+            except FileExistsError:
+                return {"session_id": sid, "action": action, "applied": False, "skipped": "sidecar_appeared_during_repair"}
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
     index_updated = False
     index_path = session_dir / "_index.json"
     index_payload = _read_json(index_path)
@@ -526,7 +581,7 @@ def _materialize_sidecar_from_state_db(session_dir: Path, state_db_path: Path | 
         index_updated = True
     return {
         "session_id": sid,
-        "action": "materialize_sidecar_from_state_db",
+        "action": action,
         "applied": True,
         "messages": len(payload.get("messages") or []),
         "index_updated": index_updated,

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -30,9 +30,10 @@ import json
 import logging
 import os
 import re
-import shutil
 import sqlite3
+import stat as stat_module
 import threading
+import uuid
 from contextlib import closing
 from pathlib import Path
 
@@ -398,29 +399,149 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
     }
 
 
-def recover_session(session_path: Path) -> dict:
-    """Restore session_path from its .bak when the bak has more messages.
+def _recovery_source_identity(models, session_path: Path):
+    """Return a CAS token for a valid or malformed live sidecar.
 
-    Returns a status dict identical to ``inspect_session_recovery_status``
-    plus a "restored" boolean.
+    Recovery must be able to replace malformed JSON, but it must not turn a
+    parse failure into an unfenced write. Valid sidecars retain their complete
+    generation/epoch/digest revision; malformed bytes use a tagged raw digest
+    that is re-read immediately before publication under the same SID
+    authority.
     """
-    status = inspect_session_recovery_status(session_path)
-    if status["recommend"] != "restore":
-        return {**status, "restored": False}
-    bak_path = session_path.with_suffix('.json.bak')
-    # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
-    # cannot leave a half-written session.json.
-    tmp_path = session_path.with_suffix('.json.recover.tmp')
     try:
-        shutil.copyfile(bak_path, tmp_path)
-        tmp_path.replace(session_path)
-    except OSError as exc:
-        logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
+        revision = models._read_sidecar_revision(session_path)
+    except RuntimeError:
+        if not session_path.exists():
+            return None
         try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return {**status, "restored": False, "error": str(exc)}
+            return ('malformed', models._sidecar_content_digest(session_path))
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeError(
+                f'Cannot verify recovery source for {session_path.name!r}'
+            ) from exc
+    return ('valid', revision) if revision is not None else None
+
+
+def recover_session(session_path: Path) -> dict:
+    """CAS-restore one sidecar while sharing the runtime SID authority."""
+    from api import models
+
+    session_path = Path(session_path)
+    sid = session_path.stem
+    if not models.is_safe_session_id(sid):
+        return {
+            'session_id': sid,
+            'recommend': 'no_action',
+            'restored': False,
+            'error': 'invalid session id',
+        }
+    bak_path = session_path.with_suffix('.json.bak')
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    with models._session_sidecar_authority(
+        sid,
+        session_dir=session_path.parent,
+    ):
+        status = inspect_session_recovery_status(session_path)
+        try:
+            if models._webui_deleted_session_is_tombstoned(
+                sid,
+                session_dir=session_path.parent,
+                strict=True,
+            ):
+                return {**status, 'restored': False, 'deleted': True}
+        except Exception as exc:
+            return {
+                **status,
+                'restored': False,
+                'error': f'cannot verify delete tombstone: {exc}',
+            }
+        if status["recommend"] != "restore":
+            return {**status, "restored": False}
+
+        source_identity_before = _recovery_source_identity(models, session_path)
+        revision_before = (
+            source_identity_before[1]
+            if source_identity_before is not None
+            and source_identity_before[0] == 'valid'
+            else None
+        )
+        tmp_path = None
+        try:
+            backup_payload = json.loads(bak_path.read_text(encoding='utf-8'))
+            if not isinstance(backup_payload, dict):
+                raise ValueError('backup payload is not a session object')
+            backup_sid = backup_payload.get('session_id')
+            if backup_sid not in (None, sid):
+                raise ValueError('backup session id does not match target')
+            backup_generation = backup_payload.get('_sidecar_generation_v1', 0)
+            if type(backup_generation) is not int or backup_generation < 0:
+                raise ValueError('backup generation is invalid')
+            base_generation = (
+                revision_before[0]
+                if revision_before is not None
+                else backup_generation
+            )
+            epoch = revision_before[1] if revision_before is not None else None
+            if epoch is None:
+                backup_epoch = backup_payload.get('_sidecar_epoch_v1')
+                epoch = (
+                    backup_epoch
+                    if isinstance(backup_epoch, str)
+                    and len(backup_epoch) == 32
+                    and all(char in '0123456789abcdef' for char in backup_epoch)
+                    else uuid.uuid4().hex
+                )
+            backup_payload['session_id'] = sid
+            backup_payload['_sidecar_generation_v1'] = base_generation + 1
+            backup_payload['_sidecar_epoch_v1'] = epoch
+            serialized = json.dumps(
+                backup_payload,
+                ensure_ascii=False,
+                indent=2,
+            ).encode('utf-8')
+            tmp_path = session_path.with_suffix(
+                f'.json.recover.tmp.{os.getpid()}.{threading.current_thread().ident}'
+            )
+            source_mode = stat_module.S_IMODE(
+                (session_path if session_path.exists() else bak_path).stat().st_mode
+            )
+            with open(tmp_path, 'xb') as handle:
+                models._set_file_descriptor_mode(handle.fileno(), source_mode)
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            if (
+                _recovery_source_identity(models, session_path)
+                != source_identity_before
+            ):
+                raise RuntimeError('session changed during recovery preparation')
+            if models._webui_deleted_session_is_tombstoned(
+                sid,
+                session_dir=session_path.parent,
+                strict=True,
+            ):
+                raise RuntimeError('session was deleted during recovery')
+            if source_identity_before is None:
+                os.link(str(tmp_path), str(session_path))
+                models._fsync_sidecar_directory(session_path.parent)
+                tmp_path.unlink(missing_ok=True)
+            else:
+                os.replace(tmp_path, session_path)
+                models._fsync_sidecar_directory(session_path.parent)
+            models._invalidate_cached_session_generation(sid)
+        except Exception as exc:
+            logger.warning("recover_session: restore failed for %s: %s", session_path, exc)
+            try:
+                if tmp_path is not None:
+                    tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return {
+                **status,
+                "restored": False,
+                "stale_generation": isinstance(exc, (FileExistsError, RuntimeError)),
+                "error": str(exc),
+            }
     logger.warning(
         "recover_session: restored %s from .bak (live=%d → bak=%d messages). "
         "See #1558 for the data-loss class this guards against.",
@@ -648,46 +769,81 @@ def _state_db_row_to_sidecar(row: dict) -> dict:
 
 
 def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Path | None) -> dict:
-    """Materialize missing WebUI JSON sidecars from canonical state.db rows."""
+    """Materialize state.db sidecars under the shared SID publication authority."""
+    from api import models
+
     rows = _read_state_db_missing_sidecar_rows(session_dir, state_db_path)
     materialized = 0
     details: list[dict] = []
     session_dir.mkdir(parents=True, exist_ok=True)
     for row in rows:
         sid = str(row.get('id') or '').strip()
-        if not sid:
+        if not sid or not models.is_safe_session_id(sid):
             continue
         target = session_dir / f"{sid}.json"
-        if target.exists():
-            continue
         payload = _state_db_row_to_sidecar(row)
-        # Per-process/per-thread tmp suffix to avoid corruption under
-        # concurrent reconciliation calls (matches api/models.py:484
-        # Session.save() convention).
-        tmp_suffix = f".json.reconcile.tmp.{os.getpid()}.{threading.current_thread().ident}"
-        tmp = target.with_suffix(tmp_suffix)
+        payload['_sidecar_generation_v1'] = 1
+        payload['_sidecar_epoch_v1'] = uuid.uuid4().hex
+        tmp = target.with_suffix(
+            f".json.reconcile.tmp.{os.getpid()}.{threading.current_thread().ident}"
+        )
         detail_recorded = False
-        try:
-            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding='utf-8')
-        except OSError as exc:
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
-            details.append({'session_id': sid, 'materialized': False, 'error': str(exc)})
-            continue
-        # Atomic create-or-fail: os.link() refuses to overwrite an existing
-        # target. Closes the TOCTOU window between the target.exists() check
-        # above and the rename — a concurrent Session.save() for the same SID
-        # will win and we silently skip rather than overwrite a live sidecar.
         materialized_now = False
         try:
-            os.link(str(tmp), str(target))
-            materialized_now = True
-        except FileExistsError:
-            # Live sidecar appeared between the check and the link — keep it.
-            pass
+            with models._session_sidecar_authority(
+                sid,
+                session_dir=session_dir,
+            ):
+                if target.exists():
+                    details.append({
+                        'session_id': sid,
+                        'materialized': False,
+                        'skipped': 'sidecar_appeared_during_reconcile',
+                    })
+                    continue
+                if models._webui_deleted_session_is_tombstoned(
+                    sid,
+                    session_dir=session_dir,
+                    strict=True,
+                ):
+                    details.append({
+                        'session_id': sid,
+                        'materialized': False,
+                        'skipped': 'deleted_session_tombstone',
+                    })
+                    continue
+                serialized = json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                    indent=2,
+                ).encode('utf-8')
+                with open(tmp, 'xb') as handle:
+                    models._set_file_descriptor_mode(handle.fileno(), 0o600)
+                    handle.write(serialized)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                if models._webui_deleted_session_is_tombstoned(
+                    sid,
+                    session_dir=session_dir,
+                    strict=True,
+                ):
+                    details.append({
+                        'session_id': sid,
+                        'materialized': False,
+                        'skipped': 'deleted_session_tombstone',
+                    })
+                    continue
+                try:
+                    os.link(str(tmp), str(target))
+                    models._fsync_sidecar_directory(session_dir)
+                    materialized_now = True
+                    models._invalidate_cached_session_generation(sid)
+                except FileExistsError:
+                    pass
         except OSError as exc:
+            details.append({'session_id': sid, 'materialized': False, 'error': str(exc)})
+            detail_recorded = True
+        except Exception as exc:
             details.append({'session_id': sid, 'materialized': False, 'error': str(exc)})
             detail_recorded = True
         finally:
@@ -697,9 +853,19 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
                 pass
         if materialized_now:
             materialized += 1
-            details.append({'session_id': sid, 'materialized': True, 'messages': len(payload.get('messages') or [])})
-        elif not detail_recorded:
-            details.append({'session_id': sid, 'materialized': False, 'skipped': 'sidecar_appeared_during_reconcile'})
+            details.append({
+                'session_id': sid,
+                'materialized': True,
+                'messages': len(payload.get('messages') or []),
+            })
+        elif not detail_recorded and not any(
+            detail.get('session_id') == sid for detail in details
+        ):
+            details.append({
+                'session_id': sid,
+                'materialized': False,
+                'skipped': 'sidecar_appeared_during_reconcile',
+            })
     return {'scanned': len(rows), 'materialized': materialized, 'details': details}
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -66,7 +66,10 @@ from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
     StateDBSessionMessagesSnapshot,
+    _delete_session_sidecar_artifacts_locked,
     _is_empty_partial_activity_message,
+    _read_sidecar_revision,
+    _session_sidecar_authority,
     _evict_sessions_over_cap,
     clear_process_wakeup_pause,
     get_state_db_session_messages,
@@ -2265,6 +2268,30 @@ def _persist_cancelled_turn(session, *, message: str = 'Task cancelled.') -> Non
         })
 
 
+def _cleanup_ephemeral_session_sidecar_locked(session, *, outcome: str) -> bool:
+    """Durably remove one hidden /btw sidecar without deleting a reincarnation."""
+    sid = str(getattr(session, 'session_id', '') or '').strip()
+    expected_path = SESSION_DIR / f'{sid}.json'
+    if Path(session.path).resolve() != expected_path.resolve():
+        raise ValueError(f"Ephemeral session path does not match SID {sid!r}")
+    expected_revision = None
+    if getattr(session, '_sidecar_revision_session_id_v1', None) == sid:
+        expected_revision = getattr(session, '_sidecar_revision_v1', None)
+    with _get_session_agent_lock(sid):
+        with _session_sidecar_authority(sid):
+            if expected_revision is None:
+                expected_revision = _read_sidecar_revision(expected_path)
+            deleted = _delete_session_sidecar_artifacts_locked(
+                sid,
+                expected_revision=expected_revision,
+            )
+    if not deleted:
+        raise RuntimeError(
+            f'Ephemeral session {sid!r} changed before {outcome} cleanup'
+        )
+    return True
+
+
 def _cleanup_ephemeral_cancelled_turn(session) -> None:
     """Remove transient /btw session state after a cancel without saving it."""
     session.active_stream_id = None
@@ -2272,11 +2299,7 @@ def _cleanup_ephemeral_cancelled_turn(session) -> None:
     session.pending_attachments = []
     session.pending_started_at = None
     session.pending_user_source = None
-    try:
-        import pathlib
-        pathlib.Path(session.path).unlink(missing_ok=True)
-    except Exception:
-        logger.debug("Failed to clean up ephemeral cancelled session", exc_info=True)
+    _cleanup_ephemeral_session_sidecar_locked(session, outcome='cancelled')
 
 
 def _resolve_current_session_for_write(session):
@@ -10795,11 +10818,7 @@ def _run_agent_streaming(
                 })
                 if _checkpoint_stop is not None:
                     _checkpoint_stop.set()
-                try:
-                    import pathlib
-                    pathlib.Path(s.path).unlink(missing_ok=True)
-                except Exception:
-                    pass
+                _cleanup_ephemeral_session_sidecar_locked(s, outcome='completed')
                 return  # skip all normal persistence for ephemeral sessions
             if _checkpoint_stop is not None:
                 _checkpoint_stop.set()

--- a/scripts/compact_session_replays.py
+++ b/scripts/compact_session_replays.py
@@ -1,0 +1,1168 @@
+#!/usr/bin/env python3
+"""Offline, bounded-memory repair for replay-bloated session sidecars.
+
+The WebUI intentionally refuses to repair very large sidecars inline. This tool
+performs a two-pass, exact-JSON replay reduction while holding an operator lock,
+then publishes only if the source generation and SHA-256 are unchanged. It keeps
+a full backup and a checksum manifest for deterministic rollback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import io
+import json
+import math
+import os
+import pickle
+import resource
+import secrets
+import shutil
+import sqlite3
+import stat as stat_module
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Literal, TextIO, overload
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Compatibility helpers shared by the independently imported classifier
+# fallbacks below. A WebUI base can expose one classifier without the others;
+# importing them as one group would silently discard the available semantics.
+_STRUCTURED_FIELDS = frozenset({
+    'tool_call_id',
+    'tool_calls',
+    'function_call',
+    'function_calls',
+    '_partial_tool_calls',
+    'refusal',
+    'attachments',
+})
+
+
+def _strict_json_tree(value) -> bool:
+    if value is None or type(value) in (str, int, bool):
+        return True
+    if type(value) is float:
+        return math.isfinite(value)
+    if type(value) is list:
+        return all(_strict_json_tree(item) for item in value)
+    if type(value) is dict:
+        return all(
+            type(key) is str and _strict_json_tree(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _message_digest(message):
+    if not _strict_json_tree(message):
+        return None
+    try:
+        payload = json.dumps(
+            message,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(',', ':'),
+            allow_nan=False,
+        ).encode('utf-8')
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(payload).digest()
+
+
+def _typed_scalar(value):
+    if isinstance(value, bool):
+        return None
+    if type(value) is str:
+        return ('str', value) if value else None
+    if type(value) is int:
+        return ('int', value)
+    if type(value) is float and math.isfinite(value):
+        return ('float', value)
+    return None
+
+
+def _plain_empty_assistant(message) -> bool:
+    content = message.get('content') if type(message) is dict else None
+    return bool(
+        type(message) is dict
+        and message.get('role') == 'assistant'
+        and (
+            content is None
+            or (
+                type(content) is str
+                and not content.strip()
+            )
+        )
+        and not any(field in message for field in _STRUCTURED_FIELDS)
+    )
+
+
+from api import models as _models  # noqa: E402
+
+_repo_partial_message_signature = getattr(
+    _models,
+    '_partial_message_signature',
+    None,
+)
+_repo_incomplete_reasoning_message_id = getattr(
+    _models,
+    '_incomplete_reasoning_message_id',
+    None,
+)
+_repo_durable_empty_assistant_replay_key = getattr(
+    _models,
+    '_durable_empty_assistant_replay_key',
+    None,
+)
+
+
+def _partial_message_signature(message) -> bytes | tuple | None:
+    if callable(_repo_partial_message_signature):
+        result = _repo_partial_message_signature(message)
+        return result if isinstance(result, (bytes, tuple)) else None
+    if type(message) is not dict:
+        return None
+    digest = _message_digest(message)
+    return ('exact', digest) if digest is not None else None
+
+
+def _incomplete_reasoning_message_id(message) -> tuple | None:
+    if callable(_repo_incomplete_reasoning_message_id):
+        result = _repo_incomplete_reasoning_message_id(message)
+        return result if isinstance(result, tuple) else None
+    if not _plain_empty_assistant(message):
+        return None
+    if str(message.get('finish_reason') or '').lower() != 'incomplete':
+        return None
+    message_id = _typed_scalar(message.get('id'))
+    digest = _message_digest(message)
+    if message_id is None or digest is None:
+        return None
+    return ('message_id', message_id, digest)
+
+
+def _durable_empty_assistant_replay_key(message) -> tuple | None:
+    if callable(_repo_durable_empty_assistant_replay_key):
+        result = _repo_durable_empty_assistant_replay_key(message)
+        return result if isinstance(result, tuple) else None
+    if not _plain_empty_assistant(message) or message.get('_partial'):
+        return None
+    if str(message.get('finish_reason') or '').lower() == 'incomplete':
+        return None
+    digest = _message_digest(message)
+    if digest is None:
+        return None
+    message_id = _typed_scalar(message.get('id'))
+    if message_id is not None:
+        return ('message_id', message_id, digest)
+    stream_id = _typed_scalar(message.get('_recovered_stream_id'))
+    timestamp = message.get('timestamp', message.get('_ts'))
+    timestamp_key = _typed_scalar(timestamp)
+    if stream_id is None or timestamp_key is None:
+        return None
+    return ('recovered', stream_id, timestamp_key, digest)
+
+_CHUNK_CHARS = 1 << 20
+_MAX_ITEM_CHARS = 64 << 20
+_MAX_CAPTURED_STRING_CHARS = 65_536
+_TARGET_ARRAYS = frozenset({'messages', 'context_messages'})
+
+
+class StreamJSONError(ValueError):
+    """Raised when a sidecar cannot be transformed safely."""
+
+
+def _reject_json_constant(constant: str):
+    raise StreamJSONError(f'invalid JSON constant: {constant}')
+
+
+def _is_json_whitespace(char: str) -> bool:
+    """Return whether ``char`` is whitespace permitted by RFC 8259."""
+    return char in ' \t\r\n'
+
+
+class StreamReader:
+    def __init__(self, handle: TextIO, chunk_chars: int = _CHUNK_CHARS):
+        self.handle = handle
+        self.chunk_chars = chunk_chars
+        self.buffer = ''
+        self.pos = 0
+        self.eof = False
+        self.decoder = json.JSONDecoder(parse_constant=_reject_json_constant)
+
+    def _compact_and_fill(self) -> bool:
+        if self.pos:
+            self.buffer = self.buffer[self.pos:]
+            self.pos = 0
+        if self.eof:
+            return False
+        chunk = self.handle.read(self.chunk_chars)
+        if chunk:
+            self.buffer += chunk
+            return True
+        self.eof = True
+        return False
+
+    def ensure(self) -> bool:
+        while self.pos >= len(self.buffer):
+            if not self._compact_and_fill():
+                return False
+        return True
+
+    def peek(self) -> str:
+        if not self.ensure():
+            return ''
+        return self.buffer[self.pos]
+
+    def take(self) -> str:
+        char = self.peek()
+        if not char:
+            raise StreamJSONError('unexpected end of JSON')
+        self.pos += 1
+        return char
+
+    def skip_ws(self) -> None:
+        while True:
+            if not self.ensure():
+                return
+            start = self.pos
+            while (
+                self.pos < len(self.buffer)
+                and _is_json_whitespace(self.buffer[self.pos])
+            ):
+                self.pos += 1
+            if self.pos == start:
+                return
+
+    def expect(self, expected: str) -> None:
+        self.skip_ws()
+        actual = self.take()
+        if actual != expected:
+            raise StreamJSONError(f'expected {expected!r}, got {actual!r}')
+
+    def decode_value(self):
+        self.skip_ws()
+        while True:
+            try:
+                value, end = self.decoder.raw_decode(self.buffer, self.pos)
+            except json.JSONDecodeError as exc:
+                retained = len(self.buffer) - self.pos
+                if retained > _MAX_ITEM_CHARS:
+                    raise StreamJSONError(
+                        f'one JSON item exceeds {_MAX_ITEM_CHARS} characters'
+                    ) from exc
+                if self._compact_and_fill():
+                    continue
+                raise StreamJSONError(f'invalid JSON value: {exc}') from exc
+            if (
+                end == len(self.buffer)
+                and not self.eof
+                and type(value) in (int, float)
+            ):
+                retained = len(self.buffer) - self.pos
+                if retained > _MAX_ITEM_CHARS:
+                    raise StreamJSONError(
+                        f'one JSON item exceeds {_MAX_ITEM_CHARS} characters'
+                    )
+                if self._compact_and_fill():
+                    continue
+            self.pos = end
+            return value
+
+    def copy_raw_value(self, output: TextIO | None, *, _depth: int = 0) -> None:
+        """Validate and copy one JSON value without materializing containers."""
+        if _depth > 512:
+            raise StreamJSONError('invalid JSON value: nesting exceeds 512 levels')
+        self._copy_ws(output)
+        first = self.peek()
+        if not first:
+            raise StreamJSONError('invalid JSON value: missing value')
+        if first == '"':
+            self._copy_string(output, capture=False)
+            return
+        if first == '{':
+            self._copy_object(output, _depth)
+            return
+        if first == '[':
+            self._copy_array(output, _depth)
+            return
+        self._copy_scalar(output)
+
+    def _copy_ws(self, output: TextIO | None) -> None:
+        pending: list[str] = []
+        while self.peek() and _is_json_whitespace(self.peek()):
+            pending.append(self.take())
+            if len(pending) >= 65_536:
+                self._flush(output, pending)
+        self._flush(output, pending)
+
+    def _copy_string(
+        self,
+        output: TextIO | None,
+        *,
+        capture: bool = True,
+    ) -> str | None:
+        opening = self.take()
+        if opening != '"':
+            raise StreamJSONError('invalid JSON string: expected opening quote')
+        pending = [opening]
+        captured = [opening] if capture else None
+        total_chars = 1
+
+        def append(char: str) -> None:
+            nonlocal total_chars
+            pending.append(char)
+            total_chars += 1
+            if total_chars > _MAX_ITEM_CHARS:
+                raise StreamJSONError(
+                    f'invalid JSON string: exceeds {_MAX_ITEM_CHARS} characters'
+                )
+            if captured is not None:
+                captured.append(char)
+                if len(captured) > _MAX_CAPTURED_STRING_CHARS:
+                    raise StreamJSONError(
+                        'captured JSON string exceeds the bounded key limit'
+                    )
+            if len(pending) >= 65_536:
+                self._flush(output, pending)
+
+        while True:
+            char = self.take()
+            append(char)
+            if char == '"':
+                break
+            if char == '\\':
+                escape = self.take()
+                append(escape)
+                if escape == 'u':
+                    for _ in range(4):
+                        digit = self.take()
+                        append(digit)
+                        if digit not in '0123456789abcdefABCDEF':
+                            raise StreamJSONError(
+                                'invalid JSON string: malformed unicode escape'
+                            )
+                elif escape not in '"\\/bfnrt':
+                    raise StreamJSONError(
+                        f'invalid JSON string escape: {escape!r}'
+                    )
+            elif ord(char) < 0x20:
+                raise StreamJSONError(
+                    'invalid JSON string: unescaped control character'
+                )
+        self._flush(output, pending)
+        if captured is None:
+            return None
+        text = ''.join(captured)
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise StreamJSONError(f'invalid JSON string: {exc}') from exc
+        if not isinstance(value, str):
+            raise StreamJSONError('invalid JSON string')
+        return value
+
+    def _copy_object(self, output: TextIO | None, depth: int) -> None:
+        opening = self.take()
+        if output is not None:
+            output.write(opening)
+        self._copy_ws(output)
+        if self.peek() == '}':
+            closing = self.take()
+            if output is not None:
+                output.write(closing)
+            return
+        while True:
+            if self.peek() != '"':
+                raise StreamJSONError('invalid JSON object key: expected string')
+            self._copy_string(output, capture=False)
+            self._copy_ws(output)
+            if self.take() != ':':
+                raise StreamJSONError("invalid JSON object: expected ':'")
+            if output is not None:
+                output.write(':')
+            self.copy_raw_value(output, _depth=depth + 1)
+            self._copy_ws(output)
+            delimiter = self.take()
+            if delimiter not in ',}':
+                raise StreamJSONError(
+                    f'invalid JSON object delimiter: {delimiter!r}'
+                )
+            if output is not None:
+                output.write(delimiter)
+            if delimiter == '}':
+                return
+            self._copy_ws(output)
+
+    def _copy_array(self, output: TextIO | None, depth: int) -> None:
+        opening = self.take()
+        if output is not None:
+            output.write(opening)
+        self._copy_ws(output)
+        if self.peek() == ']':
+            closing = self.take()
+            if output is not None:
+                output.write(closing)
+            return
+        while True:
+            self.copy_raw_value(output, _depth=depth + 1)
+            self._copy_ws(output)
+            delimiter = self.take()
+            if delimiter not in ',]':
+                raise StreamJSONError(
+                    f'invalid JSON array delimiter: {delimiter!r}'
+                )
+            if output is not None:
+                output.write(delimiter)
+            if delimiter == ']':
+                return
+            self._copy_ws(output)
+
+    def _copy_scalar(self, output: TextIO | None) -> None:
+        pending: list[str] = []
+        while True:
+            char = self.peek()
+            if not char or _is_json_whitespace(char) or char in ',}]':
+                break
+            pending.append(self.take())
+            if len(pending) > _MAX_ITEM_CHARS:
+                raise StreamJSONError(
+                    f'invalid JSON scalar: exceeds {_MAX_ITEM_CHARS} characters'
+                )
+        text = ''.join(pending)
+        if not text:
+            raise StreamJSONError('invalid JSON scalar: empty value')
+        try:
+            value = json.loads(
+                text,
+                parse_constant=_reject_json_constant,
+            )
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise StreamJSONError(f'invalid JSON scalar: {exc}') from exc
+        if isinstance(value, (dict, list)):
+            raise StreamJSONError('invalid JSON scalar')
+        if output is not None:
+            output.write(text)
+
+    @staticmethod
+    def _flush(output: TextIO | None, pending: list[str]) -> None:
+        if output is not None and pending:
+            output.write(''.join(pending))
+        pending.clear()
+
+
+def _valid_generation(value) -> int:
+    if type(value) is not int or value < 0:
+        raise StreamJSONError(
+            '_sidecar_generation_v1 must be a non-negative integer'
+        )
+    return value
+
+
+def _valid_epoch(value) -> str:
+    if type(value) is not str or len(value) != 32 or any(
+        char not in '0123456789abcdef' for char in value
+    ):
+        raise StreamJSONError('_sidecar_epoch_v1 must be 32 lowercase hex characters')
+    return value
+
+
+def _copy_with_generation(
+    source: TextIO,
+    target: TextIO,
+    generation: int,
+    epoch: str,
+) -> None:
+    generation = _valid_generation(generation)
+    epoch = _valid_epoch(epoch)
+    reader = StreamReader(source)
+    reader.expect('{')
+    target.write('{')
+    reader.skip_ws()
+    if reader.peek() == '}':
+        reader.take()
+        target.write(
+            f'"_sidecar_epoch_v1":{json.dumps(epoch)},'
+            f'"_sidecar_generation_v1":{generation}' + '}'
+        )
+        return
+    saw_generation = False
+    saw_epoch = False
+    while True:
+        reader.skip_ws()
+        if reader.peek() != '"':
+            raise StreamJSONError('sidecar object key must be a string')
+        key = reader._copy_string(None)
+        if type(key) is not str:
+            raise StreamJSONError('sidecar object key must be a string')
+        key_text = json.dumps(key, ensure_ascii=False)
+        target.write(key_text)
+        reader.expect(':')
+        target.write(':')
+        if key == '_sidecar_generation_v1':
+            reader.copy_raw_value(None)
+            target.write(str(generation))
+            saw_generation = True
+        elif key == '_sidecar_epoch_v1':
+            reader.copy_raw_value(None)
+            target.write(json.dumps(epoch))
+            saw_epoch = True
+        else:
+            reader.copy_raw_value(target)
+        reader.skip_ws()
+        delimiter = reader.take()
+        if delimiter == '}':
+            if not saw_generation:
+                target.write(f',"_sidecar_generation_v1":{generation}')
+            if not saw_epoch:
+                target.write(f',"_sidecar_epoch_v1":{json.dumps(epoch)}')
+            target.write('}')
+            return
+        if delimiter != ',':
+            raise StreamJSONError(
+                f'expected object delimiter, got {delimiter!r}'
+            )
+        target.write(',')
+
+
+@dataclass
+class ArrayStats:
+    input_count: int = 0
+    output_count: int = 0
+    changed: bool = False
+
+
+class SeenKeyIndex:
+    """Exact disk-backed membership with a bounded SQLite page cache."""
+
+    def __init__(self):
+        self.connection = sqlite3.connect('')
+        self.connection.execute('PRAGMA journal_mode=OFF')
+        self.connection.execute('PRAGMA synchronous=OFF')
+        self.connection.execute('PRAGMA temp_store=FILE')
+        self.connection.execute('PRAGMA cache_size=-4096')
+        self.connection.execute(
+            'CREATE TABLE seen ('
+            'namespace INTEGER NOT NULL, '
+            'replay_key BLOB NOT NULL, '
+            'PRIMARY KEY (namespace, replay_key)'
+            ') WITHOUT ROWID'
+        )
+
+    def add(self, namespace: int, key: tuple) -> bool:
+        encoded = sqlite3.Binary(pickle.dumps(key, protocol=5))
+        cursor = self.connection.execute(
+            'INSERT OR IGNORE INTO seen(namespace, replay_key) VALUES (?, ?)',
+            (namespace, encoded),
+        )
+        return cursor.rowcount == 1
+
+    def close(self) -> None:
+        self.connection.close()
+
+
+class ReplayReducer:
+    def __init__(self):
+        self.previous_partial = None
+        self.seen = SeenKeyIndex()
+
+    def close(self) -> None:
+        self.seen.close()
+
+    def keep(self, message) -> bool:
+        if isinstance(message, dict) and message.get('_partial'):
+            partial_key = _partial_message_signature(message)
+            if partial_key is not None and partial_key == self.previous_partial:
+                return False
+            self.previous_partial = partial_key
+        else:
+            self.previous_partial = None
+
+        incomplete_key = _incomplete_reasoning_message_id(message)
+        if incomplete_key is not None:
+            if not self.seen.add(1, incomplete_key):
+                return False
+
+        durable_key = _durable_empty_assistant_replay_key(message)
+        if durable_key is not None:
+            if not self.seen.add(2, durable_key):
+                return False
+        return True
+
+
+def _transform_array(reader: StreamReader, output: TextIO | None) -> ArrayStats:
+    stats = ArrayStats()
+    reader.expect('[')
+    if output is not None:
+        output.write('[')
+    reader.skip_ws()
+    first_output = True
+    if reader.peek() == ']':
+        reader.take()
+        if output is not None:
+            output.write(']')
+        return stats
+    reducer = ReplayReducer()
+    try:
+        while True:
+            message = reader.decode_value()
+            stats.input_count += 1
+            if reducer.keep(message):
+                stats.output_count += 1
+                if output is not None:
+                    if not first_output:
+                        output.write(',')
+                    output.write(
+                        json.dumps(
+                            message,
+                            ensure_ascii=False,
+                            separators=(',', ':'),
+                            allow_nan=False,
+                        )
+                    )
+                    first_output = False
+            else:
+                stats.changed = True
+            reader.skip_ws()
+            delimiter = reader.take()
+            if delimiter == ']':
+                break
+            if delimiter != ',':
+                raise StreamJSONError(f'expected array delimiter, got {delimiter!r}')
+    finally:
+        reducer.close()
+    if output is not None:
+        output.write(']')
+    return stats
+
+
+def transform_sidecar(
+    source: Path,
+    output: TextIO | None = None,
+    *,
+    known: dict[str, ArrayStats] | None = None,
+    write_generation: int | None = None,
+    write_epoch: str | None = None,
+    metadata: dict[str, object] | None = None,
+) -> dict[str, ArrayStats]:
+    if write_generation is not None:
+        write_generation = _valid_generation(write_generation)
+    if write_epoch is not None:
+        write_epoch = _valid_epoch(write_epoch)
+    stats: dict[str, ArrayStats] = {}
+    with source.open('r', encoding='utf-8') as handle:
+        reader = StreamReader(handle)
+        reader.expect('{')
+        if output is not None:
+            output.write('{')
+        first_field = True
+        reader.skip_ws()
+        if reader.peek() == '}':
+            reader.take()
+            if metadata is not None:
+                metadata['generation'] = 0
+                metadata['epoch'] = None
+            if output is not None:
+                injected = []
+                if write_epoch is not None:
+                    injected.append(
+                        f'"_sidecar_epoch_v1":{json.dumps(write_epoch)}'
+                    )
+                if write_generation is not None:
+                    injected.append(f'"_sidecar_generation_v1":{write_generation}')
+                output.write(','.join(injected))
+                output.write('}')
+            return stats
+        saw_generation = False
+        saw_epoch = False
+        if output is not None:
+            injected = []
+            if write_epoch is not None:
+                injected.append(f'"_sidecar_epoch_v1":{json.dumps(write_epoch)}')
+            if write_generation is not None:
+                injected.append(f'"_sidecar_generation_v1":{write_generation}')
+            if injected:
+                output.write(','.join(injected))
+                first_field = False
+        while True:
+            reader.skip_ws()
+            if reader.peek() != '"':
+                raise StreamJSONError('top-level session keys must be strings')
+            key = reader._copy_string(None)
+            if type(key) is not str:
+                raise StreamJSONError('top-level session keys must be strings')
+            reader.expect(':')
+            emit_field = not (
+                output is not None
+                and (
+                    (write_generation is not None and key == '_sidecar_generation_v1')
+                    or (write_epoch is not None and key == '_sidecar_epoch_v1')
+                )
+            )
+            if output is not None and emit_field:
+                if not first_field:
+                    output.write(',')
+                output.write(json.dumps(key, ensure_ascii=False))
+                output.write(':')
+            if key in _TARGET_ARRAYS:
+                array_stats = _transform_array(reader, output)
+                stats[key] = array_stats
+                if known is not None and array_stats != known.get(key, ArrayStats()):
+                    raise StreamJSONError(f'{key} changed between analysis and write pass')
+            elif key == 'message_count' and known is not None and 'messages' in known:
+                reader.copy_raw_value(None)
+                if output is not None:
+                    output.write(str(known['messages'].output_count))
+            elif (
+                key == 'compression_anchor_visible_idx'
+                and known is not None
+                and known.get('messages', ArrayStats()).changed
+            ):
+                reader.copy_raw_value(None)
+                if output is not None:
+                    output.write('null')
+            elif key == '_sidecar_generation_v1':
+                source_generation = _valid_generation(reader.decode_value())
+                if metadata is not None:
+                    metadata['generation'] = source_generation
+                if output is not None and emit_field:
+                    output.write(
+                        str(
+                            write_generation
+                            if write_generation is not None
+                            else source_generation
+                        )
+                    )
+                saw_generation = True
+            elif key == '_sidecar_epoch_v1':
+                source_epoch = _valid_epoch(reader.decode_value())
+                if metadata is not None:
+                    metadata['epoch'] = source_epoch
+                if output is not None and emit_field:
+                    output.write(json.dumps(write_epoch or source_epoch))
+                saw_epoch = True
+            else:
+                reader.copy_raw_value(output)
+            if output is not None and emit_field:
+                first_field = False
+            reader.skip_ws()
+            delimiter = reader.take()
+            if delimiter == '}':
+                break
+            if delimiter != ',':
+                raise StreamJSONError(
+                    f'expected top-level delimiter, got {delimiter!r}'
+                )
+        reader.skip_ws()
+        if reader.peek():
+            raise StreamJSONError('trailing data after session object')
+        if metadata is not None and not saw_generation:
+            metadata['generation'] = 0
+        if metadata is not None and not saw_epoch:
+            metadata['epoch'] = None
+        if output is not None:
+            output.write('}')
+    return stats
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as handle:
+        for chunk in iter(lambda: handle.read(4 << 20), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_open_file(handle) -> str:
+    digest = hashlib.sha256()
+    handle.seek(0)
+    for chunk in iter(lambda: handle.read(4 << 20), b''):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _open_regular_binary_nofollow(path: Path, *, label: str):
+    flags = os.O_RDONLY | getattr(os, 'O_CLOEXEC', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise StreamJSONError(f'{label} must be a non-symlink regular file: {path}') from exc
+    try:
+        if not stat_module.S_ISREG(os.fstat(descriptor).st_mode):
+            raise StreamJSONError(f'{label} must be a regular file: {path}')
+        return os.fdopen(descriptor, 'rb')
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _signature(path: Path):
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+def _fsync_dir(path: Path) -> None:
+    descriptor = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+@overload
+def _open_exclusive_private(path: Path, mode: Literal['wb']) -> BinaryIO: ...
+
+
+@overload
+def _open_exclusive_private(path: Path, mode: Literal['w']) -> TextIO: ...
+
+
+def _open_exclusive_private(path: Path, mode: Literal['w', 'wb']):
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, 'O_CLOEXEC', 0)
+    )
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        if 'b' in mode:
+            return os.fdopen(descriptor, mode)
+        return os.fdopen(descriptor, mode, encoding='utf-8')
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _copy_exclusive(
+    source: Path,
+    destination: Path,
+    *,
+    mode: int | None = None,
+) -> None:
+    try:
+        with source.open('rb') as src, _open_exclusive_private(destination, 'wb') as dst:
+            os.fchmod(
+                dst.fileno(),
+                mode if mode is not None else stat_module.S_IMODE(source.stat().st_mode),
+            )
+            shutil.copyfileobj(src, dst, length=4 << 20)
+            dst.flush()
+            os.fsync(dst.fileno())
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
+
+
+def _sidecar_lock_path(path: Path) -> Path:
+    lock_dir = path.parent / '.sidecar-locks'
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    return lock_dir / f'{path.stem}.lock'
+
+
+def _validate_sidecar_identity(path: Path) -> str:
+    try:
+        metadata = _models._read_bounded_session_metadata(path)
+    except ValueError as exc:
+        raise StreamJSONError(
+            f'invalid JSON while validating sidecar session_id: {exc}'
+        ) from exc
+    except (OSError, UnicodeError) as exc:
+        raise StreamJSONError(f'cannot validate sidecar session_id: {path}') from exc
+    session_id = metadata.get('session_id')
+    if type(session_id) is str and len(session_id) > 150:
+        raise StreamJSONError('sidecar session_id exceeds the 150-character artifact limit')
+    if (
+        type(session_id) is not str
+        or not _models.is_safe_session_id(session_id)
+        or session_id != path.stem
+    ):
+        raise StreamJSONError(
+            f'sidecar session_id must match filename: {session_id!r} != {path.stem!r}'
+        )
+    return session_id
+
+
+def _refuse_tombstoned_publication(path: Path) -> None:
+    """Fail closed if deletion fenced this SID before a publication."""
+    try:
+        deleted = _models._webui_deleted_session_is_tombstoned(
+            path.stem,
+            session_dir=path.parent,
+            strict=True,
+        )
+    except Exception as exc:
+        raise StreamJSONError(
+            f'cannot verify deleted-session tombstone for {path.stem!r}'
+        ) from exc
+    if deleted:
+        raise StreamJSONError(
+            f'session {path.stem!r} is deleted by durable tombstone'
+        )
+
+
+def compact_sidecar(path: Path, *, dry_run: bool = False) -> dict:
+    path = Path(path).expanduser().absolute()
+    if path.is_symlink():
+        raise StreamJSONError(f'source must not be a symlink: {path}')
+    path = path.resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    lock_path = _sidecar_lock_path(path)
+    with lock_path.open('a+', encoding='utf-8') as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        _refuse_tombstoned_publication(path)
+        _validate_sidecar_identity(path)
+        source_mode = stat_module.S_IMODE(path.stat().st_mode)
+        source_signature = _signature(path)
+        source_sha256 = _sha256(path)
+        source_metadata: dict[str, object] = {}
+        analysis = transform_sidecar(path, metadata=source_metadata)
+        source_generation = _valid_generation(source_metadata['generation'])
+        source_epoch = source_metadata['epoch']
+        output_epoch = (
+            _valid_epoch(source_epoch)
+            if source_epoch is not None
+            else secrets.token_hex(16)
+        )
+        output_generation = source_generation + 1
+        changed = any(value.changed for value in analysis.values())
+        result = {
+            'status': 'would_compact' if changed else 'no_change',
+            'source': str(path),
+            'source_sha256': source_sha256,
+            'source_generation': source_generation,
+            'arrays': {
+                key: {
+                    'input': value.input_count,
+                    'output': value.output_count,
+                    'removed': value.input_count - value.output_count,
+                }
+                for key, value in sorted(analysis.items())
+            },
+        }
+        if dry_run or not changed:
+            result['max_rss_kib'] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            return result
+
+        backup = path.with_name(f'{path.name}.replay-v10.{source_sha256[:16]}.bak')
+        if backup.exists():
+            if _sha256(backup) != source_sha256:
+                raise StreamJSONError(f'existing backup checksum mismatch: {backup}')
+            os.chmod(backup, source_mode)
+        else:
+            _copy_exclusive(path, backup, mode=source_mode)
+            if _sha256(backup) != source_sha256:
+                backup.unlink(missing_ok=True)
+                raise StreamJSONError('source changed while the backup was copied')
+            _fsync_dir(path.parent)
+
+        temp = path.with_name(
+            f'.{path.name}.replay-v10.tmp.{os.getpid()}.{secrets.token_hex(8)}'
+        )
+        manifest = path.with_name(
+            f'_replay-v10.{path.name}.{source_sha256[:16]}.manifest.json'
+        )
+        manifest_tmp = None
+        manifest_published = False
+        source_installed = False
+        try:
+            with _open_exclusive_private(temp, 'w') as output:
+                os.fchmod(output.fileno(), source_mode)
+                written = transform_sidecar(
+                    path,
+                    output,
+                    known=analysis,
+                    write_generation=output_generation,
+                    write_epoch=output_epoch,
+                )
+                output.flush()
+                os.fsync(output.fileno())
+            verification_metadata: dict[str, object] = {}
+            verification = transform_sidecar(temp, metadata=verification_metadata)
+            if any(item.changed for item in verification.values()):
+                raise StreamJSONError('written sidecar is not replay-idempotent')
+            if {
+                key: item.output_count for key, item in written.items()
+            } != {
+                key: item.output_count for key, item in verification.items()
+            }:
+                raise StreamJSONError('written sidecar counts failed verification')
+            if verification_metadata['generation'] != output_generation:
+                raise StreamJSONError('written sidecar generation failed verification')
+            if verification_metadata['epoch'] != output_epoch:
+                raise StreamJSONError('written sidecar epoch failed verification')
+            output_sha256 = _sha256(temp)
+            if _signature(path) != source_signature or _sha256(path) != source_sha256:
+                raise StreamJSONError('source generation changed during offline repair')
+            manifest_payload = {
+                'version': 2,
+                'source': str(path),
+                'backup': str(backup),
+                'source_sha256': source_sha256,
+                'output_sha256': output_sha256,
+                'source_generation': source_generation,
+                'output_generation': output_generation,
+                'sidecar_epoch': output_epoch,
+                'arrays': result['arrays'],
+            }
+            manifest_tmp = manifest.with_name(
+                f'.{manifest.name}.tmp.{os.getpid()}.{secrets.token_hex(8)}'
+            )
+            with _open_exclusive_private(manifest_tmp, 'w') as handle:
+                os.fchmod(handle.fileno(), source_mode)
+                handle.write(
+                    json.dumps(manifest_payload, ensure_ascii=False, indent=2) + '\n'
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            _refuse_tombstoned_publication(path)
+            if _signature(path) != source_signature or _sha256(path) != source_sha256:
+                raise StreamJSONError('source generation changed before manifest publication')
+            os.replace(manifest_tmp, manifest)
+            manifest_published = True
+            _fsync_dir(path.parent)
+            _refuse_tombstoned_publication(path)
+            if _signature(path) != source_signature or _sha256(path) != source_sha256:
+                raise StreamJSONError('source generation changed before sidecar publication')
+            os.replace(temp, path)
+            source_installed = True
+            _fsync_dir(path.parent)
+        except BaseException as exc:
+            if manifest_published and not source_installed:
+                try:
+                    manifest.unlink(missing_ok=True)
+                    _fsync_dir(path.parent)
+                except Exception as cleanup_exc:
+                    exc.add_note(
+                        f'failed to remove unpublished manifest {manifest}: '
+                        f'{cleanup_exc}'
+                    )
+            raise
+        finally:
+            temp.unlink(missing_ok=True)
+            if manifest_tmp is not None:
+                manifest_tmp.unlink(missing_ok=True)
+        result.update(
+            status='compacted',
+            backup=str(backup),
+            manifest=str(manifest),
+            output_sha256=_sha256(path),
+            output_generation=output_generation,
+            max_rss_kib=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+        )
+        return result
+
+
+def restore_manifest(manifest: Path) -> dict:
+    manifest = manifest.resolve()
+    payload = json.loads(manifest.read_text(encoding='utf-8'))
+    source = Path(payload['source'])
+    backup = Path(payload['backup'])
+    lock_path = _sidecar_lock_path(source)
+    with lock_path.open('a+', encoding='utf-8') as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        _refuse_tombstoned_publication(source)
+        source_mode = stat_module.S_IMODE(source.stat().st_mode)
+        source_signature = _signature(source)
+        if _sha256(source) != payload['output_sha256']:
+            raise StreamJSONError('current sidecar no longer matches compacted output')
+        expected_generation = payload.get('output_generation')
+        current_generation = _valid_generation(
+            expected_generation if expected_generation is not None else 0
+        )
+        restore_epoch = (
+            _valid_epoch(payload['sidecar_epoch'])
+            if payload.get('sidecar_epoch') is not None
+            else secrets.token_hex(16)
+        )
+        restore_generation = current_generation + 1
+        temp = source.with_name(
+            f'.{source.name}.replay-v10.restore.{os.getpid()}.{secrets.token_hex(8)}'
+        )
+        try:
+            with _open_regular_binary_nofollow(backup, label='backup') as backup_raw:
+                if _sha256_open_file(backup_raw) != payload['source_sha256']:
+                    raise StreamJSONError('backup checksum mismatch')
+                backup_raw.seek(0)
+                backup_text = io.TextIOWrapper(backup_raw, encoding='utf-8')
+                try:
+                    with _open_exclusive_private(temp, 'w') as output:
+                        os.fchmod(output.fileno(), source_mode)
+                        _copy_with_generation(
+                            backup_text,
+                            output,
+                            restore_generation,
+                            restore_epoch,
+                        )
+                        output.flush()
+                        os.fsync(output.fileno())
+                finally:
+                    backup_text.detach()
+            restored_metadata: dict[str, object] = {}
+            transform_sidecar(temp, metadata=restored_metadata)
+            if restored_metadata['generation'] != restore_generation:
+                raise StreamJSONError('restored sidecar generation failed verification')
+            if restored_metadata['epoch'] != restore_epoch:
+                raise StreamJSONError('restored sidecar epoch failed verification')
+            restored_sha256 = _sha256(temp)
+            if (
+                _signature(source) != source_signature
+                or _sha256(source) != payload['output_sha256']
+            ):
+                raise StreamJSONError('sidecar changed during rollback preparation')
+            _refuse_tombstoned_publication(source)
+            if (
+                _signature(source) != source_signature
+                or _sha256(source) != payload['output_sha256']
+            ):
+                raise StreamJSONError('sidecar changed before rollback publication')
+            os.replace(temp, source)
+            _fsync_dir(source.parent)
+        finally:
+            temp.unlink(missing_ok=True)
+    return {
+        'status': 'restored',
+        'source': str(source),
+        'source_sha256': payload['source_sha256'],
+        'output_sha256': restored_sha256,
+        'output_generation': restore_generation,
+        'sidecar_epoch': restore_epoch,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path', nargs='?', type=Path)
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--restore', type=Path)
+    args = parser.parse_args()
+    if bool(args.restore) == bool(args.path):
+        parser.error('provide exactly one session path or --restore MANIFEST')
+    if args.restore and args.dry_run:
+        parser.error('--dry-run cannot be combined with --restore')
+    try:
+        result = (
+            restore_manifest(args.restore)
+            if args.restore
+            else compact_sidecar(args.path, dry_run=args.dry_run)
+        )
+    except Exception as exc:
+        print(json.dumps({'status': 'error', 'error': str(exc)}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_cancelled_turn_status.py
+++ b/tests/test_cancelled_turn_status.py
@@ -23,8 +23,9 @@ def _read(rel_path: str) -> str:
 
 
 class _DummySession:
-    def __init__(self, path: str = ''):
+    def __init__(self, path: str = '', session_id: str = ''):
         self.path = path
+        self.session_id = session_id
         self.messages = []
         self.active_stream_id = 'stream-1'
         self.pending_user_message = 'hello'
@@ -90,10 +91,20 @@ class TestCancelledTurnFinalizer:
         assert session.messages[-1]['provider_details_label'] == 'Cancellation details'
         assert session.messages[-1]['_error'] is True
 
-    def test_ephemeral_cancel_finalizer_unlinks_temp_session_without_saving_error_marker(self, tmp_path):
-        temp_session = tmp_path / 'btw-session.json'
+    def test_ephemeral_cancel_finalizer_unlinks_temp_session_without_saving_error_marker(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import api.models as models
+        import api.streaming as streaming
+
+        sid = 'btw-session'
+        monkeypatch.setattr(models, 'SESSION_DIR', tmp_path)
+        monkeypatch.setattr(streaming, 'SESSION_DIR', tmp_path)
+        temp_session = tmp_path / f'{sid}.json'
         temp_session.write_text('{}', encoding='utf-8')
-        session = _DummySession(str(temp_session))
+        session = _DummySession(str(temp_session), session_id=sid)
 
         _finalize_cancelled_turn(session, ephemeral=True)
 

--- a/tests/test_file_manager_external_session.py
+++ b/tests/test_file_manager_external_session.py
@@ -452,7 +452,7 @@ def test_delete_serializes_with_workspace_recovery_and_sidecar_stays_deleted(
     )
     monkeypatch.setattr(routes_module, "prune_session_from_index", lambda _sid: None)
     monkeypatch.setattr(
-        routes_module, "_record_webui_deleted_session_tombstone", lambda _sid: None
+        models_module, "_record_webui_deleted_session_tombstone", lambda _sid: None
     )
     monkeypatch.setattr(
         routes_module, "_publish_session_list_changed", lambda *_args, **_kwargs: None
@@ -564,7 +564,7 @@ def test_delete_returns_503_without_mutation_when_session_lock_is_busy(
         lambda _sid: observed["mutations"].append("index"),
     )
     monkeypatch.setattr(
-        routes_module,
+        models_module,
         "_record_webui_deleted_session_tombstone",
         lambda _sid: observed["mutations"].append("tombstone"),
     )

--- a/tests/test_issue2057_worktree_lifecycle.py
+++ b/tests/test_issue2057_worktree_lifecycle.py
@@ -1,5 +1,4 @@
 import sqlite3
-from pathlib import Path
 from types import SimpleNamespace
 
 import api.models as models
@@ -126,15 +125,7 @@ def test_delete_session_records_tombstone_when_state_db_delete_fails(tmp_path, m
     def fail_delete(value):
         raise RuntimeError("state.db locked")
 
-    real_unlink = Path.unlink
-
-    def fail_backup_unlink(path, *args, **kwargs):
-        if path.name == f"{sid}.json.bak":
-            raise PermissionError("backup locked")
-        return real_unlink(path, *args, **kwargs)
-
     monkeypatch.setattr(models, "delete_cli_session", fail_delete)
-    monkeypatch.setattr(Path, "unlink", fail_backup_unlink)
 
     assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
 
@@ -142,6 +133,7 @@ def test_delete_session_records_tombstone_when_state_db_delete_fails(tmp_path, m
     assert captured["payload"]["ok"] is True
     assert captured["payload"]["state_db_cleanup_failed"] is True
     assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / f"{sid}.json.bak").exists()
     assert sid in models._load_webui_deleted_session_tombstone()
 
 

--- a/tests/test_issue5570_clear_backup_recovery.py
+++ b/tests/test_issue5570_clear_backup_recovery.py
@@ -303,6 +303,39 @@ def test_malformed_live_sidecar_still_recovers_larger_backup(tmp_path):
     assert json.loads(live_path.read_text(encoding="utf-8"))["messages"][0]["content"] == "pre-clear prompt"
 
 
+def test_malformed_live_recovery_rejects_changed_raw_source(monkeypatch, tmp_path):
+    import api.session_recovery as session_recovery
+
+    sid = "issue5570_malformed_live_changed"
+    live_path = tmp_path / f"{sid}.json"
+    bak_path = live_path.with_suffix(".json.bak")
+    live_path.write_text("{not json", encoding="utf-8")
+    _write_json(bak_path, _stale_pre_clear_backup(sid))
+    real_identity = session_recovery._recovery_source_identity
+    calls = 0
+
+    def mutate_after_first_identity(models, path):
+        nonlocal calls
+        identity = real_identity(models, path)
+        calls += 1
+        if calls == 1:
+            live_path.write_text("{changed raw bytes", encoding="utf-8")
+        return identity
+
+    monkeypatch.setattr(
+        session_recovery,
+        "_recovery_source_identity",
+        mutate_after_first_identity,
+    )
+
+    result = recover_session(live_path)
+
+    assert result["restored"] is False
+    assert result["stale_generation"] is True
+    assert result["error"] == "session changed during recovery preparation"
+    assert live_path.read_text(encoding="utf-8") == "{changed raw bytes"
+
+
 def test_manual_compression_recovery_behavior_is_preserved(tmp_path):
     sid = "issue5570_compression"
     live_path = tmp_path / f"{sid}.json"

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -10,6 +10,7 @@ Validates:
 import json
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -277,28 +278,55 @@ class TestIssue765FollowupHardening:
     an exception fires before the checkpoint thread is created.
     """
 
-    def test_same_session_concurrent_saves_use_distinct_temp_files(self, monkeypatch):
-        """Two concurrent saves of the same session must not collide on one tmp path.
+    def test_same_session_concurrent_saves_are_serialized_with_distinct_temp_files(
+        self, monkeypatch
+    ):
+        """Two same-session saves serialize and never collide on one tmp path.
 
-        The key regression guard here is that each save call should reach os.replace()
-        with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
-        threads would target the same path and the second replace would deterministically
-        fail once the first consume/remove happened.
+        The first replace is held behind an explicit gate. The second save must
+        attempt while that gate is held but cannot reach replace until release.
+        Each serialized call must still use its own source temp path.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
 
         original_replace = models.os.replace
-        barrier = threading.Barrier(2)
+        original_authority = models._session_sidecar_authority
+        first_at_replace = threading.Event()
+        release_first = threading.Event()
+        second_attempted_authority = threading.Event()
+        second_at_replace = threading.Event()
+        authority_lock = threading.Lock()
+        authority_calls = 0
+        replace_lock = threading.Lock()
         replace_sources = []
         errors = []
 
-        def _replace_with_barrier(src, dst):
-            replace_sources.append(str(src))
-            barrier.wait(timeout=5)
+        @contextmanager
+        def _tracked_authority(session_id):
+            nonlocal authority_calls
+            with authority_lock:
+                authority_calls += 1
+                call_number = authority_calls
+            if call_number == 2:
+                second_attempted_authority.set()
+            with original_authority(session_id):
+                yield
+
+        def _replace_with_gate(src, dst):
+            with replace_lock:
+                replace_sources.append(str(src))
+                call_number = len(replace_sources)
+            if call_number == 1:
+                first_at_replace.set()
+                if not release_first.wait(timeout=5):
+                    raise AssertionError("timed out waiting to release first replace")
+            else:
+                second_at_replace.set()
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models, "_session_sidecar_authority", _tracked_authority)
+        monkeypatch.setattr(models.os, "replace", _replace_with_gate)
 
         def _save_worker():
             try:
@@ -307,12 +335,23 @@ class TestIssue765FollowupHardening:
                 errors.append(e)
 
         t1 = threading.Thread(target=_save_worker)
-        t2 = threading.Thread(target=_save_worker)
         t1.start()
+        assert first_at_replace.wait(timeout=5), "first save never reached replace"
+        t2 = threading.Thread(target=_save_worker)
         t2.start()
+        assert second_attempted_authority.wait(timeout=5), (
+            "second save never attempted SID authority"
+        )
+        try:
+            assert not second_at_replace.wait(timeout=0.2), (
+                "second same-session save reached replace before first release"
+            )
+        finally:
+            release_first.set()
         t1.join(timeout=5)
         t2.join(timeout=5)
 
+        assert not t1.is_alive() and not t2.is_alive()
         assert not errors, f"Concurrent same-session saves should not fail: {errors}"
         assert len(replace_sources) >= 2, f"Expected replace calls, got {replace_sources}"
         assert len(set(replace_sources)) == 2, (

--- a/tests/test_offline_replay_compactor.py
+++ b/tests/test_offline_replay_compactor.py
@@ -1,0 +1,1485 @@
+import hashlib
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+def _row(message_id="assistant-a"):
+    return {
+        "role": "assistant",
+        "content": "",
+        "id": message_id,
+        "finish_reason": "stop",
+        "reasoning": "replayed",
+        "timestamp": 123,
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run_with_isolated_rss(script: Path, *args, timeout: int):
+    """Fork the measured CLI from a small launcher, not the full pytest RSS."""
+    launcher = (
+        "import subprocess,sys; "
+        "raise SystemExit(subprocess.call(sys.argv[1:]))"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", launcher, sys.executable, str(script), *map(str, args)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_large_session_load_defers_inline_repair_and_blocks_save(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+    sid = "offline-repair-required"
+    duplicate_partial = {
+        "role": "assistant",
+        "content": "streaming",
+        "_partial": True,
+    }
+    payload = {
+        "session_id": sid,
+        "messages": [duplicate_partial, duplicate_partial],
+        "context_messages": [],
+    }
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = models.Session.load(sid)
+
+    assert loaded is not None
+    assert loaded.messages == payload["messages"]
+    assert loaded.context_messages == payload["context_messages"]
+    assert loaded._replay_repair_deferred is True
+    assert not sidecar.with_suffix(".json.bak").exists()
+    with pytest.raises(RuntimeError, match="offline replay repair"):
+        loaded.save(skip_index=True)
+
+
+def test_offline_compactor_is_atomic_idempotent_and_reversible(tmp_path):
+    from scripts.compact_session_replays import compact_sidecar, restore_manifest
+
+    sidecar = tmp_path / "session.json"
+    replay = _row()
+    unique = {"role": "user", "content": "must survive", "id": "user-a"}
+    opaque = {
+        "role": "assistant",
+        "content": [{"type": "image_url", "image_url": "file:///A.png"}],
+        "id": "opaque-a",
+    }
+    payload = {
+        "session_id": "session",
+        "_sidecar_generation_v1": 7,
+        "message_count": 5,
+        "compression_anchor_visible_idx": 4,
+        "pre_compression_snapshot": {
+            "messages": [replay, replay],
+            "note": "copied raw, not recursively reduced",
+        },
+        "messages": [replay, replay, unique, opaque, opaque],
+        "context_messages": [replay, replay, opaque, opaque],
+        "tool_calls": [],
+    }
+    sidecar.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    original_sha = _sha256(sidecar)
+
+    dry_run = compact_sidecar(sidecar, dry_run=True)
+    assert dry_run["status"] == "would_compact"
+    assert dry_run["arrays"]["messages"] == {
+        "input": 5,
+        "output": 4,
+        "removed": 1,
+    }
+
+    result = compact_sidecar(sidecar)
+    repaired_text = sidecar.read_text(encoding="utf-8")
+    repaired = json.loads(repaired_text)
+
+    assert result["status"] == "compacted"
+    assert repaired["_sidecar_generation_v1"] == 8
+    sidecar_epoch = repaired["_sidecar_epoch_v1"]
+    assert len(sidecar_epoch) == 32
+    assert repaired_text.index('"_sidecar_generation_v1"') < repaired_text.index(
+        '"messages"'
+    )
+    assert repaired["message_count"] == 4
+    assert repaired["compression_anchor_visible_idx"] is None
+    assert repaired["messages"] == [replay, unique, opaque, opaque]
+    assert repaired["context_messages"] == [replay, opaque, opaque]
+    assert repaired["pre_compression_snapshot"] == payload["pre_compression_snapshot"]
+    assert compact_sidecar(sidecar, dry_run=True)["status"] == "no_change"
+
+    manifest = Path(result["manifest"])
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    backup = Path(result["backup"])
+    assert manifest_payload["source_sha256"] == original_sha == _sha256(backup)
+    assert manifest_payload["output_sha256"] == _sha256(sidecar)
+    assert manifest_payload["source_generation"] == 7
+    assert manifest_payload["output_generation"] == 8
+    assert manifest_payload["sidecar_epoch"] == sidecar_epoch
+
+    restored = restore_manifest(manifest)
+    assert restored["status"] == "restored"
+    restored_payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert restored_payload.pop("_sidecar_generation_v1") == 9
+    assert restored_payload.pop("_sidecar_epoch_v1") == sidecar_epoch
+    assert restored["sidecar_epoch"] == sidecar_epoch
+    expected_payload = dict(payload)
+    expected_payload.pop("_sidecar_generation_v1")
+    assert restored_payload == expected_payload
+    assert restored["output_sha256"] == _sha256(sidecar)
+    assert _sha256(backup) == original_sha
+
+
+@pytest.mark.skipif(os.name == "nt", reason="offline compactor is POSIX/WSL-only")
+def test_compactor_rejects_symlink_source(tmp_path):
+    from scripts.compact_session_replays import StreamJSONError, compact_sidecar
+
+    target = tmp_path / "target.json"
+    target.write_text(
+        json.dumps({
+            "session_id": "source-link",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+    source_link = tmp_path / "source-link.json"
+    source_link.symlink_to(target)
+    original = target.read_bytes()
+
+    with pytest.raises(StreamJSONError, match="source.*symlink"):
+        compact_sidecar(source_link)
+
+    assert target.read_bytes() == original
+    assert not list(tmp_path.glob("*replay-v10*"))
+
+
+def test_compactor_requires_embedded_session_id_to_match_filename(tmp_path):
+    from scripts.compact_session_replays import StreamJSONError, compact_sidecar
+
+    sidecar = tmp_path / "expected-id.json"
+    original = json.dumps({
+        "session_id": "different-id",
+        "messages": [_row(), _row()],
+        "context_messages": [],
+    })
+    sidecar.write_text(original, encoding="utf-8")
+
+    with pytest.raises(StreamJSONError, match="session_id.*filename"):
+        compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*replay-v10*"))
+
+
+def test_compactor_rejects_session_id_too_long_for_artifact_names(tmp_path):
+    from scripts.compact_session_replays import StreamJSONError, compact_sidecar
+
+    session_id = "s" * 151
+    sidecar = tmp_path / f"{session_id}.json"
+    original = json.dumps({
+        "session_id": session_id,
+        "messages": [_row(), _row()],
+        "context_messages": [],
+    })
+    sidecar.write_text(original, encoding="utf-8")
+
+    with pytest.raises(StreamJSONError, match="session_id.*150"):
+        compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*replay-v10*"))
+
+
+def test_offline_compactor_preserves_distinct_strict_partials(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+    from scripts import compact_session_replays as compactor
+
+    assert (
+        compactor._repo_partial_message_signature
+        is models._partial_message_signature
+    )
+    monkeypatch.setattr(
+        compactor,
+        "_repo_partial_message_signature",
+        compactor._message_digest,
+    )
+
+    sidecar = tmp_path / "partial-replays.json"
+    logical_partial = {
+        "role": "assistant",
+        "content": "partial answer",
+        "reasoning": "same reasoning",
+        "_partial": True,
+        "_partial_tool_calls": [
+            {
+                "name": "lookup",
+                "args": {"query": "same"},
+                "done": False,
+            }
+        ],
+    }
+    first = {
+        **logical_partial,
+        "timestamp": 1000,
+        "model": "provider-a/model",
+        "request_id": "request-a",
+    }
+    second = {
+        **logical_partial,
+        "timestamp": 2000,
+        "model": "provider-b/model",
+        "request_id": "request-b",
+    }
+    assert type(compactor._message_digest(first)) is bytes
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "partial-replays",
+                "messages": [first, second],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = compactor.compact_sidecar(sidecar)
+    repaired = json.loads(sidecar.read_text(encoding="utf-8"))
+
+    assert result["arrays"]["messages"] == {
+        "input": 2,
+        "output": 2,
+        "removed": 0,
+    }
+    assert repaired["messages"] == [first, second]
+
+
+def test_offline_compactor_collapses_identical_partials_with_bytes_signature(
+    tmp_path,
+    monkeypatch,
+):
+    from scripts import compact_session_replays as compactor
+
+    monkeypatch.setattr(
+        compactor,
+        "_repo_partial_message_signature",
+        compactor._message_digest,
+    )
+    sidecar = tmp_path / "identical-partial-replays.json"
+    partial = {
+        "role": "assistant",
+        "content": "partial answer",
+        "reasoning": "same reasoning",
+        "_partial": True,
+        "timestamp": 1000,
+        "model": "provider-a/model",
+        "request_id": "request-a",
+        "_partial_tool_calls": [
+            {
+                "name": "lookup",
+                "args": {"query": "same"},
+                "done": False,
+            }
+        ],
+    }
+    duplicate = json.loads(json.dumps(partial))
+    assert type(compactor._message_digest(partial)) is bytes
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "identical-partial-replays",
+                "messages": [partial, duplicate],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = compactor.compact_sidecar(sidecar)
+    repaired = json.loads(sidecar.read_text(encoding="utf-8"))
+
+    assert result["status"] == "compacted"
+    assert result["arrays"]["messages"] == {
+        "input": 2,
+        "output": 1,
+        "removed": 1,
+    }
+    assert repaired["messages"] == [partial]
+
+
+def test_offline_compactor_memory_is_bounded_for_many_replays(tmp_path):
+    sidecar = tmp_path / "many-replays.json"
+    replay = json.dumps(_row(), ensure_ascii=False, separators=(",", ":"))
+    copies = 60_000
+    with sidecar.open("w", encoding="utf-8") as handle:
+        handle.write('{"session_id":"many-replays","message_count":')
+        handle.write(str(copies))
+        handle.write(',"messages":[')
+        for index in range(copies):
+            if index:
+                handle.write(',')
+            handle.write(replay)
+        handle.write('],"context_messages":[]}')
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "compact_session_replays.py"
+    completed = _run_with_isolated_rss(
+        script,
+        sidecar,
+        timeout=120,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    result = json.loads(completed.stdout)
+    assert result["status"] == "compacted"
+    assert result["arrays"]["messages"] == {
+        "input": copies,
+        "output": 1,
+        "removed": copies - 1,
+    }
+    assert result["max_rss_kib"] < 256 * 1024
+    repaired = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert repaired["_sidecar_generation_v1"] == 1
+    assert repaired["message_count"] == 1
+    assert repaired["messages"] == [_row()]
+
+
+def test_offline_compactor_memory_is_bounded_for_many_unique_ids(tmp_path):
+    sidecar = tmp_path / "many-unique-replays.json"
+    copies = 500_000
+    with sidecar.open("w", encoding="utf-8") as handle:
+        handle.write('{"session_id":"many-unique-replays","messages":[')
+        for index in range(copies):
+            if index:
+                handle.write(',')
+            handle.write(
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "id": f"assistant-{index}",
+                        "finish_reason": "stop",
+                    },
+                    separators=(",", ":"),
+                )
+            )
+        handle.write('],"context_messages":[]}')
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "compact_session_replays.py"
+    completed = _run_with_isolated_rss(
+        script,
+        "--dry-run",
+        sidecar,
+        timeout=180,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    result = json.loads(completed.stdout)
+    assert result["status"] == "no_change"
+    assert result["arrays"]["messages"]["output"] == copies
+    assert result["max_rss_kib"] < 192 * 1024
+
+
+def test_offline_compactor_refuses_publish_after_source_drift(tmp_path, monkeypatch):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "session.json"
+    payload = {
+        "session_id": "session",
+        "messages": [_row(), _row()],
+        "context_messages": [],
+    }
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    original_sha = _sha256(sidecar)
+    backup = sidecar.with_name(
+        f"{sidecar.name}.replay-v10.{original_sha[:16]}.bak"
+    )
+    manifest = backup.with_suffix(f"{backup.suffix}.manifest.json")
+    original_hash = compactor._sha256
+
+    def _mutate_after_output_hash(path):
+        digest = original_hash(path)
+        if path.name.startswith(f".{sidecar.name}.replay-v10.tmp"):
+            sidecar.write_text(
+                json.dumps({"session_id": "newer-writer", "messages": []}),
+                encoding="utf-8",
+            )
+        return digest
+
+    monkeypatch.setattr(compactor, "_sha256", _mutate_after_output_hash)
+
+    with pytest.raises(compactor.StreamJSONError, match="source generation changed"):
+        compactor.compact_sidecar(sidecar)
+
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["session_id"] == "newer-writer"
+    assert _sha256(backup) == original_sha
+    assert not manifest.exists()
+    assert not list(tmp_path.glob(f".{sidecar.name}.replay-v10.tmp.*"))
+
+
+def test_restore_refuses_sidecar_changed_after_compaction(tmp_path):
+    from scripts.compact_session_replays import (
+        StreamJSONError,
+        compact_sidecar,
+        restore_manifest,
+    )
+
+    sidecar = tmp_path / "session.json"
+    sidecar.write_text(
+        json.dumps({
+            "session_id": "session",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+    result = compact_sidecar(sidecar)
+    newer = json.loads(sidecar.read_text(encoding="utf-8"))
+    newer["title"] = "newer writer"
+    sidecar.write_text(json.dumps(newer), encoding="utf-8")
+    newer_sha = _sha256(sidecar)
+
+    with pytest.raises(StreamJSONError, match="no longer matches compacted output"):
+        restore_manifest(Path(result["manifest"]))
+
+    assert _sha256(sidecar) == newer_sha
+
+
+@pytest.mark.skipif(os.name == "nt", reason="offline compactor is POSIX/WSL-only")
+def test_restore_rejects_symlinked_backup(tmp_path):
+    from scripts.compact_session_replays import (
+        StreamJSONError,
+        compact_sidecar,
+        restore_manifest,
+    )
+
+    sidecar = tmp_path / "symlink-restore.json"
+    sidecar.write_text(
+        json.dumps({
+            "session_id": "symlink-restore",
+            "title": "original",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+    result = compact_sidecar(sidecar)
+    backup = Path(result["backup"])
+    copied_backup = tmp_path / "copied-backup.json"
+    copied_backup.write_bytes(backup.read_bytes())
+    backup.unlink()
+    backup.symlink_to(copied_backup)
+
+    with pytest.raises(StreamJSONError, match="backup.*regular file|symlink"):
+        restore_manifest(Path(result["manifest"]))
+
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["messages"] == [_row()]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="offline compactor is POSIX/WSL-only")
+def test_restore_uses_the_same_backup_descriptor_for_hash_and_copy(
+    tmp_path,
+    monkeypatch,
+):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "descriptor-restore.json"
+    sidecar.write_text(
+        json.dumps({
+            "session_id": "descriptor-restore",
+            "title": "original",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+    result = compactor.compact_sidecar(sidecar)
+    backup = Path(result["backup"])
+    displaced_backup = tmp_path / "displaced-backup.json"
+    real_open = compactor.os.open
+    injected = []
+
+    def interleave_backup_replacement(path, flags, mode=0o777, *, dir_fd=None):
+        kwargs = {} if dir_fd is None else {"dir_fd": dir_fd}
+        fd = real_open(path, flags, mode, **kwargs)
+        if (
+            Path(path) == backup
+            and flags & os.O_ACCMODE == os.O_RDONLY
+            and not injected
+        ):
+            backup.rename(displaced_backup)
+            backup.write_text(
+                json.dumps({
+                    "session_id": "descriptor-restore",
+                    "title": "injected replacement",
+                    "messages": [],
+                    "context_messages": [],
+                }),
+                encoding="utf-8",
+            )
+            injected.append(True)
+        return fd
+
+    monkeypatch.setattr(compactor.os, "open", interleave_backup_replacement)
+
+    restored = compactor.restore_manifest(Path(result["manifest"]))
+
+    assert injected == [True]
+    assert restored["status"] == "restored"
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["title"] == "original"
+    assert payload["messages"] == [_row(), _row()]
+
+
+def test_ambiguous_empty_rows_are_not_removed(tmp_path):
+    from scripts.compact_session_replays import compact_sidecar
+
+    sidecar = tmp_path / "ambiguous.json"
+    bool_id = {
+        "role": "assistant",
+        "content": "",
+        "id": True,
+        "finish_reason": "stop",
+    }
+    structured = {
+        "role": "assistant",
+        "content": "",
+        "id": "structured",
+        "attachments": [],
+    }
+    sidecar.write_text(
+        json.dumps({
+            "session_id": "ambiguous",
+            "messages": [bool_id, bool_id, structured, structured],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+
+    result = compact_sidecar(sidecar, dry_run=True)
+
+    assert result["status"] == "no_change"
+    assert result["arrays"]["messages"]["removed"] == 0
+
+
+def test_offline_compactor_serializes_runtime_writer_through_publish(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+    from scripts import compact_session_replays as compactor
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    sidecar = session_dir / "race.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "race",
+                "title": "before",
+                "messages": [_row(), _row()],
+                "context_messages": [],
+                "_sidecar_generation_v1": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    writer = models.Session.load("race")
+    assert writer is not None
+    writer.title = "newer writer"
+    writer_done = threading.Event()
+    writer_errors = []
+    writer_thread = None
+    writer_finished_before_publish = []
+    real_replace = os.replace
+
+    def _save_newer():
+        try:
+            writer.save(skip_index=True)
+        except RuntimeError as exc:
+            writer_errors.append(str(exc))
+        finally:
+            writer_done.set()
+
+    def _interleave_writer(source, destination):
+        nonlocal writer_thread
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if (
+            destination_path == sidecar
+            and ".replay-v10.tmp." in source_path.name
+        ):
+            writer_thread = threading.Thread(target=_save_newer)
+            writer_thread.start()
+            writer_finished_before_publish.append(writer_done.wait(0.25))
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(compactor.os, "replace", _interleave_writer)
+
+    compactor.compact_sidecar(sidecar)
+    assert writer_thread is not None
+    writer_thread.join(timeout=3)
+
+    assert writer_finished_before_publish == [False]
+    assert writer_done.is_set()
+    assert writer_errors == [
+        "stale sidecar revision for session 'race'; reload before saving"
+    ]
+    persisted = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert persisted["title"] == "before"
+    assert persisted["messages"] == [_row()]
+    assert persisted["_sidecar_generation_v1"] == 4
+
+
+def test_runtime_save_preserves_and_advances_sidecar_generation(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    sidecar = tmp_path / "generation.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "generation",
+                "messages": [{"role": "user", "content": "keep"}],
+                "_sidecar_generation_v1": 7,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = models.Session.load("generation")
+    assert loaded is not None
+    loaded.title = "saved"
+    loaded.save(skip_index=True)
+
+    persisted = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert persisted["_sidecar_generation_v1"] == 8
+
+
+def test_fresh_runtime_writer_adopts_existing_sidecar_revision(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    original = models.Session(session_id="fresh-writer")
+    original.messages = [{"role": "user", "content": "original"}]
+    original.save(skip_index=True)
+    original_payload = json.loads(original.path.read_text(encoding="utf-8"))
+
+    replacement = models.Session(
+        session_id="fresh-writer",
+        title="replacement",
+        messages=[{"role": "user", "content": "replacement"}],
+    )
+    assert replacement._sidecar_revision_v1 is None
+
+    replacement.save(skip_index=True)
+
+    persisted = json.loads(replacement.path.read_text(encoding="utf-8"))
+    assert persisted["title"] == "replacement"
+    assert persisted["messages"] == replacement.messages
+    assert persisted["_sidecar_generation_v1"] == 2
+    assert persisted["_sidecar_epoch_v1"] == original_payload["_sidecar_epoch_v1"]
+
+
+def test_sidecar_revision_is_scoped_to_the_observed_session_id(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    session = models.Session(session_id="rotation-source")
+    session.messages = [{"role": "user", "content": "keep"}]
+    session.save(skip_index=True)
+    source_epoch = json.loads(session.path.read_text(encoding="utf-8"))[
+        "_sidecar_epoch_v1"
+    ]
+
+    session.session_id = "rotation-continuation"
+    session.save(skip_index=True)
+
+    continuation = json.loads(session.path.read_text(encoding="utf-8"))
+    assert continuation["session_id"] == "rotation-continuation"
+    assert continuation["messages"] == session.messages
+    assert continuation["_sidecar_generation_v1"] == 1
+    assert continuation["_sidecar_epoch_v1"] != source_epoch
+
+
+def test_runtime_save_rejects_owner_loaded_before_offline_compaction(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+    from scripts.compact_session_replays import compact_sidecar
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    sidecar = tmp_path / "stale-owner.json"
+    duplicate = _row()
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "stale-owner",
+                "messages": [duplicate, duplicate],
+                "context_messages": [],
+                "_sidecar_generation_v1": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    stale_owner = models.Session.load("stale-owner")
+    assert stale_owner is not None
+
+    compact_sidecar(sidecar)
+    fresh_owner = models.Session.load("stale-owner")
+    assert fresh_owner is not None
+    new_turn = {"role": "user", "content": "new durable turn"}
+    fresh_owner.messages.append(new_turn)
+    fresh_owner.save(skip_index=True)
+
+    stale_owner.title = "must not overwrite"
+    with pytest.raises(RuntimeError, match="stale sidecar revision"):
+        stale_owner.save(skip_index=True)
+
+    persisted = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert persisted["messages"] == [duplicate, new_turn]
+    assert persisted["_sidecar_generation_v1"] == 5
+
+
+def test_runtime_save_rejects_delete_recreate_epoch_aba(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    original = models.Session(session_id="epoch-aba")
+    original.messages = [{"role": "user", "content": "original"}]
+    original.save(skip_index=True)
+    stale_owner = models.Session.load("epoch-aba")
+    assert stale_owner is not None
+    original_epoch = json.loads(original.path.read_text(encoding="utf-8"))[
+        "_sidecar_epoch_v1"
+    ]
+
+    original.path.unlink()
+    recreated = models.Session(session_id="epoch-aba")
+    recreated.messages = [{"role": "user", "content": "recreated"}]
+    recreated.save(skip_index=True)
+    recreated_payload = json.loads(recreated.path.read_text(encoding="utf-8"))
+    assert recreated_payload["_sidecar_epoch_v1"] != original_epoch
+
+    stale_owner.title = "must not cross epoch"
+    with pytest.raises(RuntimeError, match="stale sidecar revision"):
+        stale_owner.save(skip_index=True)
+
+    assert json.loads(recreated.path.read_text(encoding="utf-8")) == recreated_payload
+
+
+def test_non_target_string_is_copied_in_bounded_chunks():
+    from scripts.compact_session_replays import StreamReader
+
+    value = "x" * 200_000
+    writes = []
+
+    class RecordingWriter(io.StringIO):
+        def write(self, text):
+            writes.append(len(text))
+            return super().write(text)
+
+    output = RecordingWriter()
+    StreamReader(io.StringIO(json.dumps(value))).copy_raw_value(output)
+
+    assert output.getvalue() == json.dumps(value)
+    assert max(writes) <= 65_536
+
+
+def test_non_target_32_mib_string_stays_under_bounded_rss(tmp_path):
+    sidecar = tmp_path / "large-non-target.json"
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "compact_session_replays.py"
+    )
+    chunk = "x" * (1 << 20)
+    with sidecar.open("w", encoding="utf-8") as handle:
+        handle.write('{"session_id":"large-non-target","metadata":"')
+        for _ in range(32):
+            handle.write(chunk)
+        handle.write(
+            '","messages":['
+            + json.dumps(_row(), separators=(",", ":"))
+            + ','
+            + json.dumps(_row(), separators=(",", ":"))
+            + '],"context_messages":[]}'
+        )
+
+    completed = _run_with_isolated_rss(
+        script,
+        sidecar,
+        "--dry-run",
+        timeout=120,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    result = json.loads(completed.stdout)
+    assert result["status"] == "would_compact"
+    assert result["max_rss_kib"] < 192 * 1024
+
+
+def test_target_scalar_split_at_reader_boundary_is_not_truncated():
+    from scripts.compact_session_replays import StreamReader
+
+    reader = StreamReader(io.StringIO("12345]"), chunk_chars=1)
+
+    assert reader.decode_value() == 12345
+    assert reader.take() == "]"
+
+
+def test_bounded_metadata_rejects_oversized_non_target_scalar(tmp_path):
+    from api import models
+
+    sidecar = tmp_path / "oversized-scalar.json"
+    sidecar.write_text(
+        '{"session_id":"oversized-scalar","metadata":0.'
+        + ("0" * 70_000)
+        + '1,"messages":[]}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="scalar exceeds bounded limit"):
+        models._read_bounded_session_metadata(sidecar)
+
+
+def test_runtime_save_tracks_actual_published_bytes(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    sidecar = tmp_path / "translated-newlines.json"
+    real_replace = models._safe_replace
+
+    def replace_with_translated_newlines(source, destination):
+        real_replace(source, destination)
+        if Path(destination) == sidecar:
+            sidecar.write_bytes(sidecar.read_bytes().replace(b"\n", b"\r\n"))
+
+    monkeypatch.setattr(models, "_safe_replace", replace_with_translated_newlines)
+    session = models.Session(session_id="translated-newlines")
+    session.messages = [{"role": "user", "content": "keep"}]
+    session.save(skip_index=True)
+    session.title = "second save"
+
+    session.save(skip_index=True)
+
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["title"] == "second save"
+
+
+def test_large_valid_session_can_save_after_no_change_analysis(tmp_path, monkeypatch):
+    from api import models
+    from scripts.compact_session_replays import compact_sidecar
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+    sidecar = tmp_path / "large-valid.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "large-valid",
+                "messages": [{"role": "user", "content": "unique"}],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert compact_sidecar(sidecar, dry_run=True)["status"] == "no_change"
+    loaded = models.Session.load("large-valid")
+    assert loaded is not None
+    assert loaded._replay_repair_deferred is False
+    loaded.title = "still writable"
+    loaded.save(skip_index=True)
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["title"] == "still writable"
+
+
+def test_compactor_preserves_private_source_mode(tmp_path):
+    from scripts.compact_session_replays import compact_sidecar, restore_manifest
+
+    sidecar = tmp_path / "private.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "private",
+                "messages": [_row(), _row()],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    sidecar.chmod(0o600)
+
+    result = compact_sidecar(sidecar)
+    backup = Path(result["backup"])
+    manifest = Path(result["manifest"])
+    assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    assert stat.S_IMODE(manifest.stat().st_mode) == 0o600
+
+    restore_manifest(manifest)
+    assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="offline compactor is POSIX/WSL-only")
+def test_sensitive_artifacts_are_created_private_before_fchmod(
+    tmp_path,
+    monkeypatch,
+):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "private-at-create.json"
+    sidecar.write_text(
+        json.dumps({
+            "session_id": "private-at-create",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }),
+        encoding="utf-8",
+    )
+    sidecar.chmod(0o600)
+    modes_before_fchmod = []
+    real_fchmod = compactor.os.fchmod
+
+    def record_initial_mode(fd, mode):
+        modes_before_fchmod.append(stat.S_IMODE(os.fstat(fd).st_mode))
+        return real_fchmod(fd, mode)
+
+    monkeypatch.setattr(compactor.os, "fchmod", record_initial_mode)
+    previous_umask = os.umask(0)
+    try:
+        result = compactor.compact_sidecar(sidecar)
+        compactor.restore_manifest(Path(result["manifest"]))
+    finally:
+        os.umask(previous_umask)
+
+    assert len(modes_before_fchmod) >= 4
+    assert set(modes_before_fchmod) == {0o600}
+
+
+def test_compactor_rejects_invalid_non_target_json_without_publish(tmp_path):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "invalid.json"
+    original = (
+        '{"session_id":"invalid","metadata":{"broken":},'
+        '"messages":['
+        + json.dumps(_row(), separators=(",", ":"))
+        + ','
+        + json.dumps(_row(), separators=(",", ":"))
+        + '],"context_messages":[]}'
+    )
+    sidecar.write_text(original, encoding="utf-8")
+
+    with pytest.raises(compactor.StreamJSONError, match="invalid JSON"):
+        compactor.compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*manifest*.json"))
+
+
+def test_compactor_rejects_nonstandard_target_constant_without_publish(tmp_path):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "nonstandard.json"
+    original = (
+        '{"session_id":"nonstandard","messages":[NaN],'
+        '"context_messages":[]}'
+    )
+    sidecar.write_text(original, encoding="utf-8")
+
+    with pytest.raises(compactor.StreamJSONError, match="invalid JSON constant"):
+        compactor.compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*manifest*.json"))
+
+
+def test_compactor_manifest_is_excluded_from_session_index(tmp_path, monkeypatch):
+    from api import models
+    from scripts.compact_session_replays import compact_sidecar
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", type(models.SESSIONS)())
+    sidecar = tmp_path / "indexed.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "indexed",
+                "messages": [_row(), _row()],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = compact_sidecar(sidecar)
+    assert Path(result["manifest"]).name.startswith("_")
+    models._write_session_index(updates=None)
+    index = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
+    assert [row["session_id"] for row in index] == ["indexed"]
+
+
+def test_session_delete_cleanup_removes_all_replay_v10_plaintext_artifacts(tmp_path):
+    from api import models
+
+    sidecar = tmp_path / "privacy-delete.json"
+    artifacts = [
+        tmp_path / "privacy-delete.json.replay-v10.abcdef0123456789.bak",
+        tmp_path / "_replay-v10.privacy-delete.json.abcdef0123456789.manifest.json",
+        tmp_path / ".privacy-delete.json.replay-v10.tmp.123",
+        tmp_path / ".privacy-delete.json.replay-v10.restore.123",
+        tmp_path / "._replay-v10.privacy-delete.json.abcdef0123456789.manifest.json.tmp.123",
+    ]
+    unrelated = tmp_path / "other.json.replay-v10.abcdef0123456789.bak"
+    for artifact in [*artifacts, unrelated]:
+        artifact.write_text("plaintext transcript", encoding="utf-8")
+
+    removed = models._delete_offline_replay_artifacts(sidecar)
+
+    assert removed == len(artifacts)
+    assert not any(artifact.exists() for artifact in artifacts)
+    assert unrelated.exists()
+
+
+def test_webui_session_delete_routes_replay_v10_cleanup():
+    routes_source = (
+        Path(__file__).resolve().parents[1] / "api" / "routes.py"
+    ).read_text(encoding="utf-8")
+    start = routes_source.index('parsed.path == "/api/session/delete"')
+    end = routes_source.index('parsed.path == "/api/session/clear"', start)
+
+    assert "_delete_session_sidecar_artifacts_locked(" in routes_source[start:end]
+
+
+def test_large_index_rebuild_uses_metadata_prefix(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", type(models.SESSIONS)())
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+    sidecar = tmp_path / "large-index.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "large-index",
+                "title": "Large",
+                "created_at": 1,
+                "updated_at": 2,
+                "message_count": 2,
+                "messages": [
+                    {"role": "user", "content": "one"},
+                    {"role": "assistant", "content": "two"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _must_not_collapse(_messages):
+        raise AssertionError("large index rebuild full-parsed the transcript")
+
+    monkeypatch.setattr(models, "_collapse_adjacent_duplicate_partials", _must_not_collapse)
+    models._write_session_index(updates=None)
+
+    index = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
+    assert len(index) == 1
+    assert index[0]["session_id"] == "large-index"
+    assert index[0]["message_count"] == 2
+
+
+def test_large_index_rebuild_scans_metadata_beyond_prefix_and_arrays(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", type(models.SESSIONS)())
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+
+    oversized = tmp_path / "oversized-prefix.json"
+    oversized.write_text(
+        json.dumps(
+            {
+                "session_id": "oversized-prefix",
+                "compression_anchor_summary": "x" * 70_000,
+                "title": "Oversized prefix",
+                "messages": [{"role": "user", "content": "keep"}],
+                "message_count": 1,
+                "updated_at": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    messages_first = tmp_path / "messages-first.json"
+    messages_first.write_text(
+        json.dumps(
+            {
+                "messages": [{"role": "user", "content": "keep"}],
+                "session_id": "messages-first",
+                "title": "Messages first",
+                "updated_at": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    legacy_scenes_first = tmp_path / "legacy-scenes-first.json"
+    legacy_scenes_first.write_text(
+        json.dumps(
+            {
+                "session_id": "legacy-scenes-first",
+                "title": "Legacy scenes first",
+                "anchor_activity_scenes": {
+                    "scene": {"rows": ["x" * 1024 for _ in range(80)]}
+                },
+                "message_count": 2,
+                "messages": [
+                    {"role": "user", "content": "one"},
+                    {"role": "assistant", "content": "two"},
+                ],
+                "updated_at": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    models._write_session_index(updates=None)
+
+    index = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
+    by_id = {row["session_id"]: row for row in index}
+    assert set(by_id) == {
+        "oversized-prefix",
+        "messages-first",
+        "legacy-scenes-first",
+    }
+    assert by_id["oversized-prefix"]["message_count"] == 1
+    assert by_id["messages-first"]["message_count"] == 1
+    assert by_id["legacy-scenes-first"]["message_count"] == 2
+    assert by_id["messages-first"]["title"] == "Messages first"
+
+
+def test_large_index_rebuild_rejects_malformed_and_foreign_session_ids(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", type(models.SESSIONS)())
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text(
+        '{"session_id":"malformed","junk":not_json,"messages":[]}',
+        encoding="utf-8",
+    )
+    foreign = tmp_path / "filename-authority.json"
+    foreign.write_text(
+        json.dumps(
+            {
+                "session_id": "foreign-id",
+                "title": "must not be indexed",
+                "messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    models._write_session_index(updates=None)
+
+    index = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
+    assert index == []
+    assert models.Session.load("foreign-id") is None
+
+
+def test_large_index_rebuild_uses_last_duplicate_messages_array(
+    tmp_path,
+    monkeypatch,
+):
+    from api import models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", type(models.SESSIONS)())
+    monkeypatch.setattr(models, "_INLINE_REPLAY_REPAIR_MAX_BYTES", 1)
+    sidecar = tmp_path / "duplicate-messages.json"
+    sidecar.write_text(
+        '{"session_id":"duplicate-messages",'
+        '"messages":[{"role":"user"},{"role":"assistant"}],'
+        '"messages":[{"role":"user"}]}',
+        encoding="utf-8",
+    )
+
+    models._write_session_index(updates=None)
+
+    index = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
+    assert len(index) == 1
+    assert index[0]["session_id"] == "duplicate-messages"
+    assert index[0]["message_count"] == 1
+
+
+def test_actual_over_128_mib_index_load_streams_messages_first(tmp_path):
+    from api import models
+
+    sidecar = tmp_path / "actual-large.json"
+    payload_bytes = models._INLINE_REPLAY_REPAIR_MAX_BYTES + 1
+    chunk = "x" * (1 << 20)
+    with sidecar.open("w", encoding="utf-8") as handle:
+        handle.write('{"messages":[{"role":"user","content":"')
+        remaining = payload_bytes
+        while remaining:
+            part = chunk[: min(len(chunk), remaining)]
+            handle.write(part)
+            remaining -= len(part)
+        handle.write(
+            '"}],"session_id":"actual-large","title":"Actual large",'
+            '"updated_at":5}'
+        )
+
+    loaded = models._load_session_from_path(sidecar)
+
+    assert loaded is not None
+    assert loaded.session_id == "actual-large"
+    assert loaded.title == "Actual large"
+    assert loaded._metadata_message_count == 1
+
+
+@pytest.mark.parametrize("bad_ws", ["\v", "\f"])
+@pytest.mark.parametrize(
+    "location",
+    ["top-level", "nested", "target-array", "trailing"],
+)
+def test_compactor_rejects_non_json_whitespace_without_publish(
+    tmp_path,
+    bad_ws,
+    location,
+):
+    from scripts import compact_session_replays as compactor
+
+    row = json.dumps(_row(), separators=(",", ":"))
+    if location == "top-level":
+        original = (
+            '{"session_id":"invalid"'
+            + bad_ws
+            + ',"messages":['
+            + row
+            + ','
+            + row
+            + '],"context_messages":[]}'
+        )
+    elif location == "nested":
+        original = (
+            '{"session_id":"invalid","metadata":{"value":1'
+            + bad_ws
+            + '},"messages":['
+            + row
+            + ','
+            + row
+            + '],"context_messages":[]}'
+        )
+    elif location == "target-array":
+        original = (
+            '{"session_id":"invalid","messages":['
+            + row
+            + bad_ws
+            + ','
+            + row
+            + '],"context_messages":[]}'
+        )
+    else:
+        original = (
+            '{"session_id":"invalid","messages":['
+            + row
+            + ','
+            + row
+            + '],"context_messages":[]}'
+            + bad_ws
+        )
+    sidecar = tmp_path / f"invalid-{location}.json"
+    sidecar.write_text(original, encoding="utf-8")
+
+    with pytest.raises(compactor.StreamJSONError):
+        compactor.compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*.bak"))
+    assert not list(tmp_path.glob("*manifest*.json"))
+
+
+def test_compactor_fsyncs_manifest_name_before_source_install(tmp_path, monkeypatch):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "ordered.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "ordered",
+                "messages": [_row(), _row()],
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    events = []
+    real_replace = compactor.os.replace
+
+    def _record_replace(source, destination):
+        destination = Path(destination)
+        events.append(("replace", "source" if destination == sidecar else "manifest"))
+        return real_replace(source, destination)
+
+    def _record_fsync_dir(path):
+        events.append(("fsync_dir", Path(path)))
+
+    monkeypatch.setattr(compactor.os, "replace", _record_replace)
+    monkeypatch.setattr(compactor, "_fsync_dir", _record_fsync_dir)
+
+    compactor.compact_sidecar(sidecar)
+
+    manifest_replace = events.index(("replace", "manifest"))
+    source_replace = events.index(("replace", "source"))
+    assert any(
+        event[0] == "fsync_dir"
+        for event in events[manifest_replace + 1 : source_replace]
+    )
+
+
+def test_compactor_removes_published_manifest_when_source_install_fails(
+    tmp_path,
+    monkeypatch,
+):
+    from scripts import compact_session_replays as compactor
+
+    sidecar = tmp_path / "failed-install.json"
+    original = json.dumps(
+        {
+            "session_id": "failed-install",
+            "messages": [_row(), _row()],
+            "context_messages": [],
+        }
+    )
+    sidecar.write_text(original, encoding="utf-8")
+    real_replace = compactor.os.replace
+
+    def _fail_source_install(source, destination):
+        if Path(destination) == sidecar:
+            raise OSError("injected source install failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(compactor.os, "replace", _fail_source_install)
+
+    with pytest.raises(OSError, match="injected source install failure"):
+        compactor.compact_sidecar(sidecar)
+
+    assert sidecar.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("*manifest*.json"))
+    assert not list(tmp_path.glob(".*.tmp.*"))
+
+
+def test_cli_rejects_dry_run_restore(tmp_path, monkeypatch):
+    from scripts import compact_session_replays as compactor
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["compact_session_replays.py", "--dry-run", "--restore", str(manifest)],
+    )
+    monkeypatch.setattr(
+        compactor,
+        "restore_manifest",
+        lambda _path: pytest.fail("--dry-run must not restore"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        compactor.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_state_divergence_ignores_current_hidden_manifests(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from api import config
+
+    current = tmp_path / "current"
+    current_sessions = current / "sessions"
+    current_sessions.mkdir(parents=True)
+    (current_sessions / "_replay-v10.manifest.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    sibling = tmp_path / "sibling"
+    sibling_sessions = sibling / "sessions"
+    sibling_sessions.mkdir(parents=True)
+    (sibling_sessions / "real-session.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(config, "STATE_DIR", current)
+    monkeypatch.setattr(config, "SESSION_DIR", current_sessions)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", current_sessions / "_index.json")
+
+    config._warn_state_dir_divergence("WARN")
+
+    assert str(sibling) in capsys.readouterr().out
+
+
+def test_state_divergence_ignores_sibling_hidden_manifests(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from api import config
+
+    current = tmp_path / "current"
+    current_sessions = current / "sessions"
+    current_sessions.mkdir(parents=True)
+    sibling = tmp_path / "sibling"
+    sibling_sessions = sibling / "sessions"
+    sibling_sessions.mkdir(parents=True)
+    (sibling_sessions / "_replay-v10.manifest.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "STATE_DIR", current)
+    monkeypatch.setattr(config, "SESSION_DIR", current_sessions)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", current_sessions / "_index.json")
+
+    config._warn_state_dir_divergence("WARN")
+
+    assert capsys.readouterr().out == ""

--- a/tests/test_pr7039_blocking_findings.py
+++ b/tests/test_pr7039_blocking_findings.py
@@ -1,0 +1,660 @@
+import json
+import multiprocessing
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _patch_store(monkeypatch, tmp_path):
+    from api import models, routes, streaming
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    with models.LOCK:
+        models.SESSIONS.clear()
+    return session_dir
+
+
+def _invoke_post(monkeypatch, routes, path, body):
+    captured = {}
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: dict(body))
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, extra_headers=None: (
+            captured.update(payload=payload, status=status) or True
+        ),
+    )
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, message, status=400, **_kwargs: (
+            captured.update(payload={"error": message}, status=status) or True
+        ),
+    )
+    assert routes.handle_post(object(), SimpleNamespace(path=path)) is True
+    return captured
+
+
+def _prepare_delete_route(monkeypatch, models, routes):
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda _sid: False)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+
+
+def _replay_rows():
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "id": "assistant-a",
+            "finish_reason": "stop",
+            "reasoning": "recoverable private transcript",
+            "timestamp": 123,
+        }
+        for _ in range(2)
+    ]
+
+
+def _seed_replay_artifacts(sidecar):
+    paths = [
+        sidecar.with_name(f"{sidecar.name}.replay-v10.deadbeef.bak"),
+        sidecar.with_name(
+            f"_replay-v10.{sidecar.name}.deadbeef.manifest.json"
+        ),
+        sidecar.with_name(f".{sidecar.name}.replay-v10.tmp.probe"),
+        sidecar.with_name(f".{sidecar.name}.replay-v10.restore.probe"),
+        sidecar.with_name(
+            f"._replay-v10.{sidecar.name}.deadbeef.manifest.json.tmp.probe"
+        ),
+    ]
+    for path in paths:
+        path.write_text("recoverable private transcript", encoding="utf-8")
+    return paths
+
+
+def _record_tombstone_process(session_dir, sid, peer_sid, result_queue):
+    from api import models
+
+    models.SESSION_DIR = Path(session_dir)
+    models.SESSION_INDEX_FILE = Path(session_dir) / "_index.json"
+    real_load = models._load_webui_deleted_session_tombstone
+
+    def load_then_wait_for_peer(**kwargs):
+        current = real_load(**kwargs)
+        marker_dir = Path(session_dir) / "tombstone-read-markers"
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / sid).write_text("read", encoding="utf-8")
+        deadline = time.monotonic() + 0.5
+        while not (marker_dir / peer_sid).exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        return current
+
+    models._load_webui_deleted_session_tombstone = load_then_wait_for_peer
+    try:
+        models._record_webui_deleted_session_tombstone(sid)
+    except Exception as exc:
+        result_queue.put((sid, type(exc).__name__, str(exc)))
+    else:
+        result_queue.put((sid, "ok", ""))
+
+
+def test_compactor_publish_cannot_resurrect_deleted_session(tmp_path, monkeypatch):
+    from api import models, routes
+    from scripts import compact_session_replays as compactor
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    _prepare_delete_route(monkeypatch, models, routes)
+    sid = "race-delete"
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": "Race",
+                "messages": _replay_rows(),
+                "context_messages": [],
+                "_sidecar_generation_v1": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    delete_started = threading.Event()
+    delete_done = threading.Event()
+    delete_result = {}
+    real_replace = compactor.os.replace
+    delete_thread = None
+
+    def delete_session():
+        delete_started.set()
+        delete_result.update(
+            _invoke_post(
+                monkeypatch,
+                routes,
+                "/api/session/delete",
+                {"session_id": sid},
+            )
+        )
+        delete_done.set()
+
+    def interleave_delete(source, destination):
+        nonlocal delete_thread
+        if (
+            Path(destination) == sidecar
+            and ".replay-v10.tmp." in Path(source).name
+            and delete_thread is None
+        ):
+            delete_thread = threading.Thread(target=delete_session)
+            delete_thread.start()
+            assert delete_started.wait(timeout=2)
+            # Deletion must remain blocked until compact_sidecar returns from
+            # this publication hook and eventually releases the SID authority.
+            assert not delete_done.wait(timeout=0.25)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(compactor.os, "replace", interleave_delete)
+    result = compactor.compact_sidecar(sidecar)
+    assert result["status"] == "compacted"
+    assert delete_thread is not None
+    delete_thread.join(timeout=5)
+    assert not delete_thread.is_alive()
+    assert delete_result["status"] == 200
+    assert delete_result["payload"]["ok"] is True
+    assert sid in models._load_webui_deleted_session_tombstone()
+    assert not sidecar.exists()
+    assert not list(session_dir.glob(f"*replay-v10*{sid}*"))
+
+
+def test_workspace_recovery_patch_releases_waiting_canonical_save_without_lost_turn(
+    tmp_path, monkeypatch
+):
+    from api import models
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "raw-writer"
+    session = models.Session(
+        session_id=sid,
+        title="Raw writer",
+        workspace=str(tmp_path / "before"),
+        messages=[{"role": "user", "content": "durable turn"}],
+    )
+    session.save(skip_index=True)
+    sidecar = session_dir / f"{sid}.json"
+    generation_before = json.loads(sidecar.read_text(encoding="utf-8"))[
+        "_sidecar_generation_v1"
+    ]
+    canonical = models.Session.load(sid)
+    assert canonical is not None
+    canonical.messages.append(
+        {"role": "assistant", "content": "new durable turn"}
+    )
+
+    real_replace = models._safe_replace
+    raw_ready = threading.Event()
+    release_raw = threading.Event()
+    raw_outcome = []
+    canonical_outcome = []
+
+    def gate_raw_replace(source, destination):
+        if (
+            threading.current_thread().name == "workspace-patch"
+            and Path(destination) == sidecar
+        ):
+            raw_ready.set()
+            assert release_raw.wait(timeout=5)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(models, "_safe_replace", gate_raw_replace)
+
+    def raw_writer():
+        try:
+            models.persist_recovered_workspace_binding(
+                session,
+                tmp_path / "after",
+                expected_workspace=str((tmp_path / "before").resolve()),
+            )
+        except Exception as exc:
+            raw_outcome.append(f"{type(exc).__name__}:{exc}")
+        else:
+            raw_outcome.append("saved")
+
+    def canonical_writer():
+        try:
+            canonical.save(skip_index=True)
+        except Exception as exc:
+            canonical_outcome.append(f"stale:{type(exc).__name__}:{exc}")
+        else:
+            canonical_outcome.append("saved")
+
+    raw_thread = threading.Thread(target=raw_writer, name="workspace-patch")
+    canonical_thread = threading.Thread(target=canonical_writer)
+    raw_thread.start()
+    assert raw_ready.wait(timeout=5)
+    canonical_thread.start()
+    canonical_thread.join(timeout=0.25)
+    assert canonical_thread.is_alive(), (
+        "canonical save must wait while the workspace patch owns sidecar authority"
+    )
+    release_raw.set()
+    raw_thread.join(timeout=5)
+    canonical_thread.join(timeout=5)
+    assert not raw_thread.is_alive()
+    assert not canonical_thread.is_alive()
+    assert raw_outcome == ["saved"]
+    assert canonical_outcome == ["saved"]
+
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    contents = [row.get("content") for row in payload.get("messages") or []]
+    generation_after = payload["_sidecar_generation_v1"]
+    assert generation_after >= generation_before + 2
+    assert "new durable turn" in contents
+    assert payload["workspace"] == str((tmp_path / "after").resolve())
+
+
+def test_cleanup_zero_message_removes_all_plaintext_recovery_artifacts(
+    tmp_path, monkeypatch
+):
+    from api import models, routes
+    from scripts import compact_session_replays as compactor
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "cleanup-leak"
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": "Leak",
+                "messages": _replay_rows(),
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    compacted = compactor.compact_sidecar(sidecar)
+    assert compacted["status"] == "compacted"
+    loaded = models.Session.load(sid)
+    assert loaded is not None
+    loaded.messages = []
+    loaded.save(skip_index=True)
+
+    captured = _invoke_post(
+        monkeypatch, routes, "/api/sessions/cleanup_zero_message", {}
+    )
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert not sidecar.exists()
+    assert not sidecar.with_suffix(".json.bak").exists()
+    assert not list(session_dir.glob(f"{sidecar.name}.bak.archive-*"))
+    assert not [path for path in session_dir.iterdir() if "replay-v10" in path.name]
+    assert sid in models._load_webui_deleted_session_tombstone()
+
+
+def test_delete_fails_closed_when_required_sidecar_unlink_fails(
+    tmp_path, monkeypatch
+):
+    from api import models, routes
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    _prepare_delete_route(monkeypatch, models, routes)
+    sid = "failed-unlink"
+    session = models.Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": "must remain fenced"}],
+    )
+    session.save(skip_index=True)
+    sidecar = session_dir / f"{sid}.json"
+    real_unlink = Path.unlink
+
+    def fail_sidecar_unlink(path, *args, **kwargs):
+        if Path(path) == sidecar:
+            raise PermissionError("injected unlink failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_sidecar_unlink)
+    captured = _invoke_post(
+        monkeypatch, routes, "/api/session/delete", {"session_id": sid}
+    )
+    assert captured["status"] == 500
+    assert sidecar.exists()
+    assert sid in models._load_webui_deleted_session_tombstone()
+
+
+def test_delete_fails_closed_when_tombstone_cannot_be_persisted(
+    tmp_path, monkeypatch
+):
+    from api import models, routes
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    _prepare_delete_route(monkeypatch, models, routes)
+    sid = "failed-tombstone"
+    session = models.Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": "must not be unlinked"}],
+    )
+    session.save(skip_index=True)
+    sidecar = session_dir / f"{sid}.json"
+
+    def fail_tombstone(_sid):
+        raise OSError("injected tombstone persistence failure")
+
+    monkeypatch.setattr(
+        models, "_record_webui_deleted_session_tombstone", fail_tombstone
+    )
+    captured = _invoke_post(
+        monkeypatch, routes, "/api/session/delete", {"session_id": sid}
+    )
+    assert captured["status"] == 500
+    assert sidecar.exists()
+
+
+@pytest.mark.parametrize("operation", ["record", "clear"])
+def test_deleted_tombstone_rmw_fails_closed_on_corrupt_fence(
+    tmp_path, monkeypatch, operation
+):
+    from api import models
+
+    _patch_store(monkeypatch, tmp_path)
+    existing_sid = "existing-deleted"
+    models._record_webui_deleted_session_tombstone(existing_sid)
+    tombstone = models._webui_deleted_session_tombstone_file()
+    corrupt_bytes = b'{"version": 1, "ids": ["existing-deleted"'
+    tombstone.write_bytes(corrupt_bytes)
+
+    with pytest.raises(json.JSONDecodeError):
+        if operation == "record":
+            models._record_webui_deleted_session_tombstone("new-deleted")
+        else:
+            models._clear_webui_deleted_session_tombstone(existing_sid)
+
+    assert tombstone.read_bytes() == corrupt_bytes
+
+
+def test_delete_route_fails_closed_without_unlinking_when_tombstone_is_corrupt(
+    tmp_path, monkeypatch
+):
+    from api import models, routes
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    _prepare_delete_route(monkeypatch, models, routes)
+    existing_sid = "existing-deleted-route"
+    target_sid = "target-delete-route"
+    models._record_webui_deleted_session_tombstone(existing_sid)
+    tombstone = models._webui_deleted_session_tombstone_file()
+    corrupt_bytes = b'{"version": 1, "ids": ["existing-deleted-route"'
+    tombstone.write_bytes(corrupt_bytes)
+
+    target = models.Session(
+        session_id=target_sid,
+        messages=[{"role": "user", "content": "must remain after refused delete"}],
+    )
+    target.save(skip_index=True)
+    sidecar = session_dir / f"{target_sid}.json"
+
+    captured = _invoke_post(
+        monkeypatch, routes, "/api/session/delete", {"session_id": target_sid}
+    )
+
+    assert captured["status"] == 500
+    assert sidecar.exists()
+    assert tombstone.read_bytes() == corrupt_bytes
+
+
+def test_new_tombstone_survives_capacity_trim(tmp_path, monkeypatch):
+    from api import models
+
+    _patch_store(monkeypatch, tmp_path)
+    cap = models.WEBUI_DELETED_SESSION_TOMBSTONE_CAP
+    for index in range(cap):
+        models._record_webui_deleted_session_tombstone(f"z{index:05d}")
+    target = "a-target-sid"
+    models._record_webui_deleted_session_tombstone(target)
+    loaded = models._load_webui_deleted_session_tombstone()
+    assert len(loaded) == cap
+    assert target in loaded
+
+
+def test_deleted_tombstone_rmw_is_cross_process_serialized(tmp_path, monkeypatch):
+    from api import models
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    context = multiprocessing.get_context("spawn" if os.name == "nt" else "fork")
+    result_queue = context.Queue()
+    sids = ("deleted-a", "deleted-b")
+    processes = [
+        context.Process(
+            target=_record_tombstone_process,
+            args=(session_dir, sid, sids[1 - index], result_queue),
+        )
+        for index, sid in enumerate(sids)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        results = [result_queue.get(timeout=10) for _ in processes]
+        for process in processes:
+            process.join(timeout=10)
+        assert all(not process.is_alive() for process in processes)
+        assert all(process.exitcode == 0 for process in processes)
+        assert {result[:2] for result in results} == {
+            ("deleted-a", "ok"),
+            ("deleted-b", "ok"),
+        }
+        assert models._load_webui_deleted_session_tombstone() == frozenset(sids)
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=2)
+
+
+def test_zero_message_cleanup_cannot_delete_a_concurrent_new_message(
+    tmp_path, monkeypatch
+):
+    from api import models, routes
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "cleanup-writer-race"
+    seed = models.Session(session_id=sid, title="Untitled", messages=[])
+    seed.save(skip_index=True)
+    sidecar = session_dir / f"{sid}.json"
+    writer = models.Session.load(sid)
+    assert writer is not None
+    writer.messages.append({"role": "user", "content": "must survive or go stale"})
+    writer_outcome = []
+    real_unlink = Path.unlink
+    started = threading.Event()
+    writer_threads = []
+
+    def writer_save():
+        try:
+            writer.save(skip_index=True)
+        except Exception as exc:
+            writer_outcome.append(f"stale:{type(exc).__name__}:{exc}")
+        else:
+            writer_outcome.append("saved")
+
+    def gate_cleanup_unlink(path, *args, **kwargs):
+        if (
+            threading.current_thread().name == "cleanup"
+            and Path(path) == sidecar
+            and not started.is_set()
+        ):
+            started.set()
+            thread = threading.Thread(target=writer_save)
+            thread.start()
+            thread.join(timeout=0.25)
+            writer_threads.append(thread)
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", gate_cleanup_unlink)
+    captured = {}
+
+    def cleanup():
+        captured.update(
+            _invoke_post(
+                monkeypatch,
+                routes,
+                "/api/sessions/cleanup_zero_message",
+                {},
+            )
+        )
+
+    cleanup_thread = threading.Thread(target=cleanup, name="cleanup")
+    cleanup_thread.start()
+    cleanup_thread.join(timeout=5)
+    assert not cleanup_thread.is_alive()
+    assert started.is_set()
+    assert len(writer_threads) == 1
+    writer_thread = writer_threads[0]
+    writer_thread.join(timeout=5)
+    assert not writer_thread.is_alive()
+    assert captured["status"] == 200
+    assert writer_outcome
+    if writer_outcome == ["saved"]:
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert payload["messages"][-1]["content"] == "must survive or go stale"
+    else:
+        assert writer_outcome[0].startswith("stale:")
+        assert not sidecar.exists()
+        assert sid in models._load_webui_deleted_session_tombstone()
+
+
+def test_direct_backup_restore_refuses_a_deleted_sid(tmp_path, monkeypatch):
+    from api import models, session_recovery
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "deleted-restore"
+    live_path = session_dir / f"{sid}.json"
+    live_payload = {
+        "session_id": sid,
+        "messages": [{"role": "user", "content": "live"}],
+        "_sidecar_generation_v1": 2,
+        "_sidecar_epoch_v1": "a" * 32,
+    }
+    backup_payload = {
+        "session_id": sid,
+        "messages": [
+            {"role": "user", "content": "live"},
+            {"role": "assistant", "content": "deleted backup"},
+        ],
+        "_sidecar_generation_v1": 1,
+        "_sidecar_epoch_v1": "a" * 32,
+    }
+    live_path.write_text(json.dumps(live_payload), encoding="utf-8")
+    live_path.with_suffix(".json.bak").write_text(
+        json.dumps(backup_payload), encoding="utf-8"
+    )
+    models._record_webui_deleted_session_tombstone(sid)
+
+    result = session_recovery.recover_session(live_path)
+    assert result["restored"] is False
+    assert result.get("deleted") is True
+    assert json.loads(live_path.read_text(encoding="utf-8")) == live_payload
+
+
+def test_state_db_materialization_rechecks_tombstone_before_publish(
+    tmp_path, monkeypatch
+):
+    from api import models, session_recovery
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "deleted-during-reconcile"
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, "
+            "model TEXT, started_at REAL, message_count INTEGER)"
+        )
+        connection.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, "
+            "role TEXT, content TEXT, timestamp REAL)"
+        )
+        connection.execute(
+            "INSERT INTO sessions VALUES (?, 'webui', 'deleted', 'model', 1, 1)",
+            (sid,),
+        )
+        connection.execute(
+            "INSERT INTO messages VALUES (1, ?, 'user', 'deleted', 1)",
+            (sid,),
+        )
+
+    real_read = session_recovery._read_state_db_missing_sidecar_rows
+
+    def rows_then_delete(*args, **kwargs):
+        rows = real_read(*args, **kwargs)
+        models._record_webui_deleted_session_tombstone(sid)
+        return rows
+
+    monkeypatch.setattr(
+        session_recovery, "_read_state_db_missing_sidecar_rows", rows_then_delete
+    )
+    result = session_recovery.recover_missing_sidecars_from_state_db(
+        session_dir, db_path
+    )
+    assert result["materialized"] == 0
+    assert not (session_dir / f"{sid}.json").exists()
+
+
+def test_hidden_ephemeral_cleanup_uses_complete_durable_delete_protocol(
+    tmp_path, monkeypatch
+):
+    from api import models, streaming
+
+    _patch_store(monkeypatch, tmp_path)
+    sid = "hidden-ephemeral"
+    session = models.Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": "private side question"}],
+    )
+    session.active_stream_id = "ephemeral-stream"
+    session.pending_user_message = "private side question"
+    session.save(skip_index=True)
+    replay_artifacts = _seed_replay_artifacts(session.path)
+    backup = session.path.with_suffix(".json.bak")
+    backup.write_text("recoverable private transcript", encoding="utf-8")
+
+    streaming._cleanup_ephemeral_cancelled_turn(session)
+
+    assert not session.path.exists()
+    assert not backup.exists()
+    assert all(not path.exists() for path in replay_artifacts)
+    assert sid in models._load_webui_deleted_session_tombstone()
+
+
+def test_compactor_restore_refuses_tombstoned_sid(tmp_path, monkeypatch):
+    from api import models
+    from scripts import compact_session_replays as compactor
+
+    session_dir = _patch_store(monkeypatch, tmp_path)
+    sid = "tombstoned-rollback"
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "messages": _replay_rows(),
+                "context_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    compacted = compactor.compact_sidecar(sidecar)
+    models._record_webui_deleted_session_tombstone(sid)
+
+    with pytest.raises(compactor.StreamJSONError, match="deleted|tombstone"):
+        compactor.restore_manifest(Path(compacted["manifest"]))

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -354,7 +354,13 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+2400]
+            clear_idx = max(
+                text.find("if parsed.path == '/api/session/clear':", delete_idx),
+                text.find('if parsed.path == "/api/session/clear":', delete_idx),
+            )
+            delete_block = text[
+                delete_idx:clear_idx if clear_idx >= 0 else delete_idx + 6000
+            ]
             assert "prune_session_from_index(sid)" in delete_block, \
                 f"{label} session/delete must prune SESSION_INDEX_FILE"
             return
@@ -369,9 +375,15 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+2400]
-    assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
-        "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
+    clear_idx = max(
+        routes_src.find("if parsed.path == '/api/session/clear':", delete_idx),
+        routes_src.find('if parsed.path == "/api/session/clear":', delete_idx),
+    )
+    delete_block = routes_src[
+        delete_idx:clear_idx if clear_idx >= 0 else delete_idx + 6000
+    ]
+    assert "_delete_session_sidecar_artifacts_locked(" in delete_block, \
+        "session/delete must remove the complete sidecar family, including <sid>.json.bak"
 
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
 

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -1407,7 +1407,7 @@ def test_concurrent_saves_dont_lose_data():
     sB = _make_session("sess_b", "Bravo", updated_at=200.0)
 
     for s in (sA, sB):
-        s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+        s.save(touch_updated_at=False, skip_index=True)
 
     # Build initial index
     _write_session_index(updates=None)

--- a/tests/test_session_public_share.py
+++ b/tests/test_session_public_share.py
@@ -117,6 +117,36 @@ def test_share_revoke_makes_link_unavailable():
         post("/api/session/delete", {"session_id": sid})
 
 
+def test_session_delete_removes_offline_replay_plaintext_artifacts():
+    from api.models import SESSION_DIR
+
+    sid = _make_session_with_messages()
+    sidecar = SESSION_DIR / f"{sid}.json"
+    artifacts = [
+        sidecar.with_name(f"{sidecar.name}.replay-v10.abcdef0123456789.bak"),
+        sidecar.with_name(
+            f"_replay-v10.{sidecar.name}.abcdef0123456789.manifest.json"
+        ),
+        sidecar.with_name(f".{sidecar.name}.replay-v10.tmp.123"),
+        sidecar.with_name(f".{sidecar.name}.replay-v10.restore.123"),
+        sidecar.with_name(
+            f"._replay-v10.{sidecar.name}.abcdef0123456789.manifest.json.tmp.123"
+        ),
+    ]
+    try:
+        for artifact in artifacts:
+            artifact.write_text("plaintext transcript", encoding="utf-8")
+
+        payload, status = post("/api/session/delete", {"session_id": sid})
+
+        assert status == 200, payload
+        assert not any(artifact.exists() for artifact in artifacts)
+    finally:
+        for artifact in artifacts:
+            artifact.unlink(missing_ok=True)
+        post("/api/session/delete", {"session_id": sid})
+
+
 def test_share_revoke_endpoint_hides_share_token_from_session():
     sid = _make_session_with_messages()
     try:


### PR DESCRIPTION
## Thinking Path

The runtime must not parse and copy replay-bloated sidecars inside an HTTP request, but an offline repair is safe only if it stays bounded in memory, coordinates with normal saves, preserves an exact rollback path, and fails closed on malformed or concurrently changed input. Review of the first implementation found three additional recovery hazards: large index rebuilds trusted a 64 KiB key-order prefix, the streaming validator accepted non-RFC JSON whitespace, and source publication was not durably ordered after the manifest rename.

## What Changed

- above 128 MiB, defer inline repair only when an allocation-free scan finds an actual adjacent partial replay; valid large sessions remain writable;
- compact only top-level `messages` and `context_messages` in separate analysis/write passes;
- track exact replay keys in temporary SQLite with a bounded 4 MiB page cache instead of RAM-growing Python sets;
- serialize normal `Session.save()` and offline compact/restore publication through the same per-SID lock while advancing `_sidecar_generation_v1` monotonically;
- serialize save, workspace recovery, compaction, restore, delete, and cleanup through the common SID authority; bind publication to generation + lifetime epoch, retain durable delete tombstones, and make both tombstone record/clear RMW fail closed when the fence is unreadable;
- preserve a recoverable backup when `/clear` is a no-op on an already-empty live session, while retiring pre-clear artifacts after a real truncate; restore malformed live JSON only through a tagged raw-digest CAS that is revalidated before publication;
- stream fixed index metadata regardless of top-level key order, skip large transcript/scene bodies, count `messages` when no persisted count exists, and reject a missing/invalid `session_id` instead of generating a phantom row;
- validate RFC 8259's exact whitespace set and reject non-standard constants or malformed copied JSON before any backup, manifest, or source publication;
- fsync the manifest directory entry before installing the compacted source, then fsync the source rename; remove and fsync an unpublished manifest after a non-crash source-install failure;
- preserve source mode on output, backup, manifest, and restore files; create manifest temporaries exclusively with the final private mode before writing content;
- exclude hidden maintenance manifests from session/index and startup-divergence discovery;
- reject `--dry-run --restore` rather than performing a destructive restore;
- provide fail-closed restore that refuses rollback after later sidecar changes.

## Why It Matters

Very large replay-bloated sessions can now be repaired without request-path memory spikes, silent concurrent-write loss, omitted/phantom sidebar rows, malformed JSON republication, or a crash window where the compacted source is durable but its rollback manifest is not.

## Operator Contract

Always stop or drain every WebUI process before running this strictly offline tool. The WebUI lifecycle paths hardened by this PR now share the SID authority, generation/epoch checks, and durable deletion fence; older runtimes and direct non-WebUI writers may not participate. The command is POSIX/WSL-only; use WSL rather than native Python on Windows.

```bash
python scripts/compact_session_replays.py --dry-run ~/.hermes/webui/sessions/<session-id>.json
python scripts/compact_session_replays.py ~/.hermes/webui/sessions/<session-id>.json
python scripts/compact_session_replays.py --restore <manifest-path>
```

RAM is bounded, but the temporary SQLite index needs scratch-disk headroom proportional to unique replay identities. One decoded JSON row is capped at 64 MiB. Strict stale-alias CAS after the maintenance lock is released remains the separate #7036 scope.

## Contract Routing

State layers: session sidecar JSON, sidebar `_index.json`, per-SID maintenance lock, durable generation, content-addressed backup, and hidden rollback manifest.

Relevant public docs:
- `AGENTS.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`
- `ARCHITECTURE.md`

## Scope

The cumulative reliability branch changes 15 files across the offline compactor, sidecar/recovery lifecycle, bounded metadata scanner, shared SID authority, and regression coverage. It remains one logical durability boundary: compact, restore, save, recover, delete, cleanup, index, and State DB materialization must agree on the same session lifetime.

This PR supersedes the offline-compaction portion of #6600. Please keep #6600 open as design/review history until the narrower replacements land.

## Verification

- `266 passed` — every test file modified against `origin/master`, on exact head `f6b67279`, with the Hermes Agent runtime provided and zero skips;
- `156 passed` — historical recovery/sidecar regression portfolio, zero skips;
- `9/9 PASS` — exact-SHA adversarial probes for authority ordering, delete/cleanup fail-closed behavior, epoch ABA, materializers, full-payload backup/restore, partial signatures, complete private cleanup, and bounded scanning;
- predecessor `d04170d4` failed nine GitHub matrix jobs across all three Python versions, reproducing four historical contracts: no-op clear backup preservation, malformed-live recovery, canonical ephemeral cleanup, and complete delete artifact cleanup; all four are GREEN locally on `f6b67279`, including a new mutation-between-CAS-reads rejection probe;
- exact archive SHA-256 `4e1691c0d15780e37b6a60a35468496a93cedfe5312354540c302051c3e6a070` remained stable before/after execution; Ruff diff-scoped, `py_compile`, `compileall`, and `git diff --check` pass;
- GitHub CI and independent exact-SHA review are running on `f6b67279` and are not claimed complete here.

## Risks / Follow-ups

- The compactor remains operationally offline because older runtimes and non-WebUI writers may not share this branch's authority protocol.
- Temporary-disk use grows with unique replay identities even though RAM remains bounded.
- Native Windows execution is unsupported; use WSL.
- Merge remains blocked until exact-head CI and independent review both pass.

## Model Used

OpenAI Codex / `gpt-5.6-sol`, with Hermes read-only delegated adversarial reviews and local deterministic probes.

## Related

- #6600
- #7036
