### PR TITLE
fix(windows): preserve binary bytes in anchored file reads

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1016,6 +1016,7 @@ def safe_resolve_ws(root: Path, requested: str) -> Path:
 _DIR_FD_OK = os.open in getattr(os, "supports_dir_fd", set())
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_O_BINARY = getattr(os, "O_BINARY", 0)
 
 
 def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
@@ -1037,7 +1038,11 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
         # Windows / no openat: fall back to a plain pathname open. No new race
         # protection, but no regression vs the prior path-based behaviour, and
         # symlink creation needs admin on Windows anyway.
-        flags = os.O_RDONLY | (_O_DIRECTORY if want_dir else 0) | _O_NOFOLLOW
+        flags = (
+            os.O_RDONLY
+            | (_O_DIRECTORY if want_dir else _O_BINARY)
+            | _O_NOFOLLOW
+        )
         try:
             return os.open(str(target), flags)
         except OSError:
@@ -1052,7 +1057,11 @@ def open_anchored_fd(workspace: Path, target: Path, *, want_dir: bool) -> int:
         for i, part in enumerate(rel_parts):
             is_last = i == len(rel_parts) - 1
             want_directory = (not is_last) or want_dir
-            flags = os.O_RDONLY | _O_NOFOLLOW | (_O_DIRECTORY if want_directory else 0)
+            flags = (
+                os.O_RDONLY
+                | _O_NOFOLLOW
+                | (_O_DIRECTORY if want_directory else _O_BINARY)
+            )
             try:
                 nfd = os.open(part, flags, dir_fd=fd)
             except OSError:

--- a/tests/test_media_message_snapshots.py
+++ b/tests/test_media_message_snapshots.py
@@ -89,6 +89,72 @@ def test_capture_snapshot_stores_content_addressed_bytes(snap_dir, tmp_path):
     assert stored.read_bytes() == b"<html>v1</html>"
 
 
+def test_anchored_snapshot_read_preserves_windows_ctrl_z(tmp_path):
+    """Anchored binary reads must not treat DOS Ctrl-Z as text EOF on Windows."""
+    from api.routes import _etag_and_snapshot, _open_file_read_fd
+
+    payload = b"a" * 568 + b"\x1a" + b"b" * 4096
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(payload)
+
+    fd = _open_file_read_fd(source, tmp_path)
+    try:
+        _etag, snapshot, actual_size = _etag_and_snapshot(fd, file_size=len(payload))
+    finally:
+        os.close(fd)
+
+    assert actual_size == len(payload)
+    assert snapshot == payload
+
+
+def test_anchored_file_leaf_uses_binary_open_flag(monkeypatch, tmp_path):
+    """The platform-independent flag contract keeps Windows binary-safe in CI."""
+    from api import workspace
+
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"payload")
+    seen = {}
+
+    def fake_open(path, flags, *args, **kwargs):
+        seen["path"] = path
+        seen["flags"] = flags
+        return 123
+
+    monkeypatch.setattr(workspace, "_DIR_FD_OK", False)
+    monkeypatch.setattr(workspace, "_O_BINARY", 0x40000000)
+    monkeypatch.setattr(workspace.os, "open", fake_open)
+
+    fd = workspace.open_anchored_fd(tmp_path, source, want_dir=False)
+
+    assert fd == 123
+    assert seen["path"] == str(source)
+    assert seen["flags"] & workspace._O_BINARY
+
+
+def test_anchored_directory_does_not_use_binary_open_flag(monkeypatch, tmp_path):
+    """Directory opens keep their directory-only flag contract."""
+    from api import workspace
+
+    target = tmp_path / "folder"
+    target.mkdir()
+    seen = {}
+
+    def fake_open(path, flags, *args, **kwargs):
+        seen["flags"] = flags
+        return 124
+
+    monkeypatch.setattr(workspace, "_DIR_FD_OK", False)
+    monkeypatch.setattr(workspace, "_O_BINARY", 0x40000000)
+    monkeypatch.setattr(workspace, "_O_DIRECTORY", 0x20000000)
+    monkeypatch.setattr(workspace.os, "open", fake_open)
+
+    fd = workspace.open_anchored_fd(tmp_path, target, want_dir=True)
+
+    assert fd == 124
+    assert seen["flags"] & workspace._O_DIRECTORY
+    assert not seen["flags"] & workspace._O_BINARY
+
+
 def test_capture_snapshot_dedupes_identical_content(snap_dir, tmp_path):
     from api.media_snapshots import capture_snapshot
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI serves workspace files and immutable media snapshots through an anchored file-descriptor path.
- On Windows, file descriptors opened without `O_BINARY` use text semantics.
- A valid MP4 whose first `0x1A` byte occurred at offset 568 was therefore reported and served as 568 bytes even though its real size was 5,248,045 bytes.
- The non-anchored media path already adds `O_BINARY`; the shared anchored-open helper did not.
- This change makes non-directory anchored reads binary-safe while preserving directory-open flags.

## What Changed

- Add the platform-optional `O_BINARY` flag to non-directory opens in `open_anchored_fd()`.
- Preserve the existing directory-only flag path.
- Add a Windows Ctrl-Z regression test using the real anchored snapshot read path.
- Add platform-independent flag-contract tests so Linux/macOS CI still detects removal of the Windows safety flag.

## Why It Matters

Without this flag, arbitrary binary workspace files can be truncated at the first DOS Ctrl-Z byte on Windows. For video snapshots this produces invalid Range lengths and browser playback failures even though the source file and checksum are valid.

## Verification

- Regression test on the unpatched current `origin/master`: **RED**, `actual_size == 568` instead of `4665`.
- Same test after the fix: **GREEN**.
- Focused and neighboring tests: `23 passed, 7 skipped`.
- Full four-shard Windows run: the changed tests and shard 2 were green; shards 0/1/3 reported existing Windows-environment failures. The failure sets were identical across two independent `origin/master + 1 commit` branches. A clean `origin/master` control reproduced the failures (or classified the remaining two as one platform skip and one concurrency-only pass). No failure was unique to this branch.
- `python -m py_compile api/workspace.py tests/test_media_message_snapshots.py`
- `git diff --check`

## Risks / Follow-ups

- The change is limited to read-only non-directory opens. Directory opens still use `O_DIRECTORY` and do not receive `O_BINARY`.
- `O_BINARY` resolves to zero on platforms that do not define it, preserving existing POSIX behavior.
