### PR TITLE
fix: preserve last character before tool call in streaming text

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4379,7 +4379,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     s=s.replace(/<(?:\s*｜\s*DSML\s*[｜|]\s*)?function_calls(?:>|$)[\s\S]*$/i,'');
     // Remove malformed DSML tag fragments like "<｜DSML |" that can leak in tokens.
     s=s.replace(/<\s*｜\s*DSML\s*[｜|]\s*/gi,'');
-    return s.trim();
+    return s.replace(/^\s+/, '');
   }
   function _streamDisplay(){
     return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true}).content;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7496,7 +7496,7 @@ function _stripXmlToolCallsDisplay(s){
   s=s.replace(/<(?:\s*｜\s*DSML\s*[｜|]\s*)?function_calls(?:>|$)[\s\S]*$/i,'');
   // Remove malformed DSML tag fragments like "<｜DSML |" that can leak in tokens.
   s=s.replace(/<\s*｜\s*DSML\s*[｜|]\s*/gi,'');
-  return s.trim();
+  return s.replace(/^\s+/, '');
 }
 
 function _sanitizeThinkingDisplayText(text){


### PR DESCRIPTION
## Summary

Fixes a streaming text rendering bug where the last character before a `<function_calls>` tool call block is silently dropped from the visible assistant message.

## Motivation

During streaming, when a DeepSeek-class model emits `<function_calls>...</function_calls>` immediately after prose text, the `_stripXmlToolCalls` and `_stripXmlToolCallsDisplay` functions strip the XML block but also call `.trim()` on the result. `.trim()` removes trailing whitespace — but the second regex (line 4379/7496) already removed everything from the `<function_calls` tag onward via `[\s\S]*$`. The `.trim()` can then strip trailing whitespace that was legitimately part of the prose text, and in edge cases where the last character before the tag is whitespace, the visible text is truncated by one character.

More critically, when the streaming `_smdWrite` incremental parser has already written the text up to that point, the self-heal check (`displayText.startsWith(_smdWrittenText)`) can fail because the trimmed version is shorter than what was previously written, causing a DOM rebuild that drops the trailing content.

## Changes

### `static/messages.js` — `_stripXmlToolCalls`

- **Before:** `return s.trim();`
- **After:** `return s.replace(/^\s+/, '');`

Only strips leading whitespace (which is safe — the `[\s\S]*$` regex already consumed everything from the tool call tag forward). Trailing content is preserved exactly as-is.

### `static/ui.js` — `_stripXmlToolCallsDisplay`

Same change as above for the display-only variant used in settled chat bubbles.

## Design decisions

- **`replace(/^\s+/, '')` instead of `ltrim()`** — avoids adding a custom utility; the regex is self-documenting and consistent with the existing pattern in the file.
- Trailing whitespace preserved — the streaming prose parser (`_smdWrite`) expects incremental text that only grows. `trim()` could make `displayText` shorter than the previously written `_smdWrittenText`, triggering a self-heal DOM rebuild that loses the last character.

## Backwards compatibility

Zero breaking changes. All existing behavior is preserved — the only difference is that trailing whitespace and characters before `<function_calls>` blocks are no longer stripped. For text that doesn't contain tool call blocks, the function returns early with the fast-path check and behavior is identical.

## Testing

1. Trigger a streaming response that ends prose text immediately before a `<function_calls>` block (e.g. DeepSeek model with tool calling)
2. Verify the last character of the prose text renders in the live assistant bubble
3. Verify the tool call card renders correctly after the text
4. Verify settled chat bubble (after streaming completes) also shows the full text