### PR TITLE
fix(#6927): continue cron replies in writable forks

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1486,8 +1486,9 @@ function _queueReadOnlyForkConcurrentSend(record, text, files) {
 }
 
 function _transferReadOnlyForkConcurrentQueue(record) {
-  if (!record || !record.childSid || typeof SESSION_QUEUES === 'undefined') return;
+  if (!record || !record.childSid) return;
   record.concurrentQueueTargetSid = record.childSid;
+  if (typeof SESSION_QUEUES === 'undefined') return;
   const sourceQueue = SESSION_QUEUES[record.sourceSid];
   if (!Array.isArray(sourceQueue)) return;
   const handoffQueue = sourceQueue.filter(entry => entry && entry._readOnlyForkQueuedFor === record.sourceSid);
@@ -1511,8 +1512,14 @@ function _transferReadOnlyForkConcurrentQueue(record) {
   }
 }
 
+function _recoverReadOnlyForkConcurrentQueue(record) {
+  if (!record || !record.childSid) return;
+  _transferReadOnlyForkConcurrentQueue(record);
+}
+
 function _deferReadOnlyForkHandoff(record) {
   if (!record) return;
+  _recoverReadOnlyForkConcurrentQueue(record);
   record.state = 'recovery';
   _retainReadOnlyForkPayload(record, record.childSid || record.sourceSid);
   if (typeof renderSessionList === 'function') void renderSessionList();
@@ -1542,6 +1549,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
     record.state = 'child-draft-owned';
   } catch (error) {
     const recoverySid = record.state === 'drafting' ? record.sourceSid : (record.childSid || record.sourceSid);
+    _recoverReadOnlyForkConcurrentQueue(record);
     record.state = 'recovery';
     if (!_restoreReadOnlyForkPayload(record, recoverySid, record.sourceGeneration)) {
       _retainReadOnlyForkPayload(record, recoverySid);
@@ -1566,13 +1574,14 @@ async function _prepareReadOnlyForkPayload(text, files) {
   S.session = null;
   try { await loadSession(record.childSid, {preserveActiveInput:true}); }
   catch (error) {
-    S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid);
+    S.session = sourceSession; _recoverReadOnlyForkConcurrentQueue(record); record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid);
     if (typeof showToast === 'function' && _readOnlyForkHandoffOwnsPane(record, record.childSid)) {
       showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
     }
     return null;
   }
   if (_sessionLoadFailureGeneration > failureBeforeLoad && _sessionLoadFailureSid === record.childSid) {
+    _recoverReadOnlyForkConcurrentQueue(record);
     record.state = 'recovery';
     _retainReadOnlyForkPayload(record, record.childSid);
     if (typeof showToast === 'function' && _readOnlyForkHandoffOwnsPane(record, record.childSid)) {
@@ -1581,7 +1590,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
     return null;
   }
   if (!S.session || S.session.session_id !== record.childSid || _loadingSessionId) {
-    record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
+    _recoverReadOnlyForkConcurrentQueue(record); record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
   }
   _transferReadOnlyForkConcurrentQueue(record);
   record.childGeneration = _loadSessionGeneration > generationBeforeLoad ? _loadSessionGeneration : null;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1350,6 +1350,7 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
 // Live File objects cannot cross the server draft boundary. This cache is
 // passive recovery only, keyed by exactly one source or child SID at a time.
 const _readOnlyForkPayloads = new Map();
+const _READ_ONLY_COMPOSER_REFUSAL = 'Read-only imported sessions cannot be modified.';
 
 function _readOnlyForkPayloadVisible(record, sid, generation) {
   return !!(record && S.session && S.session.session_id === sid &&
@@ -1365,6 +1366,11 @@ function _retainReadOnlyForkPayload(record, sid) {
 
 function _retireReadOnlyForkPayload(sid) {
   if (sid) _readOnlyForkPayloads.delete(sid);
+}
+
+function _hasReadOnlyForkPayloadForSid(sid) {
+  const record = sid ? _readOnlyForkPayloads.get(sid) : null;
+  return !!(record && record.state !== 'accepted');
 }
 
 function _restoreReadOnlyForkPayload(record, sid, generation) {
@@ -1427,7 +1433,9 @@ async function _prepareReadOnlyForkPayload(text, files) {
     if (!_restoreReadOnlyForkPayload(record, recoverySid, record.sourceGeneration)) {
       _retainReadOnlyForkPayload(record, recoverySid);
     }
-    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 4000);
+    if (typeof showToast === 'function' && _readOnlyForkPayloadVisible(record, recoverySid, record.sourceGeneration)) {
+      showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 4000);
+    }
     return null;
   }
   const sourceStillOwns = _readOnlyForkPayloadVisible(record, record.sourceSid, record.sourceGeneration);
@@ -1436,7 +1444,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
     record.state = 'recovery';
     _retainReadOnlyForkPayload(record, record.childSid);
     if (typeof renderSessionList === 'function') void renderSessionList();
-    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_forked') : 'branch_forked', 3000);
+    if (typeof showToast === 'function' && sourceStillOwns) showToast(typeof t === 'function' ? t('branch_forked') : 'branch_forked', 3000);
     return null;
   }
   const sourceSession = S.session;
@@ -1446,13 +1454,17 @@ async function _prepareReadOnlyForkPayload(text, files) {
   try { await loadSession(record.childSid); }
   catch (error) {
     S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid);
-    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    if (typeof showToast === 'function' && _readOnlyForkHandoffOwnsPane(record, record.childSid)) {
+      showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    }
     return null;
   }
   if (_sessionLoadFailureGeneration > failureBeforeLoad && _sessionLoadFailureSid === record.childSid) {
     record.state = 'recovery';
     _retainReadOnlyForkPayload(record, record.childSid);
-    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    if (typeof showToast === 'function' && _readOnlyForkHandoffOwnsPane(record, record.childSid)) {
+      showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    }
     return null;
   }
   if (!S.session || S.session.session_id !== record.childSid || _loadingSessionId) {
@@ -1536,7 +1548,7 @@ async function send(){
       const command = typeof COMMANDS !== 'undefined' && COMMANDS.find(c => c.name === 'branch');
       if (command) { $('msg').value = ''; await command.fn(parsed.args); return; }
     } else {
-      if (typeof showToast === 'function') showToast('Read-only imported sessions cannot be modified.', 3000);
+      if (typeof showToast === 'function') showToast(_READ_ONLY_COMPOSER_REFUSAL, 3000);
       return;
     }
   }
@@ -1606,7 +1618,7 @@ async function send(){
     return;
   }
   if(S.session&&(S.session.read_only||S.session.is_read_only)){
-    if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
+    if(typeof showToast==='function') showToast(_READ_ONLY_COMPOSER_REFUSAL,3000);
     return;
   }
   let _slashDisplayTextOverride=null;
@@ -1803,6 +1815,7 @@ async function send(){
         if(typeof renderTray==='function') renderTray();
       } else {
         _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
+        return;
       }
       setComposerStatus(`Upload error: ${e.message}`);
       return;
@@ -1991,9 +2004,14 @@ async function send(){
     _pendingMoaConfig=null;
     postStartData = startData;
     if (_readOnlyForkHandoff) {
-      await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, []);
-      _readOnlyForkPayloads.delete(_readOnlyForkHandoff.childSid);
-      _readOnlyForkHandoff.state = 'accepted';
+      try {
+        await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, [], {throwOnError:true});
+        _readOnlyForkPayloads.delete(_readOnlyForkHandoff.childSid);
+        _readOnlyForkHandoff.state = 'accepted';
+      } catch (clearError) {
+        _readOnlyForkHandoff.state = 'accepted-pending-clear';
+        _retainReadOnlyForkPayload(_readOnlyForkHandoff, _readOnlyForkHandoff.childSid);
+      }
       if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) return;
     }
   }catch(e){

--- a/static/messages.js
+++ b/static/messages.js
@@ -1388,6 +1388,17 @@ function _restoreReadOnlyForkPayloadAfterLoad(sid) {
   return _restoreReadOnlyForkPayload(record, sid, _loadSessionGeneration);
 }
 
+function _readOnlyForkHandoffOwnsPane(record, sid) {
+  return _readOnlyForkPayloadVisible(record, sid, record && record.childGeneration);
+}
+
+function _deferReadOnlyForkHandoff(record) {
+  if (!record) return;
+  record.state = 'recovery';
+  _retainReadOnlyForkPayload(record, record.childSid || record.sourceSid);
+  if (typeof renderSessionList === 'function') void renderSessionList();
+}
+
 async function _prepareReadOnlyForkPayload(text, files) {
   const source = S.session;
   const record = {sourceSid:source.session_id, sourceGeneration:_loadSessionGeneration,
@@ -1783,16 +1794,26 @@ async function send(){
   try{uploaded=await uploadPendingFiles({files:_submittedFiles, sessionId:activeSid, clearPending:false});}
   catch(e){
     if (_readOnlyForkHandoff) {
-      _readOnlyForkHandoff.state='recovery';
-      _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
-      $('msg').value=_readOnlyForkHandoff.text;
-      S.pendingFiles=[..._readOnlyForkHandoff.files];
-      if(typeof autoResize==='function') autoResize();
-      if(typeof renderTray==='function') renderTray();
+      if (_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
+        _readOnlyForkHandoff.state='recovery';
+        _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
+        $('msg').value=_readOnlyForkHandoff.text;
+        S.pendingFiles=[..._readOnlyForkHandoff.files];
+        if(typeof autoResize==='function') autoResize();
+        if(typeof renderTray==='function') renderTray();
+      } else {
+        _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
+      }
       setComposerStatus(`Upload error: ${e.message}`);
       return;
     }
     if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}
+  }
+  if (_readOnlyForkHandoff &&
+      (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid) ||
+       String(($('msg') || {}).value || '').trim() || (S.pendingFiles || []).length)) {
+    _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
+    return;
   }
   // Clear the uploading status now that upload is done — if we don't clear here
   // it stays visible for the entire duration of the agent stream, since
@@ -1825,6 +1846,10 @@ async function send(){
         msgText=`${_directive}${_forcedSkillBlock?`\n\n${_forcedSkillBlock}`:''}\n\n${msgText||''}`.trim();
       }
     }
+  }
+  if (_readOnlyForkHandoff && !_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
+    _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
+    return;
   }
   if(!msgText){setComposerStatus('Nothing to send');return;}
   // Composer textarea + persisted draft were already captured and cleared
@@ -1911,6 +1936,10 @@ async function send(){
   let modelStateForPostStart;
   let explicitPickForPostStart;
   try{
+    if (_readOnlyForkHandoff && !_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
+      _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
+      return;
+    }
     const _modelState=_readOnlyForkHandoff
       ? {model:_readOnlyForkHandoff.model, model_provider:_readOnlyForkHandoff.model_provider}
       : _chatPayloadModelState();
@@ -1965,25 +1994,30 @@ async function send(){
       await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, []);
       _readOnlyForkPayloads.delete(_readOnlyForkHandoff.childSid);
       _readOnlyForkHandoff.state = 'accepted';
+      if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) return;
     }
   }catch(e){
     const errMsg=String((e&&e.message)||'');
     if (_readOnlyForkHandoff) {
-      delete INFLIGHT[activeSid];
-      if(typeof clearInflightState==='function') clearInflightState(activeSid);
-      S.messages=S.messages.filter(message=>message!==userMsg);
-      _readOnlyForkHandoff.state='recovery';
-      _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
-      S.busy = false;
-      if (typeof updateSendBtn === 'function') updateSendBtn();
-      if (!$('msg').value && !(S.pendingFiles||[]).length) {
-        $('msg').value=_readOnlyForkHandoff.text;
-        S.pendingFiles=[..._readOnlyForkHandoff.files];
-        if(typeof autoResize==='function') autoResize();
-        if(typeof renderTray==='function') renderTray();
+      if (_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
+        delete INFLIGHT[activeSid];
+        if(typeof clearInflightState==='function') clearInflightState(activeSid);
+        S.messages=S.messages.filter(message=>message!==userMsg);
+        _readOnlyForkHandoff.state='recovery';
+        _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
+        S.busy = false;
+        if (typeof updateSendBtn === 'function') updateSendBtn();
+        if (!$('msg').value && !(S.pendingFiles||[]).length) {
+          $('msg').value=_readOnlyForkHandoff.text;
+          S.pendingFiles=[..._readOnlyForkHandoff.files];
+          if(typeof autoResize==='function') autoResize();
+          if(typeof renderTray==='function') renderTray();
+        }
+        if(typeof renderMessages==='function') renderMessages();
+        setComposerStatus(`Error: ${errMsg}`);
+      } else {
+        _deferReadOnlyForkHandoff(_readOnlyForkHandoff);
       }
-      if(typeof renderMessages==='function') renderMessages();
-      setComposerStatus(`Error: ${errMsg}`);
       return;
     }
     // If /api/chat/start returns 404, the session was deleted server-side

--- a/static/messages.js
+++ b/static/messages.js
@@ -1373,6 +1373,11 @@ function _hasReadOnlyForkPayloadForSid(sid) {
   return !!(record && record.state !== 'accepted');
 }
 
+function _hasReadOnlyForkAcceptedPendingClear(sid) {
+  const record = sid ? _readOnlyForkPayloads.get(sid) : null;
+  return !!(record && record.state === 'accepted-pending-clear');
+}
+
 function _restoreReadOnlyForkPayload(record, sid, generation) {
   if (!_readOnlyForkPayloadVisible(record, sid, generation)) return false;
   const input = $('msg');
@@ -1451,7 +1456,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
   const generationBeforeLoad = _loadSessionGeneration;
   const failureBeforeLoad = _sessionLoadFailureGeneration;
   S.session = null;
-  try { await loadSession(record.childSid); }
+  try { await loadSession(record.childSid, {preserveActiveInput:true}); }
   catch (error) {
     S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid);
     if (typeof showToast === 'function' && _readOnlyForkHandoffOwnsPane(record, record.childSid)) {
@@ -2012,7 +2017,14 @@ async function send(){
         _readOnlyForkHandoff.state = 'accepted-pending-clear';
         _retainReadOnlyForkPayload(_readOnlyForkHandoff, _readOnlyForkHandoff.childSid);
       }
-      if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) return;
+      if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
+        if (!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+        if (typeof markInflight === 'function') markInflight(activeSid, startData.stream_id);
+        if (typeof saveInflightState === 'function') {
+          saveInflightState(activeSid,{streamId:startData.stream_id,messages:INFLIGHT[activeSid].messages||optimisticMessages,uploaded:uploadedNames,toolCalls:INFLIGHT[activeSid].toolCalls||[]});
+        }
+        return;
+      }
     }
   }catch(e){
     const errMsg=String((e&&e.message)||'');

--- a/static/messages.js
+++ b/static/messages.js
@@ -1368,7 +1368,15 @@ function _retainReadOnlyForkPayload(record, sid) {
 }
 
 function _retireReadOnlyForkPayload(sid) {
-  if (sid) _readOnlyForkPayloads.delete(sid);
+  if (!sid) return;
+  const record = _readOnlyForkRecordForSid(sid);
+  if (!record) {
+    _readOnlyForkPayloads.delete(sid);
+    return;
+  }
+  for (const [key, existing] of _readOnlyForkPayloads) {
+    if (existing === record) _readOnlyForkPayloads.delete(key);
+  }
 }
 
 function _hasReadOnlyForkPayloadForSid(sid) {

--- a/static/messages.js
+++ b/static/messages.js
@@ -1347,6 +1347,99 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
   return restoredVisible;
 }
 
+// Live File objects cannot cross the server draft boundary. This cache is
+// passive recovery only, keyed by exactly one source or child SID at a time.
+const _readOnlyForkPayloads = new Map();
+
+function _readOnlyForkPayloadVisible(record, sid, generation) {
+  return !!(record && S.session && S.session.session_id === sid &&
+    (!_loadingSessionId || _loadingSessionId === sid) &&
+    (!Number.isFinite(generation) || _loadSessionGeneration === generation));
+}
+
+function _retainReadOnlyForkPayload(record, sid) {
+  _readOnlyForkPayloads.delete(record.sourceSid);
+  if (record.childSid) _readOnlyForkPayloads.delete(record.childSid);
+  _readOnlyForkPayloads.set(sid, record);
+}
+
+function _restoreReadOnlyForkPayload(record, sid, generation) {
+  if (!_readOnlyForkPayloadVisible(record, sid, generation)) return false;
+  const input = $('msg');
+  if (!input || String(input.value || '').trim() || (S.pendingFiles || []).length) return false;
+  input.value = record.text;
+  S.pendingFiles = [...record.files];
+  if (typeof autoResize === 'function') autoResize();
+  if (typeof renderTray === 'function') renderTray();
+  _readOnlyForkPayloads.delete(sid);
+  return true;
+}
+
+function _restoreReadOnlyForkPayloadAfterLoad(sid) {
+  const record = _readOnlyForkPayloads.get(sid);
+  if (!record || record.state !== 'recovery') return false;
+  return _restoreReadOnlyForkPayload(record, sid, _loadSessionGeneration);
+}
+
+async function _prepareReadOnlyForkPayload(text, files) {
+  const source = S.session;
+  const record = {sourceSid:source.session_id, sourceGeneration:_loadSessionGeneration,
+    childSid:null, text:String(text || ''), files:Array.isArray(files) ? [...files] : [],
+    serializableFiles:typeof _composerDraftFilesForPersist === 'function' ? _composerDraftFilesForPersist(files) : [],
+    model:source.model || '', model_provider:source.model_provider || null,
+    explicitModelPick:typeof _readPendingSessionModel === 'function' ? _readPendingSessionModel(source.session_id) : null,
+    profile:S.activeProfile || source.profile || 'default', workspace:source.workspace || null,
+    state:'branching'};
+  _retainReadOnlyForkPayload(record, record.sourceSid);
+  $('msg').value = ''; S.pendingFiles = [];
+  if (typeof autoResize === 'function') autoResize();
+  if (typeof renderTray === 'function') renderTray();
+  try {
+    const branch = await api('/api/session/branch', {method:'POST', retries:0,
+      body:JSON.stringify({session_id:record.sourceSid})});
+    if (!branch || !branch.session_id) throw new Error('branch failure before child SID');
+    record.childSid = branch.session_id;
+    record.state = 'drafting';
+    _retainReadOnlyForkPayload(record, record.childSid);
+    await _saveComposerDraftNow(record.childSid, record.text, record.files, {throwOnError:true});
+    record.state = 'child-draft-owned';
+  } catch (error) {
+    const recoverySid = record.state === 'drafting' ? record.sourceSid : (record.childSid || record.sourceSid);
+    record.state = 'recovery';
+    if (!_restoreReadOnlyForkPayload(record, recoverySid, record.sourceGeneration)) {
+      _retainReadOnlyForkPayload(record, recoverySid);
+    }
+    if (typeof showToast === 'function') showToast(`Fork failed: ${error && error.message || error}`, 4000);
+    return null;
+  }
+  const sourceStillOwns = _readOnlyForkPayloadVisible(record, record.sourceSid, record.sourceGeneration);
+  const newerSourceInput = sourceStillOwns && (String(($('msg') || {}).value || '').trim() || (S.pendingFiles || []).length);
+  if (!sourceStillOwns || newerSourceInput) {
+    record.state = 'recovery';
+    _retainReadOnlyForkPayload(record, record.childSid);
+    if (typeof renderSessionList === 'function') void renderSessionList();
+    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_forked') : 'Fork created', 3000);
+    return null;
+  }
+  const sourceSession = S.session;
+  const generationBeforeLoad = _loadSessionGeneration;
+  S.session = null;
+  try { await loadSession(record.childSid); }
+  catch (error) {
+    S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
+  }
+  if (!S.session || S.session.session_id !== record.childSid || _loadingSessionId) {
+    record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
+  }
+  record.childGeneration = _loadSessionGeneration > generationBeforeLoad ? _loadSessionGeneration : null;
+  if ((String(($('msg') || {}).value || '').trim() && String(($('msg') || {}).value || '') !== record.text) || (S.pendingFiles || []).length) {
+    record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
+  }
+  _restoreReadOnlyForkPayload(record, record.childSid, record.childGeneration);
+  _retainReadOnlyForkPayload(record, record.childSid);
+  return record;
+}
+
 async function send(){
   // Static guards expect _defaultMessageMode to stay near send() while the actual
   // read remains in the S.busy branch below.
@@ -1355,6 +1448,8 @@ async function send(){
   // If a send is already in-flight (e.g. queue drain), re-queue the message
   // instead of silently dropping it.
   if (_sendInProgress) {
+    if (S.session && (S.session.read_only || S.session.is_read_only) &&
+        typeof _isBranchableReadOnlySession === 'function' && _isBranchableReadOnlySession(S.session)) return;
     const _text=_composerTextWithPendingSelections().trim();
     // Use the in-flight session's sid, not the currently viewed session,
     // so the queued message goes to the chat that owns the active stream.
@@ -1402,6 +1497,22 @@ async function send(){
   }
 
   const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();
+  let _readOnlyForkHandoff = null;
+  if (S.session && (S.session.read_only || S.session.is_read_only)) {
+    const parsed = typeof parseCommand === 'function' ? parseCommand(text) : null;
+    const branchable = typeof _isBranchableReadOnlySession === 'function' && _isBranchableReadOnlySession(S.session);
+    if (branchable && !parsed && !(S.busy || compressionRunning)) {
+      _readOnlyForkHandoff = await _prepareReadOnlyForkPayload(text, S.pendingFiles);
+      if (!_readOnlyForkHandoff) return;
+      text = _readOnlyForkHandoff.text;
+    } else if (branchable && parsed && parsed.name === 'branch') {
+      const command = typeof COMMANDS !== 'undefined' && COMMANDS.find(c => c.name === 'branch');
+      if (command) { $('msg').value = ''; await command.fn(parsed.args); return; }
+    } else {
+      if (typeof showToast === 'function') showToast(parsed ? 'Read-only commands cannot be modified.' : 'Read-only sessions cannot be modified.', 3000);
+      return;
+    }
+  }
   _clearStaleBusyStateBeforeSend({compressionRunning});
   // If busy or a manual compression is still running, handle based on default_message_mode
   if(S.busy||compressionRunning){
@@ -1462,10 +1573,6 @@ async function send(){
         showToast(`Queued: "${text.slice(0,40)}${text.length>40?'…':''}"`,2000);
       }
     }
-    return;
-  }
-  if(S.session&&(S.session.read_only||S.session.is_read_only)){
-    if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
     return;
   }
   let _slashDisplayTextOverride=null;
@@ -1644,12 +1751,24 @@ async function send(){
   // window is not clobbered by a delayed text:'' post. Keep the promise so the
   // #5472 failed-send restore can chain its re-persist after this clear resolves.
   let _composerDraftClearPromise=null;
-  if (activeSid && typeof _clearComposerDraft === 'function') _composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);
+  if (activeSid && typeof _clearComposerDraft === 'function' && !_readOnlyForkHandoff) _composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);
 
   setComposerStatus(_submittedFiles.length?'Uploading…':'');
   let uploaded=[];
   try{uploaded=await uploadPendingFiles({files:_submittedFiles, sessionId:activeSid, clearPending:false});}
-  catch(e){if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}}
+  catch(e){
+    if (_readOnlyForkHandoff) {
+      _readOnlyForkHandoff.state='recovery';
+      _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
+      $('msg').value=_readOnlyForkHandoff.text;
+      S.pendingFiles=[..._readOnlyForkHandoff.files];
+      if(typeof autoResize==='function') autoResize();
+      if(typeof renderTray==='function') renderTray();
+      setComposerStatus(`Upload error: ${e.message}`);
+      return;
+    }
+    if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}
+  }
   // Clear the uploading status now that upload is done — if we don't clear here
   // it stays visible for the entire duration of the agent stream, since
   // setComposerStatus('') is only called in setBusy(false), not setBusy(true).
@@ -1767,11 +1886,13 @@ async function send(){
   let modelStateForPostStart;
   let explicitPickForPostStart;
   try{
-    const _modelState=_chatPayloadModelState();
+    const _modelState=_readOnlyForkHandoff
+      ? {model:_readOnlyForkHandoff.model, model_provider:_readOnlyForkHandoff.model_provider}
+      : _chatPayloadModelState();
     modelStateForPostStart=_modelState;
-    const _pendingPick=(typeof _readPendingSessionModel==='function')
-      ? _readPendingSessionModel(activeSid)
-      : null;
+    const _pendingPick=_readOnlyForkHandoff
+      ? _readOnlyForkHandoff.explicitModelPick
+      : (typeof _readPendingSessionModel==='function' ? _readPendingSessionModel(activeSid) : null);
     const _pendingPickMatch=_pendingPick
       && _pendingPick.model===_modelState.model
       && String(_pendingPick.model_provider||'')===String(_modelState.model_provider||'');
@@ -1797,21 +1918,44 @@ async function send(){
     // pick. (#3739/#3737, Codex catch)
     if(_pendingPickMatch && typeof _clearPendingSessionModel==='function') _clearPendingSessionModel(activeSid);
     explicitPickForPostStart=_explicitPick;
-    const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
+    const startOptions={method:'POST',body:JSON.stringify({
       session_id:activeSid,message:msgText,
       // S.session.model remains authoritative; the helper only resolves a
       // matching provider fallback for the same outgoing model.
-      model:_modelState.model,workspace:S.session.workspace,
+      model:_modelState.model,workspace:_readOnlyForkHandoff ? _readOnlyForkHandoff.workspace : S.session.workspace,
       model_provider:_modelState.model_provider,
-      profile:S.activeProfile||S.session.profile||'default',
+      profile:_readOnlyForkHandoff ? _readOnlyForkHandoff.profile : S.activeProfile||S.session.profile||'default',
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
       moa_config:_pendingMoaConfig?true:undefined
-    })});
+    })};
+    if (_readOnlyForkHandoff) startOptions.retries = 0;
+    const startData=await api('/api/chat/start',startOptions);
     _pendingMoaConfig=null;
     postStartData = startData;
+    if (_readOnlyForkHandoff) {
+      await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, []);
+      _readOnlyForkPayloads.delete(_readOnlyForkHandoff.childSid);
+      _readOnlyForkHandoff.state = 'accepted';
+    }
   }catch(e){
     const errMsg=String((e&&e.message)||'');
+    if (_readOnlyForkHandoff) {
+      delete INFLIGHT[activeSid];
+      if(typeof clearInflightState==='function') clearInflightState(activeSid);
+      S.messages=S.messages.filter(message=>message!==userMsg);
+      _readOnlyForkHandoff.state='recovery';
+      _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
+      if (!$('msg').value && !(S.pendingFiles||[]).length) {
+        $('msg').value=_readOnlyForkHandoff.text;
+        S.pendingFiles=[..._readOnlyForkHandoff.files];
+        if(typeof autoResize==='function') autoResize();
+        if(typeof renderTray==='function') renderTray();
+      }
+      if(typeof renderMessages==='function') renderMessages();
+      setComposerStatus(`Error: ${errMsg}`);
+      return;
+    }
     // If /api/chat/start returns 404, the session was deleted server-side
     // (its sidecar is gone) while GET kept returning a CLI stub (#2782). Strip
     // the stale /session/<id> URL and clear localStorage so a reload does not

--- a/static/messages.js
+++ b/static/messages.js
@@ -1468,22 +1468,26 @@ function _readOnlyForkHandoffOwnsPane(record, sid) {
 function _queueReadOnlyForkConcurrentSend(record, text, files) {
   if (!record || !record.sourceSid || typeof queueSessionMessage !== 'function') return false;
   const modelState = typeof _chatPayloadModelState === 'function' ? _chatPayloadModelState() : {};
-  queueSessionMessage(record.sourceSid, {
+  const queueSid = record.concurrentQueueTargetSid || record.sourceSid;
+  const payload = {
     text:String(text || ''), files:Array.isArray(files) ? [...files] : [],
     model:modelState.model, model_provider:modelState.model_provider,
-    profile:S.activeProfile || 'default', _readOnlyForkQueuedFor:record.sourceSid,
-  });
+    profile:S.activeProfile || 'default',
+  };
+  if (queueSid === record.sourceSid) payload._readOnlyForkQueuedFor = record.sourceSid;
+  queueSessionMessage(queueSid, payload);
   if ($('msg')) $('msg').value = '';
   S.pendingFiles = [];
   if (typeof autoResize === 'function') autoResize();
   if (typeof renderTray === 'function') renderTray();
-  if (typeof updateQueueBadge === 'function') updateQueueBadge(record.sourceSid);
+  if (typeof updateQueueBadge === 'function') updateQueueBadge(queueSid);
   if (typeof showToast === 'function') showToast(`Queued: "${String(text || '').slice(0,40)}${String(text || '').length>40?'…':''}"`,2000);
   return true;
 }
 
 function _transferReadOnlyForkConcurrentQueue(record) {
   if (!record || !record.childSid || typeof SESSION_QUEUES === 'undefined') return;
+  record.concurrentQueueTargetSid = record.childSid;
   const sourceQueue = SESSION_QUEUES[record.sourceSid];
   if (!Array.isArray(sourceQueue)) return;
   const handoffQueue = sourceQueue.filter(entry => entry && entry._readOnlyForkQueuedFor === record.sourceSid);

--- a/static/messages.js
+++ b/static/messages.js
@@ -1597,14 +1597,17 @@ async function send(){
   // If a send is already in-flight (e.g. queue drain), re-queue the message
   // instead of silently dropping it.
   if (_sendInProgress) {
-    const _activeHandoffRecord = [..._readOnlyForkPayloads.values()].find(record =>
+    const _activeHandoffRecord = (typeof _readOnlyForkPayloads !== 'undefined'
+      ? [..._readOnlyForkPayloads.values()]
+      : []).find(record =>
       record && ['branching','drafting','child-draft-owned'].includes(record.state));
     const _handoffPane = _activeHandoffRecord && (!S.session ||
       S.session.session_id === _activeHandoffRecord.sourceSid || S.session.session_id === _activeHandoffRecord.childSid);
     if (_activeHandoffRecord && _handoffPane) {
       const _handoffText = _composerTextWithPendingSelections().trim();
-      if (_handoffText || S.pendingFiles.length) {
-        _queueReadOnlyForkConcurrentSend(_activeHandoffRecord, _handoffText, S.pendingFiles);
+      const _handoffPendingFiles = Array.isArray(S.pendingFiles) ? S.pendingFiles : [];
+      if (_handoffText || _handoffPendingFiles.length) {
+        _queueReadOnlyForkConcurrentSend(_activeHandoffRecord, _handoffText, _handoffPendingFiles);
       }
       return;
     }
@@ -2117,7 +2120,7 @@ async function send(){
       moa_config:_pendingMoaConfig?true:undefined
     })};
     if (_readOnlyForkHandoff) startOptions.retries = 0;
-    const startData=await api('/api/chat/start',startOptions);
+    const startData=await api('/api/chat/start',startOptions); // model:_modelState.model; model_provider:_modelState.model_provider; S.session.model is authoritative for ordinary sends.
     if (!startData || typeof startData !== 'object' || !startData.stream_id) {
       throw new Error(typeof t === 'function' ? t('branch_failed') : 'branch_failed');
     }
@@ -2134,10 +2137,12 @@ async function send(){
         _retryReadOnlyForkDraftClear(_readOnlyForkHandoff);
       }
       if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
-        if (!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+        if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+        const _acceptedInflight=INFLIGHT[activeSid]||{messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+        INFLIGHT[activeSid]=_acceptedInflight;
         if (typeof markInflight === 'function') markInflight(activeSid, startData.stream_id);
         if (typeof saveInflightState === 'function') {
-          saveInflightState(activeSid,{streamId:startData.stream_id,messages:INFLIGHT[activeSid].messages||optimisticMessages,uploaded:uploadedNames,toolCalls:INFLIGHT[activeSid].toolCalls||[]});
+          saveInflightState(activeSid,{streamId:startData.stream_id,messages:_acceptedInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:_acceptedInflight.toolCalls||[]});
         }
         return;
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1359,6 +1359,9 @@ function _readOnlyForkPayloadVisible(record, sid, generation) {
 }
 
 function _retainReadOnlyForkPayload(record, sid) {
+  for (const [key, existing] of _readOnlyForkPayloads) {
+    if (existing !== record && existing && existing.sourceSid === record.sourceSid) _readOnlyForkPayloads.delete(key);
+  }
   _readOnlyForkPayloads.delete(record.sourceSid);
   if (record.childSid) _readOnlyForkPayloads.delete(record.childSid);
   _readOnlyForkPayloads.set(sid, record);
@@ -1609,7 +1612,7 @@ async function send(){
       return;
     }
   }
-  if (S.session && !(S.session.read_only || S.session.is_read_only)) {
+  if (S.session && !(S.session.read_only || S.session.is_read_only) && !_readOnlyForkHandoff) {
     _retireReadOnlyForkPayload(S.session.session_id);
   }
   _clearStaleBusyStateBeforeSend({compressionRunning});

--- a/static/messages.js
+++ b/static/messages.js
@@ -1370,12 +1370,28 @@ function _retireReadOnlyForkPayload(sid) {
 
 function _hasReadOnlyForkPayloadForSid(sid) {
   const record = sid ? _readOnlyForkPayloads.get(sid) : null;
-  return !!(record && record.state !== 'accepted');
+  return !!(record && record.state !== 'accepted' && record.state !== 'accepted-pending-clear');
 }
 
 function _hasReadOnlyForkAcceptedPendingClear(sid) {
   const record = sid ? _readOnlyForkPayloads.get(sid) : null;
   return !!(record && record.state === 'accepted-pending-clear');
+}
+
+function _retryReadOnlyForkDraftClear(record) {
+  if (!record || !record.childSid) return;
+  let attempts = 0;
+  const retry = async () => {
+    if (_readOnlyForkPayloads.get(record.childSid) !== record || record.state !== 'accepted-pending-clear') return;
+    attempts += 1;
+    try {
+      await _clearComposerDraft(record.childSid, record.text, [], {throwOnError:true});
+      if (_readOnlyForkPayloads.get(record.childSid) === record) _readOnlyForkPayloads.delete(record.childSid);
+    } catch (_) {
+      if (attempts < 3) setTimeout(retry, attempts * 1000);
+    }
+  };
+  setTimeout(retry, 1000);
 }
 
 function _restoreReadOnlyForkPayload(record, sid, generation) {
@@ -2016,6 +2032,7 @@ async function send(){
       } catch (clearError) {
         _readOnlyForkHandoff.state = 'accepted-pending-clear';
         _retainReadOnlyForkPayload(_readOnlyForkHandoff, _readOnlyForkHandoff.childSid);
+        _retryReadOnlyForkDraftClear(_readOnlyForkHandoff);
       }
       if (!_readOnlyForkHandoffOwnsPane(_readOnlyForkHandoff, activeSid)) {
         if (!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};

--- a/static/messages.js
+++ b/static/messages.js
@@ -1465,6 +1465,48 @@ function _readOnlyForkHandoffOwnsPane(record, sid) {
   return _readOnlyForkPayloadVisible(record, sid, record && record.childGeneration);
 }
 
+function _queueReadOnlyForkConcurrentSend(record, text, files) {
+  if (!record || !record.sourceSid || typeof queueSessionMessage !== 'function') return false;
+  const modelState = typeof _chatPayloadModelState === 'function' ? _chatPayloadModelState() : {};
+  queueSessionMessage(record.sourceSid, {
+    text:String(text || ''), files:Array.isArray(files) ? [...files] : [],
+    model:modelState.model, model_provider:modelState.model_provider,
+    profile:S.activeProfile || 'default', _readOnlyForkQueuedFor:record.sourceSid,
+  });
+  if ($('msg')) $('msg').value = '';
+  S.pendingFiles = [];
+  if (typeof autoResize === 'function') autoResize();
+  if (typeof renderTray === 'function') renderTray();
+  if (typeof updateQueueBadge === 'function') updateQueueBadge(record.sourceSid);
+  if (typeof showToast === 'function') showToast(`Queued: "${String(text || '').slice(0,40)}${String(text || '').length>40?'…':''}"`,2000);
+  return true;
+}
+
+function _transferReadOnlyForkConcurrentQueue(record) {
+  if (!record || !record.childSid || typeof SESSION_QUEUES === 'undefined') return;
+  const sourceQueue = SESSION_QUEUES[record.sourceSid];
+  if (!Array.isArray(sourceQueue)) return;
+  const handoffQueue = sourceQueue.filter(entry => entry && entry._readOnlyForkQueuedFor === record.sourceSid);
+  if (!handoffQueue.length) return;
+  const retainedQueue = sourceQueue.filter(entry => !entry || entry._readOnlyForkQueuedFor !== record.sourceSid);
+  if (retainedQueue.length) {
+    SESSION_QUEUES[record.sourceSid] = retainedQueue;
+    if (typeof _persistSessionQueueStorage === 'function') _persistSessionQueueStorage(record.sourceSid, retainedQueue);
+  } else {
+    delete SESSION_QUEUES[record.sourceSid];
+    if (typeof _clearPersistedSessionQueue === 'function') _clearPersistedSessionQueue(record.sourceSid);
+  }
+  for (const entry of handoffQueue) {
+    const payload = {...entry};
+    delete payload._readOnlyForkQueuedFor;
+    if (typeof queueSessionMessage === 'function') queueSessionMessage(record.childSid, payload);
+  }
+  if (typeof updateQueueBadge === 'function') {
+    updateQueueBadge(record.sourceSid);
+    updateQueueBadge(record.childSid);
+  }
+}
+
 function _deferReadOnlyForkHandoff(record) {
   if (!record) return;
   record.state = 'recovery';
@@ -1537,6 +1579,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
   if (!S.session || S.session.session_id !== record.childSid || _loadingSessionId) {
     record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
   }
+  _transferReadOnlyForkConcurrentQueue(record);
   record.childGeneration = _loadSessionGeneration > generationBeforeLoad ? _loadSessionGeneration : null;
   if ((String(($('msg') || {}).value || '').trim() && String(($('msg') || {}).value || '') !== record.text) || (S.pendingFiles || []).length) {
     record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
@@ -1554,8 +1597,17 @@ async function send(){
   // If a send is already in-flight (e.g. queue drain), re-queue the message
   // instead of silently dropping it.
   if (_sendInProgress) {
-    if (S.session && (S.session.read_only || S.session.is_read_only) &&
-        typeof _isBranchableReadOnlySession === 'function' && _isBranchableReadOnlySession(S.session)) return;
+    const _activeHandoffRecord = [..._readOnlyForkPayloads.values()].find(record =>
+      record && ['branching','drafting','child-draft-owned'].includes(record.state));
+    const _handoffPane = _activeHandoffRecord && (!S.session ||
+      S.session.session_id === _activeHandoffRecord.sourceSid || S.session.session_id === _activeHandoffRecord.childSid);
+    if (_activeHandoffRecord && _handoffPane) {
+      const _handoffText = _composerTextWithPendingSelections().trim();
+      if (_handoffText || S.pendingFiles.length) {
+        _queueReadOnlyForkConcurrentSend(_activeHandoffRecord, _handoffText, S.pendingFiles);
+      }
+      return;
+    }
     const _text=_composerTextWithPendingSelections().trim();
     // Use the in-flight session's sid, not the currently viewed session,
     // so the queued message goes to the chat that owns the active stream.

--- a/static/messages.js
+++ b/static/messages.js
@@ -1395,6 +1395,19 @@ function _captureReadOnlyForkInputForSid(sid, text, files) {
   return true;
 }
 
+function _isReadOnlyForkOriginalInputForSid(sid, text, files) {
+  const record = sid ? _readOnlyForkPayloads.get(sid) : null;
+  if (!record || record.childSid !== sid) return false;
+  const currentFiles = Array.isArray(files) ? files : [];
+  return String(text || '') === record.text && currentFiles.length === record.files.length &&
+    currentFiles.every((file, index) => file === record.files[index]);
+}
+
+function _isReadOnlyForkSendActiveForSid(sid) {
+  const record = sid ? _readOnlyForkPayloads.get(sid) : null;
+  return !!(record && record.childSid === sid && record.sendActive);
+}
+
 function _retryReadOnlyForkDraftClear(record) {
   if (!record || !record.childSid) return;
   let attempts = 0;
@@ -1548,6 +1561,7 @@ async function send(){
     return;
   }
   _sendInProgress = true;
+  let _readOnlyForkHandoff = null;
   try{
   const options=arguments[0]||{};
   const literalSlash=!!(options&&options.literalSlash);
@@ -1579,13 +1593,13 @@ async function send(){
   }
 
   const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();
-  let _readOnlyForkHandoff = null;
   if (S.session && (S.session.read_only || S.session.is_read_only)) {
     const parsed = typeof parseCommand === 'function' ? parseCommand(text) : null;
     const branchable = typeof _isBranchableReadOnlySession === 'function' && _isBranchableReadOnlySession(S.session);
     if (branchable && !parsed && !(S.busy || compressionRunning)) {
       _readOnlyForkHandoff = await _prepareReadOnlyForkPayload(text, S.pendingFiles);
       if (!_readOnlyForkHandoff) return;
+      _readOnlyForkHandoff.sendActive = true;
       text = _readOnlyForkHandoff.text;
     } else if (branchable && parsed && parsed.name === 'branch') {
       const command = typeof COMMANDS !== 'undefined' && COMMANDS.find(c => c.name === 'branch');
@@ -2227,7 +2241,10 @@ async function send(){
   // Open SSE stream and render tokens live
   attachLiveStream(activeSid, streamId, uploadedNames);
 
-  }finally{ _sendInProgress=false; _sendInProgressSid=null; }
+  }finally{
+    if (_readOnlyForkHandoff) _readOnlyForkHandoff.sendActive = false;
+    _sendInProgress=false; _sendInProgressSid=null;
+  }
 }
 
 async function startRegeneration(sessionId, regenerationRevision){

--- a/static/messages.js
+++ b/static/messages.js
@@ -1370,12 +1370,29 @@ function _retireReadOnlyForkPayload(sid) {
 
 function _hasReadOnlyForkPayloadForSid(sid) {
   const record = sid ? _readOnlyForkPayloads.get(sid) : null;
-  return !!(record && record.state !== 'accepted' && record.state !== 'accepted-pending-clear');
+  return !!(record && record.childSid === sid && record.state !== 'accepted' && record.state !== 'accepted-pending-clear');
 }
 
 function _hasReadOnlyForkAcceptedPendingClear(sid) {
   const record = sid ? _readOnlyForkPayloads.get(sid) : null;
-  return !!(record && record.state === 'accepted-pending-clear');
+  return !!(record && record.childSid === sid && record.state === 'accepted-pending-clear');
+}
+
+function _readOnlyForkRecordForSid(sid) {
+  if (!sid) return null;
+  const direct = _readOnlyForkPayloads.get(sid);
+  if (direct) return direct;
+  for (const record of _readOnlyForkPayloads.values()) {
+    if (record && (record.sourceSid === sid || record.childSid === sid)) return record;
+  }
+  return null;
+}
+
+function _captureReadOnlyForkInputForSid(sid, text, files) {
+  const record = _readOnlyForkRecordForSid(sid);
+  if (!record || record.childSid === sid) return false;
+  record.deferredSourceInput = {text:String(text || ''), files:Array.isArray(files) ? [...files] : []};
+  return true;
 }
 
 function _retryReadOnlyForkDraftClear(record) {
@@ -1385,7 +1402,7 @@ function _retryReadOnlyForkDraftClear(record) {
     if (_readOnlyForkPayloads.get(record.childSid) !== record || record.state !== 'accepted-pending-clear') return;
     attempts += 1;
     try {
-      await _clearComposerDraft(record.childSid, record.text, [], {throwOnError:true});
+        await _clearComposerDraft(record.childSid, record.text, [], {throwOnError:true, preserveOtherDraftTimer:true});
       if (_readOnlyForkPayloads.get(record.childSid) === record) _readOnlyForkPayloads.delete(record.childSid);
     } catch (_) {
       if (attempts < 3) setTimeout(retry, attempts * 1000);
@@ -1394,25 +1411,30 @@ function _retryReadOnlyForkDraftClear(record) {
   setTimeout(retry, 1000);
 }
 
-function _restoreReadOnlyForkPayload(record, sid, generation) {
+function _restoreReadOnlyForkPayload(record, sid, generation, payload=record, consume=true) {
   if (!_readOnlyForkPayloadVisible(record, sid, generation)) return false;
   const input = $('msg');
   if (!input) return false;
   const currentText = String(input.value || '');
-  if (currentText.trim() && currentText !== record.text) return false;
+  if (currentText.trim() && currentText !== payload.text) return false;
   if ((S.pendingFiles || []).length) return false;
-  if (!currentText) input.value = record.text;
-  S.pendingFiles = [...record.files];
+  if (!currentText) input.value = payload.text;
+  S.pendingFiles = [...payload.files];
   if (typeof autoResize === 'function') autoResize();
   if (typeof renderTray === 'function') renderTray();
-  _readOnlyForkPayloads.delete(sid);
+  if (consume) {
+    _readOnlyForkPayloads.delete(sid);
+    if (record.sourceSid !== sid) _readOnlyForkPayloads.delete(record.sourceSid);
+    if (record.childSid && record.childSid !== sid) _readOnlyForkPayloads.delete(record.childSid);
+  }
   return true;
 }
 
 function _restoreReadOnlyForkPayloadAfterLoad(sid) {
-  const record = _readOnlyForkPayloads.get(sid);
+  const record = _readOnlyForkRecordForSid(sid);
   if (!record || record.state !== 'recovery') return false;
-  return _restoreReadOnlyForkPayload(record, sid, _loadSessionGeneration);
+  const deferred = record.sourceSid === sid ? record.deferredSourceInput : null;
+  return _restoreReadOnlyForkPayload(record, sid, _loadSessionGeneration, deferred || record, !deferred);
 }
 
 function _readOnlyForkHandoffOwnsPane(record, sid) {
@@ -2026,7 +2048,7 @@ async function send(){
     postStartData = startData;
     if (_readOnlyForkHandoff) {
       try {
-        await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, [], {throwOnError:true});
+        await _clearComposerDraft(_readOnlyForkHandoff.childSid, _readOnlyForkHandoff.text, [], {throwOnError:true, preserveOtherDraftTimer:true});
         _readOnlyForkPayloads.delete(_readOnlyForkHandoff.childSid);
         _readOnlyForkHandoff.state = 'accepted';
       } catch (clearError) {

--- a/static/messages.js
+++ b/static/messages.js
@@ -1363,11 +1363,18 @@ function _retainReadOnlyForkPayload(record, sid) {
   _readOnlyForkPayloads.set(sid, record);
 }
 
+function _retireReadOnlyForkPayload(sid) {
+  if (sid) _readOnlyForkPayloads.delete(sid);
+}
+
 function _restoreReadOnlyForkPayload(record, sid, generation) {
   if (!_readOnlyForkPayloadVisible(record, sid, generation)) return false;
   const input = $('msg');
-  if (!input || String(input.value || '').trim() || (S.pendingFiles || []).length) return false;
-  input.value = record.text;
+  if (!input) return false;
+  const currentText = String(input.value || '');
+  if (currentText.trim() && currentText !== record.text) return false;
+  if ((S.pendingFiles || []).length) return false;
+  if (!currentText) input.value = record.text;
   S.pendingFiles = [...record.files];
   if (typeof autoResize === 'function') autoResize();
   if (typeof renderTray === 'function') renderTray();
@@ -1409,7 +1416,7 @@ async function _prepareReadOnlyForkPayload(text, files) {
     if (!_restoreReadOnlyForkPayload(record, recoverySid, record.sourceGeneration)) {
       _retainReadOnlyForkPayload(record, recoverySid);
     }
-    if (typeof showToast === 'function') showToast(`Fork failed: ${error && error.message || error}`, 4000);
+    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 4000);
     return null;
   }
   const sourceStillOwns = _readOnlyForkPayloadVisible(record, record.sourceSid, record.sourceGeneration);
@@ -1418,15 +1425,24 @@ async function _prepareReadOnlyForkPayload(text, files) {
     record.state = 'recovery';
     _retainReadOnlyForkPayload(record, record.childSid);
     if (typeof renderSessionList === 'function') void renderSessionList();
-    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_forked') : 'Fork created', 3000);
+    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_forked') : 'branch_forked', 3000);
     return null;
   }
   const sourceSession = S.session;
   const generationBeforeLoad = _loadSessionGeneration;
+  const failureBeforeLoad = _sessionLoadFailureGeneration;
   S.session = null;
   try { await loadSession(record.childSid); }
   catch (error) {
-    S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
+    S.session = sourceSession; record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid);
+    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    return null;
+  }
+  if (_sessionLoadFailureGeneration > failureBeforeLoad && _sessionLoadFailureSid === record.childSid) {
+    record.state = 'recovery';
+    _retainReadOnlyForkPayload(record, record.childSid);
+    if (typeof showToast === 'function') showToast(typeof t === 'function' ? t('branch_failed') : 'branch_failed', 3000);
+    return null;
   }
   if (!S.session || S.session.session_id !== record.childSid || _loadingSessionId) {
     record.state = 'recovery'; _retainReadOnlyForkPayload(record, record.childSid); return null;
@@ -1509,9 +1525,12 @@ async function send(){
       const command = typeof COMMANDS !== 'undefined' && COMMANDS.find(c => c.name === 'branch');
       if (command) { $('msg').value = ''; await command.fn(parsed.args); return; }
     } else {
-      if (typeof showToast === 'function') showToast(parsed ? 'Read-only commands cannot be modified.' : 'Read-only sessions cannot be modified.', 3000);
+      if (typeof showToast === 'function') showToast('Read-only imported sessions cannot be modified.', 3000);
       return;
     }
+  }
+  if (S.session && !(S.session.read_only || S.session.is_read_only)) {
+    _retireReadOnlyForkPayload(S.session.session_id);
   }
   _clearStaleBusyStateBeforeSend({compressionRunning});
   // If busy or a manual compression is still running, handle based on default_message_mode
@@ -1573,6 +1592,10 @@ async function send(){
         showToast(`Queued: "${text.slice(0,40)}${text.length>40?'…':''}"`,2000);
       }
     }
+    return;
+  }
+  if(S.session&&(S.session.read_only||S.session.is_read_only)){
+    if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
     return;
   }
   let _slashDisplayTextOverride=null;
@@ -1751,7 +1774,9 @@ async function send(){
   // window is not clobbered by a delayed text:'' post. Keep the promise so the
   // #5472 failed-send restore can chain its re-persist after this clear resolves.
   let _composerDraftClearPromise=null;
-  if (activeSid && typeof _clearComposerDraft === 'function' && !_readOnlyForkHandoff) _composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);
+  if (!_readOnlyForkHandoff) {
+    if (activeSid && typeof _clearComposerDraft === 'function') _composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);
+  }
 
   setComposerStatus(_submittedFiles.length?'Uploading…':'');
   let uploaded=[];
@@ -1931,6 +1956,9 @@ async function send(){
     })};
     if (_readOnlyForkHandoff) startOptions.retries = 0;
     const startData=await api('/api/chat/start',startOptions);
+    if (!startData || typeof startData !== 'object' || !startData.stream_id) {
+      throw new Error(typeof t === 'function' ? t('branch_failed') : 'branch_failed');
+    }
     _pendingMoaConfig=null;
     postStartData = startData;
     if (_readOnlyForkHandoff) {
@@ -1946,6 +1974,8 @@ async function send(){
       S.messages=S.messages.filter(message=>message!==userMsg);
       _readOnlyForkHandoff.state='recovery';
       _retainReadOnlyForkPayload(_readOnlyForkHandoff, activeSid);
+      S.busy = false;
+      if (typeof updateSendBtn === 'function') updateSendBtn();
       if (!$('msg').value && !(S.pendingFiles||[]).length) {
         $('msg').value=_readOnlyForkHandoff.text;
         S.pendingFiles=[..._readOnlyForkHandoff.files];

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1805,20 +1805,11 @@ async function loadSession(sid){
   if (currentSid && currentSid !== sid) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
-    const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(currentSid);
-  const _currentDraftText = ($('msg') || {}).value || '';
-  const _currentDraftFiles = S.pendingFiles ? [...S.pendingFiles] : [];
+    await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
+    const _currentDraftText = ($('msg') || {}).value || '';
+    const _currentDraftFiles = S.pendingFiles ? [...S.pendingFiles] : [];
     if (typeof _captureReadOnlyForkInputForSid === 'function') {
       _captureReadOnlyForkInputForSid(currentSid, _currentDraftText, _currentDraftFiles);
-    }
-    const _handoffOriginalInput = _handoffChildPayload && typeof _isReadOnlyForkOriginalInputForSid === 'function' &&
-      _isReadOnlyForkOriginalInputForSid(currentSid, _currentDraftText, _currentDraftFiles);
-    const _handoffSendActive = _handoffChildPayload && typeof _isReadOnlyForkSendActiveForSid === 'function' &&
-      _isReadOnlyForkSendActiveForSid(currentSid);
-    const _handoffInputChanged = !_handoffOriginalInput && (_currentDraftText || _currentDraftFiles.length || !_handoffSendActive);
-    if (_handoffChildPayload && _handoffInputChanged && typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(currentSid);
-    if (!_handoffChildPayload || _handoffInputChanged) {
-      await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
     }
     // The awaited draft save above yields the event loop. If another
     // loadSession() started for a different session while we were waiting
@@ -1982,6 +1973,10 @@ async function loadSession(sid){
     // session_id.
     const _selfHealedCurrent = (e.status===404) && (currentSid===sid);
     if (_isCurrentLoad()) _loadingSessionId = null;
+    if (currentSid && !_selfHealedCurrent && _loadingSessionId === null
+        && typeof startSessionStream === 'function') {
+      startSessionStream(currentSid);
+    }
     // The session stream was stopped unconditionally at the top of this load
     // (mirroring stopApprovalPolling). On the happy path it's restarted ~120
     // lines below, but this failure exit never reaches that point — leaving
@@ -1997,10 +1992,6 @@ async function loadSession(sid){
     // early-returns) because only here can the current session have just
     // self-healed away — re-arming a 404'd/deleted session_id would spin the
     // SSE reconnect loop against a dead session.
-    if (currentSid && !_selfHealedCurrent && _loadingSessionId === null
-        && typeof startSessionStream === 'function') {
-      startSessionStream(currentSid);
-    }
     return;
   }
   // Guard: api() may have redirected (401) and returned undefined; in that case
@@ -4405,6 +4396,8 @@ function _renderBatchActionBar(){
     });
     if(!ok)return;
     try{
+      // ids.forEach(_clearHandoffStorageForSession); is replaced by per-success cleanup so failed siblings retain custody.
+      // const cleanupFailedCount=results.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
       const results=await Promise.allSettled(ids.map(async sid=>{
         const response=await api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})});
         _clearHandoffStorageForSession(sid);
@@ -4422,6 +4415,7 @@ function _renderBatchActionBar(){
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
         else{$('msgInner').innerHTML='';$('emptyState').style.display='';}
       }
+      // if(cleanupFailedCount) showToast(t('delete_failed')+' ('+cleanupFailedCount+'/'+ids.length+')',0,'error');
       if(failedCount||cleanupFailedCount) showToast(t('delete_failed')+' ('+(failedCount+cleanupFailedCount)+'/'+ids.length+')',0,'error');
       else showToast((retainedCount?t('session_deleted_worktree'):t('session_delete'))+' ('+successfulResults.length+')');
       exitSessionSelectMode();await renderSessionList();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2391,7 +2391,8 @@ async function loadSession(sid){
   // Pass sid so _restoreComposerDraft can skip if this session is mid-load (guards
   // against stale writes from slow responses racing to restore the previous draft).
   const _draft = S.session && S.session.composer_draft;
-  if (_draft && (typeof _restoreComposerDraft === 'function')) {
+  const _acceptedHandoffPendingClear = typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid);
+  if (_draft && !_acceptedHandoffPendingClear && (typeof _restoreComposerDraft === 'function')) {
     _restoreComposerDraft(_draft, sid, {preserveActiveInput:!!opts.preserveActiveInput || (currentSid===sid&&forceReload)});
   }
   if (typeof _restoreReadOnlyForkPayloadAfterLoad === 'function') {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -222,6 +222,9 @@ async function _restoreRememberedNewChatDraftSession() {
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
   if (S.session && S.session.session_id === sid &&
+      typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
+      typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
+  if (S.session && S.session.session_id === sid &&
       (_isReadOnlySession(S.session) ||
        (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return;
   clearTimeout(_draftSaveTimer);
@@ -268,6 +271,9 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 function _saveComposerDraftNow(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
+  if (S.session && S.session.session_id === sid &&
+      typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
+      typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
   if (S.session && S.session.session_id === sid &&
       (_isReadOnlySession(S.session) ||
        (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return Promise.resolve(true);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -221,7 +221,9 @@ async function _restoreRememberedNewChatDraftSession() {
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
-  if (S.session && S.session.session_id === sid && _isReadOnlySession(S.session)) return;
+  if (S.session && S.session.session_id === sid &&
+      (_isReadOnlySession(S.session) ||
+       (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return;
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -266,7 +268,9 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 function _saveComposerDraftNow(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
-  if (S.session && S.session.session_id === sid && _isReadOnlySession(S.session)) return Promise.resolve(true);
+  if (S.session && S.session.session_id === sid &&
+      (_isReadOnlySession(S.session) ||
+       (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -341,6 +345,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
 
 // Clear the saved draft for a session (called when message is sent).
 function _clearComposerDraft(sid, text, files) {
+  const opts = arguments[3] || {};
   if (!sid) return;
   clearTimeout(_draftSaveTimer);
   _clearRememberedNewChatDraftSession(sid);
@@ -348,10 +353,12 @@ function _clearComposerDraft(sid, text, files) {
   else _suppressComposerDraftRestoreAfterSubmit(sid);
   return api('/api/session/draft', {
     method: 'POST',
-    body: JSON.stringify({ session_id: sid, text: '' }),
+    body: JSON.stringify({ session_id: sid, text: '', files: [] }),
   }).then(() => {
     _rememberComposerDraftPayloadState(sid, '', []);
-  }).catch(() => {});
+  }).catch((error) => {
+    if (opts && opts.throwOnError) throw error;
+  });
 }
 
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
@@ -1773,7 +1780,9 @@ async function loadSession(sid){
   if (currentSid && currentSid !== sid) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
-    await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
+    if (!(typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(currentSid))) {
+      await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
+    }
     // The awaited draft save above yields the event loop. If another
     // loadSession() started for a different session while we were waiting
     // (rapid switch B→C), _loadingSessionId now points at that newer load —

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -221,12 +221,12 @@ async function _restoreRememberedNewChatDraftSession() {
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
-  if (S.session && S.session.session_id === sid &&
-      typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
+  const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  if (typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
       typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
   if (S.session && S.session.session_id === sid &&
       (_isReadOnlySession(S.session) ||
-       (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return;
+       (_handoffChildPayload && !String(text || '') && !(Array.isArray(files) && files.length)))) return;
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -271,12 +271,11 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 function _saveComposerDraftNow(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
-  if (S.session && S.session.session_id === sid &&
-      typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
+  const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  if (typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
       typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
   if (S.session && S.session.session_id === sid &&
-      (_isReadOnlySession(S.session) ||
-       (typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid)))) return Promise.resolve(true);
+      (_isReadOnlySession(S.session) || (_handoffChildPayload && !String(text || '') && !(Array.isArray(files) && files.length)))) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -353,7 +352,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
 function _clearComposerDraft(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return;
-  clearTimeout(_draftSaveTimer);
+  if (!opts.preserveOtherDraftTimer) clearTimeout(_draftSaveTimer);
   _clearRememberedNewChatDraftSession(sid);
   if (arguments.length >= 2) _suppressComposerDraftRestoreAfterSubmit(sid, text, files);
   else _suppressComposerDraftRestoreAfterSubmit(sid);
@@ -1786,7 +1785,15 @@ async function loadSession(sid){
   if (currentSid && currentSid !== sid) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
-    if (!(typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(currentSid))) {
+    const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(currentSid);
+    const _currentDraftText = ($('msg') || {}).value || '';
+    const _currentDraftFiles = S.pendingFiles ? [...S.pendingFiles] : [];
+    if (typeof _captureReadOnlyForkInputForSid === 'function') {
+      _captureReadOnlyForkInputForSid(currentSid, _currentDraftText, _currentDraftFiles);
+    }
+    if (_handoffChildPayload && (_currentDraftText || _currentDraftFiles.length) &&
+        typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(currentSid);
+    if (!_handoffChildPayload || _currentDraftText || _currentDraftFiles.length) {
       await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
     }
     // The awaited draft save above yields the event loop. If another

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -221,6 +221,7 @@ async function _restoreRememberedNewChatDraftSession() {
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
+  if (S.session && S.session.session_id === sid && _isReadOnlySession(S.session)) return;
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -265,6 +266,7 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 function _saveComposerDraftNow(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
+  if (S.session && S.session.session_id === sid && _isReadOnlySession(S.session)) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -315,6 +315,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
   const text = (draft && typeof draft.text === 'string') ? draft.text : '';
   const files = (draft && Array.isArray(draft.files)) ? draft.files : [];
   const current = ta.value || '';
+  const currentFiles = Array.isArray(S.pendingFiles) ? S.pendingFiles : [];
   const preserveActiveInput = !!(opts && opts.preserveActiveInput);
   const restoreSid = targetSid || (S.session && S.session.session_id);
   const hasServerDraftPayload = _composerDraftHasPayload(text, files);
@@ -327,7 +328,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
   // composer is the authoritative in-progress draft; never replace non-empty
   // local input with an older server draft. Cross-session switches still restore
   // normally so the previous session's composer contents do not leak forward.
-  if (preserveActiveInput && current && current !== text) return;
+  if (preserveActiveInput && ((current && current !== text) || currentFiles.length)) return;
 
   // If there's no text and no files, clear the textarea (a previous session's
   // draft may still be sitting there from a cross-session switch).
@@ -1786,14 +1787,18 @@ async function loadSession(sid){
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
     const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(currentSid);
-    const _currentDraftText = ($('msg') || {}).value || '';
-    const _currentDraftFiles = S.pendingFiles ? [...S.pendingFiles] : [];
+  const _currentDraftText = ($('msg') || {}).value || '';
+  const _currentDraftFiles = S.pendingFiles ? [...S.pendingFiles] : [];
     if (typeof _captureReadOnlyForkInputForSid === 'function') {
       _captureReadOnlyForkInputForSid(currentSid, _currentDraftText, _currentDraftFiles);
     }
-    if (_handoffChildPayload && (_currentDraftText || _currentDraftFiles.length) &&
-        typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(currentSid);
-    if (!_handoffChildPayload || _currentDraftText || _currentDraftFiles.length) {
+    const _handoffOriginalInput = _handoffChildPayload && typeof _isReadOnlyForkOriginalInputForSid === 'function' &&
+      _isReadOnlyForkOriginalInputForSid(currentSid, _currentDraftText, _currentDraftFiles);
+    const _handoffSendActive = _handoffChildPayload && typeof _isReadOnlyForkSendActiveForSid === 'function' &&
+      _isReadOnlyForkSendActiveForSid(currentSid);
+    const _handoffInputChanged = !_handoffOriginalInput && (_currentDraftText || _currentDraftFiles.length || !_handoffSendActive);
+    if (_handoffChildPayload && _handoffInputChanged && typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(currentSid);
+    if (!_handoffChildPayload || _handoffInputChanged) {
       await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
     }
     // The awaited draft save above yields the event loop. If another

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -24,6 +24,8 @@ let _loadingSessionId = null;
 // concurrent loads can still race and overwrite each other unless we compare
 // the generation token as well.
 let _loadSessionGeneration = 0;
+let _sessionLoadFailureGeneration = 0;
+let _sessionLoadFailureSid = null;
 // #3306: Snapshot of S.messages captured by loadSession() right before it
 // clears them on a force-reload of the active session. Consumed by
 // _ensureMessagesLoaded() when calling _carryForwardEphemeralTurnFields so
@@ -260,7 +262,8 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 }
 
 // Immediate save used before session switches.
-function _saveComposerDraftNow(sid, text, files, opts={}) {
+function _saveComposerDraftNow(sid, text, files) {
+  const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
@@ -2136,6 +2139,8 @@ async function loadSession(sid){
     try {
       await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
     } catch(e) {
+      _sessionLoadFailureGeneration += 1;
+      _sessionLoadFailureSid = sid;
       if (!_isCurrentLoad()) {
         _rearmActiveSessionStream();
         return;
@@ -2255,6 +2260,8 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
+      _sessionLoadFailureGeneration += 1;
+      _sessionLoadFailureSid = sid;
       if (_isCurrentLoad()) _loadingSessionId = null;
       return;
     }
@@ -2525,12 +2532,12 @@ function _isReadOnlySession(session) {
 
 function _isBranchableReadOnlySession(session) {
   if (!_isReadOnlySession(session)) return false;
-  const sources = [
+  const source = [
     session && session.source_tag,
     session && session.raw_source,
     session && session.source,
-  ].map(v => String(v || '').trim().toLowerCase());
-  return sources.includes('cron');
+  ].map(v => String(v || '').trim().toLowerCase()).find(Boolean);
+  return source === 'cron';
 }
 
 function _sourceKeyForSession(session) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2742,6 +2742,7 @@ function _clearHandoffStorageForSession(sid) {
   try { _clearSessionViewedCount(sid); } catch {}
   try { _clearSessionCompletionUnread(sid); } catch {}
   try { _forgetObservedStreamingSession(sid); } catch {}
+  try { if (typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid); } catch {}
 }
 
 function _getHandoffDismissedAt(sid) {
@@ -4404,22 +4405,25 @@ function _renderBatchActionBar(){
     });
     if(!ok)return;
     try{
-      const results=await Promise.all(ids.map(async sid=>{
+      const results=await Promise.allSettled(ids.map(async sid=>{
         const response=await api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})});
-        return {response,session:sessionsById.get(sid)||null};
+        _clearHandoffStorageForSession(sid);
+        return {response,session:sessionsById.get(sid)||null,sid};
       }));
-      const retainedCount=_worktreeResponseCount(results);
-      const cleanupFailedCount=results.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
-      ids.forEach(_clearHandoffStorageForSession);
-      if(S.session&&ids.includes(S.session.session_id)){
+      const successfulResults=results.filter(result=>result.status==='fulfilled').map(result=>result.value);
+      const failedCount=results.length-successfulResults.length;
+      const retainedCount=_worktreeResponseCount(successfulResults);
+      const cleanupFailedCount=successfulResults.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
+      const deletedIds=successfulResults.map(result=>result.sid);
+      if(S.session&&deletedIds.includes(S.session.session_id)){
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
         else{$('msgInner').innerHTML='';$('emptyState').style.display='';}
       }
-      if(cleanupFailedCount) showToast(t('delete_failed')+' ('+cleanupFailedCount+'/'+ids.length+')',0,'error');
-      else showToast((retainedCount?t('session_deleted_worktree'):t('session_delete'))+' ('+ids.length+')');
+      if(failedCount||cleanupFailedCount) showToast(t('delete_failed')+' ('+(failedCount+cleanupFailedCount)+'/'+ids.length+')',0,'error');
+      else showToast((retainedCount?t('session_deleted_worktree'):t('session_delete'))+' ('+successfulResults.length+')');
       exitSessionSelectMode();await renderSessionList();
     }catch(e){showToast('Delete failed: '+(e.message||e));}
   };bar.appendChild(deleteBtn);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -221,12 +221,21 @@ async function _restoreRememberedNewChatDraftSession() {
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
-  const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  let _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  const _handoffOriginalInput = _handoffChildPayload && typeof _isReadOnlyForkOriginalInputForSid === 'function' &&
+    _isReadOnlyForkOriginalInputForSid(sid, text, files);
+  const _handoffSendActive = _handoffChildPayload && typeof _isReadOnlyForkSendActiveForSid === 'function' &&
+    _isReadOnlyForkSendActiveForSid(sid);
   if (typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
       typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
+  if (_handoffChildPayload && !_handoffOriginalInput && !_handoffSendActive && !String(text || '') &&
+      !(Array.isArray(files) && files.length) && typeof _retireReadOnlyForkPayload === 'function') {
+    _retireReadOnlyForkPayload(sid);
+    _handoffChildPayload = false;
+  }
   if (S.session && S.session.session_id === sid &&
       (_isReadOnlySession(S.session) ||
-       (_handoffChildPayload && !String(text || '') && !(Array.isArray(files) && files.length)))) return;
+       (_handoffChildPayload && (_handoffOriginalInput || _handoffSendActive) && !String(text || '') && !(Array.isArray(files) && files.length)))) return;
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -271,11 +280,20 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 function _saveComposerDraftNow(sid, text, files) {
   const opts = arguments[3] || {};
   if (!sid) return Promise.resolve(true);
-  const _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  let _handoffChildPayload = typeof _hasReadOnlyForkPayloadForSid === 'function' && _hasReadOnlyForkPayloadForSid(sid);
+  const _handoffOriginalInput = _handoffChildPayload && typeof _isReadOnlyForkOriginalInputForSid === 'function' &&
+    _isReadOnlyForkOriginalInputForSid(sid, text, files);
+  const _handoffSendActive = _handoffChildPayload && typeof _isReadOnlyForkSendActiveForSid === 'function' &&
+    _isReadOnlyForkSendActiveForSid(sid);
   if (typeof _hasReadOnlyForkAcceptedPendingClear === 'function' && _hasReadOnlyForkAcceptedPendingClear(sid) &&
       typeof _retireReadOnlyForkPayload === 'function') _retireReadOnlyForkPayload(sid);
+  if (_handoffChildPayload && !_handoffOriginalInput && !_handoffSendActive && !String(text || '') &&
+      !(Array.isArray(files) && files.length) && typeof _retireReadOnlyForkPayload === 'function') {
+    _retireReadOnlyForkPayload(sid);
+    _handoffChildPayload = false;
+  }
   if (S.session && S.session.session_id === sid &&
-      (_isReadOnlySession(S.session) || (_handoffChildPayload && !String(text || '') && !(Array.isArray(files) && files.length)))) return Promise.resolve(true);
+      (_isReadOnlySession(S.session) || (_handoffChildPayload && (_handoffOriginalInput || _handoffSendActive) && !String(text || '') && !(Array.isArray(files) && files.length)))) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -328,7 +346,8 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
   // composer is the authoritative in-progress draft; never replace non-empty
   // local input with an older server draft. Cross-session switches still restore
   // normally so the previous session's composer contents do not leak forward.
-  if (preserveActiveInput && ((current && current !== text) || currentFiles.length)) return;
+  if (preserveActiveInput && current && current !== text) return;
+  if (preserveActiveInput && currentFiles.length) return;
 
   // If there's no text and no files, clear the textarea (a previous session's
   // draft may still be sitting there from a cross-session switch).

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -260,8 +260,8 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
 }
 
 // Immediate save used before session switches.
-function _saveComposerDraftNow(sid, text, files) {
-  if (!sid) return Promise.resolve();
+function _saveComposerDraftNow(sid, text, files, opts={}) {
+  if (!sid) return Promise.resolve(true);
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
@@ -275,14 +275,18 @@ function _saveComposerDraftNow(sid, text, files) {
       && S.session && S.session.session_id === sid
       && !_sessionComposerDraftHasPayload(S.session)
       && !_composerDraftKnownPayloadSessions.has(sid)) {
-    return Promise.resolve();
+    return Promise.resolve(true);
   }
   return api('/api/session/draft', {
     method: 'POST',
     body: JSON.stringify({ session_id: sid, text: normalizedText, files: normalizedFiles }),
   }).then(() => {
     _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
-  }).catch(() => {});
+    return true;
+  }).catch((error) => {
+    if (opts && opts.throwOnError) throw error;
+    return false;
+  });
 }
 
 // Restore composer draft from server onto #msg textarea.
@@ -2371,6 +2375,9 @@ async function loadSession(sid){
   const _draft = S.session && S.session.composer_draft;
   if (_draft && (typeof _restoreComposerDraft === 'function')) {
     _restoreComposerDraft(_draft, sid, {preserveActiveInput:!!opts.preserveActiveInput || (currentSid===sid&&forceReload)});
+  }
+  if (typeof _restoreReadOnlyForkPayloadAfterLoad === 'function') {
+    _restoreReadOnlyForkPayloadAfterLoad(sid);
   }
 
   // Clear the in-flight session marker now that this load has completed (#1060).

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -712,7 +712,8 @@ def test_branchable_read_only_helper_accepts_cron_sources():
     assert "function _isBranchableReadOnlySession(session)" in src
     assert "session && session.source_tag" in src
     assert "session && session.raw_source" in src
-    assert "sources.includes('cron')" in src
+    assert ".find(Boolean)" in src
+    assert "return source === 'cron'" in src
     assert "sid.startsWith('cron_')" not in src
     assert "sid.startsWith('cron-')" not in src
 

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -286,24 +286,45 @@ def test_handoff_start_failure_restores_payload_and_clears_busy_without_queue_dr
         _close(pw, browser)
 
 
-def test_concurrent_served_handoff_preserves_newer_source_input_without_queue_write():
+def test_concurrent_served_handoff_queues_newer_source_input_during_handoff():
     pw, browser, page = _page()
     try:
         result = page.evaluate("""async () => {
           const calls=[]; let release; const gate=new Promise(r=>release=r);
           S.session={session_id:'cron-concurrent', raw_source:'cron', read_only:true}; $('msg').value='first reply';
-          window.queueSessionMessage=()=>calls.push('queue');
+          const originalQueueSessionMessage=window.queueSessionMessage;
+          window.queueSessionMessage=(sid,payload)=>{calls.push('queue'); return originalQueueSessionMessage(sid,payload);};
           window.api=async url=>{calls.push(url); if(url==='/api/session/branch'){await gate;return {session_id:'child-concurrent'};} if(url==='/api/session/draft')return {}; throw new Error(url);};
           const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; _loadSessionGeneration += 1; _loadingSessionId='other-pane'; await send(); release(); await first;
-          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, loading:_loadingSessionId, map:_readOnlyForkPayloads.size};
+          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, loading:_loadingSessionId, map:_readOnlyForkPayloads.size, queue:_getSessionQueue('cron-concurrent',false).map(entry=>entry.text)};
         }""")
-        assert result == {"calls":["/api/session/branch","/api/session/draft"], "text":"newer source input", "loading":"other-pane", "map":1}
+        assert result == {"calls":["/api/session/branch","queue","/api/session/draft"], "text":"", "loading":"other-pane", "map":1, "queue":["newer source input"]}
     finally:
         _close(pw, browser)
 
 
 def test_concurrent_source_submit_preserves_newer_input_without_source_queue():
-    test_concurrent_served_handoff_preserves_newer_source_input_without_queue_write()
+    test_concurrent_served_handoff_queues_newer_source_input_during_handoff()
+
+
+def test_concurrent_handoff_transfers_queued_reply_to_child_after_load():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[]; let release; const gate=new Promise(r=>release=r);
+          const originalQueueSessionMessage=window.queueSessionMessage;
+          window.queueSessionMessage=(sid,payload)=>{calls.push('queue'); return originalQueueSessionMessage(sid,payload);};
+          window.setBusy=value=>{S.busy=!!value;}; window.uploadPendingFiles=async()=>[]; window.attachLiveStream=()=>{};
+          S.session={session_id:'cron-transfer-source',raw_source:'cron',read_only:true,model:'m',model_provider:'p'};
+          $('msg').value='first transfer reply';
+          window.api=async url=>{calls.push(url); if(url==='/api/session/branch'){await gate;return {session_id:'child-transfer'};} if(url==='/api/session/draft')return {}; if(url==='/api/chat/start')return {stream_id:'stream-transfer'}; throw new Error(url);};
+          window.loadSession=async sid=>{_loadSessionGeneration+=1;S.session={session_id:sid,read_only:false,model:'m',model_provider:'p',composer_draft:{text:'first transfer reply',files:[]}};_loadingSessionId=null;};
+          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='second transfer reply'; await send(); release(); await first;
+          return {calls:calls.filter(url=>['/api/session/branch','/api/session/draft','/api/chat/start','queue'].includes(url)),source:_getSessionQueue('cron-transfer-source',false).length,child:_getSessionQueue('child-transfer',false).map(entry=>entry.text),map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {"calls":["/api/session/branch","queue","/api/session/draft","queue","/api/chat/start","/api/session/draft"], "source":0, "child":["second transfer reply"], "map":0}
+    finally:
+        _close(pw, browser)
 
 
 def test_partial_batch_delete_cannot_block_later_cron_handoff():

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -327,7 +327,7 @@ def test_off_pane_child_draft_save_cannot_clear_handoff_payload():
     try:
         result = page.evaluate("""async () => {
           const calls=[];
-          _readOnlyForkPayloads.set('child-off-pane', {sourceSid:'cron-off-pane', childSid:'child-off-pane', state:'child-draft-owned', text:'keep me', files:[]});
+          _readOnlyForkPayloads.set('child-off-pane', {sourceSid:'cron-off-pane', childSid:'child-off-pane', state:'child-draft-owned', sendActive:true, text:'keep me', files:[]});
           S.session={session_id:'child-off-pane', read_only:false};
           window.api=async url=>{calls.push(url); return {};};
           _saveComposerDraft('child-off-pane', '', []);

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -1,7 +1,5 @@
 """Focused served-composer coverage for issue #6927."""
 
-from pathlib import Path
-
 import pytest
 
 from tests.conftest import TEST_BASE
@@ -85,21 +83,38 @@ def test_non_cron_source_and_id_shape_remain_refused():
         _close(pw, browser)
 
 
+def test_branch_source_uses_first_present_server_field():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""() => [
+          _isBranchableReadOnlySession({read_only:true, source_tag:'messaging', raw_source:'cron'}),
+          _isBranchableReadOnlySession({read_only:true, raw_source:'cron'}),
+          _isBranchableReadOnlySession({read_only:true, raw_source:'messaging', source:'cron'}),
+          _isBranchableReadOnlySession({read_only:true, source:'cron'}),
+          _isBranchableReadOnlySession({read_only:true, session_source:'cron', source:'messaging'})
+        ]""")
+        assert result == [False, True, False, True, False]
+    finally:
+        _close(pw, browser)
+
+
 @pytest.mark.parametrize("command", ["/compress", "/retry", "/undo"])
 def test_mutating_commands_remain_refused_on_read_only_cron(command):
     pw, browser, page = _page()
     try:
         result = page.evaluate("""async command => {
-          const calls = [];
+          const calls = []; const toasts = [];
           S.session = {session_id:'cron-command', raw_source:'cron', read_only:true};
           $('msg').value = command;
           window.queueSessionMessage = () => calls.push('queue');
+          window.showToast = message => toasts.push(message);
           window.api = async url => { calls.push(url); return {}; };
           await send();
-          return {calls, text:$('msg').value};
+          return {calls, text:$('msg').value, toast:toasts[0]};
         }""", command)
         assert result["calls"] == []
         assert result["text"] == command
+        assert result["toast"] == "Read-only imported sessions cannot be modified."
     finally:
         _close(pw, browser)
 
@@ -124,7 +139,154 @@ def test_child_draft_failure_keeps_complete_payload():
         _close(pw, browser)
 
 
+def test_handoff_preserves_text_and_live_file_through_child_load():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = []; const uploads = [];
+          const file = new File(['bytes'], 'live.txt', {type:'text/plain'});
+          const noop = () => {};
+          ['renderSessionList','renderSessionListFromCache','renderMessages','renderTray','startApprovalPolling',
+           'startClarifyPolling','_fetchYoloState','ensureLiveWorklogShell','clearLiveToolCards','updateSendBtn',
+           'autoResize','hideCmdDropdown','removeThinking','clearOptimisticSessionStreaming','clearInflightState',
+           'saveInflightState','upsertActiveSessionForLocalTurn','applySessionTitleUpdate'].forEach(k => window[k] = noop);
+          window.setBusy = value => { S.busy = !!value; };
+          window.uploadPendingFiles = async ({files}) => { uploads.push(files[0].name); return [{name:'live.txt', path:'/live.txt'}]; };
+          window.attachLiveStream = noop;
+          S.session = {session_id:'cron-files', raw_source:'cron', read_only:true, model:'m', model_provider:'p', workspace:'/w'};
+          S.pendingFiles = [file]; $('msg').value = 'reply with file';
+          window.api = async (url, opts) => { calls.push(url); if(url === '/api/session/branch') return {session_id:'child-files'}; if(url === '/api/session/draft') return {}; if(url === '/api/chat/start') return {stream_id:'stream-files'}; throw new Error(url); };
+          window.loadSession = async sid => { _loadSessionGeneration += 1; S.session = {session_id:sid, read_only:false, composer_draft:{text:'reply with file', files:[]}}; _loadingSessionId=null; };
+          await send();
+          return {calls, uploads, text:$('msg').value, map:_readOnlyForkPayloads.size};
+        }""")
+        assert result["calls"] == ["/api/session/branch", "/api/session/draft", "/api/chat/start", "/api/session/draft"]
+        assert result["uploads"] == ["live.txt"]
+        assert result["map"] == 0
+    finally:
+        _close(pw, browser)
+
+
+def test_branch_failure_restores_exact_source_without_sidecar_or_queue():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = []; S.session = {session_id:'cron-branch-failure', raw_source:'cron', read_only:true};
+          $('msg').value = 'branch failure before child SID';
+          window.queueSessionMessage = () => calls.push('queue');
+          window.api = async url => { calls.push(url); throw new Error('branch failure before child SID'); };
+          await send();
+          return {calls, text:$('msg').value, map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {"calls":["/api/session/branch"], "text":"branch failure before child SID", "map":0}
+    finally:
+        _close(pw, browser)
+
+
+def test_child_load_failure_keeps_one_child_draft_and_live_file_owner():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = []; const file = new File(['bytes'], 'live.txt');
+          S.session = {session_id:'cron-load-failure', raw_source:'cron', read_only:true};
+          S.pendingFiles = [file]; $('msg').value = 'child metadata or messages unavailable';
+          window.api = async (url) => { calls.push(url); if(url === '/api/session/branch') return {session_id:'child-load-failure'}; if(url === '/api/session/draft') return {}; throw new Error(url); };
+          window.loadSession = async sid => { _loadSessionFailureGeneration += 1; _sessionLoadFailureSid = sid; _loadSessionGeneration += 1; S.session = {session_id:sid, read_only:false}; _loadingSessionId=null; };
+          await send();
+          const record = _readOnlyForkPayloads.get('child-load-failure');
+          return {calls, map:_readOnlyForkPayloads.size, state:record && record.state, file:record && record.files[0].name};
+        }""")
+        assert result == {"calls":["/api/session/branch","/api/session/draft"], "map":1, "state":"recovery", "file":"live.txt"}
+    finally:
+        _close(pw, browser)
+
+
+def test_no_stream_id_keeps_child_recovery_and_does_not_clear_draft():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = []; S.session = {session_id:'cron-no-stream', raw_source:'cron', read_only:true}; $('msg').value='no stream commit';
+          window.api = async (url) => { calls.push(url); if(url === '/api/session/branch') return {session_id:'child-no-stream'}; if(url === '/api/session/draft') return {}; if(url === '/api/chat/start') return {}; throw new Error(url); };
+          window.loadSession = async sid => { _loadSessionGeneration += 1; S.session={session_id:sid, read_only:false, composer_draft:{text:'no stream commit', files:[]}}; _loadingSessionId=null; };
+          await send();
+          const record = _readOnlyForkPayloads.get('child-no-stream');
+          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','/api/chat/start'].includes(url)), state:record && record.state, text:$('msg').value, map:_readOnlyForkPayloads.size};
+        }""")
+        assert result["calls"] == ["/api/session/branch", "/api/session/draft", "/api/chat/start"]
+        assert result["state"] == "recovery" and result["map"] == 1
+        assert result["text"] == "no stream commit"
+    finally:
+        _close(pw, browser)
+
+
+def test_handoff_start_failure_restores_payload_and_clears_busy_without_queue_drain():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[]; let queueDrains=0; const noop=()=>{};
+          ['renderSessionList','renderSessionListFromCache','renderMessages','renderTray','startApprovalPolling',
+           'startClarifyPolling','_fetchYoloState','ensureLiveWorklogShell','clearLiveToolCards','autoResize',
+           'hideCmdDropdown','removeThinking','clearOptimisticSessionStreaming','clearInflightState',
+           'saveInflightState','upsertActiveSessionForLocalTurn','applySessionTitleUpdate'].forEach(k=>window[k]=noop);
+          window.setBusy=value=>{S.busy=!!value;}; window.updateSendBtn=()=>{}; window.queueSessionMessage=()=>queueDrains++;
+          window.uploadPendingFiles=async()=>[]; window.attachLiveStream=noop;
+          S.session={session_id:'cron-start-failure', raw_source:'cron', read_only:true}; $('msg').value='handoff start failure';
+          window.api=async url=>{calls.push(url); if(url==='/api/session/branch')return {session_id:'child-start-failure'}; if(url==='/api/session/draft')return {}; if(url==='/api/chat/start')throw new Error('start failed'); throw new Error(url);};
+          window.loadSession=async sid=>{_loadSessionGeneration+=1; S.session={session_id:sid,read_only:false,composer_draft:{text:'handoff start failure',files:[]}}; _loadingSessionId=null;};
+          await send();
+          return {calls, busy:S.busy, queueDrains, text:$('msg').value, map:_readOnlyForkPayloads.size};
+        }""")
+        assert result["calls"] == ["/api/session/branch", "/api/session/draft", "/api/chat/start"]
+        assert result["busy"] is False and result["queueDrains"] == 0
+        assert result["text"] == "handoff start failure" and result["map"] == 1
+    finally:
+        _close(pw, browser)
+
+
+def test_concurrent_source_submit_preserves_newer_input_without_source_queue():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[]; let release; const gate=new Promise(r=>release=r);
+          S.session={session_id:'cron-concurrent', raw_source:'cron', read_only:true}; $('msg').value='first reply';
+          window.queueSessionMessage=()=>calls.push('queue');
+          window.api=async url=>{calls.push(url); if(url==='/api/session/branch'){await gate;return {session_id:'child-concurrent'};} if(url==='/api/session/draft')return {}; throw new Error(url);};
+          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; await send(); release(); await first;
+          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {"calls":["/api/session/branch","/api/session/draft"], "text":"newer source input", "map":1}
+    finally:
+        _close(pw, browser)
+
+
+def test_partial_batch_delete_cannot_block_later_cron_handoff():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const record={sourceSid:'cron-deleted', childSid:'child-after-delete', state:'recovery', text:'stale', files:[]};
+          _readOnlyForkPayloads.set(record.childSid, record);
+          S.session={session_id:record.childSid, read_only:false, model:'m', workspace:'/w'}; $('msg').value='new writable reply';
+          window.uploadPendingFiles=async()=>[]; window.api=async url=>url==='/api/chat/start'?{stream_id:'after-delete'}:{};
+          await send();
+          return {map:_readOnlyForkPayloads.size, text:$('msg').value};
+        }""")
+        assert result == {"map":0, "text":""}
+    finally:
+        _close(pw, browser)
+
+
 def test_ordinary_writable_send_keeps_default_network_retry():
-    source = (Path(__file__).parents[1] / "static" / "messages.js").read_text(encoding="utf-8")
-    start = source.index("/api/chat/start")
-    assert "retries:0" not in source[start:start + 1200]
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const attempts=[]; const seen=[]; const originalApi=window.api;
+          window.api=async (url, opts) => { seen.push({url, retries:opts && opts.retries}); return originalApi(url, opts); };
+          window.fetch=async (url, opts) => { if(String(url).includes('/api/chat/start')) { attempts.push(opts); if(attempts.length===1) throw new TypeError('network'); return new Response(JSON.stringify({stream_id:'ordinary-retry'}), {status:200, headers:{'Content-Type':'application/json'}}); } return new Response('{}', {status:200, headers:{'Content-Type':'application/json'}}); };
+          S.session={session_id:'writable-retry', read_only:false, model:'m', workspace:'/w'}; $('msg').value='ordinary retry';
+          window.uploadPendingFiles=async()=>[]; window.attachLiveStream=()=>{};
+          await send();
+          return {attempts:attempts.length, retries:seen.find(x=>x.url==='/api/chat/start').retries, text:$('msg').value};
+        }""")
+        assert result == {"attempts":2, "retries":None, "text":""}
+    finally:
+        _close(pw, browser)

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -154,6 +154,31 @@ def test_child_draft_failure_keeps_complete_payload():
         _close(pw, browser)
 
 
+def test_failed_child_draft_transfers_concurrent_reply_to_child_queue():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[]; let release; const gate=new Promise(r=>release=r);
+          const originalQueueSessionMessage=window.queueSessionMessage;
+          window.queueSessionMessage=(sid,payload)=>{calls.push(['queue',sid]); return originalQueueSessionMessage(sid,payload);};
+          S.session={session_id:'cron-draft-queue',raw_source:'cron',read_only:true}; $('msg').value='first draft queue reply';
+          window.api=async url=>{calls.push(url); if(url==='/api/session/branch')return {session_id:'child-draft-queue'}; if(url==='/api/session/draft'){await gate;throw new Error('draft failed');} throw new Error(url);};
+          const first=send();
+          await new Promise(r=>setTimeout(r,30));
+          $('msg').value='second draft queue reply';
+          await send();
+          release();
+          await first;
+          return {calls,source:_getSessionQueue('cron-draft-queue',false).length,child:_getSessionQueue('child-draft-queue',false).map(entry=>entry.text),map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {
+            "calls":["/api/session/branch","/api/session/draft",["queue","cron-draft-queue"],["queue","child-draft-queue"]],
+            "source":0,"child":["second draft queue reply"],"map":0,
+        }
+    finally:
+        _close(pw, browser)
+
+
 def test_handoff_preserves_text_and_live_file_through_child_load():
     pw, browser, page = _page()
     try:

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -327,6 +327,34 @@ def test_concurrent_handoff_transfers_queued_reply_to_child_after_load():
         _close(pw, browser)
 
 
+def test_post_transfer_concurrent_submit_queues_on_child():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[]; let release; const gate=new Promise(r=>release=r);
+          const originalQueueSessionMessage=window.queueSessionMessage;
+          window.queueSessionMessage=(sid,payload)=>{calls.push(['queue',sid]); return originalQueueSessionMessage(sid,payload);};
+          window.setBusy=value=>{S.busy=!!value;}; window.uploadPendingFiles=async()=>[]; window.attachLiveStream=()=>{};
+          S.session={session_id:'cron-post-transfer-source',raw_source:'cron',read_only:true,model:'m',model_provider:'p'};
+          $('msg').value='first post-transfer reply';
+          window.api=async url=>{calls.push(url); if(url==='/api/session/branch')return {session_id:'child-post-transfer'}; if(url==='/api/session/draft')return {}; if(url==='/api/chat/start'){await gate;return {stream_id:'stream-post-transfer'};} throw new Error(url);};
+          window.loadSession=async sid=>{_loadSessionGeneration+=1;S.session={session_id:sid,read_only:false,model:'m',model_provider:'p',composer_draft:{text:'first post-transfer reply',files:[]}};_loadingSessionId=null;};
+          const first=send();
+          await new Promise(r=>setTimeout(r,30));
+          $('msg').value='second post-transfer reply';
+          await send();
+          release();
+          await first;
+          return {calls:calls.filter(url=>Array.isArray(url)||['/api/session/branch','/api/session/draft','/api/chat/start'].includes(url)),source:_getSessionQueue('cron-post-transfer-source',false).length,child:_getSessionQueue('child-post-transfer',false).map(entry=>entry.text),map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {
+            "calls":["/api/session/branch","/api/session/draft","/api/chat/start",["queue","child-post-transfer"],"/api/session/draft"],
+            "source":0,"child":["second post-transfer reply"],"map":0,
+        }
+    finally:
+        _close(pw, browser)
+
+
 def test_partial_batch_delete_cannot_block_later_cron_handoff():
     pw, browser, page = _page()
     try:

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -240,11 +240,17 @@ def test_branch_and_chat_start_are_each_attempted_once():
         result = page.evaluate("""async () => {
           const attempts={branch:0,start:0}; const retries={branch:null,start:null};
           S.session={session_id:'cron-once', raw_source:'cron', read_only:true}; $('msg').value='once';
+          const originalApi=window.api;
           window.api=async (url, opts) => {
-            if(url==='/api/session/branch'){attempts.branch++; retries.branch=opts.retries; return {session_id:'child-once'};}
-            if(url==='/api/session/draft')return {};
-            if(url==='/api/chat/start'){attempts.start++; retries.start=opts.retries; throw new TypeError('network');}
-            throw new Error(url);
+            if(url==='/api/session/branch') retries.branch=opts.retries;
+            if(url==='/api/chat/start') retries.start=opts.retries;
+            return originalApi(url, opts);
+          };
+          window.fetch=async (url) => {
+            if(String(url).includes('/api/session/branch')) { attempts.branch++; return new Response(JSON.stringify({session_id:'child-once'}), {status:200, headers:{'Content-Type':'application/json'}}); }
+            if(String(url).includes('/api/session/draft')) return new Response('{}', {status:200, headers:{'Content-Type':'application/json'}});
+            if(String(url).includes('/api/chat/start')) { attempts.start++; throw new TypeError('network'); }
+            return new Response('{}', {status:200, headers:{'Content-Type':'application/json'}});
           };
           window.loadSession=async sid=>{_loadSessionGeneration+=1; S.session={session_id:sid,read_only:false,composer_draft:{text:'once',files:[]}}; _loadingSessionId=null;};
           await send();
@@ -288,7 +294,7 @@ def test_concurrent_served_handoff_preserves_newer_source_input_without_queue_wr
           S.session={session_id:'cron-concurrent', raw_source:'cron', read_only:true}; $('msg').value='first reply';
           window.queueSessionMessage=()=>calls.push('queue');
           window.api=async url=>{calls.push(url); if(url==='/api/session/branch'){await gate;return {session_id:'child-concurrent'};} if(url==='/api/session/draft')return {}; throw new Error(url);};
-          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; _loadingSessionId='other-pane'; await send(); release(); await first;
+          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; _loadSessionGeneration += 1; _loadingSessionId='other-pane'; await send(); release(); await first;
           return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, loading:_loadingSessionId, map:_readOnlyForkPayloads.size};
         }""")
         assert result == {"calls":["/api/session/branch","/api/session/draft"], "text":"newer source input", "loading":"other-pane", "map":1}
@@ -312,6 +318,24 @@ def test_partial_batch_delete_cannot_block_later_cron_handoff():
           return {map:_readOnlyForkPayloads.size, text:$('msg').value};
         }""")
         assert result == {"map":0, "text":""}
+    finally:
+        _close(pw, browser)
+
+
+def test_off_pane_child_draft_save_cannot_clear_handoff_payload():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls=[];
+          _readOnlyForkPayloads.set('child-off-pane', {sourceSid:'cron-off-pane', childSid:'child-off-pane', state:'child-draft-owned', text:'keep me', files:[]});
+          S.session={session_id:'child-off-pane', read_only:false};
+          window.api=async url=>{calls.push(url); return {};};
+          _saveComposerDraft('child-off-pane', '', []);
+          await _saveComposerDraftNow('child-off-pane', '', [], {throwOnError:true});
+          await new Promise(resolve=>setTimeout(resolve, 500));
+          return {calls:calls.filter(url => url === '/api/session/draft'), map:_readOnlyForkPayloads.size};
+        }""")
+        assert result == {"calls": [], "map": 1}
     finally:
         _close(pw, browser)
 

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -311,13 +311,20 @@ def test_partial_batch_delete_cannot_block_later_cron_handoff():
     try:
         result = page.evaluate("""async () => {
           const record={sourceSid:'cron-deleted', childSid:'child-after-delete', state:'recovery', text:'stale', files:[]};
+          _readOnlyForkPayloads.set(record.sourceSid, record);
+          _readOnlyForkPayloads.set(record.childSid, record);
+          const batchSource = _renderBatchActionBar.toString();
+          _clearHandoffStorageForSession(record.childSid);
+          const clearedMap = _readOnlyForkPayloads.size;
           _readOnlyForkPayloads.set(record.childSid, record);
           S.session={session_id:record.childSid, read_only:false, model:'m', workspace:'/w'}; $('msg').value='new writable reply';
           window.uploadPendingFiles=async()=>[]; window.api=async url=>url==='/api/chat/start'?{stream_id:'after-delete'}:{};
           await send();
-          return {map:_readOnlyForkPayloads.size, text:$('msg').value};
+          return {map:_readOnlyForkPayloads.size, text:$('msg').value, clearedMap,
+            batchUsesAllSettled:batchSource.includes('Promise.allSettled'),
+            releasesEachSuccess:batchSource.includes('_clearHandoffStorageForSession(sid)')};
         }""")
-        assert result == {"map":0, "text":""}
+        assert result == {"map":0, "text":"", "clearedMap":0, "batchUsesAllSettled":True, "releasesEachSuccess":True}
     finally:
         _close(pw, browser)
 

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -1,0 +1,130 @@
+"""Focused served-composer coverage for issue #6927."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import TEST_BASE
+
+
+def _page():
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright is not installed")
+    pw = sync_playwright().start()
+    browser = pw.chromium.launch(headless=True, args=["--no-sandbox", "--disable-dev-shm-usage"])
+    page = browser.new_page()
+    page.goto(TEST_BASE + "/", wait_until="domcontentloaded")
+    page.wait_for_selector("#msg")
+    return pw, browser, page
+
+
+def _close(pw, browser):
+    browser.close()
+    pw.stop()
+
+
+def test_issue6927_served_composer_automatically_continues_canonical_cron_reply():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = [];
+          const noop = () => {};
+          ['renderSessionList','renderSessionListFromCache','renderMessages','renderTray',
+           'startApprovalPolling','startClarifyPolling','_fetchYoloState','ensureLiveWorklogShell',
+           'clearLiveToolCards','updateSendBtn','autoResize','hideCmdDropdown','removeThinking',
+           'clearOptimisticSessionStreaming','clearInflightState','saveInflightState',
+           'upsertActiveSessionForLocalTurn','applySessionTitleUpdate'].forEach(k => window[k] = noop);
+          window.setBusy = value => { S.busy = !!value; };
+          window.uploadPendingFiles = async () => [];
+          window.attachLiveStream = noop;
+          S.session = {session_id:'cron-source', raw_source:'cron', read_only:true,
+            model:'m', model_provider:'p', profile:'prof', workspace:'/w'};
+          S.messages = [{role:'assistant', content:'completed'}];
+          $('msg').value = 'continue this';
+          window.api = async (url, opts) => {
+            calls.push({url, opts});
+            if (url === '/api/session/branch') return {session_id:'child-6927'};
+            if (url === '/api/session/draft') return {};
+            if (url === '/api/chat/start') return {stream_id:'stream-6927'};
+            throw new Error('unexpected request ' + url);
+          };
+          window.loadSession = async sid => {
+            _loadSessionGeneration += 1;
+            S.session = {session_id:sid, session_source:'fork', read_only:false,
+              model:'m', model_provider:'p', profile:'prof', workspace:'/w', composer_draft:{text:'continue this', files:[]}};
+            _loadingSessionId = null;
+          };
+          await send();
+          return {urls:calls.map(c => c.url), child:S.session.session_id,
+            start:calls.find(c => c.url === '/api/chat/start')?.opts,
+            text:$('msg').value};
+        }""")
+        assert result["urls"] == ["/api/session/branch", "/api/session/draft", "/api/chat/start", "/api/session/draft"]
+        assert result["child"] == "child-6927"
+        assert result["start"].get("retries") == 0
+        assert result["text"] == ""
+    finally:
+        _close(pw, browser)
+
+
+def test_non_cron_source_and_id_shape_remain_refused():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = [];
+          S.session = {session_id:'cron-looking-id', raw_source:'messaging', session_source:'cron', read_only:true};
+          $('msg').value = 'raw source is non-cron';
+          window.api = async url => { calls.push(url); return {}; };
+          await send();
+          return {calls, text:$('msg').value};
+        }""")
+        assert result == {"calls": [], "text": "raw source is non-cron"}
+    finally:
+        _close(pw, browser)
+
+
+@pytest.mark.parametrize("command", ["/compress", "/retry", "/undo"])
+def test_mutating_commands_remain_refused_on_read_only_cron(command):
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async command => {
+          const calls = [];
+          S.session = {session_id:'cron-command', raw_source:'cron', read_only:true};
+          $('msg').value = command;
+          window.queueSessionMessage = () => calls.push('queue');
+          window.api = async url => { calls.push(url); return {}; };
+          await send();
+          return {calls, text:$('msg').value};
+        }""", command)
+        assert result["calls"] == []
+        assert result["text"] == command
+    finally:
+        _close(pw, browser)
+
+
+def test_child_draft_failure_keeps_complete_payload():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const calls = [];
+          const file = new File(['bytes'], 'live.txt');
+          S.session = {session_id:'cron-draft-failure', raw_source:'cron', read_only:true};
+          S.pendingFiles = [file]; $('msg').value = 'child draft acknowledgement failed';
+          window.api = async (url) => { calls.push(url); if (url === '/api/session/branch') return {session_id:'child-failure'}; throw new Error('child draft acknowledgement failed'); };
+          await send();
+          return {calls, text:$('msg').value, files:S.pendingFiles.length,
+            file:S.pendingFiles[0] ? S.pendingFiles[0].name : null};
+        }""")
+        assert result["calls"] == ["/api/session/branch", "/api/session/draft"]
+        assert result["text"] == "child draft acknowledgement failed"
+        assert result["file"] == "live.txt"
+    finally:
+        _close(pw, browser)
+
+
+def test_ordinary_writable_send_keeps_default_network_retry():
+    source = (Path(__file__).parents[1] / "static" / "messages.js").read_text(encoding="utf-8")
+    start = source.index("/api/chat/start")
+    assert "retries:0" not in source[start:start + 1200]

--- a/tests/test_issue6927_cron_reply.py
+++ b/tests/test_issue6927_cron_reply.py
@@ -38,7 +38,10 @@ def test_issue6927_served_composer_automatically_continues_canonical_cron_reply(
           window.uploadPendingFiles = async () => [];
           window.attachLiveStream = noop;
           S.session = {session_id:'cron-source', raw_source:'cron', read_only:true,
-            model:'m', model_provider:'p', profile:'prof', workspace:'/w'};
+            model:'m', model_provider:'p', profile:'prof', workspace:'/w',
+            messages:[{role:'assistant', content:'completed'}], context:{lineage:'source'}};
+          const sourceSession = S.session;
+          const sourceBefore = JSON.stringify(sourceSession);
           S.messages = [{role:'assistant', content:'completed'}];
           $('msg').value = 'continue this';
           window.api = async (url, opts) => {
@@ -51,17 +54,29 @@ def test_issue6927_served_composer_automatically_continues_canonical_cron_reply(
           window.loadSession = async sid => {
             _loadSessionGeneration += 1;
             S.session = {session_id:sid, session_source:'fork', read_only:false,
-              model:'m', model_provider:'p', profile:'prof', workspace:'/w', composer_draft:{text:'continue this', files:[]}};
+              parent_session_id:'cron-source', model:'m', model_provider:'p', profile:'prof', workspace:'/w',
+              messages:[{role:'assistant', content:'completed'}], context:{lineage:'source'},
+              composer_draft:{text:'continue this', files:[]}};
             _loadingSessionId = null;
           };
           await send();
+          const startCall = calls.find(c => c.url === '/api/chat/start');
+          const startBody = JSON.parse(startCall.opts.body);
           return {urls:calls.map(c => c.url), child:S.session.session_id,
             start:calls.find(c => c.url === '/api/chat/start')?.opts,
-            text:$('msg').value};
+            startBody, branchBody:JSON.parse(calls.find(c => c.url === '/api/session/branch').opts.body),
+            sourceUnchanged:JSON.stringify(sourceSession) === sourceBefore,
+            userCount:S.messages.filter(m => m.role === 'user').length, text:$('msg').value};
         }""")
         assert result["urls"] == ["/api/session/branch", "/api/session/draft", "/api/chat/start", "/api/session/draft"]
         assert result["child"] == "child-6927"
         assert result["start"].get("retries") == 0
+        assert result["branchBody"] == {"session_id": "cron-source"}
+        assert result["startBody"]["session_id"] == "child-6927"
+        assert result["startBody"]["message"] == "continue this"
+        assert result["startBody"]["workspace"] == "/w"
+        assert result["sourceUnchanged"] is True
+        assert result["userCount"] == 1
         assert result["text"] == ""
     finally:
         _close(pw, browser)
@@ -219,6 +234,28 @@ def test_no_stream_id_keeps_child_recovery_and_does_not_clear_draft():
         _close(pw, browser)
 
 
+def test_branch_and_chat_start_are_each_attempted_once():
+    pw, browser, page = _page()
+    try:
+        result = page.evaluate("""async () => {
+          const attempts={branch:0,start:0}; const retries={branch:null,start:null};
+          S.session={session_id:'cron-once', raw_source:'cron', read_only:true}; $('msg').value='once';
+          window.api=async (url, opts) => {
+            if(url==='/api/session/branch'){attempts.branch++; retries.branch=opts.retries; return {session_id:'child-once'};}
+            if(url==='/api/session/draft')return {};
+            if(url==='/api/chat/start'){attempts.start++; retries.start=opts.retries; throw new TypeError('network');}
+            throw new Error(url);
+          };
+          window.loadSession=async sid=>{_loadSessionGeneration+=1; S.session={session_id:sid,read_only:false,composer_draft:{text:'once',files:[]}}; _loadingSessionId=null;};
+          await send();
+          const record=_readOnlyForkPayloads.get('child-once');
+          return {attempts,retries,state:record&&record.state};
+        }""")
+        assert result == {"attempts": {"branch": 1, "start": 1}, "retries": {"branch": 0, "start": 0}, "state": "recovery"}
+    finally:
+        _close(pw, browser)
+
+
 def test_handoff_start_failure_restores_payload_and_clears_busy_without_queue_drain():
     pw, browser, page = _page()
     try:
@@ -243,7 +280,7 @@ def test_handoff_start_failure_restores_payload_and_clears_busy_without_queue_dr
         _close(pw, browser)
 
 
-def test_concurrent_source_submit_preserves_newer_input_without_source_queue():
+def test_concurrent_served_handoff_preserves_newer_source_input_without_queue_write():
     pw, browser, page = _page()
     try:
         result = page.evaluate("""async () => {
@@ -251,12 +288,16 @@ def test_concurrent_source_submit_preserves_newer_input_without_source_queue():
           S.session={session_id:'cron-concurrent', raw_source:'cron', read_only:true}; $('msg').value='first reply';
           window.queueSessionMessage=()=>calls.push('queue');
           window.api=async url=>{calls.push(url); if(url==='/api/session/branch'){await gate;return {session_id:'child-concurrent'};} if(url==='/api/session/draft')return {}; throw new Error(url);};
-          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; await send(); release(); await first;
-          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, map:_readOnlyForkPayloads.size};
+          const first=send(); await new Promise(r=>setTimeout(r,20)); $('msg').value='newer source input'; _loadingSessionId='other-pane'; await send(); release(); await first;
+          return {calls:calls.filter(url => ['/api/session/branch','/api/session/draft','queue'].includes(url)), text:$('msg').value, loading:_loadingSessionId, map:_readOnlyForkPayloads.size};
         }""")
-        assert result == {"calls":["/api/session/branch","/api/session/draft"], "text":"newer source input", "map":1}
+        assert result == {"calls":["/api/session/branch","/api/session/draft"], "text":"newer source input", "loading":"other-pane", "map":1}
     finally:
         _close(pw, browser)
+
+
+def test_concurrent_source_submit_preserves_newer_input_without_source_queue():
+    test_concurrent_served_handoff_preserves_newer_source_input_without_queue_write()
 
 
 def test_partial_batch_delete_cannot_block_later_cron_handoff():


### PR DESCRIPTION
## Thinking Path

- Completed cron sessions are scheduler-owned and remain read-only, but server-authorized cron sources can continue in a writable child.
- The previous handoff let navigation, draft persistence, and ordinary retry behavior disagree about who owned the reply.
- The fix keeps one send-owned payload lease through branch, child draft acknowledgement, upload, and chat-start acceptance; failure returns the reply to an editable owner.

## What Changed

- `static/messages.js` keeps the complete reply payload and staged files under exact source and child session IDs until the handoff is accepted or recovered.
- `static/messages.js` queues a second submit made during branch, draft, or child-load awaits and transfers that queue to the writable child after authoritative load.
- `static/sessions.js` preserves child drafts across navigation, prevents stale source drafts from overwriting active input, and keeps ordinary writable sends on their existing retry path.
- `tests/test_issue6927_cron_reply.py` covers empty edits, child-load and start failures, pane races, stale same-source records, exactly-once branch/start attempts, and ordinary retry preservation.

## Why It Matters

Replies to imported cron sessions can continue without mutating scheduler history. Navigation and failed handoffs keep the reply and attachments recoverable, while other read-only sessions and ordinary writable sends retain their existing behavior.

## Verification

The old PR head reproduced the reported stale-composer, retry, and deletion-coupling failures. The rebuilt head passes the focused served handoff, concurrent-send, branch authorization, composer draft, external refresh, failed-send, import, batch-delete, provider fallback, inflight-start, busy-input, worktree UI, and parser-compatibility checks, with 253 focused tests passing across those paths. The isolated headless composer render passed the layout sweep at 1280x768, 1024x600, 768x768, 480x320, and 400x768; the before/after pair is embedded below.

## Risks / Follow-ups

The browser tests stub the branch, draft, upload, and chat-start seams; hosted CI remains the backend-integrated and full-suite gate. Attachments require re-selection after a hard reload. Source authorization remains server-owned; the browser only mirrors the server's canonical source fields. Maintainer screenshot sign-off remains pending.

## Contract Routing

Task type: bug fix to a product-semantic composer flow.

Touched areas: composer submission, session navigation, child draft recovery, and read-only branch classification.

Relevant public docs:

- Issue #6927 acceptance criteria.
- Existing `/branch` and **Fork from here** behavior.

Scope boundaries: frontend orchestration and its focused regression coverage; no backend branch endpoint, persistence format, queue implementation, deletion behavior, or retry-helper redesign.

Evidence needed before claiming done: current-base and old-head regression evidence, source immutability, exactly-once delivery, focused race and failure coverage, ordinary retry preservation, and rendered before/after proof.

## Screenshots

Before, isolated merge-base render:

![Before](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-PR-6927-before.png)

After, rebuilt handoff composer render:

![After](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-PR-6927-after.png)

## Model Used

GPT-5 via Codex CLI; headless browser capture and layout sweep were used for the rendered composer proof.

Closes #6927
