### PR TITLE
fix(approval): normalize legacy idless requests

### DIFF
--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -226,6 +226,13 @@ def _normalize_pending_queue_locked(session_key: str) -> list[dict]:
     if not isinstance(queue_list, list):
         _pending[session_key] = [queue_list]
         queue_list = _pending[session_key]
+    # Agent versions that predate approval identities can write directly to
+    # tools.approval._pending, bypassing this module's submit_pending wrapper.
+    # Assign the identity on first observation and persist it in the shared
+    # queue so the browser can safely target the exact entry it rendered.
+    for entry in queue_list:
+        if isinstance(entry, dict) and not str(entry.get("approval_id") or "").strip():
+            entry["approval_id"] = uuid.uuid4().hex
     return queue_list
 
 

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -69,6 +69,26 @@ def test_backward_compat_legacy_dict_value():
         "respond handler must handle legacy single-dict _pending values for backward compatibility"
 
 
+def test_normalize_pending_queue_assigns_stable_id_to_legacy_entry():
+    """An Agent-written legacy pending dict becomes safely actionable."""
+    from api import route_approvals as approvals
+
+    sid = "legacy-idless-pending"
+    try:
+        with approvals._lock:
+            approvals._pending[sid] = {"command": "echo legacy"}
+            first = approvals._normalize_pending_queue_locked(sid)
+            approval_id = first[0].get("approval_id")
+            second = approvals._normalize_pending_queue_locked(sid)
+
+        assert approval_id
+        assert len(approval_id) == 32
+        assert second[0]["approval_id"] == approval_id
+    finally:
+        with approvals._lock:
+            approvals._pending.pop(sid, None)
+
+
 # ---------------------------------------------------------------------------
 # Static-analysis: JavaScript frontend
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize legacy idless approval entries when the shared queue is first observed
- persist the generated identity in the authoritative queue so repeated polls remain stable
- add regression coverage for an already-live legacy dict entry

## Why
Older or fallback Agent paths can write directly to `tools.approval._pending` and bypass WebUI's identity-assigning wrapper. The card renders, but the frontend's stale-click guard rejects every action locally because there is no `approval_id`. This is a backward-compatible bridge for those entries and complements the native Agent producer fix.

Related: #6100

## Test
- `python -m pytest tests/test_approval_queue.py -q` (16 passed, 1 skipped)