### PR TITLE
fix(tests): guard playwright import and serve media tests from allowed roots (#7013)

### DIFF
--- a/tests/test_compression_phantom_barrier.py
+++ b/tests/test_compression_phantom_barrier.py
@@ -5,14 +5,23 @@ only the SSE transport, and dispatches events through attachLiveStream's real
 listeners. All HTTP requests are fulfilled in-process; no WebUI server or
 network access is used.
 """
-
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
 import pytest
-from playwright.sync_api import sync_playwright
+
+try:
+    from playwright.sync_api import sync_playwright
+except Exception:
+    sync_playwright = None
+
+
+def _require_playwright():
+    if sync_playwright is None:
+        pytest.skip("playwright is unavailable; run `playwright install chromium`")
+    return sync_playwright
 
 ROOT = Path(__file__).resolve().parents[1]
 STATIC = ROOT / "static"
@@ -200,7 +209,8 @@ async ({kind, doneSid}) => {
 
 @pytest.fixture(scope="module")
 def browser():
-    with sync_playwright() as playwright:
+    sp = _require_playwright()
+    with sp() as playwright:
         instance = playwright.chromium.launch(
             headless=True,
             args=["--no-sandbox", "--disable-dev-shm-usage"],

--- a/tests/test_media_etag_revalidation.py
+++ b/tests/test_media_etag_revalidation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +11,22 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def allowed_tmp_path():
+    """Provide a temp directory under an allowed root (/tmp on Linux and macOS).
+
+    The /api/media gate only serves files under its allowed roots (hermes home,
+    /tmp, ~/.hermes, the active workspace — see api/routes.py _handle_media).
+    pytest's tmp_path resolves to /tmp on Linux but /private/var/folders/... on
+    macOS, which is outside every allowed root — that made the media-serving
+    tests 403 on darwin. This fixture anchors files at /tmp (== /private/tmp on
+    macOS) regardless of TMPDIR so the gate serves them on every platform.
+    """
+    test_dir = Path(tempfile.mkdtemp(prefix="hermes-webui-media-test-", dir="/tmp"))
+    yield test_dir
+    shutil.rmtree(test_dir, ignore_errors=True)
 
 
 class _FakeHandler:
@@ -52,8 +70,8 @@ def routes():
 # ── _serve_file_bytes ETag / 304 ──────────────────────────────────────────
 
 
-def test_serve_file_bytes_emits_weak_etag(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_serve_file_bytes_emits_weak_etag(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"\x89PNG\r\n\x1a\npayload")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
 
@@ -64,8 +82,8 @@ def test_serve_file_bytes_emits_weak_etag(routes, tmp_path):
     assert etag.endswith('"')
 
 
-def test_if_none_match_matching_returns_304_no_body(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_if_none_match_matching_returns_304_no_body(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     etag = handler.header("ETag")
@@ -82,8 +100,8 @@ def test_if_none_match_matching_returns_304_no_body(routes, tmp_path):
     assert not any(k == "Content-Length" for k, _ in handler2.sent_headers)
 
 
-def test_if_none_match_star_returns_304(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_if_none_match_star_returns_304(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(
         routes, target, "image/png", "private, no-cache", headers={"If-None-Match": "*"}
@@ -91,8 +109,8 @@ def test_if_none_match_star_returns_304(routes, tmp_path):
     assert handler.status == 304
 
 
-def test_if_none_match_mismatch_returns_full_200(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_if_none_match_mismatch_returns_full_200(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(
         routes,
@@ -105,9 +123,9 @@ def test_if_none_match_mismatch_returns_full_200(routes, tmp_path):
     assert handler.body == b"abc"
 
 
-def test_if_none_match_weak_comparison_ignores_w_prefix(routes, tmp_path):
+def test_if_none_match_weak_comparison_ignores_w_prefix(routes, allowed_tmp_path):
     """RFC 7232 weak comparison: client may send the strong form (no W/)."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     strong_form = handler.header("ETag")[2:]  # strip W/ -> '"<digest>"'
@@ -117,8 +135,8 @@ def test_if_none_match_weak_comparison_ignores_w_prefix(routes, tmp_path):
     assert handler2.status == 304
 
 
-def test_if_none_match_list_any_entry_matches(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_if_none_match_list_any_entry_matches(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     etag = handler.header("ETag")
@@ -132,9 +150,9 @@ def test_if_none_match_list_any_entry_matches(routes, tmp_path):
     assert handler2.status == 304
 
 
-def test_etag_changes_when_file_replaced_in_place(routes, tmp_path):
+def test_etag_changes_when_file_replaced_in_place(routes, allowed_tmp_path):
     """Core user scenario: same-name file updated -> old ETag no longer valid."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"v1")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     old_etag = handler.header("ETag")
@@ -149,12 +167,12 @@ def test_etag_changes_when_file_replaced_in_place(routes, tmp_path):
     assert handler2.header("ETag") != old_etag
 
 
-def test_etag_changes_on_same_size_same_mtime_replacement(routes, tmp_path):
+def test_etag_changes_on_same_size_same_mtime_replacement(routes, allowed_tmp_path):
     """Regression for the metadata-only ETag gap: an in-place replacement with
     identical size AND identical mtime (e.g. 2-second filesystem granularity)
     must still produce a different ETag, so the conditional GET returns 200
     with the new content instead of a stale 304."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"AAAA")
     fixed_ns = 1_700_000_000_000_000_000
     os.utime(target, ns=(fixed_ns, fixed_ns))
@@ -174,10 +192,10 @@ def test_etag_changes_on_same_size_same_mtime_replacement(routes, tmp_path):
     assert handler2.header("ETag") != old_etag
 
 
-def test_304_path_closes_fd(routes, tmp_path, monkeypatch):
+def test_304_path_closes_fd(routes, allowed_tmp_path, monkeypatch):
     """The 304 early return must close the opened fd (no descriptor leak on
     revalidated hits)."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     etag = handler.header("ETag")
@@ -192,8 +210,8 @@ def test_304_path_closes_fd(routes, tmp_path, monkeypatch):
     assert closed, "fd was not closed on the 304 path"
 
 
-def test_range_response_includes_etag(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_range_response_includes_etag(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")
     handler, _ = _serve(
         routes, target, "image/png", "private, no-cache", headers={"Range": "bytes=0-2"}
@@ -203,9 +221,9 @@ def test_range_response_includes_etag(routes, tmp_path):
     assert handler.header("ETag") and handler.header("ETag").startswith('W/"')
 
 
-def test_if_none_match_precedes_range(routes, tmp_path):
+def test_if_none_match_precedes_range(routes, allowed_tmp_path):
     """A matched conditional request short-circuits before Range handling."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     etag = handler.header("ETag")
@@ -219,8 +237,8 @@ def test_if_none_match_precedes_range(routes, tmp_path):
     assert handler2.status == 304
 
 
-def test_invalid_range_still_416(routes, tmp_path):
-    target = tmp_path / "img.png"
+def test_invalid_range_still_416(routes, allowed_tmp_path):
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")
     handler, _ = _serve(
         routes, target, "image/png", "private, no-cache", headers={"Range": "bytes=999-1000"}
@@ -240,8 +258,26 @@ def _media_get(routes, monkeypatch, target, headers=None):
     return handler
 
 
-def test_handle_media_image_served_with_no_cache_and_etag(routes, monkeypatch, tmp_path):
-    img = tmp_path / "pic.png"
+def test_media_fixture_serves_from_allowed_root(routes, monkeypatch, allowed_tmp_path):
+    """Regression guard for #7013: media test files must resolve under an
+    allowed root (/tmp), so the media gate serves them on every platform.
+
+    pytest's tmp_path lives under /private/var/folders/... on macOS, which is
+    outside every allowed root and makes the gate 403; anchoring at /tmp keeps
+    the suite green on darwin and Linux alike without touching the gate.
+    """
+    target = allowed_tmp_path / "pic.png"
+    target.write_bytes(b"\x89PNG\r\n\x1a\nimagedata")
+    handler = _media_get(routes, monkeypatch, target)
+
+    assert handler.status == 200
+    # The served path must resolve under /tmp, the allowed root the gate
+    # accepts on both Linux and macOS (where /tmp == /private/tmp).
+    assert target.resolve().is_relative_to(Path("/tmp").resolve())
+
+
+def test_handle_media_image_served_with_no_cache_and_etag(routes, monkeypatch, allowed_tmp_path):
+    img = allowed_tmp_path / "pic.png"
     img.write_bytes(b"\x89PNG\r\n\x1a\nimagedata")
     handler = _media_get(routes, monkeypatch, img)
 
@@ -251,8 +287,8 @@ def test_handle_media_image_served_with_no_cache_and_etag(routes, monkeypatch, t
     assert bytes(handler.body) == b"\x89PNG\r\n\x1a\nimagedata"
 
 
-def test_handle_media_image_revalidation_returns_304(routes, monkeypatch, tmp_path):
-    img = tmp_path / "pic.png"
+def test_handle_media_image_revalidation_returns_304(routes, monkeypatch, allowed_tmp_path):
+    img = allowed_tmp_path / "pic.png"
     img.write_bytes(b"\x89PNG\r\n\x1a\nimagedata")
     first = _media_get(routes, monkeypatch, img)
     etag = first.header("ETag")
@@ -264,9 +300,9 @@ def test_handle_media_image_revalidation_returns_304(routes, monkeypatch, tmp_pa
     assert second.body == b""
 
 
-def test_handle_media_image_update_in_place_revalidates(routes, monkeypatch, tmp_path):
+def test_handle_media_image_update_in_place_revalidates(routes, monkeypatch, allowed_tmp_path):
     """The bug this fix targets: same-name image replaced -> preview must refresh."""
-    img = tmp_path / "pic.png"
+    img = allowed_tmp_path / "pic.png"
     img.write_bytes(b"old-content")
     first = _media_get(routes, monkeypatch, img)
     old_etag = first.header("ETag")
@@ -281,9 +317,9 @@ def test_handle_media_image_update_in_place_revalidates(routes, monkeypatch, tmp
     assert second.header("ETag") != old_etag
 
 
-def test_handle_media_html_keeps_no_store(routes, monkeypatch, tmp_path):
+def test_handle_media_html_keeps_no_store(routes, monkeypatch, allowed_tmp_path):
     """Regression guard: HTML inline preview must stay no-store (PR #6706)."""
-    page = tmp_path / "page.html"
+    page = allowed_tmp_path / "page.html"
     page.write_text("<html><body>hi</body></html>", encoding="utf-8")
     handler = _media_get(routes, monkeypatch, page)
 
@@ -291,8 +327,8 @@ def test_handle_media_html_keeps_no_store(routes, monkeypatch, tmp_path):
     assert handler.header("Cache-Control") == "no-store"
 
 
-def test_handle_media_pdf_uses_no_cache(routes, monkeypatch, tmp_path):
-    pdf = tmp_path / "doc.pdf"
+def test_handle_media_pdf_uses_no_cache(routes, monkeypatch, allowed_tmp_path):
+    pdf = allowed_tmp_path / "doc.pdf"
     pdf.write_bytes(b"%PDF-1.4\n%EOF")
     handler = _media_get(routes, monkeypatch, pdf)
 
@@ -301,20 +337,20 @@ def test_handle_media_pdf_uses_no_cache(routes, monkeypatch, tmp_path):
     assert handler.header("ETag")
 
 
-def test_large_file_skips_etag_no_hashing(routes, tmp_path):
+def test_large_file_skips_etag_no_hashing(routes, allowed_tmp_path):
     """Files above the cap must be served without ETag to avoid hashing every
     byte of a large video / Range request."""
-    target = tmp_path / "big.bin"
+    target = allowed_tmp_path / "big.bin"
     target.write_bytes(b"X" * (10 * 1024 * 1024 + 1))  # _ETAG_SIZE_CAP + 1
     handler, _ = _serve(routes, target, "application/octet-stream", "private, no-cache")
     assert handler.status == 200
     assert not handler.header("ETag")
 
 
-def test_etag_no_body_on_pread_failure(routes, tmp_path, monkeypatch):
+def test_etag_no_body_on_pread_failure(routes, allowed_tmp_path, monkeypatch):
     """If os.read fails during ETag snapshot computation, the fd must be closed and
     the response must be 500 (not an unhandled exception)."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"abc")
 
     real_close = os.close
@@ -332,10 +368,10 @@ def test_etag_no_body_on_pread_failure(routes, tmp_path, monkeypatch):
     assert closed, "fd was not closed on read failure"
 
 
-def test_pread_snapshot_matches_served_bytes(routes, tmp_path, monkeypatch):
+def test_pread_snapshot_matches_served_bytes(routes, allowed_tmp_path, monkeypatch):
     """TOCTOU: the file is replaced between ETag computation and body send;
     the pread snapshot guarantees the ETag and the served bytes agree."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"snapshot")
     handler, _ = _serve(routes, target, "image/png", "private, no-cache")
     assert handler.status == 200
@@ -356,10 +392,10 @@ def test_pread_snapshot_matches_served_bytes(routes, tmp_path, monkeypatch):
     assert handler2.header("ETag") != etag
 
 
-def test_short_read_truncation_uses_actual_size(routes, tmp_path, monkeypatch):
+def test_short_read_truncation_uses_actual_size(routes, allowed_tmp_path, monkeypatch):
     """When a file is truncated between fstat and snapshot read, the actual
     read size is used for Content-Length, not the stale fstat size."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     # Start with a 10-byte file
     target.write_bytes(b"0123456789")
     
@@ -389,9 +425,9 @@ def test_short_read_truncation_uses_actual_size(routes, tmp_path, monkeypatch):
         f"Content-Length {content_length} != body length {len(handler.body)}"
 
 
-def test_short_read_no_etag_on_truncation(routes, tmp_path, monkeypatch):
+def test_short_read_no_etag_on_truncation(routes, allowed_tmp_path, monkeypatch):
     """When the file is truncated mid-read, no ETag is sent (streaming fallback)."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")
     
     # Simulate truncation: fstat says 10, but _etag_and_snapshot's read only gets 6 bytes
@@ -428,13 +464,13 @@ def test_short_read_no_etag_on_truncation(routes, tmp_path, monkeypatch):
     assert len(handler.body) == 6, f"body should be 6-byte snapshot, got {len(handler.body)}"
 
 
-def test_shrink_again_during_body_transmission_200(routes, tmp_path, monkeypatch):
+def test_shrink_again_during_body_transmission_200(routes, allowed_tmp_path, monkeypatch):
     """When file shrinks AGAIN between first read and body transmission,
     the captured snapshot (not re-read) is served — no header/body mismatch.
     
     Round-6 regression: Codex reproduced 200 advertised 6 / wrote 3.
     """
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")  # 10 bytes initially
     
     # Track reads to simulate shrink-again after first snapshot
@@ -469,13 +505,13 @@ def test_shrink_again_during_body_transmission_200(routes, tmp_path, monkeypatch
         f"Content-Length {content_length} != body {len(handler.body)}"
 
 
-def test_shrink_again_during_body_transmission_range_206(routes, tmp_path, monkeypatch):
+def test_shrink_again_during_body_transmission_range_206(routes, allowed_tmp_path, monkeypatch):
     """When file shrinks AGAIN between first read and Range body transmission,
     the captured snapshot (not re-read) is served — no header/body mismatch.
     
     Round-6 regression: Codex reproduced 206 advertised 4 / wrote 1.
     """
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"0123456789")  # 10 bytes initially
     
     # Track reads to simulate shrink-again after first snapshot
@@ -531,10 +567,10 @@ class _DisconnectAfterHeadersHandler(_FakeHandler):
         raise BrokenPipeError()
 
 
-def test_disconnect_mid_body_snapshot_no_second_response(routes, tmp_path):
+def test_disconnect_mid_body_snapshot_no_second_response(routes, allowed_tmp_path):
     """Client disconnects while the snapshot body is written: the 200 is
     already committed, so no second 500 may be attempted afterwards."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"payload")
     handler = _DisconnectAfterHeadersHandler()
     result = routes._serve_file_bytes(
@@ -549,10 +585,10 @@ def test_disconnect_mid_body_snapshot_no_second_response(routes, tmp_path):
     assert result is True
 
 
-def test_disconnect_mid_body_stream_no_second_response(routes, tmp_path):
+def test_disconnect_mid_body_stream_no_second_response(routes, allowed_tmp_path):
     """Client disconnects while an over-cap (no-ETag) file is streamed:
     exactly one 200 status, never a trailing 500."""
-    target = tmp_path / "big.bin"
+    target = allowed_tmp_path / "big.bin"
     target.write_bytes(b"X" * (10 * 1024 * 1024 + 1))  # _ETAG_SIZE_CAP + 1
     handler = _DisconnectAfterHeadersHandler()
     result = routes._serve_file_bytes(
@@ -614,10 +650,10 @@ def _serve_with_caller(routes, handler, target, mime, cache_control):
         pytest.param(PermissionError(13, "Permission denied"), id="PermissionError"),
     ],
 )
-def test_non_disconnect_error_mid_body_snapshot_no_second_response(routes, tmp_path, error):
+def test_non_disconnect_error_mid_body_snapshot_no_second_response(routes, allowed_tmp_path, error):
     """A non-disconnect error while the snapshot body is written must not
     escape to the caller's 500 path: exactly [200], never [200, 500]."""
-    target = tmp_path / "img.png"
+    target = allowed_tmp_path / "img.png"
     target.write_bytes(b"payload")
     handler = _PostCommitErrorHandler(error)
     result = _serve_with_caller(
@@ -639,10 +675,10 @@ def test_non_disconnect_error_mid_body_snapshot_no_second_response(routes, tmp_p
         pytest.param(PermissionError(13, "Permission denied"), id="PermissionError"),
     ],
 )
-def test_non_disconnect_error_mid_body_stream_no_second_response(routes, tmp_path, error):
+def test_non_disconnect_error_mid_body_stream_no_second_response(routes, allowed_tmp_path, error):
     """Same contract for the over-cap streaming path: a non-disconnect error
     mid-stream must not produce a trailing 500."""
-    target = tmp_path / "big.bin"
+    target = allowed_tmp_path / "big.bin"
     target.write_bytes(b"X" * (10 * 1024 * 1024 + 1))  # _ETAG_SIZE_CAP + 1
     handler = _PostCommitErrorHandler(error)
     result = _serve_with_caller(

--- a/tests/test_media_message_snapshots.py
+++ b/tests/test_media_message_snapshots.py
@@ -16,13 +16,32 @@ overwritten AND deleted, while a request WITHOUT a snap keeps serving the live
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+
 ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def allowed_tmp_path():
+    """Provide a temp directory under an allowed root (/tmp on Linux and macOS).
+
+    The /api/media gate only serves files under its allowed roots (hermes home,
+    /tmp, ~/.hermes, the active workspace — see api/routes.py _handle_media).
+    pytest's tmp_path resolves to /tmp on Linux but /private/var/folders/... on
+    macOS, which is outside every allowed root — that made the media-serving
+    tests 403 on darwin. This fixture anchors files at /tmp (== /private/tmp on
+    macOS) regardless of TMPDIR so the gate serves them on every platform.
+    """
+    test_dir = Path(tempfile.mkdtemp(prefix="hermes-webui-media-test-", dir="/tmp"))
+    yield test_dir
+    shutil.rmtree(test_dir, ignore_errors=True)
 
 
 class _FakeHandler:
@@ -57,9 +76,9 @@ def routes():
 
 
 @pytest.fixture
-def snap_dir(tmp_path, monkeypatch):
-    """Isolate the snapshot store per test and point it at tmp_path."""
-    store = tmp_path / "media_snapshots"
+def snap_dir(allowed_tmp_path, monkeypatch):
+    """Isolate the snapshot store per test and point it at allowed_tmp_path."""
+    store = allowed_tmp_path / "media_snapshots"
     monkeypatch.setenv("HERMES_WEBUI_MEDIA_SNAPSHOT_DIR", str(store))
     return store
 
@@ -75,10 +94,10 @@ def _media_get(routes, monkeypatch, target, headers=None, query_extra=""):
 # ── capture_snapshot ───────────────────────────────────────────────────────
 
 
-def test_capture_snapshot_stores_content_addressed_bytes(snap_dir, tmp_path):
+def test_capture_snapshot_stores_content_addressed_bytes(snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot, snapshot_path_for_digest
 
-    source = tmp_path / "report.html"
+    source = allowed_tmp_path / "report.html"
     source.write_bytes(b"<html>v1</html>")
 
     digest = capture_snapshot(source)
@@ -89,11 +108,11 @@ def test_capture_snapshot_stores_content_addressed_bytes(snap_dir, tmp_path):
     assert stored.read_bytes() == b"<html>v1</html>"
 
 
-def test_capture_snapshot_dedupes_identical_content(snap_dir, tmp_path):
+def test_capture_snapshot_dedupes_identical_content(snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    a = tmp_path / "a.png"
-    b = tmp_path / "b.png"
+    a = allowed_tmp_path / "a.png"
+    b = allowed_tmp_path / "b.png"
     a.write_bytes(b"same-bytes")
     b.write_bytes(b"same-bytes")
 
@@ -105,29 +124,29 @@ def test_capture_snapshot_dedupes_identical_content(snap_dir, tmp_path):
     assert len(list(snap_dir.glob("*.snap"))) == 1
 
 
-def test_capture_snapshot_skips_missing_and_over_cap(snap_dir, tmp_path):
+def test_capture_snapshot_skips_missing_and_over_cap(snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    assert capture_snapshot(tmp_path / "missing.png") is None
+    assert capture_snapshot(allowed_tmp_path / "missing.png") is None
 
-    big = tmp_path / "big.mp4"
+    big = allowed_tmp_path / "big.mp4"
     big.write_bytes(b"x" * 1024)
     assert capture_snapshot(big, max_file_bytes=512) is None
 
 
-def test_capture_snapshot_skips_directories(snap_dir, tmp_path):
+def test_capture_snapshot_skips_directories(snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    assert capture_snapshot(tmp_path) is None
+    assert capture_snapshot(allowed_tmp_path) is None
 
 
 # ── resolve_media_ref / media_capture_allowed ──────────────────────────────
 
 
-def test_resolve_media_ref_handles_file_url_and_expands_home(tmp_path, monkeypatch):
+def test_resolve_media_ref_handles_file_url_and_expands_home(allowed_tmp_path, monkeypatch):
     from api.media_snapshots import resolve_media_ref
 
-    target = tmp_path / "x.html"
+    target = allowed_tmp_path / "x.html"
     target.write_text("hi")
 
     assert resolve_media_ref(str(target)) == target.resolve()
@@ -137,31 +156,31 @@ def test_resolve_media_ref_handles_file_url_and_expands_home(tmp_path, monkeypat
     assert resolve_media_ref("") is None
 
 
-def test_media_capture_allowed_denies_hermes_state(tmp_path, monkeypatch):
+def test_media_capture_allowed_denies_hermes_state(allowed_tmp_path, monkeypatch):
     from api.media_snapshots import media_capture_allowed
 
     # Files under an allowed root (tmp) are fine...
-    allowed = tmp_path / "ok.html"
+    allowed = allowed_tmp_path / "ok.html"
     allowed.write_text("x")
     assert media_capture_allowed(allowed) is True
 
     # ...but a deny-listed filename under a Hermes root is never snapshotted.
     # Point HOME at the fake tree so <fake-home>/.hermes counts as a root.
-    hermes_home = tmp_path / ".hermes"
+    hermes_home = allowed_tmp_path / ".hermes"
     hermes_home.mkdir()
     secret = hermes_home / "settings.json"
     secret.write_text("{}")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(allowed_tmp_path))
     assert media_capture_allowed(secret) is False
 
 
 # ── annotate_media_snapshots ───────────────────────────────────────────────
 
 
-def test_annotate_stamps_assistant_messages_with_snapshots(snap_dir, tmp_path):
+def test_annotate_stamps_assistant_messages_with_snapshots(snap_dir, allowed_tmp_path):
     from api.media_snapshots import annotate_media_snapshots
 
-    target = tmp_path / "report.html"
+    target = allowed_tmp_path / "report.html"
     target.write_text("<html>v1</html>")
 
     messages = [
@@ -177,10 +196,10 @@ def test_annotate_stamps_assistant_messages_with_snapshots(snap_dir, tmp_path):
     assert len(stamped[str(target)]) == 64
 
 
-def test_annotate_is_idempotent_across_settles(snap_dir, tmp_path):
+def test_annotate_is_idempotent_across_settles(snap_dir, allowed_tmp_path):
     from api.media_snapshots import annotate_media_snapshots
 
-    target = tmp_path / "report.html"
+    target = allowed_tmp_path / "report.html"
     target.write_text("<html>v1</html>")
     messages = [{"role": "assistant", "content": f"MEDIA:{target}"}]
 
@@ -189,7 +208,7 @@ def test_annotate_is_idempotent_across_settles(snap_dir, tmp_path):
     assert len(list(snap_dir.glob("*.snap"))) == 1
 
 
-def test_annotate_skips_remote_and_data_refs(snap_dir, tmp_path):
+def test_annotate_skips_remote_and_data_refs(snap_dir, allowed_tmp_path):
     from api.media_snapshots import annotate_media_snapshots
 
     messages = [
@@ -204,12 +223,12 @@ def test_annotate_skips_remote_and_data_refs(snap_dir, tmp_path):
 # ── /api/media?snap= serving ───────────────────────────────────────────────
 
 
-def test_handle_media_serves_snapshot_after_inplace_overwrite(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_serves_snapshot_after_inplace_overwrite(routes, monkeypatch, snap_dir, allowed_tmp_path):
     """THE regression test: same filename overwritten must not rewrite old
     previews when the message pins a snapshot digest."""
     from api.media_snapshots import capture_snapshot
 
-    target = tmp_path / "report.html"
+    target = allowed_tmp_path / "report.html"
     target.write_text("<html>v1</html>")
     digest = capture_snapshot(target)
 
@@ -229,10 +248,10 @@ def test_handle_media_serves_snapshot_after_inplace_overwrite(routes, monkeypatc
     assert pinned.header("Cache-Control") == "private, max-age=31536000, immutable"
 
 
-def test_handle_media_snapshot_survives_file_deletion(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snapshot_survives_file_deletion(routes, monkeypatch, snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    target = tmp_path / "pic.png"
+    target = allowed_tmp_path / "pic.png"
     target.write_bytes(b"png-bytes-v1")
     digest = capture_snapshot(target)
 
@@ -243,16 +262,16 @@ def test_handle_media_snapshot_survives_file_deletion(routes, monkeypatch, snap_
     assert bytes(pinned.body) == b"png-bytes-v1"
 
 
-def test_handle_media_invalid_snap_falls_back_to_live(routes, monkeypatch, snap_dir, tmp_path):
-    target = tmp_path / "pic.png"
+def test_handle_media_invalid_snap_falls_back_to_live(routes, monkeypatch, snap_dir, allowed_tmp_path):
+    target = allowed_tmp_path / "pic.png"
     target.write_bytes(b"live-bytes")
     replayed = _media_get(routes, monkeypatch, target, query_extra="&snap=not-a-digest")
     assert replayed.status == 200
     assert bytes(replayed.body) == b"live-bytes"
 
 
-def test_handle_media_missing_snap_falls_back_to_live(routes, monkeypatch, snap_dir, tmp_path):
-    target = tmp_path / "pic.png"
+def test_handle_media_missing_snap_falls_back_to_live(routes, monkeypatch, snap_dir, allowed_tmp_path):
+    target = allowed_tmp_path / "pic.png"
     target.write_bytes(b"live-bytes")
     missing = _media_get(
         routes, monkeypatch, target, query_extra="&snap=" + "0" * 64
@@ -261,16 +280,16 @@ def test_handle_media_missing_snap_falls_back_to_live(routes, monkeypatch, snap_
     assert bytes(missing.body) == b"live-bytes"
 
 
-def test_handle_media_snap_does_not_bypass_deny(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snap_does_not_bypass_deny(routes, monkeypatch, snap_dir, allowed_tmp_path):
     """snap= must never widen the path allow-list: a denied path stays denied
     even when a valid snapshot digest is supplied."""
     from api.media_snapshots import capture_snapshot
 
-    hermes_home = tmp_path / ".hermes"
+    hermes_home = allowed_tmp_path / ".hermes"
     hermes_home.mkdir()
     secret = hermes_home / "settings.json"
     secret.write_text("{}")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(allowed_tmp_path))
     digest = capture_snapshot(secret)  # capture itself may be blocked; if not...
 
     denied = _media_get(routes, monkeypatch, secret, query_extra=f"&snap={digest or '0'*64}")
@@ -278,7 +297,7 @@ def test_handle_media_snap_does_not_bypass_deny(routes, monkeypatch, snap_dir, t
     assert denied.status == 403
 
 
-def test_handle_media_denies_direct_store_path(routes, monkeypatch, tmp_path):
+def test_handle_media_denies_direct_store_path(routes, monkeypatch, allowed_tmp_path):
     """The snapshot STORE directory itself is not a servable media path.
 
     The store lives under STATE_DIR (a Hermes root) in production; the #3234
@@ -288,14 +307,14 @@ def test_handle_media_denies_direct_store_path(routes, monkeypatch, tmp_path):
     from api.media_snapshots import capture_snapshot
 
     # Simulate the production layout: the store lives under a Hermes root, with
-    # HOME pointing at tmp_path so that directory counts as a Hermes root. The
+    # HOME pointing at allowed_tmp_path so that directory counts as a Hermes root. The
     # #3234 deny list denies <hermes_root>/media_snapshots.
-    hermes_home = tmp_path / ".hermes"
+    hermes_home = allowed_tmp_path / ".hermes"
     store = hermes_home / "media_snapshots"
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(allowed_tmp_path))
     monkeypatch.setenv("HERMES_WEBUI_MEDIA_SNAPSHOT_DIR", str(store))
 
-    target = tmp_path / "a.png"
+    target = allowed_tmp_path / "a.png"
     target.write_bytes(b"bytes")
     digest = capture_snapshot(target)
     store_file = store / f"{digest}.snap"
@@ -305,10 +324,10 @@ def test_handle_media_denies_direct_store_path(routes, monkeypatch, tmp_path):
     assert denied.status == 403
 
 
-def test_handle_media_snapshot_range_request(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snapshot_range_request(routes, monkeypatch, snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    target = tmp_path / "clip.mp4"
+    target = allowed_tmp_path / "clip.mp4"
     target.write_bytes(b"0123456789")
     digest = capture_snapshot(target)
 
@@ -324,10 +343,10 @@ def test_handle_media_snapshot_range_request(routes, monkeypatch, snap_dir, tmp_
     assert handler.header("Content-Range") == "bytes 2-4/10"
 
 
-def test_handle_media_snapshot_download_name_uses_original(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snapshot_download_name_uses_original(routes, monkeypatch, snap_dir, allowed_tmp_path):
     from api.media_snapshots import capture_snapshot
 
-    target = tmp_path / "report.html"
+    target = allowed_tmp_path / "report.html"
     target.write_bytes(b"<html>v1</html>")
     digest = capture_snapshot(target)
     target.unlink()
@@ -341,7 +360,7 @@ def test_handle_media_snapshot_download_name_uses_original(routes, monkeypatch, 
 # ── Round 2: capture/serve deny parity + source-path binding (#6979) ────────
 
 
-def test_media_capture_allowed_denies_default_webui_state_layout(tmp_path, monkeypatch):
+def test_media_capture_allowed_denies_default_webui_state_layout(allowed_tmp_path, monkeypatch):
     """MUST-FIX 1 repro: default-layout <HERMES_HOME>/webui/sessions/victim.json
     (== STATE_DIR/sessions) must NEVER be captured.
 
@@ -350,32 +369,32 @@ def test_media_capture_allowed_denies_default_webui_state_layout(tmp_path, monke
     """
     from api.media_snapshots import media_capture_allowed
 
-    hermes_home = tmp_path / ".hermes"
+    hermes_home = allowed_tmp_path / ".hermes"
     state_dir = hermes_home / "webui"
     (state_dir / "sessions").mkdir(parents=True)
     victim = state_dir / "sessions" / "victim.json"
     victim.write_text("{}")
 
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(allowed_tmp_path))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setattr("api.config.STATE_DIR", str(state_dir))
 
     assert media_capture_allowed(victim) is False
 
 
-def test_annotate_never_captures_denied_state_file(snap_dir, tmp_path, monkeypatch):
+def test_annotate_never_captures_denied_state_file(snap_dir, allowed_tmp_path, monkeypatch):
     """MUST-FIX 1 end-to-end: annotating a message whose MEDIA: ref points at a
     denied state file must capture NOTHING (Round 1 captured it and the digest
     then acted as a bearer capability)."""
     from api.media_snapshots import annotate_media_snapshots
 
-    hermes_home = tmp_path / ".hermes"
+    hermes_home = allowed_tmp_path / ".hermes"
     state_dir = hermes_home / "webui"
     (state_dir / "sessions").mkdir(parents=True)
     victim = state_dir / "sessions" / "victim.json"
     victim.write_text('{"secret": 1}')
 
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(allowed_tmp_path))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setattr("api.config.STATE_DIR", str(state_dir))
 
@@ -386,7 +405,7 @@ def test_annotate_never_captures_denied_state_file(snap_dir, tmp_path, monkeypat
     assert len(list(snap_dir.glob("*.snap"))) == 0
 
 
-def test_handle_media_snap_requires_source_path_binding(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snap_requires_source_path_binding(routes, monkeypatch, snap_dir, allowed_tmp_path):
     """MUST-FIX 1 serve-side repro: a digest captured from path A must not be
     servable through path B, even when B is an allowed path.
 
@@ -396,7 +415,7 @@ def test_handle_media_snap_requires_source_path_binding(routes, monkeypatch, sna
     """
     from api.media_snapshots import capture_snapshot
 
-    source = tmp_path / "a.png"
+    source = allowed_tmp_path / "a.png"
     source.write_bytes(b"frozen-bytes-from-a")
     digest = capture_snapshot(source)
 
@@ -406,26 +425,26 @@ def test_handle_media_snap_requires_source_path_binding(routes, monkeypatch, sna
     assert bytes(bound.body) == b"frozen-bytes-from-a"
 
     # Unbound + absent path: NOT the snapshot; live fallback -> 404.
-    other_missing = tmp_path / "b.png"
+    other_missing = allowed_tmp_path / "b.png"
     unbound = _media_get(routes, monkeypatch, other_missing, query_extra=f"&snap={digest}")
     assert unbound.status == 404
 
     # Unbound + present path: live bytes, never the frozen snapshot.
-    other_live = tmp_path / "b.png"
+    other_live = allowed_tmp_path / "b.png"
     other_live.write_bytes(b"live-bytes-of-b")
     unbound_live = _media_get(routes, monkeypatch, other_live, query_extra=f"&snap={digest}")
     assert unbound_live.status == 200
     assert bytes(unbound_live.body) == b"live-bytes-of-b"
 
 
-def test_handle_media_snap_dedup_binds_every_source_path(routes, monkeypatch, snap_dir, tmp_path):
+def test_handle_media_snap_dedup_binds_every_source_path(routes, monkeypatch, snap_dir, allowed_tmp_path):
     """Dedup must not break source binding: identical bytes captured from two
     different paths share one digest, and BOTH paths may serve it (each was a
     legitimate capture source); a third path may not."""
     from api.media_snapshots import capture_snapshot
 
-    a = tmp_path / "a.png"
-    b = tmp_path / "b.png"
+    a = allowed_tmp_path / "a.png"
+    b = allowed_tmp_path / "b.png"
     a.write_bytes(b"same-bytes")
     b.write_bytes(b"same-bytes")
     d1 = capture_snapshot(a)
@@ -437,7 +456,7 @@ def test_handle_media_snap_dedup_binds_every_source_path(routes, monkeypatch, sn
     assert sa.status == 200 and bytes(sa.body) == b"same-bytes"
     assert sb.status == 200 and bytes(sb.body) == b"same-bytes"
 
-    c = tmp_path / "c.png"
+    c = allowed_tmp_path / "c.png"
     c.write_bytes(b"live-different-bytes")
     sc = _media_get(routes, monkeypatch, c, query_extra=f"&snap={d1}")
     assert sc.status == 200
@@ -445,17 +464,17 @@ def test_handle_media_snap_dedup_binds_every_source_path(routes, monkeypatch, sn
     assert bytes(sc.body) == b"live-different-bytes"
 
 
-def test_handle_media_denies_custom_named_store_via_bare_path(routes, monkeypatch, tmp_path):
+def test_handle_media_denies_custom_named_store_via_bare_path(routes, monkeypatch, allowed_tmp_path):
     """MUST-FIX 2 repro: a custom-named snapshot store (HERMES_WEBUI_MEDIA_SNAPSHOT_DIR
     pointing anywhere, e.g. /tmp/custom-store-name) must not be readable through
     a bare path= request. Round 1 only deny-listed the literal name
     'media_snapshots', so the blobs leaked with no snap= needed."""
     from api.media_snapshots import capture_snapshot
 
-    store = tmp_path / "custom-store-name"
+    store = allowed_tmp_path / "custom-store-name"
     monkeypatch.setenv("HERMES_WEBUI_MEDIA_SNAPSHOT_DIR", str(store))
 
-    target = tmp_path / "a.png"
+    target = allowed_tmp_path / "a.png"
     target.write_bytes(b"stored-bytes")
     digest = capture_snapshot(target)
     store_file = store / f"{digest}.snap"
@@ -478,13 +497,13 @@ def test_is_valid_digest_rejects_trailing_newline():
     assert is_valid_digest(None) is False  # type: ignore[arg-type]
 
 
-def test_annotate_evicted_snapshot_is_final(snap_dir, tmp_path):
+def test_annotate_evicted_snapshot_is_final(snap_dir, allowed_tmp_path):
     """SHOULD-FIX: a recorded digest is FINAL — after its blob is evicted, a
     re-settle must not re-capture the CURRENT live bytes and rebind the
     historical message (Round 1 did, silently following overwrites again)."""
     from api.media_snapshots import annotate_media_snapshots
 
-    target = tmp_path / "report.html"
+    target = allowed_tmp_path / "report.html"
     target.write_text("<html>v1</html>")
     messages: list = [{"role": "assistant", "content": f"MEDIA:{target}"}]
 
@@ -505,13 +524,13 @@ def test_annotate_evicted_snapshot_is_final(snap_dir, tmp_path):
     assert not blob.exists()  # no re-capture
 
 
-def test_quota_eviction_drops_source_binding_sidecar(snap_dir, tmp_path, monkeypatch):
+def test_quota_eviction_drops_source_binding_sidecar(snap_dir, allowed_tmp_path, monkeypatch):
     """Evicting a snapshot blob must also drop its source-binding sidecar."""
     from api.media_snapshots import _binding_path_for_digest, capture_snapshot
 
     monkeypatch.setenv("HERMES_WEBUI_MEDIA_SNAPSHOT_CAP_BYTES", "64")
-    old = tmp_path / "old.png"
-    new = tmp_path / "new.png"
+    old = allowed_tmp_path / "old.png"
+    new = allowed_tmp_path / "new.png"
     old.write_bytes(b"x" * 64)
     new.write_bytes(b"y" * 64)
     d_old = capture_snapshot(old)


### PR DESCRIPTION
## Summary

Fixes two test-portability gaps in the WebUI test suite, with **no product-code changes** (the media gate in `api/routes.py` is correct and untouched):

1. **Playwright import breaks test collection** in environments without `playwright` installed.
2. **17 media tests fail on macOS (darwin)** with `assert 403 == 200` because they served files from pytest's `tmp_path`, which on macOS resolves under `/private/var/folders/...` — outside every allowed root of the `/api/media` gate.

## Root Cause

- `tests/test_compression_phantom_barrier.py` imported `from playwright.sync_api import sync_playwright` at module top level with no guard. In any environment without playwright (e.g. fresh CI runners), this raised `ModuleNotFoundError` **at collection time**, aborting `pytest tests/` before a single test ran — the same class of failure #6314 fixed for other browser tests.
- `tests/test_media_etag_revalidation.py` (5 tests) and `tests/test_media_message_snapshots.py` (12 tests) wrote their files into pytest's `tmp_path` and asserted `200` through `/api/media`. The media gate only serves files under its allowed roots (hermes home, `/tmp`, `~/.hermes`, active workspace — see `api/routes.py` ~line 19580). On Linux CI, `tmp_path` lives under `/tmp` → allowed → green. On macOS, `tmp_path` lives under `/private/var/folders/...` → outside every allowed root → the gate correctly returned 403 → all 17 tests failed with `assert 403 == 200`. Maintainer-verified: with `TMPDIR=/tmp` all 66 media tests pass — the gate was doing its job; the tests just assumed `tmp_path` is servable.

## Change

- **`tests/test_compression_phantom_barrier.py`**: follow the repo's established guard pattern from `tests/test_layout_helpers.py` (try/except import with `sync_playwright = None` + a `_require_playwright()` helper that `pytest.skip`s when unavailable). The `browser` fixture now goes through `_require_playwright()`, so the module collects everywhere and the 8 tests skip cleanly when playwright is missing.
- **`tests/test_media_etag_revalidation.py` + `tests/test_media_message_snapshots.py`**: added an `allowed_tmp_path` fixture that creates a unique temp dir directly under `/tmp` (which on macOS is the same path as `/private/tmp`, and is an allowed root on both platforms) **regardless of `TMPDIR`**, and switched all tests from `tmp_path` to it (including the `snap_dir` store fixture in the snapshots suite). Also added a small regression test asserting the served target resolves under `/tmp`.
- **No changes to `api/routes.py`** — the production media gate is intentionally left as-is.

## Verification

With the repo-local venv (`.venv/bin/python -m pytest`):

```
$ .venv/bin/python -m pytest tests/test_compression_phantom_barrier.py tests/test_media_etag_revalidation.py tests/test_media_message_snapshots.py -q -p no:cacheprovider
67 passed, 8 skipped in 4.97s
```

(playwright is **not** installed in this venv — the 8 phantom-barrier tests skip cleanly instead of aborting collection; collection verified separately with `--collect-only`: 8 tests collected.)

macOS failure-mode simulation — `TMPDIR` pointed at a non-allowed directory:

```
$ TMPDIR=/root/.cache/wt-tmp .venv/bin/python -m pytest tests/test_media_etag_revalidation.py tests/test_media_message_snapshots.py -q -p no:cacheprovider
67 passed in 4.18s
```

All 67 media tests pass even with `TMPDIR` outside the allowed roots, because files now land under `/tmp` unconditionally.

## Closes #7013
