### PR TITLE
fix(#7050): report merged display count on the metadata path for foreign sessions

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8351,7 +8351,7 @@ def get_state_db_session_message_keys_before_timestamp(
 
 
 def get_state_db_session_summary(sid, *, profile=None) -> dict:
-    """Return a cheap message count/timestamp summary for one state.db session."""
+    """Return a cheap active-message count/timestamp summary for one session."""
     try:
         import sqlite3
     except ImportError:
@@ -8374,10 +8374,13 @@ def get_state_db_session_summary(sid, *, profile=None) -> dict:
             available = {str(row['name']) for row in cur.fetchall()}
             if 'session_id' not in available:
                 return {"message_count": 0, "last_message_at": 0.0}
+            active_clause = ""
+            if 'active' in available:
+                active_clause = " AND (active IS NULL OR active != 0)"
             if 'timestamp' in available:
                 cur.execute(
                     "SELECT COUNT(*) AS message_count, MAX(timestamp) AS last_message_at "
-                    "FROM messages WHERE session_id = ?",
+                    f"FROM messages WHERE session_id = ?{active_clause}",
                     (str(sid),),
                 )
                 row = cur.fetchone()
@@ -8387,7 +8390,10 @@ def get_state_db_session_summary(sid, *, profile=None) -> dict:
                     "message_count": max(0, int(row["message_count"] or 0)),
                     "last_message_at": float(row["last_message_at"] or 0) if row["last_message_at"] is not None else 0.0,
                 }
-            cur.execute("SELECT COUNT(*) AS message_count FROM messages WHERE session_id = ?", (str(sid),))
+            cur.execute(
+                f"SELECT COUNT(*) AS message_count FROM messages WHERE session_id = ?{active_clause}",
+                (str(sid),),
+            )
             row = cur.fetchone()
             return {
                 "message_count": max(0, int(row["message_count"] or 0)) if row else 0,

--- a/api/routes.py
+++ b/api/routes.py
@@ -8903,14 +8903,22 @@ def _limited_webui_messages_for_display(session, state_db_messages) -> list:
     )
 
 
-def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, state_db_messages) -> list:
+def _limited_webui_messages_for_display_with_sidecar(
+    session,
+    sidecar_messages,
+    state_db_messages,
+    *,
+    merge_parent_lineage=False,
+) -> list:
     if sidecar_messages is None:
         sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
     else:
         sidecar_messages = list(sidecar_messages or [])
     state_db_messages = list(state_db_messages or [])
     if not state_db_messages:
-        return _merged_webui_lineage_messages_for_display(session, sidecar_messages)
+        if merge_parent_lineage:
+            return _merged_webui_lineage_messages_for_display(session, sidecar_messages)
+        return sidecar_messages
     # NOTE: do not short-circuit to the sidecar when state.db has no strictly
     # newer rows. A state.db row whose timestamp is at-or-before the sidecar's
     # newest (recovery / edited-in-place / missing-timestamp cases) is still
@@ -8925,7 +8933,9 @@ def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, 
         truncation_watermark=getattr(session, "truncation_watermark", None),
         truncation_boundary=getattr(session, "truncation_boundary", None),
     )
-    return _merged_webui_lineage_messages_for_display(session, merged_messages)
+    if merge_parent_lineage:
+        return _merged_webui_lineage_messages_for_display(session, merged_messages)
+    return merged_messages
 
 
 def _sidecar_file_exceeds_threshold(session_id, threshold_bytes) -> bool:
@@ -12990,6 +13000,10 @@ def handle_get(handler, parsed) -> bool:
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
+                foreign_source = cli_meta or {
+                    key: getattr(s, key, None)
+                    for key in ("source_tag", "raw_source", "session_source", "source")
+                }
                 if msg_limit is not None:
                     (
                         state_db_since_timestamp,
@@ -13062,6 +13076,9 @@ def handle_get(handler, parsed) -> bool:
                         s,
                         limited_sidecar_messages,
                         state_db_messages,
+                        merge_parent_lineage=(
+                            is_cli_session and not _session_source_is_webui(foreign_source)
+                        ),
                     )
                 else:
                     _all_msgs = _display_coordinate_messages(s, state_db_messages)

--- a/api/routes.py
+++ b/api/routes.py
@@ -267,6 +267,9 @@ _MESSAGING_SESSION_METADATA_CACHE: dict[str, object] = {
     "identity": {},
 }
 _MESSAGING_SESSION_METADATA_LOCK = threading.Lock()
+_FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE: dict[tuple, dict] = {}
+_FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK = threading.RLock()
+_FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_MAX_ENTRIES = 128
 _STALE_MESSAGING_END_REASONS = {"session_reset", "session_switch"}
 _CSP_REPORT_LOGGER = logging.getLogger("csp_report")
 _CSP_REPORT_RATE_LIMIT: dict[str, list[float]] = {}
@@ -8907,7 +8910,7 @@ def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, 
         sidecar_messages = list(sidecar_messages or [])
     state_db_messages = list(state_db_messages or [])
     if not state_db_messages:
-        return sidecar_messages
+        return _merged_webui_lineage_messages_for_display(session, sidecar_messages)
     # NOTE: do not short-circuit to the sidecar when state.db has no strictly
     # newer rows. A state.db row whose timestamp is at-or-before the sidecar's
     # newest (recovery / edited-in-place / missing-timestamp cases) is still
@@ -8916,12 +8919,13 @@ def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, 
     # the paginated load). The append-only merge is O(n) over already-bounded
     # in-memory lists; the real latency win here is skipping the lineage-parent
     # DISK load above, which we still skip. (#4070 ship-review)
-    return merge_session_messages_append_only(
+    merged_messages = merge_session_messages_append_only(
         sidecar_messages,
         state_db_messages,
         truncation_watermark=getattr(session, "truncation_watermark", None),
         truncation_boundary=getattr(session, "truncation_boundary", None),
     )
+    return _merged_webui_lineage_messages_for_display(session, merged_messages)
 
 
 def _sidecar_file_exceeds_threshold(session_id, threshold_bytes) -> bool:
@@ -9170,6 +9174,54 @@ def _display_coordinate_messages(session, state_db_messages) -> list:
     return _merged_webui_lineage_messages_for_display(session, merged)
 
 
+def _foreign_display_coordinate_sidecar_identity(session) -> tuple:
+    """Return stat identities for the session's sidecar lineage."""
+    identities = []
+    current = session
+    seen = set()
+    for _ in range(20):
+        sid = str(getattr(current, "session_id", "") or "").strip()
+        if not sid or sid in seen:
+            break
+        seen.add(sid)
+        path = Path(getattr(current, "path", SESSION_DIR / f"{sid}.json"))
+        try:
+            stat_result = path.stat()
+            identities.append(
+                (
+                    sid,
+                    int(getattr(stat_result, "st_mtime_ns", 0)),
+                    int(stat_result.st_size),
+                    int(getattr(stat_result, "st_ctime_ns", 0)),
+                )
+            )
+        except OSError:
+            identities.append((sid, None))
+        parent_id = str(getattr(current, "parent_session_id", "") or "").strip()
+        if not parent_id or parent_id in seen:
+            break
+        current = Session.load(parent_id)
+        if not current:
+            identities.append((parent_id, None))
+            break
+    return tuple(identities)
+
+
+def _foreign_display_coordinate_cache_scope(profile) -> str:
+    """Return the state.db scope represented by a foreign summary cache key."""
+    if isinstance(profile, str) and profile.strip():
+        return profile.strip()
+    try:
+        return str(_active_state_db_path())
+    except Exception:
+        return "<active-state-db>"
+
+
+def _clear_foreign_display_coordinate_summary_cache() -> None:
+    with _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK:
+        _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE.clear()
+
+
 def _foreign_display_coordinate_summary(sid: str, profile=None):
     """Return the display-coordinate summary for a foreign metadata poll.
 
@@ -9182,12 +9234,30 @@ def _foreign_display_coordinate_summary(sid: str, profile=None):
         session = get_session(sid, metadata_only=False)
         if not session:
             return None
+        state_summary = get_state_db_session_summary(sid, profile=profile)
+        cache_key = (
+            _foreign_display_coordinate_cache_scope(profile),
+            _foreign_display_coordinate_sidecar_identity(session),
+            _numeric_count(state_summary.get("message_count")),
+            float(state_summary.get("last_message_at") or 0.0),
+        )
+        with _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK:
+            cached = _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE.get(cache_key)
+            if cached is not None:
+                return dict(cached)
         backstop = _state_db_backstop_limit_for_display(session, None)
         reader_kwargs = {"profile": profile}
         if backstop is not None:
             reader_kwargs["limit"] = backstop
         state_db_messages = get_state_db_session_messages(sid, **reader_kwargs)
-        return _message_summary(_display_coordinate_messages(session, state_db_messages))
+        summary = _message_summary(_display_coordinate_messages(session, state_db_messages))
+        with _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK:
+            _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE[cache_key] = dict(summary)
+            while len(_FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE) > _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_MAX_ENTRIES:
+                _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE.pop(
+                    next(iter(_FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE))
+                )
+        return summary
     except Exception:
         logger.debug("Foreign display-coordinate summary failed for %s", sid, exc_info=True)
         return None

--- a/api/routes.py
+++ b/api/routes.py
@@ -9217,6 +9217,20 @@ def _foreign_display_coordinate_cache_scope(profile) -> str:
         return "<active-state-db>"
 
 
+def _foreign_display_coordinate_state_db_identity(profile):
+    """Return the cheap commit-aware identity for the selected state.db."""
+    try:
+        if isinstance(profile, str) and profile.strip():
+            db_path = _get_profile_home(profile) / "state.db"
+            if not db_path.exists():
+                db_path = _active_state_db_path()
+        else:
+            db_path = _active_state_db_path()
+        return _sqlite_file_stat_cache_key(db_path)
+    except Exception:
+        return None
+
+
 def _clear_foreign_display_coordinate_summary_cache() -> None:
     with _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK:
         _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE.clear()
@@ -9239,6 +9253,7 @@ def _foreign_display_coordinate_summary(sid: str, profile=None):
         state_summary = get_state_db_session_summary(sid, profile=profile)
         cache_key = (
             _foreign_display_coordinate_cache_scope(profile),
+            _foreign_display_coordinate_state_db_identity(profile),
             _foreign_display_coordinate_sidecar_identity(session),
             _numeric_count(state_summary.get("message_count")),
             float(state_summary.get("last_message_at") or 0.0),
@@ -9252,6 +9267,8 @@ def _foreign_display_coordinate_summary(sid: str, profile=None):
         if backstop is not None:
             reader_kwargs["limit"] = backstop
         state_db_messages = get_state_db_session_messages(sid, **reader_kwargs)
+        if not state_db_messages and _numeric_count(state_summary.get("message_count")):
+            return None
         summary = _message_summary(_display_coordinate_messages(session, state_db_messages))
         with _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE_LOCK:
             _FOREIGN_DISPLAY_COORDINATE_SUMMARY_CACHE[cache_key] = dict(summary)
@@ -9730,6 +9747,8 @@ from api.models import (
     get_state_db_session_message_prefix_summary,
     get_state_db_session_message_keys_before_timestamp,
     get_state_db_session_summary,
+    _get_profile_home,
+    _sqlite_file_stat_cache_key,
     merge_session_messages_append_only,
     _reconcile_api_content_sidecars,
     _enrich_sidebar_lineage_metadata,

--- a/api/routes.py
+++ b/api/routes.py
@@ -9159,6 +9159,34 @@ def _merged_webui_lineage_messages_for_display(session, messages=None) -> list:
     return merged_messages
 
 
+def _display_coordinate_messages(session, state_db_messages) -> list:
+    """Return the reconciled message list shared by display-coordinate paths."""
+    merged = merge_session_messages_append_only(
+        _webui_sidecar_lineage_messages_for_display(session),
+        state_db_messages,
+        truncation_watermark=getattr(session, "truncation_watermark", None),
+        truncation_boundary=getattr(session, "truncation_boundary", None),
+    )
+    return _merged_webui_lineage_messages_for_display(session, merged)
+
+
+def _foreign_display_coordinate_summary(sid: str, profile=None):
+    """Return the display-coordinate summary for a foreign metadata poll."""
+    try:
+        session = get_session(sid, metadata_only=False)
+        if not session:
+            return None
+        backstop = _state_db_backstop_limit_for_display(session, None)
+        reader_kwargs = {"profile": profile}
+        if backstop is not None:
+            reader_kwargs["limit"] = backstop
+        state_db_messages = get_state_db_session_messages(sid, **reader_kwargs)
+        return _message_summary(_display_coordinate_messages(session, state_db_messages))
+    except Exception:
+        logger.debug("Foreign display-coordinate summary failed for %s", sid, exc_info=True)
+        return None
+
+
 def _message_summary(messages) -> dict:
     messages = list(messages or [])
     last_message_at = 0.0
@@ -12851,6 +12879,11 @@ def handle_get(handler, parsed) -> bool:
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
+            is_cli_session = (
+                bool(getattr(s, "is_cli_session", False) or getattr(s, "read_only", False))
+                or is_cli_session_row(s)
+                or is_cli_session_row(cli_meta)
+            )
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             cli_messages = []
             state_db_messages = []
@@ -12885,12 +12918,24 @@ def handle_get(handler, parsed) -> bool:
                     **_state_db_reader_kwargs,
                 )
             elif not is_messaging_session:
-                # Metadata-only callers still need the same append-only
-                # reconciliation contract as full loads so stale/replayed
-                # state.db rows do not make sidebar polling think the
-                # transcript is always newer. Helper threads profile= to
-                # honor #2827's TLS-vs-thread fix.
-                metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
+                # Some imported/TUI sessions carry their source markers only on
+                # the materialized Session; the metadata lookup can be empty.
+                foreign_source = cli_meta or {
+                    key: getattr(s, key, None)
+                    for key in ("source_tag", "raw_source", "session_source", "source")
+                }
+                if is_cli_session and not _session_source_is_webui(foreign_source):
+                    metadata_summary = _foreign_display_coordinate_summary(
+                        sid,
+                        profile=_session_profile,
+                    )
+                if metadata_summary is None:
+                    # Metadata-only callers still need the same append-only
+                    # reconciliation contract as full loads so stale/replayed
+                    # state.db rows do not make sidebar polling think the
+                    # transcript is always newer. Helper threads profile= to
+                    # honor #2827's TLS-vs-thread fix.
+                    metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
             _t2 = _time.monotonic()
             if _diag: _diag.stage("t2_after_state_db_load")
             effective_model = (
@@ -12922,13 +12967,7 @@ def handle_get(handler, parsed) -> bool:
                         state_db_messages,
                     )
                 else:
-                    _all_msgs = merge_session_messages_append_only(
-                        _webui_sidecar_lineage_messages_for_display(s),
-                        state_db_messages,
-                        truncation_watermark=getattr(s, "truncation_watermark", None),
-                        truncation_boundary=getattr(s, "truncation_boundary", None),
-                    )
-                    _all_msgs = _merged_webui_lineage_messages_for_display(s, _all_msgs)
+                    _all_msgs = _display_coordinate_messages(s, state_db_messages)
             else:
                 if is_messaging_session and cli_messages:
                     _all_msgs = _merged_session_messages_for_display(s, cli_messages)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9231,7 +9231,9 @@ def _foreign_display_coordinate_summary(sid: str, profile=None):
     needed; failures return ``None`` so the caller keeps the legacy summary.
     """
     try:
-        session = get_session(sid, metadata_only=False)
+        # Bypass the Session LRU so the cache key and merged rows observe an
+        # atomic sidecar replacement even when its count stays unchanged.
+        session = Session.load(sid)
         if not session:
             return None
         state_summary = get_state_db_session_summary(sid, profile=profile)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9171,7 +9171,13 @@ def _display_coordinate_messages(session, state_db_messages) -> list:
 
 
 def _foreign_display_coordinate_summary(sid: str, profile=None):
-    """Return the display-coordinate summary for a foreign metadata poll."""
+    """Return the display-coordinate summary for a foreign metadata poll.
+
+    Foreign ``messages=0`` responses use the same merged count and timestamp
+    as message loads. This costs one sidecar load plus one state.db read,
+    capped at the existing 50,000-row backstop when no boundary prefix is
+    needed; failures return ``None`` so the caller keeps the legacy summary.
+    """
     try:
         session = get_session(sid, metadata_only=False)
         if not session:

--- a/tests/test_issue7050_foreign_session_metadata_count.py
+++ b/tests/test_issue7050_foreign_session_metadata_count.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.requires_agent_modules
 def _foreign_fixture(monkeypatch, tmp_path, *, profile=None, truncation_watermark=None, truncation_boundary=None):
     import api.routes as routes
 
+    routes._clear_foreign_display_coordinate_summary_cache()
     sid = "foreign_metadata_count_7050"
     tool_call = [{"id": "call-1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}]
     sidecar_messages = [
@@ -187,6 +188,90 @@ def test_foreign_metadata_poll_keeps_boundary_read_uncapped(monkeypatch, tmp_pat
     )
     _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
     assert "limit" not in calls[-1]
+
+
+def test_foreign_paged_load_matches_non_snapshot_parent_lineage(monkeypatch, tmp_path):
+    import api.models as models
+    import api.routes as routes
+
+    routes._clear_foreign_display_coordinate_summary_cache()
+    parent_id = "foreign_metadata_parent_7050"
+    sid = "foreign_metadata_child_7050"
+    child_messages = [
+        {"role": "user", "content": f"child {idx}", "timestamp": 1000.0 + idx}
+        for idx in range(35)
+    ]
+    child = _install_test_session(monkeypatch, tmp_path, sid, child_messages)
+    parent_messages = [{"role": "user", "content": "parent", "timestamp": 900.0}]
+    parent = models.Session(
+        session_id=parent_id,
+        title="Parent",
+        workspace=str(tmp_path),
+        model="test-model",
+        messages=parent_messages,
+        created_at=899.0,
+        updated_at=900.0,
+    )
+    parent.save(touch_updated_at=False)
+    child.parent_session_id = parent_id
+    child.is_cli_session = True
+    child.source_tag = "tui"
+    child.raw_source = "tui"
+    child.session_source = "tui"
+    child.save(touch_updated_at=False)
+    monkeypatch.setattr(
+        routes,
+        "_lookup_cli_session_metadata",
+        lambda _sid: {"source_tag": "tui", "session_source": "tui", "is_cli_session": True},
+    )
+    _make_state_db(tmp_path / "state.db", sid, child_messages)
+
+    metadata = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    paged = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30",
+    )
+    unbounded = _session_payload(routes, f"/api/session?session_id={sid}&messages=1&resolve_model=0")
+
+    assert metadata["message_count"] == paged["message_count"] == unbounded["message_count"] == 36
+    assert metadata["last_message_at"] == paged["last_message_at"] == unbounded["last_message_at"] == 1034.0
+    assert len(paged["messages"]) == 30
+    assert paged["_messages_offset"] == 6
+
+
+def test_foreign_boundary_summary_cache_skips_unchanged_uncapped_read(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    summary_calls = []
+    reader_calls = []
+    real_summary = routes.get_state_db_session_summary
+    real_reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_summary",
+        lambda session_id, **kwargs: (
+            summary_calls.append((session_id, kwargs))
+            or real_summary(session_id, **kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (
+            reader_calls.append((session_id, kwargs))
+            or real_reader(session_id, **kwargs)
+        ),
+    )
+
+    first = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    second = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+
+    assert first["message_count"] == second["message_count"]
+    assert first["last_message_at"] == second["last_message_at"]
+    assert len(summary_calls) == 2
+    assert len(reader_calls) == 1
+    assert "limit" not in reader_calls[0][1]
 
 
 def test_foreign_metadata_poll_respects_truncation_watermark(monkeypatch, tmp_path):

--- a/tests/test_issue7050_foreign_session_metadata_count.py
+++ b/tests/test_issue7050_foreign_session_metadata_count.py
@@ -8,6 +8,7 @@ import pytest
 
 from tests.test_webui_state_db_reconciliation import (
     _GetHandler,
+    _append_state_db_rows,
     _install_test_session,
     _make_state_db,
 )
@@ -272,6 +273,66 @@ def test_foreign_boundary_summary_cache_skips_unchanged_uncapped_read(monkeypatc
     assert len(summary_calls) == 2
     assert len(reader_calls) == 1
     assert "limit" not in reader_calls[0][1]
+
+    _append_state_db_rows(
+        tmp_path / "state.db",
+        sid,
+        [{"role": "assistant", "content": "new", "timestamp": 1004.0}],
+    )
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    assert len(reader_calls) == 2
+
+
+def test_foreign_summary_cache_is_profile_scoped(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    real_summary = routes.get_state_db_session_summary
+    real_reader = routes.get_state_db_session_messages
+    reader_profiles = []
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_summary",
+        lambda session_id, **kwargs: real_summary(session_id, **kwargs),
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (
+            reader_profiles.append(kwargs.get("profile"))
+            or real_reader(session_id, **kwargs)
+        ),
+    )
+
+    routes._foreign_display_coordinate_summary(sid, profile="profile-a")
+    routes._foreign_display_coordinate_summary(sid, profile="profile-b")
+
+    assert reader_profiles == ["profile-a", "profile-b"]
+
+
+def test_foreign_summary_cache_reloads_changed_sidecar(monkeypatch, tmp_path):
+    import api.models as models
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    reader_calls = []
+    real_reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (
+            reader_calls.append((session_id, kwargs))
+            or real_reader(session_id, **kwargs)
+        ),
+    )
+
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    session = models.Session.load(sid)
+    session.messages[-1]["content"] = "changed without changing the count"
+    session.save(touch_updated_at=False)
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+
+    assert len(reader_calls) == 2
 
 
 def test_foreign_metadata_poll_respects_truncation_watermark(monkeypatch, tmp_path):

--- a/tests/test_issue7050_foreign_session_metadata_count.py
+++ b/tests/test_issue7050_foreign_session_metadata_count.py
@@ -1,0 +1,228 @@
+import json
+import subprocess
+import textwrap
+from urllib.parse import urlparse
+from pathlib import Path
+
+import pytest
+
+from tests.test_webui_state_db_reconciliation import (
+    _GetHandler,
+    _install_test_session,
+    _make_state_db,
+)
+
+
+pytestmark = pytest.mark.requires_agent_modules
+
+
+def _foreign_fixture(monkeypatch, tmp_path, *, profile=None, truncation_watermark=None, truncation_boundary=None):
+    import api.routes as routes
+
+    sid = "foreign_metadata_count_7050"
+    tool_call = [{"id": "call-1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}]
+    sidecar_messages = [
+        {"role": "user", "content": "hello", "timestamp": 1000.0},
+        {"role": "assistant", "content": "", "timestamp": 1001.0, "tool_calls": tool_call},
+        {"role": "tool", "content": "result", "timestamp": 1002.0, "tool_call_id": "call-1"},
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    session.is_cli_session = True
+    session.source_tag = "tui"
+    session.raw_source = "tui"
+    session.session_source = "tui"
+    session.profile = profile
+    session.truncation_watermark = truncation_watermark
+    session.truncation_boundary = truncation_boundary
+    session.save(touch_updated_at=False)
+    monkeypatch.setattr(
+        routes,
+        "_lookup_cli_session_metadata",
+        lambda _sid: {
+            "source_tag": "tui",
+            "raw_source": "tui",
+            "session_source": "tui",
+            "is_cli_session": True,
+        },
+    )
+    state_sidecar_messages = [
+        {**message, "tool_calls": json.dumps(message["tool_calls"])}
+        if message.get("tool_calls")
+        else message
+        for message in sidecar_messages
+    ]
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        state_sidecar_messages
+        + [
+            dict(sidecar_messages[0]),
+            {"role": "assistant", "content": "done", "timestamp": 1003.0},
+        ],
+    )
+    return sid
+
+
+def _session_payload(routes, path):
+    handler = _GetHandler(path)
+    routes.handle_get(handler, urlparse(handler.path))
+    assert handler.status == 200
+    return handler.response_json["session"]
+
+
+def test_foreign_metadata_count_matches_display_coordinate(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path)
+    metadata = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=0&resolve_model=0",
+    )
+    limited = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30",
+    )
+    unbounded = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0",
+    )
+
+    assert metadata["message_count"] == limited["message_count"] == unbounded["message_count"]
+    assert metadata["last_message_at"] == limited["last_message_at"] == unbounded["last_message_at"]
+    assert metadata["message_count"] == 4
+    assert metadata["message_count"] != 5
+
+
+def test_foreign_metadata_uses_session_markers_when_lookup_is_empty(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {})
+    metadata = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=0&resolve_model=0",
+    )
+    assert metadata["message_count"] == 4
+    assert metadata["last_message_at"] == 1003.0
+
+
+def test_foreign_metadata_failure_falls_back_to_legacy_summary(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("state db unavailable")),
+    )
+    payload = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=0&resolve_model=0",
+    )
+    assert payload["message_count"] == 5
+    assert payload["last_message_at"] == 1003.0
+
+
+def test_external_refresh_equal_and_mismatch_use_real_poll_consumer():
+    sessions_js = (Path(__file__).resolve().parents[1] / "static" / "sessions.js").read_text()
+    start = sessions_js.index("async function refreshActiveSessionIfExternallyUpdated")
+    end = sessions_js.index("function ensureActiveSessionExternalRefreshPoll", start)
+    function = sessions_js[start:end]
+    script = textwrap.dedent(
+        f"""
+        const outcomes = [];
+        const responses = [{{message_count: 4, last_message_at: 1003}}, {{message_count: 5, last_message_at: 1004}}];
+        let responseIndex = 0;
+        global.S = {{session: {{session_id: 'foreign', message_count: 4, last_message_at: 1003}}, messages: [1,2,3,4], busy: false, activeStreamId: null}};
+        global.document = {{hidden: false}};
+        global.window = {{}};
+        global._activeSessionExternalRefreshInFlight = false;
+        global._loadingSessionId = null;
+        global._isMessageReaderUnpinned = () => false;
+        global._deferActiveSessionExternalRefresh = () => {{}};
+        global._isExternalSession = () => true;
+        global.api = async () => ({{session: responses[responseIndex++]}});
+        global.loadSession = async () => outcomes.push('reloaded');
+        global._drainSessionUpdatedPendingCount = () => {{}};
+        {function}
+        (async () => {{
+          outcomes.push(await refreshActiveSessionIfExternallyUpdated('poll'));
+          outcomes.push(await refreshActiveSessionIfExternallyUpdated('poll'));
+          process.stdout.write(JSON.stringify(outcomes));
+        }})().catch((error) => {{ process.stderr.write(String(error.stack || error)); process.exit(1); }});
+        """
+    )
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == ["unchanged", "reloaded", "reloaded"]
+
+
+def test_foreign_metadata_poll_uses_profile_and_safe_backstop(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, profile="profile-7050")
+    monkeypatch.setattr(routes, "_session_visible_to_active_profile", lambda *_args: True)
+    calls = []
+    reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (calls.append((session_id, kwargs)) or reader(session_id, **kwargs)),
+    )
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    assert calls[-1][1]["profile"] == "profile-7050"
+    assert calls[-1][1]["limit"] == 50000
+
+
+def test_foreign_metadata_poll_keeps_boundary_read_uncapped(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    calls = []
+    reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (calls.append(kwargs) or reader(session_id, **kwargs)),
+    )
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    assert "limit" not in calls[-1]
+
+
+def test_foreign_metadata_poll_respects_truncation_watermark(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_watermark=1001.5)
+    metadata = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    unbounded = _session_payload(routes, f"/api/session?session_id={sid}&messages=1&resolve_model=0")
+    assert metadata["message_count"] == unbounded["message_count"]
+    assert metadata["last_message_at"] == unbounded["last_message_at"]
+
+
+def test_webui_metadata_control_stays_on_cheap_summary(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_metadata_control_7050"
+    sidecar = [{"role": "user", "content": "hello", "timestamp": 1000.0}]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar)
+    _make_state_db(tmp_path / "state.db", sid, sidecar + [{"role": "assistant", "content": "new", "timestamp": 1001.0}])
+    monkeypatch.setattr(routes, "_foreign_display_coordinate_summary", lambda *args, **kwargs: pytest.fail("WebUI control used foreign summary"))
+    payload = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    assert payload["message_count"] == 1
+
+
+def test_messaging_metadata_control_stays_on_messaging_path(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "messaging_metadata_control_7050"
+    sidecar = [{"role": "user", "content": "hello", "timestamp": 1000.0}]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar)
+    session.session_source = "messaging"
+    session.source_tag = "slack"
+    session.raw_source = "slack"
+    session.save(touch_updated_at=False)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {"source_tag": "slack", "session_source": "messaging"})
+    monkeypatch.setattr(routes, "get_cli_session_messages", lambda _sid: sidecar)
+    monkeypatch.setattr(routes, "_foreign_display_coordinate_summary", lambda *args, **kwargs: pytest.fail("messaging path used foreign summary"))
+    payload = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    assert payload["message_count"] == 1

--- a/tests/test_issue7050_foreign_session_metadata_count.py
+++ b/tests/test_issue7050_foreign_session_metadata_count.py
@@ -126,6 +126,19 @@ def test_foreign_metadata_failure_falls_back_to_legacy_summary(monkeypatch, tmp_
     assert payload["last_message_at"] == 1003.0
 
 
+def test_foreign_metadata_empty_read_falls_back_to_legacy_summary(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path)
+    monkeypatch.setattr(routes, "get_state_db_session_messages", lambda *_args, **_kwargs: [])
+    payload = _session_payload(
+        routes,
+        f"/api/session?session_id={sid}&messages=0&resolve_model=0",
+    )
+    assert payload["message_count"] == 5
+    assert payload["last_message_at"] == 1003.0
+
+
 def test_external_refresh_equal_and_mismatch_use_real_poll_consumer():
     sessions_js = (Path(__file__).resolve().parents[1] / "static" / "sessions.js").read_text()
     start = sessions_js.index("async function refreshActiveSessionIfExternallyUpdated")
@@ -369,6 +382,30 @@ def test_foreign_summary_cache_tracks_active_state_changes(monkeypatch, tmp_path
     assert first["message_count"] == 5
     assert second["message_count"] == unbounded["message_count"] == 4
     assert len(reader_calls) == 3
+
+
+def test_foreign_summary_cache_tracks_same_high_water_rewrite(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    reader_calls = []
+    real_reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (
+            reader_calls.append((session_id, kwargs))
+            or real_reader(session_id, **kwargs)
+        ),
+    )
+
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute("UPDATE messages SET content = 'rewritten' WHERE content = 'done'")
+        conn.commit()
+    _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+
+    assert len(reader_calls) == 2
 
 
 def test_foreign_metadata_poll_respects_truncation_watermark(monkeypatch, tmp_path):

--- a/tests/test_issue7050_foreign_session_metadata_count.py
+++ b/tests/test_issue7050_foreign_session_metadata_count.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 import subprocess
 import textwrap
 from urllib.parse import urlparse
@@ -333,6 +334,41 @@ def test_foreign_summary_cache_reloads_changed_sidecar(monkeypatch, tmp_path):
     _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
 
     assert len(reader_calls) == 2
+
+
+def test_foreign_summary_cache_tracks_active_state_changes(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = _foreign_fixture(monkeypatch, tmp_path, truncation_boundary=1001.0)
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute("ALTER TABLE messages ADD COLUMN active INTEGER NOT NULL DEFAULT 1")
+        conn.commit()
+    _append_state_db_rows(
+        tmp_path / "state.db",
+        sid,
+        [{"role": "assistant", "content": "extra", "timestamp": 1002.5}],
+    )
+    reader_calls = []
+    real_reader = routes.get_state_db_session_messages
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_messages",
+        lambda session_id, **kwargs: (
+            reader_calls.append((session_id, kwargs))
+            or real_reader(session_id, **kwargs)
+        ),
+    )
+
+    first = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute("UPDATE messages SET active = 0 WHERE content = 'extra'")
+        conn.commit()
+    second = _session_payload(routes, f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    unbounded = _session_payload(routes, f"/api/session?session_id={sid}&messages=1&resolve_model=0")
+
+    assert first["message_count"] == 5
+    assert second["message_count"] == unbounded["message_count"] == 4
+    assert len(reader_calls) == 3
 
 
 def test_foreign_metadata_poll_respects_truncation_watermark(monkeypatch, tmp_path):


### PR DESCRIPTION

## Thinking Path

- `/api/session` promises one `message_count` coordinate for pagination and the header badge, but the foreign metadata, paged, and unbounded branches previously reached different merge paths.
- Foreign sessions with tool-heavy state can expose a raw state.db count to the 30-second poll while message loads expose a deduplicated display count, so `refreshActiveSessionIfExternallyUpdated` repeatedly reloads the transcript.
- The server now routes all three foreign response modes through the same parent-lineage display coordinate. The frontend comparison stays strict, so genuine external changes still reload.
- Boundary-aware metadata reads keep the required uncapped first computation, then reuse a profile-scoped summary keyed by fresh sidecar lineage identities, active state.db high-water values, and a commit-aware state.db identity. Unchanged polls skip the full row read.
- The later "Load earlier messages" scroll churn remains under #6799, which owns the transcript-virtualization fix.

## What Changed

- `api/routes.py`: extracted the load path's sidecar+state.db merge into a single `_display_coordinate_messages()` helper and pointed the existing unbounded load branch at it, so there is one definition of the display coordinate space.
- `api/routes.py`: routed paged loads through the same parent-lineage reconciliation before windowing, preserving the existing payload limit and offset behavior.
- `api/routes.py`: added `_foreign_display_coordinate_summary()`, which computes `message_count` and `last_message_at` for a materialized foreign session on the metadata path through that same merge, with the existing boundary backstop and profile threading preserved.
- `api/routes.py` and `api/models.py`: added commit-aware, active-row-aligned cache invalidation so repeated boundary polls avoid uncapped state.db reads while sidecar edits, profile changes, active-row changes, content rewrites, and high-water changes recompute.
- `api/routes.py`: the metadata-only arm now uses that summary for foreign, non-messaging sessions and falls back to `_metadata_only_message_summary()` otherwise or on any failure. WebUI-native and messaging sessions keep their existing paths verbatim.
- `tests/test_issue7050_foreign_session_metadata_count.py`: new regression coverage.

## Why It Matters

A foreign/CLI conversation with a lot of tool calls is currently unusable: the titlebar count cycles every 30 seconds, the whole transcript is re-fetched and re-rendered on each cycle, and the scroll position resets under the reader. With all three response modes reporting the same coordinate space the poll converges to "unchanged" and the session simply sits still.

## Verification

The regression tests build synthetic foreign sessions whose raw state.db rows exceed the merged display coordinate and assert that metadata, paged, and unbounded responses agree on `message_count` and `last_message_at`, including a non-snapshot parent lineage. They also cover CLI markers carried by the `Session`, equal and changed values through the real external-refresh consumer, exception and empty-read fallback, WebUI-native and messaging controls, truncation-watermark behavior, profile scoping, active-row changes, same-high-water rewrites, changed sidecars, and the boundary cache. The focused validation passes on this head. CI runs the full matrix on 3.11, 3.12, and 3.13.

## Risks / Follow-ups

The first metadata poll for a boundary-carrying foreign session still performs the full prefix read required for correct reconciliation. Later unchanged polls use the cached merged summary after a cheap active-row aggregate and commit-aware database identity check. WebUI-native sessions, which are the common case, are untouched.

I reproduced and verified this against a synthetic session, not against a real 2543-row TUI transcript; the field numbers come from the issue reporter. A maintainer-owned real-session check remains useful, but the route contract and poll consumer are covered locally.

No before/after screenshot pair is attached. This is a server-only change, and no rendered proof is claimed.

The "Load earlier messages" scroll churn reported as a follow-up on #7050 is deliberately not addressed here. It is the estimated-height virtualization feedback loop tracked in #6799 and needs its own fix. Nothing in this PR changes `MESSAGE_VIRTUAL_THRESHOLD_ROWS` or any frontend file. #6392 (post-`done` full reload) is a sibling trigger and also stays open.

No security-sensitive surface changes: no auth, upload, or path handling is touched. The one adjacent concern is profile isolation on the state.db read, which is preserved by threading the session's profile exactly as `_metadata_only_message_summary` already does, and is covered by a test.

Release note wording, if useful: "Foreign/CLI sessions no longer reload their full transcript every 30 seconds; `/api/session` now reports the same message count on the metadata and message-load paths."

## Contract Routing

- **Task type:** bug fix with a contract-consistency component.
- **Touched areas:** `api/routes.py` `/api/session` metadata, paged, and unbounded display-coordinate paths; `api/models.py` active-row-aligned state.db summaries; `tests/test_issue7050_foreign_session_metadata_count.py`.
- **Relevant public docs:** `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, and the in-code contract statement at `api/routes.py:13136-13141`. None require an edit. This makes the existing stated contract true for foreign metadata, paged, and unbounded responses.
- **Scope boundaries:** server-side only; no frontend change; `/api/sessions` sidebar counts, the messaging correction, and transcript virtualization remain out of scope.
- **Evidence needed before claiming done:** base-run failure of the new test for the right reason; equal `message_count` and `last_message_at` across all three request modes; WebUI-native, messaging, watermark, profile, and backstop controls green.

## Model Used

GPT-5.5 via Codex CLI.

