### PR TITLE
fix(transcript): keep the active turn's user bubble above its own output

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3359,9 +3359,8 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
 // The authoritative boundary is `pending_started_at`: every row belonging to a
 // PREVIOUS turn carries a timestamp strictly older than it. So scan backwards
 // for the newest definitively-older row; the active turn starts right after it.
-// Exception: a same-text user row whose timestamp is only a sub-second earlier
-// than `pending_started_at` is this turn's own drifted row, not history — return
-// its index so the merge adopts it instead of inserting a duplicate.
+// There is no text/proximity exception: visible text and timestamp closeness are
+// not turn identity, so even a same-text row 0.4s earlier remains history.
 //
 // Every compared timestamp is normalized through _timestampSeconds /
 // _firstValidTimestampSeconds (static/ui.js), so ISO-string and millisecond
@@ -3376,7 +3375,7 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
 // `_live` rows (this turn's own streaming placeholders) are skippable. Index 0
 // is returned only when EVERY settled row is demonstrably at/after the
 // boundary; an empty or live-only window proves nothing and also returns -1.
-function _activeTurnInsertionIndex(messages,session,pendingMsg){
+function _activeTurnInsertionIndex(messages,session){
   if(typeof _timestampSeconds!=='function'||typeof _firstValidTimestampSeconds!=='function') return -1;
   const startedAt=_timestampSeconds(session&&session.pending_started_at);
   if(startedAt===null) return -1;
@@ -3389,21 +3388,7 @@ function _activeTurnInsertionIndex(messages,session,pendingMsg){
     const ts=_firstValidTimestampSeconds(msg._ts,msg.timestamp,msg.created_at);
     if(ts===null) return -1;
     sawSettledRow=true;
-    if(ts<startedAt){
-      // Sub-second earlier drift on the current prompt is still this turn.
-      // Hour-old (or even 1s-old) same-text rows stay history: return i+1.
-      const olderDrift=startedAt-ts;
-      if(
-        pendingMsg
-        && String(msg.role||'')==='user'
-        && typeof _sameTranscriptMessage==='function'
-        && _sameTranscriptMessage(msg,pendingMsg)
-        && olderDrift<1
-      ){
-        return i;
-      }
-      return i+1;
-    }
+    if(ts<startedAt) return i+1;
   }
   // Every settled row is demonstrably at/after the boundary: the whole visible
   // window belongs to the active turn, so the prompt precedes all of it.
@@ -3422,7 +3407,7 @@ function _mergePendingSessionMessage(session,messages){
   if(!pendingMsg) return false;
   if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
   const boundaryIdx=typeof _activeTurnInsertionIndex==='function'
-    ? _activeTurnInsertionIndex(messages,session,pendingMsg)
+    ? _activeTurnInsertionIndex(messages,session)
     : -1;
   if(boundaryIdx>=0){
     // A same-text user row at/after the boundary IS this turn's own row: rows

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3346,9 +3346,47 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
   return !!(existing&&_sameTranscriptMessage(existing,candidate));
 }
 
+// Resolve the index where the ACTIVE turn begins — i.e. where its user row
+// belongs, above every row that turn has already produced.
+//
+// The live assistant row is not a usable anchor on its own: by the time the
+// pending prompt has to be projected, the current turn's interim commentary and
+// tool rows are usually ALREADY SETTLED in the transcript (the server persists
+// them as the turn runs), sitting above the `_live` tail. Anchoring on the live
+// row — or, when there is none, appending — therefore drops the user's own
+// message underneath the output it triggered.
+//
+// The authoritative boundary is `pending_started_at`: every row belonging to a
+// PREVIOUS turn carries a timestamp strictly older than it. So scan backwards
+// for the newest definitively-older row; the active turn starts right after it.
+// Untimed rows (optimistic/live rows) cannot close the scan — they carry no
+// evidence of belonging to an older turn.
+//
+// Fails closed: without a usable `pending_started_at`, or when the window holds
+// no timestamped row at all to anchor against, return -1 so the caller keeps the
+// previous live-row/append behaviour rather than guessing a position.
+function _activeTurnInsertionIndex(messages,session){
+  const list=Array.isArray(messages)?messages:[];
+  const startedAt=Number(session&&session.pending_started_at);
+  if(!Number.isFinite(startedAt)||startedAt<=0) return -1;
+  let sawTimestampedRow=false;
+  for(let i=list.length-1;i>=0;i--){
+    const msg=list[i];
+    if(!msg) continue;
+    const ts=typeof _messageTimestampSeconds==='function'?_messageTimestampSeconds(msg):null;
+    if(ts===null) continue;
+    sawTimestampedRow=true;
+    if(ts<startedAt) return i+1;
+  }
+  // Every timestamped row is at/after the boundary: the whole visible window
+  // belongs to the active turn, so the prompt precedes all of it.
+  return sawTimestampedRow?0:-1;
+}
+
 // Keep pending-user recovery ordering identical across load, reconnect, and
-// explicit refresh paths. The pending prompt owns the live assistant tail and
-// must be projected before it, regardless of which recovery response arrived.
+// explicit refresh paths. The pending prompt owns the ACTIVE TURN and must be
+// projected above everything that turn produced, regardless of which recovery
+// response arrived.
 function _mergePendingSessionMessage(session,messages){
   if(!Array.isArray(messages)) return false;
   const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
@@ -3356,6 +3394,36 @@ function _mergePendingSessionMessage(session,messages){
   const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,currentTurnMessages):null;
   if(!pendingMsg) return false;
   if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
+  const boundaryIdx=typeof _activeTurnInsertionIndex==='function'
+    ? _activeTurnInsertionIndex(messages,session)
+    : -1;
+  if(boundaryIdx>=0){
+    // A same-text user row at/after the boundary IS this turn's own row: rows
+    // from earlier turns are strictly older than `pending_started_at` and thus
+    // strictly above the boundary. This is boundary-scoped identity, not text
+    // proximity, so a legitimate repeat of the same prompt in a PREVIOUS turn
+    // still yields its own bubble instead of being swallowed.
+    const existingIdx=messages.findIndex((m,idx)=>
+      idx>=boundaryIdx&&m&&m.role==='user'&&_sameTranscriptMessage(m,pendingMsg)
+    );
+    if(existingIdx>=0){
+      const existing=messages[existingIdx];
+      const attachments=Array.isArray(pendingMsg.attachments)?pendingMsg.attachments:[];
+      if(attachments.length&&!(existing.attachments&&existing.attachments.length)){
+        existing.attachments=attachments;
+      }
+      if(existingIdx>boundaryIdx){
+        // Already rendered below its own turn output — lift it back to the
+        // boundary instead of adding a second bubble.
+        messages.splice(existingIdx,1);
+        messages.splice(boundaryIdx,0,existing);
+        return true;
+      }
+      return false;
+    }
+    messages.splice(boundaryIdx,0,pendingMsg);
+    return true;
+  }
   if(liveAssistantIdx>=0){
     const misplacedIdx=messages.findIndex((m,idx)=>
       idx>liveAssistantIdx&&m&&m.role==='user'&&_sameTranscriptMessage(m,pendingMsg)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3359,28 +3359,38 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
 // The authoritative boundary is `pending_started_at`: every row belonging to a
 // PREVIOUS turn carries a timestamp strictly older than it. So scan backwards
 // for the newest definitively-older row; the active turn starts right after it.
-// Untimed rows (optimistic/live rows) cannot close the scan — they carry no
-// evidence of belonging to an older turn.
 //
-// Fails closed: without a usable `pending_started_at`, or when the window holds
-// no timestamped row at all to anchor against, return -1 so the caller keeps the
-// previous live-row/append behaviour rather than guessing a position.
+// Every compared timestamp is normalized through _timestampSeconds /
+// _firstValidTimestampSeconds (static/ui.js), so ISO-string and millisecond
+// epochs compare correctly against the seconds-based boundary. Sessions with
+// such rows are reachable in production: /api/session/import preserves the
+// supplied message timestamps verbatim in a writable session.
+//
+// Fails closed: a SETTLED row the scan crosses without a comparable timestamp
+// is indistinguishable from history, so return -1 and let the caller keep the
+// previous live-row/append behaviour rather than guess — a transient duplicate
+// bubble is recoverable, re-ordering history or swallowing a turn is not. Only
+// `_live` rows (this turn's own streaming placeholders) are skippable. Index 0
+// is returned only when EVERY settled row is demonstrably at/after the
+// boundary; an empty or live-only window proves nothing and also returns -1.
 function _activeTurnInsertionIndex(messages,session){
+  if(typeof _timestampSeconds!=='function'||typeof _firstValidTimestampSeconds!=='function') return -1;
+  const startedAt=_timestampSeconds(session&&session.pending_started_at);
+  if(startedAt===null) return -1;
   const list=Array.isArray(messages)?messages:[];
-  const startedAt=Number(session&&session.pending_started_at);
-  if(!Number.isFinite(startedAt)||startedAt<=0) return -1;
-  let sawTimestampedRow=false;
+  let sawSettledRow=false;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
-    const ts=typeof _messageTimestampSeconds==='function'?_messageTimestampSeconds(msg):null;
-    if(ts===null) continue;
-    sawTimestampedRow=true;
+    if(msg._live) continue;
+    const ts=_firstValidTimestampSeconds(msg._ts,msg.timestamp,msg.created_at);
+    if(ts===null) return -1;
+    sawSettledRow=true;
     if(ts<startedAt) return i+1;
   }
-  // Every timestamped row is at/after the boundary: the whole visible window
-  // belongs to the active turn, so the prompt precedes all of it.
-  return sawTimestampedRow?0:-1;
+  // Every settled row is demonstrably at/after the boundary: the whole visible
+  // window belongs to the active turn, so the prompt precedes all of it.
+  return sawSettledRow?0:-1;
 }
 
 // Keep pending-user recovery ordering identical across load, reconnect, and

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3359,6 +3359,9 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
 // The authoritative boundary is `pending_started_at`: every row belonging to a
 // PREVIOUS turn carries a timestamp strictly older than it. So scan backwards
 // for the newest definitively-older row; the active turn starts right after it.
+// Exception: a same-text user row whose timestamp is only a sub-second earlier
+// than `pending_started_at` is this turn's own drifted row, not history — return
+// its index so the merge adopts it instead of inserting a duplicate.
 //
 // Every compared timestamp is normalized through _timestampSeconds /
 // _firstValidTimestampSeconds (static/ui.js), so ISO-string and millisecond
@@ -3373,7 +3376,7 @@ function _hasCurrentTailUserDuplicate(messages,candidate){
 // `_live` rows (this turn's own streaming placeholders) are skippable. Index 0
 // is returned only when EVERY settled row is demonstrably at/after the
 // boundary; an empty or live-only window proves nothing and also returns -1.
-function _activeTurnInsertionIndex(messages,session){
+function _activeTurnInsertionIndex(messages,session,pendingMsg){
   if(typeof _timestampSeconds!=='function'||typeof _firstValidTimestampSeconds!=='function') return -1;
   const startedAt=_timestampSeconds(session&&session.pending_started_at);
   if(startedAt===null) return -1;
@@ -3386,7 +3389,21 @@ function _activeTurnInsertionIndex(messages,session){
     const ts=_firstValidTimestampSeconds(msg._ts,msg.timestamp,msg.created_at);
     if(ts===null) return -1;
     sawSettledRow=true;
-    if(ts<startedAt) return i+1;
+    if(ts<startedAt){
+      // Sub-second earlier drift on the current prompt is still this turn.
+      // Hour-old (or even 1s-old) same-text rows stay history: return i+1.
+      const olderDrift=startedAt-ts;
+      if(
+        pendingMsg
+        && String(msg.role||'')==='user'
+        && typeof _sameTranscriptMessage==='function'
+        && _sameTranscriptMessage(msg,pendingMsg)
+        && olderDrift<1
+      ){
+        return i;
+      }
+      return i+1;
+    }
   }
   // Every settled row is demonstrably at/after the boundary: the whole visible
   // window belongs to the active turn, so the prompt precedes all of it.
@@ -3405,7 +3422,7 @@ function _mergePendingSessionMessage(session,messages){
   if(!pendingMsg) return false;
   if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
   const boundaryIdx=typeof _activeTurnInsertionIndex==='function'
-    ? _activeTurnInsertionIndex(messages,session)
+    ? _activeTurnInsertionIndex(messages,session,pendingMsg)
     : -1;
   if(boundaryIdx>=0){
     // A same-text user row at/after the boundary IS this turn's own row: rows

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -215,16 +215,12 @@ def test_unmatched_transcript_row_does_not_duplicate_below_its_own_output():
     )
 
 
-def test_unmatched_transcript_row_slightly_before_started_at_is_adopted():
-    """Current-turn user row whose timestamp drifted slightly earlier than
-    pending_started_at must still be classified as this turn, not history.
+def test_identical_prompt_point_four_seconds_before_boundary_keeps_both_turns():
+    """A row at ``pending_started_at - 0.4s`` is historical even when its
+    normalized text matches the pending prompt.
 
-    Review 2026-08-18 (CHANGES_REQUESTED): +0.4s drift is adopted, but -0.4s
-    made the row look older than the boundary, so the classifier returned i+1
-    and the merge inserted a second bubble above the existing row.
-
-    Mirror of the +0.4 case, with attachments: one prompt bubble, existing
-    files kept, placed immediately above the first active-turn output.
+    Text plus timestamp proximity is not turn identity.  The earlier row and
+    the pending turn must each keep their own bubble and distinct attachments.
     """
     body = f"""
 {_PROBE_TAIL}
@@ -233,47 +229,39 @@ const session={{
   active_stream_id:'stream-1',
   pending_user_message:{json.dumps(_PROMPT)},
   pending_started_at:{_T0},
-  pending_attachments:[{{name:'courant.png'}}],
+  pending_attachments:[{{name:'courant.pdf'}}],
 }};
 const messages={_transcript(
         {
             "role": "user",
             "content": _PROMPT,
             "timestamp": _T0 - 0.4,
-            "attachments": [{"name": "courant.png"}],
+            "attachments": [{"name": "precedent.png"}],
         },
         with_live=False,
     )};
 const merged=_mergePendingSessionMessage(session, messages);
 const idxs=idxsOfPrompt(messages);
-const firstOutput=firstTurnOutputIdx(messages);
 process.stdout.write(JSON.stringify({{
   merged,
   promptIdxs: idxs,
-  firstOutputIdx: firstOutput,
-  belowOwnOutput: idxs.length ? (Math.max.apply(null, idxs) > firstOutput && firstOutput >= 0) : false,
-  duplicated: idxs.length > 1,
   attachmentsByIdx: messages.map(m=>Array.isArray(m&&m.attachments)?m.attachments.map(a=>a&&a.name):null),
   order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
 }}));
 """
     result = _run_probe(body)
-    assert not result["duplicated"], (
-        "the pending prompt was rendered twice (the transcript row plus a "
-        f"materialized copy): {result['order']}"
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [2, 3], (
+        "strictly pre-boundary history must not be adopted as the current turn, "
+        f"even at sub-second distance: {result['order']}"
     )
-    assert not result["belowOwnOutput"], (
-        f"the adopted bubble landed below its own turn output: {result['order']}"
+    assert result["attachmentsByIdx"][2] == ["precedent.png"], (
+        "the historical turn must keep its attachment: "
+        f"{result['attachmentsByIdx']} ({result['order']})"
     )
-    assert result["promptIdxs"] == [result["firstOutputIdx"] - 1], (
-        "the drifted current-turn user row must sit at the turn boundary; "
-        f"got indices {result['promptIdxs']} with turn output starting at "
-        f"{result['firstOutputIdx']} ({result['order']})"
-    )
-    prompt_idx = result["promptIdxs"][0]
-    assert result["attachmentsByIdx"][prompt_idx] == ["courant.png"], (
-        "adopting the slightly-earlier current-turn row must keep its "
-        f"attachments: {result['attachmentsByIdx']} ({result['order']})"
+    assert result["attachmentsByIdx"][3] == ["courant.pdf"], (
+        "the pending turn must keep its attachment: "
+        f"{result['attachmentsByIdx']} ({result['order']})"
     )
 
 

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -62,6 +62,8 @@ def _helpers() -> str:
         _function_body(UI_SRC, "function msgContent"),
         _function_body(UI_SRC, "function _isContextCompactionText"),
         _function_body(UI_SRC, "function _isContextCompactionMessage"),
+        _function_body(UI_SRC, "function _timestampSeconds"),
+        _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
         _function_body(UI_SRC, "function _messageTimestampSeconds"),
         _function_body(UI_SRC, "function _activeTurnTokenMatches"),
         _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
@@ -213,15 +215,27 @@ def test_unmatched_transcript_row_does_not_duplicate_below_its_own_output():
     )
 
 
-def test_timestampless_transcript_row_does_not_duplicate_below_its_own_output():
-    """Same class, with a transcript row carrying no timestamp at all."""
+def test_timestampless_transcript_row_fails_closed_to_prior_merge_behavior():
+    """Same class, with a transcript row carrying no timestamp at all.
+
+    Review 2026-08-17 (CHANGES_REQUESTED): a settled row without a comparable
+    timestamp is indistinguishable from history, so the classifier must fail
+    closed (-1) and keep the prior merge behaviour (no live row -> append)
+    instead of declaring the whole window active and adopting an ambiguous row.
+    The transient duplicate bubble is recoverable at settle; swallowing a real
+    turn is not.
+    """
     untimed = {"role": "user", "content": _PROMPT}
     result = _probe(untimed, with_live=False)
-    assert not result["duplicated"], (
-        f"the pending prompt was rendered twice: {result['order']}"
+    assert result["merged"] is True, (
+        f"fail-closed must keep the prior append behaviour: {result['order']}"
     )
-    assert not result["belowOwnOutput"], (
-        f"the duplicated bubble landed below its own turn output: {result['order']}"
+    # The untimed row keeps its place; the pending prompt is appended at the
+    # tail exactly as before the boundary classifier existed. Nothing is
+    # re-ordered, adopted, or dropped.
+    assert result["promptIdxs"] == [2, 7], (
+        "an untimed settled row must not be adopted nor re-ordered; the prompt "
+        f"must be appended (prior behaviour): {result['order']}"
     )
 
 
@@ -321,3 +335,150 @@ process.stdout.write(JSON.stringify({{
         "the prompt must land at the active turn boundary, not inside the "
         f"previous settled turn: {result['order']}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Review 2026-08-17 (CHANGES_REQUESTED): timestamp unit/format mishandling.
+#
+# The first classifier skipped untimed and ISO-string timestamps and read
+# millisecond epochs as seconds. `sawTimestampedRow ? 0 : -1` then declared the
+# entire window active, inserting the current prompt at index 0 above real
+# history — or adopting an earlier same-text row, swallowing a turn and losing
+# the current attachment. Such transcripts are reachable in production:
+# /api/session/import preserves supplied message timestamps and creates an
+# ordinary writable session.
+#
+# Contract pinned here: normalize every compared timestamp through
+# _timestampSeconds/_firstValidTimestampSeconds; fail closed (-1 -> prior merge
+# behaviour) when any crossed settled row lacks a comparable timestamp; return
+# index 0 only when every settled row is demonstrably at/after the boundary.
+# ---------------------------------------------------------------------------
+
+# A realistic epoch: ISO strings must round-trip through Date.parse.
+_EPOCH = 1755424800.0  # 2025-08-17T10:00:00Z
+
+
+def _epoch_session(attachments: list | None = None) -> str:
+    return json.dumps(
+        {
+            "session_id": "s1",
+            "active_stream_id": "stream-1",
+            "pending_user_message": _PROMPT,
+            "pending_started_at": _EPOCH,
+            "pending_attachments": attachments or [],
+        }
+    )
+
+
+def _run_epoch_probe(history_rows_js: str, attachments: list | None = None) -> dict:
+    body = f"""
+const session={_epoch_session(attachments)};
+const messages=[
+{history_rows_js}
+  {{role:'assistant', content:'je verifie X', timestamp:{_EPOCH + 10}}},
+  {{role:'tool', content:'{{}}', timestamp:{_EPOCH + 11}}},
+];
+const merged=_mergePendingSessionMessage(session, messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: messages.reduce((out,m,i)=>{{ if(m&&m.role==='user'&&String(m.content||'')==={json.dumps(_PROMPT)}) out.push(i); return out; }}, []),
+  attachmentsByIdx: messages.map(m=>Array.isArray(m&&m.attachments)?m.attachments.map(a=>a&&a.name):null),
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:(m._ts!==undefined?m._ts:'untimed')}}`),
+}}));
+"""
+    return _run_probe(body)
+
+
+def test_untimed_history_rows_are_never_displaced_below_current_prompt():
+    """Untimed settled HISTORY (different text) must stay first.
+
+    The first classifier skipped untimed rows, saw only the timestamped turn
+    output at/after the boundary, and returned 0 — inserting the current prompt
+    at index 0, above real history. Master kept history first (append). The
+    classifier must fail closed to that prior behaviour.
+    """
+    result = _run_epoch_probe(
+        """  {role:'user', content:'prompt precedent'},
+  {role:'assistant', content:'reponse precedente'},
+"""
+    )
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [4], (
+        "with untimed settled history the classifier must fall back to the "
+        f"prior append behaviour, never index 0: {result['order']}"
+    )
+    assert result["order"][0].startswith("user@"), result["order"]
+
+
+def test_iso_string_history_rows_stay_above_current_prompt():
+    """ISO-8601 string timestamps are comparable after normalization.
+
+    The first classifier read them through Number() -> NaN and skipped them like
+    untimed rows, so the prompt landed at index 0 above ISO-timestamped history.
+    Normalized, they are strictly older than the boundary and history stays
+    first, with the prompt at the turn boundary.
+    """
+    result = _run_epoch_probe(
+        """  {role:'user', content:'prompt precedent', timestamp:'2025-08-17T09:00:00Z'},
+  {role:'assistant', content:'reponse precedente', timestamp:'2025-08-17T09:01:00Z'},
+"""
+    )
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [2], (
+        "ISO-timestamped history must stay above the current prompt, which "
+        f"belongs at the turn boundary: {result['order']}"
+    )
+
+
+def test_millisecond_history_rows_stay_above_current_prompt():
+    """Millisecond epochs are comparable after normalization.
+
+    The first classifier compared raw ms against a seconds boundary, so history
+    looked newer than `pending_started_at` and the whole window was declared
+    active (index 0). Normalized, ms history is strictly older and stays first.
+    """
+    result = _run_epoch_probe(
+        f"""  {{role:'user', content:'prompt precedent', timestamp:{(_EPOCH - 3600) * 1000}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{(_EPOCH - 3540) * 1000}}},
+"""
+    )
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [2], (
+        "millisecond-timestamped history must stay above the current prompt: "
+        f"{result['order']}"
+    )
+
+
+def test_earlier_identical_prompt_with_different_attachments_is_not_swallowed():
+    """An earlier turn with the SAME text but different attachments must keep
+    its own bubble AND its own attachments, and the current turn must keep its.
+
+    Reproduced by review on the first classifier: the ms-timestamped history was
+    misread as at/after the boundary, index 0 was declared the turn start, and
+    sessions.js adopted the earlier same-text row — two turns rendered as one
+    and the current attachment was lost (the earlier row already had one, so the
+    adoption branch dropped the pending attachment on the floor).
+    """
+    for label, earlier_ts in (
+        ("milliseconds", json.dumps((_EPOCH - 3600) * 1000)),
+        ("ISO string", json.dumps("2025-08-17T09:00:00Z")),
+    ):
+        result = _run_epoch_probe(
+            f"""  {{role:'user', content:{json.dumps(_PROMPT)}, timestamp:{earlier_ts}, attachments:[{{name:'ancien.png'}}]}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{earlier_ts}}},
+""",
+            attachments=[{"name": "nouveau.pdf"}],
+        )
+        assert result["merged"] is True, (label, result["order"])
+        assert result["promptIdxs"] == [0, 2], (
+            f"[{label}] both the earlier identical prompt and the current one "
+            f"must keep their own bubbles: {result['order']}"
+        )
+        assert result["attachmentsByIdx"][0] == ["ancien.png"], (
+            f"[{label}] the earlier turn's attachment must survive untouched: "
+            f"{result['attachmentsByIdx']}"
+        )
+        assert result["attachmentsByIdx"][2] == ["nouveau.pdf"], (
+            f"[{label}] the current turn's attachment must not be lost: "
+            f"{result['attachmentsByIdx']}"
+        )

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -1,0 +1,323 @@
+"""Regression: the active turn's user bubble must never render BELOW its own turn output.
+
+Reported symptom (WebUI, live): while a turn is running, the user's newest
+message is drawn at the very bottom of the transcript, underneath the interim
+commentary and tool cards that this same message triggered.
+
+Server truth is correct: the active turn's user row is persisted BEFORE the
+turn's assistant/tool rows. The defect is in the browser projection.
+
+`_mergePendingSessionMessage()` (static/sessions.js) merges the sidecar's
+`pending_user_message` into `S.messages`. It positions that row relative to the
+first `_live` assistant row only:
+
+  * live row present  -> insert before it;
+  * live row absent   -> `messages.push(...)` -> lands at the very bottom.
+
+Both branches ignore the fact that the current turn's ALREADY-PERSISTED output
+(interim assistant prose + tool rows) is sitting at the tail of the transcript.
+So whenever the pending prompt has to be materialized (its transcript row is not
+identity-matched, or is not in the returned window at all), the bubble is placed
+after that output instead of at the turn boundary.
+
+These tests run the real helpers extracted from the shipped static assets.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_SRC = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        char = src[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"could not extract function body for {signature!r}")
+
+
+def _optional_function_body(src: str, signature: str) -> str:
+    try:
+        return _function_body(src, signature)
+    except (ValueError, AssertionError):
+        return ""
+
+
+def _helpers() -> str:
+    parts = [
+        "const _PENDING_ACTIVE_TURN_TS_EPSILON=1e-6;",
+        _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+        _function_body(UI_SRC, "function msgContent"),
+        _function_body(UI_SRC, "function _isContextCompactionText"),
+        _function_body(UI_SRC, "function _isContextCompactionMessage"),
+        _function_body(UI_SRC, "function _messageTimestampSeconds"),
+        _function_body(UI_SRC, "function _activeTurnTokenMatches"),
+        _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+        _function_body(UI_SRC, "function _pendingActiveTurnUserMessage"),
+        _function_body(UI_SRC, "function getPendingSessionMessage"),
+        _function_body(SESSIONS_SRC, "function _messageComparableText"),
+        _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
+        _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
+        _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
+        _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+        _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+        _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+        # The turn-boundary helper is the fix. Its ABSENCE is the regression, so
+        # extract it optionally and let the behavioral assertion do the talking.
+        _optional_function_body(SESSIONS_SRC, "function _activeTurnInsertionIndex"),
+        _function_body(SESSIONS_SRC, "function _mergePendingSessionMessage"),
+    ]
+    return "\n".join(p for p in parts if p)
+
+
+_T0 = 1000.0
+_PROMPT = "nouveau prompt"
+
+
+def _run_probe(script_body: str) -> dict:
+    script = f"{_helpers()}\n{script_body}"
+    proc = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert proc.returncode == 0, f"node probe failed: {proc.stderr[:4000]}"
+    return json.loads(proc.stdout)
+
+
+_SESSION_JS = json.dumps(
+    {
+        "session_id": "s1",
+        "active_stream_id": "stream-1",
+        "pending_user_message": _PROMPT,
+        "pending_started_at": _T0,
+        "pending_attachments": [],
+    }
+)
+
+
+def _transcript(user_row: dict | None, *, with_live: bool) -> str:
+    """Previous settled turn, optional current-turn user row, then the current
+    turn's already-persisted interim prose + tool output."""
+    rows: list[dict] = [
+        {"role": "user", "content": "prompt precedent", "timestamp": _T0 - 200},
+        {"role": "assistant", "content": "reponse precedente", "timestamp": _T0 - 150},
+    ]
+    if user_row is not None:
+        rows.append(user_row)
+    rows.extend(
+        [
+            {"role": "assistant", "content": "je verifie X", "timestamp": _T0 + 10},
+            {"role": "tool", "content": "{}", "timestamp": _T0 + 11},
+            {"role": "assistant", "content": "je verifie Y", "timestamp": _T0 + 30},
+            {"role": "tool", "content": "{}", "timestamp": _T0 + 31},
+        ]
+    )
+    if with_live:
+        rows.append({"role": "assistant", "content": "streaming", "_live": True})
+    return json.dumps(rows)
+
+
+_PROBE_TAIL = f"""
+function idxsOfPrompt(list){{
+  const out=[];
+  list.forEach((m,i)=>{{ if(m&&m.role==='user'&&String(m.content||'')==={json.dumps(_PROMPT)}) out.push(i); }});
+  return out;
+}}
+function firstTurnOutputIdx(list){{
+  return list.findIndex(m=>m&&m.role!=='user'&&Number(m.timestamp)>={_T0});
+}}
+"""
+
+
+def _probe(user_row: dict | None, *, with_live: bool) -> dict:
+    body = f"""
+{_PROBE_TAIL}
+const session={_SESSION_JS};
+const messages={_transcript(user_row, with_live=with_live)};
+const merged=_mergePendingSessionMessage(session, messages);
+const idxs=idxsOfPrompt(messages);
+const firstOutput=firstTurnOutputIdx(messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: idxs,
+  firstOutputIdx: firstOutput,
+  belowOwnOutput: idxs.length ? (Math.max.apply(null, idxs) > firstOutput && firstOutput >= 0) : false,
+  duplicated: idxs.length > 1,
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
+}}));
+"""
+    return _run_probe(body)
+
+
+def test_materialized_pending_prompt_is_not_pushed_below_its_own_turn_output():
+    """The current turn's user row is absent from the returned window.
+
+    The prompt must be materialized at the turn boundary (before the interim
+    prose it triggered), not appended after it.
+    """
+    result = _probe(None, with_live=False)
+    assert result["merged"] is True, "the pending prompt must be projected"
+    assert not result["belowOwnOutput"], (
+        "the active turn's user bubble was rendered BELOW the interim commentary "
+        f"and tool cards of its own turn: {result['order']}"
+    )
+    # `firstOutputIdx` is measured AFTER the merge, so the inserted bubble has
+    # already shifted it by one. The invariant is adjacency: the prompt sits
+    # immediately above the first row its own turn produced.
+    assert result["promptIdxs"] == [result["firstOutputIdx"] - 1], (
+        "the materialized prompt must sit exactly at the active turn boundary; "
+        f"got indices {result['promptIdxs']} with turn output starting at "
+        f"{result['firstOutputIdx']} ({result['order']})"
+    )
+
+
+def test_materialized_pending_prompt_stays_above_output_with_live_row():
+    """Same, while an assistant `_live` row is streaming at the tail.
+
+    The live row is not the turn boundary: this turn's settled interim rows are
+    already above it, so inserting immediately before the live row still places
+    the bubble under them.
+    """
+    result = _probe(None, with_live=True)
+    assert result["merged"] is True
+    assert not result["belowOwnOutput"], (
+        "the active turn's user bubble was rendered below its own turn output "
+        f"even though a live row was present: {result['order']}"
+    )
+
+
+def test_unmatched_transcript_row_does_not_duplicate_below_its_own_output():
+    """The current turn's user row IS present but is not identity-matched.
+
+    Sub-second timestamp drift defeats the exact-identity match, so the prompt is
+    materialized a second time. The duplicate must not land under the turn's own
+    output; the existing row is authoritative and must be adopted instead.
+    """
+    drifted = {"role": "user", "content": _PROMPT, "timestamp": _T0 + 0.4}
+    result = _probe(drifted, with_live=False)
+    assert not result["duplicated"], (
+        "the pending prompt was rendered twice (the transcript row plus a "
+        f"materialized copy): {result['order']}"
+    )
+    assert not result["belowOwnOutput"], (
+        f"the duplicated bubble landed below its own turn output: {result['order']}"
+    )
+
+
+def test_timestampless_transcript_row_does_not_duplicate_below_its_own_output():
+    """Same class, with a transcript row carrying no timestamp at all."""
+    untimed = {"role": "user", "content": _PROMPT}
+    result = _probe(untimed, with_live=False)
+    assert not result["duplicated"], (
+        f"the pending prompt was rendered twice: {result['order']}"
+    )
+    assert not result["belowOwnOutput"], (
+        f"the duplicated bubble landed below its own turn output: {result['order']}"
+    )
+
+
+def test_identity_matched_row_is_still_adopted_without_duplication():
+    """Guard the already-working path: an exact identity match must keep
+    adopting the transcript row rather than materializing a second bubble."""
+    tokened = {
+        "role": "user",
+        "content": _PROMPT,
+        "timestamp": _T0,
+        "_active_turn_token": f"stream-1:{_T0}",
+    }
+    result = _probe(tokened, with_live=False)
+    assert result["merged"] is False, "an identity-matched row must be adopted, not re-materialized"
+    assert result["promptIdxs"] == [2], result["order"]
+    assert not result["duplicated"]
+    assert not result["belowOwnOutput"]
+
+
+def test_pending_prompt_before_any_turn_output_still_appends():
+    """No output has been persisted yet for the active turn: the prompt is the
+    tail of the transcript and must stay there (no spurious re-ordering)."""
+    body = f"""
+{_PROBE_TAIL}
+const session={_SESSION_JS};
+const messages=[
+  {{role:'user', content:'prompt precedent', timestamp:{_T0 - 200}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{_T0 - 150}}},
+];
+const merged=_mergePendingSessionMessage(session, messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: idxsOfPrompt(messages),
+  total: messages.length,
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
+}}));
+"""
+    result = _run_probe(body)
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [2], result["order"]
+    assert result["total"] == 3
+
+
+def test_pending_prompt_inserts_before_live_row_when_turn_has_no_settled_output():
+    """Established contract (#6419): with a live assistant row and no settled
+    output for this turn, the prompt goes immediately before the live row."""
+    body = f"""
+{_PROBE_TAIL}
+const session={_SESSION_JS};
+const messages=[
+  {{role:'user', content:'prompt precedent', timestamp:{_T0 - 200}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{_T0 - 150}}},
+  {{role:'assistant', content:'streaming', _live:true}},
+];
+const merged=_mergePendingSessionMessage(session, messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: idxsOfPrompt(messages),
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
+}}));
+"""
+    result = _run_probe(body)
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [2], (
+        f"the prompt must precede the live assistant row: {result['order']}"
+    )
+
+
+def test_previous_turn_rows_are_not_treated_as_active_turn_output():
+    """Only rows at/after `pending_started_at` belong to the active turn.
+
+    A settled prior turn whose rows sit above the boundary must not pull the
+    bubble upward into history.
+    """
+    body = f"""
+{_PROBE_TAIL}
+const session={_SESSION_JS};
+const messages=[
+  {{role:'user', content:'prompt tres ancien', timestamp:{_T0 - 900}}},
+  {{role:'assistant', content:'vieille reponse', timestamp:{_T0 - 880}}},
+  {{role:'tool', content:'{{}}', timestamp:{_T0 - 870}}},
+  {{role:'user', content:'prompt precedent', timestamp:{_T0 - 200}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{_T0 - 150}}},
+  {{role:'assistant', content:'je verifie X', timestamp:{_T0 + 10}}},
+  {{role:'tool', content:'{{}}', timestamp:{_T0 + 11}}},
+];
+const merged=_mergePendingSessionMessage(session, messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: idxsOfPrompt(messages),
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
+}}));
+"""
+    result = _run_probe(body)
+    assert result["merged"] is True
+    assert result["promptIdxs"] == [5], (
+        "the prompt must land at the active turn boundary, not inside the "
+        f"previous settled turn: {result['order']}"
+    )

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -521,18 +521,26 @@ def test_earlier_identical_prompt_with_different_attachments_is_not_swallowed():
     and the current attachment was lost (the earlier row already had one, so the
     adoption branch dropped the pending attachment on the floor).
     """
-    for label, earlier_ts in (
-        ("milliseconds", json.dumps((_EPOCH - 3600) * 1000)),
-        ("ISO string", json.dumps("2025-08-17T09:00:00Z")),
+    for label, earlier_ts, expected_current_idx in (
+        # Comparable timestamps: the earlier row is strictly older than the
+        # boundary, so the current prompt is inserted AT the turn boundary (2).
+        ("milliseconds", json.dumps((_EPOCH - 3600) * 1000), 2),
+        ("ISO string", json.dumps("2025-08-17T09:00:00Z"), 2),
+        # Untimed is the third format the review named. With no comparable
+        # timestamp the classifier must fail closed (-1) rather than adopt the
+        # row, so the merge keeps the prior append behaviour (tail index 4).
+        # Either way the earlier turn keeps its own bubble and attachment.
+        ("untimed", None, 4),
     ):
+        ts_js = f", timestamp:{earlier_ts}" if earlier_ts is not None else ""
         result = _run_epoch_probe(
-            f"""  {{role:'user', content:{json.dumps(_PROMPT)}, timestamp:{earlier_ts}, attachments:[{{name:'ancien.png'}}]}},
-  {{role:'assistant', content:'reponse precedente', timestamp:{earlier_ts}}},
+            f"""  {{role:'user', content:{json.dumps(_PROMPT)}{ts_js}, attachments:[{{name:'ancien.png'}}]}},
+  {{role:'assistant', content:'reponse precedente'{ts_js}}},
 """,
             attachments=[{"name": "nouveau.pdf"}],
         )
         assert result["merged"] is True, (label, result["order"])
-        assert result["promptIdxs"] == [0, 2], (
+        assert result["promptIdxs"] == [0, expected_current_idx], (
             f"[{label}] both the earlier identical prompt and the current one "
             f"must keep their own bubbles: {result['order']}"
         )
@@ -540,7 +548,79 @@ def test_earlier_identical_prompt_with_different_attachments_is_not_swallowed():
             f"[{label}] the earlier turn's attachment must survive untouched: "
             f"{result['attachmentsByIdx']}"
         )
-        assert result["attachmentsByIdx"][2] == ["nouveau.pdf"], (
+        assert result["attachmentsByIdx"][expected_current_idx] == ["nouveau.pdf"], (
             f"[{label}] the current turn's attachment must not be lost: "
             f"{result['attachmentsByIdx']}"
+        )
+
+
+def test_uncomparable_timestamp_formats_never_declare_the_window_active():
+    """Timestamps that `_timestampSeconds` rejects must fail closed, not be
+    silently treated as at/after the boundary.
+
+    `_timestampSeconds` returns null for out-of-Date-range, zero and negative
+    epochs. A classifier that only guarded `undefined`/`null` would let these
+    fall through as "not older than the boundary", satisfy the every-settled-row
+    test and return index 0 — inserting the current prompt above real history,
+    the exact shape the review reproduced with ISO/millisecond rows.
+    """
+    for label, ts_js in (
+        ("out-of-range numeric", "1e20"),
+        ("zero epoch", "0"),
+        ("negative epoch", "-5"),
+        ("non-date string", "'pas une date'"),
+    ):
+        result = _run_epoch_probe(
+            f"""  {{role:'user', content:'prompt precedent', timestamp:{ts_js}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{ts_js}}},
+"""
+        )
+        assert result["merged"] is True, (label, result["order"])
+        assert result["promptIdxs"] == [4], (
+            f"[{label}] an uncomparable timestamp must fail closed to the prior "
+            f"append behaviour, never index 0: {result['order']}"
+        )
+        assert result["order"][0].startswith("user@"), (label, result["order"])
+
+
+def test_boundary_normalizes_iso_and_millisecond_pending_started_at():
+    """`pending_started_at` itself is normalized, not just the row timestamps.
+
+    The sidecar boundary can arrive as an ISO string or a millisecond epoch. An
+    un-normalized boundary compared against seconds-based rows makes ALL history
+    look newer (ISO -> NaN, ms -> huge), which is the same reorder defect from
+    the other side of the comparison.
+    """
+    history = f"""  {{role:'user', content:'prompt precedent', timestamp:{_EPOCH - 3600}}},
+  {{role:'assistant', content:'reponse precedente', timestamp:{_EPOCH - 3540}}},
+"""
+    for label, started_at in (
+        ("ISO string", json.dumps("2025-08-17T10:00:00Z")),
+        ("milliseconds", json.dumps(_EPOCH * 1000)),
+        ("seconds", json.dumps(_EPOCH)),
+    ):
+        body = f"""
+const session={{
+  session_id:'s1',
+  active_stream_id:'stream-1',
+  pending_user_message:{json.dumps(_PROMPT)},
+  pending_started_at:{started_at},
+  pending_attachments:[],
+}};
+const messages=[
+{history}  {{role:'assistant', content:'je verifie X', timestamp:{_EPOCH + 10}}},
+  {{role:'tool', content:'{{}}', timestamp:{_EPOCH + 11}}},
+];
+const merged=_mergePendingSessionMessage(session, messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: messages.reduce((out,m,i)=>{{ if(m&&m.role==='user'&&String(m.content||'')==={json.dumps(_PROMPT)}) out.push(i); return out; }}, []),
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'untimed'}}`),
+}}));
+"""
+        result = _run_probe(body)
+        assert result["merged"] is True, (label, result["order"])
+        assert result["promptIdxs"] == [2], (
+            f"[{label}] pending_started_at must be normalized before comparison "
+            f"so history stays above the current prompt: {result['order']}"
         )

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -215,6 +215,30 @@ def test_unmatched_transcript_row_does_not_duplicate_below_its_own_output():
     )
 
 
+def test_unmatched_transcript_row_slightly_before_started_at_is_adopted():
+    """Current-turn user row whose timestamp drifted slightly earlier than
+    pending_started_at must still be classified as this turn, not history.
+
+    Review 2026-08-18 (CHANGES_REQUESTED): +0.4s drift is adopted, but -0.4s
+    made the row look older than the boundary, so the classifier returned i+1
+    and the merge inserted a second bubble above the existing row.
+    """
+    drifted = {"role": "user", "content": _PROMPT, "timestamp": _T0 - 0.4}
+    result = _probe(drifted, with_live=False)
+    assert not result["duplicated"], (
+        "the pending prompt was rendered twice (the transcript row plus a "
+        f"materialized copy): {result['order']}"
+    )
+    assert not result["belowOwnOutput"], (
+        f"the adopted bubble landed below its own turn output: {result['order']}"
+    )
+    assert result["promptIdxs"] == [result["firstOutputIdx"] - 1], (
+        "the drifted current-turn user row must sit at the turn boundary; "
+        f"got indices {result['promptIdxs']} with turn output starting at "
+        f"{result['firstOutputIdx']} ({result['order']})"
+    )
+
+
 def test_timestampless_transcript_row_fails_closed_to_prior_merge_behavior():
     """Same class, with a transcript row carrying no timestamp at all.
 

--- a/tests/test_pending_user_turn_boundary_order.py
+++ b/tests/test_pending_user_turn_boundary_order.py
@@ -222,9 +222,42 @@ def test_unmatched_transcript_row_slightly_before_started_at_is_adopted():
     Review 2026-08-18 (CHANGES_REQUESTED): +0.4s drift is adopted, but -0.4s
     made the row look older than the boundary, so the classifier returned i+1
     and the merge inserted a second bubble above the existing row.
+
+    Mirror of the +0.4 case, with attachments: one prompt bubble, existing
+    files kept, placed immediately above the first active-turn output.
     """
-    drifted = {"role": "user", "content": _PROMPT, "timestamp": _T0 - 0.4}
-    result = _probe(drifted, with_live=False)
+    body = f"""
+{_PROBE_TAIL}
+const session={{
+  session_id:'s1',
+  active_stream_id:'stream-1',
+  pending_user_message:{json.dumps(_PROMPT)},
+  pending_started_at:{_T0},
+  pending_attachments:[{{name:'courant.png'}}],
+}};
+const messages={_transcript(
+        {
+            "role": "user",
+            "content": _PROMPT,
+            "timestamp": _T0 - 0.4,
+            "attachments": [{"name": "courant.png"}],
+        },
+        with_live=False,
+    )};
+const merged=_mergePendingSessionMessage(session, messages);
+const idxs=idxsOfPrompt(messages);
+const firstOutput=firstTurnOutputIdx(messages);
+process.stdout.write(JSON.stringify({{
+  merged,
+  promptIdxs: idxs,
+  firstOutputIdx: firstOutput,
+  belowOwnOutput: idxs.length ? (Math.max.apply(null, idxs) > firstOutput && firstOutput >= 0) : false,
+  duplicated: idxs.length > 1,
+  attachmentsByIdx: messages.map(m=>Array.isArray(m&&m.attachments)?m.attachments.map(a=>a&&a.name):null),
+  order: messages.map(m=>`${{m.role}}@${{m.timestamp!==undefined?m.timestamp:'live'}}`),
+}}));
+"""
+    result = _run_probe(body)
     assert not result["duplicated"], (
         "the pending prompt was rendered twice (the transcript row plus a "
         f"materialized copy): {result['order']}"
@@ -236,6 +269,11 @@ def test_unmatched_transcript_row_slightly_before_started_at_is_adopted():
         "the drifted current-turn user row must sit at the turn boundary; "
         f"got indices {result['promptIdxs']} with turn output starting at "
         f"{result['firstOutputIdx']} ({result['order']})"
+    )
+    prompt_idx = result["promptIdxs"][0]
+    assert result["attachmentsByIdx"][prompt_idx] == ["courant.png"], (
+        "adopting the slightly-earlier current-turn row must keep its "
+        f"attachments: {result['attachmentsByIdx']} ({result['order']})"
     )
 
 


### PR DESCRIPTION
## Problem

While a turn is running, the newest user message can render at the very bottom of
the transcript, **underneath the interim assistant commentary and tool cards that
this same message triggered**. The user's prompt appears to arrive after the work
it requested.

The defect is intermittent, which made it hard to pin down: it only manifests when
the pending prompt has to be *materialized* by the browser rather than adopted from
the transcript.

## Root cause

Server ordering is already correct — the active turn's user row is persisted
**before** that turn's assistant/tool rows. The defect is purely in the browser
projection.

`_mergePendingSessionMessage()` (`static/sessions.js`) merges the sidecar's
`pending_user_message` into the message list, positioning it relative to the first
`_live` assistant row **only**:

```js
if(liveAssistantIdx>=0){
  messages.splice(liveAssistantIdx,0,pendingMsg);  // before the live row
}else{
  messages.push(pendingMsg);                        // ...or the very bottom
}
```

Both branches ignore a third category of rows: the current turn's **already-settled
output**. The server persists interim prose and tool rows *as the turn runs*, so by
the time the pending prompt is projected those rows are ordinary settled entries
sitting above the `_live` row — not live ones. Consequently:

* **no live row** (turn output settled, stream row not yet reattached) →
  `push()` drops the bubble below the entire turn;
* **live row present** → inserting immediately before it still places the bubble
  below the settled interim rows of the same turn.

The trigger is anything that prevents the transcript's own user row from being
identity-matched: sub-second timestamp drift defeating the `1e-6` epsilon, a missing
`_active_turn_token`, or the row falling outside the returned window. Hence the
intermittency.

## Fix

Rather than patching the two branches independently, resolve the actual missing
value at the single chokepoint: **where does the active turn begin?**

A new `_activeTurnInsertionIndex()` derives that boundary from the one authoritative
value already used for pending identity, `pending_started_at`. Every row belonging to
a *previous* turn is strictly older than it, so a backwards scan stops at the newest
definitively-older row; the active turn starts right after it. Untimed rows
(optimistic/live) carry no evidence of belonging to an older turn and cannot close
the scan.

The helper **fails closed**: it returns `-1` when `pending_started_at` is unusable or
when the window holds no timestamped row to anchor against, so the previous
live-row/append behaviour is preserved rather than a position being guessed.

Adoption of a same-text user row is now **scoped to that boundary**. This matters in
both directions:

* a bubble already misplaced below its own output is **lifted back** to the boundary
  instead of a second one being appended;
* a legitimate repeat of the same prompt in an **earlier** turn is strictly above the
  boundary, so it keeps its own bubble instead of being swallowed by text proximity.

## State-space covered

| Dimension | Handling |
|---|---|
| No live row, turn output settled | bubble inserted at the turn boundary |
| Live row present, settled output above it | bubble inserted at the boundary, above both |
| Live row present, no settled output yet | unchanged — inserted before the live row |
| No turn output yet at all | unchanged — appended at the tail |
| Row present, identity-matched | unchanged — adopted, not re-materialized |
| Row present, timestamp drift | adopted at the boundary, no duplicate |
| Row present, no timestamp | adopted at the boundary, no duplicate |
| Row already below its own output | lifted back to the boundary |
| Same prompt repeated in an earlier turn | untouched — strictly above the boundary |
| `pending_started_at` missing/invalid | fails closed to previous behaviour |
| No timestamped row in window | fails closed to previous behaviour |

## Tests

`tests/test_pending_user_turn_boundary_order.py` (8 cases) executes the **real
shipped helpers** extracted from `static/ui.js` and `static/sessions.js` in a Node
harness, following the existing `test_run_journal_frontend_static.py` pattern.

Proof the tests bind to the fix, run against this PR's base (`69d5647b`):

```
# upstream static/sessions.js + this PR's test file
5 failed, 3 passed

# with the fix
8 passed
```

The 3 that pass in both directions are deliberate: they assert the established
live-row ordering and identity-adoption contracts are **unchanged**.

## Verification

```bash
./scripts/test.sh tests/test_pending_user_turn_boundary_order.py -q
# 8 passed

./scripts/test.sh tests/test_run_journal_frontend_static.py \
  tests/test_issue6419_pending_user_reconnect_order.py \
  tests/test_issue2341_pending_user_reattach.py \
  tests/test_regressions.py \
  tests/test_cross_session_message_load_isolation.py \
  tests/test_gateway_sse_reconnect_dedupe.py \
  tests/test_live_to_final_anchor_visible_order.py -q
# 152 passed, 1 skipped

python scripts/ruff_lint.py --diff origin/master
# no new violations on added/modified lines
```

Additionally validated against a **real session payload** (93 messages: pending
prompt at index 7 followed by 85 rows of turn output), replaying the three browser
states:

| Scenario | Before | After |
|---|---|---|
| Row identity-matched | index 7 | index 7 |
| Timestamp drift | indices 7 **and 93** (duplicate, at the bottom) | index 7 |
| Row outside window | index **92** (below the whole turn) | index 7 |

## Scope

Two files, one concern. No dependency, build-tool or i18n change; no server-side
change. `renderMessages()` and the live-turn reattachment path are untouched — the
ordering is corrected in the projection that owns it.

## Not verified

Manual cross-browser checking was limited to reproducing the payload states
programmatically; I did not capture before/after screenshots of a live streaming
session, since the trigger depends on transient identity-matching conditions that
are not reliably reproducible by hand.
