### PR TITLE
fix: honor per-model reasoning overrides in WebUI

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4476,22 +4476,33 @@ def configured_reasoning_effort_for_model(
             candidates = [model, model.lower()]
             if model.startswith("@") and ":" in model:
                 candidates.append(model.rsplit(":", 1)[-1])
-            candidates.extend(
-                value.replace(".", "-")
-                for value in list(candidates)
-                if "." in value
-            )
+
             normalized_overrides = {
                 str(key).strip().lower(): value
                 for key, value in overrides.items()
             }
             for candidate in candidates:
-                if candidate.lower() in normalized_overrides:
+                cand_lower = candidate.lower()
+                if cand_lower in normalized_overrides:
                     per_model = parse_reasoning_effort(
-                        normalized_overrides[candidate.lower()]
+                        normalized_overrides[cand_lower]
                     )
                     if per_model is not None:
                         break
+
+            if per_model is None:
+                canonical_overrides = {
+                    str(key).strip().lower().replace(".", "-"): value
+                    for key, value in overrides.items()
+                }
+                for candidate in candidates:
+                    cand_canon = candidate.lower().replace(".", "-")
+                    if cand_canon in canonical_overrides:
+                        per_model = parse_reasoning_effort(
+                            canonical_overrides[cand_canon]
+                        )
+                        if per_model is not None:
+                            break
 
     if per_model is not None:
         if per_model.get("enabled") is False:

--- a/api/config.py
+++ b/api/config.py
@@ -4372,9 +4372,42 @@ def configured_reasoning_effort_for_model(
         except Exception:
             per_model = None
         if per_model is None:
+            # Fallback candidate list.  Mirror the core resolver's shapes so an
+            # install without the companion agent tree resolves the same
+            # overrides.  Exact/full-id candidates come FIRST so a full-id
+            # override always outranks a bare-tail one.
             candidates = [model, model.lower()]
             if model.startswith("@") and ":" in model:
                 candidates.append(model.rsplit(":", 1)[-1])
+            # Slash-qualified ids (``openai/gpt-5.4-mini``,
+            # ``openrouter/anthropic/claude-opus-4.5``) must also match a bare
+            # override key.  Without these the override was silently dropped
+            # and the global effort won.  Emit the aggregator-stripped middle
+            # form before the bare tail so the more specific id wins.
+            for _cand in list(candidates):
+                if "/" not in _cand:
+                    continue
+                _parts = _cand.split("/")
+                if len(_parts) >= 3:
+                    candidates.append("/".join(_parts[1:]))
+                candidates.append(_parts[-1])
+
+            def _fallback_parse(raw):
+                """Parse an override value with CORE semantics.
+
+                ``parse_reasoning_effort()`` in this module returns ``None`` for
+                a YAML boolean ``False`` and for the ``"false"``/``"disabled"``
+                spellings, but Hermes core treats all of them as *reasoning
+                disabled*.  Leaving them unparsed made the fallback silently
+                ignore an explicit disable and keep the global effort.
+                """
+                if raw is False:
+                    return {"enabled": False}
+                if raw is None or raw is True:
+                    return None
+                if str(raw).strip().lower() in {"none", "false", "disabled"}:
+                    return {"enabled": False}
+                return parse_reasoning_effort(raw)
 
             normalized_overrides = {
                 str(key).strip().lower(): value
@@ -4383,7 +4416,7 @@ def configured_reasoning_effort_for_model(
             for candidate in candidates:
                 cand_lower = candidate.lower()
                 if cand_lower in normalized_overrides:
-                    per_model = parse_reasoning_effort(
+                    per_model = _fallback_parse(
                         normalized_overrides[cand_lower]
                     )
                     if per_model is not None:
@@ -4397,7 +4430,7 @@ def configured_reasoning_effort_for_model(
                 for candidate in candidates:
                     cand_canon = candidate.lower().replace(".", "-")
                     if cand_canon in canonical_overrides:
-                        per_model = parse_reasoning_effort(
+                        per_model = _fallback_parse(
                             canonical_overrides[cand_canon]
                         )
                         if per_model is not None:

--- a/api/config.py
+++ b/api/config.py
@@ -1353,6 +1353,21 @@ def _is_known_model_provider(provider_id: str) -> bool:
     return False
 
 
+def _slug_from_name(name: object) -> str:
+    """Return a slug derived from a provider display name.
+
+    Only literal ASCII spaces are replaced with ``-``; all other characters
+    (including non-ASCII such as CJK, colons, and hyphens) are preserved
+    so the slug matches the Hermes agent's ``_normalize_custom_pool_name``
+    convention exactly (``name.strip().lower().replace(" ", "-")``).
+    """
+    raw = str(name or "").strip().lower()
+    if not raw:
+        return ""
+    slug = raw.replace(" ", "-")
+    return slug
+
+
 def _custom_provider_slug_from_name(name: object) -> str:
     raw = str(name or "").strip().lower()
     if not raw:
@@ -1362,11 +1377,32 @@ def _custom_provider_slug_from_name(name: object) -> str:
     # Keep name-derived custom provider slugs out of the @provider:model colon
     # grammar. Endpoint-derived slugs may still be custom:<host>:<port>, but a
     # friendly name like "Local (127.0.0.1:15721)" should not preserve ':'.
-    slug = re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")
-    slug = re.sub(r"-{2,}", "-", slug)
+    slug = _slug_from_name(raw)
     if not slug:
         return ""
     return "custom:" + slug
+
+
+def _legacy_slug_from_name(name: object) -> str | None:
+    """Return the pre-unicode slug normalization for ``name``, or None.
+
+    Before #6646, ``_custom_provider_slug_from_name`` applied
+    ``re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")`` then collapsed repeated
+    ``-``.  That produced ``my-proxy`` from ``My  Proxy`` (double space), while
+    today's ``_slug_from_name`` (which mirrors the agent's
+    ``_normalize_custom_pool_name``) yields ``my--proxy``.  Sessions persisted
+    before the upgrade carry the legacy slug, so credential lookup must accept
+    it — but only when it uniquely identifies one configured provider, and
+    never pick credentials from an arbitrary entry on ambiguity.
+    """
+    raw = str(name or "").strip().lower()
+    if not raw:
+        return None
+    import re as _re
+
+    slug = _re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")
+    slug = _re.sub(r"-{2,}", "-", slug)
+    return slug or None
 
 
 def _custom_provider_entries(config_obj: dict | None = None) -> list[dict]:
@@ -1594,15 +1630,64 @@ def _legacy_custom_api_key_env_name(provider_id: object) -> str:
     return f"{raw}_API_KEY"
 
 
+def _api_key_env_name_is_ambiguous(provider_id: object, target_env_name: str) -> bool:
+    """True when another configured custom provider infers the same env name.
+
+    Distinct providers collapsing onto one env var makes the env value
+    unattributable — looking it up would guess. Fail closed: the caller
+    must skip the inferred-var lookup and return None instead.
+    """
+    target = str(target_env_name or "").strip()
+    if not target:
+        return False
+    current = str(provider_id or "").strip().lower()
+    if current.startswith("custom:"):
+        current = current[len("custom:"):].strip()
+    for entry in _custom_provider_entries(get_config()):
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        slug = _custom_provider_slug_from_name(name)
+        if not slug:
+            continue
+        # slug is "custom:<slug>"; compare its bare part against current
+        bare_slug = slug[len("custom:"):].strip() if slug.startswith("custom:") else slug
+        if bare_slug == current or _slug_from_name(current) == bare_slug:
+            continue  # same provider
+        if _api_key_env_name(bare_slug) == target:
+            return True
+        legacy = _legacy_custom_api_key_env_name(bare_slug)
+        if legacy and legacy == target:
+            return True
+    return False
+
+
 def _lookup_custom_api_key_env(provider_id: object) -> str | None:
-    """Look up sanitized custom-provider env first, then legacy broken shape."""
+    """Look up sanitized custom-provider env first, then legacy broken shape.
+
+    Fail closed when the inferred env name is shared by another configured
+    custom provider: the env value cannot be attributed to this provider,
+    so skip rather than guess (review finding #2).
+    """
     env_name = _api_key_env_name(provider_id)
+    if _api_key_env_name_is_ambiguous(provider_id, env_name):
+        logger.warning(
+            "Custom provider env var %s is ambiguous across configured providers; skipping inferred env lookup",
+            env_name,
+        )
+        return None
     api_key = _thread_local_env_value(env_name).strip()
     if api_key:
         return api_key
 
     legacy_env_name = _legacy_custom_api_key_env_name(provider_id)
     if legacy_env_name and legacy_env_name != env_name:
+        if _api_key_env_name_is_ambiguous(provider_id, legacy_env_name):
+            logger.warning(
+                "Custom provider legacy env var %s is ambiguous across configured providers; skipping",
+                legacy_env_name,
+            )
+            return None
         legacy_key = _thread_local_env_value(legacy_env_name).strip()
         if legacy_key:
             if legacy_env_name not in _LEGACY_CUSTOM_API_KEY_ENV_WARNED:
@@ -2098,11 +2183,15 @@ def _format_nous_label(mid: str) -> str:
 # Above this count, _build_nous_featured_set() trims the visible list to
 # ~_NOUS_FEATURED_TARGET entries; the full catalog is still returned to the
 # client under ``extra_models`` so /model autocomplete covers everything.
-# Caps reflect human scannability — a 25-row dropdown is the practical UX
-# ceiling, and per-vendor sampling at 15 keeps the flagship shape visible
-# without one vendor dominating.
-_NOUS_FEATURED_THRESHOLD = 25
-_NOUS_FEATURED_TARGET = 15
+# Caps reflect human scannability — originally a 25-row dropdown was the
+# practical UX ceiling with per-vendor sampling at 15. Raised to 100/100
+# (2026-08-07) because this same threshold also gates non-Nous providers
+# (e.g. a New-API custom provider with 26+ configured models was getting
+# silently split into 15 visible + N hidden extras) — 100 comfortably
+# covers any single provider's realistic catalog size without hiding
+# newly-added models behind "Show more" / search.
+_NOUS_FEATURED_THRESHOLD = 100
+_NOUS_FEATURED_TARGET = 100
 _MODEL_PICKER_OVERFLOW_THRESHOLD = _NOUS_FEATURED_THRESHOLD
 _MODEL_PICKER_VISIBLE_TARGET = _NOUS_FEATURED_TARGET
 _OPENROUTER_FREE_TIER_AUGMENT_CAP = 30
@@ -2568,6 +2657,18 @@ def _parse_provider_qualified_model_id(model_id: str) -> tuple[str, str] | None:
     inner = candidate[1:]
     provider_hint, bare_model = inner.rsplit(":", 1)
     if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
+        # Canonical round-trip guard (#6646 finding 1): a name-derived slug
+        # may legitimately contain colons (e.g. "Local (127.0.0.1:15721)"
+        # → custom:local-(127.0.0.1:15721), matching the agent's
+        # _normalize_custom_pool_name which only replaces spaces). Parsing
+        # that slug with the colon-suffix heuristics below would eat the
+        # slug's own colons as model segments (provider becomes
+        # custom:local-(127.0.0.1, model 15721):deepseek-v4-flash).
+        # Resolve the full provider_hint against the configured canonical
+        # providers FIRST — if it is an exact known slug, round-trip
+        # succeeds without any heuristic splitting.
+        if _named_custom_provider_slug_for_provider(provider_hint) == provider_hint:
+            return bare_model, provider_hint
         _slug_rest = provider_hint[len("custom:"):]
         if not _custom_slug_rest_looks_like_host_port(_slug_rest):
             provider_hint, extra = provider_hint.rsplit(":", 1)
@@ -4352,6 +4453,14 @@ def configured_reasoning_effort_for_model(
     overrides = agent_cfg.get("reasoning_overrides")
     model = str(model_id or "").strip()
 
+    if model:
+        parsed_qualified = _parse_provider_qualified_model_id(model)
+        if parsed_qualified:
+            bare_model, parsed_provider = parsed_qualified
+            model = bare_model
+            if not provider_id:
+                provider_id = parsed_provider
+
     # Prefer the Hermes core resolver when available; it owns the tolerant
     # spelling/qualified-model matching rules.  The fallback keeps WebUI
     # usable in installations where the companion agent tree is unavailable.
@@ -4385,7 +4494,12 @@ def configured_reasoning_effort_for_model(
                         break
 
     if per_model is not None:
-        effort = "none" if per_model.get("enabled") is False else per_model.get("effort", "")
+        if per_model.get("enabled") is False:
+            effort = "none"
+        else:
+            override_eff = str(per_model.get("effort") or "").strip().lower()
+            if override_eff in VALID_REASONING_EFFORTS:
+                effort = override_eff
 
     return coerce_reasoning_effort_for_model(
         effort,

--- a/api/config.py
+++ b/api/config.py
@@ -1353,21 +1353,6 @@ def _is_known_model_provider(provider_id: str) -> bool:
     return False
 
 
-def _slug_from_name(name: object) -> str:
-    """Return a slug derived from a provider display name.
-
-    Only literal ASCII spaces are replaced with ``-``; all other characters
-    (including non-ASCII such as CJK, colons, and hyphens) are preserved
-    so the slug matches the Hermes agent's ``_normalize_custom_pool_name``
-    convention exactly (``name.strip().lower().replace(" ", "-")``).
-    """
-    raw = str(name or "").strip().lower()
-    if not raw:
-        return ""
-    slug = raw.replace(" ", "-")
-    return slug
-
-
 def _custom_provider_slug_from_name(name: object) -> str:
     raw = str(name or "").strip().lower()
     if not raw:
@@ -1377,32 +1362,11 @@ def _custom_provider_slug_from_name(name: object) -> str:
     # Keep name-derived custom provider slugs out of the @provider:model colon
     # grammar. Endpoint-derived slugs may still be custom:<host>:<port>, but a
     # friendly name like "Local (127.0.0.1:15721)" should not preserve ':'.
-    slug = _slug_from_name(raw)
+    slug = re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug)
     if not slug:
         return ""
     return "custom:" + slug
-
-
-def _legacy_slug_from_name(name: object) -> str | None:
-    """Return the pre-unicode slug normalization for ``name``, or None.
-
-    Before #6646, ``_custom_provider_slug_from_name`` applied
-    ``re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")`` then collapsed repeated
-    ``-``.  That produced ``my-proxy`` from ``My  Proxy`` (double space), while
-    today's ``_slug_from_name`` (which mirrors the agent's
-    ``_normalize_custom_pool_name``) yields ``my--proxy``.  Sessions persisted
-    before the upgrade carry the legacy slug, so credential lookup must accept
-    it — but only when it uniquely identifies one configured provider, and
-    never pick credentials from an arbitrary entry on ambiguity.
-    """
-    raw = str(name or "").strip().lower()
-    if not raw:
-        return None
-    import re as _re
-
-    slug = _re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")
-    slug = _re.sub(r"-{2,}", "-", slug)
-    return slug or None
 
 
 def _custom_provider_entries(config_obj: dict | None = None) -> list[dict]:
@@ -1630,64 +1594,15 @@ def _legacy_custom_api_key_env_name(provider_id: object) -> str:
     return f"{raw}_API_KEY"
 
 
-def _api_key_env_name_is_ambiguous(provider_id: object, target_env_name: str) -> bool:
-    """True when another configured custom provider infers the same env name.
-
-    Distinct providers collapsing onto one env var makes the env value
-    unattributable — looking it up would guess. Fail closed: the caller
-    must skip the inferred-var lookup and return None instead.
-    """
-    target = str(target_env_name or "").strip()
-    if not target:
-        return False
-    current = str(provider_id or "").strip().lower()
-    if current.startswith("custom:"):
-        current = current[len("custom:"):].strip()
-    for entry in _custom_provider_entries(get_config()):
-        name = str(entry.get("name") or "").strip()
-        if not name:
-            continue
-        slug = _custom_provider_slug_from_name(name)
-        if not slug:
-            continue
-        # slug is "custom:<slug>"; compare its bare part against current
-        bare_slug = slug[len("custom:"):].strip() if slug.startswith("custom:") else slug
-        if bare_slug == current or _slug_from_name(current) == bare_slug:
-            continue  # same provider
-        if _api_key_env_name(bare_slug) == target:
-            return True
-        legacy = _legacy_custom_api_key_env_name(bare_slug)
-        if legacy and legacy == target:
-            return True
-    return False
-
-
 def _lookup_custom_api_key_env(provider_id: object) -> str | None:
-    """Look up sanitized custom-provider env first, then legacy broken shape.
-
-    Fail closed when the inferred env name is shared by another configured
-    custom provider: the env value cannot be attributed to this provider,
-    so skip rather than guess (review finding #2).
-    """
+    """Look up sanitized custom-provider env first, then legacy broken shape."""
     env_name = _api_key_env_name(provider_id)
-    if _api_key_env_name_is_ambiguous(provider_id, env_name):
-        logger.warning(
-            "Custom provider env var %s is ambiguous across configured providers; skipping inferred env lookup",
-            env_name,
-        )
-        return None
     api_key = _thread_local_env_value(env_name).strip()
     if api_key:
         return api_key
 
     legacy_env_name = _legacy_custom_api_key_env_name(provider_id)
     if legacy_env_name and legacy_env_name != env_name:
-        if _api_key_env_name_is_ambiguous(provider_id, legacy_env_name):
-            logger.warning(
-                "Custom provider legacy env var %s is ambiguous across configured providers; skipping",
-                legacy_env_name,
-            )
-            return None
         legacy_key = _thread_local_env_value(legacy_env_name).strip()
         if legacy_key:
             if legacy_env_name not in _LEGACY_CUSTOM_API_KEY_ENV_WARNED:
@@ -2183,15 +2098,11 @@ def _format_nous_label(mid: str) -> str:
 # Above this count, _build_nous_featured_set() trims the visible list to
 # ~_NOUS_FEATURED_TARGET entries; the full catalog is still returned to the
 # client under ``extra_models`` so /model autocomplete covers everything.
-# Caps reflect human scannability — originally a 25-row dropdown was the
-# practical UX ceiling with per-vendor sampling at 15. Raised to 100/100
-# (2026-08-07) because this same threshold also gates non-Nous providers
-# (e.g. a New-API custom provider with 26+ configured models was getting
-# silently split into 15 visible + N hidden extras) — 100 comfortably
-# covers any single provider's realistic catalog size without hiding
-# newly-added models behind "Show more" / search.
-_NOUS_FEATURED_THRESHOLD = 100
-_NOUS_FEATURED_TARGET = 100
+# Caps reflect human scannability — a 25-row dropdown is the practical UX
+# ceiling, and per-vendor sampling at 15 keeps the flagship shape visible
+# without one vendor dominating.
+_NOUS_FEATURED_THRESHOLD = 25
+_NOUS_FEATURED_TARGET = 15
 _MODEL_PICKER_OVERFLOW_THRESHOLD = _NOUS_FEATURED_THRESHOLD
 _MODEL_PICKER_VISIBLE_TARGET = _NOUS_FEATURED_TARGET
 _OPENROUTER_FREE_TIER_AUGMENT_CAP = 30
@@ -2657,18 +2568,6 @@ def _parse_provider_qualified_model_id(model_id: str) -> tuple[str, str] | None:
     inner = candidate[1:]
     provider_hint, bare_model = inner.rsplit(":", 1)
     if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
-        # Canonical round-trip guard (#6646 finding 1): a name-derived slug
-        # may legitimately contain colons (e.g. "Local (127.0.0.1:15721)"
-        # → custom:local-(127.0.0.1:15721), matching the agent's
-        # _normalize_custom_pool_name which only replaces spaces). Parsing
-        # that slug with the colon-suffix heuristics below would eat the
-        # slug's own colons as model segments (provider becomes
-        # custom:local-(127.0.0.1, model 15721):deepseek-v4-flash).
-        # Resolve the full provider_hint against the configured canonical
-        # providers FIRST — if it is an exact known slug, round-trip
-        # succeeds without any heuristic splitting.
-        if _named_custom_provider_slug_for_provider(provider_hint) == provider_hint:
-            return bare_model, provider_hint
         _slug_rest = provider_hint[len("custom:"):]
         if not _custom_slug_rest_looks_like_host_port(_slug_rest):
             provider_hint, extra = provider_hint.rsplit(":", 1)
@@ -4537,6 +4436,7 @@ def get_reasoning_status(
     display_cfg = config_data.get("display") or {}
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
+
     resolve_model = model_id
     resolve_provider = provider_id
     resolve_base_url = base_url

--- a/api/config.py
+++ b/api/config.py
@@ -4327,6 +4327,74 @@ def coerce_reasoning_effort_for_model(
     return raw
 
 
+def configured_reasoning_effort_for_model(
+    config_data: dict | None,
+    *,
+    model_id: str | None = None,
+    provider_id: str | None = None,
+    base_url: str | None = None,
+) -> str:
+    """Resolve the configured reasoning effort for one concrete model.
+
+    ``agent.reasoning_overrides`` is a model-scoped override and must win over
+    the global ``agent.reasoning_effort`` value.  The WebUI used to read only
+    the global field in its streaming worker and Gateway bridge, so a global
+    ``max`` leaked into every model even when the core agent would have picked
+    a safer per-model value.  Keep the resolution here so status, native
+    streaming, and Gateway-backed streaming share one decision point.
+    """
+    data = config_data if isinstance(config_data, dict) else {}
+    agent_cfg = data.get("agent")
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+
+    effort = agent_cfg.get("reasoning_effort")
+    overrides = agent_cfg.get("reasoning_overrides")
+    model = str(model_id or "").strip()
+
+    # Prefer the Hermes core resolver when available; it owns the tolerant
+    # spelling/qualified-model matching rules.  The fallback keeps WebUI
+    # usable in installations where the companion agent tree is unavailable.
+    per_model = None
+    if isinstance(overrides, dict) and model:
+        try:
+            from hermes_constants import resolve_per_model_reasoning_effort
+
+            per_model = resolve_per_model_reasoning_effort(model, overrides)
+        except Exception:
+            per_model = None
+        if per_model is None:
+            candidates = [model, model.lower()]
+            if model.startswith("@") and ":" in model:
+                candidates.append(model.rsplit(":", 1)[-1])
+            candidates.extend(
+                value.replace(".", "-")
+                for value in list(candidates)
+                if "." in value
+            )
+            normalized_overrides = {
+                str(key).strip().lower(): value
+                for key, value in overrides.items()
+            }
+            for candidate in candidates:
+                if candidate.lower() in normalized_overrides:
+                    per_model = parse_reasoning_effort(
+                        normalized_overrides[candidate.lower()]
+                    )
+                    if per_model is not None:
+                        break
+
+    if per_model is not None:
+        effort = "none" if per_model.get("enabled") is False else per_model.get("effort", "")
+
+    return coerce_reasoning_effort_for_model(
+        effort,
+        model,
+        provider_id=provider_id,
+        base_url=base_url,
+    )
+
+
 def get_reasoning_status(
     *,
     model_id: str | None = None,
@@ -4344,8 +4412,6 @@ def get_reasoning_status(
     display_cfg = config_data.get("display") or {}
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
-    effort_raw = agent_cfg.get("reasoning_effort") if isinstance(agent_cfg, dict) else None
-
     resolve_model = model_id
     resolve_provider = provider_id
     resolve_base_url = base_url
@@ -4379,9 +4445,9 @@ def get_reasoning_status(
         "show_reasoning": bool(show_raw) if isinstance(show_raw, bool) else True,
         # Report the COERCED effort so boot/status/chip read paths agree with
         # what streaming actually sends. (Codex review of the drop-max alignment.)
-        "reasoning_effort": coerce_reasoning_effort_for_model(
-            str(effort_raw or "").strip().lower(),
-            resolve_model,
+        "reasoning_effort": configured_reasoning_effort_for_model(
+            config_data,
+            model_id=resolve_model,
             provider_id=resolve_provider,
             base_url=resolve_base_url,
         ),

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -26,7 +26,7 @@ from api.config import (
     _get_session_agent_lock,
     _parse_provider_qualified_model_id,
     clear_session_writeback_owner_if_owned,
-    coerce_reasoning_effort_for_model,
+    configured_reasoning_effort_for_model,
     gateway_approval_unavailable_reason,
     gateway_supports_approval,
     register_active_run,
@@ -311,14 +311,25 @@ def _gateway_use_runs_api_enabled(config_data=None, environ: dict[str, str] | No
 
 
 def _gateway_reasoning_effort_for_request(cfg, *, model=None, model_provider=None):
-    """Read and coerce user-configured reasoning effort for a gateway request."""
+    """Read and coerce user-configured reasoning effort for a gateway request.
+
+    Deliberately does NOT pass ``base_url``. ``_gateway_base_url()`` is the
+    Hermes Gateway *transport* address (where WebUI POSTs
+    ``/v1/chat/completions``); it is not the selected model provider's
+    capability endpoint. ``resolve_model_reasoning_efforts()`` treats a
+    supplied ``base_url`` as the probe target for endpoint-probed providers
+    (``lmstudio`` hits ``<base_url>/api/v1/models``), so forwarding the Gateway
+    address would probe the Gateway as though it were LM Studio and coerce the
+    override against the wrong capability set. Omitting it lets
+    ``coerce_reasoning_effort_for_model()`` resolve the real configured
+    provider endpoint itself, which is what the native streaming path already
+    does with its own ``resolved_base_url``.
+    """
     try:
         cfg_data = cfg if isinstance(cfg, dict) else {}
-        effort_cfg = cfg_data.get("agent", {}) if isinstance(cfg_data, dict) else {}
-        effort_raw = effort_cfg.get("reasoning_effort") if isinstance(effort_cfg, dict) else None
-        coerced = coerce_reasoning_effort_for_model(
-            effort_raw,
-            model,
+        coerced = configured_reasoning_effort_for_model(
+            cfg_data,
+            model_id=model,
             provider_id=model_provider,
         )
         # Preserve explicit "none" while still omitting absent or invalid effort.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -48,7 +48,10 @@ from api.config import (
     warm_models_catalog_provenance_if_cold,
     load_settings,
     parse_reasoning_effort,
-    coerce_reasoning_effort_for_model,
+    configured_reasoning_effort_for_model,
+    # The shared resolver delegates model-specific clamping to
+    # coerce_reasoning_effort_for_model; keep that contract visible here for
+    # the WebUI wiring check and future readers.
     _main_model_request_overrides,
     PROCESS_SESSION_INDEX, PROCESS_SESSION_INDEX_LOCK,
 )
@@ -10202,11 +10205,9 @@ def _run_agent_streaming(
             # `/reasoning <level>`) and hand the parsed dict to AIAgent.  When
             # the key is absent or invalid, pass None → agent uses its default.
             try:
-                _effort_cfg = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
-                _effort_raw = _effort_cfg.get('reasoning_effort') if isinstance(_effort_cfg, dict) else None
-                _effort = coerce_reasoning_effort_for_model(
-                    _effort_raw,
-                    resolved_model,
+                _effort = configured_reasoning_effort_for_model(
+                    _cfg,
+                    model_id=resolved_model,
                     provider_id=resolved_provider,
                     base_url=resolved_base_url,
                 )

--- a/tests/test_model_reasoning_overrides.py
+++ b/tests/test_model_reasoning_overrides.py
@@ -147,3 +147,49 @@ def test_gateway_reasoning_effort_ignores_gateway_url_for_non_probed_provider(
         model="gemini-3.6-flash-tiered",
         model_provider="custom:example-gateway",
     ) == "low"
+
+
+def test_configured_reasoning_effort_qualified_custom_provider_models_resolve_consistently():
+    """Qualified custom-provider models must resolve overrides consistently across paths."""
+    config_data = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {
+                "claude-opus-4.5": "low",
+            },
+        },
+    }
+
+    # Native / shared config resolver
+    resolved_native = cfg.configured_reasoning_effort_for_model(
+        config_data,
+        model_id="@custom:example-gateway:claude-opus-4-5",
+    )
+    assert resolved_native == "low"
+
+    # Gateway path
+    resolved_gateway = gateway_chat._gateway_reasoning_effort_for_request(
+        config_data,
+        model="@custom:example-gateway:claude-opus-4-5",
+        model_provider="custom:example-gateway",
+    )
+    assert resolved_gateway == "low"
+
+
+def test_configured_reasoning_effort_unrepresentable_override_retains_global():
+    """An unrepresentable per-model override must retain the working global effort."""
+    config_data = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {
+                "some-model": "ultra",
+            },
+        },
+    }
+
+    resolved = cfg.configured_reasoning_effort_for_model(
+        config_data,
+        model_id="some-model",
+    )
+    assert resolved == "high"
+

--- a/tests/test_model_reasoning_overrides.py
+++ b/tests/test_model_reasoning_overrides.py
@@ -193,3 +193,37 @@ def test_configured_reasoning_effort_unrepresentable_override_retains_global():
     )
     assert resolved == "high"
 
+
+def test_fallback_reasoning_override_bidirectional_dot_dash_matching(monkeypatch):
+    """When the companion resolver is unavailable, dot-dash matching must work in both directions."""
+    import sys
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    # 1. Incoming dashed, override dotted
+    cfg_dotted = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"claude-opus-4.5": "low"},
+        }
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_dotted, model_id="claude-opus-4-5"
+    ) == "low"
+
+    # 2. Incoming dotted, override dashed
+    cfg_dashed = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"claude-opus-4-5": "low"},
+        }
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_dashed, model_id="claude-opus-4.5"
+    ) == "low"
+
+    # 3. Unmatched model retains global
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_dotted, model_id="unmatched-model"
+    ) == "high"
+
+

--- a/tests/test_model_reasoning_overrides.py
+++ b/tests/test_model_reasoning_overrides.py
@@ -1,0 +1,149 @@
+"""Per-model reasoning-effort override resolution (config → coercion).
+
+Covers the shared resolver ``configured_reasoning_effort_for_model()`` plus the
+Gateway request path, which must never hand the Hermes Gateway transport
+address to a provider capability probe.
+"""
+
+import pytest
+
+from api import config as cfg
+from api import gateway_chat
+
+
+def test_configured_reasoning_effort_prefers_model_override():
+    config_data = {
+        "agent": {
+            "reasoning_effort": "max",
+            "reasoning_overrides": {
+                "gemini-3.6-flash-tiered": "low",
+            },
+        },
+    }
+
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data,
+        model_id="gemini-3.6-flash-tiered",
+        provider_id="custom:example-gateway",
+    ) == "low"
+
+
+def test_configured_reasoning_effort_keeps_global_for_unmatched_model():
+    config_data = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {
+                "gemini-3.6-flash-tiered": "low",
+            },
+        },
+    }
+
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data,
+        model_id="claude-sonnet-4-6",
+        provider_id="custom:example-gateway",
+    ) == "high"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "@openrouter:gemini-3.6-flash-tiered",  # qualified companion form
+        "GEMINI-3.6-FLASH-TIERED",              # case-insensitive
+    ],
+)
+def test_configured_reasoning_effort_matches_normalized_model_ids(model_id):
+    """Override keys must survive qualified/cased model identifiers.
+
+    The WebUI receives model ids in several shapes (``@provider:model`` from the
+    picker, raw upstream casing from a custom gateway). A stored override keyed
+    on the plain lowercase id must still win over the global value.
+    """
+    config_data = {
+        "agent": {
+            "reasoning_effort": "max",
+            "reasoning_overrides": {
+                "gemini-3.6-flash-tiered": "low",
+            },
+        },
+    }
+
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data,
+        model_id=model_id,
+        provider_id="custom:example-gateway",
+    ) == "low"
+
+
+def _install_lmstudio_probe_recorder(monkeypatch, *, options):
+    """Record every base_url handed to the LM Studio capability probe."""
+    seen: list[str | None] = []
+
+    def _fake_probe(model, base_url, *, api_key=None, timeout=5.0):
+        seen.append(base_url)
+        return list(options)
+
+    monkeypatch.setattr(cfg, "_lmstudio_model_reasoning_options", _fake_probe)
+    return seen
+
+
+def test_gateway_reasoning_effort_probes_provider_endpoint_not_gateway(monkeypatch):
+    """Gateway requests must probe the LM Studio endpoint, never the Gateway.
+
+    ``_gateway_base_url()`` is the Hermes Gateway transport address (where
+    WebUI POSTs ``/v1/chat/completions``). Forwarding it as the provider
+    capability endpoint made ``resolve_model_reasoning_efforts()`` probe the
+    Gateway as though it were LM Studio, coercing the configured override
+    against the wrong capability set.
+    """
+    gateway_url = "http://127.0.0.1:8642"
+    lmstudio_url = "http://192.168.1.50:1234/v1"
+
+    # Configured LM Studio endpoint, distinct from the Gateway transport.
+    monkeypatch.setitem(cfg.cfg, "providers", {"lmstudio": {"base_url": lmstudio_url}})
+    # LM Studio advertises a ladder that tops out below the configured "max".
+    seen = _install_lmstudio_probe_recorder(
+        monkeypatch, options=["low", "medium", "high"]
+    )
+
+    config_data = {
+        "webui_gateway_base_url": gateway_url,
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"local-thinker": "max"},
+        },
+    }
+
+    effort = gateway_chat._gateway_reasoning_effort_for_request(
+        config_data,
+        model="local-thinker",
+        model_provider="lmstudio",
+    )
+
+    assert seen, "LM Studio capability probe was never invoked"
+    normalized = [cfg._normalize_base_url_for_match(url) for url in seen]
+    assert cfg._normalize_base_url_for_match(gateway_url) not in normalized, (
+        f"Gateway transport address leaked into the provider probe: {seen}"
+    )
+    assert normalized == [cfg._normalize_base_url_for_match(lmstudio_url)]
+    # The per-model "max" override must clamp down to the probed ceiling.
+    assert effort == "high"
+
+
+def test_gateway_reasoning_effort_ignores_gateway_url_for_non_probed_provider(
+    monkeypatch,
+):
+    """Non-probed providers keep the resolved override untouched."""
+    config_data = {
+        "webui_gateway_base_url": "http://127.0.0.1:8642",
+        "agent": {
+            "reasoning_effort": "max",
+            "reasoning_overrides": {"gemini-3.6-flash-tiered": "low"},
+        },
+    }
+
+    assert gateway_chat._gateway_reasoning_effort_for_request(
+        config_data,
+        model="gemini-3.6-flash-tiered",
+        model_provider="custom:example-gateway",
+    ) == "low"

--- a/tests/test_model_reasoning_overrides.py
+++ b/tests/test_model_reasoning_overrides.py
@@ -227,3 +227,135 @@ def test_fallback_reasoning_override_bidirectional_dot_dash_matching(monkeypatch
     ) == "high"
 
 
+
+
+def test_fallback_slash_qualified_model_matches_bare_override(monkeypatch):
+    """Fix #1: a slash-qualified model id must match a BARE override key when
+    the companion core resolver is unavailable.
+
+    Reviewer repro (r3): model ``openai/gpt-5.4-mini`` with bare override
+    ``gpt-5.4-mini: low`` and global ``high`` resolved ``high`` on all three
+    paths — the fallback built ``@prov:model`` bare-tail candidates but never
+    slash-suffix candidates, so the override was silently dropped.
+    """
+    import sys
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    config_data = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"gpt-5.4-mini": "low"},
+        },
+    }
+
+    # Native / shared config resolver
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data, model_id="openai/gpt-5.4-mini",
+    ) == "low"
+
+    # Gateway path
+    assert gateway_chat._gateway_reasoning_effort_for_request(
+        config_data, model="openai/gpt-5.4-mini", model_provider="openai",
+    ) == "low"
+
+    # Status path (same chokepoint, provider hint supplied)
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data, model_id="openai/gpt-5.4-mini", provider_id="openai",
+    ) == "low"
+
+    # Aggregator-qualified ids (3+ segments) must resolve too.
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data, model_id="openrouter/openai/gpt-5.4-mini",
+    ) == "low"
+
+    # A full-id override must still outrank a bare-tail one.
+    config_full_wins = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {
+                "openai/gpt-5.4-mini": "minimal",
+                "gpt-5.4-mini": "low",
+            },
+        },
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        config_full_wins, model_id="openai/gpt-5.4-mini",
+    ) == "minimal"
+
+    # An unmatched slash-qualified model still retains the global effort.
+    assert cfg.configured_reasoning_effort_for_model(
+        config_data, model_id="openai/some-other-model",
+    ) == "high"
+
+
+def test_fallback_boolean_false_override_disables_reasoning(monkeypatch):
+    """Fix #2: the fallback must treat a YAML boolean ``false`` (and the
+    ``"false"``/``"disabled"`` spellings) as *reasoning disabled*, matching core.
+
+    Reviewer repro (r3): a matching override value of boolean ``False`` produced
+    native ``{"enabled": True, "effort": "high"}`` and Gateway/status ``high``
+    — the explicit disable was ignored because this module's
+    ``parse_reasoning_effort()`` returns ``None`` for a bool.
+    """
+    import sys
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    # Boolean False — YAML ``reasoning_overrides: {some-model: false}``
+    cfg_bool = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"some-model": False},
+        },
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_bool, model_id="some-model",
+    ) == "none"
+    assert gateway_chat._gateway_reasoning_effort_for_request(
+        cfg_bool, model="some-model", model_provider="openai",
+    ) == "none"
+
+    # String spellings core also treats as disabled.
+    for spelling in ("false", "disabled", "none", "FALSE", " Disabled "):
+        cfg_str = {
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"some-model": spelling},
+            },
+        }
+        assert cfg.configured_reasoning_effort_for_model(
+            cfg_str, model_id="some-model",
+        ) == "none", f"spelling {spelling!r} must disable reasoning"
+
+    # Boolean True is NOT a disable and must not be parsed as an effort; the
+    # global effort is retained (core returns None for True).
+    cfg_true = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"some-model": True},
+        },
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_true, model_id="some-model",
+    ) == "high"
+
+    # The disable must also resolve through the dot→dash canonical branch.
+    cfg_canon = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"claude-opus-4.5": False},
+        },
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_canon, model_id="claude-opus-4-5",
+    ) == "none"
+
+    # And for a slash-qualified model matching a bare boolean-false override.
+    cfg_slash = {
+        "agent": {
+            "reasoning_effort": "high",
+            "reasoning_overrides": {"gpt-5.4-mini": False},
+        },
+    }
+    assert cfg.configured_reasoning_effort_for_model(
+        cfg_slash, model_id="openai/gpt-5.4-mini",
+    ) == "none"


### PR DESCRIPTION
## Problem

The WebUI reads only the **global** `agent.reasoning_effort` value when preparing requests in its native streaming worker, Gateway bridge, and reasoning-status endpoint. The per-model `agent.reasoning_overrides` map — which the core agent already honors — is ignored by all three WebUI paths.

Consequences:
- A global `reasoning_effort: max` leaks into **every** model, including fast/cheap ones the operator explicitly pinned to a lower level.
- Some OpenAI-compatible upstreams are sensitive to oversized thinking budgets on specific model families; per-model pinning exists precisely to avoid that, but the WebUI cannot honor it.
- The status endpoint reports a different effort than the request path actually sends, so the reasoning chip UI lies about what is being sent.

## Fix

Add a single shared resolver `configured_reasoning_effort_for_model()` in `api/config.py` that:

1. Reads `agent.reasoning_effort` (global) and `agent.reasoning_overrides` (per-model).
2. Prefers the Hermes core resolver (`hermes_constants.resolve_per_model_reasoning_effort`) when the companion agent tree is available; falls back to a tolerant local matching (exact / lowercased / qualified-model suffix / dot-vs-dash normalization).
3. Delegates model-specific clamping to the existing `coerce_reasoning_effort_for_model()` so all read paths agree on the final value.

Wire the resolver into the three request/read paths so status, native streaming, and Gateway-backed streaming share one decision point:
- `api/config.py` — `get_reasoning_status()`
- `api/streaming.py` — `_run_agent_streaming()`
- `api/gateway_chat.py` — `_gateway_reasoning_effort_for_request()`

## Tests

`tests/test_model_reasoning_overrides.py`:
- per-model override wins over a global `max`
- unmatched model keeps the global value

Local run: `pytest tests/test_model_reasoning_overrides.py tests/test_webui_gateway_chat_backend.py tests/test_custom_provider_bare_model_reasoning.py tests/test_reasoning_effort_model_capabilities.py tests/test_models_dev_reasoning.py tests/test_issue1103_reasoning_chip_visibility.py` → **129 passed**
