### PR TITLE
fix(sessions): isolate per-tab conversation state (reload restores the wrong chat with 2 tabs open)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3621,7 +3621,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const titleLabel=$('titlebarProfileLabel');
   if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
   const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;
-  const _savedLocalBeforeProfileSwitch=localStorage.getItem('hermes-webui-session');
+  const _savedLocalBeforeProfileSwitch=_rememberedActiveSession();
   const _profileSwitchProfileBefore=S.activeProfile||'default';
   const _profileSwitchIsDefaultBefore=!!S.activeProfileIsDefault;
   let _profileSwitchCompleted=false;
@@ -3761,10 +3761,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const _profileQueryBlocksSavedLocal=_profileQueryBlocksSavedLocalRestore(profileIntent, urlSession);
   if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){
     try{
-      if(localStorage.getItem('hermes-webui-session')===_savedLocalBeforeProfileSwitch) localStorage.removeItem('hermes-webui-session');
+      if(_rememberedActiveSession()===_savedLocalBeforeProfileSwitch) _forgetActiveSession();
     }catch(_){}
   }
-  const savedLocal=localStorage.getItem('hermes-webui-session');
+  const savedLocal=_rememberedActiveSession();
   const saved=urlSession||savedLocal;
   if(saved){
     try{
@@ -3773,7 +3773,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
         : null;
       if(savedSidebarOnlyState&&savedSidebarOnlyState.sidebarOnly){
         if(savedSidebarOnlyState.archived){
-          try{localStorage.removeItem('hermes-webui-session');}catch(_){}
+          try{_forgetActiveSession();}catch(_){}
         }
         S.session=null; S.messages=[]; S.activeStreamId=null; S.busy=false;
         S._bootReady=true;
@@ -3842,7 +3842,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       }
       S._bootReady=true;
       syncTopbar();syncWorkspacePanelState();await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();await checkInflightOnBoot(saved);await _finalizeComposerPrefillOnBoot(prefillIntent);return;}
-    catch(e){localStorage.removeItem('hermes-webui-session');}
+    catch(e){_forgetActiveSession();}
   }
   // no saved session - show empty state, wait for user to hit +
   S._bootReady=true;

--- a/static/commands.js
+++ b/static/commands.js
@@ -871,7 +871,7 @@ async function _applyManualCompressionResult(data, focusTopic, visibleCount, com
       S.messages=data.session.messages||[];
       S.toolCalls=data.session.tool_calls||[];
       clearLiveToolCards();
-      try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+      try{_rememberActiveSession(S.session.session_id);}catch(_){}
       if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
       syncTopbar();
       renderMessages();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1818,7 +1818,7 @@ async function send(){
     // re-inject the dead id via _sessionIdFromLocation(), then reset to the
     // empty state instead of pushing a confusing error bubble into the chat.
     if(e&&e.status===404){
-      try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+      try{ _forgetActiveSession(); }catch(_){ }
       try{
         if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
         else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);
@@ -6192,7 +6192,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
           if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
           if(S.session&&S.session.session_id){
-            try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+            try{_rememberActiveSession(S.session.session_id);}catch(_){}
             if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
           }
           const _markerOnlyAssistantError=_replaceMarkerOnlyAssistantWithStreamError(S.messages);
@@ -6628,7 +6628,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             _attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);
             S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
             if(S.session&&S.session.session_id){
-              try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+              try{_rememberActiveSession(S.session.session_id);}catch(_){}
               if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
             }
           } else {
@@ -7035,7 +7035,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _attachProjectedAnchorSceneToLastAssistant(S.messages);
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
         if(S.session&&S.session.session_id){
-          try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+          try{_rememberActiveSession(S.session.session_id);}catch(_){}
           if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
         }
         if(typeof _adoptRegenerationRevision==='function')_adoptRegenerationRevision(session);

--- a/static/messages.js
+++ b/static/messages.js
@@ -1818,7 +1818,7 @@ async function send(){
     // re-inject the dead id via _sessionIdFromLocation(), then reset to the
     // empty state instead of pushing a confusing error bubble into the chat.
     if(e&&e.status===404){
-      try{ _forgetActiveSession(); }catch(_){ }
+      try{ _forgetActiveSession(activeSid); }catch(_){ }
       try{
         if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
         else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1619,7 +1619,7 @@ async function newSession(flash, options={}){
  */
 function _clearStuckSessionOnBoot(sid, currentSid){
   if(!currentSid){
-    try{ _forgetActiveSession(); }catch(_){ }
+    try{ _forgetActiveSession(sid); }catch(_){ }
     try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
   }
 }
@@ -1914,7 +1914,7 @@ async function loadSession(sid){
         // Only the rethrow stays gated on !currentSid: boot rethrows to fall
         // through to empty-state; mid-session there is no boot path to reach.
         if(!currentSid || currentSid===sid){
-          try{ _forgetActiveSession(); }catch(_){ }
+          try{ _forgetActiveSession(sid); }catch(_){ }
           try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
           if (_isCurrentLoad()) _loadingSessionId = null;
           if(!currentSid){
@@ -9199,7 +9199,7 @@ async function deleteSession(sid, beforeDelete=null){
   if(S.session&&S.session.session_id===sid){
     S.session=null;S.messages=[];S.entries=[];_messagesOwnerSid=null;
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
-    _forgetActiveSession();
+    _forgetActiveSession(sid);
     // load the most recent remaining session, or show blank if none left
     const remaining=await api('/api/sessions'+_sessionListQueryString());
     if(remaining.sessions&&remaining.sessions.length){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -31,6 +31,14 @@ let _loadSessionGeneration = 0;
 // _statusCard, _anchor_stream_id) survive the wholesale replace. null when there is nothing
 // to carry forward (initial load, switch-to-different-session, etc.).
 let _pendingCarryForwardSnapshot = null;
+// Session id that the transcript currently sitting in S.messages was loaded
+// for. S.messages alone is NOT proof of ownership: several paths (INFLIGHT
+// restore, cross-tab snapshot merge, a switch whose clear was skipped) can
+// leave another conversation's rows in S. _ensureMessagesLoaded() compares
+// against this marker before taking its "already loaded, skip the fetch"
+// early return, which is what kept showing the previous conversation after
+// clicking a different session.
+let _messagesOwnerSid = null;
 
 // ── Composer draft persistence ────────────────────────────────────────────────
 
@@ -1505,14 +1513,14 @@ async function newSession(flash, options={}){
     if(consumedExplicitModelOverride&&typeof _clearEmptyComposerModelOverride==='function'){
       _clearEmptyComposerModelOverride();
     }
-    S.session=data.session;if(typeof _adoptRegenerationRevision==='function') _adoptRegenerationRevision(data.session);S.messages=data.session.messages||[];
+    S.session=data.session;if(typeof _adoptRegenerationRevision==='function') _adoptRegenerationRevision(data.session);S.messages=data.session.messages||[];_messagesOwnerSid=(data.session&&data.session.session_id)||null;
     S._pendingSessionToolsets=null;
     if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
     S.lastUsage={...(data.session.last_usage||{})};
     if(!(options&&options.worktree)) _rememberNewChatDraftSession(S.session);
     if(flash)S.session._flash=true;
-    try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+    try{_rememberActiveSession(S.session.session_id);}catch(_){}
     _setActiveSessionUrl(S.session.session_id);
     if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
     _setSessionViewedCount(S.session.session_id, S.session.message_count || 0);
@@ -1611,7 +1619,7 @@ async function newSession(flash, options={}){
  */
 function _clearStuckSessionOnBoot(sid, currentSid){
   if(!currentSid){
-    try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+    try{ _forgetActiveSession(); }catch(_){ }
     try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
   }
 }
@@ -1832,6 +1840,7 @@ async function loadSession(sid){
     if (!_keepStaleUntilLoaded) {
       S.messages = [];
       S.toolCalls = [];
+      _messagesOwnerSid = null;
       _messagesTruncated = false;
       _oldestIdx = 0;
     }
@@ -1905,7 +1914,7 @@ async function loadSession(sid){
         // Only the rethrow stays gated on !currentSid: boot rethrows to fall
         // through to empty-state; mid-session there is no boot path to reach.
         if(!currentSid || currentSid===sid){
-          try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+          try{ _forgetActiveSession(); }catch(_){ }
           try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
           if (_isCurrentLoad()) _loadingSessionId = null;
           if(!currentSid){
@@ -2062,7 +2071,7 @@ async function loadSession(sid){
     Number(data.session.message_count || 0),
     Number(data.session.last_message_at || data.session.updated_at || 0)
   );
-  try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+  try{_rememberActiveSession(S.session.session_id);}catch(_){}
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
 
@@ -2152,6 +2161,7 @@ async function loadSession(sid){
       S.messages=_dropCurrentTurnAssistantMessages(S.messages);
     }
     S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
+    _messagesOwnerSid = sid;
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
     if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[sid].messages||[])){
       INFLIGHT[sid].messages=S.messages;
@@ -3151,7 +3161,18 @@ async function _ensureMessagesLoaded(sid, opts) {
   const _ownsLoad = () => _loadingSessionId === sid && (_loadGeneration === null || _loadSessionGeneration === _loadGeneration);
   if (!_ownsLoad()) return;
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
-  if (!opts.force && S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
+  //
+  // CRITICAL: only skip the fetch when the transcript currently in S was
+  // actually loaded FOR THIS sid. The original check looked at S.messages
+  // alone, so any path that left a previous conversation's messages in S
+  // (INFLIGHT restore of another session, a cross-tab snapshot merge, or a
+  // switch that skipped the clear because forceReload was false) made this
+  // early-return fire and left conversation A's transcript rendered under
+  // conversation B's header — the "clicking a session shows the previous
+  // conversation until I refresh" bug. _messagesOwnerSid is stamped right
+  // after every authoritative assignment to S.messages below.
+  const _messagesBelongToSid = (_messagesOwnerSid === sid);
+  if (!opts.force && _messagesBelongToSid && S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
     _clearSameSessionForceReloadHint(sid);
     return;
   }
@@ -3213,6 +3234,7 @@ async function _ensureMessagesLoaded(sid, opts) {
   }
   if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
   S.messages = msgs;
+  _messagesOwnerSid = sid;
   // Expand render window to cover all loaded messages so the next
   // renderMessages() doesn't hide most of them behind a tiny window.
   if(typeof _messageRenderableMessageCount==='function'&&typeof _currentMessageRenderWindowSize==='function'){
@@ -3818,6 +3840,7 @@ async function _loadOlderMessages() {
       nextMessages = window._carryForwardEphemeralTurnFields(S.messages || [], nextMessages);
     }
     S.messages = nextMessages;
+    if(S.session&&S.session.session_id) _messagesOwnerSid = S.session.session_id;
     _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);
     // renderMessages() windows long transcripts from the end. If we do not
     // expand that window before rendering, the newly prepended page stays
@@ -3924,6 +3947,7 @@ async function _ensureAllMessagesLoaded() {
       _msgsToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], msgs);
     }
     S.messages = _msgsToAssign;
+    if(S.session&&S.session.session_id) _messagesOwnerSid = S.session.session_id;
     _messagesTruncated = false;
     _oldestIdx = 0;
     _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);
@@ -4362,7 +4386,7 @@ function _renderBatchActionBar(){
       const cleanupFailedCount=results.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
-        S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
+        S.session=null;S.messages=[];S.entries=[];_messagesOwnerSid=null;_forgetActiveSession();
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
@@ -4867,7 +4891,7 @@ async function _archiveSession(session, archived=true, beforeListRender=null){
     const cached=(_allSessions||[]).find(s=>s&&s.session_id===session.session_id);
     if(cached) cached.archived=archived;
     if(S.session&&S.session.session_id===session.session_id) S.session.archived=archived;
-    try{ if(archived&&session.session_id&&localStorage.getItem('hermes-webui-session')===session.session_id) localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+    try{ if(archived&&session.session_id&&_rememberedActiveSession()===session.session_id) _forgetActiveSession(); }catch(_){ }
     showToast(session.archived?_sessionArchiveToast(response,session):t('session_restored'));
     if(renderHold) await renderHold;
     if(_showArchived&&!_sessionPrefersReducedMotion()) _sessionSwipeReturnOffsets.set(session.session_id,'0px');
@@ -6376,6 +6400,7 @@ function startGatewaySSE(){
                       _nextToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], next);
                     }
                     S.messages = _nextToAssign;
+                    _messagesOwnerSid = activeSid;
                     if(S.session && S.session.session_id === activeSid){
                       S.session.message_count = next.length;
                       const newest = next.length ? next[next.length - 1] : null;
@@ -9018,7 +9043,9 @@ function renderSessionListFromCache(){
 }
 
 async function _handleActiveSessionStorageEvent(e){
-  if(!e || e.key !== 'hermes-webui-session') return;
+  // Match both the legacy global key and any tab-scoped variant
+  // ('hermes-webui-session::<tabId>') written by another tab.
+  if(!e || !e.key || e.key.indexOf('hermes-webui-session')!==0) return;
   // Do not treat localStorage as a global active-session bus. Each tab owns its
   // active conversation via its URL (/session/<id>), so another tab switching
   // sessions must not force this tab to navigate away from an in-flight turn.
@@ -9170,9 +9197,9 @@ async function deleteSession(sid, beforeDelete=null){
     _optimisticallyRemoveSessionFromList(sid);
   }
   if(S.session&&S.session.session_id===sid){
-    S.session=null;S.messages=[];S.entries=[];
+    S.session=null;S.messages=[];S.entries=[];_messagesOwnerSid=null;
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
-    localStorage.removeItem('hermes-webui-session');
+    _forgetActiveSession();
     // load the most recent remaining session, or show blank if none left
     const remaining=await api('/api/sessions'+_sessionListQueryString());
     if(remaining.sessions&&remaining.sessions.length){

--- a/static/ui.js
+++ b/static/ui.js
@@ -9333,313 +9333,173 @@ function autoReadLastAssistant(){
   speechSynthesis.speak(utter);
 }
 
-// ── Per-tab identity (multi-tab isolation) ──
+// ── Per-document identity (multi-tab isolation) ──
 //
-// localStorage is shared by every tab on the same origin, so any key that
-// describes "the" active conversation is really a single global slot that all
-// tabs fight over. Opening conversation A in tab 1 and conversation B in tab 2
-// made the last writer win: reload restored the wrong session, the reconnect
-// banner pointed at another tab's stream, and inflight transcript snapshots
-// from one tab were merged into another tab's chat.
-//
-// sessionStorage IS per-tab (and survives reload / is copied on tab
-// duplication), so we mint a stable tab id there and namespace all
-// tab-scoped runtime state with it. localStorage remains the storage
-// backend (sessionStorage would be lost by some PWA/BFCache restores), but
-// every entry is now explicitly owned by exactly one tab.
+// localStorage is shared by every document on the same origin, so an inherited
+// tab id cannot be made authoritative with a localStorage read/write/verify
+// sequence: those operations are not a transaction. Instead, every new
+// JavaScript document mints a fresh cryptographic id and never adopts the id
+// copied in sessionStorage by Duplicate Tab or session restore. Scoped state is
+// mirrored in this browsing context's sessionStorage, then restored under the
+// fresh id on reload. Two documents therefore never need to arbitrate a shared
+// identity, and no localStorage operation is treated as atomic.
 const TAB_ID_KEY = 'hermes-webui-tab-id';
-const TAB_ID_CLAIM_KEY = 'hermes-webui-tab-claims';
-function _newTabId(){
-  try{
-    if(typeof window!=='undefined'&&window.crypto&&typeof window.crypto.randomUUID==='function'){
-      return window.crypto.randomUUID();
-    }
-  }catch(_){}
-  return 't'+Date.now().toString(36)+Math.random().toString(36).slice(2,10);
-}
-// Duplicating a tab (Chrome "Duplicate", or a PWA restore) COPIES sessionStorage,
-// so the clone would start life with the original tab's id and both tabs would
-// write to the same per-tab keys — reintroducing exactly the cross-talk this
-// fix removes. Ownership is therefore AUTHORITATIVE, not timer-based: every JS
-// context mints a per-context nonce (kept only on `window`, never in
-// sessionStorage, so a clone can never inherit it) and records
-// `{nonce, ts, released}` for its tab id in a shared registry. An id whose
-// record carries a foreign nonce and is not explicitly released is NEVER
-// reusable — no heartbeat gap, sleep, or timer throttling can make it reusable.
-// (Previously a missed 45s lease let a duplicated tab keep the original's id.)
-//
-// Reload safety: pagehide marks the record `released` (keeping nonce+ts), so a
-// normal refresh re-claims the same id and keeps its in-flight recovery state.
-// Crash-restore is the accepted trade-off: an unreleased foreign record is
-// indistinguishable from a live duplicate, so a restored tab mints a fresh id
-// (losing its recovery snapshot) instead of risking a collision.
-const _TAB_CLAIM_HEARTBEAT_MS = 15000;
-// Throttle for the ownership revalidation performed before every scoped
-// read/write (see _revalidateTabOwnership). Correctness does not depend on
-// this value; it only bounds how often the registry round-trip happens.
-const _TAB_OWNER_REVALIDATE_MS = 5000;
-// Retention window for RELEASED ownership records and for the legacy "seen"
-// heuristic. A released tab's keys are kept this long because the browser can
-// resurrect its sessionStorage (reload, bfcache, Ctrl+Shift+T reopen). It is
-// never used to declare a CLAIMED (unreleased) tab dead — an unreleased
-// ownership record always wins over any elapsed-time heuristic.
-const _TAB_SEEN_TTL_MS = 24 * 60 * 60 * 1000;
-const TAB_ID_SEEN_KEY = 'hermes-webui-tab-seen';
-// Storage key bases for per-tab state. Declared HERE, before the helpers that
-// reference them, so _gcOrphanTabKeys() can never hit a temporal-dead-zone
-// ReferenceError — its body is inside a try/catch, so such an error would make
-// garbage collection a silent no-op and let localStorage grow unbounded.
+const TAB_ID_RELEASED_BASE = 'hermes-webui-tab-released';
+const _TAB_RELEASED_TTL_MS = 24 * 60 * 60 * 1000;
 const INFLIGHT_KEY_BASE = 'hermes-webui-inflight'; // legacy/global (migration only)
 const INFLIGHT_STATE_KEY_BASE = 'hermes-webui-inflight-state';
 const ACTIVE_SESSION_KEY_LEGACY = 'hermes-webui-session';
-// Explicit per-tab "no session" tombstone (see _forgetActiveSession): after a
-// tab forgets its session on purpose, the shared legacy fallback must not
-// bleed back into it on the next read.
 const ACTIVE_SESSION_TOMBSTONE_BASE = 'hermes-webui-session-none';
-// Per-context ownership nonce. Lives ONLY on `window` (one per JS execution
-// context): a duplicated tab copies sessionStorage but gets a fresh window, so
-// it can never present the original context's nonce during arbitration.
-function _hermesTabNonce(){
-  if(typeof window==='undefined') return 'default-nonce';
-  if(!window.__hermesTabNonce) window.__hermesTabNonce=_newTabId();
-  return window.__hermesTabNonce;
-}
-// Ownership registry: {tabId: {nonce, ts, released}}. Returns null (NOT {})
-// when the stored value is malformed, so callers can fail safe — a GC pass
-// must treat "unreadable registry" as "assume every tab is alive", and a
-// claimer must mint a fresh id instead of reusing a possibly-owned one.
-function _readTabClaims(){
-  let raw=null;
-  try{ raw=localStorage.getItem(TAB_ID_CLAIM_KEY); }catch(_){ return null; }
-  if(raw==null) return {};
-  let reg=null;
-  try{ reg=JSON.parse(raw); }catch(_){ return null; }
-  if(!reg||typeof reg!=='object'||Array.isArray(reg)) return null;
-  const out={};
-  for(const [id,rec] of Object.entries(reg)){
-    // Entries without a nonce cannot prove ownership (foreign/corrupt shapes);
-    // drop them — their tab, if alive, simply re-claims on its next
-    // revalidation pass.
-    if(!rec||typeof rec!=='object'||typeof rec.nonce!=='string'||!rec.nonce) continue;
-    const ts=Number(rec.ts);
-    out[id]={nonce:rec.nonce, ts:Number.isFinite(ts)?ts:0, released:!!rec.released};
-  }
-  return out;
-}
-function _writeTabClaims(reg){
-  try{ localStorage.setItem(TAB_ID_CLAIM_KEY, JSON.stringify(reg)); return true; }
-  catch(_){ return false; }
-}
-// Seen-registry updates are read-modify-write on a single localStorage key, and
-// two tabs can interleave between the read and the write (localStorage offers
-// no transaction). A blind whole-object write would drop the record a
-// concurrent tab just added, so this helper re-reads immediately before
-// writing and only ever touches the caller's OWN id: `stamp` refreshes it,
-// `drop` removes it, and every other tab's entry is carried over untouched
-// (minus TTL expiry).
-function _updateTabRegistry(key, id, ttlMs, drop){
-  if(!id) return;
+const TAB_ACTIVE_SESSION_MIRROR_KEY = 'hermes-webui-tab-active-session';
+const TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY = 'hermes-webui-tab-active-session-none';
+const TAB_INFLIGHT_MIRROR_KEY = 'hermes-webui-tab-inflight';
+const TAB_INFLIGHT_STATE_MIRROR_KEY = 'hermes-webui-tab-inflight-state';
+
+function _newTabId(){
   try{
-    let reg={};
-    try{ reg=JSON.parse(localStorage.getItem(key)||'{}')||{}; }catch(_){ reg={}; }
-    if(typeof reg!=='object'||!reg) reg={};
-    const now=Date.now();
-    for(const [k,v] of Object.entries(reg)){
-      if(!v||typeof v!=='number'||(now-v)>ttlMs) delete reg[k];
+    if(typeof window==='undefined'||!window.crypto) return '';
+    if(typeof window.crypto.randomUUID==='function') return window.crypto.randomUUID();
+    if(typeof window.crypto.getRandomValues==='function'){
+      const bytes=new Uint8Array(16);
+      window.crypto.getRandomValues(bytes);
+      // RFC 4122 version/variant bits make the fallback the same 122-bit UUID
+      // identity class as randomUUID().
+      bytes[6]=(bytes[6]&15)|64;
+      bytes[8]=(bytes[8]&63)|128;
+      const hex=Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('');
+      return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`;
     }
-    if(drop) delete reg[id]; else reg[id]=now;
-    localStorage.setItem(key, JSON.stringify(reg));
+  }catch(_){}
+  return '';
+}
+function _scopedTabKey(base,id){
+  const owner=id||_hermesTabId();
+  // Without a cryptographic per-document identity, shared localStorage is not
+  // safe. Throw so existing guarded callers degrade to no recovery instead of
+  // reading or writing a shared fallback key.
+  if(!owner) throw new Error('secure per-document storage identity unavailable');
+  return base+'::'+owner;
+}
+function _mirrorTabValue(key,value){
+  try{
+    if(value==null) sessionStorage.removeItem(key);
+    else sessionStorage.setItem(key,String(value));
   }catch(_){}
 }
-// "Seen" registry: records the last time a tab id was active. Only a
-// heuristic for keys with NO ownership record (pre-upgrade leftovers) — the
-// ownership registry above is the authority for everything else (#2386 quota).
-function _touchTabSeen(id){
-  _updateTabRegistry(TAB_ID_SEEN_KEY, id, _TAB_SEEN_TTL_MS, false);
+function _restoreDocumentScopedState(id){
+  if(!id) return;
+  try{
+    const active=sessionStorage.getItem(TAB_ACTIVE_SESSION_MIRROR_KEY);
+    const tombstone=sessionStorage.getItem(TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY);
+    if(active){
+      window.__hermesActiveSession=active;
+      window.__hermesActiveSessionKnown=true;
+      localStorage.setItem(_scopedTabKey(ACTIVE_SESSION_KEY_LEGACY,id),active);
+      localStorage.removeItem(_scopedTabKey(ACTIVE_SESSION_TOMBSTONE_BASE,id));
+    }else if(tombstone){
+      window.__hermesActiveSession=null;
+      window.__hermesActiveSessionKnown=true;
+      localStorage.setItem(_scopedTabKey(ACTIVE_SESSION_TOMBSTONE_BASE,id),tombstone);
+      localStorage.removeItem(_scopedTabKey(ACTIVE_SESSION_KEY_LEGACY,id));
+    }
+  }catch(_){}
+  try{
+    const marker=sessionStorage.getItem(TAB_INFLIGHT_MIRROR_KEY);
+    if(marker!=null) localStorage.setItem(_scopedTabKey(INFLIGHT_KEY_BASE,id),marker);
+  }catch(_){}
+  try{
+    const raw=sessionStorage.getItem(TAB_INFLIGHT_STATE_MIRROR_KEY);
+    if(raw!=null){
+      const parsed=JSON.parse(raw);
+      if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){
+        const restamped={};
+        for(const [sid,entry] of Object.entries(parsed)){
+          if(sid&&entry&&typeof entry==='object'&&!Array.isArray(entry)){
+            restamped[sid]={...entry,tabId:id};
+          }
+        }
+        localStorage.setItem(_scopedTabKey(INFLIGHT_STATE_KEY_BASE,id),JSON.stringify(restamped));
+        sessionStorage.setItem(TAB_INFLIGHT_STATE_MIRROR_KEY,JSON.stringify(restamped));
+      }
+    }
+  }catch(_){}
 }
-// Remove per-tab keys whose owning tab is provably gone. Without this, every
-// new tab would leave `<base>::<uuid>` entries behind and slowly fill the
-// origin's localStorage quota (#2386).
-//
-// Fail-safe rules (maintainer re-gate, PR #7084):
-//   * A malformed ownership registry DISABLES GC entirely — corrupt JSON must
-//     never be interpreted as "no tab is alive".
-//   * An id with an UNRELEASED ownership record is authoritatively alive and is
-//     never collected, no matter how much time elapsed (a suspended laptop or
-//     throttled background tab misses heartbeats without dying).
-//   * An id with a RELEASED record is collected only after the release grace
-//     window (so a reloading tab can re-claim first).
-//   * Only ids with NO record at all (pre-upgrade leftovers) fall back to the
-//     seen-TTL heuristic — and a malformed seen registry likewise disables GC.
+// GC is based only on an explicit, per-id pagehide record. Each release marker
+// has its own key, so concurrent documents never perform a shared-map
+// read-modify-write. Missing or malformed markers fail closed and retain state;
+// elapsed heartbeats are never used as proof that a live/frozen document died.
 function _gcOrphanTabKeys(){
   try{
-    const claims=_readTabClaims();
-    if(claims===null) return; // fail safe: unreadable registry ⇒ collect nothing
-    let seenRaw=null;
-    try{ seenRaw=localStorage.getItem(TAB_ID_SEEN_KEY); }catch(_){ return; }
-    let seen={};
-    if(seenRaw!=null){
-      try{ seen=JSON.parse(seenRaw); }catch(_){ return; } // fail safe
-      if(!seen||typeof seen!=='object'||Array.isArray(seen)) return; // fail safe
-    }
     const now=Date.now();
-    const prefixes=[INFLIGHT_KEY_BASE+'::', INFLIGHT_STATE_KEY_BASE+'::', ACTIVE_SESSION_KEY_LEGACY+'::', ACTIVE_SESSION_TOMBSTONE_BASE+'::'];
+    const statePrefixes=[
+      INFLIGHT_KEY_BASE+'::',
+      INFLIGHT_STATE_KEY_BASE+'::',
+      ACTIVE_SESSION_KEY_LEGACY+'::',
+      ACTIVE_SESSION_TOMBSTONE_BASE+'::',
+    ];
+    const releasePrefix=TAB_ID_RELEASED_BASE+'::';
     const doomed=[];
     for(let i=0;i<localStorage.length;i++){
       const key=localStorage.key(i);
       if(!key) continue;
-      const prefix=prefixes.find(p=>key.indexOf(p)===0);
+      const prefix=statePrefixes.find(p=>key.indexOf(p)===0);
       if(!prefix) continue;
       const owner=key.slice(prefix.length);
       if(!owner) continue;
-      const rec=Object.prototype.hasOwnProperty.call(claims,owner)?claims[owner]:null;
-      if(rec){
-        if(!rec.released) continue;                    // authoritatively alive
-        if((now-rec.ts)<=_TAB_SEEN_TTL_MS) continue;   // reload/reopen window
-        doomed.push(key);
-        continue;
-      }
-      // No ownership record: legacy leftovers only. Recent "seen" ⇒ keep.
-      const seenTs=Number(seen[owner]);
-      if(Number.isFinite(seenTs)&&(now-seenTs)<=_TAB_SEEN_TTL_MS) continue;
+      const releasedRaw=localStorage.getItem(releasePrefix+owner);
+      if(releasedRaw==null) continue;
+      const releasedAt=Number(releasedRaw);
+      if(!Number.isFinite(releasedAt)||(now-releasedAt)<=_TAB_RELEASED_TTL_MS) continue;
       doomed.push(key);
     }
     for(const key of doomed){
       try{ localStorage.removeItem(key); }catch(_){}
     }
-    // Prune long-dead registry entries so the registries themselves stay
-    // bounded. Unreleased records are never pruned (authoritative liveness).
-    try{
-      let changed=false;
-      for(const [id,rec] of Object.entries(claims)){
-        if(rec.released&&(now-rec.ts)>_TAB_SEEN_TTL_MS){ delete claims[id]; changed=true; }
+    const staleReleaseKeys=[];
+    for(let i=0;i<localStorage.length;i++){
+      const key=localStorage.key(i);
+      if(!key||key.indexOf(releasePrefix)!==0) continue;
+      const releasedAt=Number(localStorage.getItem(key));
+      if(Number.isFinite(releasedAt)&&(now-releasedAt)>_TAB_RELEASED_TTL_MS){
+        staleReleaseKeys.push(key);
       }
-      if(changed) _writeTabClaims(claims);
-    }catch(_){}
-    try{
-      let changed=false;
-      for(const [id,ts] of Object.entries(seen)){
-        const n=Number(ts);
-        if(!Number.isFinite(n)||(now-n)>_TAB_SEEN_TTL_MS){ delete seen[id]; changed=true; }
-      }
-      if(changed) localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
-    }catch(_){}
+    }
+    for(const key of staleReleaseKeys){
+      try{ localStorage.removeItem(key); }catch(_){}
+    }
   }catch(_){}
 }
-// Collision arbitration. Attempts to take ownership of `id` for THIS context's
-// nonce. Succeeds when the id is unrecorded, already ours, or explicitly
-// released; fails when a foreign unreleased record exists (a live duplicate —
-// regardless of the record's age) or when the registry is unreadable (a
-// possibly-live owner must never be raced). Compare-and-swap shaped: re-reads
-// immediately before writing and verifies its own write landed, so two
-// simultaneous claimers cannot both believe they won.
-function _claimTabOwnership(id){
-  const nonce=_hermesTabNonce();
-  const reg=_readTabClaims();
-  if(reg===null) return false; // fail safe: cannot prove the id is free
-  const rec=Object.prototype.hasOwnProperty.call(reg,id)?reg[id]:null;
-  if(rec&&rec.nonce!==nonce&&!rec.released) return false;
-  reg[id]={nonce, ts:Date.now(), released:false};
-  if(!_writeTabClaims(reg)) return false;
-  // Verify: another context interleaving between our read and write loses if
-  // its write landed after ours; re-read to confirm ownership stuck.
-  const check=_readTabClaims();
-  if(check===null) return false;
-  const mine=Object.prototype.hasOwnProperty.call(check,id)?check[id]:null;
-  return !!(mine&&mine.nonce===nonce&&!mine.released);
-}
-function _claimTabId(id){
-  // A fresh id may still collide with a concurrent claimer; arbitration
-  // re-checks after each mint. Bounded retries keep boot non-blocking even
-  // with a hostile registry — the final fallback id is context-local.
-  let candidate=id;
-  for(let attempt=0;attempt<4;attempt++){
-    if(_claimTabOwnership(candidate)) return candidate;
-    candidate=_newTabId();
-  }
-  return candidate;
-}
-function _releaseTabId(){
+function _releaseTabId(event){
+  // A BFCache pagehide does not end the document; pageshow resumes the same
+  // in-memory identity. Only a real teardown proves this id is no longer used.
+  if(event&&event.persisted) return;
   try{
     if(typeof window==='undefined'||!window.__hermesTabId) return;
-    const reg=_readTabClaims();
-    if(reg===null) return;
-    const id=window.__hermesTabId;
-    const rec=Object.prototype.hasOwnProperty.call(reg,id)?reg[id]:null;
-    // Only the owner may release: releasing a record that a newer context
-    // re-claimed would hand our id to the next duplicate.
-    if(!rec||rec.nonce!==_hermesTabNonce()) return;
-    reg[id]={nonce:rec.nonce, ts:Date.now(), released:true};
-    _writeTabClaims(reg);
-  }catch(_){}
-}
-// Ownership revalidation — the authoritative gate run before every scoped
-// read/write (throttled). If another context stole or re-claimed this tab's id
-// (clone arbitration race, registry clobber), THIS context must stop using the
-// id immediately and mint a fresh one; otherwise its next scoped write would
-// land in the thief's keyspace.
-function _revalidateTabOwnership(){
-  if(typeof window==='undefined'||!window.__hermesTabId) return;
-  const now=Date.now();
-  if(window.__hermesTabOwnerCheckedAt&&(now-window.__hermesTabOwnerCheckedAt)<_TAB_OWNER_REVALIDATE_MS) return;
-  window.__hermesTabOwnerCheckedAt=now;
-  try{
-    const nonce=_hermesTabNonce();
-    const reg=_readTabClaims();
-    if(reg===null){
-      // Registry unreadable: keep the current id (fail safe — do NOT churn
-      // identities on transient corruption; GC is disabled in this state too).
-      return;
-    }
-    const rec=Object.prototype.hasOwnProperty.call(reg,window.__hermesTabId)?reg[window.__hermesTabId]:null;
-    if(rec&&rec.nonce===nonce&&!rec.released){
-      reg[window.__hermesTabId]={nonce, ts:now, released:false};
-      _writeTabClaims(reg);
-      _touchTabSeen(window.__hermesTabId);
-      return;
-    }
-    // Record missing (pruned / first write lost) or released (bfcache restore
-    // after pagehide): arbitration decides — re-claim succeeds unless a
-    // foreign UNRELEASED record owns the id.
-    if(_claimTabOwnership(window.__hermesTabId)){ _touchTabSeen(window.__hermesTabId); return; }
-    // Foreign owner (or lost arbitration): abandon this id NOW, before any
-    // scoped read/write can touch the other tab's keyspace.
-    const fresh=_claimTabId(_newTabId());
-    window.__hermesTabId=fresh;
-    try{ sessionStorage.setItem(TAB_ID_KEY,fresh); }catch(_){}
-    _touchTabSeen(fresh);
+    localStorage.setItem(_scopedTabKey(TAB_ID_RELEASED_BASE,window.__hermesTabId),String(Date.now()));
   }catch(_){}
 }
 function _hermesTabId(){
   if(typeof window==='undefined') return 'default';
-  if(window.__hermesTabId){ _revalidateTabOwnership(); return window.__hermesTabId; }
-  let id='';
-  try{ id=sessionStorage.getItem(TAB_ID_KEY)||''; }catch(_){ id=''; }
-  const claimed=_claimTabId(id||_newTabId());
-  if(claimed!==id){
-    try{ sessionStorage.setItem(TAB_ID_KEY,claimed); }catch(_){}
+  if(window.__hermesTabId) return window.__hermesTabId;
+  const id=_newTabId();
+  if(!id){
+    window.__hermesTabAuthorityUnavailable=true;
+    return null;
   }
-  window.__hermesTabId=claimed;
-  window.__hermesTabOwnerCheckedAt=Date.now();
-  _touchTabSeen(claimed);
-  // Reclaim keys left behind by tabs that are gone for good.
+  // Deliberately overwrite (never adopt) any id inherited through copied
+  // sessionStorage. Recovery values are mirrored separately and are re-stamped
+  // under this document's fresh identity before scoped access begins.
+  window.__hermesTabId=id;
+  try{ sessionStorage.setItem(TAB_ID_KEY,id); }catch(_){}
+  _restoreDocumentScopedState(id);
   _gcOrphanTabKeys();
   try{
-    if(!window.__hermesTabClaimTimer){
-      // Refresh the ownership stamp while alive. NOTE: liveness does NOT
-      // depend on this timer (an unreleased record never expires); the stamp
-      // only feeds the released/seen grace windows.
-      window.__hermesTabClaimTimer=setInterval(()=>{
-        try{ _revalidateTabOwnership(); }catch(_){}
-      }, _TAB_CLAIM_HEARTBEAT_MS);
-      // Mark released on unload so a plain refresh keeps the same id (and
-      // therefore its in-flight recovery snapshot) instead of being treated as
-      // a clone. The "seen" entry is deliberately NOT removed here: it is what
-      // lets a reloading tab keep its keys while still allowing eventual GC.
-      window.addEventListener('pagehide', _releaseTabId);
+    if(!window.__hermesTabReleaseBound){
+      window.__hermesTabReleaseBound=true;
+      window.addEventListener('pagehide',_releaseTabId);
     }
   }catch(_){}
-  return claimed;
+  return id;
 }
 
 // ── Reconnect banner (B4/B5: reload resilience) ──
@@ -9647,59 +9507,95 @@ function _hermesTabId(){
 // starting a turn can no longer overwrite the first tab's reconnect marker.
 // (INFLIGHT_KEY_BASE / INFLIGHT_STATE_KEY_BASE are declared with the per-tab
 // identity helpers above so the storage GC can reference them safely.)
-function _inflightKey(){ return INFLIGHT_KEY_BASE+'::'+_hermesTabId(); }
-function _inflightStateKey(){ return INFLIGHT_STATE_KEY_BASE+'::'+_hermesTabId(); }
-// Back-compat aliases: several call sites (and tests) reference these names
-// directly. They now resolve per tab via the accessors above.
-if(typeof window!=='undefined'){
-  Object.defineProperty(window, '_inflightKey()', {get:_inflightKey, configurable:true});
-  Object.defineProperty(window, '_inflightStateKey()', {get:_inflightStateKey, configurable:true});
-}
+function _inflightKey(){ return _scopedTabKey(INFLIGHT_KEY_BASE); }
+function _inflightStateKey(){ return _scopedTabKey(INFLIGHT_STATE_KEY_BASE); }
 
 // Tab-scoped active session. The legacy global 'hermes-webui-session' key is
 // still written (so an unrelated/older tab and the boot fallback keep working),
 // but each tab ALSO records its own last-opened session and prefers it on
 // reload. Without this, reloading tab 1 could restore whatever conversation
 // tab 2 opened most recently.
-function _activeSessionKey(){ return ACTIVE_SESSION_KEY_LEGACY+'::'+_hermesTabId(); }
-function _activeSessionTombstoneKey(){ return ACTIVE_SESSION_TOMBSTONE_BASE+'::'+_hermesTabId(); }
+function _activeSessionKey(){ return _scopedTabKey(ACTIVE_SESSION_KEY_LEGACY); }
+function _activeSessionTombstoneKey(){ return _scopedTabKey(ACTIVE_SESSION_TOMBSTONE_BASE); }
 function _rememberActiveSession(sid){
   if(!sid) return;
+  if(!_hermesTabId()) return;
+  window.__hermesActiveSession=sid;
+  window.__hermesActiveSessionKnown=true;
   try{ localStorage.setItem(_activeSessionKey(), sid); }catch(_){}
   // Opening a session supersedes any earlier "no session" tombstone.
   try{ localStorage.removeItem(_activeSessionTombstoneKey()); }catch(_){}
+  _mirrorTabValue(TAB_ACTIVE_SESSION_MIRROR_KEY,sid);
+  _mirrorTabValue(TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY,null);
   // Keep the legacy key in sync for boot fallback + older code paths.
   try{ localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, sid); }catch(_){}
 }
 function _rememberedActiveSession(){
+  if(!_hermesTabId()) return null;
+  if(window.__hermesActiveSessionKnown) return window.__hermesActiveSession||null;
   // This tab's own choice always wins over the shared/global slot.
   // Returns null when nothing is stored, matching the original
   // localStorage.getItem() contract this helper replaced.
   try{
     const own=localStorage.getItem(_activeSessionKey());
-    if(own) return own;
-  }catch(_){}
+    if(own){
+      window.__hermesActiveSession=own;
+      window.__hermesActiveSessionKnown=true;
+      return own;
+    }
+  }catch(_){
+    window.__hermesActiveSession=null;
+    window.__hermesActiveSessionKnown=true;
+    return null;
+  }
   // Explicit per-tab tombstone: this tab deliberately forgot its session, so
   // the shared legacy fallback must NOT bleed back in (another tab may keep
   // rewriting it). Only a brand-new tab — no scoped value AND no tombstone —
   // may consult the legacy slot.
-  try{ if(localStorage.getItem(_activeSessionTombstoneKey())) return null; }catch(_){}
+  try{
+    if(localStorage.getItem(_activeSessionTombstoneKey())){
+      window.__hermesActiveSession=null;
+      window.__hermesActiveSessionKnown=true;
+      return null;
+    }
+  }catch(_){
+    window.__hermesActiveSession=null;
+    window.__hermesActiveSessionKnown=true;
+    return null;
+  }
   let legacy=null;
-  try{ legacy=localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY); }catch(_){ return null; }
+  try{ legacy=localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY); }catch(_){
+    window.__hermesActiveSession=null;
+    window.__hermesActiveSessionKnown=true;
+    return null;
+  }
   // One-shot adoption (upgrade path): copy the legacy value into this tab's
   // scoped slot so every later read/forget goes through tab-owned state and a
   // concurrent tab rewriting the shared slot can no longer change what THIS
   // tab restores.
-  if(legacy){ try{ localStorage.setItem(_activeSessionKey(), legacy); }catch(_){} }
+  if(legacy){
+    try{ localStorage.setItem(_activeSessionKey(), legacy); }catch(_){}
+    _mirrorTabValue(TAB_ACTIVE_SESSION_MIRROR_KEY,legacy);
+  }
+  // The shared legacy slot is a one-shot boot fallback. Cache even an empty
+  // result so another document cannot change this document's later reads when
+  // scoped storage is unavailable or quota constrained.
+  window.__hermesActiveSession=legacy||null;
+  window.__hermesActiveSessionKnown=true;
   return legacy;
 }
 function _forgetActiveSession(expectedSid){
+  if(!_hermesTabId()) return;
+  window.__hermesActiveSession=null;
+  window.__hermesActiveSessionKnown=true;
   let own=null;
   try{ own=localStorage.getItem(_activeSessionKey()); }catch(_){}
   try{ localStorage.removeItem(_activeSessionKey()); }catch(_){}
   // Persist an explicit "no session" tombstone so the legacy fallback cannot
   // resurrect a forgotten (possibly dead/404) session on the next read.
   try{ localStorage.setItem(_activeSessionTombstoneKey(), String(Date.now())); }catch(_){}
+  _mirrorTabValue(TAB_ACTIVE_SESSION_MIRROR_KEY,null);
+  _mirrorTabValue(TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY,String(Date.now()));
   // The legacy key is SHARED: it is the first-paint fallback for a brand-new
   // tab (which has no scoped key yet) and for any older client. Only clear it
   // when it still points at the session THIS tab is forgetting — otherwise one
@@ -9753,6 +9649,7 @@ function _getInflightStateLimits(){
 // the legacy entries so they are consumed exactly once. Invalid or stale
 // legacy payloads are removed without migrating.
 function _migrateLegacyInflight(){
+  if(!_hermesTabId()) return;
   if(typeof window!=='undefined'){
     if(window.__hermesLegacyInflightMigrated) return;
     window.__hermesLegacyInflightMigrated=true;
@@ -9769,7 +9666,9 @@ function _migrateLegacyInflight(){
         const streamOk=parsed&&(parsed.streamId==null||typeof parsed.streamId==='string');
         if(sid&&streamOk&&Number.isFinite(ts)&&(now-ts)<=10*60*1000
            &&localStorage.getItem(_inflightKey())==null){
-          localStorage.setItem(_inflightKey(), JSON.stringify({sid, streamId:parsed.streamId||null, ts}));
+          const adopted=JSON.stringify({sid, streamId:parsed.streamId||null, ts});
+          localStorage.setItem(_inflightKey(),adopted);
+          _mirrorTabValue(TAB_INFLIGHT_MIRROR_KEY,adopted);
         }
       }catch(_){}
       // One-shot: the legacy slot is consumed (or invalidated) exactly once,
@@ -9795,7 +9694,9 @@ function _migrateLegacyInflight(){
             fresh[sid]={...entry, tabId:_hermesTabId()};
           }
           if(Object.keys(fresh).length&&localStorage.getItem(_inflightStateKey())==null){
-            localStorage.setItem(_inflightStateKey(), JSON.stringify(fresh));
+            const adopted=JSON.stringify(fresh);
+            localStorage.setItem(_inflightStateKey(),adopted);
+            _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,adopted);
           }
         }
       }catch(_){}
@@ -9880,14 +9781,18 @@ function _writeInflightStateMap(all){
   }
   if(json.length>limits.jsonChars){
     localStorage.removeItem(_inflightStateKey());
+    _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,null);
     return false;
   }
   localStorage.setItem(_inflightStateKey(),json);
+  _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,json);
   return true;
 }
 function saveInflightState(sid, state){
   if(!sid||!state) return;
-  const entry={..._compactInflightState(state),updated_at:Date.now(),tabId:_hermesTabId()};
+  const tabId=_hermesTabId();
+  if(!tabId) return;
+  const entry={..._compactInflightState(state),updated_at:Date.now(),tabId};
   try{
     const all=_readInflightStateMap();
     all[sid]=entry;
@@ -9899,6 +9804,7 @@ function saveInflightState(sid, state){
       _writeInflightStateMap({[sid]:entry});
     }catch(_){
       try{localStorage.removeItem(_inflightStateKey());}catch(__){}
+      _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,null);
     }
   }
 }
@@ -9907,12 +9813,11 @@ function loadInflightState(sid, streamId){
   const all=_readInflightStateMap();
   const entry=all[sid];
   if(!entry) return null;
-  // Tab ownership: entries are stored under a per-tab key, but a duplicated tab
-  // inherits sessionStorage (hence the same tab id) and legacy entries written
-  // before this fix carry no owner at all. Reject any snapshot that explicitly
-  // belongs to a DIFFERENT tab so one tab's live transcript can never be
-  // merged into another tab's conversation.
-  if(entry.tabId && entry.tabId!==_hermesTabId()) return null;
+  // Every accepted snapshot is stamped with this document's fresh identity.
+  // Reload mirrors are re-stamped during _restoreDocumentScopedState(); an
+  // absent or foreign stamp is unverifiable and therefore rejected.
+  const tabId=_hermesTabId();
+  if(!tabId||entry.tabId!==tabId) return null;
   if(streamId&&entry.streamId&&entry.streamId!==streamId) return null;
   if(entry.updated_at&&Date.now()-entry.updated_at>10*60*1000){
     clearInflightState(sid);
@@ -9926,8 +9831,14 @@ function clearInflightState(sid){
     const all=_readInflightStateMap();
     if(!(sid in all)) return;
     delete all[sid];
-    if(Object.keys(all).length) localStorage.setItem(_inflightStateKey(), JSON.stringify(all));
-    else localStorage.removeItem(_inflightStateKey());
+    if(Object.keys(all).length){
+      const json=JSON.stringify(all);
+      localStorage.setItem(_inflightStateKey(),json);
+      _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,json);
+    }else{
+      localStorage.removeItem(_inflightStateKey());
+      _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,null);
+    }
   }catch(_){ }
 }
 
@@ -10246,6 +10157,7 @@ function restoreLiveTurnHtmlForSession(sid){
 
 function markInflight(sid, streamId) {
   const payload=JSON.stringify({sid, streamId, ts: Date.now()});
+  _mirrorTabValue(TAB_INFLIGHT_MIRROR_KEY,payload);
   try{
     localStorage.setItem(_inflightKey(), payload);
   }catch(err){
@@ -10257,7 +10169,8 @@ function markInflight(sid, streamId) {
   }
 }
 function clearInflight() {
-  localStorage.removeItem(_inflightKey());
+  _mirrorTabValue(TAB_INFLIGHT_MIRROR_KEY,null);
+  try{ localStorage.removeItem(_inflightKey()); }catch(_){}
 }
 function showReconnectBanner(msg) {
   $('reconnectMsg').textContent = msg || 'A response may have been in progress when you last left.';
@@ -11400,8 +11313,11 @@ async function checkInflightOnBoot(sid) {
   // Rollout migration: adopt a valid pre-upgrade (unsuffixed) reconnect marker
   // under this tab's scoped key before reading, or the in-flight recovery that
   // existed before the per-tab upgrade would be silently discarded.
-  try{ _migrateLegacyInflight(); }catch(_){}
-  const raw = localStorage.getItem(_inflightKey());
+  let raw=null;
+  try{
+    _migrateLegacyInflight();
+    raw=localStorage.getItem(_inflightKey());
+  }catch(_){ return; }
   if (!raw) return;
   try {
     const {sid: inflightSid, streamId, ts} = JSON.parse(raw);

--- a/static/ui.js
+++ b/static/ui.js
@@ -9346,7 +9346,7 @@ function autoReadLastAssistant(){
 const TAB_ID_KEY = 'hermes-webui-tab-id';
 const TAB_ID_RELEASED_BASE = 'hermes-webui-tab-released';
 const _TAB_RELEASED_TTL_MS = 24 * 60 * 60 * 1000;
-const INFLIGHT_KEY_BASE = 'hermes-webui-inflight'; // legacy/global (migration only)
+const INFLIGHT_KEY_BASE = 'hermes-webui-inflight'; // scoped base; unsuffixed form is legacy/ownerless
 const INFLIGHT_STATE_KEY_BASE = 'hermes-webui-inflight-state';
 const ACTIVE_SESSION_KEY_LEGACY = 'hermes-webui-session';
 const ACTIVE_SESSION_TOMBSTONE_BASE = 'hermes-webui-session-none';
@@ -9588,27 +9588,17 @@ function _forgetActiveSession(expectedSid){
   if(!_hermesTabId()) return;
   window.__hermesActiveSession=null;
   window.__hermesActiveSessionKnown=true;
-  let own=null;
-  try{ own=localStorage.getItem(_activeSessionKey()); }catch(_){}
   try{ localStorage.removeItem(_activeSessionKey()); }catch(_){}
   // Persist an explicit "no session" tombstone so the legacy fallback cannot
   // resurrect a forgotten (possibly dead/404) session on the next read.
   try{ localStorage.setItem(_activeSessionTombstoneKey(), String(Date.now())); }catch(_){}
   _mirrorTabValue(TAB_ACTIVE_SESSION_MIRROR_KEY,null);
   _mirrorTabValue(TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY,String(Date.now()));
-  // The legacy key is SHARED: it is the first-paint fallback for a brand-new
-  // tab (which has no scoped key yet) and for any older client. Only clear it
-  // when it still points at the session THIS tab is forgetting — otherwise one
-  // tab closing a conversation would drop every other tab's restore target and
-  // new tabs would open the empty state. `expectedSid` lets self-heal paths
-  // (404 / profile switch) name the dead session explicitly, so a legacy-only
-  // entry that was never adopted into scoped storage is still cleared.
-  const expected=own||(typeof expectedSid==='string'&&expectedSid?expectedSid:null);
-  try{
-    if(expected&&localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY)===expected){
-      localStorage.removeItem(ACTIVE_SESSION_KEY_LEGACY);
-    }
-  }catch(_){}
+  // The legacy key is shared, ownerless bootstrap state for brand-new and old
+  // clients. A matching SID (including expectedSid from a 404 self-heal) proves
+  // content equality, not deletion authority: another document may still rely
+  // on that same fallback. Never mutate it while forgetting document-local
+  // state; a stale fallback is advisory and each new document self-heals it.
 }
 if(typeof window!=='undefined'){
   window._rememberActiveSession=_rememberActiveSession;
@@ -9639,70 +9629,14 @@ function _getInflightStateLimits(){
   };
 }
 
-// One-shot rollout migration (maintainer re-gate, PR #7084): before this fix
-// shipped, the reconnect marker and the mid-stream transcript snapshots lived
-// in the UNSUFFIXED `hermes-webui-inflight` / `hermes-webui-inflight-state`
-// keys. Both readers below use suffixed keys exclusively, so without this
-// migration an upgrade mid-stream would silently discard the user's existing
-// recovery state. When this tab has no scoped state yet: validate the legacy
-// payload (shape + SID + age), re-stamp it under THIS tab's id, then remove
-// the legacy entries so they are consumed exactly once. Invalid or stale
-// legacy payloads are removed without migrating.
+// Pre-upgrade inflight entries in the unsuffixed keys have no authoritative
+// document owner. Shape, SID and age cannot establish ownership: the first tab
+// loading the update may be unrelated to the stream that wrote them. Keep this
+// guard at both reader boundaries, but deliberately neither adopt nor delete
+// shared legacy bytes. New documents fail closed to their scoped state while a
+// still-running legacy document/client retains its recovery data.
 function _migrateLegacyInflight(){
-  if(!_hermesTabId()) return;
-  if(typeof window!=='undefined'){
-    if(window.__hermesLegacyInflightMigrated) return;
-    window.__hermesLegacyInflightMigrated=true;
-  }
-  const now=Date.now();
-  // Reconnect marker: {sid, streamId, ts}.
-  try{
-    const legacyRaw=localStorage.getItem(INFLIGHT_KEY_BASE);
-    if(legacyRaw!=null){
-      try{
-        const parsed=JSON.parse(legacyRaw);
-        const sid=(parsed&&typeof parsed.sid==='string')?parsed.sid:'';
-        const ts=Number(parsed&&parsed.ts);
-        const streamOk=parsed&&(parsed.streamId==null||typeof parsed.streamId==='string');
-        if(sid&&streamOk&&Number.isFinite(ts)&&(now-ts)<=10*60*1000
-           &&localStorage.getItem(_inflightKey())==null){
-          const adopted=JSON.stringify({sid, streamId:parsed.streamId||null, ts});
-          localStorage.setItem(_inflightKey(),adopted);
-          _mirrorTabValue(TAB_INFLIGHT_MIRROR_KEY,adopted);
-        }
-      }catch(_){}
-      // One-shot: the legacy slot is consumed (or invalidated) exactly once,
-      // whether or not it was migratable — it must never be read again.
-      try{ localStorage.removeItem(INFLIGHT_KEY_BASE); }catch(_){}
-    }
-  }catch(_){}
-  // Transcript snapshots: {sid: entry} map.
-  try{
-    const legacyRaw=localStorage.getItem(INFLIGHT_STATE_KEY_BASE);
-    if(legacyRaw!=null){
-      try{
-        const parsed=JSON.parse(legacyRaw);
-        if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){
-          const fresh={};
-          for(const [sid,entry] of Object.entries(parsed)){
-            if(!sid||!entry||typeof entry!=='object'||Array.isArray(entry)) continue;
-            const upd=Number(entry.updated_at);
-            if(!Number.isFinite(upd)||(now-upd)>10*60*1000) continue;
-            // Re-stamp under the adopting tab: loadInflightState() rejects
-            // entries owned by a different tab id, and the pre-fix entries
-            // carry no owner (or a meaningless one).
-            fresh[sid]={...entry, tabId:_hermesTabId()};
-          }
-          if(Object.keys(fresh).length&&localStorage.getItem(_inflightStateKey())==null){
-            const adopted=JSON.stringify(fresh);
-            localStorage.setItem(_inflightStateKey(),adopted);
-            _mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY,adopted);
-          }
-        }
-      }catch(_){}
-      try{ localStorage.removeItem(INFLIGHT_STATE_KEY_BASE); }catch(_){}
-    }
-  }catch(_){}
+  return;
 }
 function _readInflightStateMap(){
   try{
@@ -11310,9 +11244,8 @@ function getPendingSessionMessage(session, messagesOverride=null){
   };
 }
 async function checkInflightOnBoot(sid) {
-  // Rollout migration: adopt a valid pre-upgrade (unsuffixed) reconnect marker
-  // under this tab's scoped key before reading, or the in-flight recovery that
-  // existed before the per-tab upgrade would be silently discarded.
+  // Enter the legacy quarantine boundary before reading this document's scoped
+  // marker. Ownerless unsuffixed state is never adopted or consumed here.
   let raw=null;
   try{
     _migrateLegacyInflight();

--- a/static/ui.js
+++ b/static/ui.js
@@ -9360,17 +9360,29 @@ function _newTabId(){
 // Duplicating a tab (Chrome "Duplicate", or a PWA restore) COPIES sessionStorage,
 // so the clone would start life with the original tab's id and both tabs would
 // write to the same per-tab keys — reintroducing exactly the cross-talk this
-// fix removes. Each tab therefore claims its id in a shared localStorage
-// registry and heartbeats it while alive; a tab that finds its id already
-// claimed by a LIVE tab mints a fresh one.
+// fix removes. Ownership is therefore AUTHORITATIVE, not timer-based: every JS
+// context mints a per-context nonce (kept only on `window`, never in
+// sessionStorage, so a clone can never inherit it) and records
+// `{nonce, ts, released}` for its tab id in a shared registry. An id whose
+// record carries a foreign nonce and is not explicitly released is NEVER
+// reusable — no heartbeat gap, sleep, or timer throttling can make it reusable.
+// (Previously a missed 45s lease let a duplicated tab keep the original's id.)
 //
-// Reload safety: the claim is released on pagehide, so a normal refresh
-// re-claims the same id and keeps its in-flight recovery snapshot. Only a
-// genuinely concurrent (duplicated) tab sees a live claim.
-const _TAB_CLAIM_TTL_MS = 45000;
+// Reload safety: pagehide marks the record `released` (keeping nonce+ts), so a
+// normal refresh re-claims the same id and keeps its in-flight recovery state.
+// Crash-restore is the accepted trade-off: an unreleased foreign record is
+// indistinguishable from a live duplicate, so a restored tab mints a fresh id
+// (losing its recovery snapshot) instead of risking a collision.
 const _TAB_CLAIM_HEARTBEAT_MS = 15000;
-// A tab id that has not been seen for this long is considered gone for good and
-// its leftover per-tab keys are garbage collected (see _gcOrphanTabKeys).
+// Throttle for the ownership revalidation performed before every scoped
+// read/write (see _revalidateTabOwnership). Correctness does not depend on
+// this value; it only bounds how often the registry round-trip happens.
+const _TAB_OWNER_REVALIDATE_MS = 5000;
+// Retention window for RELEASED ownership records and for the legacy "seen"
+// heuristic. A released tab's keys are kept this long because the browser can
+// resurrect its sessionStorage (reload, bfcache, Ctrl+Shift+T reopen). It is
+// never used to declare a CLAIMED (unreleased) tab dead — an unreleased
+// ownership record always wins over any elapsed-time heuristic.
 const _TAB_SEEN_TTL_MS = 24 * 60 * 60 * 1000;
 const TAB_ID_SEEN_KEY = 'hermes-webui-tab-seen';
 // Storage key bases for per-tab state. Declared HERE, before the helpers that
@@ -9380,24 +9392,51 @@ const TAB_ID_SEEN_KEY = 'hermes-webui-tab-seen';
 const INFLIGHT_KEY_BASE = 'hermes-webui-inflight'; // legacy/global (migration only)
 const INFLIGHT_STATE_KEY_BASE = 'hermes-webui-inflight-state';
 const ACTIVE_SESSION_KEY_LEGACY = 'hermes-webui-session';
-function _readTabClaims(){
-  let claims={};
-  try{ claims=JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY)||'{}')||{}; }catch(_){ claims={}; }
-  if(typeof claims!=='object'||!claims) claims={};
-  const now=Date.now();
-  for(const [k,v] of Object.entries(claims)){
-    if(!v||typeof v!=='number'||(now-v)>_TAB_CLAIM_TTL_MS) delete claims[k];
-  }
-  return claims;
+// Explicit per-tab "no session" tombstone (see _forgetActiveSession): after a
+// tab forgets its session on purpose, the shared legacy fallback must not
+// bleed back into it on the next read.
+const ACTIVE_SESSION_TOMBSTONE_BASE = 'hermes-webui-session-none';
+// Per-context ownership nonce. Lives ONLY on `window` (one per JS execution
+// context): a duplicated tab copies sessionStorage but gets a fresh window, so
+// it can never present the original context's nonce during arbitration.
+function _hermesTabNonce(){
+  if(typeof window==='undefined') return 'default-nonce';
+  if(!window.__hermesTabNonce) window.__hermesTabNonce=_newTabId();
+  return window.__hermesTabNonce;
 }
-// Registry updates are read-modify-write on a single localStorage key, and two
-// tabs can interleave between the read and the write (localStorage offers no
-// transaction). A blind whole-object write would drop the claim/seen record a
-// concurrent tab just added, letting a LIVE tab's id be reused or its scoped
-// keys garbage collected. Both registries are therefore updated through this
-// helper, which re-reads immediately before writing and only ever touches the
-// caller's OWN id: `stamp` refreshes it, `drop` removes it, and every other
-// tab's entry is carried over untouched (minus TTL expiry).
+// Ownership registry: {tabId: {nonce, ts, released}}. Returns null (NOT {})
+// when the stored value is malformed, so callers can fail safe — a GC pass
+// must treat "unreadable registry" as "assume every tab is alive", and a
+// claimer must mint a fresh id instead of reusing a possibly-owned one.
+function _readTabClaims(){
+  let raw=null;
+  try{ raw=localStorage.getItem(TAB_ID_CLAIM_KEY); }catch(_){ return null; }
+  if(raw==null) return {};
+  let reg=null;
+  try{ reg=JSON.parse(raw); }catch(_){ return null; }
+  if(!reg||typeof reg!=='object'||Array.isArray(reg)) return null;
+  const out={};
+  for(const [id,rec] of Object.entries(reg)){
+    // Entries without a nonce cannot prove ownership (foreign/corrupt shapes);
+    // drop them — their tab, if alive, simply re-claims on its next
+    // revalidation pass.
+    if(!rec||typeof rec!=='object'||typeof rec.nonce!=='string'||!rec.nonce) continue;
+    const ts=Number(rec.ts);
+    out[id]={nonce:rec.nonce, ts:Number.isFinite(ts)?ts:0, released:!!rec.released};
+  }
+  return out;
+}
+function _writeTabClaims(reg){
+  try{ localStorage.setItem(TAB_ID_CLAIM_KEY, JSON.stringify(reg)); return true; }
+  catch(_){ return false; }
+}
+// Seen-registry updates are read-modify-write on a single localStorage key, and
+// two tabs can interleave between the read and the write (localStorage offers
+// no transaction). A blind whole-object write would drop the record a
+// concurrent tab just added, so this helper re-reads immediately before
+// writing and only ever touches the caller's OWN id: `stamp` refreshes it,
+// `drop` removes it, and every other tab's entry is carried over untouched
+// (minus TTL expiry).
 function _updateTabRegistry(key, id, ttlMs, drop){
   if(!id) return;
   try{
@@ -9412,32 +9451,39 @@ function _updateTabRegistry(key, id, ttlMs, drop){
     localStorage.setItem(key, JSON.stringify(reg));
   }catch(_){}
 }
-// "Seen" registry: unlike claims (a short-lived liveness lock released on
-// pagehide), this records the last time a tab id was active so that closed
-// tabs' leftover keys can eventually be reclaimed instead of growing the
-// localStorage footprint forever (#2386 quota).
-function _readTabSeen(){
-  let seen={};
-  try{ seen=JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY)||'{}')||{}; }catch(_){ seen={}; }
-  if(typeof seen!=='object'||!seen) seen={};
-  // Drop entries older than the retention window so _gcOrphanTabKeys() can
-  // actually reclaim the per-tab keys of tabs that are gone for good.
-  const now=Date.now();
-  for(const [k,v] of Object.entries(seen)){
-    if(!v||typeof v!=='number'||(now-v)>_TAB_SEEN_TTL_MS) delete seen[k];
-  }
-  return seen;
-}
+// "Seen" registry: records the last time a tab id was active. Only a
+// heuristic for keys with NO ownership record (pre-upgrade leftovers) — the
+// ownership registry above is the authority for everything else (#2386 quota).
 function _touchTabSeen(id){
   _updateTabRegistry(TAB_ID_SEEN_KEY, id, _TAB_SEEN_TTL_MS, false);
 }
-// Remove per-tab keys whose owning tab has not been seen within the TTL.
-// Without this, every new tab would leave `<base>::<uuid>` entries behind and
-// slowly fill the origin's localStorage quota.
+// Remove per-tab keys whose owning tab is provably gone. Without this, every
+// new tab would leave `<base>::<uuid>` entries behind and slowly fill the
+// origin's localStorage quota (#2386).
+//
+// Fail-safe rules (maintainer re-gate, PR #7084):
+//   * A malformed ownership registry DISABLES GC entirely — corrupt JSON must
+//     never be interpreted as "no tab is alive".
+//   * An id with an UNRELEASED ownership record is authoritatively alive and is
+//     never collected, no matter how much time elapsed (a suspended laptop or
+//     throttled background tab misses heartbeats without dying).
+//   * An id with a RELEASED record is collected only after the release grace
+//     window (so a reloading tab can re-claim first).
+//   * Only ids with NO record at all (pre-upgrade leftovers) fall back to the
+//     seen-TTL heuristic — and a malformed seen registry likewise disables GC.
 function _gcOrphanTabKeys(){
   try{
-    const seen=_readTabSeen();
-    const prefixes=[INFLIGHT_KEY_BASE+'::', INFLIGHT_STATE_KEY_BASE+'::', ACTIVE_SESSION_KEY_LEGACY+'::'];
+    const claims=_readTabClaims();
+    if(claims===null) return; // fail safe: unreadable registry ⇒ collect nothing
+    let seenRaw=null;
+    try{ seenRaw=localStorage.getItem(TAB_ID_SEEN_KEY); }catch(_){ return; }
+    let seen={};
+    if(seenRaw!=null){
+      try{ seen=JSON.parse(seenRaw); }catch(_){ return; } // fail safe
+      if(!seen||typeof seen!=='object'||Array.isArray(seen)) return; // fail safe
+    }
+    const now=Date.now();
+    const prefixes=[INFLIGHT_KEY_BASE+'::', INFLIGHT_STATE_KEY_BASE+'::', ACTIVE_SESSION_KEY_LEGACY+'::', ACTIVE_SESSION_TOMBSTONE_BASE+'::'];
     const doomed=[];
     for(let i=0;i<localStorage.length;i++){
       const key=localStorage.key(i);
@@ -9446,34 +9492,127 @@ function _gcOrphanTabKeys(){
       if(!prefix) continue;
       const owner=key.slice(prefix.length);
       if(!owner) continue;
-      if(!Object.prototype.hasOwnProperty.call(seen,owner)) doomed.push(key);
+      const rec=Object.prototype.hasOwnProperty.call(claims,owner)?claims[owner]:null;
+      if(rec){
+        if(!rec.released) continue;                    // authoritatively alive
+        if((now-rec.ts)<=_TAB_SEEN_TTL_MS) continue;   // reload/reopen window
+        doomed.push(key);
+        continue;
+      }
+      // No ownership record: legacy leftovers only. Recent "seen" ⇒ keep.
+      const seenTs=Number(seen[owner]);
+      if(Number.isFinite(seenTs)&&(now-seenTs)<=_TAB_SEEN_TTL_MS) continue;
+      doomed.push(key);
     }
     for(const key of doomed){
       try{ localStorage.removeItem(key); }catch(_){}
     }
+    // Prune long-dead registry entries so the registries themselves stay
+    // bounded. Unreleased records are never pruned (authoritative liveness).
+    try{
+      let changed=false;
+      for(const [id,rec] of Object.entries(claims)){
+        if(rec.released&&(now-rec.ts)>_TAB_SEEN_TTL_MS){ delete claims[id]; changed=true; }
+      }
+      if(changed) _writeTabClaims(claims);
+    }catch(_){}
+    try{
+      let changed=false;
+      for(const [id,ts] of Object.entries(seen)){
+        const n=Number(ts);
+        if(!Number.isFinite(n)||(now-n)>_TAB_SEEN_TTL_MS){ delete seen[id]; changed=true; }
+      }
+      if(changed) localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
+    }catch(_){}
   }catch(_){}
 }
+// Collision arbitration. Attempts to take ownership of `id` for THIS context's
+// nonce. Succeeds when the id is unrecorded, already ours, or explicitly
+// released; fails when a foreign unreleased record exists (a live duplicate —
+// regardless of the record's age) or when the registry is unreadable (a
+// possibly-live owner must never be raced). Compare-and-swap shaped: re-reads
+// immediately before writing and verifies its own write landed, so two
+// simultaneous claimers cannot both believe they won.
+function _claimTabOwnership(id){
+  const nonce=_hermesTabNonce();
+  const reg=_readTabClaims();
+  if(reg===null) return false; // fail safe: cannot prove the id is free
+  const rec=Object.prototype.hasOwnProperty.call(reg,id)?reg[id]:null;
+  if(rec&&rec.nonce!==nonce&&!rec.released) return false;
+  reg[id]={nonce, ts:Date.now(), released:false};
+  if(!_writeTabClaims(reg)) return false;
+  // Verify: another context interleaving between our read and write loses if
+  // its write landed after ours; re-read to confirm ownership stuck.
+  const check=_readTabClaims();
+  if(check===null) return false;
+  const mine=Object.prototype.hasOwnProperty.call(check,id)?check[id]:null;
+  return !!(mine&&mine.nonce===nonce&&!mine.released);
+}
 function _claimTabId(id){
-  const claims=_readTabClaims();
-  // A surviving fresh claim for this id means another tab is alive with it, so
-  // this must be a duplicated tab (sessionStorage is COPIED on duplicate) and
-  // it has to mint a fresh identity. A normal reload releases its claim on
-  // pagehide first, so it keeps its id — and with it its per-tab session and
-  // in-flight recovery state.
-  const takenByLiveTab=Object.prototype.hasOwnProperty.call(claims,id);
-  const finalId=takenByLiveTab?_newTabId():id;
-  _updateTabRegistry(TAB_ID_CLAIM_KEY, finalId, _TAB_CLAIM_TTL_MS, false);
-  return finalId;
+  // A fresh id may still collide with a concurrent claimer; arbitration
+  // re-checks after each mint. Bounded retries keep boot non-blocking even
+  // with a hostile registry — the final fallback id is context-local.
+  let candidate=id;
+  for(let attempt=0;attempt<4;attempt++){
+    if(_claimTabOwnership(candidate)) return candidate;
+    candidate=_newTabId();
+  }
+  return candidate;
 }
 function _releaseTabId(){
   try{
     if(typeof window==='undefined'||!window.__hermesTabId) return;
-    _updateTabRegistry(TAB_ID_CLAIM_KEY, window.__hermesTabId, _TAB_CLAIM_TTL_MS, true);
+    const reg=_readTabClaims();
+    if(reg===null) return;
+    const id=window.__hermesTabId;
+    const rec=Object.prototype.hasOwnProperty.call(reg,id)?reg[id]:null;
+    // Only the owner may release: releasing a record that a newer context
+    // re-claimed would hand our id to the next duplicate.
+    if(!rec||rec.nonce!==_hermesTabNonce()) return;
+    reg[id]={nonce:rec.nonce, ts:Date.now(), released:true};
+    _writeTabClaims(reg);
+  }catch(_){}
+}
+// Ownership revalidation — the authoritative gate run before every scoped
+// read/write (throttled). If another context stole or re-claimed this tab's id
+// (clone arbitration race, registry clobber), THIS context must stop using the
+// id immediately and mint a fresh one; otherwise its next scoped write would
+// land in the thief's keyspace.
+function _revalidateTabOwnership(){
+  if(typeof window==='undefined'||!window.__hermesTabId) return;
+  const now=Date.now();
+  if(window.__hermesTabOwnerCheckedAt&&(now-window.__hermesTabOwnerCheckedAt)<_TAB_OWNER_REVALIDATE_MS) return;
+  window.__hermesTabOwnerCheckedAt=now;
+  try{
+    const nonce=_hermesTabNonce();
+    const reg=_readTabClaims();
+    if(reg===null){
+      // Registry unreadable: keep the current id (fail safe — do NOT churn
+      // identities on transient corruption; GC is disabled in this state too).
+      return;
+    }
+    const rec=Object.prototype.hasOwnProperty.call(reg,window.__hermesTabId)?reg[window.__hermesTabId]:null;
+    if(rec&&rec.nonce===nonce&&!rec.released){
+      reg[window.__hermesTabId]={nonce, ts:now, released:false};
+      _writeTabClaims(reg);
+      _touchTabSeen(window.__hermesTabId);
+      return;
+    }
+    // Record missing (pruned / first write lost) or released (bfcache restore
+    // after pagehide): arbitration decides — re-claim succeeds unless a
+    // foreign UNRELEASED record owns the id.
+    if(_claimTabOwnership(window.__hermesTabId)){ _touchTabSeen(window.__hermesTabId); return; }
+    // Foreign owner (or lost arbitration): abandon this id NOW, before any
+    // scoped read/write can touch the other tab's keyspace.
+    const fresh=_claimTabId(_newTabId());
+    window.__hermesTabId=fresh;
+    try{ sessionStorage.setItem(TAB_ID_KEY,fresh); }catch(_){}
+    _touchTabSeen(fresh);
   }catch(_){}
 }
 function _hermesTabId(){
   if(typeof window==='undefined') return 'default';
-  if(window.__hermesTabId) return window.__hermesTabId;
+  if(window.__hermesTabId){ _revalidateTabOwnership(); return window.__hermesTabId; }
   let id='';
   try{ id=sessionStorage.getItem(TAB_ID_KEY)||''; }catch(_){ id=''; }
   const claimed=_claimTabId(id||_newTabId());
@@ -9481,22 +9620,22 @@ function _hermesTabId(){
     try{ sessionStorage.setItem(TAB_ID_KEY,claimed); }catch(_){}
   }
   window.__hermesTabId=claimed;
+  window.__hermesTabOwnerCheckedAt=Date.now();
   _touchTabSeen(claimed);
   // Reclaim keys left behind by tabs that are gone for good.
   _gcOrphanTabKeys();
   try{
     if(!window.__hermesTabClaimTimer){
-      // Keep this tab's claim fresh so a concurrent tab never reuses its id.
+      // Refresh the ownership stamp while alive. NOTE: liveness does NOT
+      // depend on this timer (an unreleased record never expires); the stamp
+      // only feeds the released/seen grace windows.
       window.__hermesTabClaimTimer=setInterval(()=>{
-        try{
-          _updateTabRegistry(TAB_ID_CLAIM_KEY, window.__hermesTabId, _TAB_CLAIM_TTL_MS, false);
-          _touchTabSeen(window.__hermesTabId);
-        }catch(_){}
+        try{ _revalidateTabOwnership(); }catch(_){}
       }, _TAB_CLAIM_HEARTBEAT_MS);
-      // Release on unload so a plain refresh keeps the same id (and therefore
-      // its in-flight recovery snapshot) instead of being treated as a clone.
-      // The "seen" entry is deliberately NOT removed here: it is what lets a
-      // reloading tab keep its keys while still allowing eventual GC.
+      // Mark released on unload so a plain refresh keeps the same id (and
+      // therefore its in-flight recovery snapshot) instead of being treated as
+      // a clone. The "seen" entry is deliberately NOT removed here: it is what
+      // lets a reloading tab keep its keys while still allowing eventual GC.
       window.addEventListener('pagehide', _releaseTabId);
     }
   }catch(_){}
@@ -9523,9 +9662,12 @@ if(typeof window!=='undefined'){
 // reload. Without this, reloading tab 1 could restore whatever conversation
 // tab 2 opened most recently.
 function _activeSessionKey(){ return ACTIVE_SESSION_KEY_LEGACY+'::'+_hermesTabId(); }
+function _activeSessionTombstoneKey(){ return ACTIVE_SESSION_TOMBSTONE_BASE+'::'+_hermesTabId(); }
 function _rememberActiveSession(sid){
   if(!sid) return;
   try{ localStorage.setItem(_activeSessionKey(), sid); }catch(_){}
+  // Opening a session supersedes any earlier "no session" tombstone.
+  try{ localStorage.removeItem(_activeSessionTombstoneKey()); }catch(_){}
   // Keep the legacy key in sync for boot fallback + older code paths.
   try{ localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, sid); }catch(_){}
 }
@@ -9537,20 +9679,37 @@ function _rememberedActiveSession(){
     const own=localStorage.getItem(_activeSessionKey());
     if(own) return own;
   }catch(_){}
-  try{ return localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY); }catch(_){ return null; }
+  // Explicit per-tab tombstone: this tab deliberately forgot its session, so
+  // the shared legacy fallback must NOT bleed back in (another tab may keep
+  // rewriting it). Only a brand-new tab — no scoped value AND no tombstone —
+  // may consult the legacy slot.
+  try{ if(localStorage.getItem(_activeSessionTombstoneKey())) return null; }catch(_){}
+  let legacy=null;
+  try{ legacy=localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY); }catch(_){ return null; }
+  // One-shot adoption (upgrade path): copy the legacy value into this tab's
+  // scoped slot so every later read/forget goes through tab-owned state and a
+  // concurrent tab rewriting the shared slot can no longer change what THIS
+  // tab restores.
+  if(legacy){ try{ localStorage.setItem(_activeSessionKey(), legacy); }catch(_){} }
+  return legacy;
 }
-function _forgetActiveSession(){
+function _forgetActiveSession(expectedSid){
   let own=null;
   try{ own=localStorage.getItem(_activeSessionKey()); }catch(_){}
   try{ localStorage.removeItem(_activeSessionKey()); }catch(_){}
+  // Persist an explicit "no session" tombstone so the legacy fallback cannot
+  // resurrect a forgotten (possibly dead/404) session on the next read.
+  try{ localStorage.setItem(_activeSessionTombstoneKey(), String(Date.now())); }catch(_){}
   // The legacy key is SHARED: it is the first-paint fallback for a brand-new
   // tab (which has no scoped key yet) and for any older client. Only clear it
   // when it still points at the session THIS tab is forgetting — otherwise one
   // tab closing a conversation would drop every other tab's restore target and
-  // new tabs would open the empty state. A tab with no scoped value has
-  // nothing to compare against, so it leaves the shared slot alone.
+  // new tabs would open the empty state. `expectedSid` lets self-heal paths
+  // (404 / profile switch) name the dead session explicitly, so a legacy-only
+  // entry that was never adopted into scoped storage is still cleared.
+  const expected=own||(typeof expectedSid==='string'&&expectedSid?expectedSid:null);
   try{
-    if(own&&localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY)===own){
+    if(expected&&localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY)===expected){
       localStorage.removeItem(ACTIVE_SESSION_KEY_LEGACY);
     }
   }catch(_){}
@@ -9584,7 +9743,70 @@ function _getInflightStateLimits(){
   };
 }
 
+// One-shot rollout migration (maintainer re-gate, PR #7084): before this fix
+// shipped, the reconnect marker and the mid-stream transcript snapshots lived
+// in the UNSUFFIXED `hermes-webui-inflight` / `hermes-webui-inflight-state`
+// keys. Both readers below use suffixed keys exclusively, so without this
+// migration an upgrade mid-stream would silently discard the user's existing
+// recovery state. When this tab has no scoped state yet: validate the legacy
+// payload (shape + SID + age), re-stamp it under THIS tab's id, then remove
+// the legacy entries so they are consumed exactly once. Invalid or stale
+// legacy payloads are removed without migrating.
+function _migrateLegacyInflight(){
+  if(typeof window!=='undefined'){
+    if(window.__hermesLegacyInflightMigrated) return;
+    window.__hermesLegacyInflightMigrated=true;
+  }
+  const now=Date.now();
+  // Reconnect marker: {sid, streamId, ts}.
+  try{
+    const legacyRaw=localStorage.getItem(INFLIGHT_KEY_BASE);
+    if(legacyRaw!=null){
+      try{
+        const parsed=JSON.parse(legacyRaw);
+        const sid=(parsed&&typeof parsed.sid==='string')?parsed.sid:'';
+        const ts=Number(parsed&&parsed.ts);
+        const streamOk=parsed&&(parsed.streamId==null||typeof parsed.streamId==='string');
+        if(sid&&streamOk&&Number.isFinite(ts)&&(now-ts)<=10*60*1000
+           &&localStorage.getItem(_inflightKey())==null){
+          localStorage.setItem(_inflightKey(), JSON.stringify({sid, streamId:parsed.streamId||null, ts}));
+        }
+      }catch(_){}
+      // One-shot: the legacy slot is consumed (or invalidated) exactly once,
+      // whether or not it was migratable — it must never be read again.
+      try{ localStorage.removeItem(INFLIGHT_KEY_BASE); }catch(_){}
+    }
+  }catch(_){}
+  // Transcript snapshots: {sid: entry} map.
+  try{
+    const legacyRaw=localStorage.getItem(INFLIGHT_STATE_KEY_BASE);
+    if(legacyRaw!=null){
+      try{
+        const parsed=JSON.parse(legacyRaw);
+        if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){
+          const fresh={};
+          for(const [sid,entry] of Object.entries(parsed)){
+            if(!sid||!entry||typeof entry!=='object'||Array.isArray(entry)) continue;
+            const upd=Number(entry.updated_at);
+            if(!Number.isFinite(upd)||(now-upd)>10*60*1000) continue;
+            // Re-stamp under the adopting tab: loadInflightState() rejects
+            // entries owned by a different tab id, and the pre-fix entries
+            // carry no owner (or a meaningless one).
+            fresh[sid]={...entry, tabId:_hermesTabId()};
+          }
+          if(Object.keys(fresh).length&&localStorage.getItem(_inflightStateKey())==null){
+            localStorage.setItem(_inflightStateKey(), JSON.stringify(fresh));
+          }
+        }
+      }catch(_){}
+      try{ localStorage.removeItem(INFLIGHT_STATE_KEY_BASE); }catch(_){}
+    }
+  }catch(_){}
+}
 function _readInflightStateMap(){
+  try{
+    _migrateLegacyInflight();
+  }catch(_){}
   try{
     const raw=localStorage.getItem(_inflightStateKey());
     const parsed=raw?JSON.parse(raw):{};
@@ -11175,6 +11397,10 @@ function getPendingSessionMessage(session, messagesOverride=null){
   };
 }
 async function checkInflightOnBoot(sid) {
+  // Rollout migration: adopt a valid pre-upgrade (unsuffixed) reconnect marker
+  // under this tab's scoped key before reading, or the in-flight recovery that
+  // existed before the per-tab upgrade would be silently discarded.
+  try{ _migrateLegacyInflight(); }catch(_){}
   const raw = localStorage.getItem(_inflightKey());
   if (!raw) return;
   try {

--- a/static/ui.js
+++ b/static/ui.js
@@ -489,7 +489,7 @@ async function startCompressionRecovery(btn){
     const data=await api('/api/session/compression-recovery/start',{method:'POST',body:JSON.stringify({session_id:sourceSid})});
     const sid=data&&data.session&&data.session.session_id;
     if(!sid) throw new Error('Compression recovery did not return a session.');
-    try{localStorage.setItem('hermes-webui-session',sid);}catch(_){}
+    try{_rememberActiveSession(sid);}catch(_){}
     if(typeof loadSession==='function') await loadSession(sid,{preserveActiveInput:false});
     else if(data.session){S.session=data.session;if(typeof _adoptRegenerationRevision==='function')_adoptRegenerationRevision(data.session);S.messages=data.session.messages||[];syncTopbar();renderMessages();}
     if(typeof renderSessionList==='function') await renderSessionList();
@@ -9333,9 +9333,233 @@ function autoReadLastAssistant(){
   speechSynthesis.speak(utter);
 }
 
+// ── Per-tab identity (multi-tab isolation) ──
+//
+// localStorage is shared by every tab on the same origin, so any key that
+// describes "the" active conversation is really a single global slot that all
+// tabs fight over. Opening conversation A in tab 1 and conversation B in tab 2
+// made the last writer win: reload restored the wrong session, the reconnect
+// banner pointed at another tab's stream, and inflight transcript snapshots
+// from one tab were merged into another tab's chat.
+//
+// sessionStorage IS per-tab (and survives reload / is copied on tab
+// duplication), so we mint a stable tab id there and namespace all
+// tab-scoped runtime state with it. localStorage remains the storage
+// backend (sessionStorage would be lost by some PWA/BFCache restores), but
+// every entry is now explicitly owned by exactly one tab.
+const TAB_ID_KEY = 'hermes-webui-tab-id';
+const TAB_ID_CLAIM_KEY = 'hermes-webui-tab-claims';
+function _newTabId(){
+  try{
+    if(typeof window!=='undefined'&&window.crypto&&typeof window.crypto.randomUUID==='function'){
+      return window.crypto.randomUUID();
+    }
+  }catch(_){}
+  return 't'+Date.now().toString(36)+Math.random().toString(36).slice(2,10);
+}
+// Duplicating a tab (Chrome "Duplicate", or a PWA restore) COPIES sessionStorage,
+// so the clone would start life with the original tab's id and both tabs would
+// write to the same per-tab keys — reintroducing exactly the cross-talk this
+// fix removes. Each tab therefore claims its id in a shared localStorage
+// registry and heartbeats it while alive; a tab that finds its id already
+// claimed by a LIVE tab mints a fresh one.
+//
+// Reload safety: the claim is released on pagehide, so a normal refresh
+// re-claims the same id and keeps its in-flight recovery snapshot. Only a
+// genuinely concurrent (duplicated) tab sees a live claim.
+const _TAB_CLAIM_TTL_MS = 45000;
+const _TAB_CLAIM_HEARTBEAT_MS = 15000;
+// A tab id that has not been seen for this long is considered gone for good and
+// its leftover per-tab keys are garbage collected (see _gcOrphanTabKeys).
+const _TAB_SEEN_TTL_MS = 24 * 60 * 60 * 1000;
+const TAB_ID_SEEN_KEY = 'hermes-webui-tab-seen';
+// Storage key bases for per-tab state. Declared HERE, before the helpers that
+// reference them, so _gcOrphanTabKeys() can never hit a temporal-dead-zone
+// ReferenceError — its body is inside a try/catch, so such an error would make
+// garbage collection a silent no-op and let localStorage grow unbounded.
+const INFLIGHT_KEY_BASE = 'hermes-webui-inflight'; // legacy/global (migration only)
+const INFLIGHT_STATE_KEY_BASE = 'hermes-webui-inflight-state';
+const ACTIVE_SESSION_KEY_LEGACY = 'hermes-webui-session';
+function _readTabClaims(){
+  let claims={};
+  try{ claims=JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY)||'{}')||{}; }catch(_){ claims={}; }
+  if(typeof claims!=='object'||!claims) claims={};
+  const now=Date.now();
+  for(const [k,v] of Object.entries(claims)){
+    if(!v||typeof v!=='number'||(now-v)>_TAB_CLAIM_TTL_MS) delete claims[k];
+  }
+  return claims;
+}
+// Registry updates are read-modify-write on a single localStorage key, and two
+// tabs can interleave between the read and the write (localStorage offers no
+// transaction). A blind whole-object write would drop the claim/seen record a
+// concurrent tab just added, letting a LIVE tab's id be reused or its scoped
+// keys garbage collected. Both registries are therefore updated through this
+// helper, which re-reads immediately before writing and only ever touches the
+// caller's OWN id: `stamp` refreshes it, `drop` removes it, and every other
+// tab's entry is carried over untouched (minus TTL expiry).
+function _updateTabRegistry(key, id, ttlMs, drop){
+  if(!id) return;
+  try{
+    let reg={};
+    try{ reg=JSON.parse(localStorage.getItem(key)||'{}')||{}; }catch(_){ reg={}; }
+    if(typeof reg!=='object'||!reg) reg={};
+    const now=Date.now();
+    for(const [k,v] of Object.entries(reg)){
+      if(!v||typeof v!=='number'||(now-v)>ttlMs) delete reg[k];
+    }
+    if(drop) delete reg[id]; else reg[id]=now;
+    localStorage.setItem(key, JSON.stringify(reg));
+  }catch(_){}
+}
+// "Seen" registry: unlike claims (a short-lived liveness lock released on
+// pagehide), this records the last time a tab id was active so that closed
+// tabs' leftover keys can eventually be reclaimed instead of growing the
+// localStorage footprint forever (#2386 quota).
+function _readTabSeen(){
+  let seen={};
+  try{ seen=JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY)||'{}')||{}; }catch(_){ seen={}; }
+  if(typeof seen!=='object'||!seen) seen={};
+  // Drop entries older than the retention window so _gcOrphanTabKeys() can
+  // actually reclaim the per-tab keys of tabs that are gone for good.
+  const now=Date.now();
+  for(const [k,v] of Object.entries(seen)){
+    if(!v||typeof v!=='number'||(now-v)>_TAB_SEEN_TTL_MS) delete seen[k];
+  }
+  return seen;
+}
+function _touchTabSeen(id){
+  _updateTabRegistry(TAB_ID_SEEN_KEY, id, _TAB_SEEN_TTL_MS, false);
+}
+// Remove per-tab keys whose owning tab has not been seen within the TTL.
+// Without this, every new tab would leave `<base>::<uuid>` entries behind and
+// slowly fill the origin's localStorage quota.
+function _gcOrphanTabKeys(){
+  try{
+    const seen=_readTabSeen();
+    const prefixes=[INFLIGHT_KEY_BASE+'::', INFLIGHT_STATE_KEY_BASE+'::', ACTIVE_SESSION_KEY_LEGACY+'::'];
+    const doomed=[];
+    for(let i=0;i<localStorage.length;i++){
+      const key=localStorage.key(i);
+      if(!key) continue;
+      const prefix=prefixes.find(p=>key.indexOf(p)===0);
+      if(!prefix) continue;
+      const owner=key.slice(prefix.length);
+      if(!owner) continue;
+      if(!Object.prototype.hasOwnProperty.call(seen,owner)) doomed.push(key);
+    }
+    for(const key of doomed){
+      try{ localStorage.removeItem(key); }catch(_){}
+    }
+  }catch(_){}
+}
+function _claimTabId(id){
+  const claims=_readTabClaims();
+  // A surviving fresh claim for this id means another tab is alive with it, so
+  // this must be a duplicated tab (sessionStorage is COPIED on duplicate) and
+  // it has to mint a fresh identity. A normal reload releases its claim on
+  // pagehide first, so it keeps its id — and with it its per-tab session and
+  // in-flight recovery state.
+  const takenByLiveTab=Object.prototype.hasOwnProperty.call(claims,id);
+  const finalId=takenByLiveTab?_newTabId():id;
+  _updateTabRegistry(TAB_ID_CLAIM_KEY, finalId, _TAB_CLAIM_TTL_MS, false);
+  return finalId;
+}
+function _releaseTabId(){
+  try{
+    if(typeof window==='undefined'||!window.__hermesTabId) return;
+    _updateTabRegistry(TAB_ID_CLAIM_KEY, window.__hermesTabId, _TAB_CLAIM_TTL_MS, true);
+  }catch(_){}
+}
+function _hermesTabId(){
+  if(typeof window==='undefined') return 'default';
+  if(window.__hermesTabId) return window.__hermesTabId;
+  let id='';
+  try{ id=sessionStorage.getItem(TAB_ID_KEY)||''; }catch(_){ id=''; }
+  const claimed=_claimTabId(id||_newTabId());
+  if(claimed!==id){
+    try{ sessionStorage.setItem(TAB_ID_KEY,claimed); }catch(_){}
+  }
+  window.__hermesTabId=claimed;
+  _touchTabSeen(claimed);
+  // Reclaim keys left behind by tabs that are gone for good.
+  _gcOrphanTabKeys();
+  try{
+    if(!window.__hermesTabClaimTimer){
+      // Keep this tab's claim fresh so a concurrent tab never reuses its id.
+      window.__hermesTabClaimTimer=setInterval(()=>{
+        try{
+          _updateTabRegistry(TAB_ID_CLAIM_KEY, window.__hermesTabId, _TAB_CLAIM_TTL_MS, false);
+          _touchTabSeen(window.__hermesTabId);
+        }catch(_){}
+      }, _TAB_CLAIM_HEARTBEAT_MS);
+      // Release on unload so a plain refresh keeps the same id (and therefore
+      // its in-flight recovery snapshot) instead of being treated as a clone.
+      // The "seen" entry is deliberately NOT removed here: it is what lets a
+      // reloading tab keep its keys while still allowing eventual GC.
+      window.addEventListener('pagehide', _releaseTabId);
+    }
+  }catch(_){}
+  return claimed;
+}
+
 // ── Reconnect banner (B4/B5: reload resilience) ──
-const INFLIGHT_KEY = 'hermes-webui-inflight'; // localStorage key for in-flight session tracking
-const INFLIGHT_STATE_KEY = 'hermes-webui-inflight-state'; // localStorage snapshots for mid-stream reload recovery
+// Tab-scoped: each tab tracks its OWN in-flight stream, so a second tab
+// starting a turn can no longer overwrite the first tab's reconnect marker.
+// (INFLIGHT_KEY_BASE / INFLIGHT_STATE_KEY_BASE are declared with the per-tab
+// identity helpers above so the storage GC can reference them safely.)
+function _inflightKey(){ return INFLIGHT_KEY_BASE+'::'+_hermesTabId(); }
+function _inflightStateKey(){ return INFLIGHT_STATE_KEY_BASE+'::'+_hermesTabId(); }
+// Back-compat aliases: several call sites (and tests) reference these names
+// directly. They now resolve per tab via the accessors above.
+if(typeof window!=='undefined'){
+  Object.defineProperty(window, '_inflightKey()', {get:_inflightKey, configurable:true});
+  Object.defineProperty(window, '_inflightStateKey()', {get:_inflightStateKey, configurable:true});
+}
+
+// Tab-scoped active session. The legacy global 'hermes-webui-session' key is
+// still written (so an unrelated/older tab and the boot fallback keep working),
+// but each tab ALSO records its own last-opened session and prefers it on
+// reload. Without this, reloading tab 1 could restore whatever conversation
+// tab 2 opened most recently.
+function _activeSessionKey(){ return ACTIVE_SESSION_KEY_LEGACY+'::'+_hermesTabId(); }
+function _rememberActiveSession(sid){
+  if(!sid) return;
+  try{ localStorage.setItem(_activeSessionKey(), sid); }catch(_){}
+  // Keep the legacy key in sync for boot fallback + older code paths.
+  try{ localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, sid); }catch(_){}
+}
+function _rememberedActiveSession(){
+  // This tab's own choice always wins over the shared/global slot.
+  // Returns null when nothing is stored, matching the original
+  // localStorage.getItem() contract this helper replaced.
+  try{
+    const own=localStorage.getItem(_activeSessionKey());
+    if(own) return own;
+  }catch(_){}
+  try{ return localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY); }catch(_){ return null; }
+}
+function _forgetActiveSession(){
+  let own=null;
+  try{ own=localStorage.getItem(_activeSessionKey()); }catch(_){}
+  try{ localStorage.removeItem(_activeSessionKey()); }catch(_){}
+  // The legacy key is SHARED: it is the first-paint fallback for a brand-new
+  // tab (which has no scoped key yet) and for any older client. Only clear it
+  // when it still points at the session THIS tab is forgetting — otherwise one
+  // tab closing a conversation would drop every other tab's restore target and
+  // new tabs would open the empty state. A tab with no scoped value has
+  // nothing to compare against, so it leaves the shared slot alone.
+  try{
+    if(own&&localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY)===own){
+      localStorage.removeItem(ACTIVE_SESSION_KEY_LEGACY);
+    }
+  }catch(_){}
+}
+if(typeof window!=='undefined'){
+  window._rememberActiveSession=_rememberActiveSession;
+  window._rememberedActiveSession=_rememberedActiveSession;
+  window._forgetActiveSession=_forgetActiveSession;
+}
 const INFLIGHT_STATE_DEFAULT_LIMITS = {
   maxSessions:8,
   messages:24,
@@ -9362,7 +9586,7 @@ function _getInflightStateLimits(){
 
 function _readInflightStateMap(){
   try{
-    const raw=localStorage.getItem(INFLIGHT_STATE_KEY);
+    const raw=localStorage.getItem(_inflightStateKey());
     const parsed=raw?JSON.parse(raw):{};
     return parsed&&typeof parsed==='object'?parsed:{};
   }catch(_){
@@ -9433,15 +9657,15 @@ function _writeInflightStateMap(all){
     json=JSON.stringify(current?{[current[0]]:current[1]}:{});
   }
   if(json.length>limits.jsonChars){
-    localStorage.removeItem(INFLIGHT_STATE_KEY);
+    localStorage.removeItem(_inflightStateKey());
     return false;
   }
-  localStorage.setItem(INFLIGHT_STATE_KEY,json);
+  localStorage.setItem(_inflightStateKey(),json);
   return true;
 }
 function saveInflightState(sid, state){
   if(!sid||!state) return;
-  const entry={..._compactInflightState(state),updated_at:Date.now()};
+  const entry={..._compactInflightState(state),updated_at:Date.now(),tabId:_hermesTabId()};
   try{
     const all=_readInflightStateMap();
     all[sid]=entry;
@@ -9449,10 +9673,10 @@ function saveInflightState(sid, state){
   }catch(err){
     if(!_isStorageQuotaError(err)) return;
     try{
-      localStorage.removeItem(INFLIGHT_STATE_KEY);
+      localStorage.removeItem(_inflightStateKey());
       _writeInflightStateMap({[sid]:entry});
     }catch(_){
-      try{localStorage.removeItem(INFLIGHT_STATE_KEY);}catch(__){}
+      try{localStorage.removeItem(_inflightStateKey());}catch(__){}
     }
   }
 }
@@ -9461,6 +9685,12 @@ function loadInflightState(sid, streamId){
   const all=_readInflightStateMap();
   const entry=all[sid];
   if(!entry) return null;
+  // Tab ownership: entries are stored under a per-tab key, but a duplicated tab
+  // inherits sessionStorage (hence the same tab id) and legacy entries written
+  // before this fix carry no owner at all. Reject any snapshot that explicitly
+  // belongs to a DIFFERENT tab so one tab's live transcript can never be
+  // merged into another tab's conversation.
+  if(entry.tabId && entry.tabId!==_hermesTabId()) return null;
   if(streamId&&entry.streamId&&entry.streamId!==streamId) return null;
   if(entry.updated_at&&Date.now()-entry.updated_at>10*60*1000){
     clearInflightState(sid);
@@ -9474,8 +9704,8 @@ function clearInflightState(sid){
     const all=_readInflightStateMap();
     if(!(sid in all)) return;
     delete all[sid];
-    if(Object.keys(all).length) localStorage.setItem(INFLIGHT_STATE_KEY, JSON.stringify(all));
-    else localStorage.removeItem(INFLIGHT_STATE_KEY);
+    if(Object.keys(all).length) localStorage.setItem(_inflightStateKey(), JSON.stringify(all));
+    else localStorage.removeItem(_inflightStateKey());
   }catch(_){ }
 }
 
@@ -9795,17 +10025,17 @@ function restoreLiveTurnHtmlForSession(sid){
 function markInflight(sid, streamId) {
   const payload=JSON.stringify({sid, streamId, ts: Date.now()});
   try{
-    localStorage.setItem(INFLIGHT_KEY, payload);
+    localStorage.setItem(_inflightKey(), payload);
   }catch(err){
     if(!_isStorageQuotaError(err)) return;
     try{
-      localStorage.removeItem(INFLIGHT_STATE_KEY);
-      localStorage.setItem(INFLIGHT_KEY, payload);
+      localStorage.removeItem(_inflightStateKey());
+      localStorage.setItem(_inflightKey(), payload);
     }catch(_){}
   }
 }
 function clearInflight() {
-  localStorage.removeItem(INFLIGHT_KEY);
+  localStorage.removeItem(_inflightKey());
 }
 function showReconnectBanner(msg) {
   $('reconnectMsg').textContent = msg || 'A response may have been in progress when you last left.';
@@ -10945,7 +11175,7 @@ function getPendingSessionMessage(session, messagesOverride=null){
   };
 }
 async function checkInflightOnBoot(sid) {
-  const raw = localStorage.getItem(INFLIGHT_KEY);
+  const raw = localStorage.getItem(_inflightKey());
   if (!raw) return;
   try {
     const {sid: inflightSid, streamId, ts} = JSON.parse(raw);

--- a/tests/test_1694_root_saved_running_policy.py
+++ b/tests/test_1694_root_saved_running_policy.py
@@ -105,7 +105,7 @@ def test_root_archived_saved_session_clears_stale_localstorage_pointer():
     helper_pos = block.find("_savedSessionSidebarOnlyState")
     clear_guard = "if(savedSidebarOnlyState.archived)"
     guard_pos = block.find(clear_guard, helper_pos)
-    clear_pos = block.find("localStorage.removeItem('hermes-webui-session')", guard_pos)
+    clear_pos = block.find("_forgetActiveSession()", guard_pos)
     render_pos = block.find("await renderSessionList()", helper_pos)
     load_pos = block.find("await loadSession(saved, {preserveActiveInput:true})")
     assert guard_pos > helper_pos, "archived sidebar-only path must be distinguished"

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -97,6 +97,11 @@ global.localStorage = {
     delete this.store[key];
   }
 };
+// Tab-scoped active-session helpers (ui.js). In this harness there is a single
+// simulated tab, so they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
 evalSession('_consumeComposerPrefillParamsFromLocation');
@@ -113,7 +118,7 @@ global.switchToProfile = async (name) => {
   return true;
 };
 (async () => {
-  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const savedLocalBefore = _rememberedActiveSession();
   const profileSwitchProfileBefore = S.activeProfile || 'default';
   const profileSwitchIsDefaultBefore = !!S.activeProfileIsDefault;
   let profileSwitchCompleted = false;
@@ -136,9 +141,9 @@ global.switchToProfile = async (name) => {
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
-  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
-  const savedLocalAfterSuppress = localStorage.getItem('hermes-webui-session');
-  const savedLocalAfterReload = localStorage.getItem('hermes-webui-session');
+  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && _rememberedActiveSession() === savedLocalBefore) _forgetActiveSession();
+  const savedLocalAfterSuppress = _rememberedActiveSession();
+  const savedLocalAfterReload = _rememberedActiveSession();
   const keepsExplicitSession = _profileQueryBlocksSavedLocalRestore(intent, 'session-123');
   const afterProfile = window.location.pathname + window.location.search + window.location.hash;
   const promoted = _sessionUrlForSid('abc 123');
@@ -216,6 +221,11 @@ global.localStorage = {
     delete this.store[key];
   }
 };
+// Tab-scoped active-session helpers (ui.js). In this harness there is a single
+// simulated tab, so they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
 evalSession('_consumeComposerPrefillParamsFromLocation');
@@ -224,7 +234,7 @@ evalBoot('_profileQueryBlocksSavedLocalRestore');
 const intent = _profileQueryIntentFromLocation();
 global.switchToProfile = async () => true;
 (async () => {
-  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const savedLocalBefore = _rememberedActiveSession();
   const profileSwitchProfileBefore = S.activeProfile || 'default';
   const profileSwitchIsDefaultBefore = !!S.activeProfileIsDefault;
   let profileSwitchCompleted = false;
@@ -247,7 +257,7 @@ global.switchToProfile = async () => true;
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
-  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && _rememberedActiveSession() === savedLocalBefore) _forgetActiveSession();
   const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", bootSrc.indexOf("const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;"));
   console.log(JSON.stringify({
     intent,
@@ -255,7 +265,7 @@ global.switchToProfile = async () => true;
     profileSwitchCompleted,
     profileSwitchChangedProfile,
     savedLocalBefore,
-    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    savedLocalAfter: _rememberedActiveSession(),
     cleanupGuardPos,
   }));
 })().catch(err => {
@@ -307,6 +317,11 @@ global.localStorage = {
     delete this.store[key];
   }
 };
+// Tab-scoped active-session helpers (ui.js). In this harness there is a single
+// simulated tab, so they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
 evalSession('_consumeComposerPrefillParamsFromLocation');
@@ -315,7 +330,7 @@ evalBoot('_profileQueryBlocksSavedLocalRestore');
 const intent = _profileQueryIntentFromLocation();
 global.switchToProfile = async () => { throw new Error('boom'); };
 (async () => {
-  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const savedLocalBefore = _rememberedActiveSession();
   let profileSwitchCompleted = false;
   if (intent && intent.hasParam) {
     try {
@@ -333,7 +348,7 @@ global.switchToProfile = async () => { throw new Error('boom'); };
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
-  if (blocksSavedLocal && profileSwitchCompleted && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  if (blocksSavedLocal && profileSwitchCompleted && _rememberedActiveSession() === savedLocalBefore) _forgetActiveSession();
   const afterBoot = window.location.pathname + window.location.search + window.location.hash;
   _consumeComposerPrefillParamsFromLocation();
   const afterPrefill = window.location.pathname + window.location.search + window.location.hash;
@@ -341,7 +356,7 @@ global.switchToProfile = async () => { throw new Error('boom'); };
   console.log(JSON.stringify({
     blocksSavedLocal,
     profileSwitchCompleted,
-    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    savedLocalAfter: _rememberedActiveSession(),
     afterBoot,
     afterPrefill,
     promoted,
@@ -396,13 +411,18 @@ global.localStorage = {
     delete this.store[key];
   }
 };
+// Tab-scoped active-session helpers (ui.js). In this harness there is a single
+// simulated tab, so they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
 evalBoot('_profileQueryBlocksSavedLocalRestore');
 const intent = _profileQueryIntentFromLocation();
 global.switchToProfile = async () => false;
 (async () => {
-  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const savedLocalBefore = _rememberedActiveSession();
   let profileSwitchCompleted = false;
   if (intent && intent.hasParam) {
     try {
@@ -420,11 +440,11 @@ global.switchToProfile = async () => false;
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
-  if (blocksSavedLocal && profileSwitchCompleted && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  if (blocksSavedLocal && profileSwitchCompleted && _rememberedActiveSession() === savedLocalBefore) _forgetActiveSession();
   console.log(JSON.stringify({
     blocksSavedLocal,
     profileSwitchCompleted,
-    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    savedLocalAfter: _rememberedActiveSession(),
     url: window.location.pathname + window.location.search + window.location.hash,
     historyCalls: window.history.calls,
     warns,
@@ -468,6 +488,11 @@ global.document = { baseURI: 'https://example.test/app/' };
 const warns = [];
 console.warn = (...args) => { warns.push(args); };
 applyUrl('/app/?profile=../bad&q=hello&keep=1#frag');
+// Tab-scoped active-session helpers (ui.js). In this harness there is a single
+// simulated tab, so they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
 const intent = _profileQueryIntentFromLocation();
@@ -556,15 +581,20 @@ global.localStorage = {
     delete this.store[key];
   }
 };
+// Tab-scoped active-session helpers (ui.js). Single simulated tab here, so
+// they map onto the legacy global key.
+global._rememberActiveSession = (sid) => { localStorage.setItem('hermes-webui-session', sid); };
+global._rememberedActiveSession = () => localStorage.getItem('hermes-webui-session');
+global._forgetActiveSession = () => { localStorage.removeItem('hermes-webui-session'); };
 const validProfile = { hasParam: true, valid: true };
 const invalidProfile = { hasParam: true, valid: false };
 const blocksImplicit = _profileQueryBlocksSavedLocalRestore(validProfile, null);
-if (blocksImplicit) localStorage.removeItem('hermes-webui-session');
-const implicitAfter = localStorage.getItem('hermes-webui-session');
+if (blocksImplicit) _forgetActiveSession();
+const implicitAfter = _rememberedActiveSession();
 localStorage.setItem('hermes-webui-session', 'saved-local');
 const allowsExplicit = _profileQueryBlocksSavedLocalRestore(validProfile, 'session-123');
-if (allowsExplicit) localStorage.removeItem('hermes-webui-session');
-const explicitAfter = localStorage.getItem('hermes-webui-session');
+if (allowsExplicit) _forgetActiveSession();
+const explicitAfter = _rememberedActiveSession();
 console.log(JSON.stringify({
   blocksImplicit,
   allowsExplicit,

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -206,6 +206,7 @@ function createEnvironment() {
   globalThis._loadingSessionId = null;
   globalThis._loadingOlder = false;
   globalThis._loadSessionGeneration = 0;
+  globalThis._messagesOwnerSid = null;
   globalThis._pendingCarryForwardSnapshot = null;
   globalThis._messagesTruncated = false;
   globalThis._oldestIdx = 0;

--- a/tests/test_gateway_sse_reconnect_dedupe.py
+++ b/tests/test_gateway_sse_reconnect_dedupe.py
@@ -132,7 +132,7 @@ def test_load_session_persists_only_after_metadata_loads():
     # so use a stable boundary inside loadSession instead.
     load = _block(src, "async function loadSession(sid)", "// Phase 2a:")
     api_pos = load.index("data = await api(`/api/session")
-    persist_pos = load.index("localStorage.setItem('hermes-webui-session',S.session.session_id)")
+    persist_pos = load.index("_rememberActiveSession(S.session.session_id)")
 
     assert "_persistActiveSession" not in src
     assert persist_pos > api_pos

--- a/tests/test_inflight_storage_quota.py
+++ b/tests/test_inflight_storage_quota.py
@@ -27,7 +27,7 @@ def test_inflight_state_is_compacted_before_localstorage_write():
     save_body = _function_body(UI_JS, "saveInflightState")
     compact_body = _function_body(UI_JS, "_compactInflightState")
 
-    assert "const entry={..._compactInflightState(state),updated_at:Date.now()};" in save_body
+    assert "const entry={..._compactInflightState(state),updated_at:Date.now()" in save_body
     assert "const limits=_getInflightStateLimits();" in compact_body
     assert ".slice(-limits.messages)" in compact_body
     assert ".slice(-limits.toolCalls)" in compact_body
@@ -69,11 +69,11 @@ def test_inflight_marker_write_handles_quota_by_dropping_recovery_snapshots():
     mark_body = _function_body(UI_JS, "markInflight")
 
     assert "try{" in mark_body
-    assert "localStorage.setItem(INFLIGHT_KEY, payload);" in mark_body
+    assert "localStorage.setItem(_inflightKey(), payload);" in mark_body
     assert "_isStorageQuotaError(err)" in mark_body
-    assert "localStorage.removeItem(INFLIGHT_STATE_KEY);" in mark_body
-    assert mark_body.index("localStorage.removeItem(INFLIGHT_STATE_KEY);") < mark_body.rindex(
-        "localStorage.setItem(INFLIGHT_KEY, payload);"
+    assert "localStorage.removeItem(_inflightStateKey());" in mark_body
+    assert mark_body.index("localStorage.removeItem(_inflightStateKey());") < mark_body.rindex(
+        "localStorage.setItem(_inflightKey(), payload);"
     )
 
 
@@ -83,5 +83,5 @@ def test_save_inflight_state_clears_snapshots_when_quota_retry_fails():
 
     assert "catch(err)" in save_body
     assert "if(!_isStorageQuotaError(err)) return;" in save_body
-    assert "localStorage.removeItem(INFLIGHT_STATE_KEY);" in save_body
+    assert "localStorage.removeItem(_inflightStateKey());" in save_body
     assert "_writeInflightStateMap({[sid]:entry});" in save_body

--- a/tests/test_issue2386_localstorage_quota.py
+++ b/tests/test_issue2386_localstorage_quota.py
@@ -18,11 +18,31 @@ def _assert_storage_setitem_guarded(src, needle):
 
 
 def test_active_session_localstorage_writes_ignore_quota_errors():
-    """Session persistence writes are best-effort when the browser quota is full (#2386)."""
+    """Session persistence writes are best-effort when the browser quota is full (#2386).
+
+    The active-session write now goes through the tab-scoped
+    _rememberActiveSession() helper (multi-tab isolation), so the quota guard
+    lives in ui.js where that helper is defined; the call sites wrap it in
+    try/catch exactly as before.
+    """
+    # ui.js owns the actual write; it must be individually try/catch-guarded.
+    ui_js = _script("static/ui.js")
+    write_lines = [
+        line.strip() for line in ui_js.splitlines()
+        if "localStorage.setItem(_activeSessionKey(), sid)" in line
+        or "localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, sid)" in line
+    ]
+    assert len(write_lines) >= 2, "expected both the per-tab and legacy active-session writes"
+    for line in write_lines:
+        assert line.startswith("try{"), (
+            f"localStorage quota errors must not escape the active-session write: {line}"
+        )
+        assert "catch(_)" in line or "catch(e)" in line or "catch{}" in line
+    # Call sites must still swallow quota errors around the helper call.
     for path in ["static/sessions.js", "static/commands.js", "static/messages.js"]:
-        _assert_storage_setitem_guarded(
-            _script(path),
-            "localStorage.setItem('hermes-webui-session'",
+        script = _script(path)
+        assert "try{_rememberActiveSession(" in script, (
+            f"{path}: active-session write must stay wrapped in try/catch"
         )
 
 

--- a/tests/test_issue3993_session_load_self_heal.py
+++ b/tests/test_issue3993_session_load_self_heal.py
@@ -35,7 +35,9 @@ def test_clear_stuck_session_helper_exists_and_is_wired():
     # Guarded on the boot condition (no active session on screen).
     helper = js[js.index(marker): js.index(marker) + 260]
     assert "if(!currentSid){" in helper
-    assert "_forgetActiveSession()" in helper
+    # The dead sid is passed explicitly so a legacy-only (never adopted into
+    # scoped storage) saved session is still cleared on upgrade (PR #7084).
+    assert "_forgetActiveSession(sid)" in helper
     assert "history.replaceState" in helper
 
 
@@ -100,7 +102,7 @@ def test_stale_load_guard_present_before_self_heal():
     assert block.index(guard) < block.index("_clearStuckSessionOnBoot(sid, currentSid);"), \
         "stale-load guard must precede _clearStuckSessionOnBoot"
     # And before the 404 inline clear too.
-    assert block.index(guard) < block.index("_forgetActiveSession()"), \
+    assert block.index(guard) < block.index("_forgetActiveSession(sid)"), \
         "stale-load guard must precede the 404 inline self-heal"
     # It re-arms the active stream rather than leaving it torn down.
     guard_tail = block[block.index(guard): block.index(guard) + 120]

--- a/tests/test_issue3993_session_load_self_heal.py
+++ b/tests/test_issue3993_session_load_self_heal.py
@@ -35,7 +35,7 @@ def test_clear_stuck_session_helper_exists_and_is_wired():
     # Guarded on the boot condition (no active session on screen).
     helper = js[js.index(marker): js.index(marker) + 260]
     assert "if(!currentSid){" in helper
-    assert "localStorage.removeItem('hermes-webui-session')" in helper
+    assert "_forgetActiveSession()" in helper
     assert "history.replaceState" in helper
 
 
@@ -49,9 +49,15 @@ def _run_helper(current_sid_js: str) -> dict:
     helper_src = js[start:end]
     script = f"""
 let removed=false, replaced=false;
-const localStorage = {{ removeItem(k){{ if(k==='hermes-webui-session') removed=true; }} }};
+const localStorage = {{ removeItem(k){{ if(String(k).indexOf('hermes-webui-session')===0) removed=true; }} }};
 const history = {{ replaceState(){{ replaced=true; }} }};
 function _appRootPath(){{ return '/'; }}
+// Tab-scoped active-session helper (defined in ui.js). It clears both the
+// per-tab key and the legacy global key.
+function _forgetActiveSession(){{
+  try{{ localStorage.removeItem('hermes-webui-session::tab'); }}catch(_){{}}
+  try{{ localStorage.removeItem('hermes-webui-session'); }}catch(_){{}}
+}}
 {helper_src}
 _clearStuckSessionOnBoot('dead-sid', {current_sid_js});
 process.stdout.write(JSON.stringify({{removed, replaced}}));
@@ -94,7 +100,7 @@ def test_stale_load_guard_present_before_self_heal():
     assert block.index(guard) < block.index("_clearStuckSessionOnBoot(sid, currentSid);"), \
         "stale-load guard must precede _clearStuckSessionOnBoot"
     # And before the 404 inline clear too.
-    assert block.index(guard) < block.index("localStorage.removeItem('hermes-webui-session')"), \
+    assert block.index(guard) < block.index("_forgetActiveSession()"), \
         "stale-load guard must precede the 404 inline self-heal"
     # It re-arms the active stream rather than leaving it torn down.
     guard_tail = block[block.index(guard): block.index(guard) + 120]

--- a/tests/test_issue5177_hidden_tab_blank_gap.py
+++ b/tests/test_issue5177_hidden_tab_blank_gap.py
@@ -178,9 +178,15 @@ def test_ensure_messages_loaded_supports_force_override():
         "opts=opts||{};" in region
         or "constopts=arguments[1]||{};" in region
     ), "_ensureMessagesLoaded must coerce opts to an object before reading opts.force"
-    # The early-return MUST be GATED on !opts.force.
-    assert "if(!opts.force&&S.messages&&S.messages.length>0" in region, (
+    # The early-return MUST be GATED on !opts.force (and, since the multi-tab
+    # fix, also on the transcript actually belonging to this sid).
+    assert "if(!opts.force&&_messagesBelongToSid&&S.messages&&S.messages.length>0" in region, (
         "_ensureMessagesLoaded's early-return must short-circuit on opts.force"
+    )
+    # Ownership guard: a transcript left over from another conversation must not
+    # satisfy the early return (multi-tab / session-switch stale render fix).
+    assert "const_messagesBelongToSid=(_messagesOwnerSid===sid);" in region, (
+        "_ensureMessagesLoaded must verify the loaded transcript belongs to sid"
     )
 
 

--- a/tests/test_issue6414_programmatic_scroll_user_intent.py
+++ b/tests/test_issue6414_programmatic_scroll_user_intent.py
@@ -148,6 +148,7 @@ let _loadingOlder = false;
 let _messagesTruncated = true;
 let _oldestIdx = 1;
 let _messagesGeneration = 0;
+let _messagesOwnerSid = null;
 let _loadingSessionId = null;
 let _messageRenderWindowSize = 50;
 let _scrollPinned = true;

--- a/tests/test_multi_tab_session_isolation.py
+++ b/tests/test_multi_tab_session_isolation.py
@@ -346,7 +346,8 @@ const legacyAfter = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
 // A brand-new tab has no scoped key and must fall back to the shared slot.
 const tabC = makeTab();
 useTab(tabC); const fresh = _rememberedActiveSession();
-// And when the LAST writer forgets, the shared slot is released.
+// Even the last writer has no proof that an older client stopped relying
+// on the ownerless shared slot.
 useTab(tabB); _forgetActiveSession();
 const legacyFinal = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
 console.log(JSON.stringify({{legacyAfter, fresh, legacyFinal}}));
@@ -354,7 +355,9 @@ console.log(JSON.stringify({{legacyAfter, fresh, legacyFinal}}));
     out = _run(script)
     assert out["legacyAfter"] == "session-BBB", "another tab's fallback must survive"
     assert out["fresh"] == "session-BBB", "a new tab must still restore the last session"
-    assert out["legacyFinal"] is None, "the owning tab must still be able to clear it"
+    assert out["legacyFinal"] == "session-BBB", (
+        "content equality does not give a document authority over shared fallback state"
+    )
 
 
 def test_release_markers_are_independent_per_document():
@@ -601,35 +604,38 @@ console.log(JSON.stringify({{afterForget, afterRewrite, afterReopen}}));
     )
 
 
-def test_forget_clears_expected_legacy_only_sid_on_upgrade():
-    """Must-fix 3b (ui.js:9441): a legacy-only dead session (written by the
-    pre-upgrade build, so no scoped value exists) used to survive
-    _forgetActiveSession(), defeating the 404/profile-switch self-heal. The
-    caller now names the dead sid explicitly and a matching legacy value is
-    cleared even without scoped state."""
+def test_self_heal_cannot_delete_ownerless_shared_fallback():
+    """P1 r3837215782: the unsuffixed fallback has no document owner.
+
+    A tab self-healing the same SID must therefore leave it intact for a
+    brand-new document and for a pre-upgrade client that can only read the
+    shared key. Matching the SID is not authority to delete shared state.
+    """
     script = f"""
 {_HARNESS}
 {_helpers()}
-// Pre-upgrade storage: only the unsuffixed key exists.
-localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'dead-session');
-const tab = makeTab();
-useTab(tab);
-_forgetActiveSession('dead-session');           // 404 self-heal names the sid
-const legacyAfterHeal = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
-// A mismatching expected sid must NOT clear someone else's fallback.
-localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'other-tabs-session');
-useTab(makeTab());
-_forgetActiveSession('a-different-dead-sid');
-const legacyAfterMismatch = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
-console.log(JSON.stringify({{legacyAfterHeal, legacyAfterMismatch}}));
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'shared-session');
+const healingTab = makeTab();
+useTab(healingTab);
+_forgetActiveSession('shared-session');
+const fallbackAfterHeal = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+// A new document has no scoped state and depends on the shared bootstrap slot.
+const freshTab = makeTab();
+useTab(freshTab);
+const freshRestore = _rememberedActiveSession();
+// This raw read models a legacy-only client that knows no scoped key format.
+const legacyClientRestore = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+console.log(JSON.stringify({{fallbackAfterHeal, freshRestore, legacyClientRestore}}));
 """
     out = _run(script)
-    assert out["legacyAfterHeal"] is None, (
-        "forget must clear a matching legacy-only sid so a dead session cannot "
-        "survive the 404 self-heal on upgrade"
+    assert out["fallbackAfterHeal"] == "shared-session", (
+        "a self-healing tab must not delete an ownerless shared fallback"
     )
-    assert out["legacyAfterMismatch"] == "other-tabs-session", (
-        "a non-matching expected sid must leave the shared fallback alone"
+    assert out["freshRestore"] == "shared-session", (
+        "a brand-new document must retain the shared bootstrap target"
+    )
+    assert out["legacyClientRestore"] == "shared-session", (
+        "legacy-only clients must retain their sole restore target"
     )
 
 
@@ -660,53 +666,68 @@ console.log(JSON.stringify({{first, scoped, second}}));
     )
 
 
-def test_upgrade_migrates_populated_legacy_inflight_under_new_tab_stamp():
-    """Must-fix 4 (ui.js:9498): both inflight readers use suffixed keys
-    exclusively, so a populated pre-upgrade `hermes-webui-inflight` /
-    `hermes-webui-inflight-state` produced empty scoped reads and mid-stream
-    recovery was lost on upgrade. A valid legacy payload must be migrated once
-    under the adopting tab's stamp, then the legacy entries removed."""
+def test_upgrade_never_claims_or_deletes_ownerless_legacy_inflight():
+    """P1 r3837215783: valid legacy inflight data is still ownerless.
+
+    The first new document to load the update is not necessarily the document
+    whose stream produced the shared entries. It must neither re-stamp/accept
+    them nor consume them before the actual legacy document can read them.
+    """
     script = f"""
 {_HARNESS}
 {_helpers()}
-// Pre-upgrade mid-stream state, written by the old build minutes ago.
-localStorage.setItem(INFLIGHT_KEY_BASE, JSON.stringify({{sid:'sess-1', streamId:'stream-1', ts:__now-60_000}}));
-localStorage.setItem(INFLIGHT_STATE_KEY_BASE, JSON.stringify({{
-  'sess-1': {{streamId:'stream-1', messages:[{{role:'user',content:'hi'}}], updated_at:__now-60_000}},
-}}));
-const tab = makeTab();
-useTab(tab);
-const restored = loadInflightState('sess-1', 'stream-1');
-const marker = JSON.parse(localStorage.getItem(_inflightKey()) || 'null');
-const legacyMarkerGone = localStorage.getItem(INFLIGHT_KEY_BASE) === null;
-const legacyStateGone = localStorage.getItem(INFLIGHT_STATE_KEY_BASE) === null;
+const legacyMarker = JSON.stringify({{sid:'foreign-sess', streamId:'foreign-stream', ts:__now-1000}});
+const legacyState = JSON.stringify({{
+  'foreign-sess': {{streamId:'foreign-stream', messages:[{{role:'user',content:'foreign'}}], updated_at:__now-1000}},
+}});
+localStorage.setItem(INFLIGHT_KEY_BASE, legacyMarker);
+localStorage.setItem(INFLIGHT_STATE_KEY_BASE, legacyState);
+
+// The unrelated document wins the load race. Shape/SID/age all look valid,
+// but none of them prove ownership.
+const unrelated = makeTab();
+useTab(unrelated);
+const crossRecovered = loadInflightState('foreign-sess', 'foreign-stream');
+const unrelatedScopedMarker = localStorage.getItem(_inflightKey());
+const unrelatedScopedState = localStorage.getItem(_inflightStateKey());
+const markerAfterFirstLoad = localStorage.getItem(INFLIGHT_KEY_BASE);
+const stateAfterFirstLoad = localStorage.getItem(INFLIGHT_STATE_KEY_BASE);
+
+// A second upgraded document must also see only its own empty scoped state;
+// the shared bytes remain available to a still-running legacy client.
+const second = makeTab();
+useTab(second);
+const secondScopedState = _readInflightStateMap();
+const legacyClientMarker = localStorage.getItem(INFLIGHT_KEY_BASE);
+const legacyClientState = localStorage.getItem(INFLIGHT_STATE_KEY_BASE);
 console.log(JSON.stringify({{
-  restoredStream: restored && restored.streamId,
-  restoredTab: restored && restored.tabId,
-  tabId: _hermesTabId(),
-  markerSid: marker && marker.sid,
-  legacyMarkerGone, legacyStateGone,
+  crossRecovered,
+  unrelatedScopedMarker,
+  unrelatedScopedState,
+  markerAfterFirstLoad,
+  stateAfterFirstLoad,
+  secondScopedState,
+  legacyClientMarker,
+  legacyClientState,
+  legacyMarker,
+  legacyState,
 }}));
 """
     out = _run(script)
-    assert out["restoredStream"] == "stream-1", (
-        "a populated legacy inflight-state map must be readable after upgrade"
+    assert out["crossRecovered"] is None, (
+        "an unrelated document must not accept ownerless recovery state"
     )
-    assert out["restoredTab"] == out["tabId"], (
-        "migrated entries must be re-stamped under the adopting tab's id"
-    )
-    assert out["markerSid"] == "sess-1", (
-        "the legacy reconnect marker must be migrated under the scoped key"
-    )
-    assert out["legacyMarkerGone"] and out["legacyStateGone"], (
-        "legacy entries must be removed after the one-shot migration"
-    )
+    assert out["unrelatedScopedMarker"] is None
+    assert out["unrelatedScopedState"] is None
+    assert out["secondScopedState"] == {}
+    assert out["markerAfterFirstLoad"] == out["legacyMarker"]
+    assert out["stateAfterFirstLoad"] == out["legacyState"]
+    assert out["legacyClientMarker"] == out["legacyMarker"]
+    assert out["legacyClientState"] == out["legacyState"]
 
 
-def test_stale_or_malformed_legacy_inflight_is_invalidated_not_migrated():
-    """Must-fix 4 (validation): the legacy payload is validated (shape + age)
-    before adoption; stale/corrupt entries are removed without migrating, and
-    existing scoped state is never overwritten."""
+def test_stale_or_malformed_legacy_inflight_is_ignored_without_mutation():
+    """Age and parseability do not confer authority over ownerless state."""
     script = f"""
 {_HARNESS}
 {_helpers()}
@@ -718,8 +739,8 @@ useTab(tab);
 _migrateLegacyInflight();
 const scopedMarker = localStorage.getItem(_inflightKey());
 const scopedState = localStorage.getItem(_inflightStateKey());
-const legacyGone = localStorage.getItem(INFLIGHT_KEY_BASE) === null
-  && localStorage.getItem(INFLIGHT_STATE_KEY_BASE) === null;
+const staleMarkerKept = localStorage.getItem(INFLIGHT_KEY_BASE);
+const corruptStateKept = localStorage.getItem(INFLIGHT_STATE_KEY_BASE);
 // Second scenario: a tab that already HAS scoped state keeps it.
 const tab2 = makeTab();
 useTab(tab2);
@@ -728,39 +749,38 @@ localStorage.setItem(_inflightKey(), JSON.stringify({{sid:'own-sess', streamId:'
 _migrateLegacyInflight();
 const kept = JSON.parse(localStorage.getItem(_inflightKey()));
 console.log(JSON.stringify({{
-  scopedMarker, scopedState, legacyGone,
+  scopedMarker, scopedState, staleMarkerKept, corruptStateKept,
   keptSid: kept && kept.sid,
-  legacyGone2: localStorage.getItem(INFLIGHT_KEY_BASE) === null,
+  validLegacyKept: localStorage.getItem(INFLIGHT_KEY_BASE),
 }}));
 """
     out = _run(script)
     assert out["scopedMarker"] is None, "a stale legacy marker must not be migrated"
     assert out["scopedState"] is None, "a corrupt legacy state map must not be migrated"
-    assert out["legacyGone"], "invalid legacy entries must still be invalidated (removed)"
+    assert "old-sess" in out["staleMarkerKept"]
+    assert out["corruptStateKept"] == "not json at all"
     assert out["keptSid"] == "own-sess", (
-        "migration must never overwrite a tab's existing scoped marker"
+        "legacy quarantine must never overwrite a tab's existing scoped marker"
     )
-    assert out["legacyGone2"], "the legacy slot is consumed exactly once either way"
+    assert "legacy-sess" in out["validLegacyKept"]
 
 
-def test_inflight_readers_run_the_migration_before_scoped_reads():
-    """Wiring: both readers (the boot marker check and the state-map read) must
-    invoke the one-shot migration BEFORE their scoped read, or a populated
-    legacy payload stays invisible exactly as the re-gate reproduced."""
+def test_inflight_readers_enter_legacy_quarantine_before_scoped_reads():
+    """Both readers cross the explicit ownerless-state guard before scoped I/O."""
     check_body = _function_body(UI_SRC, "async function checkInflightOnBoot")
     assert "_migrateLegacyInflight()" in check_body, (
-        "checkInflightOnBoot must migrate legacy inflight before reading"
+        "checkInflightOnBoot must cross the legacy quarantine before reading"
     )
     assert check_body.index("_migrateLegacyInflight()") < check_body.index(
         "localStorage.getItem(_inflightKey())"
-    ), "migration must precede the scoped marker read"
+    ), "legacy quarantine must precede the scoped marker read"
     read_body = _function_body(UI_SRC, "function _readInflightStateMap")
     assert "_migrateLegacyInflight()" in read_body, (
-        "_readInflightStateMap must migrate legacy inflight before reading"
+        "_readInflightStateMap must cross the legacy quarantine before reading"
     )
     assert read_body.index("_migrateLegacyInflight()") < read_body.index(
         "localStorage.getItem(_inflightStateKey())"
-    ), "migration must precede the scoped state read"
+    ), "legacy quarantine must precede the scoped state read"
 
 
 def test_simultaneous_same_id_documents_remint_before_scoped_access():

--- a/tests/test_multi_tab_session_isolation.py
+++ b/tests/test_multi_tab_session_isolation.py
@@ -1,0 +1,371 @@
+"""Multi-tab conversation isolation (behavioural, executed in Node).
+
+The active-session id, the in-flight stream marker and the mid-stream
+transcript snapshots used to live in GLOBAL localStorage keys shared by every
+tab of the origin, so opening two conversations in two tabs let the last
+writer win:
+
+  * reloading tab A restored tab B's conversation,
+  * tab A's reconnect banner pointed at tab B's stream,
+  * tab A merged tab B's in-flight transcript into its own chat.
+
+These probes extract the real helpers from static/ui.js and run them against
+two simulated tabs sharing one localStorage, so they fail on the pre-fix
+build instead of merely asserting on source text.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_SRC = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        char = src[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"could not extract function body for {signature!r}")
+
+
+def _const_line(src: str, name: str) -> str:
+    marker = f"const {name} = "
+    start = src.index(marker)
+    end = src.index("\n", start)
+    return src[start:end]
+
+
+_HELPER_CONSTS = (
+    "TAB_ID_KEY",
+    "TAB_ID_CLAIM_KEY",
+    "_TAB_CLAIM_TTL_MS",
+    "_TAB_CLAIM_HEARTBEAT_MS",
+    "_TAB_SEEN_TTL_MS",
+    "TAB_ID_SEEN_KEY",
+    "INFLIGHT_KEY_BASE",
+    "INFLIGHT_STATE_KEY_BASE",
+    "ACTIVE_SESSION_KEY_LEGACY",
+)
+
+_HELPER_FUNCS = (
+    "function _newTabId",
+    "function _updateTabRegistry",
+    "function _readTabClaims",
+    "function _claimTabId",
+    "function _readTabSeen",
+    "function _touchTabSeen",
+    "function _releaseTabId",
+    "function _gcOrphanTabKeys",
+    "function _hermesTabId",
+    "function _inflightKey",
+    "function _inflightStateKey",
+    "function _activeSessionKey",
+    "function _rememberActiveSession",
+    "function _rememberedActiveSession",
+    "function _forgetActiveSession",
+)
+
+
+def _helpers() -> str:
+    parts = [_const_line(UI_SRC, name).replace("const ", "var ", 1) for name in _HELPER_CONSTS]
+    parts += [_function_body(UI_SRC, sig) for sig in _HELPER_FUNCS]
+    return "\n".join(parts)
+
+
+_HARNESS = """
+// Two tabs of the same origin share ONE localStorage but each has its OWN
+// sessionStorage AND its own window object — this is exactly how browsers
+// behave. The helpers close over `sessionStorage` / `window`, so useTab()
+// rebinds what those names resolve to instead of shadowing them.
+function makeStorage(){
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(String(k)) ? map.get(String(k)) : null),
+    setItem: (k, v) => { map.set(String(k), String(v)); },
+    removeItem: (k) => { map.delete(String(k)); },
+    clear: () => map.clear(),
+    get length(){ return map.size; },
+    key: (i) => Array.from(map.keys())[i],
+    _keys: () => Array.from(map.keys()),
+  };
+}
+// A browser tab = its own sessionStorage + its own window (module scope).
+function makeTab(){ return { store: makeStorage(), win: { addEventListener(){}, crypto: undefined } }; }
+
+const localStorage = makeStorage();
+let __tab = makeTab();
+const sessionStorage = {
+  getItem: (k) => __tab.store.getItem(k),
+  setItem: (k, v) => __tab.store.setItem(k, v),
+  removeItem: (k) => __tab.store.removeItem(k),
+  get length(){ return __tab.store.length; },
+  key: (i) => __tab.store.key(i),
+  _keys: () => __tab.store._keys(),
+};
+const window = new Proxy({}, {
+  get: (_t, prop) => __tab.win[prop],
+  set: (_t, prop, value) => { __tab.win[prop] = value; return true; },
+  has: (_t, prop) => prop in __tab.win,
+  deleteProperty: (_t, prop) => { delete __tab.win[prop]; return true; },
+});
+// The real helper installs a heartbeat interval; keep Node's event loop empty
+// so the probe exits.
+function setInterval(){ return 0; }
+let __now = 1_000_000;
+// Route the helpers' Date.now() through a controllable clock.
+const Date = { now: () => __now };
+// Bring a given tab to the foreground.
+function useTab(tab){ __tab = tab; }
+"""
+
+
+def _run(script: str) -> dict:
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_two_tabs_get_distinct_identities_and_scoped_keys():
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); const idA = _hermesTabId(); const keyA = _activeSessionKey();
+useTab(tabB); const idB = _hermesTabId(); const keyB = _activeSessionKey();
+console.log(JSON.stringify({{idA, idB, keyA, keyB}}));
+"""
+    out = _run(script)
+    assert out["idA"] and out["idB"], "each tab must mint an id"
+    assert out["idA"] != out["idB"], "two concurrent tabs must not share a tab id"
+    assert out["keyA"] != out["keyB"], "active-session keys must be tab-scoped"
+
+
+def test_reload_restores_this_tabs_conversation_not_the_other_tabs():
+    """The original bug: tab A reloads and lands in tab B's conversation."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); _rememberActiveSession('session-AAA');
+useTab(tabB); _rememberActiveSession('session-BBB');   // last writer used to win
+useTab(tabA); const restored = _rememberedActiveSession();
+console.log(JSON.stringify({{restored}}));
+"""
+    assert _run(script)["restored"] == "session-AAA"
+
+
+def test_inflight_stream_marker_is_per_tab():
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); localStorage.setItem(_inflightKey(), 'stream-A');
+useTab(tabB); localStorage.setItem(_inflightKey(), 'stream-B');
+useTab(tabA); const markerA = localStorage.getItem(_inflightKey());
+useTab(tabB); const markerB = localStorage.getItem(_inflightKey());
+console.log(JSON.stringify({{markerA, markerB}}));
+"""
+    out = _run(script)
+    assert out["markerA"] == "stream-A"
+    assert out["markerB"] == "stream-B"
+
+
+def test_duplicated_tab_remints_its_id():
+    """Chrome's "Duplicate tab" COPIES sessionStorage, so the clone would
+    otherwise start life holding the original tab's id and both tabs would
+    write to the same per-tab keys."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const original = makeTab();
+useTab(original); const idOriginal = _hermesTabId();
+// Duplicate: sessionStorage contents are copied verbatim.
+const clone = makeTab();
+for (const k of original.store._keys()) clone.store.setItem(k, original.store.getItem(k));
+useTab(clone); const idClone = _hermesTabId();
+console.log(JSON.stringify({{idOriginal, idClone}}));
+"""
+    out = _run(script)
+    assert out["idOriginal"] != out["idClone"], "a duplicated tab must re-mint its id"
+
+
+def test_plain_reload_keeps_the_same_tab_id():
+    """A reload must NOT re-mint, otherwise the tab loses its own in-flight
+    stream recovery — the release-on-pagehide path exists for this."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tab = makeTab();
+useTab(tab); const before = _hermesTabId();
+_releaseTabId();                     // pagehide fires before unload
+// Reload: sessionStorage survives, the window (and its cached id) does not.
+const reloaded = {{ store: tab.store, win: {{ addEventListener(){{}}, crypto: undefined }} }};
+useTab(reloaded); const after = _hermesTabId();
+console.log(JSON.stringify({{before, after}}));
+"""
+    out = _run(script)
+    assert out["before"] == out["after"], "a reload must keep the tab's identity"
+
+
+def test_orphan_tab_keys_are_reclaimed():
+    """Per-tab keys must not accumulate until localStorage hits quota."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tab = makeTab();
+useTab(tab);
+const live = _hermesTabId();
+// Leftovers from a tab closed long ago.
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::ghost', 'old-session');
+localStorage.setItem(INFLIGHT_KEY_BASE + '::ghost', 'old-stream');
+const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
+seen['ghost'] = __now - (_TAB_SEEN_TTL_MS * 2);
+localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
+_gcOrphanTabKeys();
+const remaining = localStorage._keys().filter(k => k.indexOf('::ghost') !== -1);
+const liveKept = localStorage._keys().filter(k => k.indexOf('::' + live) !== -1);
+console.log(JSON.stringify({{remaining, liveKeptCount: liveKept.length}}));
+"""
+    out = _run(script)
+    assert out["remaining"] == [], "keys of long-gone tabs must be reclaimed"
+
+
+def test_recent_tab_keys_are_not_reclaimed():
+    """GC must not evict a tab that is merely in a background window."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tab = makeTab();
+useTab(tab); _hermesTabId();   // this tab is live and stamps itself as seen
+// Another tab, last seen a second ago (e.g. a background window).
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::recent', 'still-used');
+const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
+seen['recent'] = __now - 1000;
+localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
+_gcOrphanTabKeys();
+const kept = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY + '::recent');
+console.log(JSON.stringify({{kept}}));
+"""
+    assert _run(script)["kept"] == "still-used"
+
+
+def test_legacy_key_still_written_for_first_paint_fallback():
+    """boot.js may read the legacy key before a tab id exists; keep it fresh so
+    a brand-new tab still lands on the last conversation."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tab = makeTab();
+useTab(tab); _rememberActiveSession('session-XYZ');
+const legacy = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+console.log(JSON.stringify({{legacy}}));
+"""
+    assert _run(script)["legacy"] == "session-XYZ"
+
+
+def test_forget_clears_this_tab_only():
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); _rememberActiveSession('session-AAA');
+useTab(tabB); _rememberActiveSession('session-BBB');
+useTab(tabA); _forgetActiveSession();
+useTab(tabA); const aScoped = localStorage.getItem(_activeSessionKey());
+useTab(tabB); const b = _rememberedActiveSession();
+console.log(JSON.stringify({{aScoped, b}}));
+"""
+    out = _run(script)
+    assert out["aScoped"] is None, "this tab's stored session must be cleared"
+    assert out["b"] == "session-BBB", "another tab's session must survive"
+
+
+def test_forget_does_not_strip_the_shared_fallback_of_other_tabs():
+    """One tab clearing its own conversation must not blank the legacy key that
+    a brand-new (or older-client) tab relies on for first paint."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); _rememberActiveSession('session-AAA');
+useTab(tabB); _rememberActiveSession('session-BBB');   // legacy key now = BBB
+// Tab A forgets ITS session; the shared slot still points at tab B's.
+useTab(tabA); _forgetActiveSession();
+const legacyAfter = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+// A brand-new tab has no scoped key and must fall back to the shared slot.
+const tabC = makeTab();
+useTab(tabC); const fresh = _rememberedActiveSession();
+// And when the LAST writer forgets, the shared slot is released.
+useTab(tabB); _forgetActiveSession();
+const legacyFinal = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+console.log(JSON.stringify({{legacyAfter, fresh, legacyFinal}}));
+"""
+    out = _run(script)
+    assert out["legacyAfter"] == "session-BBB", "another tab's fallback must survive"
+    assert out["fresh"] == "session-BBB", "a new tab must still restore the last session"
+    assert out["legacyFinal"] is None, "the owning tab must still be able to clear it"
+
+
+def test_registry_writes_do_not_clobber_a_concurrent_tab():
+    """Claim/seen updates are read-modify-write on one shared key. A tab that
+    read the registry before a second tab registered must not erase it."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+// Tab A boots and registers.
+useTab(tabA); const idA = _hermesTabId();
+// Tab B boots and registers (interleaved with A's next heartbeat below).
+useTab(tabB); const idB = _hermesTabId();
+// A heartbeats using a STALE view of the registry (it re-reads internally).
+useTab(tabA); _touchTabSeen(idA);
+const claims = JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY) || '{{}}');
+const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
+// Releasing A must not take B's claim with it.
+useTab(tabA); _releaseTabId();
+const afterRelease = JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY) || '{{}}');
+console.log(JSON.stringify({{
+  bothClaimed: !!claims[idA] && !!claims[idB],
+  bothSeen: !!seen[idA] && !!seen[idB],
+  bSurvivedRelease: !!afterRelease[idB],
+  aReleased: !afterRelease[idA],
+}}));
+"""
+    out = _run(script)
+    assert out["bothClaimed"], "a concurrent tab's claim must not be clobbered"
+    assert out["bothSeen"], "a concurrent tab's seen entry must not be clobbered"
+    assert out["bSurvivedRelease"], "releasing one tab must not drop another's claim"
+    assert out["aReleased"], "the releasing tab's own claim must be removed"
+
+
+def test_remembered_session_returns_null_when_empty():
+    """Callers treat the result as falsy-or-id; keep the original
+    localStorage.getItem() contract."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+useTab(makeTab());
+console.log(JSON.stringify({{value: _rememberedActiveSession()}}));
+"""
+    assert _run(script)["value"] is None

--- a/tests/test_multi_tab_session_isolation.py
+++ b/tests/test_multi_tab_session_isolation.py
@@ -47,29 +47,25 @@ def _const_line(src: str, name: str) -> str:
 
 _HELPER_CONSTS = (
     "TAB_ID_KEY",
-    "TAB_ID_CLAIM_KEY",
-    "_TAB_CLAIM_HEARTBEAT_MS",
-    "_TAB_OWNER_REVALIDATE_MS",
-    "_TAB_SEEN_TTL_MS",
-    "TAB_ID_SEEN_KEY",
+    "TAB_ID_RELEASED_BASE",
+    "_TAB_RELEASED_TTL_MS",
     "INFLIGHT_KEY_BASE",
     "INFLIGHT_STATE_KEY_BASE",
     "ACTIVE_SESSION_KEY_LEGACY",
     "ACTIVE_SESSION_TOMBSTONE_BASE",
+    "TAB_ACTIVE_SESSION_MIRROR_KEY",
+    "TAB_ACTIVE_SESSION_TOMBSTONE_MIRROR_KEY",
+    "TAB_INFLIGHT_MIRROR_KEY",
+    "TAB_INFLIGHT_STATE_MIRROR_KEY",
 )
 
 _HELPER_FUNCS = (
     "function _newTabId",
-    "function _hermesTabNonce",
-    "function _readTabClaims",
-    "function _writeTabClaims",
-    "function _updateTabRegistry",
-    "function _touchTabSeen",
+    "function _scopedTabKey",
+    "function _mirrorTabValue",
+    "function _restoreDocumentScopedState",
     "function _gcOrphanTabKeys",
-    "function _claimTabOwnership",
-    "function _claimTabId",
     "function _releaseTabId",
-    "function _revalidateTabOwnership",
     "function _hermesTabId",
     "function _inflightKey",
     "function _inflightStateKey",
@@ -96,6 +92,7 @@ _HARNESS = """
 // sessionStorage AND its own window object — this is exactly how browsers
 // behave. The helpers close over `sessionStorage` / `window`, so useTab()
 // rebinds what those names resolve to instead of shadowing them.
+let __uuid = 0;
 function makeStorage(){
   const map = new Map();
   return {
@@ -109,7 +106,16 @@ function makeStorage(){
   };
 }
 // A browser tab = its own sessionStorage + its own window (module scope).
-function makeTab(){ return { store: makeStorage(), win: { addEventListener(){}, crypto: undefined } }; }
+// crypto.randomUUID() is document-local and never copied with sessionStorage.
+function makeTab(){
+  return {
+    store: makeStorage(),
+    win: {
+      addEventListener(){},
+      crypto: { randomUUID(){ return 'uuid-' + (++__uuid); } },
+    },
+  };
+}
 
 const localStorage = makeStorage();
 let __tab = makeTab();
@@ -216,22 +222,42 @@ console.log(JSON.stringify({{idOriginal, idClone}}));
     assert out["idOriginal"] != out["idClone"], "a duplicated tab must re-mint its id"
 
 
-def test_plain_reload_keeps_the_same_tab_id():
-    """A reload must NOT re-mint, otherwise the tab loses its own in-flight
-    stream recovery — the release-on-pagehide path exists for this."""
+def test_plain_reload_remints_and_restores_recovery_under_the_new_id():
+    """A reload receives a fresh document id, but its sessionStorage recovery
+    mirror must be restored and re-stamped before scoped state is read."""
     script = f"""
 {_HARNESS}
 {_helpers()}
 const tab = makeTab();
 useTab(tab); const before = _hermesTabId();
+_rememberActiveSession('session-reload');
+const snapshot = {{'session-reload':{{streamId:'stream-reload', updated_at:__now, tabId:before}}}};
+localStorage.setItem(_inflightStateKey(), JSON.stringify(snapshot));
+_mirrorTabValue(TAB_INFLIGHT_STATE_MIRROR_KEY, JSON.stringify(snapshot));
+const marker = JSON.stringify({{sid:'session-reload', streamId:'stream-reload', ts:__now}});
+localStorage.setItem(_inflightKey(), marker);
+_mirrorTabValue(TAB_INFLIGHT_MIRROR_KEY, marker);
 _releaseTabId();                     // pagehide fires before unload
 // Reload: sessionStorage survives, the window (and its cached id) does not.
-const reloaded = {{ store: tab.store, win: {{ addEventListener(){{}}, crypto: undefined }} }};
+const freshDocument = makeTab();
+const reloaded = {{ store: tab.store, win: freshDocument.win }};
 useTab(reloaded); const after = _hermesTabId();
-console.log(JSON.stringify({{before, after}}));
+const restoredSession = _rememberedActiveSession();
+const restoredState = loadInflightState('session-reload', 'stream-reload');
+const restoredMarker = JSON.parse(localStorage.getItem(_inflightKey()));
+console.log(JSON.stringify({{
+  before,
+  after,
+  restoredSession,
+  restoredOwner:restoredState&&restoredState.tabId,
+  restoredMarkerSid:restoredMarker&&restoredMarker.sid,
+}}));
 """
     out = _run(script)
-    assert out["before"] == out["after"], "a reload must keep the tab's identity"
+    assert out["before"] != out["after"], "every new document must receive a fresh id"
+    assert out["restoredSession"] == "session-reload"
+    assert out["restoredOwner"] == out["after"], "recovery must be re-stamped"
+    assert out["restoredMarkerSid"] == "session-reload"
 
 
 def test_orphan_tab_keys_are_reclaimed():
@@ -245,9 +271,7 @@ const live = _hermesTabId();
 // Leftovers from a tab closed long ago.
 localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::ghost', 'old-session');
 localStorage.setItem(INFLIGHT_KEY_BASE + '::ghost', 'old-stream');
-const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
-seen['ghost'] = __now - (_TAB_SEEN_TTL_MS * 2);
-localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
+localStorage.setItem(TAB_ID_RELEASED_BASE + '::ghost', String(__now - (_TAB_RELEASED_TTL_MS * 2)));
 _gcOrphanTabKeys();
 const remaining = localStorage._keys().filter(k => k.indexOf('::ghost') !== -1);
 const liveKept = localStorage._keys().filter(k => k.indexOf('::' + live) !== -1);
@@ -263,12 +287,10 @@ def test_recent_tab_keys_are_not_reclaimed():
 {_HARNESS}
 {_helpers()}
 const tab = makeTab();
-useTab(tab); _hermesTabId();   // this tab is live and stamps itself as seen
-// Another tab, last seen a second ago (e.g. a background window).
+useTab(tab); _hermesTabId();
+// Another document was only just released; retain its recovery grace period.
 localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::recent', 'still-used');
-const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
-seen['recent'] = __now - 1000;
-localStorage.setItem(TAB_ID_SEEN_KEY, JSON.stringify(seen));
+localStorage.setItem(TAB_ID_RELEASED_BASE + '::recent', String(__now - 1000));
 _gcOrphanTabKeys();
 const kept = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY + '::recent');
 console.log(JSON.stringify({{kept}}));
@@ -335,40 +357,27 @@ console.log(JSON.stringify({{legacyAfter, fresh, legacyFinal}}));
     assert out["legacyFinal"] is None, "the owning tab must still be able to clear it"
 
 
-def test_registry_writes_do_not_clobber_a_concurrent_tab():
-    """Claim/seen updates are read-modify-write on one shared key. A tab that
-    read the registry before a second tab registered must not erase it."""
+def test_release_markers_are_independent_per_document():
+    """Teardown uses one scalar key per document, never a shared RMW registry."""
     script = f"""
 {_HARNESS}
 {_helpers()}
 const tabA = makeTab();
 const tabB = makeTab();
-// Tab A boots and registers.
 useTab(tabA); const idA = _hermesTabId();
-// Tab B boots and registers (interleaved with A's next heartbeat below).
 useTab(tabB); const idB = _hermesTabId();
-// A heartbeats using a STALE view of the registry (it re-reads internally).
-useTab(tabA); _touchTabSeen(idA);
-const claims = JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY) || '{{}}');
-const seen = JSON.parse(localStorage.getItem(TAB_ID_SEEN_KEY) || '{{}}');
-// Releasing A must not take B's claim with it.
 useTab(tabA); _releaseTabId();
-const afterRelease = JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY) || '{{}}');
+useTab(tabB); _releaseTabId();
 console.log(JSON.stringify({{
-  bothClaimed: !!claims[idA] && !!claims[idB],
-  bothSeen: !!seen[idA] && !!seen[idB],
-  bSurvivedRelease: !!(afterRelease[idB] && !afterRelease[idB].released),
-  aReleased: !!(afterRelease[idA] && afterRelease[idA].released),
+  idA, idB,
+  releasedA: localStorage.getItem(TAB_ID_RELEASED_BASE + '::' + idA),
+  releasedB: localStorage.getItem(TAB_ID_RELEASED_BASE + '::' + idB),
 }}));
 """
     out = _run(script)
-    assert out["bothClaimed"], "a concurrent tab's claim must not be clobbered"
-    assert out["bothSeen"], "a concurrent tab's seen entry must not be clobbered"
-    assert out["bSurvivedRelease"], "releasing one tab must not drop another's claim"
-    assert out["aReleased"], (
-        "the releasing tab's record must be marked released (kept for reload "
-        "re-claim, never silently dropped)"
-    )
+    assert out["idA"] != out["idB"]
+    assert out["releasedA"] == "1000000"
+    assert out["releasedB"] == "1000000"
 
 
 def test_remembered_session_returns_null_when_empty():
@@ -381,6 +390,66 @@ useTab(makeTab());
 console.log(JSON.stringify({{value: _rememberedActiveSession()}}));
 """
     assert _run(script)["value"] is None
+
+
+def test_empty_legacy_fallback_is_read_only_once_per_document():
+    """A later write by another tab must not bleed into a document that already
+    established that it had no active session."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); const before = _rememberedActiveSession();
+useTab(tabB); _rememberActiveSession('session-B');
+useTab(tabA); const after = _rememberedActiveSession();
+console.log(JSON.stringify({{before, after}}));
+"""
+    out = _run(script)
+    assert out["before"] is None
+    assert out["after"] is None
+
+
+def test_missing_crypto_fails_closed_without_scoped_access():
+    """An inherited id is never authority; without a cryptographic fresh id the
+    document must neither read nor write scoped recovery state."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const unsafe = makeTab();
+unsafe.win.crypto = undefined;
+unsafe.store.setItem(TAB_ID_KEY, 'copied-id');
+const foreignKey = ACTIVE_SESSION_KEY_LEGACY + '::copied-id';
+localStorage.setItem(foreignKey, 'foreign-session');
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'legacy-session');
+const rawGetItem = localStorage.getItem;
+let foreignReads = 0;
+localStorage.getItem = (key) => {{
+  if(key === foreignKey) foreignReads++;
+  return rawGetItem(key);
+}};
+useTab(unsafe);
+const id = _hermesTabId();
+const restored = _rememberedActiveSession();
+_rememberActiveSession('attempted-write');
+let scopedKeyRejected = false;
+try{{ _activeSessionKey(); }}catch(_){{ scopedKeyRejected = true; }}
+console.log(JSON.stringify({{
+  id,
+  restored,
+  foreignReads,
+  scopedKeyRejected,
+  foreignValue: rawGetItem(foreignKey),
+  legacyValue: rawGetItem(ACTIVE_SESSION_KEY_LEGACY),
+}}));
+"""
+    out = _run(script)
+    assert out["id"] is None
+    assert out["restored"] is None
+    assert out["foreignReads"] == 0
+    assert out["scopedKeyRejected"]
+    assert out["foreignValue"] == "foreign-session"
+    assert out["legacyValue"] == "legacy-session"
 
 
 # ── Adversarial re-gate regressions (maintainer CHANGES_REQUESTED 2026-08-17) ──
@@ -467,10 +536,8 @@ console.log(JSON.stringify({{scopedSession, scopedInflightKept: scopedInflight!=
     assert out["scopedInflightKept"], "the live tab's inflight snapshot must survive GC"
 
 
-def test_gc_is_disabled_fail_safe_on_malformed_registry_json():
-    """Must-fix 2b (ui.js:9330): malformed registry JSON used to parse to {} and
-    be read as 'no tab was ever seen', so the very next GC pass deleted every
-    live tab's keys. Parse failure must DISABLE GC entirely (fail safe)."""
+def test_gc_fails_safe_on_missing_or_malformed_release_evidence():
+    """GC may collect only after a valid, old, per-document release marker."""
     script = f"""
 {_HARNESS}
 {_helpers()}
@@ -478,30 +545,25 @@ const tab = makeTab();
 useTab(tab);
 const id = _hermesTabId();
 _rememberActiveSession('session-live');
-// Corrupt BOTH registries (extension writers, quota-truncated writes...).
-localStorage.setItem(TAB_ID_CLAIM_KEY, '{{not json');
-localStorage.setItem(TAB_ID_SEEN_KEY, '{{not json');
+localStorage.setItem(TAB_ID_RELEASED_BASE + '::' + id, 'not-a-number');
 _gcOrphanTabKeys();
-const keptAfterClaimsCorruption = localStorage.getItem(_activeSessionKey());
-// Repair claims but leave 'seen' corrupt: still fail safe (legacy keys with
-// no ownership record would otherwise be judged by garbage data).
-localStorage.removeItem(TAB_ID_CLAIM_KEY);
-_claimTabId(id);
+const keptAfterMalformedRelease = localStorage.getItem(_activeSessionKey());
+// A scoped key with no release evidence must also survive indefinitely.
 localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::unrecorded', 'legacy-key');
 _gcOrphanTabKeys();
 const keptLegacy = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY + '::unrecorded');
 console.log(JSON.stringify({{
-  keptAfterClaimsCorruption,
+  keptAfterMalformedRelease,
   keptLegacy,
   scopedStillThere: localStorage.getItem(_activeSessionKey()),
 }}));
 """
     out = _run(script)
-    assert out["keptAfterClaimsCorruption"] == "session-live", (
-        "malformed claim-registry JSON must disable GC, not unleash it"
+    assert out["keptAfterMalformedRelease"] == "session-live", (
+        "malformed release evidence must disable collection for that document"
     )
     assert out["keptLegacy"] == "legacy-key", (
-        "malformed seen-registry JSON must also disable GC for unrecorded keys"
+        "missing release evidence must retain unrecorded scoped keys"
     )
     assert out["scopedStillThere"] == "session-live"
 
@@ -699,3 +761,64 @@ def test_inflight_readers_run_the_migration_before_scoped_reads():
     assert read_body.index("_migrateLegacyInflight()") < read_body.index(
         "localStorage.getItem(_inflightStateKey())"
     ), "migration must precede the scoped state read"
+
+
+def test_simultaneous_same_id_documents_remint_before_scoped_access():
+    """Two documents inherit one copied id and boot concurrently. The registry
+    hook reproduces the stale-read schedule in the rejected CAS implementation;
+    the sessionStorage hook applies the equivalent pause to the fresh-id design.
+    Both documents must establish distinct authority before scoped access."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const inherited = 'copied-tab-id';
+const tabA = makeTab();
+const tabB = makeTab();
+tabA.store.setItem(TAB_ID_KEY, inherited);
+tabB.store.setItem(TAB_ID_KEY, inherited);
+
+// Deterministic collision schedule: A has already received the registry value
+// when this hook runs. B initializes completely before that value is returned
+// to A, so A resumes with a stale "free" view.
+const rawGetItem = localStorage.getItem;
+const rawSessionSetItem = sessionStorage.setItem;
+let interleaved = false;
+let idB = null;
+localStorage.getItem = (key) => {{
+  const value = rawGetItem(key);
+  // This raw legacy key intentionally keeps the test discriminating against the
+  // rejected read/write/verify localStorage arbitration implementation.
+  if(!interleaved && key === 'hermes-webui-tab-claims' && __tab === tabA){{
+    interleaved = true;
+    useTab(tabB);
+    idB = _hermesTabId();
+    useTab(tabA);
+  }}
+  return value;
+}};
+sessionStorage.setItem = (key, value) => {{
+  rawSessionSetItem(key, value);
+  if(!interleaved && key === TAB_ID_KEY && __tab === tabA){{
+    interleaved = true;
+    useTab(tabB);
+    idB = _hermesTabId();
+    useTab(tabA);
+  }}
+}};
+
+useTab(tabA);
+const idA = _hermesTabId();
+if(!idB){{ useTab(tabB); idB = _hermesTabId(); }}
+useTab(tabA); _rememberActiveSession('session-A');
+useTab(tabB); _rememberActiveSession('session-B');
+useTab(tabA); const restoredA = _rememberedActiveSession();
+console.log(JSON.stringify({{idA, idB, inherited, interleaved, restoredA}}));
+"""
+    out = _run(script)
+    assert out["interleaved"], "the probe must exercise a concurrent boot schedule"
+    assert out["idA"] != out["idB"], (
+        "simultaneous documents must not both accept one inherited identity"
+    )
+    assert out["restoredA"] == "session-A", (
+        "the losing document must remint before any scoped session access"
+    )

--- a/tests/test_multi_tab_session_isolation.py
+++ b/tests/test_multi_tab_session_isolation.py
@@ -48,31 +48,40 @@ def _const_line(src: str, name: str) -> str:
 _HELPER_CONSTS = (
     "TAB_ID_KEY",
     "TAB_ID_CLAIM_KEY",
-    "_TAB_CLAIM_TTL_MS",
     "_TAB_CLAIM_HEARTBEAT_MS",
+    "_TAB_OWNER_REVALIDATE_MS",
     "_TAB_SEEN_TTL_MS",
     "TAB_ID_SEEN_KEY",
     "INFLIGHT_KEY_BASE",
     "INFLIGHT_STATE_KEY_BASE",
     "ACTIVE_SESSION_KEY_LEGACY",
+    "ACTIVE_SESSION_TOMBSTONE_BASE",
 )
 
 _HELPER_FUNCS = (
     "function _newTabId",
-    "function _updateTabRegistry",
+    "function _hermesTabNonce",
     "function _readTabClaims",
-    "function _claimTabId",
-    "function _readTabSeen",
+    "function _writeTabClaims",
+    "function _updateTabRegistry",
     "function _touchTabSeen",
-    "function _releaseTabId",
     "function _gcOrphanTabKeys",
+    "function _claimTabOwnership",
+    "function _claimTabId",
+    "function _releaseTabId",
+    "function _revalidateTabOwnership",
     "function _hermesTabId",
     "function _inflightKey",
     "function _inflightStateKey",
     "function _activeSessionKey",
+    "function _activeSessionTombstoneKey",
     "function _rememberActiveSession",
     "function _rememberedActiveSession",
     "function _forgetActiveSession",
+    "function _migrateLegacyInflight",
+    "function _readInflightStateMap",
+    "function loadInflightState",
+    "function clearInflightState",
 )
 
 
@@ -348,15 +357,18 @@ const afterRelease = JSON.parse(localStorage.getItem(TAB_ID_CLAIM_KEY) || '{{}}'
 console.log(JSON.stringify({{
   bothClaimed: !!claims[idA] && !!claims[idB],
   bothSeen: !!seen[idA] && !!seen[idB],
-  bSurvivedRelease: !!afterRelease[idB],
-  aReleased: !afterRelease[idA],
+  bSurvivedRelease: !!(afterRelease[idB] && !afterRelease[idB].released),
+  aReleased: !!(afterRelease[idA] && afterRelease[idA].released),
 }}));
 """
     out = _run(script)
     assert out["bothClaimed"], "a concurrent tab's claim must not be clobbered"
     assert out["bothSeen"], "a concurrent tab's seen entry must not be clobbered"
     assert out["bSurvivedRelease"], "releasing one tab must not drop another's claim"
-    assert out["aReleased"], "the releasing tab's own claim must be removed"
+    assert out["aReleased"], (
+        "the releasing tab's record must be marked released (kept for reload "
+        "re-claim, never silently dropped)"
+    )
 
 
 def test_remembered_session_returns_null_when_empty():
@@ -369,3 +381,321 @@ useTab(makeTab());
 console.log(JSON.stringify({{value: _rememberedActiveSession()}}));
 """
     assert _run(script)["value"] is None
+
+
+# ── Adversarial re-gate regressions (maintainer CHANGES_REQUESTED 2026-08-17) ──
+# Each test below EXECUTES the real helpers under the exact race/upgrade
+# condition the maintainer reproduced against head 590debcf. They fail on the
+# timer-based design and pass only with authoritative ownership.
+
+
+def test_duplicated_tab_never_reuses_id_after_heartbeat_gap():
+    """Must-fix 1 (ui.js:9298): with timeout-based leases, advancing the clock
+    past one 45-second lease made the original tab's claim look expired, so a
+    duplicated tab (copied sessionStorage) kept the original's id and writing
+    session B in the clone made the ORIGINAL tab restore B. A missed heartbeat
+    must never make an id reusable: ownership is a per-context nonce record,
+    and only explicit release frees the id."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const original = makeTab();
+useTab(original);
+const idOriginal = _hermesTabId();
+_rememberActiveSession('session-A');
+// Duplicate the tab: sessionStorage is COPIED verbatim; the window is not.
+const clone = makeTab();
+for (const k of original.store._keys()) clone.store.setItem(k, original.store.getItem(k));
+// The original misses several heartbeats (laptop lid closed, tab throttled).
+__now += 46_000;
+useTab(clone);
+const idClone = _hermesTabId();
+_rememberActiveSession('session-B');
+// Even a WEEK of missed heartbeats must not surrender the id.
+__now += 7 * 24 * 60 * 60 * 1000;
+const late = makeTab();
+for (const k of original.store._keys()) late.store.setItem(k, original.store.getItem(k));
+useTab(late);
+const idLate = _hermesTabId();
+useTab(original);
+const restoredByOriginal = _rememberedActiveSession();
+const idOriginalAfter = _hermesTabId();
+console.log(JSON.stringify({{idOriginal, idClone, idLate, restoredByOriginal, idOriginalAfter}}));
+"""
+    out = _run(script)
+    assert out["idClone"] != out["idOriginal"], (
+        "a duplicated tab must NOT reuse the original's id after a heartbeat gap"
+    )
+    assert out["idLate"] != out["idOriginal"], (
+        "no amount of elapsed time may make a claimed (unreleased) id reusable"
+    )
+    assert out["restoredByOriginal"] == "session-A", (
+        "the clone writing session B must not change what the original restores"
+    )
+    assert out["idOriginalAfter"] == out["idOriginal"], (
+        "revalidation must keep the original tab's identity stable"
+    )
+
+
+def test_gc_does_not_collect_live_tab_after_seen_ttl():
+    """Must-fix 2a (ui.js:9330): a live tab whose 'seen' stamp aged past the
+    24-hour TTL used to have its scoped keys garbage-collected by the next
+    booting tab. Liveness is now authoritative: an unreleased ownership record
+    protects the keys no matter how much time elapsed."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const longLived = makeTab();
+useTab(longLived);
+const id = _hermesTabId();
+_rememberActiveSession('session-precious');
+localStorage.setItem(_inflightStateKey(), JSON.stringify({{'session-precious':{{streamId:'s1'}}}}));
+// 25 hours pass with no heartbeat (suspended machine). The tab is still open.
+__now += 25 * 60 * 60 * 1000;
+// A brand-new tab boots and runs the GC pass.
+useTab(makeTab());
+_hermesTabId();
+useTab(longLived);
+const scopedSession = localStorage.getItem(_activeSessionKey());
+const scopedInflight = localStorage.getItem(_inflightStateKey());
+console.log(JSON.stringify({{scopedSession, scopedInflightKept: scopedInflight!=null}}));
+"""
+    out = _run(script)
+    assert out["scopedSession"] == "session-precious", (
+        "GC must never collect a claimed (unreleased) tab's keys on elapsed time alone"
+    )
+    assert out["scopedInflightKept"], "the live tab's inflight snapshot must survive GC"
+
+
+def test_gc_is_disabled_fail_safe_on_malformed_registry_json():
+    """Must-fix 2b (ui.js:9330): malformed registry JSON used to parse to {} and
+    be read as 'no tab was ever seen', so the very next GC pass deleted every
+    live tab's keys. Parse failure must DISABLE GC entirely (fail safe)."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tab = makeTab();
+useTab(tab);
+const id = _hermesTabId();
+_rememberActiveSession('session-live');
+// Corrupt BOTH registries (extension writers, quota-truncated writes...).
+localStorage.setItem(TAB_ID_CLAIM_KEY, '{{not json');
+localStorage.setItem(TAB_ID_SEEN_KEY, '{{not json');
+_gcOrphanTabKeys();
+const keptAfterClaimsCorruption = localStorage.getItem(_activeSessionKey());
+// Repair claims but leave 'seen' corrupt: still fail safe (legacy keys with
+// no ownership record would otherwise be judged by garbage data).
+localStorage.removeItem(TAB_ID_CLAIM_KEY);
+_claimTabId(id);
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY + '::unrecorded', 'legacy-key');
+_gcOrphanTabKeys();
+const keptLegacy = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY + '::unrecorded');
+console.log(JSON.stringify({{
+  keptAfterClaimsCorruption,
+  keptLegacy,
+  scopedStillThere: localStorage.getItem(_activeSessionKey()),
+}}));
+"""
+    out = _run(script)
+    assert out["keptAfterClaimsCorruption"] == "session-live", (
+        "malformed claim-registry JSON must disable GC, not unleash it"
+    )
+    assert out["keptLegacy"] == "legacy-key", (
+        "malformed seen-registry JSON must also disable GC for unrecorded keys"
+    )
+    assert out["scopedStillThere"] == "session-live"
+
+
+def test_forgotten_tab_does_not_resurrect_another_tabs_legacy_session():
+    """Must-fix 3a (ui.js:9441): after tab A forgot its session, the legacy
+    fallback (kept fresh by tab B) used to bleed back into tab A's reads. The
+    per-tab 'no session' tombstone pins the forgotten state."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+const tabA = makeTab();
+const tabB = makeTab();
+useTab(tabA); _rememberActiveSession('session-A');
+useTab(tabB); _rememberActiveSession('session-B');   // legacy slot now = B
+useTab(tabA); _forgetActiveSession();
+const afterForget = _rememberedActiveSession();
+// Tab B keeps refreshing the shared slot; tab A must STAY forgotten.
+useTab(tabB); _rememberActiveSession('session-B');
+useTab(tabA); const afterRewrite = _rememberedActiveSession();
+// Opening a new conversation lifts the tombstone.
+_rememberActiveSession('session-C');
+const afterReopen = _rememberedActiveSession();
+console.log(JSON.stringify({{afterForget, afterRewrite, afterReopen}}));
+"""
+    out = _run(script)
+    assert out["afterForget"] is None, (
+        "a forgotten tab must not restore another tab's legacy session"
+    )
+    assert out["afterRewrite"] is None, (
+        "the tombstone must hold even while another tab rewrites the legacy slot"
+    )
+    assert out["afterReopen"] == "session-C", (
+        "remembering a new session must supersede the tombstone"
+    )
+
+
+def test_forget_clears_expected_legacy_only_sid_on_upgrade():
+    """Must-fix 3b (ui.js:9441): a legacy-only dead session (written by the
+    pre-upgrade build, so no scoped value exists) used to survive
+    _forgetActiveSession(), defeating the 404/profile-switch self-heal. The
+    caller now names the dead sid explicitly and a matching legacy value is
+    cleared even without scoped state."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+// Pre-upgrade storage: only the unsuffixed key exists.
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'dead-session');
+const tab = makeTab();
+useTab(tab);
+_forgetActiveSession('dead-session');           // 404 self-heal names the sid
+const legacyAfterHeal = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+// A mismatching expected sid must NOT clear someone else's fallback.
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'other-tabs-session');
+useTab(makeTab());
+_forgetActiveSession('a-different-dead-sid');
+const legacyAfterMismatch = localStorage.getItem(ACTIVE_SESSION_KEY_LEGACY);
+console.log(JSON.stringify({{legacyAfterHeal, legacyAfterMismatch}}));
+"""
+    out = _run(script)
+    assert out["legacyAfterHeal"] is None, (
+        "forget must clear a matching legacy-only sid so a dead session cannot "
+        "survive the 404 self-heal on upgrade"
+    )
+    assert out["legacyAfterMismatch"] == "other-tabs-session", (
+        "a non-matching expected sid must leave the shared fallback alone"
+    )
+
+
+def test_legacy_session_is_adopted_once_into_scoped_storage():
+    """Must-fix 3 (adoption): the first legacy read is copied into the tab's
+    scoped slot, so later changes to the shared slot by other tabs can no
+    longer change what THIS tab restores."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'upgraded-session');
+const tab = makeTab();
+useTab(tab);
+const first = _rememberedActiveSession();       // adopts into scoped storage
+const scoped = localStorage.getItem(_activeSessionKey());
+// Another tab moves the shared slot; this tab's restore must not follow.
+localStorage.setItem(ACTIVE_SESSION_KEY_LEGACY, 'other-session');
+const second = _rememberedActiveSession();
+console.log(JSON.stringify({{first, scoped, second}}));
+"""
+    out = _run(script)
+    assert out["first"] == "upgraded-session"
+    assert out["scoped"] == "upgraded-session", (
+        "the legacy value must be adopted into the tab's scoped key on first read"
+    )
+    assert out["second"] == "upgraded-session", (
+        "after adoption, the shared slot must no longer steer this tab"
+    )
+
+
+def test_upgrade_migrates_populated_legacy_inflight_under_new_tab_stamp():
+    """Must-fix 4 (ui.js:9498): both inflight readers use suffixed keys
+    exclusively, so a populated pre-upgrade `hermes-webui-inflight` /
+    `hermes-webui-inflight-state` produced empty scoped reads and mid-stream
+    recovery was lost on upgrade. A valid legacy payload must be migrated once
+    under the adopting tab's stamp, then the legacy entries removed."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+// Pre-upgrade mid-stream state, written by the old build minutes ago.
+localStorage.setItem(INFLIGHT_KEY_BASE, JSON.stringify({{sid:'sess-1', streamId:'stream-1', ts:__now-60_000}}));
+localStorage.setItem(INFLIGHT_STATE_KEY_BASE, JSON.stringify({{
+  'sess-1': {{streamId:'stream-1', messages:[{{role:'user',content:'hi'}}], updated_at:__now-60_000}},
+}}));
+const tab = makeTab();
+useTab(tab);
+const restored = loadInflightState('sess-1', 'stream-1');
+const marker = JSON.parse(localStorage.getItem(_inflightKey()) || 'null');
+const legacyMarkerGone = localStorage.getItem(INFLIGHT_KEY_BASE) === null;
+const legacyStateGone = localStorage.getItem(INFLIGHT_STATE_KEY_BASE) === null;
+console.log(JSON.stringify({{
+  restoredStream: restored && restored.streamId,
+  restoredTab: restored && restored.tabId,
+  tabId: _hermesTabId(),
+  markerSid: marker && marker.sid,
+  legacyMarkerGone, legacyStateGone,
+}}));
+"""
+    out = _run(script)
+    assert out["restoredStream"] == "stream-1", (
+        "a populated legacy inflight-state map must be readable after upgrade"
+    )
+    assert out["restoredTab"] == out["tabId"], (
+        "migrated entries must be re-stamped under the adopting tab's id"
+    )
+    assert out["markerSid"] == "sess-1", (
+        "the legacy reconnect marker must be migrated under the scoped key"
+    )
+    assert out["legacyMarkerGone"] and out["legacyStateGone"], (
+        "legacy entries must be removed after the one-shot migration"
+    )
+
+
+def test_stale_or_malformed_legacy_inflight_is_invalidated_not_migrated():
+    """Must-fix 4 (validation): the legacy payload is validated (shape + age)
+    before adoption; stale/corrupt entries are removed without migrating, and
+    existing scoped state is never overwritten."""
+    script = f"""
+{_HARNESS}
+{_helpers()}
+// Stale marker (2 hours old) + corrupt state map.
+localStorage.setItem(INFLIGHT_KEY_BASE, JSON.stringify({{sid:'old-sess', streamId:'old-stream', ts:__now-2*60*60*1000}}));
+localStorage.setItem(INFLIGHT_STATE_KEY_BASE, 'not json at all');
+const tab = makeTab();
+useTab(tab);
+_migrateLegacyInflight();
+const scopedMarker = localStorage.getItem(_inflightKey());
+const scopedState = localStorage.getItem(_inflightStateKey());
+const legacyGone = localStorage.getItem(INFLIGHT_KEY_BASE) === null
+  && localStorage.getItem(INFLIGHT_STATE_KEY_BASE) === null;
+// Second scenario: a tab that already HAS scoped state keeps it.
+const tab2 = makeTab();
+useTab(tab2);
+localStorage.setItem(INFLIGHT_KEY_BASE, JSON.stringify({{sid:'legacy-sess', streamId:'legacy-stream', ts:__now-1000}}));
+localStorage.setItem(_inflightKey(), JSON.stringify({{sid:'own-sess', streamId:'own-stream', ts:__now-500}}));
+_migrateLegacyInflight();
+const kept = JSON.parse(localStorage.getItem(_inflightKey()));
+console.log(JSON.stringify({{
+  scopedMarker, scopedState, legacyGone,
+  keptSid: kept && kept.sid,
+  legacyGone2: localStorage.getItem(INFLIGHT_KEY_BASE) === null,
+}}));
+"""
+    out = _run(script)
+    assert out["scopedMarker"] is None, "a stale legacy marker must not be migrated"
+    assert out["scopedState"] is None, "a corrupt legacy state map must not be migrated"
+    assert out["legacyGone"], "invalid legacy entries must still be invalidated (removed)"
+    assert out["keptSid"] == "own-sess", (
+        "migration must never overwrite a tab's existing scoped marker"
+    )
+    assert out["legacyGone2"], "the legacy slot is consumed exactly once either way"
+
+
+def test_inflight_readers_run_the_migration_before_scoped_reads():
+    """Wiring: both readers (the boot marker check and the state-map read) must
+    invoke the one-shot migration BEFORE their scoped read, or a populated
+    legacy payload stays invisible exactly as the re-gate reproduced."""
+    check_body = _function_body(UI_SRC, "async function checkInflightOnBoot")
+    assert "_migrateLegacyInflight()" in check_body, (
+        "checkInflightOnBoot must migrate legacy inflight before reading"
+    )
+    assert check_body.index("_migrateLegacyInflight()") < check_body.index(
+        "localStorage.getItem(_inflightKey())"
+    ), "migration must precede the scoped marker read"
+    read_body = _function_body(UI_SRC, "function _readInflightStateMap")
+    assert "_migrateLegacyInflight()" in read_body, (
+        "_readInflightStateMap must migrate legacy inflight before reading"
+    )
+    assert read_body.index("_migrateLegacyInflight()") < read_body.index(
+        "localStorage.getItem(_inflightStateKey())"
+    ), "migration must precede the scoped state read"

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -73,7 +73,7 @@ def test_pwa_new_chat_launch_does_not_block_first_paint_on_model_catalog():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
     launch_marker = "if(_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)){"
     assert launch_marker in boot_js
-    launch_branch = boot_js[boot_js.index(launch_marker) : boot_js.index("const savedLocal=localStorage.getItem", boot_js.index(launch_marker))]
+    launch_branch = boot_js[boot_js.index(launch_marker) : boot_js.index("const savedLocal=", boot_js.index(launch_marker))]
     assert "await newSession(true);" in launch_branch
     assert "await _startBootModelDropdown();" not in launch_branch
     assert "Promise.resolve(_startBootModelDropdown()).catch(()=>{})" in launch_branch

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1198,7 +1198,10 @@ def test_reload_recovery_persists_durable_inflight_state(cleanup_test_sessions):
     messages_src = (REPO_ROOT / "static/messages.js").read_text()
     sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
 
-    assert "const INFLIGHT_STATE_KEY = 'hermes-webui-inflight-state'" in ui_src
+    # The inflight snapshot key is now tab-scoped (multi-tab isolation): the
+    # base name is still the same, with a per-tab suffix appended at runtime.
+    assert "const INFLIGHT_STATE_KEY_BASE = 'hermes-webui-inflight-state'" in ui_src
+    assert "function _inflightStateKey()" in ui_src
     assert "function saveInflightState(sid, state)" in ui_src
     assert "function loadInflightState(sid, streamId)" in ui_src
     assert "function clearInflightState(sid)" in ui_src

--- a/tests/test_session_action_menu_regression.py
+++ b/tests/test_session_action_menu_regression.py
@@ -50,8 +50,8 @@ def test_archive_action_clears_saved_session_pointer_for_archived_current_sessio
     """Archiving the saved active session should not leave boot localStorage stale."""
     helper_body = _function_block(SESSIONS_JS, "_archiveSession")
     stale_saved_pointer_guard = (
-        "try{ if(archived&&session.session_id&&localStorage.getItem('hermes-webui-session')===session.session_id) "
-        "localStorage.removeItem('hermes-webui-session'); }catch(_){ }"
+        "try{ if(archived&&session.session_id&&_rememberedActiveSession()===session.session_id) "
+        "_forgetActiveSession(); }catch(_){ }"
     )
 
     assert stale_saved_pointer_guard in helper_body

--- a/tests/test_session_cross_tab_sync.py
+++ b/tests/test_session_cross_tab_sync.py
@@ -41,7 +41,7 @@ def test_session_switch_updates_url_path_for_tab_local_anchor():
 
 def test_boot_prefers_url_session_over_local_storage_session():
     assert "const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;" in BOOT_JS
-    assert "const savedLocal=localStorage.getItem('hermes-webui-session');" in BOOT_JS
+    assert "const savedLocal=_rememberedActiveSession();" in BOOT_JS
     assert "const saved=urlSession||savedLocal;" in BOOT_JS
     assert "const savedSidebarOnlyState=(!urlSession&&savedLocal)" in BOOT_JS
     assert "? await _savedSessionSidebarOnlyState(savedLocal)" in BOOT_JS

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -31,6 +31,6 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     settled_block = MESSAGES_JS[settled_pos : settled_pos + 1800]
 
     for block in (completion_block, settled_block):
-        assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block
+        assert "_rememberActiveSession(S.session.session_id);" in block
         assert "_setActiveSessionUrl(S.session.session_id)" in block
         assert "typeof _setActiveSessionUrl==='function'" in block

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -260,6 +260,7 @@ function _markSessionCompletionUnread(sid, count) {{
 }}
 const document = {{ visibilityState: 'visible', hasFocus: () => true }};
 let _loadingSessionId = null;
+let _messagesOwnerSid = null;
 const _allSessionsScope = null;
 const _sessionListSourceById = new Map();
 {get_counts}
@@ -348,6 +349,7 @@ let _msgLimitMax = _MSG_LIMIT_MAX;
 let _pendingCarryForwardSnapshot = null;
 let _loadingSessionId = 'open';
 let _loadSessionGeneration = 0;
+let _messagesOwnerSid = null;
 const window = {{}};
 // Tab starts VISIBLE+FOCUSED: the load begins while the user is watching.
 let _visibility = 'visible';

--- a/tests/test_stale_empty_session_restore.py
+++ b/tests/test_stale_empty_session_restore.py
@@ -94,7 +94,7 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     """A missing saved session should be removed and let boot show the empty state."""
     block = _load_session_error_block()
     assert "e.status===404" in block, "loadSession must keep a 404-specific branch"
-    assert "_forgetActiveSession()" in block, (
+    assert "_forgetActiveSession(sid)" in block, (
         "loadSession must clear stale saved session IDs on 404"
     )
     assert "history.replaceState" in block, (
@@ -126,7 +126,7 @@ def test_load_session_404_self_heal_gated_to_active_or_boot():
         "self-heal must be gated to boot or the active session, not unconditional"
     )
     heal_idx = arm.find(self_heal)
-    clear_idx = arm.find("_forgetActiveSession()")
+    clear_idx = arm.find("_forgetActiveSession(sid)")
     strip_idx = arm.find("history.replaceState")
     assert clear_idx > heal_idx, "localStorage clear must run inside the self-heal gate"
     assert strip_idx > heal_idx, "URL strip must run inside the self-heal gate"
@@ -146,7 +146,7 @@ def test_send_chat_start_404_self_heals_instead_of_error_bubble():
     assert "e.status===404" in block, (
         "send() must branch on a 404 from /api/chat/start before the generic path"
     )
-    assert "_forgetActiveSession()" in block, (
+    assert "_forgetActiveSession(activeSid)" in block, (
         "send() 404 branch must clear the saved session key"
     )
     assert "history.replaceState" in block, (

--- a/tests/test_stale_empty_session_restore.py
+++ b/tests/test_stale_empty_session_restore.py
@@ -94,7 +94,7 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     """A missing saved session should be removed and let boot show the empty state."""
     block = _load_session_error_block()
     assert "e.status===404" in block, "loadSession must keep a 404-specific branch"
-    assert "localStorage.removeItem('hermes-webui-session')" in block, (
+    assert "_forgetActiveSession()" in block, (
         "loadSession must clear stale saved session IDs on 404"
     )
     assert "history.replaceState" in block, (
@@ -126,7 +126,7 @@ def test_load_session_404_self_heal_gated_to_active_or_boot():
         "self-heal must be gated to boot or the active session, not unconditional"
     )
     heal_idx = arm.find(self_heal)
-    clear_idx = arm.find("localStorage.removeItem('hermes-webui-session')")
+    clear_idx = arm.find("_forgetActiveSession()")
     strip_idx = arm.find("history.replaceState")
     assert clear_idx > heal_idx, "localStorage clear must run inside the self-heal gate"
     assert strip_idx > heal_idx, "URL strip must run inside the self-heal gate"
@@ -146,7 +146,7 @@ def test_send_chat_start_404_self_heals_instead_of_error_bubble():
     assert "e.status===404" in block, (
         "send() must branch on a 404 from /api/chat/start before the generic path"
     )
-    assert "localStorage.removeItem('hermes-webui-session')" in block, (
+    assert "_forgetActiveSession()" in block, (
         "send() 404 branch must clear the saved session key"
     )
     assert "history.replaceState" in block, (

--- a/tests/test_tool_call_history_paging.py
+++ b/tests/test_tool_call_history_paging.py
@@ -15,8 +15,17 @@ def test_sessions_js_resyncs_tool_calls_after_history_window_replacement():
     """
     assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls)" in SESSIONS_JS
     assert "_syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);" in SESSIONS_JS
-    assert "S.messages = nextMessages;\n    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);" in SESSIONS_JS
-    assert "S.messages = _msgsToAssign;\n    _messagesTruncated = false;\n    _oldestIdx = 0;\n    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);" in SESSIONS_JS
+    assert (
+        "S.messages = nextMessages;\n"
+        "    if(S.session&&S.session.session_id) _messagesOwnerSid = S.session.session_id;\n"
+        "    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);"
+    ) in SESSIONS_JS
+    assert (
+        "S.messages = _msgsToAssign;\n"
+        "    if(S.session&&S.session.session_id) _messagesOwnerSid = S.session.session_id;\n"
+        "    _messagesTruncated = false;\n    _oldestIdx = 0;\n"
+        "    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);"
+    ) in SESSIONS_JS
 
 
 def test_sessions_js_clears_session_tool_calls_when_messages_have_own_metadata():

--- a/tests/test_workspace_files_persist_on_empty_reload.py
+++ b/tests/test_workspace_files_persist_on_empty_reload.py
@@ -28,7 +28,7 @@ BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
 
 def test_ephemeral_guard_does_not_remove_session_localstorage_key():
     """The empty-session guard block must NOT call
-    localStorage.removeItem('hermes-webui-session') — that's exactly what
+    _forgetActiveSession() — that's exactly what
     breaks the second refresh."""
     # Find the guard block (message_count===0 check)
     guard_idx = BOOT_JS.find("(S.session.message_count||0) === 0")


### PR DESCRIPTION
## Thinking Path

- Three ownerless `localStorage` keys made the last same-origin tab to write determine every tab's active conversation, reconnect marker, and in-flight transcript snapshot.
- A storage owner must be unique to one JavaScript document before any scoped read or write; a copied `sessionStorage` identifier cannot provide that authority.
- Reload recovery still needs continuity, so recoverable values are mirrored in that browsing context's `sessionStorage` and re-stamped under the next document's fresh identity.
- Pre-upgrade unsuffixed in-flight data has no attributable document owner. New code therefore quarantines it instead of guessing an owner and risking cross-tab recovery.

## What Changed

- Mint a fresh cryptographic ID for every JavaScript document and never adopt an ID copied by Duplicate Tab or session restore.
- Scope active-session, reconnect-marker, and in-flight-state keys as `<base>::<documentId>`.
- Mirror this document's recoverable state in its `sessionStorage`; on reload, restore and re-stamp it under the fresh document ID before scoped access.
- Record one release marker per document on non-BFCache `pagehide`; garbage collection removes only state with valid explicit release evidence older than 24 hours. Missing or malformed evidence retains state.
- Adopt the legacy active-session fallback once into document-scoped state. A document-local tombstone prevents another tab's later legacy writes from resurrecting a forgotten session, while forgetting never deletes the ownerless fallback needed by new or older clients.
- Stamp in-flight snapshots with the document ID and reject absent or foreign ownership. Unsuffixed legacy in-flight entries are neither adopted nor deleted by upgraded documents.
- Track `_messagesOwnerSid` so `_ensureMessagesLoaded()` only reuses `S.messages` when that transcript belongs to the requested session.

## Why It Matters

With multiple conversations open, reloading or reconnecting one tab can no longer restore another tab's conversation, attach to another tab's stream marker, or merge another tab's in-flight transcript. Session switching also cannot keep rendering a transcript owned by the previously viewed session.

## Contract Routing

- **Task type:** browser session-routing and recovery-cache bug fix.
- **Touched areas:** `static/ui.js`, session boot/load/send call sites, and behavioral regressions.
- **Relevant public docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/canonical-session-resolution.md`, and `docs/rfcs/webui-run-state-consistency-contract.md`.
- **State layers:** browser active-session pointer and in-flight recovery cache/projection. Durable session data and server stream state remain authoritative.
- **Invariant:** a document reads or writes only recovery state stamped for its own fresh identity; unverifiable ownerless state fails closed.
- **Scope boundaries:** no backend, API, durable-session schema, dependency, or visible layout change. Public docs do not require a behavior-contract change; this description records the recovery semantics.

## Verification

Candidate: `171e2453dfc6c69b3f974bc2267f146c15732fbd`, directly based on `origin/master` at `e168b67e4278df618d1cab61fdb3a8dc55b29a81` (the final rebase was a no-op).

- `./scripts/test.sh -q tests/test_multi_tab_session_isolation.py` — **24 passed**.
- All 19 changed/adjacent test files — **182 passed, 1 skipped**; the skip is the runner's reported agent-dependent test because hermes-agent is unavailable in the isolated checkout.
- `ruff_lint --diff` — no new violations on changed lines.
- `node --check` — all five changed JavaScript modules parse successfully.
- GitHub checks on the exact candidate — **22/22 successful**, including Python 3.11/3.12/3.13 shards, lint, browser smoke, and conversation-lifecycle rows.
- `git diff --check` — clean.

The 24 behavioral probes execute the real helpers in Node against two simulated same-origin documents with shared `localStorage` and separate `sessionStorage`/`window` objects. They cover distinct identities, simultaneous copied-ID startup, duplicate tabs after long suspension, reload re-stamping, per-tab active/in-flight state, foreign snapshot rejection, explicit-release garbage collection, malformed/missing release evidence, legacy active-session adoption/tombstones, ownerless fallback preservation, and ownerless legacy in-flight quarantine.

## Risks / Follow-ups

- Ownerless pre-upgrade in-flight entries are intentionally preserved but not migrated by upgraded documents: shape, SID, stream ID, and age do not prove which tab owns them. This favors isolation over a potentially cross-tab recovery.
- Garbage collection is deliberately fail-safe: only a valid non-BFCache release marker authorizes deletion. State left by a crash without `pagehide` is retained rather than risking deletion of a frozen/live tab; existing quota-recovery paths remain covered by adjacent tests.
- No visual change was made, so before/after screenshots are not applicable. Browser smoke is green; the multi-tab state machine is covered by the execution-level helper harness rather than a manual browser session in this final pass.

## Release Note

Fixed same-origin multi-tab session contamination so each browser document restores only its own conversation, reconnect marker, and in-flight transcript state.

## Model Used

- Final verification, rebase fence, and publication: OpenAI Codex `gpt-5.6-sol`, using Git/GitHub CLI, pytest, Node, and Ruff.
- Earlier implementation was AI-assisted; the exact prior model was not re-established during this final verification pass.