### PR TITLE
fix(profiles): bind and restore detached worker TLS (#6326)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8356,7 +8356,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             # (#3957): the daemon inherits neither the request-profile TLS nor
             # os.environ, so without this it would probe the default profile's
             # credentials and, over budget, publish the rebuilt catalog to the
-            # DEFAULT profile's disk cache. No-op for the default profile.
+            # DEFAULT profile's disk cache. Default still binds request TLS but
+            # does not mirror a named-profile environment.
             _worker_scope = (
                 _prof_scope_worker(_active_profile_name, "models rebuild (worker)")
                 if _prof_scope_worker is not None

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1487,26 +1487,35 @@ def profile_scope_for_detached_worker(
     Pass the profile name CAPTURED on the spawning thread (where the TLS is
     valid) into the worker, then enter this scope at the top of the worker body.
     It sets the request-profile TLS for this (worker) thread and applies the
-    profile env via ``profile_env_for_background_worker``, restoring both on exit.
-    No-op for the default/root profile.
+    profile env via ``profile_env_for_background_worker`` for named profiles,
+    restoring both on exit. An explicit default/root profile still binds the TLS
+    but keeps the existing root process environment. Only an empty profile name
+    is a no-op.
 
     Unlike ``profile_env_for_active_request`` (which reads the *current* thread's
-    TLS and must NOT clear it — the request thread keeps using it after the call),
-    this sets and then CLEARS the TLS, which is correct for a dedicated worker
-    thread that has no other use for it.
+    TLS), this temporarily replaces the worker thread's TLS and restores the exact
+    previous profile afterward. That keeps nested scopes and reused executor
+    threads compositional on both normal and exceptional exits.
     """
     name = (profile_name or "").strip()
-    if not name or _is_root_profile(name):
+    if not name:
         yield
         return
+    previous_profile = getattr(_tls, "profile", None)
     set_request_profile(name)
     try:
-        with profile_env_for_background_worker(
-            name, purpose, logger_override=logger_override
-        ):
+        if _is_root_profile(name):
             yield
+        else:
+            with profile_env_for_background_worker(
+                name, purpose, logger_override=logger_override
+            ):
+                yield
     finally:
-        clear_request_profile()
+        if previous_profile is None:
+            clear_request_profile()
+        else:
+            set_request_profile(previous_profile)
 
 
 def _set_hermes_home(home: Path):

--- a/api/routes.py
+++ b/api/routes.py
@@ -22119,7 +22119,7 @@ def _process_wakeup_provider_has_recovery_credential(
     if not provider_id:
         return False
     profile_name = str(getattr(session, "profile", "") or "").strip()
-    if profile_name and not _is_root_profile(profile_name):
+    if profile_name:
         with profile_scope_for_detached_worker(
             profile_name,
             "process_wakeup credential revalidation",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9341,7 +9341,7 @@ def _run_agent_streaming(
             # send from a NAMED profile would resolve against the DEFAULT profile's
             # config and route to the wrong provider/base_url. Bind the captured
             # owning-session profile across warm + resolve so both see the right
-            # profile (no-op for the default/root profile).
+            # profile (default/root binds TLS without named-profile env mirroring).
             from api import profiles as profiles_api
             # #5979: treat this send as a deliberate pick ONLY when the persisted
             # explicit-pick signature matches the CURRENT model+provider routing

--- a/tests/test_issue3929_process_wakeup_pause.py
+++ b/tests/test_issue3929_process_wakeup_pause.py
@@ -389,6 +389,38 @@ def test_cancelled_stale_process_wakeup_credential_failure_records_pause(tmp_pat
     assert saved_after.process_wakeup_pause["suppressed_count"] == 1
 
 
+def test_default_profile_process_wakeup_revalidation_binds_default_tls(monkeypatch):
+    """The route caller must not inherit another process-active profile."""
+    monkeypatch.setattr(profiles, "_active_profile", "work")
+    profiles.clear_request_profile()
+    observed_profiles = []
+
+    def _record_active_profile(_provider_id, *, refresh=False):
+        assert refresh is True
+        observed_profiles.append(profiles.get_active_profile_name())
+        return False
+
+    monkeypatch.setattr(
+        routes,
+        "provider_has_process_wakeup_recovery_credential",
+        _record_active_profile,
+    )
+    session = Session(
+        session_id="default_profile_wakeup_revalidation",
+        profile="default",
+    )
+
+    assert profiles.get_active_profile_name() == "work"
+    assert routes._process_wakeup_provider_has_recovery_credential(
+        session,
+        model="test-model",
+        provider="test-provider",
+        provider_id="test-provider",
+    ) is False
+    assert observed_profiles == ["default"]
+    assert profiles.get_active_profile_name() == "work"
+
+
 def test_process_wakeup_pause_revalidates_when_credential_state_changes(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes-home"
     hermes_home.mkdir()

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -436,16 +436,84 @@ def test_thread_local_env_value_none_default_returns_empty_string(monkeypatch):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_detached_worker_scope_noop_for_default_profile(monkeypatch):
-    """profile_scope_for_detached_worker is a no-op for the default profile."""
+def test_detached_worker_scope_binds_default_on_fresh_reused_executor_thread(monkeypatch):
+    """An explicit default scope overrides process state without leaking into reuse."""
+    import concurrent.futures
+    import threading
+
+    monkeypatch.setattr(profiles, "_active_profile", "work")
     monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
-    monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
-    # Default/empty name → no TLS set, no env applied.
-    with profiles.profile_scope_for_detached_worker("default", "test"):
-        assert profiles.get_active_profile_name() in ("", "default")
-        assert os.environ.get("ISSUE_3957_WPROBE") is None
-    with profiles.profile_scope_for_detached_worker("", "test"):
-        assert os.environ.get("ISSUE_3957_WPROBE") is None
+
+    def scoped_default():
+        thread_id = threading.get_ident()
+        before = profiles.get_active_profile_name()
+        with profiles.profile_scope_for_detached_worker("default", "test"):
+            inside = profiles.get_active_profile_name()
+        after = profiles.get_active_profile_name()
+        return thread_id, before, inside, after
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        first = executor.submit(scoped_default).result(timeout=5)
+        reused = executor.submit(
+            lambda: (threading.get_ident(), profiles.get_active_profile_name())
+        ).result(timeout=5)
+
+    assert first == (reused[0], "work", "default", "work")
+    assert reused[1] == "work"
+
+
+def test_detached_worker_scope_restores_outer_profile_after_nested_scope(monkeypatch):
+    """A nested worker scope restores outer request-profile TLS on normal exit."""
+    from contextlib import nullcontext
+
+    monkeypatch.setattr(
+        profiles,
+        "profile_env_for_background_worker",
+        lambda *args, **kwargs: nullcontext(),
+    )
+    profiles.set_request_profile("outer")
+    try:
+        assert profiles.get_active_profile_name() == "outer"
+        with profiles.profile_scope_for_detached_worker("inner", "test"):
+            assert profiles.get_active_profile_name() == "inner"
+        assert profiles.get_active_profile_name() == "outer"
+    finally:
+        profiles.clear_request_profile()
+
+
+def test_detached_worker_scope_restores_outer_profile_after_exception(monkeypatch):
+    """A nested worker scope restores outer request-profile TLS on exception unwind."""
+    from contextlib import nullcontext
+
+    monkeypatch.setattr(
+        profiles,
+        "profile_env_for_background_worker",
+        lambda *args, **kwargs: nullcontext(),
+    )
+    profiles.set_request_profile("outer")
+    try:
+        try:
+            with profiles.profile_scope_for_detached_worker("inner", "test"):
+                assert profiles.get_active_profile_name() == "inner"
+                raise RuntimeError("boom")
+        except RuntimeError as exc:
+            assert str(exc) == "boom"
+        else:
+            raise AssertionError("expected nested worker scope to raise")
+        assert profiles.get_active_profile_name() == "outer"
+    finally:
+        profiles.clear_request_profile()
+
+
+def test_detached_worker_scope_empty_profile_keeps_existing_tls():
+    """An absent profile name remains a no-op and does not disturb request TLS."""
+    profiles.set_request_profile("outer")
+    try:
+        with profiles.profile_scope_for_detached_worker("", "test"):
+            assert profiles.get_active_profile_name() == "outer"
+        assert profiles.get_active_profile_name() == "outer"
+    finally:
+        profiles.clear_request_profile()
 
 
 def test_detached_worker_scope_binds_profile_on_new_thread(monkeypatch, tmp_path):


### PR DESCRIPTION
## Thinking Path

- `profile_scope_for_detached_worker()` is the shared TLS boundary used by detached model/provider resolution.
- On the original reproducing base (`69d5647b60b6d5d008ab98daf76f500bff4c9557`), an explicit `default`/root profile is skipped entirely, while a named inner scope clears any prior request-profile TLS instead of restoring it.
- The narrow contract is therefore: bind every non-empty explicit profile in request TLS, mirror environment only for named profiles as before, and restore the exact prior TLS value on every exit.
- The fix stays in that shared context manager; all current callers were traced in `api/config.py`, `api/streaming.py`, and `api/routes.py`.

## What Changed

- Bind request-profile TLS for every non-empty explicit profile, including `default`/root.
- Preserve the existing environment boundary: root/default does **not** enter named-profile environment mirroring.
- Snapshot and restore the previous TLS profile in `finally`, covering nested scopes, reused executor threads, and exception unwind.
- Route root/default process-wakeup credential revalidation through the same fixed scope instead of excluding it before the chokepoint.
- Replace the obsolete default-no-op regression with focused behavior tests for:
  - fresh single-worker executor default isolation and thread reuse;
  - nested `outer → inner → outer` restoration;
  - exception-path restoration;
  - empty-name no-op preservation;
  - production process-wakeup revalidation under a default session while the process-active profile is named.
- Update only the two caller comments whose “default is a no-op” wording became false.

## Existing #6327 Overlap and Attribution

PR #6327 began with this issue's default-profile TLS lane, then expanded into a much broader process-environment, runner-fence, owner-publication, and profile-ownership rewrite. This draft intentionally does not copy or adjudicate that expanded scope. It extracts only the independently reproduced and verified #6326 request-profile TLS contract from current `master`.

Credit to @webtecnica for surfacing and working the original lane. The production control-flow shape materially reuses the initial narrow work from commit `73dc9b0f49b9`, so authorship is preserved with a `Co-authored-by` trailer on this branch's commit.

## Why It Matters

A default-scoped detached worker can otherwise fall through to a process-active named profile and resolve the wrong provider/model/credentials. Named nested scopes can also destroy their caller's TLS state, making later reads on a reused thread fall through to process state. Binding explicit root/default and restoring the previous TLS value makes the shared scope compositional without changing process-environment ownership.

## Verification

### RED on unchanged production code

```bash
./scripts/test.sh \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_binds_default_on_fresh_reused_executor_thread \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_restores_outer_profile_after_nested_scope \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_restores_outer_profile_after_exception \
  -q
```

Result: **3 failed** as expected.

- Fresh executor worker observed `work` inside the explicit `default` scope.
- Normal nested unwind returned `default` instead of `outer`.
- Exception unwind returned `default` instead of `outer`.

### GREEN after the fix

```bash
./scripts/test.sh \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_binds_default_on_fresh_reused_executor_thread \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_restores_outer_profile_after_nested_scope \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_restores_outer_profile_after_exception \
  tests/test_issue3957_profile_providers_models.py::test_detached_worker_scope_empty_profile_keeps_existing_tls \
  -q
```

Result: **4 passed**.

Reviewer follow-up RED/GREEN:

- Before the route fix, the production process-wakeup credential caller observed process-active `work` for a `default` session: **1 failed**.
- After removing the pre-chokepoint root exclusion, the same caller observed `default`: **1 passed**.

Focused regression file:

```bash
./scripts/test.sh tests/test_issue3957_profile_providers_models.py -q
```

Result: **36 passed**.

Focused + neighboring profile-isolation tests:

```bash
./scripts/test.sh \
  tests/test_issue3929_process_wakeup_pause.py \
  tests/test_issue3957_profile_providers_models.py \
  tests/test_profile_switch_1200.py \
  tests/test_issue1700_parallel_profile_switch.py \
  tests/test_profile_terminal_env.py \
  tests/test_issue3405_profile_provider_resolution.py \
  -q
```

Result on final head: **127 passed**.

Forward lint gate:

```bash
python scripts/ruff_lint.py --diff origin/master
```

Result: **0 findings on added/modified lines**.

Final base refresh and exact-head proof:

- Rebased onto `origin/master@83e490327489b6249bbc480bc1dc0e406d17756e`; final head `e48b80862be0d012d47feaad7b65cca74171b9dc`.
- The intervening master release changed only `CHANGELOG.md`, `static/ui.js`, `tests/test_blank_live_turn_preserve_guard.py`, and `tests/test_visible_video_preload.py` — disjoint from this PR.
- Stable contribution patch-id before/after rebase is identical: `0d00ee32afacb9bce8abefaae0bdc7efb988a969`; changed-path sets are identical.
- Exact-head static threat scan: **CLEAN**. Exact-head sandboxed focused/neighboring plus the two intervening-master regressions: **132 passed**.

Full-suite evidence:

- An earlier candidate serial run was invalid because its worktree was rebased while pytest was still reading it; its 50 candidate-only MCP residuals came from a moving tree and are discarded.
- A quiescent exact-head rerun completed with `14,603 passed / 9 failed / 2 errors`; the frozen-base control, run immediately afterward through the same sandbox command, completed with `14,599 passed / 9 failed / 2 errors`. The four-pass difference is exactly this PR's four added tests.
- The candidate and control have **identical 11-node non-pass sets** and zero candidate-only residuals. Guarded candidate log SHA-256: `37fb91ec0636c57c4d01a8d9c86aeb9648a1f3f06e6af8ca73c9971c2f047cec`; control: `df737c74d1d968d970b8189970556ea68dbb4504411c95e974cbe9081cf3c25a`. Their manifests record unchanged start/end HEAD and Git tree fingerprints plus clean status before/after.

Hosted exact-head CI: every one of the **22 unique reported contexts has at least one SUCCESS** at `e48b80862be0`, including all 15 Python/version shards, lint, browser smoke, and normal/terminal-error/historical-hydration lifecycle jobs. Duplicate cancelled jobs were dependency-install/retry artifacts; no hosted test body failed.

Independent reviews: Opus APPROVED the final head and verified the root process-wakeup caller gap is closed. Codex found no profile/TLS regression; its only final-head request was to retain the intervening master release, satisfied by the byte-identical rebase and exact-head regressions above. The raw process-env credential residual remains explicitly out of scope and keeps #6326 open.

## Contract Routing

Task type: narrow runtime profile-isolation bug fix  
Touched state: WebUI request-profile thread-local storage around detached-worker scopes  
Relevant docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `ARCHITECTURE.md`, `TESTING.md`, `docs/GUIDELINES.md`  
Public contract change: none; this closes an implementation gap in the existing profile-isolation contract.

## Risks / Follow-ups

- Root/default continues to use the existing process environment; this PR does not add process-env mirroring or scrubbing. Independent parent and Codex probes reproduced that a conflicting raw process credential remains visible inside a default scope, unchanged from master. This standalone PR fixes the TLS half only; #6326 stays open for the broader process-env credential residual.
- Named-profile environment scoping is unchanged.
- Empty profile names remain a no-op.
- This PR does not change runner fences, owner publication, process-env ownership, streaming settlement, or any unrelated profile contract from #6327.
- Per task scope, only focused and neighboring profile tests were run locally; the full suite is left to the serialized parent/CI gate.

Release-note wording: Detached workers now bind explicit default/root request-profile TLS and restore enclosing profile state after nested or failed scopes.

## Model Used

OpenAI Codex `gpt-5.6-sol` via Hermes Agent, with shell/file tools and an independent read-only Codex review.

Refs #6326


