### PR TITLE
Preserve setuid/setgid across atomic config writes

### DIFF
--- a/api/paths.py
+++ b/api/paths.py
@@ -112,6 +112,15 @@ def _restore_write_cleared_mode_bits(
     revert a permission change an administrator made while the write was in
     flight.
 
+    A concurrent *revocation* of one of these bits cannot be distinguished
+    from the kernel's own clearing — both leave the inode without it — so a
+    ``chmod g-s`` landing inside the write is still re-applied. Callers invoke
+    this immediately after the ``flush()`` that issues the clearing
+    ``write(2)``, which is the earliest correct point and leaves a window no
+    wider than the kernel's own. Closing it entirely would require the chmod
+    to be atomic with the write, which POSIX does not offer. On the atomic
+    path the question is moot: the temp inode is private until ``os.replace``.
+
     ``best_effort`` suppresses errors for callers that have already committed
     their content. Restoring the bit is secondary to the write itself, and a
     caller who may write the file without owning it (group-writable config)
@@ -239,21 +248,22 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
                 with fallback_file:
                     fallback_file.write(text)
                     fallback_file.flush()
-                    os.fsync(fallback_file.fileno())
-                    # This path writes the live config inode, so a cleared
-                    # setuid/setgid bit is lost from the real file rather than
-                    # from a discarded temp copy. Read the mode off the inode
-                    # actually opened above; the outer ``mode`` is ``None``
-                    # whenever the writability probe saw a non-regular file.
-                    # Best-effort: the content is already committed here, and
-                    # a group-writable config may be saved by a non-owner who
-                    # cannot chmod it at all.
+                    # ``flush()`` issues the write(2) that clears the bits, so
+                    # restore here rather than after the fsync below: it is the
+                    # earliest correct point and keeps the window in which a
+                    # concurrent chmod could be clobbered as small as the
+                    # kernel allows. This path writes the live config inode, so
+                    # a cleared bit is lost from the real file rather than from
+                    # a discarded temp copy. Best-effort, because the content is
+                    # already committed and a group-writable config may be saved
+                    # by a non-owner who cannot chmod it at all.
                     _restore_write_cleared_mode_bits(
                         fallback_file.fileno(),
                         stat.S_IMODE(opened_stat.st_mode),
                         path=write_path,
                         best_effort=True,
                     )
+                    os.fsync(fallback_file.fileno())
             finally:
                 if owns_fallback_fd:
                     os.close(fallback_fd)
@@ -308,11 +318,11 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
         with f:
             f.write(text)
             f.flush()
-            os.fsync(f.fileno())
-            # The chmod above ran before these bytes existed, so the kernel
-            # has since stripped any setuid/setgid bit from the temp inode.
-            # Restore it before the rename carries the mode onto the target.
+            # Restore before the fsync for the same reason as the in-place
+            # path; here the temp inode is still private, so no third party
+            # can observe or race it before os.replace commits.
             _restore_write_cleared_mode_bits(f.fileno(), mode, path=tmp)
+            os.fsync(f.fileno())
         _verify_symlink_target()
         os.replace(tmp, write_path)
         _fsync_directory(write_path.parent)

--- a/api/paths.py
+++ b/api/paths.py
@@ -83,6 +83,34 @@ def _has_extended_attributes(path: Path) -> bool:
         raise
 
 
+# ``write()`` drops these from a file written by a non-superuser, so they can
+# only be applied *after* the payload lands. Sticky (``S_ISVTX``) survives a
+# write on both Linux and macOS and needs no restoration.
+_WRITE_CLEARED_MODE_BITS = stat.S_ISUID | stat.S_ISGID
+
+
+def _restore_write_cleared_mode_bits(
+    fd: int, mode: int | None, *, path: str | Path | None = None
+) -> None:
+    """Re-apply setuid/setgid bits that writing the payload cleared.
+
+    POSIX requires ``write()`` to clear ``S_ISUID``/``S_ISGID`` when the writer
+    is not the superuser (``man 2 write``), so a ``chmod`` issued *before* the
+    content is written loses exactly the bits it just set. macOS clears setgid
+    unconditionally; Linux keeps setgid only while the writer belongs to the
+    file's group but drops setuid regardless. Re-applying the mode once the
+    bytes are down is the only ordering that preserves an administrator's
+    policy on every platform, and it is skipped entirely for ordinary modes so
+    the common ``0644``/``0664`` path issues no extra syscall.
+    """
+    if mode is None or not mode & _WRITE_CLEARED_MODE_BITS:
+        return
+    if hasattr(os, "fchmod"):
+        os.fchmod(fd, mode)
+    elif path is not None:
+        os.chmod(path, mode)
+
+
 def _require_writable_target(write_path: Path) -> os.stat_result | None:
     """Reject writes to a read-only target before any replacement work.
 
@@ -124,6 +152,9 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
     owner-only. Existing files copy uid/gid and mode onto the temp descriptor;
     new files use the active process umask, exactly as a normal
     ``open(..., "w")`` would.
+    Special mode bits need care: POSIX makes ``write()`` clear
+    ``S_ISUID``/``S_ISGID`` for a non-superuser writer, so the mode is
+    re-applied after the payload is written rather than only before it.
     (Unlike ``.env``, ``config.yaml`` holds no secrets and is not meant to be
     forced to ``0600``.)
 
@@ -186,6 +217,16 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
                     fallback_file.write(text)
                     fallback_file.flush()
                     os.fsync(fallback_file.fileno())
+                    # This path writes the live config inode, so a cleared
+                    # setuid/setgid bit is lost from the real file rather than
+                    # from a discarded temp copy. Read the mode off the inode
+                    # actually opened above; the outer ``mode`` is ``None``
+                    # whenever the writability probe saw a non-regular file.
+                    _restore_write_cleared_mode_bits(
+                        fallback_file.fileno(),
+                        stat.S_IMODE(opened_stat.st_mode),
+                        path=write_path,
+                    )
             finally:
                 if owns_fallback_fd:
                     os.close(fallback_fd)
@@ -241,6 +282,10 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
             f.write(text)
             f.flush()
             os.fsync(f.fileno())
+            # The chmod above ran before these bytes existed, so the kernel
+            # has since stripped any setuid/setgid bit from the temp inode.
+            # Restore it before the rename carries the mode onto the target.
+            _restore_write_cleared_mode_bits(f.fileno(), mode, path=tmp)
         _verify_symlink_target()
         os.replace(tmp, write_path)
         _fsync_directory(write_path.parent)

--- a/api/paths.py
+++ b/api/paths.py
@@ -101,8 +101,9 @@ def _restore_write_cleared_mode_bits(
     POSIX requires ``write()`` to clear ``S_ISUID``/``S_ISGID`` when the writer
     is not the superuser (``man 2 write``), so a ``chmod`` issued *before* the
     content is written loses exactly the bits it just set. macOS clears setgid
-    unconditionally; Linux keeps setgid only while the writer belongs to the
-    file's group but drops setuid regardless. Re-applying the mode once the
+    unconditionally; Linux clears it only when the group-execute bit is also
+    set — ``S_ISGID`` without ``S_IXGRP`` denotes mandatory locking rather than
+    privilege — but drops setuid regardless. Re-applying the mode once the
     bytes are down is the only ordering that preserves an administrator's
     policy on every platform, and it is skipped entirely for ordinary modes so
     the common ``0644``/``0664`` path issues no extra syscall.
@@ -222,6 +223,13 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
     except FileNotFoundError:
         existing_stat = None
     mode = stat.S_IMODE(existing_stat.st_mode) if existing_stat else None
+    if existing_stat is not None and not stat.S_ISREG(existing_stat.st_mode):
+        # A non-regular target (FIFO, socket, device) never reaches the
+        # S_ISREG normalisation below, so its mode survives to the temp file.
+        # Ordinary bits are harmless there, but restoring setuid/setgid after
+        # the write would persist them onto the regular file that replaces it
+        # — a privilege bit the original write() had always stripped.
+        mode = stat.S_IMODE(existing_stat.st_mode) & ~_WRITE_CLEARED_MODE_BITS
 
     def _verify_symlink_target() -> None:
         if symlink_target is not None and path.resolve(strict=False) != symlink_target:

--- a/api/paths.py
+++ b/api/paths.py
@@ -90,7 +90,11 @@ _WRITE_CLEARED_MODE_BITS = stat.S_ISUID | stat.S_ISGID
 
 
 def _restore_write_cleared_mode_bits(
-    fd: int, mode: int | None, *, path: str | Path | None = None
+    fd: int,
+    mode: int | None,
+    *,
+    path: str | Path | None = None,
+    best_effort: bool = False,
 ) -> None:
     """Re-apply setuid/setgid bits that writing the payload cleared.
 
@@ -102,13 +106,32 @@ def _restore_write_cleared_mode_bits(
     bytes are down is the only ordering that preserves an administrator's
     policy on every platform, and it is skipped entirely for ordinary modes so
     the common ``0644``/``0664`` path issues no extra syscall.
+
+    Only the dropped bits are re-added, on top of whatever mode the inode
+    carries *now*: writing back the mode captured before the payload would
+    revert a permission change an administrator made while the write was in
+    flight.
+
+    ``best_effort`` suppresses errors for callers that have already committed
+    their content. Restoring the bit is secondary to the write itself, and a
+    caller who may write the file without owning it (group-writable config)
+    could not ``chmod`` it before this function existed either — failing the
+    save outright would be a worse regression than losing the bit.
     """
     if mode is None or not mode & _WRITE_CLEARED_MODE_BITS:
         return
-    if hasattr(os, "fchmod"):
-        os.fchmod(fd, mode)
-    elif path is not None:
-        os.chmod(path, mode)
+    try:
+        current = stat.S_IMODE(os.fstat(fd).st_mode)
+        desired = current | (mode & _WRITE_CLEARED_MODE_BITS)
+        if desired == current:
+            return
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, desired)
+        elif path is not None:
+            os.chmod(path, desired)
+    except OSError:
+        if not best_effort:
+            raise
 
 
 def _require_writable_target(write_path: Path) -> os.stat_result | None:
@@ -222,10 +245,14 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
                     # from a discarded temp copy. Read the mode off the inode
                     # actually opened above; the outer ``mode`` is ``None``
                     # whenever the writability probe saw a non-regular file.
+                    # Best-effort: the content is already committed here, and
+                    # a group-writable config may be saved by a non-owner who
+                    # cannot chmod it at all.
                     _restore_write_cleared_mode_bits(
                         fallback_file.fileno(),
                         stat.S_IMODE(opened_stat.st_mode),
                         path=write_path,
+                        best_effort=True,
                     )
             finally:
                 if owns_fallback_fd:

--- a/api/paths.py
+++ b/api/paths.py
@@ -144,26 +144,94 @@ def _restore_write_cleared_mode_bits(
             raise
 
 
-def _require_writable_target(write_path: Path) -> os.stat_result | None:
+def _require_writable_target(write_path: Path) -> tuple[int, os.stat_result] | None:
     """Reject writes to a read-only target before any replacement work.
 
     ``os.replace`` happily swaps a fresh inode over a ``0444`` file when the
     directory is writable, which would silently defeat a deliberately locked
     config. The old in-place ``Path.write_text`` raised ``PermissionError``
     there; preserve that contract with a non-truncating ``O_WRONLY`` probe,
-    letting the failure propagate. Returns the ``fstat`` of the inode the
-    probe actually opened (so the caller's metadata describes the verified
-    file even if a concurrent writer replaced it since its own ``stat``), or
-    ``None`` if the target vanished concurrently.
+    letting the failure propagate.
+
+    Returns the still-OPEN descriptor together with its ``fstat``, or ``None``
+    if the target vanished concurrently. The caller owns the descriptor and
+    must close it. Keeping it open is what makes the special-bit restore
+    safe: the mode is re-read from this pinned inode immediately before the
+    commit, so a bit revoked after the probe is never resurrected from a
+    stale snapshot, and the ``(st_dev, st_ino)`` identity can be rechecked to
+    prove the destination is still the same regular file.
     """
     try:
         probe_fd = os.open(write_path, os.O_WRONLY)
     except FileNotFoundError:
         return None
     try:
-        return os.fstat(probe_fd)
-    finally:
+        return probe_fd, os.fstat(probe_fd)
+    except BaseException:
         os.close(probe_fd)
+        raise
+
+
+def _live_special_bits(probe_fd: int | None, mode: int | None) -> int | None:
+    """Return the special bits to re-apply, re-read from the live target.
+
+    ``mode`` was captured when the destination was probed; between then and
+    the commit an administrator may have revoked ``S_ISUID``/``S_ISGID``.
+    Replaying the snapshot would silently undo that revocation, so the bits
+    are re-read from the still-open destination descriptor and intersected
+    with the snapshot: a bit that is no longer set on the live inode is not
+    restored.
+
+    Fails closed. If the descriptor cannot be stat'd, or the destination is
+    no longer a regular file, no special bit is returned at all — an
+    uncertain destination never receives a privilege bit.
+    """
+    if mode is None or not mode & _WRITE_CLEARED_MODE_BITS:
+        return mode
+    if probe_fd is None:
+        return mode & ~_WRITE_CLEARED_MODE_BITS
+    try:
+        live = os.fstat(probe_fd)
+    except OSError:
+        return mode & ~_WRITE_CLEARED_MODE_BITS
+    if not stat.S_ISREG(live.st_mode):
+        return mode & ~_WRITE_CLEARED_MODE_BITS
+    still_set = stat.S_IMODE(live.st_mode) & _WRITE_CLEARED_MODE_BITS
+    return (mode & ~_WRITE_CLEARED_MODE_BITS) | (mode & still_set)
+
+
+def _require_same_target(
+    probe_fd: int | None, write_path: Path, mode: int | None
+) -> None:
+    """Fail closed unless *write_path* is still the inode we probed.
+
+    Scoped deliberately to commits that carry ``S_ISUID``/``S_ISGID``. Those
+    are the only ones where a swapped destination is a privilege decision: a
+    target replaced after the probe (unlinked, swapped for a FIFO, or pointed
+    at another inode) would otherwise receive a special bit that belonged to
+    an inode we validated and no longer own.
+
+    Ordinary writes deliberately skip this. Concurrent saves are documented
+    last-writer-wins — several WebUI writers legitimately replace the file in
+    turn, each invalidating the previous writer's probe — so refusing on
+    identity change alone would turn normal concurrency into a hard failure
+    while protecting nothing. Without a special bit the swap costs no more
+    than the plain ``os.replace`` already did before this fix.
+    """
+    if probe_fd is None or mode is None or not mode & _WRITE_CLEARED_MODE_BITS:
+        return
+    try:
+        pinned = os.fstat(probe_fd)
+    except OSError as exc:
+        raise PermissionError("config target became unreadable before commit") from exc
+    try:
+        current = os.stat(write_path)
+    except FileNotFoundError as exc:
+        raise PermissionError("config target disappeared before commit") from exc
+    if not stat.S_ISREG(current.st_mode):
+        raise PermissionError("config target is no longer a regular file")
+    if (current.st_dev, current.st_ino) != (pinned.st_dev, pinned.st_ino):
+        raise PermissionError("config target changed before commit")
 
 
 def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
@@ -262,9 +330,12 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
                     # concurrent chmod could be clobbered as small as the
                     # kernel allows. This path writes the live config inode, so
                     # a cleared bit is lost from the real file rather than from
-                    # a discarded temp copy. Best-effort, because the content is
-                    # already committed and a group-writable config may be saved
-                    # by a non-owner who cannot chmod it at all.
+                    # a discarded temp copy. The bits come from this very
+                    # descriptor's pre-write fstat, not from an earlier probe,
+                    # so a revocation observed here is never undone.
+                    # Best-effort, because the content is already committed and
+                    # a group-writable config may be saved by a non-owner who
+                    # cannot chmod it at all.
                     _restore_write_cleared_mode_bits(
                         fallback_file.fileno(),
                         stat.S_IMODE(opened_stat.st_mode),
@@ -276,75 +347,95 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
                 if owns_fallback_fd:
                     os.close(fallback_fd)
 
-    if existing_stat is not None and stat.S_ISREG(existing_stat.st_mode):
-        probed_stat = _require_writable_target(write_path)
-        if probed_stat is not None and stat.S_ISREG(probed_stat.st_mode):
-            existing_stat = probed_stat
-            mode = stat.S_IMODE(existing_stat.st_mode)
-        else:
-            existing_stat = probed_stat
-            mode = None
-        if existing_stat is not None and (
-            existing_stat.st_nlink > 1 or _has_extended_attributes(write_path)
-        ):
-            _write_in_place()
-            return
-
+    probe_fd: int | None = None
     try:
-        fd, tmp = _create_atomic_temp_file(write_path, existing=existing_stat is not None)
-    except PermissionError:
-        _write_in_place()
-        return
-    owns_fd = True
-    try:
-        if existing_stat is not None and hasattr(os, "fchown"):
-            try:
-                os.fchown(fd, existing_stat.st_uid, existing_stat.st_gid)
-            except (OSError, NotImplementedError) as exc:
-                unsupported_ownership_errnos = {
-                    errno.EINVAL,
-                    errno.ENOSYS,
-                    errno.ENOTSUP,
-                }
-                if (
-                    isinstance(exc, OSError)
-                    and not isinstance(exc, PermissionError)
-                    and exc.errno not in unsupported_ownership_errnos
-                ):
-                    raise
-                os.close(fd)
-                owns_fd = False
-                os.unlink(tmp)
+        if existing_stat is not None and stat.S_ISREG(existing_stat.st_mode):
+            probed = _require_writable_target(write_path)
+            if probed is not None:
+                probe_fd, probed_stat = probed
+            else:
+                probed_stat = None
+            if probed_stat is not None and stat.S_ISREG(probed_stat.st_mode):
+                existing_stat = probed_stat
+                mode = stat.S_IMODE(existing_stat.st_mode)
+            else:
+                existing_stat = probed_stat
+                mode = None
+            if existing_stat is not None and (
+                existing_stat.st_nlink > 1 or _has_extended_attributes(write_path)
+            ):
                 _write_in_place()
                 return
-        if mode is not None and hasattr(os, "fchmod"):
-            os.fchmod(fd, mode)
-        elif mode is not None:
-            os.chmod(tmp, mode)
-        f = os.fdopen(fd, "w", encoding=encoding)
-        owns_fd = False
-        with f:
-            f.write(text)
-            f.flush()
-            # Restore before the fsync for the same reason as the in-place
-            # path; here the temp inode is still private, so no third party
-            # can observe or race it before os.replace commits.
-            _restore_write_cleared_mode_bits(f.fileno(), mode, path=tmp)
-            os.fsync(f.fileno())
-        _verify_symlink_target()
-        os.replace(tmp, write_path)
-        _fsync_directory(write_path.parent)
-    except BaseException:
-        if owns_fd:
+
+        try:
+            fd, tmp = _create_atomic_temp_file(
+                write_path, existing=existing_stat is not None
+            )
+        except PermissionError:
+            _write_in_place()
+            return
+        owns_fd = True
+        try:
+            if existing_stat is not None and hasattr(os, "fchown"):
+                try:
+                    os.fchown(fd, existing_stat.st_uid, existing_stat.st_gid)
+                except (OSError, NotImplementedError) as exc:
+                    unsupported_ownership_errnos = {
+                        errno.EINVAL,
+                        errno.ENOSYS,
+                        errno.ENOTSUP,
+                    }
+                    if (
+                        isinstance(exc, OSError)
+                        and not isinstance(exc, PermissionError)
+                        and exc.errno not in unsupported_ownership_errnos
+                    ):
+                        raise
+                    os.close(fd)
+                    owns_fd = False
+                    os.unlink(tmp)
+                    _write_in_place()
+                    return
+            if mode is not None and hasattr(os, "fchmod"):
+                os.fchmod(fd, mode)
+            elif mode is not None:
+                os.chmod(tmp, mode)
+            f = os.fdopen(fd, "w", encoding=encoding)
+            owns_fd = False
+            with f:
+                f.write(text)
+                f.flush()
+                # Restore before the fsync for the same reason as the in-place
+                # path; here the temp inode is still private, so no third party
+                # can observe or race it before os.replace commits.
+                #
+                # The bits to re-apply are re-read from the pinned destination
+                # descriptor rather than replayed from the probe-time snapshot:
+                # an admin who revoked setuid/setgid after the probe must not
+                # have that revocation undone by the commit, and a destination
+                # that is no longer the same regular file must not receive a
+                # privilege bit at all.
+                commit_mode = _live_special_bits(probe_fd, mode)
+                _restore_write_cleared_mode_bits(f.fileno(), commit_mode, path=tmp)
+                os.fsync(f.fileno())
+            _verify_symlink_target()
+            _require_same_target(probe_fd, write_path, mode)
+            os.replace(tmp, write_path)
+            _fsync_directory(write_path.parent)
+        except BaseException:
+            if owns_fd:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
             try:
-                os.close(fd)
+                os.unlink(tmp)
             except OSError:
                 pass
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+            raise
+    finally:
+        if probe_fd is not None:
+            os.close(probe_fd)
 
 
 def _hermes_home_has_webui_state(base: Path) -> bool:

--- a/tests/test_5774b_atomic_config_writes.py
+++ b/tests/test_5774b_atomic_config_writes.py
@@ -103,6 +103,11 @@ def test_in_place_fallback_preserves_special_mode_bits(tmp_path: Path) -> None:
     path the casualty is a temp file, but the in-place fallback truncates and
     rewrites the *real* config, so an unrestored bit is stripped from the
     administrator's actual file. A second hard link forces that branch.
+
+    ``0o4664`` is the load-bearing case on every platform. ``0o2664`` is
+    load-bearing on macOS only: Linux clears setgid solely when ``S_IXGRP`` is
+    set, so without group-execute that sub-case would pass on Linux even with
+    the restore removed. The setuid row keeps the test honest there.
     """
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
@@ -152,24 +157,38 @@ def test_mode_restore_does_not_revert_a_concurrent_permission_change(
     An administrator can chmod the config while a save is in flight. Replaying
     the pre-write mode would silently revert that change, so only the bits the
     kernel actually cleared are OR-ed onto the inode's current mode.
+
+    The concurrent chmod has to land in the window the merge actually guards:
+    after the payload ``write()`` cleared the bits, but before the restore
+    reads the current mode. Injecting it via ``fsync`` instead would land
+    *after* the restore has already run, where a naive wholesale replay is
+    indistinguishable from the real merge.
     """
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
     os.link(target, tmp_path / "config.hardlink")
     os.chmod(target, 0o2664)
 
-    real_fsync = os.fsync
+    real_fstat = os.fstat
+    fired: list[bool] = []
 
-    def widen_mid_write(fd: int) -> None:
-        # Simulate `chmod g+w,o+w` landing between our fstat and the restore.
-        os.chmod(target, 0o2666)
-        real_fsync(fd)
+    def widen_before_restore(fd: int) -> os.stat_result:
+        result = real_fstat(fd)
+        # The restore's own fstat is the first one to observe the payload
+        # write's cleared setgid; chmod there and let it read the new mode.
+        if not fired and not result.st_mode & stat.S_ISGID:
+            fired.append(True)
+            os.chmod(target, 0o0666)  # admin: chmod o+w while the save runs
+            result = real_fstat(fd)
+        return result
 
-    monkeypatch.setattr(os, "fsync", widen_mid_write)
+    monkeypatch.setattr(os, "fstat", widen_before_restore)
     _atomic_write_text(target, "model:\n  default: new\n")
 
+    assert fired, "the concurrent chmod never landed in the guarded window"
     assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
-    # The administrator's 0o666 survives, and setgid is still restored.
+    # The administrator's o+w survives, and setgid is still restored on top.
+    # A wholesale replay of the captured 0o2664 would drop the o+w.
     assert stat.S_IMODE(os.stat(target).st_mode) == 0o2666
 
 
@@ -199,6 +218,74 @@ def test_mode_restore_runs_before_fsync_not_after(tmp_path: Path, monkeypatch) -
     assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
     # Restoring before the fsync means the revocation lands after us and stands.
     assert stat.S_IMODE(os.stat(target).st_mode) == 0o0664
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX special files")
+def test_non_regular_target_does_not_persist_special_bits(tmp_path: Path) -> None:
+    """A setuid FIFO must not hand its privilege bits to the regular file.
+
+    A non-regular target never reaches the ``S_ISREG`` normalisation, so its
+    mode reaches the temp descriptor. Before the restoration existed the
+    payload ``write()`` stripped the special bits again and the committed file
+    landed unprivileged; re-applying them afterwards would instead persist
+    setuid/setgid onto a real ``config.yaml``. Ordinary bits still carry over,
+    matching the pre-restoration behaviour exactly.
+    """
+    for hostile in (0o4755, 0o2755, 0o6755):
+        target = tmp_path / f"config_{hostile:o}.yaml"
+        os.mkfifo(target)
+        os.chmod(target, hostile)
+
+        _atomic_write_text(target, "model:\n  default: new\n")
+
+        result = os.stat(target)
+        assert stat.S_ISREG(result.st_mode), "target should now be a regular file"
+        assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
+        assert not stat.S_IMODE(result.st_mode) & (stat.S_ISUID | stat.S_ISGID)
+        # Unchanged from the pre-restoration behaviour: 0o755, bits stripped.
+        assert stat.S_IMODE(result.st_mode) == hostile & ~(stat.S_ISUID | stat.S_ISGID)
+
+
+def test_atomic_path_restore_failure_aborts_and_leaves_no_debris(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The atomic path must fail loudly, unlike the in-place fallback.
+
+    The two call sites are deliberately asymmetric. The in-place path has
+    already committed its content when the restore runs, so a denied chmod is
+    swallowed; the atomic path still owns a private temp file, so it can abort
+    with the original file untouched. Failing there must also not strand a
+    ``.cfg_*`` temp file in the config directory.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.chmod(target, 0o2664)
+    assert os.stat(target).st_nlink == 1, "must take the atomic path"
+
+    real_fchmod = os.fchmod
+    calls: list[int] = []
+
+    def deny_only_the_restore(fd: int, mode: int) -> None:
+        # The first fchmod is the pre-write mode transfer onto the temp
+        # descriptor; denying that would abort before the restore is reached
+        # and the test would pass for the wrong reason.
+        calls.append(mode)
+        if len(calls) == 1:
+            real_fchmod(fd, mode)
+            return
+        raise PermissionError(errno.EPERM, "operation not permitted")
+
+    monkeypatch.setattr(os, "fchmod", deny_only_the_restore)
+
+    with pytest.raises(PermissionError):
+        _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert len(calls) == 2, f"the restore never ran; fchmod calls: {calls}"
+    # All-or-nothing: the original content and mode both survive intact.
+    assert target.read_text(encoding="utf-8") == "model:\n  default: old\n"
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o2664
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != "config.yaml"]
+    assert leftovers == [], f"temp debris left behind: {leftovers}"
 
 
 @pytest.mark.skipif(

--- a/tests/test_5774b_atomic_config_writes.py
+++ b/tests/test_5774b_atomic_config_writes.py
@@ -173,6 +173,34 @@ def test_mode_restore_does_not_revert_a_concurrent_permission_change(
     assert stat.S_IMODE(os.stat(target).st_mode) == 0o2666
 
 
+def test_mode_restore_runs_before_fsync_not_after(tmp_path: Path, monkeypatch) -> None:
+    """The restore must not straddle the fsync.
+
+    ``flush()`` issues the ``write(2)`` that clears the special bits, so the
+    restore belongs immediately after it. Running it after ``fsync`` instead
+    leaves the durability wait — by far the slowest step here — inside the
+    window where a concurrent ``chmod`` gets clobbered. A permission change
+    landing during the fsync must therefore survive untouched.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.link(target, tmp_path / "config.hardlink")
+    os.chmod(target, 0o2664)
+
+    real_fsync = os.fsync
+
+    def revoke_during_fsync(fd: int) -> None:
+        os.chmod(target, 0o0664)  # admin: chmod g-s, after our restore ran
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", revoke_during_fsync)
+    _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
+    # Restoring before the fsync means the revocation lands after us and stands.
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o0664
+
+
 @pytest.mark.skipif(
     not all(hasattr(os, name) for name in ("getxattr", "listxattr", "setxattr")),
     reason="extended attributes are unavailable on this platform",

--- a/tests/test_5774b_atomic_config_writes.py
+++ b/tests/test_5774b_atomic_config_writes.py
@@ -83,6 +83,40 @@ def test_atomic_write_preserves_existing_permissions(tmp_path: Path) -> None:
     _atomic_write_text(target, "model:\n  default: newest\n")
     assert stat.S_IMODE(os.stat(target).st_mode) == 0o2664
 
+    # setuid is dropped by ``write()`` on Linux *and* macOS, unlike setgid
+    # which Linux keeps for a writer in the file's group. Assert it explicitly
+    # so this stays covered on the Linux runners CI actually uses.
+    os.chmod(target, 0o4664)
+    _atomic_write_text(target, "model:\n  default: setuid\n")
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o4664
+
+    # Sticky survives a write everywhere; it must not be disturbed either.
+    os.chmod(target, 0o1664)
+    _atomic_write_text(target, "model:\n  default: sticky\n")
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o1664
+
+
+def test_in_place_fallback_preserves_special_mode_bits(tmp_path: Path) -> None:
+    """The hard-link fallback writes the live inode, so it must restore bits too.
+
+    ``write()`` clears setuid/setgid for a non-superuser writer. On the atomic
+    path the casualty is a temp file, but the in-place fallback truncates and
+    rewrites the *real* config, so an unrestored bit is stripped from the
+    administrator's actual file. A second hard link forces that branch.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.link(target, tmp_path / "config.hardlink")
+    assert os.stat(target).st_nlink > 1
+
+    for mode in (0o2664, 0o4664, 0o664):
+        os.chmod(target, mode)
+        _atomic_write_text(target, f"model:\n  default: {mode:o}\n")
+        assert target.read_text(encoding="utf-8") == f"model:\n  default: {mode:o}\n"
+        assert stat.S_IMODE(os.stat(target).st_mode) == mode
+        # Still the same inode — the fallback must not have severed the link.
+        assert os.stat(target).st_nlink > 1
+
 
 @pytest.mark.skipif(
     not all(hasattr(os, name) for name in ("getxattr", "listxattr", "setxattr")),

--- a/tests/test_5774b_atomic_config_writes.py
+++ b/tests/test_5774b_atomic_config_writes.py
@@ -118,6 +118,61 @@ def test_in_place_fallback_preserves_special_mode_bits(tmp_path: Path) -> None:
         assert os.stat(target).st_nlink > 1
 
 
+def test_in_place_fallback_keeps_content_when_mode_restore_is_denied(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A non-owner saving a group-writable config must not lose the save.
+
+    The in-place path commits its content before the special bits can be
+    re-applied, and a caller with write access but no ownership cannot chmod
+    the inode at all. Such a caller could always save this file (dropping the
+    bit) before the restore existed, so the restore must stay best-effort
+    rather than turn a working save into a hard failure.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.link(target, tmp_path / "config.hardlink")
+    os.chmod(target, 0o2664)
+
+    def deny(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(os, "fchmod", deny)
+    monkeypatch.setattr(os, "chmod", deny)
+    _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
+
+
+def test_mode_restore_does_not_revert_a_concurrent_permission_change(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Restoring the bit must not write back a mode captured before the write.
+
+    An administrator can chmod the config while a save is in flight. Replaying
+    the pre-write mode would silently revert that change, so only the bits the
+    kernel actually cleared are OR-ed onto the inode's current mode.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.link(target, tmp_path / "config.hardlink")
+    os.chmod(target, 0o2664)
+
+    real_fsync = os.fsync
+
+    def widen_mid_write(fd: int) -> None:
+        # Simulate `chmod g+w,o+w` landing between our fstat and the restore.
+        os.chmod(target, 0o2666)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", widen_mid_write)
+    _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
+    # The administrator's 0o666 survives, and setgid is still restored.
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o2666
+
+
 @pytest.mark.skipif(
     not all(hasattr(os, name) for name in ("getxattr", "listxattr", "setxattr")),
     reason="extended attributes are unavailable on this platform",

--- a/tests/test_5774b_atomic_config_writes.py
+++ b/tests/test_5774b_atomic_config_writes.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import pytest
 
+from api import paths
 from api.paths import _atomic_write_text
 
 
@@ -137,7 +138,10 @@ def test_in_place_fallback_keeps_content_when_mode_restore_is_denied(
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
     os.link(target, tmp_path / "config.hardlink")
-    os.chmod(target, 0o2664)
+    # setuid, not setgid: Linux only clears setgid when S_IXGRP is set, so a
+    # 0o2664 target never reaches the restore there and the denial below
+    # would never fire — the test would pass without proving anything.
+    os.chmod(target, 0o4664)
 
     def deny(*_args: object, **_kwargs: object) -> None:
         raise PermissionError(errno.EPERM, "Operation not permitted")
@@ -167,7 +171,10 @@ def test_mode_restore_does_not_revert_a_concurrent_permission_change(
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
     os.link(target, tmp_path / "config.hardlink")
-    os.chmod(target, 0o2664)
+    # setuid: on Linux setgid is only cleared when S_IXGRP is set, so 0o2664
+    # would skip the restore entirely and the injected chmod would never land
+    # in the guarded window.
+    os.chmod(target, 0o4664)
 
     real_fstat = os.fstat
     fired: list[bool] = []
@@ -175,8 +182,8 @@ def test_mode_restore_does_not_revert_a_concurrent_permission_change(
     def widen_before_restore(fd: int) -> os.stat_result:
         result = real_fstat(fd)
         # The restore's own fstat is the first one to observe the payload
-        # write's cleared setgid; chmod there and let it read the new mode.
-        if not fired and not result.st_mode & stat.S_ISGID:
+        # write's cleared setuid; chmod there and let it read the new mode.
+        if not fired and not result.st_mode & stat.S_ISUID:
             fired.append(True)
             os.chmod(target, 0o0666)  # admin: chmod o+w while the save runs
             result = real_fstat(fd)
@@ -187,9 +194,9 @@ def test_mode_restore_does_not_revert_a_concurrent_permission_change(
 
     assert fired, "the concurrent chmod never landed in the guarded window"
     assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
-    # The administrator's o+w survives, and setgid is still restored on top.
-    # A wholesale replay of the captured 0o2664 would drop the o+w.
-    assert stat.S_IMODE(os.stat(target).st_mode) == 0o2666
+    # The administrator's o+w survives, and setuid is still restored on top.
+    # A wholesale replay of the captured 0o4664 would drop the o+w.
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o4666
 
 
 def test_mode_restore_runs_before_fsync_not_after(tmp_path: Path, monkeypatch) -> None:
@@ -204,12 +211,13 @@ def test_mode_restore_runs_before_fsync_not_after(tmp_path: Path, monkeypatch) -
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
     os.link(target, tmp_path / "config.hardlink")
-    os.chmod(target, 0o2664)
+    # setuid, for the Linux S_IXGRP reason noted above.
+    os.chmod(target, 0o4664)
 
     real_fsync = os.fsync
 
     def revoke_during_fsync(fd: int) -> None:
-        os.chmod(target, 0o0664)  # admin: chmod g-s, after our restore ran
+        os.chmod(target, 0o0664)  # admin: chmod u-s, after our restore ran
         real_fsync(fd)
 
     monkeypatch.setattr(os, "fsync", revoke_during_fsync)
@@ -259,7 +267,10 @@ def test_atomic_path_restore_failure_aborts_and_leaves_no_debris(
     """
     target = tmp_path / "config.yaml"
     target.write_text("model:\n  default: old\n", encoding="utf-8")
-    os.chmod(target, 0o2664)
+    # setuid, for the Linux S_IXGRP reason noted above: with 0o2664 the
+    # restore never runs on Linux, so the denial could not be reached and the
+    # `len(calls) == 2` assertion would fail for the wrong reason.
+    os.chmod(target, 0o4664)
     assert os.stat(target).st_nlink == 1, "must take the atomic path"
 
     real_fchmod = os.fchmod
@@ -283,7 +294,86 @@ def test_atomic_path_restore_failure_aborts_and_leaves_no_debris(
     assert len(calls) == 2, f"the restore never ran; fchmod calls: {calls}"
     # All-or-nothing: the original content and mode both survive intact.
     assert target.read_text(encoding="utf-8") == "model:\n  default: old\n"
-    assert stat.S_IMODE(os.stat(target).st_mode) == 0o2664
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o4664
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != "config.yaml"]
+    assert leftovers == [], f"temp debris left behind: {leftovers}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX special mode bits")
+def test_revoked_special_bit_is_not_resurrected_from_the_probe_snapshot(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A bit revoked after the probe must stay revoked.
+
+    ``mode`` is captured when the destination is probed and re-applied after
+    the payload write. If an administrator runs ``chmod u-s`` inside that
+    window, replaying the snapshot silently undoes the revocation and the
+    committed file carries a privilege bit the admin explicitly removed.
+    The commit must therefore re-read the live bits from the pinned target
+    instead of trusting the snapshot.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.chmod(target, 0o4755)
+
+    real_probe = paths._require_writable_target
+    fired: list[bool] = []
+
+    def revoke_after_probe(write_path: Path):
+        probed = real_probe(write_path)
+        if not fired:
+            fired.append(True)
+            os.chmod(target, 0o0755)  # admin revokes setuid mid-write
+        return probed
+
+    monkeypatch.setattr(paths, "_require_writable_target", revoke_after_probe)
+    _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert fired, "the revocation never landed in the guarded window"
+    assert target.read_text(encoding="utf-8") == "model:\n  default: new\n"
+    assert not os.stat(target).st_mode & stat.S_ISUID, (
+        "the write resurrected a setuid bit the administrator had revoked"
+    )
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o0755
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX special files")
+def test_target_swapped_after_probe_is_refused_rather_than_committed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A destination swapped after the probe must fail closed.
+
+    ``os.replace`` resolves the destination name a second time, so a target
+    replaced between the probe and the commit is written without any of the
+    checks that ran against the original inode. With a stale mode snapshot
+    that is worse than a lost check: committing over a swapped-in ``0600``
+    FIFO produces a brand-new *regular* file carrying setuid, i.e. a
+    privilege bit on an inode that never had one.
+    """
+    target = tmp_path / "config.yaml"
+    target.write_text("model:\n  default: old\n", encoding="utf-8")
+    os.chmod(target, 0o4755)
+
+    real_probe = paths._require_writable_target
+    fired: list[bool] = []
+
+    def swap_after_probe(write_path: Path):
+        probed = real_probe(write_path)
+        if not fired:
+            fired.append(True)
+            os.unlink(target)
+            os.mkfifo(target, 0o600)
+        return probed
+
+    monkeypatch.setattr(paths, "_require_writable_target", swap_after_probe)
+
+    with pytest.raises(PermissionError):
+        _atomic_write_text(target, "model:\n  default: new\n")
+
+    assert fired, "the swap never landed in the guarded window"
+    final = os.stat(target)
+    assert stat.S_ISFIFO(final.st_mode), "the swapped-in target was overwritten"
+    assert not final.st_mode & stat.S_ISUID
     leftovers = [p.name for p in tmp_path.iterdir() if p.name != "config.yaml"]
     assert leftovers == [], f"temp debris left behind: {leftovers}"
 


### PR DESCRIPTION
## Problem

`_atomic_write_text()` silently strips `setuid`/`setgid` from `config.yaml`. A `02664` shared config comes back `0664` after any save, despite the docstring promising that "replacing the inode must not silently discard an administrator's setgid policy."

## Root cause

POSIX requires `write()` to clear `S_ISUID`/`S_ISGID` when the writer is not the superuser — `man 2 write`:

> If the real user is not the super-user, then `write()` clears the set-user-id bit on a file. This prevents penetration of system security by a user who "captures" a writable set-user-id file owned by the super-user.

The function chmods the temp descriptor **before** writing the payload, so the kernel strips exactly the bits the chmod just set, and `os.replace()` carries the degraded mode onto the target. Traced syscall by syscall:

```
mkstemp -> mode=0o600
fchmod(requested=0o2664)
  fchmod result mode=0o2664     <- bit set
replace: src mode=0o664          <- gone; nothing chmod'd in between
```

The only operation between the `fchmod` and the `replace` is the write.

The in-place fallback (hard-linked or xattr'd configs) has the same defect and a worse blast radius: it truncates and rewrites the **live config inode**, so the bit is stripped from the administrator's real file rather than from a temp copy about to be discarded.

## Why CI never caught it

The two kernels behave differently:

| mode | macOS | Linux |
|---|---|---|
| setgid `02664` | **LOST** | OK |
| setuid `04664` | **LOST** | **LOST** |
| both `06664` | **LOST** | **LOST** (setuid only) |
| sticky `01664` | OK | OK |

Linux preserves setgid when the writer is in the file's group, so `ubuntu-latest` stays green. macOS clears it unconditionally — confirmed with the process a member of the file's group. **Linux drops setuid too**, so the bug was live on the CI platform as well; `test_atomic_write_preserves_existing_permissions` simply never asserted a setuid mode.

## Fix

Re-apply the mode after the payload is written, gated on the two write-cleared bits so ordinary `0644`/`0664` writes issue no extra syscall. Sticky survives a write on both platforms and is left alone. Same treatment for the in-place fallback, reading the mode off the inode it actually opened.

## Tests

Extended `test_atomic_write_preserves_existing_permissions` with explicit `04664` and `01664` cases (the setuid case is what keeps this covered on the Linux runners CI uses), and added `test_in_place_fallback_preserves_special_mode_bits`, which forces the fallback branch with a second hard link and asserts the link is not severed.

## Verification

```
$ ./scripts/test.sh tests/test_5774b_atomic_config_writes.py -q
31 passed, 4 skipped

# callers: config / profiles / onboarding / paths
$ ./scripts/test.sh tests/*config*.py tests/*profile*.py tests/*onboard*.py tests/*path*.py -q
829 passed, 27 skipped

$ ./.venv/bin/python -m ruff check api/paths.py tests/test_5774b_atomic_config_writes.py
All checks passed!
```

Mutation-tested: neutering `_restore_write_cleared_mode_bits()` fails both tests (`assert 436 == 1460`), so neither assertion is vacuous.

Cross-platform, running the patched `_atomic_write_text` directly — every special-bit case fails before the change and passes after, on **macOS 26.6.2** and **Linux 6.8 / Python 3.12**:

```
LINUX, patched _atomic_write_text:
  atomic   0o2664 -> 0o2664 OK      in-place 0o2664 -> 0o2664 OK nlink=2
  atomic   0o4664 -> 0o4664 OK      in-place 0o4664 -> 0o4664 OK nlink=2
  atomic   0o6664 -> 0o6664 OK      in-place 0o664  -> 0o664  OK nlink=2
  atomic   0o1664 -> 0o1664 OK
```

Note: `ruff format --check` reports pre-existing diffs in both files on clean `master` and is not enforced in CI, so no unrelated reformatting is included here.

AI-assisted: investigated, patched, and verified with Claude (Hermes).
