### PR TITLE
feat(server): emit initial HSTS response header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,10 +63,14 @@
 # HERMES_WEBUI_TLS_CERT=/path/to/fullchain.pem
 # HERMES_WEBUI_TLS_KEY=/path/to/privkey.pem
 
-# Opt in to the browser's HTTPS-only policy. HSTS is emitted only for actual
-# HTTPS requests (direct TLS or explicitly trusted reverse-proxy HTTPS). Do not
-# enable this if the same hostname may later be served over plain HTTP.
-# HERMES_WEBUI_HSTS=1
+# Opt in to the browser's HTTPS-only policy for a permanently HTTPS hostname.
+# HSTS is emitted only for actual HTTPS requests (direct TLS or explicitly
+# trusted reverse-proxy HTTPS). Set max-age=0 over HTTPS to unpin browsers
+# before switching the hostname back to HTTP.
+# HERMES_WEBUI_HSTS_MAX_AGE=86400
+# HSTS applies to the whole hostname across ports. Firefox does not exempt
+# localhost, so a localhost HTTPS -> HTTP change can lock out that hostname.
+# includeSubDomains and preload are intentionally not enabled.
 
 # Extra sources appended to the Content-Security-Policy (space-separated).
 # HERMES_WEBUI_CSP_CONNECT_EXTRA=https://api.example.com wss://api.example.com

--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@
 # HERMES_WEBUI_TLS_CERT=/path/to/fullchain.pem
 # HERMES_WEBUI_TLS_KEY=/path/to/privkey.pem
 
+# Opt in to the browser's HTTPS-only policy. HSTS is emitted only for actual
+# HTTPS requests (direct TLS or explicitly trusted reverse-proxy HTTPS). Do not
+# enable this if the same hostname may later be served over plain HTTP.
+# HERMES_WEBUI_HSTS=1
+
 # Extra sources appended to the Content-Security-Policy (space-separated).
 # HERMES_WEBUI_CSP_CONNECT_EXTRA=https://api.example.com wss://api.example.com
 # HERMES_WEBUI_CSP_FRAME_EXTRA=https://embed.example.com

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Signed HMAC HTTP-only cookie with 24h TTL
 - Minimal dark-themed login page at `/login`
 - Security headers on all responses (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
-- Optional HSTS (`HERMES_WEBUI_HSTS=1`) for permanently HTTPS deployments; it is emitted only on actual HTTPS requests
+- Optional HSTS (`HERMES_WEBUI_HSTS_MAX_AGE=86400`) for permanently HTTPS deployments; it is emitted only on actual HTTPS requests. To roll back, serve `HERMES_WEBUI_HSTS_MAX_AGE=0` over HTTPS before switching the hostname back to HTTP. HSTS applies across all ports on the hostname; Firefox does not exempt `localhost`. `includeSubDomains` and `preload` are intentionally not enabled.
 - 20MB POST body size limit
 - CDN resources pinned with SRI integrity hashes
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Signed HMAC HTTP-only cookie with 24h TTL
 - Minimal dark-themed login page at `/login`
 - Security headers on all responses (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
+- Optional HSTS (`HERMES_WEBUI_HSTS=1`) for permanently HTTPS deployments; it is emitted only on actual HTTPS requests
 - 20MB POST body size limit
 - CDN resources pinned with SRI integrity hashes
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -1203,6 +1203,32 @@ def _is_loopback(addr: str) -> bool:
         return False
 
 
+def _is_secure_transport(handler=None) -> bool:
+    """Return True only when the request arrived over an HTTPS transport.
+
+    Direct TLS is identified from the wrapped socket. Reverse-proxy TLS
+    termination is accepted only when the operator explicitly trusts
+    ``X-Forwarded-Proto``. This deliberately does not honor
+    ``HERMES_WEBUI_SECURE``: that setting controls cookie attributes and may be
+    used for compatibility behind a proxy, but it must not make HSTS appear on
+    a plain-HTTP response.
+    """
+    if handler is None:
+        return False
+
+    request = getattr(handler, "request", None)
+    if callable(getattr(request, "getpeercert", None)):
+        return True
+
+    trust_fwd = os.getenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", "").strip().lower()
+    if trust_fwd in ("1", "true", "yes", "on"):
+        headers = getattr(handler, "headers", None)
+        forwarded_proto = headers.get("X-Forwarded-Proto", "") if headers is not None else ""
+        return forwarded_proto.strip().lower() == "https"
+
+    return False
+
+
 def _is_secure_context(handler=None) -> bool:
     """Return True if cookies should carry the Secure flag.
 
@@ -1224,14 +1250,7 @@ def _is_secure_context(handler=None) -> bool:
         return True
     if env in ('0', 'false', 'no'):
         return False
-    if handler is not None:
-        if getattr(handler.request, 'getpeercert', None) is not None:
-            return True
-        trust_fwd = os.getenv('HERMES_WEBUI_TRUST_FORWARDED_PROTO', '').strip().lower()
-        if trust_fwd in ('1', 'true', 'yes'):
-            if handler.headers.get('X-Forwarded-Proto', '') == 'https':
-                return True
-    return False
+    return _is_secure_transport(handler)
 
 
 def set_auth_cookie(handler, cookie_value) -> None:

--- a/api/auth.py
+++ b/api/auth.py
@@ -1229,6 +1229,26 @@ def _is_secure_transport(handler=None) -> bool:
     return False
 
 
+def hsts_header_value(handler=None) -> str | None:
+    """Return the configured HSTS value for a verified HTTPS request.
+
+    HSTS is opt-in through ``HERMES_WEBUI_HSTS_MAX_AGE``. An unset, empty, or
+    invalid value disables emission. ``0`` is intentionally valid: serving
+    ``max-age=0`` over HTTPS removes a previously cached browser policy before
+    an operator switches the hostname back to plain HTTP.
+    """
+    raw = os.getenv("HERMES_WEBUI_HSTS_MAX_AGE", "").strip()
+    if not raw or not raw.isascii() or not raw.isdigit():
+        return None
+    try:
+        max_age = int(raw)
+    except ValueError:
+        return None
+    if not _is_secure_transport(handler):
+        return None
+    return f"max-age={max_age}"
+
+
 def _is_secure_context(handler=None) -> bool:
     """Return True if cookies should carry the Secure flag.
 

--- a/server.py
+++ b/server.py
@@ -99,7 +99,7 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-from api.auth import check_auth, reset_trusted_auth_request_state
+from api.auth import _is_secure_transport, check_auth, reset_trusted_auth_request_state
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import (
     j,
@@ -112,6 +112,15 @@ from api.routes import handle_delete, handle_get, handle_patch, handle_post, han
 from api.startup import auto_install_agent_deps, fix_credential_permissions
 from api.updates import WEBUI_VERSION
 from api.crash_visibility import install_crash_visibility
+
+
+_HSTS_HEADER_VALUE = "max-age=86400"
+_HSTS_TRUTHY_VALUES = frozenset(("1", "true", "yes", "on"))
+
+
+def _hsts_enabled() -> bool:
+    """Return whether the operator explicitly enabled HSTS emission."""
+    return os.getenv("HERMES_WEBUI_HSTS", "").strip().lower() in _HSTS_TRUTHY_VALUES
 
 
 class QuietHTTPServer(ThreadingHTTPServer):
@@ -327,6 +336,8 @@ class Handler(BaseHTTPRequestHandler):
         return _build_csp_report_only_policy(extra_connect_src, extra_frame_src)
 
     def end_headers(self) -> None:
+        if _hsts_enabled() and _is_secure_transport(self):
+            self.send_header("Strict-Transport-Security", _HSTS_HEADER_VALUE)
         extra_connect_src = getattr(self, "_csp_extra_connect_src", None)
         extra_frame_src = getattr(self, "_csp_extra_frame_src", None)
         self.send_header("Content-Security-Policy-Report-Only", self.csp_report_only_policy(extra_connect_src, extra_frame_src))

--- a/server.py
+++ b/server.py
@@ -98,8 +98,7 @@ except ImportError:  # pragma: no cover - resource is Unix-only
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
-
-from api.auth import _is_secure_transport, check_auth, reset_trusted_auth_request_state
+from api.auth import check_auth, hsts_header_value, reset_trusted_auth_request_state
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import (
     j,
@@ -112,16 +111,6 @@ from api.routes import handle_delete, handle_get, handle_patch, handle_post, han
 from api.startup import auto_install_agent_deps, fix_credential_permissions
 from api.updates import WEBUI_VERSION
 from api.crash_visibility import install_crash_visibility
-
-
-_HSTS_HEADER_VALUE = "max-age=86400"
-_HSTS_TRUTHY_VALUES = frozenset(("1", "true", "yes", "on"))
-
-
-def _hsts_enabled() -> bool:
-    """Return whether the operator explicitly enabled HSTS emission."""
-    return os.getenv("HERMES_WEBUI_HSTS", "").strip().lower() in _HSTS_TRUTHY_VALUES
-
 
 class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
@@ -336,8 +325,8 @@ class Handler(BaseHTTPRequestHandler):
         return _build_csp_report_only_policy(extra_connect_src, extra_frame_src)
 
     def end_headers(self) -> None:
-        if _hsts_enabled() and _is_secure_transport(self):
-            self.send_header("Strict-Transport-Security", _HSTS_HEADER_VALUE)
+        if hsts_header := hsts_header_value(self):
+            self.send_header("Strict-Transport-Security", hsts_header)
         extra_connect_src = getattr(self, "_csp_extra_connect_src", None)
         extra_frame_src = getattr(self, "_csp_extra_frame_src", None)
         self.send_header("Content-Security-Policy-Report-Only", self.csp_report_only_policy(extra_connect_src, extra_frame_src))

--- a/tests/test_issue1909_csp_enforcement.py
+++ b/tests/test_issue1909_csp_enforcement.py
@@ -16,6 +16,27 @@ class _HeaderCapture:
         self.sent_headers.append((key, value))
 
 
+class _SecureRequest:
+    def getpeercert(self):
+        return {}
+
+
+def _headers_from_handler(monkeypatch, *, request=None, headers=None):
+    sent_headers = []
+    handler = Handler.__new__(Handler)
+    handler.__dict__.update(
+        {
+            "request": request if request is not None else object(),
+            "headers": headers if headers is not None else {},
+            "send_header": lambda key, value: sent_headers.append((key, value)),
+        }
+    )
+    monkeypatch.setattr(BaseHTTPRequestHandler, "end_headers", lambda self: None)
+
+    Handler.end_headers(handler)
+    return dict(sent_headers)
+
+
 def _headers_from_security_helper():
     handler = _HeaderCapture()
     _security_headers(handler)
@@ -121,6 +142,60 @@ def test_report_only_csp_headers_still_point_to_collector(monkeypatch):
     )
     assert "report-uri /api/csp-report" in headers["Content-Security-Policy-Report-Only"]
     assert "report-to csp-endpoint" in headers["Content-Security-Policy-Report-Only"]
+
+
+def test_hsts_is_opt_in(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_HSTS", raising=False)
+
+    headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
+
+    assert "Strict-Transport-Security" not in headers
+
+
+def test_hsts_requires_secure_transport_even_when_opted_in(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
+
+    headers = _headers_from_handler(monkeypatch)
+
+    assert "Strict-Transport-Security" not in headers
+
+
+def test_hsts_emits_for_direct_tls_when_opted_in(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+
+    headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
+
+    assert headers["Strict-Transport-Security"] == "max-age=86400"
+
+
+def test_hsts_emits_for_trusted_forwarded_https_when_opted_in(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS", "true")
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", "1")
+
+    headers = _headers_from_handler(monkeypatch, headers={"X-Forwarded-Proto": "https"})
+
+    assert headers["Strict-Transport-Security"] == "max-age=86400"
+
+
+def test_hsts_does_not_trust_forwarded_https_without_proxy_opt_in(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
+
+    headers = _headers_from_handler(monkeypatch, headers={"X-Forwarded-Proto": "https"})
+
+    assert "Strict-Transport-Security" not in headers
+
+
+def test_hsts_does_not_follow_cookie_secure_override_on_plain_http(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.setenv("HERMES_WEBUI_SECURE", "1")
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
+
+    headers = _headers_from_handler(monkeypatch)
+
+    assert "Strict-Transport-Security" not in headers
+
 
 
 def test_end_headers_reuses_cached_extra_connect_validation(monkeypatch, caplog):

--- a/tests/test_issue1909_csp_enforcement.py
+++ b/tests/test_issue1909_csp_enforcement.py
@@ -145,7 +145,7 @@ def test_report_only_csp_headers_still_point_to_collector(monkeypatch):
 
 
 def test_hsts_is_opt_in(monkeypatch):
-    monkeypatch.delenv("HERMES_WEBUI_HSTS", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_HSTS_MAX_AGE", raising=False)
 
     headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
 
@@ -153,7 +153,7 @@ def test_hsts_is_opt_in(monkeypatch):
 
 
 def test_hsts_requires_secure_transport_even_when_opted_in(monkeypatch):
-    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "86400")
     monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
 
     headers = _headers_from_handler(monkeypatch)
@@ -162,15 +162,23 @@ def test_hsts_requires_secure_transport_even_when_opted_in(monkeypatch):
 
 
 def test_hsts_emits_for_direct_tls_when_opted_in(monkeypatch):
-    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "86400")
 
     headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
 
     assert headers["Strict-Transport-Security"] == "max-age=86400"
 
 
+def test_hsts_emits_zero_to_unpin_direct_tls(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "0")
+
+    headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
+
+    assert headers["Strict-Transport-Security"] == "max-age=0"
+
+
 def test_hsts_emits_for_trusted_forwarded_https_when_opted_in(monkeypatch):
-    monkeypatch.setenv("HERMES_WEBUI_HSTS", "true")
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "86400")
     monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", "1")
 
     headers = _headers_from_handler(monkeypatch, headers={"X-Forwarded-Proto": "https"})
@@ -179,7 +187,7 @@ def test_hsts_emits_for_trusted_forwarded_https_when_opted_in(monkeypatch):
 
 
 def test_hsts_does_not_trust_forwarded_https_without_proxy_opt_in(monkeypatch):
-    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "86400")
     monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
 
     headers = _headers_from_handler(monkeypatch, headers={"X-Forwarded-Proto": "https"})
@@ -188,13 +196,22 @@ def test_hsts_does_not_trust_forwarded_https_without_proxy_opt_in(monkeypatch):
 
 
 def test_hsts_does_not_follow_cookie_secure_override_on_plain_http(monkeypatch):
-    monkeypatch.setenv("HERMES_WEBUI_HSTS", "1")
+    monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", "86400")
     monkeypatch.setenv("HERMES_WEBUI_SECURE", "1")
     monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_PROTO", raising=False)
 
     headers = _headers_from_handler(monkeypatch)
 
     assert "Strict-Transport-Security" not in headers
+
+
+def test_hsts_ignores_invalid_max_age(monkeypatch):
+    for value in ("", "-1", "not-a-number"):
+        monkeypatch.setenv("HERMES_WEBUI_HSTS_MAX_AGE", value)
+
+        headers = _headers_from_handler(monkeypatch, request=_SecureRequest())
+
+        assert "Strict-Transport-Security" not in headers
 
 
 


### PR DESCRIPTION
## Summary

Add an explicit, reversible HSTS policy for HTTPS-fronted Hermes WebUI deployments.

HSTS is **off by default**. When configured, the header is emitted only when the request actually arrived over HTTPS, either through a direct TLS socket or through an explicitly trusted reverse-proxy `X-Forwarded-Proto: https` path.

## What changed

- `api/auth.py`
  - adds `hsts_header_value(handler)`, which parses the nonnegative integer `HERMES_WEBUI_HSTS_MAX_AGE` setting;
  - returns no header for an unset, empty, negative, malformed, or oversized-invalid value;
  - keeps HSTS transport detection separate from the cookie-only `HERMES_WEBUI_SECURE` override;
  - permits `max-age=0` as an explicit rollback value.
- `server.py`
  - calls the shared HSTS helper from the existing response-header boundary;
  - emits `Strict-Transport-Security: max-age=<value>` only when the request is secure;
  - remains under the repository's 750-line guard (749 lines).
- `.env.example` and `README.md`
  - document `HERMES_WEBUI_HSTS_MAX_AGE=86400`;
  - explain that rollback requires serving `HERMES_WEBUI_HSTS_MAX_AGE=0` over HTTPS before switching the hostname back to HTTP;
  - document that HSTS applies to the whole hostname across ports, Firefox does not exempt `localhost`, and `includeSubDomains` / `preload` remain disabled.
- `tests/test_issue1909_csp_enforcement.py`
  - covers default-off behavior;
  - covers plain-HTTP omission;
  - covers direct TLS and trusted reverse-proxy HTTPS;
  - covers `max-age=0` unpinning;
  - rejects untrusted forwarded HTTPS, cookie-only Secure overrides, and invalid values.

## Safety contract

- Existing installations are unchanged unless `HERMES_WEBUI_HSTS_MAX_AGE` is explicitly set.
- `HERMES_WEBUI_HSTS_MAX_AGE=0` is the supported emergency rollback: keep HTTPS working, serve `max-age=0`, verify the browser has been unpinned, and only then switch the hostname to HTTP.
- A forged `X-Forwarded-Proto` header is ignored unless `HERMES_WEBUI_TRUST_FORWARDED_PROTO` is explicitly enabled.
- HSTS is intentionally not tied to `HERMES_WEBUI_SECURE`, because that setting controls cookie attributes and is not proof that the current request used HTTPS.
- No `includeSubDomains` or `preload` directive is emitted.

## Rebuild

Reconstructed the original HSTS patch onto current WebUI `master` (`cfcc3919`) and folded the maintainer's secure-context, reversible-rollback, and server-line-count requirements into commit `3ebd0e04`.

## Verification

- RED first: the new direct-TLS, trusted-proxy, and `max-age=0` tests failed before the implementation.
- Focused security/TLS tests: **36 passed**
- `python3 scripts/ruff_lint.py --diff origin/master`: **0 new violations on added/modified lines**
- `python3 -m py_compile server.py api/auth.py tests/test_issue1909_csp_enforcement.py`: passed
- `tests/test_sprint10.py::test_server_py_under_750_lines`: passed
- Full WebUI test suite: **14,902 passed, 156 skipped, 1 xfailed, 2 xpassed, 1 pre-existing failure** (`tests/test_workspace_git.py::test_git_commit_hook_failure_returns_hook_failed_code`). The same failure reproduces on pristine `master` and is unrelated to this PR.
- `git diff --check`: passed

## Note

This contribution was developed with AI assistance and then checked against the current code and test contract. It is offered as a focused starting point; maintainers are welcome to adapt, rewrite, or decline it.
