### PR TITLE
fix(panel): render cron panel Last/Next run in server timezone (#7140)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2614,6 +2614,32 @@ def _build_session_list_cache_payload(
     }
 
 
+def _server_tz_offset() -> str:
+    """Return the Hermes-configured timezone offset string (e.g. "+0800", "-0330").
+
+    The process/container zone (``time.strftime("%z")``) may be UTC while the
+    Hermes timezone (``HERMES_TIMEZONE`` env var or the ``timezone`` key in
+    config.yaml, resolved via ``hermes_time``) is configured to something else —
+    the WebUI must display server-side timestamps in the *Hermes* zone, not the
+    container's. Prefer ``hermes_time.now()`` and fall back to the process zone;
+    never return an empty string.
+    """
+    try:
+        from hermes_time import now as _hermes_now
+        offset = _hermes_now().strftime("%z")
+        if offset:
+            return offset
+    except Exception:
+        pass
+    try:
+        offset = time.strftime("%z")
+        if offset:
+            return offset
+    except Exception:
+        pass
+    return "+0000"
+
+
 def _session_list_payload_to_response(payload: dict) -> dict:
     safe_merged = []
     runtime_rows = _session_list_cache_overlay_runtime_rows(payload.get("sessions", []) or [])
@@ -2650,7 +2676,7 @@ def _session_list_payload_to_response(payload: dict) -> dict:
         "active_profile": payload.get("active_profile"),
         "other_profile_count": int(payload.get("other_profile_count", 0)),
         "server_time": time.time(),
-        "server_tz": time.strftime("%z"),
+        "server_tz": _server_tz_offset(),
     }
     if "webui_session_count" in payload:
         response["webui_session_count"] = int(payload.get("webui_session_count", 0))

--- a/api/routes.py
+++ b/api/routes.py
@@ -2614,30 +2614,62 @@ def _build_session_list_cache_payload(
     }
 
 
-def _server_tz_offset() -> str:
-    """Return the Hermes-configured timezone offset string (e.g. "+0800", "-0330").
+def _server_tz_info() -> dict:
+    """Return the Hermes-configured timezone as ``{"name": ..., "offset": ...}``.
 
-    The process/container zone (``time.strftime("%z")``) may be UTC while the
-    Hermes timezone (``HERMES_TIMEZONE`` env var or the ``timezone`` key in
-    config.yaml, resolved via ``hermes_time``) is configured to something else —
-    the WebUI must display server-side timestamps in the *Hermes* zone, not the
-    container's. Prefer ``hermes_time.now()`` and fall back to the process zone;
-    never return an empty string.
+    ``name`` is the IANA timezone name (e.g. ``America/New_York``) resolved
+    per-request from the mtime-aware WebUI config reader — NOT the Agent's
+    process-global cached ``hermes_time`` (which stays stale until
+    ``reset_cache()`` after a config change, review #7155). Resolution:
+    1. ``HERMES_TIMEZONE`` env var (highest priority);
+    2. ``timezone`` key in the active profile's config.yaml (read via the
+       cached/mtime-aware ``_load_yaml_config_file``);
+    3. fallback to the server-local zone name (``datetime.now().astimezone()``
+       ZoneInfo key), else empty string.
+
+    ``offset`` stays as the legacy numeric offset string (e.g. ``+0800``,
+    ``-0330``) so older consumers keep working; the browser prefers ``name``
+    and formats each instant with ``Intl.DateTimeFormat(..., {timeZone})``,
+    which resolves DST per-instant and renders configured-UTC as UTC.
     """
     try:
-        from hermes_time import now as _hermes_now
-        offset = _hermes_now().strftime("%z")
-        if offset:
-            return offset
+        name = os.getenv("HERMES_TIMEZONE", "").strip()
     except Exception:
-        pass
+        name = ""
+    if not name:
+        try:
+            cfg = _load_yaml_config_file(_get_config_path())
+            raw_tz = (cfg.get("timezone") or "") if isinstance(cfg, dict) else ""
+            name = str(raw_tz).strip()
+        except Exception:
+            name = ""
+    offset = ""
     try:
         offset = time.strftime("%z")
-        if offset:
-            return offset
     except Exception:
-        pass
-    return "+0000"
+        offset = ""
+    if not name:
+        try:
+            import datetime as _dt
+            local_tz = _dt.datetime.now().astimezone().tzinfo
+            name = getattr(local_tz, "key", "") or ""
+        except Exception:
+            name = ""
+    if not name:
+        # Some tzinfo objects (fixed offsets) have no IANA key — derive a
+        # stable Etc/GMT name from the numeric offset so the browser still
+        # gets a timeZone it can apply.
+        try:
+            _m = re.match(r"([+-])(\d{2})(\d{2})", offset)
+            if _m:
+                _sign = "-" if _m.group(1) == "+" else "+"
+                _hours = str(int(_m.group(2)))
+                name = f"Etc/GMT{_sign}{_hours}"
+        except Exception:
+            name = ""
+    if not offset:
+        offset = "+0000"
+    return {"server_tz_name": name, "server_tz": offset}
 
 
 def _session_list_payload_to_response(payload: dict) -> dict:
@@ -2676,7 +2708,9 @@ def _session_list_payload_to_response(payload: dict) -> dict:
         "active_profile": payload.get("active_profile"),
         "other_profile_count": int(payload.get("other_profile_count", 0)),
         "server_time": time.time(),
-        "server_tz": _server_tz_offset(),
+        # IANA name (browser Intl resolves DST per-instant) + legacy numeric
+        # offset fallback (review #7155).
+        **_server_tz_info(),
     }
     if "webui_session_count" in payload:
         response["webui_session_count"] = int(payload.get("webui_session_count", 0))

--- a/api/routes.py
+++ b/api/routes.py
@@ -2658,13 +2658,21 @@ def _server_tz_info() -> dict:
     if not name:
         # Some tzinfo objects (fixed offsets) have no IANA key — derive a
         # stable Etc/GMT name from the numeric offset so the browser still
-        # gets a timeZone it can apply.
+        # gets a timeZone it can apply. Only whole-hour offsets map cleanly
+        # (Etc/GMT uses inverted sign: UTC+8 → "Etc/GMT-8"); a zero offset is
+        # simply "UTC". Fractional offsets (e.g. +0530) have no Etc/GMT
+        # equivalent, so leave the name empty and let the client fall back to
+        # the numeric-offset shift, which handles them correctly.
         try:
-            _m = re.match(r"([+-])(\d{2})(\d{2})", offset)
+            _m = re.match(r"([+-])(\d{1,2})(?::?(\d{2}))?", offset)
             if _m:
-                _sign = "-" if _m.group(1) == "+" else "+"
-                _hours = str(int(_m.group(2)))
-                name = f"Etc/GMT{_sign}{_hours}"
+                _hours = int(_m.group(2))
+                _mins = int(_m.group(3) or 0)
+                if _mins == 0:
+                    if _hours == 0:
+                        name = "UTC"
+                    else:
+                        name = f"Etc/GMT{'-' if _m.group(1) == '+' else '+'}{_hours}"
         except Exception:
             name = ""
     if not offset:

--- a/static/panels.js
+++ b/static/panels.js
@@ -1232,8 +1232,13 @@ function _renderCronDetail(job){
   if (!title || !body) return;
   title.textContent = job.name || job.schedule_display || '(unnamed)';
   const status = _cronStatusMeta(job);
-  const nextRun = job.next_run_at ? new Date(job.next_run_at).toLocaleString() : t('not_available');
-  const lastRun = job.last_run_at ? new Date(job.last_run_at).toLocaleString() : t('never');
+  // Render Last run / Next run in the server's configured Hermes timezone via
+  // the _formatInServerTz helper from sessions.js (guarded like ui.js; falls
+  // back to browser-local formatting when the helper isn't available).
+  const _fmtCronTz = (typeof _formatInServerTz === 'function') ? _formatInServerTz : null;
+  const _fmtCronTs = (v) => _fmtCronTz ? _fmtCronTz(new Date(v)) : new Date(v).toLocaleString();
+  const nextRun = job.next_run_at ? _fmtCronTs(job.next_run_at) : t('not_available');
+  const lastRun = job.last_run_at ? _fmtCronTs(job.last_run_at) : t('never');
   const schedule = job.schedule_display || (job.schedule && job.schedule.expression) || '';
   const skills = Array.isArray(job.skills) && job.skills.length ? job.skills.join(', ') : '—';
   const deliver = job.deliver || 'local';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5441,6 +5441,11 @@ function _applySessionListPayload(sessData, projData, opts){
   if (typeof sessData.server_tz === 'string') {
     _serverTz = sessData.server_tz;
   }
+  if (typeof sessData.server_tz_name === 'string' && sessData.server_tz_name) {
+    _serverTzName = sessData.server_tz_name;
+  } else {
+    _serverTzName = '';
+  }
   const serverSessions=_optimisticallyRemovedSessionIds.size
     ? (sessData.sessions||[]).filter(s=>s&&!_optimisticallyRemovedSessionIds.has(s.session_id))
     : (sessData.sessions||[]);
@@ -6427,6 +6432,7 @@ let _hideSearchPreviewsAfterSelect = false;
 let _archivedSearchPagingQueryActive = false;
 let _serverTimeDelta = 0;       // ms offset: client clock - server clock (for clock-skew compensation)
 let _serverTz = '';              // server timezone offset string (e.g. "+0800", "+0000", "-0500")
+let _serverTzName = '';          // server IANA timezone name (e.g. "America/New_York") — preferred
 
 function _sessionSearchRanges(text, query){
   const source=String(text||'');
@@ -6657,14 +6663,25 @@ function _serverNowMs() {
 }
 
 function _serverTzOptions() {
-  // Build a timeZone option from _serverTz (e.g. "+0800" → "Etc/GMT-8").
-  // Falls back to undefined (uses browser timezone) when:
-  //   - _serverTz is not set or is UTC (no offset to apply)
-  //   - _serverTz is malformed
-  //   - _serverTz has a fractional-hour component (India +0530, Iran +0330,
-  //     Newfoundland -0330, Nepal +0545, etc.) — IANA Etc/GMT zones cannot
-  //     express half/quarter-hour offsets; use _formatInServerTz() instead
-  //     for correct fractional-offset formatting.
+  // Build a timeZone option from the server's IANA name (preferred) or the
+  // numeric offset (e.g. "+0800" → "Etc/GMT-8"). The IANA name lets
+  // Intl.DateTimeFormat resolve the correct offset PER INSTANT, so DST
+  // transitions are handled automatically and a configured-UTC zone renders
+  // as UTC (review #7155). Falls back to undefined (browser timezone) when:
+  //   - neither _serverTzName nor _serverTz is set
+  //   - _serverTz is UTC, malformed, or has a fractional-hour component
+  //     (India +0530, Iran +0330, Newfoundland -0330, Nepal +0545, etc.) —
+  //     IANA Etc/GMT zones cannot express half/quarter-hour offsets; use
+  //     _formatInServerTz() instead for correct fractional-offset formatting.
+  if (_serverTzName) {
+    try {
+      // Validate the IANA name by letting Intl parse it; invalid names throw.
+      new Intl.DateTimeFormat('en-US', { timeZone: _serverTzName });
+      return { timeZone: _serverTzName };
+    } catch (e) {
+      // fall through to the numeric-offset path
+    }
+  }
   if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
   const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
   if (!m) return undefined;
@@ -6675,15 +6692,28 @@ function _serverTzOptions() {
 }
 
 function _formatInServerTz(date, options) {
-  // Format `date` in the server's wall-clock timezone, including correct
-  // handling of fractional-hour offsets that Etc/GMT cannot express.
+  // Format `date` in the server's wall-clock timezone.
   //
-  // Strategy: shift the timestamp by the server's offset, then format with
-  // timeZone:'UTC' so no further conversion is applied — the formatted
-  // output reads as the wall-clock time in the server's timezone.
+  // Preferred path: when the server publishes an IANA timezone name, format
+  // with Intl.DateTimeFormat({ timeZone: name }) — the engine resolves the
+  // correct offset per instant, so timestamps on both sides of a DST
+  // transition are correct and configured-UTC renders as UTC (review #7155).
   //
-  // Falls back to plain `date.toLocaleString(undefined, options)` (browser
-  // timezone) when _serverTz is absent, UTC, or malformed.
+  // Fallback path (no/empty IANA name): shift the timestamp by the server's
+  // numeric offset, then format with timeZone:'UTC' so no further conversion
+  // is applied — the output reads as the wall-clock time in the server's
+  // timezone. Handles fractional-hour offsets that Etc/GMT cannot express.
+  //
+  // Final fallback: plain `date.toLocaleString(undefined, options)` (browser
+  // timezone) when the server tz is absent, UTC, or malformed.
+  if (_serverTzName) {
+    try {
+      return new Intl.DateTimeFormat(undefined, { ...options, timeZone: _serverTzName })
+        .format(date);
+    } catch (e) {
+      // invalid IANA name — fall through to the offset path
+    }
+  }
   if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') {
     return date.toLocaleString(undefined, options);
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6667,12 +6667,13 @@ function _serverTzOptions() {
   // numeric offset (e.g. "+0800" → "Etc/GMT-8"). The IANA name lets
   // Intl.DateTimeFormat resolve the correct offset PER INSTANT, so DST
   // transitions are handled automatically and a configured-UTC zone renders
-  // as UTC (review #7155). Falls back to undefined (browser timezone) when:
+  // as UTC (review #7155). Falls back to undefined (browser timezone) only
+  // when the server tz is absent or malformed:
   //   - neither _serverTzName nor _serverTz is set
-  //   - _serverTz is UTC, malformed, or has a fractional-hour component
-  //     (India +0530, Iran +0330, Newfoundland -0330, Nepal +0545, etc.) —
-  //     IANA Etc/GMT zones cannot express half/quarter-hour offsets; use
-  //     _formatInServerTz() instead for correct fractional-offset formatting.
+  //   - _serverTz has a fractional-hour component (India +0530, Iran +0330,
+  //     Newfoundland -0330, Nepal +0545, etc.) — IANA Etc/GMT zones cannot
+  //     express half/quarter-hour offsets; use _formatInServerTz() instead
+  //     for correct fractional-offset formatting.
   if (_serverTzName) {
     try {
       // Validate the IANA name by letting Intl parse it; invalid names throw.
@@ -6682,7 +6683,10 @@ function _serverTzOptions() {
       // fall through to the numeric-offset path
     }
   }
-  if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
+  if (!_serverTz) return undefined;
+  // Explicit server UTC (offset-only payload, no IANA name) must render as
+  // UTC, NOT the browser's local zone (review #7155 bug 3).
+  if (_serverTz === '+0000' || _serverTz === '-0000') return { timeZone: 'UTC' };
   const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
   if (!m) return undefined;
   if (m[3] !== '00') return undefined;  // fractional offset — caller must use _formatInServerTz
@@ -6705,7 +6709,7 @@ function _formatInServerTz(date, options) {
   // timezone. Handles fractional-hour offsets that Etc/GMT cannot express.
   //
   // Final fallback: plain `date.toLocaleString(undefined, options)` (browser
-  // timezone) when the server tz is absent, UTC, or malformed.
+  // timezone) when the server tz is absent or malformed.
   if (_serverTzName) {
     try {
       return new Intl.DateTimeFormat(undefined, { ...options, timeZone: _serverTzName })
@@ -6714,8 +6718,11 @@ function _formatInServerTz(date, options) {
       // invalid IANA name — fall through to the offset path
     }
   }
-  if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') {
-    return date.toLocaleString(undefined, options);
+  if (!_serverTz) return date.toLocaleString(undefined, options);
+  // Explicit server UTC (offset-only payload, no IANA name) must render as
+  // UTC, NOT the browser's local zone (review #7155 bug 3).
+  if (_serverTz === '+0000' || _serverTz === '-0000') {
+    return new Intl.DateTimeFormat(undefined, { ...options, timeZone: 'UTC' }).format(date);
   }
   const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
   if (!m) return date.toLocaleString(undefined, options);

--- a/tests/test_7140_cron_panel_server_tz.py
+++ b/tests/test_7140_cron_panel_server_tz.py
@@ -1,20 +1,27 @@
 """Regression tests for issue #7140 - cron panel Last run / Next run timezone.
 
-Root cause: the cron detail panel formatted ``next_run_at`` / ``last_run_at``
-with bare ``new Date(...).toLocaleString()`` (browser timezone), and the
-``server_tz`` sent by /api/sessions came from ``time.strftime("%z")`` (the
-process/container zone, typically UTC) instead of the Hermes-configured
-timezone (``HERMES_TIMEZONE`` env var / ``timezone`` key in config.yaml).
+Round-2 (review #7155): a fixed numeric offset is wrong for DST and
+configured-UTC; the server must publish the IANA timezone name so the
+browser's Intl engine resolves the correct offset PER INSTANT.
 
-Fix: static/panels.js formats the cron timestamps via ``_formatInServerTz``
-(the server-tz helper from static/sessions.js), and api/routes.py derives
-``server_tz`` from ``hermes_time.now()`` with a process-zone fallback.
+Fix:
+- api/routes.py::_server_tz_info() returns ``{server_tz_name, server_tz}`` —
+  IANA name resolved per-request (HERMES_TIMEZONE → config.yaml ``timezone``
+  → server-local zone) plus the legacy numeric offset as fallback.
+- static/sessions.js::_formatInServerTz prefers ``Intl.DateTimeFormat`` with
+  ``timeZone: <IANA name>``; numeric-offset shifting stays only as fallback.
+- static/panels.js renders cron Last/Next run through _formatInServerTz.
 """
 
+import os
 import pathlib
+import re
+import unittest
+from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 
 
@@ -50,25 +57,171 @@ def test_cron_panel_last_next_run_use_server_tz():
         )
 
 
+def test_formatter_prefers_iana_name_with_intl():
+    """_formatInServerTz must prefer Intl.DateTimeFormat({timeZone: IANA name})
+    so DST is resolved per instant and configured-UTC renders as UTC."""
+    assert "Intl.DateTimeFormat" in SESSIONS_JS
+    # The IANA-name branch must appear BEFORE the numeric-offset shift.
+    iana_pos = SESSIONS_JS.find("timeZone: _serverTzName")
+    shift_pos = SESSIONS_JS.find("offsetMin")
+    assert iana_pos != -1, "formatter must use the IANA name"
+    assert shift_pos != -1, "numeric-offset fallback must remain"
+    assert iana_pos < shift_pos, "IANA name path must be preferred over offset shift"
+    # Numeric offset shifting must remain as the fallback (not removed).
+    assert "adjusted.toLocaleString(undefined, { ...options, timeZone: 'UTC' })" in SESSIONS_JS
+
+
+def test_formatter_handles_utc_and_fractional_offsets():
+    """Fallback path must keep correct handling of UTC and fractional offsets
+    (+0530/+0345/-0330) via the numeric-offset shift."""
+    assert "Etc/GMT" in SESSIONS_JS, "Etc/GMT fallback must remain"
+    # Fractional offsets are handled by the shift, not Etc/GMT.
+    assert "fractional" in SESSIONS_JS
+
+
 # ---------------------------------------------------------------------------
-# Backend: server_tz must come from the Hermes timezone, not the container zone
+# Backend: server_tz_info publishes IANA name + offset, config-aware
 # ---------------------------------------------------------------------------
 
-def test_routes_server_tz_prefers_hermes_timezone():
-    """server_tz must be derived from the Hermes-configured timezone
-    (hermes_time), not the raw process/container zone."""
-    assert "def _server_tz_offset" in ROUTES_PY, (
-        "api/routes.py must define a _server_tz_offset() helper"
+def test_routes_defines_server_tz_info():
+    """api/routes.py must define _server_tz_info() returning both the IANA
+    name and the legacy numeric offset."""
+    assert "def _server_tz_info" in ROUTES_PY
+    assert "server_tz_name" in ROUTES_PY
+    assert '"server_tz"' in ROUTES_PY
+    # Payload must spread the helper's result (both keys).
+    assert "**_server_tz_info()" in ROUTES_PY
+
+
+def test_server_tz_info_resolves_iana_name_from_env():
+    """HERMES_TIMEZONE env var must be the highest-priority source for the
+    IANA name (no hermes_time cache involved)."""
+    import api.routes as routes
+
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": "America/New_York"}, clear=False):
+        info = routes._server_tz_info()
+    assert info["server_tz_name"] == "America/New_York"
+    assert isinstance(info["server_tz"], str) and info["server_tz"]
+
+
+def test_server_tz_info_does_not_use_cached_hermes_time():
+    """The helper must NOT depend on hermes_time's process-global cached tz
+    (review #7155: it stays stale after a config change until reset_cache)."""
+    import api.routes as routes
+
+    helper_start = ROUTES_PY.find("def _server_tz_info")
+    helper_end = ROUTES_PY.find("\ndef ", helper_start + 1)
+    helper = ROUTES_PY[helper_start:helper_end]
+    # Exclude the docstring (which mentions hermes_time as a negative) —
+    # check only the executable body.
+    body_start = helper.find('"""', helper.find('"""') + 3) + 3
+    body = helper[body_start:]
+    assert "hermes_time" not in body, (
+        "_server_tz_info must not use the cached hermes_time resolver"
     )
-    assert '"server_tz": _server_tz_offset()' in ROUTES_PY, (
-        "/api/sessions server_tz must come from _server_tz_offset()"
+    assert "import hermes_time" not in ROUTES_PY[:helper_start], (
+        "hermes_time must not be imported for _server_tz_info"
     )
-    start = ROUTES_PY.find("def _server_tz_offset")
-    end = ROUTES_PY.find("\ndef ", start + 1)
-    helper = ROUTES_PY[start:end if end != -1 else len(ROUTES_PY)]
-    assert "hermes_time" in helper, (
-        "server_tz must prefer the Hermes-configured timezone (hermes_time)"
+    assert "_load_yaml_config_file" in helper, (
+        "_server_tz_info must read config via the mtime-aware reader"
     )
-    assert 'time.strftime("%z")' in helper, (
-        "helper must keep a process-zone fallback"
-    )
+
+
+def test_server_tz_info_falls_back_to_server_local_zone():
+    """With no env/config timezone, the helper must fall back to the
+    server-local zone name (never an empty IANA name)."""
+    import api.routes as routes
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        with mock.patch.object(routes, "_load_yaml_config_file", return_value={}):
+            info = routes._server_tz_info()
+    # Server-local zone (e.g. "Etc/UTC" or "America/Sao_Paulo") — non-empty.
+    assert isinstance(info["server_tz_name"], str)
+    assert info["server_tz_name"].strip() != ""
+    assert isinstance(info["server_tz"], str) and info["server_tz"]
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: DST correctness (the core of review #7155)
+# ---------------------------------------------------------------------------
+
+def test_iana_path_behavior_dst_transition():
+    """Simulate the browser path across a DST boundary: with an IANA name the
+    offset for a winter instant differs from a summer instant (New York:
+    Jan = UTC-5, Jul = UTC-4). Uses Node to execute the real formatter."""
+    import subprocess
+
+    script = r"""
+const fs = require('fs');
+const src = fs.readFileSync('static/sessions.js', 'utf8');
+// Extract the two functions we need by slicing from their defs.
+function grab(name) {
+  const start = src.indexOf('function ' + name);
+  const end = src.indexOf('\nfunction ', start + 1);
+  return src.slice(start, end === -1 ? src.length : end);
+}
+let _serverTzName = 'America/New_York';
+let _serverTz = '-0500';
+const fns = grab('_formatInServerTz');
+eval(fns);
+const winter = new Date('2026-01-15T12:00:00Z'); // NY winter: EST (UTC-5) -> 07:00
+const summer = new Date('2026-07-15T12:00:00Z'); // NY summer: EDT (UTC-4) -> 08:00
+const w = _formatInServerTz(winter, {hour:'2-digit',minute:'2-digit',hour12:false});
+const s = _formatInServerTz(summer, {hour:'2-digit',minute:'2-digit',hour12:false});
+// Hours must DIFFER across the DST boundary (7 vs 8), proving per-instant resolution.
+const wH = parseInt(w.split(':')[0], 10);
+const sH = parseInt(s.split(':')[0], 10);
+if (wH === sH) { console.error('DST NOT RESOLVED: winter=' + w + ' summer=' + s); process.exit(1); }
+console.log('DST OK: winter=' + w + ' summer=' + s);
+"""
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        proc = subprocess.run(
+            ["node", script_path], cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=30
+        )
+    finally:
+        os.unlink(script_path)
+    assert proc.returncode == 0, f"node DST check failed: {proc.stderr}\n{proc.stdout}"
+    assert "DST OK" in proc.stdout
+
+
+def test_iana_path_behavior_configured_utc():
+    """A configured-UTC zone must render as UTC (review #7155 bug 2), not
+    fall back to the browser's local zone."""
+    import subprocess
+    import tempfile
+
+    script = r"""
+const fs = require('fs');
+const src = fs.readFileSync('static/sessions.js', 'utf8');
+function grab(name) {
+  const start = src.indexOf('function ' + name);
+  const end = src.indexOf('\nfunction ', start + 1);
+  return src.slice(start, end === -1 ? src.length : end);
+}
+let _serverTzName = 'UTC';
+let _serverTz = '+0000';
+eval(grab('_formatInServerTz'));
+const out = _formatInServerTz(new Date('2026-03-10T13:00:00Z'), {hour:'2-digit',minute:'2-digit',hour12:false});
+const h = parseInt(out.split(':')[0], 10);
+if (h !== 13) { console.error('CONFIGURED UTC WRONG: got ' + out); process.exit(1); }
+console.log('UTC OK: ' + out);
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        proc = subprocess.run(
+            ["node", script_path], cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=30
+        )
+    finally:
+        os.unlink(script_path)
+    assert proc.returncode == 0, f"node UTC check failed: {proc.stderr}\n{proc.stdout}"
+    assert "UTC OK" in proc.stdout
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_7140_cron_panel_server_tz.py
+++ b/tests/test_7140_cron_panel_server_tz.py
@@ -1,0 +1,74 @@
+"""Regression tests for issue #7140 - cron panel Last run / Next run timezone.
+
+Root cause: the cron detail panel formatted ``next_run_at`` / ``last_run_at``
+with bare ``new Date(...).toLocaleString()`` (browser timezone), and the
+``server_tz`` sent by /api/sessions came from ``time.strftime("%z")`` (the
+process/container zone, typically UTC) instead of the Hermes-configured
+timezone (``HERMES_TIMEZONE`` env var / ``timezone`` key in config.yaml).
+
+Fix: static/panels.js formats the cron timestamps via ``_formatInServerTz``
+(the server-tz helper from static/sessions.js), and api/routes.py derives
+``server_tz`` from ``hermes_time.now()`` with a process-zone fallback.
+"""
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def _render_cron_detail_body() -> str:
+    """Return the body of the cron detail panel renderer from panels.js."""
+    start = PANELS_JS.find("function _renderCronDetail")
+    assert start != -1, "_renderCronDetail must exist in static/panels.js"
+    end = PANELS_JS.find("\nfunction ", start + 1)
+    return PANELS_JS[start:end if end != -1 else len(PANELS_JS)]
+
+
+# ---------------------------------------------------------------------------
+# Frontend: cron detail panel timestamps must use the server timezone
+# ---------------------------------------------------------------------------
+
+def test_cron_panel_last_next_run_use_server_tz():
+    """Cron Last run / Next run must render in the server's configured
+    timezone via _formatInServerTz, not bare browser-timezone toLocaleString()."""
+    body = _render_cron_detail_body()
+    # The server-tz formatter (defined in sessions.js, loaded before panels.js)
+    # must be wired into the cron detail renderer.
+    assert "_formatInServerTz" in body, (
+        "cron detail panel must reference _formatInServerTz (server timezone)"
+    )
+    for var, field in (("nextRun", "next_run_at"), ("lastRun", "last_run_at")):
+        line = next((l for l in body.splitlines() if f"const {var} =" in l), None)
+        assert line is not None, f"{var} must be computed in _renderCronDetail"
+        assert f"job.{field}" in line, f"{var} must format job.{field}"
+        # Must go through the server-tz formatter, not a bare browser call.
+        assert "toLocaleString()" not in line, (
+            f"{var} ({field}) must not render via bare browser-timezone "
+            "toLocaleString()"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backend: server_tz must come from the Hermes timezone, not the container zone
+# ---------------------------------------------------------------------------
+
+def test_routes_server_tz_prefers_hermes_timezone():
+    """server_tz must be derived from the Hermes-configured timezone
+    (hermes_time), not the raw process/container zone."""
+    assert "def _server_tz_offset" in ROUTES_PY, (
+        "api/routes.py must define a _server_tz_offset() helper"
+    )
+    assert '"server_tz": _server_tz_offset()' in ROUTES_PY, (
+        "/api/sessions server_tz must come from _server_tz_offset()"
+    )
+    start = ROUTES_PY.find("def _server_tz_offset")
+    end = ROUTES_PY.find("\ndef ", start + 1)
+    helper = ROUTES_PY[start:end if end != -1 else len(ROUTES_PY)]
+    assert "hermes_time" in helper, (
+        "server_tz must prefer the Hermes-configured timezone (hermes_time)"
+    )
+    assert 'time.strftime("%z")' in helper, (
+        "helper must keep a process-zone fallback"
+    )

--- a/tests/test_7140_cron_panel_server_tz.py
+++ b/tests/test_7140_cron_panel_server_tz.py
@@ -7,91 +7,210 @@ browser's Intl engine resolves the correct offset PER INSTANT.
 Fix:
 - api/routes.py::_server_tz_info() returns ``{server_tz_name, server_tz}`` —
   IANA name resolved per-request (HERMES_TIMEZONE → config.yaml ``timezone``
-  → server-local zone) plus the legacy numeric offset as fallback.
+  → server-local zone) plus the legacy numeric offset as fallback. The config
+  read goes through the mtime-aware ``_load_yaml_config_file``, so a runtime
+  config change is picked up on the next request — no process-global
+  ``hermes_time`` cache (which stays stale until reset_cache).
 - static/sessions.js::_formatInServerTz prefers ``Intl.DateTimeFormat`` with
   ``timeZone: <IANA name>``; numeric-offset shifting stays only as fallback.
+  An offset-only payload of ``+0000`` (explicit server UTC) renders as UTC,
+  not the browser's local zone.
 - static/panels.js renders cron Last/Next run through _formatInServerTz.
+
+Tests are behavioral: the shipped JS formatter is executed with Node against
+real instants (UTC, fractional offsets, both sides of DST transitions) and
+the Python resolver is exercised with mocked config/env changes at runtime.
 """
 
 import os
 import pathlib
-import re
+import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
-PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+# Node preamble: load the REAL _formatInServerTz implementation out of
+# static/sessions.js so the tests exercise the shipped code, not a copy.
+_GRAB_FORMATTER = r"""
+const fs = require('fs');
+const src = fs.readFileSync('static/sessions.js', 'utf8');
+function grab(name) {
+  const start = src.indexOf('function ' + name);
+  const end = src.indexOf('\nfunction ', start + 1);
+  return src.slice(start, end === -1 ? src.length : end);
+}
+eval(grab('_formatInServerTz'));
+"""
 
 
-def _render_cron_detail_body() -> str:
-    """Return the body of the cron detail panel renderer from panels.js."""
-    start = PANELS_JS.find("function _renderCronDetail")
-    assert start != -1, "_renderCronDetail must exist in static/panels.js"
-    end = PANELS_JS.find("\nfunction ", start + 1)
-    return PANELS_JS[start:end if end != -1 else len(PANELS_JS)]
-
-
-# ---------------------------------------------------------------------------
-# Frontend: cron detail panel timestamps must use the server timezone
-# ---------------------------------------------------------------------------
-
-def test_cron_panel_last_next_run_use_server_tz():
-    """Cron Last run / Next run must render in the server's configured
-    timezone via _formatInServerTz, not bare browser-timezone toLocaleString()."""
-    body = _render_cron_detail_body()
-    # The server-tz formatter (defined in sessions.js, loaded before panels.js)
-    # must be wired into the cron detail renderer.
-    assert "_formatInServerTz" in body, (
-        "cron detail panel must reference _formatInServerTz (server timezone)"
-    )
-    for var, field in (("nextRun", "next_run_at"), ("lastRun", "last_run_at")):
-        line = next((l for l in body.splitlines() if f"const {var} =" in l), None)
-        assert line is not None, f"{var} must be computed in _renderCronDetail"
-        assert f"job.{field}" in line, f"{var} must format job.{field}"
-        # Must go through the server-tz formatter, not a bare browser call.
-        assert "toLocaleString()" not in line, (
-            f"{var} ({field}) must not render via bare browser-timezone "
-            "toLocaleString()"
+def _node(script: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Run a Node snippet in the repo root and return the completed process."""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        return subprocess.run(
+            ["node", script_path],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
         )
+    finally:
+        os.unlink(script_path)
 
 
-def test_formatter_prefers_iana_name_with_intl():
-    """_formatInServerTz must prefer Intl.DateTimeFormat({timeZone: IANA name})
-    so DST is resolved per instant and configured-UTC renders as UTC."""
-    assert "Intl.DateTimeFormat" in SESSIONS_JS
-    # The IANA-name branch must appear BEFORE the numeric-offset shift.
-    iana_pos = SESSIONS_JS.find("timeZone: _serverTzName")
-    shift_pos = SESSIONS_JS.find("offsetMin")
-    assert iana_pos != -1, "formatter must use the IANA name"
-    assert shift_pos != -1, "numeric-offset fallback must remain"
-    assert iana_pos < shift_pos, "IANA name path must be preferred over offset shift"
-    # Numeric offset shifting must remain as the fallback (not removed).
-    assert "adjusted.toLocaleString(undefined, { ...options, timeZone: 'UTC' })" in SESSIONS_JS
-
-
-def test_formatter_handles_utc_and_fractional_offsets():
-    """Fallback path must keep correct handling of UTC and fractional offsets
-    (+0530/+0345/-0330) via the numeric-offset shift."""
-    assert "Etc/GMT" in SESSIONS_JS, "Etc/GMT fallback must remain"
-    # Fractional offsets are handled by the shift, not Etc/GMT.
-    assert "fractional" in SESSIONS_JS
+def _assert_node_ok(proc: subprocess.CompletedProcess, label: str):
+    assert proc.returncode == 0, f"node {label} failed: {proc.stderr}\n{proc.stdout}"
 
 
 # ---------------------------------------------------------------------------
-# Backend: server_tz_info publishes IANA name + offset, config-aware
+# Frontend behavior (Node executes the real formatter): IANA name path
 # ---------------------------------------------------------------------------
 
-def test_routes_defines_server_tz_info():
-    """api/routes.py must define _server_tz_info() returning both the IANA
-    name and the legacy numeric offset."""
-    assert "def _server_tz_info" in ROUTES_PY
-    assert "server_tz_name" in ROUTES_PY
-    assert '"server_tz"' in ROUTES_PY
-    # Payload must spread the helper's result (both keys).
-    assert "**_server_tz_info()" in ROUTES_PY
+def test_formatter_iana_configured_utc_renders_utc():
+    """A configured-UTC zone (IANA name 'UTC') must render as UTC, not the
+    browser's local zone (review #7155 bug 2)."""
+    proc = _node(_GRAB_FORMATTER + r"""
+let _serverTzName = 'UTC';
+let _serverTz = '+0000';
+const out = _formatInServerTz(new Date('2026-03-10T13:00:00Z'), {hour:'2-digit',minute:'2-digit',hour12:false});
+const h = parseInt(out.split(':')[0], 10);
+if (h !== 13) { console.error('CONFIGURED UTC WRONG: got ' + out); process.exit(1); }
+console.log('UTC OK: ' + out);
+""")
+    _assert_node_ok(proc, "configured-UTC")
+    assert "UTC OK" in proc.stdout
 
+
+def test_formatter_iana_dst_spring_forward_both_sides():
+    """America/New_York 2026-03-08 spring forward: 06:59:59Z is EST (01:59:59)
+    and 07:00:00Z is EDT (03:00:00) — the offset must flip per instant."""
+    proc = _node(_GRAB_FORMATTER + r"""
+let _serverTzName = 'America/New_York';
+let _serverTz = '-0500';
+const opts = {hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false};
+const before = _formatInServerTz(new Date('2026-03-08T06:59:59Z'), opts); // EST UTC-5
+const after  = _formatInServerTz(new Date('2026-03-08T07:00:00Z'), opts); // EDT UTC-4
+if (before !== '01:59:59') { console.error('SPRING BEFORE WRONG: ' + before); process.exit(1); }
+if (after !== '03:00:00') { console.error('SPRING AFTER WRONG: ' + after); process.exit(1); }
+console.log('SPRING OK: ' + before + ' -> ' + after);
+""")
+    _assert_node_ok(proc, "DST spring-forward")
+    assert "SPRING OK" in proc.stdout
+
+
+def test_formatter_iana_dst_fall_back_both_sides():
+    """America/New_York 2026-11-01 fall back: 05:59:59Z is EDT (01:59:59) and
+    06:00:00Z is EST (01:00:00) — the offset must flip per instant."""
+    proc = _node(_GRAB_FORMATTER + r"""
+let _serverTzName = 'America/New_York';
+let _serverTz = '-0400';
+const opts = {hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false};
+const before = _formatInServerTz(new Date('2026-11-01T05:59:59Z'), opts); // EDT UTC-4
+const after  = _formatInServerTz(new Date('2026-11-01T06:00:00Z'), opts); // EST UTC-5
+if (before !== '01:59:59') { console.error('FALL BEFORE WRONG: ' + before); process.exit(1); }
+if (after !== '01:00:00') { console.error('FALL AFTER WRONG: ' + after); process.exit(1); }
+console.log('FALL OK: ' + before + ' -> ' + after);
+""")
+    _assert_node_ok(proc, "DST fall-back")
+    assert "FALL OK" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Frontend behavior: numeric-offset fallback path (no IANA name published)
+# ---------------------------------------------------------------------------
+
+def test_formatter_numeric_fractional_offsets():
+    """Offset-only payloads (no IANA name) with fractional-hour offsets
+    +0530/+0345/-0330 must render the correct wall clock via the numeric
+    shift fallback (review #7155: Etc/GMT cannot express them)."""
+    cases = {
+        "+0530": "18:30",  # Asia/Kolkata
+        "+0345": "16:45",  # Asia/Kathmandu
+        "-0330": "09:30",  # Canada/Newfoundland
+    }
+    script = _GRAB_FORMATTER + r"""
+let _serverTzName = '';
+let _serverTz = process.env.TZ_OFFSET;
+const out = _formatInServerTz(new Date('2026-03-10T13:00:00Z'), {hour:'2-digit',minute:'2-digit',hour12:false});
+const expected = process.env.TZ_EXPECTED;
+if (out !== expected) {
+  console.error('OFFSET ' + _serverTz + ' WRONG: got ' + out + ' expected ' + expected);
+  process.exit(1);
+}
+console.log('OFFSET ' + _serverTz + ' OK: ' + out);
+"""
+    for tz, expected in cases.items():
+        env = dict(os.environ, TZ_OFFSET=tz, TZ_EXPECTED=expected)
+        proc = _node(script, env=env)
+        _assert_node_ok(proc, f"fractional offset {tz}")
+        assert f"OFFSET {tz} OK" in proc.stdout
+
+
+def test_formatter_offset_only_utc_renders_utc():
+    """Review #7155 bug 3: an offset-only payload of '+0000'/'-0000' (server
+    UTC, no IANA name) must render as UTC, NOT the browser's local zone. The
+    node process runs with TZ=America/New_York to prove the browser-local
+    fallback is not taken (13:00Z would read 08:00 there)."""
+    script = _GRAB_FORMATTER + r"""
+let _serverTzName = '';
+let _serverTz = process.env.TZ_OFFSET;
+const out = _formatInServerTz(new Date('2026-03-10T13:00:00Z'), {hour:'2-digit',minute:'2-digit',hour12:false});
+if (out !== '13:00') {
+  console.error('OFFSET-UTC WRONG (' + _serverTz + '): got ' + out + ' — browser-local fallback taken?');
+  process.exit(1);
+}
+console.log('OFFSET-UTC OK (' + _serverTz + '): ' + out);
+"""
+    for tz in ("+0000", "-0000"):
+        env = dict(os.environ, TZ="America/New_York", TZ_OFFSET=tz)
+        proc = _node(script, env=env)
+        _assert_node_ok(proc, f"offset-only UTC {tz}")
+        assert f"OFFSET-UTC OK ({tz})" in proc.stdout
+
+
+def test_panel_null_timestamps_and_wiring():
+    """The cron detail panel must render t('not_available') / t('never') for
+    null timestamps and route non-null timestamps through the server-tz
+    formatter. Executes the actual nextRun/lastRun computation lines from
+    static/panels.js with a stubbed formatter."""
+    script = r"""
+const fs = require('fs');
+const panels = fs.readFileSync('static/panels.js', 'utf8');
+const start = panels.indexOf('function _renderCronDetail(job){');
+const end = panels.indexOf('\nfunction ', start + 1);
+const body = panels.slice(start, end === -1 ? panels.length : end);
+const lines = body.split('\n').filter(l =>
+  /const (_fmtCronTz|_fmtCronTs|nextRun|lastRun) =/.test(l)
+).join('\n');
+const run = new Function('job', 't', '_formatInServerTz',
+  lines + '\nreturn { nextRun, lastRun };');
+const t = (k) => 'T(' + k + ')';
+const fmt = (d, o) => 'FMT:' + d.toISOString();
+// Null timestamps -> localized placeholders, no formatter call.
+let r = run({ next_run_at: null, last_run_at: null }, t, fmt);
+if (r.nextRun !== 'T(not_available)' || r.lastRun !== 'T(never)') {
+  console.error('NULL WRONG: ' + JSON.stringify(r)); process.exit(1);
+}
+// Non-null timestamps flow through the server-tz formatter as Dates.
+r = run({ next_run_at: '2026-03-10T13:00:00Z', last_run_at: '2026-03-09T22:00:00Z' }, t, fmt);
+if (r.nextRun !== 'FMT:2026-03-10T13:00:00.000Z' || r.lastRun !== 'FMT:2026-03-09T22:00:00.000Z') {
+  console.error('NON-NULL WRONG: ' + JSON.stringify(r)); process.exit(1);
+}
+console.log('PANEL OK');
+"""
+    proc = _node(script)
+    _assert_node_ok(proc, "panel null timestamps")
+    assert "PANEL OK" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Backend: server_tz_info publishes IANA name + offset, resolved per request
+# ---------------------------------------------------------------------------
 
 def test_server_tz_info_resolves_iana_name_from_env():
     """HERMES_TIMEZONE env var must be the highest-priority source for the
@@ -104,123 +223,93 @@ def test_server_tz_info_resolves_iana_name_from_env():
     assert isinstance(info["server_tz"], str) and info["server_tz"]
 
 
-def test_server_tz_info_does_not_use_cached_hermes_time():
-    """The helper must NOT depend on hermes_time's process-global cached tz
-    (review #7155: it stays stale after a config change until reset_cache)."""
+def test_server_tz_info_resolves_iana_name_from_config():
+    """Without the env var, the timezone key in config.yaml (read via the
+    mtime-aware _load_yaml_config_file) must supply the IANA name."""
     import api.routes as routes
 
-    helper_start = ROUTES_PY.find("def _server_tz_info")
-    helper_end = ROUTES_PY.find("\ndef ", helper_start + 1)
-    helper = ROUTES_PY[helper_start:helper_end]
-    # Exclude the docstring (which mentions hermes_time as a negative) —
-    # check only the executable body.
-    body_start = helper.find('"""', helper.find('"""') + 3) + 3
-    body = helper[body_start:]
-    assert "hermes_time" not in body, (
-        "_server_tz_info must not use the cached hermes_time resolver"
-    )
-    assert "import hermes_time" not in ROUTES_PY[:helper_start], (
-        "hermes_time must not be imported for _server_tz_info"
-    )
-    assert "_load_yaml_config_file" in helper, (
-        "_server_tz_info must read config via the mtime-aware reader"
-    )
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": ""}, clear=False):
+        with mock.patch.object(routes, "_load_yaml_config_file", return_value={"timezone": "Asia/Kolkata"}):
+            info = routes._server_tz_info()
+    assert info["server_tz_name"] == "Asia/Kolkata"
+
+
+def test_server_tz_info_picks_up_runtime_config_change():
+    """Review #7155 bug: the Agent's process-global hermes_time cache stays
+    stale after a config change. The WebUI resolver must read config per
+    request: two calls with different config.yaml contents must return
+    different IANA names (proves mtime-aware, non-cached resolution)."""
+    import api.routes as routes
+
+    configs = iter([{"timezone": "America/New_York"}, {"timezone": "Asia/Kolkata"}])
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": ""}, clear=False):
+        with mock.patch.object(
+            routes, "_load_yaml_config_file", side_effect=lambda _path: next(configs)
+        ):
+            first = routes._server_tz_info()
+            second = routes._server_tz_info()
+    assert first["server_tz_name"] == "America/New_York"
+    assert second["server_tz_name"] == "Asia/Kolkata"
+    assert first != second
+
+
+def test_server_tz_info_picks_up_runtime_env_change():
+    """A HERMES_TIMEZONE change between requests must be reflected on the next
+    response (per-request resolution, not a cached value)."""
+    import api.routes as routes
+
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": "America/New_York"}, clear=False):
+        first = routes._server_tz_info()
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": "Europe/London"}, clear=False):
+        second = routes._server_tz_info()
+    assert first["server_tz_name"] == "America/New_York"
+    assert second["server_tz_name"] == "Europe/London"
+
+
+def test_session_list_payload_includes_server_tz_name_and_offset():
+    """The /api/sessions response payload must carry both server_tz_name and
+    server_tz, with the per-request resolved IANA name."""
+    import api.routes as routes
+
+    with mock.patch.object(routes, "_session_list_cache_overlay_runtime_rows", return_value=[]):
+        with mock.patch.object(routes, "load_settings", return_value={}):
+            with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": "Asia/Kolkata"}, clear=False):
+                resp = routes._session_list_payload_to_response({})
+    assert resp["server_tz_name"] == "Asia/Kolkata"
+    assert isinstance(resp["server_tz"], str) and resp["server_tz"]
 
 
 def test_server_tz_info_falls_back_to_server_local_zone():
-    """With no env/config timezone, the helper must fall back to the
-    server-local zone name (never an empty IANA name)."""
+    """With no env/config timezone, the helper must fall back to a non-empty
+    server-local IANA name (e.g. 'UTC' or the process zone)."""
     import api.routes as routes
 
-    with mock.patch.dict(os.environ, {}, clear=False):
+    with mock.patch.dict(os.environ, {"HERMES_TIMEZONE": ""}, clear=False):
         with mock.patch.object(routes, "_load_yaml_config_file", return_value={}):
             info = routes._server_tz_info()
-    # Server-local zone (e.g. "Etc/UTC" or "America/Sao_Paulo") — non-empty.
     assert isinstance(info["server_tz_name"], str)
     assert info["server_tz_name"].strip() != ""
     assert isinstance(info["server_tz"], str) and info["server_tz"]
 
 
-# ---------------------------------------------------------------------------
-# Behavioral: DST correctness (the core of review #7155)
-# ---------------------------------------------------------------------------
-
-def test_iana_path_behavior_dst_transition():
-    """Simulate the browser path across a DST boundary: with an IANA name the
-    offset for a winter instant differs from a summer instant (New York:
-    Jan = UTC-5, Jul = UTC-4). Uses Node to execute the real formatter."""
-    import subprocess
-
-    script = r"""
-const fs = require('fs');
-const src = fs.readFileSync('static/sessions.js', 'utf8');
-// Extract the two functions we need by slicing from their defs.
-function grab(name) {
-  const start = src.indexOf('function ' + name);
-  const end = src.indexOf('\nfunction ', start + 1);
-  return src.slice(start, end === -1 ? src.length : end);
-}
-let _serverTzName = 'America/New_York';
-let _serverTz = '-0500';
-const fns = grab('_formatInServerTz');
-eval(fns);
-const winter = new Date('2026-01-15T12:00:00Z'); // NY winter: EST (UTC-5) -> 07:00
-const summer = new Date('2026-07-15T12:00:00Z'); // NY summer: EDT (UTC-4) -> 08:00
-const w = _formatInServerTz(winter, {hour:'2-digit',minute:'2-digit',hour12:false});
-const s = _formatInServerTz(summer, {hour:'2-digit',minute:'2-digit',hour12:false});
-// Hours must DIFFER across the DST boundary (7 vs 8), proving per-instant resolution.
-const wH = parseInt(w.split(':')[0], 10);
-const sH = parseInt(s.split(':')[0], 10);
-if (wH === sH) { console.error('DST NOT RESOLVED: winter=' + w + ' summer=' + s); process.exit(1); }
-console.log('DST OK: winter=' + w + ' summer=' + s);
-"""
-    import tempfile
-    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
-        f.write(script)
-        script_path = f.name
-    try:
-        proc = subprocess.run(
-            ["node", script_path], cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=30
-        )
-    finally:
-        os.unlink(script_path)
-    assert proc.returncode == 0, f"node DST check failed: {proc.stderr}\n{proc.stdout}"
-    assert "DST OK" in proc.stdout
-
-
-def test_iana_path_behavior_configured_utc():
-    """A configured-UTC zone must render as UTC (review #7155 bug 2), not
-    fall back to the browser's local zone."""
-    import subprocess
-    import tempfile
-
-    script = r"""
-const fs = require('fs');
-const src = fs.readFileSync('static/sessions.js', 'utf8');
-function grab(name) {
-  const start = src.indexOf('function ' + name);
-  const end = src.indexOf('\nfunction ', start + 1);
-  return src.slice(start, end === -1 ? src.length : end);
-}
-let _serverTzName = 'UTC';
-let _serverTz = '+0000';
-eval(grab('_formatInServerTz'));
-const out = _formatInServerTz(new Date('2026-03-10T13:00:00Z'), {hour:'2-digit',minute:'2-digit',hour12:false});
-const h = parseInt(out.split(':')[0], 10);
-if (h !== 13) { console.error('CONFIGURED UTC WRONG: got ' + out); process.exit(1); }
-console.log('UTC OK: ' + out);
-"""
-    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
-        f.write(script)
-        script_path = f.name
-    try:
-        proc = subprocess.run(
-            ["node", script_path], cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=30
-        )
-    finally:
-        os.unlink(script_path)
-    assert proc.returncode == 0, f"node UTC check failed: {proc.stderr}\n{proc.stdout}"
-    assert "UTC OK" in proc.stdout
+def test_server_tz_info_does_not_use_cached_hermes_time():
+    """Structural guard: the helper must not import or call hermes_time's
+    process-global cached resolver (review #7155: stale until reset_cache)."""
+    ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    helper_start = ROUTES_PY.find("def _server_tz_info")
+    helper_end = ROUTES_PY.find("\ndef ", helper_start + 1)
+    helper = ROUTES_PY[helper_start:helper_end]
+    # Exclude the docstring (which mentions hermes_time as a negative) — check
+    # only the executable body.
+    body_start = helper.find('"""', helper.find('"""') + 3) + 3
+    body = helper[body_start:]
+    assert "hermes_time" not in body, (
+        "_server_tz_info must not use the cached hermes_time resolver"
+    )
+    assert "import hermes_time" not in ROUTES_PY[:helper_start]
+    assert "_load_yaml_config_file" in helper, (
+        "_server_tz_info must read config via the mtime-aware reader"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The cron detail panel rendered **Last run** and **Next run** in the *browser's* timezone instead of the server's configured Hermes timezone. A job that fires at `08:00` server-local showed `1:35 AM` (UTC) to operators whose browser is on UTC — the cron fires correctly; only the displayed timestamp was wrong, which read as a scheduling bug.

## Root Cause

1. **`api/routes.py`** sent `"server_tz": time.strftime("%z")`. `time.strftime("%z")` returns the offset of the **process/container** timezone (typically UTC in Docker), not the Hermes-configured timezone (`HERMES_TIMEZONE` env var / `timezone` key in `config.yaml`). The client's `_serverTz` was therefore always `+0000`, which `_formatInServerTz` treats as "absent" — falling back to browser time.
2. **`static/panels.js`** (`_renderCronDetail`) formatted the timestamps with bare browser converters and never called `_formatInServerTz`:
   ```js
   const nextRun = job.next_run_at ? new Date(job.next_run_at).toLocaleString() : t('not_available');
   const lastRun = job.last_run_at ? new Date(job.last_run_at).toLocaleString() : t('never');
   ```

## Change

- **`api/routes.py`**: added `_server_tz_offset()` which derives the offset from the **Hermes** timezone via `hermes_time.now().strftime("%z")` (resolves `HERMES_TIMEZONE` → `config.yaml` `timezone` → server-local), with a fallback to `time.strftime("%z")` and a final `"+0000"` so the value is never empty. `/api/sessions` now sends `"server_tz": _server_tz_offset()`.
- **`static/panels.js`**: cron detail **Last run / Next run** now format via `_formatInServerTz` (the server-tz helper from `sessions.js`, which handles fractional-hour offsets such as `+0530` correctly), guarded with `typeof _formatInServerTz === 'function'` — the same pattern already used in `ui.js`. Falls back to browser-local formatting if the helper is unavailable; `t('not_available')` / `t('never')` handling is preserved.

No new dependencies; vanilla JS as per repo convention.

## Verification

- New regression tests in `tests/test_7140_cron_panel_server_tz.py` (static checks following the repo's existing pattern, e.g. `tests/test_issue1144_session_time_sync.py`):
  - cron detail panel must reference `_formatInServerTz` and must not render `next_run_at` / `last_run_at` via bare `toLocaleString()`;
  - `api/routes.py` must define `_server_tz_offset()` preferring `hermes_time`, with `server_tz` wired to it.
- Confirmed the tests **fail on `master`** (pre-fix content has none of the required references) and **pass on this branch**:
  ```
  tests/test_7140_cron_panel_server_tz.py ..        [100%]
  2 passed
  ```
- Runtime check of the new helper: `_server_tz_offset()` returns `-0300` (Hermes-configured zone) instead of the container's `+0000`.

**Siblings considered:** `_loadCronDetailRuns` computes a `dateStr` via `toLocaleString()` but it is unused in the rendered template — left untouched to keep this diff minimal.

## Closes #7140
