### PR TITLE
fix(#7050): report merged display count in metadata for foreign sessions

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -12909,6 +12909,17 @@ def handle_get(handler, parsed) -> bool:
                     _foreign_backstop = _state_db_backstop_limit_for_display(_foreign_full, None)
                     if _foreign_backstop is not None:
                         _foreign_state_kwargs["limit"] = _foreign_backstop
+                    # The limited-load path may also apply a sidecar-derived
+                    # since_timestamp floor (_state_db_since_timestamp_for_limited_display),
+                    # but that floor only fires when the sidecar and state.db
+                    # share an IDENTICAL prefix (counts AND visible keys must
+                    # match, otherwise it bails to the full read). Under that
+                    # guard the filtered state.db rows are all present in the
+                    # sidecar, so the append-only merge dedupes them and the
+                    # filtered result equals this full merge; and a metadata
+                    # poll carries no msg_limit from which to derive a floor
+                    # anyway. The unbounded read here therefore yields the
+                    # same display count as every load mode.
                     _foreign_state_messages = get_state_db_session_messages(
                         sid, **_foreign_state_kwargs
                     )

--- a/api/routes.py
+++ b/api/routes.py
@@ -12890,7 +12890,33 @@ def handle_get(handler, parsed) -> bool:
                 # state.db rows do not make sidebar polling think the
                 # transcript is always newer. Helper threads profile= to
                 # honor #2827's TLS-vs-thread fix.
-                metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
+                if cli_meta and not _session_source_is_webui(cli_meta):
+                    # Foreign (CLI/TUI/Claude Code) sessions: report the same
+                    # MERGED display count as the messages=1 branch. The cheap
+                    # COUNT(*) summary counts raw state.db rows (tool rows that
+                    # the display merge folds into assistant messages), so the
+                    # frontend's external-refresh poll would otherwise compare
+                    # 2543 vs 696 and force-reload the full transcript every
+                    # 30s (#7050). A metadata-only stub carries no messages, so
+                    # the sidecar transcript must be loaded in full to feed the
+                    # same merge pipeline the load branch uses.
+                    from api.models import Session as _Session
+                    _foreign_full = _Session.load(sid) if not getattr(s, "messages", None) else s
+                    _foreign_state_messages = get_state_db_session_messages(
+                        sid, profile=_session_profile
+                    )
+                    _metadata_display_msgs = merge_session_messages_append_only(
+                        _webui_sidecar_lineage_messages_for_display(_foreign_full),
+                        _foreign_state_messages,
+                        truncation_watermark=getattr(_foreign_full, "truncation_watermark", None),
+                        truncation_boundary=getattr(_foreign_full, "truncation_boundary", None),
+                    )
+                    _metadata_display_msgs = _merged_webui_lineage_messages_for_display(
+                        _foreign_full, _metadata_display_msgs
+                    )
+                    metadata_summary = _message_summary(_metadata_display_msgs)
+                else:
+                    metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
             _t2 = _time.monotonic()
             if _diag: _diag.stage("t2_after_state_db_load")
             effective_model = (

--- a/api/routes.py
+++ b/api/routes.py
@@ -12902,8 +12902,15 @@ def handle_get(handler, parsed) -> bool:
                     # same merge pipeline the load branch uses.
                     from api.models import Session as _Session
                     _foreign_full = _Session.load(sid) if not getattr(s, "messages", None) else s
+                    # Mirror the load branch's defensive row backstop so a
+                    # pathological >50k-row state.db is read with the same
+                    # boundaries on both response modes (Greptile review).
+                    _foreign_state_kwargs = {"profile": _session_profile}
+                    _foreign_backstop = _state_db_backstop_limit_for_display(_foreign_full, None)
+                    if _foreign_backstop is not None:
+                        _foreign_state_kwargs["limit"] = _foreign_backstop
                     _foreign_state_messages = get_state_db_session_messages(
-                        sid, profile=_session_profile
+                        sid, **_foreign_state_kwargs
                     )
                     _metadata_display_msgs = merge_session_messages_append_only(
                         _webui_sidecar_lineage_messages_for_display(_foreign_full),

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3815,6 +3815,10 @@ async function _loadOlderMessages() {
     _messagesTruncated = !!responseSession._messages_truncated;
     _oldestIdx = responseSession._messages_offset || 0;
     renderMessages({ preserveScroll: true });
+    // The titlebar message count reflects S.messages, which just grew by
+    // the older page — keep the badge in sync (it only updates on session
+    // switch / UI-state changes otherwise).
+    if (typeof syncAppTitlebar === 'function') syncAppTitlebar();
     if (container) {
       // Prepending older messages must not teleport the reader. Anchor to the
       // first visible rendered row and restore that row's top offset after the
@@ -3906,6 +3910,8 @@ async function _ensureAllMessagesLoaded() {
     if (S.session && S.session.session_id === sid) {
       S.session.message_count = Number(data.session.message_count || msgs.length);
     }
+    // Keep the titlebar badge in sync after the wholesale replace.
+    if (typeof syncAppTitlebar === 'function') syncAppTitlebar();
   } finally {
     _loadingOlder = false;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -560,6 +560,12 @@ let _messageVirtualMeasurementRetryCount=0;
 let _messageVirtualScrollActive=false;
 let _messageVirtualScrollSettleTimer=0;
 let _messageVirtualDeferredMeasurement=null;
+// #6799-family: while the user is actively scrolling, keep the virtualized
+// total height frozen (absorb measured-vs-estimated deltas into the bottom
+// spacer) so the scrollbar/scrollHeight stays stable and the viewport never
+// jumps mid-scroll. Reset on settle (150ms after the last scroll event) and
+// re-calibrate once to the true height. 0 = not frozen.
+let _messageVirtualFrozenTotalHeight=0;
 let _msgNodeRecycleEnabled=false;
 const _recycleStash=new Map();
 const _recycleResetAttrs=[
@@ -575,16 +581,29 @@ const _recycleResetAttrs=[
 ];
 let _scrollbarDragActive=false;
 function _markMessageVirtualScrollActive(){
+  const wasActive=_messageVirtualScrollActive;
   _messageVirtualScrollActive=true;
+  if(!wasActive){
+    // Scrolling just started: freeze the current total height so every
+    // measured-vs-estimated delta during the scroll is absorbed instead of
+    // lurching the scrollbar/viewport (see _enforceMessageVirtualFrozenHeight).
+    const container=$('messages');
+    _messageVirtualFrozenTotalHeight=container?container.scrollHeight:0;
+  }
   clearTimeout(_messageVirtualScrollSettleTimer);
   _messageVirtualScrollSettleTimer=setTimeout(()=>{
     _messageVirtualScrollActive=false;
+    // Unfreeze and re-calibrate once to the true height now that the user
+    // stopped scrolling (the frozen height may lag the real measured height).
+    _messageVirtualFrozenTotalHeight=0;
     if(_messageVirtualDeferredMeasurement){
       const deferred=_messageVirtualDeferredMeasurement;
       _messageVirtualDeferredMeasurement=null;
       _scheduleMessageVirtualMeasurementRefresh(deferred);
+    }else if(typeof _scheduleMessageVirtualizedRender==='function'){
+      _scheduleMessageVirtualizedRender(true);
     }
-  },150);
+  },400);
 }
 // Cached visWithIdx array — invalidated when S.messages.length changes.
 let _visWithIdxCache=null;
@@ -608,6 +627,7 @@ function _clearMessageVirtualHeightCache(){
   clearTimeout(_messageVirtualScrollSettleTimer);
   _messageVirtualScrollSettleTimer=0;
   _messageVirtualDeferredMeasurement=null;
+  _messageVirtualFrozenTotalHeight=0;
   if(typeof _clearUserRowIntrinsicHeightCache==='function') _clearUserRowIntrinsicHeightCache();
 }
 function _resetMessageRenderWindow(sid){
@@ -1260,6 +1280,23 @@ function _compensateScrollForMeasurementDelta(renderFn){
   _lastScrollTop=container.scrollTop;
   _deferClearProgrammaticScroll();
 }
+// While the user is actively scrolling a virtualized transcript, keep the
+// total height frozen at the value captured when scrolling started. The
+// window re-render swaps estimated-height spacers for measured rows, which
+// would otherwise change scrollHeight every frame and make the scrollbar /
+// viewport lurch (the #6799-family churn). Absorb the measured-vs-estimated
+// delta into the bottom spacer; on settle (_markMessageVirtualScrollActive's
+// timer) the height is unfrozen and re-calibrated once.
+function _enforceMessageVirtualFrozenHeight(container){
+  if(!container||!_messageVirtualScrollActive||_messageVirtualFrozenTotalHeight<=0) return;
+  const current=container.scrollHeight;
+  const delta=_messageVirtualFrozenTotalHeight-current;
+  if(Math.abs(delta)<0.5) return;
+  const spacer=container.querySelector('[data-virtual-spacer="after"]');
+  if(!spacer) return;
+  const h=Math.max(0,(parseFloat(spacer.style.height||'0')||0)+delta);
+  spacer.style.height=Math.round(h)+'px';
+}
 function _messageViewportIntersectsRenderedRow(){
   const container=$('messages');
   if(!container) return true;
@@ -1483,6 +1520,7 @@ function _scheduleMessageVirtualizedRender(force){
       _programmaticScroll=true;
       _programmaticScrollSetAt=performance.now();
       _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); });
+      _enforceMessageVirtualFrozenHeight(container);
       _deferClearProgrammaticScroll();
       _messageVirtualWindowKey=liveKey;
       return;
@@ -1490,6 +1528,7 @@ function _scheduleMessageVirtualizedRender(force){
     _msgNodeRecycleEnabled=true;
     try{
       _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); });
+      _enforceMessageVirtualFrozenHeight(container);
     }
     finally{ _msgNodeRecycleEnabled=false; }
   });

--- a/static/ui.js
+++ b/static/ui.js
@@ -6261,12 +6261,18 @@ if(typeof window!=='undefined'){
   },{capture:true,passive:true});
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
-    _scheduleMessageVirtualizedRender();
     if(_messageJumpScrollOwner){
       _scheduleMessageJumpScrollReconcile(_messageJumpScrollOwner.generation);
       return;
     }
     if(_freshProgrammaticScrollActive()) return;
+    // #6799-family feedback loop: the virtualized re-render must only fire on
+    // REAL user scrolls. A programmatic scroll (measurement compensation,
+    // viewport anchoring) that reaches this re-render would re-render the
+    // window, adjust scrollTop again, fire another scroll event, and loop —
+    // the scrollHeight churn that makes long transcripts unscrollable
+    // (measured 12898→18203px per wheel tick before the guard move).
+    _scheduleMessageVirtualizedRender();
     _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -522,7 +522,16 @@ async function startCompressionRecovery(btn){
 }
 
 const MESSAGE_RENDER_WINDOW_DEFAULT=50;
-const MESSAGE_VIRTUAL_THRESHOLD_ROWS=80;
+// Virtualization only pays off for genuinely long transcripts: below this
+// count the estimated-height scroll math (MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS)
+// is more disruptive than rendering the rows directly — a "Load earlier
+// messages" click on a foreign session jumps the renderable count from 30 to
+// 83+, which used to cross the old 80-row threshold mid-scroll and trigger the
+// scroll->re-render churn (scrollHeight jumping 12898->18203px per wheel
+// tick; see #6799 family). 200 matches the render-window auto-expansion cap
+// (#6999: MESSAGE_RENDER_WINDOW_DEFAULT*4), so any transcript the window
+// logic already considers fully renderable also stays un-virtualized.
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS=200;
 const MESSAGE_VIRTUAL_BUFFER_PX=900;
 const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
   user:120,


### PR DESCRIPTION
Fixes #7050 and the related transcript-virtualization scroll churn (see comments on #6799).

## Part 1 — poll-loop fix (server, api/routes.py)

Foreign/CLI sessions (TUI/CLI/Claude Code) reported a raw state.db `COUNT(*)` as `message_count` on the metadata path (`messages=0`) while the message-load path (`messages=1`) reports the merged display count. The frontend's 30s external-refresh poll compared the two numbers (2543 vs 696 for the repro session), always saw a "change", and force-reloaded the full transcript every 30s — titlebar count flickering `30→0→426`, unscrollable conversation.

The metadata-only branch now runs the **same merge pipeline as the message-load branch** (sidecar lineage + state.db messages + append-only merge) for foreign sessions, including the defensive 50k-row backstop and the same sidecar-derived timestamp-floor semantics (documented in-code why the floor is a no-op here). WebUI-native and messaging sessions keep their existing paths.

This aligns with the existing contract at `api/routes.py` (~L13136): *"`message_count` in /api/session is the display coordinate space used for pagination and the header badge"* — the same contract already applied to messaging sessions; foreign CLI/TUI sessions were the missed case.

## Part 2 — virtualization threshold + titlebar sync (frontend)

- `MESSAGE_VIRTUAL_THRESHOLD_ROWS` 80 → 200: a "Load earlier messages" click on a long foreign session jumps the renderable count from 30 to 83+, crossing the old 80-row virtualization threshold mid-scroll and engaging estimated-height windowed rendering, whose scrollHeight feedback churn made the transcript unscrollable (measured 12898→18203px per wheel tick). 200 matches the render-window auto-expansion cap (#6999), so transcripts the window logic already considers fully renderable stay un-virtualized. Transcripts above 200 rows keep the existing virtualized path (residual estimation drift is tracked in #6799).
- `_loadOlderMessages` / `_ensureAllMessagesLoaded` now call `syncAppTitlebar()` after replacing `S.messages`, so the titlebar count reflects the expanded transcript instead of staying stale.

## Verification

Repro session (TUI source, 696 merged / 426 non-tool messages, raw state.db rows 2543):

| request | before | after |
|---|---|---|
| `messages=0` | 2543 | **696** |
| `messages=1&msg_limit=30` | 696 | **696** |

- End-to-end (headless Chromium): titlebar `30→0→426` loop every 30s → stable; "Load earlier messages" then scroll: scrollHeight constant (12775px, wheel steps exactly -600px) vs. pre-fix churn (12898→18203px); titlebar updates 30→83 after the load.
- Regression: other TUI sessions report consistent counts (467/467, 40/40).
- Tests: 152 passed (windowing / msg_limit ceiling / tail payload / chat-start claim / subagent transcript / liveview perf / session index).