### PR TITLE
fix(sessions): keep reset conversations top-level

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1,4 +1,5 @@
 """Shared helpers for reading Hermes Agent sessions from state.db."""
+import json
 import logging
 import sqlite3
 from contextlib import closing
@@ -52,6 +53,14 @@ MESSAGING_SOURCES = {
 
 CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
 CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
+
+_RESET_END_REASONS = frozenset({
+    'session_reset',
+    'idle',
+    'daily',
+    'suspended',
+    'resume_pending_expired',
+})
 
 SOURCE_LABELS = {
     'acp': 'ACP',
@@ -341,6 +350,62 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         return False
 
 
+def _parse_model_config(value: object) -> dict | None:
+    """Return a model-config object, treating malformed metadata as invalid."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _is_user_visible_reset_successor(parent: dict | None, child: dict | None) -> bool:
+    """Return whether a parent-linked row starts a new visible conversation.
+
+    Agent reset successors retain ``parent_session_id`` as durable lineage, but
+    unlike compression segments, delegates, and branches they are distinct
+    conversations in the sidebar. Prefer the canonical modern marker so a
+    bounded query need not include the parent; only use the conservative
+    same-session-key fallback for older Agent rows.
+    """
+    if not child:
+        return False
+    parent_id = str(child.get('parent_session_id') or '').strip()
+    if not parent_id:
+        return False
+
+    config = _parse_model_config(child.get('model_config'))
+    if config is None:
+        return False
+
+    # An explicit branch/delegate marker wins over reset metadata. In a
+    # conflict, fail closed and preserve the historical child projection.
+    if config.get('_branched_from') or config.get('_delegate_from'):
+        return False
+
+    if '_reset_from' in config:
+        reset_from = config.get('_reset_from')
+        return isinstance(reset_from, str) and reset_from == parent_id
+
+    if not parent or str(parent.get('id') or '').strip() != parent_id:
+        return False
+    if parent.get('end_reason') not in _RESET_END_REASONS:
+        return False
+
+    parent_key = str(parent.get('session_key') or '').strip()
+    child_key = str(child.get('session_key') or '').strip()
+    return bool(parent_key and parent_key == child_key)
+
+
 def _continuation_root_id(rows_by_id: dict[str, dict], session_id: str | None) -> str | None:
     """Return the visible lineage root for ``session_id`` by walking continuations."""
     if not session_id:
@@ -379,6 +444,8 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
             continue
         children_by_parent.setdefault(parent_id, []).append(row)
         parent = rows_by_id.get(parent_id)
+        if _is_user_visible_reset_successor(parent, row):
+            continue
         if _is_continuation_session(parent, row):
             continuation_child_ids.add(row['id'])
         else:
@@ -492,6 +559,8 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         key=lambda row: _as_score(row.get('last_activity'), row.get('started_at')),
         reverse=True,
     )
+    for row in projected:
+        row.pop('model_config', None)
     return projected
 
 
@@ -579,6 +648,7 @@ def read_importable_agent_session_rows(
         chat_type_expr = _optional_col('chat_type', session_cols)
         thread_id_expr = _optional_col('thread_id', session_cols)
         session_key_expr = _optional_col('session_key', session_cols)
+        model_config_expr = _optional_col('model_config', session_cols)
         origin_chat_id_expr = _optional_col('origin_chat_id', session_cols)
         origin_user_id_expr = _optional_col('origin_user_id', session_cols)
         platform_expr = _optional_col('platform', session_cols)
@@ -698,6 +768,7 @@ def read_importable_agent_session_rows(
                    {chat_type_expr},
                    {thread_id_expr},
                    {session_key_expr},
+                   {model_config_expr},
                    {origin_chat_id_expr},
                    {origin_user_id_expr},
                    {platform_expr},
@@ -882,6 +953,8 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
             ended_expr = _optional_col('ended_at', session_cols)
             end_reason_expr = _optional_col('end_reason', session_cols)
             parent_expr = _optional_col('parent_session_id', session_cols)
+            session_key_expr = _optional_col('session_key', session_cols)
+            model_config_expr = _optional_col('model_config', session_cols)
 
             def fetch_one(row_id: str | None) -> dict | None:
                 if not row_id:
@@ -894,6 +967,8 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                            {title_expr},
                            {started_expr},
                            {parent_expr},
+                           {session_key_expr},
+                           {model_config_expr},
                            {ended_expr},
                            {end_reason_expr}
                     FROM sessions s
@@ -940,6 +1015,8 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                            {title_expr},
                            {started_expr},
                            {parent_expr},
+                           {session_key_expr},
+                           {model_config_expr},
                            {ended_expr},
                            {end_reason_expr}
                     FROM sessions s
@@ -957,6 +1034,8 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                 parent_children.sort(key=lambda row: row.get('started_at') or 0, reverse=True)
                 for child in parent_children:
                     if child['id'] in segment_ids:
+                        continue
+                    if _is_user_visible_reset_successor(parent, child):
                         continue
                     if _is_continuation_session(parent, child):
                         # A continuation outside the selected path means the
@@ -1014,6 +1093,8 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                 return {}
             session_source_expr = _optional_col('session_source', session_cols)
             source_expr = _optional_col('source', session_cols)
+            session_key_expr = _optional_col('session_key', session_cols)
+            model_config_expr = _optional_col('model_config', session_cols)
             message_count_expr = _optional_col('message_count', session_cols, '0')
             # Scoped fetch via PRIMARY KEY + idx_sessions_parent rather than a
             # full table scan. The sessions table grows unbounded over time
@@ -1050,7 +1131,7 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     placeholders = ','.join('?' * len(chunk))
                     cur.execute(
                         f"""
-                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
+                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, {session_key_expr}, {model_config_expr}, s.ended_at, s.end_reason, {message_count_expr}
                         FROM sessions s
                         WHERE s.id IN ({placeholders})
                         """,
@@ -1079,7 +1160,7 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     placeholders = ','.join('?' * len(chunk))
                     cur.execute(
                         f"""
-                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
+                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, {session_key_expr}, {model_config_expr}, s.ended_at, s.end_reason, {message_count_expr}
                         FROM sessions s
                         WHERE s.parent_session_id IN ({placeholders})
                         """,
@@ -1215,9 +1296,12 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
 
         parent_id = row.get('parent_session_id')
         parent_row = rows.get(parent_id) if parent_id else None
-        if parent_id and parent_row:
+        is_reset_successor = _is_user_visible_reset_successor(parent_row, row)
+        if parent_id and (parent_row or is_reset_successor):
             entry = metadata.setdefault(sid, {})
             entry['parent_session_id'] = parent_id
+            if is_reset_successor:
+                continue
             if not _is_continuation_session(parent_row, row):
                 entry['relationship_type'] = 'child_session'
                 entry['parent_title'] = parent_row.get('title')

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1,6 +1,7 @@
 """Shared helpers for reading Hermes Agent sessions from state.db."""
 import json
 import logging
+import math
 import sqlite3
 from contextlib import closing
 from pathlib import Path
@@ -339,6 +340,10 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         return False
     if parent.get('end_reason') not in {'compression', 'cli_close'}:
         return False
+    if _is_user_visible_reset_successor(parent, child):
+        # Reset intent is a conversation boundary in every lineage walk, even
+        # if an inconsistent parent row still records a compression ending.
+        return False
     ended_at = parent.get('ended_at')
     if ended_at is None:
         # Older state.db rows/tests may not have ended_at populated. Preserve
@@ -364,7 +369,7 @@ def _parse_model_config(value: object) -> dict | None:
         return {}
     try:
         parsed = json.loads(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, RecursionError):
         return None
     return parsed if isinstance(parsed, dict) else None
 
@@ -390,7 +395,7 @@ def _is_user_visible_reset_successor(parent: dict | None, child: dict | None) ->
 
     # An explicit branch/delegate marker wins over reset metadata. In a
     # conflict, fail closed and preserve the historical child projection.
-    if config.get('_branched_from') or config.get('_delegate_from'):
+    if '_branched_from' in config or '_delegate_from' in config:
         return False
 
     if '_reset_from' in config:
@@ -404,7 +409,21 @@ def _is_user_visible_reset_successor(parent: dict | None, child: dict | None) ->
 
     parent_key = str(parent.get('session_key') or '').strip()
     child_key = str(child.get('session_key') or '').strip()
-    return bool(parent_key and parent_key == child_key)
+    if not parent_key or parent_key != child_key:
+        return False
+
+    # /branch creates the child before switch_session ends its parent. Only
+    # infer a legacy reset when both timestamps prove the opposite ordering.
+    started_at = child.get('started_at')
+    ended_at = parent.get('ended_at')
+    if isinstance(started_at, bool) or isinstance(ended_at, bool):
+        return False
+    try:
+        started_at = float(started_at)
+        ended_at = float(ended_at)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(started_at) and math.isfinite(ended_at) and started_at >= ended_at
 
 
 def _continuation_root_id(rows_by_id: dict[str, dict], session_id: str | None) -> str | None:

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -60,6 +60,7 @@ _RESET_END_REASONS = frozenset({
     'daily',
     'suspended',
     'resume_pending_expired',
+    'session_switch',
 })
 
 SOURCE_LABELS = {

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -445,6 +445,8 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         children_by_parent.setdefault(parent_id, []).append(row)
         parent = rows_by_id.get(parent_id)
         if _is_user_visible_reset_successor(parent, row):
+            row['relationship_type'] = 'reset_successor'
+            row['_lineage_root_id'] = row['id']
             continue
         if _is_continuation_session(parent, row):
             continuation_child_ids.add(row['id'])
@@ -1301,6 +1303,8 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
             entry = metadata.setdefault(sid, {})
             entry['parent_session_id'] = parent_id
             if is_reset_successor:
+                entry['relationship_type'] = 'reset_successor'
+                entry['_lineage_root_id'] = sid
                 continue
             if not _is_continuation_session(parent_row, row):
                 entry['relationship_type'] = 'child_session'

--- a/api/models.py
+++ b/api/models.py
@@ -6157,9 +6157,22 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
         state_db_last_message_at = entry.pop('_state_db_last_message_at', None)
         state_db_display_title = entry.pop('_state_db_display_title', None)
         if state_db_source in ('webui', 'subagent'):
+            # A WebUI-native /branch sidecar is the authoritative source for
+            # fork provenance. Its mirrored state.db row is intentionally
+            # generic ``source='webui'`` and cannot represent that distinction.
+            # Preserve the explicit marker when it has the required parent;
+            # otherwise keep the authoritative state.db normalization behavior,
+            # including delegated subagent classification.
+            preserve_native_fork = bool(
+                state_db_source == 'webui'
+                and str(session.get('session_source') or '').strip().lower() == 'fork'
+                and str(session.get('parent_session_id') or '').strip()
+            )
             session['source_tag'] = state_db_source_tag
             session['raw_source'] = state_db_raw_source
-            session['session_source'] = state_db_session_source
+            session['session_source'] = (
+                'fork' if preserve_native_fork else state_db_session_source
+            )
             session['source_label'] = state_db_source_label
             session['is_cli_session'] = False
             if state_db_source == 'subagent':

--- a/api/models.py
+++ b/api/models.py
@@ -7749,7 +7749,7 @@ def _load_cli_sessions_uncached(
             _title = _sidecar_meta['title']
         _archived = bool(_sidecar_meta.get('archived'))
         _display_title = _title or f'{_source.title()} Session'
-        cli_sessions.append({
+        cli_session = {
             'session_id': sid,
             'title': _display_title,
             'workspace': _cli_workspace(),
@@ -7783,7 +7783,20 @@ def _load_cli_sessions_uncached(
             '_lineage_tip_id': row.get('_lineage_tip_id'),
             '_compression_segment_count': row.get('_compression_segment_count'),
             'is_cli_session': is_cli_session_row({**row, **_source_meta}),
-        })
+        }
+        # Preserve the projection's absence of child metadata. In particular,
+        # reset successors keep ``parent_session_id`` as durable lineage but
+        # must not acquire null child-only fields while adapting state.db rows
+        # to the sidebar response shape.
+        for key in (
+            'parent_title',
+            'parent_source',
+            'relationship_type',
+            '_parent_lineage_root_id',
+        ):
+            if key not in row:
+                cli_session.pop(key, None)
+        cli_sessions.append(cli_session)
 
     if source_filter is not None:
         return cli_sessions

--- a/api/models.py
+++ b/api/models.py
@@ -6163,10 +6163,18 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
             # Preserve the explicit marker when it has the required parent;
             # otherwise keep the authoritative state.db normalization behavior,
             # including delegated subagent classification.
+            # Compression inherits session_source but rewrites the parent link
+            # to a snapshot. Once state.db confirms that continuation, do not
+            # present this link as a fork of its own archived ancestor (#7179).
+            is_compression_continuation = bool(
+                entry.get('_lineage_root_id')
+                and entry['_lineage_root_id'] != sid
+            )
             preserve_native_fork = bool(
                 state_db_source == 'webui'
                 and str(session.get('session_source') or '').strip().lower() == 'fork'
                 and str(session.get('parent_session_id') or '').strip()
+                and not is_compression_continuation
             )
             session['source_tag'] = state_db_source_tag
             session['raw_source'] = state_db_raw_source

--- a/docs/rfcs/canonical-session-resolution.md
+++ b/docs/rfcs/canonical-session-resolution.md
@@ -59,6 +59,17 @@ correct visible session target, not moving execution ownership.
 | Continuation session | The active child/tip created after compression, usually represented by `continuation_session_id`, `_lineage_tip_id`, or newer lineage metadata. |
 | Lineage relation | Links such as `parent_session_id`, `_lineage_root_id`, `_lineage_tip_id`, and `_compression_segment_count` that connect rows belonging to one logical conversation. |
 
+### Reset successors
+
+A messaging conversation created after a user-visible reset is a separate
+top-level conversation, even when Hermes Agent retains `parent_session_id` as
+durable reset lineage. Sidebar projection must preserve that identifier without
+emitting child-session metadata for a reset successor. Compression
+continuations remain one visible conversation, while explicit branch and
+delegate sessions remain nested children. The canonical reset marker is
+`_reset_from == parent_session_id`; compatibility inference for older rows must
+require a reset end reason and the same non-empty `session_key`.
+
 ## Resolution Rules
 
 1. **Directly valid non-snapshot IDs stay stable.** If the requested session ID

--- a/docs/rfcs/canonical-session-resolution.md
+++ b/docs/rfcs/canonical-session-resolution.md
@@ -69,7 +69,19 @@ emitting child-session metadata for a reset successor. Compression
 continuations remain one visible conversation, while explicit branch and
 delegate sessions remain nested children. The canonical reset marker is
 `_reset_from == parent_session_id`; compatibility inference for older rows must
-require a reset end reason and the same non-empty `session_key`.
+require a reset end reason, the same non-empty `session_key`, and finite timestamps
+proving `child.started_at >= parent.ended_at`. Missing or invalid timestamps do
+not establish a legacy reset. The presence of `_branched_from` or `_delegate_from`
+blocks reset classification even if its value is empty; invalid model-config
+JSON (including excessive nesting) must not abort projection of other sessions.
+Canonical reset boundaries also stop compression traversal so independent
+conversations cannot share a lineage root or produce duplicate sidebar IDs.
+
+A WebUI fork's `session_source` can survive compression while its parent link is
+rewritten to an archived snapshot. When state.db confirms a different compression
+root, the sidebar response normalizes that continuation's source to WebUI so it
+remains visible. The saved sidecar and original fork snapshot retain provenance;
+uncompressed forks still preserve their explicit fork source and branch indicator.
 
 ## Resolution Rules
 

--- a/docs/rfcs/canonical-session-resolution.md
+++ b/docs/rfcs/canonical-session-resolution.md
@@ -63,7 +63,8 @@ correct visible session target, not moving execution ownership.
 
 A messaging conversation created after a user-visible reset is a separate
 top-level conversation, even when Hermes Agent retains `parent_session_id` as
-durable reset lineage. Sidebar projection must preserve that identifier without
+durable reset lineage. Sidebar projection must preserve that identifier and mark
+the exception explicitly as `relationship_type='reset_successor'` without
 emitting child-session metadata for a reset successor. Compression
 continuations remain one visible conversation, while explicit branch and
 delegate sessions remain nested children. The canonical reset marker is

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6764,6 +6764,10 @@ function _isChildSession(s){
   return !!(s&&s.parent_session_id&&s.relationship_type==='child_session');
 }
 
+function _showsForkOrBranchIndicator(s){
+  return !!(s&&s.parent_session_id&&(s.session_source==='fork'||s.relationship_type==='child_session'));
+}
+
 function _isForkWithResolvableParent(s, sessionIdsInList){
   return !!(s&&s.session_source==='fork'&&s.parent_session_id&&sessionIdsInList&&sessionIdsInList.has(s.parent_session_id));
 }
@@ -8165,8 +8169,10 @@ function renderSessionListFromCache(){
       wtInd.title=`${wtLabel}: ${s.worktree_branch||s.worktree_path}`;
       titleRow.appendChild(wtInd);
     }
-    // Parent session indicator for forked/branched sessions (#465)
-    if(s.parent_session_id){
+    // Reset successors retain parent_session_id as durable lineage but are
+    // independent top-level conversations. Only real forks/children get the
+    // fork indicator and its "Forked from" tooltip (#7178).
+    if(_showsForkOrBranchIndicator(s)){
       const branchInd=document.createElement('span');
       branchInd.className='session-branch-indicator';
       branchInd.innerHTML=li('git-branch',12);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6764,8 +6764,12 @@ function _isChildSession(s){
   return !!(s&&s.parent_session_id&&s.relationship_type==='child_session');
 }
 
+function _isResetSuccessor(s){
+  return !!(s&&s.relationship_type==='reset_successor');
+}
+
 function _showsForkOrBranchIndicator(s){
-  return !!(s&&s.parent_session_id&&(s.session_source==='fork'||s.relationship_type==='child_session'));
+  return !!(s&&s.parent_session_id&&!_isResetSuccessor(s));
 }
 
 function _isForkWithResolvableParent(s, sessionIdsInList){
@@ -8170,8 +8174,9 @@ function renderSessionListFromCache(){
       titleRow.appendChild(wtInd);
     }
     // Reset successors retain parent_session_id as durable lineage but are
-    // independent top-level conversations. Only real forks/children get the
-    // fork indicator and its "Forked from" tooltip (#7178).
+    // independent top-level conversations. Suppress the historical parent-linked
+    // branch indicator only for a positively classified reset successor so legacy
+    // /branch rows without modern fork metadata keep their provenance (#7178).
     if(_showsForkOrBranchIndicator(s)){
       const branchInd=document.createElement('span');
       branchInd.className='session-branch-indicator';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6836,7 +6836,7 @@ function _resolveSessionIdFromSidebarLineage(sid){
     );
     if(!lineageLike) continue;
     const key=_sidebarLineageKeyForRow(row);
-    if(key===sid||row.parent_session_id===sid||row._lineage_root_id===sid||row.lineage_root_id===sid||_sessionLineageContainsSession(row,sid)){
+    if(key===sid||(!_isResetSuccessor(row)&&row.parent_session_id===sid)||row._lineage_root_id===sid||row.lineage_root_id===sid||_sessionLineageContainsSession(row,sid)){
       candidates.push(row);
     }
   }

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -106,6 +106,7 @@ def _ensure_state_db(profile=None):
         ('chat_type', 'ALTER TABLE sessions ADD COLUMN chat_type TEXT'),
         ('thread_id', 'ALTER TABLE sessions ADD COLUMN thread_id TEXT'),
         ('session_key', 'ALTER TABLE sessions ADD COLUMN session_key TEXT'),
+        ('model_config', 'ALTER TABLE sessions ADD COLUMN model_config TEXT'),
         ('origin_chat_id', 'ALTER TABLE sessions ADD COLUMN origin_chat_id TEXT'),
         ('origin_user_id', 'ALTER TABLE sessions ADD COLUMN origin_user_id TEXT'),
         ('platform', 'ALTER TABLE sessions ADD COLUMN platform TEXT'),
@@ -174,14 +175,16 @@ def _insert_agent_session_row(
     parent_session_id=None,
     ended_at=None,
     end_reason=None,
+    session_key=None,
+    model_config=None,
     messages=1,
 ):
     """Insert an agent session row with optional compression lineage."""
     started_at = started_at or time.time()
     conn.execute(
         "INSERT OR REPLACE INTO sessions "
-        "(id, source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "(id, source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason, session_key, model_config) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             session_id,
             source,
@@ -192,6 +195,8 @@ def _insert_agent_session_row(
             parent_session_id,
             ended_at,
             end_reason,
+            session_key,
+            json.dumps(model_config) if isinstance(model_config, dict) else model_config,
         ),
     )
     conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
@@ -1168,6 +1173,70 @@ def test_previous_messaging_setting_keeps_reset_history(monkeypatch):
         "discord_active",
         "discord_previous_history",
     ]
+
+
+def test_sessions_route_keeps_reset_successor_top_level(cleanup_test_sessions):
+    """A reset child retains lineage without becoming a nested sidebar child."""
+    conn = _ensure_state_db()
+    parent_sid = 'reset_lineage_parent_7178'
+    child_sid = 'reset_lineage_child_7178'
+    now = time.time()
+    cleanup_test_sessions.extend([parent_sid, child_sid])
+    try:
+        _insert_agent_session_row(
+            conn,
+            session_id=parent_sid,
+            source='wecom',
+            title='Previous WeCom conversation',
+            started_at=now - 20,
+            ended_at=now - 10,
+            end_reason='session_reset',
+            session_key='same-messaging-identity',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            session_id=child_sid,
+            source='wecom',
+            title='Reset WeCom conversation',
+            started_at=now - 5,
+            parent_session_id=parent_sid,
+            session_key='same-messaging-identity',
+            model_config={'_reset_from': parent_sid},
+            messages=2,
+        )
+
+        post('/api/settings', {
+            'show_cli_sessions': True,
+            'show_previous_messaging_sessions': True,
+        })
+        data, status = get('/api/sessions')
+
+        assert status == 200
+        rows = {row['session_id']: row for row in data.get('sessions', [])}
+        assert parent_sid in rows
+        assert child_sid in rows
+        child = rows[child_sid]
+        assert child.get('parent_session_id') == parent_sid
+        for key in (
+            'relationship_type',
+            'parent_title',
+            'parent_source',
+            '_parent_lineage_root_id',
+            '_parent_lineage_tip_id',
+            'model_config',
+        ):
+            assert key not in child
+    finally:
+        try:
+            _remove_test_sessions(conn, parent_sid, child_sid)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {
+            'show_cli_sessions': False,
+            'show_previous_messaging_sessions': False,
+        })
 
 
 def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(cleanup_test_sessions):

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -18,6 +18,8 @@ import time
 import urllib.error
 import urllib.request
 
+import pytest
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 from tests._pytest_port import BASE
 
@@ -1175,11 +1177,17 @@ def test_previous_messaging_setting_keeps_reset_history(monkeypatch):
     ]
 
 
-def test_sessions_route_keeps_reset_successor_top_level(cleanup_test_sessions):
+@pytest.mark.parametrize(
+    ('end_reason', 'canonical_marker'),
+    [('session_reset', True), ('session_switch', False)],
+)
+def test_sessions_route_keeps_reset_successor_top_level(
+    cleanup_test_sessions, end_reason, canonical_marker
+):
     """A reset child retains lineage without becoming a nested sidebar child."""
     conn = _ensure_state_db()
-    parent_sid = 'reset_lineage_parent_7178'
-    child_sid = 'reset_lineage_child_7178'
+    parent_sid = f'reset_lineage_parent_7178_{end_reason}'
+    child_sid = f'reset_lineage_child_7178_{end_reason}'
     now = time.time()
     cleanup_test_sessions.extend([parent_sid, child_sid])
     try:
@@ -1190,7 +1198,7 @@ def test_sessions_route_keeps_reset_successor_top_level(cleanup_test_sessions):
             title='Previous WeCom conversation',
             started_at=now - 20,
             ended_at=now - 10,
-            end_reason='session_reset',
+            end_reason=end_reason,
             session_key='same-messaging-identity',
             messages=2,
         )
@@ -1202,7 +1210,7 @@ def test_sessions_route_keeps_reset_successor_top_level(cleanup_test_sessions):
             started_at=now - 5,
             parent_session_id=parent_sid,
             session_key='same-messaging-identity',
-            model_config={'_reset_from': parent_sid},
+            model_config=({'_reset_from': parent_sid} if canonical_marker else None),
             messages=2,
         )
 

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1218,8 +1218,9 @@ def test_sessions_route_keeps_reset_successor_top_level(cleanup_test_sessions):
         assert child_sid in rows
         child = rows[child_sid]
         assert child.get('parent_session_id') == parent_sid
+        assert child.get('relationship_type') == 'reset_successor'
+        assert child.get('_lineage_root_id') == child_sid
         for key in (
-            'relationship_type',
             'parent_title',
             'parent_source',
             '_parent_lineage_root_id',

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -93,6 +93,36 @@ console.log(_activeSessionIdForSidebar());
     assert _run_node(source) == "url-active"
 
 
+def test_reset_successor_does_not_show_fork_or_branch_indicator():
+    """Durable reset lineage must not be labelled as a user-created fork."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_showsForkOrBranchIndicator'));
+console.log(JSON.stringify({{
+  reset: _showsForkOrBranchIndicator({{session_id:'reset', parent_session_id:'parent', session_source:'messaging'}}),
+  fork: _showsForkOrBranchIndicator({{session_id:'fork', parent_session_id:'parent', session_source:'fork'}}),
+  child: _showsForkOrBranchIndicator({{session_id:'child', parent_session_id:'parent', relationship_type:'child_session'}}),
+}}));
+"""
+    result = json.loads(_run_node(source))
+    assert result == {"reset": False, "fork": True, "child": True}
+    assert "if(_showsForkOrBranchIndicator(s)){" in js
+
+
 def test_collapsed_lineage_contains_active_hidden_segment():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -31,6 +31,32 @@ def _run_node(source: str) -> str:
     return result.stdout.strip()
 
 
+def render_sidebar_rows(sessions, references):
+    """Run production sidebar grouping on API rows, including hidden ancestors."""
+    if NODE is None:
+        pytest.skip('node not on PATH')
+    js = SESSIONS_JS_PATH.read_text(encoding='utf-8')
+    return json.loads(_run_node(f"""
+const src = {json.dumps(js)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start), depth = 1;
+  for (i++; depth > 0 && i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+  }}
+  return src.slice(start, i);
+}}
+for (const name of ['_sessionTimestampMs', '_isChildSession',
+  '_isForkWithResolvableParent', '_sessionLineageKey', '_sidebarLineageKeyForRow',
+  '_collapseSessionLineageForSidebar', '_attachChildSessionsToSidebarRows',
+  '_renderSidebarRowsFromRawSessions']) eval(extractFunc(name));
+console.log(JSON.stringify(_renderSidebarRowsFromRawSessions(
+  {json.dumps(sessions)}, {json.dumps(references)})));
+"""))
+
+
 def test_sidebar_lineage_collapse_keeps_latest_tip_and_counts_segments():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -360,6 +360,7 @@ var _allSessions = [
 ];
 eval(extractFunc('_sessionTimestampMs'));
 eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isResetSuccessor'));
 eval(extractFunc('_sessionLineageKey'));
 eval(extractFunc('_sessionLineageContainsSession'));
 eval(extractFunc('_sidebarLineageKeyForRow'));
@@ -369,6 +370,53 @@ console.log(JSON.stringify({{parent:_resolveSessionIdFromSidebarLineage('parent'
 """
     result = json.loads(_run_node(source))
     assert result == {"parent": "child", "child": "child", "other": "other"}
+
+
+def test_reset_successor_parent_link_is_not_navigation_alias():
+    """Reset ancestry must not alias the old parent while compression still resolves."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _allSessions = [
+  {{session_id:'reset-child', title:'Reset child', parent_session_id:'hidden-reset-parent', relationship_type:'reset_successor', _lineage_root_id:'reset-child', updated_at:150, last_message_at:150}},
+  {{session_id:'reset-root', title:'Compressed reset root', parent_session_id:'older-reset-parent', relationship_type:'reset_successor', _lineage_root_id:'reset-root', _compression_segment_count:1, updated_at:100, last_message_at:100}},
+  {{session_id:'reset-tip', title:'Compressed reset root', parent_session_id:'reset-root', _lineage_root_id:'reset-root', _compression_segment_count:2, updated_at:200, last_message_at:200}},
+  {{session_id:'ordinary-tip', title:'Ordinary compressed chat', parent_session_id:'ordinary-parent', _lineage_root_id:'ordinary-parent', _compression_segment_count:2, updated_at:180, last_message_at:180}},
+];
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isResetSuccessor'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sessionLineageContainsSession'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_resolveSessionIdFromSidebarLineage'));
+console.log(JSON.stringify({{
+  hiddenResetParent: _resolveSessionIdFromSidebarLineage('hidden-reset-parent'),
+  compressedResetRoot: _resolveSessionIdFromSidebarLineage('reset-root'),
+  directResetTip: _resolveSessionIdFromSidebarLineage('reset-tip'),
+  ordinaryCompressionParent: _resolveSessionIdFromSidebarLineage('ordinary-parent'),
+}}));
+"""
+    assert json.loads(_run_node(source)) == {
+        "hiddenResetParent": "hidden-reset-parent",
+        "compressedResetRoot": "reset-tip",
+        "directResetTip": "reset-tip",
+        "ordinaryCompressionParent": "ordinary-tip",
+    }
 
 
 def test_sidebar_attaches_child_sessions_to_collapsed_hidden_parent_lineage():

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -111,15 +111,19 @@ function extractFunc(name) {{
   }}
   return src.slice(start, i);
 }}
+eval(extractFunc('_isResetSuccessor'));
 eval(extractFunc('_showsForkOrBranchIndicator'));
 console.log(JSON.stringify({{
-  reset: _showsForkOrBranchIndicator({{session_id:'reset', parent_session_id:'parent', session_source:'messaging'}}),
+  reset: _showsForkOrBranchIndicator({{session_id:'reset', parent_session_id:'parent', session_source:'messaging', relationship_type:'reset_successor'}}),
   fork: _showsForkOrBranchIndicator({{session_id:'fork', parent_session_id:'parent', session_source:'fork'}}),
+  legacyFork: _showsForkOrBranchIndicator({{session_id:'legacy-fork', parent_session_id:'parent', session_source:'webui'}}),
   child: _showsForkOrBranchIndicator({{session_id:'child', parent_session_id:'parent', relationship_type:'child_session'}}),
+  unmarkedParent: _showsForkOrBranchIndicator({{session_id:'unknown', parent_session_id:'parent', session_source:'messaging'}}),
+  topLevel: _showsForkOrBranchIndicator({{session_id:'top', session_source:'webui'}}),
 }}));
 """
     result = json.loads(_run_node(source))
-    assert result == {"reset": False, "fork": True, "child": True}
+    assert result == {"reset": False, "fork": True, "legacyFork": True, "child": True, "unmarkedParent": True, "topLevel": False}
     assert "if(_showsForkOrBranchIndicator(s)){" in js
 
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -1,10 +1,12 @@
 """Regression tests for /api/sessions lineage metadata used by sidebar collapse."""
 
+import json
 import sqlite3
 import time
 
 import pytest
 
+import api.agent_sessions as agent_sessions
 import api.models as models
 import api.routes as routes
 from api.models import SESSIONS, STREAMS, Session, all_sessions
@@ -50,6 +52,8 @@ def _ensure_state_db(path):
             started_at REAL NOT NULL,
             message_count INTEGER DEFAULT 0,
             parent_session_id TEXT,
+            session_key TEXT,
+            model_config TEXT,
             ended_at REAL,
             end_reason TEXT
         );
@@ -79,14 +83,38 @@ def _insert_state_message(conn, sid, *, role, content, timestamp):
     conn.commit()
 
 
-def _insert_state_row(conn, sid, *, title=None, parent=None, ended_at=None, end_reason=None, started_at=None, source='webui', session_source=None):
+def _insert_state_row(
+    conn,
+    sid,
+    *,
+    title=None,
+    parent=None,
+    ended_at=None,
+    end_reason=None,
+    started_at=None,
+    source='webui',
+    session_source=None,
+    session_key=None,
+    model_config=None,
+):
     conn.execute(
         """
         INSERT INTO sessions
-        (id, source, session_source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason)
-        VALUES (?, ?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?)
+        (id, source, session_source, title, model, started_at, message_count, parent_session_id, session_key, model_config, ended_at, end_reason)
+        VALUES (?, ?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?, ?, ?)
         """,
-        (sid, source, session_source, title or sid, started_at or time.time(), parent, ended_at, end_reason),
+        (
+            sid,
+            source,
+            session_source,
+            title or sid,
+            started_at or time.time(),
+            parent,
+            session_key,
+            json.dumps(model_config) if isinstance(model_config, dict) else model_config,
+            ended_at,
+            end_reason,
+        ),
     )
     conn.commit()
 
@@ -200,6 +228,105 @@ def test_non_compression_state_db_parent_does_not_create_sidebar_lineage(_isolat
         assert "_lineage_root_id" not in child
     finally:
         conn.close()
+
+
+def test_all_sessions_keeps_reset_successor_top_level_with_durable_lineage(_isolate):
+    """JSON-enriched rows retain reset lineage without sidebar child metadata."""
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    parent_sid = 'lineage_api_reset_parent'
+    child_sid = 'lineage_api_reset_child'
+    try:
+        _save_webui_session(parent_sid, title='Previous WeCom conversation', updated_at=t0)
+        _save_webui_session(child_sid, title='New WeCom conversation', updated_at=t0 + 10)
+        _insert_state_row(
+            conn,
+            parent_sid,
+            source='wecom',
+            started_at=t0,
+            ended_at=t0 + 5,
+            end_reason='session_reset',
+            session_key='same-messaging-identity',
+        )
+        _insert_state_row(
+            conn,
+            child_sid,
+            source='wecom',
+            parent=parent_sid,
+            started_at=t0 + 6,
+            session_key='same-messaging-identity',
+            model_config={'_reset_from': parent_sid},
+        )
+
+        child = {row['session_id']: row for row in all_sessions()}[child_sid]
+
+        assert child.get('parent_session_id') == parent_sid
+        for key in (
+            'relationship_type',
+            'parent_title',
+            'parent_source',
+            '_parent_lineage_root_id',
+            '_parent_lineage_tip_id',
+        ):
+            assert key not in child
+    finally:
+        conn.close()
+
+
+def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
+    """Legacy reset fallback stays narrow; real branch/delegate rows stay children."""
+    parent = {
+        'id': 'projection_reset_parent',
+        'title': 'Parent',
+        'source': 'wecom',
+        'session_key': 'same-messaging-identity',
+        'end_reason': 'session_reset',
+        'actual_message_count': 2,
+        'started_at': 1,
+    }
+    base_child = {
+        'source': 'wecom',
+        'parent_session_id': parent['id'],
+        'session_key': 'same-messaging-identity',
+        'actual_message_count': 2,
+        'started_at': 2,
+    }
+    rows = [
+        parent,
+        {**base_child, 'id': 'projection_legacy_reset'},
+        {
+            **base_child,
+            'id': 'projection_delegate',
+            'model_config': {'_reset_from': parent['id'], '_delegate_from': parent['id']},
+        },
+        {
+            **base_child,
+            'id': 'projection_mismatched_reset',
+            'model_config': {'_reset_from': 'other-parent'},
+        },
+        {
+            **base_child,
+            'id': 'projection_invalid_config',
+            'model_config': '{not-json',
+        },
+        {
+            **base_child,
+            'id': 'projection_orphan_canonical_reset',
+            'parent_session_id': 'parent-outside-window',
+            'model_config': {'_reset_from': 'parent-outside-window'},
+        },
+    ]
+
+    projected = {row['id']: row for row in agent_sessions._project_agent_session_rows(rows)}
+
+    assert 'relationship_type' not in projected['projection_legacy_reset']
+    assert 'relationship_type' not in projected['projection_orphan_canonical_reset']
+    for sid in (
+        'projection_delegate',
+        'projection_mismatched_reset',
+        'projection_invalid_config',
+    ):
+        assert projected[sid].get('relationship_type') == 'child_session'
 
 
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -469,6 +469,38 @@ def test_state_db_webui_source_overrides_stale_cli_json_metadata(_isolate):
         conn.close()
 
 
+def test_state_db_webui_source_preserves_explicit_sidecar_fork_metadata(_isolate):
+    """A generic WebUI mirror must not erase sidecar fork provenance."""
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    try:
+        session = Session(
+            session_id='lineage_api_native_fork_source',
+            title='Forked conversation',
+            messages=[{'role': 'user', 'content': 'hello'}, {'role': 'assistant', 'content': 'hi'}],
+            updated_at=t0,
+            parent_session_id='lineage_api_fork_parent',
+            session_source='fork',
+        )
+        session.save(touch_updated_at=False)
+        _insert_state_row(
+            conn,
+            'lineage_api_native_fork_source',
+            source='webui',
+            started_at=t0,
+        )
+
+        row = {row['session_id']: row for row in all_sessions()}['lineage_api_native_fork_source']
+
+        assert row['session_source'] == 'fork'
+        assert row['source_tag'] == 'webui'
+        assert row['raw_source'] == 'webui'
+        assert row['source_label'] == 'WebUI'
+        assert row['is_cli_session'] is False
+    finally:
+        conn.close()
+
+
 def test_sessions_route_keeps_state_db_webui_row_with_stale_cli_json_when_cli_hidden(_isolate, monkeypatch):
     """The hot route must apply state.db source correction before CLI filtering."""
     conn = _ensure_state_db(_isolate)

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -2,7 +2,9 @@
 
 import json
 import sqlite3
+import sys
 import time
+from contextlib import closing
 
 import pytest
 
@@ -10,6 +12,7 @@ import api.agent_sessions as agent_sessions
 import api.models as models
 import api.routes as routes
 from api.models import SESSIONS, STREAMS, Session, all_sessions
+from tests.test_session_lineage_collapse import render_sidebar_rows
 
 
 @pytest.fixture(autouse=True)
@@ -284,6 +287,7 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
         'end_reason': 'session_reset',
         'actual_message_count': 2,
         'started_at': 1,
+        'ended_at': 2,
     }
     switch_parent = {
         **parent,
@@ -354,6 +358,102 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
         assert projected[sid].get('relationship_type') == 'child_session'
         assert '_lineage_root_id' not in projected[sid]
 
+
+
+def test_deep_model_config_does_not_hide_other_agent_sessions(_isolate, monkeypatch):
+    """A single corrupt row must not abort the additive CLI bridge (#7179)."""
+    with closing(_ensure_state_db(_isolate)) as conn:
+        _ensure_messages_table(conn)
+        for sid, parent, config in (
+            ('parent', None, None),
+            ('bad', 'parent', '[' * (sys.getrecursionlimit() + 100) + '0'
+             + ']' * (sys.getrecursionlimit() + 100)),
+            ('healthy', None, None),
+        ):
+            _insert_state_row(conn, sid, source='cli', parent=parent, model_config=config)
+            _insert_state_message(conn, sid, role='user', content='hello', timestamp=time.time())
+    monkeypatch.setattr(
+        models, '_resolve_cli_sessions_context',
+        lambda *args, **kwargs: (_isolate.parent, _isolate, 'default', ('deep-config', str(_isolate))),
+    )
+    rows = {row['session_id']: row for row in models.get_cli_sessions(include_claude_code=False)}
+    assert set(rows) == {'parent', 'bad', 'healthy'}
+    assert rows['bad']['relationship_type'] == 'child_session'
+    assert all('model_config' not in row for row in rows.values())
+
+
+@pytest.mark.parametrize('end_reason', sorted(agent_sessions._RESET_END_REASONS))
+def test_legacy_reset_time_order_preserves_branch_in_all_projections(_isolate, end_reason):
+    """Agent /branch creates its child before switch_session closes the parent."""
+    with closing(_ensure_state_db(_isolate)) as conn:
+        _ensure_messages_table(conn)
+        _insert_state_row(conn, 'parent', started_at=1, ended_at=100,
+                          end_reason=end_reason, session_key='same-key')
+        for sid, started_at in (('branch', 50), ('reset', 150), ('boundary-reset', 100)):
+            _insert_state_row(conn, sid, parent='parent', started_at=started_at, session_key='same-key')
+        for sid in ('parent', 'branch', 'reset', 'boundary-reset'):
+            _insert_state_message(conn, sid, role='user', content='hello', timestamp=200)
+            _save_webui_session(sid, title=sid, updated_at=200)
+    projected = {row['id']: row for row in agent_sessions.read_importable_agent_session_rows(_isolate, exclude_sources=None)}
+    enriched = {row['session_id']: row for row in all_sessions()}
+    for rows in (projected, enriched):
+        assert rows['branch']['relationship_type'] == 'child_session'
+        assert rows['branch']['parent_session_id'] == 'parent'
+        for sid in ('reset', 'boundary-reset'):
+            assert rows[sid]['relationship_type'] == 'reset_successor'
+            assert rows[sid]['_lineage_root_id'] == sid
+            assert 'parent_title' not in rows[sid]
+    report = agent_sessions.read_session_lineage_report(_isolate, 'parent')
+    assert [row['session_id'] for row in report['children']] == ['branch']
+
+
+@pytest.mark.parametrize('field', ['started_at', 'ended_at'])
+@pytest.mark.parametrize('invalid', [None, '', 'invalid', 'NaN', 'Infinity', '-Infinity', True])
+def test_legacy_reset_rejects_unknown_time_boundary(field, invalid):
+    parent = {'id': 'parent', 'session_key': 'key', 'end_reason': 'session_switch', 'ended_at': 100}
+    child = {'parent_session_id': 'parent', 'session_key': 'key', 'started_at': 150}
+    (parent if field == 'ended_at' else child)[field] = invalid
+    assert not agent_sessions._is_user_visible_reset_successor(parent, child)
+    # Canonical reset intent does not depend on legacy timestamp inference.
+    child['model_config'] = {'_reset_from': 'parent'}
+    assert agent_sessions._is_user_visible_reset_successor(parent, child)
+
+
+@pytest.mark.parametrize('marker', ['_branched_from', '_delegate_from'])
+@pytest.mark.parametrize('value', [None, '', False, 0])
+@pytest.mark.parametrize('canonical', [False, True])
+def test_explicit_branch_marker_presence_prevents_reset(marker, value, canonical):
+    parent = {'id': 'parent', 'session_key': 'key', 'end_reason': 'session_switch', 'ended_at': 100}
+    config = {marker: value}
+    if canonical:
+        config['_reset_from'] = 'parent'
+    child = {'parent_session_id': 'parent', 'session_key': 'key', 'started_at': 150,
+             'model_config': config}
+    assert not agent_sessions._is_user_visible_reset_successor(parent, child)
+
+
+def test_compression_walks_stop_at_canonical_reset_boundary(_isolate):
+    """Even inconsistent reset/compression metadata must not alias or duplicate rows."""
+    with closing(_ensure_state_db(_isolate)) as conn:
+        _ensure_messages_table(conn)
+        _insert_state_row(conn, 'parent', started_at=1, ended_at=10, end_reason='compression')
+        _insert_state_row(conn, 'reset', parent='parent', started_at=11, ended_at=20,
+                          end_reason='compression', model_config={'_reset_from': 'parent'})
+        _insert_state_row(conn, 'tip', parent='reset', started_at=21)
+        for sid, timestamp in (('parent', 2), ('reset', 12), ('tip', 22)):
+            _insert_state_message(conn, sid, role='user', content='hello', timestamp=timestamp)
+    rows = agent_sessions.read_importable_agent_session_rows(_isolate, exclude_sources=None)
+    assert sorted(row['id'] for row in rows) == ['parent', 'tip']
+    tip = next(row for row in rows if row['id'] == 'tip')
+    assert tip['_lineage_root_id'] == 'reset'
+    assert tip['relationship_type'] == 'reset_successor'
+    metadata = agent_sessions.read_session_lineage_metadata(_isolate, {'parent', 'reset', 'tip'})
+    assert metadata['reset']['_lineage_root_id'] == 'reset'
+    assert metadata['tip']['_lineage_root_id'] == 'reset'
+    assert metadata['tip']['_compression_segment_count'] == 2
+    report = agent_sessions.read_session_lineage_report(_isolate, 'tip')
+    assert report['lineage_key'] == 'reset'
+    assert [row['session_id'] for row in report['segments']] == ['tip', 'reset']
 
 
 def test_child_of_hidden_compression_segment_exposes_parent_lineage_root(_isolate):
@@ -807,7 +907,10 @@ def test_state_db_display_title_does_not_override_custom_json_title(_isolate):
         conn.close()
 
 
-def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_filtered(_isolate, monkeypatch):
+@pytest.mark.parametrize('session_source', ['webui', 'fork'])
+def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_filtered(
+    _isolate, monkeypatch, session_source,
+):
     """Default /api/sessions omits archived rows but keeps their lineage metadata.
 
     The route builds the hot sidebar payload with archived rows filtered out by
@@ -824,12 +927,20 @@ def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_fil
             updated_at=t0,
         )
         archived_parent.archived = True
+        archived_parent.pre_compression_snapshot = session_source == 'fork'
+        archived_parent.session_source = session_source
+        archived_parent.parent_session_id = 'origin-outside-sidebar' if session_source == 'fork' else None
         archived_parent.save(touch_updated_at=False)
-        _save_webui_session(
+        live_tip = _save_webui_session(
             "lineage_api_visible_tip",
             title="Hermes WebUI #2",
             updated_at=t0 + 10,
         )
+        # Compression keeps the Session object's source but rewrites its parent
+        # to the archived snapshot, including on a fork of an out-of-scope row.
+        live_tip.session_source = session_source
+        live_tip.parent_session_id = archived_parent.session_id
+        live_tip.save(touch_updated_at=False)
         _insert_state_row(
             conn,
             "lineage_api_archived_parent",
@@ -863,6 +974,8 @@ def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_fil
         assert tip.get("parent_session_id") == "lineage_api_archived_parent"
         assert tip.get("_lineage_root_id") == "lineage_api_archived_parent"
         assert tip.get("_compression_segment_count") == 2
+        # Reconciliation only changes the response; persisted fork history stays.
+        assert json.loads((models.SESSION_DIR / f'{live_tip.session_id}.json').read_text())['session_source'] == session_source
 
         archived_payload = routes._build_session_list_cache_payload(
             active_profile="default",
@@ -876,5 +989,11 @@ def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_fil
             "lineage_api_visible_tip",
             "lineage_api_archived_parent",
         ]
+        if session_source == 'fork':
+            assert archived_payload['sessions'][1]['session_source'] == 'fork'
+        visible_rows = render_sidebar_rows(default_payload['sessions'], archived_payload['sessions'])
+        assert [row['session_id'] for row in visible_rows] == ['lineage_api_visible_tip']
+        assert visible_rows[0]['_lineage_root_id'] == 'lineage_api_archived_parent'
+        assert tip['session_source'] == 'webui'
     finally:
         conn.close()

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -261,8 +261,9 @@ def test_all_sessions_keeps_reset_successor_top_level_with_durable_lineage(_isol
         child = {row['session_id']: row for row in all_sessions()}[child_sid]
 
         assert child.get('parent_session_id') == parent_sid
+        assert child.get('relationship_type') == 'reset_successor'
+        assert child.get('_lineage_root_id') == child_sid
         for key in (
-            'relationship_type',
             'parent_title',
             'parent_source',
             '_parent_lineage_root_id',
@@ -319,14 +320,16 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
 
     projected = {row['id']: row for row in agent_sessions._project_agent_session_rows(rows)}
 
-    assert 'relationship_type' not in projected['projection_legacy_reset']
-    assert 'relationship_type' not in projected['projection_orphan_canonical_reset']
+    for sid in ('projection_legacy_reset', 'projection_orphan_canonical_reset'):
+        assert projected[sid].get('relationship_type') == 'reset_successor'
+        assert projected[sid].get('_lineage_root_id') == sid
     for sid in (
         'projection_delegate',
         'projection_mismatched_reset',
         'projection_invalid_config',
     ):
         assert projected[sid].get('relationship_type') == 'child_session'
+        assert '_lineage_root_id' not in projected[sid]
 
 
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -285,6 +285,11 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
         'actual_message_count': 2,
         'started_at': 1,
     }
+    switch_parent = {
+        **parent,
+        'id': 'projection_switch_parent',
+        'end_reason': 'session_switch',
+    }
     base_child = {
         'source': 'wecom',
         'parent_session_id': parent['id'],
@@ -292,9 +297,16 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
         'actual_message_count': 2,
         'started_at': 2,
     }
+    switch_child = {
+        **base_child,
+        'id': 'projection_session_switch_reset',
+        'parent_session_id': switch_parent['id'],
+    }
     rows = [
         parent,
+        switch_parent,
         {**base_child, 'id': 'projection_legacy_reset'},
+        switch_child,
         {
             **base_child,
             'id': 'projection_delegate',
@@ -320,9 +332,20 @@ def test_reset_projection_fails_closed_for_conflicting_or_invalid_metadata():
 
     projected = {row['id']: row for row in agent_sessions._project_agent_session_rows(rows)}
 
-    for sid in ('projection_legacy_reset', 'projection_orphan_canonical_reset'):
+    for sid in (
+        'projection_legacy_reset',
+        'projection_session_switch_reset',
+        'projection_orphan_canonical_reset',
+    ):
         assert projected[sid].get('relationship_type') == 'reset_successor'
         assert projected[sid].get('_lineage_root_id') == sid
+        for key in (
+            'parent_title',
+            'parent_source',
+            '_parent_lineage_root_id',
+            '_parent_lineage_tip_id',
+        ):
+            assert key not in projected[sid]
     for sid in (
         'projection_delegate',
         'projection_mismatched_reset',

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -24,6 +24,8 @@ def _ensure_state_db(path):
             started_at REAL NOT NULL,
             message_count INTEGER DEFAULT 0,
             parent_session_id TEXT,
+            session_key TEXT,
+            model_config TEXT,
             ended_at REAL,
             end_reason TEXT
         );
@@ -39,14 +41,37 @@ def _ensure_state_db(path):
     return conn
 
 
-def _insert_state_row(conn, sid, *, parent=None, ended_at=None, end_reason=None, started_at=None, source="webui", session_source=None):
+def _insert_state_row(
+    conn,
+    sid,
+    *,
+    parent=None,
+    ended_at=None,
+    end_reason=None,
+    started_at=None,
+    source="webui",
+    session_source=None,
+    session_key=None,
+    model_config=None,
+):
     conn.execute(
         """
         INSERT INTO sessions
-        (id, source, session_source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason)
-        VALUES (?, ?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?)
+        (id, source, session_source, title, model, started_at, message_count, parent_session_id, session_key, model_config, ended_at, end_reason)
+        VALUES (?, ?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?, ?, ?)
         """,
-        (sid, source, session_source, sid.replace("_", " "), started_at or time.time(), parent, ended_at, end_reason),
+        (
+            sid,
+            source,
+            session_source,
+            sid.replace("_", " "),
+            started_at or time.time(),
+            parent,
+            session_key,
+            json.dumps(model_config) if isinstance(model_config, dict) else model_config,
+            ended_at,
+            end_reason,
+        ),
     )
     conn.commit()
 
@@ -199,6 +224,41 @@ def test_lineage_report_surfaces_non_continuation_children_without_mutation(tmp_
             }
         ]
         assert report["mutation"] is False
+    finally:
+        conn.close()
+
+
+def test_lineage_report_excludes_user_visible_reset_successors_from_children(tmp_path):
+    conn = _ensure_state_db(tmp_path / 'state.db')
+    t0 = time.time() - 100
+    parent_sid = 'lineage_report_reset_parent'
+    child_sid = 'lineage_report_reset_child'
+    try:
+        _insert_state_row(
+            conn,
+            parent_sid,
+            source='wecom',
+            started_at=t0,
+            ended_at=t0 + 5,
+            end_reason='session_reset',
+            session_key='same-messaging-identity',
+        )
+        _insert_state_row(
+            conn,
+            child_sid,
+            source='wecom',
+            parent=parent_sid,
+            started_at=t0 + 6,
+            session_key='same-messaging-identity',
+            model_config={'_reset_from': parent_sid},
+        )
+
+        parent_report = agent_sessions.read_session_lineage_report(tmp_path / 'state.db', parent_sid)
+        child_report = agent_sessions.read_session_lineage_report(tmp_path / 'state.db', child_sid)
+
+        assert parent_report['children'] == []
+        assert child_report['lineage_key'] == child_sid
+        assert [row['session_id'] for row in child_report['segments']] == [child_sid]
     finally:
         conn.close()
 

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -189,11 +189,15 @@ def test_sidebar_state_db_overlay_reclassifies_authoritative_subagent_rows():
             )
         return row
 
+    fork_like_subagent = sidebar_row(
+        "row-02", "fork", session_source="fork", source_label="Fork"
+    )
+    fork_like_subagent["parent_session_id"] = "row-parent"
     sessions = [
         sidebar_row(
             "row-01", "webui", session_source="webui", source_label="WebUI", is_cli_session=False
         ),
-        sidebar_row("row-02", "fork", session_source="other", source_label="Fork"),
+        fork_like_subagent,
         sidebar_row("row-03"),
         sidebar_row("row-04", "tui", session_source="cli", source_label="TUI"),
     ]


### PR DESCRIPTION
Fixes #7178

## Thinking Path

Agent reset successors keep `parent_session_id` for durable history, but begin
independent conversations. Sidebar projection must distinguish those resets
from branches and compression continuations, including older databases.

## What Changed

- Classify canonical `_reset_from` successors and conservative legacy resets;
  emit `relationship_type="reset_successor"` with an independent lineage root.
- Preserve parent lineage while omitting child-only metadata, the misleading
  reset fork indicator, and reset-parent navigation aliases. Legacy parent-linked
  branches retain their provenance indicator.
- Address the latest review on `66ef9ba` in `efbde454`: contain deeply nested JSON
  `RecursionError`; require finite, ordered legacy reset timestamps; make branch
  and delegate marker presence authoritative even for empty values.
- Stop every compression walk at canonical reset boundaries, preventing duplicate
  IDs and cross-conversation lineage roots for inconsistent metadata.
- Normalize an inherited WebUI fork source only when state.db confirms a
  compression continuation, preventing the active tip from disappearing behind
  its archived snapshot. Persisted sidecars and original fork provenance remain.

## Why It Matters

Reset conversations remain easy to find without flattening genuine legacy
branches, blanking the Agent/CLI list because of one corrupt metadata row, or
hiding a compressed WebUI fork.

## Contract Routing

- Family: sidebar/session metadata and canonical session resolution.
- Docs: `docs/CONTRACTS.md`, `docs/rfcs/canonical-session-resolution.md`, and
  `docs/rfcs/webui-run-state-consistency-contract.md`.
- State layer: read-side state.db projection and sidebar response adaptation;
  no persisted session lineage or transcript data is rewritten.
- Invariants: independent resets, preserved branch provenance, stable navigation,
  unique projected IDs, and visible compression continuations.

## Contract Change

The legacy reset fallback previously required only a reset end reason and the
same non-empty session key. It now additionally requires finite timestamps with
`child.started_at >= parent.ended_at`. Unknown timestamps fail closed because an
Agent `/branch` can otherwise have the same reset-like metadata. Explicit reset
intent remains independent of this legacy timestamp inference.

## Verification

- `./scripts/test.sh tests/test_gateway_sync.py tests/test_session_lineage_metadata_api.py tests/test_session_lineage_report.py tests/test_session_lineage_collapse.py tests/test_webui_state_db_reconciliation.py -q`: **244 passed**.
- **143 neighboring tests passed**, covering performance/caps, readonly DB and
  descriptor lifetime, imports/caches, snapshots, pin visibility, and context
  reconciliation.
- Final new regressions transplanted onto `66ef9ba`: **39 expected failures**;
  ordinary WebUI compression control still passes.
- Python compileall, `node --check static/sessions.js`, `git diff --check`, and
  Ruff diff gates: passed, **0 new Ruff violations**.
- Real isolated WebUI servers in Chromium at **1440×1000** and **390×844**:
  legacy and modern branches nest together, reset remains top-level, and the
  compressed fork remains visible. No uncaught JavaScript errors.

Screenshots and verification details:
[review evidence](https://github.com/lowlandsheperd/hermes-webui/tree/review-evidence/pr7179-efbde454).

## Risks / Follow-ups

- The full repository suite and maintainer's private gate were not run locally;
  the updated head still needs a fresh maintainer gate.
- Browser evidence uses isolated synthetic stores, not live Agent commands.
- A markerless legacy row with absent or invalid timestamps remains a child;
  this intentionally avoids inventing reset intent from incomplete metadata.
- Compression/reset conflict hardening covers inconsistent stored metadata that
  the current Agent is not expected to produce.

Release note: Reset conversations remain top-level while legacy branches keep
their nesting; corrupt reset metadata no longer empties the Agent session list,
and compressed WebUI forks remain visible.

## Model Used

OpenAI — GPT-6 via Codex (exact backend model ID unavailable in this session).
Local Python/Node tests and Chromium browser automation; no delegated agents.
