### PR TITLE
fix(#7013): make test portability platform-neutral

### DIFF
--- a/tests/test_compression_phantom_barrier.py
+++ b/tests/test_compression_phantom_barrier.py
@@ -12,7 +12,6 @@ import re
 from pathlib import Path
 
 import pytest
-from playwright.sync_api import sync_playwright
 
 ROOT = Path(__file__).resolve().parents[1]
 STATIC = ROOT / "static"
@@ -200,7 +199,8 @@ async ({kind, doneSid}) => {
 
 @pytest.fixture(scope="module")
 def browser():
-    with sync_playwright() as playwright:
+    playwright_api = pytest.importorskip("playwright.sync_api")
+    with playwright_api.sync_playwright() as playwright:
         instance = playwright.chromium.launch(
             headless=True,
             args=["--no-sandbox", "--disable-dev-shm-usage"],

--- a/tests/test_issue2513_custom_provider_remote_models.py
+++ b/tests/test_issue2513_custom_provider_remote_models.py
@@ -47,11 +47,14 @@ def test_custom_provider_model_field_does_not_block_remote_catalog(monkeypatch, 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
+    # Keep unrelated provider probes from replacing this complete catalog assertion with the bounded fallback.
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0)
 
     old_cfg = config.cfg
     old_mtime = config._cfg_mtime
     old_cache = config._available_models_cache
     old_cache_ts = config._available_models_cache_ts
+    old_live_rebuild_ts = config._available_models_live_rebuild_ts
     old_cache_fp = config._available_models_cache_source_fingerprint
     try:
         config.cfg = {
@@ -76,6 +79,7 @@ def test_custom_provider_model_field_does_not_block_remote_catalog(monkeypatch, 
         config._cfg_mtime = 0.0
         config._available_models_cache = None
         config._available_models_cache_ts = 0.0
+        config._available_models_live_rebuild_ts = 0.0
         config._available_models_cache_source_fingerprint = None
 
         data = config.get_available_models()
@@ -84,6 +88,7 @@ def test_custom_provider_model_field_does_not_block_remote_catalog(monkeypatch, 
         config._cfg_mtime = old_mtime
         config._available_models_cache = old_cache
         config._available_models_cache_ts = old_cache_ts
+        config._available_models_live_rebuild_ts = old_live_rebuild_ts
         config._available_models_cache_source_fingerprint = old_cache_fp
 
     groups = {group["provider_id"]: group for group in data["groups"]}

--- a/tests/test_media_etag_revalidation.py
+++ b/tests/test_media_etag_revalidation.py
@@ -49,6 +49,14 @@ def routes():
     return routes
 
 
+@pytest.fixture(autouse=True)
+def media_allowed_root(tmp_path, monkeypatch):
+    # tmp_path is under /tmp only on Linux; register it and make Path.home()
+    # resolve to the same fixture root on Windows so deny tests reach #3234.
+    monkeypatch.setenv("MEDIA_ALLOWED_ROOTS", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
 # ── _serve_file_bytes ETag / 304 ──────────────────────────────────────────
 
 

--- a/tests/test_media_message_snapshots.py
+++ b/tests/test_media_message_snapshots.py
@@ -56,6 +56,14 @@ def routes():
     return routes
 
 
+@pytest.fixture(autouse=True)
+def media_allowed_root(tmp_path, monkeypatch):
+    # tmp_path is under /tmp only on Linux; register it and make Path.home()
+    # resolve to the same fixture root on Windows so deny tests reach #3234.
+    monkeypatch.setenv("MEDIA_ALLOWED_ROOTS", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
 @pytest.fixture
 def snap_dir(tmp_path, monkeypatch):
     """Isolate the snapshot store per test and point it at tmp_path."""


### PR DESCRIPTION
## Thinking Path

- Pytest's temporary directory is platform-owned, so media tests that rely on `/tmp` fail on Darwin and Windows even though the production media gate is correct.
- The test fixtures register each exact `tmp_path` through `MEDIA_ALLOWED_ROOTS`, which covers both the serve and capture consumers without changing production authorization.
- Windows' fake Hermes-root deny cases also need the platform-authoritative `USERPROFILE`; setting it to the same per-test root makes those tests reach the existing deny predicate and preserve their 403 assertions.
- The browser test resolves Playwright inside its fixture so environments without the optional package collect the module and skip its tests during execution.
- The custom-provider catalog regression isolates its complete fake-endpoint rebuild from the bounded fallback used for unrelated slow provider probes.

## What Changed

- `tests/test_compression_phantom_barrier.py` now resolves Playwright with `pytest.importorskip` inside the browser fixture.
- The two media test modules register their per-test temporary root through `MEDIA_ALLOWED_ROOTS` and set `USERPROFILE` to that root for platform-neutral fake Hermes-home coverage.
- `tests/test_issue2513_custom_provider_remote_models.py` disables the bounded rebuild fallback for its complete fake remote-catalog assertion and restores the live-rebuild timestamp state afterward.
- Production media authorization and all existing assertions remain unchanged.

## Why It Matters

Contributors on Windows and macOS can run the affected tests without weakening `/api/media` authorization. Missing Playwright skips the optional browser tests during execution instead of aborting collection. The custom-provider regression remains deterministic when unrelated provider probes are slow.

## Verification

The base reproduction had a collection abort without Playwright and 17 platform-root media failures. The head collection proof reports `8 tests collected`, and the separate execution proof reports `8 skipped`. The focused hidden headless run reports `74 passed, 1 deselected`, including the custom-provider remote-catalog regression. The deselected case is the pre-existing Windows `file://C:\\...` parsing failure, unrelated to this target. The fake Hermes-root, direct-store, and custom-store deny checks pass with 403.

## Risks / Follow-ups

The full three-file Windows run retains one pre-existing failure in `test_resolve_media_ref_handles_file_url_and_expands_home`, caused by `file://C:\\...` parsing. It is unrelated to media-root portability and is excluded only from the focused pass count. CI owns the Linux and Darwin matrix.

## Contract Routing

- **Task type:** test-only portability fix.
- **Touched areas:** the three original portability test modules and the targeted custom-provider catalog regression test.
- **Scope boundaries:** no production route, capture policy, allowed-root list, deny predicate, or session-media behavior changes.
- **Evidence:** focused collection, skip, installed browser, media-root, deny-path, and custom-provider remote-catalog proofs.

## Model Used

GPT-5 via Codex CLI.
