### PR TITLE
test(mcp): skip mcp_server tests cleanly on an unsupported mcp SDK

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,25 @@ import pytest
 # runtime environments can still collect the rest of the suite without it.
 pytest.importorskip("mcp", reason="mcp package not installed (optional MCP server dep)")
 
+# The `mcp` package being importable is not sufficient: mcp>=2.0.0 dropped the
+# Server.list_tools / Server.call_tool decorator API that mcp_server.py is built
+# on (it hard-exits at import when that API is absent — see mcp_server.py's "MCP
+# SDK version guard"). On a box whose environment has an out-of-range mcp SDK
+# installed (e.g. the shared agent venv carrying mcp 2.x), importing mcp_server
+# raises SystemExit and every test in this module errors at setup instead of
+# skipping. Reuse the SAME capability predicate the server uses so the module
+# skips cleanly on an unsupported SDK on any box, while CI (which pins
+# mcp>=1.28,<2 via requirements-dev.txt) still runs the full module.
+from mcp.server import Server as _McpServer  # noqa: E402  (after importorskip guard)
+
+if not hasattr(_McpServer, "list_tools"):
+    pytest.skip(
+        "mcp SDK out of supported range (requires mcp>=1.28,<2 with the "
+        "list_tools/call_tool decorator API); mcp_server.py hard-exits on this "
+        "SDK, so its tests skip rather than error on an incompatible environment.",
+        allow_module_level=True,
+    )
+
 # pytest-asyncio is also optional but always installed alongside mcp tests
 # in our local runs. If absent, importorskip the asyncio plugin gracefully.
 pytest.importorskip("pytest_asyncio", reason="pytest-asyncio required for MCP server tests")


### PR DESCRIPTION
## Skip `test_mcp_server.py` cleanly on an unsupported mcp SDK

**Problem.** `tests/test_mcp_server.py` guarded only with `pytest.importorskip("mcp")`, which checks the package is *present* but not that it exposes the 1.x `Server.list_tools` / `Server.call_tool` decorator API that `mcp_server.py` is built on. `mcp>=2.0.0` dropped that API, and `mcp_server.py` hard-exits (`SystemExit`) at its own "MCP SDK version guard" when it's absent. So on any environment carrying mcp 2.x, the fixture's `import mcp_server` raises `SystemExit` and **every test in the module errors at setup** (observed: 36 errors + 14 failures) instead of skipping.

This is purely an environment-shape artifact — CI pins `mcp>=1.28,<2` via `requirements-dev.txt` and is unaffected — but it makes a local/full-suite run on a box with a newer mcp look like a large regression, which it isn't.

**Fix.** After the `importorskip("mcp")` guard, reuse the *exact* predicate `mcp_server.py` uses — `hasattr(Server, "list_tools")` — to `pytest.skip(..., allow_module_level=True)` when the installed SDK is out of the supported range. Test-only, no production change.

**Verification.**
- On this box (mcp 2.0.0): `pytest tests/test_mcp_server.py` → `1 skipped` (was 36 errors + 14 failed).
- On CI (mcp>=1.28,<2, `hasattr` True): the full module runs exactly as before.
- ruff diff-gate clean; py-compile clean.

Follow-up: this is one of two classes making the local full suite non-green on a newer-mcp box; the other (a real `test_issue1699` catalog-invalidation issue) is handled separately.
