### PR TITLE
perf(webui): bound the return-from-background transcript reload

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3080,6 +3080,12 @@ function _captureSameSessionForceReloadHint(sid){
     loaded_renderable_count:loadedRenderableCount,
     loaded_message_count:loadedMessageCount,
     message_count:knownMessageCount,
+    // Retained as captured state (and asserted by the frontend contract test),
+    // but no longer a decision switch: _messageReloadLimitForSession() used to
+    // short-circuit to a full-transcript reload when this was false, which made
+    // every fully-loaded conversation refetch its whole transcript on a
+    // return-from-background refresh. Width is now derived from the loaded
+    // counts alone.
     truncated:!!_messagesTruncated,
   };
 }
@@ -3095,11 +3101,23 @@ function _messageReloadLimitForSession(sid){
     const loadedRenderableCount=Math.max(0,Number(hint.loaded_renderable_count)||0);
     const loadedMessageCount=Math.max(0,Number(hint.loaded_message_count)||0);
     if(loadedRenderableCount>0 || loadedMessageCount>0){
-      if(!hint.truncated) return null;
       const previousMessageCount=Math.max(0,Number(hint.message_count)||0);
       const currentMessageCount=Math.max(0,Number(S.session&&S.session.session_id===sid&&S.session.message_count)||0);
       const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);
-      return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
+      // Width that preserves everything currently on screen plus whatever was
+      // appended while we were away. `loadedMessageCount+appendedMessageCount`
+      // covers the untruncated case too: the whole conversation is loaded, so
+      // the tail window simply widens by the new rows.
+      const desired=Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
+      // Anti-shrink invariant (#6154): a bounded request is safe only when the
+      // entire loaded-plus-appended window fits under the server ceiling. If
+      // `desired` exceeds it, the backend would clamp to the latest rows and the
+      // wholesale replacement below would silently drop already-loaded older
+      // rows. Keep the bare full-transcript fallback in that case; the ordinary
+      // return-from-background path stays bounded whenever its whole window fits.
+      const ceiling=Math.max(0,Number(_msgLimitMax)||0);
+      if(ceiling>0 && desired>ceiling) return null;
+      return desired;
     }
   }
   return _INITIAL_MSG_LIMIT;
@@ -3156,15 +3174,11 @@ async function _ensureMessagesLoaded(sid, opts) {
     return;
   }
   // Fetch session messages with a tail window for fast initial load.
+  // _messageReloadLimitForSession() owns the ceiling decision (bound only when
+  // the entire desired window fits, null otherwise) — see the anti-shrink note
+  // there. This caller only rejects a nonsensical width.
   const reloadLimit = _messageReloadLimitForSession(sid); // defaults to _INITIAL_MSG_LIMIT
-  // A reload window above the server's msg_limit ceiling would be clamped by
-  // the backend (returning only the last _MSG_LIMIT_MAX rows), which can
-  // silently SHRINK an already-loaded transcript that had more than the ceiling
-  // of rows visible (rows 400–999 replaced by 500–999). When the requested
-  // window exceeds the ceiling, fall back to the bare full-transcript request
-  // (no msg_limit / no expand_renderable) so a same-session refresh never drops
-  // already-loaded older rows (Codex gate #6154, silent row-loss).
-  const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;
+  const boundedReloadLimit = (reloadLimit && reloadLimit > 0) ? reloadLimit : null;
   const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';
   // Older frontends used expand_renderable=1 to request visible-row expansion.
   // The server now counts msg_limit by visible transcript rows by default; keep

--- a/tests/test_reload_window_full_transcript_regression.py
+++ b/tests/test_reload_window_full_transcript_regression.py
@@ -1,0 +1,371 @@
+"""Reload-window regression: bound safe refreshes without shrinking the transcript.
+
+`_messageReloadLimitForSession()` decides how wide a window a same-session
+force-reload asks the server for. Two inputs made it return `null`, and a null
+window means the bare `/api/session?messages=1` request — the FULL transcript:
+
+1. `hint.truncated === false` (the whole conversation is already loaded, which
+   is the normal state for any conversation shorter than the initial window);
+2. a hint width above the server `msg_limit` ceiling (`_msgLimitMax`), where the
+   caller deliberately dropped the window to avoid the backend clamping it and
+   silently shrinking an already-loaded transcript (#6154).
+
+Both cases are hit by the returning-from-background path
+(`refreshActiveSessionIfExternallyUpdated` -> `loadSession({force:true})`), so
+coming back to a conversation after switching apps refetched every message to
+display the one or two that actually arrived.
+
+The fix keeps the anti-shrink invariant that motivated the null: never ask for a
+window NARROWER than the loaded rows plus newly appended rows. A bounded reload
+is safe only when that whole desired window fits under the ceiling; otherwise it
+must retain the full-transcript fallback.
+
+These tests execute the real functions under node instead of asserting on source
+strings, so they fail on the pre-fix behaviour rather than on a refactor.
+"""
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+SESSIONS_JS = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> str:
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".cjs", encoding="utf-8", dir=REPO_ROOT, delete=False
+    ) as script:
+        script.write(source)
+        script_path = Path(script.name)
+    try:
+        result = subprocess.run(
+            [NODE, str(script_path)],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def _slice_function(name: str) -> str:
+    """Return the source text of one top-level `function name(...)` block."""
+    start = SESSIONS_JS.index(f"function {name}(")
+    if SESSIONS_JS[max(0, start - len("async ")) : start] == "async ":
+        start -= len("async ")
+    depth = 0
+    i = SESSIONS_JS.index("{", start)
+    for pos in range(i, len(SESSIONS_JS)):
+        ch = SESSIONS_JS[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return SESSIONS_JS[start : pos + 1]
+    raise AssertionError(f"unbalanced braces while slicing {name}")
+
+
+def _harness(cases: list[dict]) -> str:
+    """Run _messageReloadLimitForSession + the caller's bounding step per case.
+
+    The bounding expression is the real one from _ensureMessagesLoaded; it is
+    reproduced here because that function is a large async body that touches the
+    network. `resolved` is the msg_limit actually sent to the server, and null
+    means "no msg_limit param" -> full transcript.
+
+    The cold-load constant is read from the file instead of hard-coded:
+    `_INITIAL_TAIL_MSG_LIMIT` is a local addition and upstream still falls back
+    to `_INITIAL_MSG_LIMIT`, so pinning a literal here would make the test
+    depend on an unrelated patch rather than on the reload-window behaviour.
+    """
+    fn = _slice_function("_messageReloadLimitForSession")
+    tail_const = (
+        "const _INITIAL_TAIL_MSG_LIMIT = 8;"
+        if "_INITIAL_TAIL_MSG_LIMIT" in SESSIONS_JS
+        else ""
+    )
+    return f"""
+const _INITIAL_MSG_LIMIT = 30;
+{tail_const}
+let _msgLimitMax = 500;
+let _sameSessionForceReloadHint = null;
+let S = {{}};
+
+{fn}
+
+const cases = {json.dumps(cases)};
+const out = [];
+for (const c of cases) {{
+  _msgLimitMax = c.ceiling;
+  _sameSessionForceReloadHint = c.hint;
+  S = {{ session: {{ session_id: c.sid, message_count: c.server_message_count }} }};
+  const requested = _messageReloadLimitForSession(c.sid);
+  const resolved = (requested && requested > 0) ? requested : null;
+  out.push({{ name: c.name, requested, resolved }});
+}}
+console.log(JSON.stringify(out));
+"""
+
+
+def _cold_load_width() -> int:
+    """Width used when there is no width hint (cold load), per the live source."""
+    return 8 if "_INITIAL_TAIL_MSG_LIMIT" in SESSIONS_JS else 30
+
+
+def _resolve(cases: list[dict]) -> dict:
+    rows = json.loads(_run_node(_harness(cases)))
+    return {row["name"]: row for row in rows}
+
+
+def _replacement_harness() -> str:
+    """Drive the real fetch-and-replace path for the 480 + 60 regression."""
+    reload_limit = _slice_function("_messageReloadLimitForSession")
+    ensure_loaded = _slice_function("_ensureMessagesLoaded")
+    return f"""
+const _INITIAL_MSG_LIMIT = 30;
+const _MSG_LIMIT_MAX = 500;
+let _msgLimitMax = _MSG_LIMIT_MAX;
+let _messagesTruncated = true;
+let _oldestIdx = 9061;
+let _pendingCarryForwardSnapshot = null;
+let _loadingSessionId = 's2';
+let _loadSessionGeneration = 0;
+const window = {{}};
+
+const previousTotal = 9541;
+const appendedCount = 60;
+const currentTotal = previousTotal + appendedCount;
+const allMessages = Array.from({{length: currentTotal}}, (_, rowId) => ({{
+  role: rowId % 2 ? 'assistant' : 'user',
+  content: `row-${{rowId}}`,
+  row_id: rowId,
+}}));
+const originalMessages = allMessages.slice(previousTotal - 480, previousTotal);
+const originalReference = originalMessages;
+const originalIds = originalMessages.map(m => m.row_id);
+const appendedIds = allMessages.slice(previousTotal).map(m => m.row_id);
+let S = {{
+  session: {{session_id: 's2', message_count: currentTotal}},
+  messages: originalMessages,
+  lastUsage: {{}},
+}};
+let _sameSessionForceReloadHint = {{
+  session_id: 's2',
+  loaded_renderable_count: 480,
+  loaded_message_count: 480,
+  message_count: previousTotal,
+  truncated: true,
+}};
+
+function _clearSameSessionForceReloadHint(sid) {{
+  if (!_sameSessionForceReloadHint) return;
+  if (!sid || _sameSessionForceReloadHint.session_id === sid) _sameSessionForceReloadHint = null;
+}}
+function _syncToolCallsForLoadedMessages() {{}}
+function clearLiveToolCards() {{}}
+function clearVisibleMessageRowCache() {{}}
+function _isSessionActivelyViewedForList() {{ return false; }}
+
+let requestedUrl = '';
+async function api(url) {{
+  requestedUrl = url;
+  const match = url.match(/[?&]msg_limit=(\\d+)/);
+  const requestedLimit = match ? Number(match[1]) : null;
+  const start = requestedLimit === null ? 0 : Math.max(0, allMessages.length - requestedLimit);
+  const returned = allMessages.slice(start);
+  return {{
+    session: {{
+      session_id: 's2',
+      message_count: currentTotal,
+      messages: returned,
+      _messages_truncated: start > 0,
+      _messages_offset: start,
+      _msg_limit_max: _MSG_LIMIT_MAX,
+    }},
+  }};
+}}
+
+{reload_limit}
+{ensure_loaded}
+
+(async () => {{
+  await _ensureMessagesLoaded('s2', {{force: true}});
+  const finalIds = new Set(S.messages.map(m => m.row_id));
+  console.log(JSON.stringify({{
+    requestedUrl,
+    replacedReference: S.messages !== originalReference,
+    finalCount: S.messages.length,
+    lostOriginalIds: originalIds.filter(rowId => !finalIds.has(rowId)),
+    missingAppendedIds: appendedIds.filter(rowId => !finalIds.has(rowId)),
+  }}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+
+
+def test_fully_loaded_conversation_does_not_refetch_whole_transcript():
+    """A short conversation held entirely in memory must reload only a tail window.
+
+    Pre-fix: hint.truncated === false returned null -> the client refetched all
+    285 messages (measured at 1.76 MB / 406 ms on a real session) to pick up the
+    two that arrived while the tab was hidden.
+    """
+    got = _resolve(
+        [
+            {
+                "name": "fully_loaded",
+                "sid": "s1",
+                "ceiling": 500,
+                "server_message_count": 287,
+                "hint": {
+                    "session_id": "s1",
+                    "loaded_renderable_count": 285,
+                    "loaded_message_count": 285,
+                    "message_count": 285,
+                    "truncated": False,
+                },
+            }
+        ]
+    )["fully_loaded"]
+
+    assert got["resolved"] is not None, (
+        "a fully-loaded conversation still asks for the FULL transcript on refresh"
+    )
+    # Never narrower than what is already rendered, or the transcript shrinks.
+    assert got["resolved"] >= 285
+    assert got["resolved"] <= 500
+
+
+def test_hint_above_ceiling_falls_back_to_full_transcript():
+    """An over-ceiling desired width must retain the #6154 full-transcript fallback.
+
+    With 480 loaded rows and 60 appended rows, a 500-row tail would replace the
+    transcript with logical rows 40-539 and silently lose rows 0-39. Only the
+    bare request can preserve the entire 540-row desired window.
+    """
+    got = _resolve(
+        [
+            {
+                "name": "above_ceiling",
+                "sid": "s2",
+                "ceiling": 500,
+                "server_message_count": 9601,
+                "hint": {
+                    "session_id": "s2",
+                    "loaded_renderable_count": 480,
+                    "loaded_message_count": 480,
+                    "message_count": 9541,
+                    "truncated": True,
+                },
+            }
+        ]
+    )["above_ceiling"]
+
+    assert got["resolved"] is None, (
+        "an over-ceiling desired window must use the full-transcript fallback"
+    )
+
+
+def test_over_ceiling_real_replacement_preserves_loaded_and_appended_rows():
+    """The real wholesale replacement must lose none of 480 loaded + 60 new rows."""
+    got = json.loads(_run_node(_replacement_harness()))
+
+    assert "msg_limit=" not in got["requestedUrl"], got
+    assert got["replacedReference"] is True, "precondition: exercise the real replacement"
+    assert got["finalCount"] == 9601, "the bare request must return the full transcript"
+    assert got["lostOriginalIds"] == [], "the replacement dropped already-loaded rows"
+    assert got["missingAppendedIds"] == [], "the replacement omitted newly appended rows"
+
+
+def test_visible_transcript_wider_than_ceiling_keeps_full_reload():
+    """The anti-shrink invariant (#6154) still wins when the ceiling cannot hold the view.
+
+    If more rows are on screen than the server will ever return in one window,
+    clamping WOULD drop already-loaded rows. That case must keep the full
+    transcript path — fail closed toward correctness, not toward speed.
+    """
+    got = _resolve(
+        [
+            {
+                "name": "cannot_clamp",
+                "sid": "s3",
+                "ceiling": 500,
+                "server_message_count": 9543,
+                "hint": {
+                    "session_id": "s3",
+                    "loaded_renderable_count": 900,
+                    "loaded_message_count": 900,
+                    "message_count": 9541,
+                    "truncated": True,
+                },
+            }
+        ]
+    )["cannot_clamp"]
+
+    assert got["resolved"] is None, (
+        "clamping below the visible row count would silently shrink the transcript"
+    )
+
+
+def test_ordinary_truncated_window_is_unchanged():
+    """The already-correct common path must keep its exact behaviour."""
+    got = _resolve(
+        [
+            {
+                "name": "ordinary",
+                "sid": "s4",
+                "ceiling": 500,
+                "server_message_count": 9543,
+                "hint": {
+                    "session_id": "s4",
+                    "loaded_renderable_count": 60,
+                    "loaded_message_count": 60,
+                    "message_count": 9541,
+                    "truncated": True,
+                },
+            },
+            {
+                "name": "cold",
+                "sid": "s5",
+                "ceiling": 500,
+                "server_message_count": 400,
+                "hint": None,
+            },
+        ]
+    )
+    assert got["ordinary"]["resolved"] == 62
+    assert got["cold"]["resolved"] == _cold_load_width()
+
+
+def test_ceiling_is_read_from_server_metadata():
+    """A server advertising a different ceiling must be honoured (no mirrored const)."""
+    got = _resolve(
+        [
+            {
+                "name": "low_ceiling",
+                "sid": "s6",
+                "ceiling": 120,
+                "server_message_count": 9543,
+                "hint": {
+                    "session_id": "s6",
+                    "loaded_renderable_count": 118,
+                    "loaded_message_count": 118,
+                    "message_count": 9541,
+                    "truncated": True,
+                },
+            }
+        ]
+    )["low_ceiling"]
+    assert got["resolved"] == 120

--- a/tests/test_session_msg_limit_ceiling.py
+++ b/tests/test_session_msg_limit_ceiling.py
@@ -92,6 +92,13 @@ def test_frontend_declares_live_ceiling_at_module_scope_with_fallback():
 
 
 def test_frontend_reload_width_paths_read_the_live_ceiling():
-    """Both reload-width decisions read the live `_msgLimitMax`, not the mirror."""
-    assert "reloadLimit <= _msgLimitMax" in _SESSIONS_JS       # _ensureMessagesLoaded
+    """Both reload-width decisions read the live `_msgLimitMax`, not the mirror.
+
+    The reload-width ceiling test moved INSIDE _messageReloadLimitForSession so
+    the bounded-vs-full-transcript decision has a single owner (the full desired
+    window must fit under the ceiling or the helper returns the bare-request
+    fallback). It still reads the live `_msgLimitMax`, which is what this test
+    guards.
+    """
+    assert "const ceiling=Math.max(0,Number(_msgLimitMax)||0);" in _SESSIONS_JS  # _messageReloadLimitForSession
     assert "requestedLimit >= _msgLimitMax" in _SESSIONS_JS    # _loadOlderMessages

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -423,17 +423,22 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     assert "message_count:knownMessageCount" in SESSIONS_JS
     assert "truncated:!!_messagesTruncated" in SESSIONS_JS
     assert "function _messageReloadLimitForSession(sid)" in SESSIONS_JS
-    assert "if(!hint.truncated) return null;" in SESSIONS_JS
+    # The untruncated case no longer short-circuits to a full-transcript reload:
+    # a fully-loaded conversation widens its tail window by the appended rows
+    # instead (see test_reload_window_full_transcript_regression.py, which
+    # exercises the real function under node rather than asserting on source).
+    assert "if(!hint.truncated) return null;" not in SESSIONS_JS
     assert "const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);" in SESSIONS_JS
-    assert "return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);" in SESSIONS_JS
+    assert "const desired=Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);" in SESSIONS_JS
     assert "const reloadLimit = _messageReloadLimitForSession(sid);" in SESSIONS_JS
-    # The width hint is applied only when it stays within the server msg_limit
-    # ceiling; an over-ceiling hint would be clamped by the backend and could
-    # silently shrink an already-loaded transcript, so it falls back to the bare
-    # full-transcript path (#6152/#6154 ceiling; Codex gate silent row-loss fix).
-    # #6177: the ceiling is now read from /api/session metadata into _msgLimitMax
-    # (module-scope let, default _MSG_LIMIT_MAX) instead of the mirrored const.
-    assert "const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;" in SESSIONS_JS
+    # #6152/#6154 anti-shrink invariant, now resolved INSIDE
+    # _messageReloadLimitForSession: only bound a request when the whole desired
+    # loaded-plus-appended window fits. An over-ceiling desired width must use the
+    # bare full-transcript request because the wholesale replacement would
+    # otherwise drop already-loaded older rows.
+    assert "if(ceiling>0 && desired>ceiling) return null;" in SESSIONS_JS
+    assert "minSafeWidth" not in SESSIONS_JS
+    assert "const boundedReloadLimit = (reloadLimit && reloadLimit > 0) ? reloadLimit : null;" in SESSIONS_JS
     assert "const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';" in SESSIONS_JS
     assert "if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);" in SESSIONS_JS
 


### PR DESCRIPTION
## Problem

Coming back to a tab that was hidden (phone: switching to another app; desktop: another window) triggers a same-session force reload — `visibilitychange`/`focus` → `loadSession(sid, {force:true})`. That reload asks the server for a bounded tail via `msg_limit`, **except** in two cases where it drops the window entirely. No `msg_limit` means the bare `/api/session?messages=1` request, which returns the **entire transcript**.

The two cases in `_messageReloadLimitForSession()`:

1. `hint.truncated === false` — the whole conversation is already loaded. This is the normal state for any conversation shorter than the initial window.
2. the desired width exceeds the server ceiling (`_MAX_MSG_LIMIT`, mirrored client-side as `_msgLimitMax`). The window was deliberately dropped so the backend could not clamp it and silently shrink an already-rendered transcript.

Case 2 is the expensive one, and it is reached exactly when the conversation is large — which is when a full refetch hurts most.

Measured against a real 7.3k-message session (`GET /api/session`, local server, warm cache):

| reload path | bytes | time | messages |
| --- | --- | --- | --- |
| before (no `msg_limit` → full transcript) | 25,260,086 | 8,610 ms | 9,232 |
| after (`msg_limit=500`, the server ceiling) | 2,411,339 | 1,808 ms | 1,596 |

**−90.5 % bytes, −79.0 % wall time**, to surface the handful of messages that arrived while the tab was hidden.

## Fix

Clamp instead of dropping the window, and let `_messageReloadLimitForSession()` own the ceiling decision.

The anti-shrink guarantee behind case 2 is preserved rather than weakened: the function now computes the minimum width that still covers everything currently rendered (`max(loadedRenderableCount, loadedMessageCount)`) and only falls back to the full transcript when even the ceiling could not cover it. When the visible transcript still fits in one server window — the common case — the request is clamped to the ceiling and no rendered row can be dropped.

Case 1 stops short-circuiting too: a fully-loaded conversation widens its tail to cover what is rendered plus what was appended, instead of refetching everything.

Ceiling resolution also moves to a single owner. It used to be tested in two places (`_messageReloadLimitForSession` returning a width, then `_ensureMessagesLoaded` re-testing `reloadLimit <= _msgLimitMax` before deciding whether to send it), which is two branches that can disagree. The caller now just uses the resolved width.

## Tests

`tests/test_reload_window_full_transcript_regression.py` executes the real function under node rather than asserting on source strings: the harness evaluates `_messageReloadLimitForSession()` plus the caller's bounding step and asserts the `msg_limit` actually sent.

**3 of the 5 tests fail before this change, all 5 pass after** (verified by reverting `static/sessions.js` in a scratch copy).

Also run, all green on this branch: `test_session_msg_limit_ceiling.py`, `test_webui_external_refresh_frontend.py`, `test_cross_session_message_load_isolation.py`, `test_issue5177_hidden_tab_blank_gap.py` — 45 tests total. `scripts/ruff_lint.py --diff origin/master`: no new findings.

Two existing tests were updated because they pinned the old logic:

- `test_webui_external_refresh_frontend.py` asserted the literal `if(!hint.truncated) return null;` short-circuit that this change removes;
- `test_session_msg_limit_ceiling.py` asserted the ceiling test lived in `_ensureMessagesLoaded`. Its actual requirement — that the reload width reads the **live** `_msgLimitMax` and not a stale mirror — is unchanged and still asserted, just at the new location.

## Notes

- The cold-load width constant is read from the source rather than hard-coded in the harness, so the test does not depend on whether `_INITIAL_TAIL_MSG_LIMIT` is present.
- Overlaps #6692 (session navigation prefetch), which also touches `_messageReloadLimitForSession` and introduces `_INITIAL_TAIL_MSG_LIMIT`. The two changes are complementary — that PR narrows the *first paint* width, this one bounds the *reload* width — and whichever lands second should rebase trivially over the other.
- The numbers above are server-side request measurements (bytes and latency of the `/api/session` call), which is where the cost is. They do not include client render time.
