### PR TITLE
fix(server): terminate daemon process on /api/shutdown (#7078)

### DIFF
--- a/server.py
+++ b/server.py
@@ -544,6 +544,48 @@ def _abort_if_already_serving(host: str, port: int) -> None:
         pass
 
 
+def _install_shutdown_signal_handlers(httpd, shutdown_requested) -> None:
+    """Route SIGTERM/SIGINT to an orderly serve_forever() shutdown.
+
+    ctl.sh stops the WebUI with SIGTERM. Python's default SIGTERM handler
+    terminates the process WITHOUT unwinding the try/finally around
+    serve_forever(), so drain_all_on_shutdown() (which flushes in-flight
+    fire-and-forget memory commits) would never run on the normal managed
+    stop. Install a handler that requests an orderly shutdown so
+    serve_forever() returns and the existing `finally` block drains cleanly.
+
+    SIGINT is registered for the same path: ctl.sh spawns the daemon from a
+    non-interactive bash background job, which leaves the child with
+    SIGINT = SIG_IGN (bash: "asynchronous commands ignore SIGINT and SIGQUIT
+    in addition to SIGHUP"). The Settings "Stop server" button (POST
+    /api/shutdown) signals the process with SIGINT, which would otherwise be
+    a silent OS-level no-op. Explicitly installing the handler overrides the
+    inherited ignore disposition, so the button, external `kill -INT`, and
+    foreground Ctrl-C all take the same graceful path.
+
+    httpd.shutdown() blocks until serve_forever() has exited and MUST NOT be
+    called from the thread running serve_forever() (it would deadlock), so we
+    dispatch it from a short-lived helper thread. The handler is idempotent
+    and guards against double-shutdown (e.g. repeated SIGTERM/SIGINT).
+    """
+    def _request_shutdown(signum, _frame):
+        if shutdown_requested.is_set():
+            return
+        shutdown_requested.set()
+        threading.Thread(
+            target=httpd.shutdown,
+            name="webui-sigterm-shutdown",
+            daemon=True,
+        ).start()
+
+    for _sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(_sig, _request_shutdown)
+        except (ValueError, OSError):
+            # Not on the main thread (e.g. embedded/test harness); skip handler.
+            logger.debug("Could not install %s handler", _sig, exc_info=True)
+
+
 def main() -> None:
     from api.config import print_startup_config, verify_hermes_imports, _HERMES_FOUND
 
@@ -691,34 +733,8 @@ def main() -> None:
     print(f'  Then open:     {scheme}://localhost:{PORT}', flush=True)
     print('', flush=True)
 
-    # ctl.sh stops the WebUI with SIGTERM. Python's default SIGTERM handler
-    # terminates the process WITHOUT unwinding the try/finally around
-    # serve_forever(), so drain_all_on_shutdown() (which flushes in-flight
-    # fire-and-forget memory commits) would never run on the normal managed
-    # stop. Install a handler that requests an orderly shutdown so
-    # serve_forever() returns and the existing `finally` block drains cleanly.
-    #
-    # httpd.shutdown() blocks until serve_forever() has exited and MUST NOT be
-    # called from the thread running serve_forever() (it would deadlock), so we
-    # dispatch it from a short-lived helper thread. The handler is idempotent
-    # and guards against double-shutdown (e.g. repeated SIGTERM/SIGINT).
     _shutdown_requested = threading.Event()
-
-    def _request_shutdown(signum, _frame):
-        if _shutdown_requested.is_set():
-            return
-        _shutdown_requested.set()
-        threading.Thread(
-            target=httpd.shutdown,
-            name="webui-sigterm-shutdown",
-            daemon=True,
-        ).start()
-
-    try:
-        signal.signal(signal.SIGTERM, _request_shutdown)
-    except (ValueError, OSError):
-        # Not on the main thread (e.g. embedded/test harness); skip handler.
-        logger.debug("Could not install SIGTERM handler", exc_info=True)
+    _install_shutdown_signal_handlers(httpd, _shutdown_requested)
 
     try:
         httpd.serve_forever()

--- a/tests/test_issue7078_shutdown_sigign.py
+++ b/tests/test_issue7078_shutdown_sigign.py
@@ -1,0 +1,158 @@
+"""Regression tests for #7078: 'Stop server' no-ops on ctl.sh-managed daemons.
+
+ctl.sh spawns the daemon from a non-interactive bash background job
+(`( cd ...; exec nohup python bootstrap.py ... ) >> log 2>&1 &`), so the
+child inherits SIGINT = SIG_IGN (bash: "asynchronous commands ignore SIGINT
+and SIGQUIT in addition to SIGHUP"). The Settings "Stop server" button (POST
+/api/shutdown) signals the process with SIGINT via `os.kill(os.getpid(),
+SIGINT)`; with the inherited ignore disposition that signal is a silent
+OS-level no-op and the process keeps running (200 {"status":
+"shutting_down"} but no shutdown). server.py must explicitly install its
+SIGINT handler, overriding the inherited SIG_IGN, so the button, external
+`kill -INT`, and foreground Ctrl-C all take the same graceful path through
+the serve_forever() finally block.
+"""
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import threading
+import types
+
+import pytest
+
+if os.name != "posix":
+    pytest.skip("SIGINT/SIG_IGN background-job semantics require POSIX", allow_module_level=True)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run_child_with_sigint_ignored(script: str, timeout: float = 15.0):
+    """Run `script` in a child that inherited SIGINT = SIG_IGN (ctl.sh-style).
+
+    Signal dispositions survive fork/exec, and CPython does not reinstall its
+    KeyboardInterrupt handler when SIGINT was ignored at interpreter startup,
+    so the child reproduces the exact ctl.sh daemon condition.
+    """
+    prev = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    finally:
+        signal.signal(signal.SIGINT, prev)
+
+
+# Mirrors server.py main(): installs the shutdown signal handlers, then runs
+# serve_forever() on the main thread. A helper fires the signal under test;
+# the handler's helper thread calls httpd.shutdown(), serve_forever() returns
+# and the finally block runs (the drain path).
+_CHILD_SCRIPT = textwrap.dedent(
+    f"""
+    import os, signal, sys, threading, time
+    sys.path.insert(0, {REPO_ROOT!r})
+    import server
+
+    shutdown_requested = threading.Event()
+    released = threading.Event()
+
+    class FakeHTTPD:
+        def serve_forever(self):
+            while not released.is_set():
+                time.sleep(0.02)
+
+        def shutdown(self):
+            released.set()
+
+        def server_close(self):
+            pass
+
+    httpd = FakeHTTPD()
+
+    # Precondition: the ctl.sh spawn model leaves SIGINT ignored at the OS
+    # level (bash background job with job control off, CPython preserving the
+    # inherited SIG_IGN). If this check fails the test is not simulating the
+    # bug condition, so fail loudly instead of passing vacuously.
+    if signal.getsignal(signal.SIGINT) is not signal.SIG_IGN:
+        print("SIGINT_NOT_INHERITED_IGNORED")
+        sys.exit(3)
+
+    server._install_shutdown_signal_handlers(httpd, shutdown_requested)
+
+    # The fix must override that with the graceful-shutdown handler.
+    if signal.getsignal(signal.SIGINT) == signal.SIG_IGN:
+        print("SIGINT_STILL_IGNORED")
+        sys.exit(2)
+
+    threading.Timer(0.4, lambda: os.kill(os.getpid(), signal.SIGINT)).start()
+    try:
+        httpd.serve_forever()
+        print("SERVE_FOREVER_RETURNED")
+    finally:
+        print("FINALLY_RAN")
+    """
+)
+
+
+def test_sigint_shutdown_works_when_sigint_inherited_ignored():
+    """POST /api/shutdown's SIGINT must stop a ctl.sh-style daemon (SIG_IGN)."""
+    proc = _run_child_with_sigint_ignored(_CHILD_SCRIPT)
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "SIGINT_STILL_IGNORED" not in proc.stdout, proc.stdout
+    assert "SERVE_FOREVER_RETURNED" in proc.stdout, proc.stdout
+    assert "FINALLY_RAN" in proc.stdout, proc.stdout
+
+
+def test_sigterm_shutdown_still_works_when_sigint_inherited_ignored():
+    """SIGTERM (ctl.sh stop path) keeps taking the graceful path too."""
+    script = _CHILD_SCRIPT.replace(
+        "signal.SIGINT)).start()", "signal.SIGTERM)).start()"
+    )
+    proc = _run_child_with_sigint_ignored(script)
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "SERVE_FOREVER_RETURNED" in proc.stdout, proc.stdout
+    assert "FINALLY_RAN" in proc.stdout, proc.stdout
+
+
+def test_install_shutdown_signal_handlers_wires_sigterm_and_sigint(monkeypatch):
+    """Both signals are wired to one idempotent graceful-shutdown handler."""
+    import server
+
+    registered = {}
+
+    def _fake_signal(sig, handler):
+        registered[sig] = handler
+
+    monkeypatch.setattr(signal, "signal", _fake_signal)
+
+    started = []
+
+    class FakeThread:
+        def __init__(self, target, name=None, daemon=False):
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            started.append(self)
+
+    monkeypatch.setattr(threading, "Thread", FakeThread)
+
+    httpd = types.SimpleNamespace(shutdown=lambda: None)
+    requested = threading.Event()
+    server._install_shutdown_signal_handlers(httpd, requested)
+
+    assert signal.SIGTERM in registered, registered
+    assert signal.SIGINT in registered, registered
+    assert registered[signal.SIGTERM] is registered[signal.SIGINT]
+
+    handler = registered[signal.SIGINT]
+    handler(None, None)  # first request -> spawns the shutdown helper thread
+    handler(None, None)  # second request -> idempotent guard ignores it
+    assert len(started) == 1, started
+    assert started[0].name == "webui-sigterm-shutdown"
+    assert started[0].daemon is True


### PR DESCRIPTION
## What Changed

The Settings **Stop server** button (`POST /api/shutdown`) now actually terminates the WebUI process when it runs as a `ctl.sh`-managed daemon (including launchd→`ctl.sh start` setups).

`server.py` now registers the existing graceful `_request_shutdown` handler for **SIGINT as well as SIGTERM**, overriding the `SIG_IGN` disposition that `ctl.sh` daemons inherit. The registration was extracted into a module-level `_install_shutdown_signal_handlers(httpd, shutdown_requested)` so the wiring is directly testable; `main()` behavior is unchanged for SIGTERM.

## Root Cause

`ctl.sh start` spawns the server from a non-interactive bash background job (`( cd ...; exec nohup python bootstrap.py ... ) >> log 2>&1 &`). Per POSIX/bash, asynchronous commands ignore SIGINT (and SIGQUIT) when job control is not in effect — the daemon inherits `SIGINT = SIG_IGN`. CPython preserves an inherited `SIG_IGN` for SIGINT (it does not install its KeyboardInterrupt handler), so `_handle_shutdown`'s `os.kill(os.getpid(), SIGINT)` was a silent OS-level no-op: the button returned `200 {"status": "shutting_down"}` while the process stayed alive and kept holding the port. Every later `./ctl.sh start` then died on the `_abort_if_already_serving` guard, and the pid/state files pointed at the dead new PID, so `ctl.sh stop` could not reach the real process either.

`server.py` only registered a handler for SIGTERM (`signal.signal(signal.SIGTERM, _request_shutdown)`), which is exactly why `kill -TERM` stopped the daemon cleanly while the button did nothing. An explicit `signal.signal(SIGINT, handler)` **overrides** the inherited `SIG_IGN` (CPython honors SIG_IGN only at interpreter startup), so registering the same idempotent handler for SIGINT routes the button, `kill -INT`, and foreground Ctrl-C through the same graceful path: `serve_forever()` returns and the existing `finally` block drains in-flight sessions (shutdown audit + `drain_all_on_shutdown`).

## Verification

- New regression tests `tests/test_issue7078_shutdown_sigign.py` (3 tests, all pass):
  - `test_sigint_shutdown_works_when_sigint_inherited_ignored` — spawns a child that inherits `SIGINT = SIG_IGN` (the ctl.sh spawn model; the child asserts the ignore disposition at startup so the simulation cannot silently degrade), installs server.py's **actual** `_install_shutdown_signal_handlers`, then fires SIGINT and asserts `serve_forever()` returns and the `finally` drain block runs.
  - `test_sigterm_shutdown_still_works_when_sigint_inherited_ignored` — the SIGTERM/`ctl.sh stop` path keeps working after the refactor.
  - `test_install_shutdown_signal_handlers_wires_sigterm_and_sigint` — both signals are wired to one idempotent handler; a second signal does not double-fire `httpd.shutdown()`.
  - **Fail-first proof:** with the registration temporarily reverted to SIGTERM-only, the child reports `SIGINT_STILL_IGNORED` and the first test FAILS (exit 2); with the fix it passes.
- `tests/test_issue7078_shutdown_sigign.py` + `tests/test_shutdown_audit_logging.py` + `tests/test_server_port_exclusivity.py`: **12 passed, 1 skipped** (the skip is the pre-existing Windows-only port test).
- Live end-to-end with the real server (`server.main()`, isolated `HERMES_HOME`/port 8791, spawned with inherited `SIGINT = SIG_IGN` — child logs `SIGINT disposition at start: 1`): `POST /api/shutdown` → `200 {"status": "shutting_down"}` → **process exited 0** with `[crash-visibility] process exit` logged (same clean marker as the SIGTERM path).

## Files Changed

- `server.py` — new `_install_shutdown_signal_handlers()` registers `_request_shutdown` for SIGTERM **and** SIGINT (overriding the inherited `SIG_IGN`); `main()` calls it. No CHANGELOG edit (per AGENTS.md, the release workflow owns changelog updates).

## Closes #7078
