### PR TITLE
fix(streaming): support command-backed API key cache signatures

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7968,8 +7968,21 @@ def _agent_cache_api_key_sig(resolved_api_key, credential_pool) -> str:
     """
     if credential_pool is not None:
         return 'credential-pool'
+    if callable(resolved_api_key):
+        # key_cmd providers intentionally pass a lazy token source into
+        # AIAgent so the bearer can be refreshed per request.  Do not invoke
+        # (or stringify) that source merely to key the agent cache: the
+        # surrounding cache signature already includes provider, command and
+        # args, while resolving here would mint a credential too early.
+        source_type = type(resolved_api_key)
+        return f'callable:{source_type.__module__}.{source_type.__qualname__}'
     import hashlib as _hashlib
-    return _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16]
+    key_bytes = (
+        bytes(resolved_api_key)
+        if isinstance(resolved_api_key, (bytes, bytearray))
+        else str(resolved_api_key or '').encode()
+    )
+    return _hashlib.sha256(key_bytes).hexdigest()[:16]
 
 
 def _lifecycle_commit_session_memory(session_id: str, *, agent=None, wait: bool = False) -> bool:

--- a/tests/test_streaming_agent_cache_api_key_sig.py
+++ b/tests/test_streaming_agent_cache_api_key_sig.py
@@ -1,0 +1,74 @@
+"""Regression tests for runtime credential agent-cache signatures."""
+
+import hashlib
+
+from api.streaming import _agent_cache_api_key_sig
+
+
+class CommandTokenSourceStub:
+    """A lazy token source that must stay untouched while building cache keys."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        raise AssertionError("cache signature must not resolve a command token")
+
+    def __str__(self):
+        raise AssertionError("cache signature must not stringify a command token")
+
+
+class OtherTokenSourceStub:
+    def __call__(self):
+        raise AssertionError("cache signature must not resolve a command token")
+
+
+def _expected_digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()[:16]
+
+
+def test_callable_signature_does_not_invoke_or_stringify_source():
+    source = CommandTokenSourceStub()
+
+    signature = _agent_cache_api_key_sig(source, None)
+
+    assert signature == (
+        "callable:"
+        f"{CommandTokenSourceStub.__module__}.{CommandTokenSourceStub.__qualname__}"
+    )
+    assert source.calls == 0
+
+
+def test_callable_signature_is_stable_per_source_type():
+    first = CommandTokenSourceStub()
+    second = CommandTokenSourceStub()
+
+    assert _agent_cache_api_key_sig(first, None) == _agent_cache_api_key_sig(second, None)
+    assert _agent_cache_api_key_sig(first, None) != _agent_cache_api_key_sig(
+        OtherTokenSourceStub(), None
+    )
+
+
+def test_string_and_empty_signatures_remain_content_based():
+    assert _agent_cache_api_key_sig("token-a", None) == _expected_digest(b"token-a")
+    assert _agent_cache_api_key_sig("token-a", None) != _agent_cache_api_key_sig(
+        "token-b", None
+    )
+    assert _agent_cache_api_key_sig(None, None) == _expected_digest(b"")
+
+
+def test_bytes_and_bytearray_use_their_raw_contents():
+    expected = _expected_digest(b"token-a")
+
+    assert _agent_cache_api_key_sig(b"token-a", None) == expected
+    assert _agent_cache_api_key_sig(bytearray(b"token-a"), None) == expected
+    assert _agent_cache_api_key_sig("token-a", None) == expected
+
+
+def test_credential_pool_signature_takes_precedence():
+    source = CommandTokenSourceStub()
+
+    assert _agent_cache_api_key_sig(source, object()) == "credential-pool"
+    assert _agent_cache_api_key_sig("token-a", object()) == "credential-pool"
+    assert source.calls == 0


### PR DESCRIPTION
## Thinking Path

- WebUI resolves command-backed credentials lazily so bearer tokens can refresh per request.
- That lazy source reaches the session-agent cache signature as a callable, not a string.
- `_agent_cache_api_key_sig()` unconditionally called `.encode()`, so the turn crashed before `AIAgent` could consume the credential source.
- The surrounding cache blob already includes provider, API mode, command, and args, so the narrow invariant is to identify a lazy source without resolving or stringifying it.

## What Changed

- Return a stable `callable:<module>.<qualname>` cache component for callable API-key sources.
- Preserve the existing credential-pool sentinel and its precedence.
- Hash strings as before, while accepting `bytes` and `bytearray` by their raw content.
- Add focused regression tests for non-invocation/non-stringification, same-type stability and different-type separation, strings/empty values, bytes/bytearray, and credential-pool precedence.

The helper is the only cache-key chokepoint/call site. No token acquisition, provider resolution, or request-header behavior changes.

## Why It Matters

Command-backed bearer authentication can pass a lazy token source as `resolved_api_key`. WebUI turns should preserve that lazy behavior instead of crashing while computing a cache key or minting a credential early.

Security note: the signature contains only the callable's type identity. It does not execute the command, resolve the token, stringify the source, or include secret material.

## Contract Routing

Task type: runtime compatibility bug fix

Touched areas: `api/streaming.py` session-agent cache identity; focused unit tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/README.md`

Scope boundaries: this changes only the in-process session-agent cache signature component. It does not alter persisted session state, SSE events, replay/recovery, provider selection, or credential refresh behavior.

Evidence needed before claiming done: the reporter-shaped callable must fail on base and pass on head without invocation/stringification; existing credential-pool cache behavior must remain green.

## Verification

Base (`069a55d`, `exp-v0.52.255` / `master`), before the production fix:

```text
./scripts/test.sh tests/test_streaming_agent_cache_api_key_sig.py -q
3 failed, 2 passed
```

The failures were the expected `.encode()` crashes for callable and bytes inputs.

Head:

```text
./scripts/test.sh tests/test_streaming_agent_cache_api_key_sig.py -q
5 passed

./scripts/test.sh tests/test_sprint42.py -q -k AgentCacheCredentialPoolStability
4 passed, 36 deselected

python scripts/ruff_lint.py --diff origin/master
0 on added/modified lines; OK
```

## Risks / Follow-ups

- Same-type callable instances intentionally share this component. Their provider, API mode, command, and args remain part of the surrounding cache signature. If a future callable source has additional cache-relevant configuration, that authoritative configuration should be added to the surrounding signature rather than resolving the secret.
- I did not run a live command-backed provider turn because that would require an external credential command and secret-bearing provider state. The regression test exercises the exact crash boundary without secrets.
- No docs change is needed: this restores accepted lazy credential behavior and does not change a public workflow or contract.

Release-note wording: Command-backed API-key sources no longer crash WebUI turns while the session-agent cache signature is computed.

## Model Used

OpenAI GPT-5 (Codex agent; the exact deployment model ID is not exposed to the agent). Notable tools: isolated Git checkout, repository test runner, Ruff diff gate, and GitHub CLI. AI-assisted implementation and verification.