### PR TITLE
fix(tests): pin rebuild budget in issue2513 custom-provider catalog test

### DIFF
--- a/tests/test_issue2513_custom_provider_remote_models.py
+++ b/tests/test_issue2513_custom_provider_remote_models.py
@@ -45,6 +45,12 @@ def test_custom_provider_model_field_does_not_block_remote_catalog(monkeypatch, 
         raise AssertionError(f"unexpected urlopen: {url}")
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    # This file pins the custom-provider catalog contract, not the separate
+    # async provider-catalog budget fallback. Force the synchronous rebuild
+    # path so a slow/loaded CI shard cannot blow the global 4s budget and
+    # serve the degraded fallback catalog, which drops the live-fetched
+    # models under test and leaves only the config-declared sticky model.
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
 


### PR DESCRIPTION
## Summary

`tests/test_issue2513_custom_provider_remote_models.py::test_custom_provider_model_field_does_not_block_remote_catalog` is a pre-existing wall-clock flake. On a starved CI shard the cold provider-catalog rebuild overruns `_LIVE_REBUILD_BUDGET_SECONDS` (default 4s), `get_available_models()` serves the degraded fallback catalog, and the monkeypatched live model `alpha/remote` is dropped — leaving only the config-declared sticky model.

Seen on #7051 as the only red check (`test (3.13, 4)`):

```
assert "@custom:alpha-proxy:alpha/remote" in alpha_ids
AssertionError: assert '@custom:alpha-proxy:alpha/remote' in {'alpha/sticky'}
WARNING  api.config:config.py:8355 live provider-catalog rebuild exceeded 4.0s budget
```

This is not a session-sidebar regression. Split out of #7051 so that PR stays scoped to the subagent parent-in-window fix.

## Fix

One test-only pin, matching `tests/test_issue2540_models_endpoint_error.py`:

```python
monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
```

`budget <= 0` takes the synchronous unbounded rebuild path, so the test asserts the catalog contract instead of racing the 4s budget.

No production code.

## Test plan

- [x] Unpatched at a hostile budget reproduces the CI assertion
- [x] Patched passes at budget `0`, `0.001s`, and default
- [ ] CI `test (3.13, *)` on this PR