### PR TITLE
fix(profiles): show display_name in profile panel (#7151)

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2138,7 +2138,7 @@ def list_profiles_api() -> list:
             enabled_count, total_count = _get_profile_skills_stats(p.path)
             result.append({
                 'name': p.name,
-                'display_name': str(getattr(p, 'display_name', '') or '').strip()
+                'display_name': _normalize_display_name(getattr(p, 'display_name', ''))
                     or _profile_display_name_from_meta(p.path),
                 'path': str(p.path),
                 'is_default': p.is_default,
@@ -2192,7 +2192,21 @@ def _profile_display_name_from_meta(profile_path: Path) -> str:
     if not isinstance(data, dict):
         return ''
     display_name = data.get('display_name')
-    return str(display_name).strip() if display_name else ''
+    return _normalize_display_name(display_name)
+
+
+def _normalize_display_name(value) -> str:
+    """Return ``value.strip()`` when it is a real string, else ''.
+
+    A non-string ``display_name`` in profile.yaml (e.g. ``[friendly]``
+    parsed as a list, or an integer) must fall back to the canonical label
+    instead of being stringified as ``['friendly']`` / ``42`` (review
+    #7156). ``str(...)`` on a truthy non-string is exactly the bug this
+    guards against — only strings are valid presentation labels.
+    """
+    if not isinstance(value, str):
+        return ''
+    return value.strip()
 
 
 def _default_profile_dict() -> dict:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2002,6 +2002,7 @@ def _build_profile_rows_fast() -> list | None:
         enabled_count, total_count = _get_profile_skills_stats(home)
         return {
             'name': name,
+            'display_name': _profile_display_name_from_meta(home),
             'path': str(home),
             'is_default': is_default,
             'is_active': False,  # filled in by caller (cheap, varies per request)
@@ -2070,6 +2071,7 @@ def list_profiles_api() -> list:
                     enabled_count, total_count = _get_profile_skills_stats(p.path)
                     return [{
                         'name': p.name,
+                        'display_name': _profile_display_name_from_meta(p.path),
                         'path': str(p.path),
                         'is_default': p.is_default,
                         'is_active': True,  # Always true in isolated mode
@@ -2088,6 +2090,7 @@ def list_profiles_api() -> list:
         enabled_count, total_count = _get_profile_skills_stats(hermes_home)
         return [{
             'name': active,
+            'display_name': _profile_display_name_from_meta(hermes_home),
             'path': str(hermes_home),
             'is_default': active == 'default',
             'is_active': True,
@@ -2135,6 +2138,8 @@ def list_profiles_api() -> list:
             enabled_count, total_count = _get_profile_skills_stats(p.path)
             result.append({
                 'name': p.name,
+                'display_name': str(getattr(p, 'display_name', '') or '').strip()
+                    or _profile_display_name_from_meta(p.path),
                 'path': str(p.path),
                 'is_default': p.is_default,
                 'is_active': p.name == active,
@@ -2168,11 +2173,34 @@ def _profile_visible_from_meta(profile_path: Path) -> bool:
     return visible is not False
 
 
+def _profile_display_name_from_meta(profile_path: Path) -> str:
+    """Return the presentation-only ``display_name`` from profile.yaml, or ''.
+
+    Mirrors upstream ``hermes_cli.profiles``: the canonical profile id lives
+    in the directory name (and is what all resolution/comparison code uses);
+    ``display_name`` is optional display-only metadata (e.g. a renamed
+    default profile). Never raises — a missing/corrupt profile.yaml on an
+    unrelated profile must not break the profile list.
+    """
+    try:
+        meta_path = Path(profile_path) / 'profile.yaml'
+        if not meta_path.exists():
+            return ''
+        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
+    except Exception:
+        return ''
+    if not isinstance(data, dict):
+        return ''
+    display_name = data.get('display_name')
+    return str(display_name).strip() if display_name else ''
+
+
 def _default_profile_dict() -> dict:
     """Fallback profile dict when hermes_cli is not importable."""
     enabled_count, compatible_count = _get_profile_skills_stats(_DEFAULT_HERMES_HOME)
     return {
         'name': 'default',
+        'display_name': _profile_display_name_from_meta(_DEFAULT_HERMES_HOME),
         'path': str(_DEFAULT_HERMES_HOME),
         'is_default': True,
         'is_active': True,

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2138,8 +2138,7 @@ def list_profiles_api() -> list:
             enabled_count, total_count = _get_profile_skills_stats(p.path)
             result.append({
                 'name': p.name,
-                'display_name': _normalize_display_name(getattr(p, 'display_name', ''))
-                    or _profile_display_name_from_meta(p.path),
+                'display_name': _profile_display_name_from_meta(p.path) if (p.path / "profile.yaml").exists() else _normalize_display_name(getattr(p, 'display_name', '')),
                 'path': str(p.path),
                 'is_default': p.is_default,
                 'is_active': p.name == active,

--- a/static/panels.js
+++ b/static/panels.js
@@ -6640,6 +6640,18 @@ function _refreshProfileSwitchBackground(gen){
   }).catch(function(){});
 }
 
+function _profileDisplayLabel(p){
+  // Mirror upstream hermes_cli.profiles.format_profile_label: render the
+  // presentation-only display_name (e.g. a renamed default profile) as
+  // "display_name (canonical_id)", falling back to the bare canonical id
+  // when no display_name is set (or it equals the id) — byte-for-byte the
+  // pre-feature rendering. The canonical name always stays the programmatic
+  // identity (switching, data-name, matching).
+  const dn = p && typeof p.display_name === 'string' ? p.display_name.trim() : '';
+  const name = p && typeof p.name === 'string' ? p.name : '';
+  return dn && dn !== name ? `${dn} (${name})` : name;
+}
+
 async function loadProfilesPanel() {
   const panel = $('profilesPanel');
   if (!panel) return;
@@ -6699,7 +6711,7 @@ async function loadProfilesPanel() {
       card.innerHTML = `
         <div class="profile-card-header">
           <div style="min-width:0;flex:1">
-            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}${hiddenBadge}</div>
+            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(_profileDisplayLabel(p))}${defaultBadge}${activeBadge}${hiddenBadge}</div>
             ${meta.length ? `<div class="profile-card-meta">${esc(meta.join(' \u00b7 '))}</div>` : `<div class="profile-card-meta">${esc(t('profile_no_configuration'))}</div>`}
           </div>
         </div>`;
@@ -6747,7 +6759,7 @@ function _renderProfileDetail(p, activeName){
   const body = $('profileDetailBody');
   const empty = $('profileDetailEmpty');
   if (!title || !body) return;
-  title.textContent = p.name;
+  title.textContent = _profileDisplayLabel(p);
   const isActive = p.name === activeName;
   const isDefault = !!p.is_default;
   const statusBadge = isActive
@@ -6871,7 +6883,7 @@ function renderProfileDropdown(data) {
     const gwDot = `<span class="profile-opt-badge ${p.gateway_running ? 'running' : 'stopped'}"></span>`;
     const checkmark = p.name === active ? ' <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--link)" stroke-width="3" style="vertical-align:-1px"><polyline points="20 6 9 17 4 12"/></svg>' : '';
     const defaultBadge = p.is_default ? ` <span style="opacity:.5;font-weight:400">${esc(t('profile_default_label'))}</span>` : '';
-    opt.innerHTML = `<div class="profile-opt-name">${gwDot}${esc(p.name)}${defaultBadge}${checkmark}</div>` +
+    opt.innerHTML = `<div class="profile-opt-name">${gwDot}${esc(_profileDisplayLabel(p))}${defaultBadge}${checkmark}</div>` +
       (meta.length ? `<div class="profile-opt-meta">${esc(meta.join(' \u00b7 '))}</div>` : '');
     opt.onclick = async () => {
       closeProfileDropdown();

--- a/tests/test_issue7151_profile_display_name.py
+++ b/tests/test_issue7151_profile_display_name.py
@@ -120,6 +120,36 @@ class TestApiPayload:
         assert result["malformed"]["display_name"] == ""
         assert result["empty"]["display_name"] == ""
 
+    def test_display_name_non_string_falls_back_to_canonical(self, monkeypatch, tmp_path):
+        """Review #7156: a non-string display_name (list / int / dict in
+        profile.yaml, or a non-string ProfileInfo attr) must render as the
+        bare canonical label — never stringified garbage like
+        '['friendly'] (default)' or '42 (default)'."""
+        cases = {}
+        for name, raw in (("list-name", "[friendly]"), ("int-name", "42"),
+                          ("dict-name", "{friendly: true}")):
+            pdir = tmp_path / "profiles" / name
+            pdir.mkdir(parents=True)
+            (pdir / "profile.yaml").write_text(
+                f"display_name: {raw}\n", encoding="utf-8")
+            cases[name] = pdir
+        rows = [_profile_row(n, d) for n, d in cases.items()]
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+
+        for name in cases:
+            assert result[name]["display_name"] == "", (
+                f"non-string display_name in {name} must fall back to '' "
+                f"(got {result[name]['display_name']!r})")
+
+    def test_display_name_upstream_attr_non_string_falls_back(self, monkeypatch, tmp_path):
+        """Review #7156: same fallback when ProfileInfo.display_name is a
+        non-string (upstream attr path)."""
+        pdir = tmp_path / "profiles" / "int-attr"
+        pdir.mkdir(parents=True)
+        rows = [_profile_row("int-attr", pdir, display_name=42)]
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+        assert result["int-attr"]["display_name"] == ""
+
     def test_default_profile_dict_includes_display_name_key(self, monkeypatch):
         import api.profiles as profiles
 

--- a/tests/test_issue7151_profile_display_name.py
+++ b/tests/test_issue7151_profile_display_name.py
@@ -1,0 +1,189 @@
+"""Regression guards for #7151 — profile display_name in the Profiles panel.
+
+Hermes Agent lets the default (and named) profiles carry a presentation-only
+``display_name`` in profile.yaml (canonical id unchanged; the CLI renders it
+as ``display_name (canonical_id)``). The WebUI was rendering the canonical
+``name`` everywhere. These tests pin:
+
+  * /api/profiles includes ``display_name`` in every profile payload row
+    (from profile.yaml via the fast path, or from the upstream ProfileInfo
+    attr on the slow fallback path), while the canonical ``name`` stays the
+    programmatic identity;
+  * the panel card, detail title, and compose dropdown render the display
+    label instead of the bare canonical name, mirroring the CLI format.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import textwrap
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _profile_row(name: str, path: Path, *, is_default: bool = False, display_name: str = ""):
+    return SimpleNamespace(
+        name=name,
+        path=path,
+        is_default=is_default,
+        display_name=display_name,
+        gateway_running=False,
+        model=None,
+        provider=None,
+        has_env=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_profile_rows_cache():
+    import api.profiles as profiles
+
+    profiles._LIST_PROFILES_CACHE = None
+    yield
+    profiles._LIST_PROFILES_CACHE = None
+
+
+def _install_fake_hermes_profiles(monkeypatch, rows):
+    hermes_cli = types.ModuleType("hermes_cli")
+    profiles_mod = types.ModuleType("hermes_cli.profiles")
+    profiles_mod.list_profiles = lambda: rows
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.profiles", profiles_mod)
+
+
+def _call_list_profiles_api(monkeypatch, rows):
+    import api.profiles as profiles
+
+    _install_fake_hermes_profiles(monkeypatch, rows)
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    return profiles.list_profiles_api()
+
+
+class TestApiPayload:
+    def test_display_name_read_from_profile_yaml(self, monkeypatch, tmp_path):
+        renamed_default = tmp_path / "profiles" / "default"
+        worker = tmp_path / "profiles" / "worker"
+        for path in (renamed_default, worker):
+            path.mkdir(parents=True)
+        (renamed_default / "profile.yaml").write_text(
+            "display_name: programmer\nvisible: true\n", encoding="utf-8"
+        )
+
+        rows = [
+            _profile_row("default", renamed_default, is_default=True),
+            _profile_row("worker", worker),
+        ]
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+
+        assert result["default"]["display_name"] == "programmer"
+        assert result["worker"]["display_name"] == ""
+        # Canonical identity is untouched — display_name is presentation-only.
+        assert result["default"]["name"] == "default"
+        assert result["default"]["is_default"] is True
+
+    def test_display_name_from_upstream_profile_info_attr(self, monkeypatch, tmp_path):
+        profile_dir = tmp_path / "profiles" / "default"
+        profile_dir.mkdir(parents=True)
+
+        rows = [_profile_row("default", profile_dir, is_default=True, display_name="programmer")]
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+
+        assert result["default"]["display_name"] == "programmer"
+        assert result["default"]["name"] == "default"
+
+    def test_display_name_empty_when_unset_or_unreadable(self, monkeypatch, tmp_path):
+        missing = tmp_path / "profiles" / "missing-meta"
+        malformed = tmp_path / "profiles" / "malformed"
+        empty = tmp_path / "profiles" / "empty"
+        for path in (missing, malformed, empty):
+            path.mkdir(parents=True)
+        (malformed / "profile.yaml").write_text("display_name: [\n", encoding="utf-8")
+        (empty / "profile.yaml").write_text("display_name: ''\n", encoding="utf-8")
+
+        rows = [
+            _profile_row("missing-meta", missing),
+            _profile_row("malformed", malformed),
+            _profile_row("empty", empty),
+        ]
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+
+        assert result["missing-meta"]["display_name"] == ""
+        assert result["malformed"]["display_name"] == ""
+        assert result["empty"]["display_name"] == ""
+
+    def test_default_profile_dict_includes_display_name_key(self, monkeypatch):
+        import api.profiles as profiles
+
+        monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+
+        row = profiles._default_profile_dict()
+        assert isinstance(row["display_name"], str)
+        assert row["name"] == "default"
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"{signature} not found"
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError(f"could not find end of {signature}")
+
+
+class TestPanelRendering:
+    def test_label_helper_defined_and_used_by_panel_card(self):
+        assert "function _profileDisplayLabel(p){" in PANELS_JS
+        body = _function_body(PANELS_JS, "async function loadProfilesPanel()")
+        # The card must render the display label, not the bare canonical name.
+        assert "${esc(_profileDisplayLabel(p))}" in body
+        # ...but keep the canonical name as the programmatic identity.
+        assert "card.dataset.name = p.name;" in body
+        assert "openProfileDetail(p.name, card)" in body
+
+    def test_detail_title_uses_display_label(self):
+        body = _function_body(PANELS_JS, "function _renderProfileDetail(")
+        assert "title.textContent = _profileDisplayLabel(p);" in body
+
+    def test_dropdown_option_uses_display_label_but_switches_canonical(self):
+        body = _function_body(PANELS_JS, "function renderProfileDropdown(data)")
+        assert "${esc(_profileDisplayLabel(p))}" in body
+        # Switching must keep using the canonical name (programmatic identity).
+        assert "switchToProfile(p.name)" in body
+
+    def test_label_helper_mirrors_cli_format(self):
+        # Behavioral check (node): _profileDisplayLabel must render
+        # "display_name (canonical_id)" and fall back to the bare canonical id
+        # when display_name is unset or equals the id — matching upstream
+        # format_profile_label byte-for-byte for the pre-feature rendering.
+        helper = _function_body(PANELS_JS, "function _profileDisplayLabel(")
+        script = textwrap.dedent(
+            f"""
+            const assert = require('assert');
+            {helper}
+            assert.strictEqual(_profileDisplayLabel({{name: 'default', display_name: 'programmer'}}), 'programmer (default)');
+            assert.strictEqual(_profileDisplayLabel({{name: 'default', display_name: ''}}), 'default');
+            assert.strictEqual(_profileDisplayLabel({{name: 'default', display_name: 'default'}}), 'default');
+            assert.strictEqual(_profileDisplayLabel({{name: 'worker', display_name: ''}}), 'worker');
+            assert.strictEqual(_profileDisplayLabel({{name: 'worker', display_name: '  Worker  '}}), 'Worker (worker)');
+            assert.strictEqual(_profileDisplayLabel({{name: 'default'}}), 'default');
+            assert.strictEqual(_profileDisplayLabel(null), '');
+            """
+        )
+        subprocess.run(
+            ["node", "-e", script], cwd=REPO_ROOT, check=True, text=True, capture_output=True
+        )

--- a/tests/test_issue7151_profile_display_name.py
+++ b/tests/test_issue7151_profile_display_name.py
@@ -159,6 +159,24 @@ class TestApiPayload:
         assert isinstance(row["display_name"], str)
         assert row["name"] == "default"
 
+    def test_display_name_upstream_attr_pre_stringified_falls_back(self, monkeypatch, tmp_path):
+        """Review #7156 r2: upstream pre-stringified display_name (e.g. "['friendly']", "42", "True") must not bypass normalizer."""
+        cases = {
+            "list-str": ("[friendly]", "['friendly']"),
+            "int-str": ("42", "42"),
+            "bool-str": ("true", "True"),
+        }
+        rows = []
+        for name, (yaml_val, attr_val) in cases.items():
+            pdir = tmp_path / "profiles" / name
+            pdir.mkdir(parents=True)
+            (pdir / "profile.yaml").write_text(f"display_name: {yaml_val}\n", encoding="utf-8")
+            rows.append(_profile_row(name, pdir, display_name=attr_val))
+        result = {row["name"]: row for row in _call_list_profiles_api(monkeypatch, rows)}
+        for name in cases:
+            assert result[name]["display_name"] == "", (
+                f"pre-stringified display_name in {name} must fall back to '' "
+                f"(got {result[name]['display_name']!r})")
 
 def _function_body(src: str, signature: str) -> str:
     start = src.find(signature)

--- a/tests/test_profile_dropdown_fast_open.py
+++ b/tests/test_profile_dropdown_fast_open.py
@@ -103,6 +103,7 @@ def test_poisoned_profile_cache_opens_then_switches_after_fresh_refresh():
         PANELS_JS[
             PANELS_JS.index("let _profilesCache = null;") : PANELS_JS.index("async function _profileSwitchPanelLoad(){")
         ],
+        _function_body(PANELS_JS, "function _profileDisplayLabel("),
         _function_body(PANELS_JS, "function renderProfileDropdown(data) {"),
         _function_body(PANELS_JS, "function toggleProfileDropdown(e) {"),
         _function_body(PANELS_JS, "function closeProfileDropdown() {"),


### PR DESCRIPTION
## Summary
The Hermes WebUI **Profiles** panel shows the canonical profile id (e.g. `default`) as the visible label even when the profile carries a presentation-only `display_name` (e.g. `name: default` + `display_name: programmer`). The Hermes CLI renders such profiles as `programmer (default)` — the WebUI should mirror that.

## Root Cause
The `/api/profiles` payload only included the canonical `name` field, and the panel rendering (`loadProfilesPanel`, `_renderProfileDetail`, `renderProfileDropdown` in `static/panels.js`) used `p.name` directly for the visible label. `display_name` is supported upstream (`hermes_cli.profiles.ProfileInfo.display_name`, read from `<profile_dir>/profile.yaml`) but was never surfaced in the WebUI.

## Change
- **`api/profiles.py`**: every profile row in `list_profiles_api()` now carries `display_name` — read from `profile.yaml` via a new `_profile_display_name_from_meta()` helper (fast path, isolated mode, default fallback) and from the upstream `ProfileInfo.display_name` attr on the slow fallback path (with a `profile.yaml` file-read fallback for agent versions that don't populate the attr). Canonical `name` is untouched and remains the programmatic identity.
- **`static/panels.js`**: new `_profileDisplayLabel(p)` helper mirroring upstream `format_profile_label` — renders `display_name (canonical_id)` when `display_name` is set and differs from the id, otherwise the bare canonical id (byte-for-byte the pre-feature rendering). Used by the Profiles panel card, the profile detail title, and the compose-profile dropdown option. Switching/`data-name`/matching still use the canonical `name`.
- **Tests**: `tests/test_issue7151_profile_display_name.py` (API payload behavior for profile.yaml / upstream attr / unreadable meta, canonical-name preservation, static panel-rendering assertions, and a node behavioral check of `_profileDisplayLabel` matching the CLI format). `test_profile_dropdown_fast_open.py` now evals the new helper into its node harness.

## Verification
- New + neighboring profile tests: `pytest tests/test_issue7151_profile_display_name.py tests/test_issue3623_profile_visibility.py tests/test_profiles_route_endpoint.py tests/test_profile_dropdown_fast_open.py` → **19 passed**
- Neighboring suites (`test_issue1612_renamed_root_profile.py`, `test_issue2305_profile_create_seeds_skills.py`, `test_profile_skills_stats.py`, `test_issue4717_empty_profile_skeleton.py`, `test_issue4662_profile_switch_skeleton_static.py`) → **52 passed, 11 skipped** (pre-existing skips)
- No behavior change when no `display_name` is set (label falls back to canonical name).

Closes #7151
