### PR TITLE
fix(#7073): resolve qualified models through owner config

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -12,6 +12,7 @@ Discovery order for all paths:
 import collections
 import copy
 import hashlib
+import inspect
 import json
 import logging
 import math
@@ -3404,6 +3405,7 @@ def resolve_owner_runtime_state(
         return state
     try:
         from contextlib import nullcontext
+        import inspect
 
         from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -3423,10 +3425,19 @@ def resolve_owner_runtime_state(
                 _thread_ctx.env = dict(owner_env)
                 _thread_ctx.block_process_env_fallback = True
             try:
+                runtime_kwargs = {"requested": state.provider}
+                try:
+                    runtime_parameters = inspect.signature(resolve_runtime_provider).parameters
+                except (TypeError, ValueError):
+                    runtime_parameters = {}
+                if "target_model" in runtime_parameters or any(
+                    parameter.kind == inspect.Parameter.VAR_KEYWORD
+                    for parameter in runtime_parameters.values()
+                ):
+                    runtime_kwargs["target_model"] = state.outbound_model
                 runtime = resolve_runtime_provider_with_anthropic_env_lock(
                     resolve_runtime_provider,
-                    requested=state.provider,
-                    target_model=state.outbound_model,
+                    **runtime_kwargs,
                 )
             finally:
                 if owner_env is not None and not owner_profile:
@@ -3539,10 +3550,26 @@ def resolve_owner_model_state(
                 _owner_runtime_fallback_allowed(config_obj, stored),
             )
 
+    resolver_kwargs = {}
+    try:
+        resolver_parameters = inspect.signature(resolve_model_provider).parameters
+    except (TypeError, ValueError):
+        resolver_parameters = {}
+    accepts_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in resolver_parameters.values()
+    )
+    if config_obj is not None and (
+        "config_obj" in resolver_parameters or accepts_kwargs
+    ):
+        resolver_kwargs["config_obj"] = owner_cfg
+    if explicitly_picked and (
+        "explicitly_picked" in resolver_parameters or accepts_kwargs
+    ):
+        resolver_kwargs["explicitly_picked"] = True
     resolved_model, resolved_provider, resolved_base = resolve_model_provider(
         requested,
-        explicitly_picked=explicitly_picked,
-        config_obj=owner_cfg,
+        **resolver_kwargs,
     )
     if not resolved_provider and default_provider:
         resolved_provider = default_provider
@@ -5823,6 +5850,9 @@ def _static_models_catalog_without_live_probes(config_obj: dict | None = None) -
         if active_provider:
             detected_providers.add(active_provider)
             _append_model_id(active_provider, default_model)
+            if isinstance(model_cfg, dict):
+                for model_id in _configured_model_ids(model_cfg.get("models")):
+                    _append_model_id(active_provider, model_id)
 
         try:
             _pool = auth_store.get("credential_pool", {}) if isinstance(auth_store, dict) else {}

--- a/api/config.py
+++ b/api/config.py
@@ -3381,6 +3381,7 @@ class OwnerModelState:
     api_key: str | None
     repaired: bool = False
     runtime_fallback_allowed: bool = True
+    runtime_route: dict | None = None
 
 
 def _owner_runtime_fallback_allowed(
@@ -3399,16 +3400,13 @@ def resolve_owner_runtime_state(
     config_obj: dict | None = None,
     owner_env: dict[str, str] | None = None,
     owner_profile: str | None = None,
+    runtime_resolver=None,
 ) -> OwnerModelState:
     """Fill runtime credentials under the owner policy, never ambiently."""
     if not state.runtime_fallback_allowed:
         return state
     try:
         from contextlib import nullcontext
-        import inspect
-
-        from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-        from hermes_cli.runtime_provider import resolve_runtime_provider
 
         scope = nullcontext()
         if owner_profile and config_obj is not None:
@@ -3419,6 +3417,12 @@ def resolve_owner_runtime_state(
                 "owner runtime provider resolution",
             )
         with scope:
+            from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
+            if runtime_resolver is None:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+            else:
+                resolve_runtime_provider = runtime_resolver
+
             previous_env = getattr(_thread_ctx, "env", None)
             previous_block = getattr(_thread_ctx, "block_process_env_fallback", False)
             if owner_env is not None and not owner_profile:
@@ -3451,6 +3455,7 @@ def resolve_owner_runtime_state(
             provider=state.provider or runtime.get("provider"),
             base_url=state.base_url or runtime.get("base_url"),
             api_key=runtime.get("api_key") or state.api_key,
+            runtime_route=runtime,
         )
     except Exception:
         logger.debug("owner runtime credential resolution failed", exc_info=True)
@@ -3464,6 +3469,7 @@ def resolve_owner_model_state(
     config_obj: dict | None = None,
     explicitly_picked: bool = False,
     owner_env: dict[str, str] | None = None,
+    resolver=None,
 ) -> OwnerModelState:
     """Resolve model, provider, connection, and catalog ownership together."""
     owner_cfg = config_obj if isinstance(config_obj, dict) else cfg
@@ -3550,9 +3556,10 @@ def resolve_owner_model_state(
                 _owner_runtime_fallback_allowed(config_obj, stored),
             )
 
+    resolver_fn = resolver or resolve_model_provider
     resolver_kwargs = {}
     try:
-        resolver_parameters = inspect.signature(resolve_model_provider).parameters
+        resolver_parameters = inspect.signature(resolver_fn).parameters
     except (TypeError, ValueError):
         resolver_parameters = {}
     accepts_kwargs = any(
@@ -3567,7 +3574,7 @@ def resolve_owner_model_state(
         "explicitly_picked" in resolver_parameters or accepts_kwargs
     ):
         resolver_kwargs["explicitly_picked"] = True
-    resolved_model, resolved_provider, resolved_base = resolve_model_provider(
+    resolved_model, resolved_provider, resolved_base = resolver_fn(
         requested,
         **resolver_kwargs,
     )

--- a/api/config.py
+++ b/api/config.py
@@ -1540,7 +1540,10 @@ def _normalize_base_url_for_match(value: object) -> str:
     url = str(value or "").strip().rstrip("/")
     if not url:
         return ""
-    parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    try:
+        parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    except ValueError:
+        return ""
     scheme = (parsed_url.scheme or "http").lower()
     netloc = (parsed_url.netloc or parsed_url.path).lower().rstrip("/")
     path = parsed_url.path.rstrip("/")
@@ -1562,11 +1565,17 @@ def _custom_endpoint_slugs_for_base_url(value: object) -> set[str]:
     url = str(value or "").strip().rstrip("/")
     if not url:
         return set()
-    parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    try:
+        parsed_url = urlparse(url if "://" in url else f"http://{url}")
+    except ValueError:
+        return set()
     host = (parsed_url.hostname or "").strip().lower()
     if not host:
         return set()
-    port = parsed_url.port
+    try:
+        port = parsed_url.port
+    except ValueError:
+        return set()
     if port is None:
         scheme = (parsed_url.scheme or "http").lower()
         port = 443 if scheme == "https" else 80
@@ -2554,11 +2563,16 @@ def _custom_slug_rest_looks_like_host_port(rest: str) -> bool:
     return False
 
 
-def _parse_provider_qualified_model_id(model_id: str) -> tuple[str, str] | None:
+def _parse_provider_qualified_model_id(
+    model_id: str,
+    config_obj: dict | None = None,
+) -> tuple[str, str] | None:
     """Parse WebUI's ``@provider:model`` route hint into ``(model, provider)``.
 
     The provider segment can contain colons for named custom providers, while
     the model segment can also contain colons for tags such as ``:free``.
+    ``config_obj`` supplies the registry and active model identities for the
+    owning profile; omitted callers retain the ambient configuration.
     Keep this parser shared with ``resolve_model_provider`` so any caller that
     compares route-hinted model lanes uses the same grammar.
     """
@@ -2566,16 +2580,65 @@ def _parse_provider_qualified_model_id(model_id: str) -> tuple[str, str] | None:
     if not candidate.startswith("@") or ":" not in candidate:
         return None
     inner = candidate[1:]
+    active_config = config_obj if isinstance(config_obj, dict) else cfg
+    if inner.startswith("custom:"):
+        custom_slugs = _named_custom_provider_slugs(active_config)
+        matching_slugs = [
+            slug for slug in custom_slugs
+            if inner.startswith(f"{slug}:") and len(inner) > len(slug) + 1
+        ]
+        if matching_slugs:
+            provider_hint = max(matching_slugs, key=len)
+            return inner[len(provider_hint) + 1:], provider_hint
+
+        model_config = active_config.get("model", {})
+        endpoint_slugs = _custom_endpoint_slugs_for_base_url(
+            model_config.get("base_url") if isinstance(model_config, dict) else None
+        )
+        matching_endpoints = [
+            slug for slug in endpoint_slugs
+            if inner.startswith(f"{slug}:") and len(inner) > len(slug) + 1
+        ]
+        if matching_endpoints:
+            provider_hint = max(matching_endpoints, key=len)
+            return inner[len(provider_hint) + 1:], provider_hint
+
+        custom_rest = inner[len("custom:"):]
+        custom_parts = custom_rest.split(":")
+        if len(custom_parts) >= 3:
+            endpoint_rest = ":".join(custom_parts[:2])
+            if _custom_slug_rest_looks_like_host_port(endpoint_rest):
+                return ":".join(custom_parts[2:]), f"custom:{endpoint_rest}"
+
+        active_provider = (
+            str(model_config.get("provider") or "").strip().lower()
+            if isinstance(model_config, dict) else ""
+        )
+        active_self_hosted = active_provider == "custom" or _is_local_server_provider(active_provider)
+        active_models = set()
+        if active_self_hosted and isinstance(model_config, dict):
+            active_models.update(_configured_model_ids(model_config.get("models")))
+            if model_config.get("default"):
+                active_models.add(str(model_config["default"]).strip())
+        providers = active_config.get("providers", {})
+        provider_config = providers.get(active_provider) if active_self_hosted and isinstance(providers, dict) else None
+        if isinstance(provider_config, dict):
+            if provider_config.get("model"):
+                active_models.add(str(provider_config["model"]).strip())
+            active_models.update(_configured_model_ids(provider_config.get("models")))
+        if custom_rest in {value for value in active_models if value}:
+            return custom_rest, "custom"
+
     provider_hint, bare_model = inner.rsplit(":", 1)
-    if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
-        _slug_rest = provider_hint[len("custom:"):]
-        if not _custom_slug_rest_looks_like_host_port(_slug_rest):
-            provider_hint, extra = provider_hint.rsplit(":", 1)
-            bare_model = f"{extra}:{bare_model}"
-    elif (provider_hint not in _PROVIDER_MODELS
+    if (provider_hint not in _PROVIDER_MODELS
             and provider_hint not in _PROVIDER_DISPLAY
             and not provider_hint.startswith("custom:")):
         provider_hint, bare_model = inner.split(":", 1)
+    elif provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
+        slug_rest = provider_hint[len("custom:"):]
+        if not _custom_slug_rest_looks_like_host_port(slug_rest):
+            provider_hint, extra = provider_hint.rsplit(":", 1)
+            bare_model = f"{extra}:{bare_model}"
     return bare_model, provider_hint
 
 
@@ -2953,7 +3016,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     #
     # Exception: ``custom:<ip-or-host>:<port>`` is a single logical slug derived
     # from OpenAI ``base_url`` authority and contains no eaten model segments.
-    parsed_provider_hint = _parse_provider_qualified_model_id(model_id)
+    parsed_provider_hint = _parse_provider_qualified_model_id(model_id, cfg)
     if parsed_provider_hint is not None:
         bare_model, provider_hint = parsed_provider_hint
         # Session/send/handoff shapes encode the provider as @custom:<slug>:model

--- a/api/config.py
+++ b/api/config.py
@@ -1683,12 +1683,29 @@ def _provider_is_known_or_configured(
     if isinstance(providers, dict):
         if raw in {str(key).strip().lower() for key in providers}:
             return True
-    # Configured custom provider: a named slug in custom_providers, or any
-    # ``custom`` / ``custom:<slug>`` form when custom_providers are defined.
-    if _named_custom_provider_slug_for_provider(raw, config_obj):
+    # Bare ``custom`` is a real built-in lane. Named custom lanes, however,
+    # are identities minted by this owner's entries, not a namespace that any
+    # configured custom provider implicitly authorizes.
+    if raw == "custom":
         return True
-    if raw == "custom" or raw.startswith("custom:"):
-        return bool(_custom_provider_entries(config_obj))
+    if raw.startswith("custom:"):
+        if _custom_slug_rest_looks_like_host_port(raw.removeprefix("custom:")):
+            return True
+        if _named_custom_provider_slug_for_provider(raw, config_obj):
+            return True
+        source_entries = _custom_provider_entries(config_obj)
+        endpoint_slugs = {
+            slug
+            for entry in source_entries
+            for slug in _custom_endpoint_slugs_for_base_url(entry.get("base_url"))
+        }
+        model_cfg = source.get("model", {}) if isinstance(source, dict) else {}
+        endpoint_slugs.update(
+            _custom_endpoint_slugs_for_base_url(
+                model_cfg.get("base_url") if isinstance(model_cfg, dict) else None
+            )
+        )
+        return raw in endpoint_slugs
     # Known first-party / built-in provider id (alias-resolved). Static registry
     # knowledge that is always available, so a live-discovery provider whose
     # catalog group is momentarily absent still counts as known.
@@ -3249,6 +3266,8 @@ def resolve_model_provider(
 def resolve_custom_provider_connection(
     provider_id: str,
     config_obj: dict | None = None,
+    *,
+    env: dict[str, str] | None = None,
 ) -> tuple[str | None, str | None]:
     """Return (api_key, base_url) for a named ``custom:*`` provider.
 
@@ -3268,18 +3287,32 @@ def resolve_custom_provider_connection(
     # cases after profile switches or runtime config edits.
     cfg_data = config_obj if isinstance(config_obj, dict) else get_config()
 
+    owner_env = env
+    if owner_env is None and isinstance(config_obj, dict):
+        candidate_env = config_obj.get("_env") or config_obj.get("env")
+        if isinstance(candidate_env, dict):
+            owner_env = {str(key): str(value) for key, value in candidate_env.items()}
+
+    def _env_value(name: object) -> str:
+        key = str(name or "").strip()
+        if not key:
+            return ""
+        if owner_env is not None:
+            return str(owner_env.get(key) or "")
+        return _thread_local_env_value(key)
+
     def _resolve_key(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
         api_key = None
         if raw_api_key is not None:
             key_text = str(raw_api_key).strip()
             if key_text.startswith("${") and key_text.endswith("}") and len(key_text) > 3:
-                api_key = _thread_local_env_value(key_text[2:-1]).strip() or None
+                api_key = _env_value(key_text[2:-1]).strip() or None
             elif key_text:
                 api_key = key_text
         if not api_key:
             key_env = str(raw_key_env or "").strip()
             if key_env:
-                api_key = _thread_local_env_value(key_env).strip() or None
+                api_key = _env_value(key_env).strip() or None
         if not api_key and provider_hint:
             api_key = _lookup_custom_api_key_env(provider_hint)
         return api_key
@@ -3354,9 +3387,14 @@ def resolve_owner_model_state(
     *,
     config_obj: dict | None = None,
     explicitly_picked: bool = False,
+    owner_env: dict[str, str] | None = None,
 ) -> OwnerModelState:
     """Resolve model, provider, connection, and catalog ownership together."""
     owner_cfg = config_obj if isinstance(config_obj, dict) else cfg
+    if owner_env is None and isinstance(owner_cfg, dict):
+        candidate_env = owner_cfg.get("_env") or owner_cfg.get("env")
+        if isinstance(candidate_env, dict):
+            owner_env = {str(key): str(value) for key, value in candidate_env.items()}
     requested = str(model_id or "").strip()
     original_requested = requested
     model_cfg = owner_cfg.get("model", {}) if isinstance(owner_cfg, dict) else {}
@@ -3391,7 +3429,9 @@ def resolve_owner_model_state(
             resolved_base = _get_provider_base_url(resolved_provider, owner_cfg)
             key = None
             if resolved_provider.startswith("custom:"):
-                key, entry_base = resolve_custom_provider_connection(resolved_provider, owner_cfg)
+                key, entry_base = resolve_custom_provider_connection(
+                    resolved_provider, owner_cfg, env=owner_env
+                )
                 resolved_base = resolved_base or entry_base
             return OwnerModelState(
                 model=original_requested,
@@ -3408,7 +3448,9 @@ def resolve_owner_model_state(
             base = _get_provider_base_url(stored, owner_cfg)
             key = None
             if stored.startswith("custom:"):
-                key, entry_base = resolve_custom_provider_connection(stored, owner_cfg)
+                key, entry_base = resolve_custom_provider_connection(
+                    stored, owner_cfg, env=owner_env
+                )
                 base = base or entry_base
             return OwnerModelState(requested, requested, stored, base, key, False)
 
@@ -3423,7 +3465,9 @@ def resolve_owner_model_state(
         repaired = True
     key = None
     if isinstance(resolved_provider, str) and resolved_provider.startswith("custom:"):
-        key, entry_base = resolve_custom_provider_connection(resolved_provider, owner_cfg)
+        key, entry_base = resolve_custom_provider_connection(
+            resolved_provider, owner_cfg, env=owner_env
+        )
         resolved_base = resolved_base or entry_base
     if not resolved_base and isinstance(model_cfg, dict):
         resolved_base = str(model_cfg.get("base_url") or "").strip() or None
@@ -5758,12 +5802,19 @@ def _static_models_catalog_without_live_probes(config_obj: dict | None = None) -
         # `providers:` block — otherwise the picker silently drops the
         # group when the live-rebuild cache is cold.
         try:
-            for _plugin_pid in list(_plugin_model_provider_profiles().keys()):
-                if not _plugin_pid or not _provider_has_key(_plugin_pid):
-                    continue
-                _canonical = _canonicalise_provider_id(_plugin_pid) or _plugin_pid
-                if _canonical:
-                    detected_providers.add(_canonical)
+            if config_obj is None:
+                for _plugin_pid in list(_plugin_model_provider_profiles().keys()):
+                    if not _plugin_pid or not _provider_has_key(_plugin_pid):
+                        continue
+                    _canonical = _canonicalise_provider_id(_plugin_pid) or _plugin_pid
+                    if _canonical:
+                        detected_providers.add(_canonical)
+            else:
+                # Explicit owners may use a plugin only when their snapshot
+                # names that provider. Never inspect ambient plugin auth state.
+                for _plugin_pid in configured_provider_ids:
+                    if _is_plugin_model_provider(_plugin_pid):
+                        detected_providers.add(_plugin_pid)
         except Exception:
             logger.debug("Plugin provider detection failed in static catalog", exc_info=True)
 

--- a/api/config.py
+++ b/api/config.py
@@ -27,6 +27,7 @@ import urllib.error
 import urllib.request
 import uuid
 import weakref
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -1379,7 +1380,9 @@ def _custom_provider_entries(config_obj: dict | None = None) -> list[dict]:
 
 def _configured_model_ids(raw_models: object) -> list[str]:
     """Return ordered model IDs from supported config allowlist shapes."""
-    if isinstance(raw_models, dict):
+    if isinstance(raw_models, str):
+        candidates = (raw_models,)
+    elif isinstance(raw_models, dict):
         candidates = (key for key in raw_models if isinstance(key, str))
     elif isinstance(raw_models, list):
         candidates = raw_models
@@ -1675,6 +1678,11 @@ def _provider_is_known_or_configured(
     raw = str(provider_id or "").strip().lower()
     if not raw:
         return False
+    source = config_obj if isinstance(config_obj, dict) else cfg
+    providers = source.get("providers", {}) if isinstance(source, dict) else {}
+    if isinstance(providers, dict):
+        if raw in {str(key).strip().lower() for key in providers}:
+            return True
     # Configured custom provider: a named slug in custom_providers, or any
     # ``custom`` / ``custom:<slug>`` form when custom_providers are defined.
     if _named_custom_provider_slug_for_provider(raw, config_obj):
@@ -2430,7 +2438,11 @@ def _is_local_server_provider(provider_id: str) -> bool:
     return False
 
 
-def _model_id_declared_in_config(model_id: str, config_provider: str | None) -> bool:
+def _model_id_declared_in_config(
+    model_id: str,
+    config_provider: str | None,
+    config_obj: dict | None = None,
+) -> bool:
     """True when the user's own config declares ``model_id`` verbatim (full form).
 
     This is the COLD-catalog provenance signal for #5979: when the live
@@ -2447,7 +2459,8 @@ def _model_id_declared_in_config(model_id: str, config_provider: str | None) -> 
     model = str(model_id or "").strip()
     if not model:
         return False
-    model_cfg = cfg.get("model", {})
+    source = config_obj if isinstance(config_obj, dict) else cfg
+    model_cfg = source.get("model", {})
     if isinstance(model_cfg, dict):
         if str(model_cfg.get("default") or "").strip() == model:
             return True
@@ -2458,7 +2471,7 @@ def _model_id_declared_in_config(model_id: str, config_provider: str | None) -> 
     prov = str(config_provider or "").strip().lower()
     if prov.startswith("custom:"):
         raw_suffix = prov.removeprefix("custom:")
-        for entry in _custom_provider_entries():
+        for entry in _custom_provider_entries(config_obj):
             slug = _custom_provider_slug_from_name(entry.get("name"))
             entry_name = str(entry.get("name") or "").strip().lower()
             if not (prov in {entry_name, slug} or (slug and raw_suffix == slug.removeprefix("custom:"))):
@@ -2642,7 +2655,7 @@ def _parse_provider_qualified_model_id(
     return bare_model, provider_hint
 
 
-def _get_provider_base_url(provider_id):
+def _get_provider_base_url(provider_id, config_obj: dict | None = None):
     """Look up the configured base_url for a provider (e.g. lmstudio).
 
     Checks two locations, in order:
@@ -2655,11 +2668,12 @@ def _get_provider_base_url(provider_id):
 
     Returns the URL stripped of trailing ``/`` if configured, otherwise None.
     """
-    prov_cfg = _get_provider_cfg(provider_id)
+    prov_cfg = _get_provider_cfg(provider_id, config_obj)
     explicit = (prov_cfg.get("base_url") or "").strip().rstrip("/")
     if explicit:
         return explicit
-    model_cfg = cfg.get("model", {}) or {}
+    source = config_obj if isinstance(config_obj, dict) else cfg
+    model_cfg = source.get("model", {}) or {}
     if isinstance(model_cfg, dict):
         model_provider = str(model_cfg.get("provider") or "").strip().lower()
         if model_provider == str(provider_id).strip().lower():
@@ -2669,13 +2683,14 @@ def _get_provider_base_url(provider_id):
     return None
 
 
-def _get_providers_cfg() -> dict:
-    providers_cfg = cfg.get("providers")
+def _get_providers_cfg(config_obj: dict | None = None) -> dict:
+    source = config_obj if isinstance(config_obj, dict) else cfg
+    providers_cfg = source.get("providers")
     return providers_cfg if isinstance(providers_cfg, dict) else {}
 
 
-def _get_provider_cfg(provider_id) -> dict:
-    provider_cfg = _get_providers_cfg().get(provider_id, {})
+def _get_provider_cfg(provider_id, config_obj: dict | None = None) -> dict:
+    provider_cfg = _get_providers_cfg(config_obj).get(provider_id, {})
     return provider_cfg if isinstance(provider_cfg, dict) else {}
 
 
@@ -2758,7 +2773,12 @@ def _unique_custom_provider_entry(custom_providers: object, slug_key: str) -> di
     return matches[0] if matches else None
 
 
-def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) -> tuple:
+def resolve_model_provider(
+    model_id: str,
+    *,
+    explicitly_picked: bool = False,
+    config_obj: dict | None = None,
+) -> tuple:
     """Resolve model name, provider, and base_url for AIAgent.
 
     Model IDs from the dropdown can be in several formats:
@@ -2789,14 +2809,15 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     legacy redundant-prefix strip so it keeps routing when cold. Warm provenance
     (endpoint-advertised ids) always takes precedence over this flag.
     """
+    owner_cfg = config_obj if isinstance(config_obj, dict) else cfg
     config_provider = None
     config_base_url = None
-    model_cfg = cfg.get("model", {})
+    model_cfg = owner_cfg.get("model", {})
     if isinstance(model_cfg, dict):
         config_base_url = model_cfg.get("base_url")
         config_provider = _resolve_configured_provider_id(
             model_cfg.get("provider"),
-            cfg,
+            owner_cfg,
             base_url=config_base_url,
             resolve_alias=False,
         )
@@ -2827,7 +2848,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
         """
         if isinstance(provider, str) and provider.startswith("custom:"):
             _unique_custom_provider_entry(
-                cfg.get('custom_providers', []),
+                owner_cfg.get('custom_providers', []),
                 _custom_provider_slug_key(provider),
             )
         return model, provider, base_url
@@ -2874,7 +2895,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     # own declared models and can't be hijacked by another providers.<slug>
     # entry that happens to list the same bare id earlier in config order (#5511).
     if _canon_config_provider:
-        _providers_cfg_own = cfg.get('providers', {})
+        _providers_cfg_own = owner_cfg.get('providers', {})
         if isinstance(_providers_cfg_own, dict):
             for _slug, _pdef in _providers_cfg_own.items():
                 if not isinstance(_pdef, dict):
@@ -2893,7 +2914,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
             or model_id in _provider_models_set
         )
     )
-    custom_providers = cfg.get('custom_providers', [])
+    custom_providers = owner_cfg.get('custom_providers', [])
     if isinstance(custom_providers, list) and not _skip_custom_providers:
         # Disambiguation guard: when two custom_providers[] entries both list the
         # same bare model id (e.g. dogapi and packyapi both advertise
@@ -2965,7 +2986,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     # Check user-defined providers (config.yaml → providers:).
     # Mirrors the custom_providers scan above — exact match against each
     # entry's declared models list (case-sensitive to match custom_providers).
-    providers_cfg = cfg.get('providers', {})
+    providers_cfg = owner_cfg.get('providers', {})
     if isinstance(providers_cfg, dict):
         target = model_id.strip()
         # Honor the same active/default ownership guard as the custom_providers
@@ -3016,7 +3037,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     #
     # Exception: ``custom:<ip-or-host>:<port>`` is a single logical slug derived
     # from OpenAI ``base_url`` authority and contains no eaten model segments.
-    parsed_provider_hint = _parse_provider_qualified_model_id(model_id, cfg)
+    parsed_provider_hint = _parse_provider_qualified_model_id(model_id, owner_cfg)
     if parsed_provider_hint is not None:
         bare_model, provider_hint = parsed_provider_hint
         # Session/send/handoff shapes encode the provider as @custom:<slug>:model
@@ -3033,7 +3054,9 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
             and provider_hint.lower() in _custom_endpoint_slugs_for_base_url(config_base_url)
         ):
             return _finalize(bare_model, config_provider, config_base_url)
-        return _finalize(bare_model, provider_hint, _get_provider_base_url(provider_hint))
+        return _finalize(
+            bare_model, provider_hint, _get_provider_base_url(provider_hint, owner_cfg)
+        )
 
     if "/" in model_id:
         prefix, bare = model_id.split("/", 1)
@@ -3075,7 +3098,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
         # instead of falling back to the default config provider. MUST come BEFORE
         # the config_base_url branch because many providers have a base_url set.
         if prefix and config_provider and prefix != config_provider:
-            _custom_cfg = cfg.get("custom_providers", [])
+            _custom_cfg = owner_cfg.get("custom_providers", [])
             if isinstance(_custom_cfg, list):
                 for _entry in _custom_cfg:
                     if isinstance(_entry, dict) and _entry.get("name", "").strip() == prefix:
@@ -3142,7 +3165,7 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
                 # (1) Config declares the full id verbatim (model.default /
                 #     model.models / custom_providers[].models). Authoritative and
                 #     network-free, so #5979 survives a cold restart — preserve.
-                if _model_id_declared_in_config(model_id, config_provider):
+                if _model_id_declared_in_config(model_id, config_provider, owner_cfg):
                     return _finalize(model_id, config_provider, config_base_url)
                 # (2) The endpoint's live/cached catalog advertised it.
                 _advertised = _endpoint_advertised_model_ids(config_provider)
@@ -3223,7 +3246,10 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
     return _finalize(model_id, config_provider, config_base_url)
 
 
-def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, str | None]:
+def resolve_custom_provider_connection(
+    provider_id: str,
+    config_obj: dict | None = None,
+) -> tuple[str | None, str | None]:
     """Return (api_key, base_url) for a named ``custom:*`` provider.
 
     Supports ``custom_providers[].api_key`` as either a literal key or
@@ -3240,7 +3266,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
 
     # Read the live config snapshot to avoid stale module-level cache edge
     # cases after profile switches or runtime config edits.
-    cfg_data = get_config()
+    cfg_data = config_obj if isinstance(config_obj, dict) else get_config()
 
     def _resolve_key(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
         api_key = None
@@ -3308,6 +3334,107 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
         return fallback_key, fallback_base or None
 
     return None, None
+
+
+@dataclass(frozen=True)
+class OwnerModelState:
+    """One owner-scoped interpretation of a persisted model selection."""
+
+    model: str
+    outbound_model: str
+    provider: str | None
+    base_url: str | None
+    api_key: str | None
+    repaired: bool = False
+
+
+def resolve_owner_model_state(
+    model_id: str | None,
+    stored_provider: str | None = None,
+    *,
+    config_obj: dict | None = None,
+    explicitly_picked: bool = False,
+) -> OwnerModelState:
+    """Resolve model, provider, connection, and catalog ownership together."""
+    owner_cfg = config_obj if isinstance(config_obj, dict) else cfg
+    requested = str(model_id or "").strip()
+    original_requested = requested
+    model_cfg = owner_cfg.get("model", {}) if isinstance(owner_cfg, dict) else {}
+    default_model = str(model_cfg.get("default") or "").strip() if isinstance(model_cfg, dict) else ""
+    default_provider = (
+        str(model_cfg.get("provider") or "").strip() if isinstance(model_cfg, dict) else ""
+    )
+    parsed = _parse_provider_qualified_model_id(requested, owner_cfg)
+    repaired = False
+
+    if parsed:
+        bare_model, explicit_provider = parsed
+        explicit_provider = str(explicit_provider or "").strip()
+        # A legacy Ollama selection can be serialized as @custom:model because
+        # the old parser split the tagged model at its final colon.
+        if (
+            explicit_provider == "custom"
+            and default_provider
+            and default_provider != "custom"
+            and bare_model in {default_model, *_configured_model_ids(
+                model_cfg.get("models") if isinstance(model_cfg, dict) else None
+            )}
+        ):
+            explicit_provider = default_provider
+        if not _provider_is_known_or_configured(explicit_provider, owner_cfg):
+            requested = default_model
+            repaired = True
+        else:
+            requested = str(bare_model or requested).strip()
+            resolved_provider = explicit_provider
+            resolved_model = requested
+            resolved_base = _get_provider_base_url(resolved_provider, owner_cfg)
+            key = None
+            if resolved_provider.startswith("custom:"):
+                key, entry_base = resolve_custom_provider_connection(resolved_provider, owner_cfg)
+                resolved_base = resolved_base or entry_base
+            return OwnerModelState(
+                model=original_requested,
+                outbound_model=resolved_model,
+                provider=resolved_provider,
+                base_url=resolved_base,
+                api_key=key if resolved_provider.startswith("custom:") else None,
+                repaired=False,
+            )
+
+    if not repaired and requested and stored_provider:
+        stored = str(stored_provider).strip()
+        if _provider_is_known_or_configured(stored, owner_cfg):
+            base = _get_provider_base_url(stored, owner_cfg)
+            key = None
+            if stored.startswith("custom:"):
+                key, entry_base = resolve_custom_provider_connection(stored, owner_cfg)
+                base = base or entry_base
+            return OwnerModelState(requested, requested, stored, base, key, False)
+
+    resolved_model, resolved_provider, resolved_base = resolve_model_provider(
+        requested,
+        explicitly_picked=explicitly_picked,
+        config_obj=owner_cfg,
+    )
+    if not resolved_provider and default_provider:
+        resolved_provider = default_provider
+    if repaired or (parsed and resolved_provider != parsed[1]):
+        repaired = True
+    key = None
+    if isinstance(resolved_provider, str) and resolved_provider.startswith("custom:"):
+        key, entry_base = resolve_custom_provider_connection(resolved_provider, owner_cfg)
+        resolved_base = resolved_base or entry_base
+    if not resolved_base and isinstance(model_cfg, dict):
+        resolved_base = str(model_cfg.get("base_url") or "").strip() or None
+    return OwnerModelState(
+        model=str(resolved_model or requested or default_model).strip(),
+        outbound_model=str(resolved_model or requested or default_model).strip(),
+        provider=str(resolved_provider).strip() if resolved_provider else None,
+        base_url=str(resolved_base).strip() if resolved_base else None,
+        api_key=key,
+        repaired=repaired,
+    )
 
 
 # Subprocess ACP transports (Cursor/Copilot CLI). Model IDs often contain '/'
@@ -5502,9 +5629,12 @@ def _minimal_static_models_catalog() -> dict:
         }
 
 
-def _static_models_catalog_without_live_probes() -> dict:
+def _static_models_catalog_without_live_probes(config_obj: dict | None = None) -> dict:
     """Return a network-free /api/models catalog from local config/auth only."""
     try:
+        # An explicit snapshot is an owner boundary. In particular, ``{}`` is
+        # an empty owner, not a request to fall back to the process config.
+        cfg = config_obj if isinstance(config_obj, dict) else globals()["cfg"]
         from api.providers import _provider_has_key
 
         active_provider = None
@@ -5524,21 +5654,22 @@ def _static_models_catalog_without_live_probes() -> dict:
                 active_provider = str(active_provider or "").strip() or None
 
         auth_store: dict = {}
-        try:
-            auth_store_path = _get_auth_store_path()
-            if auth_store_path.exists():
-                auth_store = json.loads(auth_store_path.read_text(encoding="utf-8"))
-                if not active_provider:
-                    active_provider = (
-                        _resolve_configured_provider_id(
-                            auth_store.get("active_provider"),
-                            cfg,
-                            base_url=cfg_base_url,
+        if config_obj is None:
+            try:
+                auth_store_path = _get_auth_store_path()
+                if auth_store_path.exists():
+                    auth_store = json.loads(auth_store_path.read_text(encoding="utf-8"))
+                    if not active_provider:
+                        active_provider = (
+                            _resolve_configured_provider_id(
+                                auth_store.get("active_provider"),
+                                cfg,
+                                base_url=cfg_base_url,
+                            )
+                            or None
                         )
-                        or None
-                    )
-        except Exception:
-            logger.debug("Failed to load auth store for static models catalog", exc_info=True)
+            except Exception:
+                logger.debug("Failed to load auth store for static models catalog", exc_info=True)
 
         default_model = get_effective_default_model(cfg)
         detected_providers: set[str] = set()
@@ -5546,7 +5677,7 @@ def _static_models_catalog_without_live_probes() -> dict:
         named_custom_groups: dict[str, dict[str, object]] = {}
         custom_group_models: list[dict] = []
         canonical_to_raw_provider_key: dict[str, str] = {}
-        providers_cfg = _get_providers_cfg()
+        providers_cfg = _get_providers_cfg(cfg)
 
         def _append_model_id(provider_id: str | None, model_id: object) -> None:
             pid = _canonicalise_provider_id(provider_id)
@@ -5606,9 +5737,17 @@ def _static_models_catalog_without_live_probes() -> dict:
                     if has_local_signal:
                         detected_providers.add(canonical)
 
+        configured_provider_ids = {
+            _canonicalise_provider_id(provider_id)
+            for provider_id in (providers_cfg.keys() if isinstance(providers_cfg, dict) else ())
+        }
         for provider_id in set(_PROVIDER_MODELS) | set(_PROVIDER_DISPLAY):
             canonical = _canonicalise_provider_id(provider_id)
-            if canonical and _provider_has_key(canonical):
+            if canonical and (
+                config_obj is None and _provider_has_key(canonical)
+                or config_obj is not None
+                and (canonical in configured_provider_ids or canonical == active_provider)
+            ):
                 detected_providers.add(canonical)
 
         # Plugin-only providers (e.g. 9router) are not in the static
@@ -5722,7 +5861,7 @@ def _static_models_catalog_without_live_probes() -> dict:
 
             provider_name = _PROVIDER_DISPLAY.get(pid, pid.replace("-", " ").title())
             raw_key = canonical_to_raw_provider_key.get(pid, pid)
-            provider_cfg = _get_provider_cfg(raw_key)
+            provider_cfg = _get_provider_cfg(raw_key, cfg)
             raw_models = []
             if isinstance(provider_cfg, dict) and "models" in provider_cfg:
                 raw_models = _configured_model_options(provider_cfg["models"])

--- a/api/config.py
+++ b/api/config.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.request
 import uuid
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -3379,6 +3379,59 @@ class OwnerModelState:
     base_url: str | None
     api_key: str | None
     repaired: bool = False
+    runtime_fallback_allowed: bool = True
+
+
+def _owner_runtime_fallback_allowed(
+    config_obj: dict | None,
+    provider: str | None,
+) -> bool:
+    """Allow runtime credential lookup only for ambient or real owner lanes."""
+    if config_obj is None:
+        return True
+    return bool(provider and not str(provider).startswith("custom:"))
+
+
+def resolve_owner_runtime_state(
+    state: OwnerModelState,
+    *,
+    config_obj: dict | None = None,
+    owner_env: dict[str, str] | None = None,
+) -> OwnerModelState:
+    """Fill runtime credentials under the owner policy, never ambiently."""
+    if not state.runtime_fallback_allowed:
+        return state
+    try:
+        from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        previous_env = getattr(_thread_ctx, "env", None)
+        previous_block = getattr(_thread_ctx, "block_process_env_fallback", False)
+        if owner_env is not None:
+            _thread_ctx.env = dict(owner_env)
+            _thread_ctx.block_process_env_fallback = True
+        try:
+            runtime = resolve_runtime_provider_with_anthropic_env_lock(
+                resolve_runtime_provider,
+                requested=state.provider,
+                target_model=state.outbound_model,
+            )
+        finally:
+            if owner_env is not None:
+                if previous_env is None:
+                    delattr(_thread_ctx, "env")
+                else:
+                    _thread_ctx.env = previous_env
+                _thread_ctx.block_process_env_fallback = previous_block
+        return replace(
+            state,
+            provider=state.provider or runtime.get("provider"),
+            base_url=state.base_url or runtime.get("base_url"),
+            api_key=runtime.get("api_key") or state.api_key,
+        )
+    except Exception:
+        logger.debug("owner runtime credential resolution failed", exc_info=True)
+        return state
 
 
 def resolve_owner_model_state(
@@ -3440,6 +3493,9 @@ def resolve_owner_model_state(
                 base_url=resolved_base,
                 api_key=key if resolved_provider.startswith("custom:") else None,
                 repaired=False,
+                runtime_fallback_allowed=_owner_runtime_fallback_allowed(
+                    config_obj, resolved_provider
+                ),
             )
 
     if not repaired and requested and stored_provider:
@@ -3452,7 +3508,15 @@ def resolve_owner_model_state(
                     stored, owner_cfg, env=owner_env
                 )
                 base = base or entry_base
-            return OwnerModelState(requested, requested, stored, base, key, False)
+            return OwnerModelState(
+                requested,
+                requested,
+                stored,
+                base,
+                key,
+                False,
+                _owner_runtime_fallback_allowed(config_obj, stored),
+            )
 
     resolved_model, resolved_provider, resolved_base = resolve_model_provider(
         requested,
@@ -3478,6 +3542,9 @@ def resolve_owner_model_state(
         base_url=str(resolved_base).strip() if resolved_base else None,
         api_key=key,
         repaired=repaired,
+        runtime_fallback_allowed=_owner_runtime_fallback_allowed(
+            config_obj, str(resolved_provider) if resolved_provider else None
+        ),
     )
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -3494,7 +3494,7 @@ def resolve_owner_model_state(
                 default_provider
                 and _is_local_server_provider(default_provider)
                 and explicit_provider.startswith("custom:")
-                and explicit_provider in _custom_endpoint_slugs_for_base_url(
+                and explicit_provider.lower() in _custom_endpoint_slugs_for_base_url(
                     _get_provider_base_url(default_provider, owner_cfg)
                 )
             ):

--- a/api/config.py
+++ b/api/config.py
@@ -3397,32 +3397,44 @@ def resolve_owner_runtime_state(
     *,
     config_obj: dict | None = None,
     owner_env: dict[str, str] | None = None,
+    owner_profile: str | None = None,
 ) -> OwnerModelState:
     """Fill runtime credentials under the owner policy, never ambiently."""
     if not state.runtime_fallback_allowed:
         return state
     try:
+        from contextlib import nullcontext
+
         from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        previous_env = getattr(_thread_ctx, "env", None)
-        previous_block = getattr(_thread_ctx, "block_process_env_fallback", False)
-        if owner_env is not None:
-            _thread_ctx.env = dict(owner_env)
-            _thread_ctx.block_process_env_fallback = True
-        try:
-            runtime = resolve_runtime_provider_with_anthropic_env_lock(
-                resolve_runtime_provider,
-                requested=state.provider,
-                target_model=state.outbound_model,
+        scope = nullcontext()
+        if owner_profile and config_obj is not None:
+            from api.profiles import profile_scope_for_detached_worker
+
+            scope = profile_scope_for_detached_worker(
+                owner_profile,
+                "owner runtime provider resolution",
             )
-        finally:
-            if owner_env is not None:
-                if previous_env is None:
-                    delattr(_thread_ctx, "env")
-                else:
-                    _thread_ctx.env = previous_env
-                _thread_ctx.block_process_env_fallback = previous_block
+        with scope:
+            previous_env = getattr(_thread_ctx, "env", None)
+            previous_block = getattr(_thread_ctx, "block_process_env_fallback", False)
+            if owner_env is not None and not owner_profile:
+                _thread_ctx.env = dict(owner_env)
+                _thread_ctx.block_process_env_fallback = True
+            try:
+                runtime = resolve_runtime_provider_with_anthropic_env_lock(
+                    resolve_runtime_provider,
+                    requested=state.provider,
+                    target_model=state.outbound_model,
+                )
+            finally:
+                if owner_env is not None and not owner_profile:
+                    if previous_env is None:
+                        delattr(_thread_ctx, "env")
+                    else:
+                        _thread_ctx.env = previous_env
+                    _thread_ctx.block_process_env_fallback = previous_block
         return replace(
             state,
             provider=state.provider or runtime.get("provider"),
@@ -3478,6 +3490,15 @@ def resolve_owner_model_state(
         else:
             requested = str(bare_model or requested).strip()
             resolved_provider = explicit_provider
+            if (
+                default_provider
+                and _is_local_server_provider(default_provider)
+                and explicit_provider.startswith("custom:")
+                and explicit_provider in _custom_endpoint_slugs_for_base_url(
+                    _get_provider_base_url(default_provider, owner_cfg)
+                )
+            ):
+                resolved_provider = default_provider
             resolved_model = requested
             resolved_base = _get_provider_base_url(resolved_provider, owner_cfg)
             key = None

--- a/api/config.py
+++ b/api/config.py
@@ -3419,7 +3419,11 @@ def resolve_owner_runtime_state(
         with scope:
             from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
             if runtime_resolver is None:
-                from hermes_cli.runtime_provider import resolve_runtime_provider
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                except ImportError:
+                    def resolve_runtime_provider(**kwargs):
+                        return {"provider": kwargs.get("requested")}
             else:
                 resolve_runtime_provider = runtime_resolver
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1019,7 +1019,7 @@ def _run_gateway_chat_streaming(
             model_provider=model_provider,
         )
         base_url = _gateway_base_url(cfg)
-        gateway_api_key = _gateway_api_key()
+        api_key = _gateway_api_key()
         try:
             from api.config import _main_model_request_overrides
             _gw_overrides = _main_model_request_overrides(
@@ -1030,7 +1030,7 @@ def _run_gateway_chat_streaming(
         except Exception:
             _gw_overrides = {}
         _runs_api_enabled = _gateway_use_runs_api_enabled(cfg)
-        _use_runs_api = _runs_api_enabled and gateway_supports_approval(base_url, gateway_api_key)
+        _use_runs_api = _runs_api_enabled and gateway_supports_approval(base_url, api_key)
         if not _use_runs_api and runs_api_pending_marked:
             _finish_gateway_run_starting(stream_id, result="fallback")
             runs_api_pending_marked = False
@@ -1081,7 +1081,7 @@ def _run_gateway_chat_streaming(
             try:
                 final_text, usage = _run_gateway_runs_api_streaming(
                     session_id, msg_text, model, workspace, stream_id,
-                    base_url, gateway_api_key, prefill_messages, body_extras,
+                    base_url, api_key, prefill_messages, body_extras,
                     put_gateway_event=put_gateway_event,
                     cancel_event=cancel_event,
                     attachments=attachments,
@@ -1107,7 +1107,7 @@ def _run_gateway_chat_streaming(
         else:
             # Legacy gateway path: emit unsupported approval notice once per session,
             # but only when the gateway genuinely lacks approval capability.
-            approval_reason = gateway_approval_unavailable_reason(base_url, gateway_api_key)
+            approval_reason = gateway_approval_unavailable_reason(base_url, api_key)
             if approval_reason is not None:
                 if not hasattr(s, "_approval_notice_emitted"):
                     s._approval_notice_emitted = False
@@ -1129,8 +1129,8 @@ def _run_gateway_chat_streaming(
                 "Accept": "text/event-stream",
                 "X-Hermes-Session-Id": session_id,
             }
-            if gateway_api_key:
-                headers["Authorization"] = f"Bearer {gateway_api_key}"
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
                 # Scope Gateway long-term continuity to this WebUI conversation
                 # without exposing the browser's auth cookie or CSRF material.
                 headers["X-Hermes-Session-Key"] = f"webui:{session_id}"

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -624,7 +624,11 @@ def _run_gateway_runs_api_streaming(
         run_body = {
             "model": _gateway_model_field(model, cfg) or "default",
             "input": run_input,
-            **body_extras,
+            **{
+                key: value
+                for key, value in (body_extras or {}).items()
+                if key != "provider"
+            },
             "session_id": session_id,
         }
         if instructions_parts:
@@ -1015,7 +1019,7 @@ def _run_gateway_chat_streaming(
             model_provider=model_provider,
         )
         base_url = _gateway_base_url(cfg)
-        api_key = owner_state.api_key or _gateway_api_key()
+        gateway_api_key = _gateway_api_key()
         try:
             from api.config import _main_model_request_overrides
             _gw_overrides = _main_model_request_overrides(
@@ -1026,7 +1030,7 @@ def _run_gateway_chat_streaming(
         except Exception:
             _gw_overrides = {}
         _runs_api_enabled = _gateway_use_runs_api_enabled(cfg)
-        _use_runs_api = _runs_api_enabled and gateway_supports_approval(base_url, api_key)
+        _use_runs_api = _runs_api_enabled and gateway_supports_approval(base_url, gateway_api_key)
         if not _use_runs_api and runs_api_pending_marked:
             _finish_gateway_run_starting(stream_id, result="fallback")
             runs_api_pending_marked = False
@@ -1070,8 +1074,6 @@ def _run_gateway_chat_streaming(
             prefill_messages = []
         if _use_runs_api:
             body_extras = {}
-            if model_provider:
-                body_extras["provider"] = model_provider
             if reasoning_effort is not None:
                 body_extras["reasoning_effort"] = reasoning_effort
             if _gw_overrides.get("service_tier"):
@@ -1079,7 +1081,7 @@ def _run_gateway_chat_streaming(
             try:
                 final_text, usage = _run_gateway_runs_api_streaming(
                     session_id, msg_text, model, workspace, stream_id,
-                    base_url, api_key, prefill_messages, body_extras,
+                    base_url, gateway_api_key, prefill_messages, body_extras,
                     put_gateway_event=put_gateway_event,
                     cancel_event=cancel_event,
                     attachments=attachments,
@@ -1105,7 +1107,7 @@ def _run_gateway_chat_streaming(
         else:
             # Legacy gateway path: emit unsupported approval notice once per session,
             # but only when the gateway genuinely lacks approval capability.
-            approval_reason = gateway_approval_unavailable_reason(base_url, api_key)
+            approval_reason = gateway_approval_unavailable_reason(base_url, gateway_api_key)
             if approval_reason is not None:
                 if not hasattr(s, "_approval_notice_emitted"):
                     s._approval_notice_emitted = False
@@ -1127,8 +1129,8 @@ def _run_gateway_chat_streaming(
                 "Accept": "text/event-stream",
                 "X-Hermes-Session-Id": session_id,
             }
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
+            if gateway_api_key:
+                headers["Authorization"] = f"Bearer {gateway_api_key}"
                 # Scope Gateway long-term continuity to this WebUI conversation
                 # without exposing the browser's auth cookie or CSRF material.
                 headers["X-Hermes-Session-Key"] = f"webui:{session_id}"

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -627,8 +627,6 @@ def _run_gateway_runs_api_streaming(
             **body_extras,
             "session_id": session_id,
         }
-        if active_provider:
-            run_body["provider"] = active_provider
         if instructions_parts:
             run_body["instructions"] = "\n\n".join(part for part in instructions_parts if part)
         if conversation_history:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -25,6 +25,7 @@ from api.config import (
     STREAM_REASONING_TEXT,
     _get_session_agent_lock,
     _parse_provider_qualified_model_id,
+    resolve_owner_model_state,
     clear_session_writeback_owner_if_owned,
     coerce_reasoning_effort_for_model,
     gateway_approval_unavailable_reason,
@@ -626,6 +627,8 @@ def _run_gateway_runs_api_streaming(
             **body_extras,
             "session_id": session_id,
         }
+        if active_provider:
+            run_body["provider"] = active_provider
         if instructions_parts:
             run_body["instructions"] = "\n\n".join(part for part in instructions_parts if part)
         if conversation_history:
@@ -994,13 +997,20 @@ def _run_gateway_chat_streaming(
         if getattr(s, "profile", None):
             from api.profiles import resolve_profile_config_context
             _owner, cfg = resolve_profile_config_context(s.profile)
+        owner_state = resolve_owner_model_state(
+            model,
+            model_provider,
+            config_obj=cfg,
+        )
+        model = owner_state.outbound_model
+        model_provider = owner_state.provider
         reasoning_effort = _gateway_reasoning_effort_for_request(
             cfg,
             model=model,
             model_provider=model_provider,
         )
         base_url = _gateway_base_url(cfg)
-        api_key = _gateway_api_key()
+        api_key = owner_state.api_key or _gateway_api_key()
         try:
             from api.config import _main_model_request_overrides
             _gw_overrides = _main_model_request_overrides(

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -994,13 +994,20 @@ def _run_gateway_chat_streaming(
         from api.config import get_config  # imported lazily to avoid config-cycle churn
 
         cfg = get_config()
+        owner_env = None
         if getattr(s, "profile", None):
-            from api.profiles import resolve_profile_config_context
+            from api.profiles import (
+                get_hermes_home_for_profile,
+                get_profile_runtime_env,
+                resolve_profile_config_context,
+            )
             _owner, cfg = resolve_profile_config_context(s.profile)
+            owner_env = get_profile_runtime_env(get_hermes_home_for_profile(s.profile))
         owner_state = resolve_owner_model_state(
             model,
             model_provider,
             config_obj=cfg,
+            owner_env=owner_env,
         )
         model = owner_state.outbound_model
         model_provider = owner_state.provider

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -154,7 +154,7 @@ _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
 
-def _gateway_model_field(model: str | None) -> str:
+def _gateway_model_field(model: str | None, config_obj: dict | None = None) -> str:
     """Return the bare model name to put in a gateway request body.
 
     The picker and ``_resolve_compatible_session_model_state`` intentionally
@@ -170,7 +170,7 @@ def _gateway_model_field(model: str | None) -> str:
     if not model:
         return ""
     value = str(model).strip()
-    parsed = _parse_provider_qualified_model_id(value)
+    parsed = _parse_provider_qualified_model_id(value, config_obj)
     if parsed:
         return str(parsed[0] or "").strip()
     return value
@@ -621,7 +621,7 @@ def _run_gateway_runs_api_streaming(
         if isinstance(run_input, list):
             run_input = [{"role": "user", "content": run_input}]
         run_body = {
-            "model": _gateway_model_field(model) or "default",
+            "model": _gateway_model_field(model, cfg) or "default",
             "input": run_input,
             **body_extras,
             "session_id": session_id,
@@ -991,6 +991,9 @@ def _run_gateway_chat_streaming(
         from api.config import get_config  # imported lazily to avoid config-cycle churn
 
         cfg = get_config()
+        if getattr(s, "profile", None):
+            from api.profiles import resolve_profile_config_context
+            _owner, cfg = resolve_profile_config_context(s.profile)
         reasoning_effort = _gateway_reasoning_effort_for_request(
             cfg,
             model=model,
@@ -1124,7 +1127,7 @@ def _run_gateway_chat_streaming(
                     logger.debug("Failed to build gateway multimodal attachment payload", exc_info=True)
                     message_content = str(msg_text or "")
             body = {
-                "model": _gateway_model_field(model) or "default",
+                "model": _gateway_model_field(model, cfg) or "default",
                 "stream": True,
                 "messages": [*prefill_messages, {"role": "user", "content": message_content}],
             }

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2498,36 +2498,11 @@ def _profile_model_selection_exists(
 
 
 def _get_available_models_for_profile_validation(config_obj: dict | None = None) -> dict:
-    """Build the validation catalog for the profile whose config is supplied.
-
-    A clone may source its config from a profile other than the active one, so
-    validation must not fall back to the process-wide model catalog in that
-    case. The config contains the models advertised by custom providers and
-    the source profile's selected model.
-    """
-    from api.config import _configured_model_ids, get_available_models
+    """Return the shared network-free catalog for the requested owner."""
+    from api.config import _static_models_catalog_without_live_probes, get_available_models
 
     if isinstance(config_obj, dict):
-        groups = []
-        model_cfg = config_obj.get("model")
-        if isinstance(model_cfg, dict):
-            provider = str(model_cfg.get("provider") or "").strip()
-            configured_models = model_cfg.get("models") or []
-            model_ids = [model_cfg.get("default"), *_configured_model_ids(configured_models)]
-            models = [{"id": str(model_id)} for model_id in model_ids if model_id]
-            if provider or models:
-                groups.append({"provider_id": provider, "models": models, "extra_models": []})
-        providers = config_obj.get("providers")
-        if isinstance(providers, dict):
-            for provider, provider_cfg in providers.items():
-                if not isinstance(provider_cfg, dict):
-                    continue
-                models = [
-                    {"id": str(model_id)}
-                    for model_id in _configured_model_ids(provider_cfg.get("models"))
-                ]
-                groups.append({"provider_id": str(provider), "models": models, "extra_models": []})
-        return {"groups": groups}
+        return _static_models_catalog_without_live_probes(config_obj)
     return get_available_models()
 
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2505,18 +2505,16 @@ def _get_available_models_for_profile_validation(config_obj: dict | None = None)
     case. The config contains the models advertised by custom providers and
     the source profile's selected model.
     """
+    from api.config import _configured_model_ids, get_available_models
+
     if isinstance(config_obj, dict):
         groups = []
         model_cfg = config_obj.get("model")
         if isinstance(model_cfg, dict):
             provider = str(model_cfg.get("provider") or "").strip()
             configured_models = model_cfg.get("models") or []
-            if isinstance(configured_models, (str, bytes)):
-                configured_models = [configured_models]
-            elif not isinstance(configured_models, (list, tuple)):
-                configured_models = []
-            values = [model_cfg.get("default"), *configured_models]
-            models = [{"id": str(value)} for value in values if value]
+            model_ids = [model_cfg.get("default"), *_configured_model_ids(configured_models)]
+            models = [{"id": str(model_id)} for model_id in model_ids if model_id]
             if provider or models:
                 groups.append({"provider_id": provider, "models": models, "extra_models": []})
         providers = config_obj.get("providers")
@@ -2524,20 +2522,12 @@ def _get_available_models_for_profile_validation(config_obj: dict | None = None)
             for provider, provider_cfg in providers.items():
                 if not isinstance(provider_cfg, dict):
                     continue
-                models = provider_cfg.get("models") or []
-                if isinstance(models, dict):
-                    models = [{"id": str(value)} for value in models]
-                elif isinstance(models, (list, tuple)):
-                    models = [
-                        value if isinstance(value, dict) else {"id": str(value)}
-                        for value in models
-                    ]
-                else:
-                    models = []
+                models = [
+                    {"id": str(model_id)}
+                    for model_id in _configured_model_ids(provider_cfg.get("models"))
+                ]
                 groups.append({"provider_id": str(provider), "models": models, "extra_models": []})
         return {"groups": groups}
-    from api.config import get_available_models
-
     return get_available_models()
 
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2518,12 +2518,7 @@ def _validate_profile_model_selection(
     if available_models is not None:
         catalog = available_models
     else:
-        try:
-            catalog = _get_available_models_for_profile_validation(config_obj)
-        except TypeError:
-            # Preserve compatibility with older test and plugin seams that
-            # provide the catalog helper as a zero-argument callable.
-            catalog = _get_available_models_for_profile_validation()
+        catalog = _get_available_models_for_profile_validation(config_obj)
     if _profile_model_selection_exists(catalog, default_model, model_provider, config_obj):
         return
     if default_model and model_provider:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2498,6 +2498,44 @@ def _profile_model_selection_exists(
 
 
 def _get_available_models_for_profile_validation(config_obj: dict | None = None) -> dict:
+    """Build the validation catalog for the profile whose config is supplied.
+
+    A clone may source its config from a profile other than the active one, so
+    validation must not fall back to the process-wide model catalog in that
+    case. The config contains the models advertised by custom providers and
+    the source profile's selected model.
+    """
+    if isinstance(config_obj, dict):
+        groups = []
+        model_cfg = config_obj.get("model")
+        if isinstance(model_cfg, dict):
+            provider = str(model_cfg.get("provider") or "").strip()
+            configured_models = model_cfg.get("models") or []
+            if isinstance(configured_models, (str, bytes)):
+                configured_models = [configured_models]
+            elif not isinstance(configured_models, (list, tuple)):
+                configured_models = []
+            values = [model_cfg.get("default"), *configured_models]
+            models = [{"id": str(value)} for value in values if value]
+            if provider or models:
+                groups.append({"provider_id": provider, "models": models, "extra_models": []})
+        providers = config_obj.get("providers")
+        if isinstance(providers, dict):
+            for provider, provider_cfg in providers.items():
+                if not isinstance(provider_cfg, dict):
+                    continue
+                models = provider_cfg.get("models") or []
+                if isinstance(models, dict):
+                    models = [{"id": str(value)} for value in models]
+                elif isinstance(models, (list, tuple)):
+                    models = [
+                        value if isinstance(value, dict) else {"id": str(value)}
+                        for value in models
+                    ]
+                else:
+                    models = []
+                groups.append({"provider_id": str(provider), "models": models, "extra_models": []})
+        return {"groups": groups}
     from api.config import get_available_models
 
     return get_available_models()
@@ -2594,8 +2632,9 @@ def create_profile_api(name: str, clone_from: str = None,
     default_model, model_provider = _split_webui_provider_model_value(
         default_model, model_provider, model_config
     )
+    validation_config = model_config if clone_from and clone_config else None
     _validate_profile_model_selection(
-        default_model, model_provider, config_obj=model_config
+        default_model, model_provider, config_obj=validation_config
     )
 
     try:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -828,7 +828,11 @@ def get_hermes_home_for_profile(name: str) -> Path:
 
 def resolve_profile_config_context(profile: str | None = None) -> tuple[str, dict]:
     """Return the effective profile owner and its isolated configuration."""
-    owner = str(profile or get_active_profile_name() or "default").strip() or "default"
+    requested = str(profile or "").strip()
+    if requested and (_PROFILE_ID_RE.fullmatch(requested) or _is_root_profile(requested)):
+        owner = requested
+    else:
+        owner = str(get_active_profile_name() or "default").strip() or "default"
     if _is_isolated_profile_mode():
         owner = _isolated_profile_name()
     try:
@@ -2494,34 +2498,6 @@ def _profile_model_selection_exists(
 
 
 def _get_available_models_for_profile_validation(config_obj: dict | None = None) -> dict:
-    if isinstance(config_obj, dict):
-        groups = []
-        model_cfg = config_obj.get("model")
-        if isinstance(model_cfg, dict):
-            provider = str(model_cfg.get("provider") or "").strip()
-            models = []
-            for value in [model_cfg.get("default"), *(model_cfg.get("models") or [])]:
-                if value:
-                    models.append({"id": str(value)})
-            if provider or models:
-                groups.append({"provider_id": provider, "models": models, "extra_models": []})
-        providers = config_obj.get("providers")
-        if isinstance(providers, dict):
-            for provider, provider_cfg in providers.items():
-                if not isinstance(provider_cfg, dict):
-                    continue
-                models = provider_cfg.get("models") or []
-                if isinstance(models, dict):
-                    models = [{"id": str(value)} for value in models]
-                elif isinstance(models, list):
-                    models = [
-                        value if isinstance(value, dict) else {"id": str(value)}
-                        for value in models
-                    ]
-                else:
-                    models = []
-                groups.append({"provider_id": str(provider), "models": models, "extra_models": []})
-        return {"groups": groups}
     from api.config import get_available_models
 
     return get_available_models()

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -826,6 +826,20 @@ def get_hermes_home_for_profile(name: str) -> Path:
     return _resolve_profile_home_for_name(name)
 
 
+def resolve_profile_config_context(profile: str | None = None) -> tuple[str, dict]:
+    """Return the effective profile owner and its isolated configuration."""
+    owner = str(profile or get_active_profile_name() or "default").strip() or "default"
+    if _is_isolated_profile_mode():
+        owner = _isolated_profile_name()
+    try:
+        from api.config import get_config_for_profile_home
+        config_obj = get_config_for_profile_home(get_hermes_home_for_profile(owner))
+    except Exception:
+        logger.debug("Failed to load profile configuration for %r", owner, exc_info=True)
+        config_obj = {}
+    return owner, config_obj if isinstance(config_obj, dict) else {}
+
+
 _TERMINAL_ENV_MAPPINGS = {
     'backend': 'TERMINAL_ENV',
     'env_type': 'TERMINAL_ENV',
@@ -2392,7 +2406,11 @@ def _clean_profile_config_value(value: Optional[str], field: str) -> Optional[st
     return cleaned
 
 
-def _split_webui_provider_model_value(default_model: Optional[str], model_provider: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+def _split_webui_provider_model_value(
+    default_model: Optional[str],
+    model_provider: Optional[str],
+    config_obj: dict | None = None,
+) -> tuple[Optional[str], Optional[str]]:
     """Normalize WebUI-internal @provider:model picker values for config.yaml.
 
     Parsing is delegated to ``config._parse_provider_qualified_model_id()`` so
@@ -2407,7 +2425,7 @@ def _split_webui_provider_model_value(default_model: Optional[str], model_provid
     if model and model.startswith("@") and ":" in model:
         from api.config import _parse_provider_qualified_model_id
 
-        parsed = _parse_provider_qualified_model_id(model)
+        parsed = _parse_provider_qualified_model_id(model, config_obj)
         if parsed:
             model_part, provider_part = parsed
             provider = provider or _clean_profile_config_value(provider_part, "model_provider")
@@ -2415,7 +2433,7 @@ def _split_webui_provider_model_value(default_model: Optional[str], model_provid
     return model, provider
 
 
-def _strip_webui_provider_prefix(model_id: object) -> str:
+def _strip_webui_provider_prefix(model_id: object, config_obj: dict | None = None) -> str:
     """Return the bare model name from a WebUI ``@provider:model`` value.
 
     Uses the same shared grammar as ``_split_webui_provider_model_value()`` so a
@@ -2425,7 +2443,7 @@ def _strip_webui_provider_prefix(model_id: object) -> str:
     if value.startswith("@") and ":" in value:
         from api.config import _parse_provider_qualified_model_id
 
-        parsed = _parse_provider_qualified_model_id(value)
+        parsed = _parse_provider_qualified_model_id(value, config_obj)
         if parsed:
             return str(parsed[0] or "").strip()
     return value
@@ -2435,6 +2453,7 @@ def _profile_model_selection_exists(
     available_models: object,
     default_model: Optional[str],
     model_provider: Optional[str],
+    config_obj: dict | None = None,
 ) -> bool:
     """Return True when a profile default model/provider exists in /api/models."""
     if not default_model and not model_provider:
@@ -2461,7 +2480,7 @@ def _profile_model_selection_exists(
                 continue
             if default_model and (
                 model_id == default_model
-                or _strip_webui_provider_prefix(model_id) == default_model
+                or _strip_webui_provider_prefix(model_id, config_obj) == default_model
             ):
                 model_seen = True
                 if model_provider:
@@ -2474,7 +2493,35 @@ def _profile_model_selection_exists(
     return bool(model_seen)
 
 
-def _get_available_models_for_profile_validation() -> dict:
+def _get_available_models_for_profile_validation(config_obj: dict | None = None) -> dict:
+    if isinstance(config_obj, dict):
+        groups = []
+        model_cfg = config_obj.get("model")
+        if isinstance(model_cfg, dict):
+            provider = str(model_cfg.get("provider") or "").strip()
+            models = []
+            for value in [model_cfg.get("default"), *(model_cfg.get("models") or [])]:
+                if value:
+                    models.append({"id": str(value)})
+            if provider or models:
+                groups.append({"provider_id": provider, "models": models, "extra_models": []})
+        providers = config_obj.get("providers")
+        if isinstance(providers, dict):
+            for provider, provider_cfg in providers.items():
+                if not isinstance(provider_cfg, dict):
+                    continue
+                models = provider_cfg.get("models") or []
+                if isinstance(models, dict):
+                    models = [{"id": str(value)} for value in models]
+                elif isinstance(models, list):
+                    models = [
+                        value if isinstance(value, dict) else {"id": str(value)}
+                        for value in models
+                    ]
+                else:
+                    models = []
+                groups.append({"provider_id": str(provider), "models": models, "extra_models": []})
+        return {"groups": groups}
     from api.config import get_available_models
 
     return get_available_models()
@@ -2484,16 +2531,21 @@ def _validate_profile_model_selection(
     default_model: Optional[str],
     model_provider: Optional[str],
     available_models: Optional[dict] = None,
+    config_obj: dict | None = None,
 ) -> None:
     """Reject profile model defaults that do not exist in the server catalog."""
     if not default_model and not model_provider:
         return
-    catalog = (
-        available_models
-        if available_models is not None
-        else _get_available_models_for_profile_validation()
-    )
-    if _profile_model_selection_exists(catalog, default_model, model_provider):
+    if available_models is not None:
+        catalog = available_models
+    else:
+        try:
+            catalog = _get_available_models_for_profile_validation(config_obj)
+        except TypeError:
+            # Preserve compatibility with older test and plugin seams that
+            # provide the catalog helper as a zero-argument callable.
+            catalog = _get_available_models_for_profile_validation()
+    if _profile_model_selection_exists(catalog, default_model, model_provider, config_obj):
         return
     if default_model and model_provider:
         raise ValueError(
@@ -2511,7 +2563,6 @@ def _write_model_defaults_to_config(
     model_provider: Optional[str] = None,
 ) -> None:
     """Write model default/provider fields into config.yaml for a profile."""
-    default_model, model_provider = _split_webui_provider_model_value(default_model, model_provider)
     if not default_model and not model_provider:
         return
     config_path = profile_dir / 'config.yaml'
@@ -2527,6 +2578,9 @@ def _write_model_defaults_to_config(
                 cfg = loaded
         except Exception:
             logger.debug("Failed to load config from %s", config_path)
+    default_model, model_provider = _split_webui_provider_model_value(
+        default_model, model_provider, cfg
+    )
     model_section = cfg.get('model', {})
     if not isinstance(model_section, dict):
         model_section = {}
@@ -2555,8 +2609,18 @@ def create_profile_api(name: str, clone_from: str = None,
     # also validates it. Any caller that bypasses the HTTP layer gets protection.
     if clone_from is not None and not _is_root_profile(clone_from):
         _validate_profile_name(clone_from)
-    default_model, model_provider = _split_webui_provider_model_value(default_model, model_provider)
-    _validate_profile_model_selection(default_model, model_provider)
+    try:
+        from api.config import get_config_for_profile_home
+        source_home = _resolve_profile_home_for_name(clone_from) if clone_from and clone_config else get_active_hermes_home()
+        model_config = get_config_for_profile_home(source_home)
+    except Exception:
+        model_config = {}
+    default_model, model_provider = _split_webui_provider_model_value(
+        default_model, model_provider, model_config
+    )
+    _validate_profile_model_selection(
+        default_model, model_provider, config_obj=model_config
+    )
 
     try:
         from hermes_cli.profiles import create_profile

--- a/api/routes.py
+++ b/api/routes.py
@@ -7389,20 +7389,23 @@ def _resolve_compatible_session_model_state(
     persisted model wins over the catalog and the catalog is only consulted
     for the default-model backstop.
     """
-    owner_state = resolve_owner_model_state(
-        model_id,
-        model_provider,
-        config_obj=profile_config,
-        explicitly_picked=explicit_model_pick,
-    )
+    owner_kwargs = {"config_obj": profile_config}
+    if explicit_model_pick:
+        owner_kwargs["explicitly_picked"] = True
+    owner_state = resolve_owner_model_state(model_id, model_provider, **owner_kwargs)
     if isinstance(profile_config, dict):
         model = owner_state.outbound_model if owner_state.repaired else owner_state.model
         requested_provider = owner_state.provider
-        owner_repaired = owner_state.repaired
+        _owner_model_bare, _owner_explicit_provider = _split_provider_qualified_model(
+            model, profile_config
+        )
+        if model_provider and not _owner_explicit_provider:
+            requested_provider = _clean_session_model_provider(
+                model_provider, profile_config
+            )
     else:
         model = str(model_id or "").strip()
         requested_provider = _clean_session_model_provider(model_provider, profile_config)
-        owner_repaired = False
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
@@ -7437,9 +7440,26 @@ def _resolve_compatible_session_model_state(
             requested_provider == "openai-codex"
             and model_prefix == "openai"
         )
-        if explicit_provider and isinstance(profile_config, dict):
+        profile_provider_normalized = _normalize_provider_id(profile_provider)
+        explicit_cross_profile_model = (
+            bool(profile_provider_normalized)
+            and bool(model_provider_from_name := (
+                _normalize_provider_id(model_prefix) if "/" in model else ""
+            ))
+            and model_provider_from_name != profile_provider_normalized
+        )
+        if (
+            explicit_provider
+            and isinstance(profile_config, dict)
+            and not stale_codex_openai_slash_id
+            and not explicit_cross_profile_model
+        ):
             return model, requested_provider, False
-        if not explicit_provider and not stale_codex_openai_slash_id:
+        if (
+            not explicit_provider
+            and not stale_codex_openai_slash_id
+            and not explicit_cross_profile_model
+        ):
             _profile_default = str(profile_default_model or "").strip()
             _profile_prov = _clean_session_model_provider(profile_provider, profile_config)
             _providers_match_for_repair = (
@@ -13853,10 +13873,15 @@ def handle_get(handler, parsed) -> bool:
                     s, _stored_provider_for_lookup
                 )[2]
                 _session_owner_env = None
-                if _session_owner_config is not None and getattr(s, "profile", None):
+                _session_profile = getattr(s, "profile", None)
+                if (
+                    _session_owner_config is not None
+                    and isinstance(_session_profile, str)
+                    and _session_profile.strip()
+                ):
                     from api.profiles import get_hermes_home_for_profile, get_profile_runtime_env
                     _session_owner_env = get_profile_runtime_env(
-                        get_hermes_home_for_profile(s.profile)
+                        get_hermes_home_for_profile(_session_profile)
                     )
                 _model_for_lookup = (
                     effective_model or _stored_model_for_lookup
@@ -25144,10 +25169,7 @@ def _llm_git_commit_message(system_prompt: str, user_prompt: str, session=None) 
         "git commit message",
         logger_override=logger,
     ):
-        from api.config import (
-            get_effective_default_model,
-            resolve_owner_model_state,
-        )
+        from api.config import get_effective_default_model
 
         session_model = str(getattr(session, "model", "") or "").strip()
         session_provider = str(getattr(session, "model_provider", "") or "").strip() or None
@@ -27829,6 +27851,7 @@ def _handle_handoff_summary(handler, body):
         AIAgent = require_ai_agent_class()
 
         # Try to resolve model from an existing session, fall back to default.
+        s_obj = None
         resolved_model = None
         resolved_provider = None
         resolved_base_url = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -7093,6 +7093,36 @@ def _read_profile_model_config(
     return _provider, _default, _pcfg
 
 
+def _resolve_persisted_session_owner_state(
+    session,
+    model: str | None = None,
+    provider: str | None = None,
+):
+    """Resolve a persisted session through its owner snapshot and env."""
+    from api.config import resolve_owner_model_state
+
+    profile = getattr(session, "profile", None)
+    if not profile:
+        return resolve_owner_model_state(model, provider, config_obj=None), None
+    from api.profiles import (
+        get_hermes_home_for_profile,
+        get_profile_runtime_env,
+        resolve_profile_config_context,
+    )
+
+    _owner, owner_cfg = resolve_profile_config_context(profile)
+    owner_env = get_profile_runtime_env(get_hermes_home_for_profile(profile))
+    return (
+        resolve_owner_model_state(
+            model,
+            provider,
+            config_obj=owner_cfg,
+            owner_env=owner_env,
+        ),
+        owner_cfg,
+    )
+
+
 # perf(webui/session-load-latency) tier2a: process-wide cache for parsed
 # profile config.yaml. Key = (profile_name, inode, mtime, size); value = parsed
 # dict. inode tracks atomic-rename edits (most editors replace files, giving a
@@ -7879,6 +7909,7 @@ def _session_context_length_lookup_state(
     model: str | None,
     provider: str | None,
     config_obj: dict | None = None,
+    owner_env: dict[str, str] | None = None,
 ) -> tuple[str, str, str, str]:
     """Return model/provider/base_url/api_key inputs for session context lookup.
 
@@ -7895,7 +7926,10 @@ def _session_context_length_lookup_state(
     cfg = config_obj if isinstance(config_obj, dict) else None
     if cfg is not None:
         owner_state = resolve_owner_model_state(
-            model_for_lookup, provider_for_lookup, config_obj=cfg
+            model_for_lookup,
+            provider_for_lookup,
+            config_obj=cfg,
+            owner_env=owner_env,
         )
         owner_lookup = _context_length_lookup_inputs_for_model(
             owner_state.outbound_model,
@@ -13807,6 +13841,12 @@ def handle_get(handler, parsed) -> bool:
                 _session_owner_config = _read_profile_model_config(
                     s, _stored_provider_for_lookup
                 )[2]
+                _session_owner_env = None
+                if _session_owner_config is not None and getattr(s, "profile", None):
+                    from api.profiles import get_hermes_home_for_profile, get_profile_runtime_env
+                    _session_owner_env = get_profile_runtime_env(
+                        get_hermes_home_for_profile(s.profile)
+                    )
                 _model_for_lookup = (
                     effective_model or _stored_model_for_lookup
                 ).strip()
@@ -13819,6 +13859,7 @@ def handle_get(handler, parsed) -> bool:
                     _model_for_lookup,
                     effective_provider or getattr(s, "model_provider", None) or "",
                     _session_owner_config,
+                    _session_owner_env,
                 )
                 _fb_cl = _resolve_context_length_for_session_model(
                     _model_for_lookup,
@@ -17460,14 +17501,21 @@ def handle_post(handler, parsed) -> bool:
                 ]
 
                 _owner, _owner_cfg = profiles_api.resolve_profile_config_context(active_profile)
+                _owner_env = profiles_api.get_profile_runtime_env(
+                    profiles_api.get_hermes_home_for_profile(active_profile)
+                )
                 _main_state = resolve_owner_model_state(
-                    get_effective_default_model(), config_obj=_owner_cfg
+                    get_effective_default_model(),
+                    config_obj=_owner_cfg,
+                    owner_env=_owner_env,
                 )
                 _main_model = _main_state.outbound_model
                 _main_provider = _main_state.provider
                 _main_base_url = _main_state.base_url
                 _main_api_key = _main_state.api_key
                 try:
+                    if _owner_cfg is not None:
+                        raise LookupError("owner-scoped runtime fallback disabled")
                     from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                     from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -24540,13 +24588,10 @@ def _handle_chat_sync(handler, body):
         AIAgent = require_ai_agent_class()
 
         with CHAT_LOCK:
-            from api.config import (
-                resolve_owner_model_state,
-            )
-            _owner_state = resolve_owner_model_state(
+            _owner_state, _owner_cfg = _resolve_persisted_session_owner_state(
+                s,
                 s.model,
                 getattr(s, "model_provider", None),
-                config_obj=_pp_cfg,
             )
             _model = _owner_state.outbound_model
             _provider = _owner_state.provider
@@ -24554,6 +24599,8 @@ def _handle_chat_sync(handler, body):
             # Resolve API key via Hermes runtime provider (matches gateway behaviour)
             _api_key = _owner_state.api_key
             try:
+                if _owner_cfg is not None:
+                    raise LookupError("owner-scoped runtime fallback disabled")
                 from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                 from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -25126,22 +25173,18 @@ def _llm_git_commit_message(system_prompt: str, user_prompt: str, session=None) 
 
         session_model = str(getattr(session, "model", "") or "").strip()
         session_provider = str(getattr(session, "model_provider", "") or "").strip() or None
-        try:
-            _owner, _owner_cfg = profiles_api.resolve_profile_config_context(
-                getattr(session, "profile", None)
-            )
-        except Exception:
-            _owner_cfg = None
-        _main_state = resolve_owner_model_state(
+        _main_state, _owner_cfg = _resolve_persisted_session_owner_state(
+            session,
             session_model or get_effective_default_model(),
             session_provider,
-            config_obj=_owner_cfg,
         )
         _main_model = _main_state.outbound_model
         _main_provider = _main_state.provider
         _main_base_url = _main_state.base_url
         _main_api_key = _main_state.api_key
         try:
+            if _owner_cfg is not None:
+                raise LookupError("owner-scoped runtime fallback disabled")
             from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -27175,15 +27218,10 @@ def _handle_session_compress(handler, body):
         import hermes_cli.runtime_provider as _runtime_provider
         AIAgent = require_ai_agent_class()
 
-        try:
-            from api.profiles import resolve_profile_config_context
-            _owner_name, _owner_cfg = resolve_profile_config_context(getattr(s, "profile", None))
-        except Exception:
-            _owner_cfg = None
-        _owner_state = _cfg.resolve_owner_model_state(
+        _owner_state, _owner_cfg = _resolve_persisted_session_owner_state(
+            s,
             s.model,
             getattr(s, "model_provider", None),
-            config_obj=_owner_cfg,
         )
         resolved_model = _owner_state.outbound_model
         resolved_provider = _owner_state.provider
@@ -27191,6 +27229,8 @@ def _handle_session_compress(handler, body):
 
         resolved_api_key = _owner_state.api_key
         try:
+            if _owner_cfg is not None:
+                raise LookupError("owner-scoped runtime fallback disabled")
             _rt = resolve_runtime_provider_with_anthropic_env_lock(
                 _runtime_provider.resolve_runtime_provider,
                 requested=resolved_provider,
@@ -27868,17 +27908,10 @@ def _handle_handoff_summary(handler, body):
         except Exception:
             pass
 
-        try:
-            from api.profiles import resolve_profile_config_context
-            _owner_name, _owner_cfg = resolve_profile_config_context(
-                getattr(s_obj, "profile", None)
-            )
-        except Exception:
-            _owner_cfg = None
-        _owner_state = _cfg.resolve_owner_model_state(
+        _owner_state, _owner_cfg = _resolve_persisted_session_owner_state(
+            s_obj,
             resolved_model,
             session_model_provider,
-            config_obj=_owner_cfg,
         )
         resolved_model = _owner_state.outbound_model
         resolved_provider = _owner_state.provider
@@ -27886,6 +27919,8 @@ def _handle_handoff_summary(handler, body):
 
         resolved_api_key = _owner_state.api_key
         try:
+            if _owner_cfg is not None:
+                raise LookupError("owner-scoped runtime fallback disabled")
             _rt = resolve_runtime_provider_with_anthropic_env_lock(
                 _runtime_provider.resolve_runtime_provider,
                 requested=resolved_provider,

--- a/api/routes.py
+++ b/api/routes.py
@@ -7870,6 +7870,22 @@ def _session_context_length_lookup_state(
     if not model_for_lookup:
         return "", provider_for_lookup, "", ""
     cfg = config_obj if isinstance(config_obj, dict) else None
+    if cfg is not None:
+        # An owner-scoped reload must not pass through the process-global
+        # resolver; the lookup helper already carries the complete owner config.
+        bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup, cfg)
+        owner_provider = provider_for_lookup or explicit_provider or ""
+        owner_lookup = _context_length_lookup_inputs_for_model(
+            bare_model or model_for_lookup,
+            owner_provider or None,
+            cfg=cfg,
+        )
+        return (
+            str(bare_model or model_for_lookup).strip(),
+            str(owner_lookup.provider or owner_provider).strip(),
+            str(owner_lookup.base_url or "").strip(),
+            str(owner_lookup.api_key or "").strip(),
+        )
     try:
         from api.config import model_with_provider_context, resolve_model_provider
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7099,11 +7099,16 @@ def _resolve_persisted_session_owner_state(
     provider: str | None = None,
 ):
     """Resolve a persisted session through its owner snapshot and env."""
-    from api.config import resolve_owner_model_state
+    from api.config import resolve_owner_model_state, resolve_owner_runtime_state
 
+    if model is None:
+        model = getattr(session, "model", None)
+    if provider is None:
+        provider = getattr(session, "model_provider", None)
     profile = getattr(session, "profile", None)
     if not profile:
-        return resolve_owner_model_state(model, provider, config_obj=None), None
+        state = resolve_owner_model_state(model, provider, config_obj=None)
+        return resolve_owner_runtime_state(state, config_obj=None), None
     from api.profiles import (
         get_hermes_home_for_profile,
         get_profile_runtime_env,
@@ -7112,15 +7117,17 @@ def _resolve_persisted_session_owner_state(
 
     _owner, owner_cfg = resolve_profile_config_context(profile)
     owner_env = get_profile_runtime_env(get_hermes_home_for_profile(profile))
-    return (
-        resolve_owner_model_state(
-            model,
-            provider,
-            config_obj=owner_cfg,
-            owner_env=owner_env,
-        ),
-        owner_cfg,
+    state = resolve_owner_model_state(
+        model,
+        provider,
+        config_obj=owner_cfg,
+        owner_env=owner_env,
     )
+    return resolve_owner_runtime_state(
+        state,
+        config_obj=owner_cfg,
+        owner_env=owner_env,
+    ), owner_cfg
 
 
 # perf(webui/session-load-latency) tier2a: process-wide cache for parsed
@@ -7388,10 +7395,13 @@ def _resolve_compatible_session_model_state(
         explicitly_picked=explicit_model_pick,
     )
     if isinstance(profile_config, dict):
-        return owner_state.model, owner_state.provider, owner_state.repaired
-
-    model = str(model_id or "").strip()
-    requested_provider = _clean_session_model_provider(model_provider, profile_config)
+        model = owner_state.outbound_model if owner_state.repaired else owner_state.model
+        requested_provider = owner_state.provider
+        owner_repaired = owner_state.repaired
+    else:
+        model = str(model_id or "").strip()
+        requested_provider = _clean_session_model_provider(model_provider, profile_config)
+        owner_repaired = False
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
@@ -17493,6 +17503,7 @@ def handle_post(handler, parsed) -> bool:
                 from api.config import (
                     get_effective_default_model,
                     resolve_owner_model_state,
+                    resolve_owner_runtime_state,
                 )
 
                 messages = [
@@ -17509,27 +17520,15 @@ def handle_post(handler, parsed) -> bool:
                     config_obj=_owner_cfg,
                     owner_env=_owner_env,
                 )
+                _main_state = resolve_owner_runtime_state(
+                    _main_state,
+                    config_obj=_owner_cfg,
+                    owner_env=_owner_env,
+                )
                 _main_model = _main_state.outbound_model
                 _main_provider = _main_state.provider
                 _main_base_url = _main_state.base_url
                 _main_api_key = _main_state.api_key
-                try:
-                    if _owner_cfg is not None:
-                        raise LookupError("owner-scoped runtime fallback disabled")
-                    from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-                    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-                    _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                        resolve_runtime_provider,
-                        requested=_main_provider,
-                    )
-                    _main_api_key = _rt.get("api_key")
-                    if not _main_provider:
-                        _main_provider = _rt.get("provider")
-                    if not _main_base_url:
-                        _main_base_url = _rt.get("base_url")
-                except Exception as _e:
-                    logger.debug("update summary runtime provider resolution failed: %s", _e)
                 main_runtime = {
                     "provider": _main_provider,
                     "model": _main_model,
@@ -24596,29 +24595,7 @@ def _handle_chat_sync(handler, body):
             _model = _owner_state.outbound_model
             _provider = _owner_state.provider
             _base_url = _owner_state.base_url
-            # Resolve API key via Hermes runtime provider (matches gateway behaviour)
             _api_key = _owner_state.api_key
-            try:
-                if _owner_cfg is not None:
-                    raise LookupError("owner-scoped runtime fallback disabled")
-                from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-                from hermes_cli.runtime_provider import resolve_runtime_provider
-
-                _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                    resolve_runtime_provider,
-                    requested=_provider,
-                )
-                _api_key = _rt.get("api_key")
-                # Also use runtime provider/base_url if the webui config didn't resolve them
-                if not _provider:
-                    _provider = _rt.get("provider")
-                if not _base_url:
-                    _base_url = _rt.get("base_url")
-            except Exception as _e:
-                print(
-                    f"[webui] WARNING: resolve_runtime_provider failed: {_e}",
-                    flush=True,
-                )
             agent = AIAgent(
                 model=_model,
                 provider=_provider,
@@ -25182,23 +25159,6 @@ def _llm_git_commit_message(system_prompt: str, user_prompt: str, session=None) 
         _main_provider = _main_state.provider
         _main_base_url = _main_state.base_url
         _main_api_key = _main_state.api_key
-        try:
-            if _owner_cfg is not None:
-                raise LookupError("owner-scoped runtime fallback disabled")
-            from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-
-            _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                resolve_runtime_provider,
-                requested=_main_provider,
-            )
-            _main_api_key = _rt.get("api_key")
-            if not _main_provider:
-                _main_provider = _rt.get("provider")
-            if not _main_base_url:
-                _main_base_url = _rt.get("base_url")
-        except Exception as _e:
-            logger.debug("git commit message runtime provider resolution failed: %s", _e)
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
@@ -27214,8 +27174,6 @@ def _handle_session_compress(handler, body):
 
         ensure_agent_runtime_current()
         import api.config as _cfg
-        from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-        import hermes_cli.runtime_provider as _runtime_provider
         AIAgent = require_ai_agent_class()
 
         _owner_state, _owner_cfg = _resolve_persisted_session_owner_state(
@@ -27228,21 +27186,6 @@ def _handle_session_compress(handler, body):
         resolved_base_url = _owner_state.base_url
 
         resolved_api_key = _owner_state.api_key
-        try:
-            if _owner_cfg is not None:
-                raise LookupError("owner-scoped runtime fallback disabled")
-            _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                _runtime_provider.resolve_runtime_provider,
-                requested=resolved_provider,
-            )
-            resolved_api_key = _rt.get("api_key")
-            if not resolved_provider:
-                resolved_provider = _rt.get("provider")
-            if not resolved_base_url:
-                resolved_base_url = _rt.get("base_url")
-        except Exception as _e:
-            logger.warning("resolve_runtime_provider failed for compression: %s", _e)
-
 
         if not resolved_api_key:
             return bad(handler, "No provider configured -- cannot compress.")
@@ -27882,8 +27825,6 @@ def _handle_handoff_summary(handler, body):
     try:
         ensure_agent_runtime_current()
         import api.config as _cfg
-        from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-        import hermes_cli.runtime_provider as _runtime_provider
         AIAgent = require_ai_agent_class()
 
         # Try to resolve model from an existing session, fall back to default.
@@ -27918,21 +27859,6 @@ def _handle_handoff_summary(handler, body):
         resolved_base_url = _owner_state.base_url
 
         resolved_api_key = _owner_state.api_key
-        try:
-            if _owner_cfg is not None:
-                raise LookupError("owner-scoped runtime fallback disabled")
-            _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                _runtime_provider.resolve_runtime_provider,
-                requested=resolved_provider,
-            )
-            resolved_api_key = _rt.get("api_key")
-            if not resolved_provider:
-                resolved_provider = _rt.get("provider")
-            if not resolved_base_url:
-                resolved_base_url = _rt.get("base_url")
-        except Exception as _e:
-            logger.warning("resolve_runtime_provider failed for handoff summary: %s", _e)
-
         if not resolved_api_key:
             summary_text = _fallback_handoff_summary(msgs)
             try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -6523,10 +6523,12 @@ def _repair_foreign_session_model_provider(
 ) -> str | None:
     """Repair a stale provider only when the cached catalog names one owner."""
     stored_model = str(getattr(session, "model", "") or "").strip()
-    stored_provider = _clean_session_model_provider(getattr(session, "model_provider", None))
-    requested_provider = _clean_session_model_provider(requested_provider)
-    resolved_provider = _clean_session_model_provider(resolved_provider)
-    profile_provider = _clean_session_model_provider(profile_provider)
+    stored_provider = _clean_session_model_provider(
+        getattr(session, "model_provider", None), profile_config
+    )
+    requested_provider = _clean_session_model_provider(requested_provider, profile_config)
+    resolved_provider = _clean_session_model_provider(resolved_provider, profile_config)
+    profile_provider = _clean_session_model_provider(profile_provider, profile_config)
     _, qualified_provider = _split_provider_qualified_model(requested_model, profile_config)
     if (
         explicit_model_pick
@@ -6744,8 +6746,10 @@ def _models_config_context_length(
     return None
 
 
-def _canonical_context_provider(value: str | None) -> str:
-    provider = _clean_session_model_provider(value) or ""
+def _canonical_context_provider(
+    value: str | None, config_obj: dict | None = None
+) -> str:
+    provider = _clean_session_model_provider(value, config_obj) or ""
     if not provider:
         return ""
     try:
@@ -6773,12 +6777,14 @@ def _custom_provider_slug_for_context(name: object) -> str:
         return f"custom:{slug}" if slug else ""
 
 
-def _providers_match_for_context(config_key: object, requested_provider: str) -> bool:
+def _providers_match_for_context(
+    config_key: object, requested_provider: str, config_obj: dict | None = None
+) -> bool:
     if not requested_provider:
         return False
     raw_key = str(config_key or "").strip().lower()
-    key = _canonical_context_provider(raw_key)
-    requested = _canonical_context_provider(requested_provider)
+    key = _canonical_context_provider(raw_key, config_obj)
+    requested = _canonical_context_provider(requested_provider, config_obj)
     return bool(
         requested
         and (
@@ -6833,7 +6839,7 @@ def _context_length_config_api_key_for_provider(
 ) -> str:
     """Return a config/env API key usable for context-window metadata lookup."""
     cfg = cfg if isinstance(cfg, dict) else {}
-    provider = _canonical_context_provider(provider)
+    provider = _canonical_context_provider(provider, cfg)
 
     def _resolve_key(raw_api_key, raw_key_env=None) -> str:
         api_key_text = str(raw_api_key or "").strip()
@@ -6859,7 +6865,7 @@ def _context_length_config_api_key_for_provider(
         for provider_key, provider_cfg in providers_cfg.items():
             if not isinstance(provider_cfg, dict):
                 continue
-            if not _providers_match_for_context(provider_key, provider):
+            if not _providers_match_for_context(provider_key, provider, cfg):
                 continue
             api_key = _resolve_key(provider_cfg.get("api_key"), provider_cfg.get("key_env"))
             if api_key:
@@ -6904,13 +6910,13 @@ def _context_length_lookup_inputs_for_model(
     cfg = cfg if isinstance(cfg, dict) else {}
 
     bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup, cfg)
-    effective_provider = _canonical_context_provider(provider or explicit_provider)
+    effective_provider = _canonical_context_provider(provider or explicit_provider, cfg)
     effective_base_url = str(base_url or "").strip()
 
     model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
     if isinstance(model_cfg, dict):
         if not effective_provider:
-            effective_provider = _canonical_context_provider(model_cfg.get("provider"))
+            effective_provider = _canonical_context_provider(model_cfg.get("provider"), cfg)
         if not effective_base_url:
             effective_base_url = str(model_cfg.get("base_url") or "").strip()
 
@@ -7032,8 +7038,8 @@ def _read_profile_model_config(
 
     Returns (profile_provider, profile_default_model, profile_config_dict).
     The first two are None when the session has no profile or the profile config
-    is unreadable; profile_config_dict is None in the same cases so callers only
-    pay for one YAML parse.
+    is unreadable; a named profile's unreadable config is returned as ``{}`` so
+    callers never fall through to another profile's process-global config.
 
     When the session already has an explicit ``requested_provider``, the profile
     ``model.provider`` is not returned (first tuple element is None) so profile
@@ -7060,10 +7066,10 @@ def _read_profile_model_config(
         _profile_home = get_hermes_home_for_profile(_profile_name)
         _profile_cfg_path = os.path.join(str(_profile_home), "config.yaml")
         if not os.path.isfile(_profile_cfg_path):
-            return None, None, None
+            return None, None, {}
         _pcfg = _read_profile_config_cached(_profile_name, _profile_cfg_path)
         if _pcfg is None:
-            return None, None, None
+            return None, None, {}
         _model_cfg = _pcfg.get("model") or {}
         if not isinstance(_model_cfg, dict):
             return None, None, _pcfg
@@ -7075,11 +7081,11 @@ def _read_profile_model_config(
             getattr(session, "profile", None),
             exc_info=True,
         )
-        return None, None, None
+        return None, None, {}
 
-    _requested = _clean_session_model_provider(requested_provider)
+    _requested = _clean_session_model_provider(requested_provider, _pcfg)
     if _requested:
-        _profile_prov = _clean_session_model_provider(_provider)
+        _profile_prov = _clean_session_model_provider(_provider, _pcfg)
         if _profile_prov != _requested:
             return None, None, _pcfg
         return None, _default, _pcfg
@@ -7244,7 +7250,7 @@ def _repair_bare_custom_provider_model(
     """
     try:
         model = str(bare_model or "").strip()
-        prov = _clean_session_model_provider(provider)
+        prov = _clean_session_model_provider(provider, config_obj)
         if not model or "/" in model or not prov:
             return None
         if prov != "custom" and not str(prov).startswith("custom:"):
@@ -7345,14 +7351,16 @@ def _resolve_compatible_session_model_state(
     for the default-model backstop.
     """
     model = str(model_id or "").strip()
-    requested_provider = _clean_session_model_provider(model_provider)
+    requested_provider = _clean_session_model_provider(model_provider, profile_config)
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
         try:
-            from api.config import cfg as _active_cfg
-
-            providers_cfg = _active_cfg.get("providers") if isinstance(_active_cfg, dict) else {}
+            providers_cfg = (
+                profile_config.get("providers")
+                if isinstance(profile_config, dict)
+                else {}
+            )
         except Exception:
             providers_cfg = {}
         if isinstance(providers_cfg, dict) and requested_provider in providers_cfg:
@@ -7369,7 +7377,7 @@ def _resolve_compatible_session_model_state(
         )
         if not explicit_provider and not stale_codex_openai_slash_id:
             _profile_default = str(profile_default_model or "").strip()
-            _profile_prov = _clean_session_model_provider(profile_provider)
+            _profile_prov = _clean_session_model_provider(profile_provider, profile_config)
             _providers_match_for_repair = (
                 _profile_prov is None or _profile_prov == requested_provider
             )
@@ -7863,18 +7871,29 @@ def _session_context_length_lookup_state(
         return "", provider_for_lookup, "", ""
     cfg = config_obj if isinstance(config_obj, dict) else None
     try:
+        from api.config import model_with_provider_context, resolve_model_provider
+
+        model_for_resolution = model_with_provider_context(
+            model_for_lookup, provider_for_lookup or None
+        )
+        resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
+            model_for_resolution
+        )
+        model_for_lookup = str(resolved_model or model_for_lookup).strip()
+        provider_for_lookup = str(resolved_provider or provider_for_lookup or "").strip()
+        base_url_for_lookup = str(resolved_base_url or "").strip()
         lookup = _context_length_lookup_inputs_for_model(
             model_for_lookup,
             provider_for_lookup or None,
+            base_url=base_url_for_lookup,
             cfg=cfg,
         )
-        model_for_lookup = str(model_for_lookup).strip()
         provider_for_lookup = str(lookup.provider or provider_for_lookup or "").strip()
-        base_url_for_lookup = str(lookup.base_url or "").strip()
+        base_url_for_lookup = str(lookup.base_url or base_url_for_lookup).strip()
         api_key_for_lookup = str(lookup.api_key or "").strip()
     except Exception:
         logger.debug("session context-length lookup state resolution failed", exc_info=True)
-    if provider_for_lookup.startswith("custom:"):
+    if provider_for_lookup.startswith("custom:") and cfg is None:
         try:
             from api.config import resolve_custom_provider_connection
 
@@ -8013,8 +8032,6 @@ def _session_model_state_from_request(
         _bare, explicit_provider = _split_provider_qualified_model(model_value, profile_config)
         if explicit_provider:
             provider = explicit_provider
-            if profile_config is not None and provider == "custom":
-                return model_value, provider
         elif requested_provider is None:
             provider = _clean_session_model_provider(current_provider, profile_config)
         model_value, provider, _changed = _resolve_compatible_session_model_state(
@@ -13776,6 +13793,7 @@ def handle_get(handler, parsed) -> bool:
                     _stored_provider_for_lookup,
                     _model_for_lookup,
                     _provider_for_lookup,
+                    _session_owner_config,
                 )
                 if _should_accept_session_context_length_refresh(
                     _persisted_cl,
@@ -15290,7 +15308,7 @@ def handle_post(handler, parsed) -> bool:
             )
         else:
             worktree_requested = _worktree_default_from_config(
-                effective_profile, owner_config
+                effective_profile, config_obj=owner_config
             )
         if worktree_requested:
             try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7358,7 +7358,7 @@ def _resolve_compatible_session_model_state(
         routing_config = (
             profile_config
             if isinstance(profile_config, dict)
-            else get_config_snapshot()
+            else get_config()
         )
         try:
             providers_cfg = (

--- a/api/routes.py
+++ b/api/routes.py
@@ -7355,10 +7355,15 @@ def _resolve_compatible_session_model_state(
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
+        routing_config = (
+            profile_config
+            if isinstance(profile_config, dict)
+            else get_config_snapshot()
+        )
         try:
             providers_cfg = (
-                profile_config.get("providers")
-                if isinstance(profile_config, dict)
+                routing_config.get("providers")
+                if isinstance(routing_config, dict)
                 else {}
             )
         except Exception:
@@ -7375,6 +7380,8 @@ def _resolve_compatible_session_model_state(
             requested_provider == "openai-codex"
             and model_prefix == "openai"
         )
+        if explicit_provider and isinstance(profile_config, dict):
+            return model, requested_provider, False
         if not explicit_provider and not stale_codex_openai_slash_id:
             _profile_default = str(profile_default_model or "").strip()
             _profile_prov = _clean_session_model_provider(profile_provider, profile_config)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7127,6 +7127,7 @@ def _resolve_persisted_session_owner_state(
         state,
         config_obj=owner_cfg,
         owner_env=owner_env,
+        owner_profile=profile,
     ), owner_cfg
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -6519,6 +6519,7 @@ def _repair_foreign_session_model_provider(
     resolved_provider: str | None,
     explicit_model_pick: bool,
     profile_provider: str | None,
+    profile_config: dict | None = None,
 ) -> str | None:
     """Repair a stale provider only when the cached catalog names one owner."""
     stored_model = str(getattr(session, "model", "") or "").strip()
@@ -6526,7 +6527,7 @@ def _repair_foreign_session_model_provider(
     requested_provider = _clean_session_model_provider(requested_provider)
     resolved_provider = _clean_session_model_provider(resolved_provider)
     profile_provider = _clean_session_model_provider(profile_provider)
-    _, qualified_provider = _split_provider_qualified_model(requested_model)
+    _, qualified_provider = _split_provider_qualified_model(requested_model, profile_config)
     if (
         explicit_model_pick
         or qualified_provider
@@ -6574,7 +6575,7 @@ def _repair_foreign_session_model_provider(
     return str(owners[0].get("provider_id") or "").strip() or resolved_provider
 
 
-def _clean_session_model_provider(value: str | None) -> str | None:
+def _clean_session_model_provider(value: str | None, config_obj: dict | None = None) -> str | None:
     """Normalize a stored/requested provider value to a bare provider ID.
 
     An ``@``-prefixed value is a provider-qualified *model* hint, so the
@@ -6590,12 +6591,12 @@ def _clean_session_model_provider(value: str | None) -> str | None:
     if not provider or provider == "default":
         return None
     if provider.startswith("@"):
-        parsed = _parse_provider_qualified_model_id(provider)
+        parsed = _parse_provider_qualified_model_id(provider, config_obj)
         provider = parsed[1].strip() if parsed else provider[1:]
     return provider or None
 
 
-def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
+def _split_provider_qualified_model(model: str, config_obj: dict | None = None) -> tuple[str, str | None]:
     """Split an ``@provider:model`` hint into ``(bare_model, provider)``.
 
     Delegates the grammar to ``config._parse_provider_qualified_model_id()``,
@@ -6606,10 +6607,10 @@ def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
     the gateway request path resolve the same provider/model pair (#6722).
     """
     model = str(model or "").strip()
-    parsed = _parse_provider_qualified_model_id(model)
+    parsed = _parse_provider_qualified_model_id(model, config_obj)
     if parsed:
         bare_model, provider_hint = parsed
-        provider = _clean_session_model_provider(provider_hint)
+        provider = _clean_session_model_provider(provider_hint, config_obj)
         bare = str(bare_model or "").strip()
         if provider and bare:
             return bare, provider
@@ -6620,6 +6621,7 @@ def _model_matches_configured_default(
     session_model: str | None,
     cfg_default: str | None,
     provider: str | None = None,
+    config_obj: dict | None = None,
 ) -> bool:
     """Return True when ``session_model`` refers to the configured ``model.default``.
 
@@ -6655,7 +6657,7 @@ def _model_matches_configured_default(
         """Return (bare_model, provider_or_None) for any of the 3 shapes."""
         value = str(value or "").strip()
         # @provider:model
-        unq, q_prov = _split_provider_qualified_model(value)
+        unq, q_prov = _split_provider_qualified_model(value, config_obj)
         if q_prov:
             return unq.strip(), str(q_prov).strip().lower()
         # provider/model (single leading slash segment)
@@ -6706,10 +6708,10 @@ def _positive_context_length(value) -> int | None:
     return parsed if parsed > 0 else None
 
 
-def _model_lookup_candidates(model: str) -> tuple[str, ...]:
+def _model_lookup_candidates(model: str, config_obj: dict | None = None) -> tuple[str, ...]:
     raw = str(model or "").strip()
     candidates = []
-    for candidate in (raw, _split_provider_qualified_model(raw)[0]):
+    for candidate in (raw, _split_provider_qualified_model(raw, config_obj)[0]):
         if candidate and candidate not in candidates:
             candidates.append(candidate)
         if "/" in candidate:
@@ -6719,8 +6721,10 @@ def _model_lookup_candidates(model: str) -> tuple[str, ...]:
     return tuple(candidates)
 
 
-def _models_config_context_length(models_cfg, model: str) -> int | None:
-    candidates = _model_lookup_candidates(model)
+def _models_config_context_length(
+    models_cfg, model: str, config_obj: dict | None = None
+) -> int | None:
+    candidates = _model_lookup_candidates(model, config_obj)
     if isinstance(models_cfg, dict):
         for candidate in candidates:
             entry = models_cfg.get(candidate)
@@ -6899,7 +6903,7 @@ def _context_length_lookup_inputs_for_model(
             cfg = {}
     cfg = cfg if isinstance(cfg, dict) else {}
 
-    bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup)
+    bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup, cfg)
     effective_provider = _canonical_context_provider(provider or explicit_provider)
     effective_base_url = str(base_url or "").strip()
 
@@ -6927,6 +6931,7 @@ def _context_length_lookup_inputs_for_model(
             provider_context_length = _models_config_context_length(
                 provider_cfg.get("models"),
                 bare_model or model_for_lookup,
+                cfg,
             )
             break
 
@@ -6951,7 +6956,7 @@ def _context_length_lookup_inputs_for_model(
                 )
             )
             base_matches = bool(target_base and entry_base_norm and target_base == entry_base_norm)
-            model_matches = bool(model_candidates.intersection(set(_model_lookup_candidates(entry.get("model")))))
+            model_matches = bool(model_candidates.intersection(set(_model_lookup_candidates(entry.get("model"), cfg))))
             models_cfg = entry.get("models")
             if isinstance(models_cfg, dict):
                 model_matches = model_matches or any(candidate in models_cfg for candidate in model_candidates)
@@ -6963,7 +6968,9 @@ def _context_length_lookup_inputs_for_model(
                 effective_base_url = entry_base
             if not effective_api_key:
                 effective_api_key = _custom_provider_api_key_for_context(entry, effective_provider or entry_slug)
-            custom_context_length = _models_config_context_length(models_cfg, bare_model or model_for_lookup)
+            custom_context_length = _models_config_context_length(
+                models_cfg, bare_model or model_for_lookup, cfg
+            )
             break
 
     global_context_length = None
@@ -6976,6 +6983,7 @@ def _context_length_lookup_inputs_for_model(
                 model_for_lookup,
                 cfg_default_model,
                 effective_provider,
+                cfg,
             )
         ):
             global_context_length = _positive_context_length(raw_cfg_ctx)
@@ -7353,7 +7361,7 @@ def _resolve_compatible_session_model_state(
         # Only safe when the model itself does not carry an ``@provider:model``
         # qualifier — qualified strings require the catalog to decide whether
         # the qualifier matches the active provider (see slow path below).
-        bare_model, explicit_provider = _split_provider_qualified_model(model)
+        bare_model, explicit_provider = _split_provider_qualified_model(model, profile_config)
         model_prefix = model.split("/", 1)[0].strip().lower() if "/" in model else ""
         stale_codex_openai_slash_id = (
             requested_provider == "openai-codex"
@@ -7423,7 +7431,9 @@ def _resolve_compatible_session_model_state(
     # active_provider / default_model. This preserves the repair path
     # (stale models still get normalized) but normalizes to the profile's
     # default model under the profile's provider rather than the global default.
-    bare_model, explicit_provider = _split_provider_qualified_model(model) if model else ("", None)
+    bare_model, explicit_provider = (
+        _split_provider_qualified_model(model, profile_config) if model else ("", None)
+    )
     if profile_provider and not explicit_provider:
         _profile_provider_normalized = _normalize_provider_id(profile_provider)
         _profile_default = str(profile_default_model or "").strip()
@@ -7506,10 +7516,10 @@ def _resolve_compatible_session_model_state(
     # is stale relative to this unknown active provider. (#1023)
     raw_active_provider = str(catalog.get("active_provider") or "").strip().lower()
     if not active_provider and not raw_active_provider:
-        bare_model, explicit_provider = _split_provider_qualified_model(model)
+        bare_model, explicit_provider = _split_provider_qualified_model(model, profile_config)
         return model, explicit_provider or requested_provider, False
 
-    bare_for_context, explicit_provider = _split_provider_qualified_model(model)
+    bare_for_context, explicit_provider = _split_provider_qualified_model(model, profile_config)
     if requested_provider and not explicit_provider:
         model_prefix = model.split("/", 1)[0].strip().lower() if "/" in model else ""
         stale_codex_openai_slash_id = (
@@ -7795,6 +7805,7 @@ def _resolve_context_length_for_session_model(
     *,
     base_url: str | None = None,
     api_key: str | None = None,
+    cfg: dict | None = None,
 ) -> int:
     """Best-effort current context window for a session model.
 
@@ -7809,7 +7820,7 @@ def _resolve_context_length_for_session_model(
         from agent.model_metadata import get_model_context_length as _get_cl
         from api.config import get_config as _get_config_for_cl
 
-        _cfg_for_cl = _get_config_for_cl()
+        _cfg_for_cl = cfg if isinstance(cfg, dict) else _get_config_for_cl()
         _ctx_lookup = _context_length_lookup_inputs_for_model(
             model_for_lookup,
             provider,
@@ -7836,6 +7847,7 @@ def _resolve_context_length_for_session_model(
 def _session_context_length_lookup_state(
     model: str | None,
     provider: str | None,
+    config_obj: dict | None = None,
 ) -> tuple[str, str, str, str]:
     """Return model/provider/base_url/api_key inputs for session context lookup.
 
@@ -7849,14 +7861,17 @@ def _session_context_length_lookup_state(
     api_key_for_lookup = ""
     if not model_for_lookup:
         return "", provider_for_lookup, "", ""
+    cfg = config_obj if isinstance(config_obj, dict) else None
     try:
-        from api.config import resolve_model_provider
-
-        model_for_resolution = model_with_provider_context(model_for_lookup, provider_for_lookup or None)
-        resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model_for_resolution)
-        model_for_lookup = str(resolved_model or model_for_lookup).strip()
-        provider_for_lookup = str(resolved_provider or provider_for_lookup or "").strip()
-        base_url_for_lookup = str(resolved_base_url or "").strip()
+        lookup = _context_length_lookup_inputs_for_model(
+            model_for_lookup,
+            provider_for_lookup or None,
+            cfg=cfg,
+        )
+        model_for_lookup = str(model_for_lookup).strip()
+        provider_for_lookup = str(lookup.provider or provider_for_lookup or "").strip()
+        base_url_for_lookup = str(lookup.base_url or "").strip()
+        api_key_for_lookup = str(lookup.api_key or "").strip()
     except Exception:
         logger.debug("session context-length lookup state resolution failed", exc_info=True)
     if provider_for_lookup.startswith("custom:"):
@@ -7877,6 +7892,7 @@ def _session_model_identity_matches(
     stored_provider: str | None,
     resolved_model: str | None,
     resolved_provider: str | None,
+    config_obj: dict | None = None,
 ) -> bool:
     stored = str(stored_model or "").strip()
     resolved = str(resolved_model or "").strip()
@@ -7890,7 +7906,7 @@ def _session_model_identity_matches(
         # ``@provider:model`` form; without the slash case a reload of a
         # slash-stored model is wrongly treated as a model change, bypassing the
         # #4248 256k-clobber guard (Codex regression gate, v0.51.x).
-        bare, prov = _split_provider_qualified_model(value)
+        bare, prov = _split_provider_qualified_model(value, config_obj)
         if prov is None and "/" in value:
             prefix, rest = value.split("/", 1)
             prefix = prefix.strip()
@@ -7946,7 +7962,7 @@ def _rescale_threshold_tokens_for_context_window(
     return max(1, int(threshold * new_window / old_window))
 
 
-def _worktree_default_from_config(profile: str | None) -> bool:
+def _worktree_default_from_config(profile: str | None, config_obj: dict | None = None) -> bool:
     """Return the agent's config-level ``worktree:`` default for *profile*.
 
     The agent CLI honors ``worktree: true`` in config.yaml for every session
@@ -7962,7 +7978,9 @@ def _worktree_default_from_config(profile: str | None) -> bool:
     profile's config.yaml directly off disk (see #3294).
     """
     try:
-        if profile:
+        if isinstance(config_obj, dict):
+            cfg_dict = config_obj
+        elif profile:
             from api.profiles import get_hermes_home_for_profile
 
             cfg_dict = get_config_for_profile_home(get_hermes_home_for_profile(profile))
@@ -7983,22 +8001,26 @@ def _session_model_state_from_request(
     model: str | None,
     requested_provider: str | None,
     current_provider: str | None = None,
+    profile_config: dict | None = None,
 ) -> tuple[str | None, str | None]:
     model_value = str(model).strip() if model is not None else None
     provider = (
-        _clean_session_model_provider(requested_provider)
+        _clean_session_model_provider(requested_provider, profile_config)
         if requested_provider is not None
         else None
     )
     if model_value:
-        _bare, explicit_provider = _split_provider_qualified_model(model_value)
+        _bare, explicit_provider = _split_provider_qualified_model(model_value, profile_config)
         if explicit_provider:
             provider = explicit_provider
+            if profile_config is not None and provider == "custom":
+                return model_value, provider
         elif requested_provider is None:
-            provider = _clean_session_model_provider(current_provider)
+            provider = _clean_session_model_provider(current_provider, profile_config)
         model_value, provider, _changed = _resolve_compatible_session_model_state(
             model_value,
             provider,
+            profile_config=profile_config,
         )
     return model_value, provider
 
@@ -13726,6 +13748,9 @@ def handle_get(handler, parsed) -> bool:
             if (not _persisted_cl) or resolve_model:
                 _stored_model_for_lookup = getattr(s, "model", "") or ""
                 _stored_provider_for_lookup = getattr(s, "model_provider", None) or ""
+                _session_owner_config = _read_profile_model_config(
+                    s, _stored_provider_for_lookup
+                )[2]
                 _model_for_lookup = (
                     effective_model or _stored_model_for_lookup
                 ).strip()
@@ -13737,12 +13762,14 @@ def handle_get(handler, parsed) -> bool:
                 ) = _session_context_length_lookup_state(
                     _model_for_lookup,
                     effective_provider or getattr(s, "model_provider", None) or "",
+                    _session_owner_config,
                 )
                 _fb_cl = _resolve_context_length_for_session_model(
                     _model_for_lookup,
                     _provider_for_lookup,
                     base_url=_base_url_for_lookup,
                     api_key=_api_key_for_lookup,
+                    cfg=_session_owner_config,
                 )
                 _model_changed_for_context = not _session_model_identity_matches(
                     _stored_model_for_lookup,
@@ -15248,6 +15275,8 @@ def handle_post(handler, parsed) -> bool:
         # isolation for the same repo.  Clients that must never create a
         # worktree (e.g. the boot-time auto-bind) send ``worktree: false``
         # explicitly.
+        from api.profiles import resolve_profile_config_context
+        effective_profile, owner_config = resolve_profile_config_context(body.get("profile"))
         raw_worktree = body.get("worktree")
         # Presence-based, not truthiness-based: a client that sends the key at
         # all (even ``worktree: null``) has spoken explicitly and never falls
@@ -15260,7 +15289,9 @@ def handle_post(handler, parsed) -> bool:
                 or str(raw_worktree).strip().lower() in {"1", "true", "yes", "on"}
             )
         else:
-            worktree_requested = _worktree_default_from_config(body.get("profile") or None)
+            worktree_requested = _worktree_default_from_config(
+                effective_profile, owner_config
+            )
         if worktree_requested:
             try:
                 from api.worktrees import create_worktree_for_workspace
@@ -15285,6 +15316,7 @@ def handle_post(handler, parsed) -> bool:
         model, model_provider = _session_model_state_from_request(
             body.get("model"),
             body.get("model_provider"),
+            profile_config=owner_config,
         )
         try:
             enabled_toolsets = _validate_session_toolsets_shape(body.get("enabled_toolsets"))
@@ -15350,7 +15382,7 @@ def handle_post(handler, parsed) -> bool:
             workspace=workspace,
             model=model,
             model_provider=model_provider,
-            profile=body.get("profile") or None,
+            profile=effective_profile,
             project_id=body.get("project_id") or None,
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,
@@ -15830,6 +15862,8 @@ def handle_post(handler, parsed) -> bool:
         old_ws = getattr(s, "workspace", "")
         old_model = getattr(s, "model", None)
         old_provider = getattr(s, "model_provider", None)
+        from api.profiles import resolve_profile_config_context
+        _owner, owner_config = resolve_profile_config_context(getattr(s, "profile", None))
         try:
             new_ws = str(resolve_trusted_workspace(body.get("workspace", s.workspace)))
         except ValueError as e:
@@ -15841,6 +15875,7 @@ def handle_post(handler, parsed) -> bool:
                     body.get("model", s.model),
                     body.get("model_provider") if "model_provider" in body else None,
                     getattr(s, "model_provider", None),
+                    profile_config=owner_config,
                 )
                 if model is not None:
                     s.model = model
@@ -15852,6 +15887,7 @@ def handle_post(handler, parsed) -> bool:
                     s.context_length = _resolve_context_length_for_session_model(
                         getattr(s, "model", None),
                         getattr(s, "model_provider", None),
+                        cfg=owner_config,
                     )
                     s.threshold_tokens = 0
                     s.last_prompt_tokens = 0
@@ -24253,6 +24289,7 @@ def _handle_chat_start(handler, body, diag=None):
             resolved_provider=model_provider,
             explicit_model_pick=explicit_model_pick,
             profile_provider=catalog_profile_provider,
+            profile_config=_pp_cfg,
         )
         if model_provider == "moa" and gateway_chat_enabled:
             from api.config import get_effective_default_model

--- a/api/routes.py
+++ b/api/routes.py
@@ -7368,6 +7368,12 @@ def _resolve_compatible_session_model_state(
             )
         except Exception:
             providers_cfg = {}
+        if not isinstance(providers_cfg, dict) and profile_config is None:
+            providers_cfg = {}
+        if profile_config is None:
+            live_cfg = getattr(api_config, "cfg", {})
+            if isinstance(live_cfg, dict) and isinstance(live_cfg.get("providers"), dict):
+                providers_cfg = live_cfg["providers"]
         if isinstance(providers_cfg, dict) and requested_provider in providers_cfg:
             return model, requested_provider, False
     if model and requested_provider:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2919,6 +2919,7 @@ from api.config import (
     _cfg_lock,
     PENDING_BG_TASK_COMPLETIONS,
     _parse_provider_qualified_model_id,
+    resolve_owner_model_state,
 )
 from api import config as api_config
 from api.helpers import (
@@ -7350,6 +7351,15 @@ def _resolve_compatible_session_model_state(
     persisted model wins over the catalog and the catalog is only consulted
     for the default-model backstop.
     """
+    owner_state = resolve_owner_model_state(
+        model_id,
+        model_provider,
+        config_obj=profile_config,
+        explicitly_picked=explicit_model_pick,
+    )
+    if isinstance(profile_config, dict):
+        return owner_state.model, owner_state.provider, owner_state.repaired
+
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider, profile_config)
     if model and requested_provider == "moa":
@@ -7884,20 +7894,20 @@ def _session_context_length_lookup_state(
         return "", provider_for_lookup, "", ""
     cfg = config_obj if isinstance(config_obj, dict) else None
     if cfg is not None:
-        # An owner-scoped reload must not pass through the process-global
-        # resolver; the lookup helper already carries the complete owner config.
-        bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup, cfg)
-        owner_provider = provider_for_lookup or explicit_provider or ""
+        owner_state = resolve_owner_model_state(
+            model_for_lookup, provider_for_lookup, config_obj=cfg
+        )
         owner_lookup = _context_length_lookup_inputs_for_model(
-            bare_model or model_for_lookup,
-            owner_provider or None,
+            owner_state.outbound_model,
+            owner_state.provider,
+            base_url=owner_state.base_url or "",
             cfg=cfg,
         )
         return (
-            str(bare_model or model_for_lookup).strip(),
-            str(owner_lookup.provider or owner_provider).strip(),
-            str(owner_lookup.base_url or "").strip(),
-            str(owner_lookup.api_key or "").strip(),
+            str(owner_state.outbound_model).strip(),
+            str(owner_state.provider or owner_lookup.provider or provider_for_lookup).strip(),
+            str(owner_state.base_url or owner_lookup.base_url or "").strip(),
+            str(owner_state.api_key or owner_lookup.api_key or "").strip(),
         )
     try:
         from api.config import model_with_provider_context, resolve_model_provider
@@ -17441,8 +17451,7 @@ def handle_post(handler, parsed) -> bool:
             ):
                 from api.config import (
                     get_effective_default_model,
-                    resolve_model_provider,
-                    resolve_custom_provider_connection,
+                    resolve_owner_model_state,
                 )
 
                 messages = [
@@ -17450,8 +17459,14 @@ def handle_post(handler, parsed) -> bool:
                     {"role": "user", "content": user_prompt},
                 ]
 
-                _main_model, _main_provider, _main_base_url = resolve_model_provider(get_effective_default_model())
-                _main_api_key = None
+                _owner, _owner_cfg = profiles_api.resolve_profile_config_context(active_profile)
+                _main_state = resolve_owner_model_state(
+                    get_effective_default_model(), config_obj=_owner_cfg
+                )
+                _main_model = _main_state.outbound_model
+                _main_provider = _main_state.provider
+                _main_base_url = _main_state.base_url
+                _main_api_key = _main_state.api_key
                 try:
                     from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                     from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -17467,13 +17482,6 @@ def handle_post(handler, parsed) -> bool:
                         _main_base_url = _rt.get("base_url")
                 except Exception as _e:
                     logger.debug("update summary runtime provider resolution failed: %s", _e)
-                if isinstance(_main_provider, str) and _main_provider.startswith("custom:"):
-                    _cp_key, _cp_base = resolve_custom_provider_connection(_main_provider)
-                    if not _main_api_key and _cp_key:
-                        _main_api_key = _cp_key
-                    if not _main_base_url and _cp_base:
-                        _main_base_url = _cp_base
-
                 main_runtime = {
                     "provider": _main_provider,
                     "model": _main_model,
@@ -24533,15 +24541,18 @@ def _handle_chat_sync(handler, body):
 
         with CHAT_LOCK:
             from api.config import (
-                resolve_model_provider,
-                resolve_custom_provider_connection,
+                resolve_owner_model_state,
             )
-
-            _model, _provider, _base_url = resolve_model_provider(
-                model_with_provider_context(s.model, getattr(s, "model_provider", None))
+            _owner_state = resolve_owner_model_state(
+                s.model,
+                getattr(s, "model_provider", None),
+                config_obj=_pp_cfg,
             )
+            _model = _owner_state.outbound_model
+            _provider = _owner_state.provider
+            _base_url = _owner_state.base_url
             # Resolve API key via Hermes runtime provider (matches gateway behaviour)
-            _api_key = None
+            _api_key = _owner_state.api_key
             try:
                 from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                 from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -24561,12 +24572,6 @@ def _handle_chat_sync(handler, body):
                     f"[webui] WARNING: resolve_runtime_provider failed: {_e}",
                     flush=True,
                 )
-            if isinstance(_provider, str) and _provider.startswith("custom:"):
-                _cp_key, _cp_base = resolve_custom_provider_connection(_provider)
-                if not _api_key and _cp_key:
-                    _api_key = _cp_key
-                if not _base_url and _cp_base:
-                    _base_url = _cp_base
             agent = AIAgent(
                 model=_model,
                 provider=_provider,
@@ -25116,20 +25121,26 @@ def _llm_git_commit_message(system_prompt: str, user_prompt: str, session=None) 
     ):
         from api.config import (
             get_effective_default_model,
-            model_with_provider_context,
-            resolve_custom_provider_connection,
-            resolve_model_provider,
+            resolve_owner_model_state,
         )
 
         session_model = str(getattr(session, "model", "") or "").strip()
         session_provider = str(getattr(session, "model_provider", "") or "").strip() or None
-        model_for_resolution = (
-            model_with_provider_context(session_model, session_provider)
-            if session_model
-            else get_effective_default_model()
+        try:
+            _owner, _owner_cfg = profiles_api.resolve_profile_config_context(
+                getattr(session, "profile", None)
+            )
+        except Exception:
+            _owner_cfg = None
+        _main_state = resolve_owner_model_state(
+            session_model or get_effective_default_model(),
+            session_provider,
+            config_obj=_owner_cfg,
         )
-        _main_model, _main_provider, _main_base_url = resolve_model_provider(model_for_resolution)
-        _main_api_key = None
+        _main_model = _main_state.outbound_model
+        _main_provider = _main_state.provider
+        _main_base_url = _main_state.base_url
+        _main_api_key = _main_state.api_key
         try:
             from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
             from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -25145,13 +25156,6 @@ def _llm_git_commit_message(system_prompt: str, user_prompt: str, session=None) 
                 _main_base_url = _rt.get("base_url")
         except Exception as _e:
             logger.debug("git commit message runtime provider resolution failed: %s", _e)
-        if isinstance(_main_provider, str) and _main_provider.startswith("custom:"):
-            _cp_key, _cp_base = resolve_custom_provider_connection(_main_provider)
-            if not _main_api_key and _cp_key:
-                _main_api_key = _cp_key
-            if not _main_base_url and _cp_base:
-                _main_base_url = _cp_base
-
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
@@ -27171,11 +27175,21 @@ def _handle_session_compress(handler, body):
         import hermes_cli.runtime_provider as _runtime_provider
         AIAgent = require_ai_agent_class()
 
-        resolved_model, resolved_provider, resolved_base_url = _cfg.resolve_model_provider(
-            _cfg.model_with_provider_context(s.model, getattr(s, "model_provider", None))
+        try:
+            from api.profiles import resolve_profile_config_context
+            _owner_name, _owner_cfg = resolve_profile_config_context(getattr(s, "profile", None))
+        except Exception:
+            _owner_cfg = None
+        _owner_state = _cfg.resolve_owner_model_state(
+            s.model,
+            getattr(s, "model_provider", None),
+            config_obj=_owner_cfg,
         )
+        resolved_model = _owner_state.outbound_model
+        resolved_provider = _owner_state.provider
+        resolved_base_url = _owner_state.base_url
 
-        resolved_api_key = None
+        resolved_api_key = _owner_state.api_key
         try:
             _rt = resolve_runtime_provider_with_anthropic_env_lock(
                 _runtime_provider.resolve_runtime_provider,
@@ -27189,12 +27203,6 @@ def _handle_session_compress(handler, body):
         except Exception as _e:
             logger.warning("resolve_runtime_provider failed for compression: %s", _e)
 
-        if isinstance(resolved_provider, str) and resolved_provider.startswith("custom:"):
-            _cp_key, _cp_base = _cfg.resolve_custom_provider_connection(resolved_provider)
-            if not resolved_api_key and _cp_key:
-                resolved_api_key = _cp_key
-            if not resolved_base_url and _cp_base:
-                resolved_base_url = _cp_base
 
         if not resolved_api_key:
             return bad(handler, "No provider configured -- cannot compress.")
@@ -27860,12 +27868,23 @@ def _handle_handoff_summary(handler, body):
         except Exception:
             pass
 
-        model_for_resolution = _cfg.model_with_provider_context(
-            resolved_model, session_model_provider
+        try:
+            from api.profiles import resolve_profile_config_context
+            _owner_name, _owner_cfg = resolve_profile_config_context(
+                getattr(s_obj, "profile", None)
+            )
+        except Exception:
+            _owner_cfg = None
+        _owner_state = _cfg.resolve_owner_model_state(
+            resolved_model,
+            session_model_provider,
+            config_obj=_owner_cfg,
         )
-        resolved_model, resolved_provider, resolved_base_url = _cfg.resolve_model_provider(model_for_resolution)
+        resolved_model = _owner_state.outbound_model
+        resolved_provider = _owner_state.provider
+        resolved_base_url = _owner_state.base_url
 
-        resolved_api_key = None
+        resolved_api_key = _owner_state.api_key
         try:
             _rt = resolve_runtime_provider_with_anthropic_env_lock(
                 _runtime_provider.resolve_runtime_provider,
@@ -27878,13 +27897,6 @@ def _handle_handoff_summary(handler, body):
                 resolved_base_url = _rt.get("base_url")
         except Exception as _e:
             logger.warning("resolve_runtime_provider failed for handoff summary: %s", _e)
-
-        if isinstance(resolved_provider, str) and resolved_provider.startswith("custom:"):
-            _cp_key, _cp_base = _cfg.resolve_custom_provider_connection(resolved_provider)
-            if not resolved_api_key and _cp_key:
-                resolved_api_key = _cp_key
-            if not resolved_base_url and _cp_base:
-                resolved_base_url = _cp_base
 
         if not resolved_api_key:
             summary_text = _fallback_handoff_summary(msgs)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7099,6 +7099,11 @@ def _resolve_persisted_session_owner_state(
     provider: str | None = None,
 ):
     """Resolve a persisted session through its owner snapshot and env."""
+    # resolve_runtime_provider_with_anthropic_env_lock is centralized in the owner-state resolver.
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider as _route_runtime_resolver
+    except ImportError:
+        _route_runtime_resolver = None
     from api.config import resolve_owner_model_state, resolve_owner_runtime_state
 
     if model is None:
@@ -7108,7 +7113,9 @@ def _resolve_persisted_session_owner_state(
     profile = getattr(session, "profile", None)
     if not profile:
         state = resolve_owner_model_state(model, provider, config_obj=None)
-        return resolve_owner_runtime_state(state, config_obj=None), None
+        return resolve_owner_runtime_state(
+            state, config_obj=None, runtime_resolver=_route_runtime_resolver
+        ), None
     from api.profiles import (
         get_hermes_home_for_profile,
         get_profile_runtime_env,
@@ -7128,6 +7135,7 @@ def _resolve_persisted_session_owner_state(
         config_obj=owner_cfg,
         owner_env=owner_env,
         owner_profile=profile,
+        runtime_resolver=_route_runtime_resolver,
     ), owner_cfg
 
 
@@ -7399,7 +7407,7 @@ def _resolve_compatible_session_model_state(
         _owner_model_bare, _owner_explicit_provider = _split_provider_qualified_model(
             model, profile_config
         )
-        if model_provider and not _owner_explicit_provider:
+        if model_provider and not _owner_explicit_provider and not owner_state.repaired:
             requested_provider = _clean_session_model_provider(
                 model_provider, profile_config
             )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8681,6 +8681,7 @@ def _resolve_stream_owner_model_state(
         config_obj=owner_cfg,
         explicitly_picked=explicitly_picked,
         owner_env=owner_env,
+        resolver=resolve_model_provider,
     )
     from api.config import resolve_owner_runtime_state
     return resolve_owner_runtime_state(
@@ -10056,9 +10057,12 @@ def _run_agent_streaming(
                 resolved_model = _owner_state.outbound_model
                 resolved_provider = _owner_state.provider
                 configured_base_url = _owner_state.base_url
+                _rt = _owner_state.runtime_route or {}
 
                 resolved_api_key = _owner_state.api_key
-                resolved_base_url = configured_base_url
+                resolved_base_url = _runtime_preferred_base_url(
+                    _rt, resolved_provider, configured_base_url
+                )
 
                 # Named custom providers (custom:slug) may not be resolvable by
                 # hermes_cli.runtime_provider directly. Fall back to config.yaml
@@ -10072,8 +10076,6 @@ def _run_agent_streaming(
                         resolved_provider, resolved_api_key, resolved_base_url,
                         profile_name=_resolved_profile_name,
                     )
-                else:
-                    resolved_base_url = configured_base_url
 
             # Read per-profile config at call time (not module-level snapshot).
             # The streaming worker is a detached thread that does NOT inherit the
@@ -10688,7 +10690,12 @@ def _run_agent_streaming(
             # Persist the user message BEFORE streaming starts so it's durable even if
             # the server crashes before the first checkpoint fires (every 15s).
             with _agent_lock:
-                s.save(touch_updated_at=True, skip_index=False)
+                try:
+                    s.save(touch_updated_at=True, skip_index=False)
+                except TypeError as _save_error:
+                    if "skip_index" not in str(_save_error):
+                        raise
+                    s.save(touch_updated_at=True)
 
             _ckpt_thread = threading.Thread(
                 target=_periodic_checkpoint, daemon=True,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8675,11 +8675,17 @@ def _resolve_stream_owner_model_state(
 
     owner_cfg = get_config_for_profile_home(profile_home) if profile_name else None
     owner_env = get_profile_runtime_env(profile_home) if owner_cfg is not None else None
-    return resolve_owner_model_state(
+    state = resolve_owner_model_state(
         model,
         provider,
         config_obj=owner_cfg,
         explicitly_picked=explicitly_picked,
+        owner_env=owner_env,
+    )
+    from api.config import resolve_owner_runtime_state
+    return resolve_owner_runtime_state(
+        state,
+        config_obj=owner_cfg,
         owner_env=owner_env,
     )
 
@@ -10045,32 +10051,13 @@ def _run_agent_streaming(
                     provider_context,
                     explicitly_picked=_explicitly_picked,
                 )
-                _owner_cfg = {"owner": _resolved_profile_name} if _resolved_profile_name else None
+                _owner_scoped = bool(_resolved_profile_name)
                 resolved_model = _owner_state.outbound_model
                 resolved_provider = _owner_state.provider
                 configured_base_url = _owner_state.base_url
 
-                # Resolve API key via Hermes runtime provider (matches gateway behaviour).
-                # Pass the resolved provider so non-default providers get their own credentials.
                 resolved_api_key = _owner_state.api_key
-                try:
-                    if _owner_cfg is not None:
-                        raise LookupError("owner-scoped runtime fallback disabled")
-                    from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-                    from hermes_cli.runtime_provider import resolve_runtime_provider
-                    _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                        resolve_runtime_provider,
-                        requested=resolved_provider,
-                        target_model=resolved_model,
-                    )
-                    resolved_api_key = _rt.get("api_key")
-                    if not resolved_provider:
-                        resolved_provider = _rt.get("provider")
-                    resolved_base_url = _runtime_preferred_base_url(
-                        _rt, resolved_provider, configured_base_url
-                    )
-                except Exception as _e:
-                    print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
+                resolved_base_url = configured_base_url
 
                 # Named custom providers (custom:slug) may not be resolvable by
                 # hermes_cli.runtime_provider directly. Fall back to config.yaml
@@ -10079,7 +10066,7 @@ def _run_agent_streaming(
                 # still select the exact custom_providers entry after the rewrite
                 # to "custom" below.
                 _session_requested_provider = resolved_provider
-                if _owner_cfg is None:
+                if not _owner_scoped:
                     resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                         resolved_provider, resolved_api_key, resolved_base_url,
                         profile_name=_resolved_profile_name,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -43,6 +43,7 @@ from api.config import (
     clear_session_writeback_owner_if_owned,
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
     resolve_model_provider,
+    resolve_owner_model_state,
     resolve_custom_provider_connection,
     model_with_provider_context,
     warm_models_catalog_provenance_if_cold,
@@ -10014,15 +10015,24 @@ def _run_agent_streaming(
                 _resolved_profile_name, "model + credential resolution", logger_override=logger
             ):
                 warm_models_catalog_provenance_if_cold()
-                resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
-                    model_with_provider_context(model, provider_context),
+                from api.config import get_config_for_profile_home as _get_owner_config
+                try:
+                    _owner_cfg = _get_owner_config(_profile_home)
+                except Exception:
+                    _owner_cfg = {}
+                _owner_state = resolve_owner_model_state(
+                    model,
+                    provider_context,
+                    config_obj=_owner_cfg,
                     explicitly_picked=_explicitly_picked,
                 )
-                configured_base_url = resolved_base_url
+                resolved_model = _owner_state.outbound_model
+                resolved_provider = _owner_state.provider
+                configured_base_url = _owner_state.base_url
 
                 # Resolve API key via Hermes runtime provider (matches gateway behaviour).
                 # Pass the resolved provider so non-default providers get their own credentials.
-                resolved_api_key = None
+                resolved_api_key = _owner_state.api_key
                 try:
                     from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                     from hermes_cli.runtime_provider import resolve_runtime_provider

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8661,6 +8661,29 @@ def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
             rt['is_anthropic_oauth'] = getattr(agent, '_is_anthropic_oauth')
 
 
+def _resolve_stream_owner_model_state(
+    profile_name,
+    profile_home,
+    model,
+    provider,
+    *,
+    explicitly_picked=False,
+):
+    """Resolve a streaming session through its persisted owner snapshot."""
+    from api.config import get_config_for_profile_home
+    from api.profiles import get_profile_runtime_env
+
+    owner_cfg = get_config_for_profile_home(profile_home) if profile_name else None
+    owner_env = get_profile_runtime_env(profile_home) if owner_cfg is not None else None
+    return resolve_owner_model_state(
+        model,
+        provider,
+        config_obj=owner_cfg,
+        explicitly_picked=explicitly_picked,
+        owner_env=owner_env,
+    )
+
+
 def _run_agent_streaming(
     session_id,
     msg_text,
@@ -10015,17 +10038,14 @@ def _run_agent_streaming(
                 _resolved_profile_name, "model + credential resolution", logger_override=logger
             ):
                 warm_models_catalog_provenance_if_cold()
-                from api.config import get_config_for_profile_home as _get_owner_config
-                try:
-                    _owner_cfg = _get_owner_config(_profile_home)
-                except Exception:
-                    _owner_cfg = {}
-                _owner_state = resolve_owner_model_state(
+                _owner_state = _resolve_stream_owner_model_state(
+                    _resolved_profile_name,
+                    _profile_home,
                     model,
                     provider_context,
-                    config_obj=_owner_cfg,
                     explicitly_picked=_explicitly_picked,
                 )
+                _owner_cfg = {"owner": _resolved_profile_name} if _resolved_profile_name else None
                 resolved_model = _owner_state.outbound_model
                 resolved_provider = _owner_state.provider
                 configured_base_url = _owner_state.base_url
@@ -10034,6 +10054,8 @@ def _run_agent_streaming(
                 # Pass the resolved provider so non-default providers get their own credentials.
                 resolved_api_key = _owner_state.api_key
                 try:
+                    if _owner_cfg is not None:
+                        raise LookupError("owner-scoped runtime fallback disabled")
                     from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
                     from hermes_cli.runtime_provider import resolve_runtime_provider
                     _rt = resolve_runtime_provider_with_anthropic_env_lock(
@@ -10057,10 +10079,13 @@ def _run_agent_streaming(
                 # still select the exact custom_providers entry after the rewrite
                 # to "custom" below.
                 _session_requested_provider = resolved_provider
-                resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
-                    resolved_provider, resolved_api_key, resolved_base_url,
-                    profile_name=_resolved_profile_name,
-                )
+                if _owner_cfg is None:
+                    resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
+                        resolved_provider, resolved_api_key, resolved_base_url,
+                        profile_name=_resolved_profile_name,
+                    )
+                else:
+                    resolved_base_url = configured_base_url
 
             # Read per-profile config at call time (not module-level snapshot).
             # The streaming worker is a detached thread that does NOT inherit the

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8687,6 +8687,7 @@ def _resolve_stream_owner_model_state(
         state,
         config_obj=owner_cfg,
         owner_env=owner_env,
+        owner_profile=profile_name,
     )
 
 

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -296,13 +296,14 @@ def test_gateway_runs_api_submission():
     ):
         runs_called["called"] = True
         captured["body_extras"] = body_extras
+        captured["api_key"] = api_key
         return (original_text, {"input_tokens": 10, "output_tokens": 5})
 
     mock_session = MagicMock()
     mock_session.active_stream_id = stream_id
     mock_session.workspace = "/tmp"
     mock_session.model = "test"
-    mock_session.model_provider = None
+    mock_session.model_provider = "openai-codex"
     mock_session.profile = None
     mock_session.context_messages = []
     mock_session.messages = []
@@ -314,6 +315,15 @@ def test_gateway_runs_api_submission():
         with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway", "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1"}):
             with patch("api.gateway_chat.gateway_supports_approval", lambda *_args, **_kwargs: True), \
                  patch("api.gateway_chat._run_gateway_runs_api_streaming", fake_runs_streaming), \
+                 patch("api.gateway_chat._gateway_api_key", return_value="gateway-server-key"), \
+                 patch(
+                     "api.gateway_chat.resolve_owner_model_state",
+                     return_value=SimpleNamespace(
+                         outbound_model="test-model",
+                         provider="openai-codex",
+                         api_key="provider-auth-store-key",
+                     ),
+                 ), \
                  patch("api.gateway_chat._gateway_reasoning_effort_for_request", return_value="high"), \
                  patch("api.gateway_chat.get_session", return_value=mock_session), \
                  patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
@@ -324,6 +334,7 @@ def test_gateway_runs_api_submission():
                     model="test-model",
                     workspace="/tmp",
                     stream_id=stream_id,
+                    model_provider="openai-codex",
                 )
     finally:
         with STREAMS_LOCK:
@@ -331,6 +342,8 @@ def test_gateway_runs_api_submission():
 
     assert runs_called["called"], "The runs-API streaming path should have been invoked"
     assert captured["body_extras"]["reasoning_effort"] == "high"
+    assert "provider" not in captured["body_extras"]
+    assert captured["api_key"] == "gateway-server-key"
 
 
 # ---------------------------------------------------------------------------
@@ -471,7 +484,7 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     assert run_body["input"] == "hi"
     assert run_body["instructions"] == "system prompt"
     assert run_body["conversation_history"] == [{"role": "assistant", "content": "earlier reply"}]
-    assert run_body["provider"] == "anthropic"
+    assert "provider" not in run_body
     assert run_body["session_id"] == "sess1"
     assert "messages" not in run_body
 

--- a/tests/test_issue1855_resolve_model_provider_fast_path.py
+++ b/tests/test_issue1855_resolve_model_provider_fast_path.py
@@ -196,6 +196,14 @@ class TestSlowPathStillFires:
                 result = _resolve_compatible_session_model_state(
                     "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
                     "local-llama",
+                    profile_config={
+                        "providers": {
+                            "local-llama": {
+                                "base_url": "http://127.0.0.1:8088/v1",
+                                "api_key": "test-key",
+                            },
+                        },
+                    },
                 )
         finally:
             config.cfg.clear()

--- a/tests/test_issue3405_profile_provider_resolution.py
+++ b/tests/test_issue3405_profile_provider_resolution.py
@@ -300,7 +300,7 @@ class TestReadProfileModelConfig:
             profile = "work"
 
         result = _read_profile_model_config(FakeSession(), "openai-codex")
-        assert result == (None, None, None)
+        assert result == (None, None, {})
 
     def test_reads_profile_config(self, tmp_path):
         """Reads model.provider and model.default from profile config.yaml."""
@@ -323,7 +323,7 @@ class TestReadProfileModelConfig:
         assert result[2] == {"model": {"provider": "anthropic", "default": "claude-sonnet-4.6"}}
 
     def test_missing_config_returns_none(self):
-        """Missing config.yaml returns (None, None, None)."""
+        """Missing config.yaml returns an empty owner config boundary."""
         from api.routes import _read_profile_model_config
         import tempfile
 
@@ -334,7 +334,7 @@ class TestReadProfileModelConfig:
             with patch("api.profiles.get_hermes_home_for_profile", return_value=Path(td)):
                 result = _read_profile_model_config(FakeSession(), None)
 
-        assert result == (None, None, None)
+        assert result == (None, None, {})
 
     def test_empty_provider_returns_none(self, tmp_path):
         """Empty model.provider in config returns (None, default, config)."""

--- a/tests/test_issue6022_worktree_config_default.py
+++ b/tests/test_issue6022_worktree_config_default.py
@@ -35,7 +35,7 @@ def _post_session_new(tmp_path, monkeypatch, body, *, config_default, workspace_
     monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
     monkeypatch.setattr(routes, "read_body", lambda handler: body)
     monkeypatch.setattr(
-        routes, "_worktree_default_from_config", lambda profile: config_default
+        routes, "_worktree_default_from_config", lambda profile, **_kwargs: config_default
     )
     if workspace_dir is not None:
         monkeypatch.setattr(

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -40,30 +40,27 @@ OWNER = {
 }
 
 
-@pytest.fixture(autouse=True)
-def _configured_custom_provider_registry():
+@pytest.fixture
+def configured_named_custom_provider(monkeypatch):
     import api.config as cfg_mod
 
-    missing = object()
-    old_custom = cfg_mod.cfg.get("custom_providers", missing)
-    old_model = cfg_mod.cfg.get("model", missing)
+    old_custom = cfg_mod.cfg.get("custom_providers")
+    old_model = cfg_mod.cfg.get("model")
     cfg_mod.cfg["custom_providers"] = [{"name": "backup"}]
     cfg_mod.cfg["model"] = {
         "provider": "ollama",
         "default": "hermes-reasoner:latest",
         "base_url": "http://127.0.0.1:11434/v1",
     }
-    try:
-        yield
-    finally:
-        if old_custom is missing:
-            cfg_mod.cfg.pop("custom_providers", None)
-        else:
-            cfg_mod.cfg["custom_providers"] = old_custom
-        if old_model is missing:
-            cfg_mod.cfg.pop("model", None)
-        else:
-            cfg_mod.cfg["model"] = old_model
+    yield
+    if old_custom is None:
+        cfg_mod.cfg.pop("custom_providers", None)
+    else:
+        cfg_mod.cfg["custom_providers"] = old_custom
+    if old_model is None:
+        cfg_mod.cfg.pop("model", None)
+    else:
+        cfg_mod.cfg["model"] = old_model
 
 
 # (qualified value, expected bare model, expected provider)
@@ -297,20 +294,20 @@ class TestGatewayRequestBodiesCarryBareModel:
         assert payload["model"] == "deepseek-v4-flash"
         assert not payload["model"].startswith("@")
 
-    def test_legacy_body_keeps_named_custom_provider_model_intact(self, tmp_path, monkeypatch):
+    def test_legacy_body_keeps_named_custom_provider_model_intact(self, tmp_path, monkeypatch, configured_named_custom_provider):
         """The multi-segment case a positional split would truncate."""
         payload = _run_legacy_gateway_chat(
             tmp_path, monkeypatch, "@custom:backup:model-a:free"
         )
         assert payload["model"] == "model-a:free"
 
-    def test_legacy_body_keeps_host_port_custom_provider_model_intact(self, tmp_path, monkeypatch):
+    def test_legacy_body_keeps_host_port_custom_provider_model_intact(self, tmp_path, monkeypatch, configured_named_custom_provider):
         payload = _run_legacy_gateway_chat(
             tmp_path, monkeypatch, "@custom:192.168.1.5:11434:llama4"
         )
         assert payload["model"] == "llama4"
 
-    def test_runs_api_body_has_bare_model(self, monkeypatch):
+    def test_runs_api_body_has_bare_model(self, monkeypatch, configured_named_custom_provider):
         """The runs API builder is the second gateway request site."""
         captured = {}
 
@@ -343,7 +340,7 @@ class TestGatewayRequestBodiesCarryBareModel:
         assert payload["model"] == "model-a:free"
         assert not payload["model"].startswith("@")
 
-    def test_runs_api_body_forwards_canonical_provider_pair(self, monkeypatch):
+    def test_runs_api_body_uses_canonical_model_without_unsupported_provider_field(self, monkeypatch):
         captured = {}
 
         def fake_urlopen(req, timeout=0):
@@ -373,4 +370,4 @@ class TestGatewayRequestBodiesCarryBareModel:
 
         payload = json.loads(captured["body"])
         assert payload["model"] == "org/model"
-        assert payload["provider"] == "custom:backup"
+        assert "provider" not in payload

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -360,7 +360,7 @@ class TestGatewayRequestBodiesCarryBareModel:
                 "http://gateway.local",
                 "owner-key",
                 [],
-                {},
+                {"provider": "custom:backup"},
                 put_gateway_event=lambda *a, **k: None,
                 cancel_event=None,
                 active_provider="custom:backup",

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -34,6 +34,12 @@ from api.config import STREAMS, create_stream_channel
 from api.models import new_session
 
 
+OWNER = {
+    "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+    "providers": {"openai-codex": {"models": ["gpt-5.5"]}},
+}
+
+
 @pytest.fixture(autouse=True)
 def _configured_custom_provider_registry():
     import api.config as cfg_mod
@@ -160,7 +166,10 @@ class TestSessionModelStatePreservesQualifierForRepair:
             },
         )
         model_value, provider = routes._session_model_state_from_request(
-            "@removed:mistral-large", None, "removed"
+            "@removed:mistral-large",
+            None,
+            current_provider="removed",
+            profile_config=OWNER,
         )
         assert model_value == "gpt-5.5", (
             f"removed/unconfigured qualified provider must repair to the active "
@@ -333,3 +342,35 @@ class TestGatewayRequestBodiesCarryBareModel:
         payload = json.loads(captured["body"])
         assert payload["model"] == "model-a:free"
         assert not payload["model"].startswith("@")
+
+    def test_runs_api_body_forwards_canonical_provider_pair(self, monkeypatch):
+        captured = {}
+
+        def fake_urlopen(req, timeout=0):
+            captured["body"] = req.data.decode("utf-8")
+            raise AssertionError("stop after the POST body is captured")
+
+        monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(gateway_chat, "update_active_run", lambda *a, **k: None)
+
+        try:
+            gateway_chat._run_gateway_runs_api_streaming(
+                "sess-6722",
+                "hi",
+                "org/model",
+                "/tmp",
+                "stream-6722-runs-provider",
+                "http://gateway.local",
+                "owner-key",
+                [],
+                {},
+                put_gateway_event=lambda *a, **k: None,
+                cancel_event=None,
+                active_provider="custom:backup",
+            )
+        except Exception:
+            pass
+
+        payload = json.loads(captured["body"])
+        assert payload["model"] == "org/model"
+        assert payload["provider"] == "custom:backup"

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -25,12 +25,39 @@ guessing either way breaks the other. These tests pin both shapes so a future
 
 from collections import OrderedDict
 import json
+import pytest
 
 import api.gateway_chat as gateway_chat
 import api.models as models
 import api.streaming as streaming
 from api.config import STREAMS, create_stream_channel
 from api.models import new_session
+
+
+@pytest.fixture(autouse=True)
+def _configured_custom_provider_registry():
+    import api.config as cfg_mod
+
+    missing = object()
+    old_custom = cfg_mod.cfg.get("custom_providers", missing)
+    old_model = cfg_mod.cfg.get("model", missing)
+    cfg_mod.cfg["custom_providers"] = [{"name": "backup"}]
+    cfg_mod.cfg["model"] = {
+        "provider": "ollama",
+        "default": "hermes-reasoner:latest",
+        "base_url": "http://127.0.0.1:11434/v1",
+    }
+    try:
+        yield
+    finally:
+        if old_custom is missing:
+            cfg_mod.cfg.pop("custom_providers", None)
+        else:
+            cfg_mod.cfg["custom_providers"] = old_custom
+        if old_model is missing:
+            cfg_mod.cfg.pop("model", None)
+        else:
+            cfg_mod.cfg["model"] = old_model
 
 
 # (qualified value, expected bare model, expected provider)

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -8,6 +8,7 @@ import api.config as config
 import api.gateway_chat as gateway_chat
 import api.profiles as profiles
 import api.routes as routes
+import api.streaming as streaming
 
 
 OLLAMA_CONFIG = {
@@ -52,6 +53,18 @@ def test_owner_reconciliation_matrix():
     assert (matching.outbound_model, matching.provider) == ("org/model", "custom:backup")
 
 
+def test_unknown_named_custom_qualifier_repairs_without_borrowing_backup():
+    state = config.resolve_owner_model_state(
+        "@custom:other:org/model",
+        "custom:other",
+        config_obj=CUSTOM_OWNER_CONFIG,
+        owner_env={"BACKUP_KEY": "owner-secret"},
+    )
+    assert state.repaired is True
+    assert (state.provider, state.outbound_model) == ("custom:backup", "org/model")
+    assert state.api_key == "owner-secret"
+
+
 def test_explicit_pick_unknown_qualifier_repairs_to_owner_default():
     state = config.resolve_owner_model_state(
         "@removed:mistral-large",
@@ -82,6 +95,64 @@ def test_owner_connection_uses_env_backed_key_from_same_entry(monkeypatch):
     ) == ("env-secret", "https://backup.example/v1")
 
 
+def test_owner_env_mapping_wins_over_foreign_process_environment(monkeypatch):
+    monkeypatch.setenv("BACKUP_KEY", "foreign-secret")
+    owner = {
+        **CUSTOM_OWNER_CONFIG,
+        "_env": {"BACKUP_KEY": "owner-secret"},
+    }
+    assert config.resolve_custom_provider_connection("custom:backup", owner) == (
+        "owner-secret",
+        "https://backup.example/v1",
+    )
+
+
+def test_persisted_session_runtime_consumers_use_owner_state_and_connection(monkeypatch):
+    owner = {
+        **CUSTOM_OWNER_CONFIG,
+        "_env": {"BACKUP_KEY": "owner-secret"},
+    }
+    monkeypatch.setattr(profiles, "resolve_profile_config_context", lambda _name: ("owner", owner))
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda _name: "/owner")
+    monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {"BACKUP_KEY": "owner-secret"})
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda _home: owner)
+    session = SimpleNamespace(profile="owner", model="org/model", model_provider="custom:backup")
+
+    route_state, route_cfg = routes._resolve_persisted_session_owner_state(
+        session, session.model, session.model_provider
+    )
+    stream_state = streaming._resolve_stream_owner_model_state(
+        "owner", "/owner", session.model, session.model_provider
+    )
+    assert route_cfg is owner
+    for state in (route_state, stream_state):
+        assert (state.provider, state.base_url, state.api_key) == (
+            "custom:backup",
+            "https://backup.example/v1",
+            "owner-secret",
+        )
+
+
+def test_empty_owner_runtime_consumers_do_not_fill_ambient_provider(monkeypatch):
+    monkeypatch.setattr(profiles, "resolve_profile_config_context", lambda _name: ("empty", {}))
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda _name: "/empty")
+    monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {})
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda _home: {})
+    monkeypatch.setattr(config, "cfg", CUSTOM_OWNER_CONFIG)
+    session = SimpleNamespace(profile="empty", model="org/model", model_provider=None)
+
+    route_state, _ = routes._resolve_persisted_session_owner_state(session)
+    stream_state = streaming._resolve_stream_owner_model_state(
+        "empty", "/empty", session.model, session.model_provider
+    )
+    assert route_state.provider is None
+    assert route_state.base_url is None
+    assert route_state.api_key is None
+    assert stream_state.provider is None
+    assert stream_state.base_url is None
+    assert stream_state.api_key is None
+
+
 def test_known_unconfigured_qualifier_is_not_removed():
     state = config.resolve_owner_model_state(
         "@openrouter:some/model", "openrouter", config_obj={}
@@ -96,6 +167,28 @@ def test_explicit_empty_owner_never_falls_back_to_ambient_config(monkeypatch):
     assert state.provider is None
     assert state.base_url is None
     assert not catalog.get("groups")
+
+
+def test_explicit_empty_owner_does_not_import_plugin_catalog(monkeypatch):
+    import api.providers as providers
+
+    monkeypatch.setattr(
+        config,
+        "_plugin_model_provider_profiles",
+        lambda: {"ambient-plugin": object()},
+    )
+    monkeypatch.setattr(
+        providers,
+        "_provider_has_key",
+        lambda _provider: (_ for _ in ()).throw(
+            AssertionError("explicit owner must not inspect ambient plugin auth")
+        ),
+    )
+    catalog = config._static_models_catalog_without_live_probes({})
+    assert all(
+        group.get("provider_id") != "ambient-plugin"
+        for group in catalog.get("groups", [])
+    )
 
 
 def test_omitted_owner_config_preserves_ambient_resolver_contract(monkeypatch):

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -1,6 +1,7 @@
 """Regression coverage for profile-owned qualified model parsing (#7073)."""
 
 import json
+from contextlib import contextmanager
 from types import SimpleNamespace
 from urllib.parse import urlparse
 
@@ -105,6 +106,56 @@ def test_owner_env_mapping_wins_over_foreign_process_environment(monkeypatch):
         "owner-secret",
         "https://backup.example/v1",
     )
+
+
+def test_owner_runtime_builtin_uses_profile_scope_for_credentials(monkeypatch):
+    owner = {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "providers": {"openai-codex": {"models": ["gpt-5.5"]}},
+    }
+    observed = {}
+
+    @contextmanager
+    def fake_scope(profile, purpose):
+        observed["scope"] = (profile, purpose)
+        yield
+
+    monkeypatch.setattr(profiles, "profile_scope_for_detached_worker", fake_scope)
+    def fake_runtime(_resolver, **kwargs):
+        observed["runtime"] = kwargs
+        return {"provider": "openai-codex", "api_key": "owner-auth-store-key"}
+
+    monkeypatch.setattr(
+        "api.oauth.resolve_runtime_provider_with_anthropic_env_lock", fake_runtime
+    )
+    state = config.resolve_owner_model_state(
+        "gpt-5.5", "openai-codex", config_obj=owner
+    )
+    resolved = config.resolve_owner_runtime_state(
+        state, config_obj=owner, owner_profile="owner"
+    )
+    assert observed["scope"][0] == "owner"
+    assert observed["runtime"]["requested"] == "openai-codex"
+    assert resolved.api_key == "owner-auth-store-key"
+
+
+def test_owner_endpoint_slug_keeps_local_provider_identity():
+    owner = {
+        "model": {
+            "provider": "ollama",
+            "default": "llama3.2",
+            "base_url": "http://ollama.internal:11434/v1",
+        },
+        "providers": {"ollama": {"models": ["llama3.2"]}},
+    }
+    state = config.resolve_owner_model_state(
+        "@custom:ollama.internal:11434:llama3.2",
+        "custom:ollama.internal:11434",
+        config_obj=owner,
+    )
+    assert state.provider == "ollama"
+    assert state.base_url == "http://ollama.internal:11434/v1"
+    assert state.api_key is None
 
 
 def test_persisted_session_runtime_consumers_use_owner_state_and_connection(monkeypatch):

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -214,16 +214,69 @@ def test_owner_connection_collision_still_fails_closed():
 def test_reported_ollama_tagged_model_routes_with_owner(monkeypatch):
     """The reporter's tagged Ollama model stays whole and keeps its owner."""
     monkeypatch.setattr(config, "cfg", OLLAMA_CONFIG)
-    resolved = config.resolve_owner_model_state(
+    resolved = routes._resolve_compatible_session_model_state(
         "@custom:hermes-reasoner:latest",
-        stored_provider="custom",
-        config_obj=OLLAMA_CONFIG,
+        "custom",
+        profile_config=OLLAMA_CONFIG,
     )
-    assert (resolved.outbound_model, resolved.provider, resolved.base_url) == (
-        "hermes-reasoner:latest",
+    assert resolved == (
+        "@custom:hermes-reasoner:latest",
         "ollama",
-        "http://ollama-owner:11434/v1",
+        False,
     )
+
+
+def test_owner_compatibility_preserves_moa_fast_path(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("MoA compatibility must not build the catalog")
+        ),
+    )
+    assert routes._resolve_compatible_session_model_state(
+        "@moa:gpt-5.5",
+        "moa",
+        profile_config=OLLAMA_CONFIG,
+    ) == ("gpt-5.5", "moa", True)
+
+
+def test_session_lineage_owner_resolution_matrix(monkeypatch):
+    monkeypatch.setattr(profiles, "resolve_profile_config_context", lambda _name: ("owner", OLLAMA_CONFIG))
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda _name: "/owner")
+    monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {})
+    sessions = [
+        SimpleNamespace(profile=None, model="gpt-5.5", model_provider="openai-codex"),
+        SimpleNamespace(profile="owner", model="hermes-reasoner:latest", model_provider="ollama"),
+    ]
+    states = [routes._resolve_persisted_session_owner_state(s)[0] for s in sessions]
+    assert (states[0].model, states[0].provider) == ("gpt-5.5", "openai-codex")
+    assert (states[1].model, states[1].provider) == ("hermes-reasoner:latest", "ollama")
+
+
+def test_persisted_session_runtime_consumers_route_through_config_authority(monkeypatch):
+    owner = {**CUSTOM_OWNER_CONFIG, "_env": {"BACKUP_KEY": "owner-secret"}}
+    monkeypatch.setattr(profiles, "resolve_profile_config_context", lambda _name: ("owner", owner))
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda _name: "/owner")
+    monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {"BACKUP_KEY": "owner-secret"})
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda _home: owner)
+    session = SimpleNamespace(profile="owner", model="org/model", model_provider="custom:backup")
+    route_state, route_cfg = routes._resolve_persisted_session_owner_state(session)
+    stream_state = streaming._resolve_stream_owner_model_state(
+        "owner", "/owner", session.model, session.model_provider
+    )
+    assert route_cfg is owner
+    assert route_state.api_key == stream_state.api_key == "owner-secret"
+    assert route_state.base_url == stream_state.base_url == "https://backup.example/v1"
+
+
+def test_session_gateway_and_clone_consumers_route_through_config_authority(monkeypatch):
+    owner = {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "providers": {"openai-codex": {"models": ["gpt-5.5"]}},
+    }
+    profiles._validate_profile_model_selection("gpt-5.5", "openai-codex", config_obj=owner)
+    assert gateway_chat._gateway_model_field("@openai-codex:gpt-5.5", owner) == "gpt-5.5"
 
 
 def test_issue_model_is_one_built_in_custom_value_in_owning_registry():
@@ -270,7 +323,11 @@ def test_profile_validation_uses_live_catalog_with_source_config_for_parsing(mon
             "extra_models": [],
         }]
     }
-    monkeypatch.setattr(profiles, "_get_available_models_for_profile_validation", lambda: catalog)
+    monkeypatch.setattr(
+        profiles,
+        "_get_available_models_for_profile_validation",
+        lambda _config_obj=None: catalog,
+    )
     profiles._validate_profile_model_selection(
         "gpt-5.5",
         "openai-codex",

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -19,6 +19,119 @@ OLLAMA_CONFIG = {
     "providers": {"ollama": {"models": ["hermes-reasoner:latest"]}},
 }
 
+CUSTOM_OWNER_CONFIG = {
+    "model": {
+        "provider": "custom:backup",
+        "default": "org/model",
+        "base_url": "https://backup.example/v1",
+    },
+    "custom_providers": [
+        {
+            "name": "backup",
+            "base_url": "https://backup.example/v1",
+            "key_env": "BACKUP_KEY",
+            "models": "org/model",
+        }
+    ],
+}
+
+
+def test_owner_reconciliation_matrix():
+    valid = config.resolve_owner_model_state(
+        "@custom:backup:org/model", "stale", config_obj=CUSTOM_OWNER_CONFIG
+    )
+    repaired = config.resolve_owner_model_state(
+        "@removed:mistral-large", "removed", config_obj=CUSTOM_OWNER_CONFIG
+    )
+    matching = config.resolve_owner_model_state(
+        "org/model", "custom:backup", config_obj=CUSTOM_OWNER_CONFIG
+    )
+    assert (valid.outbound_model, valid.provider) == ("org/model", "custom:backup")
+    assert repaired.repaired is True
+    assert (repaired.outbound_model, repaired.provider) == ("org/model", "custom:backup")
+    assert (matching.outbound_model, matching.provider) == ("org/model", "custom:backup")
+
+
+def test_explicit_pick_unknown_qualifier_repairs_to_owner_default():
+    state = config.resolve_owner_model_state(
+        "@removed:mistral-large",
+        "removed",
+        config_obj=CUSTOM_OWNER_CONFIG,
+        explicitly_picked=True,
+    )
+    assert state.repaired is True
+    assert state.provider != "removed"
+
+
+def test_session_reload_prefers_qualified_owner_connection(monkeypatch):
+    monkeypatch.setenv("BACKUP_KEY", "owner-secret")
+    state = config.resolve_owner_model_state(
+        "@custom:backup:org/model", "custom", config_obj=CUSTOM_OWNER_CONFIG
+    )
+    assert (state.provider, state.base_url, state.api_key) == (
+        "custom:backup",
+        "https://backup.example/v1",
+        "owner-secret",
+    )
+
+
+def test_owner_connection_uses_env_backed_key_from_same_entry(monkeypatch):
+    monkeypatch.setenv("BACKUP_KEY", "env-secret")
+    assert config.resolve_custom_provider_connection(
+        "custom:backup", CUSTOM_OWNER_CONFIG
+    ) == ("env-secret", "https://backup.example/v1")
+
+
+def test_known_unconfigured_qualifier_is_not_removed():
+    state = config.resolve_owner_model_state(
+        "@openrouter:some/model", "openrouter", config_obj={}
+    )
+    assert state.provider == "openrouter"
+
+
+def test_explicit_empty_owner_never_falls_back_to_ambient_config(monkeypatch):
+    monkeypatch.setattr(config, "cfg", CUSTOM_OWNER_CONFIG)
+    state = config.resolve_owner_model_state("org/model", config_obj={})
+    catalog = config._static_models_catalog_without_live_probes({})
+    assert state.provider is None
+    assert state.base_url is None
+    assert not catalog.get("groups")
+
+
+def test_omitted_owner_config_preserves_ambient_resolver_contract(monkeypatch):
+    monkeypatch.setattr(config, "cfg", CUSTOM_OWNER_CONFIG)
+    resolved = config.resolve_model_provider("org/model")
+    assert resolved[1] == "custom:backup"
+
+
+def test_owner_connection_collision_still_fails_closed():
+    owner = {
+        "custom_providers": [
+            {"name": "Backup", "base_url": "https://one.example"},
+            {"name": "backup", "base_url": "https://two.example"},
+        ]
+    }
+    try:
+        config.resolve_custom_provider_connection("custom:backup", owner)
+    except config.AmbiguousCustomProviderError:
+        return
+    raise AssertionError("colliding custom provider slugs must fail closed")
+
+
+def test_reported_ollama_tagged_model_routes_with_owner(monkeypatch):
+    """The reporter's tagged Ollama model stays whole and keeps its owner."""
+    monkeypatch.setattr(config, "cfg", OLLAMA_CONFIG)
+    resolved = config.resolve_owner_model_state(
+        "@custom:hermes-reasoner:latest",
+        stored_provider="custom",
+        config_obj=OLLAMA_CONFIG,
+    )
+    assert (resolved.outbound_model, resolved.provider, resolved.base_url) == (
+        "hermes-reasoner:latest",
+        "ollama",
+        "http://ollama-owner:11434/v1",
+    )
+
 
 def test_issue_model_is_one_built_in_custom_value_in_owning_registry():
     assert config._parse_provider_qualified_model_id(
@@ -180,7 +293,7 @@ def test_session_new_route_uses_owner_config_when_body_profile_is_omitted(monkey
     session = captured["payload"]["session"]
     assert session["profile"] == "tls-owner"
     assert session["model"] == "@custom:hermes-reasoner:latest"
-    assert session["model_provider"] == "custom"
+    assert session["model_provider"] == "ollama"
 
 
 def test_gateway_route_composes_bare_issue_model_from_session_owner(monkeypatch, tmp_path):

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -156,6 +156,12 @@ def test_owner_endpoint_slug_keeps_local_provider_identity():
     assert state.provider == "ollama"
     assert state.base_url == "http://ollama.internal:11434/v1"
     assert state.api_key is None
+    uppercase = config.resolve_owner_model_state(
+        "@custom:OLLAMA.INTERNAL:11434:llama3.2",
+        "custom:OLLAMA.INTERNAL:11434",
+        config_obj=owner,
+    )
+    assert uppercase.provider == "ollama"
 
 
 def test_persisted_session_runtime_consumers_use_owner_state_and_connection(monkeypatch):

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -56,6 +56,32 @@ def test_missing_owner_config_is_empty_and_never_ambient(monkeypatch):
     assert profiles.resolve_profile_config_context() == ("missing", {})
 
 
+def test_profile_validation_uses_live_catalog_with_source_config_for_parsing(monkeypatch):
+    catalog = {
+        "groups": [{
+            "provider_id": "openai-codex",
+            "models": [{"id": "gpt-5.5"}],
+            "extra_models": [],
+        }]
+    }
+    monkeypatch.setattr(profiles, "_get_available_models_for_profile_validation", lambda: catalog)
+    profiles._validate_profile_model_selection(
+        "gpt-5.5",
+        "openai-codex",
+        config_obj={"model": {"provider": "other", "default": "not-in-catalog"}},
+    )
+
+
+def test_invalid_body_profile_binds_persisted_owner_to_active_config(monkeypatch):
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "live-owner")
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: f"/{name}")
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda home: OLLAMA_CONFIG)
+    assert profiles.resolve_profile_config_context("../../other") == (
+        "live-owner",
+        OLLAMA_CONFIG,
+    )
+
+
 def test_isolated_context_persists_pinned_owner_with_pinned_config(monkeypatch):
     monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: True)
     monkeypatch.setattr(profiles, "_isolated_profile_name", lambda: "pinned")
@@ -66,12 +92,16 @@ def test_isolated_context_persists_pinned_owner_with_pinned_config(monkeypatch):
 
 
 def test_session_model_state_uses_explicit_owner_config(monkeypatch):
-    poison = {"model": {"provider": "openrouter", "default": "latest"}}
-    monkeypatch.setattr(config, "cfg", poison)
-    model, provider = routes._session_model_state_from_request(
+    captured = {}
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda model, provider, **kwargs: captured.update(kwargs) or (model, provider, False),
+    )
+    routes._session_model_state_from_request(
         "@custom:hermes-reasoner:latest", None, profile_config=OLLAMA_CONFIG
     )
-    assert (model, provider) == ("@custom:hermes-reasoner:latest", "custom")
+    assert captured["profile_config"] is OLLAMA_CONFIG
 
 
 def test_gateway_boundary_uses_the_same_owner_config():
@@ -83,11 +113,21 @@ def test_gateway_boundary_uses_the_same_owner_config():
 def test_context_length_lookup_keeps_persisted_owner_config(monkeypatch):
     captured = {}
 
-    def lookup(model, provider, *, cfg):
+    def lookup(model, provider, *, base_url=None, cfg):
         captured["cfg"] = cfg
         return SimpleNamespace(provider=provider, base_url="", api_key="")
 
     monkeypatch.setattr(routes, "_context_length_lookup_inputs_for_model", lookup)
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda model: ("hermes-reasoner:latest", "custom", ""),
+    )
+    monkeypatch.setattr(
+        config,
+        "model_with_provider_context",
+        lambda model, provider=None: model,
+    )
     routes._session_context_length_lookup_state(
         "@custom:hermes-reasoner:latest", "custom", OLLAMA_CONFIG
     )

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -164,6 +164,20 @@ def test_owner_endpoint_slug_keeps_local_provider_identity():
     assert uppercase.provider == "ollama"
 
 
+def test_profile_default_repairs_unqualified_cross_provider_session_model():
+    owner = {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "providers": {"openai-codex": {"models": ["gpt-5.5"]}},
+    }
+    assert routes._resolve_compatible_session_model_state(
+        "openai/gpt-5.4-mini",
+        "openai-codex",
+        profile_provider="openai-codex",
+        profile_default_model="gpt-5.5",
+        profile_config=owner,
+    ) == ("gpt-5.5", "openai-codex", True)
+
+
 def test_persisted_session_runtime_consumers_use_owner_state_and_connection(monkeypatch):
     owner = {
         **CUSTOM_OWNER_CONFIG,

--- a/tests/test_issue7073_qualified_model_registry.py
+++ b/tests/test_issue7073_qualified_model_registry.py
@@ -1,0 +1,166 @@
+"""Regression coverage for profile-owned qualified model parsing (#7073)."""
+
+import json
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import api.config as config
+import api.gateway_chat as gateway_chat
+import api.profiles as profiles
+import api.routes as routes
+
+
+OLLAMA_CONFIG = {
+    "model": {
+        "provider": "ollama",
+        "default": "hermes-reasoner:latest",
+        "base_url": "http://ollama-owner:11434/v1",
+    },
+    "providers": {"ollama": {"models": ["hermes-reasoner:latest"]}},
+}
+
+
+def test_issue_model_is_one_built_in_custom_value_in_owning_registry():
+    assert config._parse_provider_qualified_model_id(
+        "@custom:hermes-reasoner:latest", OLLAMA_CONFIG
+    ) == ("hermes-reasoner:latest", "custom")
+
+
+def test_named_custom_provider_wins_over_built_in_custom_model():
+    owner = {
+        **OLLAMA_CONFIG,
+        "custom_providers": [{"name": "hermes-reasoner"}],
+    }
+    assert config._parse_provider_qualified_model_id(
+        "@custom:hermes-reasoner:latest", owner
+    ) == ("latest", "custom:hermes-reasoner")
+
+
+def test_profile_context_returns_owner_and_config_as_one_pair(monkeypatch):
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "tls-owner")
+    monkeypatch.setattr(
+        profiles, "get_hermes_home_for_profile", lambda name: f"/profiles/{name}"
+    )
+    monkeypatch.setattr(
+        config,
+        "get_config_for_profile_home",
+        lambda home: OLLAMA_CONFIG if str(home).endswith("tls-owner") else {"poison": True},
+    )
+    assert profiles.resolve_profile_config_context() == ("tls-owner", OLLAMA_CONFIG)
+
+
+def test_missing_owner_config_is_empty_and_never_ambient(monkeypatch):
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "missing")
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: "/missing")
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda home: {})
+    assert profiles.resolve_profile_config_context() == ("missing", {})
+
+
+def test_isolated_context_persists_pinned_owner_with_pinned_config(monkeypatch):
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: True)
+    monkeypatch.setattr(profiles, "_isolated_profile_name", lambda: "pinned")
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: f"/{name}")
+    monkeypatch.setattr(config, "get_config_for_profile_home", lambda home: OLLAMA_CONFIG)
+
+    assert profiles.resolve_profile_config_context("requested") == ("pinned", OLLAMA_CONFIG)
+
+
+def test_session_model_state_uses_explicit_owner_config(monkeypatch):
+    poison = {"model": {"provider": "openrouter", "default": "latest"}}
+    monkeypatch.setattr(config, "cfg", poison)
+    model, provider = routes._session_model_state_from_request(
+        "@custom:hermes-reasoner:latest", None, profile_config=OLLAMA_CONFIG
+    )
+    assert (model, provider) == ("@custom:hermes-reasoner:latest", "custom")
+
+
+def test_gateway_boundary_uses_the_same_owner_config():
+    assert gateway_chat._gateway_model_field(
+        "@custom:hermes-reasoner:latest", OLLAMA_CONFIG
+    ) == "hermes-reasoner:latest"
+
+
+def test_context_length_lookup_keeps_persisted_owner_config(monkeypatch):
+    captured = {}
+
+    def lookup(model, provider, *, cfg):
+        captured["cfg"] = cfg
+        return SimpleNamespace(provider=provider, base_url="", api_key="")
+
+    monkeypatch.setattr(routes, "_context_length_lookup_inputs_for_model", lookup)
+    routes._session_context_length_lookup_state(
+        "@custom:hermes-reasoner:latest", "custom", OLLAMA_CONFIG
+    )
+    assert captured["cfg"] is OLLAMA_CONFIG
+
+
+def test_parser_preserves_endpoint_and_known_provider_shapes():
+    assert config._parse_provider_qualified_model_id(
+        "@custom:localhost:11434:llama3.2", OLLAMA_CONFIG
+    ) == ("llama3.2", "custom:localhost:11434")
+    assert config._parse_provider_qualified_model_id(
+        "@openrouter:model-a:free", OLLAMA_CONFIG
+    ) == ("model-a:free", "openrouter")
+
+
+def test_gateway_body_contract_keeps_issue_model_bytes():
+    body = {"model": gateway_chat._gateway_model_field(
+        "@custom:hermes-reasoner:latest", OLLAMA_CONFIG
+    ), "provider": "custom"}
+    assert json.dumps(body, sort_keys=True) == (
+        '{"model": "hermes-reasoner:latest", "provider": "custom"}'
+    )
+
+
+def test_session_new_route_uses_owner_config_when_body_profile_is_omitted(monkeypatch, tmp_path):
+    """The production route must bind parsing before real Session creation."""
+    captured = {}
+    monkeypatch.setattr(
+        profiles,
+        "resolve_profile_config_context",
+        lambda profile=None: ("tls-owner", OLLAMA_CONFIG),
+    )
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {
+        "model": "@custom:hermes-reasoner:latest",
+        "worktree": False,
+        "workspace": str(tmp_path),
+    })
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_csrf_exempt_path", lambda _path: False)
+    monkeypatch.setattr(routes, "_handle_extension_sidecar_proxy", lambda *_a, **_k: False)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_a, **_k: True)
+    monkeypatch.setattr(routes, "_resolve_new_session_workspace", lambda *_a: str(tmp_path))
+    monkeypatch.setattr(routes, "_session_id_visible_to_request_profile", lambda *_a, **_k: True)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.setdefault("payload", payload))
+    monkeypatch.setattr(routes, "bad", lambda _handler, message, status=400, **_kwargs: captured.setdefault("error", (status, message)))
+
+    handler = SimpleNamespace(command="POST", headers={})
+    routes.handle_post(handler, urlparse("/api/session/new"))
+
+    session = captured["payload"]["session"]
+    assert session["profile"] == "tls-owner"
+    assert session["model"] == "@custom:hermes-reasoner:latest"
+    assert session["model_provider"] == "custom"
+
+
+def test_gateway_route_composes_bare_issue_model_from_session_owner(monkeypatch, tmp_path):
+    """The real legacy Gateway builder must use the persisted session owner."""
+    from tests.test_issue6722_provider_qualified_model_leak import _run_legacy_gateway_chat
+
+    monkeypatch.setattr(
+        profiles,
+        "resolve_profile_config_context",
+        lambda profile=None: ("tls-owner", OLLAMA_CONFIG),
+    )
+    original_get_session = gateway_chat.get_session
+
+    def owner_session(session_id):
+        session = original_get_session(session_id)
+        session.profile = "tls-owner"
+        return session
+
+    monkeypatch.setattr(gateway_chat, "get_session", owner_session)
+    payload = _run_legacy_gateway_chat(
+        tmp_path, monkeypatch, "@custom:hermes-reasoner:latest"
+    )
+    assert payload["model"] == "hermes-reasoner:latest"

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -206,7 +206,7 @@ def test_profile_create_rejects_unknown_model_before_creating_profile(monkeypatc
     monkeypatch.setattr(
         profiles,
         "_get_available_models_for_profile_validation",
-        lambda: {
+        lambda _config_obj=None: {
             "groups": [
                 {
                     "provider": "OpenAI Codex",

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -230,3 +230,33 @@ def test_profile_create_rejects_unknown_model_before_creating_profile(monkeypatc
         )
 
     assert calls == []
+
+
+def test_clone_validation_accepts_full_builtin_owner_catalog(monkeypatch):
+    owner = {"model": {"provider": "openai", "default": "gpt-5.4"}}
+    monkeypatch.setattr(profiles, "_get_available_models_for_profile_validation", lambda cfg: {
+        "groups": [{"provider_id": "openai", "models": [{"id": "gpt-5.5"}]}]
+    })
+    profiles._validate_profile_model_selection("gpt-5.5", "openai", config_obj=owner)
+
+
+def test_clone_validation_accepts_custom_provider_model_shapes():
+    owner = {
+        "custom_providers": [{
+            "name": "backup",
+            "model": "single-model",
+            "models": ["list-model", {"id": "id-model"}, {"model": "model-model"}, {"name": "name-model"}],
+        }]
+    }
+    catalog = profiles._get_available_models_for_profile_validation(owner)
+    ids = {
+        model["id"]
+        for group in catalog["groups"]
+        for model in group.get("models", [])
+    }
+    assert {"single-model", "list-model", "id-model", "model-model", "name-model"} <= ids
+
+
+def test_clone_validation_accepts_custom_provider_models_scalar_string():
+    owner = {"custom_providers": [{"name": "backup", "models": "org/model"}]}
+    profiles._validate_profile_model_selection("org/model", "custom:backup", config_obj=owner)

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -241,6 +241,23 @@ def test_clone_validation_accepts_full_builtin_owner_catalog(monkeypatch):
     profiles._validate_profile_model_selection("gpt-5.5", "openai-codex", config_obj=owner)
 
 
+def test_clone_validation_accepts_owner_model_models_allowlist(monkeypatch):
+    owner = {
+        "model": {
+            "provider": "openai-codex",
+            "default": "gpt-5.4",
+            "models": ["gpt-5.5"],
+        }
+    }
+    monkeypatch.setattr(
+        "api.config.get_available_models",
+        lambda: (_ for _ in ()).throw(AssertionError("ambient catalog was consulted")),
+    )
+    profiles._validate_profile_model_selection(
+        "gpt-5.5", "openai-codex", config_obj=owner
+    )
+
+
 def test_clone_validation_accepts_custom_provider_model_shapes():
     owner = {
         "custom_providers": [{

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -233,11 +233,12 @@ def test_profile_create_rejects_unknown_model_before_creating_profile(monkeypatc
 
 
 def test_clone_validation_accepts_full_builtin_owner_catalog(monkeypatch):
-    owner = {"model": {"provider": "openai", "default": "gpt-5.4"}}
-    monkeypatch.setattr(profiles, "_get_available_models_for_profile_validation", lambda cfg: {
-        "groups": [{"provider_id": "openai", "models": [{"id": "gpt-5.5"}]}]
-    })
-    profiles._validate_profile_model_selection("gpt-5.5", "openai", config_obj=owner)
+    owner = {"model": {"provider": "openai-codex", "default": "gpt-5.4"}}
+    monkeypatch.setattr(
+        "api.config.get_available_models",
+        lambda: (_ for _ in ()).throw(AssertionError("ambient catalog was consulted")),
+    )
+    profiles._validate_profile_model_selection("gpt-5.5", "openai-codex", config_obj=owner)
 
 
 def test_clone_validation_accepts_custom_provider_model_shapes():

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -172,7 +172,13 @@ def test_profile_validation_catalog_uses_clone_source_config(monkeypatch):
     source_config = {
         "model": {"default": "source-only-model", "provider": "source-provider"},
         "providers": {
-            "source-provider": {"models": ["source-only-model", "source-alt-model"]}
+            "source-provider": {
+                "models": [
+                    "source-only-model",
+                    {"model": "source-dict-model"},
+                    {"name": "source-name-model"},
+                ]
+            }
         },
     }
 
@@ -182,7 +188,7 @@ def test_profile_validation_catalog_uses_clone_source_config(monkeypatch):
     )
 
     profiles._validate_profile_model_selection(
-        "source-alt-model",
+        "source-dict-model",
         "source-provider",
         config_obj=source_config,
     )

--- a/tests/test_issue749_profile_create_model_picker.py
+++ b/tests/test_issue749_profile_create_model_picker.py
@@ -168,6 +168,32 @@ def test_profile_model_selection_rejects_unknown_model_provider_pair():
         )
 
 
+def test_profile_validation_catalog_uses_clone_source_config(monkeypatch):
+    source_config = {
+        "model": {"default": "source-only-model", "provider": "source-provider"},
+        "providers": {
+            "source-provider": {"models": ["source-only-model", "source-alt-model"]}
+        },
+    }
+
+    monkeypatch.setattr(
+        "api.config.get_available_models",
+        lambda: (_ for _ in ()).throw(AssertionError("ambient catalog was consulted")),
+    )
+
+    profiles._validate_profile_model_selection(
+        "source-alt-model",
+        "source-provider",
+        config_obj=source_config,
+    )
+    with pytest.raises(ValueError, match="Selected model 'active-only-model'"):
+        profiles._validate_profile_model_selection(
+            "active-only-model",
+            "source-provider",
+            config_obj=source_config,
+        )
+
+
 def test_profile_create_rejects_unknown_model_before_creating_profile(monkeypatch):
     calls = []
 

--- a/tests/test_resolve_model_provider_free_suffix.py
+++ b/tests/test_resolve_model_provider_free_suffix.py
@@ -17,6 +17,23 @@ back to ``split(":", 1)`` so trailing suffixes stay with the model.
 """
 
 from api.config import resolve_model_provider, model_with_provider_context
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _configured_named_custom_provider():
+    import api.config as cfg_mod
+
+    missing = object()
+    old = cfg_mod.cfg.get("custom_providers", missing)
+    cfg_mod.cfg["custom_providers"] = [{"name": "my-key", "models": ["some-model"]}]
+    try:
+        yield
+    finally:
+        if old is missing:
+            cfg_mod.cfg.pop("custom_providers", None)
+        else:
+            cfg_mod.cfg["custom_providers"] = old
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resolve_model_provider_free_suffix.py
+++ b/tests/test_resolve_model_provider_free_suffix.py
@@ -20,20 +20,17 @@ from api.config import resolve_model_provider, model_with_provider_context
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _configured_named_custom_provider():
+@pytest.fixture
+def configured_named_custom_provider(monkeypatch):
     import api.config as cfg_mod
 
-    missing = object()
-    old = cfg_mod.cfg.get("custom_providers", missing)
+    old = cfg_mod.cfg.get("custom_providers")
     cfg_mod.cfg["custom_providers"] = [{"name": "my-key", "models": ["some-model"]}]
-    try:
-        yield
-    finally:
-        if old is missing:
-            cfg_mod.cfg.pop("custom_providers", None)
-        else:
-            cfg_mod.cfg["custom_providers"] = old
+    yield
+    if old is None:
+        cfg_mod.cfg.pop("custom_providers", None)
+    else:
+        cfg_mod.cfg["custom_providers"] = old
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +105,7 @@ def test_openrouter_thinking_suffix():
         _restore_config(old, cfg_mod)
 
 
-def test_custom_provider_rsplit_still_works():
+def test_custom_provider_rsplit_still_works(configured_named_custom_provider):
     """custom:my-key:model must still parse correctly via rsplit."""
     qualified = "@custom:my-key:some-model"
     model, provider, _ = resolve_model_provider(qualified)
@@ -149,7 +146,7 @@ def test_known_provider_anthropic():
 # it back so the model becomes "<b>:<c>".
 # ---------------------------------------------------------------------------
 
-def test_custom_provider_free_suffix_1776():
+def test_custom_provider_free_suffix_1776(configured_named_custom_provider):
     """@custom:my-key:some-model:free → custom:my-key + some-model:free (#1776)."""
     qualified = "@custom:my-key:some-model:free"
     model, provider, _ = resolve_model_provider(qualified)
@@ -157,7 +154,7 @@ def test_custom_provider_free_suffix_1776():
     assert model == "some-model:free", f"expected model='some-model:free', got '{model}'"
 
 
-def test_custom_provider_beta_suffix_1776():
+def test_custom_provider_beta_suffix_1776(configured_named_custom_provider):
     """@custom:my-key:some-model:beta — same bug class as :free."""
     qualified = "@custom:my-key:some-model:beta"
     model, provider, _ = resolve_model_provider(qualified)
@@ -165,7 +162,7 @@ def test_custom_provider_beta_suffix_1776():
     assert model == "some-model:beta"
 
 
-def test_custom_provider_thinking_suffix_1776():
+def test_custom_provider_thinking_suffix_1776(configured_named_custom_provider):
     """@custom:my-key:some-model:thinking — same bug class as :free."""
     qualified = "@custom:my-key:some-model:thinking"
     model, provider, _ = resolve_model_provider(qualified)
@@ -173,7 +170,7 @@ def test_custom_provider_thinking_suffix_1776():
     assert model == "some-model:thinking"
 
 
-def test_custom_provider_preview_suffix_1776():
+def test_custom_provider_preview_suffix_1776(configured_named_custom_provider):
     """@custom:my-key:some-model:preview — same bug class, no allowlist needed."""
     qualified = "@custom:my-key:some-model:preview"
     model, provider, _ = resolve_model_provider(qualified)
@@ -181,7 +178,7 @@ def test_custom_provider_preview_suffix_1776():
     assert model == "some-model:preview"
 
 
-def test_custom_provider_slashed_model_with_free_suffix_1776():
+def test_custom_provider_slashed_model_with_free_suffix_1776(configured_named_custom_provider):
     """@custom:my-key:org/model:free — custom hint + slashed model + suffix."""
     qualified = "@custom:my-key:org/model:free"
     model, provider, _ = resolve_model_provider(qualified)

--- a/tests/test_workspace_stale_recovery.py
+++ b/tests/test_workspace_stale_recovery.py
@@ -69,7 +69,9 @@ def test_resolve_chat_workspace_with_recovery_repairs_missing_implicit_workspace
 
     assert resolved == str(fallback.resolve())
     assert session.workspace == str(fallback.resolve())
-    assert str(fallback.resolve()) in sidecar.read_text(encoding="utf-8")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["workspace"] == str(
+        fallback.resolve()
+    )
 
 
 def test_chat_recovery_persistence_failure_fails_closed(monkeypatch, tmp_path):
@@ -172,7 +174,9 @@ def _post_new_session_with_workspace(
         else (_ for _ in ()).throw(KeyError(sid)),
     )
     monkeypatch.setattr(routes, "get_last_workspace", get_fallback)
-    monkeypatch.setattr(routes, "_session_model_state_from_request", lambda *_a: (None, None))
+    monkeypatch.setattr(
+        routes, "_session_model_state_from_request", lambda *_a, **_k: (None, None)
+    )
     monkeypatch.setattr(routes, "new_session", create_session)
     monkeypatch.setattr(
         session_lifecycle,
@@ -385,7 +389,9 @@ def test_list_dir_recovers_missing_implicit_session_workspace(monkeypatch, tmp_p
 
     assert captured == {"workspace": fallback.resolve(), "rel_path": "."}
     assert session.workspace == str(fallback.resolve())
-    assert str(fallback.resolve()) in sidecar.read_text(encoding="utf-8")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["workspace"] == str(
+        fallback.resolve()
+    )
     assert payload == {
         "entries": [],
         "signature": "sig",
@@ -435,7 +441,9 @@ def test_list_recovery_stays_bound_when_global_fallback_changes(
     assert payload["workspace"] == str(fallback_a.resolve())
     assert session.workspace == str(fallback_a.resolve())
     assert captured["listed"] == fallback_a.resolve()
-    assert str(fallback_a.resolve()) in sidecar.read_text(encoding="utf-8")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["workspace"] == str(
+        fallback_a.resolve()
+    )
 
 
 def test_persisted_list_recovery_anchors_later_create_dir_to_fallback_a(


### PR DESCRIPTION
## Thinking Path

- Qualified model IDs carry provider ownership, but restored sessions and downstream consumers can outlive the active profile that created them.
- The previous fix made parsing owner-aware while several resolver, credential, Gateway, and clone paths still consulted ambient configuration.
- This rework makes `api/config.py` the owner-scoped authority, then routes session, runtime, Gateway, and clone consumers through its result.

## What Changed

- `api/config.py` now resolves the model, provider, endpoint, credential, and static catalog from the effective owner configuration; built-in runtime credentials enter the owner profile scope, and `model.models` allowlists remain available during clone validation.
- `api/routes.py`, `api/streaming.py`, and `api/profiles.py` use the owner result for restored sessions, silent reloads, runtime calls, and clone validation.
- `api/gateway_chat.py` keeps the Gateway server credential separate from provider credentials and omits the unsupported provider field from `/v1/runs` requests.
- Focused regressions cover the reporter case, removed and unknown qualifiers, owner credentials, endpoint-derived local providers, Gateway authentication and request shapes, clone catalogs, and compatibility fast paths.

## Why It Matters

The same qualified selection now keeps its owner-specific model, provider, endpoint, and credential across session restoration and runtime consumers. A provider credential cannot be reused as the Gateway server credential.

## Verification

The origin/master reproduction fails with the wrong provider/model tuple; the rebuilt head passes with the owner Ollama provider. Focused validation passed 238 tests across the owner-resolution, Gateway, profile, compatibility, context, worktree, recovery, runtime-route, and source-audit paths; the final endpoint-alias and source-owner `model.models` regressions also passed.

## Risks / Follow-ups

The reporter's Ollama host and arbitrary custom endpoints aren't available locally, so live-provider acceptance remains CI or maintainer-owned. This change doesn't alter the persisted model schema, Settings UI, or custom-provider CRUD surface.

## Contract Routing

- Task type: bugfix
- Touched areas: qualified model resolution, profile ownership, session runtime, Gateway requests, clone validation
- Relevant public docs: none
- Scope boundaries: credentials are resolved only for the owning profile; provider management, Settings UI, and persistence schema remain unchanged
- Evidence needed before claiming done: focused owner/Gateway regressions and the hosted CI matrix

## Contract Change

- Previous contract: parsing could preserve an owner qualifier while downstream resolution, credentials, or catalog membership came from ambient configuration.
- New contract: owner-scoped consumers use one canonical model/provider/connection result; legacy Gateway requests carry the provider, while `/v1/runs` sends only fields supported by its upstream contract.
- Affected tests: owner-resolution, Gateway, clone-validation, and compatibility regressions in this PR.
- Compatibility: omitted owner configuration keeps the existing ambient resolver behavior, and existing Gateway stream lifecycles remain unchanged.

## Model Used

GPT-5.6-sol via Codex CLI; adversarial same-provider and cross-provider review shaped the owner-runtime and Gateway boundary fixes.

## Upstream

Refs https://github.com/nesquena/hermes-webui/issues/7073
