### PR TITLE
fix(sessions): overlay live state.db freshness onto sidebar rows

### DIFF
--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -538,6 +538,53 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
             sid, item, cron_job_prefixes
         )
         overlaid.append(item)
+    # State.db freshness overlay (#local): desktop/CLI-owned sessions write to
+    # the agent state.db, not the WebUI sidecar, so their index rows freeze at
+    # import time. Overlay fresh updated_at / last_message_at / message_count /
+    # title from the agent state.db projection (same source the gateway watcher
+    # uses) so the sidebar tracks live activity for external sessions. Fail-open:
+    # any error leaves the rows as-is.
+    try:
+        from api.gateway_watcher import _get_agent_sessions_from_db
+        fresh_rows = _get_agent_sessions_from_db() or []
+        fresh_by_id = {str(r.get("session_id") or "").strip(): r for r in fresh_rows if r.get("session_id")}
+    except Exception:
+        fresh_by_id = {}
+    if fresh_by_id:
+        for item in overlaid:
+            sid = str(item.get("session_id") or "").strip()
+            fr = fresh_by_id.get(sid)
+            if not fr:
+                continue
+            # Only overlay when state.db is genuinely newer than the sidecar
+            # row (last_activity comparison) — the sidecar stays authoritative
+            # for WebUI-native or more-recently-written sessions. Monotonic:
+            # never downgrade a newer value.
+            fresh_activity = _session_list_row_numeric_value(fr.get("updated_at"))
+            current_activity = _session_list_row_numeric_value(item.get("updated_at"))
+            if fresh_activity <= current_activity:
+                continue
+            for key in ("updated_at", "last_message_at"):
+                fresh_val = _session_list_row_numeric_value(fr.get(key))
+                cur_val = _session_list_row_numeric_value(item.get(key))
+                if fresh_val > cur_val:
+                    item[key] = fr.get(key)
+            # The watcher projection carries `updated_at` = state.db last_activity
+            # but no `last_message_at`. The sort timestamp prefers last_message_at
+            # FIRST (last_message_at -> updated_at -> created_at), so a stale
+            # sidecar last_message_at would still pin the row to the past and
+            # defeat the live updated_at overlay above. When the fresh
+            # last_activity is newer than the row's last_message_at, propagate it
+            # so both display and sort follow live activity.
+            stale_last_msg = _session_list_row_numeric_value(item.get("last_message_at"))
+            if fresh_activity > stale_last_msg and not _session_list_row_numeric_value(fr.get("last_message_at")):
+                item["last_message_at"] = fr.get("updated_at")
+            fresh_cnt = _session_list_row_numeric_value(fr.get("message_count"))
+            if fresh_cnt > _session_list_row_numeric_value(item.get("message_count")):
+                item["message_count"] = fresh_cnt
+            fresh_title = str(fr.get("title") or "").strip()
+            if fresh_title and str(item.get("title") or "").strip() != fresh_title:
+                item["title"] = fresh_title
     overlaid.sort(key=_session_list_runtime_sort_key, reverse=True)
     return overlaid
 

--- a/tests/test_sidebar_state_db_freshness.py
+++ b/tests/test_sidebar_state_db_freshness.py
@@ -1,0 +1,133 @@
+"""Regression tests: sidebar rows for desktop/CLI-owned sessions must track
+live agent state.db activity, not the frozen WebUI sidecar/index copy.
+
+Desktop and CLI sessions write to the agent ``state.db`` (via hermes-agent),
+NOT to the WebUI sidecar files. The WebUI sidebar list is served from its own
+session registry (``webui/sessions/_index.json`` + sidecars), so rows for
+external sessions freeze at import time: stale timestamps, message counts, and
+sort position. The gateway watcher already reads fresh state.db every poll —
+the overlay must apply that freshness to every sidebar response.
+
+The freshness overlay in ``_session_list_cache_overlay_runtime_rows``:
+- bumps ``updated_at`` / ``last_message_at`` when state.db last_activity is newer
+- bumps ``message_count`` when state.db has more messages
+- refreshes ``title`` from state.db
+- is monotonic (never downgrades a newer sidecar value)
+- fails open (any DB error leaves rows untouched)
+"""
+
+import pytest
+
+
+def _fresh_row(sid="20260823_092817_7259ce", **overrides):
+    row = {
+        "session_id": sid,
+        "title": "Fresh title from state.db",
+        "message_count": 999,
+        "updated_at": 2000.0,  # newer than any stale sidecar value
+        # NOTE: the watcher projection carries updated_at = state.db
+        # last_activity but deliberately NO last_message_at.
+    }
+    row.update(overrides)
+    return row
+
+
+def _stale_row(sid="20260823_092817_7259ce", **overrides):
+    row = {
+        "session_id": sid,
+        "title": "Stale imported title",
+        "message_count": 444,
+        "updated_at": 1000.0,
+        "last_message_at": 900.0,
+        "source_tag": "desktop",
+        "is_cli_session": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def _patch_fresh_db(monkeypatch, rows):
+    import api.gateway_watcher as gw
+    import api.route_session_list_cache as slc
+
+    monkeypatch.setattr(gw, "_get_agent_sessions_from_db", lambda: rows)
+    monkeypatch.setattr(slc, "_session_list_cache_active_stream_ids", lambda: set())
+    return slc
+
+
+def test_overlay_freshens_stale_index_row_from_state_db(monkeypatch):
+    import api.route_session_list_cache as slc
+
+    _patch_fresh_db(monkeypatch, [_fresh_row()])
+    out = slc._session_list_cache_overlay_runtime_rows([_stale_row()])
+    assert len(out) == 1
+    row = out[0]
+    # updated_at follows state.db last_activity.
+    assert row["updated_at"] == 2000.0
+    # last_message_at propagates state.db activity when the fresh projection
+    # has no real last_message_at, so the row both displays AND sorts live.
+    assert row["last_message_at"] == 2000.0
+    # message_count follows state.db.
+    assert row["message_count"] == 999
+    # title follows state.db.
+    assert row["title"] == "Fresh title from state.db"
+
+
+def test_overlay_uses_real_last_message_at_when_present(monkeypatch):
+    import api.route_session_list_cache as slc
+
+    # If the projection DOES carry a last_message_at, it wins over the
+    # updated_at propagation (it is the more precise signal).
+    fresh = _fresh_row(last_message_at=2100.0)
+    _patch_fresh_db(monkeypatch, [fresh])
+    out = slc._session_list_cache_overlay_runtime_rows([_stale_row()])
+    assert out[0]["last_message_at"] == 2100.0
+    assert out[0]["updated_at"] == 2000.0
+
+
+def test_overlay_never_downgrades_newer_sidecar_values(monkeypatch):
+    import api.route_session_list_cache as slc
+
+    # Sidecar is NEWER than state.db (e.g. WebUI-native session written
+    # through the WebUI). The overlay must be monotonic: no downgrade.
+    fresh = _fresh_row(updated_at=500.0, message_count=10, title="Older db title")
+    _patch_fresh_db(monkeypatch, [fresh])
+    stale = _stale_row(
+        updated_at=1000.0,
+        last_message_at=1200.0,
+        message_count=444,
+        title="Stale imported title",
+    )
+    out = slc._session_list_cache_overlay_runtime_rows([stale])
+    row = out[0]
+    assert row["updated_at"] == 1000.0
+    assert row["last_message_at"] == 1200.0
+    assert row["message_count"] == 444
+    assert row["title"] == "Stale imported title"
+
+
+def test_overlay_ignores_sessions_not_in_state_db(monkeypatch):
+    import api.route_session_list_cache as slc
+
+    _patch_fresh_db(monkeypatch, [_fresh_row(sid="other-session")])
+    row = _stale_row(sid="unknown-session", message_count=3, updated_at=100.0)
+    out = slc._session_list_cache_overlay_runtime_rows([row])
+    assert out[0]["message_count"] == 3
+    assert out[0]["updated_at"] == 100.0
+
+
+def test_overlay_fails_open_when_state_db_unavailable(monkeypatch):
+    import api.gateway_watcher as gw
+    import api.route_session_list_cache as slc
+
+    def _boom():
+        raise RuntimeError("state.db locked")
+
+    monkeypatch.setattr(gw, "_get_agent_sessions_from_db", _boom)
+    monkeypatch.setattr(slc, "_session_list_cache_active_stream_ids", lambda: set())
+    row = _stale_row()
+    out = slc._session_list_cache_overlay_runtime_rows([row])
+    # Fail-open: the row passes through untouched.
+    assert out[0]["message_count"] == 444
+    assert out[0]["updated_at"] == 1000.0
+    assert out[0]["last_message_at"] == 900.0


### PR DESCRIPTION
## Bug Description

The WebUI sidebar shows stale session data for desktop/CLI-owned sessions. The row's timestamp, message count, and title freeze at the moment the session was first imported into the WebUI — even while the chat is actively streaming new messages. The sidebar sort position also lags, so an active session can sit below older, idle ones.

Observed: a session whose `state.db` `last_activity` was continuously advancing (live chat) showed a sidebar `last_message_at` frozen 90 minutes in the past; `message_count` stayed at its import-time value.

## Root Cause

Desktop and CLI sessions write to the agent **`state.db`** (via hermes-agent), not to the WebUI sidecar files. The sidebar list is served from the WebUI's own session registry (`webui/sessions/_index.json` + per-session sidecars), which only refreshes for sessions written *through* the WebUI. The gateway watcher (`api/gateway_watcher.py`) already projects fresh `state.db` rows every 5s — but it only pushes SSE notifications; the session-list response never applied that freshness to its rows.

## Fix

`_session_list_cache_overlay_runtime_rows()` (api/route_session_list_cache.py) now overlays the live agent state.db projection onto every sidebar row before the response is sent:

- `updated_at` / `last_message_at` → state.db `last_activity` when newer (the projection carries `updated_at` = last_activity; when it has no real `last_message_at`, the fresh activity is propagated there too so the **sort timestamp** follows live activity — the sort prefers `last_message_at` first)
- `message_count` → state.db count when larger
- `title` → state.db title when present

**Monotonic & fail-open by construction:** the overlay only fires when state.db `last_activity` is strictly newer than the sidecar row's `updated_at` (sidecar stays authoritative for WebUI-native or more-recently-written sessions), and any DB error leaves rows untouched.

## How to Verify

1. Start a desktop/CLI chat (agent writes to `state.db`).
2. Open the WebUI sidebar and note the row's timestamp/message count.
3. Send more messages in the chat; refresh the sidebar — the row now tracks live activity instead of freezing at import time.
4. (Negative) WebUI-native sessions and sessions not in state.db are untouched; a DB failure degrades to the previous behavior.

## Test Plan

- [x] Added regression test (`tests/test_sidebar_state_db_freshness.py`, 5 tests) — **verified red before the fix** (2 failed: `test_overlay_freshens_stale_index_row_from_state_db`, `test_overlay_uses_real_last_message_at_when_present`), green after
- [x] Existing sibling suites pass: `test_6728_cron_running_sidebar.py`, `test_4167_sidebar_payload_and_scope.py`, `test_cli_sessions_cache_cap.py`, `test_cli_sessions_cache_fingerprint.py` (18 passed)
- [x] Manual verification against a live install: stale 12:44 row → live timestamp, correct re-sort

## Risk Assessment

**Low.** The overlay is read-only (no writes to state.db or the index), gated on a strictly-newer comparison, and fail-open. Only sidebar display metadata is affected; the transcript/streaming paths are untouched. Cost: one extra read of the already-cached watcher projection per session-list response (the watcher reads it every 5s anyway; `_get_agent_sessions_from_db` opens state.db read-only).

## Not Verified

- Cross-profile session rows (patch overlays only rows present in the response; per-profile DB resolution follows the existing watcher path).