### PR TITLE
fix: unlock delayed browser TTS on iOS

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2021,13 +2021,15 @@ window.renderTranscript=function(container, messages, opts){
     modeBtn.classList.add('active');
     _setButtonTooltip(modeBtn, t('voice_mode_toggle_active'));
     showToast(t('voice_mode_active'),1500);
+    // Cancel first so it cannot cancel the silent iOS Web Speech unlock.  Prime
+    // before the busy guard as voice mode may be enabled while a turn is running.
+    if(typeof stopTTS==='function') stopTTS();
+    if(typeof _primeBrowserTtsFromGesture==='function') _primeBrowserTtsFromGesture(true);
     // If the agent is busy, wait — state will be 'thinking' and we'll detect completion
     if(typeof S!=='undefined'&&S.busy){
       _setState('thinking');
       return;
     }
-    // Cancel any existing TTS
-    if(typeof stopTTS==='function') stopTTS();
     _startListening();
   }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1348,6 +1348,9 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
 }
 
 async function send(){
+  // Must run before any guard/await: iOS Safari's transient user activation is
+  // only available in the original Send / Enter event handler.
+  if(typeof _primeBrowserTtsFromGesture==='function') _primeBrowserTtsFromGesture(false);
   // Static guards expect _defaultMessageMode to stay near send() while the actual
   // read remains in the S.busy branch below.
   // _defaultMessageMode

--- a/static/ui.js
+++ b/static/ui.js
@@ -8958,6 +8958,33 @@ let _ttsChunkQueue=[];
 let _ttsChunkIndex=0;
 let _ttsActiveBtn=null;
 let _playingEdgeAudio=null;
+let _browserTtsPrimeUtterance=null;
+
+// iOS Safari will silently discard speech queued after an async response unless
+// speech synthesis was first used during a trusted user gesture.  Prime the
+// native Web Speech session from Send / Voice Mode while that activation is
+// still live; later auto-read utterances can then speak normally.
+function _primeBrowserTtsFromGesture(force){
+  if(!('speechSynthesis' in window)||typeof SpeechSynthesisUtterance!=='function') return false;
+  if(typeof navigator!=='undefined'&&navigator.userActivation&&navigator.userActivation.isActive!==true) return false;
+  const engine=localStorage.getItem('hermes-tts-engine')||'browser';
+  const autoRead=localStorage.getItem('hermes-tts-auto-read')==='true';
+  if(engine!=='browser'||(!force&&!autoRead)) return false;
+  try{
+    const utter=new SpeechSynthesisUtterance('');
+    const clear=()=>{
+      if(_browserTtsPrimeUtterance===utter) _browserTtsPrimeUtterance=null;
+    };
+    utter.onend=clear;
+    utter.onerror=clear;
+    _browserTtsPrimeUtterance=utter;
+    speechSynthesis.speak(utter);
+    return true;
+  }catch(_){
+    _browserTtsPrimeUtterance=null;
+    return false;
+  }
+}
 
 function _buildBrowserUtterance(text, btn){
   const utter=new SpeechSynthesisUtterance(text);

--- a/tests/test_ios_browser_tts_activation.py
+++ b/tests/test_ios_browser_tts_activation.py
@@ -1,0 +1,149 @@
+"""Regression coverage for delayed browser TTS on iOS Safari/PWA.
+
+Mobile Safari only permits later, asynchronous speech synthesis after an
+utterance has first been queued during a trusted user gesture.  Hermes receives
+the assistant response long after the Send / Voice Mode tap, so the browser TTS
+path must be primed while that activation is still live.
+"""
+
+from pathlib import Path
+import json
+import subprocess
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _extract_function(src: str, name: str) -> str:
+    anchor = f"function {name}("
+    start = src.find(anchor)
+    assert start != -1, f"{name}() must exist"
+    body_start = src.find("{", start)
+    assert body_start != -1, f"{name}() must have a body"
+    depth = 1
+    idx = body_start + 1
+    while depth and idx < len(src):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+        idx += 1
+    assert depth == 0, f"{name}() body must balance braces"
+    return src[start:idx]
+
+
+def test_prime_helper_obeys_activation_and_browser_engine():
+    src = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+    helper = _extract_function(src, "_primeBrowserTtsFromGesture")
+
+    harness = f"""
+let _browserTtsPrimeUtterance=null;
+{helper}
+
+function runCase(active, engine, autoRead, force) {{
+  const calls=[];
+  global.window={{speechSynthesis:{{}}}};
+  Object.defineProperty(global, 'navigator', {{
+    value:{{userActivation:{{isActive:active}}}},
+    configurable:true,
+  }});
+  global.localStorage={{getItem:(key)=>{{
+    if(key==='hermes-tts-engine') return engine;
+    if(key==='hermes-tts-auto-read') return autoRead;
+    return null;
+  }}}};
+  global.SpeechSynthesisUtterance=function(text){{this.text=text;}};
+  global.speechSynthesis={{speak:(utter)=>calls.push(utter)}};
+  const result=_primeBrowserTtsFromGesture(force);
+  return {{result, count:calls.length, text:calls[0]&&calls[0].text}};
+}}
+
+process.stdout.write(JSON.stringify([
+  runCase(true, 'browser', 'true', false),
+  runCase(false, 'browser', 'true', false),
+  runCase(true, 'edge', 'true', false),
+  runCase(true, 'browser', 'false', false),
+  runCase(true, 'browser', 'false', true),
+]));
+"""
+    proc = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    results = json.loads(proc.stdout)
+    assert results == [
+        {"result": True, "count": 1, "text": ""},
+        {"result": False, "count": 0},
+        {"result": False, "count": 0},
+        {"result": False, "count": 0},
+        {"result": True, "count": 1, "text": ""},
+    ]
+
+
+def test_user_gesture_prime_unlocks_a_later_async_reply():
+    src = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+    helper = _extract_function(src, "_primeBrowserTtsFromGesture")
+    harness = f"""
+let _browserTtsPrimeUtterance=null;
+{helper}
+
+let active=true;
+let unlocked=false;
+const spoken=[];
+global.window={{speechSynthesis:{{}}}};
+Object.defineProperty(global, 'navigator', {{
+  value:{{userActivation:{{get isActive(){{return active;}}}}}},
+  configurable:true,
+}});
+global.localStorage={{getItem:(key)=>{{
+  if(key==='hermes-tts-engine') return 'browser';
+  if(key==='hermes-tts-auto-read') return 'true';
+  return null;
+}}}};
+global.SpeechSynthesisUtterance=function(text){{this.text=text;}};
+global.speechSynthesis={{speak:(utter)=>{{
+  if(active && utter.text==='') unlocked=true;
+  if(utter.text && (active || unlocked)) spoken.push(utter.text);
+}}}};
+
+// Send tap: unlock with an empty utterance while activation is live.
+_primeBrowserTtsFromGesture(false);
+// Model response: user activation has expired by the time auto-read fires.
+active=false;
+speechSynthesis.speak(new SpeechSynthesisUtterance('Hermes reply'));
+process.stdout.write(JSON.stringify({{unlocked, spoken}}));
+"""
+    proc = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert json.loads(proc.stdout) == {
+        "unlocked": True,
+        "spoken": ["Hermes reply"],
+    }
+
+
+def test_send_primes_before_any_async_or_busy_guard():
+    src = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+    send = _extract_function(src, "send")
+    prime_at = send.find("_primeBrowserTtsFromGesture(false)")
+    assert prime_at != -1
+    assert prime_at < send.find("if (_sendInProgress)")
+    assert prime_at < send.find("await ") if "await " in send else True
+
+
+def test_voice_mode_stops_then_primes_before_busy_or_listening():
+    src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    activate = _extract_function(src, "_activate")
+    stop_at = activate.find("stopTTS()")
+    prime_at = activate.find("_primeBrowserTtsFromGesture(true)")
+    busy_at = activate.find("S.busy")
+    listen_at = activate.find("_startListening()")
+    assert -1 not in (stop_at, prime_at, busy_at, listen_at)
+    assert stop_at < prime_at < busy_at < listen_at


### PR DESCRIPTION
## Summary

- prime the native Web Speech API during the trusted Send / Enter gesture when browser auto-read is enabled
- prime browser speech when Voice Mode is activated, including while a turn is already running
- keep programmatic sends and non-browser TTS engines unchanged

## Root cause

On iOS Safari and installed PWAs, a `speechSynthesis.speak()` call made only after an asynchronous model response may be silently ignored unless speech synthesis was first used during a user gesture. Hermes currently waits for stream completion and another 300 ms before speaking, after the original user activation has expired.

The fix queues an empty native utterance during the original gesture. This unlocks later browser utterances without adding a server TTS dependency or changing Edge/OpenAI/ElevenLabs engines.

## Tests

- base regression: 3 failed
- head: `68 passed`
- `node --check static/ui.js static/messages.js static/boot.js`
- `git diff --check`

The behavioral regression simulates iOS rejecting delayed speech before the gesture prime and accepting the assistant reply afterward.
