### PR TITLE
fix(skills): decode JSON-array string skills.disabled in panel read and toggle write (#7120)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -817,12 +817,52 @@ def _get_disabled_skill_names_for_profile() -> set:
     return _normalize_disabled_set(skills_cfg.get("disabled"))
 
 
+def _parse_config_string_list(value) -> list:
+    """Decode a config value that may hold a JSON-array string into a list.
+
+    ``hermes config set`` (and JSON-mode editor saves) store lists as quoted
+    JSON strings (``'[\"a\",\"b\"]'`` or the Python-literal ``\"['a']\"``), so a
+    disabled list read from ``config.yaml`` can arrive as a single string
+    instead of a YAML list. Treating it as one literal name makes the Skills
+    panel show every skill as enabled and makes the toggle write a destructive
+    single-entry list (hermes-webui#7120).
+
+    Reuses ``agent.skill_utils.parse_config_string_list`` (hermes-agent #86661
+    fix) when the bundled agent source is importable, and mirrors its logic
+    otherwise so the two surfaces cannot drift. A scalar string still means one
+    name.
+    """
+    try:
+        from agent.skill_utils import parse_config_string_list
+
+        return parse_config_string_list(value)
+    except ImportError:
+        pass
+    import ast
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.startswith("["):
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                parsed = None
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        return [value]
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [str(item) for item in value]
+    return []
+
+
 def _normalize_disabled_set(values) -> set:
     """Normalize a YAML disabled list into a set of stripped strings."""
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        values = _parse_config_string_list(values)
     return {str(v).strip() for v in values if str(v).strip()}
 
 
@@ -26841,7 +26881,7 @@ def _normalize_names_list(names) -> list[str]:
     if names is None:
         return []
     if isinstance(names, str):
-        names = [names]
+        names = _parse_config_string_list(names)
     elif not isinstance(names, list):
         names = list(names) if names else []
     return list(dict.fromkeys(str(d).strip() for d in names if str(d).strip()))

--- a/tests/test_issue3066_disabled_read_profile.py
+++ b/tests/test_issue3066_disabled_read_profile.py
@@ -161,3 +161,58 @@ def test_normalize_disabled_set_handles_edge_cases():
     assert _normalize_disabled_set(["a", "b"]) == {"a", "b"}
     assert _normalize_disabled_set([" spaced ", "  "]) == {"spaced"}
     assert _normalize_disabled_set([]) == set()
+
+
+def test_disabled_read_decodes_json_array_string(tmp_path, monkeypatch):
+    """Issue #7120: skills.disabled stored as a JSON-array string (the shape
+    produced by `hermes config set skills.disabled ...`) must decode to the
+    real names, not one literal entry."""
+    from api import routes
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"skills": {"disabled": '["skill-x", "skill-y"]'}})
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == {"skill-x", "skill-y"}
+
+
+def test_disabled_read_platform_webui_decodes_json_array_string(tmp_path, monkeypatch):
+    """Issue #7120: platform_disabled.webui stored as a JSON-array string is
+    decoded the same way as the global disabled list."""
+    from api import routes
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {
+        "skills": {
+            "disabled": ["global-disabled"],
+            "platform_disabled": {"webui": '["webui-disabled-a", "webui-disabled-b"]'},
+        }
+    })
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == {"webui-disabled-a", "webui-disabled-b"}
+    assert "global-disabled" not in result
+
+
+@requires_agent_modules
+def test_skills_list_disabled_decodes_json_array_string(tmp_path, monkeypatch):
+    """Issue #7120: the Skills panel (skills list endpoint) must report both
+    skills as disabled when config.yaml stores disabled as a JSON-array string."""
+    from api import routes
+
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "skill-a")
+    _write_skill(skills_dir, "skill-b")
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"skills": {"disabled": '["skill-a", "skill-b"]'}})
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+    monkeypatch.setattr("api.routes._active_skills_dir", lambda: skills_dir)
+
+    result = routes._skills_list_from_dir(skills_dir)
+    skills = {s["name"]: s for s in result["skills"]}
+
+    assert skills["skill-a"]["disabled"] is True
+    assert skills["skill-b"]["disabled"] is True

--- a/tests/test_skills_toggle.py
+++ b/tests/test_skills_toggle.py
@@ -197,3 +197,43 @@ def test_platform_disabled_no_write_through_when_key_absent(tmp_path, monkeypatc
     assert "skill-b" in cfg_after["skills"]["disabled"]
     # platform_disabled was never created
     assert "platform_disabled" not in cfg_after.get("skills", {})
+
+
+def test_toggle_preserves_json_array_string_entries(tmp_path, monkeypatch):
+    """Issue #7120: when skills.disabled is stored as a JSON-array string,
+    a toggle must decode it before add/remove so the other entries survive
+    the write (previously the whole string was treated as one name and the
+    list was destroyed on the next save)."""
+    from unittest.mock import MagicMock
+    from api.routes import _handle_skill_toggle
+    from api.config import _load_yaml_config_file
+
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    import yaml
+
+    config = {"skills": {"disabled": '["skill-a", "skill-b"]'}}
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(config), encoding="utf-8")
+
+    fake_dir = tmp_path / "skills" / "skill-c"
+    fake_dir.mkdir(parents=True, exist_ok=True)
+    fake_md = fake_dir / "SKILL.md"
+    fake_md.write_text("---\nname: skill-c\n---\nC skill", encoding="utf-8")
+    monkeypatch.setattr(
+        "api.routes._find_skill_in_dirs",
+        lambda name, dirs: (fake_dir, fake_md),
+    )
+
+    handler = MagicMock()
+
+    # Toggle skill-c OFF — must append without dropping skill-a/skill-b
+    _handle_skill_toggle(handler, {"name": "skill-c", "enabled": False})
+    cfg_after = _load_yaml_config_file(config_path)
+    assert cfg_after["skills"]["disabled"] == ["skill-a", "skill-b", "skill-c"]
+
+    # Toggle skill-a ON — must remove only skill-a, preserving skill-b
+    _handle_skill_toggle(handler, {"name": "skill-a", "enabled": True})
+    cfg_after2 = _load_yaml_config_file(config_path)
+    assert cfg_after2["skills"]["disabled"] == ["skill-b", "skill-c"]


### PR DESCRIPTION
## Summary
The Skills panel shows the wrong enabled/disabled state for any profile whose `config.yaml` stores `skills.disabled` in the JSON-array **string** form (e.g. `disabled: '["skill-a", "skill-b"]'` — the normal shape produced by `hermes config set skills.disabled ...` on the backing agent). The whole quoted array is treated as one literal skill name, so every real skill renders as enabled — and a single toggle then rewrites `skills.disabled` to a one-entry list, silently deleting the other entries.

## Root Cause
`api/routes.py` does not decode list-shaped strings, while the upstream agent does:
- `_normalize_disabled_set` (~line 784): `if isinstance(values, str): values = [values]` — no JSON-array decode.
- `_normalize_names_list` (~line 25624): same flaw; this is the read path used by `_handle_skill_toggle`, which is why the write is destructive too.

The agent side fixed exactly this bug in NousResearch/hermes-agent#86661 via `agent/skill_utils.parse_config_string_list` (ast.literal_eval decode of strings that start with `[`, preserving the single-scalar-means-one-name contract). The WebUI container already bundles that fixed `agent/skill_utils.py` but `api/routes.py` never uses it.

## Change
- `api/routes.py`: new module-level `_parse_config_string_list(value)` which **reuses `agent.skill_utils.parse_config_string_list`** (same function-local import pattern already used at lines 701/800/882/1023 — confirmed importable at runtime and in tests) and mirrors its logic (`ast.literal_eval` when the stripped string starts with `[`, scalar-string-means-one-name, on-parse-error keeps the single name) as an `ImportError` fallback for runtimes where the agent source isn't bundled.
- Both `_normalize_disabled_set` and `_normalize_names_list` now route strings through it, covering every read/write surface: `skills.platform_disabled.*` (routes.py:780), global `skills.disabled` (:781), and the toggle write path `_toggle_name_in_list` → `_normalize_names_list` (:25677). No other callers exist (verified by grep).

## Verification
- 4 new regression tests (in `tests/test_issue3066_disabled_read_profile.py` and `tests/test_skills_toggle.py`): read path decodes JSON-array string for global disabled and for `platform_disabled.webui`; panel path reports **both** skills disabled; toggle on a JSON-array-string config **preserves the other entries** (add case: `["a","b"]` + toggle c-off → `["a","b","c"]`; remove case: toggle a-on → `["b","c"]`).
- Pre-fix verification: simulated old function bodies → the new assertions fail (AssertionError), i.e. tests fail before the fix / pass after.
- `tests/test_skills_toggle.py` + `tests/test_issue3066_disabled_read_profile.py` + `tests/test_issue3066_profile_skill_disabled_state.py`: **26 passed**
- Smoke test: `_normalize_disabled_set`/`_normalize_names_list`/`_toggle_name_in_list` against JSON-array, Python-literal, scalar, None, empty, and whitespace shapes — all correct; confirmed `agent.skill_utils.parse_config_string_list` reuse is active.

## Notes
- The `@requires_agent_modules` tests skip in a bare environment unless `PYTHONPATH` includes the agent source (pre-existing conftest behavior that affects the older tests too — not introduced by this fix).

Closes #7120
