### PR TITLE
fix(ui): reseed reasoning chip on profile switch (#7206)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4327,20 +4327,27 @@ def coerce_reasoning_effort_for_model(
     return raw
 
 
-def get_reasoning_status(
+def reasoning_status_for_config(
+    config_data,
     *,
     model_id: str | None = None,
     provider_id: str | None = None,
     base_url: str | None = None,
 ) -> dict:
-    """Return current reasoning configuration from the active profile's
-    config.yaml — the same source of truth the CLI reads from.
+    """Compute the effective reasoning status from a supplied config dict.
+
+    Same keys and the same provider/model capability + effort-coercion
+    authority as :func:`get_reasoning_status`, but the config data comes from
+    the caller instead of the active profile — used by the profile switch
+    path to resolve the DESTINATION profile's effective reasoning status
+    without mutating process-global state (#7206).
 
     Keys:
       - show_reasoning: bool — from ``display.show_reasoning`` (default True)
-      - reasoning_effort: str — from ``agent.reasoning_effort`` ('' = default)
+      - reasoning_effort: str — COERCED effort for the resolved model/provider
+        ('' = default); raw ``agent.reasoning_effort`` is never exposed
+        verbatim, matching what streaming actually sends.
     """
-    config_data = _load_yaml_config_file(_get_config_path())
     display_cfg = config_data.get("display") or {}
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
@@ -4392,6 +4399,31 @@ def get_reasoning_status(
         # toggle but not the effort ladder. False hides the chip entirely.
         "supports_thinking_toggle": supports_thinking_toggle,
     }
+
+
+def get_reasoning_status(
+    *,
+    model_id: str | None = None,
+    provider_id: str | None = None,
+    base_url: str | None = None,
+) -> dict:
+    """Return current reasoning configuration from the active profile's
+    config.yaml — the same source of truth the CLI reads from.
+
+    Delegates to :func:`reasoning_status_for_config` so the /api/profile/switch
+    contract (#7206) shares the exact same coercion authority.
+
+    Keys:
+      - show_reasoning: bool — from ``display.show_reasoning`` (default True)
+      - reasoning_effort: str — COERCED effort ('' = default)
+    """
+    config_data = _load_yaml_config_file(_get_config_path())
+    return reasoning_status_for_config(
+        config_data,
+        model_id=model_id,
+        provider_id=provider_id,
+        base_url=base_url,
+    )
 
 
 def _parse_positive_int_config_value(raw) -> int | None:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1750,7 +1750,46 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
         'default_model': default_model,
         'default_model_provider': default_model_provider,
         'default_workspace': default_workspace,
+        # Effective reasoning status for the DESTINATION profile — explicit
+        # response contract so the frontend can reseed the reasoning chip the
+        # moment the switch completes (#7206). Computed through the same
+        # provider/model capability + effort-coercion authority as GET
+        # /api/reasoning (reasoning_status_for_config / get_reasoning_status),
+        # but against the destination profile's config.yaml (`cfg` above)
+        # instead of the process-global active config. Only the COERCED
+        # effective effort is exposed — never the raw agent.reasoning_effort,
+        # which could be unsupported for the destination's default model.
+        'reasoning': _destination_reasoning_status(
+            cfg, default_model, default_model_provider, model_cfg
+        ),
     }
+
+
+def _destination_reasoning_status(cfg, default_model, default_model_provider, model_cfg):
+    """Best-effort effective reasoning status for a destination profile.
+
+    Returns None (frontend falls back to the /api/reasoning GET) if the
+    destination config cannot be resolved — the switch itself must never fail
+    because reasoning metadata could not be computed.
+    """
+    try:
+        from api.config import reasoning_status_for_config
+
+        base_url = None
+        if isinstance(model_cfg, dict):
+            base_url = str(model_cfg.get('base_url') or '').strip() or None
+        return reasoning_status_for_config(
+            cfg,
+            model_id=default_model,
+            provider_id=default_model_provider,
+            base_url=base_url,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to resolve destination reasoning status for profile switch",
+            exc_info=True,
+        )
+        return None
 
 
 _SKILLS_STATS_CACHE: dict[Path, tuple[int, int, int, float]] = {}

--- a/static/panels.js
+++ b/static/panels.js
@@ -7152,7 +7152,7 @@ async function switchToProfile(name) {
       S.session.profile = data.active || name;
     }
     if (typeof refreshProfileTransitionReasoningChip === 'function') {
-      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
+      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider, data.agent && data.agent.reasoning_effort);
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────

--- a/static/panels.js
+++ b/static/panels.js
@@ -7152,7 +7152,7 @@ async function switchToProfile(name) {
       S.session.profile = data.active || name;
     }
     if (typeof refreshProfileTransitionReasoningChip === 'function') {
-      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider, data.agent && data.agent.reasoning_effort);
+      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider, data.reasoning && data.reasoning.reasoning_effort);
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1665,7 +1665,7 @@ async function _switchProfileForSessionLoad(profile){
     if(data.default_model) window._defaultModel=data.default_model;
     if(data.default_model_provider) window._activeProvider=data.default_model_provider;
     if(typeof refreshProfileTransitionReasoningChip==='function'){
-      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
+      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider, data.agent && data.agent.reasoning_effort);
     }
     if(typeof startGatewaySSE==='function') startGatewaySSE();
     if(typeof syncTopbar==='function') syncTopbar();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1665,7 +1665,7 @@ async function _switchProfileForSessionLoad(profile){
     if(data.default_model) window._defaultModel=data.default_model;
     if(data.default_model_provider) window._activeProvider=data.default_model_provider;
     if(typeof refreshProfileTransitionReasoningChip==='function'){
-      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider, data.agent && data.agent.reasoning_effort);
+      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider, data.reasoning && data.reasoning.reasoning_effort);
     }
     if(typeof startGatewaySSE==='function') startGatewaySSE();
     if(typeof syncTopbar==='function') syncTopbar();

--- a/static/ui.js
+++ b/static/ui.js
@@ -5271,7 +5271,7 @@ let _lastReasoningFetchKey=null;
 // a different agent.reasoning_effort) — #4650 review.
 let _reasoningFetchSeq=0;
 
-function fetchReasoningChip(keyOverride){
+function fetchReasoningChip(keyOverride, effortOverride){
   // Set the cache key OPTIMISTICALLY before the request so rapid routine syncs
   // while this GET is in flight short-circuit instead of re-dispatching (that
   // in-flight window is exactly where the #4650 storm lived).
@@ -5282,18 +5282,20 @@ function fetchReasoningChip(keyOverride){
     // Ignore a stale/superseded response: only the most recent dispatch may
     // apply, so an older in-flight GET can't poison the current chip (#4650).
     if(seq!==_reasoningFetchSeq) return;
-    _applyReasoningChip((st&&st.reasoning_effort)||'', st||{});
+    const effort = effortOverride !== undefined ? effortOverride : (st&&st.reasoning_effort)||'';
+    _applyReasoningChip(effort, st||{});
   }).catch(function(){
     // Same staleness guard on failure: a stale error must neither hide the chip
     // nor clear a newer fetch's key. Only the latest dispatch clears the key so
     // routine syncs retry after a genuine transient failure.
     if(seq!==_reasoningFetchSeq) return;
+    const effort = effortOverride !== undefined ? effortOverride : '';
     _lastReasoningFetchKey=null;
-    _applyReasoningChip('', {supported_efforts:[], supports_thinking_toggle:false});
+    _applyReasoningChip(effort, {supported_efforts:[], supports_thinking_toggle:false});
   });
 }
 
-function refreshProfileTransitionReasoningChip(model, provider){
+function refreshProfileTransitionReasoningChip(model, provider, reasoningEffort){
   _profileTransitionReasoningContext={profile:(S&&S.activeProfile)||'default',model,provider};
   _currentReasoningEffort=null;
   _currentReasoningEffortsSupported=null;
@@ -5304,7 +5306,7 @@ function refreshProfileTransitionReasoningChip(model, provider){
   const params=new URLSearchParams();
   if(model) params.set('model',model);
   if(provider) params.set('provider',provider);
-  fetchReasoningChip(params.size?'?'+params.toString():undefined);
+  fetchReasoningChip(params.size?'?'+params.toString():undefined, reasoningEffort);
 }
 
 function clearProfileTransitionReasoningContext(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -5302,7 +5302,17 @@ function refreshProfileTransitionReasoningChip(model, provider, reasoningEffort)
   _currentReasoningToggleSupported=undefined;
   _lastReasoningFetchKey=null;
   ++_reasoningFetchSeq;
-  _applyReasoningChip('', {supported_efforts:[], supports_thinking_toggle:false});
+  // Seed the destination profile's EFFECTIVE effort (explicit contract of
+  // /api/profile/switch, coerced by the backend through the same authority as
+  // /api/reasoning) SYNCHRONOUSLY — the chip must never paint the stale source
+  // profile's effort, not even during the in-flight window of the
+  // destination-scoped GET below (#7206). The GET still refreshes the
+  // capability ladder (supported_efforts / supports_thinking_toggle) once it
+  // lands; its success AND failure paths re-apply the same override, so no
+  // response can repaint the seeded effort. Empty string means "model default"
+  // and keeps the chip in its hidden/reset state.
+  const seededEffort=(reasoningEffort!==undefined&&reasoningEffort!==null)?reasoningEffort:'';
+  _applyReasoningChip(seededEffort, {supported_efforts:[], supports_thinking_toggle:false});
   const params=new URLSearchParams();
   if(model) params.set('model',model);
   if(provider) params.set('provider',provider);

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -824,3 +824,64 @@ def test_chat_start_rejects_invalid_request_profile(monkeypatch):
 
     assert result == {"error": "invalid profile"}
     assert errors == [("invalid profile", 400)]
+
+
+def test_switch_profile_returns_coerced_reasoning_contract_for_destination(tmp_path, monkeypatch):
+    """
+    /api/profile/switch must expose the DESTINATION profile's EFFECTIVE
+    reasoning status — computed through the same provider/model capability +
+    effort-coercion authority as GET /api/reasoning — never the raw
+    agent.reasoning_effort (#7206 re-gate).
+
+    The destination config stores agent.reasoning_effort: max for a pre-5.6
+    GPT-5 / openai default, a level the provider ceiling strips. The switch
+    response must report the coerced 'xhigh' (and a supported_efforts list
+    WITHOUT 'max') so the frontend reseeds the chip with the effort streaming
+    will actually send, instead of an override that is never applied.
+    """
+    import api.profiles as profiles
+
+    default_home = tmp_path / '.hermes'
+    default_home.mkdir()
+    target_home = default_home / 'profiles' / 'vops'
+    target_home.mkdir(parents=True)
+
+    (target_home / 'config.yaml').write_text(
+        'model:\n'
+        '  default: gpt-5\n'
+        '  provider: openai\n'
+        'agent:\n'
+        '  reasoning_effort: max\n',
+        encoding='utf-8',
+    )
+
+    orig_default = profiles._DEFAULT_HERMES_HOME
+    profiles._DEFAULT_HERMES_HOME = default_home
+    orig_active = profiles._active_profile
+    profiles._active_profile = 'default'
+    profiles._tls.profile = None
+
+    try:
+        result = profiles.switch_profile('vops', process_wide=False)
+        reasoning = result.get('reasoning')
+        assert reasoning is not None, (
+            "switch response must include the explicit reasoning contract"
+        )
+        # Effective (coerced) effort: 'max' is above the pre-5.6 GPT-5 ceiling.
+        assert reasoning['reasoning_effort'] == 'xhigh', reasoning
+        # Raw config value must never leak through the contract.
+        assert reasoning['reasoning_effort'] != 'max'
+        # Capability list must not advertise the stripped level.
+        assert 'max' not in reasoning['supported_efforts'], reasoning['supported_efforts']
+        assert reasoning['supports_reasoning_effort'] is True
+        assert reasoning['show_reasoning'] is True
+        # Shared coercion authority: identical to what GET /api/reasoning would
+        # report for the same destination model/provider.
+        from api.config import coerce_reasoning_effort_for_model
+        assert reasoning['reasoning_effort'] == coerce_reasoning_effort_for_model(
+            'max', 'gpt-5', provider_id='openai'
+        )
+    finally:
+        profiles._DEFAULT_HERMES_HOME = orig_default
+        profiles._active_profile = orig_active
+        profiles._tls.profile = None


### PR DESCRIPTION
Fixes #7206. Ao trocar de perfil, o reasoning dropdown reseeda para o agent.reasoning_effort do perfil.