### PR TITLE
fix: route to the custom_providers[] entry that owns the model, not the first sharing base_url (#7176)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1379,6 +1379,26 @@ def _custom_provider_entries(config_obj: dict | None = None) -> list[dict]:
 
 def _configured_model_ids(raw_models: object) -> list[str]:
     """Return ordered model IDs from supported config allowlist shapes."""
+    if isinstance(raw_models, str):
+        # ``models`` is occasionally persisted as a JSON-encoded string
+        # (e.g. round-tripped through a form field / API layer that
+        # serializes dict/list values) rather than a native dict/list. A
+        # bare string was previously always treated as "no allowlist" and
+        # silently dropped, which defeats model-ownership matching for any
+        # entry stored in that shape (same class of bug as #7134/#7165). Only
+        # accept a decoded list or dict — anything else (an invalid string,
+        # or a decoded scalar) is not a supported allowlist shape.
+        text = raw_models.strip()
+        if not text:
+            return []
+        try:
+            decoded = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        if isinstance(decoded, (list, dict)):
+            raw_models = decoded
+        else:
+            return []
     if isinstance(raw_models, dict):
         candidates = (key for key in raw_models if isinstance(key, str))
     elif isinstance(raw_models, list):
@@ -1550,7 +1570,16 @@ def _normalize_base_url_for_match(value: object) -> str:
     url = str(value or "").strip().rstrip("/")
     if not url:
         return ""
-    parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    try:
+        parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    except ValueError:
+        # Malformed URLs (e.g. an unbalanced "[" that urlparse treats as a
+        # bad IPv6 literal) must not abort resolution for every OTHER entry
+        # sharing the base_url being matched against — treat the entry as
+        # simply not matching rather than raising. See #7176 review: a valid
+        # first match followed by a malformed later config.yaml entry used to
+        # crash the whole scan and break provider resolution entirely.
+        return ""
     scheme = (parsed_url.scheme or "http").lower()
     netloc = (parsed_url.netloc or parsed_url.path).lower().rstrip("/")
     path = parsed_url.path.rstrip("/")
@@ -5654,7 +5683,9 @@ def _static_models_catalog_without_live_probes() -> dict:
 
         if cfg_base_url:
             detected_providers.add(
-                _named_custom_provider_slug_for_base_url(cfg_base_url, cfg)
+                _named_custom_provider_slug_for_base_url(
+                    cfg_base_url, cfg, model_id=default_model
+                )
                 or active_provider
                 or "custom"
             )
@@ -7309,10 +7340,19 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             if isinstance(model_cfg, dict):
                 model_base_url = _normalize_base_url_for_match(model_cfg.get("base_url"))
                 if model_base_url == target:
+                    # Pass default_model so a base_url shared by several named
+                    # custom providers resolves to the entry that actually
+                    # owns the configured default model, instead of always
+                    # the first declared entry (#7176). Without this, the
+                    # cold/uncached get_available_models() build path keeps
+                    # attributing the initial endpoint probe to the wrong
+                    # sibling provider even though active_provider elsewhere
+                    # in this function is resolved model-aware.
                     provider_hint = _resolve_configured_provider_id(
                         model_cfg.get("provider"),
                         cfg,
                         base_url=base_url,
+                        model_id=default_model,
                     )
                     if provider_hint:
                         return str(provider_hint).strip().lower()
@@ -7680,7 +7720,9 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 detected_providers.discard("custom")
 
         _named_custom_slugs = _named_custom_provider_slugs(cfg)
-        _base_matched_named_slug = _named_custom_provider_slug_for_base_url(cfg_base_url, cfg)
+        _base_matched_named_slug = _named_custom_provider_slug_for_base_url(
+            cfg_base_url, cfg, model_id=default_model
+        )
         if _base_matched_named_slug and _named_custom_slugs:
             for _pid in list(detected_providers):
                 _pid_norm = str(_pid or "").strip().lower()

--- a/api/config.py
+++ b/api/config.py
@@ -1452,6 +1452,7 @@ def _resolve_configured_provider_id(
     *,
     base_url: object = None,
     resolve_alias: bool = True,
+    model_id: object = None,
 ) -> str:
     """Normalize a configured provider id.
 
@@ -1464,6 +1465,11 @@ def _resolve_configured_provider_id(
     ``lmstudio``. The base-url-to-named-slug fallback still runs in both
     modes when applicable.
 
+    ``model_id``, when supplied, is forwarded to
+    ``_named_custom_provider_slug_for_base_url`` so a ``base_url`` shared by
+    several named custom providers resolves to the entry that actually owns
+    the requested model, instead of always the first one declared (#7176).
+
     See in-stage absorption note on stage-313 for the #1625 regression that
     motivated the ``resolve_alias`` flag.
     """
@@ -1474,7 +1480,9 @@ def _resolve_configured_provider_id(
     if not resolve_alias:
         raw = str(provider or "").strip().lower()
         if base_url and raw == "custom":
-            by_base_url = _named_custom_provider_slug_for_base_url(base_url, config_obj)
+            by_base_url = _named_custom_provider_slug_for_base_url(
+                base_url, config_obj, model_id=model_id
+            )
             if by_base_url:
                 return by_base_url
         return str(provider or "")
@@ -1484,7 +1492,9 @@ def _resolve_configured_provider_id(
         base_url
         and str(resolved or "").strip().lower() == "custom"
     ):
-        by_base_url = _named_custom_provider_slug_for_base_url(base_url, config_obj)
+        by_base_url = _named_custom_provider_slug_for_base_url(
+            base_url, config_obj, model_id=model_id
+        )
         if by_base_url:
             return by_base_url
 
@@ -1619,16 +1629,51 @@ def _lookup_custom_api_key_env(provider_id: object) -> str | None:
 def _named_custom_provider_slug_for_base_url(
     base_url: object,
     config_obj: dict | None = None,
+    *,
+    model_id: object = None,
 ) -> str:
+    """Resolve a ``custom_providers[]`` slug by matching ``base_url``.
+
+    Multiple named custom providers commonly share one physical endpoint
+    (e.g. an internal gateway fronting several APIs: an OpenAI-chat route, an
+    Anthropic-messages route, a Responses/codex route, all on the same
+    ``base_url`` with different ``api_mode``/``model``). A plain first-match
+    scan always resolves to whichever entry appears first in ``config.yaml``,
+    independent of which model was actually requested — so a
+    ``model.default: claude-...`` configured under an *Anthropic* provider
+    entry silently gets routed through an unrelated *OpenAI-chat* entry that
+    happens to share the same ``base_url`` and sit earlier in the list. The
+    wrong entry's ``api_mode``/headers are then used for every request,
+    surfacing as an opaque upstream 401/400 with no obvious cause (#7176).
+
+    When ``model_id`` is given, prefer an entry that actually owns that model
+    (via its ``model`` field or ``models`` allowlist) over plain base_url
+    order — mirroring the disambiguation ``resolve_model_provider`` already
+    does for models selected from the dropdown. Falls back to the first
+    base_url match when no entry claims the model, or when ``model_id`` is
+    not supplied, preserving prior behavior for existing callers.
+    """
     target = _normalize_base_url_for_match(base_url)
     if not target:
         return ""
+    matches: list[dict] = []
     for entry in _custom_provider_entries(config_obj):
         entry_base_url = _normalize_base_url_for_match(entry.get("base_url"))
         if entry_base_url != target:
             continue
-        return _custom_provider_slug_from_name(entry.get("name")) or "custom"
-    return ""
+        matches.append(entry)
+    if not matches:
+        return ""
+    wanted_model = str(model_id or "").strip()
+    if wanted_model:
+        for entry in matches:
+            entry_model = str(entry.get("model") or "").strip()
+            owned_ids = set(_configured_model_ids(entry.get("models")))
+            if entry_model:
+                owned_ids.add(entry_model)
+            if wanted_model in owned_ids:
+                return _custom_provider_slug_from_name(entry.get("name")) or "custom"
+    return _custom_provider_slug_from_name(matches[0].get("name")) or "custom"
 
 
 def _provider_is_known_or_configured(
@@ -2736,6 +2781,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
             cfg,
             base_url=config_base_url,
             resolve_alias=False,
+            model_id=model_id,
         )
 
     # Heal legacy ``provider: local`` entries (written by WebUI < v0.50.252)
@@ -5387,10 +5433,11 @@ def _minimal_static_models_catalog() -> dict:
         if isinstance(model_cfg, dict):
             active_provider = model_cfg.get("provider")
             cfg_base_url = model_cfg.get("base_url", "") or ""
+        default_model = get_effective_default_model(cfg)
         if active_provider:
             try:
                 active_provider = _resolve_configured_provider_id(
-                    active_provider, cfg, base_url=cfg_base_url
+                    active_provider, cfg, base_url=cfg_base_url, model_id=default_model
                 )
             except Exception:
                 active_provider = str(active_provider or "").strip() or None
@@ -5401,13 +5448,13 @@ def _minimal_static_models_catalog() -> dict:
                     _store = json.loads(_ap.read_text(encoding="utf-8"))
                     active_provider = (
                         _resolve_configured_provider_id(
-                            _store.get("active_provider"), cfg, base_url=cfg_base_url
+                            _store.get("active_provider"), cfg, base_url=cfg_base_url,
+                            model_id=default_model,
                         )
                         or None
                     )
             except Exception:
                 pass
-        default_model = get_effective_default_model(cfg)
         groups: list[dict] = []
         if default_model:
             try:
@@ -5450,12 +5497,14 @@ def _static_models_catalog_without_live_probes() -> dict:
         if isinstance(model_cfg, dict):
             active_provider = model_cfg.get("provider")
             cfg_base_url = model_cfg.get("base_url", "") or ""
+        default_model = get_effective_default_model(cfg)
         if active_provider:
             try:
                 active_provider = _resolve_configured_provider_id(
                     active_provider,
                     cfg,
                     base_url=cfg_base_url,
+                    model_id=default_model,
                 )
             except Exception:
                 active_provider = str(active_provider or "").strip() or None
@@ -5471,13 +5520,13 @@ def _static_models_catalog_without_live_probes() -> dict:
                             auth_store.get("active_provider"),
                             cfg,
                             base_url=cfg_base_url,
+                            model_id=default_model,
                         )
                         or None
                     )
         except Exception:
             logger.debug("Failed to load auth store for static models catalog", exc_info=True)
 
-        default_model = get_effective_default_model(cfg)
         detected_providers: set[str] = set()
         configured_model_ids: dict[str, list[str]] = {}
         named_custom_groups: dict[str, dict[str, object]] = {}
@@ -6944,11 +6993,15 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # providers are first-class provider ids in WebUI routing; accept the
         # user-facing name from config.yaml (``provider: ollama-local``) and
         # route it through the same ``custom:<name>`` slug the picker emits.
+        # Pass default_model so a base_url shared by several named custom
+        # providers resolves to the entry that actually owns the configured
+        # default model, instead of always the first declared entry (#7176).
         if active_provider:
             active_provider = _resolve_configured_provider_id(
                 active_provider,
                 cfg,
                 base_url=cfg_base_url,
+                model_id=default_model,
             )
 
         # 2. Read auth store (active_provider fallback + credential_pool inspection)
@@ -6964,6 +7017,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         auth_store.get("active_provider"),
                         cfg,
                         base_url=cfg_base_url,
+                        model_id=default_model,
                     )
             except Exception:
                 logger.debug("Failed to load auth store from %s", auth_store_path)

--- a/tests/test_issue7176_shared_base_url_custom_provider_routing.py
+++ b/tests/test_issue7176_shared_base_url_custom_provider_routing.py
@@ -1,0 +1,184 @@
+# Copyright 2025 the Hermes WebUI contributors
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for GitHub issue #7176.
+
+Symptom: an internal gateway that fronts several APIs on ONE physical
+``base_url`` (e.g. an OpenAI-chat route, an Anthropic-messages route, and a
+Responses/codex route all served from the same host) is commonly declared as
+several ``custom_providers[]`` entries sharing that ``base_url``, one per
+``api_mode``. When ``model.provider: custom`` + ``model.base_url`` point at
+that shared endpoint, resolving the ACTIVE provider always returned the
+FIRST ``custom_providers[]`` entry with a matching ``base_url`` — regardless
+of which entry actually declares the configured ``model.default`` — because
+``_named_custom_provider_slug_for_base_url()`` did a plain first-match scan
+with no model awareness.
+
+Concretely: with
+
+    model:
+      default: claude-sonnet-5@default
+      provider: custom
+      base_url: https://gateway.example/v1
+    custom_providers:
+      - name: Gateway OpenAI Chat      # listed first
+        base_url: https://gateway.example/v1
+        api_mode: chat_completions
+        models: {gpt-5: {}, ...}       # does NOT include claude-sonnet-5@default
+      - name: Gateway Claude
+        base_url: https://gateway.example/v1
+        api_mode: anthropic_messages
+        models: {claude-sonnet-5@default: {}, ...}
+
+every chat request for ``claude-sonnet-5@default`` was silently routed
+through "Gateway OpenAI Chat" (``chat_completions``), which the real gateway
+correctly rejects (observed as an opaque upstream 401/400 with no client-side
+clue) since that model only exists on the Anthropic-style route.
+
+Fix: ``_named_custom_provider_slug_for_base_url()`` now accepts an optional
+``model_id`` and prefers an entry that actually owns that model (by its
+``model`` field or ``models`` allowlist) over base_url declaration order,
+mirroring the disambiguation ``resolve_model_provider()`` already does when a
+model is selected explicitly from the picker. ``resolve_model_provider()``
+now forwards its own ``model_id`` argument through
+``_resolve_configured_provider_id()`` so this disambiguation actually fires
+on the path that resolves ``model.provider: custom`` + ``model.default``.
+"""
+
+from api.config import (
+    _named_custom_provider_slug_for_base_url,
+    resolve_model_provider,
+)
+
+
+SHARED_BASE_URL = "https://gateway.example/v1"
+
+CUSTOM_PROVIDERS = [
+    {
+        "name": "Gateway OpenAI Chat",
+        "base_url": SHARED_BASE_URL,
+        "api_mode": "chat_completions",
+        "models": {"gpt-5": {}, "gpt-5-mini": {}},
+    },
+    {
+        "name": "Gateway Claude",
+        "base_url": SHARED_BASE_URL,
+        "api_mode": "anthropic_messages",
+        "models": {"claude-sonnet-5@default": {}, "claude-opus-5@default": {}},
+    },
+]
+
+
+def _apply_config(cfg_module, model_id: str):
+    old_model = cfg_module.cfg.get("model")
+    old_custom = cfg_module.cfg.get("custom_providers")
+    cfg_module.cfg["model"] = {
+        "default": model_id,
+        "provider": "custom",
+        "base_url": SHARED_BASE_URL,
+    }
+    cfg_module.cfg["custom_providers"] = CUSTOM_PROVIDERS
+    return old_model, old_custom
+
+
+def _restore(cfg_module, old_model, old_custom):
+    if old_model is None:
+        cfg_module.cfg.pop("model", None)
+    else:
+        cfg_module.cfg["model"] = old_model
+    if old_custom is None:
+        cfg_module.cfg.pop("custom_providers", None)
+    else:
+        cfg_module.cfg["custom_providers"] = old_custom
+
+
+def test_slug_for_base_url_prefers_owning_entry_over_declaration_order():
+    """Unit-level: passing model_id picks the entry that owns the model,
+    not simply the first custom_providers[] entry with a matching base_url.
+    """
+    import api.config as cfg_mod
+
+    slug = _named_custom_provider_slug_for_base_url(
+        SHARED_BASE_URL, {"custom_providers": CUSTOM_PROVIDERS},
+        model_id="claude-sonnet-5@default",
+    )
+    assert slug == "custom:gateway-claude", (
+        f"Expected the Claude entry (which owns claude-sonnet-5@default), "
+        f"got {slug!r} — likely fell back to declaration-order first match."
+    )
+
+    # Sanity: a model owned by the first entry still resolves to it.
+    slug_openai = _named_custom_provider_slug_for_base_url(
+        SHARED_BASE_URL, {"custom_providers": CUSTOM_PROVIDERS},
+        model_id="gpt-5",
+    )
+    assert slug_openai == "custom:gateway-openai-chat"
+
+    # No model_id: preserves prior first-match behavior for existing callers.
+    slug_no_model = _named_custom_provider_slug_for_base_url(
+        SHARED_BASE_URL, {"custom_providers": CUSTOM_PROVIDERS},
+    )
+    assert slug_no_model == "custom:gateway-openai-chat"
+
+
+def test_resolve_model_provider_routes_configured_default_to_owning_entry():
+    """End-to-end: resolve_model_provider() for the configured default model
+    must route through the custom_providers[] entry that actually declares
+    it, not whichever shared-base_url entry is listed first.
+    """
+    import api.config as cfg_mod
+
+    old_model, old_custom = _apply_config(cfg_mod, "claude-sonnet-5@default")
+    try:
+        model, provider, base_url = resolve_model_provider("claude-sonnet-5@default")
+        assert provider == "custom:gateway-claude", (
+            f"Expected provider=custom:gateway-claude, got {provider!r}. "
+            f"The configured Claude model was routed through the wrong "
+            f"shared-base_url custom provider entry (issue #7176)."
+        )
+        assert base_url == SHARED_BASE_URL
+        assert model == "claude-sonnet-5@default"
+    finally:
+        _restore(cfg_mod, old_model, old_custom)
+
+
+def test_resolve_model_provider_still_routes_other_default_correctly():
+    """Symmetry check: when the configured default belongs to the FIRST
+    shared-base_url entry instead, resolution must still land there (proves
+    the fix is genuinely model-aware, not just order-reversed).
+    """
+    import api.config as cfg_mod
+
+    old_model, old_custom = _apply_config(cfg_mod, "gpt-5")
+    try:
+        model, provider, base_url = resolve_model_provider("gpt-5")
+        assert provider == "custom:gateway-openai-chat", (
+            f"Expected provider=custom:gateway-openai-chat, got {provider!r}"
+        )
+        assert base_url == SHARED_BASE_URL
+        assert model == "gpt-5"
+    finally:
+        _restore(cfg_mod, old_model, old_custom)
+
+
+def test_minimal_static_models_catalog_active_provider_owns_default_model():
+    """Reproduces the exact real-world failure (#7176): the WebUI's /api/models
+    'Default' group and its active_provider must reflect the custom_providers[]
+    entry that actually owns the configured default model, not just the first
+    entry sharing model.base_url. This was the code path that silently routed
+    every chat turn to the wrong endpoint (observed by the reporter as an
+    upstream 401 'Invalid ApiKey' with no client-side indication of why).
+    """
+    import api.config as cfg_mod
+
+    old_model, old_custom = _apply_config(cfg_mod, "claude-sonnet-5@default")
+    try:
+        result = cfg_mod._minimal_static_models_catalog()
+        assert result["active_provider"] == "custom:gateway-claude", (
+            f"Expected active_provider=custom:gateway-claude, got "
+            f"{result['active_provider']!r}. The configured default model "
+            f"was attributed to the wrong shared-base_url custom provider."
+        )
+        assert result["default_model"] == "claude-sonnet-5@default"
+    finally:
+        _restore(cfg_mod, old_model, old_custom)

--- a/tests/test_issue7176_shared_base_url_custom_provider_routing.py
+++ b/tests/test_issue7176_shared_base_url_custom_provider_routing.py
@@ -182,3 +182,118 @@ def test_minimal_static_models_catalog_active_provider_owns_default_model():
         assert result["default_model"] == "claude-sonnet-5@default"
     finally:
         _restore(cfg_mod, old_model, old_custom)
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for review defects found on the #7176 fix itself.
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_later_entry_does_not_crash_resolution():
+    """CORE defect #1 (review): a valid first match followed by a malformed
+    ``base_url`` on a LATER shared-base_url entry must not abort resolution
+    for the whole scan. Before the fix, ``urlparse("http://[")`` raises
+    ``ValueError: Invalid IPv6 URL`` and that exception propagated straight
+    out of ``_named_custom_provider_slug_for_base_url``, breaking provider
+    resolution (and therefore chat start) entirely — even though a perfectly
+    valid earlier entry already matched.
+    """
+    from api.config import _named_custom_provider_slug_for_base_url
+
+    config_obj = {
+        "custom_providers": [
+            {"name": "A", "base_url": "http://gw.local", "model": "x"},
+            {"name": "B", "base_url": "http://[", "model": "y"},
+        ]
+    }
+    # Must not raise, and must still resolve the valid entry.
+    slug = _named_custom_provider_slug_for_base_url(
+        "http://gw.local", config_obj, model_id="x"
+    )
+    assert slug == "custom:a"
+
+
+def test_configured_model_ids_decodes_json_array_string():
+    """CORE defect #2 (review): ``models`` persisted as a JSON-encoded string
+    (e.g. ``'["claude-sonnet-5@default"]'``) must be decoded like a native
+    list/dict, not silently treated as an empty allowlist. Before the fix,
+    ``_configured_model_ids('[\"claude\"]')`` returned ``[]``, so an entry
+    whose ``models`` field round-tripped through a string-serializing layer
+    would never be recognized as owning any model and ownership matching
+    would silently fall back to declaration-order (the exact bug this PR
+    fixes for the native dict/list shapes).
+    """
+    from api.config import _configured_model_ids
+
+    assert _configured_model_ids('["claude-sonnet-5@default", "gpt-5"]') == [
+        "claude-sonnet-5@default",
+        "gpt-5",
+    ]
+    # A dict-shaped JSON string also decodes.
+    assert _configured_model_ids('{"claude-sonnet-5@default": {}}') == [
+        "claude-sonnet-5@default"
+    ]
+    # Invalid JSON / non-list-or-dict decodes still degrade to empty, not a crash.
+    assert _configured_model_ids("not json") == []
+    assert _configured_model_ids("42") == []
+    assert _configured_model_ids("") == []
+    # Existing native shapes are unaffected.
+    assert _configured_model_ids(["a", "b"]) == ["a", "b"]
+    assert _configured_model_ids({"a": {}}) == ["a"]
+
+
+def test_slug_for_base_url_prefers_owning_entry_with_json_string_models():
+    """End-to-end version of defect #2: the ownership-preferring resolver
+    must recognize a JSON-string ``models`` allowlist the same way it
+    recognizes a native list/dict one.
+    """
+    from api.config import _named_custom_provider_slug_for_base_url
+
+    config_obj = {
+        "custom_providers": [
+            {
+                "name": "Gateway OpenAI Chat",
+                "base_url": SHARED_BASE_URL,
+                "models": '["gpt-5", "gpt-5-mini"]',
+            },
+            {
+                "name": "Gateway Claude",
+                "base_url": SHARED_BASE_URL,
+                "models": '["claude-sonnet-5@default", "claude-opus-5@default"]',
+            },
+        ]
+    }
+    slug = _named_custom_provider_slug_for_base_url(
+        SHARED_BASE_URL, config_obj, model_id="claude-sonnet-5@default"
+    )
+    assert slug == "custom:gateway-claude", (
+        f"Expected the Claude entry (JSON-string models allowlist) to be "
+        f"recognized as owning the model, got {slug!r}."
+    )
+
+
+def test_static_models_catalog_without_live_probes_passes_model_id_through():
+    """CORE defect #1/cold-catalog gap (review): the uncached
+    ``_static_models_catalog_without_live_probes()`` builder must also
+    resolve the *initial endpoint probe's* provider attribution
+    model-aware, not just the already-fixed ``active_provider`` field.
+    Before the fix, ``_configured_provider_for_base_url()`` (used to key
+    ``auto_detected_models_by_provider`` and named-provider bookkeeping)
+    called ``_resolve_configured_provider_id()`` WITHOUT ``model_id``, so a
+    shared-base_url probe could still be filed under the sibling provider
+    even though ``active_provider`` elsewhere in the same function was
+    already correctly resolved to the model-owning entry. This builder is
+    network-free by design (its whole point is "no live probes"), so no
+    mocking of network calls is needed here.
+    """
+    import api.config as cfg_mod
+
+    old_model, old_custom = _apply_config(cfg_mod, "claude-sonnet-5@default")
+    try:
+        result = cfg_mod._static_models_catalog_without_live_probes()
+        assert result["active_provider"] == "custom:gateway-claude", (
+            f"Expected active_provider=custom:gateway-claude, got "
+            f"{result['active_provider']!r}."
+        )
+    finally:
+        _restore(cfg_mod, old_model, old_custom)


### PR DESCRIPTION
Fixes #7176

## Problem

Multiple named `custom_providers[]` entries commonly share one physical `base_url` (one internal gateway exposing several `api_mode` routes: `chat_completions`, `anthropic_messages`, `codex_responses`). Resolving `model.provider: custom` + `model.base_url` always picked the **first** `custom_providers[]` entry whose `base_url` matched — regardless of whether that entry actually declared the configured `model.default` — because `_named_custom_provider_slug_for_base_url()` did a plain first-match scan with no model awareness.

Concretely, with an Anthropic-style entry listed *after* an OpenAI-chat entry on the same `base_url`, every chat turn for the configured Claude default model was silently routed through the OpenAI-chat entry's `api_mode`/headers instead. The upstream gateway correctly rejects the mismatched combination, surfacing as an opaque `401 Invalid ApiKey` with no client-side indication that provider *selection* (not the credential itself) was the actual problem. Verified the credential was fine by hitting the gateway directly with `curl` (200 OK).

## Fix

- `_named_custom_provider_slug_for_base_url()` now accepts an optional `model_id` and prefers an entry that actually owns that model (via its `model` field or `models` allowlist) over base_url declaration order. Falls back to the prior first-match behavior when no entry claims the model or `model_id` isn't supplied — existing callers are unaffected.
- `_resolve_configured_provider_id()` forwards a new `model_id` parameter through to that helper.
- Every call site that already computes `default_model` before resolving `active_provider` now passes it through: `resolve_model_provider()`, `_minimal_static_models_catalog()`, `_static_models_catalog_without_live_probes()`, and the main `get_available_models()` cold-path builder. In `_minimal_static_models_catalog()`, `default_model` computation was moved earlier (it was previously computed *after* `active_provider` resolution) so it's available at the point of use.

## Testing

New file `tests/test_issue7176_shared_base_url_custom_provider_routing.py`, 4 tests:

- `test_slug_for_base_url_prefers_owning_entry_over_declaration_order` — unit-level coverage of the resolver helper, both directions (Claude-first-requested and OpenAI-first-requested), plus the no-`model_id` fallback path.
- `test_resolve_model_provider_routes_configured_default_to_owning_entry` — end-to-end via `resolve_model_provider()`.
- `test_resolve_model_provider_still_routes_other_default_correctly` — symmetry check (the entry declared first must still win when it's the one that's actually requested — proves the fix is model-aware, not just order-reversed).
- `test_minimal_static_models_catalog_active_provider_owns_default_model` — reproduces the exact reported code path (`/api/models` "Default" group + `active_provider`).

All 4 fail on current `master` (except the direct-hit symmetry test, expected) and pass with this patch. Confirmed via `git stash`/`git stash pop` around the isolated repro script and the new test file.

Ran the full existing suite locally (`pytest tests/`) — no new failures introduced. Two pre-existing failures in `tests/test_model_resolver.py` (`test_warm_models_catalog_provenance_if_cold_publishes_from_disk_5979`, `test_no_duplicate_when_default_model_is_prefixed`) and one in `tests/test_5774b_atomic_config_writes.py` (`test_atomic_write_preserves_existing_permissions`, POSIX chmod semantics not applicable on NTFS) reproduce identically on `master` without this change — confirmed by running each in isolation before and after `git stash`.

## Scope

Diff is limited to the routing/disambiguation function and its call sites plus the new test file — no unrelated refactors.
