### PR TITLE
fix(streaming): preserve process wakeup checkpoint metadata

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1780,6 +1780,45 @@ def _active_turn_has_checkpoint(messages, identity):
     return any(_active_turn_token_matches(message, identity) for message in messages or [])
 
 
+def _collapse_active_turn_checkpoints(messages, identity):
+    messages = list(messages or [])
+    if not isinstance(identity, dict) or not identity.get('token'):
+        return messages
+    matching = [
+        index
+        for index, message in enumerate(messages)
+        if _active_turn_token_matches(message, identity)
+    ]
+    if len(matching) < 2:
+        return messages
+    checkpoint = identity.get('checkpoint')
+    checkpoint_key = _message_replay_key(checkpoint) if isinstance(checkpoint, dict) else None
+    expected_text = identity.get('text')
+    normalized_expected = (
+        _normalize_user_text(_message_text(expected_text))
+        if expected_text is not None
+        else None
+    )
+    keep_index = max(
+        matching,
+        key=lambda index: (
+            checkpoint_key is not None
+            and _message_replay_key(messages[index]) == checkpoint_key,
+            normalized_expected is not None
+            and _normalize_user_text(_message_text(messages[index].get('content')))
+            == normalized_expected,
+            bool(messages[index].get('_db_persisted')),
+            index,
+        ),
+    )
+    matching = set(matching)
+    return [
+        message
+        for index, message in enumerate(messages)
+        if index == keep_index or index not in matching
+    ]
+
+
 def _mark_active_turn_checkpoint(message, identity):
     if (
         isinstance(message, dict)
@@ -1788,6 +1827,7 @@ def _mark_active_turn_checkpoint(message, identity):
         and identity.get('token')
     ):
         message['_active_turn_token'] = identity['token']
+        stamp_message_source(message, identity.get('source'))
     return message
 
 
@@ -1795,7 +1835,12 @@ def _mark_active_turn_checkpoint_in_history(messages, identity, msg_text, *, all
     messages = list(messages or [])
     if not isinstance(identity, dict):
         return messages, False
+    messages = _collapse_active_turn_checkpoints(messages, identity)
     if _active_turn_has_checkpoint(messages, identity):
+        for message in messages:
+            if _active_turn_token_matches(message, identity):
+                _mark_active_turn_checkpoint(message, identity)
+                break
         return messages, True
     if not allow_index_fallback:
         return messages, False
@@ -1901,7 +1946,7 @@ def _materialize_active_turn_user(identity, msg_text, source):
 
 def _settle_current_turn_boundary(previous_context, result_messages, identity, msg_text, source):
     """Insert the pending turn before assistant/tool output when it is absent."""
-    result_messages = list(result_messages or [])
+    result_messages = _collapse_active_turn_checkpoints(result_messages, identity)
     if not result_messages or not isinstance(identity, dict):
         return result_messages
     _checkpoint_idx = _find_active_turn_checkpoint_index(
@@ -1920,6 +1965,12 @@ def _settle_current_turn_boundary(previous_context, result_messages, identity, m
                 and existing_checkpoint.get('id') is not None
             ):
                 retained_checkpoint['id'] = existing_checkpoint['id']
+            if (
+                not retained_checkpoint.get('_db_persisted')
+                and isinstance(existing_checkpoint, dict)
+                and existing_checkpoint.get('_db_persisted')
+            ):
+                retained_checkpoint['_db_persisted'] = existing_checkpoint['_db_persisted']
             result_messages[_checkpoint_idx] = retained_checkpoint
         else:
             _mark_active_turn_checkpoint(existing_checkpoint, identity)
@@ -1952,12 +2003,19 @@ def _settle_current_turn_boundary(previous_context, result_messages, identity, m
     )
 
 
-def _align_current_turn_display(previous_display, previous_context, identity):
+def _align_current_turn_display(
+    previous_display,
+    previous_context,
+    identity,
+    *,
+    allow_context_checkpoint_append=False,
+):
     """Make a context-only exact checkpoint visible before shared settlement."""
     display = list(previous_display or [])
     context = list(previous_context or [])
     if not isinstance(identity, dict):
         return display, context
+    context = _collapse_active_turn_checkpoints(context, identity)
     display, _ = _mark_active_turn_checkpoint_in_history(
         display,
         identity,
@@ -1965,6 +2023,10 @@ def _align_current_turn_display(previous_display, previous_context, identity):
         allow_index_fallback=False,
     )
     if _active_turn_has_checkpoint(display, identity):
+        if allow_context_checkpoint_append and not _active_turn_has_checkpoint(context, identity):
+            checkpoint = _owner_projection_current_turn_row(display, identity)
+            if checkpoint is not None:
+                context.append(checkpoint)
         return display, context
     checkpoint = _owner_projection_current_turn_row(
         context,
@@ -2069,7 +2131,10 @@ def _settle_result_messages(
         if result_messages
         else list(next_context_messages or [])
     )
-    if result_messages:
+    if result_messages or _active_turn_has_checkpoint(
+        session.context_messages,
+        active_turn_identity,
+    ):
         session.context_messages = _settle_current_turn_boundary(
             previous_context_messages,
             session.context_messages,
@@ -2081,6 +2146,7 @@ def _settle_result_messages(
         previous_messages,
         session.context_messages,
         active_turn_identity,
+        allow_context_checkpoint_append=not result_messages,
     )
     session.messages = _merge_display_messages_after_agent_result(
         previous_display_for_writeback,

--- a/tests/test_process_wakeup_synthetic.py
+++ b/tests/test_process_wakeup_synthetic.py
@@ -1,11 +1,18 @@
 """Test coverage for source field threading on process-wakeup synthetic turns."""
 
 import time
+import types
 from pathlib import Path
 
 from api.models import Session, _append_recovered_pending_turn, _apply_core_sync_or_error_marker
 from api.routes import _checkpoint_user_message_for_eager_session_save
-from api.streaming import _materialize_pending_user_turn_before_error, _merge_display_messages_after_agent_result
+from api.streaming import (
+    _materialize_pending_user_turn_before_error,
+    _merge_display_messages_after_agent_result,
+    _normalize_user_text,
+    _message_text,
+)
+from api import streaming
 
 
 def test_append_recovered_pending_turn_stamps_process_wakeup_source():
@@ -190,3 +197,276 @@ def test_apply_core_sync_or_error_marker_clears_pending_user_source(tmp_path):
 
     assert _apply_core_sync_or_error_marker(s, Path(tmp_path / "missing-core.json")) is True
     assert s.pending_user_source is None
+
+
+_DEFERRED_WAKEUP_TEXT = (
+    "[IMPORTANT: Background process proc_deferred_1 completed (exit_code=3).\n"
+    "Command: cargo test -q\n"
+    "Output:\n"
+    "build failed\n"
+)
+_DEFERRED_TOKEN = "ws-deferred:1700000000"
+_DEFERRED_HISTORY = [
+    {"role": "user", "content": "earlier question"},
+    {"role": "assistant", "content": "earlier answer"},
+]
+_DEFERRED_WAKEUP_META = {
+    "type": "completion",
+    "task_id": "proc_deferred_1",
+    "command": "cargo test -q",
+    "exit_code": 3,
+}
+
+
+def _deferred_active_turn_identity(source):
+    """Server-owned active-turn authority for a deferred-save settlement."""
+    return {
+        "session_id": "test-session-wakeup-deferred",
+        "token": _DEFERRED_TOKEN,
+        "text": _DEFERRED_WAKEUP_TEXT,
+        "timestamp": 1700000000.0,
+        "source": source,
+        "attachments": [],
+        "checkpoint": None,
+        "current_turn_user_idx": len(_DEFERRED_HISTORY),
+        "turn_id": "turn-deferred-1",
+    }
+
+
+def _run_deferred_settlement(
+    source,
+    *,
+    result_messages=None,
+    duplicate_token_row=False,
+    authoritative_checkpoint=False,
+    display_only_checkpoint=False,
+):
+    """Settle a retained token-owned current-turn row lacking provenance.
+
+    The retained row shape mirrors deferred Agent/state.db reconciliation:
+    role=user, ``_db_persisted=True``, matching ``_active_turn_token``, but no
+    ``_source`` and no ``_wakeup_meta``. Display and context hold distinct row
+    copies, as they do when reloaded from persisted state.
+    """
+    def retained_row():
+        return {
+            "role": "user",
+            "content": _DEFERRED_WAKEUP_TEXT,
+            "timestamp": 1700000000.0,
+            "_db_persisted": True,
+            "_active_turn_token": _DEFERRED_TOKEN,
+        }
+
+    def checkpoint_rows():
+        retained = retained_row()
+        if authoritative_checkpoint:
+            retained["id"] = "user-2"
+        rows = [retained]
+        if duplicate_token_row:
+            rows.insert(0, {
+                "role": "user",
+                "content": "historical same-token text",
+                "_active_turn_token": _DEFERRED_TOKEN,
+            })
+        if authoritative_checkpoint:
+            checkpoint = retained_row()
+            checkpoint["_db_persisted"] = False
+            rows.append(checkpoint)
+        return rows
+
+    previous_display = [dict(m) for m in _DEFERRED_HISTORY] + checkpoint_rows()
+    previous_context = [dict(m) for m in _DEFERRED_HISTORY]
+    if not display_only_checkpoint:
+        previous_context += checkpoint_rows()
+    active_turn_identity = _deferred_active_turn_identity(source)
+    if authoritative_checkpoint:
+        active_turn_identity["checkpoint"] = dict(previous_context[-1])
+    if result_messages is None:
+        result_messages = (
+            [dict(m) for m in _DEFERRED_HISTORY]
+            + [retained_row()]
+            + [{"role": "assistant", "content": "The background job failed; here is why."}]
+        )
+    session = types.SimpleNamespace(
+        messages=list(previous_display),
+        context_messages=list(previous_context),
+    )
+    streaming._settle_result_messages(
+        session,
+        previous_display,
+        previous_context,
+        result_messages,
+        _DEFERRED_WAKEUP_TEXT,
+        source,
+        active_turn_identity,
+    )
+    return session
+
+
+def _current_turn_survivors(messages):
+    same_token = [
+        m for m in messages
+        if isinstance(m, dict) and m.get("_active_turn_token") == _DEFERRED_TOKEN
+    ]
+    same_text = [
+        m for m in messages
+        if isinstance(m, dict)
+        and m.get("role") == "user"
+        and _normalize_user_text(_message_text(m.get("content")))
+        == _normalize_user_text(_DEFERRED_WAKEUP_TEXT)
+    ]
+    return same_token, same_text
+
+
+def test_deferred_settlement_restores_wakeup_provenance_on_retained_token_row():
+    """A token-owned retained user row regains trusted wakeup provenance."""
+    session = _run_deferred_settlement("process_wakeup")
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["role"] == "user", label
+        assert survivor["_db_persisted"] is True, label
+        assert survivor["_source"] == "process_wakeup", label
+        assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META, label
+
+
+def test_empty_result_aligns_display_checkpoint_into_context():
+    """An exact display checkpoint is copied into an empty context projection."""
+    session = _run_deferred_settlement(
+        "process_wakeup",
+        result_messages=[],
+        display_only_checkpoint=True,
+    )
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["_db_persisted"] is True, label
+        assert survivor["_source"] == "process_wakeup", label
+        assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META, label
+
+
+def test_prefix_mismatch_does_not_tail_append_display_checkpoint_to_context():
+    """A failed non-empty boundary settlement must not move wakeup into context tail."""
+    session = _run_deferred_settlement(
+        "process_wakeup",
+        result_messages=[
+            {"role": "user", "content": "unrelated"},
+            {"role": "assistant", "content": "answer"},
+        ],
+        display_only_checkpoint=True,
+    )
+
+    context_tokens = [
+        message
+        for message in session.context_messages
+        if message.get("_active_turn_token") == _DEFERRED_TOKEN
+    ]
+    assert not context_tokens
+    assert session.context_messages[-1]["role"] == "assistant"
+    assert session.context_messages[-1]["content"] == "answer"
+
+    same_token, same_text = _current_turn_survivors(session.messages)
+    assert len(same_token) == 1
+    assert len(same_text) == 1
+    survivor = same_token[0]
+    assert same_text[0] is survivor
+    assert survivor["_db_persisted"] is True
+    assert survivor["_source"] == "process_wakeup"
+    assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META
+
+
+def test_deferred_settlement_leaves_webui_canonical_lookalike_unstamped():
+    """An ordinary webui turn with canonical-prompt-shaped text stays plain."""
+    session = _run_deferred_settlement("webui")
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["role"] == "user", label
+        assert survivor["_db_persisted"] is True, label
+        assert "_source" not in survivor, label
+        assert "_wakeup_meta" not in survivor, label
+
+
+def test_empty_result_settlement_restores_wakeup_provenance_in_context():
+    """An empty Agent result still enriches the retained context checkpoint."""
+    session = _run_deferred_settlement("process_wakeup", result_messages=[])
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["_db_persisted"] is True, label
+        assert survivor["_source"] == "process_wakeup", label
+        assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META, label
+
+
+def test_empty_result_collapses_duplicate_token_checkpoints_to_retained_row():
+    """Same-token history cannot displace the retained canonical completion row."""
+    session = _run_deferred_settlement(
+        "process_wakeup",
+        result_messages=[],
+        duplicate_token_row=True,
+    )
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["content"] == _DEFERRED_WAKEUP_TEXT, label
+        assert survivor["_db_persisted"] is True, label
+        assert survivor["_source"] == "process_wakeup", label
+        assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META, label
+
+
+def test_empty_result_preserves_persisted_authoritative_checkpoint_replacement():
+    """Replacing an authoritative checkpoint keeps durable persistence state."""
+    session = _run_deferred_settlement(
+        "process_wakeup",
+        result_messages=[],
+        authoritative_checkpoint=True,
+    )
+
+    for label, messages in (
+        ("display", session.messages),
+        ("context", session.context_messages),
+    ):
+        same_token, same_text = _current_turn_survivors(messages)
+        assert len(same_token) == 1, label
+        assert len(same_text) == 1, label
+        survivor = same_token[0]
+        assert same_text[0] is survivor, label
+        assert survivor["_db_persisted"] is True, label
+        assert survivor["id"] == "user-2", label
+        assert survivor["_source"] == "process_wakeup", label
+        assert survivor["_wakeup_meta"] == _DEFERRED_WAKEUP_META, label


### PR DESCRIPTION
## Thinking Path

- When a server-started background process completes, deferred reconciliation can reload its completion as a raw `[IMPORTANT: Background process ...]` user bubble instead of the existing wakeup card.
- The persisted row still had its active-turn token and durability marker, but it had lost `_source` and `_wakeup_meta`. Reconciliation kept the row without restoring its server-owned source.
- The active-turn token already defines ownership. This change restores the trusted source only on the exact token-owned row and reuses the existing source/metadata helper.
- Context alignment now projects a display-only checkpoint only when the cleaned Agent result is empty. If a non-empty result has no safe turn boundary, reconciliation does not place the wakeup after an assistant answer.
- The change does not infer provenance from message text, reclassify historical rows, alter Agent persistence, or add a frontend renderer.

## What Changed

- Reapply active-turn source metadata when marking or retaining an exact token-owned user checkpoint.
- Collapse duplicate checkpoints deterministically while preserving the canonical persisted row, stable ID, and truthy `_db_persisted` state.
- Gate display-to-context checkpoint append on an empty post-cleanup Agent result so non-empty prefix-mismatched results keep correct user/assistant ordering.
- Add settlement-level regression coverage for retained process-wakeup rows, empty-result projection alignment, duplicate collapse, persisted authoritative checkpoints, prefix-mismatched non-empty results, and ordinary WebUI lookalike text.

## Why It Matters

- Completed background tasks render through the existing compact process-wakeup card after deferred reconciliation and reload.
- Model-facing context cannot acquire a completed wakeup as a new trailing user turn after an assistant response.
- Ordinary browser-authored text remains ordinary user content, even when it resembles the canonical process-completion scaffold.

## Contract Routing

Task type: runtime/streaming contract preservation.

Touched areas: active-turn checkpoint settlement and process-wakeup regression coverage.

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

Scope boundaries: preserve the existing current-turn identity and projection contract; no Agent schema change, frontend change, migration, or historical text-based backfill.

Evidence needed before claiming done: exact-token behavioral tests, ordering regression coverage, persisted API state, and matched real-instance before/after rendering.

## Screenshots

Before: the retained completion renders as a raw user bubble in an isolated real WebUI instance (`1210×900`, DPR `1`).

<img width="1210" height="900" alt="Before: raw process completion scaffold rendered as a user message" src="https://raw.githubusercontent.com/starship-s/hermes-webui/24d899a1c65a1aa3bb2b48ee8cead68bd1cd47ea/docs/pr-evidence/process-wakeup-metadata/before.png" />

After: the same completion renders as one closed `BACKGROUND WAKEUP` card (`1210×900`, DPR `1`).

<img width="1210" height="900" alt="After: process completion rendered as a collapsed background wakeup card" src="https://raw.githubusercontent.com/starship-s/hermes-webui/24d899a1c65a1aa3bb2b48ee8cead68bd1cd47ea/docs/pr-evidence/process-wakeup-metadata/after.png" />

Both captures use neutral task text and isolated session/state data. Each branch generated and persisted its own session, which the real server API and frontend rendered. The baseline API row had no source/display metadata. The patched API row had `_source: process_wakeup` and parsed completion metadata.

## Verification

Focused process-wakeup, notification, settlement, journal, and state-reconciliation matrix:

```bash
./scripts/test.sh tests/test_process_wakeup_synthetic.py tests/test_wakeup_meta_recovery_paths.py tests/test_wakeup_display_meta.py tests/test_process_wakeup_rendering.py tests/test_process_wakeup_card_rendering.py tests/test_background_process_wakeup_format.py tests/test_notify_on_complete_webui.py tests/test_background_process_restart_recovery.py tests/test_bg_task_complete_wakeup.py tests/test_wakeup_defer_race.py tests/test_issue6481_verification_evidence_phantom.py tests/test_tool_limit_terminal_state.py tests/test_run_journal_streaming_static.py tests/test_webui_state_db_reconciliation.py tests/test_stale_stream_writeback.py -q
```

Result: `195 passed`.

Remaining wakeup routing, model, pause, and session-channel matrix:

```bash
./scripts/test.sh tests/test_xsession_wakeup_misroute.py tests/test_wakeup_model_resolve_hang.py tests/test_wakeup_card_responsive.py tests/test_issue5127_process_wakeup_bare_model.py tests/test_issue4251_wakeup_model_picker_race.py tests/test_issue3929_process_wakeup_pause.py tests/test_session_channel_option_x.py --deselect tests/test_wakeup_model_resolve_hang.py::test_chat_start_survives_slow_provider_probe -q
```

Result: `109 passed, 2 skipped, 1 deselected`. The deselected provider-catalog timing test fails identically on the baseline and is outside the changed files.

Direct settlement probes:

- Empty Agent result with historical context: context gains one stamped checkpoint after the prior history.
- Non-empty prefix mismatch ending in an assistant answer: context gains no checkpoint, while the display keeps one stamped row.

Syntax and hygiene:

- `.venv/bin/python -m py_compile api/streaming.py tests/test_process_wakeup_synthetic.py`
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master` → `0` findings on added or modified lines (`11` pre-existing findings elsewhere in the changed files).
- `git diff --check origin/master...HEAD`

Real-instance evidence:

- Baseline: `0` process-wakeup cards; raw scaffold visible.
- Patched: `1` closed process-wakeup card; raw scaffold hidden.
- Both PNGs: `1210×900`, DPR `1`, visually inspected, privacy checked, and fetched back from their full-SHA raw URLs with matching SHA-256 hashes.

Hosted exact-head gates on `2b9a34fc13ccf5d3173457128db952653a8e2cc3`:

- Native CI: `22/22` checks passed.
- Greptile: `SUCCESS`, confidence `4/5`, no correctness blocker. Greptile accepted the existing-contract rationale and resolved its documentation thread without requesting a change.

## Risks / Follow-ups

- The fix intentionally requires live server-owned active-turn identity. Previously persisted rows without that authority remain unchanged rather than being guessed from text.
- When a non-empty Agent result has no safe current-turn boundary, context reconciliation now omits the display-only checkpoint instead of risking a user row after the assistant response.
- The existing run-state RFC already defines cross-projection coherence, owner-before-assistant ordering, idempotent reconciliation, and PR-level state-layer/test routing. This patch preserves those invariants rather than adding helper-specific implementation detail to the contract.

## Models Used

- Hermes Agent / `gpt-5.6-sol` (`Default`) via openai-codex: Coordinator - diagnosis, implementation specification, diff review, verification, evidence, and publication.
- OpenCode / `opencode/x-preview-f-free` (`max`) via OpenCode: Implementation - initial source and regression-test changes.
- Codex CLI / `gpt-5.6-luna` (`max`) via OpenAI Codex: Implementation - hardening, ordering remediation, and behavioral validation.
- Claude Code / `claude-opus-5` (`medium`) via Anthropic first-party: Independent review - identified the context-ordering blocker and verified its exact-SHA remediation.
