### PR TITLE
fix(sessions): preserve restore state on transient errors

### DIFF
--- a/docs/rfcs/canonical-session-resolution.md
+++ b/docs/rfcs/canonical-session-resolution.md
@@ -83,6 +83,12 @@ correct visible session target, not moving execution ownership.
 7. **404 self-heal is separate from lineage resolution.** Missing/deleted sessions
    should still use the stale-route recovery path. A present archived parent with
    a live continuation is not a 404; it is a canonicalization problem.
+8. **Metadata restore failures preserve recovery state unless this load owns a
+   definitive metadata 404.** A non-404 failure from the session metadata
+   request—including network, timeout, ambiguous 4xx, and 5xx errors—must
+   preserve the saved active-session ID and session URL. A definitive 404 from
+   that metadata request may independently clear only the saved-pointer or
+   route component whose current value still equals the requested ID.
 
 ## Entry Point Matrix
 
@@ -108,6 +114,9 @@ restore, direct session open, or URL parsing, answer:
 - Do sidebar collapse and `loadSession()` pick the same visible representative?
 - Is missing-session 404 recovery kept distinct from present-but-archived lineage
   canonicalization?
+- Does metadata restore preserve the saved ID and session URL for non-404
+  failures, and clear only matching recovery components after a definitive
+  metadata 404?
 - What regression proves route, query parameter, localStorage, and sidebar paths
   agree for compressed lineage rows?
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1575,33 +1575,6 @@ async function newSession(flash, options={}){
   }
 }
 
-/**
- * Self-heal: clear the stuck session ID from localStorage and URL when a
- * loadSession() call failed during boot (no currentSid). This prevents the
- * browser from retrying the same dead session on every refresh.
- *
- * Called from loadSession() after 401 redirect (undefined data) or any
- * non-404 error (400, 403, 500, network). The 404 path has its own
- * inline self-heal; this helper consolidates the non-404 cases.
- *
- * Only clears when !currentSid — no session is active on screen, so
- * the stored ID is definitely stale. When currentSid is set (already
- * viewing a session), a non-404 failure could be a transient server error
- * and the session may still exist on the server; wiping localStorage in
- * that case is unnecessarily destructive (#4028 follow-up).
- *
- * A click into a *different* dead session (currentSid && currentSid!==sid)
- * must not run it: localStorage and the URL still point at the live session
- * (both are only updated on a successful load), so wiping them would log
- * the user out of a healthy session (#2782).
- */
-function _clearStuckSessionOnBoot(sid, currentSid){
-  if(!currentSid){
-    try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
-    try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
-  }
-}
-
 // #2971 (Greptile P1 r3377162160): loadSession() tears down the live
 // per-session SSE at the top via stopSessionStream() (line ~754), but only the
 // success path re-arms it via startSessionStream() (line ~875). Every
@@ -1691,7 +1664,7 @@ async function loadSession(sid){
     }
   }
   const forceReload = !!opts.force;
-  const currentSid = S.session ? S.session.session_id : null;
+  let currentSid = S.session ? S.session.session_id : null;
   const sameSessionForceReload = forceReload && currentSid===sid;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
   // tears down active pane state and can reset the long-session scroll window
@@ -1860,8 +1833,9 @@ async function loadSession(sid){
         }
         if (_isCurrentLoad()) _loadingSessionId = null;
         return loadSession(sid,{...opts,skipProfileResolve:true,force:true,_preloadNotified:true});
-      }catch(switchErr){
-        e=switchErr;
+      }catch(_switchErr){
+        // Keep e as the original metadata failure: a failed profile switch
+        // does not prove that the requested session is missing.
       }
     }
     const _msgInner = $('msgInner');
@@ -1876,36 +1850,45 @@ async function loadSession(sid){
       _rearmActiveSessionStream();
       return;
     }
+    // A non-loadSession transition can change S.session while metadata awaits.
+    // Refresh the snapshot before deciding ownership or rearming a stream.
+    currentSid = S.session ? S.session.session_id : null;
     if(_msgInner){
       if(e.status===404){
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Session not available in web UI.</div>';
-        // Self-heal (clear saved id + strip /session/<id> URL) only when the
-        // 404'd id is the one we are activating: a boot-time restore
-        // (!currentSid, #2798) or a mid-session reload of the *current* session
-        // whose sidecar was deleted server-side (#2782). A click into a
-        // *different* dead session (currentSid && currentSid!==sid) must not run
-        // it: localStorage and the URL still point at the live session (both are
-        // only updated on a successful load), so wiping them would log the user
-        // out of a healthy session. The URL strip is needed in the self-heal
-        // case because _sessionIdFromLocation() re-injects the id on reload.
-        // Only the rethrow stays gated on !currentSid: boot rethrows to fall
-        // through to empty-state; mid-session there is no boot path to reach.
-        if(!currentSid || currentSid===sid){
+        // Self-heal (clear saved id + strip /session/<id> URL) only when this
+        // load still owns recovery state: it is loading the active session, or
+        // boot has no active session and the saved pointer and route (if
+        // present) still target sid.
+        // A concurrent boot load of a different dead session must not wipe the
+        // live saved route. The URL strip is needed because
+        // _sessionIdFromLocation() re-injects the id on reload. Only an owned
+        // boot 404 rethrows to fall through to empty-state.
+        let _savedSid;
+        let _routeSid;
+        try{ _savedSid=localStorage.getItem('hermes-webui-session'); }catch(_){ }
+        try{
+          _routeSid=typeof _sessionIdFromLocation==='function'
+            ? _sessionIdFromLocation()
+            : undefined;
+        }catch(_){ }
+        const _savedOwned = _savedSid===sid;
+        const _routeOwned = _routeSid===sid;
+        if(_savedOwned){
           try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+        }
+        if(_routeOwned){
           try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
+        }
+        if(!currentSid && (_savedOwned || _routeOwned)){
           if (_isCurrentLoad()) _loadingSessionId = null;
-          if(!currentSid){
-            throw e;
-          }
+          throw e;
         }
       } else {
         // Non-404, non-401 failure (400, 403, 500, network): 401 is handled
         // via the if(!data) guard below since api() returns undefined on 401
-        // rather than throwing. Clear the stuck session ID only during boot
-        // (!currentSid) so the next boot doesn't retry the same dead session.
-        // When currentSid is set, a 500/network error may be transient — the
-        // session might still exist on the server (#4028 follow-up).
-        _clearStuckSessionOnBoot(sid, currentSid);
+        // rather than throwing. These failures do not prove the session is
+        // missing, so preserve the saved ID and URL for recovery.
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try refreshing or switching sessions.</div>';
         if(typeof showToast==='function') showToast('Failed to load session',3000,'error');
       }

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -136,7 +136,10 @@ def test_same_session_force_refresh_does_not_reset_scroll_direction_tracker():
     body = _function_body(SESSIONS_JS, "loadSession")
     compact = _compact(body)
 
-    assert "constcurrentSid=S.session?S.session.session_id:null;" in compact
+    assert any(
+        f"{keyword}currentSid=S.session?S.session.session_id:null;" in compact
+        for keyword in ("const", "let")
+    )
     assert "if(currentSid!==sid&&typeofwindow!=='undefined'&&typeofwindow._resetScrollDirectionTracker==='function')" in compact
 
 

--- a/tests/test_issue3993_session_load_self_heal.py
+++ b/tests/test_issue3993_session_load_self_heal.py
@@ -1,101 +1,439 @@
-"""Regression tests for #3993 — self-heal stuck session loads on non-404 failures.
-
-A session load that fails with a non-404, non-401 error (400 / 403 / 500 /
-network) during boot used to leave a stale session id in localStorage + URL, so
-every subsequent refresh retried the same dead session and the WebUI could not
-load ANY chat. loadSession() now calls _clearStuckSessionOnBoot(sid, currentSid)
-which clears the stale id ONLY when no session is currently on screen
-(!currentSid) — never when the user is already viewing a healthy session (a
-500/network blip there may be transient, #4028), and never on a click into a
-*different* dead session (localStorage/URL still point at the live one, #2782).
-"""
+"""Executable regression coverage for loadSession() metadata restore state."""
 from __future__ import annotations
 
 import json
 import shutil
 import subprocess
+import textwrap
+from functools import lru_cache
 from pathlib import Path
+
+import pytest
+
 
 REPO = Path(__file__).resolve().parent.parent
 SESSIONS_JS = REPO / "static" / "sessions.js"
 NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for executable coverage")
 
 
-def _read(p: Path) -> str:
-    return p.read_text(encoding="utf-8")
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
 
-def test_clear_stuck_session_helper_exists_and_is_wired():
-    """The non-404 failure branch must delegate to _clearStuckSessionOnBoot."""
-    js = _read(SESSIONS_JS)
-    marker = "function _clearStuckSessionOnBoot(sid, currentSid){"
-    assert marker in js
-    # Wired into the non-404 error branch.
-    assert "_clearStuckSessionOnBoot(sid, currentSid);" in js
-    # Guarded on the boot condition (no active session on screen).
-    helper = js[js.index(marker): js.index(marker) + 260]
-    assert "if(!currentSid){" in helper
-    assert "localStorage.removeItem('hermes-webui-session')" in helper
-    assert "history.replaceState" in helper
+def _extract_js_block(source: str, marker: str) -> str:
+    start = source.index(marker)
+    brace_start = source.index("{", start)
+    depth = 0
+    string = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < len(source) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            continue
+        if block_comment:
+            if char == "*" and next_char == "/":
+                block_comment = False
+            continue
+        if string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == string:
+                string = None
+            continue
+        if char == "/" and next_char == "/":
+            line_comment = True
+            continue
+        if char == "/" and next_char == "*":
+            block_comment = True
+            continue
+        if char in "'\"`":
+            string = char
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"JavaScript block did not close: {marker}")
 
 
-def _run_helper(current_sid_js: str) -> dict:
-    """Run _clearStuckSessionOnBoot in node with a fake localStorage/history and
-    report whether each was cleared."""
-    assert NODE, "node is required"
-    js = _read(SESSIONS_JS)
-    start = js.index("function _clearStuckSessionOnBoot(sid, currentSid){")
-    end = js.index("\n}", start) + 2
-    helper_src = js[start:end]
-    script = f"""
-let removed=false, replaced=false;
-const localStorage = {{ removeItem(k){{ if(k==='hermes-webui-session') removed=true; }} }};
-const history = {{ replaceState(){{ replaced=true; }} }};
-function _appRootPath(){{ return '/'; }}
-{helper_src}
-_clearStuckSessionOnBoot('dead-sid', {current_sid_js});
-process.stdout.write(JSON.stringify({{removed, replaced}}));
-"""
-    out = subprocess.run([NODE, "-e", script], capture_output=True, text=True, timeout=20)
-    assert out.returncode == 0, f"node failed: {out.stderr}"
-    return json.loads(out.stdout)
+def _extract_optional(source: str, marker: str) -> str:
+    return _extract_js_block(source, marker) if marker in source else ""
 
 
-def test_clears_stale_session_on_boot_failure():
-    """No active session (boot) + a failed load → clear the stale id so the next
-    boot doesn't retry the dead session."""
-    data = _run_helper("null")
-    assert data["removed"] is True
-    assert data["replaced"] is True
+@lru_cache(maxsize=1)
+def _run_frontend_scenarios() -> dict:
+    sessions_js = _read(SESSIONS_JS)
+    scenarios = {
+        "http500": {
+            "sid": "boot-session",
+            "savedSid": "boot-session",
+            "routeSid": "boot-session",
+            "metadataFailure": {"status": 500},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "network": {
+            "sid": "boot-session",
+            "savedSid": "boot-session",
+            "routeSid": "boot-session",
+            "metadataFailure": {"status": None, "message": "network down"},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "http404": {
+            "sid": "dead-session",
+            "savedSid": "dead-session",
+            "routeSid": "dead-session",
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "urlOnly404": {
+            "sid": "url-only-dead-session",
+            "savedSid": None,
+            "routeSid": "url-only-dead-session",
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "localStorageOnly404": {
+            "sid": "saved-only-dead-session",
+            "savedSid": "saved-only-dead-session",
+            "routeSid": None,
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "conflictingState404": {
+            "sid": "session-B",
+            "savedSid": "session-A",
+            "routeSid": "session-B",
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "liveActiveConflict404": {
+            "sid": "session-A",
+            "savedSid": "session-B",
+            "routeSid": "session-B",
+            "activeSid": "session-A",
+            "force": True,
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "liveActiveChanges404": {
+            "sid": "session-A",
+            "savedSid": "session-B",
+            "routeSid": "session-B",
+            "activeSid": "session-A",
+            "activeSidBeforeReject": "session-B",
+            "deferMetadata": True,
+            "force": True,
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "storageReadFailure404": {
+            "sid": "route-owned-dead-session",
+            "savedSid": "saved-live-session",
+            "routeSid": "route-owned-dead-session",
+            "storageReadFailure": True,
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "routeReadFailure404": {
+            "sid": "saved-owned-dead-session",
+            "savedSid": "saved-owned-dead-session",
+            "routeSid": "route-live-session",
+            "routeReadFailure": True,
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+        },
+        "profileSwitch404": {
+            "sid": "profile-session",
+            "savedSid": "profile-session",
+            "routeSid": "profile-session",
+            "metadataFailure": {
+                "status": 409,
+                "body": json.dumps(
+                    {
+                        "code": "session_profile_mismatch",
+                        "profile": "other",
+                        "session_id": "profile-session",
+                    }
+                ),
+            },
+            "profileSwitchFailure": {"status": 404},
+        },
+        "deadBWithSavedA": {
+            "sid": "session-B",
+            "savedSid": "session-A",
+            "routeSid": "session-A",
+            "metadataFailure": {"status": 404},
+            "profileSwitchFailure": {"status": 500},
+            "concurrent": True,
+        },
+    }
+    script = textwrap.dedent(
+        """
+        const vm = require('vm');
+        const helperSource = %s;
+        const profileMismatchSource = %s;
+        const loadSessionSource = %s;
+        const scenarios = %s;
+
+        function makeError(spec) {
+          const error = new Error(spec.message || 'HTTP failure');
+          if (spec.status !== null && spec.status !== undefined) error.status = spec.status;
+          if (spec.body !== undefined) error.body = spec.body;
+          return error;
+        }
+
+        async function runScenario(config) {
+          const values = new Map([['hermes-webui-session', config.savedSid]]);
+          const historyCalls = [];
+          const apiCalls = [];
+          let pendingFirstLoadReject;
+          let pendingMetadataReject;
+          let storageReadFailed = false;
+          const location = { href: config.routeSid === null
+            ? 'https://hermes.test/'
+            : `https://hermes.test/session/${encodeURIComponent(config.routeSid)}` };
+          const message = { innerHTML: '' };
+          const streamStarts = [];
+          const context = {
+            console,
+            window: {},
+            S: {
+              session: config.activeSid ? {session_id: config.activeSid} : null,
+              messages: [], toolCalls: [], busy: false, activeStreamId: null,
+            },
+            INFLIGHT: {},
+            _loadingSessionId: null,
+            _loadSessionGeneration: 0,
+            _messagesTruncated: false,
+            _oldestIdx: 0,
+            _loadingOlder: false,
+            _yoloEnabled: false,
+            localStorage: {
+              getItem(key) {
+                if (config.storageReadFailure && !storageReadFailed) {
+                  storageReadFailed = true;
+                  throw new Error('storage read failed');
+                }
+                return values.has(key) ? values.get(key) : null;
+              },
+              setItem(key, value) { values.set(key, String(value)); },
+              removeItem(key) { values.delete(key); },
+            },
+            history: {
+              replaceState(...args) {
+                historyCalls.push(args);
+                location.href = args[2];
+              },
+            },
+            location,
+            $: id => id === 'msgInner' ? message : null,
+            _appRootPath: () => '/',
+            _sessionIdFromLocation: () => {
+              if (config.routeReadFailure) throw new Error('route read failed');
+              return config.routeSid;
+            },
+            _rearmActiveSessionStream: () => {},
+            _updateYoloPill: () => {},
+            stopApprovalPolling: () => {},
+            hideApprovalCard: () => {},
+            stopSessionStream: () => {},
+            _clearSameSessionForceReloadHint: () => {},
+            _captureSameSessionForceReloadHint: () => {},
+            startSessionStream: sid => streamStarts.push(sid),
+            api(path) {
+              apiCalls.push(String(path));
+              if (config.concurrent && path.includes('session_id=session-A')) {
+                return new Promise((resolve, reject) => { pendingFirstLoadReject = reject; });
+              }
+              if (config.deferMetadata && path.startsWith('/api/session?')) {
+                return new Promise((resolve, reject) => { pendingMetadataReject = reject; });
+              }
+              const failure = path === '/api/profile/switch'
+                ? config.profileSwitchFailure
+                : config.metadataFailure;
+              return Promise.reject(makeError(failure));
+            },
+            showToast: () => {},
+          };
+          context._switchProfileForSessionLoad = () => context.api('/api/profile/switch');
+          vm.createContext(context);
+          vm.runInContext(
+            helperSource + profileMismatchSource + loadSessionSource,
+            context,
+            {filename: 'sessions.js'},
+          );
+          let firstLoad;
+          if (config.concurrent) {
+            firstLoad = vm.runInContext(
+              "loadSession('session-A', {skipLineageResolve:true, skipExtHooks:true})",
+              context,
+            );
+            await Promise.resolve();
+          }
+          const loadOptions = config.force
+            ? {skipLineageResolve:true, skipExtHooks:true, force:true}
+            : {skipLineageResolve:true, skipExtHooks:true};
+          const loadExpression = `loadSession(${JSON.stringify(config.sid)}, ${JSON.stringify(loadOptions)})`;
+          let pendingLoad;
+          if (config.deferMetadata) {
+            pendingLoad = vm.runInContext(loadExpression, context);
+            await Promise.resolve();
+            context.S.session = {session_id: config.activeSidBeforeReject};
+            pendingMetadataReject(makeError(config.metadataFailure));
+          }
+          let rejectedStatus = null;
+          try {
+            await (pendingLoad || vm.runInContext(loadExpression, context));
+          } catch (error) {
+            rejectedStatus = error && error.status || null;
+          }
+          if (firstLoad) {
+            pendingFirstLoadReject(makeError({status: 404}));
+            await firstLoad;
+          }
+          return {
+            remainingPointer: context.localStorage.getItem('hermes-webui-session'),
+            historyCalls,
+            url: context.location.href,
+            rejectedStatus,
+            apiCalls,
+            loadingSessionId: context._loadingSessionId,
+            streamStarts,
+          };
+        }
+
+        (async () => {
+          const result = {};
+          for (const [name, config] of Object.entries(scenarios)) {
+            result[name] = await runScenario(config);
+          }
+          process.stdout.write(JSON.stringify(result));
+        })().catch(error => {
+          console.error(error && error.stack || error);
+          process.exit(1);
+        });
+        """
+        % (
+            json.dumps(_extract_optional(sessions_js, "function _clearStuckSessionOnBoot(")),
+            json.dumps(_extract_js_block(sessions_js, "function _sessionProfileMismatchFromError(")),
+            json.dumps(_extract_js_block(sessions_js, "async function loadSession(")),
+            json.dumps(scenarios),
+        )
+    )
+    result = subprocess.run(
+        [NODE, "-e", script],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"node failed:\n{result.stderr}\n{result.stdout}"
+    return json.loads(result.stdout)
 
 
-def test_does_not_clear_when_viewing_a_healthy_session():
-    """An active session on screen (currentSid set) → do NOT wipe localStorage/URL;
-    the failure may be transient and the live session must survive (#2782/#4028)."""
-    data = _run_helper("'live-session-123'")
-    assert data["removed"] is False
-    assert data["replaced"] is False
+def test_non_404_metadata_failures_preserve_saved_session_state():
+    results = _run_frontend_scenarios()
+    for name in ("http500", "network"):
+        result = results[name]
+        assert result["remainingPointer"] == "boot-session", result
+        assert result["historyCalls"] == [], result
+        assert result["url"] == "https://hermes.test/session/boot-session", result
+        assert result["loadingSessionId"] is None, result
 
 
-def test_stale_load_guard_present_before_self_heal():
-    """A superseded in-flight load (a newer loadSession started during the await)
-    must bail BEFORE any self-heal/DOM mutation, so a failed boot restore can't
-    wipe localStorage/URL for the session the user navigated to mid-flight (Codex
-    race finding). The guard re-arms the active stream and returns."""
-    js = _read(SESSIONS_JS)
-    # Anchor on the self-heal CALL (unique; the bare name also appears in the
-    # helper's docstring), then look at the preceding window of the same
-    # loadSession catch block for the stale-load guard.
-    heal_idx = js.index("_clearStuckSessionOnBoot(sid, currentSid);")
-    block = js[heal_idx - 2400: heal_idx + 60]
-    guard = "if (!_isCurrentLoad()) {"
-    assert guard in block, "stale-load guard missing from the loadSession catch block"
-    # The guard must come BEFORE the self-heal call (so a superseded load can't clear).
-    assert block.index(guard) < block.index("_clearStuckSessionOnBoot(sid, currentSid);"), \
-        "stale-load guard must precede _clearStuckSessionOnBoot"
-    # And before the 404 inline clear too.
-    assert block.index(guard) < block.index("localStorage.removeItem('hermes-webui-session')"), \
-        "stale-load guard must precede the 404 inline self-heal"
-    # It re-arms the active stream rather than leaving it torn down.
-    guard_tail = block[block.index(guard): block.index(guard) + 120]
-    assert "_rearmActiveSessionStream()" in guard_tail
+def test_direct_metadata_404_clears_owned_saved_session_state():
+    result = _run_frontend_scenarios()["http404"]
+    assert result["remainingPointer"] is None, result
+    assert result["historyCalls"] == [[None, "", "/"]], result
+    assert result["url"] == "/", result
+    assert result["rejectedStatus"] == 404, result
+    assert result["loadingSessionId"] is None, result
+
+
+def test_url_only_metadata_404_clears_owned_route():
+    result = _run_frontend_scenarios()["urlOnly404"]
+    assert result["remainingPointer"] is None, result
+    assert result["historyCalls"] == [[None, "", "/"]], result
+    assert result["url"] == "/", result
+    assert result["rejectedStatus"] == 404, result
+    assert result["loadingSessionId"] is None, result
+
+
+def test_localstorage_only_metadata_404_clears_only_saved_pointer():
+    result = _run_frontend_scenarios()["localStorageOnly404"]
+    assert result["remainingPointer"] is None, result
+    assert result["historyCalls"] == [], result
+    assert result["url"] == "https://hermes.test/", result
+    assert result["rejectedStatus"] == 404, result
+    assert result["loadingSessionId"] is None, result
+
+
+def test_conflicting_metadata_404_clears_only_matching_route():
+    result = _run_frontend_scenarios()["conflictingState404"]
+    assert result["remainingPointer"] == "session-A", result
+    assert result["historyCalls"] == [[None, "", "/"]], result
+    assert result["url"] == "/", result
+    assert result["rejectedStatus"] == 404, result
+    assert result["loadingSessionId"] is None, result
+
+
+def test_live_active_metadata_404_preserves_conflicting_recovery_state():
+    result = _run_frontend_scenarios()["liveActiveConflict404"]
+    assert result["remainingPointer"] == "session-B", result
+    assert result["historyCalls"] == [], result
+    assert result["url"] == "https://hermes.test/session/session-B", result
+    assert result["rejectedStatus"] is None, result
+    assert result["loadingSessionId"] is None, result
+
+
+def test_live_active_transition_rearms_the_live_session_stream():
+    result = _run_frontend_scenarios()["liveActiveChanges404"]
+    assert result["remainingPointer"] == "session-B", result
+    assert result["historyCalls"] == [], result
+    assert result["url"] == "https://hermes.test/session/session-B", result
+    assert result["rejectedStatus"] is None, result
+    assert result["loadingSessionId"] is None, result
+    assert result["streamStarts"] == ["session-B"], result
+
+
+def test_metadata_404_component_reads_fail_independently():
+    storage_failure = _run_frontend_scenarios()["storageReadFailure404"]
+    assert storage_failure["remainingPointer"] == "saved-live-session", storage_failure
+    assert storage_failure["historyCalls"] == [[None, "", "/"]], storage_failure
+    assert storage_failure["rejectedStatus"] == 404, storage_failure
+    route_failure = _run_frontend_scenarios()["routeReadFailure404"]
+    assert route_failure["remainingPointer"] is None, route_failure
+    assert route_failure["historyCalls"] == [], route_failure
+    assert route_failure["url"] == "https://hermes.test/session/route-live-session", route_failure
+    assert route_failure["rejectedStatus"] == 404, route_failure
+
+
+def test_profile_switch_404_does_not_reclassify_metadata_failure():
+    result = _run_frontend_scenarios()["profileSwitch404"]
+    assert result["remainingPointer"] == "profile-session", result
+    assert result["historyCalls"] == [], result
+    assert result["url"] == "https://hermes.test/session/profile-session", result
+    assert result["rejectedStatus"] is None, result
+    assert result["apiCalls"][1] == "/api/profile/switch", result
+
+
+def test_unowned_boot_404_does_not_clear_saved_session_a_state():
+    result = _run_frontend_scenarios()["deadBWithSavedA"]
+    assert result["remainingPointer"] == "session-A", result
+    assert result["historyCalls"] == [], result
+    assert result["url"] == "https://hermes.test/session/session-A", result
+    assert result["rejectedStatus"] is None, result
+    assert result["loadingSessionId"] is None, result
+    assert "session_id=session-A" in result["apiCalls"][0], result
+    assert "session_id=session-B" in result["apiCalls"][1], result

--- a/tests/test_issue5671_workspace_switcher_a11y.py
+++ b/tests/test_issue5671_workspace_switcher_a11y.py
@@ -111,7 +111,7 @@ def test_new_chat_has_screen_reader_only_workspace_announcer():
 
 def test_new_session_announces_started_workspace_without_leaving_stale_browse_text():
     helper = _block(SESSIONS_JS, "function _setNewSessionWorkspaceCue", "function _setNewSessionPending")
-    new_session = _block(SESSIONS_JS, "async function newSession", "/**\n * Self-heal")
+    new_session = _block(SESSIONS_JS, "async function newSession", "function _rearmActiveSessionStream")
 
     assert "const announcer=$('a11yAnnouncer')" in helper
     assert "const composerCue=$('composerWorkspaceContext')" in helper

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -935,11 +935,12 @@ def test_load_session_rearms_stream_on_every_early_return():
         "helper must (re)arm startSessionStream for the currently-shown S.session"
     )
 
-    # Isolate the loadSession body. Widened window: the #4946 visit-ack helpers
-    # added inside loadSession pushed the fetch-error catch's stream restart past
-    # the old 14000-char cutoff.
+    # Isolate the loadSession body through its stable end marker. The #4946
+    # visit-ack helpers and restore-state handling can grow the catch path, so a
+    # fixed character window can cut off the restart assertion.
     fn_ix = js.index("async function loadSession(")
-    body = js[fn_ix:fn_ix + 16000]
+    body_end = js.index("  // Sync context usage indicator", fn_ix)
+    body = js[fn_ix:body_end]
 
     # The unconditional teardown must still be there (this is what creates the
     # dead-stream window the re-arm closes).
@@ -973,7 +974,7 @@ def test_load_session_rearms_stream_on_every_early_return():
     # but guarded against the self-healed-current (404'd) case so it never
     # spins the reconnect loop against a dead session_id.
     catch_ix = body.index("const _selfHealedCurrent")
-    catch_src = body[catch_ix:catch_ix + 2200]
+    catch_src = body[catch_ix:]
     assert "!_selfHealedCurrent" in catch_src and "startSessionStream(currentSid)" in catch_src, (
         "fetch-error path must restart the on-screen stream, guarded against "
         "the self-healed-current (deleted/404) session"

--- a/tests/test_stale_empty_session_restore.py
+++ b/tests/test_stale_empty_session_restore.py
@@ -104,9 +104,10 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     assert "_loadingSessionId = null" in block, (
         "loadSession must clear the in-flight load marker on 404"
     )
-    # Boot-time (!currentSid) rethrow so boot falls through to the empty state.
-    assert "!currentSid" in block, (
-        "loadSession must keep the !currentSid gate around the boot-time rethrow"
+    # Boot-time with no live active session rethrows so boot falls through to
+    # the empty state, after clearing only owned recovery components.
+    assert "!currentSid && (_savedOwned || _routeOwned)" in block, (
+        "loadSession must keep the no-live-session gate around the boot-time rethrow"
     )
     assert re.search(r"throw\s+e", block), (
         "loadSession must rethrow the stale saved-session 404 so boot can fall "
@@ -114,27 +115,26 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     )
 
 
-def test_load_session_404_self_heal_gated_to_active_or_boot():
-    """#2782: the localStorage clear + URL strip self-heal runs only when the
-    404'd id is the one being activated, gated on (!currentSid || currentSid===sid):
-    a boot-time restore (#2798) or a reload of the *current* session whose sidecar
-    was deleted. A click into a *different* dead session preserves the live
-    session's saved id and URL. Only the rethrow stays gated on !currentSid."""
+def test_load_session_404_self_heal_uses_component_ownership():
+    """#2782: self-heal independently clears matching recovery components."""
+    block = _load_session_error_block()
     arm = _load_session_404_block()
-    self_heal = "if(!currentSid || currentSid===sid)"
-    assert self_heal in arm, (
-        "self-heal must be gated to boot or the active session, not unconditional"
+    assert "currentSid = S.session ? S.session.session_id : null;" in block, (
+        "metadata failure handling must refresh the live active session"
     )
-    heal_idx = arm.find(self_heal)
-    clear_idx = arm.find("localStorage.removeItem('hermes-webui-session')")
-    strip_idx = arm.find("history.replaceState")
-    assert clear_idx > heal_idx, "localStorage clear must run inside the self-heal gate"
-    assert strip_idx > heal_idx, "URL strip must run inside the self-heal gate"
-    # The boot-time rethrow stays nested on !currentSid, inside the self-heal gate.
-    rethrow_gate_idx = arm.find("if(!currentSid)")
-    assert rethrow_gate_idx > heal_idx, "the !currentSid rethrow gate must remain"
-    assert re.search(r"throw\s+e", arm[rethrow_gate_idx:]), (
-        "the !currentSid gate must still contain the boot-time rethrow"
+    assert "const _savedOwned = _savedSid===sid;" in arm, (
+        "saved-pointer cleanup must be independently owned"
+    )
+    assert "const _routeOwned = _routeSid===sid;" in arm, (
+        "route cleanup must be independently owned"
+    )
+    assert "if(_savedOwned){" in arm, "saved-pointer cleanup must use its own ownership"
+    assert "if(_routeOwned){" in arm, "route cleanup must use its own ownership"
+    assert "if(!currentSid && (_savedOwned || _routeOwned)){" in arm, (
+        "boot rethrow must depend on live state and owned components"
+    )
+    assert re.search(r"throw\s+e", arm), (
+        "the owned boot 404 must still rethrow to the empty state"
     )
 
 

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -27,7 +27,7 @@ def _scroll_listener_block() -> str:
 def test_clicking_current_session_is_noop_before_load_session_side_effects():
     load_session = _function_body(SESSIONS_JS, "async function loadSession")
 
-    current_idx = load_session.index("const currentSid = S.session ? S.session.session_id : null")
+    current_idx = load_session.index("currentSid = S.session ? S.session.session_id : null")
     noop_idx = load_session.index("if(currentSid===sid && !forceReload) return")
     loading_idx = load_session.index("_loadingSessionId = sid")
     stop_idx = load_session.index("stopApprovalPolling")


### PR DESCRIPTION
## Thinking Path

- A WebUI reload can leave a valid conversation and its draft intact while returning the user to New Chat.
- The session metadata recovery path treated transient failures as proof that the saved session was stale and removed its recovery state.
- This change preserves the saved pointer and route for non-404 metadata failures, while retaining cleanup for recovery components that still belong to a definitive metadata 404.
- The fix is limited to session restoration. It does not claim to prevent or identify the event that initiated the page reload.
- Cleanup is component-specific so a dead URL cannot remove an unrelated saved-session pointer.
- Session loading, profile switching, streaming, and unrelated navigation behavior should remain unchanged outside failure recovery.

## What Changed

- Removed destructive saved-session cleanup from non-404 metadata failure handling.
- Kept metadata 404 cleanup limited to the saved pointer or route whose current value still matches the requested session.
- Preserved the original metadata failure classification when an attempted profile switch also fails.
- Refreshed active-session ownership after asynchronous metadata work before deciding cleanup and stream recovery.
- Added executable recovery scenarios and updated the canonical session-resolution contract.

## Why It Matters

- A transient timeout, network failure, or server error no longer converts a recoverable conversation into a New Chat fallback.
- A valid saved-session pointer survives when only a conflicting URL identifies a missing session.
- Concurrent navigation cannot use a stale pre-request session snapshot to remove newer recovery state.
- A later reload can retry the preserved conversation instead of losing the selected-session context.

## UI Evidence

This change does not alter layout or styling. The affected transition is intermittent and has not been reproduced on demand against this exact draft SHA, so no screenshot is attached yet.

Expected behavior: after a transient restore failure, WebUI keeps the existing session recovery state rather than binding the page to New Chat.

## Verification

Targeted and adjacent coverage:

`python -m pytest -q --noconftest tests/test_session_channel_option_x.py::test_load_session_rearms_stream_on_every_early_return tests/test_tars_scroll_reset_regressions.py::test_clicking_current_session_is_noop_before_load_session_side_effects tests/test_issue5671_workspace_switcher_a11y.py::test_new_session_announces_started_workspace_without_leaving_stale_browse_text tests/test_issue3479_ios_stream_scroll_jump.py::test_same_session_force_refresh_does_not_reset_scroll_direction_tracker tests/test_issue3993_session_load_self_heal.py tests/test_stale_empty_session_restore.py tests/test_canonical_session_resolution_rfc.py tests/test_issue6572_loadsession_compression_cleanup.py tests/test_parallel_session_switch.py`

Result: `63 passed`

Syntax and hygiene checks:

- `node --check static/sessions.js`
- `ruff check tests/test_issue3993_session_load_self_heal.py tests/test_stale_empty_session_restore.py`
- `python scripts/ruff_lint.py --diff origin/master`
- `git diff --check origin/master...HEAD`

Result: all passed.

Native CI is pending on the published draft SHA.

## Contract Routing

This change updates the restoration rules in `docs/rfcs/canonical-session-resolution.md`. The session metadata load path owns whether a failure proves absence and which recovery components may be removed.

## Contract Change

A non-404 session metadata failure now preserves the saved active-session ID and session URL. A metadata 404 may clear each recovery component only when that component still identifies the requested session.

## Risks / Follow-ups

- Draft blocker: the broad boot catch can still remove an unrelated saved pointer after a route-only metadata 404. This must be resolved before the PR is marked ready.
- Draft blocker: the runtime regression harness needs simplification, and remaining source-shape assertions should be replaced with observable behavior checks.
- The event that initiates the full page reload remains unknown and is intentionally out of scope.
- Physical-device validation against this exact SHA is pending.

## Models Used

- Hermes Agent / `gpt-5.6-sol` (`Default`) via OpenAI Codex: Investigation, specification, orchestration, and verification.
- Codex / `gpt-5.6-luna` (`max`) via OpenAI Codex CLI: Implementation, regression coverage, and adversarial review.
