### PR TITLE
test(#1699): make static-catalog invalidation assertions overflow-aware

### DIFF
--- a/tests/test_issue1699_model_cache_source_fingerprint.py
+++ b/tests/test_issue1699_model_cache_source_fingerprint.py
@@ -161,7 +161,17 @@ def test_memory_models_cache_invalidates_when_static_catalog_changes(tmp_path, m
     result = config.get_available_models()
 
     opencode_group = next(g for g in result["groups"] if g.get("provider_id") == "opencode-go")
-    assert any(m.get("id") == "new-catalog-model" for m in opencode_group["models"])
+    # The opencode-go static catalog now exceeds the picker overflow threshold
+    # (_MODEL_PICKER_OVERFLOW_THRESHOLD), so the rebuilt group splits into a
+    # visible `models` head plus an `extra_models` overflow tail. The newly
+    # appended catalog entry is surfaced in that combined catalog — assert on
+    # the full surface, not just the visible head, so this stays a pure
+    # cache-invalidation regression check independent of the overflow cap.
+    surfaced_ids = {
+        m.get("id")
+        for m in (opencode_group.get("models", []) + opencode_group.get("extra_models", []))
+    }
+    assert "new-catalog-model" in surfaced_ids
 
 
 def test_disk_models_cache_invalidates_when_static_catalog_changes(tmp_path, monkeypatch):
@@ -179,4 +189,11 @@ def test_disk_models_cache_invalidates_when_static_catalog_changes(tmp_path, mon
 
     assert result != stale_opencode
     opencode_group = next(g for g in result["groups"] if g.get("provider_id") == "opencode-go")
-    assert any(m.get("id") == "new-disk-catalog-model" for m in opencode_group["models"])
+    # See sibling test: the oversized opencode-go catalog splits into
+    # `models` + `extra_models`, so assert the appended entry is surfaced
+    # across the combined picker catalog after cache invalidation.
+    surfaced_ids = {
+        m.get("id")
+        for m in (opencode_group.get("models", []) + opencode_group.get("extra_models", []))
+    }
+    assert "new-disk-catalog-model" in surfaced_ids


### PR DESCRIPTION
## Make the #1699 static-catalog invalidation tests overflow-aware (stale-test fix)

`tests/test_issue1699_model_cache_source_fingerprint.py` has two tests —
`test_memory_models_cache_invalidates_when_static_catalog_changes` and
`test_disk_models_cache_invalidates_when_static_catalog_changes` — that started
failing (in isolation, on clean master).

**Root cause: stale test, not a code bug.** Both append a new model to
`config._PROVIDER_MODELS["opencode-go"]` and asserted it shows up in the rebuilt
opencode-go group's **visible** `models` list. That held when the tests were
written (opencode-go had **14** static entries). The curated list has since
grown to **27**, past the model-picker overflow threshold, so the rebuilt group
now splits into a capped visible `models` head + an `extra_models` overflow
tail. The appended entry is added at the *end* of the list, so it correctly
lands in `extra_models`. The cache invalidation the test exists to guard works
exactly as intended — only the assertion's assumption (no overflow split) went
stale.

**Fix (test-only, no production change).** Assert the appended model is surfaced
across the **combined** picker catalog (`models` + `extra_models`), so the test
stays a pure cache-invalidation regression check independent of the overflow
cap.

**Verification**
- Both target tests + full file: `5 passed` (were 2 failing).
- 84 related picker/model-resolver tests: pass.
- **Non-vacuity proven:** swapping in a genuinely-absent model id makes the
  assertion FAIL — so it still genuinely detects a broken invalidation, it's
  just overflow-aware now.

This is the second of two classes that made the local full suite non-green on
this box; the first (mcp SDK version skip) landed in #7196.
