### PR TITLE
fix(tests): make mtime_invalidation and glm_5_3 robust (#7100)

### DIFF
--- a/tests/test_glm_5_3_catalog.py
+++ b/tests/test_glm_5_3_catalog.py
@@ -197,6 +197,20 @@ def test_glm_5_3_in_models_payload_for_zai_provider(tmp_path, monkeypatch):
     except Exception:
         pass
 
+    # Pin the agent-core catalog: get_available_models() sources the zai
+    # model list from the INSTALLED hermes-cli core (via
+    # _read_live_provider_model_ids -> provider_model_ids), not from the
+    # repo's static _PROVIDER_MODELS. On a box whose installed core predates
+    # glm-5.3 this test previously failed spuriously ("glm-5.3 missing from
+    # zai group models"). Stub the core catalog to a deterministic empty
+    # list so the repo's own _PROVIDER_MODELS fallback is exercised — this
+    # tests WebUI catalog propagation, not the installed core version.
+    try:
+        import hermes_cli.models as hm
+        monkeypatch.setattr(hm, "provider_model_ids", lambda _pid: [])
+    except Exception:
+        pass
+
     result = c.get_available_models()
     c.reload_config()
 

--- a/tests/test_ttl_cache.py
+++ b/tests/test_ttl_cache.py
@@ -111,39 +111,61 @@ def test_ttl_expiry():
 def test_mtime_invalidation():
     """Populate the cache, then change _cfg_mtime to simulate a config file
     change on disk. The next call should invalidate the cache and re-scan.
+
+    This test is fully self-contained: it invalidates both memory and disk
+    caches first, then populates the cache via a priming call, then verifies
+    that an mtime mismatch triggers a cache rebuild. It does not depend on
+    any sibling test's execution order.
     """
-    _reset_cache()
+    # Fully invalidate (memory + disk) so we start from a known clean state.
+    config.invalidate_models_cache()
 
-    # Ensure _cfg_mtime matches file so first call doesn't re-scan due to mtime
+    # Force the synchronous (unbounded) rebuild path so the priming call is
+    # guaranteed to have published the cache when it returns. With the
+    # default bounded budget (_LIVE_REBUILD_BUDGET_SECONDS=4.0), a cold
+    # rebuild on a slow/loaded box can exceed the budget and return a
+    # static fallback WITHOUT populating _available_models_cache — which
+    # made this test fail when run in isolation (it previously only passed
+    # because a sibling test had already warmed the cache in-process).
+    original_budget = config._LIVE_REBUILD_BUDGET_SECONDS
+    config._LIVE_REBUILD_BUDGET_SECONDS = 0.0
+    real_mtime = 0.0
+
     try:
-        real_mtime = config.Path(config._get_config_path()).stat().st_mtime
-    except OSError:
-        real_mtime = 0.0
-    config._cfg_mtime = real_mtime
+        # Ensure _cfg_mtime matches file so first call doesn't re-scan due to mtime
+        try:
+            real_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except OSError:
+            real_mtime = 0.0
+        config._cfg_mtime = real_mtime
 
-    # First call populates cache
-    result1 = config.get_available_models()
-    assert config._available_models_cache is not None
+        # Priming call: populate the cache (both memory and disk)
+        result1 = config.get_available_models()
+        assert config._available_models_cache is not None, (
+            "Priming call should populate the in-memory cache"
+        )
+        assert config._available_models_cache_ts > 0.0, (
+            "Priming call should set a valid cache timestamp"
+        )
 
-    # Simulate config.yaml changed on disk by setting _cfg_mtime to 0
-    # (which won't match the actual file mtime)
-    config._cfg_mtime = 0.0
+        # Simulate config.yaml changed on disk by setting _cfg_mtime to 0
+        # (which won't match the actual file mtime)
+        config._cfg_mtime = 0.0
 
-    # The next call should detect mtime mismatch, reload, and invalidate cache
-    old_cache = config._available_models_cache
-    old_ts = config._available_models_cache_ts
+        # The next call should detect mtime mismatch, reload, and invalidate cache
+        result2 = config.get_available_models()
 
-    result2 = config.get_available_models()
-
-    # Cache must have been refreshed — timestamp advanced since we reset it
-    # to 0.0 on invalidation.
-    assert config._available_models_cache_ts > 0.0, (
-        "Cache timestamp should be updated after invalidation + rebuild"
-    )
-
-    # Restore
-    config._cfg_mtime = real_mtime
-    _reset_cache()
+        # Cache must have been refreshed — timestamp advanced since we reset it
+        # to 0.0 on invalidation.
+        assert config._available_models_cache_ts > 0.0, (
+            "Cache timestamp should be updated after invalidation + rebuild"
+        )
+        # Both calls must return a valid /api/models payload.
+        assert "groups" in result1 and "groups" in result2
+    finally:
+        config._LIVE_REBUILD_BUDGET_SECONDS = original_budget
+        config._cfg_mtime = real_mtime
+        config.invalidate_models_cache()
 
 
 # ── 4. test_deepcopy_isolation ────────────────────────────────────────────


### PR DESCRIPTION
## What Changed

Hardened two fragile tests so the full suite no longer produces spurious failures under `SHARDED=1` / isolated runs:

### `tests/test_ttl_cache.py::test_mtime_invalidation`
- Made the test fully self-contained: it now invalidates both memory **and** disk caches first, then primes the cache via an explicit call inside the test body, instead of relying on cache state established by an earlier sibling test (`test_cache_hit_within_ttl` / `test_ttl_expiry`).
- The priming call now forces the synchronous (unbounded) rebuild path by temporarily setting `_LIVE_REBUILD_BUDGET_SECONDS = 0.0`, so the cache is guaranteed to be published before the first assertion runs. Previously, a cold rebuild on a slow/loaded box could exceed the 4s budget and return a static fallback *without* populating `_available_models_cache`, making the test fail when picked up by a shard without its predecessors.
- Added explicit assertions on the priming call (`_available_models_cache is not None`, `_available_models_cache_ts > 0.0`) so failures are diagnosed at the exact precondition, not downstream.

### `tests/test_glm_5_3_catalog.py::test_glm_5_3_in_models_payload_for_zai_provider`
- `get_available_models()` sources the zai model list from the **installed** hermes-cli core catalog (`_read_live_provider_model_ids` → `provider_model_ids`), not from the repo's static `_PROVIDER_MODELS`. On a box whose installed core predates `glm-5.3` (e.g. only `glm-5/5.1/5.2`), the test failed with "glm-5.3 missing from zai group models".
- The test now stubs the core catalog (`provider_model_ids` → `[]`) so the repo's own `_PROVIDER_MODELS` fallback is exercised deterministically — verifying WebUI catalog propagation, independent of the installed agent-core version. This matches the issue's suggested fix (a): "pin/stub the core catalog in the test".

## Verification

- `pytest tests/test_ttl_cache.py::test_mtime_invalidation` — **PASSED** in isolation (previously order-dependent).
- `pytest tests/test_glm_5_3_catalog.py::test_glm_5_3_in_models_payload_for_zai_provider` — **PASSED** (previously FAILED on this box: installed core lacks glm-5.3).
- `pytest tests/test_ttl_cache.py tests/test_glm_5_3_catalog.py` — **13 passed** (full-file run intact, no sibling regressions).

## Closes #7100