### PR TITLE
fix(profiles): propagate root .env vars to agent runtime

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -201,6 +201,30 @@ def _unwrap_profile_home_to_base(home: Path) -> Path:
 _PROTECTED_ENV_KEYS = frozenset({'HERMES_WEBUI_ISOLATED_PROFILE'})
 
 
+# #7048: explicit, origin-aware allowlist of root/parent .env keys that MAY fall
+# back into a named profile's agent runtime env. The root .env is the
+# deployment/operator layer ($HERMES_HOME/.env in the Docker two-container
+# setup); only the operator/runtime settings listed here are intended to be
+# shared across profiles (e.g. SEARXNG_URL, FIRECRAWL_*). Everything else —
+# server auth secrets, provider credentials, arbitrary *_API_KEY — stays at the
+# root and is NEVER blanket-inherited, preserving the named-profile isolation
+# invariant. A profile that defines any of these keys itself (even empty) still
+# wins over the root fallback.
+_ROOT_ENV_SHARE_ALLOWLIST = frozenset({
+    'SEARXNG_URL',
+})
+_ROOT_ENV_SHARE_ALLOWLIST_PREFIXES = (
+    'FIRECRAWL_',
+)
+
+
+def _root_env_key_allowlisted(key: str) -> bool:
+    """Return True when *key* is an explicitly allowlisted root .env setting."""
+    return key in _ROOT_ENV_SHARE_ALLOWLIST or key.startswith(
+        _ROOT_ENV_SHARE_ALLOWLIST_PREFIXES
+    )
+
+
 def _isolated_profile_opt_in() -> bool:
     """Return True only when isolated single-profile mode is EXPLICITLY enabled.
     Isolated mode is an intentional multi-user deployment posture (each user is
@@ -863,6 +887,54 @@ def _stringify_env_value(value) -> str:
     return str(value)
 
 
+def _parse_dotenv_text(text: str) -> dict[str, str]:
+    """Parse dotenv text into a key/value dict (canonical module parser).
+
+    Handles blank lines, ``#`` comments, the ``export KEY=value`` prefix
+    (supported copy-pasted shell-rc syntax — a naive ``split('=', 1)`` would
+    misparse the key as ``export KEY``), and single/double-quoted values.
+
+    Empty values are preserved on purpose: a profile that defines a key as
+    empty must be able to *suppress* root/process inheritance for that key
+    (#7048 precedence: profile-defined key, including empty, wins).
+    """
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#'):
+            continue
+        # Strip an optional 'export ' prefix (supported dotenv syntax).
+        if line.startswith('export '):
+            line = line[len('export '):].lstrip()
+        if '=' not in line:
+            continue
+        k, v = line.split('=', 1)
+        k = k.strip()
+        v = v.strip().strip('"').strip("'")
+        if k:
+            values[k] = v
+    return values
+
+
+def _root_env_path_for(home: Path) -> Optional[Path]:
+    """Return the root/parent .env a named profile may inherit from, else None.
+
+    Only a named profile home at ``*/profiles/<name>`` has a root layer
+    (``<base>/.env`` — the ``$HERMES_HOME/.env`` of the Docker two-container
+    deployment). The default/root profile and any other layout have no root
+    fallback: their own ``.env`` is already the top layer (#7048).
+    """
+    try:
+        home = Path(home).expanduser()
+        if home.name != 'default' and home.parent.name == 'profiles':
+            root_candidate = home.parent.parent / '.env'
+            if root_candidate.exists():
+                return root_candidate
+    except Exception:
+        pass
+    return None
+
+
 def get_profile_runtime_env(home: Path) -> dict[str, str]:
     """Return env vars needed to run an agent turn for a profile home.
 
@@ -872,6 +944,14 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
     environment variables (matching ``hermes -p <profile>``), so streaming must
     apply the selected profile's terminal config and ``.env`` for the duration
     of that run.
+
+    Precedence for the resulting env dict (#7048):
+      1. profile-defined key — from the profile's ``.env``, INCLUDING an empty
+         value (empty deliberately suppresses inheritance below);
+      2. existing launcher/process value — keys already present in the server
+         process env are never overridden by the root fallback;
+      3. root/parent ``.env`` fallback — only explicitly allowlisted
+         operator/runtime settings (never credentials or server auth secrets).
     """
     home = Path(home).expanduser()
     env: dict[str, str] = {}
@@ -895,22 +975,39 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
     env_path = home / '.env'
     if env_path.exists():
         try:
-            for line in env_path.read_text(encoding='utf-8').splitlines():
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    k, v = line.split('=', 1)
-                    k = k.strip()
-                    v = v.strip().strip('"').strip("'")
-                    if k and v:
-                        # #4589: never let a profile's own .env override an
-                        # operator/deployment posture (e.g. disable isolation via
-                        # HERMES_WEBUI_ISOLATED_PROFILE=0) on the runtime-env path
-                        # the same way _reload_dotenv() protects the live env.
-                        if k in _PROTECTED_ENV_KEYS:
-                            continue
-                        env[k] = v
+            for k, v in _parse_dotenv_text(env_path.read_text(encoding='utf-8')).items():
+                # #4589: never let a profile's own .env override an
+                # operator/deployment posture (e.g. disable isolation via
+                # HERMES_WEBUI_ISOLATED_PROFILE=0) on the runtime-env path
+                # the same way _reload_dotenv() protects the live env.
+                if k in _PROTECTED_ENV_KEYS:
+                    continue
+                env[k] = v
         except Exception:
             logger.debug("Failed to read runtime env from %s", env_path)
+
+    # #7048: root/parent .env fallback — explicit allowlist only, so a named
+    # profile inherits intended operator/runtime settings (SEARXNG_URL,
+    # FIRECRAWL_*) without blanket-inheriting credentials or server auth
+    # secrets. Profile-defined keys (including empty) and existing
+    # launcher/process values always win over this fallback.
+    root_env_path = _root_env_path_for(home)
+    if root_env_path is not None and root_env_path != env_path and root_env_path.exists():
+        try:
+            for k, v in _parse_dotenv_text(root_env_path.read_text(encoding='utf-8')).items():
+                if not v:
+                    continue  # an empty root value carries no fallback
+                if not _root_env_key_allowlisted(k):
+                    continue  # never blanket-inherit credentials/auth secrets
+                if k in _PROTECTED_ENV_KEYS:
+                    continue  # defense-in-depth: posture keys stay operator-only
+                if k in env:
+                    continue  # profile-defined key (incl. empty) suppresses
+                if k in os.environ:
+                    continue  # launcher/process value wins over root fallback
+                env[k] = v
+        except Exception:
+            logger.debug("Failed to read root env from %s", root_env_path)
 
     return env
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -205,24 +205,28 @@ _PROTECTED_ENV_KEYS = frozenset({'HERMES_WEBUI_ISOLATED_PROFILE'})
 # back into a named profile's agent runtime env. The root .env is the
 # deployment/operator layer ($HERMES_HOME/.env in the Docker two-container
 # setup); only the operator/runtime settings listed here are intended to be
-# shared across profiles (e.g. SEARXNG_URL, FIRECRAWL_*). Everything else —
-# server auth secrets, provider credentials, arbitrary *_API_KEY — stays at the
-# root and is NEVER blanket-inherited, preserving the named-profile isolation
-# invariant. A profile that defines any of these keys itself (even empty) still
-# wins over the root fallback.
+# shared across profiles (e.g. SEARXNG_URL and the non-secret FIRECRAWL_*
+# configuration: API/GATEWAY URLs and browser TTL). Everything else — server
+# auth secrets, provider credentials, and any *_API_KEY such as
+# FIRECRAWL_API_KEY (classified password=True by the agent's
+# hermes_cli/config_defaults.py) — stays at the root and is NEVER
+# blanket-inherited, preserving the named-profile isolation invariant. The
+# list is exact-match only: no prefix sweeping, so a future FIRECRAWL_* secret
+# cannot sneak in through a prefix. A profile that defines any of these keys
+# itself (even empty) still wins over the root fallback.
 _ROOT_ENV_SHARE_ALLOWLIST = frozenset({
     'SEARXNG_URL',
+    # Non-secret Firecrawl operator settings (password=False upstream); the
+    # self-hosted URL needs no key and the cloud key stays operator-scoped.
+    'FIRECRAWL_API_URL',
+    'FIRECRAWL_GATEWAY_URL',
+    'FIRECRAWL_BROWSER_TTL',
 })
-_ROOT_ENV_SHARE_ALLOWLIST_PREFIXES = (
-    'FIRECRAWL_',
-)
 
 
 def _root_env_key_allowlisted(key: str) -> bool:
     """Return True when *key* is an explicitly allowlisted root .env setting."""
-    return key in _ROOT_ENV_SHARE_ALLOWLIST or key.startswith(
-        _ROOT_ENV_SHARE_ALLOWLIST_PREFIXES
-    )
+    return key in _ROOT_ENV_SHARE_ALLOWLIST
 
 
 def _isolated_profile_opt_in() -> bool:
@@ -987,10 +991,11 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
             logger.debug("Failed to read runtime env from %s", env_path)
 
     # #7048: root/parent .env fallback — explicit allowlist only, so a named
-    # profile inherits intended operator/runtime settings (SEARXNG_URL,
-    # FIRECRAWL_*) without blanket-inheriting credentials or server auth
-    # secrets. Profile-defined keys (including empty) and existing
-    # launcher/process values always win over this fallback.
+    # profile inherits intended operator/runtime settings (SEARXNG_URL and the
+    # non-secret FIRECRAWL_* config keys) without blanket-inheriting
+    # credentials (incl. FIRECRAWL_API_KEY) or server auth secrets.
+    # Profile-defined keys (including empty) and existing launcher/process
+    # values always win over this fallback.
     root_env_path = _root_env_path_for(home)
     if root_env_path is not None and root_env_path != env_path and root_env_path.exists():
         try:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -891,46 +891,148 @@ def _stringify_env_value(value) -> str:
     return str(value)
 
 
+# #7048: the operator's env as it was at import time — the baseline the
+# "launcher/process value" precedence layer is measured against. The live
+# ``os.environ`` is deliberately NOT used for that check: any WebUI turn may
+# have mirrored another profile's runtime env into the process env, and reading
+# those values as inherited operator settings is what let a profile skip the
+# root ``.env`` fallback (or inherit a sibling profile's value) during
+# overlapping turns.
+_INITIAL_ENV = dict(os.environ)
+
+
+def _context_local_env_values() -> dict[str, str]:
+    """Context-local env values set for the active profile turn (#7048).
+
+    Read lazily through ``api.config``: ``api.profiles`` and ``api.config``
+    import each other, so a module-level import would create a cycle.
+    """
+    try:
+        from api.config import _thread_ctx
+
+        env = getattr(_thread_ctx, 'env', None)
+        if isinstance(env, dict) and env:
+            return {str(k): v for k, v in env.items() if isinstance(v, str)}
+    except Exception:
+        pass
+    return {}
+
+
+def _env_provided_by_launcher(key: str) -> bool:
+    """True when ``key`` was already provided before profile env application.
+
+    Covers the two legitimate sources of a pre-existing value: the import-time
+    process baseline (``_INITIAL_ENV`` — what the operator exported when the
+    WebUI server started) and the context-local env of the active profile turn.
+    Everything else, including mutations another profile turn mirrored into
+    ``os.environ``, does not count — the root ``.env`` layer stays eligible for
+    those keys instead of being suppressed by an unrelated value (#7048).
+    """
+    if key in _INITIAL_ENV:
+        return True
+    return key in _context_local_env_values()
+
+
+# Dotenv grammar shared with the launcher (``ctl.sh`` ``_apply_env_file_safely``)
+# so the WebUI resolves exactly the value a ``hermes -p`` shell would (#7048).
+# A key must be a POSIX-style identifier, which also keeps
+# ``os.environ.update()`` safe: a malformed key (empty, containing ``=`` or
+# NUL) raises ``ValueError`` and would brick every turn of the profile.
+# Keys ``ctl.sh`` refuses to export (bash keeps them read-only). Skipped here as
+# well so both loaders resolve the same ``.env`` identically (#7048).
+_DOTENV_SHELL_RESERVED_KEYS = frozenset({'UID', 'GID', 'EUID', 'EGID', 'PPID'})
+
+_DOTENV_KEY_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*')
+_DOTENV_DOUBLE_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"(?:[ \t]*#.*)?[ \t]*$', re.DOTALL)
+_DOTENV_SINGLE_QUOTED_RE = re.compile(r"'([^']*)'(?:[ \t]*#.*)?[ \t]*$", re.DOTALL)
+_DOTENV_INLINE_COMMENT_RE = re.compile(r'[ \t]+#.*$', re.DOTALL)
+_DOTENV_ESCAPES = {'n': '\n', 'r': '\r', 't': '\t', '"': '"', '\\': '\\'}
+
+
+def _parse_dotenv_value(value: str) -> str:
+    """Resolve the value half of a dotenv assignment (``ctl.sh``-compatible).
+
+    Double quotes honour backslash escapes and allow trailing whitespace plus an
+    inline ``#`` comment after the closing quote; single quotes are literal (no
+    escape processing); an unquoted value is cut at the first whitespace-then-
+    ``#`` comment, while a bare ``#`` with no leading whitespace stays data. A
+    value whose quotes never close falls back to the unquoted rule (kept as
+    written) instead of dropping the key — the same result the launcher gives.
+    """
+    value = value.lstrip()
+    match = _DOTENV_DOUBLE_QUOTED_RE.match(value)
+    if match:
+        inner = match.group(1)
+        if '\\' not in inner:
+            return inner
+        out: list[str] = []
+        i = 0
+        while i < len(inner):
+            ch = inner[i]
+            if ch == '\\' and i + 1 < len(inner):
+                nxt = inner[i + 1]
+                out.append(_DOTENV_ESCAPES.get(nxt, '\\' + nxt))
+                i += 2
+                continue
+            out.append(ch)
+            i += 1
+        return ''.join(out)
+    match = _DOTENV_SINGLE_QUOTED_RE.match(value)
+    if match:
+        return match.group(1)
+    return _DOTENV_INLINE_COMMENT_RE.sub('', value).rstrip()
+
+
 def _parse_dotenv_text(text: str) -> dict[str, str]:
     """Parse dotenv text into a key/value dict (canonical module parser).
 
-    Handles blank lines, ``#`` comments, the ``export KEY=value`` prefix
-    (supported copy-pasted shell-rc syntax — a naive ``split('=', 1)`` would
-    misparse the key as ``export KEY``), and single/double-quoted values.
+    Handles blank lines, full-line ``#`` comments, the ``export KEY=value``
+    prefix (supported copy-pasted shell-rc syntax — a naive ``split('=', 1)``
+    would misparse the key as ``export KEY``; whitespace after ``export`` —
+    including a tab — is valid), quoting/escapes and inline comments via
+    ``_parse_dotenv_value``, and whitespace around ``=``.
 
     Empty values are preserved on purpose: a profile that defines a key as
     empty must be able to *suppress* root/process inheritance for that key
-    (#7048 precedence: profile-defined key, including empty, wins).
+    (#7048 precedence: profile-defined key, including empty, wins). Lines whose
+    key is not a valid identifier are skipped rather than exported.
     """
     values: dict[str, str] = {}
-    for raw_line in text.splitlines():
+    for raw_line in (text or '').splitlines():
         line = raw_line.strip()
         if not line or line.startswith('#'):
             continue
-        # Strip an optional 'export ' prefix (supported dotenv syntax).
-        if line.startswith('export '):
-            line = line[len('export '):].lstrip()
+        # Strip an optional 'export' prefix (supported dotenv syntax).
+        rest = line[len('export'):]
+        if line.startswith('export') and rest[:1].isspace():
+            line = rest.strip()
         if '=' not in line:
             continue
-        k, v = line.split('=', 1)
-        k = k.strip()
-        v = v.strip().strip('"').strip("'")
-        if k:
-            values[k] = v
+        raw_key, raw_value = line.split('=', 1)
+        key = ''.join(raw_key.split())
+        if not _DOTENV_KEY_RE.fullmatch(key) or key in _DOTENV_SHELL_RESERVED_KEYS:
+            continue
+        value = _parse_dotenv_value(raw_value)
+        if '\x00' in value:
+            continue
+        values[key] = value
     return values
 
 
 def _root_env_path_for(home: Path) -> Optional[Path]:
-    """Return the root/parent .env a named profile may inherit from, else None.
+    """Return the root/parent .env a profile may inherit from, else None.
 
-    Only a named profile home at ``*/profiles/<name>`` has a root layer
+    Any canonical profile home at ``*/profiles/<name>`` has a root layer
     (``<base>/.env`` — the ``$HERMES_HOME/.env`` of the Docker two-container
-    deployment). The default/root profile and any other layout have no root
-    fallback: their own ``.env`` is already the top layer (#7048).
+    deployment), and that includes ``*/profiles/default``: that directory is
+    still a profile home inside ``profiles/``, so its ``.env`` is a profile
+    layer and the parent ``.env`` is the root layer it may inherit from. A home
+    that is not inside a ``profiles/`` directory (a plain ``$HERMES_HOME``, whose
+    own ``.env`` is already the top layer) has no root fallback (#7048).
     """
     try:
         home = Path(home).expanduser()
-        if home.name != 'default' and home.parent.name == 'profiles':
+        if home.parent.name == 'profiles':
             root_candidate = home.parent.parent / '.env'
             if root_candidate.exists():
                 return root_candidate
@@ -952,8 +1054,12 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
     Precedence for the resulting env dict (#7048):
       1. profile-defined key — from the profile's ``.env``, INCLUDING an empty
          value (empty deliberately suppresses inheritance below);
-      2. existing launcher/process value — keys already present in the server
-         process env are never overridden by the root fallback;
+      2. existing launcher/process value — keys present in the import-time
+         process baseline (``_INITIAL_ENV``) or in the active profile turn's
+         context-local env are never overridden by the root fallback. The live
+         ``os.environ`` does not count here: another profile's turn may have
+         mirrored its own values into the process env, and those must not read
+         as an inherited operator setting (#7048);
       3. root/parent ``.env`` fallback — only explicitly allowlisted
          operator/runtime settings (never credentials or server auth secrets).
     """
@@ -1008,7 +1114,7 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
                     continue  # defense-in-depth: posture keys stay operator-only
                 if k in env:
                     continue  # profile-defined key (incl. empty) suppresses
-                if k in os.environ:
+                if k in os.environ and _env_provided_by_launcher(k):
                     continue  # launcher/process value wins over root fallback
                 env[k] = v
         except Exception:
@@ -1189,15 +1295,72 @@ def _profile_secret_env_names(profile_home_path: Path) -> set[str]:
     return names
 
 
+def _root_only_env_names_for_profile(
+    profile_home_path: Path,
+    safe_runtime_env: dict[str, str],
+) -> set[str]:
+    """Return root ``.env`` keys a named-profile turn must not inherit (#7048).
+
+    The ``.env`` next to ``profiles/`` is server/operator scope: a named profile
+    inherits only its explicitly allowlisted keys (plus whatever it defines
+    itself). When a turn mirrors its runtime env into the *process* env, every
+    other root key has to be scrubbed for the duration of that turn — otherwise
+    a key that only profile ``alpha`` defined would survive into a later profile
+    ``beta`` turn through the process env (overlapping alpha/beta turns on one
+    server process).
+
+    Shell-identity keys (``_BLOCKED_RUNTIME_ENV_KEYS``), protected posture keys
+    and ``HERMES_HOME`` are excluded: they are governed by the dedicated
+    context-local/process home machinery, not by the root-env mirror.
+    """
+    root_env_path = _root_env_path_for(Path(profile_home_path))
+    if root_env_path is None:
+        return set()
+    try:
+        root_values = _parse_dotenv_text(root_env_path.read_text(encoding='utf-8'))
+    except Exception:
+        logger.debug("Failed to read root env from %s", root_env_path)
+        return set()
+    profile_defined = set(safe_runtime_env or {})
+    root_only: set[str] = set()
+    for key, value in root_values.items():
+        if not value:
+            continue  # an empty root value carries no inherited default
+        if key in profile_defined:
+            continue  # the profile's own layer owns this key
+        if _root_env_key_allowlisted(key):
+            continue  # shared operator settings stay inherited
+        if key in _PROTECTED_ENV_KEYS or key in _BLOCKED_RUNTIME_ENV_KEYS:
+            continue  # posture/identity keys are handled elsewhere
+        if key == 'HERMES_HOME':
+            continue  # the profile home override has its own machinery
+        root_only.add(key)
+    return root_only
+
+
 def _apply_profile_env_to_process(
     process_env,
     safe_runtime_env: dict[str, str],
     *,
     secret_env_names: set[str],
+    root_only_env_names: Optional[set[str]] = None,
 ) -> dict[str, Optional[str]]:
-    scoped_keys = set(safe_runtime_env) | set(secret_env_names)
+    """Scope the process env to one profile turn; return the pre-turn values.
+
+    ``root_only_env_names`` are keys the root ``.env`` defines for the server
+    scope. A named profile does not inherit them (#7048), so they are dropped
+    from the process env for the duration of the turn — otherwise a key only
+    profile ``alpha`` defined would still be visible during a later ``beta``
+    turn. The returned map carries their pre-turn values, so the caller's
+    restore path puts them back.
+    """
+    root_scoped = set(root_only_env_names or ())
+    scoped_keys = set(safe_runtime_env) | set(secret_env_names) | root_scoped
     previous_env = {key: process_env.get(key) for key in scoped_keys}
     for key in secret_env_names:
+        if key not in safe_runtime_env:
+            process_env.pop(key, None)
+    for key in root_scoped:
         if key not in safe_runtime_env:
             process_env.pop(key, None)
     return previous_env
@@ -1386,6 +1549,14 @@ def profile_env_for_background_worker(
                 _SKILL_HOME_MODULE_PATCH_LOCK.acquire()
                 _acquired_skill_home_patch_lock = True
 
+        # #7048: keys the root .env defines for the server scope. A named
+        # profile does not inherit them, so any left in the process env by a
+        # previous turn (overlapping alpha/beta turns) must be dropped for this
+        # turn. Computed before the env lock: it only reads files.
+        root_only_env_names = _root_only_env_names_for_profile(
+            profile_home_path, safe_runtime_env
+        )
+
         with _ENV_LOCK:
             if scope_skill_modules and should_restore_skill_modules:
                 # Snapshot and patch before mutating process env so setup
@@ -1397,6 +1568,7 @@ def profile_env_for_background_worker(
                 os.environ,
                 safe_runtime_env,
                 secret_env_names=secret_env_names,
+                root_only_env_names=root_only_env_names,
             )
             had_hermes_home = "HERMES_HOME" in os.environ
             old_hermes_home = os.environ.get("HERMES_HOME")
@@ -1655,25 +1827,23 @@ def _reload_dotenv(home: Path):
         return
     try:
         loaded_keys: set[str] = set()
-        for line in env_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                k, v = line.split('=', 1)
-                k = k.strip()
-                v = v.strip().strip('"').strip("'")
-                if k and v:
-                    # Operator/deployment-level keys are never overridable by a
-                    # profile's own .env (#4589 — prevents a contained user from
-                    # disabling their isolation via HERMES_WEBUI_ISOLATED_PROFILE=0).
-                    if k in _PROTECTED_ENV_KEYS:
-                        logger.warning(
-                            "Ignoring protected key %s in profile .env %s; "
-                            "operator/deployment env takes precedence",
-                            k, env_path,
-                        )
-                        continue
-                    os.environ[k] = v
-                    loaded_keys.add(k)
+        # Same dotenv grammar as the root/profile layers (#7048), which is the
+        # grammar ``ctl.sh`` itself uses: a ``.env`` that the launcher parses
+        # resolves to the same key/value here.
+        for k, v in _parse_dotenv_text(env_path.read_text(encoding="utf-8")).items():
+            if v:
+                # Operator/deployment-level keys are never overridable by a
+                # profile's own .env (#4589 — prevents a contained user from
+                # disabling their isolation via HERMES_WEBUI_ISOLATED_PROFILE=0).
+                if k in _PROTECTED_ENV_KEYS:
+                    logger.warning(
+                        "Ignoring protected key %s in profile .env %s; "
+                        "operator/deployment env takes precedence",
+                        k, env_path,
+                    )
+                    continue
+                os.environ[k] = v
+                loaded_keys.add(k)
         _loaded_profile_env_keys = loaded_keys
     except Exception:
         _loaded_profile_env_keys = set()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9510,6 +9510,7 @@ def _run_agent_streaming(
                 snapshot_skill_home_modules,
                 get_hermes_home_for_profile,
                 get_profile_runtime_env,
+                _root_only_env_names_for_profile,
                 _skill_modules_support_profile_home,
                 _SKILL_HOME_MODULE_PATCH_LOCK,
             )
@@ -9518,10 +9519,17 @@ def _run_agent_streaming(
             _streaming_cron_profile_home_token = _STREAMING_CRON_PROFILE_HOME.set(_profile_home)
             _profile_runtime_env = get_profile_runtime_env(_profile_home_path)
             _safe_profile_runtime_env = filter_runtime_env_for_gateway_parity(_profile_runtime_env)
+            # #7048: root-scoped keys this profile must not inherit. Mirrored
+            # below so an overlapping turn of another profile cannot read them
+            # out of the process env.
+            _root_only_env_names = _root_only_env_names_for_profile(
+                _profile_home_path, _safe_profile_runtime_env
+            )
         except ImportError:
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
             _safe_profile_runtime_env = {}
+            _root_only_env_names = set()
             patch_skill_home_modules = None
             snapshot_skill_home_modules = None
             restore_skill_home_modules = None
@@ -9627,7 +9635,13 @@ def _run_agent_streaming(
                 # failures can unwind without leaking either state.
                 _streaming_skill_home_snapshot = snapshot_skill_home_modules()
                 patch_skill_home_modules(Path(_profile_home))
-            old_profile_env = {key: os.environ.get(key) for key in _safe_profile_runtime_env}
+            old_profile_env = {
+                key: os.environ.get(key)
+                for key in (set(_safe_profile_runtime_env) | _root_only_env_names)
+            }
+            for _root_scope_key in _root_only_env_names:
+                if _root_scope_key not in _safe_profile_runtime_env:
+                    os.environ.pop(_root_scope_key, None)
             old_cwd = os.environ.get('TERMINAL_CWD')
             old_exec_ask = os.environ.get('HERMES_EXEC_ASK')
             old_session_key = os.environ.get('HERMES_SESSION_KEY')

--- a/tests/test_issue7048_root_env_runtime_propagation.py
+++ b/tests/test_issue7048_root_env_runtime_propagation.py
@@ -1,0 +1,228 @@
+"""
+Regression tests for issue #7048: root/parent .env propagation into a named
+profile's agent runtime env (``get_profile_runtime_env``).
+
+The first fix attempt propagated EVERY non-profile key from the root
+``$HERMES_HOME/.env`` into the agent runtime. That leaked WebUI/server auth
+secrets and arbitrary ``*_API_KEY`` credentials into named profiles (breaking
+the named-profile isolation invariant) and misparsed the supported
+``export KEY=value`` dotenv syntax. This suite pins the corrected contract:
+
+  - explicit origin-aware allowlist (SEARXNG_URL, FIRECRAWL_*) — never a
+    blanket root→profile merge;
+  - precedence: profile-defined key (INCLUDING empty) > existing
+    launcher/process value > allowlisted root fallback;
+  - canonical dotenv parsing (``export`` prefix handled);
+  - default-profile and isolated-profile layouts stay safe.
+"""
+
+from pathlib import Path
+
+from api.profiles import get_profile_runtime_env, _parse_dotenv_text
+
+# Ambient vars that could act as launcher/process values or leaks if left set.
+_AMBIENT_ENV_KEYS = (
+    "SEARXNG_URL",
+    "FIRECRAWL_API_KEY",
+    "FIRECRAWL_BASE_URL",
+    "HERMES_WEBUI_PASSWORD",
+    "HERMES_WEBUI_ISOLATED_PROFILE",
+    "OPENAI_API_KEY",
+    "MY_RANDOM_VAR",
+    "MY_PROFILE_KEY",
+)
+
+
+def _write_env(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_root_secret_and_credential_keys_are_never_inherited(tmp_path, monkeypatch):
+    """[root-secret exclusion] Non-allowlisted root keys never cross into a
+    named profile — server auth secrets, arbitrary credentials, and plain
+    non-allowlisted vars stay at the root."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(
+        base / ".env",
+        "SEARXNG_URL=http://root-searx:8080\n"
+        "HERMES_WEBUI_PASSWORD=server-auth-secret\n"
+        "OPENAI_API_KEY=sk-root-secret\n"
+        "MY_RANDOM_VAR=not-allowlisted\n"
+        "HERMES_WEBUI_ISOLATED_PROFILE=0\n",
+    )
+
+    env = get_profile_runtime_env(alpha)
+
+    # The allowlisted operator setting IS shared…
+    assert env.get("SEARXNG_URL") == "http://root-searx:8080"
+    # …but server auth secrets, arbitrary credentials and non-allowlisted
+    # keys are NOT blanket-inherited, and the isolation posture stays
+    # operator-only.
+    assert "HERMES_WEBUI_PASSWORD" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "MY_RANDOM_VAR" not in env
+    assert "HERMES_WEBUI_ISOLATED_PROFILE" not in env
+
+
+def test_allowlisted_firecrawl_prefix_is_shared(tmp_path, monkeypatch):
+    """[allowlisted shared variable] FIRECRAWL_* (the #7048 operator settings)
+    propagate from the root .env into the named profile runtime env."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(
+        base / ".env",
+        "FIRECRAWL_API_KEY=fc-123\nFIRECRAWL_BASE_URL=http://fc:3002\n",
+    )
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("FIRECRAWL_API_KEY") == "fc-123"
+    assert env.get("FIRECRAWL_BASE_URL") == "http://fc:3002"
+
+
+def test_launcher_process_value_wins_over_root_fallback(tmp_path, monkeypatch):
+    """[launcher precedence] An existing launcher/process value is never
+    overridden by the allowlisted root fallback (the returned dict omits the
+    key so the process value stands after the merge)."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    monkeypatch.setenv("SEARXNG_URL", "http://launcher:8080")
+    _write_env(base / ".env", "SEARXNG_URL=http://root:8080\n")
+
+    env = get_profile_runtime_env(alpha)
+
+    assert "SEARXNG_URL" not in env, (
+        "root fallback must not override an existing launcher/process value"
+    )
+
+
+def test_empty_profile_key_suppresses_root_inheritance(tmp_path, monkeypatch):
+    """[empty-profile suppression] A profile that defines a key as EMPTY
+    suppresses root inheritance — the root value must not resurrect it."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(base / ".env", "SEARXNG_URL=http://root:8080\n")
+    _write_env(alpha / ".env", "SEARXNG_URL=\n")
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("SEARXNG_URL") == "", (
+        "a profile-defined empty key must suppress root inheritance, "
+        "not let the root value resurrect"
+    )
+
+
+def test_non_empty_profile_key_wins_over_root(tmp_path, monkeypatch):
+    """[non-empty-profile precedence] A non-empty profile value beats the root
+    fallback for the same allowlisted key."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(base / ".env", "SEARXNG_URL=http://root:8080\n")
+    _write_env(alpha / ".env", "SEARXNG_URL=http://profile:8080\n")
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("SEARXNG_URL") == "http://profile:8080"
+
+
+def test_default_profile_has_no_root_fallback_layer(tmp_path, monkeypatch):
+    """[default-profile behavior] The default/root profile's home IS the base:
+    its own .env is already the top layer, so no extra root fallback may be
+    layered on top (and its own .env stays unrestricted)."""
+    base, _alpha = _layout(tmp_path, monkeypatch)
+    _write_env(base / ".env", "SEARXNG_URL=http://default:8080\nMY_RANDOM_VAR=ok\n")
+
+    env = get_profile_runtime_env(base)
+
+    # Own .env read through the normal profile path — no double-source issue.
+    assert env.get("SEARXNG_URL") == "http://default:8080"
+    # The profile .env path is unrestricted (allowlist only governs ROOT keys).
+    assert env.get("MY_RANDOM_VAR") == "ok"
+
+
+def test_isolated_profile_layout_still_respects_allowlist(tmp_path, monkeypatch):
+    """[isolated-profile behavior] In isolated multi-user mode the pinned
+    profile home is still */profiles/<name>: the allowlisted root fallback
+    applies, but the isolation invariant holds — server auth secrets and
+    non-allowlisted root keys never cross into the pinned profile, and the
+    posture flag is never propagated."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_WEBUI_ISOLATED_PROFILE", "1")
+    _write_env(
+        base / ".env",
+        "SEARXNG_URL=http://root:8080\n"
+        "HERMES_WEBUI_PASSWORD=server-auth-secret\n"
+        "OPENAI_API_KEY=sk-root\n",
+    )
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("SEARXNG_URL") == "http://root:8080"
+    assert "HERMES_WEBUI_PASSWORD" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "HERMES_WEBUI_ISOLATED_PROFILE" not in env
+
+
+def test_export_prefixed_lines_parse_canonically(tmp_path, monkeypatch):
+    """[export parsing] 'export KEY=value' root lines parse as KEY (not
+    'export KEY') — both exact-allowlist and prefix-allowlist keys."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(
+        base / ".env",
+        "export SEARXNG_URL=http://root-export:8080\n"
+        "export FIRECRAWL_API_KEY=fc-export\n",
+    )
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("SEARXNG_URL") == "http://root-export:8080", (
+        "'export KEY=value' must parse as KEY, not 'export KEY'"
+    )
+    assert env.get("FIRECRAWL_API_KEY") == "fc-export"
+
+
+def test_export_prefix_in_profile_env_parses(tmp_path, monkeypatch):
+    """The canonical parser also serves the profile .env read: 'export' lines
+    parse correctly and protected keys stay filtered."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(
+        alpha / ".env",
+        "export MY_PROFILE_KEY=value1\n"
+        "export HERMES_WEBUI_ISOLATED_PROFILE=0\n",
+    )
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("MY_PROFILE_KEY") == "value1"
+    assert "HERMES_WEBUI_ISOLATED_PROFILE" not in env
+
+
+def test_parse_dotenv_text_handles_export_and_quoting():
+    """Direct unit coverage of the canonical parser: comments, export prefix
+    (incl. extra whitespace), quoting, and preserved empty values."""
+    parsed = _parse_dotenv_text(
+        "# comment\n"
+        "export KEY_ONE=value1\n"
+        "KEY_TWO=\"quoted value\"\n"
+        "export  KEY_THREE='single'\n"
+        "KEY_FOUR=\n"
+        "\n"
+    )
+    assert parsed == {
+        "KEY_ONE": "value1",
+        "KEY_TWO": "quoted value",
+        "KEY_THREE": "single",
+        "KEY_FOUR": "",
+    }
+
+
+def _layout(tmp_path, monkeypatch):
+    """Docker-style layout: base ~/.hermes with a root .env + named profiles.
+
+    Returns (base, alpha_home). Ambient vars are cleared first so they cannot
+    masquerade as launcher/process values or leaks.
+    """
+    base = tmp_path / ".hermes"
+    profiles_root = base / "profiles"
+    alpha = profiles_root / "alpha"
+    (profiles_root / "beta").mkdir(parents=True)
+    alpha.mkdir(parents=True, exist_ok=True)
+    for key in _AMBIENT_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return base, alpha

--- a/tests/test_issue7048_root_env_runtime_propagation.py
+++ b/tests/test_issue7048_root_env_runtime_propagation.py
@@ -8,7 +8,8 @@ secrets and arbitrary ``*_API_KEY`` credentials into named profiles (breaking
 the named-profile isolation invariant) and misparsed the supported
 ``export KEY=value`` dotenv syntax. This suite pins the corrected contract:
 
-  - explicit origin-aware allowlist (SEARXNG_URL, FIRECRAWL_*) — never a
+  - explicit origin-aware allowlist (SEARXNG_URL + non-secret FIRECRAWL_*
+    config keys; never FIRECRAWL_API_KEY or any *_API_KEY) — never a
     blanket root→profile merge;
   - precedence: profile-defined key (INCLUDING empty) > existing
     launcher/process value > allowlisted root fallback;
@@ -24,6 +25,9 @@ from api.profiles import get_profile_runtime_env, _parse_dotenv_text
 _AMBIENT_ENV_KEYS = (
     "SEARXNG_URL",
     "FIRECRAWL_API_KEY",
+    "FIRECRAWL_API_URL",
+    "FIRECRAWL_GATEWAY_URL",
+    "FIRECRAWL_BROWSER_TTL",
     "FIRECRAWL_BASE_URL",
     "HERMES_WEBUI_PASSWORD",
     "HERMES_WEBUI_ISOLATED_PROFILE",
@@ -39,14 +43,16 @@ def _write_env(path: Path, content: str) -> None:
 
 def test_root_secret_and_credential_keys_are_never_inherited(tmp_path, monkeypatch):
     """[root-secret exclusion] Non-allowlisted root keys never cross into a
-    named profile — server auth secrets, arbitrary credentials, and plain
-    non-allowlisted vars stay at the root."""
+    named profile — server auth secrets, arbitrary credentials (including the
+    password=True FIRECRAWL_API_KEY), and plain non-allowlisted vars stay at
+    the root."""
     base, alpha = _layout(tmp_path, monkeypatch)
     _write_env(
         base / ".env",
         "SEARXNG_URL=http://root-searx:8080\n"
         "HERMES_WEBUI_PASSWORD=server-auth-secret\n"
-        "OPENAI_API_KEY=sk-root-secret\n"
+        "OPENAI_API_KEY=«redacted:sk-…»\n"
+        "FIRECRAWL_API_KEY=fc-root-secret\n"
         "MY_RANDOM_VAR=not-allowlisted\n"
         "HERMES_WEBUI_ISOLATED_PROFILE=0\n",
     )
@@ -55,28 +61,38 @@ def test_root_secret_and_credential_keys_are_never_inherited(tmp_path, monkeypat
 
     # The allowlisted operator setting IS shared…
     assert env.get("SEARXNG_URL") == "http://root-searx:8080"
-    # …but server auth secrets, arbitrary credentials and non-allowlisted
-    # keys are NOT blanket-inherited, and the isolation posture stays
-    # operator-only.
+    # …but server auth secrets, arbitrary credentials (incl. FIRECRAWL_API_KEY)
+    # and non-allowlisted keys are NOT blanket-inherited, and the isolation
+    # posture stays operator-only.
     assert "HERMES_WEBUI_PASSWORD" not in env
     assert "OPENAI_API_KEY" not in env
+    assert "FIRECRAWL_API_KEY" not in env
     assert "MY_RANDOM_VAR" not in env
     assert "HERMES_WEBUI_ISOLATED_PROFILE" not in env
 
 
-def test_allowlisted_firecrawl_prefix_is_shared(tmp_path, monkeypatch):
-    """[allowlisted shared variable] FIRECRAWL_* (the #7048 operator settings)
-    propagate from the root .env into the named profile runtime env."""
+def test_allowlisted_firecrawl_config_keys_are_shared_but_key_is_not(tmp_path, monkeypatch):
+    """[allowlisted shared variable] The non-secret FIRECRAWL_* operator
+    settings (API/GATEWAY URLs, browser TTL — password=False upstream)
+    propagate from the root .env into the named profile runtime env, while
+    FIRECRAWL_API_KEY (password=True) stays at the root."""
     base, alpha = _layout(tmp_path, monkeypatch)
     _write_env(
         base / ".env",
-        "FIRECRAWL_API_KEY=fc-123\nFIRECRAWL_BASE_URL=http://fc:3002\n",
+        "FIRECRAWL_API_URL=http://fc:3002\n"
+        "FIRECRAWL_GATEWAY_URL=http://fc-gw:3003\n"
+        "FIRECRAWL_BROWSER_TTL=600\n"
+        "FIRECRAWL_API_KEY=fc-123\n",
     )
 
     env = get_profile_runtime_env(alpha)
 
-    assert env.get("FIRECRAWL_API_KEY") == "fc-123"
-    assert env.get("FIRECRAWL_BASE_URL") == "http://fc:3002"
+    assert env.get("FIRECRAWL_API_URL") == "http://fc:3002"
+    assert env.get("FIRECRAWL_GATEWAY_URL") == "http://fc-gw:3003"
+    assert env.get("FIRECRAWL_BROWSER_TTL") == "600"
+    # The Firecrawl credential is classified password=True and must never be
+    # blanket-inherited by a named profile (#3961 isolation invariant).
+    assert "FIRECRAWL_API_KEY" not in env
 
 
 def test_launcher_process_value_wins_over_root_fallback(tmp_path, monkeypatch):
@@ -161,12 +177,14 @@ def test_isolated_profile_layout_still_respects_allowlist(tmp_path, monkeypatch)
 
 def test_export_prefixed_lines_parse_canonically(tmp_path, monkeypatch):
     """[export parsing] 'export KEY=value' root lines parse as KEY (not
-    'export KEY') — both exact-allowlist and prefix-allowlist keys."""
+    'export KEY') — for both exact-allowlist keys, while an exported
+    FIRECRAWL_API_KEY credential is still refused."""
     base, alpha = _layout(tmp_path, monkeypatch)
     _write_env(
         base / ".env",
         "export SEARXNG_URL=http://root-export:8080\n"
-        "export FIRECRAWL_API_KEY=fc-export\n",
+        "export FIRECRAWL_API_URL=http://fc-export:3002\n"
+        "export FIRECRAWL_API_KEY=fc-export-secret\n",
     )
 
     env = get_profile_runtime_env(alpha)
@@ -174,7 +192,8 @@ def test_export_prefixed_lines_parse_canonically(tmp_path, monkeypatch):
     assert env.get("SEARXNG_URL") == "http://root-export:8080", (
         "'export KEY=value' must parse as KEY, not 'export KEY'"
     )
-    assert env.get("FIRECRAWL_API_KEY") == "fc-export"
+    assert env.get("FIRECRAWL_API_URL") == "http://fc-export:3002"
+    assert "FIRECRAWL_API_KEY" not in env
 
 
 def test_export_prefix_in_profile_env_parses(tmp_path, monkeypatch):

--- a/tests/test_issue7048_root_env_runtime_propagation.py
+++ b/tests/test_issue7048_root_env_runtime_propagation.py
@@ -17,8 +17,15 @@ the named-profile isolation invariant) and misparsed the supported
   - default-profile and isolated-profile layouts stay safe.
 """
 
+import base64
+import os
+import shlex
+import subprocess
 from pathlib import Path
 
+import pytest
+
+import api.profiles as profiles
 from api.profiles import get_profile_runtime_env, _parse_dotenv_text
 
 # Ambient vars that could act as launcher/process values or leaks if left set.
@@ -96,17 +103,37 @@ def test_allowlisted_firecrawl_config_keys_are_shared_but_key_is_not(tmp_path, m
 
 
 def test_launcher_process_value_wins_over_root_fallback(tmp_path, monkeypatch):
-    """[launcher precedence] An existing launcher/process value is never
-    overridden by the allowlisted root fallback (the returned dict omits the
-    key so the process value stands after the merge)."""
+    """[launcher precedence] A value the operator exported before the server
+    started is present both in the import-time baseline and in the process env;
+    the allowlisted root fallback must not override it (the returned dict omits
+    the key so the launcher value stands after the merge)."""
     base, alpha = _layout(tmp_path, monkeypatch)
     monkeypatch.setenv("SEARXNG_URL", "http://launcher:8080")
+    monkeypatch.setitem(profiles._INITIAL_ENV, "SEARXNG_URL", "http://launcher:8080")
     _write_env(base / ".env", "SEARXNG_URL=http://root:8080\n")
 
     env = get_profile_runtime_env(alpha)
 
     assert "SEARXNG_URL" not in env, (
-        "root fallback must not override an existing launcher/process value"
+        "root fallback must not override a launcher-provided process value"
+    )
+    assert os.environ["SEARXNG_URL"] == "http://launcher:8080"
+
+
+def test_live_process_env_mirror_does_not_mask_root_fallback(tmp_path, monkeypatch):
+    """[live env is not a launcher value] A key mirrored into os.environ after
+    import (a concurrent turn applying its own env to the process env) must not
+    be mistaken for a launcher-provided value: the profile still resolves the
+    root layer instead of silently losing the key (#7048)."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(base / ".env", "SEARXNG_URL=http://root:8080\n")
+    monkeypatch.setenv("SEARXNG_URL", "http://mirrored-by-another-turn:8080")
+
+    env = get_profile_runtime_env(alpha)
+
+    assert env.get("SEARXNG_URL") == "http://root:8080", (
+        "a value another turn mirrored into the process env must not suppress "
+        "the root fallback"
     )
 
 
@@ -229,6 +256,207 @@ def test_parse_dotenv_text_handles_export_and_quoting():
         "KEY_THREE": "single",
         "KEY_FOUR": "",
     }
+
+
+# ---------------------------------------------------------------------------
+# #7048 follow-up: one dotenv grammar for both loaders (WebUI <-> ctl.sh)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CTL_SH = _REPO_ROOT / "ctl.sh"
+
+# Every construct the launcher's loader has to agree on with this parser.
+_CTL_PARITY_ENV_TEXT = "\n".join(
+    [
+        "# a comment line",
+        "",
+        "export\tPARITY_TAB=after-tab",
+        "export PARITY_SPACE=after-space",
+        'PARITY_DQ="quoted value"',
+        'PARITY_DQ_ESCAPES="line\\nbreak\\tend"',
+        'PARITY_DQ_QUOTE="say \\"hi\\""',
+        "PARITY_SQ='literal \\n kept'",
+        'PARITY_DQ_COMMENT="kept" # trailing comment',
+        "PARITY_UNQUOTED=plain # trailing comment",
+        "PARITY_UNQUOTED_HASH=a#b",
+        "PARITY_EMPTY=",
+        'PARITY_EMPTY_DQ=""',
+        "PARITY_TRAILING=back\\",
+        "UID=1000",
+        "PARITY_BAD KEY=whitespace-stripped",
+        "1BAD=invalid",
+        "no-equals-sign",
+    ]
+)
+
+_CTL_PARITY_KEYS = (
+    "PARITY_TAB",
+    "PARITY_SPACE",
+    "PARITY_DQ",
+    "PARITY_DQ_ESCAPES",
+    "PARITY_DQ_QUOTE",
+    "PARITY_SQ",
+    "PARITY_DQ_COMMENT",
+    "PARITY_UNQUOTED",
+    "PARITY_UNQUOTED_HASH",
+    "PARITY_EMPTY",
+    "PARITY_EMPTY_DQ",
+    "PARITY_BADKEY",
+    "PARITY_TRAILING",
+)
+
+
+def _ctl_sh_loader_source() -> str:
+    """Extract ``_apply_env_file_safely`` (and the awk helper it calls) from ctl.sh."""
+    source = _CTL_SH.read_text(encoding="utf-8")
+    start = source.index("_apply_env_file_safely() {")
+    end = source.index("\n}\n", start) + len("\n}\n")
+    body = source[start:end]
+    if "awk" not in body:  # pragma: no cover - launcher refactor guard
+        pytest.skip("ctl.sh loader implementation changed; parity harness needs review")
+    return body
+
+
+def test_parser_grammar_matches_launcher_expectations():
+    """[grammar parity] A .env the launcher resolves must resolve identically here."""
+    parsed = _parse_dotenv_text(_CTL_PARITY_ENV_TEXT)
+
+    assert parsed["PARITY_TAB"] == "after-tab"
+    assert parsed["PARITY_SPACE"] == "after-space"
+    assert parsed["PARITY_DQ"] == "quoted value"
+    assert parsed["PARITY_DQ_ESCAPES"] == "line\nbreak\tend"
+    assert parsed["PARITY_DQ_QUOTE"] == 'say "hi"'
+    assert parsed["PARITY_SQ"] == "literal \\n kept"
+    assert parsed["PARITY_DQ_COMMENT"] == "kept"
+    assert parsed["PARITY_UNQUOTED"] == "plain"
+    assert parsed["PARITY_UNQUOTED_HASH"] == "a#b"
+    assert parsed["PARITY_TRAILING"] == "back\\"
+    # Whitespace inside the key is stripped (launcher: ${key//[[:space:]]/}).
+    assert parsed["PARITY_BADKEY"] == "whitespace-stripped"
+    # Valid keys keep an empty value instead of being dropped: an empty profile
+    # value is what suppresses inheritance from the layer below (#7048).
+    assert parsed["PARITY_EMPTY"] == ""
+    assert parsed["PARITY_EMPTY_DQ"] == ""
+    # Non-key lines and bash read-only identity keys are never exported.
+    assert "1BAD" not in parsed
+    assert "no-equals-sign" not in parsed
+    assert "UID" not in parsed
+
+
+def test_parser_matches_ctl_sh_env_loader(tmp_path):
+    """[cross-loader parity] Run the real ctl.sh loader over the same .env and
+    require the same present/absent set and the same byte-exact values."""
+    if not _CTL_SH.exists():  # pragma: no cover - repo layout guard
+        pytest.skip("ctl.sh not present")
+
+    env_file = tmp_path / "parity.env"
+    env_file.write_text(_CTL_PARITY_ENV_TEXT + "\n", encoding="utf-8")
+
+    key_list = " ".join(_CTL_PARITY_KEYS)
+    script = f"""set -uo pipefail
+{_ctl_sh_loader_source()}
+_apply_env_file_safely {shlex.quote(str(env_file))}
+for k in {key_list}; do
+  if [[ -v $k ]]; then
+    printf '%s\\tset\\t%s\\n' "$k" "$(printf %s "${{!k}}" | base64 -w0)"
+  else
+    printf '%s\\tunset\\t\\n' "$k"
+  fi
+done
+"""
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, f"ctl.sh loader probe failed: {result.stderr}"
+
+    launcher: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, state, encoded = line.split("\t")
+        if state == "set":
+            launcher[key] = base64.b64decode(encoded).decode("utf-8")
+
+    parsed = _parse_dotenv_text(_CTL_PARITY_ENV_TEXT)
+    here = {k: parsed[k] for k in _CTL_PARITY_KEYS if k in parsed}
+
+    assert here == launcher, (
+        "WebUI dotenv parser diverged from ctl.sh::_apply_env_file_safely "
+        f"(webui={here!r} launcher={launcher!r})"
+    )
+
+
+def test_reload_dotenv_uses_shared_grammar(tmp_path, monkeypatch):
+    """[live-env reload] _reload_dotenv must resolve a .env with the same
+    grammar as the root/profile layers: an `export` with a tab used to land as a
+    key literally named "export\\tCTL_PARITY_TAB", a quoted value with an inline
+    comment kept the quote and the comment, and escapes were left unexpanded."""
+    base = tmp_path / ".hermes"
+    base.mkdir()
+    monkeypatch.setattr(profiles, "_loaded_profile_env_keys", set())
+    for key in (
+        "CTL_PARITY_TAB",
+        "CTL_PARITY_COMMENT",
+        "CTL_PARITY_ESCAPES",
+        "CTL_PARITY_BROKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    _write_env(
+        base / ".env",
+        "export\tCTL_PARITY_TAB=after-tab\n"
+        'CTL_PARITY_COMMENT="kept value" # trailing comment\n'
+        'CTL_PARITY_ESCAPES="line\\nbreak"\n'
+        "CTL_PARITY_BROKEN not a kv line\n",
+    )
+
+    profiles._reload_dotenv(base)
+
+    assert os.environ["CTL_PARITY_TAB"] == "after-tab"
+    assert os.environ["CTL_PARITY_COMMENT"] == "kept value"
+    assert os.environ["CTL_PARITY_ESCAPES"] == "line\nbreak"
+    assert "CTL_PARITY_BROKEN" not in os.environ
+
+
+def test_named_profile_turn_scrubs_root_scope_keys(tmp_path, monkeypatch):
+    """[overlapping turns] Only the root .env defines ROOT_SCOPE_KEY; a beta turn
+    mirrors its value into the shared process env. During the alpha turn that key
+    must be scrubbed (and the pre-turn value handed back for restore) instead of
+    leaking root-scoped values into a named-profile turn."""
+    base, alpha = _layout(tmp_path, monkeypatch)
+    _write_env(
+        base / ".env",
+        "ROOT_SCOPE_KEY=root-value\n"
+        "SEARXNG_URL=http://root:8080\n"
+        "BACKEND_API_KEY=root-secret\n"
+        "HERMES_HOME=/srv/root\n"
+        "PATH=/usr/bin:/bin\n",
+    )
+    _write_env(alpha / ".env", "ALPHA_KEY=a\n")
+
+    safe_runtime_env = {"ALPHA_KEY": "a", "HERMES_HOME": str(alpha)}
+    root_only = profiles._root_only_env_names_for_profile(alpha, safe_runtime_env)
+
+    assert "ROOT_SCOPE_KEY" in root_only
+    assert "BACKEND_API_KEY" in root_only  # root credential scope never inherited
+    assert "SEARXNG_URL" not in root_only  # allowlisted share keeps being inherited
+    assert "HERMES_HOME" not in root_only  # profile-home machinery owns this key
+    assert "PATH" not in root_only  # shell identity is never touched
+    assert "ALPHA_KEY" not in root_only  # the profile's own key is not root-scoped
+
+    process_env = dict(os.environ)
+    process_env["ROOT_SCOPE_KEY"] = "mirrored-by-a-beta-turn"
+    process_env["BACKEND_API_KEY"] = "mirrored-by-a-beta-turn"
+
+    previous = profiles._apply_profile_env_to_process(
+        process_env,
+        safe_runtime_env,
+        secret_env_names=set(),
+        root_only_env_names=root_only,
+    )
+
+    assert "ROOT_SCOPE_KEY" not in process_env
+    assert "BACKEND_API_KEY" not in process_env
+    assert previous["ROOT_SCOPE_KEY"] == "mirrored-by-a-beta-turn"
+    assert previous["BACKEND_API_KEY"] == "mirrored-by-a-beta-turn"
+    assert "ALPHA_KEY" in previous  # profile's own key is still snapshotted
 
 
 def _layout(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Since v2026.7.30, env vars set in `$HERMES_HOME/.env` (e.g. SEARXNG_URL, FIRECRAWL_*) are not propagated to the WebUI's in-process agent in multi-container Docker setups.

## Root Cause

`api/profiles.py::get_profile_runtime_env()` only reads the **profile's** `.env` file (profiles/<name>/.env), missing env vars set in the **root** `$HERMES_HOME/.env` where Docker deployment configs typically place them.

## Change

After reading the profile `.env`, also read the root/parent `.env` and merge its keys that are not already set (profile values take precedence). Protected env keys (operator/deployment posture) are preserved unchanged.

## Verification

- `tests/test_bootstrap_dotenv.py` + `tests/test_docker_env_readonly_vars.py`: **28 passed**.
- `python3 -m py_compile api/profiles.py` clean.

Closes #7048