### PR TITLE
fix(sessions): keep evicted subagent parents in the import window

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -517,6 +517,19 @@ def read_importable_agent_session_rows(
     ``exclude_sources=None``. ``include_sources`` is an additional narrowing
     filter; callers that want an include-only query should explicitly pass
     ``exclude_sources=None`` so the default exclusions do not also apply.
+
+    ``limit`` bounds the *recency slice*, not the returned row count. Subagent
+    rows only render as children when their parent row is in the same payload,
+    so subagent ancestors of selected rows are re-added afterwards and the
+    result can exceed ``limit`` by the number of such anchors. Callers must
+    therefore iterate the result rather than assume ``len(rows) <= limit``.
+
+    That recovery is deliberately bounded by the oversampled candidate set
+    (``limit * 8`` newest sessions): it re-uses rows the projection already
+    fetched and never issues an extra query, so an ancestor older than the
+    oversample stays unresolved and its children render top-level, exactly as
+    they did before. Widening that window is a ``candidate_limit`` change, not
+    a change to this walk.
     """
     db_path = Path(db_path)
     if not db_path.exists():
@@ -776,6 +789,14 @@ def read_importable_agent_session_rows(
         # promoted to top-level sidebar rows. Re-add subagent parents that the
         # oversampled candidate set already projected (no extra query); webui
         # ancestors are left out because that sidebar bucket already has them.
+        #
+        # Bounded by construction: ``by_id`` only holds the ``limit * 8``
+        # newest candidates, so an ancestor older than that oversample is not
+        # recovered and its children stay top-level — the pre-existing
+        # behaviour, narrowed rather than fixed. Resolving those would need an
+        # unbounded per-row ancestor query on the hot sidebar path; widen
+        # ``candidate_limit`` instead if the window proves too tight.
+        # NOTE: this can return more than ``limit`` rows (see docstring).
         have = {row.get('id') for row in selected}
         by_id = {row.get('id'): row for row in projected if row.get('id')}
         pending = list(selected)

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -766,7 +766,35 @@ def read_importable_agent_session_rows(
         projected = [row for row in projected if is_cli_session_row_visible(row)]
         if limit is None:
             return projected
-        return projected[:max(0, int(limit))]
+        selected = projected[:max(0, int(limit))]
+
+        # The recency slice is per-row, but subagent rows are only renderable as
+        # children: the sidebar nests a child under its parent solely when that
+        # parent row is present in the same payload. A frozen orchestrator stops
+        # writing while its leaves keep streaming, so the leaves win the recency
+        # race and the parent falls outside the window — leaving the leaves to be
+        # promoted to top-level sidebar rows. Re-add subagent parents that the
+        # oversampled candidate set already projected (no extra query); webui
+        # ancestors are left out because that sidebar bucket already has them.
+        have = {row.get('id') for row in selected}
+        by_id = {row.get('id'): row for row in projected if row.get('id')}
+        pending = list(selected)
+        while pending:
+            row = pending.pop()
+            if str(row.get('raw_source') or row.get('source') or '').strip().lower() != 'subagent':
+                continue
+            parent_id = row.get('parent_session_id')
+            if not parent_id or parent_id in have:
+                continue
+            parent = by_id.get(parent_id)
+            if parent is None:
+                continue
+            if str(parent.get('raw_source') or parent.get('source') or '').strip().lower() != 'subagent':
+                continue
+            selected.append(parent)
+            have.add(parent_id)
+            pending.append(parent)
+        return selected
 
 
 

--- a/tests/test_subagent_parent_in_import_window.py
+++ b/tests/test_subagent_parent_in_import_window.py
@@ -80,3 +80,68 @@ def test_webui_parent_is_not_force_imported(tmp_path):
     # The webui sidebar bucket already owns its own rows; don't duplicate them.
     assert "orch" not in {r["id"] for r in rows}
     assert {f"leaf{i}" for i in range(3)} <= {r["id"] for r in rows}
+
+
+def test_recovered_parent_is_returned_beyond_limit(tmp_path):
+    """`limit` bounds the recency slice, not the row count (documented contract)."""
+    db = tmp_path / "state.db"
+    _lineage_db(db)
+
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+
+    # 3 sliced leaves + 1 re-added anchor: callers must iterate, not assume <= limit.
+    assert len(rows) == 4
+    assert {r["id"] for r in rows} == {"leaf0", "leaf1", "leaf2", "orch"}
+
+
+def _window_db(path, filler):
+    """Quiet parent, `filler` newer unrelated rows, one hot child of that parent."""
+    sessions: list[tuple[str, str, str, str | None]] = [("orch", "Orchestrator", "subagent", None)]
+    messages = [("orch", "user", 100.0), ("orch", "assistant", 100.5)]
+    for i in range(filler):
+        sessions.append((f"fill{i}", f"Filler {i}", "subagent", None))
+        messages += [(f"fill{i}", "user", 200.0 + i), (f"fill{i}", "assistant", 200.5 + i)]
+    sessions.append(("leaf", "Leaf", "subagent", "orch"))
+    messages += [("leaf", "user", 9000.0), ("leaf", "assistant", 9001.0)]
+    _make_db(path, sessions, messages)
+
+
+def test_parent_inside_candidate_oversample_is_recovered(tmp_path):
+    """The oversample is limit * 8, so a parent ranked within it is still restored."""
+    db = tmp_path / "state.db"
+    _window_db(db, filler=22)  # orch is candidate #24 of 24
+
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+
+    assert "orch" in {r["id"] for r in rows}
+
+
+def test_parent_beyond_candidate_oversample_stays_unresolved(tmp_path):
+    """Documented bound: recovery reuses the limit * 8 candidate set, never a new query.
+
+    A parent ranked below that oversample is not fetched, so its child renders
+    top-level — the pre-existing behaviour. This pins the boundary so widening
+    it becomes a deliberate `candidate_limit` change, not an accidental one.
+    """
+    db = tmp_path / "state.db"
+    _window_db(db, filler=23)  # orch is pushed to candidate #25 of 24
+
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+    ids = {r["id"] for r in rows}
+
+    assert "leaf" in ids
+    assert "orch" not in ids
+
+
+def test_parent_cycle_does_not_hang(tmp_path):
+    """A corrupt self/mutual parent link must not spin the ancestor walk."""
+    db = tmp_path / "state.db"
+    _make_db(
+        db,
+        [("a", "A", "subagent", "b"), ("b", "B", "subagent", "a")],
+        [("a", "user", 900.0), ("a", "assistant", 901.0), ("b", "user", 100.0), ("b", "assistant", 101.0)],
+    )
+
+    rows = read_importable_agent_session_rows(db, limit=1, exclude_sources=None)
+
+    assert {r["id"] for r in rows} == {"a", "b"}

--- a/tests/test_subagent_parent_in_import_window.py
+++ b/tests/test_subagent_parent_in_import_window.py
@@ -1,0 +1,82 @@
+"""Regression tests: a recency-sliced subagent leaf must keep its parent row.
+
+`read_importable_agent_session_rows()` applied the visible-window limit as a
+flat per-row recency slice. Subagent rows only render as children when their
+parent row is in the same payload, so a frozen orchestrator (no longer writing)
+lost the recency race against its own still-streaming leaves and fell out of the
+window — promoting the leaves to top-level sidebar rows. The projection now
+re-adds subagent parents that the oversampled candidate set already projected.
+"""
+import sqlite3
+
+from api.agent_sessions import read_importable_agent_session_rows
+
+
+def _make_db(path, sessions, messages):
+    """sessions: (id, title, source, parent_session_id); messages: (session_id, role, ts)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, model TEXT, "
+        "message_count INTEGER, started_at REAL, source TEXT, parent_session_id TEXT)"
+    )
+    conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, timestamp REAL)")
+    for sid, title, source, parent in sessions:
+        conn.execute(
+            "INSERT INTO sessions (id, title, model, message_count, started_at, source, parent_session_id) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (sid, title, "gpt", 2, 1000.0, source, parent),
+        )
+    for sid, role, ts in messages:
+        conn.execute("INSERT INTO messages (session_id, role, timestamp) VALUES (?,?,?)", (sid, role, ts))
+    conn.commit()
+    conn.close()
+
+
+def _lineage_db(path, parent_source="subagent"):
+    """One quiet orchestrator + 3 hot leaves + an unrelated hot subagent row."""
+    sessions: list[tuple[str, str, str, str | None]] = [
+        ("orch", "Orchestrator", parent_source, None),
+        ("loner", "Unrelated", "subagent", None),
+    ]
+    messages = [("orch", "user", 100.0), ("orch", "assistant", 101.0)]  # went quiet early
+    for i in range(3):
+        sessions.append((f"leaf{i}", f"Leaf {i}", "subagent", "orch"))
+        messages += [(f"leaf{i}", "user", 900.0 + i), (f"leaf{i}", "assistant", 901.0 + i)]
+    messages += [("loner", "user", 800.0), ("loner", "assistant", 801.0)]
+    _make_db(path, sessions, messages)
+
+
+def test_evicted_subagent_parent_is_kept_in_window(tmp_path):
+    db = tmp_path / "state.db"
+    _lineage_db(db)
+
+    # limit=3 is exactly the three hot leaves; the quiet parent is sliced off.
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+    by_id = {r["id"]: r for r in rows}
+
+    assert "orch" in by_id, "quiet subagent parent must survive the recency slice"
+    for i in range(3):
+        leaf = by_id[f"leaf{i}"]
+        assert leaf["parent_session_id"] == "orch"
+        assert leaf["relationship_type"] == "child_session"
+
+
+def test_unrelated_older_subagent_row_stays_excluded(tmp_path):
+    db = tmp_path / "state.db"
+    _lineage_db(db)
+
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+
+    # Only ancestors are rescued — an unrelated quieter subagent row stays out.
+    assert "loner" not in {r["id"] for r in rows}
+
+
+def test_webui_parent_is_not_force_imported(tmp_path):
+    db = tmp_path / "state.db"
+    _lineage_db(db, parent_source="webui")
+
+    rows = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+
+    # The webui sidebar bucket already owns its own rows; don't duplicate them.
+    assert "orch" not in {r["id"] for r in rows}
+    assert {f"leaf{i}" for i in range(3)} <= {r["id"] for r in rows}


### PR DESCRIPTION
Replaces #7031 with a much smaller fix.

## Problem

Some Subagent Sessions render as top-level left-toolbar rows instead of children.

Lineage in `state.db` is correct. The issue is the import window: `read_importable_agent_session_rows()` applied the visible limit as a flat per-row recency slice (`projected[:limit]`). A subagent row is only renderable as a child when its parent row is in the same payload — the client's `_attachChildSessionsToSidebarRows` promotes a child to top level when the parent is missing.

An orchestrator parent is frozen while its children run, so it stops writing. Its still-streaming leaves win the recency race and the parent gets sliced out of the window, orphaning the leaves.

(#5305 doesn't cover this: it only suppresses when `_cross_surface_child_session`, which is set when `parent.source != child.source`. That marks `webui→subagent` but not `subagent→subagent`.)

## Fix

29 lines in `read_importable_agent_session_rows()`. After the recency slice, re-add subagent parents that are **already in `projected`** — the candidate query oversamples `limit * 8`, so these rows are in memory already.

- No extra SQL, no new helper module, no client changes.
- `CLI_VISIBLE_SESSION_LIMIT` stays 20.
- webui ancestors are deliberately **not** imported — that sidebar bucket already owns them.
- Terminates via the `have` set (cycle-safe), and only walks subagent→subagent edges.

Children are shown **as children**, not hidden.

## Why not #7031

#7031 (~304 production lines: extra SQL hops, re-projection with candidate rows, cycle/filter/hop-cap helpers) was correct but far more machinery than this bug needs. Closed in favour of this.

## Tests

`tests/test_subagent_parent_in_import_window.py` (82 lines), black-box through `read_importable_agent_session_rows`:

1. quiet subagent parent survives the slice; leaves keep `parent_session_id` + `relationship_type=child_session`
2. an unrelated older subagent row stays excluded (only ancestors are rescued)
3. a webui parent is not force-imported

Verified the first test fails without the production change (parent absent, leaves orphaned) and passes with it.

Supersedes #7031.