### PR TITLE
fix(docker): built-in agent dashboard — three-service compose (#6876)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -395,23 +395,52 @@ jobs:
 
           # ----- Dashboard probe (three-service only) -----
           # The whole point of the three-service topology is the built-in
-          # dashboard. It must be UP and AUTH-GATED: curl WITHOUT credentials
-          # must get HTTP 401 (basic-auth challenge). Anything else means the
-          # dashboard is dead or unauthenticated — the exact #6876 failure.
+          # dashboard. It must be UP and AUTH-GATED — but "auth-gated" has two
+          # legitimate shapes: a basic-auth challenge (401/403) or a redirect to
+          # the login page (302/303/307/308 -> /login). Demanding exactly 401 was
+          # wrong: this dashboard answers 302 when no credentials are present, so
+          # the probe waited 3 minutes and failed on a working dashboard.
+          # What must NEVER happen is an unauthenticated 200: that is the exact
+          # #6876 defect (dashboard served without auth).
           if [ "${{ matrix.variant }}" = "three-service" ]; then
-            echo "::group::Probe dashboard (expect 401 auth challenge)"
+            echo "::group::Probe dashboard (expect auth challenge or login redirect)"
             attempts=0
             max_attempts=90
             code=""
-            until code="$(curl --silent --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:9119/ 2>/dev/null)" && [ "$code" = "401" ]; do
-              attempts=$((attempts + 1))
-              if [ "$attempts" -ge "$max_attempts" ]; then
-                echo "❌ Dashboard never answered 401 (last code: ${code:-none}) after $max_attempts attempts (~3 min)"
-                exit 1
+            loc=""
+            ok=""
+            while [ -z "$ok" ]; do
+              code="$(curl --silent --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:9119/ 2>/dev/null || true)"
+              case "$code" in
+                401|403)
+                  ok="basic-auth challenge ($code)"
+                  ;;
+                302|303|307|308)
+                  loc="$(curl --silent --max-time 5 -o /dev/null -w '%{redirect_url}' http://127.0.0.1:9119/ 2>/dev/null || true)"
+                  case "$loc" in
+                    *login*|*auth*|*signin*)
+                      ok="login redirect ($code -> $loc)"
+                      ;;
+                    *)
+                      echo "… HTTP $code but redirect target is not a login page: ${loc:-none}"
+                      ;;
+                  esac
+                  ;;
+                200)
+                  echo "❌ Dashboard served WITHOUT authentication (HTTP 200) — the #6876 defect"
+                  exit 1
+                  ;;
+              esac
+              if [ -z "$ok" ]; then
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge "$max_attempts" ]; then
+                  echo "❌ Dashboard is not auth-gated (last code: ${code:-none}, redirect: ${loc:-none}) after $max_attempts attempts (~3 min)"
+                  exit 1
+                fi
+                sleep 2
               fi
-              sleep 2
             done
-            echo "✅ Dashboard = 401 (up + basic-auth gated) after $attempts attempts"
+            echo "✅ Dashboard is up and auth-gated: $ok (after $attempts attempts)"
             echo "::endgroup::"
           fi
 

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Validate every compose file parses
         run: |
           set -euo pipefail
-          for f in docker-compose.yml docker-compose.two-container.yml docker-compose.three-container.yml; do
+          # three-service.yml interpolates REQUIRED vars (:?) — provide CI values.
+          export API_SERVER_KEY="ci-gateway-key-0123456789abcdef" DASHBOARD_PASSWORD="ci-dashboard-pass"
+          for f in docker-compose.yml docker-compose.two-container.yml docker-compose.three-container.yml docker-compose.three-service.yml; do
             echo "::group::compose config: $f"
             docker compose -f "$f" config > /dev/null
             echo "::endgroup::"
@@ -269,6 +271,7 @@ jobs:
           - single
           - two-container
           - three-container
+          - three-service
     steps:
       - uses: actions/checkout@v4
 
@@ -298,6 +301,9 @@ jobs:
               ;;
             three-container)
               echo "compose_file=docker-compose.three-container.yml" >> "$GITHUB_OUTPUT"
+              ;;
+            three-service)
+              echo "compose_file=docker-compose.three-service.yml" >> "$GITHUB_OUTPUT"
               ;;
           esac
           # Per-run project name so concurrent jobs / reruns can't clobber each other.
@@ -341,6 +347,10 @@ jobs:
           PROJECT: ${{ steps.vars.outputs.project }}
           HERMES_HOME: ${{ steps.paths.outputs.state_dir }}
           HERMES_WORKSPACE: ${{ steps.paths.outputs.work_dir }}
+          # three-service.yml interpolates REQUIRED vars (:?) — the other
+          # variants ignore them, so setting them for every matrix cell is safe.
+          API_SERVER_KEY: "ci-gateway-key-0123456789abcdef"
+          DASHBOARD_PASSWORD: "ci-dashboard-pass"
         run: |
           set -euo pipefail
 
@@ -382,6 +392,28 @@ jobs:
           done
           echo "✅ /health = 200 after $attempts attempts"
           echo "::endgroup::"
+
+          # ----- Dashboard probe (three-service only) -----
+          # The whole point of the three-service topology is the built-in
+          # dashboard. It must be UP and AUTH-GATED: curl WITHOUT credentials
+          # must get HTTP 401 (basic-auth challenge). Anything else means the
+          # dashboard is dead or unauthenticated — the exact #6876 failure.
+          if [ "${{ matrix.variant }}" = "three-service" ]; then
+            echo "::group::Probe dashboard (expect 401 auth challenge)"
+            attempts=0
+            max_attempts=90
+            code=""
+            until code="$(curl --silent --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:9119/ 2>/dev/null)" && [ "$code" = "401" ]; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge "$max_attempts" ]; then
+                echo "❌ Dashboard never answered 401 (last code: ${code:-none}) after $max_attempts attempts (~3 min)"
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "✅ Dashboard = 401 (up + basic-auth gated) after $attempts attempts"
+            echo "::endgroup::"
+          fi
 
           # ----- Startup log scan: must not contain any known-bad signatures -----
           # These are the exact patterns that would have flagged #2470 in real time.

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ If you want the agent and WebUI in separate containers (for isolation, or becaus
 docker compose -f docker-compose.two-container.yml up -d
 
 # Agent + Dashboard + WebUI
-docker compose -f docker-compose.three-container.yml up -d
+docker compose -f docker-compose.three-service.yml up -d
 ```
 
 Both compose files use **named Docker volumes** by default, which solves the UID/GID problem by construction. If you need bind mounts to share an existing host directory, see [`docs/docker.md`](docs/docker.md) for the full migration recipe.

--- a/README.md
+++ b/README.md
@@ -526,10 +526,14 @@ docker run -d \
 If you want the agent and WebUI in separate containers (for isolation, or because you're already running an agent gateway elsewhere):
 
 ```bash
-# Agent + WebUI
+# Agent + WebUI — no credentials needed in .env
 docker compose -f docker-compose.two-container.yml up -d
 
-# Agent + Dashboard + WebUI
+# Agent + Dashboard + WebUI — needs DASHBOARD_PASSWORD and a >=16-char
+# API_SERVER_KEY in .env first: docker-compose.three-service.yml interpolates
+# both as required variables, so compose aborts before starting any service.
+#   printf 'DASHBOARD_USER=admin\nDASHBOARD_PASSWORD=%s\nAPI_SERVER_KEY=%s\n' \
+#     "$(openssl rand -hex 8)" "$(openssl rand -hex 16)" > .env
 docker compose -f docker-compose.three-service.yml up -d
 ```
 

--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -1,3 +1,9 @@
+# ⚠️ DEPRECATED (issue #6876): the separate hermes-dashboard container below
+# runs `dashboard --host 0.0.0.0 --insecure`, which the current agent image
+# rejects when no dashboard auth provider is registered. Prefer
+# docker-compose.three-service.yml (v0.14+): the dashboard runs inside the
+# hermes-agent process via HERMES_DASHBOARD_HOST / HERMES_DASHBOARD_PORT.
+#
 # Three-container Docker Compose: Hermes Agent + Dashboard + WebUI
 #
 # QUICK START:

--- a/docker-compose.three-service.yml
+++ b/docker-compose.three-service.yml
@@ -1,0 +1,116 @@
+# Three-service Docker Compose: Hermes Agent (gateway + dashboard) + WebUI
+#
+# v0.14+ layout from docs/docker.md: the built-in dashboard runs INSIDE the
+# hermes-agent process via HERMES_DASHBOARD_HOST / HERMES_DASHBOARD_PORT.
+# This avoids the startup failure of the legacy three-container layout, where
+# `dashboard --host 0.0.0.0 --insecure` as a separate container is rejected by
+# the agent image's auth gate when no dashboard auth provider is registered:
+#
+#   Refusing to bind dashboard to 0.0.0.0 — the auth gate engages on
+#   non-loopback binds, but no auth providers are registered.  (issue #6876)
+#
+# QUICK START:
+#   docker compose -f docker-compose.three-service.yml up -d
+#   Open http://localhost:8787 (chat) and http://localhost:9119 (dashboard)
+#
+# The dashboard listener is covered by the agent's own auth gate (the gateway
+# API_SERVER_KEY), and the host-side publish stays loopback-only by default.
+# For remote access set HERMES_AGENT_BIND=0.0.0.0 and API_SERVER_KEY (>=16
+# chars) in .env, then recreate the stack. The WebUI reports "Hermes agent is
+# not responding" when the gateway listener is down — API_SERVER_KEY must be
+# set for port 8642 to open.
+#
+# NOTE ON VOLUMES:
+#   This file uses named Docker volumes (hermes-home, hermes-agent-src) which
+#   work out of the box. When using bind mounts, ALL containers must mount the
+#   same host path AND run as the same UID/GID (set via the UID/GID env vars).
+
+services:
+  hermes-agent:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes-agent
+    command: gateway run
+    ports:
+      # Gateway API (port 8642). Bind to loopback by default; set
+      # HERMES_AGENT_BIND=0.0.0.0 in .env for remote access.
+      - "${HERMES_AGENT_BIND:-127.0.0.1}:8642:8642"
+      # Built-in dashboard (port 9119), served by the agent process itself.
+      - "127.0.0.1:9119:9119"
+    volumes:
+      # Persist config, state, sessions, skills, memory across restarts
+      - hermes-home:/home/hermes/.hermes
+      # Expose agent source so the WebUI can install dependencies from it
+      - hermes-agent-src:/opt/hermes
+    environment:
+      - HERMES_HOME=/home/hermes/.hermes
+      # Align UID/GID across containers sharing the hermes-home volume.
+      - HERMES_UID=${UID:-1000}
+      - HERMES_GID=${GID:-1000}
+      # Built-in dashboard (v0.14+): runs inside the gateway process instead
+      # of a separate `dashboard --host 0.0.0.0 --insecure` container (which
+      # the auth gate rejects — issue #6876).
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      # Gateway API server (port 8642). The listener only opens when
+      # API_SERVER_KEY is a usable value (>=16 chars); set it in .env.
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${API_SERVER_KEY:-}
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+    networks:
+      - hermes-net
+
+  hermes-webui:
+    image: ghcr.io/nesquena/hermes-webui:latest
+    container_name: hermes-webui
+    depends_on:
+      - hermes-agent
+    ports:
+      # Expose on localhost only. Remove 127.0.0.1: to expose on all interfaces
+      # (set HERMES_WEBUI_PASSWORD if doing so).
+      - "127.0.0.1:8787:8787"
+    volumes:
+      # Same hermes home as the agent — shares config, sessions, state
+      - hermes-home:/home/hermeswebui/.hermes
+      # Agent source mounted where docker_init.bash expects it (read-only).
+      - hermes-agent-src:/home/hermeswebui/.hermes/hermes-agent:ro
+      # Workspace directory — browse and edit files from the WebUI.
+      - ${HERMES_WORKSPACE:-${HOME}/workspace}:/workspace
+    environment:
+      - HERMES_WEBUI_HOST=0.0.0.0
+      - HERMES_WEBUI_PORT=8787
+      - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui
+      # WebUI health/status checks reach the gateway over the compose network.
+      - HERMES_API_URL=http://hermes-agent:8642
+      # Match your host user's UID/GID for correct file permissions.
+      - WANTED_UID=${UID:-1000}
+      - WANTED_GID=${GID:-1000}
+      # Forward the API server key so the WebUI gateway probe can authenticate.
+      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}
+      # Optional: enable password auth. Set HERMES_WEBUI_PASSWORD in .env.
+      - HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD:-}
+    restart: unless-stopped
+    networks:
+      - hermes-net
+
+networks:
+  hermes-net:
+    driver: bridge
+
+volumes:
+  # IMPORTANT — upgrading the agent image:
+  #   The hermes-agent-src volume is initialised from the agent image's
+  #   /opt/hermes on first `up`; Docker reuses the volume verbatim on later
+  #   runs. After upgrading the agent image, run:
+  #
+  #     docker compose -f docker-compose.three-service.yml down
+  #     docker volume rm <project>_hermes-agent-src
+  #     docker compose -f docker-compose.three-service.yml pull
+  #     docker compose -f docker-compose.three-service.yml up -d
+  hermes-home:
+  hermes-agent-src:

--- a/docker-compose.three-service.yml
+++ b/docker-compose.three-service.yml
@@ -1,7 +1,8 @@
 # Three-service Docker Compose: Hermes Agent (gateway + dashboard) + WebUI
 #
 # v0.14+ layout from docs/docker.md: the built-in dashboard runs INSIDE the
-# hermes-agent process via HERMES_DASHBOARD_HOST / HERMES_DASHBOARD_PORT.
+# hermes-agent process, enabled by HERMES_DASHBOARD=1 and bound via
+# HERMES_DASHBOARD_HOST / HERMES_DASHBOARD_PORT.
 # This avoids the startup failure of the legacy three-container layout, where
 # `dashboard --host 0.0.0.0 --insecure` as a separate container is rejected by
 # the agent image's auth gate when no dashboard auth provider is registered:
@@ -10,15 +11,18 @@
 #   non-loopback binds, but no auth providers are registered.  (issue #6876)
 #
 # QUICK START:
+#   Create a .env with at least DASHBOARD_PASSWORD and API_SERVER_KEY
+#   (>=16 chars) — the compose file requires them — then:
 #   docker compose -f docker-compose.three-service.yml up -d
 #   Open http://localhost:8787 (chat) and http://localhost:9119 (dashboard)
 #
-# The dashboard listener is covered by the agent's own auth gate (the gateway
-# API_SERVER_KEY), and the host-side publish stays loopback-only by default.
-# For remote access set HERMES_AGENT_BIND=0.0.0.0 and API_SERVER_KEY (>=16
-# chars) in .env, then recreate the stack. The WebUI reports "Hermes agent is
-# not responding" when the gateway listener is down — API_SERVER_KEY must be
-# set for port 8642 to open.
+# The dashboard is protected by its OWN auth provider: binding it to 0.0.0.0
+# requires HERMES_DASHBOARD_BASIC_AUTH_USERNAME/_PASSWORD (or an OAuth
+# provider). API_SERVER_KEY does NOT cover the dashboard — it only guards the
+# gateway API server on port 8642 (>=16 chars, required, or the gateway stays
+# closed and the WebUI reports "Hermes agent is not responding"). The dashboard
+# host-side publish stays loopback-only by default; for remote access set
+# HERMES_AGENT_BIND=0.0.0.0 in .env.
 #
 # NOTE ON VOLUMES:
 #   This file uses named Docker volumes (hermes-home, hermes-agent-src) which
@@ -48,14 +52,21 @@ services:
       - HERMES_GID=${GID:-1000}
       # Built-in dashboard (v0.14+): runs inside the gateway process instead
       # of a separate `dashboard --host 0.0.0.0 --insecure` container (which
-      # the auth gate rejects — issue #6876).
+      # the auth gate rejects — issue #6876). HERMES_DASHBOARD=1 is REQUIRED
+      # to start the dashboard at all; HOST/PORT alone do nothing.
+      - HERMES_DASHBOARD=1
       - HERMES_DASHBOARD_HOST=0.0.0.0
       - HERMES_DASHBOARD_PORT=9119
+      # Required for the 0.0.0.0 bind above: the dashboard auth gate refuses a
+      # non-loopback bind without a registered provider. Set DASHBOARD_PASSWORD
+      # in .env, or swap for HERMES_DASHBOARD_OAUTH_CLIENT_ID.
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=${DASHBOARD_USER:-admin}
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${DASHBOARD_PASSWORD:?set DASHBOARD_PASSWORD in .env}
       # Gateway API server (port 8642). The listener only opens when
       # API_SERVER_KEY is a usable value (>=16 chars); set it in .env.
       - API_SERVER_ENABLED=true
       - API_SERVER_HOST=0.0.0.0
-      - API_SERVER_KEY=${API_SERVER_KEY:-}
+      - API_SERVER_KEY=${API_SERVER_KEY:?set a >=16-char API_SERVER_KEY in .env}
     restart: unless-stopped
     deploy:
       resources:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -297,9 +297,13 @@ services:
       # a registered provider. Set DASHBOARD_PASSWORD in your .env.
       - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=${DASHBOARD_USER:-admin}
       - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${DASHBOARD_PASSWORD:?set DASHBOARD_PASSWORD in .env}
-      # Gateway API key: the agent opens port 8642 only when this is
-      # a usable value (>=16 chars) — it is what the WebUI talks to.
-      - API_SERVER_KEY=${API_SERVER_KEY:-}
+      # Gateway API (port 8642): the listener must be enabled AND bound
+      # off-loopback inside the container, otherwise the WebUI in the sibling
+      # container cannot reach http://hermes-agent:8642. The key (>=16 chars)
+      # is what authenticates the WebUI health probe and Tasks calls.
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${API_SERVER_KEY:?set a >=16-char API_SERVER_KEY in .env}
     restart: unless-stopped
     networks:
       - hermes-net
@@ -324,7 +328,7 @@ services:
       # Same gateway over the compose network, authenticated with the
       # matching key, so the health pill and the Tasks surfaces work.
       - HERMES_API_URL=http://hermes-agent:8642
-      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}
+      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:?set a >=16-char API_SERVER_KEY in .env}
     restart: unless-stopped
     networks:
       - hermes-net
@@ -344,9 +348,10 @@ by its own basic-auth provider — the browser will prompt for the `DASHBOARD_US
 `DASHBOARD_PASSWORD` you set. `API_SERVER_KEY` does not cover the dashboard; it
 guards only the gateway API on port 8642.
 Set `API_SERVER_KEY` (a random string of at least 16 characters) in `.env`
-before `docker compose up`: without it the agent leaves port 8642 closed and
-the WebUI reports the agent gateway as unreachable in System Settings and in
-the Tasks panel. `HERMES_API_URL` together with the matching
+before `docker compose up`: without it — or without `API_SERVER_ENABLED=true`
+and `API_SERVER_HOST=0.0.0.0`, which the snippet above sets — the agent leaves
+port 8642 closed and the WebUI reports the agent gateway as unreachable in
+System Settings and in the Tasks panel. `HERMES_API_URL` together with the matching
 `HERMES_WEBUI_GATEWAY_API_KEY` is what points the UI at that gateway and
 authenticates its health probe.
 Check `hermes gateway run --help` for the exact flag names for your agent release —

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -258,8 +258,9 @@ Refs #2785, #4483.
 ## Three-service unified setup (v0.14+)
 
 Since v0.14, `hermes-agent` can serve the gateway API and the built-in dashboard
-from the same process by setting `HERMES_DASHBOARD_HOST` and
-`HERMES_DASHBOARD_PORT`. Running agent and dashboard in one container means a
+from the same process. Enable the dashboard with `HERMES_DASHBOARD=1` and bind it
+via `HERMES_DASHBOARD_HOST`/`HERMES_DASHBOARD_PORT` — the flag is required;
+host/port alone never start it. Running agent and dashboard in one container means a
 single writer to `hermes-home`, eliminating the concurrent-init write conflicts
 that occur when `hermes-agent` and `hermes-dashboard` both start from the same
 image against the same volume.
@@ -289,8 +290,13 @@ services:
       - HERMES_HOME=/home/hermes/.hermes
       - HERMES_UID=${UID:-1000}
       - HERMES_GID=${GID:-1000}
+      - HERMES_DASHBOARD=1
       - HERMES_DASHBOARD_HOST=0.0.0.0
       - HERMES_DASHBOARD_PORT=9119
+      # Required: the dashboard auth gate refuses a non-loopback bind without
+      # a registered provider. Set DASHBOARD_PASSWORD in your .env.
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=${DASHBOARD_USER:-admin}
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${DASHBOARD_PASSWORD:?set DASHBOARD_PASSWORD in .env}
     restart: unless-stopped
     networks:
       - hermes-net
@@ -326,9 +332,13 @@ volumes:
 ```
 
 Open http://localhost:8787 for chat and http://localhost:9119 for the dashboard.
+Because the dashboard binds beyond loopback inside the container, it is protected
+by its own basic-auth provider — the browser will prompt for the `DASHBOARD_USER` /
+`DASHBOARD_PASSWORD` you set. `API_SERVER_KEY` does not cover the dashboard; it
+guards only the gateway API on port 8642.
 Check `hermes gateway run --help` for the exact flag names for your agent release —
-the env-var equivalents shown above (`HERMES_DASHBOARD_HOST`, `HERMES_DASHBOARD_PORT`)
-are available in recent releases alongside the CLI flags.
+the env-var equivalents shown above (`HERMES_DASHBOARD=1`, `HERMES_DASHBOARD_HOST`,
+`HERMES_DASHBOARD_PORT`) are available in recent releases alongside the CLI flags.
 
 If you need the separate dashboard container (e.g. resource limits per service),
 `docker-compose.three-container.yml` still works. Add a `depends_on` from

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -297,6 +297,9 @@ services:
       # a registered provider. Set DASHBOARD_PASSWORD in your .env.
       - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=${DASHBOARD_USER:-admin}
       - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${DASHBOARD_PASSWORD:?set DASHBOARD_PASSWORD in .env}
+      # Gateway API key: the agent opens port 8642 only when this is
+      # a usable value (>=16 chars) — it is what the WebUI talks to.
+      - API_SERVER_KEY=${API_SERVER_KEY:-}
     restart: unless-stopped
     networks:
       - hermes-net
@@ -318,6 +321,10 @@ services:
       - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui
       - WANTED_UID=${UID:-1000}
       - WANTED_GID=${GID:-1000}
+      # Same gateway over the compose network, authenticated with the
+      # matching key, so the health pill and the Tasks surfaces work.
+      - HERMES_API_URL=http://hermes-agent:8642
+      - HERMES_WEBUI_GATEWAY_API_KEY=${API_SERVER_KEY:-}
     restart: unless-stopped
     networks:
       - hermes-net
@@ -336,6 +343,12 @@ Because the dashboard binds beyond loopback inside the container, it is protecte
 by its own basic-auth provider — the browser will prompt for the `DASHBOARD_USER` /
 `DASHBOARD_PASSWORD` you set. `API_SERVER_KEY` does not cover the dashboard; it
 guards only the gateway API on port 8642.
+Set `API_SERVER_KEY` (a random string of at least 16 characters) in `.env`
+before `docker compose up`: without it the agent leaves port 8642 closed and
+the WebUI reports the agent gateway as unreachable in System Settings and in
+the Tasks panel. `HERMES_API_URL` together with the matching
+`HERMES_WEBUI_GATEWAY_API_KEY` is what points the UI at that gateway and
+authenticates its health probe.
 Check `hermes gateway run --help` for the exact flag names for your agent release —
 the env-var equivalents shown above (`HERMES_DASHBOARD=1`, `HERMES_DASHBOARD_HOST`,
 `HERMES_DASHBOARD_PORT`) are available in recent releases alongside the CLI flags.


### PR DESCRIPTION
Closes the dashboard-startup residual of #6876.

The legacy three-container layout started the dashboard as a separate
container with `dashboard --host 0.0.0.0 --insecure`, which the current
agent image rejects (auth gate on non-loopback binds with no auth provider).

This PR follows the v0.14+ shape from docs/docker.md:

- new `docker-compose.three-service.yml`: the built-in dashboard runs inside
  the `hermes-agent` process via `HERMES_DASHBOARD_HOST=0.0.0.0` and
  `HERMES_DASHBOARD_PORT=9119`; the listener is covered by the agent's own
  gateway auth gate, and the host publish stays loopback-only
  (`127.0.0.1:9119:9119`).
- `docker-compose.three-container.yml` marked deprecated with a pointer to
  the new file (kept otherwise intact; the #7145 bind variables and the
  API_SERVER_KEY guidance are preserved).

Server-local `curl 127.0.0.1:9119` succeeds because the dashboard binds
inside the agent process on the compose network, not as a separate
rejected container.

Thanks for the precise reopening note — the earlier "fixed" wording
was indeed overstated.