### PR TITLE
Fix provider-qualified auxiliary model persistence

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4963,6 +4963,31 @@ def _coerce_optional_positive_int(value, field: str):
     return number
 
 
+def _provider_native_auxiliary_model(provider: str, model: str) -> str:
+    """Return the provider-native model stored by an auxiliary slot.
+
+    ``@provider:model`` is a WebUI picker routing token. Auxiliary slots already
+    store the selected provider separately, so only an exact matching prefix is
+    safe to remove. Reject other qualified forms instead of persisting an
+    ambiguous upstream model name.
+    """
+    provider_id = str(provider or "").strip() or "auto"
+    model_id = str(model or "").strip()
+    if not model_id.startswith("@") or ":" not in model_id:
+        return model_id
+
+    matching_prefix = f"@{provider_id}:"
+    if provider_id != "auto" and model_id.startswith(matching_prefix):
+        native_model = model_id[len(matching_prefix) :]
+        if native_model:
+            return native_model
+
+    raise ValueError(
+        "provider-qualified auxiliary model must match the selected provider "
+        "and include a model name"
+    )
+
+
 def set_auxiliary_model(task: str, provider: str, model: str, advanced: dict | None = None) -> dict:
     """Persist an auxiliary model assignment in config.yaml.
 
@@ -4971,6 +4996,8 @@ def set_auxiliary_model(task: str, provider: str, model: str, advanced: dict | N
     Sensitive api_key values are write-only: get_auxiliary_models() only reports
     whether one is set.
     """
+    provider = str(provider or "").strip() or "auto"
+    model = str(model or "").strip()
     config_path = _get_config_path()
     with _cfg_lock:
         config_data = _load_yaml_config_file(config_path)
@@ -4996,11 +5023,12 @@ def set_auxiliary_model(task: str, provider: str, model: str, advanced: dict | N
             aux_cfg = config_data.get("auxiliary", {})
             if not isinstance(aux_cfg, dict):
                 aux_cfg = {}
+            model = _provider_native_auxiliary_model(provider, model)
             slot_cfg = aux_cfg.get(task, {})
             if not isinstance(slot_cfg, dict):
                 slot_cfg = {}
-            slot_cfg["provider"] = provider or "auto"
-            slot_cfg["model"] = model or ""
+            slot_cfg["provider"] = provider
+            slot_cfg["model"] = model
             if provider and (provider.startswith("custom:") or provider == "custom"):
                 # Resolve the auxiliary slot's base_url against the SELECTED
                 # provider, not the active main provider. A bare

--- a/static/panels.js
+++ b/static/panels.js
@@ -1889,15 +1889,17 @@ function cancelCronForm(){
   _clearCronDetail();
 }
 
-function _cronModelBareName(model, provider) {
+function _modelBareNameForProvider(model, provider) {
   // Strip @provider: prefix from a model value when provider is stored separately.
-  // The model dropdown may contain values like "@custom:9router:chat" (from
-  // _apply_provider_prefix) but cron jobs store model and provider separately,
-  // so the model should be just "chat".
   if (model && provider && model.startsWith('@' + provider + ':')) {
     return model.slice(('@' + provider + ':').length);
   }
   return model;
+}
+
+function _cronModelBareName(model, provider) {
+  // Cron jobs store model and provider separately, just like auxiliary slots.
+  return _modelBareNameForProvider(model, provider);
 }
 
 async function saveCronForm(){
@@ -12333,17 +12335,25 @@ function _buildAuxModelOptions(sel,provider,providers,currentModel){
  const emptyOpt=document.createElement('option');
  emptyOpt.value='';emptyOpt.textContent=t('settings_aux_model_auto')||'auto (use provider default)';
  sel.appendChild(emptyOpt);
+ const canonicalCurrent=_modelBareNameForProvider(currentModel,provider)||'';
  if(!provider||provider==='auto'){
-  sel.value=currentModel||'';
-  return;
+  sel.value=canonicalCurrent;
+  return canonicalCurrent;
  }
  // Find matching provider in cached list
  const pData=providers.find(p=>p.slug===provider);
+ const modelValues=new Set();
  if(pData&&pData.models){
-  for(const mId of pData.models){
+  for(const modelEntry of pData.models){
+   const routeId=typeof modelEntry==='string'?modelEntry:String(modelEntry?.id||'');
+   const mId=_modelBareNameForProvider(routeId,provider)||'';
+   if(!mId||modelValues.has(mId)) continue;
+   modelValues.add(mId);
+   const routeLabel=typeof modelEntry==='string'?'':String(modelEntry?.label||'');
+   const modelLabel=_modelBareNameForProvider(routeLabel,provider)||mId;
    const opt=document.createElement('option');
-   opt.value=mId;opt.textContent=mId;
-   if(mId===currentModel) opt.selected=true;
+   opt.value=mId;opt.textContent=modelLabel;
+   if(mId===canonicalCurrent) opt.selected=true;
    sel.appendChild(opt);
   }
  }
@@ -12352,12 +12362,13 @@ function _buildAuxModelOptions(sel,provider,providers,currentModel){
  customOpt.value='__custom__';customOpt.textContent=t('settings_aux_model_custom')||'Custom model…';
  sel.appendChild(customOpt);
  // If currentModel not in list and not empty, add it as a custom option
- if(currentModel&&!pData?.models?.includes(currentModel)){
+ if(canonicalCurrent&&!modelValues.has(canonicalCurrent)){
   const existingOpt=document.createElement('option');
-  existingOpt.value=currentModel;existingOpt.textContent=currentModel+' (configured)';
+  existingOpt.value=canonicalCurrent;existingOpt.textContent=canonicalCurrent+' (configured)';
   existingOpt.selected=true;
   sel.insertBefore(existingOpt,customOpt);
  }
+ return canonicalCurrent;
 }
 
 function _onAuxProviderChange(taskKey,providers){
@@ -12375,13 +12386,16 @@ async function _onAuxModelChange(taskKey){
  if(modelSel.value==='__custom__'){
   const customModel=await showPromptDialog({title:t('settings_aux_model_custom')||'Custom model',message:t('settings_aux_model_custom_prompt')||'Enter model ID:',placeholder:'model/provider:model-id',confirmLabel:t('settings_btn_apply_aux_models')||'Apply'});
   if(customModel&&customModel.trim()){
+   const provider=$('aux-prov-'+taskKey)?.value||'';
+   const enteredModel=customModel.trim();
+   const canonicalModel=_modelBareNameForProvider(enteredModel,provider)||enteredModel;
    // Insert custom model option before the __custom__ option
    const opt=document.createElement('option');
-   opt.value=customModel.trim();opt.textContent=customModel.trim();
+   opt.value=canonicalModel;opt.textContent=canonicalModel;
    // Remove __custom__ selection
    const customIdx=[...modelSel.options].findIndex(o=>o.value==='__custom__');
    if(customIdx>=0) modelSel.insertBefore(opt,modelSel.options[customIdx]);
-   modelSel.value=customModel.trim();
+   modelSel.value=canonicalModel;
   }else{
    modelSel.value='';
   }
@@ -12588,7 +12602,7 @@ async function _loadAuxiliaryModels(){
   _auxProviders=groups.filter(g=>g.provider&&((g.models&&g.models.length>0)||(g.extra_models&&g.extra_models.length>0))).map(g=>({
    slug:g.provider_id||g.provider,
    name:g.provider,
-   models:[...(g.models||[]),...(g.extra_models||[])].map(m=>m.id),
+   models:[...(g.models||[]),...(g.extra_models||[])].map(m=>({id:m.id,label:m.label||m.id})),
   }));
   if(auxData&&Object.prototype.hasOwnProperty.call(auxData,'main')){
    _mainAdvancedConfig=auxData.main||{};
@@ -12603,6 +12617,7 @@ async function _loadAuxiliaryModels(){
   _auxOriginalConfig=JSON.parse(JSON.stringify(taskMap));
 
   container.innerHTML='';
+  let needsCanonicalSave=false;
   for(const task of _auxTasks){
    const cfg=taskMap[task.task]||{provider:'auto',model:''};
    const row=document.createElement('div');
@@ -12626,7 +12641,8 @@ async function _loadAuxiliaryModels(){
    const modelSel=document.createElement('select');
    modelSel.id='aux-model-'+task.task;
    modelSel.style.cssText=_auxSelectStyle();
-   _buildAuxModelOptions(modelSel,cfg.provider,_auxProviders,cfg.model);
+   const canonicalModel=_buildAuxModelOptions(modelSel,cfg.provider,_auxProviders,cfg.model);
+   if(canonicalModel!==cfg.model) needsCanonicalSave=true;
    modelSel.addEventListener('change',()=>_onAuxModelChange(task.task));
    row.appendChild(modelSel);
 
@@ -12643,9 +12659,9 @@ async function _loadAuxiliaryModels(){
 
    container.appendChild(row);
   }
-  // Hide apply button (no changes yet)
+  // Matching legacy @provider:model values can be repaired with one explicit Apply.
   const applyBtn=$('btnApplyAuxModels');
-  if(applyBtn) applyBtn.style.display='none';
+  if(applyBtn) applyBtn.style.display=needsCanonicalSave?'':'none';
 
   // Reset button
   const resetBtn=$('btnResetAuxModels');

--- a/tests/test_auxiliary_model_provider_prefix.py
+++ b/tests/test_auxiliary_model_provider_prefix.py
@@ -1,0 +1,253 @@
+"""Regression coverage for provider-qualified auxiliary model persistence.
+
+``GET /api/models`` may expose WebUI-only ``@provider:model`` routing IDs, but
+auxiliary configuration stores provider and model in separate fields.  The
+provider-native model value must be used by both the settings UI and the shared
+backend persistence boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[1]
+PANELS_JS_PATH = REPO / "static" / "panels.js"
+NODE = shutil.which("node")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_auxiliary_picker_uses_provider_native_model_values():
+    """A custom-provider catalog must render and select provider-native values."""
+    script = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[1], 'utf8');
+
+function extract(name){
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if(start < 0) return '';
+  let i = src.indexOf('{', start);
+  let depth = 0;
+  while(i < src.length){
+    const ch = src[i];
+    if(ch === '{') depth += 1;
+    else if(ch === '}'){
+      depth -= 1;
+      if(depth === 0) return src.slice(start, i + 1);
+    }
+    i += 1;
+  }
+  throw new Error(name + ' parse failed');
+}
+
+global.t = () => '';
+global.document = {
+  createElement: () => ({value:'', textContent:'', selected:false}),
+};
+
+function makeSelect(){
+  return {
+    children: [],
+    _value: '',
+    set innerHTML(_value){ this.children = []; this._value = ''; },
+    get innerHTML(){ return ''; },
+    get options(){ return this.children; },
+    appendChild(opt){ this.children.push(opt); },
+    insertBefore(opt, before){
+      const idx = this.children.indexOf(before);
+      if(idx < 0) this.children.push(opt);
+      else this.children.splice(idx, 0, opt);
+    },
+    set value(value){
+      this._value = value;
+      for(const opt of this.children) opt.selected = opt.value === value;
+    },
+    get value(){
+      const selected = this.children.find((opt) => opt.selected);
+      return selected ? selected.value : this._value;
+    },
+  };
+}
+
+const sharedHelper = extract('_modelBareNameForProvider');
+const buildOptions = extract('_buildAuxModelOptions');
+if(!buildOptions) throw new Error('_buildAuxModelOptions not found');
+eval(sharedHelper + '\n' + buildOptions);
+
+const select = makeSelect();
+const providers = [{
+  slug: 'my-local-ai-gateway',
+  name: 'My Local AI Gateway',
+  models: [
+    {
+      id: '@my-local-ai-gateway:example-chat-model',
+      label: 'Example Chat Model',
+    },
+    {
+      id: '@my-local-ai-gateway:example-side-model',
+      label: '@my-local-ai-gateway:example-side-model',
+    },
+    {id: 'vendor/example-model', label: 'Vendor Example Model'},
+    {id: 'example-chat-model', label: 'Duplicate Chat Model'},
+  ],
+}];
+
+const canonicalCurrent = _buildAuxModelOptions(
+  select,
+  'my-local-ai-gateway',
+  providers,
+  '@my-local-ai-gateway:example-side-model',
+);
+
+const modelOptions = select.options.filter(
+  (opt) => opt.value && opt.value !== '__custom__',
+);
+const helperCases = sharedHelper ? [
+  _modelBareNameForProvider('@custom:router-alias:chat-model', 'custom'),
+  _modelBareNameForProvider('@custom:backup:model:free', 'custom:backup'),
+  _modelBareNameForProvider('vendor/example-model', 'my-local-ai-gateway'),
+  _modelBareNameForProvider('@other-gateway:other-model', 'my-local-ai-gateway'),
+] : null;
+
+console.log(JSON.stringify({
+  values: modelOptions.map((opt) => opt.value),
+  labels: modelOptions.map((opt) => opt.textContent),
+  selected: select.value,
+  canonicalCurrent,
+  helperCases,
+}));
+"""
+
+    proc = subprocess.run(
+        [NODE, "-e", script, str(PANELS_JS_PATH)],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert proc.returncode == 0, f"node probe failed:\n{proc.stderr}"
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    assert result == {
+        "values": [
+            "example-chat-model",
+            "example-side-model",
+            "vendor/example-model",
+        ],
+        "labels": [
+            "Example Chat Model",
+            "example-side-model",
+            "Vendor Example Model",
+        ],
+        "selected": "example-side-model",
+        "canonicalCurrent": "example-side-model",
+        "helperCases": [
+            "router-alias:chat-model",
+            "model:free",
+            "vendor/example-model",
+            "@other-gateway:other-model",
+        ],
+    }
+
+
+def test_matching_legacy_value_exposes_explicit_apply_repair():
+    """Loading a safe legacy prefix should offer, but not force, a config write."""
+    source = PANELS_JS_PATH.read_text(encoding="utf-8")
+
+    assert "if(canonicalModel!==cfg.model) needsCanonicalSave=true;" in source
+    assert "applyBtn.style.display=needsCanonicalSave?'':'none'" in source
+
+
+@pytest.mark.parametrize(
+    ("provider", "requested_model", "persisted_model"),
+    [
+        (
+            "my-local-ai-gateway",
+            "@my-local-ai-gateway:example-side-model",
+            "example-side-model",
+        ),
+        (
+            "custom",
+            "@custom:router-alias:chat-model",
+            "router-alias:chat-model",
+        ),
+        ("custom:backup", "@custom:backup:model:free", "model:free"),
+        (
+            "my-local-ai-gateway",
+            "vendor/example-model",
+            "vendor/example-model",
+        ),
+        (
+            "my-local-ai-gateway",
+            "example-side-model",
+            "example-side-model",
+        ),
+    ],
+)
+def test_set_auxiliary_model_persists_provider_native_model(
+    monkeypatch,
+    tmp_path,
+    provider,
+    requested_model,
+    persisted_model,
+):
+    from api import config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "auxiliary:\n  vision:\n    provider: auto\n    model: ''\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda model: (model, provider, None),
+    )
+
+    result = config.set_auxiliary_model("vision", provider, requested_model)
+
+    saved = config._load_yaml_config_file(config_path)["auxiliary"]["vision"]
+    assert saved["provider"] == provider
+    assert saved["model"] == persisted_model
+    assert result["provider"] == provider
+    assert result["model"] == persisted_model
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("my-local-ai-gateway", "@other-gateway:other-model"),
+        ("my-local-ai-gateway", "@my-local-ai-gateway:"),
+        ("auto", "@my-local-ai-gateway:example-side-model"),
+    ],
+)
+def test_set_auxiliary_model_rejects_invalid_qualified_pair_without_write(
+    monkeypatch,
+    tmp_path,
+    provider,
+    model,
+):
+    from api import config
+
+    config_path = tmp_path / "config.yaml"
+    original = (
+        "auxiliary:\n"
+        "  vision:\n"
+        "    provider: openai\n"
+        "    model: gpt-5.5\n"
+    )
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+
+    with pytest.raises(ValueError, match="provider-qualified auxiliary model"):
+        config.set_auxiliary_model("vision", provider, model)
+
+    assert config_path.read_text(encoding="utf-8") == original

--- a/tests/test_issue4813_cron_model_bare_name.py
+++ b/tests/test_issue4813_cron_model_bare_name.py
@@ -39,7 +39,7 @@ def _fn_body(name: str) -> str:
 
 
 def _strip(model, provider):
-    body = _fn_body("_cronModelBareName")
+    body = _fn_body("_modelBareNameForProvider") + "\n" + _fn_body("_cronModelBareName")
     script = (
         body
         + "\nconst args = "


### PR DESCRIPTION
Closes #7260.

## Thinking Path

- Hermes WebUI exposes `@provider:model` values in the general model catalog so
  chat selections can carry routing context.
- Auxiliary slots already persist provider and model as separate fields.
- Reusing the catalog routing value as the auxiliary model duplicated the
  provider context and allowed a WebUI-only token to reach the upstream model
  API as if it were a native model name.
- The narrow fix is to adapt catalog values at the auxiliary picker boundary and
  defend the shared auxiliary persistence boundary against raw routing tokens.
- This keeps general chat routing unchanged while making every auxiliary save
  path persist a provider-native model name.

## What Changed

- Added a shared frontend helper that removes only the exact `@{provider}:`
  prefix when provider and model are stored separately; the existing Cron path
  now uses the same helper.
- Kept auxiliary catalog IDs and labels together, then built dropdown values from
  provider-native model IDs while preserving user-facing labels, slash IDs, and
  colon suffixes.
- Deduplicated auxiliary options after canonicalization so a bare ID and its
  matching routed form cannot produce duplicate choices.
- Made custom model entry, the normal Apply action, and the advanced-options save
  path consume the canonical dropdown value.
- Added an explicit repair path for existing matching legacy values: the picker
  renders the native value and exposes Apply, but loading Settings does not
  mutate `config.yaml` automatically.
- Added defense in depth to `set_auxiliary_model()`: matching routed values are
  canonicalized before base-URL resolution and persistence; mismatched,
  auto-provider, and empty qualified values fail before any write.
- Added frontend and backend regression coverage using the sanitized provider
  `my-local-ai-gateway` and generic model names.

## Why It Matters

Without this fix, an auxiliary task can fail only when it is invoked, even while
ordinary chat continues to work. The persisted value looks superficially valid
but is a WebUI routing token rather than a model name understood by the selected
provider. Canonicalizing at both UI and backend boundaries prevents new bad
values and gives existing safe-to-repair values a deliberate recovery path.

## Verification

Proof that the regression test bites:

- Before the product-code change, the new focused file ran 9 cases: 7 failed and
  2 already-valid bare-model cases passed. The failures showed routed option
  values/labels, verbatim backend persistence, and missing rejection of invalid
  provider/model pairs.
- After the fix, the focused file also covers catalog object labels,
  post-canonicalization deduplication, named custom providers, colon-suffixed and
  slash model IDs, no-write rejection, and the explicit legacy Apply repair.

Commands and results:

- `python -m pytest tests/test_auxiliary_model_provider_prefix.py tests/test_issue4813_cron_model_bare_name.py -q`
  — 15 passed.
- `python -m pytest tests/test_auxiliary_models_settings.py -q`
  — 57 passed.
- `python -m pytest tests/test_model_resolver.py tests/test_issue895_894_nous_prefix.py tests/test_issue6722_provider_qualified_model_leak.py -q`
  — 104 passed.
- `npm exec --yes --package=eslint@10.4.0 -- eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`
  — passed.
- `node --check static/panels.js` — passed.
- `python -m py_compile api/config.py tests/test_auxiliary_model_provider_prefix.py tests/test_issue4813_cron_model_bare_name.py`
  — passed.
- Ruff on both changed test files — passed. A whole-file Ruff run on
  `api/config.py` reports the same four unrelated findings present on upstream
  `master`; this change adds no finding on a modified line.
- `git diff --check` — passed.

The DOM regression uses the field-level `/api/models` shape that triggers the
bug, with provider and model names replaced by neutral examples. It proves the
in-page picker transformation. Hermes Agent and third-party provider APIs are
outside this repository's test boundary; no live-provider request was used as
proof.

Issue #7260 includes the before screenshot showing the internal routed value in
the auxiliary dropdown. This patch does not change layout, responsive behavior,
or interaction structure; its visible delta is the option text/value. The
Node-backed DOM regression provides the after-state evidence:

| State | Selected auxiliary option | Apply state for a legacy value |
|---|---|---|
| Before | `@my-local-ai-gateway:example-side-model` | Hidden because the raw persisted value appears unchanged |
| After | `example-side-model` | Visible until the canonical value is explicitly saved |

## Risks / Follow-ups

- Qualified auxiliary model values are treated as internal routing syntax. A
  direct caller that sends a different provider qualifier, an `auto` provider,
  or an empty qualified model now receives a 400 instead of persisting an
  ambiguous value.
- Existing values are not rewritten on read. Exact matching prefixes are
  repaired only when the user clicks Apply or saves advanced options; mismatched
  legacy pairs require manual correction because guessing would risk routing to
  the wrong provider.
- General chat catalog IDs and `resolve_model_provider()` behavior are unchanged.
- A live Hermes Agent/provider round trip was not used as proof; the external
  provider contract remains a manual integration check.

## Contract Routing

- Task type: focused configuration-boundary bug fix.
- Touched contracts: Auxiliary Models picker values, `POST /api/model/set` for
  `scope=auxiliary`, and `auxiliary.<task>.model` persistence.
- Neighbor reviewed: general chat routing, default-model persistence, Cron model
  persistence, custom-provider base-URL resolution, and auxiliary advanced
  options.
- Public guidance reviewed: `AGENTS.md`, `CONTRIBUTING.md`,
  `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `docs/UIUX-GUIDE.md`, `DESIGN.md`,
  `ARCHITECTURE.md`, and `TESTING.md`.
- Documentation change: no user-facing docs are needed for this focused bug fix;
  release-note wording is included below instead of editing `CHANGELOG.md`.

## Contract Change

For auxiliary writes only, a model value beginning with the exact selected
provider qualifier is now interpreted as a WebUI routing token and stored
without that qualifier. Other provider-qualified values fail closed. Already
bare model IDs, slash IDs, empty/default-model behavior, and reset behavior are
unchanged. Successful responses return the canonical provider/model pair that
was persisted.

## Release Note

Fixed Auxiliary Models settings so provider-qualified WebUI routing IDs are
saved as provider-native model names, preventing custom-provider auxiliary tasks
from failing with an unknown routed model ID.

## Model Used

OpenAI Codex (GPT-5). Used local repository inspection, Git worktree tooling,
Node-based DOM regression probes, Pytest, ESLint, and static syntax checks. No
sub-agents were used.
