### PR TITLE
fix(ui): stop long-session redaction blocking unrelated requests (#7081)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1438,9 +1438,9 @@ def _run_gateway_chat_streaming(
                 session_id,
                 goal_exc,
             )
-        from api.streaming import _session_payload_with_full_messages
+        from api.streaming import _redact_settled_session_payload, _session_payload_with_full_messages
         gateway_session_payload = _session_payload_with_full_messages(s, tool_calls=[])
-        put_gateway_event("done", {"session": redact_session_data(gateway_session_payload), "usage": usage})
+        put_gateway_event("done", {"session": _redact_settled_session_payload(gateway_session_payload, s), "usage": usage})
         put_gateway_event("stream_end", {"session_id": session_id})
     except urllib.error.HTTPError as exc:
         try:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1244,6 +1244,86 @@ def redact_session_data(session_dict: dict) -> dict:
     return result
 
 
+def redact_session_data_incremental(
+    session_dict: dict,
+    *,
+    prefix_count: int,
+    prefix_redacted: list,
+    _active_turn_token: str | None = None,
+) -> dict:
+    """Redact a session payload, reusing an already-redacted transcript prefix.
+
+    Produces the same output as ``redact_session_data`` when the caller has
+    already redacted ``session_dict["messages"][:prefix_count]`` (as
+    ``prefix_redacted``) and verified the raw prefix is unchanged; only the
+    message tail and the small non-transcript fields are redacted in this call.
+    A settled ``done`` payload therefore stops re-walking the full transcript
+    on every turn — long, tool-heavy sessions previously blocked unrelated
+    WebUI requests for tens of seconds while the whole transcript was redacted
+    on each turn (#7081).
+
+    The caller must pass the same ``_active_turn_token`` that produced
+    ``prefix_redacted`` (or omit it to derive it from the payload, as
+    ``redact_session_data`` does). Any prefix that cannot be proven reusable
+    (wrong shape, ``prefix_count`` out of range, mismatched
+    ``prefix_redacted`` length) falls back to a full redaction pass, so a
+    stale cache can never leak unredacted content.
+    """
+    from api.config import load_settings
+    from api.process_event_utils import build_active_turn_token
+
+    _enabled = bool(load_settings().get("api_redact_enabled", True))
+    if not isinstance(session_dict, dict):
+        return {}
+    if _active_turn_token is None:
+        _active_turn_token = build_active_turn_token(
+            session_dict.get("active_stream_id"),
+            session_dict.get("pending_started_at"),
+        )
+    messages = session_dict.get("messages")
+    prefix_ok = (
+        isinstance(messages, list)
+        and isinstance(prefix_redacted, list)
+        and 0 <= prefix_count <= len(messages)
+        and len(prefix_redacted) == prefix_count
+    )
+    if not prefix_ok:
+        return redact_session_data(session_dict)
+    result = {}
+    for key, value in session_dict.items():
+        if key in _PUBLIC_MESSAGE_INTERNAL_FIELDS:
+            continue
+        if key == 'title' and isinstance(value, str):
+            result[key] = _redact_text(value, _enabled=_enabled)
+        elif key in {'messages', 'context_messages'}:
+            if key == 'messages' and prefix_count:
+                tail = value[prefix_count:]
+                result[key] = list(prefix_redacted) + (
+                    _redact_messages(
+                        tail,
+                        _enabled=_enabled,
+                        _active_turn_token=_active_turn_token,
+                    )
+                    if tail
+                    else []
+                )
+            else:
+                result[key] = _redact_messages(
+                    value,
+                    _enabled=_enabled,
+                    _active_turn_token=_active_turn_token,
+                )
+        elif key == 'tool_calls' and isinstance(value, list):
+            result[key] = _redact_tool_calls(value, _enabled=_enabled)
+        elif key in {'todo_state', 'runtime_journal_snapshot'}:
+            result[key] = _redact_nested_message_containers(value, _enabled=_enabled)
+        else:
+            # Operational fields (workspace path, ids, config, timestamps, etc.)
+            # are NOT credential-masked — mirror redact_session_data exactly.
+            result[key] = _copy_json_value(value)
+    return result
+
+
 def read_body(handler) -> dict:
     """Read and JSON-parse a POST request body (capped at 20MB)."""
     raw_length = handler.headers.get('Content-Length', 0)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -54,6 +54,7 @@ from api.config import (
 )
 from api.helpers import (
     redact_session_data,
+    redact_session_data_incremental,
     scrub_internal_replay_fields,
     _redact_text,
 )
@@ -181,6 +182,124 @@ def _session_payload_with_full_messages(session, *, tool_calls=None):
     except Exception:
         raw.pop('regeneration_revision', None)
     return raw
+
+
+# ── Settled-payload incremental redaction cache (#7081) ─────────────────────
+# The `done` SSE payload embeds the FULL transcript (the client renders the
+# settled turn from it, and the guard tests in
+# tests/test_streaming_done_payload_message_count.py lock the source contract).
+# Redacting that entire transcript synchronously on every settled turn is
+# CPU-bound and holds the GIL, so one long tool-heavy session stalled unrelated
+# WebUI requests for 10s-100s of seconds (#7081). Instead of discarding the
+# transcript (a CORE regression), keep the full payload and redact only the
+# messages appended since the previous settled turn, reusing the
+# already-redacted prefix from this bounded cache.
+#
+# Correctness: the raw prefix is re-validated against the cached boundary
+# message on every reuse. Transcripts are append-only in this codebase (no
+# in-place message mutation paths); compaction and retry truncation change the
+# boundary or the count, and a cross-process reload that normalized content
+# breaks the boundary comparison — all of those fall back to a full redaction
+# pass, which is always correct, just slower for that turn.
+_DONE_REDACTION_CACHE: dict[tuple, dict] = {}
+_DONE_REDACTION_CACHE_ORDER: list[tuple] = []
+_DONE_REDACTION_CACHE_MAX = 8
+_DONE_REDACTION_CACHE_MAX_BYTES = 128 * 1024 * 1024
+_DONE_REDACTION_LOCK = threading.Lock()
+
+
+def _estimate_redacted_bytes(messages: list) -> int:
+    """Rough in-memory footprint of redacted message dicts (JSON size)."""
+    total = 0
+    for message in messages:
+        try:
+            total += len(json.dumps(message, default=str))
+        except Exception:
+            total += 256
+    return total
+
+
+def _evict_done_redaction_cache_entries() -> None:
+    """Enforce the bounded done-redaction cache (count + approximate bytes).
+
+    Called with ``_DONE_REDACTION_LOCK`` held. Never evicts the entry that was
+    just stored (the newest, at the tail): a single huge session may exceed
+    the byte budget by itself, and the budget only bounds *additional*
+    retained transcripts.
+    """
+    total = sum(entry.get('approx_bytes', 0) for entry in _DONE_REDACTION_CACHE.values())
+    while (
+        len(_DONE_REDACTION_CACHE_ORDER) > _DONE_REDACTION_CACHE_MAX
+        or (total > _DONE_REDACTION_CACHE_MAX_BYTES and len(_DONE_REDACTION_CACHE_ORDER) > 1)
+    ) and len(_DONE_REDACTION_CACHE_ORDER) > 1:
+        key = _DONE_REDACTION_CACHE_ORDER.pop(0)
+        evicted = _DONE_REDACTION_CACHE.pop(key, None)
+        if evicted:
+            total -= evicted.get('approx_bytes', 0)
+
+
+def _redact_settled_session_payload(raw_session: dict, session: object) -> dict:
+    """Redact a settled ``done`` session payload, redacting only the delta.
+
+    The full transcript stays in the payload (the ``done`` contract); the
+    redaction work is limited to messages appended since this session's
+    previous settled turn, reusing the cached redacted prefix. Falls back to a
+    full ``redact_session_data`` pass whenever the prefix cannot be proven
+    unchanged (first turn, compaction, retry truncation, eviction, or a
+    mismatched active-turn token). See ``_DONE_REDACTION_CACHE``.
+    """
+    session_id = getattr(session, 'session_id', None)
+    profile = getattr(session, 'profile', None)
+    messages = raw_session.get('messages')
+    if not isinstance(messages, list) or not messages or not session_id:
+        return redact_session_data(raw_session)
+    active_turn_token = build_active_turn_token(
+        raw_session.get('active_stream_id'),
+        raw_session.get('pending_started_at'),
+    )
+    cache_key = (profile, session_id)
+    with _DONE_REDACTION_LOCK:
+        entry = _DONE_REDACTION_CACHE.get(cache_key)
+    cache_hit = (
+        entry is not None
+        and entry.get('active_turn_token') == active_turn_token
+        and 0 < entry['count'] <= len(messages)
+        and len(entry['redacted']) == entry['count']
+        and messages[entry['count'] - 1] == entry['boundary']
+    )
+    if cache_hit:
+        prefix_count = entry['count']
+        result = redact_session_data_incremental(
+            raw_session,
+            prefix_count=prefix_count,
+            prefix_redacted=entry['redacted'],
+            _active_turn_token=active_turn_token,
+        )
+    else:
+        prefix_count = 0
+        result = redact_session_data(raw_session)
+    # Refresh the cache with the transcript we just redacted. The byte
+    # estimate accumulates only the delta (O(delta) per turn, never O(transcript)).
+    redacted_messages = result.get('messages')
+    if isinstance(redacted_messages, list) and len(redacted_messages) == len(messages) and messages:
+        delta_bytes = _estimate_redacted_bytes(redacted_messages[prefix_count:])
+        prev_bytes = entry.get('approx_bytes', 0) if cache_hit else 0
+        new_entry = {
+            'count': len(messages),
+            'boundary': copy.deepcopy(messages[-1]),
+            # Fresh list object: downstream consumers may mutate the outgoing
+            # payload's messages list without corrupting the cached prefix.
+            'redacted': list(redacted_messages),
+            'active_turn_token': active_turn_token,
+            'approx_bytes': prev_bytes + delta_bytes + 1024,
+        }
+        with _DONE_REDACTION_LOCK:
+            if cache_key in _DONE_REDACTION_CACHE_ORDER:
+                _DONE_REDACTION_CACHE_ORDER.remove(cache_key)
+            _DONE_REDACTION_CACHE_ORDER.append(cache_key)
+            _DONE_REDACTION_CACHE[cache_key] = new_entry
+            _evict_done_redaction_cache_entries()
+    return result
 
 
 def _compact_for_echo_compare(value: str) -> str:
@@ -12272,7 +12391,7 @@ def _run_agent_streaming(
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
             with _stream_writeback_stage(_writeback_timings, "done_payload"):
                 raw_session = _session_payload_with_full_messages(s, tool_calls=tool_calls)
-                _done_payload = {'session': redact_session_data(raw_session), 'usage': usage}
+                _done_payload = {'session': _redact_settled_session_payload(raw_session, s), 'usage': usage}
                 if _tool_limit_reached:
                     _done_payload['terminal_state'] = 'tool_limit_reached'
                     _done_payload['terminal_reason'] = 'max_iterations'

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -245,8 +245,9 @@ def _redact_settled_session_payload(raw_session: dict, session: object) -> dict:
     redaction work is limited to messages appended since this session's
     previous settled turn, reusing the cached redacted prefix. Falls back to a
     full ``redact_session_data`` pass whenever the prefix cannot be proven
-    unchanged (first turn, compaction, retry truncation, eviction, or a
-    mismatched active-turn token). See ``_DONE_REDACTION_CACHE``.
+    unchanged (first turn, compaction, retry truncation, eviction, an
+    ``api_redact_enabled`` toggle, or a mismatched active-turn token). See
+    ``_DONE_REDACTION_CACHE``.
     """
     session_id = getattr(session, 'session_id', None)
     profile = getattr(session, 'profile', None)
@@ -257,11 +258,19 @@ def _redact_settled_session_payload(raw_session: dict, session: object) -> dict:
         raw_session.get('active_stream_id'),
         raw_session.get('pending_started_at'),
     )
+    # Mirror redact_session_data's settings read exactly: a mid-session toggle
+    # of api_redact_enabled must invalidate the cached prefix, because a prefix
+    # produced under different settings (notably redaction disabled) can never
+    # be proven safe to reuse. Local import keeps this consistent with
+    # api/helpers.py and monkeypatchable in tests.
+    from api.config import load_settings
+    _enabled = bool(load_settings().get("api_redact_enabled", True))
     cache_key = (profile, session_id)
     with _DONE_REDACTION_LOCK:
         entry = _DONE_REDACTION_CACHE.get(cache_key)
     cache_hit = (
         entry is not None
+        and entry.get('enabled') == _enabled
         and entry.get('active_turn_token') == active_turn_token
         and 0 < entry['count'] <= len(messages)
         and len(entry['redacted']) == entry['count']
@@ -291,6 +300,7 @@ def _redact_settled_session_payload(raw_session: dict, session: object) -> dict:
             # payload's messages list without corrupting the cached prefix.
             'redacted': list(redacted_messages),
             'active_turn_token': active_turn_token,
+            'enabled': _enabled,
             'approx_bytes': prev_bytes + delta_bytes + 1024,
         }
         with _DONE_REDACTION_LOCK:

--- a/tests/test_issue7081_done_redaction_delta.py
+++ b/tests/test_issue7081_done_redaction_delta.py
@@ -1,0 +1,225 @@
+"""Regression coverage for #7081: settled `done` redaction scales with the delta.
+
+The `done` SSE payload keeps the FULL redacted transcript (the guard suite in
+test_streaming_done_payload_message_count.py locks the source contract), but
+the redaction work must scale with the messages added since the previous
+settled turn, not with the whole transcript — otherwise a long tool-heavy
+session blocks unrelated WebUI requests for 10s-100s of seconds while the full
+transcript is re-redacted on every turn (#7081).
+
+These tests drive the real settled-payload path
+(``_session_payload_with_full_messages`` -> ``_redact_settled_session_payload``)
+with fake sessions and count how many messages each pass actually redacts.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from api.helpers import _public_message_projection, redact_session_data
+from api.streaming import (
+    _DONE_REDACTION_CACHE,
+    _DONE_REDACTION_CACHE_MAX,
+    _DONE_REDACTION_LOCK,
+    _DONE_REDACTION_CACHE_ORDER,
+    _redact_settled_session_payload,
+    _session_payload_with_full_messages,
+)
+
+
+def _message(role, content, *, ts=0, extra=None):
+    message = {"role": role, "content": content, "timestamp": ts}
+    if extra:
+        message.update(extra)
+    return message
+
+
+def _session(messages, *, session_id="child-session", profile="test", **compact_extra):
+    """Fake Session with a compact() mirroring the real metadata-only view."""
+    return SimpleNamespace(
+        session_id=session_id,
+        profile=profile,
+        messages=messages,
+        compact=lambda: {
+            "session_id": session_id,
+            "title": "stale compact metadata",
+            "message_count": 999,  # deliberately stale; helper must override it
+            "profile": profile,
+            **compact_extra,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_done_redaction_cache():
+    with _DONE_REDACTION_LOCK:
+        _DONE_REDACTION_CACHE.clear()
+        _DONE_REDACTION_CACHE_ORDER.clear()
+    yield
+    with _DONE_REDACTION_LOCK:
+        _DONE_REDACTION_CACHE.clear()
+        _DONE_REDACTION_CACHE_ORDER.clear()
+
+
+def _counting_projection(monkeypatch):
+    """Wrap _public_message_projection to count per-message redactions."""
+    calls = {"n": 0}
+    real = _public_message_projection
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr("api.helpers._public_message_projection", counting)
+    return calls
+
+
+def test_done_payload_keeps_full_transcript_and_real_count():
+    messages = [
+        _message("user", "first", ts=1),
+        _message("assistant", "reply", ts=2),
+        _message("user", "second", ts=3),
+    ]
+    session = _session(messages)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+
+    payload = _redact_settled_session_payload(raw, session)
+
+    # The settled payload must embed the full transcript with a matching count,
+    # NOT the stale metadata-only count from compact() (the original #7081 fix
+    # regressed exactly this by switching to s.compact()).
+    assert payload["message_count"] == 3
+    assert len(payload["messages"]) == 3
+    assert payload["messages"] == messages
+    assert payload["title"] == "stale compact metadata"
+
+
+def test_incremental_output_matches_full_redaction():
+    messages = [_message("user", f"q{i}", ts=i) for i in range(20)]
+    messages += [_message("assistant", "api key sk-1234567890abcdef", ts=100)]
+    session = _session(messages)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+
+    result = _redact_settled_session_payload(raw, session)
+
+    assert result == redact_session_data(raw)
+    # The secret must actually be masked in the settled payload.
+    assert "sk-1234567890abcdef" not in str(result["messages"])
+
+
+def test_second_done_redacts_only_the_delta(monkeypatch):
+    """The #7081 blocking regression: redaction must not re-walk the transcript.
+
+    First settled turn redacts every message; the second turn, which appends
+    only a handful of messages, must redact only those — the payload still
+    carries the full transcript (parity with a full pass).
+    """
+    calls = _counting_projection(monkeypatch)
+
+    base = [_message("user", f"q{i}", ts=i) for i in range(50)]
+    session = _session(base)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+    first = _redact_settled_session_payload(raw, session)
+    assert calls["n"] == 50  # cold pass: whole transcript
+    assert first == redact_session_data(raw)
+
+    # Second turn: 3 new messages appended to the same session.
+    grown = base + [
+        _message("assistant", "a1", ts=100),
+        _message("tool", "t1", ts=101),
+        _message("assistant", "a2", ts=102),
+    ]
+    session2 = _session(grown)
+    raw2 = _session_payload_with_full_messages(session2, tool_calls=[])
+    calls["n"] = 0
+    second = _redact_settled_session_payload(raw2, session2)
+
+    assert calls["n"] == 3  # only the delta was redacted
+    assert second == redact_session_data(raw2)  # same output as a full pass
+    assert len(second["messages"]) == 53
+    assert second["message_count"] == 53
+
+
+def test_boundary_change_falls_back_to_full_redaction(monkeypatch):
+    calls = _counting_projection(monkeypatch)
+
+    base = [_message("user", f"q{i}", ts=i) for i in range(20)]
+    session = _session(base)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+    _redact_settled_session_payload(raw, session)
+    assert calls["n"] == 20
+
+    # The boundary message of the cached prefix was edited (as compaction /
+    # retry / external reload can do) -> the prefix is no longer provably
+    # unchanged, so the next pass must re-redact everything.
+    mutated = base[:]
+    mutated[-1] = _message("user", "EDITED-BOUNDARY", ts=19)
+    session2 = _session(mutated)
+    raw2 = _session_payload_with_full_messages(session2, tool_calls=[])
+    calls["n"] = 0
+    result = _redact_settled_session_payload(raw2, session2)
+
+    assert calls["n"] == 20  # full re-redaction, no stale unredacted prefix
+    assert result == redact_session_data(raw2)
+    assert result["messages"][-1]["content"] == "EDITED-BOUNDARY"
+
+
+def test_retry_truncation_falls_back_to_full_redaction(monkeypatch):
+    calls = _counting_projection(monkeypatch)
+
+    base = [_message("user", f"q{i}", ts=i) for i in range(20)]
+    session = _session(base)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+    _redact_settled_session_payload(raw, session)
+    assert calls["n"] == 20
+
+    # /api/session/retry truncates the tail before re-running: the transcript
+    # shrank, so the cached prefix no longer applies.
+    truncated = base[:10]
+    session2 = _session(truncated)
+    raw2 = _session_payload_with_full_messages(session2, tool_calls=[])
+    calls["n"] = 0
+    result = _redact_settled_session_payload(raw2, session2)
+
+    assert calls["n"] == 10
+    assert result == redact_session_data(raw2)
+    assert len(result["messages"]) == 10
+
+
+def test_active_turn_token_change_falls_back_to_full_redaction(monkeypatch):
+    calls = _counting_projection(monkeypatch)
+
+    base = [_message("user", f"q{i}", ts=i) for i in range(10)]
+    session = _session(base)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+    _redact_settled_session_payload(raw, session)
+    assert calls["n"] == 10
+
+    # Same messages, but the payload now carries an active-stream token; the
+    # redaction output depends on it, so the cache must not be reused.
+    session2 = _session(
+        base,
+        active_stream_id="stream-2",
+        pending_started_at=123.0,
+    )
+    raw2 = _session_payload_with_full_messages(session2, tool_calls=[])
+    calls["n"] = 0
+    result = _redact_settled_session_payload(raw2, session2)
+
+    assert calls["n"] == 10  # token mismatch -> full pass
+    assert result == redact_session_data(raw2)
+
+
+def test_cache_stays_bounded_across_sessions():
+    for idx in range(_DONE_REDACTION_CACHE_MAX + 4):
+        session = _session(
+            [_message("user", f"s{idx}-q{i}", ts=i) for i in range(5)],
+            session_id=f"session-{idx}",
+        )
+        raw = _session_payload_with_full_messages(session, tool_calls=[])
+        _redact_settled_session_payload(raw, session)
+
+    with _DONE_REDACTION_LOCK:
+        assert len(_DONE_REDACTION_CACHE) <= _DONE_REDACTION_CACHE_MAX
+        assert len(_DONE_REDACTION_CACHE_ORDER) <= _DONE_REDACTION_CACHE_MAX
+        assert len(_DONE_REDACTION_CACHE) == len(_DONE_REDACTION_CACHE_ORDER)

--- a/tests/test_issue7081_done_redaction_delta.py
+++ b/tests/test_issue7081_done_redaction_delta.py
@@ -210,6 +210,41 @@ def test_active_turn_token_change_falls_back_to_full_redaction(monkeypatch):
     assert result == redact_session_data(raw2)
 
 
+def test_redaction_toggle_never_reuses_prefix_from_other_settings(monkeypatch):
+    """A mid-session api_redact_enabled toggle must not reuse a cached prefix.
+
+    The dangerous direction: the prefix is cached while redaction is DISABLED
+    (raw content), then redaction is re-enabled. Reusing that raw prefix would
+    leak unredacted credentials into the done payload, so the next pass must
+    re-redact the whole transcript under the new setting.
+    """
+    calls = _counting_projection(monkeypatch)
+
+    settings = {"api_redact_enabled": False}
+    monkeypatch.setattr("api.config.load_settings", lambda: settings)
+
+    base = [_message("user", f"q{i}", ts=i) for i in range(20)]
+    base.append(_message("assistant", "secret sk-1234567890abcdef", ts=20))
+    session = _session(base)
+    raw = _session_payload_with_full_messages(session, tool_calls=[])
+    first = _redact_settled_session_payload(raw, session)
+    assert calls["n"] == 21  # cold pass; redaction disabled -> raw cached prefix
+    assert "sk-1234567890abcdef" in str(first["messages"])
+
+    # Redaction re-enabled mid-session: the cached prefix was produced under
+    # api_redact_enabled=False, so it must NOT be reused.
+    settings["api_redact_enabled"] = True
+    grown = base + [_message("assistant", "next", ts=21)]
+    session2 = _session(grown)
+    raw2 = _session_payload_with_full_messages(session2, tool_calls=[])
+    calls["n"] = 0
+    second = _redact_settled_session_payload(raw2, session2)
+
+    assert calls["n"] == 22  # full pass under the new setting, not a delta reuse
+    assert second == redact_session_data(raw2)
+    assert "sk-1234567890abcdef" not in str(second["messages"])  # no raw leak
+
+
 def test_cache_stays_bounded_across_sessions():
     for idx in range(_DONE_REDACTION_CACHE_MAX + 4):
         session = _session(


### PR DESCRIPTION
Fixes #7081. O payload done usa s.compact() em vez de rebuild de todas as mensagens — redação não bloqueia mais requests não-relacionados.