### PR TITLE
fix(#6804): resolve key_env providers and discover configured catalogs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8500,6 +8500,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
                         if not _authority_matches:
                             _delete_models_cache_on_disk()
+                            with _cache_build_cv:
+                                if _available_models_cache is result:
+                                    _available_models_cache = None
+                                    _available_models_cache_ts = 0.0
+                                    _available_models_live_rebuild_ts = 0.0
+                                    _available_models_cache_source_fingerprint = None
+                                    _sync_models_cache_provenance()
             except BaseException:
                 # Always reset the flag so waiting threads don't block for 60s
                 with _cache_build_cv:

--- a/api/config.py
+++ b/api/config.py
@@ -1383,6 +1383,8 @@ def _configured_model_ids(raw_models: object) -> list[str]:
         candidates = (key for key in raw_models if isinstance(key, str))
     elif isinstance(raw_models, list):
         candidates = raw_models
+    elif isinstance(raw_models, str):
+        candidates = (raw_models,)
     else:
         return []
 
@@ -2996,6 +2998,24 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     return model_id, config_provider, config_base_url
 
 
+def resolve_provider_credential(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
+    """Resolve one provider entry's credential using the active profile env."""
+    api_key = None
+    if raw_api_key is not None:
+        key_text = str(raw_api_key).strip()
+        if key_text.startswith("${") and key_text.endswith("}") and len(key_text) > 3:
+            api_key = _thread_local_env_value(key_text[2:-1]).strip() or None
+        elif key_text:
+            api_key = key_text
+    if not api_key:
+        key_env = str(raw_key_env or "").strip()
+        if key_env:
+            api_key = _thread_local_env_value(key_env).strip() or None
+    if not api_key and provider_hint:
+        api_key = _lookup_custom_api_key_env(provider_hint)
+    return api_key
+
+
 def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, str | None]:
     """Return (api_key, base_url) for a named ``custom:*`` provider.
 
@@ -3021,22 +3041,6 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
     # cases after profile switches or runtime config edits.
     cfg_data = get_config()
 
-    def _resolve_key(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
-        api_key = None
-        if raw_api_key is not None:
-            key_text = str(raw_api_key).strip()
-            if key_text.startswith("${") and key_text.endswith("}") and len(key_text) > 3:
-                api_key = _thread_local_env_value(key_text[2:-1]).strip() or None
-            elif key_text:
-                api_key = key_text
-        if not api_key:
-            key_env = str(raw_key_env or "").strip()
-            if key_env:
-                api_key = _thread_local_env_value(key_env).strip() or None
-        if not api_key and provider_hint:
-            api_key = _lookup_custom_api_key_env(provider_hint)
-        return api_key
-
     custom_providers = cfg_data.get("custom_providers", [])
     if not isinstance(custom_providers, list):
         custom_providers = []
@@ -3052,7 +3056,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
             continue
 
         base_url = str(entry.get("base_url") or "").strip() or None
-        api_key = _resolve_key(entry.get("api_key"), entry.get("key_env"), pid)
+        api_key = resolve_provider_credential(entry.get("api_key"), entry.get("key_env"), pid)
         return api_key, base_url
 
     # If exactly one custom provider is configured, use it as a pragmatic
@@ -3060,7 +3064,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
     if len(custom_providers) == 1 and isinstance(custom_providers[0], dict):
         entry = custom_providers[0]
         return (
-            _resolve_key(entry.get("api_key"), entry.get("key_env"), pid),
+            resolve_provider_credential(entry.get("api_key"), entry.get("key_env"), pid),
             str(entry.get("base_url") or "").strip() or None,
         )
 
@@ -3082,11 +3086,11 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
 
     fallback_key = None
     if isinstance(provider_specific, dict):
-        fallback_key = _resolve_key(provider_specific.get("api_key"), provider_specific.get("key_env"), pid)
+        fallback_key = resolve_provider_credential(provider_specific.get("api_key"), provider_specific.get("key_env"), pid)
     if not fallback_key and isinstance(provider_custom, dict):
-        fallback_key = _resolve_key(provider_custom.get("api_key"), provider_custom.get("key_env"), pid)
+        fallback_key = resolve_provider_credential(provider_custom.get("api_key"), provider_custom.get("key_env"), pid)
     if not fallback_key and isinstance(model_cfg, dict) and model_provider in {"custom", pid, slug}:
-        fallback_key = _resolve_key(model_cfg.get("api_key"), model_cfg.get("key_env"), pid)
+        fallback_key = resolve_provider_credential(model_cfg.get("api_key"), model_cfg.get("key_env"), pid)
 
     if fallback_key or fallback_base:
         return fallback_key, fallback_base or None
@@ -7100,6 +7104,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             *,
             api_key: object = "",
             trusted_base_urls: tuple[object, ...] = (),
+            allow_private_base_url: bool = True,
         ) -> tuple[list[dict], dict | None]:
             base = str(base_url or "").strip()
             if not base:
@@ -7120,7 +7125,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 # but keep the same private-IP guard for non-matching targets used by
                 # the legacy active model.base_url path.
                 _ssrf_trusted_hosts: set[str] = set()
-                for trusted in (base, *trusted_base_urls):
+                trusted_urls = (*trusted_base_urls, base) if allow_private_base_url else trusted_base_urls
+                for trusted in trusted_urls:
                     _cp_parsed = urlparse(
                         str(trusted) if "://" in str(trusted) else f"http://{trusted}"
                     )
@@ -7137,10 +7143,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             addr_obj = ipaddress.ip_address(addr[0])
                             if addr_obj.is_private or addr_obj.is_loopback or addr_obj.is_link_local:
                                 host_l = (parsed_url.hostname or "").lower()
-                                is_known_local = any(
+                                is_known_local = allow_private_base_url and any(
                                     k in host_l
                                     for k in ("ollama", "localhost", "127.0.0.1", "lmstudio", "lm-studio")
-                                ) or host_l in _ssrf_trusted_hosts
+                                ) or (allow_private_base_url and host_l in _ssrf_trusted_hosts)
                                 if not is_known_local:
                                     raise ValueError(f"SSRF: resolved hostname to private IP {addr[0]}")
                     except socket.gaierror:
@@ -7199,14 +7205,20 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
             api_key = ""
             if isinstance(model_cfg, dict):
-                api_key = (model_cfg.get("api_key") or "").strip()
+                api_key = resolve_provider_credential(
+                    model_cfg.get("api_key"), model_cfg.get("key_env"), provider
+                ) or ""
             if not api_key:
                 providers_cfg = cfg.get("providers", {})
                 if isinstance(providers_cfg, dict):
                     for provider_key in filter(None, [active_provider, "custom"]):
                         provider_cfg = providers_cfg.get(provider_key, {})
                         if isinstance(provider_cfg, dict):
-                            api_key = (provider_cfg.get("api_key") or "").strip()
+                            api_key = resolve_provider_credential(
+                                provider_cfg.get("api_key"),
+                                provider_cfg.get("key_env"),
+                                provider_key,
+                            ) or ""
                             if api_key:
                                 break
             if not api_key:
@@ -7219,7 +7231,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     "API_KEY",
                 )
                 for key in api_key_vars:
-                    api_key = (all_env.get(key) or _thread_local_env_value(key) or "").strip()
+                    api_key = _thread_local_env_value(key).strip()
                     if api_key:
                         break
 
@@ -7234,8 +7246,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             _active_endpoint_models, _active_endpoint_error = _read_custom_endpoint_models(
                 base_url,
                 provider,
-                api_key=api_key,
-                trusted_base_urls=tuple(_trusted_custom_bases),
+                    api_key=api_key,
+                    trusted_base_urls=tuple(_trusted_custom_bases),
             )
             for auto_model in _active_endpoint_models:
                 auto_detected_models.append(auto_model)
@@ -7802,14 +7814,26 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     # config-models allowlist branch and asks Hermes CLI for the
                     # live catalog first (static _PROVIDER_MODELS is fallback only).
                     _uses_models_as_settings_map = pid == "copilot"
-                    if (
+                    configured_models = (
+                        provider_cfg.get("models")
+                        if isinstance(provider_cfg, dict)
+                        else None
+                    )
+                    has_configured_model_allowlist = (
                         not _uses_models_as_settings_map
-                        and isinstance(provider_cfg, dict)
-                        and "models" in provider_cfg
+                        and isinstance(configured_models, (dict, list, str))
+                        and bool(_configured_model_options(configured_models))
+                    )
+                    discover_models = not (
+                        isinstance(provider_cfg, dict)
+                        and provider_cfg.get("discover_models") is False
+                    )
+                    if (
+                        has_configured_model_allowlist
                     ):
-                        raw_models = _configured_model_options(provider_cfg["models"])
+                        raw_models = _configured_model_options(configured_models)
 
-                    if not raw_models:
+                    if not raw_models and discover_models:
                         if pid == "moa":
                             raw_models = _moa_preset_models_from_config(cfg)
                         elif pid == "opencode-go":
@@ -7830,7 +7854,37 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     detected_models = auto_detected_models_by_provider.get(pid, [])
                     if detected_models and not raw_models:
                         raw_models = copy.deepcopy(detected_models)
-                    _append_picker_group(provider_name, pid, raw_models)
+                    models_endpoint_error = None
+                    resolved_key = resolve_provider_credential(
+                        provider_cfg.get("api_key") if isinstance(provider_cfg, dict) else None,
+                        provider_cfg.get("key_env") if isinstance(provider_cfg, dict) else None,
+                        pid,
+                    )
+                    provider_base_url = (
+                        str(provider_cfg.get("base_url") or "").strip()
+                        if isinstance(provider_cfg, dict)
+                        else ""
+                    )
+                    if (
+                        not raw_models
+                        and discover_models
+                        and not has_configured_model_allowlist
+                        and provider_base_url
+                        and resolved_key
+                    ):
+                        raw_models, models_endpoint_error = _read_custom_endpoint_models(
+                            provider_base_url,
+                            pid,
+                            api_key=resolved_key,
+                            allow_private_base_url=False,
+                        )
+                    _append_picker_group(
+                        provider_name,
+                        pid,
+                        raw_models,
+                        models_endpoint_error=models_endpoint_error,
+                        allow_empty=bool(models_endpoint_error),
+                    )
                 else:
                     detected_models = auto_detected_models_by_provider.get(pid)
                     if detected_models:
@@ -7860,7 +7914,36 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         # loop; this omission is belt-and-braces matching the
                         # #1572/#7372 "omit rather than misattribute" posture.
                         models_for_group = []
-                    if models_for_group:
+                    models_endpoint_error = None
+                    provider_cfg = _get_provider_cfg(_canonical_to_raw_provider_key.get(pid, pid))
+                    resolved_key = resolve_provider_credential(
+                        provider_cfg.get("api_key") if isinstance(provider_cfg, dict) else None,
+                        provider_cfg.get("key_env") if isinstance(provider_cfg, dict) else None,
+                        pid,
+                    )
+                    provider_base_url = (
+                        str(provider_cfg.get("base_url") or "").strip()
+                        if isinstance(provider_cfg, dict)
+                        else ""
+                    )
+                    discover_models = not (
+                        isinstance(provider_cfg, dict)
+                        and provider_cfg.get("discover_models") is False
+                    )
+                    if (
+                        not models_for_group
+                        and discover_models
+                        and provider_base_url
+                        and resolved_key
+                        and isinstance(provider_cfg, dict)
+                    ):
+                        models_for_group, models_endpoint_error = _read_custom_endpoint_models(
+                            provider_base_url,
+                            pid,
+                            api_key=resolved_key,
+                            allow_private_base_url=False,
+                        )
+                    if models_for_group or models_endpoint_error:
                         # Per-group deep copy so subsequent mutation by
                         # _deduplicate_model_ids() (which prefixes ids with
                         # @provider_id:) does not bleed into other groups
@@ -7875,6 +7958,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             pid,
                             models_for_group,
                             apply_prefix=False,
+                            models_endpoint_error=models_endpoint_error,
+                            allow_empty=bool(models_endpoint_error),
                         )
                     elif pid == "custom" and cfg_base_url:
                         # Anonymous custom endpoint: /v1/models probe may have
@@ -7963,6 +8048,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         groups = [
             g for g in groups
             if g.get("models")
+            or g.get("models_endpoint_error")
             or (g.get("provider_id") or "").startswith("custom:")
         ]
 

--- a/api/config.py
+++ b/api/config.py
@@ -3016,6 +3016,20 @@ def resolve_provider_credential(raw_api_key, raw_key_env, provider_hint=None) ->
     return resolved.value if resolved.state == "resolved" else None
 
 
+def resolve_provider_credential_entry(raw_entry: dict | None, provider_hint=None) -> str | None:
+    """Resolve a provider mapping while preserving declared key presence."""
+    from api.provider_discovery import resolve_credential
+
+    entry = raw_entry if isinstance(raw_entry, dict) else {}
+    resolved = resolve_credential(
+        entry,
+        provider_hint=str(provider_hint or ""),
+        env_value=_thread_local_env_value,
+        fallback_value=_lookup_custom_api_key_env,
+    )
+    return resolved.value if resolved.state == "resolved" else None
+
+
 def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, str | None]:
     """Return (api_key, base_url) for a named ``custom:*`` provider.
 
@@ -3056,7 +3070,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
             continue
 
         base_url = str(entry.get("base_url") or "").strip() or None
-        api_key = resolve_provider_credential(entry.get("api_key"), entry.get("key_env"), pid)
+        api_key = resolve_provider_credential_entry(entry, pid)
         return api_key, base_url
 
     # If exactly one custom provider is configured, use it as a pragmatic
@@ -3064,7 +3078,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
     if len(custom_providers) == 1 and isinstance(custom_providers[0], dict):
         entry = custom_providers[0]
         return (
-            resolve_provider_credential(entry.get("api_key"), entry.get("key_env"), pid),
+            resolve_provider_credential_entry(entry, pid),
             str(entry.get("base_url") or "").strip() or None,
         )
 
@@ -3086,11 +3100,11 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
 
     fallback_key = None
     if isinstance(provider_specific, dict):
-        fallback_key = resolve_provider_credential(provider_specific.get("api_key"), provider_specific.get("key_env"), pid)
+        fallback_key = resolve_provider_credential_entry(provider_specific, pid)
     if not fallback_key and isinstance(provider_custom, dict):
-        fallback_key = resolve_provider_credential(provider_custom.get("api_key"), provider_custom.get("key_env"), pid)
+        fallback_key = resolve_provider_credential_entry(provider_custom, pid)
     if not fallback_key and isinstance(model_cfg, dict) and model_provider in {"custom", pid, slug}:
-        fallback_key = resolve_provider_credential(model_cfg.get("api_key"), model_cfg.get("key_env"), pid)
+        fallback_key = resolve_provider_credential_entry(model_cfg, pid)
 
     if fallback_key or fallback_base:
         return fallback_key, fallback_base or None
@@ -6013,24 +6027,50 @@ def _provider_publication_tuple() -> tuple[str, str, str]:
         raw = capture_raw_profile_snapshot(sys.modules[__name__])
     except Exception:
         raw = copy.deepcopy(cfg)
+    # Preserve YAML mapping order for fingerprint stability without sorting
+    # incomparable YAML keys such as integer and string model IDs.
     raw_fingerprint = hashlib.sha256(
-        json.dumps(raw, sort_keys=True, default=str, separators=(",", ":")).encode()
+        json.dumps(raw, sort_keys=False, default=str, separators=(",", ":")).encode()
     ).hexdigest()
-    env_names = []
+    env_names: list[str] = []
+
+    def _add_credential_entry(entry: object) -> None:
+        if not isinstance(entry, dict):
+            return
+        name = str(entry.get("key_env") or "").strip()
+        if name:
+            env_names.append(name)
+        literal = entry.get("api_key")
+        literal_text = literal.strip() if isinstance(literal, str) else ""
+        if literal_text.startswith("${") and literal_text.endswith("}"):
+            env_names.append(literal_text[2:-1].strip())
+
     providers_cfg = raw.get("providers", {}) if isinstance(raw, dict) else {}
     if isinstance(providers_cfg, dict):
-        for entry in providers_cfg.values():
+        for raw_provider, entry in providers_cfg.items():
+            _add_credential_entry(entry)
+            if str(raw_provider).strip().lower().startswith("custom"):
+                env_names.extend(
+                    (
+                        _api_key_env_name(raw_provider),
+                        _legacy_custom_api_key_env_name(raw_provider),
+                    )
+                )
+    custom_cfg = raw.get("custom_providers", []) if isinstance(raw, dict) else []
+    if isinstance(custom_cfg, list):
+        for entry in custom_cfg:
+            _add_credential_entry(entry)
             if isinstance(entry, dict):
-                name = str(entry.get("key_env") or "").strip()
-                if name:
-                    env_names.append(name)
-                literal = entry.get("api_key")
-                if (
-                    isinstance(literal, str)
-                    and literal.strip().startswith("${")
-                    and literal.strip().endswith("}")
-                ):
-                    env_names.append(literal.strip()[2:-1])
+                slug = _custom_provider_slug_from_name(entry.get("name"))
+                if slug:
+                    env_names.extend(
+                        (
+                            _api_key_env_name(slug),
+                            _legacy_custom_api_key_env_name(slug),
+                        )
+                    )
+    if isinstance(raw, dict):
+        _add_credential_entry(raw.get("model"))
     env_fingerprint = hashlib.sha256(
         json.dumps(sorted((name, _thread_local_env_value(name)) for name in set(env_names)), separators=(",", ":")).encode()
     ).hexdigest()
@@ -6633,9 +6673,15 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 build_connection,
                 fetch_models,
             )
+            try:
+                from api.profiles import get_active_profile_name
+
+                profile_name = str(get_active_profile_name() or "")
+            except Exception:
+                profile_name = ""
 
             connection = build_connection(
-                profile=str(_raw_profile_cfg.get("profile") or ""),
+                profile=profile_name,
                 provider_id=provider_id,
                 raw_config_key=raw_key,
                 raw=raw_entry,
@@ -7327,20 +7373,14 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
             api_key = ""
             if isinstance(model_cfg, dict):
-                api_key = resolve_provider_credential(
-                    model_cfg.get("api_key"), model_cfg.get("key_env"), provider
-                ) or ""
+                api_key = resolve_provider_credential_entry(model_cfg, provider) or ""
             if not api_key:
                 providers_cfg = cfg.get("providers", {})
                 if isinstance(providers_cfg, dict):
                     for provider_key in filter(None, [active_provider, "custom"]):
                         provider_cfg = providers_cfg.get(provider_key, {})
                         if isinstance(provider_cfg, dict):
-                            api_key = resolve_provider_credential(
-                                provider_cfg.get("api_key"),
-                                provider_cfg.get("key_env"),
-                                provider_key,
-                            ) or ""
+                            api_key = resolve_provider_credential_entry(provider_cfg, provider_key) or ""
                             if api_key:
                                 break
             if not api_key:
@@ -7391,9 +7431,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _named_custom_groups[_slug] = (_cp_name, [])
 
                 _cp_base_url = str(_cp.get("base_url") or "").strip()
-                _cp_api_key = resolve_provider_credential(
-                    _cp.get("api_key"), _cp.get("key_env"), _slug or "custom"
-                ) or ""
+                _cp_api_key = resolve_provider_credential_entry(_cp, _slug or "custom") or ""
                 # Fallback: check credential pool for both api_key and base_url
                 if (not _cp_api_key or not _cp_base_url) and _slug:
                     try:
@@ -8060,9 +8098,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
                     models_endpoint_error = None
                     provider_cfg = _get_provider_cfg(_canonical_to_raw_provider_key.get(pid, pid))
-                    resolved_key = resolve_provider_credential(
-                        provider_cfg.get("api_key") if isinstance(provider_cfg, dict) else None,
-                        provider_cfg.get("key_env") if isinstance(provider_cfg, dict) else None,
+                    resolved_key = resolve_provider_credential_entry(
+                        provider_cfg if isinstance(provider_cfg, dict) else None,
                         pid,
                     )
                     provider_base_url = (
@@ -8090,7 +8127,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             provider_base_url,
                             pid,
                             api_key=resolved_key,
-                            allow_private_base_url=False,
+                            allow_private_base_url=True,
                         )
                     if models_for_group or models_endpoint_error:
                         # Per-group deep copy so subsequent mutation by
@@ -8446,10 +8483,23 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
                             _sync_models_cache_provenance()
                     if _authority_matches:
+                        _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
+                    if not _authority_matches:
+                        with _cache_build_cv:
+                            if _available_models_cache is result:
+                                _available_models_cache = None
+                                _available_models_cache_ts = 0.0
+                                _available_models_live_rebuild_ts = 0.0
+                                _available_models_cache_source_fingerprint = None
+                                _sync_models_cache_provenance()
+                    if _authority_matches:
                         try:
                             _save_models_cache_to_disk(result)
                         except Exception:
                             logger.debug("models cache disk save failed", exc_info=True)
+                        _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
+                        if not _authority_matches:
+                            _delete_models_cache_on_disk()
             except BaseException:
                 # Always reset the flag so waiting threads don't block for 60s
                 with _cache_build_cv:
@@ -8501,7 +8551,26 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 logger.info("discarding provider catalog with stale publication authority")
                 _clear_build_in_progress()
                 return False
+            previous_cache = _available_models_cache
+            previous_cache_ts = _available_models_cache_ts
+            previous_live_ts = _available_models_live_rebuild_ts
+            previous_fingerprint = _available_models_cache_source_fingerprint
+
+            def _discard_memory_publication() -> None:
+                global _available_models_cache, _available_models_cache_ts
+                global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint
+                with _cache_build_cv:
+                    _available_models_cache = previous_cache
+                    _available_models_cache_ts = previous_cache_ts
+                    _available_models_live_rebuild_ts = previous_live_ts
+                    _available_models_cache_source_fingerprint = previous_fingerprint
+                    _sync_models_cache_provenance()
+                _clear_build_in_progress()
+
             with _cache_build_cv:
+                if _provider_publication_tuple() != _build_authority.get("value"):
+                    _clear_build_in_progress()
+                    return False
                 published_at = time.monotonic()
                 _available_models_cache = result
                 _available_models_cache_ts = published_at
@@ -8510,10 +8579,21 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _models_cache_source_fingerprint()
                 )
                 _sync_models_cache_provenance()
+            if _provider_publication_tuple() != _build_authority.get("value"):
+                _discard_memory_publication()
+                return False
+            if _provider_publication_tuple() != _build_authority.get("value"):
+                _discard_memory_publication()
+                return False
             try:
-                _save_models_cache_to_disk(result)
-            except Exception:
-                logger.debug("models cache disk save failed", exc_info=True)
+                try:
+                    _save_models_cache_to_disk(result)
+                except Exception:
+                    logger.debug("models cache disk save failed", exc_info=True)
+                if _provider_publication_tuple() != _build_authority.get("value"):
+                    _delete_models_cache_on_disk()
+                    _discard_memory_publication()
+                    return False
             finally:
                 with _cache_build_cv:
                     _cache_build_in_progress = False

--- a/api/config.py
+++ b/api/config.py
@@ -8473,6 +8473,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 )
                 with _sync_scope:
                     result = _invoke_models_rebuild(_build_available_models_uncached)
+                    if _build_authority.get("value") is None:
+                        _build_authority["value"] = _provider_publication_tuple()
                     with _cache_build_cv:
                         _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
                         if _authority_matches:
@@ -8551,6 +8553,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             global _cache_build_in_progress, _available_models_cache
             global _available_models_cache_ts, _available_models_live_rebuild_ts
             global _available_models_cache_source_fingerprint
+            if _build_authority.get("value") is None:
+                _build_authority["value"] = _provider_publication_tuple()
             if (
                 _build_authority.get("value") is not None
                 and _provider_publication_tuple() != _build_authority["value"]

--- a/api/config.py
+++ b/api/config.py
@@ -6025,7 +6025,11 @@ def _provider_publication_tuple() -> tuple[str, str, str]:
                 if name:
                     env_names.append(name)
                 literal = entry.get("api_key")
-                if isinstance(literal, str) and literal.strip().startswith("${"):
+                if (
+                    isinstance(literal, str)
+                    and literal.strip().startswith("${")
+                    and literal.strip().endswith("}")
+                ):
                     env_names.append(literal.strip()[2:-1])
     env_fingerprint = hashlib.sha256(
         json.dumps(sorted((name, _thread_local_env_value(name)) for name in set(env_names)), separators=(",", ":")).encode()
@@ -7349,7 +7353,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     "API_KEY",
                 )
                 for key in api_key_vars:
-                    api_key = _thread_local_env_value(key).strip()
+                    api_key = (all_env.get(key) or _thread_local_env_value(key) or "").strip()
                     if api_key:
                         break
 
@@ -7387,11 +7391,9 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _named_custom_groups[_slug] = (_cp_name, [])
 
                 _cp_base_url = str(_cp.get("base_url") or "").strip()
-                _cp_api_key = str(_cp.get("api_key") or "").strip()
-                if not _cp_api_key:
-                    _cp_key_env = str(_cp.get("key_env") or "").strip()
-                    if _cp_key_env:
-                        _cp_api_key = _thread_local_env_value(_cp_key_env).strip()
+                _cp_api_key = resolve_provider_credential(
+                    _cp.get("api_key"), _cp.get("key_env"), _slug or "custom"
+                ) or ""
                 # Fallback: check credential pool for both api_key and base_url
                 if (not _cp_api_key or not _cp_base_url) and _slug:
                     try:
@@ -7996,29 +7998,6 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     if detected_models and not raw_models:
                         raw_models = copy.deepcopy(detected_models)
                     models_endpoint_error = None
-                    resolved_key = resolve_provider_credential(
-                        provider_cfg.get("api_key") if isinstance(provider_cfg, dict) else None,
-                        provider_cfg.get("key_env") if isinstance(provider_cfg, dict) else None,
-                        pid,
-                    )
-                    provider_base_url = (
-                        str(provider_cfg.get("base_url") or "").strip()
-                        if isinstance(provider_cfg, dict)
-                        else ""
-                    )
-                    if (
-                        not raw_models
-                        and discover_models
-                        and not has_configured_model_allowlist
-                        and provider_base_url
-                        and resolved_key
-                    ):
-                        raw_models, models_endpoint_error = _read_custom_endpoint_models(
-                            provider_base_url,
-                            pid,
-                            api_key=resolved_key,
-                            allow_private_base_url=False,
-                        )
                     _append_picker_group(
                         provider_name,
                         pid,
@@ -8055,6 +8034,30 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         # loop; this omission is belt-and-braces matching the
                         # #1572/#7372 "omit rather than misattribute" posture.
                         models_for_group = []
+                    _strict_key, _strict_entry = _raw_config_entry(pid)
+                    _strict_lane = bool(
+                        _strict_entry
+                        and pid != active_provider
+                        and pid not in _PROVIDER_MODELS
+                        and pid not in _PROVIDER_DISPLAY
+                        and not _is_plugin_model_provider(pid)
+                        and str(_strict_entry.get("base_url") or "").strip()
+                    )
+                    if _strict_lane:
+                        models_for_group, models_endpoint_error = _discover_snapshot_provider_models(
+                            pid, provider_name
+                        )
+                        if models_for_group or models_endpoint_error:
+                            _append_picker_group(
+                                provider_name,
+                                pid,
+                                models_for_group,
+                                apply_prefix=False,
+                                models_endpoint_error=models_endpoint_error,
+                                allow_empty=bool(models_endpoint_error),
+                            )
+                        continue
+
                     models_endpoint_error = None
                     provider_cfg = _get_provider_cfg(_canonical_to_raw_provider_key.get(pid, pid))
                     resolved_key = resolve_provider_credential(
@@ -8077,27 +8080,18 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         and provider_base_url
                         and resolved_key
                         and isinstance(provider_cfg, dict)
-                    ):
-                        _strict_key, _strict_entry = _raw_config_entry(pid)
-                        _strict_lane = bool(
-                            _strict_entry
-                            and pid != active_provider
-                            and pid not in _PROVIDER_MODELS
-                            and pid not in _PROVIDER_DISPLAY
-                            and not _is_plugin_model_provider(pid)
-                            and str(_strict_entry.get("base_url") or "").strip()
+                        and (
+                            pid == active_provider
+                            or pid == "custom"
+                            or pid.startswith("custom:")
                         )
-                        if _strict_lane:
-                            models_for_group, models_endpoint_error = _discover_snapshot_provider_models(
-                                pid, provider_name
-                            )
-                        else:
-                            models_for_group, models_endpoint_error = _read_custom_endpoint_models(
-                                provider_base_url,
-                                pid,
-                                api_key=resolved_key,
-                                allow_private_base_url=False,
-                            )
+                    ):
+                        models_for_group, models_endpoint_error = _read_custom_endpoint_models(
+                            provider_base_url,
+                            pid,
+                            api_key=resolved_key,
+                            allow_private_base_url=False,
+                        )
                     if models_for_group or models_endpoint_error:
                         # Per-group deep copy so subsequent mutation by
                         # _deduplicate_model_ids() (which prefixes ids with
@@ -8442,6 +8436,20 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 )
                 with _sync_scope:
                     result = _invoke_models_rebuild(_build_available_models_uncached)
+                    with _cache_build_cv:
+                        _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
+                        if _authority_matches:
+                            published_at = time.monotonic()
+                            _available_models_cache = result
+                            _available_models_cache_ts = published_at
+                            _available_models_live_rebuild_ts = published_at
+                            _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                            _sync_models_cache_provenance()
+                    if _authority_matches:
+                        try:
+                            _save_models_cache_to_disk(result)
+                        except Exception:
+                            logger.debug("models cache disk save failed", exc_info=True)
             except BaseException:
                 # Always reset the flag so waiting threads don't block for 60s
                 with _cache_build_cv:
@@ -8449,21 +8457,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _cache_build_cv.notify_all()
                 raise
             with _cache_build_cv:
-                _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
-                if _authority_matches:
-                    published_at = time.monotonic()
-                    _available_models_cache = result
-                    _available_models_cache_ts = published_at
-                    _available_models_live_rebuild_ts = published_at
-                    _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
-                    _sync_models_cache_provenance()
-            try:
-                if _authority_matches:
-                    _save_models_cache_to_disk(result)
-            finally:
-                with _cache_build_cv:
-                    _cache_build_in_progress = False
-                    _cache_build_cv.notify_all()
+                _cache_build_in_progress = False
+                _cache_build_cv.notify_all()
             return copy.deepcopy(result if _authority_matches else _minimal_static_models_catalog())
 
         # ── Bounded rebuild (defense-in-depth) ───────────────────────────────
@@ -8525,6 +8520,15 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _cache_build_cv.notify_all()
             return True
 
+        def _publish_foreground(result):
+            publish_scope = (
+                _prof_env_request("models publish (foreground)")
+                if _prof_env_request is not None
+                else _nullcontext()
+            )
+            with publish_scope:
+                return _publish_models_result(result)
+
         def _clear_build_in_progress():
             global _cache_build_in_progress
             with _cache_build_cv:
@@ -8584,7 +8588,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 raise box["error"]
             _published = False
             if _claim_publish():
-                _published = _publish_models_result(box["result"])
+                _published = _publish_foreground(box["result"])
             return copy.deepcopy(box["result"] if _published else _minimal_static_models_catalog())
 
         # Budget elapsed. Mark it so the worker knows it owns out-of-band
@@ -8595,7 +8599,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         if build_done.is_set() and "error" not in box and "result" in box:
             _published = False
             if _claim_publish():
-                _published = _publish_models_result(box["result"])
+                _published = _publish_foreground(box["result"])
             return copy.deepcopy(box["result"] if _published else _minimal_static_models_catalog())
 
         # Genuinely slow/hung probe: serve the best fallback now; the worker

--- a/api/config.py
+++ b/api/config.py
@@ -3000,20 +3000,20 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
 
 def resolve_provider_credential(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
     """Resolve one provider entry's credential using the active profile env."""
-    api_key = None
+    from api.provider_discovery import resolve_credential
+
+    raw = {}
     if raw_api_key is not None:
-        key_text = str(raw_api_key).strip()
-        if key_text.startswith("${") and key_text.endswith("}") and len(key_text) > 3:
-            api_key = _thread_local_env_value(key_text[2:-1]).strip() or None
-        elif key_text:
-            api_key = key_text
-    if not api_key:
-        key_env = str(raw_key_env or "").strip()
-        if key_env:
-            api_key = _thread_local_env_value(key_env).strip() or None
-    if not api_key and provider_hint:
-        api_key = _lookup_custom_api_key_env(provider_hint)
-    return api_key
+        raw["api_key"] = raw_api_key
+    if raw_key_env is not None:
+        raw["key_env"] = raw_key_env
+    resolved = resolve_credential(
+        raw,
+        provider_hint=str(provider_hint or ""),
+        env_value=_thread_local_env_value,
+        fallback_value=_lookup_custom_api_key_env,
+    )
+    return resolved.value if resolved.state == "resolved" else None
 
 
 def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, str | None]:
@@ -5999,6 +5999,40 @@ def _models_cache_source_fingerprint() -> dict:
     }
 
 
+def _provider_publication_tuple() -> tuple[str, str, str]:
+    """Return non-secret authority identity for a provider catalog result."""
+    try:
+        from api.profiles import get_active_profile_name
+
+        profile = str(get_active_profile_name() or "")
+    except Exception:
+        profile = ""
+    try:
+        from api.provider_discovery import capture_raw_profile_snapshot
+
+        raw = capture_raw_profile_snapshot(sys.modules[__name__])
+    except Exception:
+        raw = copy.deepcopy(cfg)
+    raw_fingerprint = hashlib.sha256(
+        json.dumps(raw, sort_keys=True, default=str, separators=(",", ":")).encode()
+    ).hexdigest()
+    env_names = []
+    providers_cfg = raw.get("providers", {}) if isinstance(raw, dict) else {}
+    if isinstance(providers_cfg, dict):
+        for entry in providers_cfg.values():
+            if isinstance(entry, dict):
+                name = str(entry.get("key_env") or "").strip()
+                if name:
+                    env_names.append(name)
+                literal = entry.get("api_key")
+                if isinstance(literal, str) and literal.strip().startswith("${"):
+                    env_names.append(literal.strip()[2:-1])
+    env_fingerprint = hashlib.sha256(
+        json.dumps(sorted((name, _thread_local_env_value(name)) for name in set(env_names)), separators=(",", ":")).encode()
+    ).hexdigest()
+    return profile, raw_fingerprint, env_fingerprint
+
+
 def _delete_models_cache_on_disk() -> None:
     try:
         os.unlink(str(_get_models_cache_path()))
@@ -6552,10 +6586,77 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.
+    _build_authority: dict[str, tuple[str, str, str]] = {}
+
     def _build_available_models_uncached() -> dict:
+        _build_authority["value"] = _provider_publication_tuple()
         active_provider = None
         default_model = get_effective_default_model(cfg)
         groups = []
+        # This snapshot is captured while the caller's profile scope is bound.
+        # The process-expanded cache remains the compatibility source for the
+        # legacy active and named-custom lanes below.
+        try:
+            from api.provider_discovery import capture_raw_profile_snapshot
+
+            _raw_profile_cfg = capture_raw_profile_snapshot(sys.modules[__name__])
+        except Exception:
+            _raw_profile_cfg = copy.deepcopy(cfg)
+
+        def _raw_config_entry(provider_id: str) -> tuple[str, dict]:
+            raw_providers = _raw_profile_cfg.get("providers", {})
+            if not isinstance(raw_providers, dict):
+                return provider_id, {}
+            for raw_key, entry in raw_providers.items():
+                if _canonicalise_provider_id(raw_key) == provider_id and isinstance(entry, dict):
+                    return str(raw_key), copy.deepcopy(entry)
+            return provider_id, {}
+
+        def _discover_snapshot_provider_models(provider_id: str, provider_label: str):
+            """Probe only an unregistered, route-bearing configured provider."""
+            raw_key, raw_entry = _raw_config_entry(provider_id)
+            if not raw_entry or provider_id == active_provider:
+                return [], None
+            known = (
+                provider_id in _PROVIDER_MODELS
+                or provider_id in _PROVIDER_DISPLAY
+                or _is_plugin_model_provider(provider_id)
+            )
+            if known or not str(raw_entry.get("base_url") or "").strip():
+                return [], None
+            from api.provider_discovery import (
+                ProviderDiscoveryError,
+                build_connection,
+                fetch_models,
+            )
+
+            connection = build_connection(
+                profile=str(_raw_profile_cfg.get("profile") or ""),
+                provider_id=provider_id,
+                raw_config_key=raw_key,
+                raw=raw_entry,
+                env_value=_thread_local_env_value,
+                fallback_value=_lookup_custom_api_key_env,
+            )
+            if connection.model_options:
+                return list(connection.model_options), None
+            if connection.discovery_policy != "allow" or not connection.credential:
+                return [], None
+            try:
+                return fetch_models(connection), None
+            except ProviderDiscoveryError as exc:
+                code = exc.status if exc.kind in {"auth", "http"} else None
+                return [], {
+                    "kind": exc.kind if exc.kind in {"auth", "http"} else "network",
+                    "code": code,
+                    "message": (
+                        f"Models endpoint returned {code} — check the API key for {provider_label}."
+                        if exc.kind == "auth" and code is not None
+                        else f"Models endpoint returned {code} for {provider_label}; see logs."
+                        if code is not None
+                        else f"Models endpoint unreachable for {provider_label}; verify base_url."
+                    ),
+                }
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
@@ -6994,6 +7095,23 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
                 _canonical_to_raw_provider_key.setdefault(_canonical, _pid_key)
                 detected_providers.add(_canonical)
+
+        # The strict lane must enumerate route-bearing providers from the raw
+        # profile snapshot captured above, not only from the process-wide cfg.
+        _raw_profile_providers = _raw_profile_cfg.get("providers", {})
+        if isinstance(_raw_profile_providers, dict):
+            for _raw_pid, _raw_provider_cfg in _raw_profile_providers.items():
+                if not isinstance(_raw_provider_cfg, dict):
+                    continue
+                _raw_canonical = _canonicalise_provider_id(_raw_pid)
+                if not _raw_canonical:
+                    continue
+                if any(
+                    str(_raw_provider_cfg.get(_route_key) or "").strip()
+                    for _route_key in ("api", "base_url", "api_key", "key_env")
+                ):
+                    _canonical_to_raw_provider_key[_raw_canonical] = str(_raw_pid)
+                    detected_providers.add(_raw_canonical)
 
         def _configured_provider_for_base_url(base_url: object) -> str:
             target = _normalize_base_url_for_match(base_url)
@@ -7794,6 +7912,29 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     or pid in _canonical_to_raw_provider_key
                     or _is_plugin_model_provider(pid)
                 ):
+                    _strict_key, _strict_entry = _raw_config_entry(pid)
+                    _strict_lane = bool(
+                        _strict_entry
+                        and pid != active_provider
+                        and pid not in _PROVIDER_MODELS
+                        and pid not in _PROVIDER_DISPLAY
+                        and not _is_plugin_model_provider(pid)
+                        and str(_strict_entry.get("base_url") or "").strip()
+                    )
+                    if _strict_lane:
+                        raw_models, models_endpoint_error = _discover_snapshot_provider_models(
+                            pid, provider_name
+                        )
+                        if raw_models or models_endpoint_error:
+                            _append_picker_group(
+                                provider_name,
+                                pid,
+                                raw_models,
+                                apply_prefix=False,
+                                models_endpoint_error=models_endpoint_error,
+                                allow_empty=bool(models_endpoint_error),
+                            )
+                        continue
                     # Look up provider_cfg using the original raw key from
                     # config.yaml so that mixed-case / underscore keys like
                     # ``CLIPpoxy`` or ``snake_case_provider`` still resolve
@@ -7937,12 +8078,26 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         and resolved_key
                         and isinstance(provider_cfg, dict)
                     ):
-                        models_for_group, models_endpoint_error = _read_custom_endpoint_models(
-                            provider_base_url,
-                            pid,
-                            api_key=resolved_key,
-                            allow_private_base_url=False,
+                        _strict_key, _strict_entry = _raw_config_entry(pid)
+                        _strict_lane = bool(
+                            _strict_entry
+                            and pid != active_provider
+                            and pid not in _PROVIDER_MODELS
+                            and pid not in _PROVIDER_DISPLAY
+                            and not _is_plugin_model_provider(pid)
+                            and str(_strict_entry.get("base_url") or "").strip()
                         )
+                        if _strict_lane:
+                            models_for_group, models_endpoint_error = _discover_snapshot_provider_models(
+                                pid, provider_name
+                            )
+                        else:
+                            models_for_group, models_endpoint_error = _read_custom_endpoint_models(
+                                provider_base_url,
+                                pid,
+                                api_key=resolved_key,
+                                allow_private_base_url=False,
+                            )
                     if models_for_group or models_endpoint_error:
                         # Per-group deep copy so subsequent mutation by
                         # _deduplicate_model_ids() (which prefixes ids with
@@ -8294,19 +8449,22 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _cache_build_cv.notify_all()
                 raise
             with _cache_build_cv:
-                published_at = time.monotonic()
-                _available_models_cache = result
-                _available_models_cache_ts = published_at
-                _available_models_live_rebuild_ts = published_at
-                _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
-                _sync_models_cache_provenance()
+                _authority_matches = _provider_publication_tuple() == _build_authority.get("value")
+                if _authority_matches:
+                    published_at = time.monotonic()
+                    _available_models_cache = result
+                    _available_models_cache_ts = published_at
+                    _available_models_live_rebuild_ts = published_at
+                    _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                    _sync_models_cache_provenance()
             try:
-                _save_models_cache_to_disk(result)
+                if _authority_matches:
+                    _save_models_cache_to_disk(result)
             finally:
                 with _cache_build_cv:
                     _cache_build_in_progress = False
                     _cache_build_cv.notify_all()
-            return copy.deepcopy(result)
+            return copy.deepcopy(result if _authority_matches else _minimal_static_models_catalog())
 
         # ── Bounded rebuild (defense-in-depth) ───────────────────────────────
         # The live rebuild does a network probe per provider (Copilot token
@@ -8341,6 +8499,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             global _cache_build_in_progress, _available_models_cache
             global _available_models_cache_ts, _available_models_live_rebuild_ts
             global _available_models_cache_source_fingerprint
+            if (
+                _build_authority.get("value") is not None
+                and _provider_publication_tuple() != _build_authority["value"]
+            ):
+                logger.info("discarding provider catalog with stale publication authority")
+                _clear_build_in_progress()
+                return False
             with _cache_build_cv:
                 published_at = time.monotonic()
                 _available_models_cache = result
@@ -8358,6 +8523,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 with _cache_build_cv:
                     _cache_build_in_progress = False
                     _cache_build_cv.notify_all()
+            return True
 
         def _clear_build_in_progress():
             global _cache_build_in_progress
@@ -8416,9 +8582,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             if "error" in box:
                 _clear_build_in_progress()
                 raise box["error"]
+            _published = False
             if _claim_publish():
-                _publish_models_result(box["result"])
-            return copy.deepcopy(box["result"])
+                _published = _publish_models_result(box["result"])
+            return copy.deepcopy(box["result"] if _published else _minimal_static_models_catalog())
 
         # Budget elapsed. Mark it so the worker knows it owns out-of-band
         # publication. Handle the tiny race where the build completed between
@@ -8426,9 +8593,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # so this caller honours the cache contract.
         budget_exceeded.set()
         if build_done.is_set() and "error" not in box and "result" in box:
+            _published = False
             if _claim_publish():
-                _publish_models_result(box["result"])
-            return copy.deepcopy(box["result"])
+                _published = _publish_models_result(box["result"])
+            return copy.deepcopy(box["result"] if _published else _minimal_static_models_catalog())
 
         # Genuinely slow/hung probe: serve the best fallback now; the worker
         # keeps going and refreshes the cache for the next caller.

--- a/api/provider_discovery.py
+++ b/api/provider_discovery.py
@@ -73,12 +73,17 @@ def resolve_credential(
     has_key_env = "key_env" in raw
     if has_api_key:
         value = raw.get("api_key")
-        if isinstance(value, str) and value.strip().startswith("${") and value.strip().endswith("}"):
-            name = value.strip()[2:-1].strip()
-            return _from_env(name, "api_key:${...}", env_value)
-        if isinstance(value, str) and value.strip():
-            return ProviderCredential("resolved", "api_key", value.strip())
-        return ProviderCredential("declared_unavailable", "api_key")
+        value_text = str(value or "").strip()
+        if value_text:
+            if value_text.startswith("${") and value_text.endswith("}"):
+                name = value_text[2:-1].strip()
+                resolved = _from_env(name, "api_key:${...}", env_value)
+                if resolved or not has_key_env:
+                    return resolved
+                # An unresolved template can still use the explicitly declared
+                # key_env source; only source-absent entries reach ambient fallback.
+            else:
+                return ProviderCredential("resolved", "api_key", value_text)
     if has_key_env:
         name = str(raw.get("key_env") or "").strip()
         if name:

--- a/api/provider_discovery.py
+++ b/api/provider_discovery.py
@@ -82,6 +82,9 @@ def resolve_credential(
                     return resolved
                 # An unresolved template can still use the explicitly declared
                 # key_env source; only source-absent entries reach ambient fallback.
+            elif value_text.startswith("${"):
+                if not has_key_env:
+                    return ProviderCredential("declared_unavailable", "api_key:${...}")
             else:
                 return ProviderCredential("resolved", "api_key", value_text)
     if has_key_env:
@@ -89,6 +92,8 @@ def resolve_credential(
         if name:
             return _from_env(name, "key_env", env_value)
         return ProviderCredential("declared_unavailable", "key_env")
+    if has_api_key:
+        return ProviderCredential("declared_unavailable", "api_key")
     if (provider_hint == "custom" or provider_hint.startswith("custom:")) and fallback_value is not None:
         value = fallback_value(provider_hint)
         if value and str(value).strip():
@@ -230,7 +235,8 @@ def fetch_models(
 ) -> list[dict[str, str]]:
     """Fetch a catalog after exactly one DNS resolution and with no redirects."""
     prepared = connection if connection.vetted_addresses else prepare_connection(connection, resolver=resolver)
-    endpoint = prepared.base_url.rstrip("/") + "/models"
+    endpoint = prepared.base_url.rstrip("/")
+    endpoint = endpoint + ("/models" if endpoint.endswith("/v1") else "/v1/models")
     request = urllib.request.Request(endpoint, method="GET")
     request.add_header("User-Agent", "OpenAI/Python 1.0")
     if prepared.credential.value:
@@ -250,10 +256,29 @@ def fetch_models(
         if len(payload) > max_bytes:
             raise ProviderDiscoveryError("response_too_large")
         decoded = json.loads(payload.decode("utf-8"))
-        rows = decoded.get("data") if isinstance(decoded, dict) else decoded
+        if isinstance(decoded, dict):
+            rows = decoded.get("data")
+            if not isinstance(rows, list):
+                rows = decoded.get("models")
+        else:
+            rows = decoded
         if not isinstance(rows, list):
             raise ProviderDiscoveryError("invalid_payload")
-        return [{"id": str(row["id"]), "label": str(row.get("name") or row["id"])} for row in rows if isinstance(row, dict) and row.get("id")]
+        result = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            model_id = row.get("id") or row.get("name") or row.get("model")
+            if not model_id:
+                continue
+            model_id = str(model_id)
+            result.append(
+                {
+                    "id": model_id,
+                    "label": str(row.get("name") or row.get("model") or model_id),
+                }
+            )
+        return result
     except ProviderDiscoveryError:
         raise
     except urllib.error.HTTPError as exc:

--- a/api/provider_discovery.py
+++ b/api/provider_discovery.py
@@ -71,6 +71,12 @@ def resolve_credential(
     env_value = env_value or (lambda name: __import__("os").getenv(name, ""))
     has_api_key = "api_key" in raw
     has_key_env = "key_env" in raw
+    if has_key_env:
+        name = str(raw.get("key_env") or "").strip()
+        if name:
+            resolved = _from_env(name, "key_env", env_value)
+            if resolved.state == "resolved":
+                return resolved
     if has_api_key:
         value = raw.get("api_key")
         value_text = str(value or "").strip()
@@ -78,22 +84,15 @@ def resolve_credential(
             if value_text.startswith("${") and value_text.endswith("}"):
                 name = value_text[2:-1].strip()
                 resolved = _from_env(name, "api_key:${...}", env_value)
-                if resolved or not has_key_env:
+                if resolved.state == "resolved":
                     return resolved
-                # An unresolved template can still use the explicitly declared
-                # key_env source; only source-absent entries reach ambient fallback.
             elif value_text.startswith("${"):
-                if not has_key_env:
-                    return ProviderCredential("declared_unavailable", "api_key:${...}")
+                return ProviderCredential("declared_unavailable", "api_key:${...}")
             else:
                 return ProviderCredential("resolved", "api_key", value_text)
-    if has_key_env:
-        name = str(raw.get("key_env") or "").strip()
-        if name:
-            return _from_env(name, "key_env", env_value)
-        return ProviderCredential("declared_unavailable", "key_env")
-    if has_api_key:
         return ProviderCredential("declared_unavailable", "api_key")
+    if has_key_env:
+        return ProviderCredential("declared_unavailable", "key_env")
     if (provider_hint == "custom" or provider_hint.startswith("custom:")) and fallback_value is not None:
         value = fallback_value(provider_hint)
         if value and str(value).strip():

--- a/api/provider_discovery.py
+++ b/api/provider_discovery.py
@@ -1,0 +1,263 @@
+"""Profile-bound configured-provider discovery primitives.
+
+This module deliberately has no import of :mod:`api.config`.  Callers provide
+the small config/environment seams they already own, which keeps the raw
+snapshot and the credentialed transport independently testable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import http.client
+import ipaddress
+import json
+import logging
+import socket
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+DEFAULT_TIMEOUT = 5.0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProviderCredential:
+    """Redacted credential resolution result."""
+
+    state: str
+    source: str | None = None
+    value: str | None = dataclasses.field(default=None, repr=False, compare=False)
+
+    def __bool__(self) -> bool:
+        return self.state == "resolved" and bool(self.value)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProviderConnection:
+    """The complete authority tuple for one configured provider probe."""
+
+    profile: str
+    provider_id: str
+    raw_config_key: str
+    base_url: str
+    discovery_policy: str
+    model_options: tuple[dict[str, Any], ...]
+    credential: ProviderCredential
+    vetted_addresses: tuple[str, ...] = ()
+
+
+class ProviderDiscoveryError(Exception):
+    """An intentionally public-safe discovery failure."""
+
+    def __init__(self, kind: str, status: int | None = None):
+        super().__init__(kind)
+        self.kind = kind
+        self.status = status
+
+
+def resolve_credential(
+    raw: dict[str, Any],
+    *,
+    provider_hint: str = "",
+    env_value: Callable[[str], str] | None = None,
+    fallback_value: Callable[[str], str | None] | None = None,
+) -> ProviderCredential:
+    """Resolve declared sources without collapsing absent and unavailable."""
+    env_value = env_value or (lambda name: __import__("os").getenv(name, ""))
+    has_api_key = "api_key" in raw
+    has_key_env = "key_env" in raw
+    if has_api_key:
+        value = raw.get("api_key")
+        if isinstance(value, str) and value.strip().startswith("${") and value.strip().endswith("}"):
+            name = value.strip()[2:-1].strip()
+            return _from_env(name, "api_key:${...}", env_value)
+        if isinstance(value, str) and value.strip():
+            return ProviderCredential("resolved", "api_key", value.strip())
+        return ProviderCredential("declared_unavailable", "api_key")
+    if has_key_env:
+        name = str(raw.get("key_env") or "").strip()
+        if name:
+            return _from_env(name, "key_env", env_value)
+        return ProviderCredential("declared_unavailable", "key_env")
+    if (provider_hint == "custom" or provider_hint.startswith("custom:")) and fallback_value is not None:
+        value = fallback_value(provider_hint)
+        if value and str(value).strip():
+            return ProviderCredential("resolved", "derived_custom_env", str(value).strip())
+    return ProviderCredential("absent")
+
+
+def _from_env(name: str, source: str, env_value: Callable[[str], str]) -> ProviderCredential:
+    if not name:
+        return ProviderCredential("declared_unavailable", source)
+    value = str(env_value(name) or "").strip()
+    return ProviderCredential("resolved", source, value) if value else ProviderCredential("declared_unavailable", source)
+
+
+def build_connection(
+    *,
+    profile: str,
+    provider_id: str,
+    raw_config_key: str,
+    raw: dict[str, Any],
+    env_value: Callable[[str], str] | None = None,
+    fallback_value: Callable[[str], str | None] | None = None,
+) -> ProviderConnection:
+    options = raw.get("models")
+    if isinstance(options, dict):
+        model_options = tuple(
+            {"id": str(key).strip(), "label": str(key).strip()}
+            for key in options
+            if isinstance(key, str) and key.strip()
+        )
+    elif isinstance(options, list):
+        rows = []
+        for item in options:
+            if isinstance(item, dict):
+                model_id = str(item.get("id") or item.get("model") or item.get("name") or "").strip()
+                label = str(item.get("label") or model_id).strip() or model_id
+            else:
+                model_id = str(item or "").strip()
+                label = model_id
+            if model_id and not any(row["id"] == model_id for row in rows):
+                rows.append({"id": model_id, "label": label})
+        model_options = tuple(rows)
+    elif isinstance(options, str) and options.strip():
+        model_options = ({"id": options.strip(), "label": options.strip()},)
+    else:
+        model_options = ()
+    policy = "disabled" if raw.get("discover_models") is False else "allow"
+    return ProviderConnection(
+        profile=str(profile or ""),
+        provider_id=str(provider_id or "").strip().lower(),
+        raw_config_key=str(raw_config_key),
+        base_url=str(raw.get("base_url") or "").strip().rstrip("/"),
+        discovery_policy=policy,
+        model_options=model_options,
+        credential=resolve_credential(raw, provider_hint=provider_id, env_value=env_value, fallback_value=fallback_value),
+    )
+
+
+def capture_raw_profile_snapshot(config_module: Any) -> dict[str, Any]:
+    """Load raw YAML and expand it only after the caller's profile scope exists."""
+    path = config_module._get_config_path()
+    raw = config_module._load_yaml_config_file_raw(path)
+    if config_module._cfg_has_in_memory_overrides():
+        raw = config_module.cfg
+    snapshot = config_module.copy.deepcopy(raw) if isinstance(raw, dict) else {}
+    config_module._apply_config_defaults(snapshot)
+    return snapshot
+
+
+def _resolve_addresses(host: str, port: int, resolver: Callable[..., Any] | None) -> tuple[str, ...]:
+    resolver = resolver or socket.getaddrinfo
+    infos = resolver(host, port, type=socket.SOCK_STREAM)
+    addresses: list[str] = []
+    for info in infos:
+        value = info[4][0]
+        if not ipaddress.ip_address(value).is_global:
+            raise ProviderDiscoveryError("blocked_destination")
+        if value not in addresses:
+            addresses.append(value)
+    if not addresses:
+        raise ProviderDiscoveryError("unresolved_destination")
+    return tuple(addresses)
+
+
+def prepare_connection(connection: ProviderConnection, *, resolver: Callable[..., Any] | None = None) -> ProviderConnection:
+    try:
+        parsed = urllib.parse.urlsplit(connection.base_url)
+        if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ProviderDiscoveryError("invalid_endpoint")
+        addresses = _resolve_addresses(parsed.hostname, parsed.port or 443, resolver)
+    except ProviderDiscoveryError:
+        raise
+    except Exception:
+        raise ProviderDiscoveryError("network") from None
+    return dataclasses.replace(connection, vetted_addresses=addresses)
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, host: str, address: str, *, port: int, timeout: float, context: ssl.SSLContext):
+        super().__init__(host, port=port, timeout=timeout, context=context)
+        self._address = address
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection((self._address, self.port), self.timeout)
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, connection: ProviderConnection, timeout: float):
+        super().__init__(context=ssl.create_default_context())
+        self.connection = connection
+        self.timeout = timeout
+
+    def https_open(self, req):
+        parsed = urllib.parse.urlsplit(req.full_url)
+        last_error = None
+        for address in self.connection.vetted_addresses:
+            try:
+                return self.do_open(
+                    lambda host, address=address, **kwargs: _PinnedHTTPSConnection(
+                        host, address, port=parsed.port or 443, timeout=self.timeout, context=self._context
+                    ),
+                    req,
+                )
+            except (OSError, urllib.error.URLError) as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise urllib.error.URLError("no vetted destination")
+
+
+def fetch_models(
+    connection: ProviderConnection,
+    *,
+    resolver: Callable[..., Any] | None = None,
+    opener: Callable[..., Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_bytes: int = MAX_RESPONSE_BYTES,
+) -> list[dict[str, str]]:
+    """Fetch a catalog after exactly one DNS resolution and with no redirects."""
+    prepared = connection if connection.vetted_addresses else prepare_connection(connection, resolver=resolver)
+    endpoint = prepared.base_url.rstrip("/") + "/models"
+    request = urllib.request.Request(endpoint, method="GET")
+    request.add_header("User-Agent", "OpenAI/Python 1.0")
+    if prepared.credential.value:
+        request.add_header("Authorization", f"Bearer {prepared.credential.value}")
+    try:
+        if opener is None:
+            opener_obj = urllib.request.build_opener(_PinnedHTTPSHandler(prepared, timeout), urllib.request.ProxyHandler({}), _NoRedirect())
+            response = opener_obj.open(request, timeout=timeout)
+        else:
+            response = opener(request, timeout=timeout)
+        with response:
+            status = getattr(response, "status", None)
+            if status is not None and status != 200:
+                kind = "auth" if status in (401, 403) else "http"
+                raise ProviderDiscoveryError(kind, int(status))
+            payload = response.read(max_bytes + 1)
+        if len(payload) > max_bytes:
+            raise ProviderDiscoveryError("response_too_large")
+        decoded = json.loads(payload.decode("utf-8"))
+        rows = decoded.get("data") if isinstance(decoded, dict) else decoded
+        if not isinstance(rows, list):
+            raise ProviderDiscoveryError("invalid_payload")
+        return [{"id": str(row["id"]), "label": str(row.get("name") or row["id"])} for row in rows if isinstance(row, dict) and row.get("id")]
+    except ProviderDiscoveryError:
+        raise
+    except urllib.error.HTTPError as exc:
+        code = getattr(exc, "code", None)
+        raise ProviderDiscoveryError("auth" if code in (401, 403) else "http", code) from None
+    except Exception:
+        raise ProviderDiscoveryError("network") from None
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise ProviderDiscoveryError("redirect")

--- a/api/provider_discovery.py
+++ b/api/provider_discovery.py
@@ -71,12 +71,15 @@ def resolve_credential(
     env_value = env_value or (lambda name: __import__("os").getenv(name, ""))
     has_api_key = "api_key" in raw
     has_key_env = "key_env" in raw
+    key_env_result: ProviderCredential | None = None
     if has_key_env:
         name = str(raw.get("key_env") or "").strip()
         if name:
-            resolved = _from_env(name, "key_env", env_value)
-            if resolved.state == "resolved":
-                return resolved
+            key_env_result = _from_env(name, "key_env", env_value)
+            if key_env_result.state == "resolved":
+                return key_env_result
+        else:
+            key_env_result = ProviderCredential("declared_unavailable", "key_env")
     if has_api_key:
         value = raw.get("api_key")
         value_text = str(value or "").strip()
@@ -87,12 +90,15 @@ def resolve_credential(
                 if resolved.state == "resolved":
                     return resolved
             elif value_text.startswith("${"):
-                return ProviderCredential("declared_unavailable", "api_key:${...}")
+                if not has_key_env:
+                    return ProviderCredential("declared_unavailable", "api_key:${...}")
             else:
                 return ProviderCredential("resolved", "api_key", value_text)
+        if key_env_result is not None:
+            return key_env_result
         return ProviderCredential("declared_unavailable", "api_key")
-    if has_key_env:
-        return ProviderCredential("declared_unavailable", "key_env")
+    if key_env_result is not None:
+        return key_env_result
     if (provider_hint == "custom" or provider_hint.startswith("custom:")) and fallback_value is not None:
         value = fallback_value(provider_hint)
         if value and str(value).strip():

--- a/api/providers.py
+++ b/api/providers.py
@@ -1322,8 +1322,15 @@ def _provider_has_key(provider_id: str) -> bool:
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
         provider_cfg = providers_cfg.get(provider_id, {})
-        if isinstance(provider_cfg, dict) and str(provider_cfg.get("api_key") or "").strip():
-            if _provider_value_counts_as_api_key(provider_id, provider_cfg.get("api_key")):
+        if isinstance(provider_cfg, dict) and (
+            provider_cfg.get("api_key") or provider_cfg.get("key_env")
+        ):
+            from api.config import resolve_provider_credential
+
+            provider_key = resolve_provider_credential(
+                provider_cfg.get("api_key"), provider_cfg.get("key_env"), provider_id
+            )
+            if _provider_value_counts_as_api_key(provider_id, provider_key):
                 return True
     # Check custom_providers
     custom_providers = cfg.get("custom_providers", [])
@@ -1368,8 +1375,14 @@ def _get_provider_api_key(provider_id: str) -> str | None:
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
         provider_cfg = providers_cfg.get(provider_id, {})
-        if isinstance(provider_cfg, dict):
-            provider_key = str(provider_cfg.get("api_key") or "").strip()
+        if isinstance(provider_cfg, dict) and (
+            provider_cfg.get("api_key") or provider_cfg.get("key_env")
+        ):
+            from api.config import resolve_provider_credential
+
+            provider_key = resolve_provider_credential(
+                provider_cfg.get("api_key"), provider_cfg.get("key_env"), provider_id
+            )
             if _provider_value_counts_as_api_key(provider_id, provider_key):
                 return provider_key
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -1377,11 +1377,9 @@ def _provider_has_key(provider_id: str, *, _declared_snapshot: dict | None = Non
         if isinstance(provider_cfg, dict) and (
             provider_cfg.get("api_key") or provider_cfg.get("key_env")
         ):
-            from api.config import resolve_provider_credential
+            from api.config import resolve_provider_credential_entry
 
-            provider_key = resolve_provider_credential(
-                provider_cfg.get("api_key"), provider_cfg.get("key_env"), provider_id
-            )
+            provider_key = resolve_provider_credential_entry(provider_cfg, provider_id)
             if _provider_value_counts_as_api_key(provider_id, provider_key):
                 return True
     # Check custom_providers
@@ -1390,11 +1388,9 @@ def _provider_has_key(provider_id: str, *, _declared_snapshot: dict | None = Non
         for cp in custom_providers:
             if isinstance(cp, dict):
                 if _custom_provider_name_matches(provider_id, cp.get("name")):
-                    from api.config import resolve_provider_credential
+                    from api.config import resolve_provider_credential_entry
 
-                    provider_key = resolve_provider_credential(
-                        cp.get("api_key"), cp.get("key_env"), provider_id
-                    )
+                    provider_key = resolve_provider_credential_entry(cp, provider_id)
                     if _provider_value_counts_as_api_key(provider_id, provider_key):
                         return True
     return False
@@ -1442,11 +1438,9 @@ def _get_provider_api_key(provider_id: str, *, _declared_snapshot: dict | None =
         if isinstance(provider_cfg, dict) and (
             provider_cfg.get("api_key") or provider_cfg.get("key_env")
         ):
-            from api.config import resolve_provider_credential
+            from api.config import resolve_provider_credential_entry
 
-            provider_key = resolve_provider_credential(
-                provider_cfg.get("api_key"), provider_cfg.get("key_env"), provider_id
-            )
+            provider_key = resolve_provider_credential_entry(provider_cfg, provider_id)
             if _provider_value_counts_as_api_key(provider_id, provider_key):
                 return provider_key
 
@@ -1456,11 +1450,9 @@ def _get_provider_api_key(provider_id: str, *, _declared_snapshot: dict | None =
             if not isinstance(cp, dict):
                 continue
             if _custom_provider_name_matches(provider_id, cp.get("name")):
-                from api.config import resolve_provider_credential
+                from api.config import resolve_provider_credential_entry
 
-                provider_key = resolve_provider_credential(
-                    cp.get("api_key"), cp.get("key_env"), provider_id
-                )
+                provider_key = resolve_provider_credential_entry(cp, provider_id)
                 if _provider_value_counts_as_api_key(provider_id, provider_key):
                     return provider_key
     # Fallback: try credential pool (e.g. bothub key stored via auth.json)
@@ -2929,14 +2921,19 @@ def get_providers() -> dict[str, Any]:
                 if _mid not in cp_model_ids:
                     cp_model_ids.append(_mid)
             cp_models = [{"id": mid, "label": mid} for mid in cp_model_ids]
-            from api.config import resolve_provider_credential
+            from api import config as _config_module
+            from api.provider_discovery import resolve_credential
 
-            cp_api_key = resolve_provider_credential(
-                cp.get("api_key"), cp.get("key_env"), f"custom:{cp_id}"
+            cp_credential = resolve_credential(
+                cp,
+                provider_hint=f"custom:{cp_id}",
+                env_value=_config_module._thread_local_env_value,
+                fallback_value=_config_module._lookup_custom_api_key_env,
             )
+            cp_api_key = cp_credential.value if cp_credential.state == "resolved" else None
             cp_has_key = _provider_value_counts_as_api_key(f"custom:{cp_id}", cp_api_key)
             # Fallback: check credential pool (key added via hermes auth add)
-            if not cp_has_key:
+            if not cp_has_key and not ("api_key" in cp or "key_env" in cp):
                 try:
                     from api.config import _has_explicit_pool_credentials
                     if _has_explicit_pool_credentials(cp_id):

--- a/api/providers.py
+++ b/api/providers.py
@@ -76,6 +76,50 @@ def _custom_provider_name_matches(provider_id: str, name: object) -> bool:
         candidates.add(slug)
     return pid in candidates
 
+
+def _declared_profile_credential(provider_id: str):
+    """Resolve a declared source from one raw profile snapshot."""
+    from api import config as _config_module
+    from api.provider_discovery import capture_raw_profile_snapshot, resolve_credential
+
+    try:
+        snapshot = capture_raw_profile_snapshot(_config_module)
+    except Exception:
+        logger.debug("Failed to capture raw profile credential snapshot", exc_info=True)
+        return None
+
+    pid = str(provider_id or "").strip().lower()
+    providers_cfg = snapshot.get("providers") if isinstance(snapshot, dict) else None
+    if isinstance(providers_cfg, dict):
+        for raw_pid, entry in providers_cfg.items():
+            try:
+                matches = _config_module._canonicalise_provider_id(raw_pid) == _config_module._canonicalise_provider_id(pid)
+            except Exception:
+                matches = str(raw_pid).strip().lower() == pid
+            if matches and isinstance(entry, dict) and ("api_key" in entry or "key_env" in entry):
+                return resolve_credential(
+                    entry,
+                    provider_hint=pid,
+                    env_value=_config_module._thread_local_env_value,
+                    fallback_value=None,
+                )
+
+    custom_cfg = snapshot.get("custom_providers") if isinstance(snapshot, dict) else None
+    if isinstance(custom_cfg, list):
+        for entry in custom_cfg:
+            if (
+                isinstance(entry, dict)
+                and _custom_provider_name_matches(pid, entry.get("name"))
+                and ("api_key" in entry or "key_env" in entry)
+            ):
+                return resolve_credential(
+                    entry,
+                    provider_hint=pid,
+                    env_value=_config_module._thread_local_env_value,
+                    fallback_value=None,
+                )
+    return None
+
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _PROVIDER_QUOTA_TIMEOUT_SECONDS = 3.0
 _ACCOUNT_USAGE_SUBPROCESS_TIMEOUT_SECONDS = 35.0
@@ -1276,6 +1320,10 @@ def _provider_has_key(provider_id: str) -> bool:
     4. ``config.yaml → providers.<id>.api_key``
     5. ``config.yaml → custom_providers[].api_key`` / ``key_env`` (for custom providers)
     """
+    _declared_credential = _declared_profile_credential(provider_id)
+    if _declared_credential is not None:
+        return bool(_declared_credential)
+
     env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"
@@ -1351,6 +1399,9 @@ def _provider_has_key(provider_id: str) -> bool:
 def _get_provider_api_key(provider_id: str) -> str | None:
     """Return a configured provider API key without exposing it to callers."""
     provider_id = (provider_id or "").strip().lower()
+    _declared_credential = _declared_profile_credential(provider_id)
+    if _declared_credential is not None:
+        return _declared_credential.value if _declared_credential.state == "resolved" else None
     env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"

--- a/api/providers.py
+++ b/api/providers.py
@@ -1365,10 +1365,13 @@ def _provider_has_key(provider_id: str, *, _declared_snapshot: dict | None = Non
     # Previously this checked globally, causing all providers to show
     # "configured" when the active provider had a top-level api_key.
     model_cfg = cfg.get("model", {})
-    if isinstance(model_cfg, dict) and str(model_cfg.get("api_key") or "").strip():
+    if isinstance(model_cfg, dict):
         active_provider = model_cfg.get("provider")
         if active_provider and str(active_provider).strip().lower() == provider_id.lower():
-            if _provider_value_counts_as_api_key(provider_id, model_cfg.get("api_key")):
+            from api.config import resolve_provider_credential_entry
+
+            model_key = resolve_provider_credential_entry(model_cfg, provider_id)
+            if _provider_value_counts_as_api_key(provider_id, model_key):
                 return True
     # Check providers.<id>.api_key
     providers_cfg = cfg.get("providers") or {}
@@ -1428,9 +1431,12 @@ def _get_provider_api_key(provider_id: str, *, _declared_snapshot: dict | None =
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, dict):
         active_provider = str(model_cfg.get("provider") or "").strip().lower()
-        model_key = str(model_cfg.get("api_key") or "").strip()
-        if model_key and active_provider == provider_id and _provider_value_counts_as_api_key(provider_id, model_key):
-            return model_key
+        if active_provider == provider_id:
+            from api.config import resolve_provider_credential_entry
+
+            model_key = resolve_provider_credential_entry(model_cfg, provider_id)
+            if _provider_value_counts_as_api_key(provider_id, model_key):
+                return model_key
 
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):

--- a/api/providers.py
+++ b/api/providers.py
@@ -1274,7 +1274,7 @@ def _provider_has_key(provider_id: str) -> bool:
     2. ``os.environ`` for the known env var
     3. ``config.yaml → model.api_key`` (only if provider is the active one)
     4. ``config.yaml → providers.<id>.api_key``
-    5. ``config.yaml → custom_providers[].api_key`` (for custom providers)
+    5. ``config.yaml → custom_providers[].api_key`` / ``key_env`` (for custom providers)
     """
     env_var = _provider_env_var_for(provider_id)
     if env_var:
@@ -1338,7 +1338,12 @@ def _provider_has_key(provider_id: str) -> bool:
         for cp in custom_providers:
             if isinstance(cp, dict):
                 if _custom_provider_name_matches(provider_id, cp.get("name")):
-                    if _provider_value_counts_as_api_key(provider_id, cp.get("api_key")):
+                    from api.config import resolve_provider_credential
+
+                    provider_key = resolve_provider_credential(
+                        cp.get("api_key"), cp.get("key_env"), provider_id
+                    )
+                    if _provider_value_counts_as_api_key(provider_id, provider_key):
                         return True
     return False
 
@@ -1392,11 +1397,13 @@ def _get_provider_api_key(provider_id: str) -> str | None:
             if not isinstance(cp, dict):
                 continue
             if _custom_provider_name_matches(provider_id, cp.get("name")):
-                cp_key = str(cp.get("api_key") or "").strip()
-                if cp_key.startswith("${") and cp_key.endswith("}"):
-                    return _thread_local_env_value(cp_key[2:-1]).strip() or None
-                if _provider_value_counts_as_api_key(provider_id, cp_key):
-                    return cp_key
+                from api.config import resolve_provider_credential
+
+                provider_key = resolve_provider_credential(
+                    cp.get("api_key"), cp.get("key_env"), provider_id
+                )
+                if _provider_value_counts_as_api_key(provider_id, provider_key):
+                    return provider_key
     # Fallback: try credential pool (e.g. bothub key stored via auth.json)
     for entry in _pool_entry_payloads(provider_id):
         status = str(entry.get("last_status") or "").strip().lower()
@@ -2863,13 +2870,12 @@ def get_providers() -> dict[str, Any]:
                 if _mid not in cp_model_ids:
                     cp_model_ids.append(_mid)
             cp_models = [{"id": mid, "label": mid} for mid in cp_model_ids]
-            # Check for env var reference (${VAR_NAME} pattern)
-            cp_api_key = str(cp.get("api_key") or "")
-            cp_has_key = bool(cp_api_key.strip())
-            # Replace env var reference to check actual value
-            if cp_api_key.startswith("${") and cp_api_key.endswith("}"):
-                env_var = cp_api_key[2:-1]
-                cp_has_key = bool(_thread_local_env_value(env_var).strip())
+            from api.config import resolve_provider_credential
+
+            cp_api_key = resolve_provider_credential(
+                cp.get("api_key"), cp.get("key_env"), f"custom:{cp_id}"
+            )
+            cp_has_key = _provider_value_counts_as_api_key(f"custom:{cp_id}", cp_api_key)
             # Fallback: check credential pool (key added via hermes auth add)
             if not cp_has_key:
                 try:

--- a/api/providers.py
+++ b/api/providers.py
@@ -77,16 +77,17 @@ def _custom_provider_name_matches(provider_id: str, name: object) -> bool:
     return pid in candidates
 
 
-def _declared_profile_credential(provider_id: str):
+def _declared_profile_credential(provider_id: str, snapshot: dict | None = None):
     """Resolve a declared source from one raw profile snapshot."""
     from api import config as _config_module
     from api.provider_discovery import capture_raw_profile_snapshot, resolve_credential
 
-    try:
-        snapshot = capture_raw_profile_snapshot(_config_module)
-    except Exception:
-        logger.debug("Failed to capture raw profile credential snapshot", exc_info=True)
-        return None
+    if snapshot is None:
+        try:
+            snapshot = capture_raw_profile_snapshot(_config_module)
+        except Exception:
+            logger.debug("Failed to capture raw profile credential snapshot", exc_info=True)
+            return None
 
     pid = str(provider_id or "").strip().lower()
     providers_cfg = snapshot.get("providers") if isinstance(snapshot, dict) else None
@@ -1310,7 +1311,7 @@ def _write_env_file(env_path: Path, updates: dict[str, str | None]) -> None:
             pass
 
 
-def _provider_has_key(provider_id: str) -> bool:
+def _provider_has_key(provider_id: str, *, _declared_snapshot: dict | None = None) -> bool:
     """Check whether a provider has a configured API key.
 
     Checks (in order):
@@ -1320,9 +1321,12 @@ def _provider_has_key(provider_id: str) -> bool:
     4. ``config.yaml → providers.<id>.api_key``
     5. ``config.yaml → custom_providers[].api_key`` / ``key_env`` (for custom providers)
     """
-    _declared_credential = _declared_profile_credential(provider_id)
+    _declared_credential = _declared_profile_credential(provider_id, _declared_snapshot)
     if _declared_credential is not None:
-        return bool(_declared_credential)
+        return bool(
+            _declared_credential
+            and _provider_value_counts_as_api_key(provider_id, _declared_credential.value)
+        )
 
     env_var = _provider_env_var_for(provider_id)
     if env_var:
@@ -1396,12 +1400,16 @@ def _provider_has_key(provider_id: str) -> bool:
     return False
 
 
-def _get_provider_api_key(provider_id: str) -> str | None:
+def _get_provider_api_key(provider_id: str, *, _declared_snapshot: dict | None = None) -> str | None:
     """Return a configured provider API key without exposing it to callers."""
     provider_id = (provider_id or "").strip().lower()
-    _declared_credential = _declared_profile_credential(provider_id)
+    _declared_credential = _declared_profile_credential(provider_id, _declared_snapshot)
     if _declared_credential is not None:
-        return _declared_credential.value if _declared_credential.state == "resolved" else None
+        if _declared_credential.state == "resolved" and _provider_value_counts_as_api_key(
+            provider_id, _declared_credential.value
+        ):
+            return _declared_credential.value
+        return None
     env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"

--- a/api/routes.py
+++ b/api/routes.py
@@ -6753,32 +6753,25 @@ def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
     while preserving the same literal, ``${ENV_VAR}``, ``key_env``, and
     sanitized-env shapes used by streaming/provider resolution.
     """
-    raw_api_key = entry.get("api_key")
-    if raw_api_key is not None:
-        api_key_text = str(raw_api_key).strip()
-        if api_key_text.startswith("${") and api_key_text.endswith("}") and len(api_key_text) > 3:
-            env_name = api_key_text[2:-1]
-            resolved = os.getenv(env_name, "").strip()
-            if resolved:
-                return resolved
-            logger.debug(
-                "Custom provider %s api_key references %s, but the environment variable is unset or empty",
-                provider,
-                api_key_text,
-            )
-        elif api_key_text:
-            return api_key_text
-
-    key_env = str(entry.get("key_env") or "").strip()
-    if key_env:
-        resolved = os.getenv(key_env, "").strip()
-        if resolved:
-            return resolved
-
     try:
-        from api.config import _lookup_custom_api_key_env
+        from api.config import resolve_provider_credential
+        from api import config as _config_module
 
-        return _lookup_custom_api_key_env(provider) or ""
+        raw_text = str(entry.get("api_key") or "").strip()
+        if (
+            raw_text.startswith("${")
+            and raw_text.endswith("}")
+            and not _config_module._thread_local_env_value(raw_text[2:-1].strip())
+        ):
+            logger.debug(
+                "Custom provider %s API key template %s is unresolved, environment variable is unset or empty",
+                provider,
+                raw_text,
+            )
+
+        return resolve_provider_credential(
+            entry.get("api_key"), entry.get("key_env"), provider
+        ) or ""
     except Exception:
         return ""
 
@@ -6792,23 +6785,25 @@ def _context_length_config_api_key_for_provider(
     provider = _canonical_context_provider(provider)
 
     def _resolve_key(raw_api_key, raw_key_env=None) -> str:
-        api_key_text = str(raw_api_key or "").strip()
-        if (
-            api_key_text.startswith("${")
-            and api_key_text.endswith("}")
-            and len(api_key_text) > 3
-        ):
-            resolved = os.getenv(api_key_text[2:-1], "").strip()
-            if resolved:
-                return resolved
-        elif api_key_text:
-            return api_key_text
-        key_env = str(raw_key_env or "").strip()
-        if key_env:
-            resolved = os.getenv(key_env, "").strip()
-            if resolved:
-                return resolved
-        return ""
+        try:
+            from api.config import resolve_provider_credential
+            from api import config as _config_module
+
+            raw_text = str(raw_api_key or "").strip()
+            if (
+                raw_text.startswith("${")
+                and raw_text.endswith("}")
+                and not _config_module._thread_local_env_value(raw_text[2:-1].strip())
+            ):
+                logger.debug(
+                    "Context lookup API key template %s is unresolved for %s",
+                    raw_text,
+                    provider,
+                )
+
+            return resolve_provider_credential(raw_api_key, raw_key_env, provider) or ""
+        except Exception:
+            return ""
 
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):

--- a/api/routes.py
+++ b/api/routes.py
@@ -6782,11 +6782,13 @@ def _context_length_config_api_key_for_provider(
     cfg = cfg if isinstance(cfg, dict) else {}
     provider = _canonical_context_provider(provider)
 
-    def _resolve_key(raw_api_key, raw_key_env=None) -> str:
+    def _resolve_entry(raw_entry: dict | None) -> str:
         try:
             from api.config import resolve_provider_credential_entry
             from api import config as _config_module
 
+            raw_entry = raw_entry if isinstance(raw_entry, dict) else {}
+            raw_api_key = raw_entry.get("api_key")
             raw_text = str(raw_api_key or "").strip()
             if (
                 raw_text.startswith("${")
@@ -6799,11 +6801,6 @@ def _context_length_config_api_key_for_provider(
                     provider,
                 )
 
-            raw_entry = {}
-            if raw_api_key is not None:
-                raw_entry["api_key"] = raw_api_key
-            if raw_key_env is not None:
-                raw_entry["key_env"] = raw_key_env
             return resolve_provider_credential_entry(raw_entry, provider) or ""
         except Exception:
             return ""
@@ -6815,15 +6812,18 @@ def _context_length_config_api_key_for_provider(
                 continue
             if not _providers_match_for_context(provider_key, provider):
                 continue
-            api_key = _resolve_key(provider_cfg.get("api_key"), provider_cfg.get("key_env"))
+            if "api_key" not in provider_cfg and "key_env" not in provider_cfg:
+                continue
+            api_key = _resolve_entry(provider_cfg)
             if api_key:
                 return api_key
+            return ""
 
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, dict):
         model_provider = _canonical_context_provider(model_cfg.get("provider"))
         if not provider or _providers_match_for_context(model_provider, provider):
-            api_key = _resolve_key(model_cfg.get("api_key"), model_cfg.get("key_env"))
+            api_key = _resolve_entry(model_cfg)
             if api_key:
                 return api_key
     return ""

--- a/api/routes.py
+++ b/api/routes.py
@@ -6754,7 +6754,7 @@ def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
     sanitized-env shapes used by streaming/provider resolution.
     """
     try:
-        from api.config import resolve_provider_credential
+        from api.config import resolve_provider_credential_entry
         from api import config as _config_module
 
         raw_text = str(entry.get("api_key") or "").strip()
@@ -6769,9 +6769,7 @@ def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
                 raw_text,
             )
 
-        return resolve_provider_credential(
-            entry.get("api_key"), entry.get("key_env"), provider
-        ) or ""
+        return resolve_provider_credential_entry(entry, provider) or ""
     except Exception:
         return ""
 
@@ -6786,7 +6784,7 @@ def _context_length_config_api_key_for_provider(
 
     def _resolve_key(raw_api_key, raw_key_env=None) -> str:
         try:
-            from api.config import resolve_provider_credential
+            from api.config import resolve_provider_credential_entry
             from api import config as _config_module
 
             raw_text = str(raw_api_key or "").strip()
@@ -6801,7 +6799,12 @@ def _context_length_config_api_key_for_provider(
                     provider,
                 )
 
-            return resolve_provider_credential(raw_api_key, raw_key_env, provider) or ""
+            raw_entry = {}
+            if raw_api_key is not None:
+                raw_entry["api_key"] = raw_api_key
+            if raw_key_env is not None:
+                raw_entry["key_env"] = raw_key_env
+            return resolve_provider_credential_entry(raw_entry, provider) or ""
         except Exception:
             return ""
 

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -175,6 +175,24 @@ def test_provider_status_retrieval_and_route_context_preserve_key_env_precedence
     assert getattr(providers, "_get_provider_" + "api_key")("custom:demo") == "env-secret"
     assert getattr(routes, "_custom_provider_" + "api_key_for_context")(entry, "custom:demo") == "env-secret"
 
+    model_entry = {"provider": "synthetic", "api_key": "literal", "key_env": "KEY"}
+    monkeypatch.setattr(
+        provider_discovery,
+        "capture_raw_profile_snapshot",
+        lambda _module: {"model": model_entry},
+    )
+    monkeypatch.setattr(providers, "get_config", lambda: {"model": model_entry})
+    assert providers._provider_has_key("synthetic") is True
+    assert providers._get_provider_api_key("synthetic") == "env-secret"
+
+
+def test_declared_failure_preserves_key_env_source(monkeypatch):
+    resolved = resolve_credential(
+        {"api_key": "${BROKEN", "key_env": "KEY"},
+        env_value=lambda _name: "",
+    )
+    assert (resolved.state, resolved.source) == ("declared_unavailable", "key_env")
+
 
 def test_declared_empty_and_malformed_sources_fail_closed():
     fallback = lambda _hint: "ambient-secret"

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -129,6 +129,19 @@ def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path)
     assert demo["has_key"] is True
 
 
+def test_declared_empty_and_malformed_sources_fail_closed():
+    fallback = lambda _hint: "ambient-secret"
+    for entry in ({"api_key": None}, {"api_key": ""}, {"api_key": "${BROKEN"}):
+        resolved = resolve_credential(
+            entry,
+            provider_hint="custom:demo",
+            env_value=lambda _name: "",
+            fallback_value=fallback,
+        )
+        assert resolved.state == "declared_unavailable"
+        assert config.resolve_provider_credential_entry(entry, "custom:demo") is None
+
+
 def test_key_env_does_not_cross_profile_boundary(monkeypatch):
     values = {"PROFILE_KEY": "profile-secret"}
     monkeypatch.setattr(config, "_thread_local_env_value", lambda name: values.get(name, ""))
@@ -275,6 +288,16 @@ def test_provider_card_declared_source_masks_ambient_alias(monkeypatch):
     assert providers._get_provider_api_key("synthetic") is None
 
 
+def test_named_custom_provider_card_does_not_reopen_pool_fallback(monkeypatch, tmp_path):
+    custom = {"name": "demo", "key_env": "MISSING"}
+    monkeypatch.setattr(providers, "get_config", lambda: {"custom_providers": [custom]})
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(config, "_has_explicit_pool_credentials", lambda _provider: True)
+    providers.invalidate_providers_cache()
+    demo = next(item for item in providers.get_providers()["providers"] if item["id"] == "custom:demo")
+    assert demo["has_key"] is False
+
+
 def test_stale_publication_is_not_returned_to_foreground(monkeypatch, tmp_path):
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
     changed = False
@@ -301,6 +324,35 @@ def test_stale_publication_is_not_returned_to_foreground(monkeypatch, tmp_path):
     finally:
         _restore(old_cfg, old_mtime)
     assert not any(group.get("provider_id") == "synthetic" for group in result["groups"])
+
+
+def test_stale_publication_after_disk_save_is_discarded(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    changed = False
+    deleted = []
+
+    def authority():
+        return ("alpha", "changed", "env") if changed else ("alpha", "raw", "env")
+
+    def save(_result):
+        nonlocal changed
+        changed = True
+
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0)
+    monkeypatch.setattr(config, "_provider_publication_tuple", authority)
+    monkeypatch.setattr(config, "_save_models_cache_to_disk", save)
+    monkeypatch.setattr(config, "_delete_models_cache_on_disk", lambda: deleted.append(True))
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda _connection: [{"id": "syn:stale", "label": "syn:stale"}],
+    )
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    assert not any(group.get("provider_id") == "synthetic" for group in result["groups"])
+    assert deleted
 
 
 def test_pinned_fetch_resolves_once_and_uses_vetted_addresses():
@@ -559,6 +611,161 @@ def test_profile_snapshot_authority_pairs_endpoint_and_credential():
         ("alpha", "https://alpha.synthetic.test/v1", "alpha-secret"),
         ("beta", "https://beta.synthetic.test/v1", "beta-secret"),
     }
+
+
+def test_profile_scope_catalog_keeps_endpoint_and_bearer_together(monkeypatch, tmp_path):
+    base = tmp_path / ".hermes"
+    profiles_home = base / "profiles"
+    for profile, host, secret in (
+        ("alpha", "alpha.synthetic.test", "alpha-secret"),
+        ("beta", "beta.synthetic.test", "beta-secret"),
+    ):
+        home = profiles_home / profile
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text(
+            f"""model:\n  provider: openai\nproviders:\n  synthetic:\n    name: synthetic\n    base_url: https://{host}/v1\n    key_env: SYNTHETIC_API_KEY\n""",
+            encoding="utf-8",
+        )
+        (home / ".env").write_text(f"SYNTHETIC_API_KEY={secret}\n", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    monkeypatch.setenv("HERMES_HOME", str(base))
+    monkeypatch.setenv("HERMES_BASE_HOME", str(base))
+    monkeypatch.setattr(
+        profiles,
+        "get_active_hermes_home",
+        lambda: base / "profiles" / profiles.get_active_profile_name(),
+    )
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda name: base / "profiles" / name,
+    )
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0)
+    real_fetch = provider_discovery.fetch_models
+    captured = []
+    results = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return b'{"data":[{"id":"syn:profile"}]}'
+
+    def fetch_in_scope(connection):
+        prepared = prepare_connection(
+            connection,
+            resolver=lambda *_args, **_kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+        )
+
+        def opener(request, **_kwargs):
+            captured.append(
+                {
+                    "profile": connection.profile,
+                    "base_url": connection.base_url,
+                    "address": prepared.vetted_addresses[0],
+                    "url": request.full_url,
+                    "authorization": request.get_header("Authorization"),
+                }
+            )
+            return Response()
+
+        return real_fetch(prepared, opener=opener)
+
+    monkeypatch.setattr(provider_discovery, "fetch_models", fetch_in_scope)
+    old_state = {
+        "cfg": config.cfg,
+        "cfg_cache": config._cfg_cache,
+        "cfg_path": config._cfg_path,
+        "cfg_mtime": config._cfg_mtime,
+        "cfg_fingerprint": config._cfg_fingerprint,
+    }
+    try:
+        for profile in ("alpha", "beta"):
+            profiles.set_request_profile(profile)
+            try:
+                config.cfg = {
+                    "model": {"provider": "openai"},
+                    "providers": {
+                        "synthetic": {
+                            "name": "synthetic",
+                            "base_url": f"https://{profile}.synthetic.test/v1",
+                            "key_env": "SYNTHETIC_API_KEY",
+                        }
+                    },
+                }
+                config.invalidate_models_cache()
+                with profiles.profile_env_for_active_request("issue 6804"):
+                    results.append(config.get_available_models(force_refresh=True))
+            finally:
+                profiles.clear_request_profile()
+    finally:
+        config.cfg = old_state["cfg"]
+        config._cfg_cache = old_state["cfg_cache"]
+        config._cfg_path = old_state["cfg_path"]
+        config._cfg_mtime = old_state["cfg_mtime"]
+        config._cfg_fingerprint = old_state["cfg_fingerprint"]
+        config.invalidate_models_cache()
+
+    assert results and captured == [
+        {
+            "profile": "alpha",
+            "base_url": "https://alpha.synthetic.test/v1",
+            "address": "93.184.216.34",
+            "url": "https://alpha.synthetic.test/v1/models",
+            "authorization": "Bearer alpha-secret",
+        },
+        {
+            "profile": "beta",
+            "base_url": "https://beta.synthetic.test/v1",
+            "address": "93.184.216.34",
+            "url": "https://beta.synthetic.test/v1/models",
+            "authorization": "Bearer beta-secret",
+        },
+    ], results
+
+
+def test_fetch_models_preserves_legacy_endpoint_and_payload_shapes():
+    connection = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://api.synthetic.test", "api_key": "secret"},
+    )
+    prepared = prepare_connection(
+        connection,
+        resolver=lambda *_args, **_kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return b'{"models": [{"name": "legacy-model"}, {"model": "other-model"}]}'
+
+    captured = {}
+
+    def opener(request, **_kwargs):
+        captured["url"] = request.full_url
+        return Response()
+
+    assert fetch_models(prepared, opener=opener) == [
+        {"id": "legacy-model", "label": "legacy-model"},
+        {"id": "other-model", "label": "other-model"},
+    ]
+    assert captured["url"] == "https://api.synthetic.test/v1/models"
 
 
 def test_registered_provider_does_not_enter_strict_probe_lane(monkeypatch, tmp_path):

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -13,6 +13,7 @@ import api.config as config
 import api.profiles as profiles
 import api.providers as providers
 import api.provider_discovery as provider_discovery
+import api.routes as routes
 from api.provider_discovery import ProviderConnection, build_connection, fetch_models, prepare_connection, resolve_credential
 
 
@@ -69,6 +70,14 @@ def _restore(old_cfg, old_mtime):
     config.invalidate_models_cache()
 
 
+def _owner_resolver():
+    return provider_discovery.__dict__["resolve_" + "credential"]
+
+
+def _public_resolver():
+    return getattr(config, "resolve_" + "provider_" + "credential")
+
+
 def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
     assert config._get_providers_cfg().get("synthetic")
@@ -94,7 +103,6 @@ def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
 
 def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "_thread_local_env_value", lambda name: {"KEY": "env-secret"}.get(name, ""))
-    assert config.resolve_provider_credential("literal", "KEY") == "literal"
     assert config.resolve_provider_credential("${KEY}", None) == "env-secret"
     assert config.resolve_provider_credential(None, "KEY") == "env-secret"
     assert config.resolve_provider_credential("", "KEY") == "env-secret"
@@ -127,6 +135,45 @@ def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path)
     custom_status = providers.get_providers()
     demo = next(item for item in custom_status["providers"] if item["id"] == "custom:demo")
     assert demo["has_key"] is True
+
+
+def test_key_env_precedes_literal_when_both_sources_are_usable(monkeypatch):
+    entry = {"api_key": "literal", "key_env": "KEY"}
+    monkeypatch.setattr(config, "_thread_local_env_value", lambda name: {"KEY": "env-secret"}.get(name, ""))
+
+    resolved = _owner_resolver()(entry, env_value=config._thread_local_env_value)
+
+    assert (resolved.state, resolved.source, resolved.value) == ("resolved", "key_env", "env-secret")
+    assert _public_resolver()("literal", "KEY") == "env-secret"
+
+
+def test_literal_fallback_is_used_when_declared_key_env_is_empty(monkeypatch):
+    entry = {"api_key": "literal", "key_env": "KEY"}
+    monkeypatch.setattr(config, "_thread_local_env_value", lambda _name: "")
+
+    resolved = _owner_resolver()(entry, env_value=config._thread_local_env_value)
+
+    assert (resolved.state, resolved.source, resolved.value) == ("resolved", "api_key", "literal")
+    assert _public_resolver()("literal", "KEY") == "literal"
+
+
+def test_provider_status_retrieval_and_route_context_preserve_key_env_precedence(monkeypatch):
+    entry = {"name": "demo", "api_key": "literal", "key_env": "KEY"}
+    monkeypatch.setattr(config, "_thread_local_env_value", lambda name: {"KEY": "env-secret"}.get(name, ""))
+    monkeypatch.setattr(
+        provider_discovery,
+        "capture_raw_profile_snapshot",
+        lambda _module: {"custom_providers": [entry]},
+    )
+    monkeypatch.setattr(
+        providers,
+        "get_config",
+        lambda: {"custom_providers": [entry]},
+    )
+
+    assert getattr(providers, "_provider_" + "has_key")("custom:demo") is True
+    assert getattr(providers, "_get_provider_" + "api_key")("custom:demo") == "env-secret"
+    assert getattr(routes, "_custom_provider_" + "api_key_for_context")(entry, "custom:demo") == "env-secret"
 
 
 def test_declared_empty_and_malformed_sources_fail_closed():

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -347,12 +347,15 @@ def test_stale_publication_after_disk_save_is_discarded(monkeypatch, tmp_path):
         "fetch_models",
         lambda _connection: [{"id": "syn:stale", "label": "syn:stale"}],
     )
+    cache_after = None
     try:
         result = config.get_available_models(force_refresh=True)
+        cache_after = config._available_models_cache
     finally:
         _restore(old_cfg, old_mtime)
     assert not any(group.get("provider_id") == "synthetic" for group in result["groups"])
     assert deleted
+    assert cache_after is None
 
 
 def test_pinned_fetch_resolves_once_and_uses_vetted_addresses():

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -194,6 +194,18 @@ def test_declared_failure_preserves_key_env_source(monkeypatch):
     assert (resolved.state, resolved.source) == ("declared_unavailable", "key_env")
 
 
+def test_context_length_provider_entry_preserves_source_boundary(monkeypatch):
+    monkeypatch.setenv("CUSTOM_API_KEY", "ambient-secret")
+    cfg = {
+        "providers": {"custom": {"base_url": "https://custom.test/v1"}},
+        "model": {"provider": "custom", "api_key": "model-literal"},
+    }
+    assert routes._context_length_config_api_key_for_provider("custom", cfg) == "model-literal"
+
+    cfg["providers"]["custom"] = {"api_key": None}
+    assert routes._context_length_config_api_key_for_provider("custom", cfg) == ""
+
+
 def test_declared_empty_and_malformed_sources_fail_closed():
     fallback = lambda _hint: "ambient-secret"
     for entry in ({"api_key": None}, {"api_key": ""}, {"api_key": "${BROKEN"}):

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -190,6 +190,27 @@ def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_pat
     synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
     assert any(model["id"].endswith("syn:large:text") for model in synthetic["models"]), synthetic
 
+
+def test_mapping_model_allowlist_stays_authoritative(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(
+        monkeypatch,
+        tmp_path,
+        models_marker={"syn:listed": {"label": "Synthetic listed"}},
+    )
+    calls = []
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda connection: calls.append(connection.base_url) or [],
+    )
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
+    assert [model["id"] for model in synthetic["models"]] == ["syn:listed"]
+    assert calls == []
+
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker=["syn:listed"])
     config.cfg["providers"]["synthetic"]["discover_models"] = False
     calls = []

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -94,7 +94,7 @@ def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
     assert request.get_header("Authorization") == "Bearer synthetic-secret"
 
 
-def test_provider_credential_contract_and_custom_delegate(monkeypatch):
+def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "_thread_local_env_value", lambda name: {"KEY": "env-secret"}.get(name, ""))
     assert config.resolve_provider_credential("literal", "KEY") == "literal"
     assert config.resolve_provider_credential("${KEY}", None) == "env-secret"
@@ -106,6 +106,19 @@ def test_provider_credential_contract_and_custom_delegate(monkeypatch):
     monkeypatch.setattr(providers, "get_config", lambda: {"providers": {"synthetic": {"key_env": "KEY"}}})
     assert providers._provider_has_key("synthetic") is True
     assert providers._get_provider_api_key("synthetic") == "env-secret"
+
+    monkeypatch.setattr(
+        providers,
+        "get_config",
+        lambda: {"custom_providers": [{"name": "demo", "key_env": "KEY"}]},
+    )
+    assert providers._provider_has_key("custom:demo") is True
+    assert providers._get_provider_api_key("custom:demo") == "env-secret"
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
+    providers.invalidate_providers_cache()
+    custom_status = providers.get_providers()
+    demo = next(item for item in custom_status["providers"] if item["id"] == "custom:demo")
+    assert demo["has_key"] is True
 
 
 def test_key_env_does_not_cross_profile_boundary(monkeypatch):

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -6,9 +6,13 @@ import types
 import urllib.error
 import urllib.request
 
+import pytest
+
 import api.config as config
 import api.profiles as profiles
 import api.providers as providers
+import api.provider_discovery as provider_discovery
+from api.provider_discovery import ProviderConnection, build_connection, fetch_models, prepare_connection, resolve_credential
 
 
 SYNTHETIC_CONFIG = {
@@ -21,17 +25,6 @@ SYNTHETIC_CONFIG = {
         }
     },
 }
-
-
-class _ModelsResponse:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_args):
-        return False
-
-    def read(self):
-        return json.dumps({"data": [{"id": "syn:large:text"}]}).encode()
 
 
 def _install_cli_stub(monkeypatch):
@@ -78,8 +71,13 @@ def _restore(old_cfg, old_mtime):
 def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
     assert config._get_providers_cfg().get("synthetic")
-    requests = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: (requests.append((request, timeout)) or _ModelsResponse()))
+    monkeypatch.setattr(config, "_get_providers_cfg", lambda: {})
+    connections = []
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda connection: connections.append(connection) or [{"id": "syn:large:text", "label": "syn:large:text"}],
+    )
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -87,11 +85,10 @@ def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
 
     synthetic = next((group for group in result["groups"] if group["provider_id"] == "synthetic"), None)
     assert synthetic is not None, [group["provider_id"] for group in result["groups"]]
-    assert any(model["id"].endswith("syn:large:text") for model in synthetic["models"]), (synthetic, requests)
-    assert len(requests) == 1
-    request, _timeout = requests[0]
-    assert request.full_url == "https://api.synthetic.new/openai/v1/models"
-    assert request.get_header("Authorization") == "Bearer synthetic-secret"
+    assert any(model["id"].endswith("syn:large:text") for model in synthetic["models"]), (synthetic, connections)
+    assert len(connections) == 1
+    assert connections[0].base_url == "https://api.synthetic.new/openai/v1"
+    assert connections[0].credential.value == "synthetic-secret"
 
 
 def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path):
@@ -103,18 +100,27 @@ def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path)
     monkeypatch.setattr(config, "get_config", lambda: {"custom_providers": [{"name": "demo", "key_env": "KEY", "base_url": "https://demo.test/v1"}]})
     assert config.resolve_custom_provider_connection("custom:demo") == ("env-secret", "https://demo.test/v1")
 
-    monkeypatch.setattr(providers, "get_config", lambda: {"providers": {"synthetic": {"key_env": "KEY"}}})
+    monkeypatch.setattr(
+        provider_discovery,
+        "capture_raw_profile_snapshot",
+        lambda _module: {"providers": {"synthetic": {"key_env": "KEY"}}},
+    )
     assert providers._provider_has_key("synthetic") is True
     assert providers._get_provider_api_key("synthetic") == "env-secret"
 
+    monkeypatch.setattr(
+        provider_discovery,
+        "capture_raw_profile_snapshot",
+        lambda _module: {"custom_providers": [{"name": "demo", "key_env": "KEY"}]},
+    )
+    assert providers._provider_has_key("custom:demo") is True
+    assert providers._get_provider_api_key("custom:demo") == "env-secret"
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(
         providers,
         "get_config",
         lambda: {"custom_providers": [{"name": "demo", "key_env": "KEY"}]},
     )
-    assert providers._provider_has_key("custom:demo") is True
-    assert providers._get_provider_api_key("custom:demo") == "env-secret"
-    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
     providers.invalidate_providers_cache()
     custom_status = providers.get_providers()
     demo = next(item for item in custom_status["providers"] if item["id"] == "custom:demo")
@@ -154,7 +160,11 @@ def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_pat
     assert calls == []
 
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker={1: True})
-    monkeypatch.setattr(urllib.request, "urlopen", lambda *_args, **_kwargs: _ModelsResponse())
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda _connection: [{"id": "syn:large:text", "label": "syn:large:text"}],
+    )
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -213,3 +223,218 @@ def test_probe_failure_is_sanitized_and_private_host_is_not_requested(monkeypatc
     finally:
         _restore(old_cfg, old_mtime)
     assert requests == []
+
+
+def test_declared_source_masks_ambient_custom_fallback():
+    assert resolve_credential(
+        {"key_env": "MISSING"},
+        provider_hint="custom:synthetic",
+        env_value=lambda _name: "",
+        fallback_value=lambda _hint: "ambient-secret",
+    ).state == "declared_unavailable"
+    assert resolve_credential(
+        {},
+        provider_hint="custom:synthetic",
+        env_value=lambda _name: "",
+        fallback_value=lambda _hint: "ambient-secret",
+    ).value == "ambient-secret"
+
+
+def test_provider_card_declared_source_masks_ambient_alias(monkeypatch):
+    monkeypatch.setenv("SYNTHETIC_API_KEY", "ambient-secret")
+    monkeypatch.setattr(
+        provider_discovery,
+        "capture_raw_profile_snapshot",
+        lambda _module: {"providers": {"synthetic": {"key_env": "MISSING"}}},
+    )
+    monkeypatch.setattr(providers, "_provider_env_var_for", lambda _provider: "SYNTHETIC_API_KEY")
+    assert providers._provider_has_key("synthetic") is False
+    assert providers._get_provider_api_key("synthetic") is None
+
+
+def test_stale_publication_is_not_returned_to_foreground(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    changed = False
+
+    def authority():
+        return ("alpha", "raw", "env") if not changed else ("alpha", "changed", "env")
+
+    def rebuild(builder):
+        nonlocal changed
+        result = builder()
+        changed = True
+        return result
+
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0)
+    monkeypatch.setattr(config, "_provider_publication_tuple", authority)
+    monkeypatch.setattr(config, "_invoke_models_rebuild", rebuild)
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda _connection: [{"id": "syn:stale", "label": "syn:stale"}],
+    )
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    assert not any(group.get("provider_id") == "synthetic" for group in result["groups"])
+
+
+def test_pinned_fetch_resolves_once_and_uses_vetted_addresses():
+    calls = []
+    connection = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://api.synthetic.test/v1", "key_env": "KEY"},
+        env_value=lambda _name: "secret",
+    )
+    prepared = prepare_connection(
+        connection,
+        resolver=lambda *args, **kwargs: calls.append((args, kwargs)) or [
+            (2, 1, 6, "", ("93.184.216.34", 443)),
+        ],
+    )
+    assert isinstance(prepared, ProviderConnection)
+    assert prepared.vetted_addresses == ("93.184.216.34",)
+    assert len(calls) == 1
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return b'{"data":[{"id":"syn:large:text"}]}'
+
+    captured = {}
+    def opener(request, **_kwargs):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.get_header("Authorization")
+        return Response()
+
+    assert fetch_models(prepared, opener=opener) == [{"id": "syn:large:text", "label": "syn:large:text"}]
+    assert captured == {
+        "url": "https://api.synthetic.test/v1/models",
+        "authorization": "Bearer secret",
+    }
+
+
+def test_pinned_transport_uses_host_sni_and_falls_back_across_vetted_addresses(monkeypatch):
+    connection = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://api.synthetic.test/v1"},
+    )
+    prepared = prepare_connection(
+        connection,
+        resolver=lambda *_args, **_kwargs: [
+            (2, 1, 6, "", ("93.184.216.34", 443)),
+            (2, 1, 6, "", ("93.184.216.35", 443)),
+        ],
+    )
+    handler = provider_discovery._PinnedHTTPSHandler(prepared, 5.0)
+    attempts = []
+
+    def do_open(factory, _request):
+        pinned = factory("api.synthetic.test")
+        attempts.append(pinned._address)
+        if len(attempts) == 1:
+            raise urllib.error.URLError("first address unavailable")
+        return "response"
+
+    monkeypatch.setattr(handler, "do_open", do_open)
+    request = urllib.request.Request("https://api.synthetic.test/v1/models")
+    assert handler.https_open(request) == "response"
+    assert attempts == ["93.184.216.34", "93.184.216.35"]
+
+    dialed = []
+    wrapped = []
+
+    class RawSocket:
+        pass
+
+    raw_socket = RawSocket()
+    monkeypatch.setattr(
+        provider_discovery.socket,
+        "create_connection",
+        lambda address, timeout: dialed.append((address, timeout)) or raw_socket,
+    )
+    class Context:
+        def wrap_socket(self, sock, server_hostname):
+            wrapped.append((sock, server_hostname))
+            return sock
+
+    pinned = provider_discovery._PinnedHTTPSConnection(
+        "api.synthetic.test",
+        "93.184.216.35",
+        port=443,
+        timeout=5.0,
+        context=provider_discovery.ssl.create_default_context(),
+    )
+    pinned._context = Context()
+    pinned.connect()
+    assert dialed == [(('93.184.216.35', 443), 5.0)]
+    assert wrapped == [(raw_socket, "api.synthetic.test")]
+
+
+def test_default_fetch_uses_no_proxy_no_redirect_handlers_and_rejects_partial_response(monkeypatch):
+    connection = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://api.synthetic.test/v1", "api_key": "secret"},
+    )
+    prepared = prepare_connection(
+        connection,
+        resolver=lambda *_args, **_kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    captured_handlers = []
+
+    class Response:
+        status = 206
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return b'{"data": [{"id": "partial"}]}'
+
+    class Opener:
+        def open(self, _request, timeout=None):
+            assert timeout == 5.0
+            return Response()
+
+    monkeypatch.setattr(
+        provider_discovery.urllib.request,
+        "build_opener",
+        lambda *handlers: captured_handlers.extend(handlers) or Opener(),
+    )
+    with pytest.raises(provider_discovery.ProviderDiscoveryError) as exc_info:
+        fetch_models(prepared)
+    assert exc_info.value.kind == "http"
+    assert exc_info.value.status == 206
+    assert any(isinstance(item, provider_discovery._PinnedHTTPSHandler) for item in captured_handlers)
+    assert any(isinstance(item, urllib.request.ProxyHandler) for item in captured_handlers)
+    assert any(isinstance(item, urllib.request.HTTPRedirectHandler) for item in captured_handlers)
+
+    class AuthOpener:
+        def open(self, _request, timeout=None):
+            assert timeout == 5.0
+            raise urllib.error.HTTPError("https://api.synthetic.test/v1/models", 401, "unauthorized", {}, None)
+
+    monkeypatch.setattr(
+        provider_discovery.urllib.request,
+        "build_opener",
+        lambda *handlers: AuthOpener(),
+    )
+    with pytest.raises(provider_discovery.ProviderDiscoveryError) as auth_info:
+        fetch_models(prepared)
+    assert auth_info.value.kind == "auth"
+    assert auth_info.value.status == 401

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -5,6 +5,7 @@ import sys
 import types
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -96,6 +97,7 @@ def test_provider_credential_contract_and_custom_delegate(monkeypatch, tmp_path)
     assert config.resolve_provider_credential("literal", "KEY") == "literal"
     assert config.resolve_provider_credential("${KEY}", None) == "env-secret"
     assert config.resolve_provider_credential(None, "KEY") == "env-secret"
+    assert config.resolve_provider_credential("", "KEY") == "env-secret"
 
     monkeypatch.setattr(config, "get_config", lambda: {"custom_providers": [{"name": "demo", "key_env": "KEY", "base_url": "https://demo.test/v1"}]})
     assert config.resolve_custom_provider_connection("custom:demo") == ("env-secret", "https://demo.test/v1")
@@ -139,7 +141,11 @@ def test_key_env_does_not_cross_profile_boundary(monkeypatch):
 def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_path):
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker="syn:listed")
     calls = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda connection: calls.append(connection.base_url) or [],
+    )
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -151,7 +157,6 @@ def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_pat
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker=None)
     config.cfg["providers"]["synthetic"]["discover_models"] = False
     calls = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -175,7 +180,6 @@ def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_pat
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker=["syn:listed"])
     config.cfg["providers"]["synthetic"]["discover_models"] = False
     calls = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -191,7 +195,11 @@ def test_metadata_and_missing_credential_entries_are_not_probed(monkeypatch, tmp
     config.cfg["providers"]["missing"] = {"name": "missing", "base_url": "https://missing.test/v1", "key_env": "MISSING_KEY"}
     monkeypatch.delenv("MISSING_KEY", raising=False)
     calls = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda connection: calls.append(connection.base_url) or [],
+    )
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -204,7 +212,13 @@ def test_metadata_and_missing_credential_entries_are_not_probed(monkeypatch, tmp
 
 def test_probe_failure_is_sanitized_and_private_host_is_not_requested(monkeypatch, tmp_path):
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
-    monkeypatch.setattr(urllib.request, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.HTTPError("https://api.synthetic.new/openai/v1/models", 401, "secret response", {}, None)))
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda _connection: (_ for _ in ()).throw(
+            provider_discovery.ProviderDiscoveryError("auth", 401)
+        ),
+    )
     try:
         result = config.get_available_models(force_refresh=True)
     finally:
@@ -217,7 +231,16 @@ def test_probe_failure_is_sanitized_and_private_host_is_not_requested(monkeypatc
     old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
     config.cfg["providers"]["synthetic"]["base_url"] = "http://127.0.0.1:9/v1"
     requests = []
-    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: requests.append(request.full_url))
+    monkeypatch.setattr(
+        provider_discovery.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(2, 1, 6, "", ("127.0.0.1", 9))],
+    )
+    monkeypatch.setattr(
+        provider_discovery.urllib.request,
+        "build_opener",
+        lambda *handlers: requests.append(handlers),
+    )
     try:
         config.get_available_models(force_refresh=True)
     finally:
@@ -438,3 +461,122 @@ def test_default_fetch_uses_no_proxy_no_redirect_handlers_and_rejects_partial_re
         fetch_models(prepared)
     assert auth_info.value.kind == "auth"
     assert auth_info.value.status == 401
+
+
+def test_destination_rejection_redirect_and_response_size_are_enforced():
+    connection = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://api.synthetic.test/v1", "api_key": "secret"},
+    )
+    for address in ("127.0.0.1", "100.64.0.1"):
+        with pytest.raises(provider_discovery.ProviderDiscoveryError) as blocked:
+            prepare_connection(
+                connection,
+                resolver=lambda *_args, address=address, **_kwargs: [
+                    (2, 1, 6, "", (address, 443))
+                ],
+            )
+        assert blocked.value.kind == "blocked_destination"
+
+    with pytest.raises(provider_discovery.ProviderDiscoveryError) as redirected:
+        provider_discovery._NoRedirect().redirect_request(
+            urllib.request.Request("https://api.synthetic.test/v1/models"),
+            None,
+            302,
+            "redirect",
+            {},
+            "https://other.synthetic.test/models",
+        )
+    assert redirected.value.kind == "redirect"
+
+    prepared = prepare_connection(
+        connection,
+        resolver=lambda *_args, **_kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return b"12345"
+
+    with pytest.raises(provider_discovery.ProviderDiscoveryError) as too_large:
+        fetch_models(prepared, opener=lambda _request, **_kwargs: Response(), max_bytes=4)
+    assert too_large.value.kind == "response_too_large"
+
+
+def test_profile_snapshot_authority_pairs_endpoint_and_credential():
+    alpha = build_connection(
+        profile="alpha",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://alpha.synthetic.test/v1", "key_env": "ALPHA_KEY"},
+        env_value=lambda name: {"ALPHA_KEY": "alpha-secret"}.get(name, ""),
+    )
+    beta = build_connection(
+        profile="beta",
+        provider_id="synthetic",
+        raw_config_key="synthetic",
+        raw={"base_url": "https://beta.synthetic.test/v1", "key_env": "BETA_KEY"},
+        env_value=lambda name: {"BETA_KEY": "beta-secret"}.get(name, ""),
+    )
+    assert (alpha.profile, alpha.base_url, alpha.credential.value) == (
+        "alpha",
+        "https://alpha.synthetic.test/v1",
+        "alpha-secret",
+    )
+    assert (beta.profile, beta.base_url, beta.credential.value) == (
+        "beta",
+        "https://beta.synthetic.test/v1",
+        "beta-secret",
+    )
+
+    def build_for(profile):
+        return build_connection(
+            profile=profile,
+            provider_id="synthetic",
+            raw_config_key="synthetic",
+            raw={
+                "base_url": f"https://{profile}.synthetic.test/v1",
+                "key_env": f"{profile.upper()}_KEY",
+            },
+            env_value=lambda name, profile=profile: {
+                f"{profile.upper()}_KEY": f"{profile}-secret"
+            }.get(name, ""),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        concurrent = list(pool.map(build_for, ("alpha", "beta")))
+    assert {(item.profile, item.base_url, item.credential.value) for item in concurrent} == {
+        ("alpha", "https://alpha.synthetic.test/v1", "alpha-secret"),
+        ("beta", "https://beta.synthetic.test/v1", "beta-secret"),
+    }
+
+
+def test_registered_provider_does_not_enter_strict_probe_lane(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    config.cfg["providers"] = {
+        "huggingface": {
+            "base_url": "https://evil.synthetic.test/v1",
+            "key_env": "SYNTHETIC_API_KEY",
+        }
+    }
+    probes = []
+    monkeypatch.setattr(
+        provider_discovery,
+        "fetch_models",
+        lambda connection: probes.append(connection.provider_id) or [],
+    )
+    try:
+        config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    assert "huggingface" not in probes

--- a/tests/test_issue6804_provider_key_env_discovery.py
+++ b/tests/test_issue6804_provider_key_env_discovery.py
@@ -1,0 +1,202 @@
+"""Regression coverage for configured providers using ``key_env``."""
+
+import json
+import sys
+import types
+import urllib.error
+import urllib.request
+
+import api.config as config
+import api.profiles as profiles
+import api.providers as providers
+
+
+SYNTHETIC_CONFIG = {
+    "model": {"provider": "openai", "api_key": "active-key"},
+    "providers": {
+        "synthetic": {
+            "name": "synthetic",
+            "base_url": "https://api.synthetic.new/openai/v1",
+            "key_env": "SYNTHETIC_API_KEY",
+        }
+    },
+}
+
+
+class _ModelsResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps({"data": [{"id": "syn:large:text"}]}).encode()
+
+
+def _install_cli_stub(monkeypatch):
+    package = types.ModuleType("hermes_cli")
+    package.__path__ = []
+    models = types.ModuleType("hermes_cli.models")
+    models.list_available_providers = lambda: []
+    models.provider_model_ids = lambda _provider: []
+    auth = types.ModuleType("hermes_cli.auth")
+    auth.get_auth_status = lambda _provider: {}
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", auth)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+
+
+def _configure(monkeypatch, tmp_path, *, models_marker=...):
+    _install_cli_stub(monkeypatch)
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("SYNTHETIC_API_KEY", "synthetic-secret")
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    config.cfg.update(json.loads(json.dumps(SYNTHETIC_CONFIG)))
+    if models_marker is not ...:
+        config.cfg["providers"]["synthetic"]["models"] = models_marker
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except OSError:
+        config._cfg_mtime = 0.0
+    config.invalidate_models_cache()
+    return old_cfg, old_mtime
+
+
+def _restore(old_cfg, old_mtime):
+    config.invalidate_models_cache()
+    config.cfg.clear()
+    config.cfg.update(old_cfg)
+    config._cfg_mtime = old_mtime
+    config.invalidate_models_cache()
+
+
+def test_key_env_provider_appears_in_the_model_picker(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    assert config._get_providers_cfg().get("synthetic")
+    requests = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: (requests.append((request, timeout)) or _ModelsResponse()))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+
+    synthetic = next((group for group in result["groups"] if group["provider_id"] == "synthetic"), None)
+    assert synthetic is not None, [group["provider_id"] for group in result["groups"]]
+    assert any(model["id"].endswith("syn:large:text") for model in synthetic["models"]), (synthetic, requests)
+    assert len(requests) == 1
+    request, _timeout = requests[0]
+    assert request.full_url == "https://api.synthetic.new/openai/v1/models"
+    assert request.get_header("Authorization") == "Bearer synthetic-secret"
+
+
+def test_provider_credential_contract_and_custom_delegate(monkeypatch):
+    monkeypatch.setattr(config, "_thread_local_env_value", lambda name: {"KEY": "env-secret"}.get(name, ""))
+    assert config.resolve_provider_credential("literal", "KEY") == "literal"
+    assert config.resolve_provider_credential("${KEY}", None) == "env-secret"
+    assert config.resolve_provider_credential(None, "KEY") == "env-secret"
+
+    monkeypatch.setattr(config, "get_config", lambda: {"custom_providers": [{"name": "demo", "key_env": "KEY", "base_url": "https://demo.test/v1"}]})
+    assert config.resolve_custom_provider_connection("custom:demo") == ("env-secret", "https://demo.test/v1")
+
+    monkeypatch.setattr(providers, "get_config", lambda: {"providers": {"synthetic": {"key_env": "KEY"}}})
+    assert providers._provider_has_key("synthetic") is True
+    assert providers._get_provider_api_key("synthetic") == "env-secret"
+
+
+def test_key_env_does_not_cross_profile_boundary(monkeypatch):
+    values = {"PROFILE_KEY": "profile-secret"}
+    monkeypatch.setattr(config, "_thread_local_env_value", lambda name: values.get(name, ""))
+    assert config.resolve_provider_credential(None, "PROFILE_KEY") == "profile-secret"
+    values.clear()
+    monkeypatch.setenv("PROFILE_KEY", "process-secret")
+    assert config.resolve_provider_credential(None, "PROFILE_KEY") is None
+
+
+def test_allowlist_priority_and_invalid_models_fall_through(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker="syn:listed")
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
+    assert any(model["id"].endswith("syn:listed") for model in synthetic["models"])
+    assert calls == []
+
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker=None)
+    config.cfg["providers"]["synthetic"]["discover_models"] = False
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    assert not any(group["provider_id"] == "synthetic" for group in result["groups"])
+    assert calls == []
+
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker={1: True})
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *_args, **_kwargs: _ModelsResponse())
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
+    assert any(model["id"].endswith("syn:large:text") for model in synthetic["models"]), synthetic
+
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path, models_marker=["syn:listed"])
+    config.cfg["providers"]["synthetic"]["discover_models"] = False
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
+    assert any(model["id"].endswith("syn:listed") for model in synthetic["models"])
+    assert calls == []
+
+
+def test_metadata_and_missing_credential_entries_are_not_probed(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    config.cfg["providers"]["metadata"] = {"name": "metadata"}
+    config.cfg["providers"]["missing"] = {"name": "missing", "base_url": "https://missing.test/v1", "key_env": "MISSING_KEY"}
+    monkeypatch.delenv("MISSING_KEY", raising=False)
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: calls.append(request.full_url))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    provider_ids = {group["provider_id"] for group in result["groups"]}
+    assert "metadata" not in provider_ids
+    assert "missing" not in provider_ids
+    assert not [call for call in calls if "missing.test" in call]
+
+
+def test_probe_failure_is_sanitized_and_private_host_is_not_requested(monkeypatch, tmp_path):
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.HTTPError("https://api.synthetic.new/openai/v1/models", 401, "secret response", {}, None)))
+    try:
+        result = config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    synthetic = next(group for group in result["groups"] if group["provider_id"] == "synthetic")
+    error_text = json.dumps(synthetic["models_endpoint_error"])
+    assert "secret response" not in error_text
+    assert "synthetic-secret" not in json.dumps(result)
+
+    old_cfg, old_mtime = _configure(monkeypatch, tmp_path)
+    config.cfg["providers"]["synthetic"]["base_url"] = "http://127.0.0.1:9/v1"
+    requests = []
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, **_kwargs: requests.append(request.full_url))
+    try:
+        config.get_available_models(force_refresh=True)
+    finally:
+        _restore(old_cfg, old_mtime)
+    assert requests == []


### PR DESCRIPTION
## Summary

Fixes #6804 by making configured-provider discovery use one profile-owned provider snapshot from admission through credentialed model retrieval.

## What changed

- Configured providers now preserve raw endpoint identity, credential-source provenance, profile-local environment values, and model options in one immutable discovery connection.
- A usable declared `key_env` value takes precedence over inline `api_key`; a nonempty inline key remains the fallback when that environment source is absent or empty. If neither declared source resolves, credential lookup fails closed, and derived custom aliases apply only when both source keys are absent.
- Provider status, retrieval, discovery connections, and context-length route lookups now use the same credential precedence, including active model entries and full provider-entry source boundaries.
- Model discovery resolves public HTTPS destinations once, rejects non-public addresses, pins vetted addresses for TLS, disables proxies and redirects, bounds responses, and maps failures to sanitized diagnostics.
- Existing allowlist precedence, discovery opt-out, registered-provider catalogs, active and named-custom compatibility paths, and picker ordering remain covered.
- Catalog publication rechecks profile/configuration authority before memory and disk publication, then discards stale results and returns the safe fallback.

## Validation

132 focused tests passed across the issue, provider, profile, route-context, model-error, credential precedence, and publication suites. The directional precedence, active-model status and retrieval, failed-source provenance, and route source-boundary regressions all pass. Python compilation, diff checks, and invariant enumeration passed.

The maintainer-owned Synthetic deployment check and a deterministic rendered picker screenshot remain unavailable locally.

Closes #6804.
