### PR TITLE
perf(media): preload visible inline videos

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2587,6 +2587,7 @@ function _applyMediaPlaybackRate(media, rate=_getStoredMediaPlaybackRate()){
 let _mediaVisibilityObserver=null;
 function _promoteVisibleVideoPreload(video){
   if(!video||!video.matches||!video.matches('.msg-media-video')) return;
+  if(video.isConnected===false) return;
   if(video.dataset&&video.dataset.visiblePreload==='1') return;
   if(video.dataset) video.dataset.visiblePreload='1';
   video.preload='auto';

--- a/static/ui.js
+++ b/static/ui.js
@@ -2584,6 +2584,36 @@ function _applyMediaPlaybackRate(media, rate=_getStoredMediaPlaybackRate()){
   media.playbackRate=rate;
   _syncMediaSpeedButtons(media.closest('.msg-media-editor,.preview-media-wrap'),rate);
 }
+let _mediaVisibilityObserver=null;
+function _promoteVisibleVideoPreload(video){
+  if(!video||!video.matches||!video.matches('.msg-media-video')) return;
+  if(video.dataset&&video.dataset.visiblePreload==='1') return;
+  if(video.dataset) video.dataset.visiblePreload='1';
+  video.preload='auto';
+  // Off-screen history stays metadata-only. Once a card approaches the
+  // viewport, restart just that resource so Chromium fills a playable buffer.
+  if(video.paused&&video.readyState<4&&typeof video.load==='function') video.load();
+}
+function _observeVideoPreload(video){
+  if(!video||!video.matches||!video.matches('.msg-media-video')) return;
+  if(video.dataset&&video.dataset.visiblePreload==='1') return;
+  if(_mediaVisibilityObserver) _mediaVisibilityObserver.observe(video);
+}
+function _unobserveVideoPreload(video){
+  if(!video||!_mediaVisibilityObserver) return;
+  _mediaVisibilityObserver.unobserve(video);
+}
+function _initMediaVisibilityObserver(){
+  if(_mediaVisibilityObserver||typeof IntersectionObserver==='undefined') return;
+  _mediaVisibilityObserver=new IntersectionObserver(entries=>{
+    for(const entry of entries){
+      if(!entry.isIntersecting) continue;
+      const video=entry.target;
+      _unobserveVideoPreload(video);
+      _promoteVisibleVideoPreload(video);
+    }
+  },{root:null,rootMargin:'300px 0px',threshold:0.01});
+}
 function _mediaKindForName(name=''){
   const clean=String(name||'').split('?')[0].toLowerCase();
   if(_VIDEO_EXTS.test(clean)) return 'video';
@@ -2750,21 +2780,40 @@ document.addEventListener("loadedmetadata", e=>{
     _applyMediaPlaybackRate(e.target);
   }
 },true);
+document.addEventListener('play',e=>{
+  if(e.target&&e.target.matches&&e.target.matches('.msg-media-video')){
+    _promoteVisibleVideoPreload(e.target);
+  }
+},true);
 function _initMediaPlaybackObserver(){
   if(!document.body||window._mediaPlaybackObserver) return;
+  _initMediaVisibilityObserver();
   window._mediaPlaybackObserver=new MutationObserver(records=>{
     for(const rec of records){
+      for(const node of rec.removedNodes||[]){
+        if(!node||node.nodeType!==1) continue;
+        const videos=[];
+        if(node.matches&&node.matches('.msg-media-video')) videos.push(node);
+        if(node.querySelectorAll) videos.push(...node.querySelectorAll('.msg-media-video'));
+        videos.forEach(_unobserveVideoPreload);
+      }
       for(const node of rec.addedNodes||[]){
         if(!node||node.nodeType!==1) continue;
         const media=[];
         if(node.matches&&node.matches('audio,video')) media.push(node);
         if(node.querySelectorAll) media.push(...node.querySelectorAll('audio,video'));
-        media.forEach(m=>_applyMediaPlaybackRate(m));
+        media.forEach(m=>{
+          _applyMediaPlaybackRate(m);
+          _observeVideoPreload(m);
+        });
       }
     }
   });
   window._mediaPlaybackObserver.observe(document.body,{childList:true,subtree:true});
-  document.querySelectorAll('audio,video').forEach(m=>_applyMediaPlaybackRate(m));
+  document.querySelectorAll('audio,video').forEach(m=>{
+    _applyMediaPlaybackRate(m);
+    _observeVideoPreload(m);
+  });
 }
 if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',_initMediaPlaybackObserver);
 else _initMediaPlaybackObserver();

--- a/tests/test_visible_video_preload.py
+++ b/tests/test_visible_video_preload.py
@@ -1,0 +1,126 @@
+"""Behavioral tests for visibility-driven chat video preloading."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _extract_function(name: str) -> str:
+    start = UI_JS.index(f"function {name}(")
+    brace = UI_JS.index("{", start)
+    depth = 1
+    i = brace + 1
+    while depth:
+        if UI_JS[i] == "{":
+            depth += 1
+        elif UI_JS[i] == "}":
+            depth -= 1
+        i += 1
+    return UI_JS[start:i]
+
+
+def _run_node(body: str) -> dict:
+    script = "\n".join(
+        [
+            "let _mediaVisibilityObserver=null;",
+            _extract_function("_promoteVisibleVideoPreload"),
+            _extract_function("_observeVideoPreload"),
+            _extract_function("_unobserveVideoPreload"),
+            _extract_function("_initMediaVisibilityObserver"),
+            body,
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_offscreen_video_stays_metadata_only_until_first_intersection():
+    result = _run_node(
+        r"""
+let callback=null;
+const observed=[];
+const unobserved=[];
+global.IntersectionObserver=class {
+  constructor(cb,options){callback=cb;this.options=options;}
+  observe(v){observed.push(v);}
+  unobserve(v){unobserved.push(v);}
+};
+const video={
+  dataset:{}, preload:'metadata', paused:true, readyState:1, loads:0,
+  matches:s=>s==='.msg-media-video', load(){this.loads+=1;}
+};
+_initMediaVisibilityObserver();
+_observeVideoPreload(video);
+const before={preload:video.preload,loads:video.loads,observed:observed.length};
+callback([{target:video,isIntersecting:false}]);
+const offscreen={preload:video.preload,loads:video.loads,unobserved:unobserved.length};
+callback([{target:video,isIntersecting:true}]);
+const first={preload:video.preload,loads:video.loads,unobserved:unobserved.length};
+callback([{target:video,isIntersecting:true}]);
+const second={preload:video.preload,loads:video.loads,unobserved:unobserved.length};
+console.log(JSON.stringify({before,offscreen,first,second,options:_mediaVisibilityObserver.options}));
+"""
+    )
+
+    assert result["before"] == {"preload": "metadata", "loads": 0, "observed": 1}
+    assert result["offscreen"] == {"preload": "metadata", "loads": 0, "unobserved": 0}
+    assert result["first"] == {"preload": "auto", "loads": 1, "unobserved": 1}
+    assert result["second"] == {"preload": "auto", "loads": 1, "unobserved": 2}
+    assert result["options"]["rootMargin"] == "300px 0px"
+
+
+def test_removed_video_is_unobserved_before_it_intersects():
+    script = "\n".join(
+        [
+            "let _mediaVisibilityObserver=null;",
+            _extract_function("_promoteVisibleVideoPreload"),
+            _extract_function("_observeVideoPreload"),
+            _extract_function("_unobserveVideoPreload"),
+            _extract_function("_initMediaVisibilityObserver"),
+            _extract_function("_initMediaPlaybackObserver"),
+            r"""
+let ioCallback=null,mutationCallback=null;
+const observed=[],unobserved=[];
+global.IntersectionObserver=class {
+  constructor(cb){ioCallback=cb;}
+  observe(v){observed.push(v);}
+  unobserve(v){unobserved.push(v);}
+};
+global.MutationObserver=class {
+  constructor(cb){mutationCallback=cb;}
+  observe(){}
+};
+const documentVideos=[];
+global.document={
+  body:{}, readyState:'complete',
+  querySelectorAll:()=>documentVideos,
+  addEventListener:()=>{}
+};
+global.window={};
+global._applyMediaPlaybackRate=()=>{};
+const video={nodeType:1,dataset:{},matches:s=>s==='.msg-media-video'||s==='audio,video',querySelectorAll:()=>[]};
+_initMediaPlaybackObserver();
+mutationCallback([{addedNodes:[video],removedNodes:[]}]);
+mutationCallback([{addedNodes:[],removedNodes:[video]}]);
+console.log(JSON.stringify({observed:observed.length,unobserved:unobserved.length}));
+""",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], cwd=ROOT, capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"observed": 1, "unobserved": 1}

--- a/tests/test_visible_video_preload.py
+++ b/tests/test_visible_video_preload.py
@@ -111,11 +111,13 @@ global.document={
 };
 global.window={};
 global._applyMediaPlaybackRate=()=>{};
-const video={nodeType:1,dataset:{},matches:s=>s==='.msg-media-video'||s==='audio,video',querySelectorAll:()=>[]};
+const video={nodeType:1,isConnected:true,dataset:{},preload:'metadata',loads:0,load(){this.loads+=1;},matches:s=>s==='.msg-media-video'||s==='audio,video',querySelectorAll:()=>[]};
 _initMediaPlaybackObserver();
 mutationCallback([{addedNodes:[video],removedNodes:[]}]);
 mutationCallback([{addedNodes:[],removedNodes:[video]}]);
-console.log(JSON.stringify({observed:observed.length,unobserved:unobserved.length}));
+video.isConnected=false;
+ioCallback([{target:video,isIntersecting:true}]);
+console.log(JSON.stringify({observed:observed.length,unobserved:unobserved.length,preload:video.preload,loads:video.loads,marker:video.dataset.visiblePreload||null}));
 """,
         ]
     )
@@ -123,4 +125,10 @@ console.log(JSON.stringify({observed:observed.length,unobserved:unobserved.lengt
         ["node", "-e", script], cwd=ROOT, capture_output=True, text=True, timeout=30
     )
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout) == {"observed": 1, "unobserved": 1}
+    assert json.loads(result.stdout) == {
+        "observed": 1,
+        "unobserved": 2,
+        "preload": "metadata",
+        "loads": 0,
+        "marker": None,
+    }


### PR DESCRIPTION
## Thinking Path

- Chat history can contain many inline videos, so eagerly buffering every video would waste bandwidth.
- Keeping every player at `preload="metadata"` avoids that cost, but a currently visible mobile player can appear stalled because Chromium stops after metadata.
- The smallest behavioral change is to preserve metadata-only loading off-screen and promote only videos that approach the viewport.
- A shared `IntersectionObserver` provides that boundary without changing media URLs, server caching, or playback controls.

## What Changed

- Observe inline chat videos with one shared `IntersectionObserver`.
- Keep off-screen history videos at `preload="metadata"`.
- Promote a visible video to `preload="auto"` and restart its load once.
- Promote immediately when playback starts.
- Unobserve video nodes removed before intersection.
- Add Node-executed behavioral tests for off-screen, first-intersection, duplicate-intersection, and removal paths.

## Why It Matters

Visible video cards begin filling a playable buffer instead of appearing stuck after metadata, while long conversations do not download every historical video.

## Verification

- Behavioral tests against current unpatched `origin/master`: **2 failed** because the visibility-preload implementation was absent.
- Media behavior and neighboring shard: **93 passed**.
- Focused test class: **67 passed**.
- Real Chromium with the exact branch code: while off-screen the player stayed at `preload=metadata` with no promotion marker; after entering the viewport it switched once to `preload=auto` and extended its buffered range from 2.006 seconds to the full 10.041667 seconds with no decode error.
- `node --check static/ui.js`
- `git diff --check`

## Risks / Follow-ups

- Persistent browser caching is intentionally out of scope and tracked separately in #7074.
- Browsers without `IntersectionObserver` retain the existing metadata-only behavior; pressing play remains handled by the native player.
- The 300px root margin intentionally begins buffering shortly before the player enters view.
- There is no layout or visual-control change, so before/after screenshots are visually identical; verification targets the observable preload/load behavior instead.
