### PR TITLE
fix: expose max reasoning for GPT-5.6 models

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3513,6 +3513,24 @@ def _zai_glm_thinking_toggle_supported(model_id: str, provider_id: str) -> bool 
     return cls in {"effort", "thinking"}
 
 
+_OPENAI_FAMILY_REASONING_PROVIDERS = frozenset({
+    "openai-codex", "openai", "openai-api",
+    "azure-foundry", "azure-openai", "azure",
+})
+
+_GPT_5_6_REASONING_MODELS = frozenset({
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+})
+
+
+def _is_gpt_5_6_reasoning_model(bare_model: str) -> bool:
+    """Return whether an OpenAI-family model uses GPT-5.6's max ladder."""
+    return str(bare_model or "").strip().lower() in _GPT_5_6_REASONING_MODELS
+
+
 def _filter_reasoning_efforts_for_provider(
     efforts: list[str],
     model_id: str,
@@ -3527,15 +3545,15 @@ def _filter_reasoning_efforts_for_provider(
     normalized = list(dict.fromkeys(normalized))
     provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
     bare = _strip_provider_hint_for_reasoning(model_id).lower().rsplit("/", 1)[-1]
-    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap GPT-5 at xhigh
-    # and o-series at high — 'max' is a WebUI-only level none of them accept.
-    if provider in {"openai-codex", "openai", "openai-api", "azure-foundry", "azure-openai", "azure"}:
+    # OpenAI-family lanes cap pre-GPT-5.6 GPT-5 models at xhigh and o-series at
+    # high. GPT-5.6's alias and Sol/Terra/Luna variants natively accept max.
+    if provider in _OPENAI_FAMILY_REASONING_PROVIDERS:
         if bare.startswith(("o1", "o3", "o4")):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
-        if bare.startswith("gpt-5"):
+        if bare.startswith("gpt-5") and not _is_gpt_5_6_reasoning_model(bare):
             return [eff for eff in normalized if eff != "max"]
-    # 'max' is a WebUI-level ceiling; providers whose native ladder tops out lower
-    # must NOT advertise it, otherwise a stored/CLI 'max' degrades WORSE than the
+    # Providers whose native ladder tops out below 'max' must NOT advertise it,
+    # otherwise a stored/CLI 'max' degrades WORSE than the
     # prior max->xhigh coercion (Gemini's adapter treats unknown 'max' as medium;
     # pre-adaptive Anthropic manual-thinking lacks a 'max' budget and falls to 8k).
     # Dropping 'max' here lets the existing downgrade ladder land on xhigh/high.
@@ -3882,11 +3900,11 @@ def resolve_model_reasoning_efforts(
     """Return supported reasoning-effort levels for *model_id*, or [] if none.
 
     Always passes the sourced list through _filter_reasoning_efforts_for_provider
-    so the hard provider ceilings (openai-codex/openai/azure GPT-5 cap at xhigh,
-    Gemini + pre-adaptive/cloud-hosted Claude cap at xhigh) are applied uniformly
-    — the UI dropdown (which gates options on this list) and coercion therefore
-    agree: 'max' is offered ONLY for models whose native ladder genuinely includes
-    it, and is stripped everywhere it would be rejected/mishandled.
+    so the hard provider ceilings (OpenAI-family GPT-5 before 5.6 at xhigh and
+    o-series at high; Gemini + pre-adaptive/cloud-hosted Claude at xhigh) are
+    applied uniformly. The UI dropdown and coercion therefore agree: ``max`` is
+    retained for GPT-5.6 and other models whose native ladder includes it, and
+    stripped where it would be rejected or mishandled.
     """
     raw = _resolve_model_reasoning_efforts_impl(model_id, provider_id, base_url)
     if not raw:
@@ -4079,16 +4097,17 @@ def coerce_reasoning_effort_for_model(
     # Hard provider ceilings must win regardless of what the sourced capability
     # list says. resolve_model_reasoning_efforts() draws from hermes_cli /
     # models.dev / heuristics, and those can (a) return [] for an unrecognized
-    # model or (b) wrongly advertise a WebUI-only level like 'max' for a provider
+    # model or (b) wrongly advertise 'max' for a provider
     # whose native ladder tops out lower. _filter_reasoning_efforts_for_provider
-    # encodes the known ceilings (openai-codex gpt-5, Gemini, pre-adaptive
-    # Anthropic all cap below 'max'); if it actively EXCLUDES the requested level,
-    # honor that ceiling and degrade down the ladder even when the sourced list is
-    # empty or (mistakenly) includes the level. This keeps a stored/CLI 'max' from
-    # reaching an adapter that would silently downgrade it worse than xhigh/high
-    # (Gemini→medium, legacy Claude manual-thinking→8k). For providers with NO
-    # ceiling rule the filter returns the full list unchanged, so genuinely
-    # unknown models still preserve the configured effort (#3505 behavior).
+    # encodes the known ceilings (OpenAI-family GPT-5 before 5.6, Gemini, and
+    # pre-adaptive Anthropic all cap below 'max'); if it actively EXCLUDES the
+    # requested level, honor that ceiling and degrade down the ladder even when
+    # the sourced list is empty or (mistakenly) includes the level. This keeps a
+    # stored/CLI 'max' from reaching an adapter that would silently downgrade it
+    # worse than xhigh/high (Gemini→medium, legacy Claude manual-thinking→8k).
+    # GPT-5.6 is intentionally not capped. For providers with NO ceiling rule the
+    # filter returns the full list unchanged, so genuinely unknown models still
+    # preserve the configured effort (#3505 behavior).
     ceiling = _filter_reasoning_efforts_for_provider(
         list(VALID_REASONING_EFFORTS), str(model_id or ""), str(provider_id or "")
     )
@@ -4106,15 +4125,15 @@ def coerce_reasoning_effort_for_model(
     # both for models KNOWN not to support reasoning AND for models we simply
     # don't recognize (custom providers, aggregator-rewritten ids, brand-new
     # releases). Coercion exists to avoid sending a level a KNOWN-incompatible
-    # model rejects (e.g. openai-codex gpt-5 'max', o1/o3/o4 above 'high') -
+    # model rejects (e.g. pre-5.6 GPT-5 'max', o1/o3/o4 above 'high') -
     # those paths return a NON-empty clamped set, so the degrade ladder below
     # still applies. When the set is empty we can't tell "unsupported" from
     # "unknown", so preserve the user's configured effort verbatim where it is
     # still valid. (#3505 review)
     #
     # EXCEPTION for 'max' (the #3505 default-deny refinement, maintainer call
-    # 2026-07-11): 'max' is a WebUI-only level ABOVE the universally-safe ceiling
-    # 'xhigh'. A genuinely unknown/custom provider will 400 on it. So when the
+    # 2026-07-11): 'max' is ABOVE the universally-safe ceiling 'xhigh'. A
+    # genuinely unknown/custom provider will 400 on it. So when the
     # capability list is empty AND the provider is not one we recognize as
     # reasoning-capable, degrade 'max' -> 'xhigh' rather than send an unsupported
     # supra-ceiling level. But do NOT degrade for a RECOGNIZED reasoning provider

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -3,6 +3,23 @@
 from api import config as cfg
 
 
+GPT_5_6_MODELS = (
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+)
+
+OPENAI_FAMILY_PROVIDERS = (
+    "openai",
+    "openai-api",
+    "openai-codex",
+    "azure",
+    "azure-openai",
+    "azure-foundry",
+)
+
+
 def test_cursor_acp_models_do_not_support_reasoning_effort_levels():
     assert cfg.resolve_model_reasoning_efforts(
         "cursor/composer-2.5",
@@ -38,6 +55,21 @@ def test_openai_codex_max_effort_is_clamped_before_streaming():
         "gpt-5.5",
         provider_id="openai-codex",
     ) == "xhigh"
+
+
+def test_openai_family_gpt56_models_expose_and_preserve_max():
+    for provider in OPENAI_FAMILY_PROVIDERS:
+        for model in GPT_5_6_MODELS:
+            efforts = cfg.resolve_model_reasoning_efforts(
+                f"@{provider}:{model}",
+                provider_id=provider,
+            )
+            assert "max" in efforts, f"{model} on {provider} must expose max"
+            assert cfg.coerce_reasoning_effort_for_model(
+                "max",
+                f"@{provider}:{model}",
+                provider_id=provider,
+            ) == "max", f"{model} on {provider} must preserve max"
 
 
 def test_unsupported_xhigh_degrades_to_high_not_disabled():
@@ -79,8 +111,8 @@ def test_coerce_preserves_effort_for_unrecognized_model():
         "some-unknown-model-xyz",
         provider_id="some-custom-provider",
     ) == "high"
-    # #3505 default-deny refinement (maintainer 2026-07-11): 'max' is a supra-
-    # ceiling WebUI-only level, so on an UNRECOGNIZED provider it degrades to
+    # #3505 default-deny refinement (maintainer 2026-07-11): 'max' is above the
+    # universally safe ceiling, so on an UNRECOGNIZED provider it degrades to
     # xhigh (a truly-unknown provider would 400 on max). All OTHER levels still
     # preserve verbatim below.
     assert cfg.coerce_reasoning_effort_for_model(
@@ -434,16 +466,18 @@ def test_max_effort_preserved_for_adaptive_anthropic_and_deepseek():
     ) == "max"
 
 
-def test_max_degrades_across_all_openai_family_lanes():
-    # 'max' is WebUI-only; direct OpenAI, openai-api, and Azure Foundry GPT-5 all
-    # cap at xhigh (o-series at high), not just openai-codex. (#4627 re-gate)
-    for prov in ("openai", "openai-api", "azure-foundry", "openai-codex"):
-        assert cfg.coerce_reasoning_effort_for_model(
-            "max", model_id="gpt-5.1", provider_id=prov
-        ) == "xhigh", f"gpt-5 on {prov} must degrade max->xhigh"
-        assert cfg.coerce_reasoning_effort_for_model(
-            "max", model_id="o3", provider_id=prov
-        ) == "high", f"o-series on {prov} must degrade max->high"
+def test_max_degrades_for_pre_gpt56_and_o_series_across_openai_family_lanes():
+    # GPT-5 models before 5.6 cap at xhigh, while o1/o3/o4 cap at high, across
+    # direct OpenAI, ChatGPT/Codex, and Azure provider aliases.
+    for provider in OPENAI_FAMILY_PROVIDERS:
+        for model in ("gpt-5", "gpt-5.1", "gpt-5.5"):
+            assert cfg.coerce_reasoning_effort_for_model(
+                "max", model_id=model, provider_id=provider
+            ) == "xhigh", f"{model} on {provider} must degrade max->xhigh"
+        for model in ("o1", "o3-mini", "o4-mini"):
+            assert cfg.coerce_reasoning_effort_for_model(
+                "max", model_id=model, provider_id=provider
+            ) == "high", f"{model} on {provider} must degrade max->high"
 
 
 def test_max_degrades_for_azure_bedrock_hosted_legacy_claude():
@@ -461,7 +495,7 @@ def test_max_degrades_for_azure_bedrock_hosted_legacy_claude():
 
 def test_max_degrades_on_unknown_provider_but_other_levels_preserved():
     # #3505 default-deny refinement (maintainer call 2026-07-11): 'max' is above
-    # the universal ceiling, so an unknown/custom provider (empty capability list)
+    # the universally safe ceiling, so an unknown/custom provider (empty capability list)
     # must degrade 'max'->'xhigh' rather than send an unsupported level — while all
     # other levels keep the conservative preserve-verbatim behavior.
     assert cfg.coerce_reasoning_effort_for_model(
@@ -560,4 +594,3 @@ def test_qwen_prefixed_alias_reasoning_detection():
             f"{model} must remain reasoning-capable (DeepSeek-R1 hybrid, "
             f"Qwen 2.x must not shadow the DeepSeek detector)"
         )
-


### PR DESCRIPTION
## Thinking Path

Hermes WebUI aims to preserve the model and reasoning controls available from the underlying agent. OpenAI's GPT-5.6 release added a native `max` reasoning effort and introduced the GPT-5.6 family (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`).

The WebUI still applied an older blanket rule that removed `max` from every OpenAI-family GPT-5 model. As a result, GPT-5.6 models authenticated through the ChatGPT/Codex provider were incorrectly limited to `xhigh`, and the WebUI reasoning dropdown did not offer the model's highest effort.

## What Changed

- Updated the shared reasoning-capability filter in `api/config.py`.
- Exposed and preserved `max` for the GPT-5.6 alias and Sol/Terra/Luna variants across the OpenAI-family provider lanes, including `openai-codex`.
- Kept the existing compatibility ceilings for pre-GPT-5.6 GPT-5 models (`xhigh`) and o1/o3/o4 models (`high`).
- Added behavioral regression coverage for provider-qualified model IDs, capability-list visibility, and effort coercion.
- Updated the affected comments/docstrings so the capability contract is explicit.

## Why This PR Is Needed

Without this change, the WebUI silently downgraded a valid GPT-5.6 `max` setting to `xhigh` and hid the `Max` control from users. This creates a capability mismatch between the provider and the WebUI, especially for GPT-5.6 Luna users and ChatGPT/Codex users selecting GPT-5.6 models from the composer.

The change is deliberately scoped to the shared model/provider gate. It does not alter the request format, provider adapters, older-model behavior, or the frontend option definitions. Once the backend reports the capability, the existing WebUI dropdown renders `Max` normally.

## Upstream References

- [OpenAI API changelog: GPT-5.6 adds `max` reasoning effort and the Sol/Terra/Luna family](https://platform.openai.com/docs/changelog)
- [OpenAI Help: GPT-5.6 in ChatGPT](https://help.openai.com/en/articles/20001354-gpt-56-in-chatgpt)

## Verification

- `HERMES_WEBUI_AGENT_DIR=/usr/local/lib/hermes-agent ./scripts/test.sh tests/test_reasoning_effort_model_capabilities.py -q` — **32 passed**
- `HERMES_WEBUI_AGENT_DIR=/usr/local/lib/hermes-agent ./scripts/test.sh tests/test_*reasoning*.py -q` — **328 passed**
- `git diff --check` — passed
- Live authenticated WebUI smoke test — `/api/reasoning` returned `max` for all four GPT-5.6 IDs, and the rendered composer dropdown contained `Max` for GPT-5.6 Luna.

The complete local 14,651-test suite was not claimed: its first collection was blocked by the optional Playwright dependency, and after installing the documented browser dependency the full run exceeded the local command timeout. The focused and reasoning-related suites pass, and CI should provide the complete repository gate.

## Contract Routing

- **Task type:** provider/model capability bug fix
- **Touched areas:** reasoning capability resolution, effort coercion, reasoning picker visibility
- **Relevant docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`
- **Evidence:** OpenAI's published GPT-5.6 capability documentation, behavioral resolver tests, and an authenticated live WebUI smoke test

## Contract Change

- **Previous behavior:** all OpenAI-family GPT-5 models were capped at `xhigh` by the WebUI gate.
- **New behavior:** GPT-5.6 models expose and preserve native `max`; pre-GPT-5.6 GPT-5 and o-series ceilings remain unchanged.
- **Compatibility:** unknown/custom providers and unrelated model families retain their existing behavior.

## Risks / Follow-ups

The main risk is a future provider model ID that does not match the known GPT-5.6 family list; that model will conservatively retain the existing pre-5.6 behavior until explicitly classified. No request-wire or adapter changes are included in this PR.

## Model Used

Implementation and review were performed through the authenticated OpenAI Codex CLI using `gpt-5.6-sol` with medium reasoning effort.