### PR TITLE
fix(ui): avoid full transcript fetch on regenerate (#6826)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8598,6 +8598,144 @@ def get_state_db_session_message_keys_before_timestamp(
         return None
 
 
+def get_state_db_regeneration_tail_snapshot(
+    sid,
+    floor,
+    *,
+    profile=None,
+):
+    """Return prefix proof + bounded tail from ONE read transaction (#6826 r3).
+
+    The regeneration guard must not suffer TOCTOU: the prefix summary, the
+    ordered prefix keys, and the bounded tail must come from the same SQLite
+    snapshot, otherwise a row inserted between the proof and the data read
+    can be silently omitted while the proof still authorizes the bounded path.
+
+    Returns ``None`` when a stable single-connection snapshot cannot be
+    obtained (callers must fall back to the full read). Otherwise returns::
+
+        {
+          "prefix": {"count": N, "null_timestamp_count": M},
+          "prefix_keys": [visible-key, ...],       # rows < floor, db order
+          "tail": [message-dict, ...],             # rows >= floor (bounded)
+          "tail_keys": [visible-key, ...],         # rows >= floor, db order
+        }
+    """
+    try:
+        import sqlite3
+    except ImportError:
+        return None
+
+    if not sid:
+        return None
+    try:
+        floor_ts = float(floor)
+    except (TypeError, ValueError):
+        return None
+    if isinstance(profile, str) and profile:
+        db_path = _get_profile_home(profile) / 'state.db'
+        if not db_path.exists():
+            db_path = _active_state_db_path()
+    else:
+        db_path = _active_state_db_path()
+    if not db_path.exists():
+        return {"prefix": {"count": 0, "null_timestamp_count": 0}, "prefix_keys": [], "tail": [], "tail_keys": []}
+
+    try:
+        with closing(open_state_db_readonly(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("BEGIN")
+            cur.execute("PRAGMA table_info(messages)")
+            available = {str(row['name']) for row in cur.fetchall()}
+            if not {'session_id', 'role', 'content', 'timestamp'}.issubset(available):
+                cur.execute("ROLLBACK")
+                return None
+            active_clause = ""
+            if 'active' in available:
+                active_clause = " AND (active IS NULL OR active != 0)"
+            # 1) prefix summary (rows with timestamp < floor)
+            cur.execute(
+                f"""
+                SELECT
+                    COUNT(CASE WHEN timestamp IS NOT NULL AND timestamp < ? THEN 1 END) AS count,
+                    COUNT(CASE WHEN timestamp IS NULL THEN 1 END) AS null_timestamp_count
+                FROM messages
+                WHERE session_id = ? {active_clause}
+                """,
+                (floor_ts, str(sid)),
+            )
+            row = cur.fetchone()
+            prefix = {
+                "count": int(row["count"]) if row else 0,
+                "null_timestamp_count": int(row["null_timestamp_count"]) if row else 0,
+            }
+            # 2) ordered prefix keys (rows < floor)
+            prefix_key_cols = "COALESCE(role,'') AS role, COALESCE(content,'') AS content"
+            if 'tool_calls' in available:
+                prefix_key_cols += ", tool_calls"
+            if 'api_content' in available:
+                prefix_key_cols += ", api_content"
+            if 'id' in available:
+                prefix_key_sql = (
+                    f"SELECT {prefix_key_cols} FROM messages "
+                    "WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ? "
+                    f"{active_clause} ORDER BY timestamp ASC, id ASC"
+                )
+                prefix_params = (str(sid), floor_ts)
+            else:
+                prefix_key_sql = (
+                    f"SELECT {prefix_key_cols} FROM messages "
+                    "WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ? "
+                    f"{active_clause} ORDER BY timestamp ASC"
+                )
+                prefix_params = (str(sid), floor_ts)
+            try:
+                cur.execute(prefix_key_sql, prefix_params)
+            except Exception:
+                cur.execute("ROLLBACK")
+                return None
+            prefix_keys = [
+                _session_message_visible_key({
+                    "role": r["role"],
+                    "content": r["content"],
+                    "tool_calls": _json_loads_if_string(r["tool_calls"]) if "tool_calls" in r.keys() else None,
+                    "api_content": r["api_content"] if "api_content" in r.keys() else None,
+                }, normalize_workspace_prefix=True)
+                for r in cur.fetchall()
+            ]
+            # 3) bounded tail (rows >= floor) with the columns the reconciler uses
+            tail_select = ['role', 'content', 'timestamp']
+            for col in ('tool_call_id', 'tool_calls', 'tool_name', 'reasoning', 'api_content', 'active', 'id'):
+                if col in available:
+                    tail_select.append(col)
+            tail_sql = (
+                f"SELECT {', '.join(tail_select)} FROM messages "
+                f"WHERE session_id = ? AND (timestamp IS NULL OR timestamp >= ?) {active_clause} "
+                "ORDER BY timestamp ASC, id ASC"
+            )
+            cur.execute(tail_sql, (str(sid), floor_ts))
+            tail_rows = [dict(r) for r in cur.fetchall()]
+            tail_keys = [
+                _session_message_visible_key({
+                    "role": r.get("role"),
+                    "content": r.get("content"),
+                    "tool_calls": _json_loads_if_string(r["tool_calls"]) if r.get("tool_calls") is not None else None,
+                    "api_content": r.get("api_content"),
+                }, normalize_workspace_prefix=True)
+                for r in tail_rows
+            ]
+            cur.execute("COMMIT")
+            return {
+                "prefix": prefix,
+                "prefix_keys": prefix_keys,
+                "tail": tail_rows,
+                "tail_keys": tail_keys,
+            }
+    except Exception:
+        return None
+
+
 def get_state_db_session_summary(sid, *, profile=None) -> dict:
     """Return a cheap message count/timestamp summary for one state.db session."""
     try:

--- a/api/models.py
+++ b/api/models.py
@@ -8178,6 +8178,41 @@ def _state_db_active_rows_digest(rows) -> str:
     return digest.hexdigest() if stamped else ''
 
 
+def _project_state_db_message(row, available, id_col, optional):
+    """Authoritative state.db row → WebUI message projection (#6826 r4).
+
+    Shared by ``get_state_db_session_messages`` and the regeneration
+    single-snapshot helper so the bounded tail can never drift from the
+    canonical reader: JSON-decode tool_calls/reasoning payloads, omit
+    empty fields, keep durable row id private (``_state_db_row_id`` only for
+    real Agent api_content replays), and apply ``tool_name → name``.
+    """
+    msg = {
+        'role': row['role'],
+        'content': row['content'],
+        'timestamp': row['timestamp'],
+    }
+    for col in optional:
+        if col not in row.keys():
+            continue
+        value = row[col]
+        if value in (None, ''):
+            continue
+        if col in {'tool_calls', 'reasoning_details', 'codex_reasoning_items', 'codex_message_items'}:
+            value = _json_loads_if_string(value)
+        msg[col] = value
+    if (
+        id_col
+        and row['id'] is not None
+        and isinstance(msg.get('api_content'), str)
+        and msg['api_content']
+    ):
+        msg['_state_db_row_id'] = row['id']
+    if msg.get('role') == 'tool' and msg.get('tool_name') and not msg.get('name'):
+        msg['name'] = msg['tool_name']
+    return msg
+
+
 @overload
 def get_state_db_session_messages(
     sid,
@@ -8418,38 +8453,9 @@ def get_state_db_session_messages(
 
             msgs = []
             for row in rows:
-                msg = {
-                    'role': row['role'],
-                    'content': row['content'],
-                    'timestamp': row['timestamp'],
-                }
-                # ``id`` is the durable SQLite row identity, not the WebUI's
-                # session-local stable message id.  Keep it in a private
-                # provenance field so duplicate reconciliation can align a
-                # state.db sidecar without changing the existing ``id`` key
-                # used by WebUI transcript merge/dedup logic.
-                for col in optional:
-                    if col not in row.keys():
-                        continue
-                    value = row[col]
-                    if value in (None, ''):
-                        continue
-                    if col in {'tool_calls', 'reasoning_details', 'codex_reasoning_items', 'codex_message_items'}:
-                        value = _json_loads_if_string(value)
-                    msg[col] = value
-                # Keep durable provenance only alongside a real Agent replay
-                # sidecar. Ordinary state.db rows must retain their historic
-                # shape and must not acquire internal bookkeeping fields.
-                if (
-                    id_col
-                    and row['id'] is not None
-                    and isinstance(msg.get('api_content'), str)
-                    and msg['api_content']
-                ):
-                    msg['_state_db_row_id'] = row['id']
-                if msg.get('role') == 'tool' and msg.get('tool_name') and not msg.get('name'):
-                    msg['name'] = msg['tool_name']
-                msgs.append(msg)
+                msgs.append(
+                    _project_state_db_message(row, available, bool(id_col), optional)
+                )
     except Exception:
         return _state_db_session_messages_result([], None, with_revision=with_revision)
     return _state_db_session_messages_result(msgs, revision, with_revision=with_revision)
@@ -8645,6 +8651,8 @@ def get_state_db_regeneration_tail_snapshot(
         with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
+            cur.execute("PRAGMA data_version")
+            dv_before = cur.fetchone()[0]
             cur.execute("BEGIN")
             cur.execute("PRAGMA table_info(messages)")
             available = {str(row['name']) for row in cur.fetchall()}
@@ -8654,6 +8662,9 @@ def get_state_db_regeneration_tail_snapshot(
             active_clause = ""
             if 'active' in available:
                 active_clause = " AND (active IS NULL OR active != 0)"
+            # durable order: id ASC when present (matches the canonical reader),
+            # else timestamp ASC
+            durable_order = 'id' if 'id' in available else 'timestamp'
             # 1) prefix summary (rows with timestamp < floor)
             cur.execute(
                 f"""
@@ -8670,28 +8681,19 @@ def get_state_db_regeneration_tail_snapshot(
                 "count": int(row["count"]) if row else 0,
                 "null_timestamp_count": int(row["null_timestamp_count"]) if row else 0,
             }
-            # 2) ordered prefix keys (rows < floor)
+            # 2) ordered prefix keys (rows < floor) in durable order
             prefix_key_cols = "COALESCE(role,'') AS role, COALESCE(content,'') AS content"
             if 'tool_calls' in available:
                 prefix_key_cols += ", tool_calls"
             if 'api_content' in available:
                 prefix_key_cols += ", api_content"
-            if 'id' in available:
-                prefix_key_sql = (
-                    f"SELECT {prefix_key_cols} FROM messages "
-                    "WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ? "
-                    f"{active_clause} ORDER BY timestamp ASC, id ASC"
-                )
-                prefix_params = (str(sid), floor_ts)
-            else:
-                prefix_key_sql = (
-                    f"SELECT {prefix_key_cols} FROM messages "
-                    "WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ? "
-                    f"{active_clause} ORDER BY timestamp ASC"
-                )
-                prefix_params = (str(sid), floor_ts)
+            prefix_key_sql = (
+                f"SELECT {prefix_key_cols} FROM messages "
+                "WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ? "
+                f"{active_clause} ORDER BY {durable_order} ASC"
+            )
             try:
-                cur.execute(prefix_key_sql, prefix_params)
+                cur.execute(prefix_key_sql, (str(sid), floor_ts))
             except Exception:
                 cur.execute("ROLLBACK")
                 return None
@@ -8699,33 +8701,50 @@ def get_state_db_regeneration_tail_snapshot(
                 _session_message_visible_key({
                     "role": r["role"],
                     "content": r["content"],
-                    "tool_calls": _json_loads_if_string(r["tool_calls"]) if "tool_calls" in r.keys() else None,
+                    "tool_calls": _json_loads_if_string(r["tool_calls"]) if "tool_calls" in r.keys() and r["tool_calls"] is not None else None,
                     "api_content": r["api_content"] if "api_content" in r.keys() else None,
                 }, normalize_workspace_prefix=True)
                 for r in cur.fetchall()
             ]
-            # 3) bounded tail (rows >= floor) with the columns the reconciler uses
-            tail_select = ['role', 'content', 'timestamp']
-            for col in ('tool_call_id', 'tool_calls', 'tool_name', 'reasoning', 'api_content', 'active', 'id'):
-                if col in available:
+            # 3) bounded tail (rows >= floor) with the canonical projection
+            optional = [
+                'tool_call_id', 'tool_calls', 'tool_name', 'reasoning',
+                'reasoning_details', 'codex_reasoning_items', 'reasoning_content',
+                'codex_message_items', 'api_content',
+            ]
+            tail_select = ['id', 'role', 'content', 'timestamp'] if 'id' in available else ['role', 'content', 'timestamp']
+            for col in optional + (['active'] if 'active' in available else []):
+                if col in available and col not in tail_select:
                     tail_select.append(col)
             tail_sql = (
                 f"SELECT {', '.join(tail_select)} FROM messages "
                 f"WHERE session_id = ? AND (timestamp IS NULL OR timestamp >= ?) {active_clause} "
-                "ORDER BY timestamp ASC, id ASC"
+                f"ORDER BY {durable_order} ASC"
             )
             cur.execute(tail_sql, (str(sid), floor_ts))
-            tail_rows = [dict(r) for r in cur.fetchall()]
+            tail_rows = [
+                _project_state_db_message(r, available, 'id' in available, optional)
+                for r in cur.fetchall()
+            ]
             tail_keys = [
-                _session_message_visible_key({
-                    "role": r.get("role"),
-                    "content": r.get("content"),
-                    "tool_calls": _json_loads_if_string(r["tool_calls"]) if r.get("tool_calls") is not None else None,
-                    "api_content": r.get("api_content"),
-                }, normalize_workspace_prefix=True)
+                _session_message_visible_key(
+                    {
+                        "role": r.get("role"),
+                        "content": r.get("content"),
+                        "tool_calls": r.get("tool_calls"),
+                        "api_content": r.get("api_content"),
+                    },
+                    normalize_workspace_prefix=True,
+                )
                 for r in tail_rows
             ]
             cur.execute("COMMIT")
+            cur.execute("PRAGMA data_version")
+            dv_after = cur.fetchone()[0]
+            if dv_before != dv_after:
+                # a concurrent WAL commit landed during the proof → stale
+                # snapshot; refuse the bounded path (TOCTOU).
+                return None
             return {
                 "prefix": prefix,
                 "prefix_keys": prefix_keys,

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -120,7 +120,7 @@ def plan_regeneration(session, *, expected_revision=None, lock_held=False):
     """Prepare one canonical display/context pair for a locked regeneration."""
     lock_context = nullcontext() if lock_held else _get_session_agent_lock(session.session_id)
     with lock_context:
-        rows, context = regeneration_state(session)
+        rows, context = regeneration_state(session, use_sidecar=True)
         revision = regeneration_revision_for(rows, session=session, context=context)
         if expected_revision is not None and expected_revision != revision:
             raise RegenerationUnavailable("stale_regeneration_revision")
@@ -217,8 +217,13 @@ def regeneration_context(session):
     return regeneration_state(session)[1]
 
 
-def regeneration_state(session):
+def regeneration_state(session, *, use_sidecar=False):
     """Read one immutable state.db snapshot and reconcile both transcript views."""
+    if use_sidecar:
+        # Use the WebUI sidecar messages to avoid hitting state.db (e.g., for regeneration)
+        messages = getattr(session, "messages", [])
+        context = getattr(session, "context_messages", [])
+        return messages, context
     from api.models import (
         get_state_db_session_messages,
         reconciled_state_db_messages_for_session,
@@ -242,7 +247,7 @@ def regeneration_state(session):
 
 
 def regeneration_revision(session) -> str:
-    rows, context = regeneration_state(session)
+    rows, context = regeneration_state(session, use_sidecar=True)
     return regeneration_revision_for(
         rows,
         session=session,

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -217,21 +217,67 @@ def regeneration_context(session):
     return regeneration_state(session)[1]
 
 
+_REGENERATION_SIDECAR_ANCHOR_BUDGET = 200
+
+
+def _sidecar_regeneration_read_floor(session):
+    """Return a state.db tail-read floor anchored by the already-loaded sidecar.
+
+    #6826: regenerating a large session must not re-materialize the full
+    state.db transcript (a >1min stall on big sessions).  When the in-memory
+    sidecar is a usable reconciliation base — append-only session with no
+    active truncation markers and timestamped rows — return the timestamp
+    floor for a bounded ``since_timestamp`` tail read.  Rows at/after the
+    floor (including any gateway/server-applied tail the sidecar has not seen
+    yet) are re-read and merged, and rows the sidecar already carries are
+    deduplicated by the append-only merge, so the #6611 reconciliation
+    authority is preserved on the fast path.
+
+    Returns ``None`` when the sidecar cannot anchor a tail read; callers then
+    fall back to the full state.db read (unchanged behavior).
+    """
+    if getattr(session, "truncation_watermark", None) not in (None, ""):
+        return None
+    if getattr(session, "truncation_boundary", None) not in (None, ""):
+        return None
+    messages = getattr(session, "messages", None)
+    if not isinstance(messages, list) or not messages:
+        return None
+    from api.models import _message_timestamp_as_float
+
+    timestamps = [_message_timestamp_as_float(message) for message in messages]
+    if any(timestamp is None for timestamp in timestamps):
+        return None
+    # Conservative anchor: re-read a bounded tip window so sub-second/clock
+    # drift near the sidecar tip cannot hide a concurrently appended state.db
+    # row, while the raw read stays tiny for huge sessions.
+    return min(timestamps[-_REGENERATION_SIDECAR_ANCHOR_BUDGET:])
+
+
 def regeneration_state(session, *, use_sidecar=False):
-    """Read one immutable state.db snapshot and reconcile both transcript views."""
-    if use_sidecar:
-        # Use the WebUI sidecar messages to avoid hitting state.db (e.g., for regeneration)
-        messages = getattr(session, "messages", [])
-        context = getattr(session, "context_messages", [])
-        return messages, context
+    """Read one immutable state.db snapshot and reconcile both transcript views.
+
+    ``use_sidecar=True`` (#6826) anchors the state.db read to the already
+    loaded in-memory sidecar: only a bounded tail (``since_timestamp`` floor)
+    is re-read instead of the full transcript, and both views still route
+    through :func:`reconciled_state_db_messages_for_session`, so the #6611
+    reconciliation authority (recovered display/context pair survives local
+    and gateway apply) is preserved on the fast path.
+    """
     from api.models import (
         get_state_db_session_messages,
         reconciled_state_db_messages_for_session,
     )
 
+    state_reader_kwargs = {}
+    if use_sidecar:
+        read_floor = _sidecar_regeneration_read_floor(session)
+        if read_floor is not None:
+            state_reader_kwargs["since_timestamp"] = read_floor
     state_messages = get_state_db_session_messages(
         getattr(session, "session_id", None),
         profile=getattr(session, "profile", None),
+        **state_reader_kwargs,
     )
     return (
         reconciled_state_db_messages_for_session(

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -254,35 +254,34 @@ def _sidecar_regeneration_read_floor(session):
     return min(timestamps[-_REGENERATION_SIDECAR_ANCHOR_BUDGET:])
 
 
-def _bounded_tail_read_is_safe(session, read_floor) -> bool:
-    """Prove the skipped state.db prefix is represented identically in the
-    sidecar; otherwise the caller MUST fall back to the full read (#6826 r3).
+def _bounded_tail_snapshot_if_safe(session, read_floor):
+    """Return the bounded tail rows ONLY when it is provably identical to the
+    full read; otherwise None (caller must fall back to the full read).
 
-    The bounded ``since_timestamp`` read silently omits every state.db row
-    older than the floor. That is only safe when the skipped prefix is
-    provably identical in the already-loaded sidecar — same count AND same
-    ordered visible identity — and when a compression anchor (if any) is
-    covered by the floor. Any mismatch, missing database, or uncertainty
-    returns False (full-read fallback), so the #6611 regeneration authority
-    never operates on an unreconciled view.
+    #6826 r3: the skipped state.db prefix (rows older than the floor) must be
+    represented identically in the sidecar — same count AND same ordered
+    visible identity — and the bounded tail must not repeat any skipped key
+    (occurrence-count collision: a new tail turn repeating an older prompt
+    would be mistaken for the old sidecar duplicate and dropped). The prefix
+    proof and the tail data come from ONE read transaction (no TOCTOU).
+
+    Any mismatch, missing database, or uncertainty returns None, so the #6611
+    regeneration authority never operates on an unreconciled view.
     """
     sid = getattr(session, "session_id", None)
     if not sid:
-        return False
+        return None
     profile = getattr(session, "profile", None)
     from api.models import (
         _session_message_visible_key,
-        get_state_db_session_message_keys_before_timestamp,
-        get_state_db_session_message_prefix_summary,
+        get_state_db_regeneration_tail_snapshot,
     )
 
-    prefix = get_state_db_session_message_prefix_summary(sid, read_floor, profile=profile)
-    if prefix is None:
-        return False  # cannot prove the prefix → full read
-    # Compression-anchor coverage: auto-compressed sessions keep context rows
-    # around the anchor; if the anchor predates the floor the bounded read can
-    # drop compacted-tail context rows (display may still match). The anchor
-    # is a dict {"role","text","ts","attachments"} — compare its timestamp.
+    snap = get_state_db_regeneration_tail_snapshot(sid, read_floor, profile=profile)
+    if snap is None:
+        return None  # cannot obtain a stable single-snapshot → full read
+    # Compression-anchor coverage: if the anchor predates the floor the bounded
+    # read can drop compacted-tail context rows (display may still match).
     anchor = getattr(session, "compression_anchor_message_key", None)
     if isinstance(anchor, dict):
         try:
@@ -290,16 +289,12 @@ def _bounded_tail_read_is_safe(session, read_floor) -> bool:
         except (TypeError, ValueError):
             anchor_ts = None
         if anchor_ts is None or anchor_ts < read_floor:
-            return False
+            return None
+    prefix = snap["prefix"]
     if prefix.get("count") == 0 and prefix.get("null_timestamp_count") == 0:
         # Empty skipped prefix: the bounded read already covers every row.
-        return True
+        return snap["tail"]
     # Non-empty skipped prefix: prove identical ordered visible identity.
-    db_keys = get_state_db_session_message_keys_before_timestamp(
-        sid, read_floor, profile=profile
-    )
-    if db_keys is None:
-        return False
     sidecar_keys = []
     for message in getattr(session, "messages", None) or []:
         if not isinstance(message, dict):
@@ -311,11 +306,18 @@ def _bounded_tail_read_is_safe(session, read_floor) -> bool:
         if ts is not None and ts < read_floor:
             key = _session_message_visible_key(message)
             if key is None:
-                return False
+                return None
             sidecar_keys.append(key)
-    if list(db_keys) != sidecar_keys:
-        return False  # mismatch → full read
-    return True
+    if list(snap["prefix_keys"]) != sidecar_keys:
+        return None  # mismatch → full read
+    # Occurrence-count collision (#6826 r3 #1): if any bounded-tail key ALSO
+    # occurs in the skipped prefix, the reconciler may drop the repeated tail
+    # row — fall back conservatively.
+    prefix_key_set = set(snap["prefix_keys"])
+    for key in snap["tail_keys"]:
+        if key in prefix_key_set:
+            return None
+    return snap["tail"]
 
 
 def regeneration_state(session, *, use_sidecar=False):
@@ -329,25 +331,29 @@ def regeneration_state(session, *, use_sidecar=False):
     and gateway apply) is preserved on the fast path.
 
     The bounded tail is only trusted when
-    :func:`_bounded_tail_read_is_safe` proves the skipped state.db prefix is
-    identical in the sidecar (count + ordered visible identity + compression
-    anchor coverage); otherwise the read falls back to the full transcript.
+    :func:`_bounded_tail_snapshot_if_safe` proves the skipped state.db prefix
+    is identical in the sidecar (count + ordered visible identity + no
+    occurrence collision + compression anchor coverage), and the tail rows
+    come from the SAME single read transaction as the proof (no TOCTOU);
+    otherwise the read falls back to the full transcript.
     """
     from api.models import (
         get_state_db_session_messages,
         reconciled_state_db_messages_for_session,
     )
 
-    state_reader_kwargs = {}
+    bounded_tail = None
     if use_sidecar:
         read_floor = _sidecar_regeneration_read_floor(session)
-        if read_floor is not None and _bounded_tail_read_is_safe(session, read_floor):
-            state_reader_kwargs["since_timestamp"] = read_floor
-    state_messages = get_state_db_session_messages(
-        getattr(session, "session_id", None),
-        profile=getattr(session, "profile", None),
-        **state_reader_kwargs,
-    )
+        if read_floor is not None:
+            bounded_tail = _bounded_tail_snapshot_if_safe(session, read_floor)
+    if bounded_tail is not None:
+        state_messages = bounded_tail
+    else:
+        state_messages = get_state_db_session_messages(
+            getattr(session, "session_id", None),
+            profile=getattr(session, "profile", None),
+        )
     return (
         reconciled_state_db_messages_for_session(
             session,

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -317,6 +317,11 @@ def _bounded_tail_snapshot_if_safe(session, read_floor):
     for key in snap["tail_keys"]:
         if key in prefix_key_set:
             return None
+    # In-tail duplicates (#6826 r5): a repeated message wholly inside the
+    # bounded tail makes the reconciler's context dedup diverge from the full
+    # read (display may still match) → refuse the bounded path.
+    if len(snap["tail_keys"]) != len(set(snap["tail_keys"])):
+        return None
     return snap["tail"]
 
 

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -254,6 +254,70 @@ def _sidecar_regeneration_read_floor(session):
     return min(timestamps[-_REGENERATION_SIDECAR_ANCHOR_BUDGET:])
 
 
+def _bounded_tail_read_is_safe(session, read_floor) -> bool:
+    """Prove the skipped state.db prefix is represented identically in the
+    sidecar; otherwise the caller MUST fall back to the full read (#6826 r3).
+
+    The bounded ``since_timestamp`` read silently omits every state.db row
+    older than the floor. That is only safe when the skipped prefix is
+    provably identical in the already-loaded sidecar — same count AND same
+    ordered visible identity — and when a compression anchor (if any) is
+    covered by the floor. Any mismatch, missing database, or uncertainty
+    returns False (full-read fallback), so the #6611 regeneration authority
+    never operates on an unreconciled view.
+    """
+    sid = getattr(session, "session_id", None)
+    if not sid:
+        return False
+    profile = getattr(session, "profile", None)
+    from api.models import (
+        _session_message_visible_key,
+        get_state_db_session_message_keys_before_timestamp,
+        get_state_db_session_message_prefix_summary,
+    )
+
+    prefix = get_state_db_session_message_prefix_summary(sid, read_floor, profile=profile)
+    if prefix is None:
+        return False  # cannot prove the prefix → full read
+    # Compression-anchor coverage: auto-compressed sessions keep context rows
+    # around the anchor; if the anchor predates the floor the bounded read can
+    # drop compacted-tail context rows (display may still match). The anchor
+    # is a dict {"role","text","ts","attachments"} — compare its timestamp.
+    anchor = getattr(session, "compression_anchor_message_key", None)
+    if isinstance(anchor, dict):
+        try:
+            anchor_ts = float(anchor.get("ts"))
+        except (TypeError, ValueError):
+            anchor_ts = None
+        if anchor_ts is None or anchor_ts < read_floor:
+            return False
+    if prefix.get("count") == 0 and prefix.get("null_timestamp_count") == 0:
+        # Empty skipped prefix: the bounded read already covers every row.
+        return True
+    # Non-empty skipped prefix: prove identical ordered visible identity.
+    db_keys = get_state_db_session_message_keys_before_timestamp(
+        sid, read_floor, profile=profile
+    )
+    if db_keys is None:
+        return False
+    sidecar_keys = []
+    for message in getattr(session, "messages", None) or []:
+        if not isinstance(message, dict):
+            continue
+        try:
+            ts = float(message.get("timestamp"))
+        except (TypeError, ValueError):
+            ts = None
+        if ts is not None and ts < read_floor:
+            key = _session_message_visible_key(message)
+            if key is None:
+                return False
+            sidecar_keys.append(key)
+    if list(db_keys) != sidecar_keys:
+        return False  # mismatch → full read
+    return True
+
+
 def regeneration_state(session, *, use_sidecar=False):
     """Read one immutable state.db snapshot and reconcile both transcript views.
 
@@ -263,6 +327,11 @@ def regeneration_state(session, *, use_sidecar=False):
     through :func:`reconciled_state_db_messages_for_session`, so the #6611
     reconciliation authority (recovered display/context pair survives local
     and gateway apply) is preserved on the fast path.
+
+    The bounded tail is only trusted when
+    :func:`_bounded_tail_read_is_safe` proves the skipped state.db prefix is
+    identical in the sidecar (count + ordered visible identity + compression
+    anchor coverage); otherwise the read falls back to the full transcript.
     """
     from api.models import (
         get_state_db_session_messages,
@@ -272,7 +341,7 @@ def regeneration_state(session, *, use_sidecar=False):
     state_reader_kwargs = {}
     if use_sidecar:
         read_floor = _sidecar_regeneration_read_floor(session)
-        if read_floor is not None:
+        if read_floor is not None and _bounded_tail_read_is_safe(session, read_floor):
             state_reader_kwargs["since_timestamp"] = read_floor
     state_messages = get_state_db_session_messages(
         getattr(session, "session_id", None),

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -890,7 +890,6 @@ def test_in_tail_duplicate_guard_refuses_bounded_and_full_revision_accepted(monk
         regeneration_revision_for,
         regeneration_state,
     )
-    from api.streaming import _session_payload_with_full_messages
 
     # 212 rows (above the 200-row anchor budget); the user row at index 210
     # repeats the visible key of the user row at index 100 — a duplicate that

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -745,3 +745,127 @@ def test_regeneration_tail_snapshot_reads_real_sqlite(monkeypatch, tmp_path):
     # the repeated prompt key appears in BOTH the skipped prefix and the tail —
     # exactly the occurrence-count collision the guard must refuse
     assert snap["prefix_keys"][0] == snap["tail_keys"][0]
+
+
+def _make_state_db(tmp_path, rows, with_id=True):
+    """Create a real state.db with the given rows (list of dicts)."""
+    import sqlite3
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    cols = ["session_id TEXT", "role TEXT", "content TEXT", "timestamp REAL",
+            "tool_calls TEXT", "tool_name TEXT", "reasoning TEXT", "active INTEGER"]
+    if with_id:
+        cols.append("id INTEGER PRIMARY KEY")
+    conn.execute(f"CREATE TABLE messages ({', '.join(cols)})")
+    for i, r in enumerate(rows):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, tool_calls, tool_name, reasoning, active) "
+            "VALUES (?,?,?,?,?,?,?,1)",
+            ("s1", r.get("role"), r.get("content"), r.get("timestamp"),
+             r.get("tool_calls"), r.get("tool_name"), r.get("reasoning")),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_snapshot_tail_uses_canonical_projection(monkeypatch, tmp_path):
+    """#6826 r4 #1: the snapshot tail must use the SAME projection as the
+    canonical reader — JSON tool_calls decoded, tool_name → name, no raw
+    id/active exposure (tool-call/gateway-row sessions)."""
+    from api import models
+
+    db = _make_state_db(tmp_path, [
+        {"role": "user", "content": "p", "timestamp": 100.0},
+        {"role": "tool", "content": "result", "timestamp": 200.0,
+         "tool_calls": '[{"name": "x", "arguments": {"a": 1}}]',
+         "tool_name": "read_file", "reasoning": "r1"},
+        {"role": "assistant", "content": "a", "timestamp": 300.0},
+    ])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+    snap = models.get_state_db_regeneration_tail_snapshot("s1", 50.0)
+    assert snap is not None
+    tool = [m for m in snap["tail"] if m.get("role") == "tool"][0]
+    assert isinstance(tool["tool_calls"], list), "tool_calls must be JSON-decoded"
+    assert tool["name"] == "read_file", "tool_name → name must be applied"
+    assert "id" not in tool and "active" not in tool, "raw id/active must not leak"
+    assert "reasoning" in tool and tool["reasoning"] == "r1"
+
+
+def test_snapshot_uses_durable_id_order(monkeypatch, tmp_path):
+    """#6826 r4 #2: durable id ASC order (not timestamp) — a later-id user at
+    ts=600 followed by its assistant at ts=550 must stay user → assistant."""
+    from api import models
+
+    db = _make_state_db(tmp_path, [
+        {"role": "user", "content": "later user", "timestamp": 600.0},
+        {"role": "assistant", "content": "assistant 550", "timestamp": 550.0},
+    ])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+    snap = models.get_state_db_regeneration_tail_snapshot("s1", 50.0)
+    assert snap is not None
+    roles = [m.get("role") for m in snap["tail"]]
+    assert roles == ["user", "assistant"], f"durable id order violated: {roles}"
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self._c = conn._real.cursor()
+        self._conn = conn
+        self._dv = None
+
+    def execute(self, sql, *args):
+        s = sql.strip()
+        if s.startswith("PRAGMA data_version"):
+            self._conn._dv_calls += 1
+            self._dv = 42 if self._conn._dv_calls == 1 else 43  # changed on 2nd read
+            return self
+        return self._c.execute(sql, *args)
+
+    def fetchone(self):
+        if self._dv is not None:
+            v, self._dv = self._dv, None
+            return (v,)
+        return self._c.fetchone()
+
+    def fetchall(self):
+        return self._c.fetchall()
+
+
+class _FakeConn:
+    def __init__(self, real):
+        self._real = real
+        self._dv_calls = 0
+        self.row_factory = None
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def close(self):
+        self._real.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.close()
+
+
+def test_snapshot_refuses_when_wal_data_version_changes(monkeypatch, tmp_path):
+    """#6826 r4 #3 (WAL TOCTOU): if PRAGMA data_version changes during the
+    proof (a concurrent WAL commit), the snapshot must return None so the
+    caller falls back to the full read."""
+    import sqlite3
+
+    from api import models
+
+    db = _make_state_db(tmp_path, [
+        {"role": "user", "content": "p", "timestamp": 100.0},
+        {"role": "assistant", "content": "a", "timestamp": 200.0},
+    ])
+    real_conn = sqlite3.connect(db)
+    fake = _FakeConn(real_conn)
+    monkeypatch.setattr(models, "open_state_db_readonly", lambda _p: fake)
+    snap = models.get_state_db_regeneration_tail_snapshot("s1", 50.0)
+    assert snap is None, "changed data_version must refuse the bounded snapshot"

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -514,30 +514,32 @@ def test_regeneration_sidecar_path_avoids_full_transcript_refetch(monkeypatch):
     )
 
     # The bounded guard must prove the skipped prefix (rows < floor) is
-    # identical in the sidecar: the fake state.db carries the same 300 prefix
-    # rows, so simulate the prefix summary + keys from the sidecar itself.
+    # identical in the sidecar and return the tail from ONE snapshot. The fake
+    # state.db carries the same 300 prefix rows as the sidecar.
     from api.models import _session_message_visible_key
 
     floor = min(row["timestamp"] for row in session.messages[-200:])
     prefix_rows = [r for r in session.messages if (r.get("timestamp") or 0) < floor]
+    tail_rows = [r for r in state_rows if (r.get("timestamp") or 0) >= floor]
     monkeypatch.setattr(
         models_api,
-        "get_state_db_session_message_prefix_summary",
-        lambda *_a, **_k: {"count": len(prefix_rows), "null_timestamp_count": 0},
-    )
-    monkeypatch.setattr(
-        models_api,
-        "get_state_db_session_message_keys_before_timestamp",
-        lambda *_a, **_k: [_session_message_visible_key(r) for r in prefix_rows],
+        "get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: {
+            "prefix": {"count": len(prefix_rows), "null_timestamp_count": 0},
+            "prefix_keys": [_session_message_visible_key(r) for r in prefix_rows],
+            "tail": [dict(r) for r in tail_rows],
+            "tail_keys": [_session_message_visible_key(r) for r in tail_rows],
+        },
     )
 
     full_rows, full_context = regeneration_state(session)
     assert calls[-1].get("since_timestamp") is None  # full read
 
+    # provably effective: the fast path does NOT consult the full reader — the
+    # bounded tail comes from the single snapshot
+    calls_before = len(calls)
     fast_rows, fast_context = regeneration_state(session, use_sidecar=True)
-    # provably effective: the fast path requests only the bounded tip window
-    assert calls[-1].get("since_timestamp") is not None
-    assert calls[-1]["since_timestamp"] > 0
+    assert len(calls) == calls_before, "bounded path must not touch the full reader"
 
     # authority preserved: identical reconciled transcript on both paths,
     # including the state.db-only gateway tail row.
@@ -566,25 +568,33 @@ def _sidecar_session(rows=3, *, anchor_key=None, anchor_ts=None):
     return s
 
 
+def _snap(prefix_count=0, prefix_keys=None, tail=None, tail_keys=None):
+    """Factory for a fake get_state_db_regeneration_tail_snapshot result."""
+    tail = tail if tail is not None else []
+    return {
+        "prefix": {"count": prefix_count, "null_timestamp_count": 0},
+        "prefix_keys": prefix_keys or [],
+        "tail": tail,
+        "tail_keys": tail_keys if tail_keys is not None else [],
+    }
+
+
 def test_bounded_guard_empty_prefix_allows_tail_read(monkeypatch):
     from api import session_ops
 
     session = _sidecar_session(3)
     monkeypatch.setattr(
-        "api.models.get_state_db_session_message_prefix_summary",
-        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: _snap(tail=[{"role": "user", "content": "t", "timestamp": 300.0}]),
     )
     seen = {}
-    monkeypatch.setattr(
-        "api.models.get_state_db_session_message_keys_before_timestamp",
-        lambda *_a, **_k: [],
-    )
     monkeypatch.setattr(
         "api.models.get_state_db_session_messages",
         lambda *_a, **_k: _capture(seen, _k),
     )
     session_ops.regeneration_state(session, use_sidecar=True)
-    assert seen.get("since_timestamp") is not None, "empty skipped prefix must take the bounded tail read"
+    # bounded path: full reader NOT consulted (tail comes from the snapshot)
+    assert seen == {}, "empty skipped prefix must take the bounded tail from the snapshot"
 
 
 def test_bounded_guard_unrepresented_prefix_row_falls_back(monkeypatch):
@@ -593,12 +603,11 @@ def test_bounded_guard_unrepresented_prefix_row_falls_back(monkeypatch):
     session = _sidecar_session(3)
     # state.db has one row older than the floor that the sidecar does NOT carry
     monkeypatch.setattr(
-        "api.models.get_state_db_session_message_prefix_summary",
-        lambda *_a, **_k: {"count": 1, "null_timestamp_count": 0},
-    )
-    monkeypatch.setattr(
-        "api.models.get_state_db_session_message_keys_before_timestamp",
-        lambda *_a, **_k: [("user", "recoverable-only-in-db")],
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: _snap(
+            prefix_count=1,
+            prefix_keys=[("user", "recoverable-only-in-db")],
+        ),
     )
     seen = {}
     monkeypatch.setattr(
@@ -606,7 +615,33 @@ def test_bounded_guard_unrepresented_prefix_row_falls_back(monkeypatch):
         lambda *_a, **_k: _capture(seen, _k),
     )
     session_ops.regeneration_state(session, use_sidecar=True)
-    assert "since_timestamp" not in seen, "unrepresented prefix row must force the full read (no since_timestamp)"
+    assert seen != {}, "unrepresented prefix row must force the full read (full reader consulted)"
+
+
+def test_bounded_guard_repeated_tail_key_falls_back(monkeypatch):
+    """#6826 r3 #1: a bounded-tail key that ALSO occurs in the skipped prefix
+    must force the full read (occurrence-count collision would drop the
+    repeated tail row)."""
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    repeated_key = ("user", "m0")  # m0 lives below the floor AND repeats in the tail
+    monkeypatch.setattr(
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: _snap(
+            prefix_count=1,
+            prefix_keys=[repeated_key],
+            tail=[{"role": "user", "content": "m0", "timestamp": 300.0}],
+            tail_keys=[repeated_key],
+        ),
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert seen != {}, "repeated tail key must force the full read"
 
 
 def test_bounded_guard_compression_anchor_below_floor_falls_back(monkeypatch):
@@ -616,12 +651,8 @@ def test_bounded_guard_compression_anchor_below_floor_falls_back(monkeypatch):
     # anchor timestamp predates the floor → bounded read cannot cover it
     session.compression_anchor_message_key = {"role": "user", "text": "m0", "ts": 100.0}
     monkeypatch.setattr(
-        "api.models.get_state_db_session_message_prefix_summary",
-        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
-    )
-    monkeypatch.setattr(
-        "api.models.get_state_db_session_message_keys_before_timestamp",
-        lambda *_a, **_k: [],
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: _snap(),
     )
     # shrink the anchor budget window so the floor (300.0) sits above the anchor
     monkeypatch.setattr(session_ops, "_REGENERATION_SIDECAR_ANCHOR_BUDGET", 1)
@@ -631,7 +662,7 @@ def test_bounded_guard_compression_anchor_below_floor_falls_back(monkeypatch):
         lambda *_a, **_k: _capture(seen, _k),
     )
     session_ops.regeneration_state(session, use_sidecar=True)
-    assert "since_timestamp" not in seen, "compression anchor below floor must force the full read"
+    assert seen != {}, "compression anchor below floor must force the full read"
 
 
 def test_bounded_guard_compression_anchor_covered_allows(monkeypatch):
@@ -641,12 +672,8 @@ def test_bounded_guard_compression_anchor_covered_allows(monkeypatch):
     session.compression_anchor_message_key = {"role": "user", "text": "m0", "ts": 100.0}
     # budget 200 covers all 3 rows → floor = min(all) = 100 → anchor at floor is covered
     monkeypatch.setattr(
-        "api.models.get_state_db_session_message_prefix_summary",
-        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
-    )
-    monkeypatch.setattr(
-        "api.models.get_state_db_session_message_keys_before_timestamp",
-        lambda *_a, **_k: [],
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: _snap(tail=[{"role": "user", "content": "t", "timestamp": 300.0}]),
     )
     seen = {}
     monkeypatch.setattr(
@@ -654,9 +681,67 @@ def test_bounded_guard_compression_anchor_covered_allows(monkeypatch):
         lambda *_a, **_k: _capture(seen, _k),
     )
     session_ops.regeneration_state(session, use_sidecar=True)
-    assert seen.get("since_timestamp") is not None, "anchor covered by floor must keep the bounded tail read"
+    assert seen == {}, "anchor covered by floor must keep the bounded tail read"
+
+
+def test_bounded_guard_missing_snapshot_falls_back(monkeypatch):
+    """#6826 r3 #2 (TOCTOU): if a stable single-connection snapshot cannot be
+    obtained, the guard must refuse the bounded path entirely."""
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    monkeypatch.setattr(
+        "api.models.get_state_db_regeneration_tail_snapshot",
+        lambda *_a, **_k: None,
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert seen != {}, "missing snapshot must force the full read (no TOCTOU window)"
 
 
 def _capture(seen, kwargs):
     seen.update(kwargs)
     return []
+
+
+def test_regeneration_tail_snapshot_reads_real_sqlite(monkeypatch, tmp_path):
+    """Real-SQLite: the single-connection snapshot returns prefix proof + tail
+    from one read, including the repeated-prompt collision shape from the
+    round-3 review (a prompt that lives both below and above the floor)."""
+    import sqlite3
+
+    from api import models
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, "
+        "content TEXT, timestamp REAL, tool_calls TEXT, active INTEGER)"
+    )
+    rows = [
+        ("s1", "user", "prompt", 100.0),
+        ("s1", "assistant", "a1", 200.0),
+        ("s1", "user", "prompt", 300.0),   # repeated prompt above the floor
+        ("s1", "assistant", "a2", 400.0),
+    ]
+    for sid, role, content, ts in rows:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, active) VALUES (?,?,?,?,1)",
+            (sid, role, content, ts),
+        )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+    snap = models.get_state_db_regeneration_tail_snapshot("s1", 250.0)
+    assert snap is not None
+    assert snap["prefix"]["count"] == 2, "rows < floor must be counted"
+    assert len(snap["prefix_keys"]) == 2
+    assert len(snap["tail"]) == 2, "rows >= floor must be the bounded tail"
+    # the repeated prompt key appears in BOTH the skipped prefix and the tail —
+    # exactly the occurrence-count collision the guard must refuse
+    assert snap["prefix_keys"][0] == snap["tail_keys"][0]

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -513,6 +513,24 @@ def test_regeneration_sidecar_path_avoids_full_transcript_refetch(monkeypatch):
         fake_get_state_db_session_messages,
     )
 
+    # The bounded guard must prove the skipped prefix (rows < floor) is
+    # identical in the sidecar: the fake state.db carries the same 300 prefix
+    # rows, so simulate the prefix summary + keys from the sidecar itself.
+    from api.models import _session_message_visible_key
+
+    floor = min(row["timestamp"] for row in session.messages[-200:])
+    prefix_rows = [r for r in session.messages if (r.get("timestamp") or 0) < floor]
+    monkeypatch.setattr(
+        models_api,
+        "get_state_db_session_message_prefix_summary",
+        lambda *_a, **_k: {"count": len(prefix_rows), "null_timestamp_count": 0},
+    )
+    monkeypatch.setattr(
+        models_api,
+        "get_state_db_session_message_keys_before_timestamp",
+        lambda *_a, **_k: [_session_message_visible_key(r) for r in prefix_rows],
+    )
+
     full_rows, full_context = regeneration_state(session)
     assert calls[-1].get("since_timestamp") is None  # full read
 
@@ -526,3 +544,119 @@ def test_regeneration_sidecar_path_avoids_full_transcript_refetch(monkeypatch):
     assert fast_rows == full_rows
     assert fast_context == full_context
     assert fast_rows[-1]["content"] == "gateway applied turn"
+
+
+# ── #6826 r3: bounded tail-read guard ────────────────────────────────────────
+
+def _sidecar_session(rows=3, *, anchor_key=None, anchor_ts=None):
+    """Session whose sidecar carries `rows` timestamped display messages."""
+    messages = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}", "timestamp": 100.0 + i * 100.0}
+        for i in range(rows)
+    ]
+    s = Session(
+        session_id="sidecar-guard-6826",
+        messages=messages,
+        context_messages=[dict(m) for m in messages],
+    )
+    if anchor_key:
+        s.compression_anchor_message_key = anchor_key
+        if anchor_ts is not None:
+            s._anchor_ts = anchor_ts
+    return s
+
+
+def test_bounded_guard_empty_prefix_allows_tail_read(monkeypatch):
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_prefix_summary",
+        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_keys_before_timestamp",
+        lambda *_a, **_k: [],
+    )
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert seen.get("since_timestamp") is not None, "empty skipped prefix must take the bounded tail read"
+
+
+def test_bounded_guard_unrepresented_prefix_row_falls_back(monkeypatch):
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    # state.db has one row older than the floor that the sidecar does NOT carry
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_prefix_summary",
+        lambda *_a, **_k: {"count": 1, "null_timestamp_count": 0},
+    )
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_keys_before_timestamp",
+        lambda *_a, **_k: [("user", "recoverable-only-in-db")],
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert "since_timestamp" not in seen, "unrepresented prefix row must force the full read (no since_timestamp)"
+
+
+def test_bounded_guard_compression_anchor_below_floor_falls_back(monkeypatch):
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    # anchor timestamp predates the floor → bounded read cannot cover it
+    session.compression_anchor_message_key = {"role": "user", "text": "m0", "ts": 100.0}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_prefix_summary",
+        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
+    )
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_keys_before_timestamp",
+        lambda *_a, **_k: [],
+    )
+    # shrink the anchor budget window so the floor (300.0) sits above the anchor
+    monkeypatch.setattr(session_ops, "_REGENERATION_SIDECAR_ANCHOR_BUDGET", 1)
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert "since_timestamp" not in seen, "compression anchor below floor must force the full read"
+
+
+def test_bounded_guard_compression_anchor_covered_allows(monkeypatch):
+    from api import session_ops
+
+    session = _sidecar_session(3)
+    session.compression_anchor_message_key = {"role": "user", "text": "m0", "ts": 100.0}
+    # budget 200 covers all 3 rows → floor = min(all) = 100 → anchor at floor is covered
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_prefix_summary",
+        lambda *_a, **_k: {"count": 0, "null_timestamp_count": 0},
+    )
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_message_keys_before_timestamp",
+        lambda *_a, **_k: [],
+    )
+    seen = {}
+    monkeypatch.setattr(
+        "api.models.get_state_db_session_messages",
+        lambda *_a, **_k: _capture(seen, _k),
+    )
+    session_ops.regeneration_state(session, use_sidecar=True)
+    assert seen.get("since_timestamp") is not None, "anchor covered by floor must keep the bounded tail read"
+
+
+def _capture(seen, kwargs):
+    seen.update(kwargs)
+    return []

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -837,7 +837,16 @@ class _FakeConn:
     def __init__(self, real):
         self._real = real
         self._dv_calls = 0
-        self.row_factory = None
+
+    @property
+    def row_factory(self):
+        return self._real.row_factory
+
+    @row_factory.setter
+    def row_factory(self, value):
+        # the real cursor must see the row_factory, or the interleaving path
+        # dies on tuple indexing instead of exercising data_version
+        self._real.row_factory = value
 
     def cursor(self):
         return _FakeCursor(self)
@@ -869,3 +878,52 @@ def test_snapshot_refuses_when_wal_data_version_changes(monkeypatch, tmp_path):
     monkeypatch.setattr(models, "open_state_db_readonly", lambda _p: fake)
     snap = models.get_state_db_regeneration_tail_snapshot("s1", 50.0)
     assert snap is None, "changed data_version must refuse the bounded snapshot"
+
+
+def test_in_tail_duplicate_guard_refuses_bounded_and_full_revision_accepted(monkeypatch, tmp_path):
+    """#6826 r5: a repeated message wholly INSIDE the bounded tail must refuse
+    the fast path (full-read fallback), so the minted full-read revision is
+    accepted by plan_regeneration (no 409 stale_regeneration_revision)."""
+    from api import models
+    from api.session_ops import (
+        plan_regeneration,
+        regeneration_revision_for,
+        regeneration_state,
+    )
+    from api.streaming import _session_payload_with_full_messages
+
+    # 212 rows (above the 200-row anchor budget); the user row at index 210
+    # repeats the visible key of the user row at index 100 — a duplicate that
+    # lives entirely within the tail. The final assistant row (211) answers
+    # the current turn so the session is regenerable.
+    rows = []
+    for i in range(212):
+        if i == 211:
+            rows.append({"role": "assistant", "content": "final answer", "timestamp": 100.0 + i})
+            continue
+        role = "user" if i % 2 == 0 else "assistant"
+        content = "m100" if i == 210 else f"m{i}"
+        rows.append({"role": role, "content": content, "timestamp": 100.0 + i})
+    db = _make_state_db(tmp_path, rows)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+
+    session = Session(
+        session_id="s1",
+        messages=[dict(r) for r in rows],
+        context_messages=[dict(r) for r in rows],
+    )
+    # guard must refuse the bounded path (in-tail duplicate)
+    floor = min(m["timestamp"] for m in session.messages[-200:])
+    snap = models.get_state_db_regeneration_tail_snapshot("s1", floor)
+    assert snap is not None
+    assert len(snap["tail_keys"]) > len(set(snap["tail_keys"])), "fixture must repeat a key inside the tail"
+    from api import session_ops
+    assert session_ops._bounded_tail_snapshot_if_safe(session, floor) is None, \
+        "in-tail duplicate must refuse the bounded path"
+
+    # mint → validate: the full-read revision must be accepted
+    full_rows, full_context = regeneration_state(session)
+    full_rev = regeneration_revision_for(full_rows, session=session, context=full_context)
+    assert full_rev
+    plan = plan_regeneration(session, expected_revision=full_rev, lock_held=True)
+    assert plan is not None and plan.revision == full_rev

--- a/tests/test_issue6611_regeneration_authority.py
+++ b/tests/test_issue6611_regeneration_authority.py
@@ -412,25 +412,117 @@ def test_terminal_payload_embeds_the_rows_it_hashes(monkeypatch):
 
 
 def test_recovered_display_context_pair_survives_local_and_gateway_apply(monkeypatch):
-    session = _session()
+    """#6611: the recovered display/context pair survives apply on BOTH paths.
+
+    The state.db authority path (empty sidecar, recovery) and the #6826
+    sidecar-anchored path (pair already loaded in memory) must both plan the
+    same canonical pair, and the recovered pair must survive local and
+    gateway apply on each path.
+    """
+    from api import models as models_api
+
     canonical_rows = [
-        {"role": "user", "content": "recovered", "id": "u-recovered", "_source": "webui"},
-        {"role": "assistant", "content": "failed"},
+        {"role": "user", "content": "recovered", "id": "u-recovered", "_source": "webui", "timestamp": 100.0},
+        {"role": "assistant", "content": "failed", "timestamp": 101.0},
     ]
     canonical_context = [
-        {"role": "system", "content": "recovered context only"},
+        {"role": "system", "content": "recovered context only", "timestamp": 99.0},
         *canonical_rows,
     ]
     monkeypatch.setattr(
-        "api.session_ops.regeneration_state",
-        lambda _session: (canonical_rows, canonical_context),
+        models_api,
+        "get_state_db_session_messages",
+        lambda *_args, **_kwargs: [dict(row) for row in canonical_rows],
     )
     from api.session_ops import apply_regeneration_plan, plan_regeneration
 
+    # --- state.db authority path: empty sidecar (recovery), the authority
+    # reconciles the state.db snapshot into the canonical pair.
+    session = _session()
+    session.messages = []
+    session.context_messages = []
     plan = plan_regeneration(session)
-    assert apply_regeneration_plan(session, plan)
-    assert session.messages == canonical_rows[:1]
-    assert any(row.get("content") == "recovered" for row in session.context_messages)
+    assert plan.canonical_rows == canonical_rows
+    assert plan.canonical_context == canonical_rows
     payload = _session_payload_with_full_messages(session)
     assert payload["messages"] == canonical_rows
     assert payload["message_count"] == len(canonical_rows)
+    assert apply_regeneration_plan(session, plan)
+    assert session.messages == canonical_rows[:1]
+    assert any(row.get("content") == "recovered" for row in session.context_messages)
+
+    # --- sidecar-anchored path: the recovered pair is already loaded in
+    # memory; the bounded state.db tail read must not lose it, and the same
+    # canonical pair must survive local + gateway apply.
+    session = _session()
+    session.messages = [dict(row) for row in canonical_rows]
+    session.context_messages = [dict(row) for row in canonical_context]
+    plan = plan_regeneration(session)
+    assert plan.canonical_rows == canonical_rows
+    assert plan.canonical_context == canonical_context
+    payload = _session_payload_with_full_messages(session)
+    assert payload["messages"] == canonical_rows
+    assert payload["message_count"] == len(canonical_rows)
+    assert apply_regeneration_plan(session, plan)
+    assert session.messages == canonical_rows[:1]
+    assert any(row.get("content") == "recovered" for row in session.context_messages)
+
+
+def test_regeneration_sidecar_path_avoids_full_transcript_refetch(monkeypatch):
+    """#6826: regenerate reads a bounded state.db tail, not the full transcript.
+
+    The full authority read materializes the entire state.db transcript (the
+    >1min stall on large sessions).  The sidecar-anchored regeneration path
+    must pass ``since_timestamp`` so the SQL scan is bounded, while still
+    reconciling through ``reconciled_state_db_messages_for_session`` — a
+    state.db-only gateway tail row must be picked up identically on both
+    paths (authority preserved).
+    """
+    from api import models as models_api
+    from api.session_ops import regeneration_state
+
+    session = _session()
+    session.messages = [
+        {"role": "user", "content": f"m{index}", "timestamp": float(index)}
+        for index in range(500)
+    ]
+    session.context_messages = [dict(row) for row in session.messages]
+    # state.db has the same transcript plus a gateway-applied tail the sidecar
+    # has not seen yet.
+    state_rows = [dict(row) for row in session.messages]
+    state_rows.append(
+        {"role": "assistant", "content": "gateway applied turn", "timestamp": 500.0}
+    )
+
+    calls = []
+
+    def fake_get_state_db_session_messages(*_args, **_kwargs):
+        calls.append(dict(_kwargs))
+        since = _kwargs.get("since_timestamp")
+        if since is None:
+            return [dict(row) for row in state_rows]
+        return [
+            dict(row)
+            for row in state_rows
+            if (row.get("timestamp") or 0) >= since
+        ]
+
+    monkeypatch.setattr(
+        models_api,
+        "get_state_db_session_messages",
+        fake_get_state_db_session_messages,
+    )
+
+    full_rows, full_context = regeneration_state(session)
+    assert calls[-1].get("since_timestamp") is None  # full read
+
+    fast_rows, fast_context = regeneration_state(session, use_sidecar=True)
+    # provably effective: the fast path requests only the bounded tip window
+    assert calls[-1].get("since_timestamp") is not None
+    assert calls[-1]["since_timestamp"] > 0
+
+    # authority preserved: identical reconciled transcript on both paths,
+    # including the state.db-only gateway tail row.
+    assert fast_rows == full_rows
+    assert fast_context == full_context
+    assert fast_rows[-1]["content"] == "gateway applied turn"


### PR DESCRIPTION
Fixes #6826. Regenerate usa a janela já carregada em vez de refetch do transcript completo — remove o stall de >1min e o cancelamento silencioso.