### PR TITLE
fix: deliver completed turns to per-session SSE

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -17925,6 +17925,11 @@ def _handle_session_run_journal_stream_for_session(handler, parsed, session_id):
     # are side-effect-free (header read + stat-only fingerprint), safe pre-response.
     resume_event_id = _session_events_resume_event_id(handler, parsed)
     _idle_journal_fp = session_journal_fingerprint(session_id)
+    # A completed turn may finish between active-stream probes. Subscribe to the
+    # in-process session-change bus before committing the response so the idle
+    # path can still deliver a scoped transcript snapshot immediately instead of
+    # relying on the next manual sidebar refresh.
+    session_change_subscriber = subscribe_session_events()
 
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
@@ -17999,6 +18004,14 @@ def _handle_session_run_journal_stream_for_session(handler, parsed, session_id):
                 subscriber, subscriber_stream, stream_snapshot, active_stream_id = attach_active_stream()
                 if subscriber is not None:
                     break
+                try:
+                    session_change = session_change_subscriber.get_nowait()
+                except queue.Empty:
+                    session_change = None
+                if isinstance(session_change, dict):
+                    changed_session_id = str(session_change.get("session_id") or "").strip()
+                    if not changed_session_id or changed_session_id == session_id:
+                        emit_session_snapshot(active_stream_id)
                 # Journal advanced with no live stream to attach → a run completed
                 # entirely within the wait (or the first attach). Re-sync via a
                 # snapshot boundary (the same honest-recovery contract used for a
@@ -18066,6 +18079,7 @@ def _handle_session_run_journal_stream_for_session(handler, parsed, session_id):
                 subscriber_stream.unsubscribe(subscriber)
             except Exception:
                 pass
+        unsubscribe_session_events(session_change_subscriber)
     return True
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11957,6 +11957,16 @@ def _run_agent_streaming(
         # CLI/cron env fallback resumes — same lifecycle slot as the env
         # restore above.
         _reset_turn_session_identity(_turn_session_identity_tokens)
+        try:
+            from api.session_events import publish_session_list_changed
+
+            publish_session_list_changed(
+                "session_turn_complete",
+                profile=getattr(s, "profile", None) if s is not None else None,
+                session_id=getattr(s, "session_id", None) or session_id,
+            )
+        except Exception:
+            logger.debug("Failed to publish completed session turn", exc_info=True)
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
             CANCEL_FLAGS.pop(stream_id, None)

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -159,6 +159,27 @@ def test_session_event_queue_unscoped_pending_stays_unscoped_when_followed_by_sc
         session_events.unsubscribe_session_events(q)
 
 
+def test_per_session_sse_idle_path_consumes_scoped_completion_events():
+    """Keep the warm open-chat stream live when a turn ends between probes."""
+    routes = Path("api/routes.py").read_text(encoding="utf-8")
+    handler_start = routes.find("def _handle_session_run_journal_stream_for_session")
+    assert handler_start >= 0
+    handler_end = routes.find("\ndef ", handler_start + 1)
+    handler_body = routes[handler_start:handler_end if handler_end >= 0 else None]
+    assert "session_change_subscriber = subscribe_session_events()" in handler_body
+    assert "session_change_subscriber.get_nowait()" in handler_body
+    assert "changed_session_id == session_id" in handler_body
+    assert "unsubscribe_session_events(session_change_subscriber)" in handler_body
+
+
+def test_streaming_publishes_scoped_turn_completion_event():
+    """Ensure every durable WebUI turn invalidates matching open transcripts."""
+    streaming = Path("api/streaming.py").read_text(encoding="utf-8")
+    assert '"session_turn_complete"' in streaming
+    assert "publish_session_list_changed(" in streaming
+    assert 'session_id=getattr(s, "session_id", None) or session_id' in streaming
+
+
 def test_session_event_queue_drain_race_preserves_incoming_profile():
     from api import session_events
 


### PR DESCRIPTION
## Thinking Path

An already-open per-session SSE connection can miss an external WebUI/TUI turn when the run finishes between active-stream probes. The client can recover on refresh, but it needs a server-side invalidation signal to trigger an authoritative snapshot.

## What Changed

- Subscribe the per-session SSE handler to the in-process session-change bus before committing SSE headers.
- Consume matching session-scoped completion notifications in the idle path and emit a fresh `session_snapshot`.
- Publish `session_turn_complete` from the streaming teardown path with the affected session ID.
- Unsubscribe the per-session listener on teardown.
- Add focused coverage for the subscription/completion wiring.

## Why It Matters

This complements the Goku iOS client continuity work. PR #28 provides client reconciliation/reconnect behavior; this PR supplies the server-side completion signal that can cause an already-open session stream to reconcile after a desktop/WebUI turn.

## Contract Routing

- Task type: runtime streaming/session recovery fix.
- Touched areas: per-session SSE relay, streaming teardown, session-change bus.
- Relevant docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/session-sse-contract-v1.md`.
- State layer: in-process session-change subscription plus canonical session snapshot; no new durable session state.
- Boundary: this does not change the Goku iOS client, global sidebar stream contract, or reasoning capability contract.

## Verification

- `./scripts/test.sh tests/test_session_events.py tests/test_session_events_http_integration.py` — **16 passed**.
- `python3 -m compileall -q api/routes.py api/streaming.py tests/test_session_events.py` — passed.
- `git diff --check` — passed.

## Risks / Follow-ups

- This is a draft because end-to-end proof of an external turn appearing in an already-open iOS transcript without refresh/navigation/relaunch remains outstanding.
- Full repository CI and maintainer review are still required.
- `max` selection/persistent per-session reasoning is intentionally out of scope; it requires a separate server/provider capability and session-override contract.

## Model Used

GPT-5.6 Luna via Hermes; focused implementation and verification.
