### PR TITLE
fix(streaming): tolerate null tool call history

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7513,7 +7513,7 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
                             pending_names[tid] = part.get('name', '')
                             pending_args[tid] = part.get('input', {})
                             pending_asst_idx[tid] = msg_idx
-            for tc in m.get('tool_calls', []):
+            for tc in m.get('tool_calls') or []:
                 if not isinstance(tc, dict):
                     continue
                 tid = tc.get('id', '') or tc.get('call_id', '')

--- a/tests/test_tool_call_persistence.py
+++ b/tests/test_tool_call_persistence.py
@@ -33,6 +33,34 @@ def test_extract_tool_calls_from_openai_message_linkage():
     assert result[0]["snippet"] == "file.txt"
 
 
+def test_extract_tool_calls_ignores_explicit_null_tool_calls_in_history():
+    """Legacy assistant rows with tool_calls=None must not abort later turns."""
+    messages = [
+        {"role": "assistant", "content": "An old TickTick response", "tool_calls": None},
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-current",
+                "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-current",
+            "content": '{"output":"/workspace","exit_code":0}',
+        },
+    ]
+
+    result = _extract_tool_calls_from_messages(messages)
+
+    assert len(result) == 1
+    assert result[0]["name"] == "terminal"
+    assert result[0]["assistant_msg_idx"] == 2
+    assert result[0]["snippet"] == "/workspace"
+
+
 def test_tool_result_snippet_allows_frontend_show_more_threshold_but_stays_bounded():
     """Persisted snippets should be long enough for frontend Show more but capped."""
     medium_output = "m" * 1200


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI finalization scans the full session message history to build persisted tool-call summaries.
- Legacy assistant rows can contain an explicit `tool_calls: null` field.
- `m.get('tool_calls', [])` defaults only when the key is absent; it still returns `None` for an explicit null.
- The resulting `TypeError` occurs before WebUI session writeback is marked successful, so the ordinary error-recovery path adds a duplicate recovered prompt, a partial duplicate answer, and a false error marker.

## Contract Routing

Task type: runtime streaming regression fix
Touched areas: `api/streaming.py` tool-call summary extraction and its regression test
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
Scope boundaries: normalize legacy null tool-call metadata only; do not rewrite existing session sidecars or change provider behavior.
Evidence needed before claiming done: focused regression, neighboring streaming tests, actual legacy session-data probe, live service health/source verification.

## What Changed

- Normalize nullable `tool_calls` with `m.get('tool_calls') or []` in the shared extraction helper.
- Add a regression test that places a legacy assistant message with `tool_calls=None` before a later valid assistant/tool pair and verifies the later tool summary is still extracted.

## Why It Matters

A malformed historical metadata field can no longer poison every later turn in the session. The normal completion path can reach `done`/`stream_end` instead of entering the pre-save provider-style error path, so WebUI will not manufacture a second prompt and false `_error` marker for this case.

## Verification

- RED: before the fix, `./scripts/test.sh tests/test_tool_call_persistence.py -q` failed the new regression with the production traceback at `api/streaming.py:7213`; the other 5 tests passed.
- GREEN: live checkout focused and neighboring tests: `34 passed`.
- GREEN: clean PR worktree focused test: `6 passed`.
- `python3 -m py_compile api/streaming.py tests/test_tool_call_persistence.py` passed.
- `git diff --check` passed.
- Actual historical TickTick parser sidecar probe: 351 messages, 1 assistant row with `tool_calls: null`, 166 tool summaries extracted without error.
- Live WebUI restarted from the patched checkout; `/health` returned `status: ok`, `active_streams: 0`, and `active_runs: 0`. The service interpreter loaded the patched guard from the live module path.
- The full repository suite was started separately as the broader CI/local gate; its final result is reported separately if it completes after PR creation.

## Risks / Follow-ups

- Existing duplicate/error markers in the affected historical sidecar are intentionally not rewritten by this fix; the code change prevents recurrence.
- CI should run the full repository matrix before merge.

## Model Used

OpenAI Codex provider, `gpt-5.6-luna`; Hermes tools performed the implementation and verification.
