### PR TITLE
perf: bound concurrent full-session resolution

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4684,7 +4684,46 @@ def get_session_for_scan(sid):
         return None
 
 
-def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_miss=True):
+class _FullSessionResolveRequired(RuntimeError):
+    """Internal signal that a full sidecar load must enter the bounded path."""
+
+
+_FULL_SESSION_RESOLVE_MAX_CONCURRENT = 2
+_FULL_SESSION_RESOLVE_SLOTS = threading.BoundedSemaphore(
+    _FULL_SESSION_RESOLVE_MAX_CONCURRENT
+)
+_FULL_SESSION_RESOLVE_INFLIGHT: dict[str, threading.Event] = {}
+_FULL_SESSION_RESOLVE_INFLIGHT_LOCK = threading.Lock()
+_FULL_SESSION_RESOLVE_LOCAL = threading.local()
+
+
+def _claim_full_session_resolve(session_id: str) -> tuple[bool, threading.Event]:
+    """Return whether this caller owns the single-flight for ``session_id``."""
+    with _FULL_SESSION_RESOLVE_INFLIGHT_LOCK:
+        event = _FULL_SESSION_RESOLVE_INFLIGHT.get(session_id)
+        if event is not None:
+            return False, event
+        event = threading.Event()
+        _FULL_SESSION_RESOLVE_INFLIGHT[session_id] = event
+        return True, event
+
+
+def _finish_full_session_resolve(session_id: str, event: threading.Event) -> None:
+    """Release one single-flight owner and wake every waiter."""
+    with _FULL_SESSION_RESOLVE_INFLIGHT_LOCK:
+        if _FULL_SESSION_RESOLVE_INFLIGHT.get(session_id) is event:
+            _FULL_SESSION_RESOLVE_INFLIGHT.pop(session_id, None)
+    event.set()
+
+
+def _resolve_session_once(
+    sid,
+    metadata_only=False,
+    *,
+    promote_cache=True,
+    cache_on_miss=True,
+    allow_full_load=False,
+):
     """Resolve a session through the canonical freshness/recovery path.
 
     ``get_session_for_scan`` shares this resolver with normal reads so that
@@ -4715,6 +4754,8 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
             cached = None
     if cached is not None:
         if not metadata_only and _cached_session_lags_disk(cached):
+            if not allow_full_load:
+                raise _FullSessionResolveRequired
             try:
                 disk_session = Session.load(sid)
                 with LOCK:
@@ -4727,6 +4768,8 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
                     "cached session disk-freshness check failed for session %s", sid, exc_info=True,
                 )
         if not metadata_only and _inactive_cache_tail_needs_disk_check(cached):
+            if not allow_full_load:
+                raise _FullSessionResolveRequired
             try:
                 disk_session = Session.load(sid)
                 if _cache_has_stale_unsaved_user_tail(cached, disk_session):
@@ -4759,6 +4802,8 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
         if s:
             return s
     else:
+        if not allow_full_load:
+            raise _FullSessionResolveRequired
         s = Session.load(sid)
     if s:
         if cache_on_miss:
@@ -4797,6 +4842,72 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
                 pass  # repair is best-effort
         return s
     raise KeyError(sid)
+
+
+def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_miss=True):
+    """Resolve a session while single-flighting heavyweight full sidecar loads.
+
+    Metadata-only reads and full sessions that remain current in the cache take
+    the lock-free path. A cache miss or stale cache entry elects one leader per
+    session; waiters retry the canonical resolver after that leader publishes its
+    result. Leaders for different sessions share a small global slot budget so
+    concurrent JSON parses cannot multiply a large sidecar's transient memory.
+    """
+    if metadata_only:
+        return _resolve_session_once(
+            sid,
+            metadata_only=True,
+            promote_cache=promote_cache,
+            cache_on_miss=cache_on_miss,
+        )
+
+    session_id = str(sid)
+    while True:
+        try:
+            return _resolve_session_once(
+                sid,
+                metadata_only=False,
+                promote_cache=promote_cache,
+                cache_on_miss=cache_on_miss,
+            )
+        except _FullSessionResolveRequired:
+            pass
+
+        active: set[str] = set(
+            getattr(_FULL_SESSION_RESOLVE_LOCAL, "active", ()) or ()
+        )
+        if active:
+            # Nested resolution already owns one global slot. Re-enter directly
+            # instead of waiting on this thread's own flight or consuming a
+            # second slot; the canonical resolver still owns all cache checks.
+            return _resolve_session_once(
+                sid,
+                metadata_only=False,
+                promote_cache=promote_cache,
+                cache_on_miss=cache_on_miss,
+                allow_full_load=True,
+            )
+
+        leader, event = _claim_full_session_resolve(session_id)
+        if not leader:
+            event.wait()
+            continue
+
+        active.add(session_id)
+        _FULL_SESSION_RESOLVE_LOCAL.active = active
+        try:
+            with _FULL_SESSION_RESOLVE_SLOTS:
+                return _resolve_session_once(
+                    sid,
+                    metadata_only=False,
+                    promote_cache=promote_cache,
+                    cache_on_miss=cache_on_miss,
+                    allow_full_load=True,
+                )
+        finally:
+            active.discard(session_id)
+            _FULL_SESSION_RESOLVE_LOCAL.active = active
+            _finish_full_session_resolve(session_id, event)
 
 
 def get_session(sid, metadata_only=False):

--- a/tests/test_full_session_resolve_gate.py
+++ b/tests/test_full_session_resolve_gate.py
@@ -1,0 +1,238 @@
+"""Regression coverage for bounded full-session resolution."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+def _install_lightweight_resolve_stubs(monkeypatch, models) -> None:
+    """Keep the tests focused on full sidecar materialization."""
+    monkeypatch.setattr(models, "_sync_sidecar_from_state_db_if_newer", lambda _session: False)
+    monkeypatch.setattr(models, "_repair_stale_pending", lambda _session: False)
+    monkeypatch.setattr(models, "_session_has_pending_journal_retry", lambda _session: False)
+
+
+def _empty_session(models, sid: str):
+    return models.Session(session_id=sid, messages=[])
+
+
+@pytest.fixture(autouse=True)
+def _clear_session_cache():
+    import api.models as models
+
+    with models.LOCK:
+        models.SESSIONS.clear()
+    yield
+    with models.LOCK:
+        models.SESSIONS.clear()
+
+
+def test_same_session_cold_load_is_single_flight(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    workers = 4
+    start = threading.Barrier(workers)
+    state_lock = threading.Lock()
+    calls = 0
+    active = 0
+    peak = 0
+
+    def fake_load(cls, sid):
+        nonlocal calls, active, peak
+        with state_lock:
+            calls += 1
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.08)
+        with state_lock:
+            active -= 1
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+
+    def resolve():
+        start.wait(timeout=2)
+        return models.get_session("same-session")
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = [future.result(timeout=3) for future in [executor.submit(resolve) for _ in range(workers)]]
+
+    assert calls == 1
+    assert peak == 1
+    assert {result.session_id for result in results} == {"same-session"}
+
+
+def test_stale_cached_session_is_single_flight(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    stale = _empty_session(models, "stale-session")
+    with models.LOCK:
+        models.SESSIONS[stale.session_id] = stale
+    monkeypatch.setattr(models, "_cached_session_lags_disk", lambda session: session is stale)
+    monkeypatch.setattr(models, "_inactive_cache_tail_needs_disk_check", lambda _session: False)
+
+    workers = 4
+    start = threading.Barrier(workers)
+    state_lock = threading.Lock()
+    calls = 0
+    active = 0
+    peak = 0
+
+    def fake_load(cls, sid):
+        nonlocal calls, active, peak
+        with state_lock:
+            calls += 1
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.08)
+        with state_lock:
+            active -= 1
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+
+    def resolve():
+        start.wait(timeout=2)
+        return models.get_session("stale-session")
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = [
+            future.result(timeout=3)
+            for future in [executor.submit(resolve) for _ in range(workers)]
+        ]
+
+    assert calls == 1
+    assert peak == 1
+    assert all(result is results[0] for result in results)
+    assert results[0] is not stale
+
+
+def test_distinct_cold_loads_have_a_global_concurrency_bound(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    session_ids = ("session-a", "session-b", "session-c", "session-d")
+    start = threading.Barrier(len(session_ids))
+    state_lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def fake_load(cls, sid):
+        nonlocal active, peak
+        with state_lock:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.08)
+        with state_lock:
+            active -= 1
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+
+    def resolve(sid):
+        start.wait(timeout=2)
+        return models.get_session(sid)
+
+    with ThreadPoolExecutor(max_workers=len(session_ids)) as executor:
+        results = [
+            future.result(timeout=3)
+            for future in [executor.submit(resolve, sid) for sid in session_ids]
+        ]
+
+    assert peak == 2
+    assert {result.session_id for result in results} == set(session_ids)
+
+
+def test_metadata_only_load_bypasses_full_resolve_slots(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    heavy_entered = threading.Barrier(3)
+    release_heavy = threading.Event()
+
+    def fake_load(cls, sid):
+        heavy_entered.wait(timeout=2)
+        assert release_heavy.wait(timeout=2)
+        return _empty_session(models, sid)
+
+    def fake_load_metadata_only(cls, sid):
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+    monkeypatch.setattr(models.Session, "load_metadata_only", classmethod(fake_load_metadata_only))
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        first = executor.submit(models.get_session, "heavy-a")
+        second = executor.submit(models.get_session, "heavy-b")
+        heavy_entered.wait(timeout=2)
+        metadata = executor.submit(models.get_session, "metadata", True)
+        try:
+            assert metadata.result(timeout=0.5).session_id == "metadata"
+        finally:
+            release_heavy.set()
+        assert first.result(timeout=2).session_id == "heavy-a"
+        assert second.result(timeout=2).session_id == "heavy-b"
+
+
+def test_fresh_cache_hit_bypasses_full_resolve_slots(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    cached = _empty_session(models, "cached")
+    with models.LOCK:
+        models.SESSIONS[cached.session_id] = cached
+    monkeypatch.setattr(models, "_cached_session_lags_disk", lambda _session: False)
+    monkeypatch.setattr(models, "_inactive_cache_tail_needs_disk_check", lambda _session: False)
+
+    heavy_entered = threading.Barrier(3)
+    release_heavy = threading.Event()
+
+    def fake_load(cls, sid):
+        heavy_entered.wait(timeout=2)
+        assert release_heavy.wait(timeout=2)
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        first = executor.submit(models.get_session, "heavy-a")
+        second = executor.submit(models.get_session, "heavy-b")
+        heavy_entered.wait(timeout=2)
+        cache_hit = executor.submit(models.get_session, "cached")
+        try:
+            assert cache_hit.result(timeout=0.5) is cached
+        finally:
+            release_heavy.set()
+        first.result(timeout=2)
+        second.result(timeout=2)
+
+
+def test_failed_leader_releases_single_flight_state(monkeypatch):
+    import api.models as models
+
+    _install_lightweight_resolve_stubs(monkeypatch, models)
+    attempts = 0
+
+    def fake_load(cls, sid):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("simulated sidecar failure")
+        return _empty_session(models, sid)
+
+    monkeypatch.setattr(models.Session, "load", classmethod(fake_load))
+
+    with pytest.raises(OSError, match="simulated sidecar failure"):
+        models.get_session("retryable")
+
+    recovered = models.get_session("retryable")
+
+    assert recovered.session_id == "retryable"
+    assert attempts == 2
+    assert models._FULL_SESSION_RESOLVE_INFLIGHT == {}


### PR DESCRIPTION
## Thinking Path

- The bounded `SESSIONS` LRU (#4765/#5357) limits retained histories, but it acts only after a `Session.load()` completes.
- Concurrent cold or stale reads can therefore parse the same large sidecar several times before any result reaches the cache.
- The canonical chokepoint is `_resolve_session()`: route, scan, and recovery callers already converge there.
- A per-session single-flight removes duplicate work; a small global slot budget bounds different large sidecars.
- Metadata-only reads and fresh cache hits must remain outside the heavyweight path.

Fixes #7123.

## What Changed

- Split the canonical resolver into a cheap probe and a bounded full-load wrapper.
- Added one in-flight leader per session ID; waiters retry the canonical resolver after the leader publishes.
- Limited leaders for different session IDs to two concurrent full resolutions.
- Kept `metadata_only=True` and disk-current cache hits outside the bound.
- Added cleanup for every leader exit, including exceptions, so later retries cannot inherit a stale flight.
- Kept nested same-thread resolution from consuming another slot or waiting on itself.

## Why It Matters

A 31.8 MB / 5,287-message production-shaped sidecar can create a large transient object graph while parsing and reconciling. Four overlapping browser bootstrap/reconnect requests previously produced four overlapping `Session.load()` calls. The resident cache cannot prevent that first-wave amplification.

This is complementary to:

- #6651: serialized resident-cache byte budgeting (explicitly does not bound one transcript's decode peak);
- #6317/#6891: bounded initial-sidecar parsing;
- #5776: compression-lineage pagination.

## Contract Routing

Task type: runtime/session-resolution performance and concurrency guard.

Touched state:
- process-local per-session in-flight map;
- process-local global full-resolution slots;
- canonical session cache publication remains owned by `_resolve_session_once()`.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`

Invariant: at most one full load per session ID is active; at most two different full loads are active; lightweight reads stay independent; uncertainty/failure still follows the existing canonical resolver semantics.

Public contract change: none.

## Verification

Regression bite on current `master`:

```text
same cold session: 4 Session.load calls, peak concurrency 4
four distinct cold sessions: peak concurrency 4
3 tests failed, 2 passed
```

Current head:

```text
same cold/stale session: 1 Session.load call, peak concurrency 1
four distinct cold sessions: peak concurrency 2
metadata-only and fresh-cache reads complete while both slots are occupied
failed leader releases state; next retry succeeds
```

Local gates after rebasing onto `59023b78`:

```text
169 passed
ruff_lint --diff origin/master: no new violations
git diff --check: passed
```

Covered neighboring areas: safe LRU eviction, sidecar repair, stale-stream cleanup, lost-response/journal retry, in-flight purge, and session save mode.

The full suite is running in an isolated transient systemd unit and will be reported separately; it is not claimed green here yet.

## Risks / Follow-ups

- A third different large session waits rather than allocating immediately; bounded latency is intentional.
- `get_session_for_scan()` preserves non-promoting/non-caching semantics. Concurrent scans of the same uncached ID are serialized but cannot reuse a result because that accessor deliberately does not populate the LRU.
- Direct `Session.load()` sites outside the canonical resolver are out of scope; this PR covers callers that resolve sessions through `get_session()` / `get_session_for_scan()`.
- No UI files, storage schema, dependencies, or configuration changed.

## Release Note

Bound concurrent full-session resolution so overlapping requests cannot multiply large sidecar parsing and reconciliation work.

## Model Used

OpenAI Codex `gpt-5.6-sol` through Hermes Agent. AI assistance included repository inspection, isolated worktrees, TDD/sabotage verification, GitHub duplicate-work review, and focused regression execution.
