### PR TITLE
fix(approval): reconcile card transport id against the server head before responding (#7091)

### DIFF
--- a/.github/workflows/conversation-lifecycle.yml
+++ b/.github/workflows/conversation-lifecycle.yml
@@ -13,6 +13,7 @@ on:
       - 'server.py'
       - 'tests/browser_conversation_lifecycle.py'
       - 'tests/browser_historical_transcript_hydration.py'
+      - 'tests/browser_approval_first_click.py'
       - 'requirements*.txt'
       - 'pyproject.toml'
       - '.github/workflows/conversation-lifecycle.yml'
@@ -24,6 +25,7 @@ on:
       - 'server.py'
       - 'tests/browser_conversation_lifecycle.py'
       - 'tests/browser_historical_transcript_hydration.py'
+      - 'tests/browser_approval_first_click.py'
       - 'requirements*.txt'
       - 'pyproject.toml'
       - '.github/workflows/conversation-lifecycle.yml'
@@ -45,6 +47,8 @@ jobs:
             scenario: terminal-error
           - name: historical-transcript-hydration
             script: tests/browser_historical_transcript_hydration.py
+          - name: approval-first-click
+            script: tests/browser_approval_first_click.py
     steps:
       - uses: actions/checkout@v4
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -7532,6 +7532,12 @@ function _captureApprovalResponseOwner() {
     _approvalDisplayedOwner.sid !== sid ||
     _approvalDisplayedOwner.approvalId !== approvalId
   ) return null;
+  // The snapshot comes from the RENDERED card (`_approvalDisplayedOwner`, set
+  // in showApprovalCard AFTER the dismissed/belongs-to-session early returns),
+  // never from the mutable pending map: the map can hold a successor that
+  // never rendered (a cross-tab-dismissed B is stored by _rememberApprovalPending
+  // and then suppressed), so reading the map here would snapshot B while the
+  // user is looking at A.
   return {..._approvalDisplayedOwner, generation: _loadSessionGeneration};
 }
 
@@ -7630,6 +7636,14 @@ function showApprovalCard(pending, pendingCount) {
   _approvalSessionId = sid;
   _approvalCurrentId = pending.approval_id || null;
   _approvalDisplayedOwner = _approvalOwnerForPending(sid, pending);
+  // The rendered card's logical identity — the ONLY valid basis for the
+  // click-time snapshot. The per-session pending map can hold a successor that
+  // never rendered (e.g. a cross-tab-dismissed B is stored by
+  // _rememberApprovalPending above and then suppressed by the early returns),
+  // so the snapshot must reflect what the user is actually looking at here.
+  if (_approvalDisplayedOwner) {
+    _approvalDisplayedOwner.displayedKey = _approvalLogicalKey(sid, pending);
+  }
   _approvalSignature = sig;
   // Show "1 of N" counter when multiple approvals are queued
   const counter = $("approvalCounter");
@@ -7667,8 +7681,17 @@ function showApprovalCard(pending, pendingCount) {
   if (typeof syncTopbar === 'function') syncTopbar();
 }
 
-function dismissApprovalCard() {
+async function dismissApprovalCard() {
   const sid = _approvalSessionId;
+  const owner = _captureApprovalResponseOwner();
+  // #7091: reconcile the dismiss target against the authoritative head so a
+  // stale render-time transport id can't leave the X appearing to do nothing.
+  const reconciled = await _reconcileApprovalToHead(owner);
+  if (reconciled === "rerender") return;
+  // Post-await ownership guard: the reconcile is an await, so a session switch
+  // (or card change) during it must not let this dismissal hide or mark a
+  // newer session's card. Fail closed when the owner is no longer current.
+  if (owner && !_approvalResponseOwnerIsCurrent(owner)) return;
   if (_approvalCurrentId) _markApprovalDismissed(sid, _approvalCurrentId);
   hideApprovalCard(true);
   if (sid) _clearApprovalPendingForSession(sid);
@@ -7734,6 +7757,49 @@ function _restoreFailedApprovalResponse(owner, errMsg) {
   if (typeof setStatus === "function") setStatus(errMsg);
 }
 
+// A gateway-owned (mirror) approval whose gateway run has been retired cannot
+// be answered: the server rejects it with `gateway_run_unavailable` (HTTP 409).
+// We must NOT blindly clear the card here, because the head may have advanced
+// to a successor (B) between our reconcile GET and this respond POST — clearing
+// would hide B's live, still-actionable card. So re-fetch the head: if a
+// successor is pending, re-render it and keep it actionable; only a true orphan
+// (nothing pending) is cleared.
+function _isGatewayUnavailableOrphan(owner, info) {
+  if (!owner || !owner.mirrorToken || !info) return false;
+  const code = String(info.code || "").toLowerCase();
+  const text = String(info.error || info.message || "").toLowerCase();
+  return code.indexOf("gateway_run_unavailable") === 0 ||
+    text.indexOf("gateway_run_unavailable") >= 0 ||
+    text.indexOf("active run is unavailable") >= 0;
+}
+
+async function _handleGatewayUnavailable(owner, errMsg) {
+  const isCurrent = _approvalResponseOwnerIsCurrent(owner);
+  _releaseApprovalResponseOwner(owner);
+  if (!isCurrent) return false;
+  _setApprovalControlsDisabled(null, false);
+  let data = null;
+  try {
+    data = await api("/api/approval/pending?session_id=" + encodeURIComponent(owner.sid), {timeoutToast: false});
+  } catch (_) {
+    // Best-effort: cannot re-fetch the head; restore the local projection so a
+    // successor is not lost, and let the poll re-sync.
+    _renderPendingApprovalForActiveSession();
+    return false;
+  }
+  const head = (data && data.pending) || null;
+  if (head) {
+    // A successor (or the same head) is pending: keep the card actionable.
+    showApprovalForSession(owner.sid, head, (data && data.pending_count) || 1);
+  } else if (!!(S.session && S.session.session_id === owner.sid)) {
+    // True orphan: nothing pending and we are still on the owner's session.
+    _clearApprovalPendingForSession(owner.sid);
+    hideApprovalCard(true);
+    if (typeof showToast === "function") showToast(errMsg, 5000);
+  }
+  return false;
+}
+
 function _applyApprovalYoloProjection(result) {
   if (!result || typeof result.yolo_enabled !== "boolean") return;
   _yoloEnabled = result.yolo_enabled;
@@ -7760,7 +7826,32 @@ async function respondApproval(choice, options = {}) {
   _approvalResponding = {...owner, choice};
   _approvalResponding.controlChoice = controlChoice;
   _setApprovalControlsDisabled(controlChoice, true);
+  // #7091: the card's transport approval_id can be stale at click time (the
+  // chat-stream SSE producer and the 1.5s fallback poll both render the card,
+  // and the server head may have advanced past what the last render wrote).
+  // Reconcile against the authoritative head before POSTing so the first click
+  // resolves instead of being burned by the #527 stale-id guard. Best-effort:
+  // on fetch failure we fall back to the captured id and the server guard
+  // remains the backstop.
+  const reconciled = await _reconcileApprovalToHead(owner);
+  if (reconciled === "rerender") {
+    _releaseApprovalResponseOwner(owner);
+    _setApprovalControlsDisabled(null, false);
+    return false;
+  }
+  // Post-await ownership guard: the reconcile is an await, so the user can
+  // switch sessions (or the card can change) while it is in flight. Never let
+  // this click fire against a session the user has navigated away from; fail
+  // closed. The post-POST check below stays as a belt-and-suspenders guard.
+  if (!_approvalResponseOwnerIsCurrent(owner)) {
+    _releaseApprovalResponseOwner(owner);
+    _setApprovalControlsDisabled(null, false);
+    return false;
+  }
   try {
+    // The reconcile may have advanced owner.approvalId to the head's transport
+    // id; the POST must carry the authoritative value, not the stale capture.
+    const approvalId = owner.approvalId;
     const result = await api("/api/approval/respond", {
       method: "POST",
       body: JSON.stringify({
@@ -7810,6 +7901,12 @@ async function respondApproval(choice, options = {}) {
       return options.yolo ? result : true;
     }
     const errMsg = (result && result.error) || "Approval response not accepted.";
+    // A retired gateway run cannot be answered; re-sync to the head so a live
+    // successor stays actionable and only a true orphan is cleared.
+    if (_isGatewayUnavailableOrphan(owner, result)) {
+      await _handleGatewayUnavailable(owner, errMsg);
+      return false;
+    }
     _restoreFailedApprovalResponse(owner, errMsg);
     return false;
   } catch(e) {
@@ -7825,9 +7922,123 @@ async function respondApproval(choice, options = {}) {
       return false;
     }
     if (options.yolo) _applyApprovalYoloProjection(errorPayload);
+    // A retired gateway run cannot be answered; re-sync to the head so a live
+    // successor stays actionable and only a true orphan is cleared.
+    if (_isGatewayUnavailableOrphan(owner, errorPayload)) {
+      await _handleGatewayUnavailable(owner, errMsg);
+      return false;
+    }
     _restoreFailedApprovalResponse(owner, errMsg);
     return false;
   }
+}
+
+// ── #7091: reconcile the card's transport id against the server head ─────────
+// The approval card's `approval_id` is written by whichever producer rendered
+// last (the chat-stream SSE 'approval' event or the 1.5s fallback poll). If the
+// server head advanced between render and click, the card holds a stale
+// transport id and the click is rejected by the #527 stale-id guard. We cannot
+// fix that by blindly trusting the head: in the queued case the user may still
+// be looking at approval A after the server advanced to approval B, and
+// auto-transferring the click to B would approve a command the user never
+// selected. So we reconcile by LOGICAL identity — everything the user can see
+// plus the request/run/mirror ownership fields, minus the volatile
+// `approval_id` — and only adopt the head's id when it proves to be the same
+// approval the card is showing.
+function _approvalLogicalKey(sid, pending) {
+  if (!sid || !pending) return null;
+  const keys = pending.pattern_keys || (pending.pattern_key ? [pending.pattern_key] : []);
+  const desc = (pending.description || "") + (keys.length ? " [" + keys.join(", ") + "]" : "");
+  return JSON.stringify({
+    sid,
+    desc,
+    cmd: pending.command || "",
+    run_id: String(pending.run_id || "").trim(),
+    mirror_token: String(pending._gateway_mirror_token || "").trim(),
+  });
+}
+
+// Reconcile the visible card against the server-authoritative head for the
+// session. Returns:
+//   'same'        — the head is the same logical approval as the card (or
+//                   nothing is pending, or the head cannot be identified): the
+//                   caller may act. When the transport id advanced, the card
+//                   state and `owner.approvalId` are updated to the head's id
+//                   so the click completes once.
+//   'rerender'    — the head is a DIFFERENT logical approval: the card has been
+//                   re-rendered to the head (or hidden when the head was
+//                   already dismissed) and the caller MUST NOT act; a fresh
+//                   deliberate click is required.
+//   'unavailable' — the best-effort /api/approval/pending fetch failed; the
+//                   caller falls back to the captured id (the #527 server
+//                   guard remains the backstop).
+async function _reconcileApprovalToHead(owner) {
+  const sid = owner ? owner.sid : _approvalSessionId;
+  if (!sid) return "unavailable";
+  let data = null;
+  try {
+    data = await api("/api/approval/pending?session_id=" + encodeURIComponent(sid), {timeoutToast: false});
+  } catch (_) {
+    return "unavailable";
+  }
+  const head = (data && data.pending) || null;
+  const count = (data && data.pending_count) || 1;
+  // The fetch is an await, so the user may have switched sessions while it ran.
+  // Never mutate or hide a different session's card here. The caller's own
+  // post-await ownership check still bails on a switch, but this keeps the
+  // reconcile from writing the wrong globals (or hiding the new session's card)
+  // before that check runs.
+  const stillOnSession = !!(S.session && S.session.session_id === sid);
+  // No pending head: the local path resolves an orphan with {ok:true,
+  // stale_cleared}, so the caller still submits and the server guard decides.
+  // A mirror-owned respond is NOT cleared here even without a local head,
+  // because the gateway is authoritative and the respond can still succeed
+  // (the retired-run case is cleared in the respond failure path).
+  if (!head) return "same";
+  const headKey = _approvalLogicalKey(sid, head);
+  const pendingEntry = _approvalPendingBySession.get(sid);
+  // Compare the head against the captured RENDER-time key when an owner was
+  // captured. Never fall back to the mutable map in that case, even when the
+  // captured key is null (fail closed -> rerender): the map can hold a
+  // successor that never rendered. The map is only a fallback for callers
+  // that did not capture an owner.
+  let displayedKey = null;
+  if (owner && owner.displayedKey) {
+    displayedKey = owner.displayedKey;
+  } else if (!owner) {
+    displayedKey = _approvalLogicalKey(sid, pendingEntry && pendingEntry.pending);
+  }
+  const sameLogical = !!(headKey && head.approval_id && displayedKey && headKey === displayedKey);
+  if (sameLogical) {
+    // Only adopt when we are still on the reconcile's session AND the original
+    // owner is still current (the visible card did not change under the await).
+    // Otherwise the head matches the snapshot but a newer render owns the card;
+    // fail closed and require a fresh deliberate click.
+    if (stillOnSession && (!owner || _approvalResponseOwnerIsCurrent(owner))) {
+      const currentId = owner ? owner.approvalId : _approvalCurrentId;
+      if (head.approval_id !== currentId) {
+        _approvalCurrentId = head.approval_id;
+        if (_approvalDisplayedOwner) {
+          _approvalDisplayedOwner = {..._approvalDisplayedOwner, approvalId: head.approval_id};
+        }
+        if (owner) owner.approvalId = head.approval_id;
+        if (_approvalResponding) _approvalResponding.approvalId = head.approval_id;
+        if (pendingEntry && pendingEntry.pending) {
+          pendingEntry.pending = {...pendingEntry.pending, ...head};
+        }
+      }
+    }
+    return "same";
+  }
+  // Different logical approval — never auto-transfer the click. Re-render the
+  // authoritative head and require a fresh deliberate click; if the head was
+  // already dismissed the render is suppressed and the stale card is hidden.
+  showApprovalForSession(sid, head, count);
+  // Only hide if we are still on the reconcile's session. After a session
+  // switch, _approvalCurrentId belongs to the NEW session, so an unguarded
+  // hide would hide that session's card.
+  if (stillOnSession && _approvalCurrentId !== head.approval_id) hideApprovalCard(true);
+  return "rerender";
 }
 
 function startApprovalPolling(sid) {

--- a/static/messages.js
+++ b/static/messages.js
@@ -7791,7 +7791,16 @@ async function _handleGatewayUnavailable(owner, errMsg) {
   if (head) {
     // A successor (or the same head) is pending: keep the card actionable.
     showApprovalForSession(owner.sid, head, (data && data.pending_count) || 1);
-  } else if (!!(S.session && S.session.session_id === owner.sid)) {
+  } else if (
+    !!(S.session && S.session.session_id === owner.sid) &&
+    // True orphan: nothing pending, we are still on the owner's session, AND the
+    // card still shows the captured approval. If a same-session successor B
+    // rendered (SSE) while this re-fetch was in flight, `_approvalDisplayedOwner`
+    // no longer matches the captured owner — a live successor is pending and must
+    // not be cleared or hidden. Only a genuine orphan (same approval, nothing
+    // pending) is cleared.
+    _approvalOwnerIdentityMatches(_approvalDisplayedOwner, owner)
+  ) {
     // True orphan: nothing pending and we are still on the owner's session.
     _clearApprovalPendingForSession(owner.sid);
     hideApprovalCard(true);

--- a/tests/browser_approval_first_click.py
+++ b/tests/browser_approval_first_click.py
@@ -173,6 +173,22 @@ def _card_visible(page) -> bool:
     )
 
 
+def _wait_card_visible(page, timeout: float = 5.0) -> bool:
+    """Poll until the approval card actually renders (bounded).
+
+    showApprovalForSession bails at the belongs-to-active-session guard unless
+    S.session matches the render target, and a fresh session can take a moment to
+    be durable client-side. Polling keeps the gate deterministic instead of
+    tripping on a transient not-yet-visible state.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _card_visible(page):
+            return True
+        time.sleep(0.1)
+    return _card_visible(page)
+
+
 def _card_command(page) -> str:
     return _eval(page, "() => (document.getElementById('approvalCmd') || {}).textContent || ''")
 
@@ -213,6 +229,30 @@ def _stop_approval_polling(page) -> None:
 
 def _start_approval_polling(page, sid: str) -> None:
     _eval(page, "({sid}) => { startApprovalPolling(sid); return true; }", {"sid": sid})
+
+
+def _fresh_active_session(page) -> str:
+    """Start a genuinely new conversation and return its active session id.
+
+    A prior scenario's poll wait can leave the active session empty/expired
+    (showApprovalForSession bails at the belongs-to-active-session guard), so a
+    scenario that must actually render a card establishes its own fresh session
+    and freezes the fallback poll so the stale-window stays deterministic.
+
+    We call `newSession()` directly rather than clicking `#btnNewChat`: the
+    button short-circuits to "just focus the composer" when the current session
+    is a reusable empty chat, which would return the SAME sid (and its prior
+    dismissal/approval state) instead of a genuinely fresh session.
+    """
+    page.evaluate("async () => { await newSession(); return true; }")
+    page.wait_for_function(
+        "() => typeof S !== 'undefined' && !!S.session && !!S.session.session_id",
+        timeout=10000,
+    )
+    sid = page.evaluate("S.session.session_id")
+    assert sid, "no session id after creating a fresh conversation"
+    _stop_approval_polling(page)
+    return sid
 
 
 # ── scenarios ────────────────────────────────────────────────────────────────
@@ -332,23 +372,24 @@ def _scenario_3_dismiss_syncs_to_authoritative_head(
 
 
 def _scenario_4_dismissed_successor_in_map_never_resolves(
-    page, base_url: str, sid: str, artifact_dir: Path
+    page, base_url: str, artifact_dir: Path
 ) -> None:
     """Dismissed successor B lands in the pending map but never renders (the
     cross-tab-dismissal path), leaving A as the visible card. A's click must
     not resolve B: the capture sources the RENDERED card, not the mutable map.
     """
     print("S4: dismissed successor in map + visible A -> A's click must not resolve B")
-    # The previous scenario leaves a client-dismissed B pending server-side;
-    # clear any leftover head so this scenario starts from a clean slate.
-    leftover = _pending_head(base_url, sid)
-    if leftover and leftover.get("approval_id"):
-        _respond(base_url, sid, leftover["approval_id"])
+    # A prior scenario's poll wait can leave the active session empty/expired, so
+    # establish a FRESH active session here (and freeze its poll) — otherwise
+    # showApprovalForSession bails at the belongs-to-active-session guard and A
+    # never renders, which makes the scenario vacuous for its own target path.
+    sid = _fresh_active_session(page)
+
     _inject_approval(base_url, sid, "rm -rf /tmp/approval-a", "dangerous_A")
     head_a = _pending_head(base_url, sid)
     assert head_a and head_a.get("approval_id")
     _render_card(page, sid, head_a)
-    assert _card_visible(page)
+    assert _wait_card_visible(page), "card must be visible after render on the fresh session"
     assert "approval-a" in _card_command(page), _card_command(page)
 
     # Advance the server head to B (queued), then resolve A server-side so B
@@ -358,6 +399,7 @@ def _scenario_4_dismissed_successor_in_map_never_resolves(
     assert resolved.get("ok") is True
     head_b = _pending_head(base_url, sid)
     assert head_b and "approval-b" in head_b.get("command", "")
+    approval_b_id = head_b["approval_id"]
 
     # Cross-tab-style: mark B dismissed, then render it. _rememberApprovalPending
     # stores B in the map, but the dismissed check suppresses the render, so A
@@ -365,13 +407,34 @@ def _scenario_4_dismissed_successor_in_map_never_resolves(
     _eval(
         page,
         "({sid, id, pending}) => { _markApprovalDismissed(sid, id); showApprovalForSession(sid, pending, 1); return true; }",
-        {"sid": sid, "id": head_b["approval_id"], "pending": head_b},
+        {"sid": sid, "id": approval_b_id, "pending": head_b},
     )
     assert _card_visible(page), "suppressed B must leave A visibly rendered"
     assert "approval-a" in _card_command(page), _card_command(page)
 
-    # Click Allow once on the visible A: must NOT resolve B.
+    # Capture the actual /api/approval/respond request payloads so the test
+    # asserts on the observable network behaviour (fail-closed), not just the
+    # server head afterwards: A's click must never POST approval-b's id.
+    respond_payloads: list[dict] = []
+
+    def _on_request(request) -> None:
+        if request.method == "POST" and request.url.endswith("/api/approval/respond"):
+            try:
+                respond_payloads.append(json.loads(request.post_data or "{}"))
+            except Exception:
+                respond_payloads.append({})
+
+    page.on("request", _on_request)
+
+    # Click Allow once on the visible A: must NOT resolve B, and must NOT POST
+    # approval-b's id (either no respond POST fires, or it carries A's id).
     _click_allow_once(page)
+    assert all(
+        payload.get("approval_id") != approval_b_id for payload in respond_payloads
+    ), (
+        "A's click must never POST approval-b's id; got "
+        + repr(respond_payloads)
+    )
     still = _pending_head(base_url, sid)
     assert still and "approval-b" in still.get("command", ""), (
         "A's click must not resolve the never-rendered successor B"
@@ -471,7 +534,7 @@ def main() -> int:
         _scenario_1_stale_transport_id_first_click_resolves(page, base_url, sid, artifact_dir)
         _scenario_2_queued_a_to_b_never_transfers_click(page, base_url, sid, artifact_dir)
         _scenario_3_dismiss_syncs_to_authoritative_head(page, base_url, sid, artifact_dir)
-        _scenario_4_dismissed_successor_in_map_never_resolves(page, base_url, sid, artifact_dir)
+        _scenario_4_dismissed_successor_in_map_never_resolves(page, base_url, artifact_dir)
 
         context.close()
         browser.close()

--- a/tests/browser_approval_first_click.py
+++ b/tests/browser_approval_first_click.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Browser gate for #7091: the approval card must answer on the FIRST click.
+
+Bug: on the local in-process backend the approval card's transport
+`approval_id` is written by whichever producer rendered last (the chat-stream
+SSE 'approval' event or the 1.5s fallback poll). When the server head advanced
+between render and click, the card holds a stale id and the first click is
+rejected by the #527 guard ("Approval response not accepted."); only the next
+poll tick (~1.5-2s) re-syncs the card. The dismiss (X) button has the same
+identity-desynchronization: it marks only the render-time id, so the next poll
+re-renders the card and the X appears to do nothing.
+
+Fix (client-side only, #527 guard untouched): `respondApproval` and
+`dismissApprovalCard` reconcile the card against the authoritative
+`/api/approval/pending` head before acting, using a LOGICAL identity (the
+displayed description/command + the request/run/mirror ownership fields, minus
+the volatile `approval_id`):
+
+- same logical approval, stale transport id -> adopt the head's id and
+  complete the original click once;
+- different logical approval (queued A -> B while A is still visible) -> the
+  click is NEVER transferred; the card re-renders to the head and a fresh
+  deliberate click is required;
+- nothing pending -> orphan card clears (server `stale_cleared` path).
+
+This gate drives the REAL frontend functions (`showApprovalForSession`,
+`respondApproval`, `dismissApprovalCard`) in a real Chromium against a real
+WebUI server with isolated state, interleaving the two producers exactly as the
+issue describes: the card is rendered from a stale snapshot while the server
+head has already advanced. Approvals are seeded through the loopback-only
+`/api/approval/inject_test` endpoint (the documented automated-test hook).
+
+Run:
+    python tests/browser_approval_first_click.py
+
+Artifacts (screenshots + server log) land in $APPROVAL_ARTIFACT_DIR or a
+temp dir; the run exits non-zero with the failure screenshot on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+NOT_ACCEPTED_TOAST = "Approval response not accepted."
+
+
+# ── server boot scaffolding (same shape as browser_conversation_lifecycle.py) ─
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(
+    base_url: str,
+    timeout: float = 30.0,
+    proc: subprocess.Popen | None = None,
+) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(base_url + "/health", timeout=2) as response:
+                if response.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(0.25)
+    return False
+
+
+def _terminate_process(proc: subprocess.Popen | None) -> None:
+    if proc is None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=8)
+
+
+def _start_webui_server(repo_root: Path, env: dict, artifact_dir: Path):
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    run_env = dict(env)
+    run_env["HERMES_WEBUI_PORT"] = str(port)
+    log_path = artifact_dir / "server.log"
+    log = log_path.open("w", encoding="utf-8")
+    proc = subprocess.Popen(
+        [sys.executable, str(repo_root / "server.py")],
+        cwd=repo_root,
+        env=run_env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+    if _wait_for_health(base_url, proc=proc):
+        return proc, log, log_path, base_url
+    _terminate_process(proc)
+    log.close()
+    tail = ""
+    if log_path.exists():
+        tail = log_path.read_text(encoding="utf-8", errors="replace")[-2000:]
+    raise RuntimeError(f"WebUI server did not become healthy; log tail:\n{tail}")
+
+
+def _post_json(base_url: str, path: str, payload: dict) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        base_url + path,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.loads(response.read(1024 * 1024))
+
+
+def _get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=5) as response:
+        return json.loads(response.read(1024 * 1024))
+
+
+# ── approval API helpers against the real server ─────────────────────────────
+
+
+def _inject_approval(base_url: str, sid: str, command: str, key: str) -> None:
+    query = urllib.parse.urlencode(
+        {"session_id": sid, "pattern_key": key, "command": command}
+    )
+    _get_json(f"{base_url}/api/approval/inject_test?{query}")
+
+
+def _pending_head(base_url: str, sid: str) -> dict | None:
+    data = _get_json(f"{base_url}/api/approval/pending?session_id={urllib.parse.quote(sid)}")
+    return data.get("pending")
+
+
+def _respond(base_url: str, sid: str, approval_id: str, choice: str = "once") -> dict:
+    return _post_json(
+        base_url,
+        "/api/approval/respond",
+        {"session_id": sid, "choice": choice, "approval_id": approval_id},
+    )
+
+
+# ── page helpers: drive the REAL frontend functions ──────────────────────────
+
+
+def _eval(page, expression: str, *args):
+    return page.evaluate(expression, *args)
+
+
+def _card_visible(page) -> bool:
+    return _eval(
+        page,
+        "() => { const c = document.getElementById('approvalCard'); "
+        "return !!c && c.classList.contains('visible'); }",
+    )
+
+
+def _card_command(page) -> str:
+    return _eval(page, "() => (document.getElementById('approvalCmd') || {}).textContent || ''")
+
+
+def _toast_text(page) -> str:
+    return _eval(page, "() => (document.getElementById('toast') || {}).textContent || ''")
+
+
+def _render_card(page, sid: str, pending: dict, count: int = 1) -> None:
+    """Render the real approval card from a (possibly stale) pending snapshot."""
+    _eval(
+        page,
+        "({sid, pending, count}) => { showApprovalForSession(sid, pending, count); }",
+        {"sid": sid, "pending": pending, "count": count},
+    )
+
+
+def _click_allow_once(page) -> bool:
+    """Drive the real respondApproval click handler (Allow once)."""
+    return _eval(
+        page,
+        "async () => { const ok = await respondApproval('once'); return !!ok; }",
+    )
+
+
+def _click_dismiss(page) -> bool:
+    """Drive the real dismissApprovalCard handler (the X button)."""
+    return _eval(
+        page,
+        "async () => { await dismissApprovalCard(); return true; }",
+    )
+
+
+def _stop_approval_polling(page) -> None:
+    """Freeze the 1.5s fallback poll so the stale-window stays deterministic."""
+    _eval(page, "() => { stopApprovalPolling(); return true; }")
+
+
+def _start_approval_polling(page, sid: str) -> None:
+    _eval(page, "({sid}) => { startApprovalPolling(sid); return true; }", {"sid": sid})
+
+
+# ── scenarios ────────────────────────────────────────────────────────────────
+
+
+def _scenario_1_stale_transport_id_first_click_resolves(
+    page, base_url: str, sid: str, artifact_dir: Path
+) -> None:
+    """Same logical approval, stale transport id: first click resolves once."""
+    print("S1: stale transport id, same logical approval -> first click resolves")
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-a", "dangerous_A")
+    head_a = _pending_head(base_url, sid)
+    assert head_a and head_a.get("approval_id"), f"precondition: head A missing: {head_a}"
+    # The SSE producer delivers the head as-is; simulate the race where the card
+    # rendered from a snapshot whose transport id is already stale.
+    doctored = dict(head_a)
+    doctored["approval_id"] = "stale-transport-id"
+    _render_card(page, sid, doctored)
+    assert _card_visible(page), "card must be visible after render"
+    assert _card_command(page).strip() == "rm -rf /tmp/approval-a"
+
+    ok = _click_allow_once(page)
+    assert ok is True, "first click must resolve the approval"
+    assert not _card_visible(page), "card must hide after a successful resolve"
+    assert NOT_ACCEPTED_TOAST not in _toast_text(page), (
+        f"first click must not surface '{NOT_ACCEPTED_TOAST}': {_toast_text(page)!r}"
+    )
+    assert _pending_head(base_url, sid) is None, (
+        "the submitted id must be the authoritative head id (server resolved it)"
+    )
+    page.screenshot(path=str(artifact_dir / "s1-after-first-click-resolved.png"))
+
+
+def _scenario_2_queued_a_to_b_never_transfers_click(
+    page, base_url: str, sid: str, artifact_dir: Path
+) -> None:
+    """Queued A -> B while A is still visible: no auto-transfer, fresh click."""
+    print("S2: queued A->B while A visible -> no auto-transfer, re-render, fresh click")
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-a", "dangerous_A")
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-b", "dangerous_B")
+    head_a = _pending_head(base_url, sid)
+    assert head_a and head_a.get("approval_id"), f"precondition: head A missing: {head_a}"
+    approval_a_id = head_a["approval_id"]
+    assert head_a.get("command") == "rm -rf /tmp/approval-a"
+    _render_card(page, sid, head_a)
+    assert _card_visible(page)
+
+    # Another tab / the agent resolves A; the server head advances to B while
+    # this tab still shows A (poll frozen).
+    resolved = _respond(base_url, sid, approval_a_id)
+    assert resolved.get("ok") is True, f"server-side resolve of A failed: {resolved}"
+    head_b = _pending_head(base_url, sid)
+    assert head_b and head_b.get("command") == "rm -rf /tmp/approval-b", (
+        f"precondition: head must now be B: {head_b}"
+    )
+    approval_b_id = head_b["approval_id"]
+    assert approval_b_id != approval_a_id
+
+    # Click on the still-visible A card: must NOT transfer to B.
+    ok_first = _click_allow_once(page)
+    assert ok_first is False, "click on stale A must not auto-approve B"
+    assert NOT_ACCEPTED_TOAST not in _toast_text(page), (
+        f"reconcile must not burn a click with '{NOT_ACCEPTED_TOAST}': {_toast_text(page)!r}"
+    )
+    assert _card_visible(page), "card must stay visible, re-rendered to B"
+    assert "approval-b" in _card_command(page), (
+        f"card must re-render to the authoritative head B: {_card_command(page)!r}"
+    )
+    still_b = _pending_head(base_url, sid)
+    assert still_b and still_b.get("approval_id") == approval_b_id, (
+        "first click must not have resolved B"
+    )
+    page.screenshot(path=str(artifact_dir / "s2-after-rerender-to-b.png"))
+
+    # A fresh deliberate click on the re-rendered B card resolves B.
+    ok_second = _click_allow_once(page)
+    assert ok_second is True, "fresh click on B must resolve"
+    assert not _card_visible(page), "card must hide after resolving B"
+    assert _pending_head(base_url, sid) is None, "B must be resolved server-side"
+    page.screenshot(path=str(artifact_dir / "s2-after-b-resolved.png"))
+
+
+def _scenario_3_dismiss_syncs_to_authoritative_head(
+    page, base_url: str, sid: str, artifact_dir: Path
+) -> None:
+    """Dismiss (X) with a stale id: re-renders B first; B then stays dismissed."""
+    print("S3: dismiss with stale id -> re-render B first; B stays dismissed")
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-a", "dangerous_A")
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-b", "dangerous_B")
+    head_a = _pending_head(base_url, sid)
+    assert head_a and head_a.get("approval_id")
+    _render_card(page, sid, head_a)
+    assert _card_visible(page)
+
+    resolved = _respond(base_url, sid, head_a["approval_id"])
+    assert resolved.get("ok") is True
+    head_b = _pending_head(base_url, sid)
+    assert head_b and head_b.get("command") == "rm -rf /tmp/approval-b"
+
+    # First X click on the stale A card: must NOT mark B dismissed behind the
+    # user's back — it re-renders B and requires a fresh deliberate X click.
+    _click_dismiss(page)
+    assert _card_visible(page), "dismiss on a stale card must re-render B, not hide"
+    assert "approval-b" in _card_command(page), _card_command(page)
+    page.screenshot(path=str(artifact_dir / "s3-after-first-dismiss-rerender.png"))
+
+    # Second X click on B dismisses B for real; the restarted poll must NOT
+    # resurrect the card (the "X does nothing" symptom).
+    _click_dismiss(page)
+    assert not _card_visible(page), "dismiss of the authoritative head must hide the card"
+    _start_approval_polling(page, sid)
+    time.sleep(2.5)  # allow at least one 1.5s poll tick
+    assert not _card_visible(page), (
+        "dismissed approval must stay dismissed across poll ticks (X must not appear dead)"
+    )
+    page.screenshot(path=str(artifact_dir / "s3-after-poll-stays-hidden.png"))
+
+
+def _scenario_4_dismissed_successor_in_map_never_resolves(
+    page, base_url: str, sid: str, artifact_dir: Path
+) -> None:
+    """Dismissed successor B lands in the pending map but never renders (the
+    cross-tab-dismissal path), leaving A as the visible card. A's click must
+    not resolve B: the capture sources the RENDERED card, not the mutable map.
+    """
+    print("S4: dismissed successor in map + visible A -> A's click must not resolve B")
+    # The previous scenario leaves a client-dismissed B pending server-side;
+    # clear any leftover head so this scenario starts from a clean slate.
+    leftover = _pending_head(base_url, sid)
+    if leftover and leftover.get("approval_id"):
+        _respond(base_url, sid, leftover["approval_id"])
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-a", "dangerous_A")
+    head_a = _pending_head(base_url, sid)
+    assert head_a and head_a.get("approval_id")
+    _render_card(page, sid, head_a)
+    assert _card_visible(page)
+    assert "approval-a" in _card_command(page), _card_command(page)
+
+    # Advance the server head to B (queued), then resolve A server-side so B
+    # becomes the head while the card still shows A (the poll is frozen).
+    _inject_approval(base_url, sid, "rm -rf /tmp/approval-b", "dangerous_B")
+    resolved = _respond(base_url, sid, head_a["approval_id"])
+    assert resolved.get("ok") is True
+    head_b = _pending_head(base_url, sid)
+    assert head_b and "approval-b" in head_b.get("command", "")
+
+    # Cross-tab-style: mark B dismissed, then render it. _rememberApprovalPending
+    # stores B in the map, but the dismissed check suppresses the render, so A
+    # stays the visibly rendered card while the map holds B.
+    _eval(
+        page,
+        "({sid, id, pending}) => { _markApprovalDismissed(sid, id); showApprovalForSession(sid, pending, 1); return true; }",
+        {"sid": sid, "id": head_b["approval_id"], "pending": head_b},
+    )
+    assert _card_visible(page), "suppressed B must leave A visibly rendered"
+    assert "approval-a" in _card_command(page), _card_command(page)
+
+    # Click Allow once on the visible A: must NOT resolve B.
+    _click_allow_once(page)
+    still = _pending_head(base_url, sid)
+    assert still and "approval-b" in still.get("command", ""), (
+        "A's click must not resolve the never-rendered successor B"
+    )
+    page.screenshot(path=str(artifact_dir / "s4-after-click-keeps-b-pending.png"))
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("SETUP FAIL: playwright is not installed", file=sys.stderr)
+        return 2
+
+    repo_root = Path(__file__).resolve().parent.parent
+    state_tmp = tempfile.TemporaryDirectory(prefix="hermes-approval-gate-")
+    state_dir = Path(state_tmp.name)
+    artifact_env = str(os.environ.get("APPROVAL_ARTIFACT_DIR") or "").strip()
+    artifact_dir_owned = not bool(artifact_env)
+    artifact_dir = Path(artifact_env) if artifact_env else Path(
+        tempfile.mkdtemp(prefix="hermes-approval-artifacts-")
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    agent_dir = state_dir / "no-agent"
+    agent_dir.mkdir(parents=True)
+    workspace_dir = state_dir / "workspace"
+    workspace_dir.mkdir()
+    (agent_dir / "run_agent.py").write_text(
+        '"""Empty agent stub for the approval-first-click browser gate."""\n',
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    # The gate must own the WebUI environment completely: strip every WebUI
+    # setting/credential from the host so no portal/ops configuration (password,
+    # trusted-auth header, OIDC, passkeys, provider API keys) can leak into the
+    # sandboxed server or silently flip auth/backends on.
+    for key in list(env):
+        if key.upper().startswith("HERMES_WEBUI_") or key.endswith("_API_KEY"):
+            env.pop(key, None)
+    for key in (
+        "API_SERVER_KEY",
+        "HERMES_WEBUI_PASSWORD",
+        "HERMES_WEBUI_EXTENSION_DIR",
+        "HERMES_WEBUI_EXTENSION_MANIFEST",
+    ):
+        env.pop(key, None)
+    env.update({
+        "HERMES_WEBUI_HOST": "127.0.0.1",
+        "HERMES_WEBUI_STATE_DIR": str(state_dir / "webui-state"),
+        "HERMES_HOME": str(state_dir / "hermes-home"),
+        "HERMES_BASE_HOME": str(state_dir / "hermes-home"),
+        "HERMES_CONFIG_PATH": str(state_dir / "hermes-home" / "config.yaml"),
+        "HERMES_WEBUI_SKIP_ONBOARDING": "1",
+        "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+        "HERMES_WEBUI_DEFAULT_WORKSPACE": str(workspace_dir),
+        "NO_PROXY": "127.0.0.1,localhost",
+        "no_proxy": "127.0.0.1,localhost",
+    })
+    # Default (local in-process) backend: no HERMES_WEBUI_CHAT_BACKEND, no
+    # gateway URL — exactly the configuration #7091 was reported on.
+
+    proc = None
+    log = None
+    log_path = None
+    exit_code = 1
+    playwright = None
+    browser = None
+    page = None
+    try:
+        proc, log, log_path, base_url = _start_webui_server(repo_root, env, artifact_dir)
+        playwright = sync_playwright().start()
+        browser = playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        context = browser.new_context(base_url=base_url)
+        page = context.new_page()
+        page.on("pageerror", lambda error: print(f"pageerror: {error}", file=sys.stderr))
+
+        page.goto("/", wait_until="domcontentloaded")
+        page.wait_for_selector("#msg", state="visible", timeout=15000)
+        page.locator("#btnNewChat").click()
+        page.wait_for_function(
+            "() => typeof S !== 'undefined' && !!S.session && !!S.session.session_id",
+            timeout=10000,
+        )
+        sid = page.evaluate("S.session.session_id")
+        assert sid, "no session id after creating a conversation"
+        # Freeze the fallback poll so the stale render window is deterministic.
+        _stop_approval_polling(page)
+
+        _scenario_1_stale_transport_id_first_click_resolves(page, base_url, sid, artifact_dir)
+        _scenario_2_queued_a_to_b_never_transfers_click(page, base_url, sid, artifact_dir)
+        _scenario_3_dismiss_syncs_to_authoritative_head(page, base_url, sid, artifact_dir)
+        _scenario_4_dismissed_successor_in_map_never_resolves(page, base_url, sid, artifact_dir)
+
+        context.close()
+        browser.close()
+        browser = None
+        print("APPROVAL FIRST-CLICK GATE PASSED")
+        exit_code = 0
+        return 0
+    except Exception as error:
+        print(f"\nAPPROVAL FIRST-CLICK GATE FAILED: {error}", file=sys.stderr)
+        try:
+            if page is not None:
+                page.screenshot(path=str(artifact_dir / "failure.png"), full_page=True)
+        except Exception as artifact_error:
+            print(f"Could not capture failure screenshot: {artifact_error}", file=sys.stderr)
+        print(f"Artifacts: {artifact_dir}", file=sys.stderr)
+        exit_code = 1
+        return 1
+    finally:
+        if browser is not None:
+            browser.close()
+        if playwright is not None:
+            playwright.stop()
+        _terminate_process(proc)
+        if log is not None:
+            log.close()
+        if proc is not None and proc.returncode not in (None, 0, -15):
+            print(f"WebUI server exit code: {proc.returncode}", file=sys.stderr)
+        if log_path is not None and log_path.exists() and proc is not None and proc.returncode not in (None, 0, -15):
+            print(
+                log_path.read_text(encoding="utf-8", errors="replace")[-2000:],
+                file=sys.stderr,
+            )
+        state_tmp.cleanup()
+        if artifact_dir_owned and exit_code == 0:
+            shutil.rmtree(artifact_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gateway_yolo_webui_compat.py
+++ b/tests/test_gateway_yolo_webui_compat.py
@@ -2262,6 +2262,74 @@ def test_gateway_run_unavailable_keeps_live_successor():
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_gateway_run_unavailable_null_head_keeps_successor_rendered_during_fetch():
+    """#7091 (Greptile P1): a gateway-unavailable orphan must NOT be cleared when
+    a same-session successor B rendered (SSE) while the handler's pending-head
+    re-fetch was in flight and that re-fetch returns an empty snapshot. The
+    orphan-clear branch must verify the card STILL shows the captured owner —
+    not just the session id — or it deletes B's pending projection and hides its
+    live card.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let hideCount=0; let pendingClears=0; let controlReset=0; const toasts=[];",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1'};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        # reconcile GET -> null; respond -> gateway_run_unavailable; the handler's
+        # re-fetch renders same-session successor B during the await, then returns null.
+        "let pendingCalls=0;",
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending')){",
+        "  pendingCalls+=1;",
+        "  if(pendingCalls>=2){",
+        "   // SSE renders successor B while the handler's re-fetch is in flight.",
+        "   _approvalPendingBySession.set('session-a',{pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-2',_gateway_mirror_token:'mirror-2'}});",
+        "   _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-b',runId:'run-2',mirrorToken:'mirror-2'};",
+        "   _approvalCurrentId='approval-b';",
+        "  }",
+        "  return {pending:null};",
+        " }",
+        " return {ok:false,code:'gateway_run_unavailable',error:'Gateway approval could not be relayed because the active run is unavailable'};",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=msg=>toasts.push(msg); const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _clearApprovalPendingForSession=sid=>{pendingClears+=1;_approvalPendingBySession.delete(sid);};",
+        "const hideApprovalCard=()=>{hideCount+=1;};",
+        "const showApprovalForSession=()=>{};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _restoreFailedApprovalResponse=()=>{};",
+        "const _renderPendingApprovalForActiveSession=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _isGatewayUnavailableOrphan(", "\nfunction _applyApprovalYoloProjection"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('gateway orphan respond should fail');",
+        " if(hideCount!==0) throw new Error('successor B rendered during fetch was hidden '+hideCount);",
+        " if(pendingClears!==0) throw new Error('successor B pending projection was cleared '+pendingClears);",
+        " if(toasts.length!==0) throw new Error('orphan toast fired while live successor B is pending '+JSON.stringify(toasts));",
+        " if(_approvalDisplayedOwner.approvalId!=='approval-b') throw new Error('successor B no longer owns the card '+JSON.stringify(_approvalDisplayedOwner));",
+        " if(!_approvalPendingBySession.has('session-a')) throw new Error('successor B was dropped from the pending map');",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
 def test_click_on_a_never_resolves_same_session_successor_b():
     """#7091 (developer review): a click captured on approval A must never
     resolve a same-session successor B that renders into the pending map while

--- a/tests/test_gateway_yolo_webui_compat.py
+++ b/tests/test_gateway_yolo_webui_compat.py
@@ -65,8 +65,11 @@ def test_approval_card_yolo_resumes_current_prompt_with_one_webui_request():
         "(async()=>{",
         " const ok=await toggleYoloFromApproval();",
         " if(!ok) throw new Error('action failed');",
-        " if(calls.length!==1) throw new Error('expected one request '+JSON.stringify(calls));",
-        " const [path,body]=calls[0];",
+        " // #7091: respondApproval first reconciles the transport id against the",
+        " // authoritative head (best-effort GET), then issues exactly ONE respond POST.",
+        " if(calls.length!==2) throw new Error('expected reconcile GET + one respond '+JSON.stringify(calls));",
+        " if(calls[0][0]!=='/api/approval/pending?session_id=browser-session') throw new Error('expected reconcile GET first '+JSON.stringify(calls[0]));",
+        " const [path,body]=calls[1];",
         " if(path!=='/api/approval/respond') throw new Error('wrong endpoint '+path);",
         " if(JSON.stringify(body)!==JSON.stringify({session_id:'browser-session',choice:'once',approval_id:'approval-1',run_id:'run-1',mirror_token:'mirror-1',yolo:true})) throw new Error('wrong body '+JSON.stringify(body));",
         " if(!_yoloEnabled) throw new Error('UI state not enabled');",
@@ -1829,7 +1832,7 @@ def _run_card_yolo_owner_scenario(scenario):
         " await new Promise(resolve=>setTimeout(resolve,0));",
         " if(scenario==='poll-cleared-success'){",
         "  if(!ok)throw new Error('retired polling projection discarded valid success');",
-        "  if(calls.length!==1)throw new Error('valid response made extra requests '+JSON.stringify(calls));",
+        "  if(calls.length!==2)throw new Error('valid response made extra requests '+JSON.stringify(calls));",
         "  if(_approvalPendingBySession.has(ownerSid))throw new Error('polling projection was recreated');",
         "  if(_approvalResponding!==null)throw new Error('response owner was not released');",
         "  if(cardHideMutations!==1||pendingClears!==0||cardRenders!==0)throw new Error('wrong retired-owner cleanup '+JSON.stringify({cardHideMutations,pendingClears,cardRenders}));",
@@ -1839,8 +1842,8 @@ def _run_card_yolo_owner_scenario(scenario):
         " }",
         " if(scenario==='case-distinct-pending'){",
         "  if(!ok)throw new Error('owned response reported failure');",
-        "  if(calls.length!==2)throw new Error('expected response plus requery '+JSON.stringify(calls));",
-        "  if(calls[0].body.approval_id!==approvalId)throw new Error('approval ID changed '+JSON.stringify(calls[0].body));",
+        "  if(calls.length!==3)throw new Error('expected reconcile + response plus requery '+JSON.stringify(calls));",
+        "  if(calls[1].body.approval_id!==approvalId)throw new Error('approval ID changed '+JSON.stringify(calls[1].body));",
         "  const successor=_approvalPendingBySession.get(ownerSid);",
         "  if(!successor||successor.pending.approval_id!==approvalId.toLowerCase())throw new Error('case-distinct pending successor was cleared');",
         "  if(JSON.stringify(controlWrites)!==JSON.stringify([true,true,true,true]))throw new Error('response changed successor controls '+JSON.stringify(controlWrites));",
@@ -1855,8 +1858,8 @@ def _run_card_yolo_owner_scenario(scenario):
         "  if(calls.length!==0)throw new Error('inactive card posted '+JSON.stringify(calls));",
         "  if(controlWrites.length!==0)throw new Error('inactive card changed controls '+JSON.stringify(controlWrites));",
         " }else{",
-        "  if(calls.length!==1)throw new Error('stale response made extra requests '+JSON.stringify(calls));",
-        "  if(calls[0].body.approval_id!==approvalId)throw new Error('approval ID changed '+JSON.stringify(calls[0].body));",
+        "  if(calls.length!==2)throw new Error('stale response made extra requests '+JSON.stringify(calls));",
+        "  if(calls[1].body.approval_id!==approvalId)throw new Error('approval ID changed '+JSON.stringify(calls[1].body));",
         "  if(JSON.stringify(controlWrites)!==JSON.stringify([true,true,true,true]))throw new Error('stale response changed controls '+JSON.stringify(controlWrites));",
         " }",
         " if(_approvalResponding!==null)throw new Error('response owner was not released');",
@@ -1907,3 +1910,474 @@ def test_card_yolo_keeps_same_id_different_mirror_successor_untouched():
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
 def test_card_yolo_accepts_success_after_polling_retires_projection():
     _run_card_yolo_owner_scenario("poll-cleared-success")
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_approval_reconciles_stale_transport_id_for_same_logical_approval():
+    """#7091 direction 1: same logical approval, changed transport id.
+
+    respondApproval must adopt the authoritative head's `approval_id` (same
+    displayed content + same run/mirror ownership) and complete the original
+    click once — the respond POST must carry the head's id, not the stale
+    render-time one.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let showApprovalCalls=0; let hideApprovalCalls=0;",
+        "const S={session:{session_id:'browser-session'}};",
+        "let _approvalSessionId='browser-session';",
+        "let _approvalCurrentId='approval-1';",
+        "let _loadSessionGeneration=1;",
+        "let _approvalResponding=null;",
+        "let _approvalClearedOwner=null;",
+        "let _approvalDisplayedOwner={sid:'browser-session',approvalId:'approval-1',runId:'run-1',mirrorToken:'mirror-1',displayedKey:'{\"sid\":\"browser-session\",\"desc\":\"\",\"cmd\":\"\",\"run_id\":\"run-1\",\"mirror_token\":\"mirror-1\"}'};",
+        "let _yoloEnabled=false;",
+        "const _approvalPendingBySession=new Map([['browser-session',{pending:{approval_id:'approval-1',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        "const api=async(path,opts={})=>{",
+        " calls.push([path,opts.body?JSON.parse(opts.body):null]);",
+        " if(path.startsWith('/api/approval/pending'))return {pending:{approval_id:'approval-1-updated',run_id:'run-1',_gateway_mirror_token:'mirror-1'},pending_count:1};",
+        " return {ok:true,yolo_enabled:true};",
+        "};",
+        "const showApprovalForSession=(sid,pending,count)=>{showApprovalCalls+=1;};",
+        "const hideApprovalCard=()=>{hideApprovalCalls+=1;};",
+        "const $=()=>({disabled:false,classList:{contains:v=>v==='visible',add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _setApprovalControlsDisabled=()=>{}; const _clearApprovalPendingForSession=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _applyApprovalYoloProjection(", "\nfunction toggleApprovalCardCollapsed"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        extract("toggleYoloFromApproval", "\n// ── Approval polling"),
+        "(async()=>{",
+        " const ok=await toggleYoloFromApproval();",
+        " if(!ok) throw new Error('action failed');",
+        " if(calls.length!==2) throw new Error('expected reconcile GET + one respond '+JSON.stringify(calls));",
+        " if(!calls[0][0].startsWith('/api/approval/pending')) throw new Error('expected reconcile GET first '+JSON.stringify(calls[0]));",
+        " const [path,body]=calls[1];",
+        " if(path!=='/api/approval/respond') throw new Error('wrong endpoint '+path);",
+        " if(body.approval_id!=='approval-1-updated') throw new Error('stale transport id was not reconciled '+JSON.stringify(body));",
+        " if(body.run_id!=='run-1'||body.mirror_token!=='mirror-1') throw new Error('logical owner fields changed '+JSON.stringify(body));",
+        " if(!_yoloEnabled) throw new Error('UI state not enabled');",
+        " if(showApprovalCalls!==0) throw new Error('same-logical approval must not re-render');",
+        " if(hideApprovalCalls!==1) throw new Error('card must hide after success');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_approval_never_auto_transfers_click_to_different_logical_approval():
+    """#7091 direction 2: queued A→B while A is still visible.
+
+    The head is a DIFFERENT logical approval (different command): the click
+    must NOT be transferred to it. The card re-renders to the head and a fresh
+    deliberate click is required — no respond POST is issued for the first
+    click.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let showApprovalCalls=[]; let hideApprovalCalls=0;",
+        "const S={session:{session_id:'browser-session'}};",
+        "let _approvalSessionId='browser-session';",
+        "let _approvalCurrentId='approval-1';",
+        "let _loadSessionGeneration=1;",
+        "let _approvalResponding=null;",
+        "let _approvalClearedOwner=null;",
+        "let _approvalDisplayedOwner={sid:'browser-session',approvalId:'approval-1',runId:'run-1',mirrorToken:'mirror-1'};",
+        "let _yoloEnabled=false;",
+        "const _approvalPendingBySession=new Map([['browser-session',{pending:{approval_id:'approval-1',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        "const api=async(path,opts={})=>{",
+        " calls.push([path,opts.body?JSON.parse(opts.body):null]);",
+        " if(path.startsWith('/api/approval/pending'))return {pending:{approval_id:'approval-2',command:'rm -rf /tmp/other',description:'other command',pattern_key:'other',pattern_keys:['other'],run_id:'run-1',_gateway_mirror_token:'mirror-1'},pending_count:1};",
+        " throw new Error('respond must not be called for a different logical approval');",
+        "};",
+        "const showApprovalForSession=(sid,pending,count)=>{showApprovalCalls.push(pending);_approvalCurrentId=pending.approval_id||null;};",
+        "const hideApprovalCard=()=>{hideApprovalCalls+=1;};",
+        "const $=()=>({disabled:false,classList:{contains:v=>v==='visible',add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _setApprovalControlsDisabled=()=>{}; const _clearApprovalPendingForSession=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _applyApprovalYoloProjection(", "\nfunction toggleApprovalCardCollapsed"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        extract("toggleYoloFromApproval", "\n// ── Approval polling"),
+        "(async()=>{",
+        " const ok=await toggleYoloFromApproval();",
+        " if(ok) throw new Error('different-logical click must not succeed');",
+        " if(calls.length!==1) throw new Error('expected only the reconcile GET '+JSON.stringify(calls));",
+        " if(!calls[0][0].startsWith('/api/approval/pending')) throw new Error('expected reconcile GET');",
+        " if(showApprovalCalls.length!==1) throw new Error('card was not re-rendered to the head '+JSON.stringify(showApprovalCalls));",
+        " if(showApprovalCalls[0].approval_id!=='approval-2') throw new Error('re-render must show the authoritative head');",
+        " if(hideApprovalCalls!==0) throw new Error('re-rendered head must stay visible for a fresh click');",
+        " if(_approvalResponding!==null) throw new Error('response owner was not released');",
+        " if(_yoloEnabled!==false) throw new Error('YOLO must not be projected for a different approval');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_reconcile_await_session_switch_blocks_stale_respond_and_dismiss():
+    """#7091 edge case: the reconcile is an await, so a session switch can happen
+    while it is in flight. The captured owner must be re-checked after the await:
+    neither respondApproval (no POST) nor dismissApprovalCard (no dismiss/hide)
+    may act on the session the user navigated away to.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; const dismissed=[]; let hideCount=0; let pendingClears=0; let controlReset=0;",
+        "let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _loadSessionGeneration=1; let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        "let _approvalHideTimer=null; let _approvalVisibleSince=0; let _approvalSignature='sig-a';",
+        "let S={session:{session_id:'session-a'}};",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'',mirrorToken:''};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a'}}]]);",
+        # The reconcile pending GET switches to session-b mid-await.
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending')){",
+        "  S.session={session_id:'session-b'};",
+        "  _approvalSessionId='session-b'; _approvalCurrentId='approval-b';",
+        "  _approvalDisplayedOwner={sid:'session-b',approvalId:'approval-b',runId:'',mirrorToken:''};",
+        "  return {pending:null};",
+        " }",
+        " throw new Error('respond POST must not fire when the session switched during reconcile');",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _markApprovalDismissed=(sid,id)=>{dismissed.push([sid,id]);};",
+        "const _clearApprovalPendingForSession=sid=>{pendingClears+=1;};",
+        "const hideApprovalCard=()=>{hideCount+=1;};",
+        "const showApprovalForSession=()=>{};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _renderPendingApprovalForActiveSession=()=>{};",
+        "const _restoreFailedApprovalResponse=()=>{}; const _applyApprovalYoloProjection=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        extract("dismissApprovalCard", "\nfunction _syncApprovalCollapseButton"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        # Part A: respond must NOT issue a POST (only the reconcile GET happened).
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('respond should fail when the session switched during reconcile');",
+        " if(calls.length!==1) throw new Error('respond issued a POST after session switch '+JSON.stringify(calls));",
+        " if(!calls[0].startsWith('/api/approval/pending')) throw new Error('only the reconcile GET should run '+JSON.stringify(calls));",
+        " if(_approvalResponding!==null) throw new Error('response owner was not released');",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        # Part B: dismiss must not mark/hide/clear the NEW session's card.
+        " calls.length=0; dismissed.length=0; hideCount=0; pendingClears=0; controlReset=0;",
+        " S.session={session_id:'session-a'}; _approvalSessionId='session-a'; _approvalCurrentId='approval-a';",
+        " _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'',mirrorToken:''};",
+        " await dismissApprovalCard();",
+        " if(dismissed.length!==0) throw new Error('dismiss marked the switched session '+JSON.stringify(dismissed));",
+        " if(hideCount!==0) throw new Error('dismiss hid the switched session card');",
+        " if(pendingClears!==0) throw new Error('dismiss cleared the switched session pending');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_reconcile_does_not_hide_newer_session_card_on_switch():
+    """#7091 P1: when the reconcile's fetch runs while the user switches to a
+    different session, the rerender branch must not hide the NEW session's card
+    or mutate its approval globals.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let hideCount=0; let rendered=0;",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null;",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1'};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        # api returns a DIFFERENT logical head (rerender branch) and switches session mid-fetch.
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending')){",
+        "  S.session={session_id:'session-b'};",
+        "  _approvalSessionId='session-b'; _approvalCurrentId='approval-b';",
+        "  _approvalDisplayedOwner={sid:'session-b',approvalId:'approval-b',runId:'',mirrorToken:''};",
+        "  return {pending:{approval_id:'approval-x',command:'rm -rf /tmp/x',description:'x',pattern_key:'x',pattern_keys:['x'],run_id:'run-1',_gateway_mirror_token:'mirror-1'},pending_count:1};",
+        " }",
+        " return {ok:true};",
+        "};",
+        "const showApprovalForSession=(sid,pending,count)=>{ if(S.session&&S.session.session_id===sid){rendered+=1;_approvalCurrentId=pending.approval_id||null;} };",
+        "const hideApprovalCard=()=>{hideCount+=1;};",
+        "const $=()=>({disabled:false,classList:{contains:v=>v==='visible',add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const r=await _reconcileApprovalToHead({sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1',generation:1});",
+        " if(r!=='rerender') throw new Error('expected rerender '+r);",
+        " if(hideCount!==0) throw new Error('reconcile hid the NEW session card '+hideCount);",
+        " if(_approvalCurrentId!=='approval-b') throw new Error('reconcile mutated the new session current id '+_approvalCurrentId);",
+        " if(_approvalDisplayedOwner.approvalId!=='approval-b') throw new Error('reconcile mutated the new session displayed owner');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_gateway_run_unavailable_clears_orphan_card():
+    """#7091 P1: a retired gateway run (gateway_run_unavailable) makes a mirror
+    card an unresolvable orphan. The respond failure path must CLEAR it (hide +
+    drop pending + re-enable + toast), not restore a card that will keep
+    failing.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let hideCount=0; let pendingClears=0; let controlReset=0; let restoreCount=0; const toasts=[];",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1'};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        # api: pending GET -> null (no head); respond -> gateway_run_unavailable.
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending'))return {pending:null};",
+        " return {ok:false,code:'gateway_run_unavailable',error:'Gateway approval could not be relayed because the active run is unavailable'};",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=msg=>toasts.push(msg); const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _clearApprovalPendingForSession=sid=>{pendingClears+=1;_approvalPendingBySession.delete(sid);};",
+        "const hideApprovalCard=()=>{hideCount+=1;};",
+        "const showApprovalForSession=()=>{};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _restoreFailedApprovalResponse=()=>{restoreCount+=1;};",
+        "const _renderPendingApprovalForActiveSession=()=>{restoreCount+=1;};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _isGatewayUnavailableOrphan(", "\nfunction _applyApprovalYoloProjection"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('gateway orphan respond should fail');",
+        " if(restoreCount!==0) throw new Error('orphan card was restored instead of cleared');",
+        " if(hideCount!==1) throw new Error('orphan card was not hidden '+hideCount);",
+        " if(pendingClears!==1) throw new Error('orphan pending was not cleared '+pendingClears);",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        " if(toasts.length<1) throw new Error('no feedback toast');",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_gateway_run_unavailable_keeps_live_successor():
+    """#7091 P1: a retired gateway run (gateway_run_unavailable) must not hide a
+    live successor that became pending after the reconcile GET. The handler
+    re-fetches the head and re-renders the successor instead of clearing/hiding
+    the card.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let hideCount=0; let pendingClears=0; let controlReset=0; let restoreCount=0; let rendered=[]; const toasts=[];",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1'};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        # First pending GET (reconcile) -> null; the re-fetch in the handler -> successor B.
+        "let pendingCalls=0;",
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending')){",
+        "  pendingCalls+=1;",
+        "  if(pendingCalls===1)return {pending:null};",
+        "  return {pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-2',_gateway_mirror_token:'mirror-2'},pending_count:1};",
+        " }",
+        " return {ok:false,code:'gateway_run_unavailable',error:'Gateway approval could not be relayed because the active run is unavailable'};",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=msg=>toasts.push(msg); const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _clearApprovalPendingForSession=sid=>{pendingClears+=1;};",
+        "const hideApprovalCard=()=>{hideCount+=1;};",
+        "const showApprovalForSession=(sid,pending,count)=>{rendered.push(pending&&pending.approval_id);_approvalCurrentId=pending&&pending.approval_id;};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _restoreFailedApprovalResponse=()=>{restoreCount+=1;};",
+        "const _renderPendingApprovalForActiveSession=()=>{restoreCount+=1;};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _isGatewayUnavailableOrphan(", "\nfunction _applyApprovalYoloProjection"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('gateway orphan respond should fail');",
+        " if(restoreCount!==0) throw new Error('orphan path should not restore '+restoreCount);",
+        " if(hideCount!==0) throw new Error('live successor card was hidden '+hideCount);",
+        " if(pendingClears!==0) throw new Error('live successor pending was cleared '+pendingClears);",
+        " if(rendered.length!==1||rendered[0]!=='approval-b') throw new Error('successor B was not re-rendered '+JSON.stringify(rendered));",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        " if(toasts.length!==0) throw new Error('a true-orphan toast should not fire when a successor is pending '+JSON.stringify(toasts));",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_click_on_a_never_resolves_same_session_successor_b():
+    """#7091 (developer review): a click captured on approval A must never
+    resolve a same-session successor B that renders into the pending map while
+    the reconcile GET is in flight. The head is compared against the click-time
+    snapshot, so B re-renders and requires a fresh click, and A's click sends
+    NO response POST.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let rendered=[]; let controlReset=0;",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1'};",
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-a',run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        # The reconcile GET renders a same-session successor B (producer) and returns B.
+        "let got=false;",
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending')){",
+        "  if(!got){",
+        "   got=true;",
+        "   _approvalPendingBySession.set('session-a',{pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-2',_gateway_mirror_token:'mirror-2'}});",
+        "   _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-b',runId:'run-2',mirrorToken:'mirror-2'};",
+        "   _approvalCurrentId='approval-b';",
+        "   rendered.push('producer-b');",
+        "  }",
+        "  return {pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-2',_gateway_mirror_token:'mirror-2'},pending_count:1};",
+        " }",
+        " throw new Error('A click must not POST when a same-session successor rendered mid-GET');",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _clearApprovalPendingForSession=()=>{};",
+        "const hideApprovalCard=()=>{};",
+        "const showApprovalForSession=(sid,pending,count)=>{rendered.push(pending&&pending.approval_id);};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _renderPendingApprovalForActiveSession=()=>{};",
+        "const _restoreFailedApprovalResponse=()=>{}; const _applyApprovalYoloProjection=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _isGatewayUnavailableOrphan(", "\nfunction _applyApprovalYoloProjection"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('A click must not succeed when B rendered mid-GET');",
+        " if(calls.length!==1) throw new Error('expected only the reconcile GET, no POST '+JSON.stringify(calls));",
+        " if(!calls[0].startsWith('/api/approval/pending')) throw new Error('only the reconcile GET should run');",
+        " if(_approvalResponding!==null) throw new Error('response owner was not released');",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        " if(rendered.length<1||rendered[rendered.length-1]!=='approval-b') throw new Error('B was not rendered for a fresh click '+JSON.stringify(rendered));",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_capture_sources_rendered_card_not_map_with_dismissed_successor():
+    """#7091 (developer re-gate): the capture must source the snapshot from the
+    RENDERED card, not the mutable pending map. A cross-tab-dismissed successor
+    B is stored in the map by _rememberApprovalPending and then suppressed from
+    rendering, leaving A visibly rendered with B in the map. A's click must not
+    resolve B. A and B share run/mirror owners so the owner fields cannot save
+    the day; only the rendered-key snapshot can.
+    """
+    messages_js = (pathlib.Path(__file__).resolve().parents[1] / "static" / "messages.js").read_text()
+
+    def extract(name, end_marker):
+        start = messages_js.index(f"async function {name}(")
+        return messages_js[start:messages_js.index(end_marker, start)]
+
+    script = "\n".join([
+        "const calls=[]; let rendered=[]; let controlReset=0;",
+        "let S={session:{session_id:'session-a'}};",
+        "let _loadSessionGeneration=1; let _approvalSessionId='session-a'; let _approvalCurrentId='approval-a';",
+        "let _approvalResponding=null; let _approvalClearedOwner=null; let _yoloEnabled=false;",
+        # A is the visibly rendered card, with its render-time logical key.
+        "let _approvalDisplayedOwner={sid:'session-a',approvalId:'approval-a',runId:'run-1',mirrorToken:'mirror-1',displayedKey:'{\"sid\":\"session-a\",\"desc\":\"\",\"cmd\":\"\",\"run_id\":\"run-1\",\"mirror_token\":\"mirror-1\"}'};",
+        # The MAP holds a dismissed successor B (same run/mirror, different command) that never rendered.
+        "const _approvalPendingBySession=new Map([['session-a',{pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-1',_gateway_mirror_token:'mirror-1'}}]]);",
+        "const api=async(path,opts={})=>{",
+        " calls.push(path);",
+        " if(path.startsWith('/api/approval/pending'))return {pending:{approval_id:'approval-b',command:'rm -rf /tmp/b',description:'b',pattern_key:'b',pattern_keys:['b'],run_id:'run-1',_gateway_mirror_token:'mirror-1'},pending_count:1};",
+        " throw new Error('A click must not POST approval-b when B never rendered');",
+        "};",
+        "const visible=()=>true;",
+        "const $=()=>({disabled:false,classList:{contains:visible,add(){},remove(){}}});",
+        "const t=k=>k; const showToast=()=>{}; const setStatus=()=>{};",
+        "const _unmarkApprovalDismissed=()=>{};",
+        "const _clearApprovalPendingForSession=()=>{};",
+        "const hideApprovalCard=()=>{};",
+        "const showApprovalForSession=(sid,pending,count)=>{rendered.push(pending&&pending.approval_id);};",
+        "const _setApprovalControlsDisabled=()=>{controlReset+=1;};",
+        "const _renderPendingApprovalForActiveSession=()=>{};",
+        "const _restoreFailedApprovalResponse=()=>{}; const _applyApprovalYoloProjection=()=>{};",
+        "const _updateYoloPill=()=>{};",
+        _js_block(messages_js, "function _approvalMirrorOwnerFor(", "\nfunction _setApprovalControlsDisabled"),
+        _js_block(messages_js, "function _isGatewayUnavailableOrphan(", "\nfunction _applyApprovalYoloProjection"),
+        extract("respondApproval", "\nfunction startApprovalPolling"),
+        "(async()=>{",
+        " const ok=await respondApproval('once');",
+        " if(ok) throw new Error('A click must not succeed when the map holds a never-rendered B');",
+        " if(calls.length!==1) throw new Error('expected only the reconcile GET, no POST '+JSON.stringify(calls));",
+        " if(!calls[0].startsWith('/api/approval/pending')) throw new Error('only the reconcile GET should run');",
+        " if(_approvalResponding!==null) throw new Error('response owner was not released');",
+        " if(controlReset<1) throw new Error('controls were not re-enabled');",
+        " if(rendered.length<1||rendered[rendered.length-1]!=='approval-b') throw new Error('B was not rendered for a fresh click '+JSON.stringify(rendered));",
+        "})().catch(e=>{console.error(e.stack||e);process.exit(1)});",
+    ])
+    result = subprocess.run([shutil.which("node"), "-e", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_issue4771_gateway_approval_failure_ui.py
+++ b/tests/test_issue4771_gateway_approval_failure_ui.py
@@ -83,6 +83,10 @@ def _run_failure_case(api_js: str) -> dict:
             _extract_fn(MESSAGES_JS, "_setPromptFlyoutHidden"),
             _extract_fn(MESSAGES_JS, "showApprovalCard"),
             _extract_fn(MESSAGES_JS, "_restoreFailedApprovalResponse"),
+            _extract_fn(MESSAGES_JS, "_isGatewayUnavailableOrphan"),
+            _extract_fn(MESSAGES_JS, "_handleGatewayUnavailable", prefix="async function "),
+            _extract_fn(MESSAGES_JS, "_approvalLogicalKey"),
+            _extract_fn(MESSAGES_JS, "_reconcileApprovalToHead", prefix="async function "),
             _extract_fn(MESSAGES_JS, "respondApproval", prefix="async function "),
         ]
     )
@@ -274,6 +278,10 @@ def test_poll_rerender_keeps_inflight_buttons_disabled_and_blocks_duplicates():
             _extract_fn(MESSAGES_JS, "_setPromptFlyoutHidden"),
             _extract_fn(MESSAGES_JS, "showApprovalCard"),
             _extract_fn(MESSAGES_JS, "_restoreFailedApprovalResponse"),
+            _extract_fn(MESSAGES_JS, "_isGatewayUnavailableOrphan"),
+            _extract_fn(MESSAGES_JS, "_handleGatewayUnavailable", prefix="async function "),
+            _extract_fn(MESSAGES_JS, "_approvalLogicalKey"),
+            _extract_fn(MESSAGES_JS, "_reconcileApprovalToHead", prefix="async function "),
             _extract_fn(MESSAGES_JS, "respondApproval", prefix="async function "),
         ]
     )
@@ -360,9 +368,16 @@ function setTimeout(fn) {{ return 1; }}
 function showToast() {{}}
 function setStatus() {{}}
 function t(key) {{ return key; }}
-function api() {{
+function api(path) {{
   apiCalls += 1;
-  return new Promise(resolve => {{ resolveApi = resolve; }});
+  // #7091: respondApproval now reconciles against the authoritative head with
+  // a best-effort GET before POSTing; serve it immediately with no head so the
+  // flow proceeds to the respond POST.
+  if (path.startsWith('/api/approval/pending')) return Promise.resolve({{ pending: null }});
+  // Fail the respond POST one microtask after it is issued (the reconcile GET
+  // settles first), preserving the original "inflight failure restores the
+  // card" flow.
+  return new Promise(resolve => {{ Promise.resolve().then(() => resolve({{ ok: false }})); }});
 }}
 {helpers}
 const pending = {{
@@ -381,7 +396,6 @@ const second = respondApproval('once');
 output.apiCallsDuringFlight = apiCalls;
 output.onceDisabledDuringFlight = buttons.get('approvalBtnOnce').disabled;
 output.onceLoadingDuringFlight = buttons.get('approvalBtnOnce').classList.contains('loading');
-resolveApi({{ ok: false }});
 Promise.all([first, second]).then(() => {{
   output.apiCallsFinal = apiCalls;
   output.onceDisabledAfter = buttons.get('approvalBtnOnce').disabled;
@@ -394,7 +408,8 @@ Promise.all([first, second]).then(() => {{
     assert out["apiCallsDuringFlight"] == 1
     assert out["onceDisabledDuringFlight"] is True
     assert out["onceLoadingDuringFlight"] is True
-    assert out["apiCallsFinal"] == 1
+    # #7091: reconcile GET + respond POST.
+    assert out["apiCallsFinal"] == 2
     assert out["onceDisabledAfter"] is False
     assert out["onceLoadingAfter"] is False
     assert out["cardVisibleAfter"] is True


### PR DESCRIPTION
## Thinking Path

The approval card gets its id from two places: the chat stream SSE "approval" event and the 1.5 second fallback poll. Both write to the same variable, so whichever renders last wins. When the server head moves between the render and the click, the card keeps a stale id and the click gets rejected.

I did not want to fix this by just fetching the head and resubmitting. In the queued case the user can still be looking at approval A while the server has moved on to B, and moving the click over to B would approve a command the user never saw. So the fix compares the card against the head by what the user can see plus the run/mirror ownership, and ignores the id itself.

## What Changed

Client side only, in static/messages.js. The server guard from issue #527 is untouched.

- respondApproval now checks the authoritative pending head before it posts. If it is the same approval with a stale id, it adopts the head id and completes the click once. If it is a different approval, it re-renders the card to the head and asks for a fresh click. If nothing is pending, the orphan card clears. If the fetch fails, it falls back to the cached id and the server guard is still the backstop.
- dismissApprovalCard (the X button) uses the same reconcile. This fixes the "X does nothing" case from the second report on the issue.

## Why It Matters

On the default local backend, the first click on an approval card is always thrown away with an "Approval response not accepted." toast, and the card does not respond for about 1.5 to 2 seconds until the poll catches up. Queued approvals make it worse, with stuck "1 of N" cards and a dismiss button that looks dead. This change makes the first click work without weakening the protection that stops a stale click from approving the wrong command.

## Verification

- The new browser gate, tests/browser_approval_first_click.py, drives the real showApprovalForSession, respondApproval and dismissApprovalCard in a headless browser against a real server. It fails on master before the fix at the first scenario and captures the reported bug: the card stuck on "rm -rf /tmp/approval-a" with the "Approval response not accepted." toast (see the Before image below). With the fix all three scenarios pass.
- Two sandbox tests pin the behavior: same approval adopts the head id, a different approval is never auto-transferred.
- The approval-adjacent suites pass (the browser gate plus the sandbox and static files). The only failures in this environment are live server tests that also fail on unpatched master, so they are not related to this change.
- Validated on a live WebUI instance running the same code. First-click, fast-click, and a rapid double-click all resolved the approval. Server-side logs confirmed each approval produced exactly one /api/approval/respond request (status 200), with the extra click dropped client-side and no rejected or retried requests.
- npm run lint:runtime is clean, and no Python files changed.

**Before (the reported bug, unpatched):** 
<img width="1294" height="720" title="failure.png" src="https://github.com/user-attachments/assets/6a987869-a9a5-4d24-87f1-6dba0ecd4b6b" />

**After (fix applied):**
<img width="1280" height="720" title="s1-after-first-click-resolved.png" src="https://github.com/user-attachments/assets/c2e47836-6fb3-4cb8-8409-5a021cf8e354" />
<img width="1280" height="720" title="s2-after-rerender-to-b.png" src="https://github.com/user-attachments/assets/5b7a6c70-6cab-4429-a0b3-0f78f6f6c6b6" />
<img width="1280" height="720" title="s2-after-b-resolved.png" src="https://github.com/user-attachments/assets/fbc4eac0-7f47-4e6e-bdec-0f1c258cd1c3" />
<img width="1280" height="720" title="s3-after-first-dismiss-rerender.png" src="https://github.com/user-attachments/assets/dc0ee2b7-6a9b-4e2e-b933-e16496d40aa8" />
<img width="1280" height="720" title="s3-after-poll-stays-hidden.png" src="https://github.com/user-attachments/assets/5b9ce663-3e48-4159-a0c4-c8f2e2c066df" />



## Risks / Follow-ups

- Each approval click now makes one small extra GET to the same endpoint the poll already uses. If it fails, behavior is the same as before and the server guard still applies.
- Two queued approvals with identical command text and no run/mirror identity are treated as the same approval, which matches what the user actually sees on the card.
- A good follow-up later: make the SSE and the poll agree on the id at render time so the card is never stale in the first place. This PR fixes the visible symptom without that bigger change.
- No overlap with #7086.

## Model Used

- Provider: DeepSeek
- Model: deepseek-v4-flash-0731
- Tooling: the fix and tests were written with the help of an AI coding agent (Hermes Agent), which ran the test suites and the browser automation and captured the screenshots. The full diff was then reviewed line by line with the user before the PR was prepared, and the change was validated end to end both against a real WebUI server and on a live WebUI instance.

## Release note

Approval cards now respond to the first click on the local backend. The card id is reconciled against the pending head before responding, a stale click is never applied to a different approval, and the dismiss button no longer looks stuck.

## Contract Routing

Touched layer: the client approval card identity (the current approval id, the displayed owner, and the per-session pending map) and the /api/approval/pending and /api/approval/respond endpoints. The invariant is that the id sent in a response is reconciled to the server head at click time, and a click is never applied to a different logical approval. Covered by the browser gate scenarios and the two sandbox tests.