### PR TITLE
fix(reasoning): expose thinking-level control for Gemini and Grok routes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3287,6 +3287,77 @@ def _reasoning_name_candidates(model_id: str) -> list[str]:
     return candidates
 
 
+# Gemini routes that have no thinking ladder at all, whatever their version.
+# Checked BEFORE the version gate so an image/embedding id cannot ride in on
+# its major number (e.g. `gemini-3-pro-image-preview`).
+_GEMINI_NON_TEXT_RE = re.compile(r"(?:^|[^a-z0-9])(?:image|imagine|embedding)")
+
+# xAI Grok builds that accept `reasoning_effort`, as explicit shapes.
+#
+# Mirrors the Agent core's `_GROK_EFFORT_CAPABLE_PREFIXES`
+# (agent/model_metadata.py), which was verified live against api.x.ai
+# /v1/responses. The lineup is NOT monotonic in the version number, so a
+# ">= 4.5" comparison is wrong in both directions:
+#
+#   accepts effort : grok-3-mini(-fast), grok-4.3, grok-4.5, grok-4.6,
+#                    grok-4.20-multi-agent
+#   rejects effort : grok-3, grok-4, grok-4-0709, grok-4-fast(-reasoning),
+#                    grok-4-1-fast, grok-4.20 / grok-4.20-non-reasoning,
+#                    grok-code-fast-1
+#
+# Ids are normalised to `-` separators before matching, so `grok-4.5` arrives
+# here as `grok-4-5`; both spellings are listed.
+_GROK_EFFORT_CAPABLE_PREFIXES = (
+    "grok-3-mini",
+    "grok-4-20-multi-agent",
+    "grok-4.20-multi-agent",
+    "grok-4-3",
+    "grok-4.3",
+    "grok-4-5",
+    "grok-4.5",
+    "grok-4-6",
+    "grok-4.6",
+)
+
+# Shapes that would otherwise be caught by a prefix above but must NOT be
+# treated as effort-capable. `grok-4.20-non-reasoning` starts with the same
+# `grok-4-20` stem as the multi-agent build in normalised form, so an
+# exclusion pass is required rather than prefix matching alone.
+_GROK_EFFORT_DENY_SUBSTRINGS = (
+    "non-reasoning",
+    "code-fast",
+)
+
+
+def _grok_supports_effort(normalized: str) -> bool:
+    """True when an xAI Grok id accepts a `reasoning_effort` dial.
+
+    A prefix must end on a version boundary, not merely start the string. A
+    bare `startswith` lets a date stamp be absorbed into the version: an
+    aggregator id like `grok-4-520250101` (that is `grok-4` plus the date
+    `20250101`) begins with `grok-4-5` and would read as the effort-capable
+    4.5 build, so the composer would offer levels the model rejects and the
+    request would fail. Requiring the next character to be a non-digit keeps
+    `grok-4.5-20250101` (a genuinely dated 4.5) capable while classifying
+    `grok-4-520250101` as the `grok-4` it actually is.
+
+    This mirrors the `(?!\\d)` date-stamp guard the Claude branch below already
+    uses for the same class of bug.
+    """
+    name = (normalized or "").strip().lower().rsplit("/", 1)[-1]
+    if not name:
+        return False
+    if any(bad in name for bad in _GROK_EFFORT_DENY_SUBSTRINGS):
+        return False
+    for prefix in _GROK_EFFORT_CAPABLE_PREFIXES:
+        if not name.startswith(prefix):
+            continue
+        rest = name[len(prefix):]
+        if not rest or not rest[0].isdigit():
+            return True
+    return False
+
+
 def _candidate_supports_reasoning(candidate: str) -> bool:
     normalized = re.sub(r"[^a-z0-9]+", "-", str(candidate or "").strip().lower()).strip("-")
     if not normalized:
@@ -3294,6 +3365,15 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
 
     tokens = [token for token in normalized.split("-") if token]
     token_set = set(tokens)
+
+    # Grok is decided FIRST, by explicit shape, because the generic
+    # "reasoning"/"thinking" keyword shortcut below would otherwise claim
+    # `grok-4-fast-reasoning` and `grok-4.20-non-reasoning` — both of which
+    # reason natively but REJECT a `reasoning_effort` dial. The keyword says
+    # "this model reasons", which is not the same question as "this model
+    # exposes an effort control".
+    if "grok" in token_set or normalized.startswith("grok"):
+        return _grok_supports_effort(normalized)
 
     if "thinking" in token_set or "reasoning" in token_set:
         return True
@@ -3319,7 +3399,28 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
             if major >= 4 or (major == 3 and minor >= 7):
                 return True
         return False
-    # Positive-only prefixed Qwen 3+ detection (e.g. "al-qwen3-8-max-preview"
+    if "gemini" in token_set or normalized.startswith("gemini"):
+        # Hard-deny non-text routes FIRST. An image / imagine / embedding model
+        # has no thinking ladder at all, and a bare version match would happily
+        # let `gemini-3-pro-image-preview` through on its `3`.
+        if _GEMINI_NON_TEXT_RE.search(normalized):
+            return False
+        # Thinking/effort controls are documented for Gemini 2.5+ and 3-era.
+        # 1.5 / 2.0 have no ladder — a selector there would 400.
+        #
+        # The minor group is capped at 1-2 digits with a (?!\d) guard so a
+        # trailing date stamp is NOT read as a minor version — otherwise a
+        # dated id like "gemini-2-20250219" would parse minor=20250219 and
+        # wrongly satisfy the 2.5+ gate. (Same defense the Claude branch
+        # above already uses.)
+        match = re.search(r"gemini.*?(\d+)(?:\D+(\d{1,2})(?!\d))?", normalized)
+        if match:
+            major = int(match.group(1))
+            minor = int(match.group(2)) if match.group(2) else 0
+            if major >= 3 or (major == 2 and minor >= 5):
+                return True
+        return False
+    # Positive-only prefixed Qwen 3+ detection (e.g. "al-qwen3-8-max-preview")
     # → tokens ["al","qwen3","8",...]). Scan for any token starting with
     # "qwen" followed by version >= 3 and immediately allow. Do NOT return
     # False here — Qwen 2.x embedded in hybrid IDs like
@@ -3533,6 +3634,98 @@ def _is_gpt_5_6_reasoning_model(bare_model: str) -> bool:
     return str(bare_model or "").strip().lower() in _GPT_5_6_REASONING_MODELS
 
 
+# Grok models that accept an effort ladder but REJECT turning reasoning off.
+# Explicit per-model, never a blanket `grok` prefix: the lineup is not
+# monotonic in the version number, and a prefix deny silently removes a
+# working control. Verified live against api.x.ai /v1/responses and recorded
+# in the Agent core (`agent/model_metadata.py`): grok-4.5 "REJECTS 'none'
+# (This model does not support `reasoning_effort` value `none`), unlike
+# grok-4.3", and grok-4.6 is its drop-in successor with the same dial.
+#
+# grok-4.3 and grok-3-mini DO accept disabling, so they keep "None". Removing
+# it there is not cosmetic: the installed xAI transport then defaults
+# reasoning back on at medium, so a user who picks "None" silently gets
+# medium reasoning.
+_DISABLE_REASONING_DENY_PREFIXES = (
+    "grok-4.5",
+    "grok-4-5",
+    "grok-4.6",
+    "grok-4-6",
+)
+
+# Per-model `thinking_level` ladders, transcribed from Google's published
+# "Controlling thinking" table (https://ai.google.dev/gemini-api/docs/thinking).
+# The ladder is genuinely model-specific: 3.1 Pro and the whole 2.5 line have
+# no `minimal`, and 3 Pro exposes only the two endpoints. A single universal
+# ladder therefore advertises levels the model will not honor.
+# Longest-prefix wins, so `gemini-3.5-flash-lite` is matched before
+# `gemini-3.5-flash`.
+_GEMINI_THINKING_LEVELS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("gemini-3.7-flash", ("low", "medium", "high")),
+    ("gemini-3.6-flash", ("minimal", "low", "medium", "high")),
+    ("gemini-3.5-flash-lite", ("minimal", "low", "medium", "high")),
+    ("gemini-3.5-flash", ("minimal", "low", "medium", "high")),
+    ("gemini-3.1-pro", ("low", "medium", "high")),
+    ("gemini-3-flash", ("minimal", "low", "medium", "high")),
+    ("gemini-3-pro", ("low", "high")),
+    ("gemini-2.5-pro", ("low", "medium", "high")),
+    ("gemini-2.5-flash-lite", ("low", "medium", "high")),
+    ("gemini-2.5-flash", ("low", "medium", "high")),
+)
+
+# Conservative default for a Gemini id not in the table (new releases). Every
+# published text Gemini ladder contains at least low/medium/high, and no
+# published ladder omits them, so this offers only levels that are universal.
+_GEMINI_DEFAULT_THINKING_LEVELS = ("low", "medium", "high")
+
+
+def _gemini_thinking_levels(model_id: str) -> list[str]:
+    """Return the published `thinking_level` ladder for a Gemini id.
+
+    Falls back to the universally-supported low/medium/high for ids not in the
+    table rather than guessing `minimal`, which several families reject.
+    """
+    name = str(model_id or "").strip().lower().rsplit("/", 1)[-1]
+    if not name:
+        return []
+    best: tuple[str, tuple[str, ...]] | None = None
+    for prefix, levels in _GEMINI_THINKING_LEVELS:
+        if name.startswith(prefix) and (best is None or len(prefix) > len(best[0])):
+            best = (prefix, levels)
+    if best is not None:
+        return list(best[1])
+    return list(_GEMINI_DEFAULT_THINKING_LEVELS)
+
+
+def supports_disable_reasoning(
+    model_id: str | None,
+    provider_id: str | None = None,
+    base_url: str | None = None,
+) -> bool:
+    """True when the model accepts turning reasoning OFF entirely.
+
+    Distinct from ``supports_thinking_toggle``, which only asks whether the
+    composer should render a control at all. A model can have a perfectly good
+    effort ladder and still have no "off" position: xAI's Grok reasoning builds
+    accept ``low``/``medium``/``high`` but reject ``reasoning_effort:"none"``
+    outright, and the native xAI endpoint silently ignores it and leaves
+    reasoning on — so offering "None" there is either an error or a lie.
+
+    Z.AI GLM models are the opposite case: they accept the ``thinking`` toggle
+    and their whole control is the on/off pair, so they must keep "None".
+    """
+    zai_thinking = _zai_glm_thinking_toggle_supported(model_id, provider_id)
+    if zai_thinking is not None:
+        return zai_thinking
+
+    name = str(model_id or "").strip().lower().rsplit("/", 1)[-1]
+    if not name:
+        return False
+    if any(name.startswith(prefix) for prefix in _DISABLE_REASONING_DENY_PREFIXES):
+        return False
+    return True
+
+
 def _filter_reasoning_efforts_for_provider(
     efforts: list[str],
     model_id: str,
@@ -3559,6 +3752,26 @@ def _filter_reasoning_efforts_for_provider(
     # prior max->xhigh coercion (Gemini's adapter treats unknown 'max' as medium;
     # pre-adaptive Anthropic manual-thinking lacks a 'max' budget and falls to 8k).
     # Dropping 'max' here lets the existing downgrade ladder land on xhigh/high.
+    # Gemini has no 'xhigh' and no 'max' — Google documents
+    # minimal/low/medium/high. Advertising a level the API does not have lets a
+    # user pick a depth the model never uses (the adapter treats an unknown
+    # 'max' as medium), so clamp to the real contract.
+    #
+    # Keyed on the MODEL, not just the provider name: Gemini also arrives via
+    # aggregators (`google/gemini-2.5-pro` on openrouter, `vertex/gemini-…` on
+    # a custom gateway), where a provider-name check would miss it entirely.
+    if _is_gemini_id(bare) or _is_gemini_id(_strip_provider_hint_for_reasoning(model_id)):
+        # Share the published per-model table rather than re-encoding a second,
+        # looser ladder here: a universal ceiling would put `minimal` back on
+        # the models that reject it (3.1 Pro, the whole 2.5 line).
+        gemini_id = bare if _is_gemini_id(bare) else _strip_provider_hint_for_reasoning(model_id)
+        if _is_native_gemini_provider(provider):
+            # The native adapter collapses several levels onto one request, so
+            # only offer what it can actually distinguish.
+            gemini_ladder = tuple(_gemini_native_wire_ladder(gemini_id))
+        else:
+            gemini_ladder = tuple(_gemini_thinking_levels(gemini_id))
+        return [eff for eff in normalized if eff in gemini_ladder]
     if provider in {"gemini", "google", "google-gemini", "google-vertex", "vertex"}:
         return [eff for eff in normalized if eff != "max"]
     # Legacy Claude is pre-adaptive whether served natively OR via Azure Foundry /
@@ -3640,8 +3853,163 @@ def _is_pre_adaptive_anthropic(bare_model: str) -> bool:
     return (major, minor) < (4, 6)
 
 
+# Levels the NATIVE Gemini path can actually distinguish on the wire.
+#
+# The installed adapter (`agent/transports/chat_completions.py`,
+# `_build_gemini_thinking_config`) collapses Hermes' effort levels when it
+# builds `thinkingConfig`, so several UI choices produce byte-identical
+# requests. Measured against that function:
+#
+#   gemini-2.5-*     every level -> {"includeThoughts": True}   (1 outcome)
+#   gemini-3*-pro    minimal/low/medium -> "low", high+ -> "high"  (2 outcomes)
+#   gemini-3*-flash  minimal/low -> "low", medium -> "medium",
+#                    high/xhigh/max -> "high"                    (3 outcomes)
+#
+# Offering aliased levels lets a user pick a depth that never reaches the
+# model, so the native ladder exposes one representative level per distinct
+# wire outcome. 2.5 has a single outcome and therefore no meaningful
+# intensity control at all until a `thinkingBudget` translation exists;
+# `None`/`Default` still work there because they are handled before this
+# ladder (`enabled: False` / `effort == "none"` -> `includeThoughts: False`).
+#
+# Aggregator routes (openrouter, vertex gateways) do NOT go through this
+# adapter, so they keep the published per-model ladder.
+_GEMINI_NATIVE_WIRE_LADDERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("gemini-2.5", ()),
+    ("gemini-3-pro", ("low", "high")),
+    ("gemini-3.1-pro", ("low", "high")),
+)
+
+_GEMINI_NATIVE_FLASH_LADDER = ("low", "medium", "high")
+
+
+def _gemini_native_wire_ladder(model_id: str) -> list[str]:
+    """Levels the native Gemini adapter turns into DISTINCT requests."""
+    name = str(model_id or "").strip().lower().rsplit("/", 1)[-1]
+    if not name:
+        return []
+
+    best: tuple[str, tuple[str, ...]] | None = None
+    for prefix, levels in _GEMINI_NATIVE_WIRE_LADDERS:
+        if name.startswith(prefix) and (best is None or len(prefix) > len(best[0])):
+            best = (prefix, levels)
+    if best is not None:
+        return list(best[1])
+
+    if name.startswith("gemini-3"):
+        # Flash and every other Gemini 3 shape take the flash branch, which
+        # keeps three distinct thinkingLevel values.
+        return list(_GEMINI_NATIVE_FLASH_LADDER)
+
+    # Unknown Gemini generation: fall back to the published ladder rather than
+    # guessing at a collapse this adapter may not perform.
+    return _gemini_thinking_levels(model_id)
+
+
+def _is_native_gemini_provider(provider_id: str) -> bool:
+    """True for the first-party Gemini endpoints that use the native adapter."""
+    return str(provider_id or "").strip().lower() in {
+        "gemini",
+        "google",
+        "google-gemini",
+        "google-ai-studio",
+    }
+
+
+def _gemini_model_segments(model_id: str) -> list[str]:
+    """Path segments of *model_id* that are themselves Gemini model ids.
+
+    A routed id can nest a model under wrapper namespaces
+    (`image-router/gemini-3.6-flash`). Only the segment that IS the model
+    carries the model's identity; wrapper names are infrastructure. Returning
+    the segments — rather than a bare bool — lets every Gemini-specific
+    predicate ask its question *about the model*, instead of scanning the whole
+    route and mixing a keyword from one segment with the family name from
+    another.
+    """
+    lowered = str(model_id or "").strip().lower()
+    if not lowered:
+        return []
+    found: list[str] = []
+    for segment in lowered.split("/"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        # `gemini`, `gemini-2.5-pro`, `gemini_3_flash` — the family name must
+        # start the segment and be followed by a version separator or nothing,
+        # so `gemini-router` (a gateway name) and `notgemini-…` do not match.
+        if segment == "gemini":
+            found.append(segment)
+            continue
+        if segment.startswith("gemini"):
+            rest = segment[len("gemini"):]
+            if rest[:1] in {"-", "_", "."} and rest[1:2].isdigit():
+                found.append(segment)
+    return found
+
+
+def _is_gemini_id(model_id: str) -> bool:
+    """True when an id belongs to the Gemini family, at any nesting depth.
+
+    Matches Gemini-shaped PATH SEGMENTS rather than searching the whole string
+    for `gemini-`. An unrestricted substring test claims ids that merely
+    mention the word: `notgemini-deepseek-r1` and `acme-gemini-router/deepseek-r1`
+    are DeepSeek models that were being clamped to Gemini's ladder and losing
+    xhigh/max. A segment must BE a Gemini model id, not contain one.
+    """
+    return bool(_gemini_model_segments(model_id))
+
+
+def _gemini_route_is_non_text(model_id: str) -> bool:
+    """True when the Gemini MODEL segment is an image/imagine/embedding route.
+
+    Both halves of this question must be asked of the same path segment. A
+    top-level scan that finds `image` anywhere in the route and `gemini`
+    anywhere else in it denies valid text models: `image-router/gemini-3.6-flash`
+    matched `image` in the wrapper and `gemini` in the model, and lost its
+    ladder even though the model segment is an ordinary text Gemini. Same for
+    `embedding-gateway/gemini-3.1-pro-preview`.
+
+    `vendor/gemini-3-pro-image-preview` and `vendor/gemini-embedding-001` stay
+    denied, because there the keyword is inside the model segment itself.
+    """
+    for segment in _gemini_model_segments(model_id):
+        normalized = re.sub(r"[^a-z0-9]+", "-", segment).strip("-")
+        if _GEMINI_NON_TEXT_RE.search(normalized):
+            return True
+    return False
+
+
+def _gemini_text_ladder(model_id: str = "") -> list[str]:
+    """Gemini's exact thinking ladder for heuristic (non-catalog) fallbacks.
+
+    Model-specific: Google publishes a different `thinking_level` set per
+    model (3.1 Pro and the 2.5 line have no `minimal`; 3 Pro exposes only
+    `low`/`high`), and no Gemini has `xhigh` or `max`. Offering a level the
+    model does not accept lets a user pick a depth the API then rejects or
+    silently clamps, which is worse than not offering it — the UI would be
+    reporting a depth the model never used.
+    """
+    return _gemini_thinking_levels(model_id) if model_id else list(
+        _GEMINI_DEFAULT_THINKING_LEVELS
+    )
+
+
 def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     """Fallback when hermes_cli is unavailable."""
+    efforts = _heuristic_reasoning_efforts_impl(model_id, provider_id)
+    # Single chokepoint for Gemini's exact ladder. Gemini reaches this function
+    # through several branches (copilot, slash-prefixed vendor routes, nested
+    # gateway routes, the candidate scan), and every one of them used to hand
+    # back the full VALID_REASONING_EFFORTS including xhigh/max — levels Gemini
+    # does not have. Clamping at the exit keeps the contract in one place
+    # rather than repeating it in each branch.
+    if efforts and _is_gemini_id(_strip_provider_hint_for_reasoning(model_id)):
+        return _gemini_text_ladder(_strip_provider_hint_for_reasoning(model_id))
+    return efforts
+
+
+def _heuristic_reasoning_efforts_impl(model_id: str, provider_id: str) -> list[str]:
     model = _strip_provider_hint_for_reasoning(model_id).lower()
     provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
     if not model or provider in {"cursor-acp", "copilot-acp"}:
@@ -3654,10 +4022,33 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
             list(VALID_REASONING_EFFORTS), model, provider
         )
     if provider in {"copilot", "github-copilot"}:
-        if bare.startswith(("gpt-5", "o1", "o3", "o4")):
-            if bare.startswith(("o1", "o3", "o4")):
-                return ["low", "medium", "high"]
+        # Copilot is a CLOSED set: whatever this branch decides is final, so it
+        # must not fall through to the generic prefix table below. Falling
+        # through is how `grok-4.20-non-reasoning` and `grok-3-mini` used to
+        # come back with the full six-level ladder — the first rejects an
+        # effort dial entirely, the second only accepts low/medium/high.
+        if bare.startswith(("o1", "o3", "o4")):
+            return ["low", "medium", "high"]
+        if bare.startswith("gpt-5"):
             return list(VALID_REASONING_EFFORTS)
+        if "claude" in bare:
+            return (
+                ["low", "medium", "high"]
+                if not _is_pre_adaptive_anthropic(bare)
+                else []
+            )
+        if bare.startswith("gemini"):
+            # image / imagine / embedding routes have no ladder at all.
+            if not _candidate_supports_reasoning(bare):
+                return []
+            return _gemini_thinking_levels(bare)
+        if bare.startswith("grok"):
+            # Explicit per-shape table (see _grok_supports_effort). Every
+            # effort-capable Grok build accepts exactly low/medium/high.
+            return ["low", "medium", "high"] if _grok_supports_effort(bare) else []
+        if bare.startswith("mai-code"):
+            return ["low", "medium", "high"]
+        return []
     prefixes = (
         "deepseek/",
         "anthropic/",
@@ -3673,6 +4064,14 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
         return list(VALID_REASONING_EFFORTS)
     if _nested_gateway_route_reasoning(model):
         return list(VALID_REASONING_EFFORTS)
+    # Grok is decided by the WHOLE id, before the candidate scan below.
+    # `_reasoning_name_candidates` splits on dots, so `grok-4.20-non-reasoning`
+    # yields the fragment `20-non-reasoning` — which has lost the `grok` prefix
+    # and gets claimed by the generic "reasoning" keyword shortcut. Deciding
+    # here keeps the explicit shape table authoritative for the whole family.
+    if bare.startswith("grok") or "grok" in re.split(r"[^a-z0-9]+", bare):
+        return ["low", "medium", "high"] if _grok_supports_effort(bare) else []
+
     # Named custom providers often rewrite model ids with dots, underscores, or
     # extra vendor namespaces. Normalize those shapes before applying family-level
     # reasoning heuristics so "deepseek.v3.2", "deepseek_v4_flash", and
@@ -3956,6 +4355,240 @@ def _configured_reasoning_effort_lists(provider_entry, model_id: str) -> list:
     return configured_lists
 
 
+def _copilot_catalog_reasoning_efforts(
+    model_id: str,
+) -> tuple[list[str], bool, list[str], str]:
+    """Ask the core for a Copilot model's ladder.
+
+    Returns ``(efforts, resolved, core_levels, core_verdict)``.
+
+    ``resolved`` reflects the outcome of THIS lookup:
+
+    * ``True``  — a concrete catalog answered. A non-empty list is its ladder;
+      an empty list means the catalog positively says this model has no ladder
+      (``claude-haiku-4.5``), which must be honoured rather than guessed over.
+    * ``False`` — no catalog was consulted this time (core too old, no
+      credential, fetch failed). Fall back to the heuristic.
+
+    ``core_levels`` / ``core_verdict`` describe what the INSTALLED core would
+    send for this model, carried out of the same observation so the caller
+    never has to call the resolver again:
+
+    * ``"absent"`` — no core, or no resolver. Nothing to disagree with.
+    * ``"inert"``  — a core with no catalog path resolved nothing for this
+      model, so a control would be visible but do nothing on the wire.
+    * ``"answer"`` — ``core_levels`` is what it would send; the heuristic must
+      not offer levels beyond it (the published table can be wider than the
+      core's offline table — Copilot lists ``minimal`` for Gemini 3.x Flash
+      while the core's static fallback stops at high).
+    * ``"trust"``  — a catalog-aware core came back empty, i.e. a transient
+      fetch failure that says nothing about this model.
+
+    ONE fetch backs the classification, the resolution AND the core verdict.
+    Deriving them from separate calls is a check/use race: a transient failure
+    on the first call and a success on the second yields "empty" AND
+    "authoritative", which reads as a positive deny and silently drops the
+    ladder for any model the core's offline table does not know
+    (`grok-3-mini`, `grok-4.3`). Passing the fetched catalog straight into the
+    resolver makes them physically unable to disagree.
+    """
+    try:
+        import hermes_cli.models as copilot_models
+    except Exception:
+        return [], False, [], "absent"
+
+    resolver = getattr(copilot_models, "github_model_reasoning_efforts", None)
+    if resolver is None:
+        return [], False, [], "absent"
+
+    if not _copilot_core_reads_catalog_unprompted(copilot_models):
+        # Core never consults a catalog. Whatever it returns comes from its own
+        # static table: a ladder is usable, an empty result is not an answer.
+        try:
+            efforts = list(resolver(model_id) or [])
+        except Exception:
+            return [], False, [], "trust"
+        if efforts:
+            return efforts, True, efforts, "answer"
+        return [], False, [], "inert"
+
+    catalog = _fetch_copilot_catalog_once(copilot_models)
+    if not catalog:
+        # The catalog is unreachable this time. The core will still answer from
+        # its own offline table on the wire, so ask it what that answer is.
+        # An EMPTY catalog is passed explicitly: a bare call would make the
+        # resolver fetch again, and a second fetch is exactly the check/use
+        # gap this function exists to close. The core's table can be NARROWER
+        # than the vendor's published one (Copilot lists `minimal` for Gemini
+        # 3.x Flash; the core's fallback stops at high), and offering the extra
+        # level would render a control the runtime silently drops.
+        try:
+            if _resolver_accepts_catalog_kwarg(resolver):
+                offline = resolver(model_id, catalog=[])
+            else:
+                offline = resolver(model_id)
+            core_levels = [
+                str(x).strip().lower()
+                for x in (offline or [])
+                if str(x).strip()
+            ]
+        except Exception:
+            return [], False, [], "trust"
+        if core_levels:
+            return [], False, core_levels, "answer"
+        return [], False, [], "trust"
+
+    # Ask the signature whether the resolver accepts `catalog`, rather than
+    # calling and catching TypeError. Catching cannot tell a signature
+    # mismatch from a TypeError raised INSIDE a modern resolver — the latter
+    # would be retried without the catalog, quietly reintroducing the
+    # two-observation gap this function exists to close.
+    try:
+        efforts = list(_call_copilot_resolver(resolver, model_id, catalog) or [])
+    except Exception:
+        return [], False, [], "trust"
+
+    if efforts:
+        return efforts, True, efforts, "answer"
+
+    # Empty from a live catalog is authoritative ONLY if the catalog actually
+    # lists this model. When the id is absent the core falls back to its own
+    # static table, and that table returning `[]` means "I don't know this
+    # model", not "this model has no ladder" — the difference between
+    # `claude-haiku-4.5` (listed, genuinely no ladder) and `grok-4.3`
+    # (unlisted on a partial catalog, ladder must come from the heuristic).
+    if _catalog_lists_model(catalog, copilot_models, model_id):
+        return [], True, [], "answer"
+    return [], False, [], "trust"
+
+
+def _resolver_accepts_catalog_kwarg(resolver) -> bool:
+    """True when *resolver* can be called with a ``catalog=`` keyword.
+
+    Determined from the signature rather than by calling and catching
+    ``TypeError``: a modern resolver that raises ``TypeError`` internally is
+    indistinguishable from an old signature at the call site, and retrying it
+    without the catalog would silently reintroduce the two-observation gap.
+    When the signature cannot be read (C builtins, exotic callables), fail
+    closed to the bare call — that is the historical behaviour.
+    """
+    try:
+        import inspect
+
+        params = inspect.signature(resolver).parameters
+    except (TypeError, ValueError):
+        return False
+    if "catalog" in params:
+        return True
+    return any(p.kind is p.VAR_KEYWORD for p in params.values())
+
+
+def _call_copilot_resolver(resolver, model_id: str, catalog):
+    """Invoke the core resolver, passing *catalog* only when it is accepted."""
+    if _resolver_accepts_catalog_kwarg(resolver):
+        return resolver(model_id, catalog=catalog)
+    return resolver(model_id)
+
+
+def _catalog_lists_model(catalog, copilot_models, model_id: str) -> bool:
+    """True when *catalog* carries an entry for *model_id*.
+
+    Normalises through the core's own id resolver when available, so an alias
+    or a provider-prefixed id still matches its catalog entry.
+    """
+    wanted = str(model_id or "").strip().lower()
+    if not wanted:
+        return False
+
+    normalize = getattr(copilot_models, "normalize_copilot_model_id", None)
+    if callable(normalize):
+        try:
+            normalized = str(normalize(model_id, catalog=catalog) or "").strip().lower()
+            if normalized:
+                wanted = normalized
+        except Exception:
+            pass
+
+    for entry in catalog or ():
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("id") or "").strip().lower() == wanted:
+            return True
+    return False
+
+
+def _fetch_copilot_catalog_once(copilot_models):
+    """Fetch the Copilot catalog once, or return a falsy value."""
+    fetch = getattr(copilot_models, "fetch_github_model_catalog", None)
+    if fetch is None:
+        return None
+
+    resolve_key = getattr(copilot_models, "_resolve_copilot_catalog_api_key", None)
+    api_key = ""
+    if callable(resolve_key):
+        try:
+            api_key = resolve_key() or ""
+        except Exception:
+            api_key = ""
+
+    try:
+        return fetch(api_key=api_key) if api_key else fetch()
+    except Exception:
+        return None
+
+
+_COPILOT_CATALOG_PROBE_ID = "hermes-probe-catalog-capability"
+
+# Witness for the bare-call probe: a Copilot model that no core's OFFLINE
+# table has ever known, so a non-empty bare answer can only have come from a
+# catalog the core fetched by itself. The old static tables covered GPT-5 /
+# o-series only, which is why a Claude id is the right witness — using
+# `gpt-5.5` would answer from the static table and report catalog support that
+# is not there.
+_COPILOT_BARE_CALL_WITNESS_ID = "claude-opus-5"
+
+
+def _copilot_core_reads_catalog_unprompted(copilot_models) -> bool:
+    """True when the core resolves Copilot ladders on a BARE call.
+
+    This is deliberately the bare-call question, not "does the resolver accept
+    a ``catalog=`` keyword". The two came apart in a released core: it accepts
+    the keyword, but a bare call still resolves Claude/Gemini/Grok/MAI from its
+    old static table and returns ``[]``. The agent's wire path calls it bare.
+    So a keyword-shaped check would let the WebUI substitute a heuristic ladder
+    and render a control while the runtime sends no reasoning field at all —
+    visible but inert.
+
+    Answered by asking the installed core about a model it can only know from a
+    live catalog. A core that self-fetches returns a ladder; the older one
+    returns ``[]`` and we must not paper over it.
+
+    Touches no module state. An earlier version installed temporary
+    ``mock.patch.object`` stand-ins for the core's token and fetch helpers.
+    ``patch.object`` restores whatever the attribute held when it was entered,
+    so two concurrent probes could interleave as A-enter, B-enter, A-exit,
+    B-exit — leaving B to write A's probe lambda back as the permanent value.
+    The server is threaded, so concurrent first-time lookups made that
+    reachable, and the damage was unbounded: core catalog discovery would keep
+    returning the synthetic probe model for the life of the process. Never
+    mutate shared module globals to answer a capability question.
+    """
+    resolver = getattr(copilot_models, "github_model_reasoning_efforts", None)
+    if not callable(resolver):
+        return False
+    if not _resolver_accepts_catalog_kwarg(resolver):
+        return False
+
+    # A catalog-only model: absent from every core's static table, so a
+    # non-empty answer can only have come from a catalog the core fetched
+    # itself. Fail closed on any error.
+    try:
+        efforts = resolver(_COPILOT_BARE_CALL_WITNESS_ID)
+    except Exception:
+        return False
+    return bool(efforts)
+
+
 def _resolve_model_reasoning_efforts_impl(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -3989,6 +4622,21 @@ def _resolve_model_reasoning_efforts_impl(
     if _nested_route_reasoning_denied(hinted_model):
         return []
 
+    # Same hard deny for FLAT non-text Gemini ids (`gemini-embedding-001`,
+    # `gemini-3-pro-image-preview`). The nested check above only matches
+    # gateway-prefixed routes, and a catalog — including the live Copilot one —
+    # can advertise an effort ladder for an image model that would then 400.
+    # can advertise an effort ladder for an image model that would then 400.
+    # A non-text route has no thinking control on any provider, so this
+    # outranks every source below, catalog included.
+    #
+    # Both halves of the question are asked of the SAME path segment: scanning
+    # the whole route for the keyword while matching the family name elsewhere
+    # denied valid text models routed under a wrapper namespace
+    # (`image-router/gemini-3.6-flash`).
+    if _gemini_route_is_non_text(hinted_model):
+        return []
+
     # 0. Model/provider config: a models.<model>.reasoning_efforts list takes
     # precedence over its provider-level reasoning_efforts list. Explicit valid
     # config is authoritative — no heuristics or models.dev lookup. Invalid or
@@ -4019,12 +4667,58 @@ def _resolve_model_reasoning_efforts_impl(
         pass
 
     if provider in {"copilot", "github-copilot"}:
-        try:
-            from hermes_cli.models import github_model_reasoning_efforts
-        except Exception:
-            return _heuristic_reasoning_efforts(hinted_model, provider)
+        # Tri-state, not a bare passthrough.
+        #
+        #   answer      -> the catalog spoke: honour it verbatim, including an
+        #                  authoritative empty list (haiku-4.5 genuinely has no
+        #                  ladder, and inventing one would 400).
+        #   unavailable -> the catalog could not be consulted at all: fall back
+        #                  to the local heuristic.
+        #   deny        -> a model the core positively rejects: stays empty.
+        #
+        # The distinction matters because a released core returns `[]` for
+        # Claude/Gemini/Grok/MAI *without* having read the catalog — it has no
+        # entry for them in its static table and no way to fetch one. Treating
+        # that `[]` as an answer made this whole feature inert in production:
+        # the resolver returned before the heuristic below could run.
+        efforts, resolved, core_levels, core_verdict = (
+            _copilot_catalog_reasoning_efforts(hinted_model)
+        )
+        if resolved:
+            return _filter_reasoning_efforts_for_provider(
+                efforts, hinted_model, provider
+            )
+        # Not resolved. The heuristic below is only safe to expose when the
+        # installed core would actually SEND what the control offers, so ask
+        # THIS model's question rather than a global one: a core that cannot
+        # resolve Claude/Gemini/Grok still resolves gpt-5 from its static
+        # table, and gating those off too would hide a control that works.
+        #
+        # When no core is importable at all there is no runtime to disagree
+        # with (a standalone WebUI, or CI), so the heuristic stands as the
+        # only available answer.
+        if core_verdict == "inert":
+            # The core is installed, has no catalog path, and resolves nothing
+            # for this model: the control would be visible but inert. Hide it.
+            return []
+        heuristic = _heuristic_reasoning_efforts(hinted_model, provider)
+        # The heuristic comes from the vendor's published table, which can be
+        # wider than the installed core's own offline table (the Copilot
+        # catalog lists `minimal` for Gemini 3.x Flash; the core's static
+        # fallback stops at low/medium/high). Offering the extra level would
+        # put a control on screen that the runtime silently drops, so narrow
+        # to what the core will actually resolve for this model.
+        #
+        # The single call above already consulted the core and
+        # cached its answer for this lookup, so this reuses that observation
+        # rather than calling the resolver a second time — a second call is
+        # exactly the two-observation gap the single-fetch collapse removed.
+        if core_levels:
+            heuristic = [eff for eff in heuristic if eff in core_levels]
         return _filter_reasoning_efforts_for_provider(
-            github_model_reasoning_efforts(hinted_model), hinted_model, provider
+            heuristic,
+            hinted_model,
+            provider,
         )
 
     if provider == "lmstudio":
@@ -4088,6 +4782,13 @@ def coerce_reasoning_effort_for_model(
     if raw == "none" and _zai_glm_classification(model_id, provider_id) == "forced":
         return ""
     if raw == "none":
+        # Models with an effort ladder but no off position (Grok) must not
+        # receive reasoning_effort:"none" — xAI rejects it outright and the
+        # native endpoint silently ignores it, leaving reasoning on while the
+        # UI claims it is off. Degrade to the provider default instead, which
+        # is the honest representation of "this cannot be turned off".
+        if not supports_disable_reasoning(model_id, provider_id, base_url):
+            return ""
         return "none"
     if raw not in VALID_REASONING_EFFORTS:
         return ""
@@ -4121,6 +4822,15 @@ def coerce_reasoning_effort_for_model(
             raw_idx = None
         if raw_idx is not None:
             for level in reversed(ladder[:raw_idx]):  # strictly lower, highest first
+                if level in ceiling:
+                    return level
+            # Nothing lower is supported. This happens when the EXCLUDED level
+            # is at the bottom of the ladder: Gemini 3.1 Pro and the 2.5 line
+            # publish no `minimal`, so a stored `minimal` has nowhere to
+            # degrade. Falling through would return it unchanged and send the
+            # very value the ceiling just rejected. Climb to the nearest
+            # supported level instead — the smallest legal amount of thinking.
+            for level in ladder[raw_idx + 1:]:  # strictly higher, lowest first
                 if level in ceiling:
                     return level
     # An empty list is ambiguous: resolve_model_reasoning_efforts() returns []
@@ -4238,6 +4948,14 @@ def get_reasoning_status(
         # effort-capable model OR a ZAI GLM model that accepts the thinking
         # toggle but not the effort ladder. False hides the chip entirely.
         "supports_thinking_toggle": supports_thinking_toggle,
+        # Whether "None" (reasoning off) is a legal position. Separate from
+        # supports_thinking_toggle: Grok has a full effort ladder but no off
+        # position, so the composer must render the ladder WITHOUT "None".
+        "supports_disable_reasoning": supports_disable_reasoning(
+            resolve_model,
+            provider_id=resolve_provider,
+            base_url=resolve_base_url,
+        ),
     }
 
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -5092,6 +5092,11 @@ let _currentReasoningEffortsSupported=null;
 // is empty (GLM-4.5–5.1 on native zai). Undefined = unknown, treated as true
 // so the chip stays visible by default (prior behavior).
 let _currentReasoningToggleSupported=undefined;
+// Whether "None" (reasoning off) is a legal position for this model. Separate
+// from the toggle flag: Grok has a full effort ladder but rejects
+// reasoning_effort:"none", so the ladder must render without "None".
+// Undefined = unknown, treated as true (prior behavior).
+let _currentReasoningDisableSupported=undefined;
 let _profileTransitionReasoningContext=null;
 
 function _normalizeReasoningEffort(eff){
@@ -5137,21 +5142,29 @@ function _reasoningEffortQuery(){
   return qs?('?'+qs):'';
 }
 
-function _applyReasoningOptions(supportedEfforts){
+function _applyReasoningOptions(supportedEfforts, canDisable){
   const dd=$('composerReasoningDropdown');
   if(!dd) return;
   const supported=new Set(Array.isArray(supportedEfforts)?supportedEfforts:[]);
+  const allowNone=(typeof canDisable==='boolean')?canDisable:true;
   dd.querySelectorAll('.reasoning-option').forEach(function(opt){
     const effort=opt.dataset.effort;
-    // 'none' (turn thinking off) and '' (Default = clear override, provider
-    // default = thinking on) are meta-options outside the effort ladder. They
-    // are always shown so a thinking-toggle-only model (GLM-4.5–5.1 on native
-    // zai, where the ladder is empty) still has an operable two-state control:
-    // Default (on) + None (off). Without the Default option the toggle is
-    // one-way off-only — the user can disable thinking but cannot re-enable it.
-    // (#6219 round-3)
-    if(effort==='none'||effort===''){
+    // '' (Default = clear override) is always available: it is the only way
+    // back to the provider default once an override is set.
+    if(effort===''){
       opt.style.display='';
+      return;
+    }
+    // 'none' (turn thinking off) is a meta-option outside the effort ladder,
+    // shown so a thinking-toggle-only model (GLM-4.5–5.1 on native zai, where
+    // the ladder is empty) still has an operable two-state control:
+    // Default (on) + None (off). Without the Default option the toggle is
+    // one-way off-only. (#6219 round-3)
+    // But it is NOT universal: models with an effort ladder and no off
+    // position (Grok) reject reasoning_effort:"none", so offering it there
+    // would send a value the runtime cannot honor.
+    if(effort==='none'){
+      opt.style.display=allowNone?'':'none';
       return;
     }
     if(!supported.size){
@@ -5178,6 +5191,10 @@ function _applyReasoningChip(eff){
   if(meta&&typeof meta.supports_thinking_toggle==='boolean'){
     _currentReasoningToggleSupported=meta.supports_thinking_toggle;
   }
+  // supports_disable_reasoning: whether "None" is a legal position at all.
+  if(meta&&typeof meta.supports_disable_reasoning==='boolean'){
+    _currentReasoningDisableSupported=meta.supports_disable_reasoning;
+  }
   const wrap=$('composerReasoningWrap');
   const label=$('composerReasoningLabel');
   const chip=$('composerReasoningChip');
@@ -5203,7 +5220,12 @@ function _applyReasoningChip(eff){
   }
   wrap.style.display='';
   if(mobileAction) mobileAction.style.display='';
-  if(typeof _applyReasoningOptions==='function') _applyReasoningOptions(supportedEfforts);
+  if(typeof _applyReasoningOptions==='function'){
+    const canDisable=(typeof _currentReasoningDisableSupported==='undefined')
+      ?true
+      :_currentReasoningDisableSupported;
+    _applyReasoningOptions(supportedEfforts, canDisable);
+  }
   const text=_formatReasoningEffortLabel(effort);
   label.textContent=text;
   if(mobileLabel) mobileLabel.textContent=text;

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -145,6 +145,312 @@ def test_openrouter_slash_prefix_unaffected():
     assert set(efforts) >= {"low", "medium", "high"}
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-3.6-flash",
+        "github_copilot/gemini-3.6-flash",
+        "github_copilot/gemini-3.1-pro-preview",
+        "grok-4.6",
+        "github_copilot/grok-4.5",
+    ],
+)
+def test_custom_litellm_gemini_and_grok_routes_expose_reasoning(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:litellm",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} via custom:litellm should expose reasoning efforts"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-1.5-pro",
+        "gemini-2.0-flash",
+        "grok-4",
+        "grok-4-fast",
+    ],
+)
+def test_custom_litellm_pre_reasoning_gemini_grok_stay_hidden(model_id):
+    assert cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:litellm",
+    ) == [], f"{model_id} must not expose a reasoning ladder"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        # xAI ships dated ids for the base Grok 4 line. A naive version parser
+        # reads "0709" / "20250709" as a minor >= 5 and wrongly exposes the
+        # ladder for a model that rejects reasoning_effort outright.
+        "grok-4-0709",
+        "grok-4-20250709",
+        "github_copilot/grok-4-0709",
+        # Same class on the Gemini side.
+        "gemini-2-20250219",
+    ],
+)
+def test_dated_model_ids_are_not_read_as_minor_versions(model_id):
+    assert cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:litellm",
+    ) == [], (
+        f"{model_id}: a trailing date stamp must not be parsed as a minor "
+        "version — the base model rejects reasoning_effort"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "grok-4.5",
+        "grok-4.6",
+        "gemini-2.5-pro",
+    ],
+)
+def test_date_stamp_guard_does_not_hide_real_minor_versions(model_id):
+    """The date-stamp guard must not over-tighten.
+
+    Paired with the test above: clamping the minor group to 1-2 digits has to
+    keep genuine `<major>.<minor>` ids working, or the fix trades a false
+    positive for a false negative.
+    """
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:litellm",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} has a real minor version and must still expose the ladder"
+    )
+
+
+# ── Grok: explicit shapes, NOT a monotonic version comparison ────────────────
+#
+# xAI's lineup is not ordered by version: grok-3-mini accepts an effort dial
+# while grok-3 does not, and within the 4.20 line only the multi-agent build
+# accepts one. A ">= 4.5" rule is wrong in BOTH directions, so both directions
+# are asserted here.
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "grok-3-mini",
+        "grok-3-mini-fast",
+        "grok-4.3",
+        "grok-4.5",
+        "grok-4.6",
+        "grok-4.20-multi-agent",
+    ],
+)
+def test_grok_effort_capable_shapes_expose_ladder(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id, provider_id="custom:litellm"
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} accepts reasoning_effort and must expose the ladder"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        # Reason natively but REJECT a reasoning_effort dial.
+        "grok-3",
+        "grok-4",
+        "grok-4-fast",
+        "grok-4-fast-reasoning",
+        "grok-4-fast-non-reasoning",
+        "grok-4-1-fast",
+        "grok-4.20",
+        "grok-4.20-non-reasoning",
+        "grok-code-fast-1",
+        # Dated build of the base 4 line.
+        "grok-4-0709",
+    ],
+)
+def test_grok_effort_incapable_shapes_stay_hidden(model_id):
+    """These would 400 on a `reasoning_effort` parameter.
+
+    `grok-4-fast-reasoning` is the interesting one: the generic
+    "reasoning"/"thinking" keyword shortcut in `_candidate_supports_reasoning`
+    claims any id containing that token, but "this model reasons" is a
+    different question from "this model exposes an effort control".
+    """
+    assert cfg.resolve_model_reasoning_efforts(
+        model_id, provider_id="custom:litellm"
+    ) == [], f"{model_id} rejects reasoning_effort and must stay hidden"
+
+
+# ── Gemini: non-text routes have no ladder at any version ────────────────────
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-embedding-001",
+        "gemini-3-pro-image-preview",
+        "gemini-imagine-2",
+        "gemini-2.5-flash-image",
+    ],
+)
+def test_gemini_non_text_routes_never_expose_ladder(model_id):
+    """Image / imagine / embedding routes must be denied before the version gate.
+
+    Checking the version first would let `gemini-3-pro-image-preview` in on
+    its `3`. Asserted for both provider shapes because the deny has to sit
+    above the Copilot branch as well as the custom-provider heuristic.
+    """
+    for provider in ("custom:litellm", "copilot"):
+        assert cfg.resolve_model_reasoning_efforts(
+            model_id, provider_id=provider
+        ) == [], f"{model_id} via {provider} must not expose a reasoning ladder"
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_ladder"),
+    [
+        # The non-text keyword sits in the WRAPPER segment while the model
+        # segment is an ordinary text Gemini. Scanning the whole route for
+        # `image`/`embedding` and the family name separately denied these.
+        ("image-router/gemini-3.6-flash", True),
+        ("embedding-gateway/gemini-3.1-pro-preview", True),
+        ("imagine-proxy/gemini-2.5-pro", True),
+        # The keyword is inside the MODEL segment itself: still denied.
+        ("vendor/gemini-3-pro-image-preview", False),
+        ("vendor/gemini-embedding-001", False),
+        ("router/gemini-imagine-2", False),
+    ],
+)
+def test_gemini_non_text_deny_is_scoped_to_the_model_segment(model_id, expected_ladder):
+    """The keyword and the family name must be read from the SAME segment.
+
+    A routed id can nest a model under a wrapper namespace. Asking "does the
+    route contain image/imagine/embedding" and "does the route mention gemini"
+    as two independent questions lets a wrapper name deny a valid text model:
+    `image-router/gemini-3.6-flash` matched `image` in the wrapper and `gemini`
+    in the model, and lost its ladder entirely.
+
+    Both directions are asserted here because either one alone is satisfiable
+    by a broken predicate: a whole-route scan passes the negatives, and
+    dropping the deny passes the positives.
+    """
+    for provider in ("custom:litellm", "custom:newapi"):
+        efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider)
+        if expected_ladder:
+            assert efforts, (
+                f"{model_id} via {provider}: the model segment is a text Gemini, "
+                f"but the wrapper name suppressed its ladder"
+            )
+            assert set(efforts) <= {"minimal", "low", "medium", "high"}, (
+                model_id,
+                provider,
+                efforts,
+            )
+        else:
+            assert efforts == [], (
+                f"{model_id} via {provider}: a non-text model segment must never "
+                f"expose a ladder (got {efforts})"
+            )
+
+
+def test_gemini_segment_helpers_agree_on_identity_and_text_ness():
+    """The two predicates must read the same segment, not different ones."""
+    # Wrapper namespace does not contribute identity...
+    assert cfg._gemini_model_segments("image-router/gemini-3.6-flash") == [
+        "gemini-3.6-flash"
+    ]
+    assert cfg._gemini_model_segments("acme-gemini-router/deepseek-r1") == []
+    # ...and non-text-ness is judged only on the identified segment.
+    assert cfg._gemini_route_is_non_text("image-router/gemini-3.6-flash") is False
+    assert cfg._gemini_route_is_non_text("vendor/gemini-3-pro-image-preview") is True
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("gemini-3.6-flash", "custom:litellm"),
+        ("gemini-3.6-flash", "gemini"),
+        ("gemini-3.6-flash", "copilot"),
+        ("gemini-2.5-pro", "gemini"),
+        ("google/gemini-2.5-pro", "openrouter"),
+        ("vertex/gemini-3-pro-preview", "custom:newapi"),
+        ("github_copilot/gemini-3.6-flash", "custom:litellm"),
+    ],
+)
+def test_gemini_ladder_is_exact_never_xhigh_or_max(model_id, provider_id):
+    """Gemini never offers `xhigh` or `max`, on any route.
+
+    Gemini has no such levels; the adapter reads an unknown `max` as medium,
+    so offering one would report a thinking depth that never happened.
+
+    Whether a ladder is offered AT ALL is a separate question answered by the
+    runtime, not by this test: on Copilot the control only appears when the
+    installed core resolves that model (see
+    `test_copilot_gemini_ladder_matches_runtime_capability` below), and on the
+    native provider the ladder is narrowed to the levels the adapter can
+    actually distinguish. Asserting a non-empty ladder unconditionally here
+    would contradict both of those and re-assert the visible-but-inert
+    behaviour this PR removes.
+    """
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+    assert "xhigh" not in efforts, (model_id, provider_id, efforts)
+    assert "max" not in efforts, (model_id, provider_id, efforts)
+    assert set(efforts) <= {"minimal", "low", "medium", "high"}, (
+        model_id,
+        provider_id,
+        efforts,
+    )
+
+
+def test_copilot_gemini_ladder_matches_runtime_capability():
+    """On Copilot, the Gemini control appears exactly when the runtime sends it.
+
+    This replaces an unconditional "must expose a ladder" assertion. The real
+    contract is agreement with the installed runtime: if the core resolves a
+    ladder for the model, the UI must offer one; if it does not, the UI must
+    stay empty rather than render a control the runtime ignores.
+    """
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    model_id = "gemini-3.6-flash"
+    wire = list(copilot_models.github_model_reasoning_efforts(model_id) or [])
+    ui = cfg.resolve_model_reasoning_efforts(model_id, provider_id="copilot")
+
+    if wire:
+        assert ui, (
+            f"{model_id}: the runtime resolves {wire} but the UI offers nothing"
+        )
+        assert set(ui) <= set(wire), (
+            f"{model_id}: UI offers levels the runtime will not send: "
+            f"ui={ui} wire={wire}"
+        )
+    else:
+        assert ui == [], (
+            f"{model_id}: the runtime sends no reasoning field, so the control "
+            f"must stay hidden (got {ui})"
+        )
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("claude-opus-5", "anthropic"),
+        ("gpt-5.5", "openai-codex"),
+        ("deepseek-v4-flash", "custom:newapi"),
+    ],
+)
+def test_gemini_clamp_does_not_touch_other_families(model_id, provider_id):
+    """The Gemini clamp must not narrow anyone else's ladder."""
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+    assert "xhigh" in efforts, (model_id, provider_id, efforts)
+
+
 def test_generalized_model_families_and_suffixed_ids():
     test_models = [
         # GPT
@@ -252,20 +558,28 @@ def test_deepseek_non_reasoning_variants_excluded(model_id):
 
 
 @pytest.mark.parametrize(
-    "model_id",
+    ("model_id", "expected"),
     [
-        "vertex/gemini-3.1-pro-preview",
-        "vertex/gemini-3-pro-preview",
-        "gemini_cli/gemini-3-pro-preview",
+        # Ladders are model-specific and come from Google's published
+        # "Controlling thinking" table. 3 Pro exposes only the two endpoints,
+        # so asserting a fixed low/medium/high for every route would demand a
+        # level the model does not accept.
+        ("vertex/gemini-3.1-pro-preview", {"low", "medium", "high"}),
+        ("vertex/gemini-3-pro-preview", {"low", "high"}),
+        ("gemini_cli/gemini-3-pro-preview", {"low", "high"}),
     ],
 )
-def test_custom_nested_gemini_routes_expose_reasoning(model_id):
+def test_custom_nested_gemini_routes_expose_reasoning(model_id, expected):
     efforts = cfg.resolve_model_reasoning_efforts(
         model_id,
         provider_id="custom:newapi",
     )
-    assert set(efforts) >= {"low", "medium", "high"}, (
-        f"{model_id} via custom:newapi should expose reasoning efforts"
+    # The point of this test is that a nested/prefixed route still resolves a
+    # usable ladder at all — plus that the ladder matches what the model
+    # actually publishes.
+    assert efforts, f"{model_id} via custom:newapi should expose reasoning efforts"
+    assert set(efforts) == expected, (
+        f"{model_id} via custom:newapi should expose exactly {sorted(expected)}"
     )
 
 

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -108,18 +108,552 @@ def test_codex_metadata_false_returns_empty(monkeypatch):
     ) == []
 
 
-def test_copilot_gpt55_caps_at_high(monkeypatch):
+@pytest.fixture(autouse=True)
+def _isolate_copilot_module_caches():
+    """Reset the core's module-level Copilot caches around every test.
+
+    `hermes_cli.models` memoises both the resolved catalog token and the
+    catalog itself, deliberately and for the whole process. A test that
+    monkeypatches the resolution seams therefore leaves its result behind:
+    the patch is undone at teardown, but the cached VALUE survives and the
+    next test silently reuses it.
+
+    Concretely, the static-fallback test caches an empty token, and the
+    live-catalog test that follows then resolves through the offline
+    fallback instead of the catalog it just installed — passing alone and
+    failing in file order. Reset before and after so neither direction of
+    leakage is possible.
+    """
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        yield
+        return
+
+    import api.config as cfg  # noqa: F401  (import kept for fixture parity)
+
+    names = (
+        "_copilot_reasoning_token_cache",
+        "_copilot_reasoning_token_cache_time",
+        "_github_model_catalog_cache",
+        "_github_model_catalog_cache_key",
+        "_github_model_catalog_cache_time",
+    )
+
+    def _clear():
+        for name in names:
+            if hasattr(copilot_models, name):
+                setattr(
+                    copilot_models,
+                    name,
+                    0.0 if name.endswith("_time") else None,
+                )
+
+    _clear()
+    yield
+    _clear()
+
+
+def test_copilot_gpt55_static_fallback_caps_at_high(monkeypatch):
     import api.config as cfg
 
     try:
-        from hermes_cli.models import github_model_reasoning_efforts
+        import hermes_cli.models as copilot_models
     except ImportError:
         pytest.skip("hermes_cli not available")
+
+    # Force the "no catalog available" world this test is about. Without
+    # pinning the capability flag, a catalog-aware core resolves the capability
+    # probe as True and the lookup takes the catalog branch instead of the
+    # static fallback — the test would then be asserting about a path it did
+    # not mean to exercise.
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: False
+    )
+    monkeypatch.setattr(copilot_models, "_resolve_copilot_catalog_api_key", lambda: "")
+    monkeypatch.setattr(copilot_models, "fetch_github_model_catalog", lambda **_k: None)
 
     result = cfg.resolve_model_reasoning_efforts(
         "gpt-5.5", provider_id="copilot"
     )
+    assert "medium" in result
+    assert "high" in result
     assert "xhigh" not in result
+    assert "max" not in result
+
+
+def test_copilot_catalog_ladder_wins_through_public_resolver(monkeypatch):
+    """The catalog ladder must survive all the way through the PUBLIC resolver.
+
+    This deliberately asserts on `resolve_model_reasoning_efforts()` rather
+    than on the private heuristic. An earlier revision passed a
+    heuristic-level assertion while the public resolver still returned `[]` on
+    a released core — the feature was inert in production and the suite was
+    green, because the test never exercised the path the UI actually calls.
+
+    Forcing the capability on (rather than skipping when the core lacks it)
+    also means this cannot silently stop testing anything: the tri-state
+    lookup has to classify a real catalog answer as an answer.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    catalog = [
+        {
+            "id": "claude-opus-5",
+            "capabilities": {
+                "type": "chat",
+                "supports": {
+                    "reasoning_effort": ["low", "medium", "high", "xhigh", "max"]
+                },
+            },
+        },
+        {
+            "id": "gemini-3.6-flash",
+            "capabilities": {
+                "type": "chat",
+                "supports": {"reasoning_effort": ["minimal", "low", "medium", "high"]},
+            },
+        },
+        {
+            "id": "grok-4.6",
+            "capabilities": {
+                "type": "chat",
+                "supports": {"reasoning_effort": ["low", "medium", "high", "xhigh"]},
+            },
+        },
+        {
+            "id": "claude-haiku-4.5",
+            "capabilities": {"type": "chat", "supports": {}},
+        },
+    ]
+
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "tok", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: catalog, raising=False
+    )
+    # The core is the authority here, so make it behave like one regardless of
+    # which core is installed: answer from the injected catalog.
+    def _from_catalog(model_id, **_kw):
+        entry = next((e for e in catalog if e["id"] == model_id), None)
+        if entry is None:
+            return []
+        return list(entry["capabilities"].get("supports", {}).get("reasoning_effort", []))
+
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _from_catalog, raising=False
+    )
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "claude-opus-5", provider_id="copilot"
+    ) == ["low", "medium", "high", "xhigh", "max"]
+    assert cfg.resolve_model_reasoning_efforts(
+        "gemini-3.6-flash", provider_id="copilot"
+    ) == ["minimal", "low", "medium", "high"]
+    assert cfg.resolve_model_reasoning_efforts(
+        "grok-4.6", provider_id="copilot"
+    ) == ["low", "medium", "high", "xhigh"]
+    # An authoritative EMPTY entry must be honoured, not replaced by a guess.
+    assert cfg.resolve_model_reasoning_efforts(
+        "claude-haiku-4.5", provider_id="copilot"
+    ) == []
+
+
+def test_released_core_hides_control_it_cannot_actually_send(monkeypatch):
+    """A core that ignores the ladder must get NO control, not a heuristic one.
+
+    Earlier this test asserted the opposite — that a released core should still
+    surface a heuristic ladder. That encoded the bug: the released core's wire
+    path calls `github_model_reasoning_efforts()` bare, gets `[]` for
+    Claude/Gemini/Grok/MAI, and sends no reasoning field at all. Showing a
+    populated control on top of that is a visible-but-inert widget: the user
+    picks a thinking level and nothing whatsoever changes on the wire.
+
+    The honest contract is that the UI must not offer a reasoning value the
+    installed runtime will not send. The ladder returns once the core resolves
+    it on a bare call (covered by the sibling test below).
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    # Simulate the released core exactly: the reasoning lookup ignores the
+    # catalog entirely and knows only GPT-5 / o-series.
+    def _released_core(model_id, **_kw):
+        bare = str(model_id or "").lower()
+        if bare.startswith("gpt-5"):
+            return ["minimal", "low", "medium", "high"]
+        return []
+
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _released_core, raising=False
+    )
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: False
+    )
+
+    for model_id in ("claude-opus-5", "gemini-3.6-flash", "grok-4.6", "mai-code-1.1-flash"):
+        efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="copilot")
+        assert efforts == [], (
+            f"{model_id}: a control was offered but this core sends no reasoning "
+            f"field for it — visible but inert (got {efforts})"
+        )
+
+    # The model this core DOES resolve keeps its ladder: the gate is about
+    # runtime agreement, not about suppressing Copilot reasoning wholesale.
+    gpt = cfg.resolve_model_reasoning_efforts("gpt-5.5", provider_id="copilot")
+    assert {"low", "medium", "high"} <= set(gpt), gpt
+
+    # Models that genuinely have no ladder must stay empty either way.
+    for model_id in ("claude-haiku-4.5", "grok-4", "gemini-embedding-001"):
+        assert cfg.resolve_model_reasoning_efforts(
+            model_id, provider_id="copilot"
+        ) == [], model_id
+
+
+def test_catalog_aware_core_exposes_full_ladder(monkeypatch):
+    """The counterpart: when the core DOES resolve bare calls, show the ladder.
+
+    Pairs with the test above so the gate is proven in both directions — the
+    control must appear exactly when the runtime will honour it.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    ladders = {
+        "claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
+        "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
+        "grok-4.6": ["low", "medium", "high", "xhigh"],
+        "mai-code-1.1-flash": ["low", "medium", "high"],
+    }
+
+    def _catalog_core(model_id, **_kw):
+        return list(ladders.get(str(model_id or "").lower(), []))
+
+    # Stub the fetch too: without it the resolver takes the real catalog path
+    # and this test silently measures the live catalog instead of the branch
+    # it names. A stub must match production on every dimension the code under
+    # test depends on, and only simulate the one being varied.
+    catalog = [
+        {
+            "id": model_id,
+            "capabilities": {
+                "type": "chat",
+                "supports": {"reasoning_effort": levels},
+            },
+        }
+        for model_id, levels in ladders.items()
+    ]
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: catalog, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "probe", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _catalog_core, raising=False
+    )
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+
+    for model_id, expected in ladders.items():
+        efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="copilot")
+        assert efforts == expected, (model_id, efforts, expected)
+
+
+def test_catalog_capable_core_with_failing_fetch_falls_back(monkeypatch):
+    """A live fetch failure is "unavailable", not "authoritatively empty".
+
+    The discriminator has to reflect THIS lookup's outcome, not a static
+    capability of the installed core. A catalog-aware core whose real fetch
+    fails right now still returns `[]`, and calling that authoritative drops
+    the ladder for every model its own offline table does not know —
+    `grok-3-mini` and `grok-4.3` are exactly that shape, so they lose the
+    control whenever the network or the credential is down.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    # Core CAN read catalogs (capability probe passes) but the real fetch fails.
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: None, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "", raising=False
+    )
+
+    def _empty_for_non_gpt(model_id, **_kw):
+        return [] if not str(model_id or "").lower().startswith("gpt-5") else ["low", "high"]
+
+    monkeypatch.setattr(
+        copilot_models,
+        "github_model_reasoning_efforts",
+        _empty_for_non_gpt,
+        raising=False,
+    )
+
+    for model_id in ("grok-4.3", "grok-3-mini", "claude-opus-5"):
+        efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="copilot")
+        assert {"low", "medium", "high"} <= set(efforts), (
+            f"{model_id}: a failed catalog fetch was treated as an authoritative "
+            f"empty answer — the ladder vanished (got {efforts})"
+        )
+
+    # Models with genuinely no ladder stay empty via the heuristic.
+    for model_id in ("grok-4", "claude-haiku-4.5"):
+        assert cfg.resolve_model_reasoning_efforts(
+            model_id, provider_id="copilot"
+        ) == [], model_id
+
+
+def test_transient_fetch_failure_then_success_keeps_ladder(monkeypatch):
+    """A `None -> catalog` fetch sequence must not drop the ladder.
+
+    Classification and resolution used to come from two separate fetches. With
+    a transient failure on the first and a success on the second, the pair read
+    as "empty" AND "authoritative" — a positive deny — so `grok-4.3` lost its
+    control during exactly the network/auth-recovery window it should survive.
+
+    Asserts on the public resolver, and also pins that only ONE fetch happens:
+    a single fetch is what makes the two answers unable to disagree, so the
+    call count is part of the contract rather than an efficiency note.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    catalog = [
+        {
+            "id": "claude-opus-5",
+            "capabilities": {
+                "type": "chat",
+                "supports": {"reasoning_effort": ["low", "medium", "high"]},
+            },
+        },
+        {
+            "id": "claude-haiku-4.5",
+            "capabilities": {"type": "chat", "supports": {}},
+        },
+    ]
+
+    calls = {"n": 0}
+
+    def _transient_fetch(**_kw):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else catalog
+
+    def _resolver(model_id, **kwargs):
+        cat = kwargs.get("catalog")
+        if cat is None:
+            cat = copilot_models.fetch_github_model_catalog(api_key="tok")
+        if not cat:
+            return []
+        entry = next((e for e in cat if e["id"] == model_id), None)
+        if entry is None:
+            return []
+        return list(entry["capabilities"].get("supports", {}).get("reasoning_effort", []))
+
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", _transient_fetch, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "tok", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _resolver, raising=False
+    )
+
+    efforts = cfg.resolve_model_reasoning_efforts("grok-4.3", provider_id="copilot")
+    assert {"low", "medium", "high"} <= set(efforts), (
+        f"grok-4.3 lost its ladder across a transient fetch failure (got {efforts})"
+    )
+    assert calls["n"] == 1, (
+        f"expected exactly one catalog fetch, saw {calls['n']} — a second fetch "
+        "reintroduces the check/use gap"
+    )
+
+
+def test_model_absent_from_catalog_is_not_an_authoritative_deny(monkeypatch):
+    """A live catalog that simply does not list a model is not a deny.
+
+    When the id is absent the core falls back to its own static table, and that
+    table returning `[]` means "unknown to me", not "no ladder". Conflating the
+    two would drop the control for any model missing from a partial catalog,
+    while a model the catalog DOES list with no ladder must still stay empty.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    # grok-4.3 is deliberately absent; claude-haiku-4.5 is listed with no ladder.
+    catalog = [
+        {
+            "id": "claude-haiku-4.5",
+            "capabilities": {"type": "chat", "supports": {}},
+        },
+    ]
+
+    def _resolver(model_id, **kwargs):
+        cat = kwargs.get("catalog") or catalog
+        entry = next((e for e in cat if e["id"] == model_id), None)
+        if entry is None:
+            return []
+        return list(entry["capabilities"].get("supports", {}).get("reasoning_effort", []))
+
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: catalog, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "tok", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _resolver, raising=False
+    )
+
+    absent = cfg.resolve_model_reasoning_efforts("grok-4.3", provider_id="copilot")
+    assert {"low", "medium", "high"} <= set(absent), (
+        f"grok-4.3 is absent from the catalog, not denied by it (got {absent})"
+    )
+
+    listed = cfg.resolve_model_reasoning_efforts(
+        "claude-haiku-4.5", provider_id="copilot"
+    )
+    assert listed == [], (
+        f"claude-haiku-4.5 IS listed with no ladder — that deny must be honoured "
+        f"(got {listed})"
+    )
+
+
+def test_legacy_resolver_without_catalog_kwarg_still_resolves(monkeypatch):
+    """A core resolver predating the `catalog=` keyword must still work.
+
+    Decided from the signature rather than by catching TypeError, so it must
+    be called bare — exactly once, with no failed probe call first.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    catalog = [{
+        "id": "claude-opus-5",
+        "capabilities": {
+            "type": "chat",
+            "supports": {"reasoning_effort": ["low", "medium", "high", "xhigh", "max"]},
+        },
+    }]
+    calls = []
+
+    def _legacy(model_id):          # no catalog kwarg at all
+        calls.append(model_id)
+        return ["low", "medium", "high", "xhigh", "max"]
+
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: catalog, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "tok", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _legacy, raising=False
+    )
+
+    efforts = cfg.resolve_model_reasoning_efforts("claude-opus-5", provider_id="copilot")
+    assert efforts == ["low", "medium", "high", "xhigh", "max"]
+    assert len(calls) == 1, f"legacy resolver should be called once, saw {len(calls)}"
+
+
+def test_internal_typeerror_is_not_mistaken_for_an_old_signature(monkeypatch):
+    """A TypeError raised INSIDE a modern resolver must not trigger a retry.
+
+    Catching TypeError at the call site cannot distinguish "this resolver has
+    no catalog parameter" from "this resolver blew up internally". Retrying
+    the second case without the catalog would resolve from a different
+    observation than the one used to classify — the very gap the single-fetch
+    collapse removed. The resolver must be called exactly once, and the
+    failure must fall back rather than silently produce a second-observation
+    answer.
+    """
+    import api.config as cfg
+
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    catalog = [{
+        "id": "claude-opus-5",
+        "capabilities": {
+            "type": "chat",
+            "supports": {"reasoning_effort": ["low", "medium", "high", "xhigh", "max"]},
+        },
+    }]
+    seen = []
+
+    def _modern_but_broken(model_id, **kwargs):
+        seen.append("with_catalog" if "catalog" in kwargs else "bare")
+        raise TypeError("unrelated internal failure")
+
+    monkeypatch.setattr(
+        cfg, "_copilot_core_reads_catalog_unprompted", lambda _m: True
+    )
+    monkeypatch.setattr(
+        copilot_models, "fetch_github_model_catalog", lambda **_k: catalog, raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "_resolve_copilot_catalog_api_key", lambda: "tok", raising=False
+    )
+    monkeypatch.setattr(
+        copilot_models, "github_model_reasoning_efforts", _modern_but_broken, raising=False
+    )
+
+    cfg.resolve_model_reasoning_efforts("claude-opus-5", provider_id="copilot")
+
+    assert seen == ["with_catalog"], (
+        f"expected a single catalog-passing call, saw {seen} — an internal "
+        "TypeError was misread as an old signature and retried"
+    )
 
 
 def test_get_reasoning_status_uses_config_default_model(monkeypatch, tmp_path):
@@ -152,3 +686,88 @@ display:
     assert status["reasoning_effort"] == "medium"
     assert status["supported_efforts"] == list(cfg.VALID_REASONING_EFFORTS)
     assert status["supports_reasoning_effort"] is True
+
+
+@pytest.mark.parametrize(
+    ("shape", "accepts_catalog"),
+    [
+        ("plain_modern", True),
+        ("plain_legacy", False),
+        ("var_keyword", True),
+        ("wrapped_modern", True),
+        ("wrapped_legacy", False),
+        ("partial_modern", True),
+        ("partial_legacy", False),
+        ("callable_modern", True),
+        ("callable_legacy", False),
+        ("c_builtin", False),
+        ("unreadable_signature", False),
+        ("unreadable_signature_valueerror", False),
+    ],
+)
+def test_signature_probe_handles_exotic_callables(shape, accepts_catalog):
+    """Signature introspection must survive wrappers, partials and builtins.
+
+    The dispatcher decides by signature rather than by calling and catching
+    TypeError, so every callable shape a resolver can arrive in has to be
+    classified correctly. A false positive passes `catalog=` to something that
+    rejects it; a false negative silently drops the catalog and reintroduces
+    the two-observation gap. Where the signature genuinely cannot be read
+    (C-level builtins) the answer must be False -- fail closed to the bare
+    call, which is the historical behaviour.
+    """
+    import functools
+
+    import api.config as cfg
+
+    def modern(model_id, *, catalog=None, api_key=None):
+        return ["low", "medium", "high"]
+
+    def legacy(model_id):
+        return ["low", "medium", "high"]
+
+    def var_kw(model_id, **kwargs):
+        return ["low", "medium", "high"]
+
+    def wrap(fn):
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        return inner
+
+    class CallableModern:
+        def __call__(self, model_id, *, catalog=None, api_key=None):
+            return ["low", "medium", "high"]
+
+    class CallableLegacy:
+        def __call__(self, model_id):
+            return ["low", "medium", "high"]
+
+    resolvers = {
+        "plain_modern": modern,
+        "plain_legacy": legacy,
+        "var_keyword": var_kw,
+        "wrapped_modern": wrap(modern),
+        "wrapped_legacy": wrap(legacy),
+        "partial_modern": functools.partial(modern, api_key="k"),
+        "partial_legacy": functools.partial(legacy),
+        "callable_modern": CallableModern(),
+        "callable_legacy": CallableLegacy(),
+        "c_builtin": len,
+        # inspect.signature() raises for these -- the fail-closed branch.
+        # `len` is NOT such a case: its signature reads fine as (obj, /),
+        # so it exercises the ordinary "no catalog param" path instead.
+        "unreadable_signature": object(),
+        "unreadable_signature_valueerror": type,
+    }
+    resolver = resolvers[shape]
+
+    assert cfg._resolver_accepts_catalog_kwarg(resolver) is accepts_catalog
+
+    # And the dispatch that uses the answer must not raise for any real shape.
+    if shape not in {"c_builtin", "unreadable_signature",
+                     "unreadable_signature_valueerror"}:
+        assert cfg._call_copilot_resolver(
+            resolver, "claude-opus-5", [{"id": "claude-opus-5"}]
+        ) == ["low", "medium", "high"]

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -1,5 +1,7 @@
 """Tests for model-aware reasoning effort chip visibility."""
 
+import pytest
+
 from api import config as cfg
 
 
@@ -431,14 +433,24 @@ def test_get_reasoning_status_coerces_stale_max_to_xhigh(monkeypatch):
     assert status["reasoning_effort"] != "max"
 
 
-def test_max_effort_degrades_to_xhigh_for_gemini():
+def test_max_effort_degrades_to_top_supported_for_gemini():
     # Gemini's native ladder tops out below 'max'; its adapter would silently
-    # treat an unknown 'max' as medium. A stored/CLI 'max' must degrade to xhigh
-    # (the highest supported), not fall through to a worse level. (#4627 gate)
+    # treat an unknown 'max' as medium. A stored/CLI 'max' must degrade to the
+    # HIGHEST SUPPORTED level, not fall through to a worse one. (#4627 gate)
+    #
+    # That top level is 'high', not 'xhigh': Google documents
+    # minimal/low/medium/high and Gemini has no 'xhigh' either. This assertion
+    # previously read 'xhigh' because the ladder itself advertised one — the
+    # invariant ("degrade to the top of the real ladder") is unchanged, the
+    # ladder is simply accurate now.
     for model in ("gemini-3-pro", "gemini-3-flash"):
         assert cfg.coerce_reasoning_effort_for_model(
             "max", model_id=model, provider_id="gemini"
-        ) == "xhigh", f"{model} max must degrade to xhigh"
+        ) == "high", f"{model} max must degrade to the top supported level"
+        # And the degraded value must be a level the ladder actually offers.
+        assert "high" in cfg.resolve_model_reasoning_efforts(
+            model, provider_id="gemini"
+        ), model
 
 
 def test_max_effort_degrades_to_xhigh_for_pre_adaptive_anthropic():
@@ -593,4 +605,263 @@ def test_qwen_prefixed_alias_reasoning_detection():
         assert cfg._candidate_supports_reasoning(model) is True, (
             f"{model} must remain reasoning-capable (DeepSeek-R1 hybrid, "
             f"Qwen 2.x must not shadow the DeepSeek detector)"
+        )
+def test_grok_rejects_disable_reasoning():
+    """Grok 4.5/4.6 have an effort ladder but no off position.
+
+    xAI rejects `reasoning_effort:"none"` on these builds, and the native
+    endpoint silently ignores it and leaves reasoning on — so a "None" choice
+    would either error or lie about what the model is doing. The capability is
+    per-model and separate from "should a control be rendered at all": Grok 4.3
+    accepts disabling and keeps its None (see
+    `test_grok_disable_capability_is_per_model_not_a_blanket_prefix`).
+    """
+    for model_id in ("grok-4.6", "grok-4.5"):
+        assert cfg.supports_disable_reasoning(model_id) is False, model_id
+        assert cfg.coerce_reasoning_effort_for_model("none", model_id) == "", model_id
+
+    # The ladder itself must survive: this is about the off position only.
+    assert {"low", "medium", "high"} <= set(
+        cfg.resolve_model_reasoning_efforts("grok-4.6")
+    )
+    for level in ("low", "medium", "high"):
+        assert cfg.coerce_reasoning_effort_for_model(level, "grok-4.6") == level
+
+    # `grok-4-fast-reasoning` reasons natively but exposes NO effort dial, so
+    # it has no ladder at all — a different condition from "ladder without an
+    # off position", and not evidence about the disable capability.
+    assert cfg.resolve_model_reasoning_efforts("grok-4-fast-reasoning") == []
+
+
+def test_models_with_an_off_position_keep_none():
+    """The negative side of the gate: don't over-restrict.
+
+    A fix that hides "None" everywhere would break the Z.AI GLM thinking
+    toggle, whose entire control is the on/off pair.
+    """
+    assert cfg.supports_disable_reasoning("glm-4.6", "zai") is True
+    assert cfg.coerce_reasoning_effort_for_model("none", "glm-4.6", provider_id="zai") == "none"
+
+    assert cfg.supports_disable_reasoning("claude-opus-5") is True
+    assert cfg.coerce_reasoning_effort_for_model("none", "claude-opus-5") == "none"
+
+    # GLM-4.7 forces thinking on: it has no off position either.
+    assert cfg.supports_disable_reasoning("glm-4.7", "zai") is False
+
+
+def test_capability_probe_does_not_mutate_core_globals():
+    """The probe must answer without touching shared module state.
+
+    An earlier probe installed `mock.patch.object` stand-ins for the core's
+    token and fetch helpers. `patch.object` restores whatever the attribute
+    held when it was ENTERED, so two concurrent probes interleaving as
+    A-enter, B-enter, A-exit, B-exit left B writing A's probe lambda back as
+    the permanent value — permanently collapsing core catalog discovery to a
+    synthetic probe model. The server is threaded, so this was reachable.
+    """
+    try:
+        import hermes_cli.models as copilot_models
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    watched = (
+        "github_model_reasoning_efforts",
+        "fetch_github_model_catalog",
+        "_resolve_copilot_catalog_api_key",
+        "_cached_copilot_reasoning_token",
+    )
+    before = {
+        name: getattr(copilot_models, name, None)
+        for name in watched
+    }
+
+    for _ in range(5):
+        cfg._copilot_core_reads_catalog_unprompted(copilot_models)
+
+    for name in watched:
+        assert getattr(copilot_models, name, None) is before[name], (
+            f"{name} was replaced by the capability probe"
+        )
+
+
+def test_copilot_ladders_survive_without_hermes_cli(monkeypatch):
+    """No installed core at all must not suppress the Copilot controls.
+
+    The wire-agreement gate exists to avoid rendering a control the runtime
+    will silently ignore. When no core is importable there is no runtime to
+    disagree with — a standalone WebUI, or CI — so the heuristic is the only
+    answer available and must stand.
+
+    This is a real regression that reached CI: the first version of the gate
+    imported hermes_cli and failed closed, which erased every Copilot ladder
+    in an environment that has no core installed, `gpt-5.5` included.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_hermes_cli(name, *args, **kwargs):
+        if name.startswith("hermes_cli"):
+            raise ImportError("simulated: no hermes_cli installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_hermes_cli)
+
+    for model_id, provider_id in (
+        ("gpt-5.5", "copilot"),
+        ("gpt-5.5", "github-copilot"),
+        ("gemini-3.6-flash", "copilot"),
+        ("claude-opus-5", "copilot"),
+    ):
+        efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+        assert efforts, (
+            f"{model_id} via {provider_id}: the ladder vanished with no core "
+            "installed — the wire-agreement gate must not fire when there is "
+            "no runtime to disagree with"
+        )
+        assert {"low", "medium", "high"} <= set(efforts), (model_id, efforts)
+
+
+def test_grok_disable_capability_is_per_model_not_a_blanket_prefix():
+    """Only the Grok builds that reject `none` lose it — 4.3 keeps working.
+
+    A blanket `grok` prefix-deny is a silent regression, not a cosmetic one:
+    with `None` removed, the installed xAI transport defaults reasoning back
+    on at medium, so a user who picks "None" on Grok 4.3 silently gets medium
+    reasoning. The Agent core records the live verification: grok-4.5 rejects
+    `reasoning_effort: "none"` "unlike grok-4.3", and 4.6 is its successor.
+    """
+    # Verified to REJECT disabling.
+    for model_id in ("grok-4.5", "grok-4.6", "x-ai/grok-4.6"):
+        assert cfg.supports_disable_reasoning(model_id) is False, model_id
+        assert cfg.coerce_reasoning_effort_for_model("none", model_id) == "", model_id
+
+    # Verified to ACCEPT disabling — must keep None.
+    for model_id in ("grok-4.3", "grok-3-mini", "x-ai/grok-4.3"):
+        assert cfg.supports_disable_reasoning(model_id) is True, model_id
+        assert cfg.coerce_reasoning_effort_for_model("none", model_id) == "none", model_id
+
+    # The effort ladder itself is unaffected on both sides.
+    for model_id in ("grok-4.3", "grok-4.6"):
+        assert {"low", "medium", "high"} <= set(
+            cfg.resolve_model_reasoning_efforts(model_id)
+        ), model_id
+
+
+@pytest.mark.parametrize(
+    "model_id,is_gemini",
+    [
+        # Real Gemini ids, at every nesting depth.
+        ("gemini-3.6-flash", True),
+        ("google/gemini-2.5-pro", True),
+        ("vertex/gemini-3-pro-preview", True),
+        ("gemini", True),
+        # Models that merely CONTAIN the word — an unrestricted substring
+        # match clamped these to Gemini's ladder and dropped xhigh/max.
+        ("notgemini-deepseek-r1", False),
+        ("acme-gemini-router/deepseek-r1", False),
+        ("gemini-router/deepseek-r1", False),
+        ("deepseek-r1", False),
+    ],
+)
+def test_gemini_detection_matches_model_shaped_segments(model_id, is_gemini):
+    assert cfg._is_gemini_id(model_id) is is_gemini, model_id
+
+
+def test_non_gemini_model_named_like_gemini_keeps_its_full_ladder():
+    """The misclassification had a visible cost: levels silently disappeared."""
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "notgemini-deepseek-r1", provider_id="custom:litellm"
+    )
+    # Whatever the heuristic decides, it must NOT be Gemini's clamped ladder.
+    assert efforts != ["minimal", "low", "medium", "high"], efforts
+
+
+def test_native_gemini_offers_only_levels_the_adapter_distinguishes():
+    """Every offered native level must produce a distinct wire request.
+
+    The installed adapter collapses efforts when building `thinkingConfig`:
+    Gemini 2.5 maps every level to `{"includeThoughts": True}`, 3.x Pro maps
+    minimal/low/medium to `low`, and 3.x Flash maps minimal/low to `low`.
+    Offering an aliased level lets a user pick a depth that never reaches the
+    model. Asserted against the adapter's own function so this test tracks the
+    runtime rather than a copy of its rules.
+    """
+    try:
+        from agent.transports.chat_completions import (
+            _build_gemini_thinking_config as build,
+        )
+    except ImportError:
+        pytest.skip("agent transport not available")
+
+    for model_id in (
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3.6-flash",
+        "gemini-3.5-flash",
+    ):
+        ladder = cfg.resolve_model_reasoning_efforts(model_id, provider_id="gemini")
+        wires = [repr(build(model_id, {"effort": lv})) for lv in ladder]
+        assert len(set(wires)) == len(ladder), (
+            f"{model_id}: native ladder {ladder} collapses to "
+            f"{len(set(wires))} distinct request(s) — aliased levels offered"
+        )
+
+    # Gemini 2.5 distinguishes nothing, so it must offer no intensity control.
+    assert cfg.resolve_model_reasoning_efforts("gemini-2.5-pro", provider_id="gemini") == []
+
+
+def test_aggregator_gemini_keeps_the_published_ladder():
+    """Only the NATIVE path is narrowed — aggregators skip that adapter."""
+    assert cfg.resolve_model_reasoning_efforts(
+        "google/gemini-2.5-pro", provider_id="openrouter"
+    ) == ["low", "medium", "high"]
+    assert cfg.resolve_model_reasoning_efforts(
+        "gemini-3.6-flash", provider_id="custom:litellm"
+    ) == ["minimal", "low", "medium", "high"]
+
+
+@pytest.mark.parametrize(
+    ("model_id", "capable"),
+    [
+        # A date stamp must not be absorbed into the version number. These are
+        # `grok-4` plus a date, which a bare `startswith("grok-4-5")` reads as
+        # the effort-capable 4.5 build -- the composer would then offer levels
+        # the model rejects and the request fails.
+        ("grok-4-520250101", False),
+        ("grok-4-620250101", False),
+        ("grok-4-320250101", False),
+        ("grok-4-20250101", False),
+        # Genuinely dated capable builds must keep their ladder: the guard is
+        # about the version boundary, not about rejecting dates.
+        ("grok-4.5-20250101", True),
+        ("grok-4.6-20250101", True),
+        ("grok-3-mini-20250101", True),
+        # Undated baselines, unchanged.
+        ("grok-4", False),
+        ("grok-3", False),
+        ("grok-4.5", True),
+        ("grok-4.6", True),
+        ("grok-4.3", True),
+    ],
+)
+def test_grok_version_prefix_does_not_absorb_date_stamps(model_id, capable):
+    """Effort capability is decided on a version boundary, not a raw prefix.
+
+    Mirrors the `(?!\\d)` date-stamp guard the Claude branch already applies:
+    the character after a matched version prefix must not be a digit, or an
+    aggregator id like `grok-4-520250101` silently promotes `grok-4` to 4.5.
+    """
+    normalized = model_id.replace(".", "-")
+    assert cfg._grok_supports_effort(normalized) is capable, (model_id, capable)
+
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="custom:newapi")
+    if capable:
+        assert efforts, f"{model_id} should expose a ladder"
+        assert "xhigh" not in efforts and "max" not in efforts, (model_id, efforts)
+    else:
+        assert efforts == [], (
+            f"{model_id} rejects reasoning_effort but a ladder was offered: {efforts}"
         )


### PR DESCRIPTION
## Problem

When I select certain models in the composer, the thinking-level control does not appear at all — there is no way to pick a reasoning level from the UI, even for models that clearly support one.

The chip is gated on `resolve_model_reasoning_efforts()` returning a non-empty ladder. Two independent paths return `[]` for models that do support a reasoning ladder:

**1. `_candidate_supports_reasoning()` has no Gemini or Grok branch.**

This is the heuristic used for custom / aggregator providers. It recognises Claude, GPT-5, o-series, Qwen, Kimi, MiniMax, MiMo, GLM, Step and DeepSeek — but nothing for Gemini or Grok, so a proxied route like `<proxy-namespace>/<gemini-model>` falls through to the final `return False`.

**2. The Copilot branch of `_heuristic_reasoning_efforts()` only knows GPT-5 and the o-series.**

This is the fallback used when the agent-side catalog lookup is unavailable. Claude, Gemini, Grok and MAI-Code all resolve to an empty ladder there.

Because the same resolved list drives both the chip's visibility and the level that is actually applied, the effect is not only a hidden control — a configured level cannot be changed from the UI for these models.

## Fix

Add version-gated Gemini and Grok branches to the heuristic, and extend the Copilot fallback to cover Claude / Gemini / Grok / MAI-Code.

Every branch is version-gated so models **without** an effort dial stay hidden:

| Family | Exposed | Stays hidden |
|---|---|---|
| Gemini | 2.5+, 3-era | 1.5, 2.0 (no thinking control) |
| Grok | 4.5+, 5+ | grok-4, grok-4-fast (reason natively, reject `reasoning_effort`) |
| Claude | 4.6+ | pre-4.6, via the existing `_is_pre_adaptive_anthropic()` predicate |

Claude deliberately reuses the predicate that already exists in this file rather than introducing a second version rule that could drift from it.

The live provider catalog remains authoritative — it may advertise more levels (`xhigh`, `max`) or deny a family outright. This only fixes the fallback that runs when no catalog answer is available, so a model the catalog explicitly denies is still correctly hidden.

## Tests

`tests/test_custom_provider_bare_model_reasoning.py` and `tests/test_models_dev_reasoning.py`.

Both directions are asserted, so **widening the gate too far fails just as loudly as not widening it at all**:

- positive: Gemini 3.x and Grok 4.5+ (bare and `github_copilot/`-prefixed) expose `low/medium/high`
- negative: `gemini-1.5-pro`, `gemini-2.0-flash`, `grok-4`, `grok-4-fast` must stay `[]`
- catalog-authoritative: when the catalog answers, its ladder wins verbatim (including `xhigh`/`max`), and a family the catalog does not advertise stays `[]`
- the pre-existing GPT-5 ceiling assertion is kept and split so the static-fallback path is pinned explicitly

Verification on this branch, rebuilt on current `master`:

```
tests/test_models_dev_reasoning.py
tests/test_custom_provider_bare_model_reasoning.py
tests/test_reasoning_effort_model_capabilities.py
tests/test_auxiliary_models_settings.py
tests/test_copilot_provider_model_settings_not_allowlist.py
139 passed
```

I also confirmed the failure first: before the fix, the new positive cases fail with `assert set() >= {'high', 'low', 'medium'}`.

## Manual verification

Confirmed against a running instance rather than tests alone — `/api/reasoning` returns `supports_reasoning_effort: true` with the expected ladders, and the chip renders in the composer with the levels selectable.

## Not verified

The corresponding agent-side resolution (where a provider catalog can supply a richer ladder than this fallback) lives in a different repository and is out of scope here. This PR only changes what the WebUI resolves when it has no catalog answer to defer to.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests

@nesquena
