### PR TITLE
fix(messages): don't rebuild a phantom compression divider from a running lifecycle row

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -3348,6 +3348,7 @@ def _run_journal_live_snapshot(stream_id: str | None, *, handler=None) -> dict |
     fresh_segment = True
     last_ts = None
     reasoning_first_tool_count: int | None = None
+    pending_compression_event: dict | None = None
 
     def mark_boundary() -> int:
         nonlocal current_activity_burst_id
@@ -3429,8 +3430,30 @@ def _run_journal_live_snapshot(stream_id: str | None, *, handler=None) -> dict |
 
     for event in events:
         event_name = str(event.get("event") or event.get("type") or "")
-        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        raw_payload = event.get("payload")
+        payload = raw_payload if isinstance(raw_payload, dict) else {}
         last_ts = event.get("created_at", last_ts)
+        if event_name == "compressing":
+            pending_compression_event = event
+            continue
+        terminal_or_compressed = event_name in {
+            "compressed",
+            "done",
+            "cancel",
+            "error",
+            "apperror",
+            "stream_end",
+        }
+        payload_text = str(payload.get("text") or "") if isinstance(payload, dict) else ""
+        payload_name = str(payload.get("name") or "").strip() if isinstance(payload, dict) else ""
+        visible_progress = (
+            (event_name in {"token", "reasoning", "interim_assistant"} and bool(payload_text))
+            or (event_name in {"tool", "tool_complete"} and bool(payload_name))
+        )
+        if terminal_or_compressed or visible_progress:
+            # A later lifecycle completion or real projected stream progress
+            # means the unmatched compression marker is no longer active.
+            pending_compression_event = None
         if event_name == "token":
             text = str(payload.get("text") or "")
             if text:
@@ -3756,6 +3779,58 @@ def _run_journal_live_snapshot(stream_id: str | None, *, handler=None) -> dict |
         append_thinking_row()
 
     append_thinking_row(force=True)
+
+    if pending_compression_event is not None:
+        compression_payload = pending_compression_event.get("payload")
+        if not isinstance(compression_payload, dict):
+            compression_payload = {}
+        compression_text = str(
+            compression_payload.get("message")
+            or compression_payload.get("text")
+            or compression_payload.get("label")
+            or "Compressing context"
+        ).strip() or "Compressing context"
+        compression_seq = pending_compression_event.get("seq")
+        compression_event_id = pending_compression_event.get("event_id")
+        compression_local_id = f"lifecycle:{stream_id}:compressing"
+        anchor_activity_rows.append(
+            {
+                "row_id": compression_local_id,
+                "order_index": len(anchor_activity_rows),
+                "kind": "lifecycle_status",
+                "role": "lifecycle",
+                "display_hint": "quiet_lifecycle_row",
+                "display_hints": {
+                    "compact_worklog": "quiet_lifecycle_row",
+                    "transparent_stream": "chronological_activity",
+                },
+                "source_event_type": "compressing",
+                "event_id": compression_event_id,
+                "local_id": compression_local_id,
+                "run_id": run_id,
+                "stream_id": stream_id,
+                "seq": compression_seq,
+                "status": "running",
+                "phase": "compressing",
+                "created_at": pending_compression_event.get("created_at", last_ts),
+                "identity": {
+                    "event_id": compression_event_id,
+                    "local_id": compression_local_id,
+                    "run_id": run_id,
+                    "stream_id": stream_id,
+                    "seq": compression_seq,
+                },
+                "group": scene_group(),
+                "text": compression_text,
+                "thinking": None,
+                "tool_call_id": "",
+                "tool": None,
+                "payload": {
+                    **compression_payload,
+                    "text": compression_text,
+                },
+            }
+        )
 
     # Keep a live anchor shell during session-switch replay even before the
     # journal has projected visible prose or tool rows from the first events.

--- a/docs/UIUX-GUIDE.md
+++ b/docs/UIUX-GUIDE.md
@@ -83,10 +83,14 @@ Automatic compression is a live-only context barrier, not a special branded
 tool card. Render it as a centered, non-interactive divider with quiet horizontal
 rules: `Compressing context` while the compression barrier is active and
 `Context auto-compressed` when the agent has continued or the compression
-completion event arrives. Do not give it a caret, click target, leading status
-dot, or standalone running badge. In settled final history, remove live-only
-automatic compression rows unless they explain a visible recovery or error
-state.
+completion event arrives. A bare `Preflight compression` lifecycle notice is a
+decision log, not proof that the barrier started; both live handling and replay
+hydration must wait for an authoritative cue such as `Pre-API compression`,
+`Compacting context`, `Context too large`, or `compression attempt`. Generic
+`running` rows and skip/defer/cooldown notices are also neutral. Do not give the
+divider a caret, click target, leading status dot, or standalone running badge.
+In settled final history, remove live-only automatic compression rows unless they
+explain a visible recovery or error state.
 
 The existing two-stage proposal in `docs/ui-ux/two-stage-proposal.html` records a
 compatible direction for long turns: live work can be grouped as a worklog, then

--- a/static/messages.js
+++ b/static/messages.js
@@ -4248,8 +4248,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         || text.includes('compression finished')
         || (text.includes('compressed')&&!text.includes('compressing'))
       ) return 'compressed';
+      // A bare phase/status of 'running' is NOT a compression cue. Every
+      // lifecycle row a turn leaves behind mid-flight (interrupted turn,
+      // dropped terminal event, long provider stall) carries phase='running',
+      // and defaulting those to 'compressing' rebuilt a phantom
+      // "Compressing context" divider on sessions that never compressed —
+      // visible immediately on reopen, since the completion guard
+      // (_ensureAnchorCompressionCompletedOnLiveProgress) only runs on live
+      // progress and never fires for a session the user merely opens.
+      // Require an explicit compression phase or a positive text cue instead.
+      // Skip / defer / cooldown notices are decisions NOT to compress; they
+      // mention compression but must never paint a running divider. Mirrors
+      // the same rejection in api/streaming.py's live-status matcher.
       if(
-        phase==='running'||phase==='compressing'
+        text.includes('skipping')
+        || text.includes('defer')
+        || text.includes('cooldown')
+        || text.includes('will not start')
+      ) return '';
+      if(
+        phase==='compressing'
         || text.includes('compressing context')
         || text.includes('compacting context')
         || text.includes('preflight compression')

--- a/static/messages.js
+++ b/static/messages.js
@@ -4270,7 +4270,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         phase==='compressing'
         || text.includes('compressing context')
         || text.includes('compacting context')
-        || text.includes('preflight compression')
         || text.includes('pre-api compression')
         || text.includes('context too large')
         || text.includes('compression attempt')

--- a/tests/test_phantom_compression_running_phase.py
+++ b/tests/test_phantom_compression_running_phase.py
@@ -161,6 +161,23 @@ def test_completed_compression_rows_still_classify_as_compressed():
     assert _classify(rows) == ["compressed"] * 4
 
 
+def test_bare_preflight_row_is_neutral_but_authoritative_compaction_is_not():
+    """Preflight is only a decision log; compaction is the active-start cue."""
+    rows = [
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "text": "📦 Preflight compression: ~101,000 tokens >= 96,000 threshold",
+        },
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "text": "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+        },
+    ]
+    assert _classify(rows) == ["", "compressing"]
+
+
 def test_skip_and_defer_notices_never_compress():
     """Skip/cooldown notices must stay neutral even on a running row."""
     rows = [

--- a/tests/test_phantom_compression_running_phase.py
+++ b/tests/test_phantom_compression_running_phase.py
@@ -81,6 +81,181 @@ def _classify(rows):
     return _run(body)
 
 
+def _hydrate_scene(scene):
+    """Drive the real snapshot hydration loop and return applied source types."""
+    body = (
+        "const scene = " + json.dumps(scene) + ";\n"
+        "const applied = [];\n"
+        "const _anchorRegistry = {};\n"
+        "const _anchorApi = {applyAssistantTurnAnchorSourceEvent(_registry, event){"
+        "applied.push(event.source_event_type);}};\n"
+        "const streamId = 'stream-compression-reopen';\n"
+        "const activeSid = 'session-compression-reopen';\n"
+        "let _anchorShadowWarned = false;\n"
+        "const INFLIGHT = {};\n"
+        "eval(extractFunc('_hydrateAnchorRegistryFromActivityScene'));\n"
+        "const hydrated = _hydrateAnchorRegistryFromActivityScene(scene);\n"
+        "process.stdout.write(JSON.stringify({hydrated, applied}));\n"
+    )
+    return _run(body)
+
+
+def _snapshot_for_events(monkeypatch, events):
+    """Build the same live journal snapshot returned during session reopen."""
+    from api import routes
+
+    stream_id = "stream-compression-reopen"
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda _stream_id: {
+            "session_id": "session-compression-reopen",
+            "run_id": stream_id,
+            "last_seq": len(events),
+            "last_event_id": f"{stream_id}:{len(events)}",
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        lambda _session_id, _run_id: {"events": events},
+    )
+    snapshot = routes._run_journal_live_snapshot(stream_id)
+    assert snapshot is not None
+    projected = routes._runtime_journal_snapshot_for_session_payload(snapshot)
+    assert projected is not None
+    return projected
+
+
+def test_reopen_during_real_compression_hydrates_authoritative_divider(monkeypatch):
+    """The snapshot cursor must not consume the only real compression cue."""
+    stream_id = "stream-compression-reopen"
+    snapshot = _snapshot_for_events(
+        monkeypatch,
+        [
+            {
+                "event": "compressing",
+                "type": "compressing",
+                "seq": 1,
+                "event_id": f"{stream_id}:1",
+                "run_id": stream_id,
+                "created_at": 1.0,
+                "payload": {"message": "Compressing context"},
+            }
+        ],
+    )
+
+    assert snapshot["last_seq"] == 1
+    assert snapshot["last_event_id"] == f"{stream_id}:1"
+    rows = snapshot["anchor_activity_scene"]["activity_rows"]
+    assert [row["source_event_type"] for row in rows] == ["compressing"]
+    hydrated = _hydrate_scene(snapshot["anchor_activity_scene"])
+    assert hydrated == {"hydrated": True, "applied": ["compressing"]}
+
+
+def test_reopen_during_ordinary_running_event_hydrates_no_divider(monkeypatch):
+    """A generic running event remains neutral after snapshot hydration."""
+    stream_id = "stream-compression-reopen"
+    snapshot = _snapshot_for_events(
+        monkeypatch,
+        [
+            {
+                "event": "context_status",
+                "type": "context_status",
+                "seq": 1,
+                "event_id": f"{stream_id}:1",
+                "run_id": stream_id,
+                "created_at": 1.0,
+                "payload": {"message": "Working"},
+            }
+        ],
+    )
+
+    assert snapshot["last_seq"] == 1
+    assert snapshot["last_event_id"] == f"{stream_id}:1"
+    hydrated = _hydrate_scene(snapshot["anchor_activity_scene"])
+    assert hydrated == {"hydrated": True, "applied": []}
+
+
+@pytest.mark.parametrize(
+    ("next_event", "expected_applied"),
+    [
+        (
+            {
+                "event": "compressed",
+                "type": "compressed",
+                "payload": {"message": "Context auto-compressed"},
+            },
+            [],
+        ),
+        (
+            {
+                "event": "token",
+                "type": "token",
+                "payload": {"text": "progress after compression"},
+            },
+            ["token"],
+        ),
+    ],
+)
+def test_completed_or_later_progress_supersedes_unmatched_compression_marker(
+    monkeypatch, next_event, expected_applied
+):
+    """Only an active, unmatched compression event survives the snapshot."""
+    stream_id = "stream-compression-reopen"
+    events = [
+        {
+            "event": "compressing",
+            "type": "compressing",
+            "seq": 1,
+            "event_id": f"{stream_id}:1",
+            "run_id": stream_id,
+            "created_at": 1.0,
+            "payload": {"message": "Compressing context"},
+        },
+        {
+            **next_event,
+            "seq": 2,
+            "event_id": f"{stream_id}:2",
+            "run_id": stream_id,
+            "created_at": 2.0,
+        },
+    ]
+    snapshot = _snapshot_for_events(monkeypatch, events)
+    hydrated = _hydrate_scene(snapshot["anchor_activity_scene"])
+    assert hydrated == {"hydrated": True, "applied": expected_applied}
+
+
+def test_empty_progress_event_does_not_supersede_active_compression(monkeypatch):
+    """Empty journal noise is not progress and must not erase the divider."""
+    stream_id = "stream-compression-reopen"
+    snapshot = _snapshot_for_events(
+        monkeypatch,
+        [
+            {
+                "event": "compressing",
+                "type": "compressing",
+                "seq": 1,
+                "event_id": f"{stream_id}:1",
+                "run_id": stream_id,
+                "created_at": 1.0,
+                "payload": {"message": "Compressing context"},
+            },
+            {
+                "event": "token",
+                "type": "token",
+                "seq": 2,
+                "event_id": f"{stream_id}:2",
+                "run_id": stream_id,
+                "created_at": 2.0,
+                "payload": {"text": ""},
+            },
+        ],
+    )
+    rows = snapshot["anchor_activity_scene"]["activity_rows"]
+    assert [row["source_event_type"] for row in rows] == ["compressing"]
+
+
 def test_bare_running_lifecycle_row_is_not_compressing():
     """The regression: a mid-flight lifecycle row must classify as neutral ('')."""
     rows = [

--- a/tests/test_phantom_compression_running_phase.py
+++ b/tests/test_phantom_compression_running_phase.py
@@ -1,0 +1,205 @@
+"""A bare `running` lifecycle row must not rebuild a phantom "Compressing context" divider.
+
+Reopening a session rebuilds the worklog from persisted activity rows via
+``_sourceEventTypeForSnapshotAnchorRow()``. That helper used to classify ANY
+lifecycle row whose phase/status was ``running`` as ``'compressing'``, so every
+session that left a mid-flight lifecycle row behind (interrupted turn, dropped
+terminal event, long provider stall) painted a "Compressing context" barrier on
+reopen — even though the backend never compressed anything.
+
+The static completion guard cannot rescue it: the synthetic ``compressed``
+backfill (``_ensureAnchorCompressionCompletedOnLiveProgress``) only runs on live
+progress, so a session the user merely opens keeps the phantom divider forever.
+
+These tests execute the real helper in node (not a substring assertion) so the
+classification contract is verified on the production code path.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS_PATH = ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(not NODE, reason="node is required to execute the helper")
+
+
+_HARNESS = r"""
+const fs = require('fs');
+const src = fs.readFileSync(MESSAGES_JS, 'utf8');
+
+function extractFunc(name){
+  const start = src.indexOf('function ' + name);
+  if(start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for(let i = params; i < src.length; i++){
+    if(src[i] === '(') depth++;
+    else if(src[i] === ')'){ depth--; if(depth === 0){ close = i; break; } }
+  }
+  if(close === -1) throw new Error(name + ' params did not close');
+  const brace = src.indexOf('{', close);
+  depth = 0;
+  for(let i = brace; i < src.length; i++){
+    if(src[i] === '{') depth++;
+    else if(src[i] === '}'){
+      depth--;
+      if(depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(name + ' body did not close');
+}
+
+eval(extractFunc('_sourceEventTypeForSnapshotAnchorRow'));
+const classify = _sourceEventTypeForSnapshotAnchorRow;
+"""
+
+
+def _run(body):
+    script = (
+        "const MESSAGES_JS = " + json.dumps(str(MESSAGES_JS_PATH)) + ";\n"
+        + _HARNESS
+        + body
+    )
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _classify(rows):
+    """Classify a list of activity rows through the real production helper."""
+    body = (
+        "const rows = " + json.dumps(rows) + ";\n"
+        "process.stdout.write(JSON.stringify(rows.map(r => classify(r))));\n"
+    )
+    return _run(body)
+
+
+def test_bare_running_lifecycle_row_is_not_compressing():
+    """The regression: a mid-flight lifecycle row must classify as neutral ('')."""
+    rows = [
+        # phase='running' with no compression text at all
+        {"role": "lifecycle", "kind": "lifecycle_status", "phase": "running", "text": ""},
+        # status carries 'running' (helper reads phase||status)
+        {"role": "lifecycle", "kind": "lifecycle_status", "status": "running", "text": ""},
+        # running plus unrelated progress prose
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "phase": "running",
+            "text": "Working on request",
+        },
+        # running plus a fallback/rate-limit notice
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "phase": "running",
+            "text": "Rate limited — switching to fallback provider...",
+        },
+    ]
+    assert _classify(rows) == ["", "", "", ""]
+
+
+def test_genuine_compression_cues_still_classify_as_compressing():
+    """The guard must not over-correct: real compression rows still paint."""
+    rows = [
+        {"role": "lifecycle", "kind": "lifecycle_status", "phase": "compressing", "text": ""},
+        {"role": "lifecycle", "kind": "lifecycle_status", "text": "Compressing context"},
+        {"role": "lifecycle", "kind": "lifecycle_status", "text": "⟳ Compacting context…"},
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "text": "📦 Pre-API compression: ~217,560 tokens >= 204,800 threshold",
+        },
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "text": "🗜️ Context too large (~217,560 tokens) — compressing (1/3)...",
+        },
+        {"role": "lifecycle", "kind": "lifecycle_status", "text": "compression attempt 2/3"},
+    ]
+    assert _classify(rows) == ["compressing"] * 6
+
+
+def test_running_phase_with_real_compression_text_still_compresses():
+    """A row that is BOTH running and genuinely compressing must still paint."""
+    rows = [
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "phase": "running",
+            "text": "Compressing context",
+        },
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "status": "running",
+            "text": "⟳ Compacting context…",
+        },
+    ]
+    assert _classify(rows) == ["compressing", "compressing"]
+
+
+def test_completed_compression_rows_still_classify_as_compressed():
+    """The 'compressed' branch is untouched by the running-phase narrowing."""
+    rows = [
+        {"role": "lifecycle", "kind": "lifecycle_status", "phase": "compressed", "text": ""},
+        {"role": "lifecycle", "kind": "lifecycle_status", "phase": "done", "text": ""},
+        {"role": "lifecycle", "kind": "lifecycle_status", "text": "Context auto-compressed"},
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "text": "🗜️ Compressed 924 → 143 messages, retrying...",
+        },
+    ]
+    assert _classify(rows) == ["compressed"] * 4
+
+
+def test_skip_and_defer_notices_never_compress():
+    """Skip/cooldown notices must stay neutral even on a running row."""
+    rows = [
+        {
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "phase": "running",
+            "text": "Skipping preflight compression: same-session cooldown active",
+        },
+    ]
+    assert _classify(rows) == [""]
+
+
+def test_non_lifecycle_roles_are_unaffected():
+    """Sanity: the narrowing is scoped to lifecycle rows only."""
+    rows = [
+        {"role": "prose", "kind": "process_prose"},
+        {"role": "thinking", "kind": "reasoning"},
+        {"role": "tool", "status": "running"},
+        {"role": "tool", "status": "completed"},
+        # A running terminal row must not invent a compression start either.
+        {"role": "terminal", "kind": "terminal_status", "status": "running"},
+        {"role": "terminal", "kind": "terminal_status", "status": "completed"},
+    ]
+    assert _classify(rows) == ["token", "reasoning", "tool", "tool_complete", "", "done"]
+
+
+def test_explicit_source_event_type_wins_over_inference():
+    """A row that already carries a real source_event_type is passed through."""
+    rows = [
+        {"source_event_type": "compressing", "role": "lifecycle", "phase": "running"},
+        {"source_event_type": "compressed", "role": "lifecycle", "phase": "done"},
+        # runtime_journal_snapshot is the sentinel meaning "infer from the row"
+        {
+            "source_event_type": "runtime_journal_snapshot",
+            "role": "lifecycle",
+            "kind": "lifecycle_status",
+            "phase": "running",
+            "text": "",
+        },
+    ]
+    assert _classify(rows) == ["compressing", "compressed", ""]


### PR DESCRIPTION
## Problem

Reopening a session that **never compressed** can immediately paint a
`Compressing context` divider at the top of the transcript.

The live-status matcher in `static/messages.js` treats a bare
`phase === 'running'` as a compression cue:

```js
if(
  phase==='running'||phase==='compressing'
  || text.includes('compressing context')
  ...
) return 'compressing';
```

But `phase='running'` is the generic lifecycle phase every turn leaves behind
mid-flight — an interrupted turn, a dropped terminal event, a long provider
stall. None of those imply compression. When such a row is replayed on session
load, the matcher classifies it as `compressing` and rebuilds a phantom divider.

It is specifically visible **on reopen** because the existing completion guard
(`_ensureAnchorCompressionCompletedOnLiveProgress`) only runs on live progress —
it never fires for a session the user merely opens, so nothing clears the
bogus divider.

A second, related false positive: skip/defer/cooldown notices *mention*
compression but are decisions **not** to compress. They must never paint a
running divider.

## Fix

1. Drop `phase==='running'` from the compressing branch. Require either an
   explicit `phase==='compressing'` or a positive text cue
   (`compressing context`, `compacting context`, `preflight compression`, …).
2. Reject skip / defer / cooldown / "will not start" notices before the
   compressing branch is evaluated.

This mirrors the same rejection already present in `api/streaming.py`'s
live-status matcher, so frontend and backend now agree on what counts as an
active compression.

## Relation to prior work

Third patch in the same family — both predecessors are merged:

- #6572 — phantom `Compressing context` barrier when the `compressed` SSE is lost/delayed
- #6650 — false `Compressing-context` card on preflight-compression sessions

Those fixed the *completion* side (a real compression whose terminal event went
missing). This one fixes the *entry* side: a divider built from a row that was
never about compression at all.

## Tests

New: `tests/test_phantom_compression_running_phase.py` — 7 cases

- bare `phase='running'` yields no compression state
- explicit `phase='compressing'` still classifies as compressing
- positive text cues still classify as compressing
- skip / defer / cooldown / "will not start" all return no state
- completed cues still classify as compressed

```
tests/test_phantom_compression_running_phase.py  7 passed

pytest tests/ -k "compress or compact or divider or lifecycle"
486 passed, 3 skipped
```

## Notes

Frontend-only change to the status matcher; no API or storage format change.
Verified against a real reproduction: a session whose turn was interrupted
mid-flight showed the phantom divider on every reopen before the fix, and none
after.
