### PR TITLE
fix(redaction): recognize multi-picture JPEG payloads

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -613,8 +613,9 @@ def _is_native_raster_data_uri(text: str) -> bool:
     Native image content is opaque binary, not text that the credential regexes
     can safely rewrite. The exemption is a credential-boundary decision, so a
     matching header or magic prefix is not enough: decode the entire canonical
-    base64 payload and require the image format to terminate exactly at the end
-    of the decoded bytes. Any malformed, ambiguous, or trailing content falls
+    base64 payload and require it to contain only complete raster content through
+    the end of the decoded bytes. JPEG additionally permits an MPO-style sequence
+    of complete images. Any malformed, ambiguous, or trailing content falls
     through to normal text redaction.
     """
     if not isinstance(text, str):
@@ -724,37 +725,38 @@ _JPEG_SOF_MARKERS = {
 }
 
 
-def _is_complete_jpeg(raw: bytes) -> bool:
-    if len(raw) < 4 or raw[:2] != b"\xff\xd8":
-        return False
-    pos = 2
+def _complete_jpeg_end(raw: bytes, start: int) -> int | None:
+    """Return the byte after one complete JPEG image, or ``None``."""
+    if len(raw) - start < 4 or raw[start:start + 2] != b"\xff\xd8":
+        return None
+    pos = start + 2
     saw_sof = False
     saw_scan = False
     while pos < len(raw):
         marker_start = pos
         if raw[pos] != 0xFF:
-            return False
+            return None
         while pos < len(raw) and raw[pos] == 0xFF:
             pos += 1
         if pos >= len(raw):
-            return False
+            return None
         marker = raw[pos]
         pos += 1
         if marker == 0xD9:
-            return saw_sof and saw_scan and pos == len(raw)
+            return pos if saw_sof and saw_scan else None
         if marker in {0x00, 0x01, 0xD8} or 0xD0 <= marker <= 0xD7:
-            return False
+            return None
         if pos + 2 > len(raw):
-            return False
+            return None
         segment_length = int.from_bytes(raw[pos:pos + 2], "big")
         if segment_length < 2:
-            return False
+            return None
         segment_end = pos + segment_length
         if segment_end > len(raw):
-            return False
+            return None
         if marker in _JPEG_SOF_MARKERS:
             if segment_length < 8:
-                return False
+                return None
             saw_sof = True
         if marker != 0xDA:
             pos = segment_end
@@ -770,7 +772,7 @@ def _is_complete_jpeg(raw: bytes) -> bool:
             while pos < len(raw) and raw[pos] == 0xFF:
                 pos += 1
             if pos >= len(raw):
-                return False
+                return None
             scan_marker = raw[pos]
             if scan_marker == 0x00 or 0xD0 <= scan_marker <= 0xD7:
                 pos += 1
@@ -778,8 +780,20 @@ def _is_complete_jpeg(raw: bytes) -> bool:
             pos = marker_start
             break
         else:
+            return None
+    return None
+
+
+def _is_complete_jpeg(raw: bytes) -> bool:
+    """Validate a JPEG or an MPO-style sequence of complete JPEG images."""
+    pos = 0
+    images = 0
+    while pos < len(raw):
+        pos = _complete_jpeg_end(raw, pos)
+        if pos is None:
             return False
-    return False
+        images += 1
+    return images > 0
 
 
 def _gif_subblocks_end(raw: bytes, pos: int) -> int | None:

--- a/tests/test_raster_data_uri_redaction.py
+++ b/tests/test_raster_data_uri_redaction.py
@@ -353,6 +353,66 @@ def test_supported_raster_requires_exact_terminal_boundary(mime, raw):
     assert helpers._is_native_raster_data_uri(trailing) is False
 
 
+def test_multi_picture_jpeg_bypasses_text_redactor(monkeypatch):
+    """A complete JPEG sequence, as stored by MPO phone images, stays opaque."""
+    raw = _ONE_PIXEL_JPEG + _ONE_PIXEL_JPEG
+    uri = f"data:image/jpeg;base64,{base64.b64encode(raw).decode('ascii')}"
+    calls = []
+    monkeypatch.setattr(
+        helpers,
+        "_redact_fn_cached",
+        lambda text: calls.append(text) or "unexpected-redaction",
+    )
+
+    content_part = {"type": "image_url", "image_url": {"url": uri}}
+    assert helpers._is_native_raster_data_uri(uri) is True
+    result = helpers.redact_session_data(
+        {"messages": [{"role": "user", "content": [content_part]}]}
+    )
+
+    assert result["messages"][0]["content"][0] == content_part
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        _ONE_PIXEL_JPEG + b"trailing-bytes" + _ONE_PIXEL_JPEG,
+        _ONE_PIXEL_JPEG + _ONE_PIXEL_JPEG[:-2],
+        _ONE_PIXEL_JPEG + _ONE_PIXEL_JPEG + b"trailing-bytes",
+    ],
+)
+def test_malformed_multi_picture_jpeg_keeps_security_boundary(raw):
+    uri = f"data:image/jpeg;base64,{base64.b64encode(raw).decode('ascii')}"
+
+    assert helpers._is_native_raster_data_uri(uri) is False
+
+
+def test_multi_picture_jpeg_trailing_credential_is_redacted(monkeypatch):
+    raw = _ONE_PIXEL_JPEG * 3 + base64.b64decode(
+        _FAKE_AWS_KEY,
+        validate=True,
+    )
+    uri = f"data:image/jpeg;base64,{base64.b64encode(raw).decode('ascii')}"
+    assert uri.endswith(_FAKE_AWS_KEY)
+    calls = []
+
+    def redact(text):
+        calls.append(text)
+        return text.replace(_FAKE_AWS_KEY, "[REDACTED]")
+
+    monkeypatch.setattr(helpers, "_redact_fn_cached", redact)
+    content_part = {"type": "image_url", "image_url": {"url": uri}}
+    result = helpers.redact_session_data(
+        {"messages": [{"role": "user", "content": [content_part]}]}
+    )
+
+    redacted_uri = result["messages"][0]["content"][0]["image_url"]["url"]
+    assert _FAKE_AWS_KEY not in redacted_uri
+    assert calls == [uri]
+    assert helpers._is_native_raster_data_uri(uri) is False
+
+
 def test_webp_animation_frame_requires_real_nested_image_chunk():
     fake_frame = b"\x00" * 16
     anmf = b"ANMF" + struct.pack("<I", len(fake_frame)) + fake_frame


### PR DESCRIPTION
## Thinking Path

- Native multimodal images are exempted from credential-regex scanning only after complete structural validation.
- A real phone-uploaded JPEG reproduced a ~33 second response-redaction path even though the image bytes were valid.
- Pillow identifies that payload as a two-frame MPO: two complete JPEG images stored back-to-back.
- The JPEG validator stopped at the first EOI and rejected any remaining bytes, so the canonical base64 payload fell through to the text redactor.
- This change keeps the boundary fail-closed while recognizing a payload made entirely of one or more complete JPEG images.

## What Changed

- Split single-image JPEG parsing into `_complete_jpeg_end(raw, start)`, which returns the exact end of one structurally complete JPEG or fails closed.
- Let `_is_complete_jpeg()` consume one or more complete JPEG images and require the final image to end exactly at EOF.
- Add regression coverage for a valid two-image sequence and for arbitrary inter-image bytes, a truncated second image, and trailing bytes after the final image.

## Why It Matters

Some phone images are stored as MPO (`image/jpeg`) rather than a single JPEG stream. Rejecting those valid payloads sends multi-megabyte base64 strings through the credential regex chain for every session response. In the production reproduction, full session redaction dropped from about 33 seconds to about 0.50 seconds while preserving exact terminal-boundary checks.

## Verification

- RED proof: `test_multi_picture_jpeg_bypasses_text_redactor` failed on `exp-v0.52.262` before the implementation (`_is_native_raster_data_uri(uri) is False`).
- `./scripts/test.sh tests/test_raster_data_uri_redaction.py -q` — 22 passed.
- `./scripts/test.sh tests/test_raster_data_uri_redaction.py tests/test_security_redaction.py tests/test_session_export_html_palette.py tests/test_session_public_share_static.py tests/test_todo_state_emission.py tests/test_v050255_opus_followups.py -q` — 127 passed, 1 agent-dependent skip.
- `./scripts/test.sh tests/test_issue5204_redactor_memoization_contract.py tests/test_native_image_attachments.py tests/test_context_history_sanitization.py -q` — 64 passed.
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master` — no new violations on modified lines.
- `.venv/bin/ruff check --select E9,F63,F7,F82 api/helpers.py tests/test_raster_data_uri_redaction.py` — passed.
- `.venv/bin/python -m py_compile api/helpers.py tests/test_raster_data_uri_redaction.py` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Real local MPO reproduction (not committed): Pillow reports `format=MPO`, `n_frames=2`; patched `_is_native_raster_data_uri()` returns `True`.
- Real 3.69 MB session payload benchmark: full `redact_session_data()` median improved from ~33.4 s to ~0.50 s.

## Security Boundary / State Space

Accepted:
- one complete JPEG ending at EOF (existing behavior);
- multiple complete JPEG images adjacent with no intervening bytes, ending at EOF (MPO-style payload).

Rejected:
- arbitrary bytes between images;
- an incomplete/truncated later image;
- arbitrary bytes after the final image;
- all existing malformed/non-canonical base64 and non-image cases.

The exemption remains limited to direct native user image content parts. Metadata, assistant content, tools, todos, and journals keep their existing redaction behavior.

## Contract Routing

- State layer changed: response-layer raster validation used by API redaction projection only.
- Durable transcript, model context, streaming, replay, and session ordering are unchanged.
- Relevant guidance: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, and `docs/GUIDELINES.md`.
- Docs update is not needed because this is a narrow correction to the existing complete-raster validation contract; no public API shape changes.

## Risks / Follow-ups

- The parser accepts any sequence made entirely of structurally complete JPEG images, not only sequences carrying MPO APP2 metadata. This is deliberate: every accepted byte belongs to a validated image, preserving the original no-trailing-data security property without adding an EXIF/MPF dependency.
- The production WebUI was not modified or restarted during investigation.
- A full unsharded run cannot complete meaningfully as root in this deployment: `./scripts/test.sh -x -q` reached 643 passed / 35 skipped, then the unchanged `test_readonly_parent_with_unwritable_file_still_raises` expected `PermissionError` from `0444`/`0555` POSIX modes, which root bypasses. Hosted CI remains the authoritative supported-user sharded matrix.
- Independent security review found no blocking issues. Its low-severity recommendation to prove the full malformed-JPEG redaction path was incorporated as `test_multi_picture_jpeg_trailing_credential_is_redacted`; the helper contract wording was updated too. The production MPO itself remains the live/manual fixture because it contains a private user image and is not committed.

Release note: Multi-picture JPEG/MPO uploads no longer make image-heavy sessions take tens of seconds to reopen because their base64 payloads are recognized as complete native raster content instead of being scanned as text.

## Model Used

AI-assisted with Nous Research Hermes Agent using OpenAI `gpt-5.6-sol` (`openai-codex`). Used live production timing evidence, strict TDD, pytest, ruff, Git/GitHub inspection, and an independent delegated security review.
