### PR TITLE
fix(recovery): do not reattach cancelling runs

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -271,6 +271,77 @@ def subscribe_to_session_channel(
         return ch, q
 
 
+# Bounded window a cancelling worker may stay lifecycle-busy before an entry
+# with no live SSE channel is treated as an orphan. Matches the unwind ceiling
+# used by the chat-start successor guard in ``api.routes``.
+_ACTIVE_RUN_CANCEL_UNWIND_SECONDS = 180.0
+
+
+def _active_run_ids_for_session(
+    session_id: str,
+    *,
+    attachable_only: bool,
+) -> list[str]:
+    """Return this session's run stream ids under the requested semantics.
+
+    ``attachable_only`` selects browser-recovery semantics and drops every
+    ``phase="cancelling"`` row: cancellation is already terminal for the client
+    even while the worker unwinds. Busy checks pass ``False`` so a freshly
+    cancelled run still blocks a successor for its bounded unwind window.
+
+    A cancelling row past that window with no live ``STREAMS`` channel is an
+    orphan: it is dropped from ``ACTIVE_RUNS`` and its stream-owner entry is
+    released, so a wedged worker cannot suppress background wakeups forever.
+    """
+    from api import config as _cfg
+
+    sid = str(session_id or "").strip()
+    if not sid:
+        return []
+    try:
+        with _cfg.STREAMS_LOCK:
+            live_stream_ids = set((_cfg.STREAMS or {}).keys())
+        now = time.time()
+        matches: list[str] = []
+        stale_keys: list[str] = []
+        with _cfg.ACTIVE_RUNS_LOCK:
+            for run_key, meta in list((_cfg.ACTIVE_RUNS or {}).items()):
+                if not isinstance(meta, dict) or meta.get("session_id") != sid:
+                    continue
+                stream_id = str(meta.get("stream_id") or run_key or "").strip()
+                if not stream_id:
+                    continue
+                cancelling = not _cfg.active_run_is_attachable(meta)
+                stale_cancel = (
+                    cancelling
+                    and _cfg.active_run_cancel_is_stale(
+                        meta,
+                        grace_seconds=_ACTIVE_RUN_CANCEL_UNWIND_SECONDS,
+                        now=now,
+                    )
+                    and run_key not in live_stream_ids
+                    and stream_id not in live_stream_ids
+                )
+                if stale_cancel:
+                    stale_keys.append(run_key)
+                    continue
+                if attachable_only and cancelling:
+                    continue
+                matches.append(stream_id)
+            for run_key in stale_keys:
+                (_cfg.ACTIVE_RUNS or {}).pop(run_key, None)
+        for run_key in stale_keys:
+            _cfg.unregister_stream_owner(run_key)
+        return matches
+    except Exception:
+        logger.debug(
+            "ACTIVE_RUNS lookup failed for %s",
+            sid,
+            exc_info=True,
+        )
+        return []
+
+
 def active_stream_id_for_session(session_id: str) -> Optional[str]:
     """Return the stream_id of the live run for *session_id*, or None.
 
@@ -288,25 +359,14 @@ def active_stream_id_for_session(session_id: str) -> Optional[str]:
 
     Keys on ACTIVE_RUNS (worker-lifecycle registry) — the same source
     ``_session_has_active_turn`` / ``_emit_to_session_streams`` already trust
-    to map a stream back to its owning session. Returns the first matching
-    stream_id (a session has at most one live run; cancel/reconnect can
-    briefly hold two — either is a valid attach target, the frontend dedupes
-    by stream_id).
+    to map a stream back to its owning session — but returns only rows that
+    are still ATTACHABLE. A ``phase="cancelling"`` row stays lifecycle-busy
+    while its worker unwinds, yet the client already reached a terminal state
+    for that run, so replaying ``server_turn_started`` for it makes the tab
+    attach, receive the terminal event, resubscribe, and loop forever.
     """
-    from api import config as _cfg
-
-    try:
-        with _cfg.ACTIVE_RUNS_LOCK:
-            for _stream_id, meta in (_cfg.ACTIVE_RUNS or {}).items():
-                if isinstance(meta, dict) and meta.get("session_id") == session_id:
-                    return str(_stream_id)
-    except Exception:
-        logger.debug(
-            "active_stream_id_for_session lookup failed for %s",
-            session_id,
-            exc_info=True,
-        )
-    return None
+    matches = _active_run_ids_for_session(session_id, attachable_only=True)
+    return matches[0] if matches else None
 
 
 def persisted_message_count_for_session(session_id: str) -> Optional[int]:
@@ -1518,16 +1578,7 @@ def _session_has_active_turn(session_id: str) -> bool:
     ``_start_chat_stream_for_session``'s own active-stream guard — i.e. the
     same lock /api/chat/start uses is the authoritative race backstop.
     """
-    from api import config as _cfg
-
-    try:
-        with _cfg.ACTIVE_RUNS_LOCK:
-            for _stream_id, meta in (_cfg.ACTIVE_RUNS or {}).items():
-                if isinstance(meta, dict) and meta.get("session_id") == session_id:
-                    return True
-    except Exception:
-        logger.debug("ACTIVE_RUNS active-turn check failed", exc_info=True)
-    return False
+    return bool(_active_run_ids_for_session(session_id, attachable_only=False))
 
 
 def _start_server_side_wakeup_turn(

--- a/api/config.py
+++ b/api/config.py
@@ -9146,6 +9146,56 @@ LAST_RUN_FINISHED_AT: float | None = None
 SERVER_START_TIME = time.time()
 
 
+def active_run_is_attachable(run_entry) -> bool:
+    """Return whether a run row still represents renderable live work.
+
+    ``ACTIVE_RUNS`` tracks WORKER LIFECYCLE, which is deliberately broader than
+    "a turn a browser may attach to": ``cancel_stream()`` leaves the row in
+    ``phase="cancelling"`` while the worker unwinds so a successor cannot start
+    on top of it. That row is already terminal from the client's perspective —
+    its run journal ends in a terminal event — so recovery paths that hand a
+    stream id to the renderer must exclude it. Otherwise every fresh
+    ``/api/session/stream`` subscription replays ``server_turn_started`` for a
+    cancelled run, the client attaches, consumes the terminal event, tears the
+    renderer down and resubscribes, and the loop repeats indefinitely.
+
+    Non-dict entries stay attachable so callers that store an opaque marker are
+    unaffected; production registrations are dicts carrying ``phase``.
+    """
+    return not (
+        isinstance(run_entry, dict)
+        and str(run_entry.get("phase") or "").strip() == "cancelling"
+    )
+
+
+def active_run_cancel_is_stale(
+    run_entry,
+    *,
+    grace_seconds: float,
+    now: float | None = None,
+) -> bool:
+    """Return whether a cancelling worker outlived its bounded unwind window.
+
+    The age anchor is ``cancelled_at`` rather than the original ``started_at``
+    so a long-running turn that was just cancelled is never mistaken for an
+    orphan; ``started_at`` remains the fallback for rows created before the
+    cancellation timestamp existed. Callers own the grace window because the
+    tolerated unwind differs per surface.
+    """
+    if not isinstance(run_entry, dict):
+        return False
+    if str(run_entry.get("phase") or "").strip() != "cancelling":
+        return False
+    anchor = run_entry.get("cancelled_at") or run_entry.get("started_at")
+    if not anchor:
+        return False
+    try:
+        age = (time.time() if now is None else float(now)) - float(anchor)
+        return age >= float(grace_seconds)
+    except (TypeError, ValueError):
+        return False
+
+
 def register_active_run(stream_id: str, **metadata) -> None:
     """Mark a WebUI agent worker as alive until its outer finally exits."""
     if not stream_id:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2934,16 +2934,15 @@ def _cancelled_run_is_stale(run_entry) -> bool:
     phase="cancelling". ``started_at`` is accepted as a fallback anchor so runs
     cancelled before the stamp was introduced are still reclaimed eventually.
     """
-    if not isinstance(run_entry, dict) or run_entry.get("phase") != "cancelling":
-        return False
-    anchor = run_entry.get("cancelled_at") or run_entry.get("started_at")
-    if not anchor:
-        return False
     try:
-        age = time.time() - float(anchor)
-    except (TypeError, ValueError):
+        from api import config as _live_config
+
+        return _live_config.active_run_cancel_is_stale(
+            run_entry,
+            grace_seconds=_STALE_CANCELLED_RUN_GRACE_SECONDS,
+        )
+    except Exception:
         return False
-    return age >= _STALE_CANCELLED_RUN_GRACE_SECONDS
 
 
 def _clear_stale_stream_state(session) -> bool:

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -30,19 +30,26 @@ def _live_active_stream_id(session) -> str | None:
     the hidden-tab poller) would make a client attach its renderer to a stream
     that never emits — a permanent fake "thinking" state. Liveness test mirrors
     routes._clear_stale_stream_state: live iff present in STREAMS (open SSE
-    channel) or ACTIVE_RUNS (worker bookkeeping).
+    channel) or ACTIVE_RUNS (worker bookkeeping) — except that a
+    ``phase="cancelling"`` run is excluded on both paths, because the worker may
+    still be unwinding while the client already reached a terminal state for
+    that stream.
     """
     stream_id = getattr(session, 'active_stream_id', None)
     if not stream_id:
         return None
     try:
         from api import config as _cfg
+        with _cfg.ACTIVE_RUNS_LOCK:
+            _active_run_present = stream_id in (_cfg.ACTIVE_RUNS or {})
+            _active_run_entry = (_cfg.ACTIVE_RUNS or {}).get(stream_id)
+        if _active_run_present and not _cfg.active_run_is_attachable(_active_run_entry):
+            return None
         with _cfg.STREAMS_LOCK:
             if stream_id in _cfg.STREAMS:
                 return stream_id
-        with _cfg.ACTIVE_RUNS_LOCK:
-            if stream_id in (_cfg.ACTIVE_RUNS or {}):
-                return stream_id
+        if _active_run_present:
+            return stream_id
     except Exception:
         # On any introspection failure, fail SAFE (report no live stream) rather
         # than surfacing a possibly-stale id.

--- a/docs/rfcs/webui-run-state-consistency-contract.md
+++ b/docs/rfcs/webui-run-state-consistency-contract.md
@@ -70,6 +70,7 @@ and 5; it does not mark every run-state boundary implemented.
 | Model context / `context_messages` | Supplies conversation state to the agent | Must include the current visible user turn unless deliberately excluded with a user-visible reason | Let the agent resume from context that contradicts what the user can see |
 | Pending turn metadata | Bridges submitted-but-not-yet-finalized user input | Must identify the user turn and stream that own active work | Become a permanent duplicate transcript row after recovery |
 | Live stream / SSE | Delivers active runtime events to the browser | Must remain an observation path, not the only durable truth for already-emitted events | Lose the visible scene on refresh, reconnect, or session switch |
+| Worker lifecycle registry (`ACTIVE_RUNS`) | Tracks whether a worker still occupies the session, so a successor turn cannot start on top of it | Broader than "attachable UI work": a cancelled worker stays registered while it unwinds | Be read directly as the set of runs a browser may attach to |
 | Run journal / replay | Rebuilds emitted runtime events after reconnect or restart | Must be cursor-safe and idempotent | Duplicate assistant text, thinking text, tool cards, or compression cards |
 | Compression summary / handoff | Gives the agent recovery context after automatic compression | Must remain agent-facing recovery material unless explicitly rendered as history | Pollute the active turn or become implicit current user intent |
 | Live UI scene/cache | Preserves expanded rows, in-progress cards, local scroll, and transient grouping | May optimize presentation but must be rebuildable or degradable from transcript/replay | Become the only place where chronological ordering exists |
@@ -121,6 +122,26 @@ and 5; it does not mark every run-state boundary implemented.
 8. **Every mutation names its layer.** A PR touching streaming, recovery,
    context reconstruction, compression, replay, or sidebar metadata should state
    which layer it changes and what regression proves the invariant still holds.
+9. **Lifecycle-busy is not client-attachable.** `ACTIVE_RUNS` answers "may a new
+   turn start?", not "may a browser attach a renderer?". Cancellation splits the
+   two: `cancel_stream()` keeps the row as `phase="cancelling"` so a successor
+   cannot overlap the unwinding worker, but the client has already reached a
+   terminal state for that stream because its run journal ends in a terminal
+   event. Recovery paths that hand a stream id to a renderer — session SSE
+   recovery and hidden-tab status polling — must therefore exclude cancelling
+   rows, while busy/admission checks must keep counting them. Reading the
+   registry with a single meaning resurrects a cancelled run on every fresh
+   subscription: the client attaches, consumes the terminal event, tears the
+   renderer down, resubscribes, and the loop repeats indefinitely.
+
+   Because a cancelling row can otherwise persist forever, cancellation unwind is
+   bounded: a cancelling row older than that window **and** owning no live
+   `STREAMS` channel is reclaimed from `ACTIVE_RUNS` along with its stream-owner
+   entry, so a wedged worker cannot suppress background wakeups permanently.
+   Reclamation requires both conditions — age alone must not evict a row that
+   still owns a live channel. Staleness is measured from the cancellation
+   timestamp (falling back to run start), so a long-running turn cancelled
+   moments ago is never mistaken for an orphan.
 
 ## Review Checklist
 
@@ -138,6 +159,11 @@ context reconstruction, or session metadata:
   interim assistant text, tool cards, compression cards, and terminal states?
 - Can this change move a session in the sidebar without meaningful user or
   assistant activity?
+- Does this change read `ACTIVE_RUNS` for admission ("may a turn start?") or for
+  attachment ("may a browser render this?"), and does it use the matching
+  predicate for that question?
+- If it introduces or changes a reclamation window, what proves an in-flight
+  cancellation is not evicted early, and that a wedged one is eventually freed?
 - Can automatic compression or recovery text become visible active-turn content?
 - What test or manual evidence proves the invariant?
 

--- a/tests/test_cancelling_run_not_attachable.py
+++ b/tests/test_cancelling_run_not_attachable.py
@@ -1,0 +1,178 @@
+"""A cancelling run is lifecycle-busy but NOT attachable live UI work.
+
+``ACTIVE_RUNS`` tracks worker lifecycle. ``cancel_stream()`` deliberately keeps
+the row as ``phase="cancelling"`` while the worker unwinds so a successor turn
+cannot start on top of it. The client, however, has already reached a terminal
+state for that stream: its run journal ends in a terminal event.
+
+Before this fix the recovery lookups treated every same-session ``ACTIVE_RUNS``
+row as attachable, so an idle session whose sidecar had already cleared
+``active_stream_id`` still received a recovered ``server_turn_started`` for the
+cancelled stream on EVERY ``/api/session/stream`` subscription. The client
+attached, replayed the terminal event, tore the renderer down, resubscribed, and
+the server replayed the same frame again — an endless attach/replay loop.
+
+These tests pin both directions of the resulting contract:
+
+* browser recovery excludes cancelling rows, while busy checks still keep a
+  FRESH cancellation busy (a successor must not overlap the unwinding worker);
+* a cancelling row past the bounded unwind window with no live ``STREAMS``
+  channel is reclaimed, so a wedged worker cannot suppress wakeups forever;
+* a cancelling row that still owns a live ``STREAMS`` channel is NOT reclaimed
+  on age alone.
+"""
+
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from api import background_process as bp  # noqa: E402
+from api import config as cfg  # noqa: E402
+from api.session_ops import _live_active_stream_id  # noqa: E402
+
+
+def _clear(stream_id: str) -> None:
+    cfg.unregister_active_run(stream_id)
+    with cfg.STREAMS_LOCK:
+        cfg.STREAMS.pop(stream_id, None)
+
+
+def test_running_run_is_still_attachable_and_busy():
+    """Control: an ordinary running turn keeps both semantics unchanged."""
+    sid = "sess-running-control"
+    stream_id = "stream-running-control"
+    cfg.register_active_run(stream_id, session_id=sid, phase="running")
+    try:
+        assert bp.active_stream_id_for_session(sid) == stream_id
+        assert bp._session_has_active_turn(sid) is True
+        assert _live_active_stream_id(
+            SimpleNamespace(session_id=sid, active_stream_id=stream_id)
+        ) == stream_id
+    finally:
+        _clear(stream_id)
+
+
+def test_fresh_cancelling_run_is_not_attachable_but_stays_busy():
+    """The loop-producing case: recovery must not replay a cancelled run.
+
+    The same row must still count as busy so a successor cannot start while the
+    cancelled worker is unwinding.
+    """
+    sid = "sess-cancelling-fresh"
+    stream_id = "stream-cancelling-fresh"
+    cfg.register_active_run(
+        stream_id,
+        session_id=sid,
+        phase="cancelling",
+        cancelled_at=time.time() - 5.0,
+    )
+    try:
+        assert bp.active_stream_id_for_session(sid) is None
+        assert bp._session_has_active_turn(sid) is True
+        assert stream_id in cfg.ACTIVE_RUNS
+    finally:
+        _clear(stream_id)
+
+
+def test_hidden_tab_status_does_not_resurrect_a_cancelling_run():
+    """/api/session/status must not hand a cancelling stream to the poller."""
+    sid = "sess-cancelling-status"
+    stream_id = "stream-cancelling-status"
+    cfg.register_active_run(stream_id, session_id=sid, phase="cancelling")
+    try:
+        assert _live_active_stream_id(
+            SimpleNamespace(session_id=sid, active_stream_id=stream_id)
+        ) is None
+    finally:
+        _clear(stream_id)
+
+
+def test_hidden_tab_status_ignores_cancelling_run_with_live_stream_channel():
+    """A cancelling row is terminal for the client even if STREAMS still holds it."""
+    sid = "sess-cancelling-status-live-channel"
+    stream_id = "stream-cancelling-status-live-channel"
+    cfg.register_active_run(stream_id, session_id=sid, phase="cancelling")
+    with cfg.STREAMS_LOCK:
+        cfg.STREAMS[stream_id] = object()
+    try:
+        assert _live_active_stream_id(
+            SimpleNamespace(session_id=sid, active_stream_id=stream_id)
+        ) is None
+    finally:
+        _clear(stream_id)
+
+
+def test_stale_cancelling_orphan_stops_blocking_and_is_reclaimed():
+    """Past the unwind window with no live channel, the row is an orphan."""
+    sid = "sess-cancelling-stale"
+    stream_id = "stream-cancelling-stale"
+    cfg.register_active_run(
+        stream_id,
+        session_id=sid,
+        phase="cancelling",
+        cancelled_at=time.time() - 240.0,
+    )
+    cfg.register_stream_owner(stream_id, sid)
+    try:
+        assert bp._session_has_active_turn(sid) is False
+        assert stream_id not in cfg.ACTIVE_RUNS
+        assert cfg.stream_owner_session_id(stream_id) is None
+    finally:
+        _clear(stream_id)
+
+
+def test_stale_cancelling_run_with_live_channel_is_not_reclaimed():
+    """Reverse control: age alone must not reap a row that still owns a channel."""
+    sid = "sess-cancelling-stale-live-channel"
+    stream_id = "stream-cancelling-stale-live-channel"
+    cfg.register_active_run(
+        stream_id,
+        session_id=sid,
+        phase="cancelling",
+        cancelled_at=time.time() - 240.0,
+    )
+    with cfg.STREAMS_LOCK:
+        cfg.STREAMS[stream_id] = object()
+    try:
+        assert bp._session_has_active_turn(sid) is True
+        assert stream_id in cfg.ACTIVE_RUNS
+    finally:
+        _clear(stream_id)
+
+
+def test_cancel_staleness_anchors_on_cancel_time_not_run_start():
+    """A long-running turn cancelled just now must not read as stale."""
+    entry = {
+        "session_id": "sess-anchor",
+        "phase": "cancelling",
+        "started_at": time.time() - 4000.0,
+        "cancelled_at": time.time() - 5.0,
+    }
+    assert cfg.active_run_cancel_is_stale(entry, grace_seconds=180.0) is False
+
+    legacy = {
+        "session_id": "sess-anchor-legacy",
+        "phase": "cancelling",
+        "started_at": time.time() - 4000.0,
+    }
+    assert cfg.active_run_cancel_is_stale(legacy, grace_seconds=180.0) is True
+
+    running = {
+        "session_id": "sess-anchor-running",
+        "phase": "running",
+        "started_at": time.time() - 4000.0,
+    }
+    assert cfg.active_run_cancel_is_stale(running, grace_seconds=180.0) is False
+
+
+def test_attachability_predicate_edges():
+    """Non-dict/opaque entries stay attachable; only cancelling is excluded."""
+    assert cfg.active_run_is_attachable({"phase": "running"}) is True
+    assert cfg.active_run_is_attachable({"phase": "cancelling"}) is False
+    assert cfg.active_run_is_attachable({"phase": " cancelling "}) is False
+    assert cfg.active_run_is_attachable({}) is True
+    assert cfg.active_run_is_attachable(object()) is True


### PR DESCRIPTION
## Summary

`ACTIVE_RUNS` tracks **worker lifecycle**, which is deliberately broader than *"a turn a browser may attach to"*. `cancel_stream()` keeps the row as `phase="cancelling"` while the worker unwinds, so a successor turn cannot start on top of it. But the client has already reached a terminal state for that stream — its run journal ends in a terminal event.

The recovery lookups treated **every** same-session `ACTIVE_RUNS` row as attachable. An idle session holding a cancelling row therefore received a recovered `server_turn_started` on *every* `/api/session/stream` subscription:

1. client subscribes → server replays `server_turn_started` for the cancelled stream
2. client attaches its renderer → immediately consumes the terminal event
3. renderer tears down → client resubscribes
4. server replays the same frame again → **loop**

The user-visible symptom is a transcript that rebuilds and jumps repeatedly on an idle session, with a steady trickle of replay requests. Because the row never leaves `ACTIVE_RUNS` on its own, the loop persists indefinitely.

## The fix

The two meanings are separated at a shared chokepoint rather than by narrowing one call site:

- **`api/config.py`** gains `active_run_is_attachable()` and `active_run_cancel_is_stale()` as the shared predicates.
- **`active_stream_id_for_session()`** (browser recovery) returns attachable rows only.
- **`_session_has_active_turn()`** (busy check) still counts a *fresh* cancellation, so a successor cannot overlap the unwinding worker. This is the direction that must **not** change.
- **`_live_active_stream_id()`** applies the same rule to the hidden-tab status poller, on both the `STREAMS` and `ACTIVE_RUNS` paths.
- **`routes._cancelled_run_is_stale()`** now delegates to the shared predicate instead of keeping a parallel copy of the staleness rule.
- A cancelling row past a bounded unwind window **with no live `STREAMS` channel** is reclaimed from `ACTIVE_RUNS` and its stream owner released, so a wedged worker cannot suppress background wakeups forever. Age alone does **not** reclaim a row that still owns a live channel.

Staleness anchors on `cancelled_at`, falling back to `started_at`, so a long-running turn cancelled moments ago is never mistaken for an orphan.

### State layer being mutated

`ACTIVE_RUNS` (worker-lifecycle registry) and its companion stream-owner map. The invariant being restored: *a row is lifecycle-busy and client-attachable independently; cancellation ends the second while the first is still unwinding.*

### Siblings found and fixed

The same "any `ACTIVE_RUNS` row for this session is live UI work" assumption appeared in four places — session SSE recovery, the busy check, the hidden-tab status poller, and a duplicated staleness rule in `routes.py`. All four now route through the shared predicates. The busy check is intentionally the one caller that keeps counting cancelling rows.

## Testing

`tests/test_cancelling_run_not_attachable.py` — 8 tests covering **both directions** of each rule, including a running-turn control, a live-channel reverse control, the `cancelled_at` vs `started_at` anchor, and predicate edge cases (blank/whitespace phase, non-dict entries stay attachable).

**Test fails before, passes after:**

```
# unpatched tree + new tests
6 failed, 2 passed

# with the fix
8 passed
```

**Mutation checks** (each turns the suite red, so the tests genuinely bite):

| Mutation | Result |
|---|---|
| Force `active_run_is_attachable()` to always return `True` | 5 failed, 3 passed |
| Disable the staleness reaper (`stale_cancel` never true) | 1 failed, 7 passed |

**Neighboring suites** — cancel / recovery / wakeup / hidden-tab / restore families:

```
117 passed in 18.48s
```

covering `test_cancel_interrupt`, `test_cancel_stream_owner_guard`, `test_cancelled_turn_status`, `test_issue6623_cancel_owner_race`, `test_evict_session_agent_active_run_guard`, `test_background_process_restart_recovery`, `test_background_process_wakeup_format`, `test_bg_task_complete_wakeup`, `test_bg_task_complete_loadsession_stream_restart`, `test_5428_stale_client_recovery`, `test_hidden_tab_server_initiated_turn`, `test_hard_refresh_session_restore`.

**Lint:** `scripts/ruff_lint.py --diff origin/master` → `no new violations on added/modified lines. OK.`

## Relationship to #6623 / #6636

#6636 fixed the cancel **owner race** — stuck sessions, cancel write-back clobbering a successor, and cancel-worker timeout reclamation. This is a different layer: the row remains legitimately present in the lifecycle registry, and the defect is that the **recovery/attach** path reads that registry as "renderable live work." Both are needed; neither subsumes the other.

## Not verified

- No UI change, so no before/after images apply.
- Verified against a reproduction of the loop and the neighboring automated suites; I have not exercised the multi-worker gateway/ACP surfaces beyond their existing tests.

