### PR TITLE
fix(sse): bound proxy-acked subscriber lifetimes

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -46,6 +46,7 @@ import queue
 import threading
 import time
 import uuid
+from collections import deque
 from typing import Any, Optional
 
 from api.process_event_utils import (
@@ -105,6 +106,7 @@ _PENDING_EMIT_TIMERS: dict[str, threading.Timer] = {}
 #   stream_end / cancel / reconnect.
 SESSION_CHANNELS: dict[str, "SessionChannel"] = {}
 SESSION_CHANNELS_LOCK = threading.Lock()
+_SESSION_CHANNEL_REPLAY_LIMIT = 32
 
 
 class SessionChannel:
@@ -112,9 +114,9 @@ class SessionChannel:
 
     Subscribers are ``queue.Queue`` instances owned by the SSE route
     handler — one per active EventSource (tab). ``emit`` broadcasts to every
-    live subscriber; subscribers whose buffer is full silently drop the
-    event (the tab will reconnect on disconnect and the SSE-level disconnect
-    detection will tear it down).
+    live subscriber. Events carrying a stable ``event_id`` also enter a small
+    bounded replay history so EventSource reconnect can bridge a connection-
+    generation gap. A fresh tab with no cursor never receives old history.
 
     Lifecycle:
       - Created on demand by ``get_or_create_session_channel`` when the first
@@ -122,25 +124,65 @@ class SessionChannel:
       - ``subscribe`` / ``unsubscribe`` are refcount-style: zero subscribers
         does NOT immediately collect the channel; the reaper waits a 60s
         grace so a quick navigation away/back doesn't churn the registry.
-      - The reaper collects the channel when subscribers stay empty past the
-        grace period, OR when subscribers are empty AND ``created_at`` is
-        older than SESSION_CHANNEL_IDLE_TTL_SECS (zombie cap — applies only
-        when nobody is subscribed; a live subscriber keeps the channel even
-        past the idle TTL).
+      - After a subscriber drops, the reaper always preserves the full grace
+        period for EventSource reconnect and cursor replay. A never-subscribed
+        empty channel is capped by SESSION_CHANNEL_IDLE_TTL_SECS.
     """
 
     def __init__(self, session_id: str):
         self.session_id = session_id
         self._lock = threading.Lock()
         self._subscribers: list[queue.Queue] = []
+        # Only events with stable event_id values are replayable. This closes the
+        # tiny gap between a bounded SSE generation reaching EOF and EventSource
+        # opening its replacement without replaying old toasts on a fresh tab.
+        self._history: deque[tuple[str, dict, str]] = deque(
+            maxlen=_SESSION_CHANNEL_REPLAY_LIMIT
+        )
         now = time.time()
         self.created_at = now
         self.last_event_at = now
         self.last_subscriber_drop_at: float | None = None
 
-    def subscribe(self, maxsize: int = 16) -> queue.Queue:
+    def subscribe(
+        self,
+        maxsize: int = 16,
+        after_event_id: str | None = None,
+    ) -> queue.Queue:
         q: queue.Queue = queue.Queue(maxsize=maxsize)
         with self._lock:
+            matched_cursor = False
+            replay_count = 0
+            if after_event_id:
+                history = list(self._history)
+                match_index = next(
+                    (
+                        index
+                        for index in range(len(history) - 1, -1, -1)
+                        if history[index][2] == after_event_id
+                    ),
+                    None,
+                )
+                if match_index is not None:
+                    matched_cursor = True
+                    pending = [
+                        item for item in history[match_index + 1:] if item[0]
+                    ]
+                    if len(pending) <= maxsize:
+                        for event, data, _event_id in pending:
+                            q.put_nowait((event, dict(data)))
+                        replay_count = len(pending)
+            if matched_cursor:
+                initial_event_id = str(after_event_id)
+            else:
+                # A first connection has no Last-Event-ID. Give its `initial`
+                # frame a cursor marker so an event emitted during the later
+                # EOF/reconnect gap can still replay. Unknown/evicted cursors
+                # get a new marker after old history and never replay stale data.
+                initial_event_id = f"session-channel:{uuid.uuid4().hex}"
+                self._history.append(("", {}, initial_event_id))
+            q._session_channel_initial_event_id = initial_event_id
+            q._session_channel_replay_count = replay_count
             self._subscribers.append(q)
             # Cancel any pending subscribers-empty grace timer.
             self.last_subscriber_drop_at = None
@@ -163,6 +205,13 @@ class SessionChannel:
         """Broadcast (event, data) to all live subscribers. Returns delivered count."""
         delivered = 0
         with self._lock:
+            event_id = (
+                str(data.get("event_id") or "").strip()
+                if isinstance(data, dict)
+                else ""
+            )
+            if event_id:
+                self._history.append((event, dict(data), event_id))
             subs = list(self._subscribers)
             self.last_event_at = time.time()
         for q in subs:
@@ -170,13 +219,9 @@ class SessionChannel:
                 q.put_nowait((event, data))
                 delivered += 1
             except queue.Full:
-                # Slow tab: drop this event for that tab. SSE-level disconnect
-                # detection will eventually tear the connection down and the
-                # browser will reconnect, replaying the live stream from
-                # whatever fires next. process_complete is intrinsically
-                # idempotent (frontend dedupes by ``(session_id, event_id)``
-                # using a small ring-buffer in static/messages.js — see the
-                # bg_task_complete consumer-side dedupe introduced in PR #2971).
+                # Slow tab: drop from this queue. If the payload carries an
+                # event_id, reconnect can replay it from the bounded history;
+                # the frontend also dedupes by (session_id, event_id).
                 logger.debug("SessionChannel emit: subscriber buffer full, dropping")
             except Exception:
                 logger.debug("SessionChannel emit failed", exc_info=True)
@@ -188,8 +233,8 @@ class SessionChannel:
         Two collection conditions (per Option X spec):
           1. Subscribers empty AND last_subscriber_drop_at is older than
              SESSION_CHANNEL_SUBSCRIBER_GRACE_SECS (normal teardown).
-          2. created_at older than SESSION_CHANNEL_IDLE_TTL_SECS AND
-             subscribers empty (zombie cap — survived too long).
+          2. A never-subscribed empty channel is older than
+             SESSION_CHANNEL_IDLE_TTL_SECS (zombie cap).
         """
         from api import config as _cfg
 
@@ -204,10 +249,13 @@ class SessionChannel:
             return False
         # No subscribers — check grace period.
         grace = float(getattr(_cfg, "SESSION_CHANNEL_SUBSCRIBER_GRACE_SECS", 60))
-        if drop_at is not None and (now - drop_at) >= grace:
-            return True
-        # Hard cap on lifetime (even if subscribers oscillated): if created
-        # long ago AND nobody's subscribed right now, sweep.
+        if drop_at is not None:
+            # A bounded SSE generation may expire after the channel itself is
+            # older than the idle TTL. Preserve the complete reconnect grace;
+            # otherwise the reaper can delete its replay history during the
+            # browser's normal ~3s EventSource gap (#7105).
+            return (now - drop_at) >= grace
+        # Hard cap for a channel that was created but never acquired a viewer.
         ttl = float(getattr(_cfg, "SESSION_CHANNEL_IDLE_TTL_SECS", 14400))
         if (now - created_at) >= ttl:
             return True
@@ -231,7 +279,9 @@ def get_session_channel(session_id: str) -> Optional[SessionChannel]:
 
 
 def subscribe_to_session_channel(
-    session_id: str, maxsize: int = 16
+    session_id: str,
+    maxsize: int = 16,
+    after_event_id: str | None = None,
 ) -> tuple["SessionChannel", "queue.Queue"]:
     """Atomically get-or-create the channel for ``session_id`` AND register a
     subscriber on it, both under ``SESSION_CHANNELS_LOCK``.
@@ -267,8 +317,10 @@ def subscribe_to_session_channel(
         if ch is None:
             ch = SessionChannel(session_id)
             SESSION_CHANNELS[session_id] = ch
-        q = ch.subscribe(maxsize=maxsize)
-        return ch, q
+        return ch, ch.subscribe(
+            maxsize=maxsize,
+            after_event_id=after_event_id,
+        )
 
 
 # Bounded window a cancelling worker may stay lifecycle-busy before an entry

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -109,6 +109,28 @@ SESSION_CHANNELS_LOCK = threading.Lock()
 _SESSION_CHANNEL_REPLAY_LIMIT = 32
 
 
+def _parse_channel_cursor_watermark(cursor: str | None) -> int | None:
+    """Extract the replay watermark from a synthetic subscribe cursor.
+
+    A synthetic cursor has the shape ``session-channel:<uuid>@<seq>`` where
+    ``<seq>`` is the channel's monotonic replay counter observed at connect
+    time. Returns the integer watermark, or ``None`` when ``cursor`` is not a
+    watermarked synthetic cursor (a real event id, a legacy marker without an
+    ``@seq`` suffix, or anything malformed) so the caller fails closed.
+    """
+    if not cursor or not isinstance(cursor, str):
+        return None
+    if not cursor.startswith("session-channel:"):
+        return None
+    marker, sep, seq_text = cursor.rpartition("@")
+    if not sep or not marker.startswith("session-channel:"):
+        return None
+    try:
+        return int(seq_text)
+    except (TypeError, ValueError):
+        return None
+
+
 class SessionChannel:
     """A long-lived multi-subscriber SSE channel for one WebUI session.
 
@@ -136,9 +158,16 @@ class SessionChannel:
         # Only events with stable event_id values are replayable. This closes the
         # tiny gap between a bounded SSE generation reaching EOF and EventSource
         # opening its replacement without replaying old toasts on a fresh tab.
-        self._history: deque[tuple[str, dict, str]] = deque(
+        # Each retained event carries a monotonic ``seq`` so a fresh/reconnecting
+        # subscriber's cursor can point at a replay watermark WITHOUT occupying a
+        # slot in this bounded deque — fresh-connection churn from other tabs must
+        # never evict another subscriber's still-replayable events (#7105 gate).
+        self._history: deque[tuple[str, dict, str, int]] = deque(
             maxlen=_SESSION_CHANNEL_REPLAY_LIMIT
         )
+        # Monotonic counter over replayable events. A subscribe cursor encodes the
+        # value observed at connect time; reconnect replays only events past it.
+        self._event_seq: int = 0
         now = time.time()
         self.created_at = now
         self.last_event_at = now
@@ -152,9 +181,13 @@ class SessionChannel:
         q: queue.Queue = queue.Queue(maxsize=maxsize)
         with self._lock:
             matched_cursor = False
+            matched_real_id = False
             replay_count = 0
             if after_event_id:
                 history = list(self._history)
+                oldest_seq = history[0][3] if history else None
+                # 1. Real event cursor — the client's Last-Event-ID is a genuine
+                #    event's id. Match it and replay everything after it.
                 match_index = next(
                     (
                         index
@@ -163,24 +196,47 @@ class SessionChannel:
                     ),
                     None,
                 )
+                pending: list[tuple[str, dict, str, int]] = []
                 if match_index is not None:
                     matched_cursor = True
+                    matched_real_id = True
                     pending = [
                         item for item in history[match_index + 1:] if item[0]
                     ]
-                    if len(pending) <= maxsize:
-                        for event, data, _event_id in pending:
-                            q.put_nowait((event, dict(data)))
-                        replay_count = len(pending)
-            if matched_cursor:
+                else:
+                    # 2. Synthetic subscribe cursor — carries an ``@<seq>``
+                    #    watermark instead of occupying a replay slot. Only
+                    #    replay when the watermark is provably contiguous with
+                    #    retained history; a watermark older than the oldest
+                    #    retained event means an intervening event was evicted,
+                    #    so fail closed (fresh marker, replay nothing).
+                    watermark = _parse_channel_cursor_watermark(after_event_id)
+                    if watermark is not None and (
+                        oldest_seq is None or watermark >= oldest_seq - 1
+                    ):
+                        matched_cursor = True
+                        pending = [
+                            item
+                            for item in history
+                            if item[3] > watermark and item[0]
+                        ]
+                if matched_cursor and pending and len(pending) <= maxsize:
+                    for event, data, _event_id, _seq in pending:
+                        q.put_nowait((event, dict(data)))
+                    replay_count = len(pending)
+            if matched_real_id:
+                # Continue from the exact real event id the client last saw.
                 initial_event_id = str(after_event_id)
             else:
-                # A first connection has no Last-Event-ID. Give its `initial`
-                # frame a cursor marker so an event emitted during the later
-                # EOF/reconnect gap can still replay. Unknown/evicted cursors
-                # get a new marker after old history and never replay stale data.
-                initial_event_id = f"session-channel:{uuid.uuid4().hex}"
-                self._history.append(("", {}, initial_event_id))
+                # A first connection (or a synthetic-cursor reconnect) gets a
+                # cursor encoding the CURRENT replay watermark so an event
+                # emitted during the later EOF/reconnect gap can still replay —
+                # without appending anything to the bounded replay history.
+                # Unknown/evicted cursors fall here too and never replay stale
+                # data (fail-closed).
+                initial_event_id = (
+                    f"session-channel:{uuid.uuid4().hex}@{self._event_seq}"
+                )
             q._session_channel_initial_event_id = initial_event_id
             q._session_channel_replay_count = replay_count
             self._subscribers.append(q)
@@ -211,7 +267,8 @@ class SessionChannel:
                 else ""
             )
             if event_id:
-                self._history.append((event, dict(data), event_id))
+                self._event_seq += 1
+                self._history.append((event, dict(data), event_id, self._event_seq))
             subs = list(self._subscribers)
             self.last_event_at = time.time()
         for q in subs:

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -227,13 +227,23 @@ class SessionChannel:
             if matched_real_id:
                 # Continue from the exact real event id the client last saw.
                 initial_event_id = str(after_event_id)
+            elif matched_cursor and replay_count > 0:
+                # A synthetic reconnect WITH queued replay: keep advertising the
+                # client's INCOMING watermark cursor, not the post-replay one.
+                # The replay events are delivered AFTER this `initial` frame; if
+                # the connection drops between the initial frame and replay
+                # delivery, the next reconnect must still re-replay them. (Once a
+                # replay frame is actually delivered, its own real ``event_id``
+                # advances the client's Last-Event-ID past it, so resumption is
+                # correct on either side of the drop.)
+                initial_event_id = str(after_event_id)
             else:
-                # A first connection (or a synthetic-cursor reconnect) gets a
-                # cursor encoding the CURRENT replay watermark so an event
-                # emitted during the later EOF/reconnect gap can still replay —
-                # without appending anything to the bounded replay history.
-                # Unknown/evicted cursors fall here too and never replay stale
-                # data (fail-closed).
+                # A first connection, a fail-closed reconnect, or a synthetic
+                # reconnect with nothing pending: issue a cursor encoding the
+                # CURRENT replay watermark so an event emitted during the later
+                # EOF/reconnect gap can still replay — without appending anything
+                # to the bounded replay history. Unknown/evicted cursors fall
+                # here too and never replay stale data (fail-closed).
                 initial_event_id = (
                     f"session-channel:{uuid.uuid4().hex}@{self._event_seq}"
                 )
@@ -269,19 +279,25 @@ class SessionChannel:
             if event_id:
                 self._event_seq += 1
                 self._history.append((event, dict(data), event_id, self._event_seq))
-            subs = list(self._subscribers)
             self.last_event_at = time.time()
-        for q in subs:
-            try:
-                q.put_nowait((event, data))
-                delivered += 1
-            except queue.Full:
-                # Slow tab: drop from this queue. If the payload carries an
-                # event_id, reconnect can replay it from the bounded history;
-                # the frontend also dedupes by (session_id, event_id).
-                logger.debug("SessionChannel emit: subscriber buffer full, dropping")
-            except Exception:
-                logger.debug("SessionChannel emit failed", exc_info=True)
+            # Deliver to live subscribers INSIDE the lock so history ordering and
+            # subscriber-queue ordering are one atomic serialized operation.
+            # Concurrent emits must never record A-before-B in history yet
+            # deliver B-before-A: a drop after B would then resume real-ID replay
+            # past B and permanently lose A. ``put_nowait`` is non-blocking
+            # (raises ``queue.Full`` immediately), so holding the lock across it
+            # cannot stall other threads.
+            for q in list(self._subscribers):
+                try:
+                    q.put_nowait((event, data))
+                    delivered += 1
+                except queue.Full:
+                    # Slow tab: drop from this queue. If the payload carries an
+                    # event_id, reconnect can replay it from the bounded history;
+                    # the frontend also dedupes by (session_id, event_id).
+                    logger.debug("SessionChannel emit: subscriber buffer full, dropping")
+                except Exception:
+                    logger.debug("SessionChannel emit failed", exc_info=True)
         return delivered
 
     def reaper_should_collect(self, now: float) -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1140,7 +1140,38 @@ def _skill_view_from_active_dir(name: str) -> dict:
 # Trivial; many production SSE deployments run 5-15s heartbeats specifically
 # to handle proxies and mobile NAT.
 _SSE_HEARTBEAT_INTERVAL_SECONDS = 5
+# A proxy can keep ACKing server heartbeats after the downstream browser has
+# disappeared, so socket keepalive and write deadlines alone cannot prove the
+# subscriber is still alive (#7105). Rotate the three indefinite subscription
+# streams after five minutes. A live EventSource renews the lease by reconnecting;
+# a dead browser does not, which bounds the handler thread and subscriber queue.
+# This is an internal correctness bound, not a user-facing tuning surface.
+_SSE_SUBSCRIBER_LEASE_SECONDS = 300.0
 _SESSION_SSE_SENT_EVENT_ID_LIMIT = 4096
+
+
+def _sse_subscriber_lease_deadline() -> float:
+    return time.monotonic() + max(0.0, float(_SSE_SUBSCRIBER_LEASE_SECONDS))
+
+
+def _sse_subscriber_lease_expired(handler, deadline: float) -> bool:
+    if time.monotonic() < deadline:
+        return False
+    # Do not emit `Connection: close` in the response headers: #3103 proved that
+    # header creates reconnect storms. Setting the BaseHTTPRequestHandler flag
+    # only when the bounded response finishes makes this generation reach EOF.
+    handler.close_connection = True
+    return True
+
+
+def _sse_subscriber_wait_seconds(deadline: float) -> float:
+    return max(
+        0.0,
+        min(
+            float(_SSE_HEARTBEAT_INTERVAL_SECONDS),
+            deadline - time.monotonic(),
+        ),
+    )
 
 
 def _normalize_messaging_source(raw_source) -> str:
@@ -19284,6 +19315,7 @@ def _handle_gateway_sse_stream(handler, parsed):
     _sse_set_write_deadline(handler)  # Defect A: slow tab can't pin this thread
 
     q = watcher.subscribe()
+    lease_deadline = _sse_subscriber_lease_deadline()
     try:
         # Send initial snapshot immediately
         from api.models import get_cli_sessions
@@ -19291,9 +19323,13 @@ def _handle_gateway_sse_stream(handler, parsed):
         _sse(handler, 'sessions_changed', {'sessions': initial})
 
         while True:
+            if _sse_subscriber_lease_expired(handler, lease_deadline):
+                break
             try:
-                event_data = q.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                event_data = q.get(timeout=_sse_subscriber_wait_seconds(lease_deadline))
             except queue.Empty:
+                if _sse_subscriber_lease_expired(handler, lease_deadline):
+                    break
                 handler.wfile.write(b': keepalive\n\n')
                 handler.wfile.flush()
                 continue
@@ -19319,11 +19355,16 @@ def _handle_session_events_stream(handler):
     _sse_set_write_deadline(handler)  # Defect A: slow tab can't pin this thread
 
     q = subscribe_session_events()
+    lease_deadline = _sse_subscriber_lease_deadline()
     try:
         while True:
+            if _sse_subscriber_lease_expired(handler, lease_deadline):
+                break
             try:
-                event_data = q.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                event_data = q.get(timeout=_sse_subscriber_wait_seconds(lease_deadline))
             except queue.Empty:
+                if _sse_subscriber_lease_expired(handler, lease_deadline):
+                    break
                 handler.wfile.write(b': keepalive\n\n')
                 handler.wfile.flush()
                 continue
@@ -21162,8 +21203,10 @@ def _handle_session_sse_stream(handler, parsed):
 
     Lifecycle: opened by the frontend at session mount, closed at unmount or
     on tab close. Multiple tabs share one SessionChannel (refcounted via
-    subscribe/unsubscribe). 30s SSE keepalive comments keep the proxy alive.
-    Reaper-driven idle TTL (default 4h) prevents zombie channels.
+    subscribe/unsubscribe). Five-second SSE comments keep proxies alive, and
+    each subscription generation is capped at five minutes so a proxy-ACKed
+    dead browser cannot pin the thread/channel forever. A live EventSource
+    reconnects and gets a fresh generation; the reaper can collect the old one.
     """
     sid = parse_qs(parsed.query).get("session_id", [""])[0]
     if not sid:
@@ -21195,7 +21238,13 @@ def _handle_session_sse_stream(handler, parsed):
     # orphaning this subscriber on a channel no longer in SESSION_CHANNELS.
     # bg_task_complete emits would then never reach this queue. See
     # subscribe_to_session_channel for the full rationale (PR #2971 Greptile P1).
-    ch, q = subscribe_to_session_channel(sid, maxsize=64)
+    last_event_id = str(handler.headers.get("Last-Event-ID", "") or "").strip()
+    ch, q = subscribe_to_session_channel(
+        sid,
+        maxsize=64,
+        after_event_id=last_event_id or None,
+    )
+    lease_deadline = _sse_subscriber_lease_deadline()
 
     # NOTE: ``subscribe_to_session_channel`` above acquires a subscriber slot
     # that MUST be released on every exit path. Header setup
@@ -21229,7 +21278,49 @@ def _handle_session_sse_stream(handler, parsed):
         # live (mirrors approval/clarify which send an 'initial' frame). No
         # snapshot data is needed — this channel only carries forward-looking
         # events, not pending state.
-        _sse(handler, 'initial', {"session_id": sid})
+        initial_event_id = str(
+            getattr(q, "_session_channel_initial_event_id", "") or ""
+        ).strip()
+        if initial_event_id:
+            _sse_with_id(
+                handler,
+                'initial',
+                {"session_id": sid},
+                initial_event_id,
+            )
+        else:
+            _sse(handler, 'initial', {"session_id": sid})
+
+        def emit_channel_payload(payload) -> bool:
+            if payload is None:
+                return False
+            event_name, data = payload
+            event_id = (
+                str(data.get("event_id") or "").strip()
+                if isinstance(data, dict)
+                else ""
+            )
+            if event_id:
+                _sse_with_id(handler, event_name, data, event_id)
+            else:
+                _sse(handler, event_name, data)
+            return True
+
+        # Cursor replay was queued atomically before this handler registered as
+        # a live subscriber. Deliver it before `server_turn_started` recovery:
+        # that frontend event hands the pane to /api/chat/stream and suspends
+        # this EventSource, which would otherwise drop the completion toast/ack.
+        replay_count = max(
+            0,
+            int(getattr(q, "_session_channel_replay_count", 0) or 0),
+        )
+        for _ in range(replay_count):
+            try:
+                replay_payload = q.get_nowait()
+            except queue.Empty:
+                break
+            if not emit_channel_payload(replay_payload):
+                return True
 
         # ── Open-tab live-view self-heal (root cause: lost server_turn_started) ──
         # The `server_turn_started` fan-out (routes.start_session_turn) is a
@@ -21309,16 +21400,19 @@ def _handle_session_sse_stream(handler, parsed):
             )
 
         while True:
+            if _sse_subscriber_lease_expired(handler, lease_deadline):
+                break
             try:
-                payload = q.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                payload = q.get(timeout=_sse_subscriber_wait_seconds(lease_deadline))
             except queue.Empty:
+                if _sse_subscriber_lease_expired(handler, lease_deadline):
+                    break
                 handler.wfile.write(b': keepalive\n\n')
                 handler.wfile.flush()
                 continue
             if payload is None:
                 break
-            event_name, data = payload
-            _sse(handler, event_name, data)
+            emit_channel_payload(payload)
     except _CLIENT_DISCONNECT_ERRORS:
         pass  # client went away — normal for long-lived connections
     finally:

--- a/docs/rfcs/session-sse-contract-v1.md
+++ b/docs/rfcs/session-sse-contract-v1.md
@@ -65,6 +65,36 @@ is a global invalidation signal, not a per-session lifecycle stream. The propose
 heartbeat interval for SSE streams. Phase 1 reuses this constant rather than
 adding a separate configurable knob.
 
+### Implemented browser-subscriber lifetime and replay
+
+The existing browser-facing subscription streams are not one unbounded HTTP
+generation. `_SSE_SUBSCRIBER_LEASE_SECONDS = 300` caps each generation for:
+
+- `GET /api/session/stream` (per-session background-completion/live-turn bridge),
+- `GET /api/sessions/events` (global session-list invalidation), and
+- `GET /api/gateway/sessions/stream` (gateway session snapshots).
+
+At the lease boundary the handler sets `BaseHTTPRequestHandler.close_connection`
+and returns; it does **not** emit a `Connection: close` response header. A live
+`EventSource` treats the resulting EOF as reconnectable and opens a replacement
+generation. If only an upstream proxy remains, no browser reconnect arrives, so
+the old handler releases its exact subscriber queue and the channel reaper can
+collect it. Active tabs therefore incur one reconnect plus the endpoint's normal
+refresh/snapshot work every five minutes.
+
+`GET /api/session/stream` also uses the native `Last-Event-ID` request header to
+bridge the reconnect gap. `SessionChannel` retains at most 32 copied events that
+carry stable payload `event_id` values. Every first `initial` frame establishes a
+synthetic cursor; a known cursor replays only the later retained FIFO prefix. A
+fresh, unknown, or evicted cursor replays no old completion toast and falls back
+to the existing active-turn and persisted-message-count recovery. The channel's
+subscriber-drop grace is preserved for the full reconnect interval even when the
+channel itself is older than its idle TTL.
+
+This lifecycle applies only to the three endpoints above. Approval/clarify SSE,
+run-journal observers, the proposed `GET /api/sessions/{session_id}/events`, and
+other event streams keep their own documented contracts.
+
 ### Run-journal cursor and replay
 
 Current replay identity is run/stream-scoped:
@@ -77,8 +107,8 @@ shift in `api/routes.py` cannot invalidate the doc or its contract test.
 - `_parse_run_journal_event_id()` and `_parse_run_journal_after_seq()` (both in
   `api/routes.py`) parse the replay cursor from the `after_event_id` /
   `after_seq` **query params** (not the
-  `Last-Event-ID` header — that header is the *proposed* new-endpoint contract
-  below, §Reconnect).
+  `Last-Event-ID` header used by `GET /api/session/stream` above and proposed for
+  the new endpoint below, §Reconnect).
 - `_runner_event_id()` (in `api/routes.py`) constructs the event `id`
   field as `stream_id:seq`.
 - SSE frames carry their `id:` via the `_sse_with_id()` helper, emitted on the

--- a/tests/test_issue7105_sse_subscriber_lease.py
+++ b/tests/test_issue7105_sse_subscriber_lease.py
@@ -1,0 +1,454 @@
+"""Regression coverage for proxy-ACKed half-open SSE subscribers (#7105).
+
+A reverse proxy can keep acknowledging the server's five-second heartbeat after
+the downstream browser has disappeared. Socket keepalive/write deadlines then
+see a healthy TCP peer while each handler thread and subscriber queue stay
+pinned forever. The server must bound each subscription generation and let a
+live EventSource renew it by reconnecting.
+"""
+
+from __future__ import annotations
+
+import io
+import queue
+import threading
+import time
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import api.background_process as background_process
+import api.config as config
+import api.gateway_watcher as gateway_watcher
+import api.models as models
+import api.routes as routes
+
+
+class _AcceptingWriter:
+    """Proxy-shaped writer: every heartbeat is accepted immediately."""
+
+    def __init__(self) -> None:
+        self.body = bytearray()
+        self.first_write = threading.Event()
+
+    def write(self, data: bytes) -> int:
+        self.body.extend(data)
+        self.first_write.set()
+        return len(data)
+
+    def flush(self) -> None:
+        pass
+
+
+class _FakeHandler:
+    def __init__(self) -> None:
+        self.status = None
+        self.sent_headers: list[tuple[str, str]] = []
+        self.headers = {}
+        self.wfile = _AcceptingWriter()
+        self.rfile = io.BytesIO()
+        self.close_connection = False
+
+    def send_response(self, status: int) -> None:
+        self.status = status
+
+    def send_header(self, name: str, value: str) -> None:
+        self.sent_headers.append((name, value))
+
+    def end_headers(self) -> None:
+        pass
+
+
+def _run_bounded(target, *, timeout: float = 0.75) -> None:
+    finished = threading.Event()
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            target()
+        except BaseException as exc:  # surfaced on the test thread below
+            errors.append(exc)
+        finally:
+            finished.set()
+
+    threading.Thread(target=worker, daemon=True).start()
+    assert finished.wait(timeout), "proxy-ACKed SSE handler outlived its subscriber lease"
+    assert not errors, errors
+
+
+def _short_lease(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "_SSE_SUBSCRIBER_LEASE_SECONDS", 0.04, raising=False)
+    monkeypatch.setattr(routes, "_SSE_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(routes, "_sse_set_write_deadline", lambda handler: None)
+
+
+def test_session_channel_lease_releases_only_the_expired_generation(monkeypatch):
+    _short_lease(monkeypatch)
+    old_q: queue.Queue = queue.Queue()
+    new_q: queue.Queue = queue.Queue()
+
+    class Channel:
+        def __init__(self) -> None:
+            self.subscribers = [old_q]
+            self.unsubscribed: list[queue.Queue] = []
+
+        def unsubscribe(self, q: queue.Queue) -> None:
+            self.subscribers.remove(q)
+            self.unsubscribed.append(q)
+
+    channel = Channel()
+    monkeypatch.setattr(
+        background_process,
+        "subscribe_to_session_channel",
+        lambda sid, maxsize=64, after_event_id=None: (channel, old_q),
+    )
+    monkeypatch.setattr(background_process, "active_stream_id_for_session", lambda sid: None)
+    monkeypatch.setattr(background_process, "persisted_message_count_for_session", lambda sid: None)
+    monkeypatch.setattr(background_process, "should_emit_session_updated", lambda known, current: False)
+
+    handler = _FakeHandler()
+
+    def run() -> None:
+        routes._handle_session_sse_stream(
+            handler,
+            urlparse("http://example.test/api/session/stream?session_id=s-1"),
+        )
+
+    finished = threading.Event()
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            run()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            finished.set()
+
+    threading.Thread(target=worker, daemon=True).start()
+    assert handler.wfile.first_write.wait(0.5), "session stream never sent its initial frame"
+    channel.subscribers.append(new_q)  # a reconnect/new tab owns a newer generation
+    assert finished.wait(0.75), "proxy-ACKed session stream outlived its lease"
+    assert not errors, errors
+    assert channel.unsubscribed == [old_q]
+    assert channel.subscribers == [new_q]
+    assert handler.close_connection is True
+    assert ("Connection", "close") not in handler.sent_headers
+
+
+def test_session_channel_reconnect_recovers_turn_completed_during_lease_gap(monkeypatch):
+    """The forced rotation must reuse the existing completed-gap self-heal."""
+    _short_lease(monkeypatch)
+    queues = [queue.Queue(), queue.Queue()]
+    persisted_count = {"value": 0}
+
+    class Channel:
+        def __init__(self) -> None:
+            self.unsubscribed = []
+
+        def unsubscribe(self, q: queue.Queue) -> None:
+            self.unsubscribed.append(q)
+
+    channel = Channel()
+    monkeypatch.setattr(
+        background_process,
+        "subscribe_to_session_channel",
+        lambda sid, maxsize=64, after_event_id=None: (channel, queues.pop(0)),
+    )
+    monkeypatch.setattr(background_process, "active_stream_id_for_session", lambda sid: None)
+    monkeypatch.setattr(
+        background_process,
+        "persisted_message_count_for_session",
+        lambda sid: persisted_count["value"],
+    )
+
+    first = _FakeHandler()
+    _run_bounded(
+        lambda: routes._handle_session_sse_stream(
+            first,
+            urlparse("http://example.test/api/session/stream?session_id=s-gap&known_count=0"),
+        )
+    )
+
+    # The browser is between EventSource generations while a server-owned turn
+    # finishes. Its durable transcript count advances even though the ephemeral
+    # bg_task_complete/server_turn_started frames had no connected subscriber.
+    persisted_count["value"] = 2
+
+    second = _FakeHandler()
+    _run_bounded(
+        lambda: routes._handle_session_sse_stream(
+            second,
+            urlparse("http://example.test/api/session/stream?session_id=s-gap&known_count=0"),
+        )
+    )
+
+    assert len(channel.unsubscribed) == 2
+    assert b"event: session-updated" in second.wfile.body
+    assert b'"message_count": 2' in second.wfile.body
+
+
+def test_session_channel_replays_event_emitted_between_lease_generations(monkeypatch):
+    """Forward-only completion frames need cursor replay across forced EOF."""
+    _short_lease(monkeypatch)
+    sid = "s-replay"
+    channel = background_process.SessionChannel(sid)
+    with background_process.SESSION_CHANNELS_LOCK:
+        background_process.SESSION_CHANNELS[sid] = channel
+    monkeypatch.setattr(background_process, "active_stream_id_for_session", lambda _sid: None)
+    monkeypatch.setattr(background_process, "persisted_message_count_for_session", lambda _sid: None)
+
+    first = _FakeHandler()
+    first_done = threading.Event()
+
+    def first_worker() -> None:
+        try:
+            routes._handle_session_sse_stream(
+                first,
+                urlparse(f"http://example.test/api/session/stream?session_id={sid}"),
+            )
+        finally:
+            first_done.set()
+
+    threading.Thread(target=first_worker, daemon=True).start()
+    assert first.wfile.first_write.wait(0.5)
+    assert first_done.wait(0.75)
+    initial_ids = [
+        line.split(b": ", 1)[1]
+        for line in first.wfile.body.splitlines()
+        if line.startswith(b"id: ")
+    ]
+    assert len(initial_ids) == 1, first.wfile.body
+    initial_cursor = initial_ids[0].decode("utf-8")
+
+    # Exact production race: the durable completion lands after the old queue
+    # is gone but before EventSource creates the replacement HTTP request. No
+    # prior completion event exists, so the initial frame's cursor is the only
+    # way native EventSource can request this gap event.
+    assert channel.emit(
+        "bg_task_complete",
+        {"event_id": "evt-2", "session_id": sid},
+    ) == 0
+
+    second = _FakeHandler()
+    second.headers["Last-Event-ID"] = initial_cursor
+    _run_bounded(
+        lambda: routes._handle_session_sse_stream(
+            second,
+            urlparse(f"http://example.test/api/session/stream?session_id={sid}"),
+        )
+    )
+
+    assert second.wfile.body.count(b"id: evt-2") == 1
+    assert second.wfile.body.count(b'"event_id": "evt-2"') == 1
+    with background_process.SESSION_CHANNELS_LOCK:
+        background_process.SESSION_CHANNELS.pop(sid, None)
+
+
+def test_session_channel_does_not_replay_history_without_a_known_cursor():
+    channel = background_process.SessionChannel("s-fresh")
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "old-event", "session_id": "s-fresh"},
+    )
+
+    fresh = channel.subscribe(maxsize=64)
+    unknown = channel.subscribe(maxsize=64, after_event_id="not-in-history")
+    try:
+        assert fresh.empty()
+        assert unknown.empty()
+        assert fresh._session_channel_initial_event_id.startswith("session-channel:")
+        assert unknown._session_channel_initial_event_id.startswith("session-channel:")
+        assert fresh._session_channel_initial_event_id != unknown._session_channel_initial_event_id
+    finally:
+        channel.unsubscribe(fresh)
+        channel.unsubscribe(unknown)
+
+
+def test_aged_channel_keeps_reconnect_grace_and_gap_history(monkeypatch):
+    monkeypatch.setattr(config, "SESSION_CHANNEL_IDLE_TTL_SECS", 10)
+    monkeypatch.setattr(config, "SESSION_CHANNEL_SUBSCRIBER_GRACE_SECS", 60)
+    channel = background_process.SessionChannel("s-aged")
+    channel.created_at -= 11
+
+    first = channel.subscribe(maxsize=64)
+    cursor = first._session_channel_initial_event_id
+    channel.unsubscribe(first)
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "aged-gap-event", "session_id": "s-aged"},
+    )
+
+    # A five-minute lease can expire after the channel has existed for four
+    # hours. The ordinary 60s reconnect grace must win over the age TTL, or the
+    # reaper deletes the channel/history before EventSource's ~3s reconnect.
+    assert channel.reaper_should_collect(time.time()) is False
+
+    replacement = channel.subscribe(maxsize=64, after_event_id=cursor)
+    try:
+        event, payload = replacement.get_nowait()
+        assert event == "bg_task_complete"
+        assert payload["event_id"] == "aged-gap-event"
+    finally:
+        channel.unsubscribe(replacement)
+
+
+def test_replay_precedes_live_turn_recovery_that_suspends_session_stream(monkeypatch):
+    """Replay the completion toast before server_turn_started hands off the UI."""
+    _short_lease(monkeypatch)
+    sid = "s-order"
+    channel = background_process.SessionChannel(sid)
+    baseline = channel.subscribe(maxsize=64)
+    cursor = baseline._session_channel_initial_event_id
+    channel.unsubscribe(baseline)
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "gap-completion", "session_id": sid},
+    )
+    with background_process.SESSION_CHANNELS_LOCK:
+        background_process.SESSION_CHANNELS[sid] = channel
+
+    monkeypatch.setattr(
+        background_process,
+        "active_stream_id_for_session",
+        lambda _sid: "recovered-run",
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid, metadata_only=True: SimpleNamespace(pending_started_at=1.0),
+    )
+
+    handler = _FakeHandler()
+    handler.headers["Last-Event-ID"] = cursor
+    _run_bounded(
+        lambda: routes._handle_session_sse_stream(
+            handler,
+            urlparse(f"http://example.test/api/session/stream?session_id={sid}"),
+        )
+    )
+
+    body = bytes(handler.wfile.body)
+    assert body.index(b"event: bg_task_complete") < body.index(
+        b"event: server_turn_started"
+    )
+    with background_process.SESSION_CHANNELS_LOCK:
+        background_process.SESSION_CHANNELS.pop(sid, None)
+
+
+def test_only_preloaded_replay_prefix_runs_before_live_turn_recovery(monkeypatch):
+    _short_lease(monkeypatch)
+    sid = "s-prefix"
+    q: queue.Queue = queue.Queue()
+    q.put_nowait(
+        ("bg_task_complete", {"event_id": "replay-event", "session_id": sid})
+    )
+    q.put_nowait(
+        ("bg_task_complete", {"event_id": "live-event", "session_id": sid})
+    )
+    q._session_channel_replay_count = 1
+
+    class Channel:
+        def unsubscribe(self, _q):
+            pass
+
+    monkeypatch.setattr(
+        background_process,
+        "subscribe_to_session_channel",
+        lambda _sid, maxsize=64, after_event_id=None: (Channel(), q),
+    )
+    monkeypatch.setattr(
+        background_process,
+        "active_stream_id_for_session",
+        lambda _sid: "recovered-run",
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid, metadata_only=True: SimpleNamespace(pending_started_at=1.0),
+    )
+
+    handler = _FakeHandler()
+    _run_bounded(
+        lambda: routes._handle_session_sse_stream(
+            handler,
+            urlparse(f"http://example.test/api/session/stream?session_id={sid}"),
+        )
+    )
+
+    body = bytes(handler.wfile.body)
+    assert body.index(b"replay-event") < body.index(b"event: server_turn_started")
+    assert body.index(b"event: server_turn_started") < body.index(b"live-event")
+
+
+def test_session_list_stream_lease_unsubscribes_proxy_acked_client(monkeypatch):
+    _short_lease(monkeypatch)
+    q: queue.Queue = queue.Queue()
+    unsubscribed: list[queue.Queue] = []
+    monkeypatch.setattr(routes, "subscribe_session_events", lambda: q)
+    monkeypatch.setattr(routes, "unsubscribe_session_events", unsubscribed.append)
+    handler = _FakeHandler()
+
+    _run_bounded(lambda: routes._handle_session_events_stream(handler))
+
+    assert unsubscribed == [q]
+    assert handler.close_connection is True
+    assert ("Connection", "close") not in handler.sent_headers
+    assert b"keepalive" in handler.wfile.body
+
+
+def test_session_list_stream_lease_expires_under_continuous_events(monkeypatch):
+    """An active producer must not postpone the connection-age bound."""
+    _short_lease(monkeypatch)
+
+    class BusyQueue:
+        def get(self, timeout=None):
+            return {"type": "sessions_changed", "reason": "busy"}
+
+    q = BusyQueue()
+    unsubscribed = []
+    monkeypatch.setattr(routes, "subscribe_session_events", lambda: q)
+    monkeypatch.setattr(routes, "unsubscribe_session_events", unsubscribed.append)
+    handler = _FakeHandler()
+
+    _run_bounded(lambda: routes._handle_session_events_stream(handler))
+
+    assert unsubscribed == [q]
+    assert handler.close_connection is True
+    assert b"sessions_changed" in handler.wfile.body
+
+
+def test_gateway_stream_lease_unsubscribes_proxy_acked_client(monkeypatch):
+    _short_lease(monkeypatch)
+    q: queue.Queue = queue.Queue()
+
+    class Watcher:
+        def __init__(self) -> None:
+            self.unsubscribed: list[queue.Queue] = []
+
+        def is_alive(self) -> bool:
+            return True
+
+        def subscribe(self) -> queue.Queue:
+            return q
+
+        def unsubscribe(self, subscriber: queue.Queue) -> None:
+            self.unsubscribed.append(subscriber)
+
+    watcher = Watcher()
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": True})
+    monkeypatch.setattr(gateway_watcher, "get_watcher", lambda: watcher)
+    monkeypatch.setattr(models, "get_cli_sessions", lambda: [])
+    handler = _FakeHandler()
+
+    _run_bounded(
+        lambda: routes._handle_gateway_sse_stream(
+            handler,
+            urlparse("http://example.test/api/sessions/gateway/stream"),
+        )
+    )
+
+    assert watcher.unsubscribed == [q]
+    assert handler.close_connection is True
+    assert ("Connection", "close") not in handler.sent_headers
+    assert b"sessions_changed" in handler.wfile.body
+    assert b"keepalive" in handler.wfile.body

--- a/tests/test_issue7105_sse_subscriber_lease.py
+++ b/tests/test_issue7105_sse_subscriber_lease.py
@@ -571,3 +571,93 @@ def test_synthetic_cursor_replays_only_gap_events_after_its_watermark():
         assert replacement.empty()  # pre-connect event was never replayed
     finally:
         channel.unsubscribe(replacement)
+
+
+def test_synthetic_reconnect_with_queued_replay_keeps_incoming_cursor():
+    """Drop between the initial frame and replay delivery must not lose events.
+
+    A synthetic reconnect that has queued replay delivers those events AFTER its
+    `initial` frame. If it advertised the post-replay watermark and the client
+    dropped between the initial frame and the replay loop, the next reconnect
+    would resume past the undelivered events and lose them. The initial frame
+    must therefore keep advertising the client's INCOMING cursor whenever replay
+    is queued, so a drop-before-replay still re-replays.
+    """
+    channel = background_process.SessionChannel("s-preserve")
+
+    tab = channel.subscribe(maxsize=64)
+    cursor = tab._session_channel_initial_event_id
+    channel.unsubscribe(tab)
+
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "queued-gap", "session_id": "s-preserve"},
+    )
+
+    # Reconnect: replay is queued, so the advertised cursor must equal the
+    # incoming cursor (not an advanced watermark).
+    reconnect = channel.subscribe(maxsize=64, after_event_id=cursor)
+    assert reconnect._session_channel_replay_count == 1
+    assert reconnect._session_channel_initial_event_id == cursor
+    # Simulate a drop AFTER the initial frame but BEFORE the replay loop ran:
+    # the client's Last-Event-ID is still the advertised (== incoming) cursor.
+    channel.unsubscribe(reconnect)
+
+    recovery = channel.subscribe(
+        maxsize=64,
+        after_event_id=reconnect._session_channel_initial_event_id,
+    )
+    try:
+        event, payload = recovery.get_nowait()
+        assert event == "bg_task_complete"
+        assert payload["event_id"] == "queued-gap"  # NOT lost across the drop
+    finally:
+        channel.unsubscribe(recovery)
+
+
+def test_emit_serializes_history_order_with_subscriber_delivery():
+    """Concurrent emits must record and deliver in the SAME order.
+
+    ``emit`` appends to ``_history`` and enqueues to live subscribers under one
+    lock. If delivery happened outside the lock, concurrent emits could record
+    ``A,B`` in history but deliver ``B,A``; a drop after B would resume real-ID
+    replay past B and permanently lose A. This drives many concurrent emits and
+    asserts every subscriber's received order matches history order exactly.
+    """
+    import threading
+
+    channel = background_process.SessionChannel("s-order-race")
+    sub = channel.subscribe(maxsize=10000)
+
+    n = 200
+    barrier = threading.Barrier(n)
+
+    def do_emit(i):
+        barrier.wait()
+        channel.emit("e", {"event_id": f"evt-{i}", "session_id": "s-order-race"})
+
+    threads = [threading.Thread(target=do_emit, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # History order (seq-ordered) is the authoritative order.
+    with channel._lock:
+        history_order = [item[2] for item in channel._history if item[0]]
+
+    delivered_order = []
+    while True:
+        try:
+            _event, data = sub.get_nowait()
+        except queue.Empty:
+            break
+        delivered_order.append(data["event_id"])
+    channel.unsubscribe(sub)
+
+    # Every delivered event that is still in the (bounded) history must appear in
+    # the exact same relative order it was recorded — never transposed.
+    retained = set(history_order)
+    delivered_retained = [e for e in delivered_order if e in retained]
+    # history is capped; compare the tail of delivered against history order
+    assert delivered_retained[-len(history_order):] == history_order

--- a/tests/test_issue7105_sse_subscriber_lease.py
+++ b/tests/test_issue7105_sse_subscriber_lease.py
@@ -452,3 +452,122 @@ def test_gateway_stream_lease_unsubscribes_proxy_acked_client(monkeypatch):
     assert ("Connection", "close") not in handler.sent_headers
     assert b"sessions_changed" in handler.wfile.body
     assert b"keepalive" in handler.wfile.body
+
+
+def test_fresh_subscription_churn_cannot_evict_a_valid_subscribers_gap_event():
+    """>32 fresh subscriptions must not consume another tab's replay capacity.
+
+    Regression for the gate-reproduced SILENT defect: synthetic subscribe
+    cursors used to be appended into the same bounded ``_history`` deque that
+    holds replayable events, so one tab's fresh-connection churn evicted
+    another tab's still-replayable completion. The fix keeps ``_history`` for
+    genuine events only and encodes the subscribe watermark in the cursor.
+    """
+    channel = background_process.SessionChannel("s-churn")
+
+    # Tab A connects fresh, records its cursor, then drops (EOF/reconnect gap).
+    tab_a = channel.subscribe(maxsize=64)
+    cursor_a = tab_a._session_channel_initial_event_id
+    channel.unsubscribe(tab_a)
+
+    # A completion is emitted during Tab A's reconnect gap.
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "gap-completion", "session_id": "s-churn"},
+    )
+
+    # Far more than the 32-slot replay limit of *fresh* subscriptions churn
+    # through the channel while Tab A is away. Under the old code each of these
+    # appended a synthetic marker and evicted the gap completion.
+    churn = background_process._SESSION_CHANNEL_REPLAY_LIMIT * 3
+    for _ in range(churn):
+        other = channel.subscribe(maxsize=64)
+        channel.unsubscribe(other)
+
+    # The single genuine event is still the only thing in replay history and
+    # still replayable — the churn consumed zero capacity.
+    with channel._lock:
+        assert len(channel._history) == 1
+        assert channel._history[0][2] == "gap-completion"
+
+    # Tab A reconnects with its original cursor and STILL receives its
+    # reconnect-gap completion.
+    replacement = channel.subscribe(maxsize=64, after_event_id=cursor_a)
+    try:
+        event, payload = replacement.get_nowait()
+        assert event == "bg_task_complete"
+        assert payload["event_id"] == "gap-completion"
+        assert replacement.empty()
+    finally:
+        channel.unsubscribe(replacement)
+
+
+def test_synthetic_cursor_fails_closed_when_watermarked_event_was_evicted():
+    """A watermark older than retained history must NOT replay a wrong prefix.
+
+    When genuine events overflow the bounded deque past a subscriber's
+    watermark, the oldest replayable event is gone. Rather than replay a
+    partial/incorrect suffix (or crash), the reconnect must fail closed:
+    fresh marker, replay nothing, no stale/incorrect data.
+    """
+    channel = background_process.SessionChannel("s-evict")
+
+    tab = channel.subscribe(maxsize=64)
+    cursor = tab._session_channel_initial_event_id
+    channel.unsubscribe(tab)
+
+    # Overflow the replay history with genuine events well past the watermark.
+    overflow = background_process._SESSION_CHANNEL_REPLAY_LIMIT + 5
+    for i in range(overflow):
+        channel.emit(
+            "bg_task_complete",
+            {"event_id": f"evt-{i}", "session_id": "s-evict"},
+        )
+
+    replacement = channel.subscribe(maxsize=64, after_event_id=cursor)
+    try:
+        # Fail closed: no replay (the watermarked position was evicted), and a
+        # brand-new synthetic cursor is issued rather than a stale continuation.
+        assert replacement.empty()
+        assert replacement._session_channel_replay_count == 0
+        assert replacement._session_channel_initial_event_id.startswith(
+            "session-channel:"
+        )
+        assert replacement._session_channel_initial_event_id != cursor
+    finally:
+        channel.unsubscribe(replacement)
+
+
+def test_synthetic_cursor_replays_only_gap_events_after_its_watermark():
+    """A synthetic reconnect replays events emitted AFTER connect, not before."""
+    channel = background_process.SessionChannel("s-watermark")
+
+    # An event exists before Tab A ever connects — Tab A must NOT receive it.
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "pre-connect", "session_id": "s-watermark"},
+    )
+
+    tab = channel.subscribe(maxsize=64)
+    cursor = tab._session_channel_initial_event_id
+    channel.unsubscribe(tab)
+
+    # Two events land during the reconnect gap — both must replay, in order.
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "gap-1", "session_id": "s-watermark"},
+    )
+    channel.emit(
+        "bg_task_complete",
+        {"event_id": "gap-2", "session_id": "s-watermark"},
+    )
+
+    replacement = channel.subscribe(maxsize=64, after_event_id=cursor)
+    try:
+        first = replacement.get_nowait()
+        second = replacement.get_nowait()
+        assert first[1]["event_id"] == "gap-1"
+        assert second[1]["event_id"] == "gap-2"
+        assert replacement.empty()  # pre-connect event was never replayed
+    finally:
+        channel.unsubscribe(replacement)

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -33,6 +33,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _function_source(src: str, name: str) -> str:
+    start = src.index(f"def {name}(")
+    end = src.find("\ndef ", start + 1)
+    return src[start:end if end != -1 else len(src)]
+
+
 # ---------------------------------------------------------------------------
 # Defect B — server-initiated turn fans `server_turn_started` to SessionChannel
 # ---------------------------------------------------------------------------
@@ -381,8 +387,7 @@ def test_session_sse_handler_wires_on_subscribe_recovery():
     assert "active_stream_id_for_session" in src
     # The recovery must be inside the session SSE handler and use the
     # recovered marker so the frontend uses the replay attach path.
-    handler_ix = src.index("def _handle_session_sse_stream")
-    handler_src = src[handler_ix:handler_ix + 9000]
+    handler_src = _function_source(src, "_handle_session_sse_stream")
     assert "active_stream_id_for_session" in handler_src
     assert '"recovered": True' in handler_src
     assert "server_turn_started" in handler_src
@@ -653,8 +658,7 @@ def test_session_sse_handler_wires_finished_during_gap_self_heal():
     and (c) emit a `session-updated` frame when the server is ahead — all so a
     turn that finished during the SSE gap still self-heals on a visible tab."""
     src = (REPO_ROOT / "api" / "routes.py").read_text()
-    handler_ix = src.index("def _handle_session_sse_stream")
-    handler_src = src[handler_ix:handler_ix + 9000]
+    handler_src = _function_source(src, "_handle_session_sse_stream")
     # (a) the subscriber reports its last-known count.
     assert "known_count" in handler_src
     assert "subscriber_known_count" in handler_src
@@ -704,8 +708,7 @@ def test_sse_handler_uses_shared_emit_gate_not_inline_comparison():
     tested function (greptile P2 r…: the gate test must exercise the handler,
     not a copy)."""
     src = (REPO_ROOT / "api" / "routes.py").read_text()
-    handler_ix = src.index("def _handle_session_sse_stream")
-    handler_src = src[handler_ix:handler_ix + 9000]
+    handler_src = _function_source(src, "_handle_session_sse_stream")
     # The shared gate is imported and called in the emit branch.
     assert "should_emit_session_updated" in handler_src
     # And the inline form is GONE (the comparison lives only in the gate fn).


### PR DESCRIPTION
## Summary

Closes #7105.

A reverse proxy can continue acknowledging WebUI SSE heartbeats after its downstream browser has disappeared. In that state, socket keepalive, `TCP_USER_TIMEOUT`, and write deadlines prove only that the proxy is alive. The server thread and subscriber queue remain pinned indefinitely, and enough abandoned connections can push the process into OOM.

This change gives the three field-observed indefinite subscriber streams a five-minute HTTP-generation lease:

- `/api/session/stream`
- `/api/sessions/events`
- `/api/gateway/sessions/stream`

A live `EventSource` renews by reconnecting. A dead browser does not, so its handler and exact subscriber queue are released within a bounded interval.

Reported and instrumented with detailed socket evidence by @Aris-qin.

## Correctness details

- Does **not** emit a `Connection: close` response header, preserving the #3103 reconnect-storm fix. It sets only `BaseHTTPRequestHandler.close_connection` when the bounded response ends.
- Checks the lease before queue reads and after timeouts, so a continuously busy stream cannot postpone expiry.
- Unsubscribes only the expired generation's exact queue.
- Gives `/api/session/stream` a bounded, copied event-ID history and native `Last-Event-ID` replay so a completion emitted in the ordinary reconnect gap is delivered exactly once.
- Establishes a synthetic cursor on the first `initial` frame, which covers the first gap even when no prior payload event had an ID.
- Replays only a precisely recorded preloaded FIFO prefix before active/completed-turn recovery. Concurrent live events retain their normal order.
- Preserves the full subscriber reconnect grace even when the channel itself is older than the idle TTL.
- Keeps first-connect and unknown/evicted-cursor behavior fail-closed: no stale completion toast is replayed. Existing active-turn and persisted-count recovery remain the fallback.

## Tests and verification

- `138 passed` across the new regressions and neighboring SessionChannel, Option-Z, gateway, and #3103 suites.
- Full suite: `14692 passed, 154 skipped, 1 xfailed, 2 xpassed, 34 subtests passed`.
- Ruff forward gate: no new violations on changed lines.
- Codex final convergence gate: `SAFE TO SHIP` after reproducing the prior event-loss, aged-channel, and replay-order defects and verifying their regressions.
- Opus/Fable final convergence gate: `SAFE TO OPEN PR`.
- Local Chromium/CDP with a 750 ms test lease:
  - no payload event existed before the first forced EOF;
  - the first completion was emitted while subscriber count was zero;
  - native `EventSource` reconnected with the synthetic cursor;
  - the gap event arrived once, with matching SSE `lastEventId` and payload `event_id`;
  - the connection returned to `CONNECTING`, not a closed/reconnect-storm state.

## Risk and bounds

- Active tabs reconnect every five minutes. Session-list and gateway streams perform their existing reconnect refresh/snapshot work, which adds small periodic load.
- Per-session replay history is capped at 32 entries, below the route's 64-entry subscriber queue. An evicted cursor or a gap exceeding the bound falls back to the existing transcript/active-turn self-heal rather than replaying stale data.
- Legacy approval/clarify SSE, run-journal observers, and Kanban SSE have similar long-lived shapes but were not part of the field-observed #7105 leak. They remain separate follow-up candidates rather than widening this PR across unrelated event contracts.
- Rollback is the single commit on this branch; there is no schema, dependency, or persisted-state migration.
