### PR TITLE
fix(docker): source-built SQLite must load on arm64 (ld.so.conf.d) — follow-up to #6900

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,7 @@ RUN apt-get update -y --fix-missing --no-install-recommends \
 # https://sqlite.org/wal.html#walresetbug
 #
 # Debian has not backported the fix, so we compile from the amalgamation.
-# Installs to /usr/local/lib, which is registered in ld.so.conf.d and given
-# priority via ldconfig so Python's sqlite3 loads it ahead of the base image's
-# /usr/lib multiarch copy (the default ld.so path does NOT include
-# /usr/local/lib on Debian arm64, so the explicit conf entry is required).
+# Installs to /usr/local/lib (registered in ld.so.conf.d for arm64 priority).
 # Build tools are purged after compilation to keep the image lean.
 # Build args are for forward version bumps only (3.54+, etc.).
 # When bumping SQLITE_VERSION, recompute the SHA-256 from the official

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN apt-get update -y --fix-missing --no-install-recommends \
 # https://sqlite.org/wal.html#walresetbug
 #
 # Debian has not backported the fix, so we compile from the amalgamation.
-# Installs to /usr/local/lib (takes ldconfig priority over /usr/lib).
+# Installs to /usr/local/lib, which is registered in ld.so.conf.d and given
+# priority via ldconfig so Python's sqlite3 loads it ahead of the base image's
+# /usr/lib multiarch copy (the default ld.so path does NOT include
+# /usr/local/lib on Debian arm64, so the explicit conf entry is required).
 # Build tools are purged after compilation to keep the image lean.
 # Build args are for forward version bumps only (3.54+, etc.).
 # When bumping SQLITE_VERSION, recompute the SHA-256 from the official
@@ -56,6 +59,7 @@ RUN apt-get update \
        --enable-fts5 --enable-fts4 --enable-rtree \
     && make -j"$(nproc)" \
     && make install \
+    && echo "/usr/local/lib" > /etc/ld.so.conf.d/000-usr-local-lib.conf \
     && /sbin/ldconfig \
     && cd / && rm -rf /tmp/sqlite* \
     && apt-get purge -y gcc make libc6-dev \


### PR DESCRIPTION
## The problem
#6900 (exp-v0.52.227) compiles SQLite 3.53.0 from source. The amd64 `docker-smoke` passed, but the **multi-arch Release build failed on `linux/arm64`**:
```
AssertionError: SQLite 3.46.1 still vulnerable
```
Python's `sqlite3` kept loading the base image's `/usr/lib` multiarch `libsqlite3` (3.46.1) instead of the freshly-compiled `/usr/local/lib` copy (3.53.0), because **`/usr/local/lib` is not in the default `ld.so` search path on Debian arm64** (it happened to be found on amd64). So the release image failed to build/push — no broken image shipped (the PR's own build-time version assertion correctly fails-closed), but exp-v0.52.227 has no Docker image.

## The fix
Register `/usr/local/lib` in `/etc/ld.so.conf.d/` before `ldconfig`, so the source-built SQLite wins on every architecture. The PR's build-time `>= 3.51.3` + `PRAGMA secure_delete == 1` assertions verify correctness once the arm64 build runs.

## Verification
amd64 docker-smoke runs on this PR. The multi-arch (amd64+arm64) build only runs on a release tag — so the authoritative verification is watching the Release & Docker workflow on the follow-up tag (exp-v0.52.228).