### PR TITLE
fix(ui): keep context compactions visible in long transcripts

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -15135,10 +15135,48 @@ function _loadedCompactionMarkerRawIdxs(messages){
 // A settled compaction whose marker sits before the server-loaded tail must
 // remain visible at the top of that tail. Anchoring it to an old assistant/tool
 // turn can bury it inside a hidden worklog, which makes compaction look absent.
-function _pinSettledCompressionReferenceAtTop(inner,node,referenceMessageRawIdx){
-  if(!inner||!node||referenceMessageRawIdx>=0) return false;
+function _selectCompactionCardPlacements(markerRawIdxs,firstRenderedRawIdx){
+  const inlineMarkers=[];
+  let latestPreWindowMarker=null;
+  const boundary=Number.isFinite(firstRenderedRawIdx)?firstRenderedRawIdx:-1;
+  for(const value of Array.isArray(markerRawIdxs)?markerRawIdxs:[]){
+    const rawIdx=Number(value);
+    if(!Number.isInteger(rawIdx)||rawIdx<0) continue;
+    if(rawIdx<boundary) latestPreWindowMarker=rawIdx;
+    else inlineMarkers.push(rawIdx);
+  }
+  const taskOwner=inlineMarkers.length
+    ?{kind:'inline',rawIdx:inlineMarkers[inlineMarkers.length-1]}
+    :latestPreWindowMarker===null
+      ?null
+      :{kind:'pre-window',rawIdx:latestPreWindowMarker};
+  return {inlineMarkers,latestPreWindowMarker,taskOwner};
+}
+function _insertCompactionCardNodes(entries,taskOwner,insertNode){
+  const insertedNodes=[];
+  let taskOwnerNode=null;
+  if(!Array.isArray(entries)||typeof insertNode!=='function') return {insertedNodes,taskOwnerNode};
+  for(const entry of entries){
+    if(!entry?.node) continue;
+    const inserted=insertNode(entry.node,entry.rawIdx,entry.kind)!==false;
+    if(!inserted||!entry.node.parentElement) continue;
+    insertedNodes.push(entry.node);
+    if(taskOwner&&entry.kind===taskOwner.kind&&entry.rawIdx===taskOwner.rawIdx) taskOwnerNode=entry.node;
+  }
+  return {insertedNodes,taskOwnerNode};
+}
+function _insertPreservedCompressionTaskFallback(taskOwnerNode,standaloneNode,insertNode){
+  if(taskOwnerNode?.parentElement||!standaloneNode||typeof insertNode!=='function') return false;
+  return insertNode(standaloneNode)!==false&&!!standaloneNode.parentElement;
+}
+function _pinCompactionCardAtTop(inner,node){
+  if(!inner||!node) return false;
   inner.appendChild(node);
   return true;
+}
+function _pinSettledCompressionReferenceAtTop(inner,node,referenceMessageRawIdx){
+  if(referenceMessageRawIdx>=0) return false;
+  return _pinCompactionCardAtTop(inner,node);
 }
 function _compressionReferenceCardHtml(text, open=false){
   const copy=_engineAwareCompressionCopy();
@@ -16791,11 +16829,13 @@ function renderMessages(options){
   })();
   // Ultra-compact display (2026-08-18): every compaction marker loaded in the
   // transcript renders as its own collapsed card at its real position, so the
-  // user SEES each compaction and can reopen its digest inline. The single
-  // anchored reference card remains only for the settled-summary case where
-  // no marker message is loaded (server-truncated tail).
+  // user SEES each compaction and can reopen its digest inline. If a marker is
+  // older than the virtual window, only the latest such marker is pinned above
+  // the rendered rows; markers inside the window stay inline.
+  const firstRenderedRawIdx=renderVisWithIdx.length?renderVisWithIdx[0].rawIdx:Infinity;
   const loadedCompactionRawIdxs=(!compressionState)?_loadedCompactionMarkerRawIdxs(S.messages):[];
-  const compactionCardNodes=loadedCompactionRawIdxs.map((markerRawIdx,pos)=>{
+  const compactionPlacements=_selectCompactionCardPlacements(loadedCompactionRawIdxs,firstRenderedRawIdx);
+  const _compactionCardEntry=(markerRawIdx,kind)=>{
     const markerMsg=S.messages[markerRawIdx];
     let raw='';
     try{
@@ -16805,16 +16845,28 @@ function renderMessages(options){
     }
     const segment=_compactionSummarySegment(raw);
     const text=segment!==null?segment:raw;
-    const isLatest=pos===loadedCompactionRawIdxs.length-1;
+    const ownsTasks=!!(compactionPlacements.taskOwner
+      && compactionPlacements.taskOwner.kind===kind
+      && compactionPlacements.taskOwner.rawIdx===markerRawIdx);
     const row=document.createElement('div');
-    row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(text,false)}${isLatest?_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages):''}</div></div>`;
-    return {node:row.firstElementChild, rawIdx:markerRawIdx};
-  });
-  const referenceNode=(!compressionState && !compactionCardNodes.length && _shouldShowSettledCompressionReference(referenceText) && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
-    ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
+    row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(text,false)}${ownsTasks?_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages):''}</div></div>`;
+    const node=row.firstElementChild;
+    if(node){
+      node.setAttribute('data-compaction-placement',kind);
+      node.setAttribute('data-compaction-raw-idx',String(markerRawIdx));
+      if(ownsTasks&&preservedCompressionTaskMessages.length) node.setAttribute('data-compaction-task-owner','1');
+    }
+    return {node,rawIdx:markerRawIdx,kind};
+  };
+  const preWindowCompactionCard=compactionPlacements.latestPreWindowMarker===null
+    ?null
+    :_compactionCardEntry(compactionPlacements.latestPreWindowMarker,'pre-window');
+  const compactionCardNodes=compactionPlacements.inlineMarkers.map(markerRawIdx=>_compactionCardEntry(markerRawIdx,'inline'));
+  const referenceNode=(!compressionState && loadedCompactionRawIdxs.length===0 && _shouldShowSettledCompressionReference(referenceText) && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
+    ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;const node=row.firstElementChild;if(node&&preservedCompressionTaskMessages.length) node.setAttribute('data-compaction-task-owner','1');return node;})()
     : null;
   let referenceNodePinnedAtTop=false;
-  let preservedCompressionTaskCardsAttached=!!referenceNode||compactionCardNodes.length>0;
+  let preservedCompressionTaskOwnerNode=null;
   const preservedCompressionRawIdxs=[];
   let rawIdx=0;
   for(const m of S.messages){
@@ -16822,7 +16874,6 @@ function renderMessages(options){
     if(_isPreservedCompressionTaskListMessage(m)){preservedCompressionRawIdxs.push(rawIdx);rawIdx++;continue;}
     rawIdx++;
   }
-  const firstRenderedRawIdx=renderVisWithIdx.length?renderVisWithIdx[0].rawIdx:Infinity;
   // #6999: the turn-content maps MUST see the FULL visWithIdx, not the
   // virtual render window. _assistantTurnFinalVisibleContentMap /
   // _assistantTurnVisibleContentMap derive the echo-strip context for a
@@ -16855,7 +16906,16 @@ function renderMessages(options){
     // Keep the settled compacted-context card immediately visible in a long,
     // tail-loaded conversation. Put it in flow (not inside an old tool turn).
     referenceNodePinnedAtTop=_pinSettledCompressionReferenceAtTop(inner,referenceNode,referenceMessageRawIdx);
+    if(referenceNodePinnedAtTop&&referenceNode?.parentElement&&preservedCompressionTaskMessages.length){
+      preservedCompressionTaskOwnerNode=referenceNode;
+    }
   }
+  const preWindowInsertion=_insertCompactionCardNodes(
+    preWindowCompactionCard?[preWindowCompactionCard]:[],
+    compactionPlacements.taskOwner,
+    node=>_pinCompactionCardAtTop(inner,node)
+  );
+  if(preWindowInsertion.taskOwnerNode) preservedCompressionTaskOwnerNode=preWindowInsertion.taskOwnerNode;
   let lastUserRawIdx=-1;
   for(let i=visWithIdx.length-1;i>=0;i--){
     if(visWithIdx[i].m&&visWithIdx[i].m.role==='user'){
@@ -17402,7 +17462,7 @@ function renderMessages(options){
   }
 
   function _insertCompressionLikeNode(node, anchorIndex){
-    if(!node) return;
+    if(!node) return false;
     const anchorIdx=anchorIndex===undefined?insertionAnchor:anchorIndex;
     if(anchorIdx!==null && renderVisWithIdx[anchorIdx]){
       const anchorRawIdx=renderVisWithIdx[anchorIdx].rawIdx;
@@ -17412,23 +17472,24 @@ function renderMessages(options){
         const blocks=_assistantTurnBlocks(turn);
         if(blocks){
           blocks.appendChild(node);
-          return;
+          return !!node.parentElement;
         }
       }
       const userRow=userRows.get(anchorRawIdx);
       if(userRow && userRow.parentElement){
         userRow.parentElement.insertBefore(node, userRow.nextSibling);
-        return;
+        return !!node.parentElement;
       }
     }
     inner.appendChild(node);
+    return !!node.parentElement;
   }
   function _insertCompressionLikeNodeByRawIdx(node, rawIdx){
-    if(!node) return;
-    if(rawIdx<firstRenderedRawIdx) return;
+    if(!node) return false;
+    if(rawIdx<firstRenderedRawIdx) return false;
     if(!renderVisWithIdx.length){
       inner.appendChild(node);
-      return;
+      return !!node.parentElement;
     }
     let anchorIdx=null;
     for(let i=0;i<renderVisWithIdx.length;i++){
@@ -17439,7 +17500,7 @@ function renderMessages(options){
     }
     if(anchorIdx===null){
       inner.appendChild(node);
-      return;
+      return !!node.parentElement;
     }
     const anchorRawIdx=renderVisWithIdx[anchorIdx].rawIdx;
     const anchorSeg=assistantSegments.get(anchorRawIdx);
@@ -17448,23 +17509,24 @@ function renderMessages(options){
       const blocks=_assistantTurnBlocks(turn);
       if(blocks){
         blocks.insertBefore(node, anchorSeg);
-        return;
+        return !!node.parentElement;
       }
       const turnParent=turn && turn.parentElement;
       if(turnParent){
         turnParent.insertBefore(node, turn);
-        return;
+        return !!node.parentElement;
       }
     }
     const userRow=userRows.get(anchorRawIdx);
     if(userRow && userRow.parentElement){
       userRow.parentElement.insertBefore(node, userRow);
-      return;
+      return !!node.parentElement;
     }
     inner.appendChild(node);
+    return !!node.parentElement;
   }
-  const preservedOnlyNode=(!preservedCompressionTaskCardsAttached&&(!referenceNode||compressionState)&&preservedCompressionTaskMessages.length)
-    ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
+  const preservedOnlyNode=preservedCompressionTaskMessages.length
+    ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn" data-compaction-task-fallback="1"><div class="compression-turn-blocks">${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
     : null;
   const preservedOnlyAnchor=preservedCompressionRawIdxs.length
     ? (()=>{let idx=null;for(let i=0;i<renderVisWithIdx.length;i++){if(renderVisWithIdx[i].rawIdx<preservedCompressionRawIdxs[0]) idx=i;}return idx;})()
@@ -17472,12 +17534,25 @@ function renderMessages(options){
   const handoffSummaryStates=_collectHandoffSummaryStates(S.messages);
 
   _insertCompressionLikeNode(compressionNode);
-  for(const entry of compactionCardNodes) _insertCompressionLikeNodeByRawIdx(entry.node, entry.rawIdx);
+  const inlineCompactionInsertion=_insertCompactionCardNodes(
+    compactionCardNodes,
+    compactionPlacements.taskOwner,
+    (node,markerRawIdx)=>_insertCompressionLikeNodeByRawIdx(node,markerRawIdx)
+  );
+  if(inlineCompactionInsertion.taskOwnerNode) preservedCompressionTaskOwnerNode=inlineCompactionInsertion.taskOwnerNode;
   if(!referenceNodePinnedAtTop){
-    if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);
-    else _insertCompressionLikeNode(referenceNode);
+    const referenceInserted=referenceNode&&referenceMessageRawIdx>=0
+      ?_insertCompressionLikeNodeByRawIdx(referenceNode,referenceMessageRawIdx)
+      :_insertCompressionLikeNode(referenceNode);
+    if(referenceInserted&&referenceNode?.parentElement&&preservedCompressionTaskMessages.length){
+      preservedCompressionTaskOwnerNode=referenceNode;
+    }
   }
-  _insertCompressionLikeNode(preservedOnlyNode, preservedOnlyAnchor);
+  _insertPreservedCompressionTaskFallback(
+    preservedCompressionTaskOwnerNode,
+    preservedOnlyNode,
+    node=>_insertCompressionLikeNode(node,preservedOnlyAnchor)
+  );
   _insertCompressionLikeNode(handoffState?_handoffCardsNode(handoffState):null, renderVisWithIdx.length?renderVisWithIdx.length-1:null);
   for(const entry of handoffSummaryStates){
     if(!entry||!entry.state) continue;

--- a/static/ui.js
+++ b/static/ui.js
@@ -15136,21 +15136,21 @@ function _loadedCompactionMarkerRawIdxs(messages){
 // remain visible at the top of that tail. Anchoring it to an old assistant/tool
 // turn can bury it inside a hidden worklog, which makes compaction look absent.
 function _selectCompactionCardPlacements(markerRawIdxs,firstRenderedRawIdx){
+  const preWindowMarkers=[];
   const inlineMarkers=[];
-  let latestPreWindowMarker=null;
   const boundary=Number.isFinite(firstRenderedRawIdx)?firstRenderedRawIdx:-1;
   for(const value of Array.isArray(markerRawIdxs)?markerRawIdxs:[]){
     const rawIdx=Number(value);
     if(!Number.isInteger(rawIdx)||rawIdx<0) continue;
-    if(rawIdx<boundary) latestPreWindowMarker=rawIdx;
+    if(rawIdx<boundary) preWindowMarkers.push(rawIdx);
     else inlineMarkers.push(rawIdx);
   }
   const taskOwner=inlineMarkers.length
     ?{kind:'inline',rawIdx:inlineMarkers[inlineMarkers.length-1]}
-    :latestPreWindowMarker===null
+    :!preWindowMarkers.length
       ?null
-      :{kind:'pre-window',rawIdx:latestPreWindowMarker};
-  return {inlineMarkers,latestPreWindowMarker,taskOwner};
+      :{kind:'pre-window',rawIdx:preWindowMarkers[preWindowMarkers.length-1]};
+  return {preWindowMarkers,inlineMarkers,taskOwner};
 }
 function _insertCompactionCardNodes(entries,taskOwner,insertNode){
   const insertedNodes=[];
@@ -16829,9 +16829,9 @@ function renderMessages(options){
   })();
   // Ultra-compact display (2026-08-18): every compaction marker loaded in the
   // transcript renders as its own collapsed card at its real position, so the
-  // user SEES each compaction and can reopen its digest inline. If a marker is
-  // older than the virtual window, only the latest such marker is pinned above
-  // the rendered rows; markers inside the window stay inline.
+  // user SEES each compaction and can reopen its digest inline. Markers older
+  // than the virtual window are pinned above the rendered rows in transcript
+  // order; markers inside the window stay inline.
   const firstRenderedRawIdx=renderVisWithIdx.length?renderVisWithIdx[0].rawIdx:Infinity;
   const loadedCompactionRawIdxs=(!compressionState)?_loadedCompactionMarkerRawIdxs(S.messages):[];
   const compactionPlacements=_selectCompactionCardPlacements(loadedCompactionRawIdxs,firstRenderedRawIdx);
@@ -16858,9 +16858,7 @@ function renderMessages(options){
     }
     return {node,rawIdx:markerRawIdx,kind};
   };
-  const preWindowCompactionCard=compactionPlacements.latestPreWindowMarker===null
-    ?null
-    :_compactionCardEntry(compactionPlacements.latestPreWindowMarker,'pre-window');
+  const preWindowCompactionCards=compactionPlacements.preWindowMarkers.map(markerRawIdx=>_compactionCardEntry(markerRawIdx,'pre-window'));
   const compactionCardNodes=compactionPlacements.inlineMarkers.map(markerRawIdx=>_compactionCardEntry(markerRawIdx,'inline'));
   const referenceNode=(!compressionState && loadedCompactionRawIdxs.length===0 && _shouldShowSettledCompressionReference(referenceText) && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
     ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;const node=row.firstElementChild;if(node&&preservedCompressionTaskMessages.length) node.setAttribute('data-compaction-task-owner','1');return node;})()
@@ -16911,7 +16909,7 @@ function renderMessages(options){
     }
   }
   const preWindowInsertion=_insertCompactionCardNodes(
-    preWindowCompactionCard?[preWindowCompactionCard]:[],
+    preWindowCompactionCards,
     compactionPlacements.taskOwner,
     node=>_pinCompactionCardAtTop(inner,node)
   );

--- a/static/ui.js
+++ b/static/ui.js
@@ -15007,6 +15007,22 @@ function _isContextCompactionMessage(m){
 function _isContextCompactionText(text){
   return /^\s*\[context compaction/i.test(String(text||'')) || /^\s*context compaction/i.test(String(text||''));
 }
+function _compactionSummarySegment(text){
+  // Mirror of api/compression_anchor.py compaction_summary_segment(). The
+  // replay patch carries this helper so it stays self-contained on upstream.
+  const s=String(text||'').replace(/^\s+/,'');
+  const low=s.toLowerCase();
+  if(low.startsWith('[context compaction')||low.startsWith('context compaction')) return s;
+  if(!low.startsWith('[prior context')) return null;
+  const delim=low.indexOf('[end of prior context');
+  if(delim===-1) return null;
+  const after=s.slice(delim);
+  const close=after.indexOf(']');
+  if(close===-1) return null;
+  const segment=after.slice(close+1).replace(/^\s+/,'');
+  if(segment.toLowerCase().startsWith('[context compaction')) return segment;
+  return null;
+}
 function _isPreservedCompressionTaskListMarkerText(text){
   return /^\s*\[your active task list was preserved across context compression\]/i.test(String(text||''));
 }
@@ -15086,9 +15102,47 @@ function _latestCompressionReferenceMessage(messages, summaryText=''){
 function _shouldShowSettledCompressionReference(referenceText){
   return !!String(referenceText||'').trim() && !_isContextCompactionText(referenceText);
 }
+// Ultra-compact display (2026-08-18): the compaction marker text starts with a
+// long fixed envelope of handling instructions. The conversation card must
+// preview the DIGEST (goal/state the user cares about), never the envelope.
+function _compactionDigestText(text){
+  const s=String(text||'');
+  // The envelope prose ends right before the first markdown heading on its
+  // own line. Quoted headings inside the envelope (e.g. "from '## Historical
+  // Task Snapshot' or any other section") never sit at line start.
+  const m=s.match(/(^|\n)#{1,3} [^\n]/);
+  if(!m) return s.trim();
+  const start=m.index+(m[1]?1:0);
+  return s.slice(start).trim();
+}
+function _compactionCardPreview(text){
+  const digest=_compactionDigestText(text)
+    .replace(/^#{1,3} /gm,'')
+    .replace(/^Historical Task Snapshot\s*/i,'');
+  return digest.split(/\n+/).map(l=>l.trim()).filter(Boolean).slice(0,2).join(' ').slice(0,220);
+}
+// All compaction markers present in the LOADED transcript, oldest first. Each
+// one renders as its own collapsed card at its real position so the user can
+// see when the context was compacted and reopen the digest inline.
+function _loadedCompactionMarkerRawIdxs(messages){
+  const out=[];
+  if(!Array.isArray(messages)) return out;
+  for(let i=0;i<messages.length;i++){
+    if(_isContextCompactionMessage(messages[i])) out.push(i);
+  }
+  return out;
+}
+// A settled compaction whose marker sits before the server-loaded tail must
+// remain visible at the top of that tail. Anchoring it to an old assistant/tool
+// turn can bury it inside a hidden worklog, which makes compaction look absent.
+function _pinSettledCompressionReferenceAtTop(inner,node,referenceMessageRawIdx){
+  if(!inner||!node||referenceMessageRawIdx>=0) return false;
+  inner.appendChild(node);
+  return true;
+}
 function _compressionReferenceCardHtml(text, open=false){
   const copy=_engineAwareCompressionCopy();
-  const preview=text.split(/\n+/).filter(Boolean).slice(0,2).join(' ');
+  const preview=_compactionCardPreview(text)||text.split(/\n+/).filter(Boolean).slice(0,2).join(' ');
   return `
     <div class="tool-card-row compression-card-row" data-compression-card="1" data-raw-text="${esc(text)}">
       <div class="tool-card tool-card-compress-reference${open?' open':''}">
@@ -16729,13 +16783,38 @@ function renderMessages(options){
     S.messages,
     sessionCompressionSummary
   );
-  const referenceText=referenceMessage
-    ? msgContent(referenceMessage)||String(referenceMessage.content||'')
-    : sessionCompressionSummary;
-  const referenceNode=(!compressionState && _shouldShowSettledCompressionReference(referenceText) && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
+  const referenceText=(()=>{
+    if(!referenceMessage) return sessionCompressionSummary;
+    const raw=msgContent(referenceMessage)||String(referenceMessage.content||'');
+    const segment=_compactionSummarySegment(raw);
+    return segment!==null?segment:raw;
+  })();
+  // Ultra-compact display (2026-08-18): every compaction marker loaded in the
+  // transcript renders as its own collapsed card at its real position, so the
+  // user SEES each compaction and can reopen its digest inline. The single
+  // anchored reference card remains only for the settled-summary case where
+  // no marker message is loaded (server-truncated tail).
+  const loadedCompactionRawIdxs=(!compressionState)?_loadedCompactionMarkerRawIdxs(S.messages):[];
+  const compactionCardNodes=loadedCompactionRawIdxs.map((markerRawIdx,pos)=>{
+    const markerMsg=S.messages[markerRawIdx];
+    let raw='';
+    try{
+      raw=String(msgContent(markerMsg)||'');
+    }catch(_){
+      raw=String((markerMsg&&markerMsg.content)||'');
+    }
+    const segment=_compactionSummarySegment(raw);
+    const text=segment!==null?segment:raw;
+    const isLatest=pos===loadedCompactionRawIdxs.length-1;
+    const row=document.createElement('div');
+    row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(text,false)}${isLatest?_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages):''}</div></div>`;
+    return {node:row.firstElementChild, rawIdx:markerRawIdx};
+  });
+  const referenceNode=(!compressionState && !compactionCardNodes.length && _shouldShowSettledCompressionReference(referenceText) && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
     ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
     : null;
-  let preservedCompressionTaskCardsAttached=!!referenceNode;
+  let referenceNodePinnedAtTop=false;
+  let preservedCompressionTaskCardsAttached=!!referenceNode||compactionCardNodes.length>0;
   const preservedCompressionRawIdxs=[];
   let rawIdx=0;
   for(const m of S.messages){
@@ -16773,6 +16852,9 @@ function renderMessages(options){
       : (typeof t==='function'?t('load_older_messages'):'Load earlier messages');
     inner.appendChild(indicator);
     _wireMessageWindowLoadEarlierButton();
+    // Keep the settled compacted-context card immediately visible in a long,
+    // tail-loaded conversation. Put it in flow (not inside an old tool turn).
+    referenceNodePinnedAtTop=_pinSettledCompressionReferenceAtTop(inner,referenceNode,referenceMessageRawIdx);
   }
   let lastUserRawIdx=-1;
   for(let i=visWithIdx.length-1;i>=0;i--){
@@ -17390,8 +17472,11 @@ function renderMessages(options){
   const handoffSummaryStates=_collectHandoffSummaryStates(S.messages);
 
   _insertCompressionLikeNode(compressionNode);
-  if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);
-  else _insertCompressionLikeNode(referenceNode);
+  for(const entry of compactionCardNodes) _insertCompressionLikeNodeByRawIdx(entry.node, entry.rawIdx);
+  if(!referenceNodePinnedAtTop){
+    if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);
+    else _insertCompressionLikeNode(referenceNode);
+  }
   _insertCompressionLikeNode(preservedOnlyNode, preservedOnlyAnchor);
   _insertCompressionLikeNode(handoffState?_handoffCardsNode(handoffState):null, renderVisWithIdx.length?renderVisWithIdx.length-1:null);
   for(const entry of handoffSummaryStates){

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -684,7 +684,7 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
         function _formatTurnDuration() {{ return ''; }}
         function _loadedCompactionMarkerRawIdxs() {{ return []; }}
         function _selectCompactionCardPlacements() {{
-          return {{ inlineMarkers: [], latestPreWindowMarker: null, taskOwner: null }};
+          return {{ preWindowMarkers: [], inlineMarkers: [], taskOwner: null }};
         }}
         function _insertCompactionCardNodes() {{
           return {{ insertedNodes: [], taskOwnerNode: null }};

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -682,6 +682,7 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
         function _gatewayModelWarningText() {{ return ''; }}
         function _usedModelTurnChipLabel() {{ return ''; }}
         function _formatTurnDuration() {{ return ''; }}
+        function _loadedCompactionMarkerRawIdxs() {{ return []; }}
         function _renderSettledAnchorSceneForMessage(message, segment, rawIdx) {{
           const group = new FakeElement('div');
           group.className = 'tool-worklog-group agent-activity-group';

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -683,6 +683,14 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
         function _usedModelTurnChipLabel() {{ return ''; }}
         function _formatTurnDuration() {{ return ''; }}
         function _loadedCompactionMarkerRawIdxs() {{ return []; }}
+        function _selectCompactionCardPlacements() {{
+          return {{ inlineMarkers: [], latestPreWindowMarker: null, taskOwner: null }};
+        }}
+        function _insertCompactionCardNodes() {{
+          return {{ insertedNodes: [], taskOwnerNode: null }};
+        }}
+        function _insertPreservedCompressionTaskFallback() {{ return false; }}
+        function _pinCompactionCardAtTop() {{ return false; }}
         function _renderSettledAnchorSceneForMessage(message, segment, rawIdx) {{
           const group = new FakeElement('div');
           group.className = 'tool-worklog-group agent-activity-group';

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -1076,9 +1076,10 @@ def test_context_anchor_reference_uses_session_summary_fallback():
 
     assert "sessionCompressionSummary" in src
     assert "const sessionCompressionSummary" in src
-    assert "referenceText=referenceMessage" in src
-    assert ": sessionCompressionSummary" in src
-    assert "_shouldShowSettledCompressionReference(referenceText)" in src
+    assert "const referenceText=(()=>{" in src
+    assert "if(!referenceMessage) return sessionCompressionSummary;" in src
+    assert "return segment!==null?segment:raw;" in src
+    assert "!compactionCardNodes.length && _shouldShowSettledCompressionReference(referenceText)" in src
     assert "!_isContextCompactionText(referenceText)" in src
 
 
@@ -1234,7 +1235,7 @@ def test_preserved_task_list_attaches_once_per_render():
     assert ".reverse().find(m=>_isPreservedCompressionTaskListMessage(m))" in src
     assert "const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);" in src
     assert "S.messages.filter(m=>_isPreservedCompressionTaskListMessage(m))" not in src
-    assert "let preservedCompressionTaskCardsAttached=!!referenceNode;" in src
+    assert "let preservedCompressionTaskCardsAttached=!!referenceNode||compactionCardNodes.length>0;" in src
     assert "const preservedOnlyNode=" in src
     assert "(!preservedCompressionTaskCardsAttached&&(!referenceNode||compressionState)&&preservedCompressionTaskMessages.length)" in src
 

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -1079,7 +1079,7 @@ def test_context_anchor_reference_uses_session_summary_fallback():
     assert "const referenceText=(()=>{" in src
     assert "if(!referenceMessage) return sessionCompressionSummary;" in src
     assert "return segment!==null?segment:raw;" in src
-    assert "!compactionCardNodes.length && _shouldShowSettledCompressionReference(referenceText)" in src
+    assert "loadedCompactionRawIdxs.length===0 && _shouldShowSettledCompressionReference(referenceText)" in src
     assert "!_isContextCompactionText(referenceText)" in src
 
 
@@ -1116,8 +1116,9 @@ def test_reference_message_uses_raw_transcript_position_before_anchor_fallback()
     src = _read("static/ui.js")
 
     assert "const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(" in src
-    assert "if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);" in src
-    assert "else _insertCompressionLikeNode(referenceNode);" in src
+    assert "referenceNode&&referenceMessageRawIdx>=0" in src
+    assert "?_insertCompressionLikeNodeByRawIdx(referenceNode,referenceMessageRawIdx)" in src
+    assert ":_insertCompressionLikeNode(referenceNode);" in src
 
 
 def test_reference_message_inserted_before_future_assistant_anchor():
@@ -1200,7 +1201,7 @@ def test_frontend_reference_insertion_skips_when_reference_is_before_render_wind
     assert end != -1, "raw-index insertion helper end not found"
     helper = src[start:end]
 
-    assert "if(rawIdx<firstRenderedRawIdx) return;" in helper
+    assert "if(rawIdx<firstRenderedRawIdx) return false;" in helper
 
 
 def test_reference_message_selection_prefers_latest_matching_marker():
@@ -1228,16 +1229,14 @@ def test_reference_message_falls_back_to_current_summary_when_only_stale_markers
     assert "return {message:null, rawIdx:-1};" in helper
 
 
-def test_preserved_task_list_attaches_once_per_render():
+def test_preserved_task_list_source_uses_latest_snapshot():
     src = _read("static/ui.js")
 
     assert "function _latestPreservedCompressionTaskListMessages" in src
     assert ".reverse().find(m=>_isPreservedCompressionTaskListMessage(m))" in src
     assert "const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);" in src
     assert "S.messages.filter(m=>_isPreservedCompressionTaskListMessage(m))" not in src
-    assert "let preservedCompressionTaskCardsAttached=!!referenceNode||compactionCardNodes.length>0;" in src
-    assert "const preservedOnlyNode=" in src
-    assert "(!preservedCompressionTaskCardsAttached&&(!referenceNode||compressionState)&&preservedCompressionTaskMessages.length)" in src
+
 
 
 def test_preserved_task_list_is_suppressed_when_latest_todo_state_has_no_active_items():

--- a/tests/test_compaction_card_display.py
+++ b/tests/test_compaction_card_display.py
@@ -52,10 +52,10 @@ def test_compaction_digest_and_preview_drop_instruction_envelope() -> None:
     )
     digest = (
         '## Historical Task Snapshot\nUser asked: "fix the planning bug"\n'
-        "## Goal\nFix the MES planning defect.\n"
+        "## Goal\nFix the planning defect.\n"
         "## Active State\n- worktree ready\n"
         "## Détail complet\nRésumé intégral : lire la note "
-        "/opt/obsidian/vault/MES/Hermes/Compactions/compaction-test.md"
+        "docs/compaction-test.md"
     )
     marker = envelope + "\n" + digest + "\n--- END OF CONTEXT SUMMARY ---"
     script = f"""

--- a/tests/test_compaction_card_display.py
+++ b/tests/test_compaction_card_display.py
@@ -1,0 +1,125 @@
+"""Regression tests for visible ultra-compact compaction cards."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "static" / "ui.js"
+
+
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"function {name} not found")
+    brace = source.find("{", start)
+    depth = 1
+    pos = brace + 1
+    while depth and pos < len(source):
+        if source[pos] == "{":
+            depth += 1
+        elif source[pos] == "}":
+            depth -= 1
+        pos += 1
+    return source[start:pos]
+
+
+def _run_node(script: str) -> None:
+    completed = subprocess.run(
+        ["node", "-e", script],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+
+
+def test_compaction_digest_and_preview_drop_instruction_envelope() -> None:
+    source = UI_JS.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _extract_function(source, name)
+        for name in ("_compactionDigestText", "_compactionCardPreview")
+    )
+    envelope = (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+        "into the summary below. This is a handoff from a previous context window."
+    )
+    digest = (
+        '## Historical Task Snapshot\nUser asked: "fix the planning bug"\n'
+        "## Goal\nFix the MES planning defect.\n"
+        "## Active State\n- worktree ready\n"
+        "## Détail complet\nRésumé intégral : lire la note "
+        "/opt/obsidian/vault/MES/Hermes/Compactions/compaction-test.md"
+    )
+    marker = envelope + "\n" + digest + "\n--- END OF CONTEXT SUMMARY ---"
+    script = f"""
+const assert = require('assert');
+{functions}
+const marker = {json.dumps(marker)};
+const digest = _compactionDigestText(marker);
+assert.ok(digest.startsWith('## Historical Task Snapshot'));
+assert.ok(!digest.includes('REFERENCE ONLY'));
+assert.ok(digest.includes('compaction-test.md'));
+const preview = _compactionCardPreview(marker);
+assert.ok(preview.includes('fix the planning bug'));
+assert.ok(!/REFERENCE ONLY|compacted into the summary/i.test(preview));
+assert.ok(preview.length <= 220);
+"""
+    _run_node(script)
+
+
+def test_loaded_compaction_marker_scan_finds_every_non_tool_marker() -> None:
+    source = UI_JS.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _extract_function(source, name)
+        for name in (
+            "_compactionSummarySegment",
+            "_isContextCompactionText",
+            "_isContextCompactionMessage",
+            "_loadedCompactionMarkerRawIdxs",
+        )
+    )
+    marker = "[CONTEXT COMPACTION — REFERENCE ONLY]\n## Goal\nKeep the digest visible."
+    messages = [
+        {"role": "user", "content": "first request"},
+        {"role": "assistant", "content": marker},
+        {"role": "tool", "content": marker},
+        {"role": "assistant", "content": "normal answer"},
+        {"role": "assistant", "content": marker},
+    ]
+    script = f"""
+const assert = require('assert');
+const msgContent = (message) => message && typeof message.content === 'string' ? message.content : '';
+{functions}
+assert.deepStrictEqual(_loadedCompactionMarkerRawIdxs({json.dumps(messages)}), [1, 4]);
+"""
+    _run_node(script)
+
+
+def test_settled_reference_is_pinned_at_top_when_marker_is_outside_tail() -> None:
+    source = UI_JS.read_text(encoding="utf-8")
+    helper = _extract_function(source, "_pinSettledCompressionReferenceAtTop")
+    script = f"""
+const assert = require('assert');
+{helper}
+const children = [];
+const inner = {{ appendChild(node) {{ children.push(node); return node; }} }};
+const card = {{ id: 'compaction-card' }};
+assert.strictEqual(_pinSettledCompressionReferenceAtTop(inner, card, -1), true);
+assert.deepStrictEqual(children, [card]);
+assert.strictEqual(_pinSettledCompressionReferenceAtTop(inner, {{id:'inline'}}, 12), false);
+assert.deepStrictEqual(children, [card]);
+"""
+    _run_node(script)
+    assert re.search(
+        r"referenceNodePinnedAtTop\s*=\s*_pinSettledCompressionReferenceAtTop\(",
+        source,
+    ), "render path must pin the settled summary before transcript rows"
+    assert "if(!referenceNodePinnedAtTop)" in source

--- a/tests/test_compaction_card_display.py
+++ b/tests/test_compaction_card_display.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 from pathlib import Path
 
@@ -103,11 +102,51 @@ assert.deepStrictEqual(_loadedCompactionMarkerRawIdxs({json.dumps(messages)}), [
     _run_node(script)
 
 
+def test_compaction_placement_selection_covers_window_boundaries() -> None:
+    source = UI_JS.read_text(encoding="utf-8")
+    helper = _extract_function(source, "_selectCompactionCardPlacements")
+    script = f"""
+const assert = require('assert');
+{helper}
+assert.deepStrictEqual(
+  _selectCompactionCardPlacements([3, 11, 49, 50, 88], 50),
+  {{
+    inlineMarkers: [50, 88],
+    latestPreWindowMarker: 49,
+    taskOwner: {{kind: 'inline', rawIdx: 88}},
+  }},
+);
+assert.deepStrictEqual(
+  _selectCompactionCardPlacements([3, 11, 49], 50),
+  {{
+    inlineMarkers: [],
+    latestPreWindowMarker: 49,
+    taskOwner: {{kind: 'pre-window', rawIdx: 49}},
+  }},
+);
+assert.deepStrictEqual(
+  _selectCompactionCardPlacements([50, 88], 50),
+  {{
+    inlineMarkers: [50, 88],
+    latestPreWindowMarker: null,
+    taskOwner: {{kind: 'inline', rawIdx: 88}},
+  }},
+);
+assert.deepStrictEqual(
+  _selectCompactionCardPlacements([], 50),
+  {{inlineMarkers: [], latestPreWindowMarker: null, taskOwner: null}},
+);
+"""
+    _run_node(script)
+
+
 def test_settled_reference_is_pinned_at_top_when_marker_is_outside_tail() -> None:
     source = UI_JS.read_text(encoding="utf-8")
+    pin_helper = _extract_function(source, "_pinCompactionCardAtTop")
     helper = _extract_function(source, "_pinSettledCompressionReferenceAtTop")
     script = f"""
 const assert = require('assert');
+{pin_helper}
 {helper}
 const children = [];
 const inner = {{ appendChild(node) {{ children.push(node); return node; }} }};
@@ -118,8 +157,3 @@ assert.strictEqual(_pinSettledCompressionReferenceAtTop(inner, {{id:'inline'}}, 
 assert.deepStrictEqual(children, [card]);
 """
     _run_node(script)
-    assert re.search(
-        r"referenceNodePinnedAtTop\s*=\s*_pinSettledCompressionReferenceAtTop\(",
-        source,
-    ), "render path must pin the settled summary before transcript rows"
-    assert "if(!referenceNodePinnedAtTop)" in source

--- a/tests/test_compaction_card_display.py
+++ b/tests/test_compaction_card_display.py
@@ -111,30 +111,30 @@ const assert = require('assert');
 assert.deepStrictEqual(
   _selectCompactionCardPlacements([3, 11, 49, 50, 88], 50),
   {{
+    preWindowMarkers: [3, 11, 49],
     inlineMarkers: [50, 88],
-    latestPreWindowMarker: 49,
     taskOwner: {{kind: 'inline', rawIdx: 88}},
   }},
 );
 assert.deepStrictEqual(
   _selectCompactionCardPlacements([3, 11, 49], 50),
   {{
+    preWindowMarkers: [3, 11, 49],
     inlineMarkers: [],
-    latestPreWindowMarker: 49,
     taskOwner: {{kind: 'pre-window', rawIdx: 49}},
   }},
 );
 assert.deepStrictEqual(
   _selectCompactionCardPlacements([50, 88], 50),
   {{
+    preWindowMarkers: [],
     inlineMarkers: [50, 88],
-    latestPreWindowMarker: null,
     taskOwner: {{kind: 'inline', rawIdx: 88}},
   }},
 );
 assert.deepStrictEqual(
   _selectCompactionCardPlacements([], 50),
-  {{inlineMarkers: [], latestPreWindowMarker: null, taskOwner: null}},
+  {{preWindowMarkers: [], inlineMarkers: [], taskOwner: null}},
 );
 """
     _run_node(script)

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -120,18 +120,35 @@ const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
 const MESSAGE_VIRTUAL_BUFFER_PX = 0;
 eval(extractFunc('_messageVirtualDefaultHeightForRole'));
 eval(extractFunc('_messageVirtualWindow'));
+eval(extractFunc('_compactionDigestText'));
+eval(extractFunc('_compactionCardPreview'));
+eval(extractFunc('_compressionReferenceCardHtml'));
 eval(extractFunc('_selectCompactionCardPlacements'));
 eval(extractFunc('_pinCompactionCardAtTop'));
 eval(extractFunc('_insertCompactionCardNodes'));
 eval(extractFunc('_insertPreservedCompressionTaskFallback'));
 eval(extractFunc('_insertCompressionLikeNodeByRawIdx'));
 
+class MiniClassList {
+  constructor(...names) { this.names = new Set(names); }
+  add(...names) { names.forEach(name => this.names.add(name)); }
+  contains(name) { return this.names.has(name); }
+  toggle(name) {
+    if (this.names.has(name)) {
+      this.names.delete(name);
+      return false;
+    }
+    this.names.add(name);
+    return true;
+  }
+}
 class MiniNode {
   constructor(label, rawIdx = null) {
     this.label = label;
     this.rawIdx = rawIdx;
     this.children = [];
     this.parentElement = null;
+    this.classList = new MiniClassList();
   }
   appendChild(node) {
     if (node.parentElement) node.remove();
@@ -153,18 +170,59 @@ class MiniNode {
     if (index >= 0) this.parentElement.children.splice(index, 1);
     this.parentElement = null;
   }
+  closest(selector) {
+    let node = this;
+    while (node) {
+      if (selector === '.tool-card' && node.classList.contains('tool-card')) return node;
+      node = node.parentElement;
+    }
+    return null;
+  }
 }
 function _assistantTurnBlocks() { return null; }
+function _engineAwareCompressionCopy() {
+  return {label: 'Context compacted', preview: 'Reference only'};
+}
+function esc(value) {
+  return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+function li(name) { return `<i data-icon="${name}"></i>`; }
+function t(key) { return key; }
 function taskCount(node) {
   return (node.label === 'task' ? 1 : 0)
     + node.children.reduce((total, child) => total + taskCount(child), 0);
 }
 function card(kind, rawIdx, taskOwner) {
   const node = new MiniNode(`${kind}:${rawIdx}`, rawIdx);
+  const marker = `[CONTEXT COMPACTION — REFERENCE ONLY]\n## Goal\nDigest ${rawIdx}`;
+  const html = _compressionReferenceCardHtml(marker, false);
+  const handler = html.match(/class="tool-card-header" onclick="([^"]+)"/);
+  assert.ok(handler, `card ${rawIdx} must expose its disclosure handler`);
+  const disclosure = new MiniNode(`disclosure:${rawIdx}`);
+  disclosure.classList.add('tool-card');
+  const header = new MiniNode(`header:${rawIdx}`);
+  header.click = () => Function(handler[1]).call(header);
+  disclosure.appendChild(header);
+  node.appendChild(disclosure);
+  node.disclosure = disclosure;
+  node.markerHtml = html;
   if (taskOwner && taskOwner.kind === kind && taskOwner.rawIdx === rawIdx) {
     node.appendChild(new MiniNode('task'));
   }
   return {kind, rawIdx, node};
+}
+function compactionCards(node) {
+  return node.children.filter(child => /^pre-window:|^inline:/.test(child.label));
+}
+function reopen(cardNode) {
+  assert.strictEqual(cardNode.disclosure.classList.contains('open'), false);
+  cardNode.children[0].children[0].click();
+  assert.strictEqual(cardNode.disclosure.classList.contains('open'), true);
+  cardNode.children[0].children[0].click();
+  assert.strictEqual(cardNode.disclosure.classList.contains('open'), false);
+  cardNode.children[0].children[0].click();
+  assert.strictEqual(cardNode.disclosure.classList.contains('open'), true);
+  assert.ok(cardNode.markerHtml.includes(`Digest ${cardNode.rawIdx}`));
 }
 
 const visible = Array.from({length: 100}, (_, index) => ({
@@ -196,10 +254,12 @@ function renderScenario(markers) {
   userRows = new Map();
   let taskOwnerNode = null;
 
-  if (placements.latestPreWindowMarker !== null) {
-    const entry = card('pre-window', placements.latestPreWindowMarker, placements.taskOwner);
+  if (placements.preWindowMarkers.length) {
+    const entries = placements.preWindowMarkers.map(rawIdx =>
+      card('pre-window', rawIdx, placements.taskOwner)
+    );
     const mounted = _insertCompactionCardNodes(
-      [entry],
+      entries,
       placements.taskOwner,
       node => _pinCompactionCardAtTop(inner, node),
     );
@@ -234,20 +294,35 @@ function renderScenario(markers) {
 
 const mixed = renderScenario([1, 79, 159, 170]);
 assert.deepStrictEqual(mixed.placements, {
+  preWindowMarkers: [1, 79, 159],
   inlineMarkers: [170],
-  latestPreWindowMarker: 159,
   taskOwner: {kind: 'inline', rawIdx: 170},
 });
-assert.strictEqual(mixed.inner.children[0].label, 'pre-window:159');
+const mixedCards = compactionCards(mixed.inner);
+assert.deepStrictEqual(mixedCards.map(node => node.rawIdx), [1, 79, 159, 170]);
+reopen(mixedCards[0]);
+assert.strictEqual(mixedCards[1].disclosure.classList.contains('open'), false);
+reopen(mixedCards[1]);
 assert.ok(
   mixed.inner.children.indexOf(mixed.taskOwnerNode)
     < mixed.inner.children.findIndex(node => node.rawIdx > 170),
+);
+assert.deepStrictEqual(
+  mixedCards.filter(node => node.children.some(child => child.label === 'task')).map(node => node.rawIdx),
+  [170],
 );
 assert.strictEqual(taskCount(mixed.inner), 1);
 assert.strictEqual(mixed.fallbackInserted, false);
 
 const preWindowOnly = renderScenario([1, 79, 159]);
+assert.deepStrictEqual(compactionCards(preWindowOnly.inner).map(node => node.rawIdx), [1, 79, 159]);
 assert.strictEqual(preWindowOnly.taskOwnerNode.label, 'pre-window:159');
+assert.deepStrictEqual(
+  compactionCards(preWindowOnly.inner)
+    .filter(node => node.children.some(child => child.label === 'task'))
+    .map(node => node.rawIdx),
+  [159],
+);
 assert.strictEqual(taskCount(preWindowOnly.inner), 1);
 assert.strictEqual(preWindowOnly.fallbackInserted, false);
 

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -101,6 +101,165 @@ console.log(JSON.stringify(metrics));
     assert metrics["bottomPad"] == 0
 
 
+def test_compaction_cards_cross_virtualization_threshold_with_one_task_owner():
+    """Execute the real window and compaction DOM helpers with a tiny DOM.
+
+    This deliberately reuses issue #500's proven virtualization harness instead
+    of evaluating all of renderMessages() against a hand-built browser clone.
+    """
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + r"""
+const assert = require('assert');
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 0;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+eval(extractFunc('_selectCompactionCardPlacements'));
+eval(extractFunc('_pinCompactionCardAtTop'));
+eval(extractFunc('_insertCompactionCardNodes'));
+eval(extractFunc('_insertPreservedCompressionTaskFallback'));
+eval(extractFunc('_insertCompressionLikeNodeByRawIdx'));
+
+class MiniNode {
+  constructor(label, rawIdx = null) {
+    this.label = label;
+    this.rawIdx = rawIdx;
+    this.children = [];
+    this.parentElement = null;
+  }
+  appendChild(node) {
+    if (node.parentElement) node.remove();
+    node.parentElement = this;
+    this.children.push(node);
+    return node;
+  }
+  insertBefore(node, reference) {
+    if (node.parentElement) node.remove();
+    node.parentElement = this;
+    const index = this.children.indexOf(reference);
+    if (index < 0) this.children.push(node);
+    else this.children.splice(index, 0, node);
+    return node;
+  }
+  remove() {
+    if (!this.parentElement) return;
+    const index = this.parentElement.children.indexOf(this);
+    if (index >= 0) this.parentElement.children.splice(index, 1);
+    this.parentElement = null;
+  }
+}
+function _assistantTurnBlocks() { return null; }
+function taskCount(node) {
+  return (node.label === 'task' ? 1 : 0)
+    + node.children.reduce((total, child) => total + taskCount(child), 0);
+}
+function card(kind, rawIdx, taskOwner) {
+  const node = new MiniNode(`${kind}:${rawIdx}`, rawIdx);
+  if (taskOwner && taskOwner.kind === kind && taskOwner.rawIdx === rawIdx) {
+    node.appendChild(new MiniNode('task'));
+  }
+  return {kind, rawIdx, node};
+}
+
+const visible = Array.from({length: 100}, (_, index) => ({
+  rawIdx: index * 2,
+  m: {role: 'user'},
+}));
+const virtualWindow = _messageVirtualWindow({
+  total: visible.length,
+  scrollTop: 120 * 200,
+  viewportHeight: 720,
+  heights: Array.from({length: visible.length}, () => 120),
+  defaultHeight: 120,
+  bufferPx: 0,
+  threshold: MESSAGE_VIRTUAL_THRESHOLD_ROWS,
+  keepTailCount: 20,
+});
+assert.strictEqual(virtualWindow.virtualized, true);
+const renderVisWithIdx = visible.slice(virtualWindow.start);
+const firstRenderedRawIdx = renderVisWithIdx[0].rawIdx;
+assert.strictEqual(firstRenderedRawIdx, 160);
+
+let inner;
+let assistantSegments;
+let userRows;
+function renderScenario(markers) {
+  const placements = _selectCompactionCardPlacements(markers, firstRenderedRawIdx);
+  inner = new MiniNode('inner');
+  assistantSegments = new Map();
+  userRows = new Map();
+  let taskOwnerNode = null;
+
+  if (placements.latestPreWindowMarker !== null) {
+    const entry = card('pre-window', placements.latestPreWindowMarker, placements.taskOwner);
+    const mounted = _insertCompactionCardNodes(
+      [entry],
+      placements.taskOwner,
+      node => _pinCompactionCardAtTop(inner, node),
+    );
+    taskOwnerNode = mounted.taskOwnerNode;
+  }
+
+  for (const entry of renderVisWithIdx) {
+    const row = new MiniNode(`row:${entry.rawIdx}`, entry.rawIdx);
+    inner.appendChild(row);
+    userRows.set(entry.rawIdx, row);
+  }
+
+  const inlineEntries = placements.inlineMarkers.map(rawIdx =>
+    card('inline', rawIdx, placements.taskOwner)
+  );
+  const mounted = _insertCompactionCardNodes(
+    inlineEntries,
+    placements.taskOwner,
+    (node, rawIdx) => _insertCompressionLikeNodeByRawIdx(node, rawIdx),
+  );
+  taskOwnerNode = mounted.taskOwnerNode || taskOwnerNode;
+
+  const fallback = new MiniNode('standalone-tasks');
+  fallback.appendChild(new MiniNode('task'));
+  const fallbackInserted = _insertPreservedCompressionTaskFallback(
+    taskOwnerNode,
+    fallback,
+    node => { inner.appendChild(node); return true; },
+  );
+  return {placements, inner, taskOwnerNode, fallbackInserted};
+}
+
+const mixed = renderScenario([1, 79, 159, 170]);
+assert.deepStrictEqual(mixed.placements, {
+  inlineMarkers: [170],
+  latestPreWindowMarker: 159,
+  taskOwner: {kind: 'inline', rawIdx: 170},
+});
+assert.strictEqual(mixed.inner.children[0].label, 'pre-window:159');
+assert.ok(
+  mixed.inner.children.indexOf(mixed.taskOwnerNode)
+    < mixed.inner.children.findIndex(node => node.rawIdx > 170),
+);
+assert.strictEqual(taskCount(mixed.inner), 1);
+assert.strictEqual(mixed.fallbackInserted, false);
+
+const preWindowOnly = renderScenario([1, 79, 159]);
+assert.strictEqual(preWindowOnly.taskOwnerNode.label, 'pre-window:159');
+assert.strictEqual(taskCount(preWindowOnly.inner), 1);
+assert.strictEqual(preWindowOnly.fallbackInserted, false);
+
+const noMarkers = renderScenario([]);
+assert.strictEqual(noMarkers.taskOwnerNode, null);
+assert.strictEqual(noMarkers.fallbackInserted, true);
+assert.strictEqual(taskCount(noMarkers.inner), 1);
+console.log('ok');
+"""
+    assert _run_node(source) == "ok"
+
+
 def test_render_messages_uses_virtual_window_and_spacer_measurement_path():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     render_start = js.index("function renderMessages(options)")


### PR DESCRIPTION
## Problem

Context-compaction marker messages are filtered from the normal transcript rows. The existing fallback rendered only one settled reference card and could leave it anchored before the server-loaded tail, so users could see no indication that a long conversation had been compacted.

The marker envelope is also much longer than its useful digest; displaying the first lines surfaces handling instructions rather than the request/state the user needs.

## Changes

- render one collapsed compaction card for every marker present in the loaded transcript, at its raw transcript position;
- show the digest (request/goal/state), not the fixed compaction-instruction envelope;
- keep the single settled-summary fallback only when no marker is loaded;
- pin that fallback immediately above a server-truncated tail when its marker is outside the loaded window;
- attach preserved task cards once, to the latest inline compaction card;
- replace the standalone JS probe with a pytest-collected Node harness and update the existing static contracts.

## State-space covered

- zero, one, and multiple loaded compaction markers;
- tool rows carrying marker-like text (ignored);
- current-context markers and merged prior-context envelopes;
- server-truncated tails where the matching marker is not loaded;
- preserved tasks with inline cards versus the settled fallback;
- settled reference insertion without duplication.

## RED / GREEN proof

On unmodified `origin/master` (`cced4f35094a`), transplanting the new regression test fails all three cases because the digest, marker scan, and tail-pin helpers do not exist.

On this commit:

```text
90 passed
```

The focused matrix includes the new tests plus neighboring automatic-card, anchor-helper, marker-timeout, and mobile-reload coverage. `node --check`, the runtime ESLint gate, Ruff diff gate, and `git diff --check` also pass.

## Scope / overlap

This PR changes only the render contract. It does not mutate compression, persistence, lineage, or SSE state. PR #7087 handles active DOM tail reduction and is not semantically replaced by this change.

A local follow-up that projects the freshest Agent continuation-tip digest is intentionally excluded: on current `master` it depends on lineage-root tip metadata that is not yet available there. This PR therefore preserves the existing `compression_anchor_summary` API and remains independently mergeable.

## Visual before/after evidence

Rendered with the product's own `static/style.css` and the real card-building
functions extracted from each revision (`origin/master` vs this branch), then
captured headless at desktop (1280px) and narrow (420px) widths.

### Desktop

| Before (`origin/master`) | After (this PR) |
| --- | --- |
| ![before desktop](https://raw.githubusercontent.com/ruizanthony/hermes-webui/evidence/compaction-cards/docs/evidence/compaction-cards/before-desktop.png) | ![after desktop](https://raw.githubusercontent.com/ruizanthony/hermes-webui/evidence/compaction-cards/docs/evidence/compaction-cards/after-desktop.png) |

### Narrow (420px)

| Before (`origin/master`) | After (this PR) |
| --- | --- |
| ![before narrow](https://raw.githubusercontent.com/ruizanthony/hermes-webui/evidence/compaction-cards/docs/evidence/compaction-cards/before-narrow.png) | ![after narrow](https://raw.githubusercontent.com/ruizanthony/hermes-webui/evidence/compaction-cards/docs/evidence/compaction-cards/after-narrow.png) |

The rendered card text starts with the handling envelope before
(`[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted…`) and with
the digest after (`## Historical Task Snapshot` / the user's actual request).

### Correction to an earlier claim in this description

An earlier revision of this description said the *collapsed preview line* was
the surface being fixed. That was checked against the live stylesheet and is
**wrong**: `.tool-card-preview` is `display:none` globally in `static/style.css`
(lines 4068 and 6331, both at top-level scope), so the collapsed preview is not
rendered inside `#msgInner` at all. Measured computed style, both revisions:

```text
preview : display=none  height=0px      (collapsed and open)
detail  : display=block height=175px    (open)
```

The user-visible improvement is therefore in the **card body**, whose text is
resolved by `_resolvedSessionCompressionSummary()` — a function that does not
exist on `origin/master`. `_compactionCardPreview()` still correctly strips the
envelope and remains covered by tests; it is simply not the visible surface
today. No behavioral claim in the "Changes" list depends on the preview line
being visible.
