### PR TITLE
fix(projects): serialize and atomically persist mutations

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -6474,7 +6474,81 @@ def title_from(messages, fallback: str='Untitled'):
 # ── Project helpers ──────────────────────────────────────────────────────────
 
 _PROJECTS_MIGRATION_LOCK = threading.Lock()
+_PROJECTS_THREAD_LOCK = threading.RLock()
 _projects_migrated = False
+
+
+@contextmanager
+def _projects_process_lock():
+    """Serialize projects.json mutations across WebUI and MCP processes."""
+    lock_path = PROJECTS_FILE.with_name(f".{PROJECTS_FILE.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    with os.fdopen(fd, "r+b", buffering=0) as lock_file:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+            return
+        if _msvcrt is not None:
+            if os.fstat(lock_file.fileno()).st_size == 0:
+                lock_file.write(b"\0")
+            lock_file.seek(0)
+            _msvcrt.locking(  # type: ignore[attr-defined]
+                lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
+            )
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                _msvcrt.locking(  # type: ignore[attr-defined]
+                    lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+                )
+            return
+        raise RuntimeError("cross-process project locking is unavailable")
+
+
+def _read_projects_file() -> list:
+    if not PROJECTS_FILE.exists():
+        return []
+    try:
+        data = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
+    except Exception:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _write_projects_file_atomic(projects) -> None:
+    PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = PROJECTS_FILE.with_name(f".{PROJECTS_FILE.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open('x', encoding='utf-8') as handle:
+            json.dump(projects, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, PROJECTS_FILE)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def mutate_projects(mutator):
+    """Apply one locked read-modify-write transaction to projects.json.
+
+    ``mutator`` receives the current list and returns ``(result, changed)``.
+    The file is atomically replaced only when ``changed`` is true.
+    """
+    with _PROJECTS_THREAD_LOCK:
+        with _projects_process_lock():
+            projects = _read_projects_file()
+            result, changed = mutator(projects)
+            if changed:
+                _write_projects_file_atomic(projects)
+            return result
 
 
 def _backfill_project_profiles_if_needed(projects: list) -> bool:
@@ -6526,41 +6600,30 @@ def load_projects(*, _migrate: bool = True) -> list:
     callsites that want the raw on-disk shape (test fixtures, e.g.).
     """
     global _projects_migrated
-    if not PROJECTS_FILE.exists():
-        return []
-    try:
-        projects = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
-    except Exception:
-        return []
+    projects = _read_projects_file()
     if _migrate and not _projects_migrated:
         with _PROJECTS_MIGRATION_LOCK:
-            # Re-check inside the lock — another thread may have raced.
-            if _projects_migrated:
-                # Per Opus advisor on stage-293: another thread completed
-                # migration and wrote new state to disk while we waited for
-                # the lock. Our `projects` snapshot is the pre-migration
-                # version; re-read so the caller doesn't see stale untagged
-                # rows (which a mutation route could then write back,
-                # silently overwriting the migration).
+            if not _projects_migrated:
+                def _migrate_projects(current):
+                    changed = _backfill_project_profiles_if_needed(current)
+                    return current, changed
+
                 try:
-                    return json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
-                except Exception:
-                    return projects
-            if _backfill_project_profiles_if_needed(projects):
-                try:
-                    save_projects(projects)
+                    projects = mutate_projects(_migrate_projects)
                     _projects_migrated = True
                 except Exception:
                     logger.debug("Failed to persist project profile backfill")
                     # Leave _projects_migrated False so a future call retries.
             else:
-                # Nothing to migrate — already tagged.
-                _projects_migrated = True
+                projects = _read_projects_file()
     return projects
 
+
 def save_projects(projects) -> None:
-    """Write project list to disk."""
-    PROJECTS_FILE.write_text(json.dumps(projects, ensure_ascii=False, indent=2), encoding='utf-8')
+    """Atomically replace the project list under the shared process lock."""
+    with _PROJECTS_THREAD_LOCK:
+        with _projects_process_lock():
+            _write_projects_file_atomic(projects)
 
 
 CRON_PROJECT_NAME = 'Cron Jobs'
@@ -6591,38 +6654,35 @@ def ensure_cron_project(create: bool = True) -> str | None:
 
     active = get_active_profile_name() or 'default'
     with _CRON_PROJECT_LOCK:
-        projects = load_projects()
-        # Look for an existing per-profile cron project. Match either an exact
-        # profile tag or the renamed-root alias (a 'default'-tagged project
-        # under a renamed root, or a renamed-root-tagged project under
-        # 'default'). _is_root_profile is the canonical alias check.
-        for p in projects:
-            if p.get('name') != CRON_PROJECT_NAME:
-                continue
-            row_profile = p.get('profile')
-            if row_profile == active:
-                return p['project_id']
-            if _is_root_profile(row_profile or 'default') and _is_root_profile(active):
-                return p['project_id']
-        # Reuse a legacy untagged cron project — back-tag it to the active profile.
-        for p in projects:
-            if p.get('name') == CRON_PROJECT_NAME and not p.get('profile'):
-                p['profile'] = active
-                save_projects(projects)
-                return p['project_id']
-        if not create:
-            return None
-        # Otherwise create a new one tagged with the active profile.
-        project_id = uuid.uuid4().hex[:12]
-        projects.append({
-            'project_id': project_id,
-            'name': CRON_PROJECT_NAME,
-            'color': '#6366f1',
-            'profile': active,
-            'created_at': time.time(),
-        })
-        save_projects(projects)
-        return project_id
+        def _mutate(projects):
+            # Look for an existing per-profile cron project. Match either an exact
+            # profile tag or the renamed-root alias.
+            for p in projects:
+                if p.get('name') != CRON_PROJECT_NAME:
+                    continue
+                row_profile = p.get('profile')
+                if row_profile == active:
+                    return p['project_id'], False
+                if _is_root_profile(row_profile or 'default') and _is_root_profile(active):
+                    return p['project_id'], False
+            # Reuse a legacy untagged cron project — back-tag it to the active profile.
+            for p in projects:
+                if p.get('name') == CRON_PROJECT_NAME and not p.get('profile'):
+                    p['profile'] = active
+                    return p['project_id'], True
+            if not create:
+                return None, False
+            project_id = uuid.uuid4().hex[:12]
+            projects.append({
+                'project_id': project_id,
+                'name': CRON_PROJECT_NAME,
+                'color': '#6366f1',
+                'profile': active,
+                'created_at': time.time(),
+            })
+            return project_id, True
+
+        return mutate_projects(_mutate)
 
 
 WEBHOOK_PROJECT_NAME = 'Webhooks'
@@ -6635,30 +6695,30 @@ def ensure_webhook_project() -> str:
 
     active = get_active_profile_name() or 'default'
     with _WEBHOOK_PROJECT_LOCK:
-        projects = load_projects()
-        for p in projects:
-            if p.get('name') != WEBHOOK_PROJECT_NAME:
-                continue
-            row_profile = p.get('profile')
-            if row_profile == active:
-                return p['project_id']
-            if _is_root_profile(row_profile or 'default') and _is_root_profile(active):
-                return p['project_id']
-        for p in projects:
-            if p.get('name') == WEBHOOK_PROJECT_NAME and not p.get('profile'):
-                p['profile'] = active
-                save_projects(projects)
-                return p['project_id']
-        project_id = uuid.uuid4().hex[:12]
-        projects.append({
-            'project_id': project_id,
-            'name': WEBHOOK_PROJECT_NAME,
-            'color': '#0ea5e9',
-            'profile': active,
-            'created_at': time.time(),
-        })
-        save_projects(projects)
-        return project_id
+        def _mutate(projects):
+            for p in projects:
+                if p.get('name') != WEBHOOK_PROJECT_NAME:
+                    continue
+                row_profile = p.get('profile')
+                if row_profile == active:
+                    return p['project_id'], False
+                if _is_root_profile(row_profile or 'default') and _is_root_profile(active):
+                    return p['project_id'], False
+            for p in projects:
+                if p.get('name') == WEBHOOK_PROJECT_NAME and not p.get('profile'):
+                    p['profile'] = active
+                    return p['project_id'], True
+            project_id = uuid.uuid4().hex[:12]
+            projects.append({
+                'project_id': project_id,
+                'name': WEBHOOK_PROJECT_NAME,
+                'color': '#0ea5e9',
+                'profile': active,
+                'created_at': time.time(),
+            })
+            return project_id, True
+
+        return mutate_projects(_mutate)
 
 
 def _profile_has_user_projects() -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -10283,7 +10283,7 @@ from api.models import (
     SESSION_INDEX_FILE,
     _active_state_db_path,
     load_projects,
-    save_projects,
+    mutate_projects,
     import_cli_session,
     CLAUDE_CODE_SOURCE,
     get_cli_sessions,
@@ -14898,6 +14898,7 @@ def _resolve_new_session_workspace(body, visible_prev_session_id):
     )
     return str(workspace)
 
+
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
     diag = RequestDiagnostics.maybe_start("POST", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
@@ -17179,11 +17180,7 @@ def handle_post(handler, parsed) -> bool:
         color = body.get("color")
         if color and not _re.match(r"^#[0-9a-fA-F]{3,8}$", color):
             return bad(handler, "Invalid color format")
-        projects = load_projects()
-        # #3331 follow-up (Codex+Opus gate): validate the optional client-supplied
-        # `profile` before stamping it, mirroring /api/profile/switch — otherwise a
-        # client could create a project tagged with an arbitrary/unknown profile,
-        # producing hidden cross-profile rows that can't be managed normally.
+        # #3331: validate optional client profile before persisting the project.
         _requested_profile = str(body.get('profile') or "").strip()
         if _requested_profile and _requested_profile != "default":
             from api.profiles import _PROFILE_ID_RE
@@ -17196,8 +17193,12 @@ def handle_post(handler, parsed) -> bool:
             "profile": _requested_profile or get_active_profile_name() or 'default',
             "created_at": time.time(),
         }
-        projects.append(proj)
-        save_projects(projects)
+
+        def _create_project(projects):
+            projects.append(proj)
+            return proj, True
+
+        proj = mutate_projects(_create_project)
         return j(handler, {"ok": True, "project": proj})
 
     if parsed.path == "/api/projects/rename":
@@ -17207,23 +17208,26 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         import re as _re
 
-        projects = load_projects()
-        proj = next(
-            (p for p in projects if p["project_id"] == body["project_id"]), None
-        )
+        color_present = "color" in body
+        color = body.get("color")
+        if color_present and color and not _re.match(r"^#[0-9a-fA-F]{3,8}$", color):
+            return bad(handler, "Invalid color format")
+        active_profile = get_active_profile_name()
+
+        def _rename_project(projects):
+            proj = next(
+                (p for p in projects if p["project_id"] == body["project_id"]), None
+            )
+            if not proj or not _profiles_match(proj.get("profile"), active_profile):
+                return None, False
+            proj["name"] = body["name"].strip()[:128]
+            if color_present:
+                proj["color"] = color
+            return proj, True
+
+        proj = mutate_projects(_rename_project)
         if not proj:
             return bad(handler, "Project not found", 404)
-        # #1614: a project can only be renamed by the profile that owns it.
-        active_profile = get_active_profile_name()
-        if not _profiles_match(proj.get("profile"), active_profile):
-            return bad(handler, "Project not found", 404)
-        proj["name"] = body["name"].strip()[:128]
-        if "color" in body:
-            color = body["color"]
-            if color and not _re.match(r"^#[0-9a-fA-F]{3,8}$", color):
-                return bad(handler, "Invalid color format")
-            proj["color"] = color
-        save_projects(projects)
         return j(handler, {"ok": True, "project": proj})
 
     if parsed.path == "/api/projects/delete":
@@ -17231,18 +17235,20 @@ def handle_post(handler, parsed) -> bool:
             require(body, "project_id")
         except ValueError as e:
             return bad(handler, str(e))
-        projects = load_projects()
-        proj = next(
-            (p for p in projects if p["project_id"] == body["project_id"]), None
-        )
-        if not proj:
-            return bad(handler, "Project not found", 404)
-        # #1614: a project can only be deleted by the profile that owns it.
         active_profile = get_active_profile_name()
-        if not _profiles_match(proj.get("profile"), active_profile):
+
+        def _delete_project(projects):
+            for index, proj in enumerate(projects):
+                if proj.get("project_id") != body["project_id"]:
+                    continue
+                if not _profiles_match(proj.get("profile"), active_profile):
+                    return False, False
+                projects.pop(index)
+                return True, True
+            return False, False
+
+        if not mutate_projects(_delete_project):
             return bad(handler, "Project not found", 404)
-        projects = [p for p in projects if p["project_id"] != body["project_id"]]
-        save_projects(projects)
         # Unassign all sessions that belonged to this project.
         # #3746: this loop is O(N) full-JSON read+save per session, and each
         # save() reserializes the entire messages array. For a project with many

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -55,7 +55,7 @@ import api.config as _cfg
 from api.config import (
     STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
 )
-from api.models import load_projects, save_projects
+from api.models import load_projects, mutate_projects
 from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match
 
 # ── Apply --profile override before any module uses get_active_profile_name
@@ -263,14 +263,6 @@ async def handle_create_project(arguments: dict) -> list[TextContent]:
             {"error": color_err}, ensure_ascii=False))]
 
     active = _active_profile()
-    projects = load_projects()
-
-    # Title collision: exact match (consistent with ensure_cron_project)
-    if any(p.get("name") == name and _profiles_match(p.get("profile"), active)
-           for p in projects):
-        return [TextContent(type="text", text=json.dumps(
-            {"error": f"Project '{name}' already exists"}, ensure_ascii=False))]
-
     proj = {
         "project_id": uuid.uuid4().hex[:12],
         "name": name,
@@ -278,8 +270,18 @@ async def handle_create_project(arguments: dict) -> list[TextContent]:
         "profile": active,
         "created_at": time.time(),
     }
-    projects.append(proj)
-    save_projects(projects)
+
+    def _create(projects):
+        if any(p.get("name") == name and _profiles_match(p.get("profile"), active)
+               for p in projects):
+            return None, False
+        projects.append(proj)
+        return proj, True
+
+    proj = mutate_projects(_create)
+    if proj is None:
+        return [TextContent(type="text", text=json.dumps(
+            {"error": f"Project '{name}' already exists"}, ensure_ascii=False))]
 
     proj["session_count"] = 0
     return [TextContent(type="text", text=json.dumps(proj, ensure_ascii=False, indent=2))]
@@ -300,21 +302,20 @@ async def handle_rename_project(arguments: dict) -> list[TextContent]:
             {"error": color_err}, ensure_ascii=False))]
 
     active = _active_profile()
-    projects = load_projects()
-    proj = next((p for p in projects if p["project_id"] == project_id), None)
+
+    def _rename(projects):
+        proj = next((p for p in projects if p["project_id"] == project_id), None)
+        if not proj or not _profiles_match(proj.get("profile"), active):
+            return None, False
+        proj["name"] = name
+        if color is not None:
+            proj["color"] = color
+        return proj, True
+
+    proj = mutate_projects(_rename)
     if not proj:
         return [TextContent(type="text", text=json.dumps(
             {"error": "Project not found"}, ensure_ascii=False))]
-
-    # #1614: profile ownership check
-    if not _profiles_match(proj.get("profile"), active):
-        return [TextContent(type="text", text=json.dumps(
-            {"error": "Project not found"}, ensure_ascii=False))]
-
-    proj["name"] = name
-    if color is not None:
-        proj["color"] = color
-    save_projects(projects)
     return [TextContent(type="text", text=json.dumps(proj, ensure_ascii=False, indent=2))]
 
 
@@ -326,19 +327,21 @@ async def handle_delete_project(arguments: dict) -> list[TextContent]:
             {"error": "project_id is required"}, ensure_ascii=False))]
 
     active = _active_profile()
-    projects = load_projects()
-    proj = next((p for p in projects if p["project_id"] == project_id), None)
+
+    def _delete(projects):
+        for index, project in enumerate(projects):
+            if project.get("project_id") != project_id:
+                continue
+            if not _profiles_match(project.get("profile"), active):
+                return None, False
+            removed = projects.pop(index)
+            return removed, True
+        return None, False
+
+    proj = mutate_projects(_delete)
     if not proj:
         return [TextContent(type="text", text=json.dumps(
             {"error": "Project not found"}, ensure_ascii=False))]
-
-    # #1614: profile ownership check
-    if not _profiles_match(proj.get("profile"), active):
-        return [TextContent(type="text", text=json.dumps(
-            {"error": "Project not found"}, ensure_ascii=False))]
-
-    projects = [p for p in projects if p["project_id"] != project_id]
-    save_projects(projects)
 
     # Unassign sessions only when we can do it cache-safely via the HTTP API.
     # The previous filesystem fallback wrote session_data directly with

--- a/tests/test_project_mutation_transactions.py
+++ b/tests/test_project_mutation_transactions.py
@@ -1,0 +1,123 @@
+"""Regression coverage for atomic, serialized projects.json mutations."""
+
+import json
+import multiprocessing
+import threading
+import time
+
+import pytest
+
+
+def _isolate_projects(tmp_path, monkeypatch):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+    monkeypatch.setattr(models, "_PROJECTS_THREAD_LOCK", threading.RLock())
+    return models, projects_file
+
+
+def test_mutate_projects_serializes_concurrent_threads(tmp_path, monkeypatch):
+    models, projects_file = _isolate_projects(tmp_path, monkeypatch)
+    first_inside = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+
+    def first_mutation():
+        def _mutate(projects):
+            projects.append({"project_id": "first"})
+            first_inside.set()
+            assert release_first.wait(timeout=5)
+            return "first", True
+
+        models.mutate_projects(_mutate)
+
+    def second_mutation():
+        second_started.set()
+
+        def _mutate(projects):
+            projects.append({"project_id": "second"})
+            return "second", True
+
+        models.mutate_projects(_mutate)
+
+    first = threading.Thread(target=first_mutation)
+    second = threading.Thread(target=second_mutation)
+    first.start()
+    assert first_inside.wait(timeout=5)
+    second.start()
+    assert second_started.wait(timeout=5)
+    assert second.is_alive(), "second mutation must wait for the first transaction"
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    saved = json.loads(projects_file.read_text(encoding="utf-8"))
+    assert [project["project_id"] for project in saved] == ["first", "second"]
+
+
+def test_mutate_projects_serializes_separate_processes(tmp_path, monkeypatch):
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires fork to preserve isolated module paths")
+
+    models, projects_file = _isolate_projects(tmp_path, monkeypatch)
+    ctx = multiprocessing.get_context("fork")
+    first_inside = ctx.Event()
+    release_first = ctx.Event()
+
+    def first_mutation():
+        def _mutate(projects):
+            projects.append({"project_id": "mcp"})
+            first_inside.set()
+            if not release_first.wait(timeout=5):
+                raise TimeoutError("parent did not release first transaction")
+            return "mcp", True
+
+        models.mutate_projects(_mutate)
+
+    def second_mutation():
+        def _mutate(projects):
+            projects.append({"project_id": "webui"})
+            return "webui", True
+
+        models.mutate_projects(_mutate)
+
+    first = ctx.Process(target=first_mutation)
+    second = ctx.Process(target=second_mutation)
+    first.start()
+    assert first_inside.wait(timeout=5)
+    second.start()
+    time.sleep(0.1)
+    assert second.is_alive(), "second process must wait on the projects file lock"
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert first.exitcode == 0
+    assert second.exitcode == 0
+    saved = json.loads(projects_file.read_text(encoding="utf-8"))
+    assert [project["project_id"] for project in saved] == ["mcp", "webui"]
+
+
+def test_atomic_write_failure_preserves_existing_projects(tmp_path, monkeypatch):
+    models, projects_file = _isolate_projects(tmp_path, monkeypatch)
+    original = [{"project_id": "existing", "name": "Existing"}]
+    projects_file.write_text(json.dumps(original), encoding="utf-8")
+
+    def fail_replace(_source, _destination):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(models.os, "replace", fail_replace)
+
+    def _mutate(projects):
+        projects.append({"project_id": "new", "name": "New"})
+        return "new", True
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        models.mutate_projects(_mutate)
+
+    assert json.loads(projects_file.read_text(encoding="utf-8")) == original
+    assert list(tmp_path.glob(".projects.json.*.tmp")) == []


### PR DESCRIPTION
## Thinking Path

- `projects.json` is mutated from multiple owners: HTTP project CRUD, the standalone MCP server, cron/webhook project helpers, and the one-time profile migration.
- Each path previously performed an unlocked `load_projects()` → mutate → `save_projects()` sequence, sometimes under a path-specific lock that other writers did not share.
- A concurrent writer could therefore save a stale snapshot over a newer mutation; direct writes also exposed readers to partial JSON if the process stopped mid-write.
- This PR introduces one canonical project-mutation transaction and routes every production read-modify-write path through it.

## What Changed

- Added `mutate_projects(mutator)` in `api/models.py`:
  - in-process `RLock`;
  - cross-process advisory lock (`fcntl.flock` on POSIX, one-byte `msvcrt.locking` on Windows);
  - fresh read inside the lock;
  - same-directory temporary file, `flush` + `fsync`, then atomic `os.replace`;
  - cleanup of failed temporary writes.
- Migrated project profile backfill, cron/webhook project creation, HTTP create/rename/delete, and MCP create/rename/delete to the shared transaction.
- Kept `save_projects()` as an atomic locked replacement helper for existing direct/test callers.
- Added deterministic thread and forked-process race tests plus an atomic-replace failure test.

## Why It Matters

This prevents a WebUI request, background helper, or standalone MCP process from silently erasing another project mutation. It also guarantees that readers observe either the previous valid JSON document or the complete replacement, never a partially written file.

This is intentionally a prerequisite hardening PR rather than another workspace-auto-assignment implementation. It complements the broader project-bindings work in #6836 by making its project persistence layer safe under concurrent WebUI/MCP/background writers.

## Verification

- `./scripts/test.sh tests/test_project_mutation_transactions.py tests/test_issue1614_project_profile_filtering.py tests/test_mcp_server.py tests/test_1079_cron_session_project.py tests/test_webhook_project_sessions.py tests/test_sprint15.py -q`
  - **88 passed**
- `python -m py_compile` on changed production code and tests: passed
- Ruff on the new test: passed
- `python3 scripts/ruff_lint.py --diff origin/master`: no new violations
- `git diff --check`: passed
- Deterministic race coverage proves the second thread/process blocks until the first transaction commits and that both project IDs survive.
- Replace-failure coverage proves the previous `projects.json` remains intact and temporary files are removed.

## Risks / Follow-ups

- The lock file is deliberately persistent; unlinking a lock file while another process waits can split callers across inodes.
- The transaction callback must remain local and non-blocking except for bounded mutation work; callers should not perform network I/O while holding it.
- Directory durability (`fsync` on the parent directory) is not added here; this matches existing atomic-file patterns in the repository and keeps the change scoped to lost updates/partial writes.
- No UI behavior or user-visible project semantics change.

## Contract Routing

Task type: reliability fix / persistence hardening

Touched areas:
- WebUI project persistence (`projects.json`)
- HTTP project CRUD
- MCP project CRUD
- cron/webhook project helpers
- legacy project-profile migration

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`

State owner and invariant:
- `api.models.mutate_projects` owns every production project read-modify-write transaction.
- Concurrent project mutations must serialize across threads and processes.
- A failed replacement must leave the prior valid project document intact.

Scope boundaries:
- no project-binding or auto-assignment product behavior;
- no UI changes;
- no schema migration;
- no session mutation changes.

## Release Note

Project mutations are now serialized across WebUI and MCP processes and persisted with atomic file replacement, preventing concurrent project actions from losing data or exposing partial JSON.

## Model Used

OpenAI `gpt-5.6-sol` via Hermes Agent, with terminal/file tools and an independent exact-snapshot code review during development.
