### PR TITLE
fix(approval): match the notified gateway-copy to its producer by request_id (#4948 local variant)

### DIFF
--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -439,6 +439,29 @@ def submit_gateway_pending_mirror(session_key: str, approval: dict) -> tuple[dic
                 ),
                 None,
             )
+        if exact_local_entry is None and not run_id:
+            # Fall back to matching on the core's per-approval `request_id`.
+            # The gateway core notifies WebUI with a COPY of the entry payload
+            # (`notify_cb(dict(entry.data))`), so the identity match above
+            # (`entry.data is approval`) never holds for a real gateway head,
+            # and a local `_ApprovalEntry` carries a `request_id` but no
+            # `approval_id`, so the approval_id fallback misses too. The
+            # `request_id` is stamped once on the source entry
+            # (`_ApprovalEntry.__init__` -> `data.setdefault("request_id", ...)`)
+            # and preserved through the copy, so it uniquely reunites the
+            # notified copy with its queued entry. Without this, the mirror is
+            # created with no token, reconcile keeps the orphan, and
+            # `_session_has_pending_approval` stays True after the entry is
+            # dropped (the stale-approval-card dead-end, #4948 local variant).
+            request_id = str(approval.get("request_id") or "").strip()
+            if request_id:
+                exact_local_entry = next(
+                    (
+                        entry for entry in live_gateway_queue
+                        if str(((getattr(entry, "data", None) or {}).get("request_id") or "")).strip() == request_id
+                    ),
+                    None,
+                )
         if exact_local_entry is not None:
             mirror_entries = _normalize_pending_queue_locked(session_key)
             entries_to_mirror = [live_gateway_queue[0]] if live_gateway_queue else []

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -418,13 +418,20 @@ class TestApprovalHTTPEndpoints:
         with _lock:
             r._pending.pop(sid, None)
             r._gateway_queues.pop(sid, None)
-            r._gateway_queues[sid] = [_ApprovalEntry(approval_a)]
+            entry_a = _ApprovalEntry(approval_a)
+            r._gateway_queues[sid] = [entry_a]
         try:
-            ra.submit_gateway_pending_mirror(sid, approval_a)
+            # Production notifies WebUI with a COPY of the entry payload
+            # (core: notify_cb(dict(entry.data))), which carries the entry's
+            # stamped request_id — pass that faithful copy, not the pre-stamp
+            # source dict, so the mirror matches its producer the way it does
+            # in production.
+            ra.submit_gateway_pending_mirror(sid, dict(entry_a.data))
             with _lock:
                 r._gateway_queues.pop(sid, None)
-                r._gateway_queues[sid] = [_ApprovalEntry(approval_b)]
-            ra.submit_gateway_pending_mirror(sid, approval_b)
+                entry_b = _ApprovalEntry(approval_b)
+                r._gateway_queues[sid] = [entry_b]
+            ra.submit_gateway_pending_mirror(sid, dict(entry_b.data))
 
             parsed = urllib.parse.urlparse(f"/api/approval/pending?session_id={urllib.parse.quote(sid)}")
             r._handle_approval_pending(object(), parsed)
@@ -507,7 +514,8 @@ class TestApprovalHTTPEndpoints:
             r._pending.pop(sid, None)
             r._gateway_queues[sid] = [entry_a]
         try:
-            ra.submit_gateway_pending_mirror(sid, approval_a)
+            # Faithful to production: submit the stamped copy (see note above).
+            ra.submit_gateway_pending_mirror(sid, dict(entry_a.data))
             with _lock:
                 mirror_aid_a = r._pending[sid][0]["approval_id"]
 
@@ -516,7 +524,7 @@ class TestApprovalHTTPEndpoints:
             entry_b = _ApprovalEntry(approval_b)
             with _lock:
                 r._gateway_queues[sid] = [entry_b]
-            ra.submit_gateway_pending_mirror(sid, approval_b)
+            ra.submit_gateway_pending_mirror(sid, dict(entry_b.data))
 
             resolved = r._resolve_approval_legacy(sid, mirror_aid_a, "once")
             assert resolved is False, "stale approval_id must not resolve live B"
@@ -617,7 +625,8 @@ class TestApprovalHTTPEndpoints:
             r._pending.pop(sid, None)
             r._gateway_queues[sid] = [entry, sibling_entry]
         try:
-            ra.submit_gateway_pending_mirror(sid, approval)
+            # Faithful to production: submit the stamped copy (see note above).
+            ra.submit_gateway_pending_mirror(sid, dict(entry.data))
             with _lock:
                 approval_id = r._pending[sid][0]["approval_id"]
 
@@ -728,8 +737,9 @@ class TestApprovalHTTPEndpoints:
             r._pending.pop(sid, None)
             r._gateway_queues[sid] = [entry_a, entry_b]
         try:
-            ra.submit_gateway_pending_mirror(sid, approval_a)
-            ra.submit_gateway_pending_mirror(sid, approval_b)
+            # Faithful to production: submit the stamped copies (see note above).
+            ra.submit_gateway_pending_mirror(sid, dict(entry_a.data))
+            ra.submit_gateway_pending_mirror(sid, dict(entry_b.data))
             with _lock:
                 approval_b_id = next(
                     item["approval_id"] for item in r._pending[sid]


### PR DESCRIPTION
## Fix approval-mirror producer match on the gateway-copy notify boundary

### The bug (real, but invisible to CI)
`submit_gateway_pending_mirror()` matches an incoming approval back to its queued producer entry by (1) object identity (`entry.data is approval`) then (2) `approval_id`. On the **local backend** neither holds:

- The installed hermes-agent core delivers the approval to WebUI's notify callback as a **copy** — `notify_cb(dict(entry.data))` (core `tools/approval.py`) — so the identity match never holds for a real gateway head.
- A local `_ApprovalEntry` stamps a `request_id` but **no `approval_id`** (`_ApprovalEntry.__init__` → `data.setdefault("request_id", uuid…)`), so the `approval_id` fallback misses too.

With both misses, the mirror is created **without a token** → `reconcile_gateway_pending_mirror_locked` keeps the orphan → `_session_has_pending_approval` stays `True` after the entry is dropped. User symptom: a stale approval card dead-ends with "Approval response not accepted." and a stuck card (**#4948 local variant**).

This class is **invisible on GitHub CI** because CI never installs the agent core, so `from tools.approval import …` raises ImportError and both approval test files `skipif`-skip entirely. Their green there never exercised these paths — on a box **with** the core installed, all 8 tests fail on master.

### The fix
`api/route_approvals.py` (+23 production lines): add a third fallback after identity + approval_id, gated on the local `not run_id` path, matching on the core's per-approval `request_id` — stamped once on the source entry and preserved through the copy, so it uniquely reunites the notified copy with its queued entry. Non-empty-request_id guarded; scoped to this session's locked gateway queue.

`tests/test_approval_unblock.py` (4 tests): these were **unfaithful to production** — they built `_ApprovalEntry(approval)` (stamping request_id onto a copy in `entry.data`, not the source) then submitted the pre-stamp `approval`. They now submit `dict(entry.data)`, matching what the core actually passes. **Assertions unchanged** — only payload fidelity. (The 4 tests in `test_issue4948_local_stale_approval.py` already simulated the copy faithfully and pass on the production fix alone.)

### Verification
- **Codex regression gate: SAFE TO SHIP** — fallback correctly scoped, gateway `run_id` path unchanged, cross-session collision + reverse-callback-ordering probes pass.
- All 8 previously-failing approval tests now pass; full suite green except one unrelated `test_static_asset_resolver` cross-file isolation flake (passes in isolation; documented shard-sensitivity, no relation to this change).
- **Non-vacuous proof:** with the fidelity-fixed tests but the production change reverted, the 8 tests **fail** — they detect the real regression, they don't pass vacuously.

### ⚠️ Independent review
Self-built (nesquena-hermes) fix on the approval path — requesting an independent review from the nesquena account before merge.

🤖 Authored by the release-manager agent.