### PR TITLE
fix(#7257): notify on backgrounded cron completions with an output preview

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -21847,6 +21847,55 @@ def _cron_output_snippet(text: str, limit: int = 600) -> str:
     return body[:limit] or "(empty)"
 
 
+_CRON_PREVIEW_LIMIT = 400
+
+
+def _cron_completion_output_preview(job_id: str, completed_at: float) -> str:
+    try:
+        from cron.jobs import OUTPUT_DIR as CRON_OUT
+        import re as _re
+
+        if job_id in (".", "..") or not _re.fullmatch(
+            r"[A-Za-z0-9_-][A-Za-z0-9_.-]{0,63}", job_id
+        ):
+            return ""
+        out_dir = CRON_OUT / job_id
+        if not out_dir.exists():
+            return ""
+        output_file = max(
+            (
+                path
+                for path in out_dir.glob("*.md")
+                if path.is_file() and path.stat().st_mtime <= completed_at
+            ),
+            key=lambda path: path.stat().st_mtime,
+            default=None,
+        )
+        if output_file is None:
+            return ""
+        # The scheduler saves output before mark_job_run writes last_run_at, so
+        # the newest qualifying file belongs to this successful completion.
+        text = output_file.read_text(encoding="utf-8", errors="replace")
+        if any(
+            line.startswith("## Response") or line.startswith("# Response")
+            for line in text.splitlines()
+        ):
+            preview = _cron_output_snippet(text, limit=_CRON_PREVIEW_LIMIT)
+        else:
+            lines = text.splitlines()
+            separator = next(
+                (index for index, line in enumerate(lines) if line.strip() == "---"),
+                None,
+            )
+            if separator is None:
+                return ""
+            preview = "\n".join(lines[separator + 1:]).strip()[:_CRON_PREVIEW_LIMIT] or "(empty)"
+        return "" if preview == "(empty)" else preview
+    except (ImportError, OSError, TypeError, ValueError) as exc:
+        logger.debug("Failed to read cron completion preview for %s: %s", job_id, exc)
+        return ""
+
+
 def _handle_cron_output(handler, parsed):
     from cron.jobs import OUTPUT_DIR as CRON_OUT
     import re as _re
@@ -21928,15 +21977,18 @@ def _handle_cron_recent(handler, parsed):
             else:
                 ts = float(last_run)
             if ts > since:
-                completions.append(
-                    {
-                        "job_id": job_id,
-                        "name": job.get("name", "Unknown"),
-                        "status": job.get("last_status", "unknown"),
-                        "completed_at": ts,
-                        "toast_notifications": job.get("toast_notifications") is not False,
-                    }
-                )
+                completion = {
+                    "job_id": job_id,
+                    "name": job.get("name", "Unknown"),
+                    "status": job.get("last_status", "unknown"),
+                    "completed_at": ts,
+                    "toast_notifications": job.get("toast_notifications") is not False,
+                }
+                completions.append(completion)
+                if completion["status"] == "ok":
+                    preview = _cron_completion_output_preview(job_id, ts)
+                    if preview:
+                        completion["output_preview"] = preview
         latest_session_info = _latest_cron_session_info_for_jobs(
             [job.get("id", "") for job in jobs],
             [c["job_id"] for c in completions],

--- a/static/messages.js
+++ b/static/messages.js
@@ -9149,7 +9149,7 @@ function playAttentionSound(key){
 }
 
 function _notificationOptions(body,options={}){
-  const hasSid=!!(options&&Object.prototype.hasOwnProperty.call(options,'sid'));
+  const hasSid=!!(options&&Object.prototype.hasOwnProperty.call(options,'sid'))&&options.sid!==undefined;
   const sid=(options&&options.sid)||(S&&S.session&&S.session.session_id);
   const effectiveSid=hasSid?options.sid:sid;
   const url=effectiveSid?`${location.origin}${_sessionUrlForSid(sid)}`:

--- a/static/messages.js
+++ b/static/messages.js
@@ -9197,6 +9197,7 @@ function _showPwaNotification(title,body,options={}){
     ]);
     return reg$.then(inspectAndShow);
   }
+  // Direct notifications do not expose browser-owned displayed records.
   return inspectAndShow(null);
 }
 function requestNotificationPermission(){
@@ -9231,10 +9232,8 @@ function sendBrowserNotification(title,body,options={}){
   // explicit "Send test" override); only the visibility gate is bypassed.
   const forceHidden=!!(options&&options.forceHidden);
   const outcome=(reason,retryable=false)=>Promise.resolve({delivered:false,alreadyDisplayed:false,retryable,reason});
-  const settingGateSatisfied=()=>{if(!force&&!window._notificationsEnabled) return;return true;};
-  const visibilityGateSatisfied=()=>{if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;return true;};
-  if(settingGateSatisfied()!==true) return outcome('setting-disabled');
-  if(visibilityGateSatisfied()!==true) return outcome('foreground');
+  if(!force&&!window._notificationsEnabled) return outcome('setting-disabled');
+  if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return outcome('foreground');
   if(!('Notification' in window)) return outcome('unsupported');
   if(Notification.permission==='granted'){
     return _showPwaNotification(title,body,options);

--- a/static/messages.js
+++ b/static/messages.js
@@ -73,7 +73,7 @@ function _isBackgroundedForBrowserNotification(){
   return !!(typeof document!=='undefined'&&document.hidden)||_desktopBackgroundedForNotifications;
 }
 function _isBrowserNotificationReady(){
-  return typeof window!=='undefined'&&window._notificationsEnabled===true&&
+  return typeof window!=='undefined'&&!!window._notificationsEnabled&&
     'Notification' in window&&Notification.permission==='granted';
 }
 
@@ -9158,7 +9158,7 @@ function _notificationOptions(body,options={}){
   const tag=options&&Object.prototype.hasOwnProperty.call(options,'tag')?options.tag:
     (hasSid&&!effectiveSid?'hermes-webui':defaults.tag);
   const renotify=options&&Object.prototype.hasOwnProperty.call(options,'renotify')?!!options.renotify:true;
-  return {...defaults,tag,renotify,data:{url}};
+  return {...defaults,tag,renotify};
 }
 function _showPwaNotification(title,body,options={}){
   const botName=assistantDisplayName();

--- a/static/messages.js
+++ b/static/messages.js
@@ -72,6 +72,10 @@ if(typeof window!=='undefined'){
 function _isBackgroundedForBrowserNotification(){
   return !!(typeof document!=='undefined'&&document.hidden)||_desktopBackgroundedForNotifications;
 }
+function _isBrowserNotificationReady(){
+  return typeof window!=='undefined'&&window._notificationsEnabled===true&&
+    'Notification' in window&&Notification.permission==='granted';
+}
 
 function _isSessionCurrentPane(sid) {
   if(!sid || !S.session || S.session.session_id!==sid) return false;
@@ -9145,14 +9149,41 @@ function playAttentionSound(key){
 }
 
 function _notificationOptions(body,options={}){
+  const hasSid=!!(options&&Object.prototype.hasOwnProperty.call(options,'sid'));
   const sid=(options&&options.sid)||(S&&S.session&&S.session.session_id);
-  const url=sid?`${location.origin}${_sessionUrlForSid(sid)}`:location.href;
-  return {body:body||'',tag:sid?`hermes-${sid}`:'hermes-webui',renotify:true,icon:'static/favicon-192.png',badge:'static/favicon-32.png',data:{url}};
+  const effectiveSid=hasSid?options.sid:sid;
+  const url=effectiveSid?`${location.origin}${_sessionUrlForSid(sid)}`:
+    (hasSid&&typeof _appRootPath==='function'?`${location.origin}${_appRootPath()}`:location.href);
+  const defaults={body:body||'',tag:sid?`hermes-${sid}`:'hermes-webui',renotify:true,icon:'static/favicon-192.png',badge:'static/favicon-32.png',data:{url}};
+  const tag=options&&Object.prototype.hasOwnProperty.call(options,'tag')?options.tag:
+    (hasSid&&!effectiveSid?'hermes-webui':defaults.tag);
+  const renotify=options&&Object.prototype.hasOwnProperty.call(options,'renotify')?!!options.renotify:true;
+  return {...defaults,tag,renotify,data:{url}};
 }
 function _showPwaNotification(title,body,options={}){
   const botName=assistantDisplayName();
   const opts=_notificationOptions(body,options);
-  const direct=()=>new Notification(title||botName,opts);
+  const delivered=()=>({delivered:true,alreadyDisplayed:false,retryable:false,reason:'delivered'});
+  const failed=reason=>({delivered:false,alreadyDisplayed:false,retryable:true,reason});
+  const direct=()=>{
+    try{new Notification(title||botName,opts);return Promise.resolve(delivered());}
+    catch(_err){return Promise.resolve(failed('direct-presentation-failed'));}
+  };
+  const showWithFallback=reg=>{
+    if(!reg||!reg.active||!reg.showNotification) return direct();
+    return Promise.resolve().then(()=>reg.showNotification(title||botName,opts))
+      .then(()=>delivered(),()=>direct().then(result=>result.delivered?result:failed('worker-and-direct-presentation-failed')));
+  };
+  const inspectAndShow=reg=>{
+    if(options&&options.dedupe&&opts.tag&&reg&&typeof reg.getNotifications==='function'){
+      return Promise.resolve().then(()=>reg.getNotifications({tag:opts.tag})).then(records=>{
+        if(Array.isArray(records)&&records.length>0)
+          return {delivered:false,alreadyDisplayed:true,retryable:false,reason:'already-displayed'};
+        return showWithFallback(reg);
+      },()=>showWithFallback(reg));
+    }
+    return showWithFallback(reg);
+  };
   // Prefer the service worker (the only path that works in a standalone PWA,
   // notably iOS). Use getRegistration() + a short timeout race rather than
   // navigator.serviceWorker.ready, because `.ready` NEVER settles when no
@@ -9164,11 +9195,9 @@ function _showPwaNotification(title,body,options={}){
       navigator.serviceWorker.getRegistration().catch(()=>null),
       new Promise(res=>setTimeout(()=>res(null),2000))
     ]);
-    return reg$.then(reg=>(reg&&reg.active&&reg.showNotification)
-      ? reg.showNotification(title||botName,opts)
-      : direct());
+    return reg$.then(inspectAndShow);
   }
-  return Promise.resolve(direct());
+  return inspectAndShow(null);
 }
 function requestNotificationPermission(){
   if(!('Notification' in window)){
@@ -9201,16 +9230,22 @@ function sendBrowserNotification(title,body,options={}){
   // notifications-enabled SETTING is still honored (unlike `force`, which is the
   // explicit "Send test" override); only the visibility gate is bypassed.
   const forceHidden=!!(options&&options.forceHidden);
-  if(!force&&!window._notificationsEnabled) return;
-  if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;
-  if(!('Notification' in window)) return;
+  const outcome=(reason,retryable=false)=>Promise.resolve({delivered:false,alreadyDisplayed:false,retryable,reason});
+  const settingGateSatisfied=()=>{if(!force&&!window._notificationsEnabled) return;return true;};
+  const visibilityGateSatisfied=()=>{if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;return true;};
+  if(settingGateSatisfied()!==true) return outcome('setting-disabled');
+  if(visibilityGateSatisfied()!==true) return outcome('foreground');
+  if(!('Notification' in window)) return outcome('unsupported');
   if(Notification.permission==='granted'){
-    _showPwaNotification(title,body,options).catch(()=>{try{new Notification(title||assistantDisplayName(),_notificationOptions(body,options));}catch(_err){}});
+    return _showPwaNotification(title,body,options);
   }else if(Notification.permission==='denied'){
     // Explicit "Send test" (force) deserves feedback instead of a silent no-op.
     if(force&&typeof showToast==='function') showToast(t('notifications_denied'),3500,'error');
+    return outcome('permission-denied');
   }else{
-    requestNotificationPermission().then(p=>{if(p==='granted') _showPwaNotification(title,body,options).catch(()=>{try{new Notification(title||assistantDisplayName(),_notificationOptions(body,options));}catch(_err){}});});
+    return requestNotificationPermission().then(p=>p==='granted'
+      ? _showPwaNotification(title,body,options)
+      : outcome('permission-not-granted')).catch(()=>outcome('permission-request-failed',true));
   }
 }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -9163,22 +9163,22 @@ function _notificationOptions(body,options={}){
 function _showPwaNotification(title,body,options={}){
   const botName=assistantDisplayName();
   const opts=_notificationOptions(body,options);
-  const delivered=()=>({delivered:true,alreadyDisplayed:false,retryable:false,reason:'delivered'});
-  const failed=reason=>({delivered:false,alreadyDisplayed:false,retryable:true,reason});
+  const delivered=()=>({delivered:true,alreadyDisplayed:false});
+  const failed=()=>({delivered:false,alreadyDisplayed:false});
   const direct=()=>{
     try{new Notification(title||botName,opts);return Promise.resolve(delivered());}
-    catch(_err){return Promise.resolve(failed('direct-presentation-failed'));}
+    catch(_err){return Promise.resolve(failed());}
   };
   const showWithFallback=reg=>{
     if(!reg||!reg.active||!reg.showNotification) return direct();
     return Promise.resolve().then(()=>reg.showNotification(title||botName,opts))
-      .then(()=>delivered(),()=>direct().then(result=>result.delivered?result:failed('worker-and-direct-presentation-failed')));
+      .then(()=>delivered(),()=>direct().then(result=>result.delivered?result:failed()));
   };
   const inspectAndShow=reg=>{
     if(options&&options.dedupe&&opts.tag&&reg&&typeof reg.getNotifications==='function'){
       return Promise.resolve().then(()=>reg.getNotifications({tag:opts.tag})).then(records=>{
         if(Array.isArray(records)&&records.length>0)
-          return {delivered:false,alreadyDisplayed:true,retryable:false,reason:'already-displayed'};
+          return {delivered:false,alreadyDisplayed:true};
         return showWithFallback(reg);
       },()=>showWithFallback(reg));
     }
@@ -9231,20 +9231,20 @@ function sendBrowserNotification(title,body,options={}){
   // notifications-enabled SETTING is still honored (unlike `force`, which is the
   // explicit "Send test" override); only the visibility gate is bypassed.
   const forceHidden=!!(options&&options.forceHidden);
-  const outcome=(reason,retryable=false)=>Promise.resolve({delivered:false,alreadyDisplayed:false,retryable,reason});
-  if(!force&&!window._notificationsEnabled) return outcome('setting-disabled');
-  if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return outcome('foreground');
-  if(!('Notification' in window)) return outcome('unsupported');
+  const skip=()=>Promise.resolve({delivered:false,alreadyDisplayed:false});
+  if(!force&&!window._notificationsEnabled) return skip();
+  if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return skip();
+  if(!('Notification' in window)) return skip();
   if(Notification.permission==='granted'){
     return _showPwaNotification(title,body,options);
   }else if(Notification.permission==='denied'){
     // Explicit "Send test" (force) deserves feedback instead of a silent no-op.
     if(force&&typeof showToast==='function') showToast(t('notifications_denied'),3500,'error');
-    return outcome('permission-denied');
+    return skip();
   }else{
     return requestNotificationPermission().then(p=>p==='granted'
       ? _showPwaNotification(title,body,options)
-      : outcome('permission-not-granted')).catch(()=>outcome('permission-request-failed',true));
+      : skip()).catch(()=>skip());
   }
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -12943,7 +12943,6 @@ async function disableAuth(){
 
 let _cronPollSince=Date.now()/1000;  // track from page load
 let _cronPollTimer=null;
-let _cronPollInFlight=false;
 let _cronUnreadCount=0;
 let _cronPollGeneration=0;
 const _cronNewJobIds=new Set();  // track which job IDs had new completions (unread)
@@ -12979,19 +12978,22 @@ function startCronPolling(){
   _cronPollTimer=setInterval(async()=>{
     const hidden=document.hidden;
     if(hidden&&!_cronBrowserNotificationsDeliverable()) return;
-    if(typeof _cronPollInFlight==='undefined') _cronPollInFlight=false;
-    if(_cronPollInFlight) return;
-    _cronPollInFlight=true;
+    if(startCronPolling._inFlight) return;
+    startCronPolling._inFlight=true;
     try{
       const pollGeneration=_cronPollGeneration;
       const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
       if(pollGeneration!==_cronPollGeneration) return;
+      const completionHidden=document.hidden;
+      if(completionHidden&&!_cronBrowserNotificationsDeliverable()) return;
       if(data.completions&&data.completions.length>0){
         for(const c of data.completions){
           if(c.toast_notifications !== false){
-            if(hidden){
+            if(completionHidden){
               const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
-              sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+              if(c.session_id){
+                sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+              }
             }
             else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
@@ -13009,7 +13011,7 @@ function startCronPolling(){
         updateCronBadge();
       }
     }catch(e){}finally{
-      _cronPollInFlight=false;
+      startCronPolling._inFlight=false;
     }
   },30000);
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -12947,13 +12947,6 @@ let _cronUnreadCount=0;
 let _cronPollGeneration=0;
 const _cronNewJobIds=new Set();  // track which job IDs had new completions (unread)
 
-function _cronBrowserNotificationsDeliverable(){
-  return typeof sendBrowserNotification==='function' &&
-    typeof Notification!=='undefined' &&
-    window._notificationsEnabled===true &&
-    Notification.permission==='granted';
-}
-
 function _resetCronUnreadForProfileSwitch(){
   _cronPollGeneration++;
   _cronNewJobIds.clear();
@@ -12976,39 +12969,47 @@ window.addEventListener('hermes:cron_created', () => {
 function startCronPolling(){
   if(_cronPollTimer) return;
   _cronPollTimer=setInterval(async()=>{
-    const hidden=document.hidden;
-    if(hidden&&!_cronBrowserNotificationsDeliverable()) return;
+    const backgrounded=typeof _isBackgroundedForBrowserNotification==='function'&&_isBackgroundedForBrowserNotification();
+    if(backgrounded&&((typeof _isBrowserNotificationReady==='function'&&!_isBrowserNotificationReady())||typeof sendBrowserNotification!=='function')) return;
     if(startCronPolling._inFlight) return;
     startCronPolling._inFlight=true;
+    let committedCompletion=false;
     try{
       const pollGeneration=_cronPollGeneration;
+      const pollProfile=(typeof S!=='undefined'&&S&&S.activeProfile)||'default';
       const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
       if(pollGeneration!==_cronPollGeneration) return;
-      const completionHidden=document.hidden;
-      if(completionHidden&&!_cronBrowserNotificationsDeliverable()) return;
+      const completionBackgrounded=typeof _isBackgroundedForBrowserNotification==='function'&&_isBackgroundedForBrowserNotification();
+      if(completionBackgrounded&&((typeof _isBrowserNotificationReady==='function'&&!_isBrowserNotificationReady())||typeof sendBrowserNotification!=='function')) return;
       if(data.completions&&data.completions.length>0){
-        for(const c of data.completions){
+        const completions=[...data.completions].sort((a,b)=>{
+          const timeDiff=Number(a.completed_at)-Number(b.completed_at);
+          return timeDiff||String(a.job_id||'').localeCompare(String(b.job_id||''));
+        });
+        for(const c of completions){
           if(c.toast_notifications !== false){
-            if(completionHidden){
+            if(completionBackgrounded){
               const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
-              sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+              const tag=`hermes-cron-${pollProfile}-${c.job_id||'unknown'}-${c.completed_at}`;
+              const outcome=await sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});
+              if(pollGeneration!==_cronPollGeneration) return;
+              if(!outcome||(outcome.delivered!==true&&outcome.alreadyDisplayed!==true)) return;
             }
             else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
+          committedCompletion=true;
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
           if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
-            const activeProfile=(typeof S!=='undefined'&&S&&S.activeProfile)||'default';
             _markSessionCompletionUnreadIfBackground(c.session_id, c.message_count, {
               source:'cron',
-              profile:activeProfile,
+              profile:pollProfile,
             });
           }
         }
-        // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
-        updateCronBadge();
       }
     }catch(e){}finally{
+      if(committedCompletion) updateCronBadge();
       startCronPolling._inFlight=false;
     }
   },30000);

--- a/static/panels.js
+++ b/static/panels.js
@@ -13009,8 +13009,8 @@ function startCronPolling(){
         }
       }
     }catch(e){}finally{
-      if(committedCompletion) updateCronBadge();
       startCronPolling._inFlight=false;
+      if(committedCompletion){try{updateCronBadge();}catch(_err){}}
     }
   },30000);
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -12989,8 +12989,10 @@ function startCronPolling(){
       if(data.completions&&data.completions.length>0){
         for(const c of data.completions){
           if(c.toast_notifications !== false){
-            const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
-            if(hidden) sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+            if(hidden){
+              const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
+              sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+            }
             else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);

--- a/static/panels.js
+++ b/static/panels.js
@@ -12969,8 +12969,11 @@ window.addEventListener('hermes:cron_created', () => {
 function startCronPolling(){
   if(_cronPollTimer) return;
   _cronPollTimer=setInterval(async()=>{
+    const backgroundNotificationUnavailable=()=>
+      (typeof _isBrowserNotificationReady==='function'&&!_isBrowserNotificationReady())||
+      typeof sendBrowserNotification!=='function';
     const backgrounded=typeof _isBackgroundedForBrowserNotification==='function'&&_isBackgroundedForBrowserNotification();
-    if(backgrounded&&((typeof _isBrowserNotificationReady==='function'&&!_isBrowserNotificationReady())||typeof sendBrowserNotification!=='function')) return;
+    if(backgrounded&&backgroundNotificationUnavailable()) return;
     if(startCronPolling._inFlight) return;
     startCronPolling._inFlight=true;
     let committedCompletion=false;
@@ -12980,7 +12983,7 @@ function startCronPolling(){
       const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
       if(pollGeneration!==_cronPollGeneration) return;
       const completionBackgrounded=typeof _isBackgroundedForBrowserNotification==='function'&&_isBackgroundedForBrowserNotification();
-      if(completionBackgrounded&&((typeof _isBrowserNotificationReady==='function'&&!_isBrowserNotificationReady())||typeof sendBrowserNotification!=='function')) return;
+      if(completionBackgrounded&&backgroundNotificationUnavailable()) return;
       if(data.completions&&data.completions.length>0){
         const completions=[...data.completions].sort((a,b)=>{
           const timeDiff=Number(a.completed_at)-Number(b.completed_at);
@@ -12988,14 +12991,14 @@ function startCronPolling(){
         });
         for(const c of completions){
           if(c.toast_notifications !== false){
+            const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
             if(completionBackgrounded){
-              const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
               const tag=`hermes-cron-${pollProfile}-${c.job_id||'unknown'}-${c.completed_at}`;
               const outcome=await sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});
               if(pollGeneration!==_cronPollGeneration) return;
               if(!outcome||(outcome.delivered!==true&&outcome.alreadyDisplayed!==true)) return;
             }
-            else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
+            else showToast(completionStatus,4000);
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           committedCompletion=true;

--- a/static/panels.js
+++ b/static/panels.js
@@ -12991,9 +12991,7 @@ function startCronPolling(){
           if(c.toast_notifications !== false){
             if(completionHidden){
               const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
-              if(c.session_id){
-                sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
-              }
+              sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
             }
             else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }

--- a/static/panels.js
+++ b/static/panels.js
@@ -12998,7 +12998,7 @@ function startCronPolling(){
               if(pollGeneration!==_cronPollGeneration) return;
               if(!outcome||(outcome.delivered!==true&&outcome.alreadyDisplayed!==true)) return;
             }
-            else showToast(completionStatus,4000);
+            else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           committedCompletion=true;

--- a/static/panels.js
+++ b/static/panels.js
@@ -12991,8 +12991,8 @@ function startCronPolling(){
         });
         for(const c of completions){
           if(c.toast_notifications !== false){
-            const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
             if(completionBackgrounded){
+              const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
               const tag=`hermes-cron-${pollProfile}-${c.job_id||'unknown'}-${c.completed_at}`;
               const outcome=await sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});
               if(pollGeneration!==_cronPollGeneration) return;

--- a/static/panels.js
+++ b/static/panels.js
@@ -12992,6 +12992,7 @@ function startCronPolling(){
         for(const c of completions){
           if(c.toast_notifications !== false){
             if(completionBackgrounded){
+              if(backgroundNotificationUnavailable()) return;
               const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
               const tag=`hermes-cron-${pollProfile}-${c.job_id||'unknown'}-${c.completed_at}`;
               const outcome=await sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});

--- a/static/panels.js
+++ b/static/panels.js
@@ -12943,9 +12943,17 @@ async function disableAuth(){
 
 let _cronPollSince=Date.now()/1000;  // track from page load
 let _cronPollTimer=null;
+let _cronPollInFlight=false;
 let _cronUnreadCount=0;
 let _cronPollGeneration=0;
 const _cronNewJobIds=new Set();  // track which job IDs had new completions (unread)
+
+function _cronBrowserNotificationsDeliverable(){
+  return typeof sendBrowserNotification==='function' &&
+    typeof Notification!=='undefined' &&
+    window._notificationsEnabled===true &&
+    Notification.permission==='granted';
+}
 
 function _resetCronUnreadForProfileSwitch(){
   _cronPollGeneration++;
@@ -12969,7 +12977,11 @@ window.addEventListener('hermes:cron_created', () => {
 function startCronPolling(){
   if(_cronPollTimer) return;
   _cronPollTimer=setInterval(async()=>{
-    if(document.hidden) return;  // don't poll when tab is in background
+    const hidden=document.hidden;
+    if(hidden&&!_cronBrowserNotificationsDeliverable()) return;
+    if(typeof _cronPollInFlight==='undefined') _cronPollInFlight=false;
+    if(_cronPollInFlight) return;
+    _cronPollInFlight=true;
     try{
       const pollGeneration=_cronPollGeneration;
       const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
@@ -12977,7 +12989,9 @@ function startCronPolling(){
       if(data.completions&&data.completions.length>0){
         for(const c of data.completions){
           if(c.toast_notifications !== false){
-            showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
+            const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
+            if(hidden) sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id});
+            else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
@@ -12992,7 +13006,9 @@ function startCronPolling(){
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
         updateCronBadge();
       }
-    }catch(e){}
+    }catch(e){}finally{
+      _cronPollInFlight=false;
+    }
   },30000);
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -12986,22 +12986,30 @@ function startCronPolling(){
       if(completionBackgrounded&&backgroundNotificationUnavailable()) return;
       if(data.completions&&data.completions.length>0){
         const completions=[...data.completions].sort((a,b)=>{
-          const timeDiff=Number(a.completed_at)-Number(b.completed_at);
-          return timeDiff||String(a.job_id||'').localeCompare(String(b.job_id||''));
+          return Number(a.completed_at)-Number(b.completed_at);
         });
-        for(const c of completions){
+        for(let i=0;i<completions.length;i++){
+          const c=completions[i];
           if(c.toast_notifications !== false){
             if(completionBackgrounded){
               if(backgroundNotificationUnavailable()) return;
               const completionStatus=t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed'));
+              let notificationBody=completionStatus;
+              if(typeof c.output_preview==='string'&&c.output_preview){
+                const preview=typeof _completionNotificationPreviewText==='function'
+                  ? _completionNotificationPreviewText(null,{liveDisplayText:c.output_preview})
+                  : c.output_preview;
+                if(preview) notificationBody=preview;
+              }
               const tag=`hermes-cron-${pollProfile}-${c.job_id||'unknown'}-${c.completed_at}`;
-              const outcome=await sendBrowserNotification(c.name||t('untitled'),completionStatus,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});
+              const outcome=await sendBrowserNotification(c.name||t('untitled'),notificationBody,{forceHidden:true,sid:c.session_id||'',tag,renotify:false,dedupe:true});
               if(pollGeneration!==_cronPollGeneration) return;
               if(!outcome||(outcome.delivered!==true&&outcome.alreadyDisplayed!==true)) return;
             }
             else showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           }
-          _cronPollSince=Math.max(_cronPollSince,c.completed_at);
+          const next=completions[i+1];
+          if(!next||Number(next.completed_at)!==Number(c.completed_at)) _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           committedCompletion=true;
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
           if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){

--- a/tests/test_4109_notification_focus_existing_tab.py
+++ b/tests/test_4109_notification_focus_existing_tab.py
@@ -91,7 +91,7 @@ const _appRootPath=()=>'/app/';
 eval({json.dumps(function)});
 process.stdout.write(JSON.stringify({{url:_notificationOptions('body',{{}}).data.url,empty:_notificationOptions('body',{{sid:''}}).data.url}}));
 """
-    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=True)
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, encoding="utf-8", check=True)
     options = json.loads(result.stdout)
     assert options == {"url": "http://localhost:8080/#/s/current", "empty": "http://localhost:8080/app/"}
     assert "sendBrowserNotification('Hermes test','Notifications are ready.',{force:true});" in (

--- a/tests/test_4109_notification_focus_existing_tab.py
+++ b/tests/test_4109_notification_focus_existing_tab.py
@@ -84,12 +84,11 @@ def test_test_notification_without_sid_still_targets_current_page_for_reuse():
     else:
         raise AssertionError("_notificationOptions body did not terminate")
     script = f"""
-const S={{session:null}};
-const location={{origin:'http://localhost:8080',href:'http://localhost:8080/#/s/current'}};
-const _sessionUrlForSid=sid=>'/session/'+sid;
-const _appRootPath=()=>'/app/';
-eval({json.dumps(function)});
-process.stdout.write(JSON.stringify({{url:_notificationOptions('body',{{}}).data.url,empty:_notificationOptions('body',{{sid:''}}).data.url}}));
+const vm=require('vm');
+const context={{S:{{session:null}},location:{{origin:'http://localhost:8080',href:'http://localhost:8080/#/s/current'}},_sessionUrlForSid:sid=>'/session/'+sid,_appRootPath:()=>'/app/'}};
+vm.createContext(context);
+vm.runInContext({json.dumps(function)},context);
+process.stdout.write(JSON.stringify({{url:vm.runInContext("_notificationOptions('body',{{}}).data.url",context),empty:vm.runInContext("_notificationOptions('body',{{sid:''}}).data.url",context)}}));
 """
     result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, encoding="utf-8", check=True)
     options = json.loads(result.stdout)

--- a/tests/test_4109_notification_focus_existing_tab.py
+++ b/tests/test_4109_notification_focus_existing_tab.py
@@ -1,6 +1,9 @@
 """Regression coverage for notification clicks reusing an open WebUI tab (#4109)."""
 
 from pathlib import Path
+import json
+import shutil
+import subprocess
 
 import pytest
 
@@ -9,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SW_SRC = (ROOT / "static" / "sw.js").read_text(encoding="utf-8")
 MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 ROUTES_SRC = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+NODE = shutil.which("node")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -66,7 +70,30 @@ def test_notification_click_open_window_remains_no_reusable_client_fallback():
 
 
 def test_test_notification_without_sid_still_targets_current_page_for_reuse():
-    assert "const url=sid?`${location.origin}${_sessionUrlForSid(sid)}`:location.href;" in MESSAGES_SRC
+    if NODE is None:
+        pytest.skip("node is required for notification option behavior")
+    start = MESSAGES_SRC.index("function _notificationOptions(")
+    brace = MESSAGES_SRC.index("{", MESSAGES_SRC.index(")", start))
+    depth = 0
+    for index in range(brace, len(MESSAGES_SRC)):
+        depth += MESSAGES_SRC[index] == "{"
+        depth -= MESSAGES_SRC[index] == "}"
+        if depth == 0:
+            function = MESSAGES_SRC[start : index + 1]
+            break
+    else:
+        raise AssertionError("_notificationOptions body did not terminate")
+    script = f"""
+const S={{session:null}};
+const location={{origin:'http://localhost:8080',href:'http://localhost:8080/#/s/current'}};
+const _sessionUrlForSid=sid=>'/session/'+sid;
+const _appRootPath=()=>'/app/';
+eval({json.dumps(function)});
+process.stdout.write(JSON.stringify({{url:_notificationOptions('body',{{}}).data.url,empty:_notificationOptions('body',{{sid:''}}).data.url}}));
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=True)
+    options = json.loads(result.stdout)
+    assert options == {"url": "http://localhost:8080/#/s/current", "empty": "http://localhost:8080/app/"}
     assert "sendBrowserNotification('Hermes test','Notifications are ready.',{force:true});" in (
         ROOT / "static" / "index.html"
     ).read_text(encoding="utf-8")

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -104,13 +104,14 @@ Notification.permission='granted';
 const registration={{active:null}}; registration.active=registration;
 registration.getNotifications=({{tag}})=>Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);
 registration.showNotification=(title,options)=>{{
+  if(caseName==='worker-fallback') return Promise.reject(new Error('worker failed'));
   if(shouldFail(options)) return Promise.reject(new Error('worker failed'));
   const existing=registry.get(options.tag); registry.set(options.tag,{{title,options}}); shown.push({{title,options}});
   if(caseName==='stale-after-notification') context._cronPollGeneration++;
   if(caseName==='partial-failure') failPresentation=true;
   if(!existing || options.renotify) alertCount++; return Promise.resolve();
 }};
-const document={{hidden:!['foreground','desktop'].includes(caseName),baseURI:'https://example.test/',hasFocus:()=>false}};
+const document={{hidden:!['foreground','desktop','desktop-transition','desktop-unavailable'].includes(caseName),baseURI:'https://example.test/',hasFocus:()=>false}};
 const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},addEventListener:()=>{{}}}};
 const context={{window,document,Notification,navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(registration)}}}},location:window.location,
   S:{{activeProfile:'profile-a',session:{{session_id:'sess-active'}}}},_sessionUrlForSid:sid=>'/session/'+sid,_appRootPath:()=>'/app/',assistantDisplayName:()=> 'Hermes',
@@ -132,15 +133,16 @@ async function main() {{
     const options=caseName==='owner-empty'?{{sid:'',tag:'hermes-cron-profile-a-job-1-42',renotify:false}}:caseName==='owner-false'?{{renotify:false}}:{{}};
     return {{result:vm.runInContext(`_notificationOptions('body',${{JSON.stringify(options)}})`,context)}};
   }}
-  const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
+  const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'&&caseName!=='after-unavailable-muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
   const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure')?2:1);
   const p=setupPoller(completions); vm.runInContext('startCronPolling()',context);
-  if(caseName==='desktop') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable') window._notificationsEnabled=false;
-  if(caseName==='unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}}; }}
+  if(caseName==='desktop'||caseName==='desktop-unavailable') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable'||caseName==='desktop-unavailable') window._notificationsEnabled=false;
+  if(caseName==='unavailable'||caseName==='desktop-unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}}; }}
   if(caseName==='no-query') delete registration.getNotifications;
   if(caseName==='rejected-api') {{ const first=p.timer.callback(); await Promise.resolve(); p.reject(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
+  else if(caseName==='overlap') {{ const first=p.timer.callback(); const second=p.timer.callback(); p.resolve(); await Promise.all([first,second]); }}
   else if(caseName==='badge-failure') {{ const first=p.timer.callback(); p.resolve(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
-  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable') window._notificationsEnabled=false; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
+  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
   return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}};
 }}
 main().then(v=>process.stdout.write(JSON.stringify(v))).catch(e=>{{console.error(e);process.exit(1)}});
@@ -201,8 +203,18 @@ def test_desktop_background_transition_after_await_uses_canonical_state():
     assert result["toasts"] == [] and result["since"] == 42 and result["shown"]
 
 
+def test_visible_desktop_background_with_notifications_off_preserves_base_skip():
+    result = _run("desktop-unavailable")
+    assert result["apiCalls"] == 0 and result["since"] == 0 and result["ids"] == []
+
+
 def test_after_await_readiness_loss_preserves_backlog_and_badge():
     result = _run("after-unavailable")
+    assert result["since"] == 0 and result["ids"] == [] and result["marks"] == [] and result["badgeCalls"] == 0
+
+
+def test_after_await_readiness_loss_blocks_muted_completion_effects():
+    result = _run("after-unavailable-muted")
     assert result["since"] == 0 and result["ids"] == [] and result["marks"] == [] and result["badgeCalls"] == 0
 
 
@@ -244,6 +256,11 @@ def test_get_notifications_absent_falls_through_to_show():
     assert _run("no-query")["shown"]
 
 
+def test_worker_failure_falls_back_to_direct_notification():
+    result = _run("worker-fallback")
+    assert result["since"] == 42 and result["shown"]
+
+
 def test_failed_presentation_retries_without_cursor_advance():
     result = _run("failure")
     assert result["since"] == 42 and result["alerts"] == 1
@@ -257,6 +274,11 @@ def test_successful_completion_updates_badge_before_later_retryable_failure():
 def test_rejected_api_clears_in_flight_and_next_request_succeeds():
     result = _run("rejected-api")
     assert result["apiCalls"] == 2 and result["since"] == 42
+
+
+def test_overlapping_polls_keep_one_request_in_flight():
+    result = _run("overlap")
+    assert result["apiCalls"] == 1 and result["since"] == 42
 
 
 def test_earlier_failure_blocks_later_completion():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -48,6 +48,7 @@ async function runCase() {{
   const _cronNewJobIds = new Set();
   const toasts = [];
   const notifications = [];
+  const markCalls = [];
   let apiCalls = 0;
   let resolveApi;
   const document = {{
@@ -68,7 +69,7 @@ async function runCase() {{
   const showToast = (message) => toasts.push(message);
   const sendBrowserNotification = (title, body, options) => notifications.push({{title, body, options}});
   const updateCronBadge = () => {{}};
-  const _markSessionCompletionUnreadIfBackground = () => {{}};
+  const _markSessionCompletionUnreadIfBackground = (...args) => markCalls.push(args);
   const completions = [{{name: 'Nightly', status: 'success', completed_at: 42, job_id: 'job-1', session_id: caseName === 'no-session' ? '' : 'sid-1', message_count: 7, toast_notifications: caseName !== 'muted'}}];
   let rejectApi;
   const api = () => {{
@@ -116,7 +117,7 @@ async function runCase() {{
     resolveApi();
     await pending;
   }}
-  process.stdout.write(JSON.stringify({{apiCalls, toasts, notifications, since: _cronPollSince, ids: [..._cronNewJobIds]}}));
+  process.stdout.write(JSON.stringify({{apiCalls, toasts, notifications, markCalls, since: _cronPollSince, ids: [..._cronNewJobIds]}}));
 }}
 runCase().catch(error => {{ console.error(error); process.exit(1); }});
 """
@@ -157,18 +158,18 @@ def test_muted_completion_keeps_unread_without_alert():
 
 def test_hidden_without_permission_or_setting_preserves_backlog():
     result = _run_node("unavailable")
-    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "since": 0, "ids": []}
+    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
 
 
 @pytest.mark.parametrize("case", ["setting-off", "permission-denied", "permission-default", "missing-api"])
 def test_hidden_unavailable_delivery_modes_preserve_backlog(case):
     result = _run_node(case)
-    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "since": 0, "ids": []}
+    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
 
 
 def test_hidden_transition_to_unavailable_preserves_backlog():
     result = _run_node("transition")
-    assert result == {"apiCalls": 1, "toasts": [], "notifications": [], "since": 0, "ids": []}
+    assert result == {"apiCalls": 1, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
 
 
 def test_rejected_poll_clears_in_flight_guard():
@@ -178,11 +179,24 @@ def test_rejected_poll_clears_in_flight_guard():
     assert result["since"] == 42
 
 
-def test_hidden_completion_without_session_id_skips_origin_notification():
+def test_hidden_sessionless_completion_hands_off_without_session_unread_mark():
     result = _run_node("no-session")
-    assert result["notifications"] == []
+    assert result["notifications"] == [{
+        "title": "Nightly",
+        "body": "cron_completion_status:Nightly|status_completed:",
+        "options": {"forceHidden": True, "sid": ""},
+    }]
+    assert result["markCalls"] == []
     assert result["since"] == 42
     assert result["ids"] == ["job-1"]
+
+
+def test_hidden_session_bound_completion_marks_session_unread():
+    result = _run_node("hidden")
+    assert result["markCalls"] == [["sid-1", 7, {
+        "source": "cron",
+        "profile": "default",
+    }]]
 
 
 def test_stale_generation_drops_completion():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -107,7 +107,7 @@ const owner={json.dumps(OWNER)};
 const poller={json.dumps(POLLER)};
 const caseName={json.dumps(case)};
 const registry=new Map(),shown=[],toasts=[],marks=[];
-let badgeCalls=0,getNotificationCalls=0,ownerCalls=0;
+let badgeCalls=0,getNotificationCalls=0,ownerCalls=0,permissionRequests=0;
 let alertCount=0,failPresentation=caseName==='failure'||caseName==='ordered';
 const shouldFail=options=>failPresentation&&(caseName!=='ordered'||String(options&&options.tag).endsWith('-42'));
 function Notification(title,options) {{ if(shouldFail(options)) throw new Error('native seam failed'); shown.push({{title,options}}); alertCount++; }}
@@ -119,6 +119,7 @@ registration.showNotification=(title,options)=>{{
   if(shouldFail(options)) return Promise.reject(new Error('worker failed'));
   const existing=registry.get(options.tag); registry.set(options.tag,{{title,options}}); shown.push({{title,options}});
   if(caseName==='force-hidden-transition'&&shown.length===1) {{ document.hidden=false; window.__hermesSetBackgrounded(false); }}
+  if(caseName==='permission-transition'&&shown.length===1) Notification.permission='default';
   if(caseName==='stale-after-notification') context._cronPollGeneration++;
   if(caseName==='partial-failure') failPresentation=true;
   if(!existing || options.renotify) alertCount++; return Promise.resolve();
@@ -127,7 +128,7 @@ const document={{hidden:!['foreground','desktop','desktop-transition','desktop-u
 const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},addEventListener:()=>{{}}}};
 const context={{window,document,Notification,navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(registration)}}}},location:window.location,
   S:{{activeProfile:'profile-a',session:{{session_id:'sess-active'}}}},_sessionUrlForSid:sid=>'/session/'+sid,_appRootPath:()=>'/app/',assistantDisplayName:()=> 'Hermes',
-  t:(key,...args)=>key+':'+args.join('|'),showToast:msg=>toasts.push(msg),updateNotificationPermissionStatus:()=>{{}},requestNotificationPermission:()=>caseName==='permission-reject'?Promise.reject(new Error('permission request failed')):Promise.resolve('granted'),
+  t:(key,...args)=>key+':'+args.join('|'),showToast:msg=>toasts.push(msg),updateNotificationPermissionStatus:()=>{{}},requestNotificationPermission:()=>{{permissionRequests++;return caseName==='permission-reject'?Promise.reject(new Error('permission request failed')):Promise.resolve('granted');}},
   setTimeout,clearTimeout,Promise,console,globalThis:null}};
 context.globalThis=context; context.window.Notification=Notification; vm.createContext(context); vm.runInContext(owner,context);
 const realSendBrowserNotification=context.sendBrowserNotification;
@@ -154,7 +155,7 @@ async function main() {{
     return {{result,ownerCalls,getNotificationCalls,shown}};
   }}
   const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'&&caseName!=='after-unavailable-muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
-  const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure'||caseName==='force-hidden-transition')?2:1);
+  const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure'||caseName==='force-hidden-transition'||caseName==='permission-transition')?2:1);
   const p=setupPoller(completions); vm.runInContext('startCronPolling()',context);
   if(caseName==='desktop'||caseName==='desktop-unavailable') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable'||caseName==='desktop-unavailable') window._notificationsEnabled=false;
   if(caseName==='unavailable'||caseName==='desktop-unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls}}; }}
@@ -163,7 +164,7 @@ async function main() {{
   else if(caseName==='overlap') {{ const first=p.timer.callback(); const second=p.timer.callback(); p.resolve(); await Promise.all([first,second]); }}
   else if(caseName==='badge-failure') {{ const first=p.timer.callback(); p.resolve(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
   else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='profile-transition') context.S.activeProfile='profile-b'; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{firstTick={{since:context._cronPollSince,ids:[...context._cronNewJobIds],marks:marks.length}}; failPresentation=false;const retry=p.timer.callback();p.resolve();await retry; }} }}
-  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls,firstTick}};
+  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls,permissionRequests,firstTick}};
 }}
 main().then(v=>process.stdout.write(JSON.stringify(v))).catch(e=>{{console.error(e);process.exit(1)}});
 """
@@ -368,6 +369,11 @@ def test_profile_capture_survives_change_during_api_await():
 def test_force_hidden_keeps_multi_completion_delivery_after_return_to_foreground():
     result = _run("force-hidden-transition")
     assert result["since"] == 43 and len(result["shown"]) == 2
+
+
+def test_mid_batch_permission_loss_preserves_backlog_without_prompting():
+    result = _run("permission-transition")
+    assert result["since"] == 42 and len(result["shown"]) == 1 and result["permissionRequests"] == 0
 
 
 def test_badge_failure_does_not_stick_in_flight_guard():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -31,8 +31,9 @@ def _function_source(name: str) -> str:
     raise AssertionError(f"{name} body did not terminate")
 
 
-@pytest.mark.skipif(NODE is None, reason="node is required for the behavioral harness")
 def _run_node(case: str) -> dict:
+    if NODE is None:
+        pytest.skip("node is required for the behavioral harness")
     helper = _function_source("_cronBrowserNotificationsDeliverable")
     poller = _function_source("startCronPolling")
     script = f"""

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -72,21 +72,28 @@ POLLER = _function(PANELS, "startCronPolling")
 
 def _run_base_head_reproduction() -> dict:
     script = f"""
-const vm=require('vm'),base={json.dumps(BASE_POLLER)},head={json.dumps(POLLER)};
+const vm=require('vm'),owner={json.dumps(OWNER)},base={json.dumps(BASE_POLLER)},head={json.dumps(POLLER)};
 async function run(source,isHead) {{
   let timer,apiCalls=0,presentations=0;
-  const context={{document:{{hidden:true}},window:{{_notificationsEnabled:true}},Notification:{{permission:'granted'}},
+  function Notification(title,options) {{ presentations++; }}
+  Notification.permission='granted';
+  const registration={{active:null}}; registration.active=registration;
+  registration.getNotifications=()=>Promise.resolve([]);
+  registration.showNotification=()=>{{presentations++;return Promise.resolve();}};
+  const context={{document:{{hidden:true}},window:{{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},addEventListener:()=>{{}}}},Notification,
     _cronPollTimer:null,_cronPollSince:0,_cronPollGeneration:0,_cronNewJobIds:new Set(),
     S:{{activeProfile:'profile-a',session:null}},setInterval:cb=>{{timer=cb;return 1;}},
     api:async()=>{{apiCalls++;return {{completions:[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',toast_notifications:true}}]}};}},
-    sendBrowserNotification:async()=>{{presentations++;return {{delivered:true,alreadyDisplayed:false}};}},showToast:()=>{{}},updateCronBadge:()=>{{}},
+    navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(registration)}}}},location:{{origin:'https://example.test',href:'https://example.test/'}},
+    _sessionUrlForSid:sid=>'/session/'+sid,_appRootPath:()=>'/app/',assistantDisplayName:()=> 'Hermes',
+    requestNotificationPermission:()=>Promise.resolve('granted'),showToast:()=>{{}},updateCronBadge:()=>{{}},
     t:(key,...args)=>key+':'+args.join('|'),
-    _isBackgroundedForBrowserNotification:()=>true,_isBrowserNotificationReady:()=>true,Promise,console}};
-  vm.createContext(context);vm.runInContext(source,context);vm.runInContext('startCronPolling()',context);await timer();return {{apiCalls,presentations}};
+    setTimeout,clearTimeout,Promise,console,globalThis:null}};
+  context.globalThis=context; context.window.Notification=Notification; vm.createContext(context);vm.runInContext(owner,context);vm.runInContext(source,context);vm.runInContext('startCronPolling()',context);await timer();return {{apiCalls,presentations}};
 }}
 Promise.all([run(base,false),run(head,true)]).then(([baseResult,headResult])=>process.stdout.write(JSON.stringify({{base:baseResult,head:headResult}}))).catch(e=>{{console.error(e);process.exit(1)}});
 """
-    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True).stdout)
+    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=True).stdout)
 
 
 def _run(case: str) -> dict:
@@ -96,17 +103,18 @@ const owner={json.dumps(OWNER)};
 const poller={json.dumps(POLLER)};
 const caseName={json.dumps(case)};
 const registry=new Map(),shown=[],toasts=[],marks=[];
-let badgeCalls=0;
+let badgeCalls=0,getNotificationCalls=0,ownerCalls=0;
 let alertCount=0,failPresentation=caseName==='failure'||caseName==='ordered';
 const shouldFail=options=>failPresentation&&(caseName!=='ordered'||String(options&&options.tag).endsWith('-42'));
 function Notification(title,options) {{ if(shouldFail(options)) throw new Error('native seam failed'); shown.push({{title,options}}); alertCount++; }}
 Notification.permission='granted';
 const registration={{active:null}}; registration.active=registration;
-registration.getNotifications=({{tag}})=>Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);
+registration.getNotifications=({{tag}})=>{{getNotificationCalls++;return Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);}};
 registration.showNotification=(title,options)=>{{
   if(caseName==='worker-fallback') return Promise.reject(new Error('worker failed'));
   if(shouldFail(options)) return Promise.reject(new Error('worker failed'));
   const existing=registry.get(options.tag); registry.set(options.tag,{{title,options}}); shown.push({{title,options}});
+  if(caseName==='force-hidden-transition'&&shown.length===1) {{ document.hidden=false; window.__hermesSetBackgrounded(false); }}
   if(caseName==='stale-after-notification') context._cronPollGeneration++;
   if(caseName==='partial-failure') failPresentation=true;
   if(!existing || options.renotify) alertCount++; return Promise.resolve();
@@ -118,6 +126,8 @@ const context={{window,document,Notification,navigator:{{serviceWorker:{{getRegi
   t:(key,...args)=>key+':'+args.join('|'),showToast:msg=>toasts.push(msg),updateNotificationPermissionStatus:()=>{{}},requestNotificationPermission:()=>caseName==='permission-reject'?Promise.reject(new Error('permission request failed')):Promise.resolve('granted'),
   setTimeout,clearTimeout,Promise,console,globalThis:null}};
 context.globalThis=context; context.window.Notification=Notification; vm.createContext(context); vm.runInContext(owner,context);
+const realSendBrowserNotification=context.sendBrowserNotification;
+context.sendBrowserNotification=(...args)=>{{ownerCalls++;return realSendBrowserNotification(...args);}};
 function setupPoller(completions) {{
   let timer=null,apiCalls=0,resolveApi,rejectApi;
   context._cronPollSince=0; context._cronPollTimer=null; context._cronPollGeneration=0; context._cronNewJobIds=new Set(); context.updateCronBadge=()=>{{badgeCalls++;if(caseName==='badge-failure')throw new Error('badge failed');}};
@@ -128,26 +138,31 @@ function setupPoller(completions) {{
 }}
 async function main() {{
   if(caseName==='permission-reject') {{ Notification.permission='default'; return {{result:await vm.runInContext("sendBrowserNotification('title','body',{{forceHidden:true}})",context)}}; }}
-  if(caseName.startsWith('owner-')) {{
+  if(caseName.startsWith('owner-')&&caseName!=='owner-no-dedupe') {{
     if(caseName==='owner-no-session') context.S.session=null;
     const options=caseName==='owner-empty'?{{sid:'',tag:'hermes-cron-profile-a-job-1-42',renotify:false}}:caseName==='owner-false'?{{renotify:false}}:{{}};
     return {{result:vm.runInContext(`_notificationOptions('body',${{JSON.stringify(options)}})`,context)}};
   }}
+  if(caseName==='owner-no-dedupe') {{
+    registry.set('hermes-sess-active',{{title:'existing',options:{{tag:'hermes-sess-active'}}}});
+    const result=await vm.runInContext("sendBrowserNotification('title','body',{{force:true}})",context);
+    return {{result,ownerCalls,getNotificationCalls,shown}};
+  }}
   const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'&&caseName!=='after-unavailable-muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
-  const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure')?2:1);
+  const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure'||caseName==='force-hidden-transition')?2:1);
   const p=setupPoller(completions); vm.runInContext('startCronPolling()',context);
   if(caseName==='desktop'||caseName==='desktop-unavailable') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable'||caseName==='desktop-unavailable') window._notificationsEnabled=false;
-  if(caseName==='unavailable'||caseName==='desktop-unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}}; }}
+  if(caseName==='unavailable'||caseName==='desktop-unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls}}; }}
   if(caseName==='no-query') delete registration.getNotifications;
   if(caseName==='rejected-api') {{ const first=p.timer.callback(); await Promise.resolve(); p.reject(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
   else if(caseName==='overlap') {{ const first=p.timer.callback(); const second=p.timer.callback(); p.resolve(); await Promise.all([first,second]); }}
   else if(caseName==='badge-failure') {{ const first=p.timer.callback(); p.resolve(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
-  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
-  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}};
+  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='profile-transition') context.S.activeProfile='profile-b'; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
+  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls}};
 }}
 main().then(v=>process.stdout.write(JSON.stringify(v))).catch(e=>{{console.error(e);process.exit(1)}});
 """
-    result = subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True)
+    result = subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=True)
     return json.loads(result.stdout)
 
 
@@ -160,7 +175,7 @@ function makeRealm(id) {{
   const Notification=function(){{}}; Notification.permission='granted';
   const reg={{active:null}}; reg.active=reg;
   reg.getNotifications=({{tag}})=>{{entered++;if(!simultaneous)return Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);if(entered===2) release();return bothEntered.then(()=>registry.has(tag)?[registry.get(tag)]:[]);}};
-  reg.showNotification=(title,options)=>{{const existed=registry.has(options.tag);registry.set(options.tag,{{title,options,realm:id}});alerts.push({{id,options}});if(!existed) audible++;return Promise.resolve();}};
+  reg.showNotification=(title,options)=>{{const existed=registry.has(options.tag);registry.set(options.tag,{{title,options,realm:id}});alerts.push({{id,options}});if(!existed||options.renotify) audible++;return Promise.resolve();}};
   const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},Notification}};
   const context={{window,document:{{hidden:true}},Notification,navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(reg)}}}},location:window.location,S:{{session:null}},assistantDisplayName:()=> 'Hermes',_appRootPath:()=>'/app/',_sessionUrlForSid:s=>'/session/'+s,setTimeout,Promise,console}};
   context.globalThis=context;vm.createContext(context);vm.runInContext(owner,context);return context;
@@ -184,7 +199,7 @@ main().catch(e=>{{console.error(e);process.exit(1)}});
 
 def test_issue_repro_hidden_completion_reaches_presentation_owner():
     result = _run("hidden")
-    assert result["since"] == 42 and result["toasts"] == [] and result["shown"]
+    assert result["since"] == 42 and result["toasts"] == [] and result["shown"] and result["getNotificationCalls"] > 0
     assert result["shown"][0]["options"]["renotify"] is False
 
 
@@ -203,14 +218,14 @@ def test_desktop_background_transition_after_await_uses_canonical_state():
     assert result["toasts"] == [] and result["since"] == 42 and result["shown"]
 
 
-def test_visible_desktop_background_with_notifications_off_preserves_base_skip():
+def test_visible_desktop_background_with_notifications_off_skips_request_and_preserves_backlog():
     result = _run("desktop-unavailable")
     assert result["apiCalls"] == 0 and result["since"] == 0 and result["ids"] == []
 
 
 def test_after_await_readiness_loss_preserves_backlog_and_badge():
     result = _run("after-unavailable")
-    assert result["since"] == 0 and result["ids"] == [] and result["marks"] == [] and result["badgeCalls"] == 0
+    assert result["since"] == 0 and result["ids"] == [] and result["marks"] == [] and result["badgeCalls"] == 0 and result["ownerCalls"] == 0
 
 
 def test_after_await_readiness_loss_blocks_muted_completion_effects():
@@ -329,6 +344,23 @@ def test_omitted_sid_without_active_session_uses_current_location():
 
 def test_explicit_renotify_false_is_preserved():
     assert _run("owner-false")["result"]["renotify"] is False
+
+
+def test_owner_without_dedupe_does_not_query_displayed_records():
+    result = _run("owner-no-dedupe")
+    assert result["result"] == {"delivered": True, "alreadyDisplayed": False, "retryable": False, "reason": "delivered"}
+    assert result["getNotificationCalls"] == 0
+
+
+def test_profile_capture_survives_change_during_api_await():
+    result = _run("profile-transition")
+    assert result["marks"][0][2]["profile"] == "profile-a"
+    assert "profile-a" in result["shown"][0]["options"]["tag"]
+
+
+def test_force_hidden_keeps_multi_completion_delivery_after_return_to_foreground():
+    result = _run("force-hidden-transition")
+    assert result["since"] == 43 and len(result["shown"]) == 2
 
 
 def test_badge_failure_does_not_stick_in_flight_guard():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -1,4 +1,8 @@
-"""Composed owner and cron-poller proof for issue #7257."""
+"""Composed owner and cron-poller proof for issue #7257.
+
+The harness stubs only the final presentation seam; real service-worker registration,
+OS delivery, and OS-level tag collapse remain unreached.
+"""
 
 from __future__ import annotations
 
@@ -137,6 +141,7 @@ function setupPoller(completions) {{
   vm.runInContext(poller,context); return {{get timer(){{return timer;}},get apiCalls(){{return apiCalls;}},resolve:()=>resolveApi(),reject:()=>rejectApi()}};
 }}
 async function main() {{
+  let firstTick=null;
   if(caseName==='permission-reject') {{ Notification.permission='default'; return {{result:await vm.runInContext("sendBrowserNotification('title','body',{{forceHidden:true}})",context)}}; }}
   if(caseName.startsWith('owner-')&&caseName!=='owner-no-dedupe') {{
     if(caseName==='owner-no-session') context.S.session=null;
@@ -157,8 +162,8 @@ async function main() {{
   if(caseName==='rejected-api') {{ const first=p.timer.callback(); await Promise.resolve(); p.reject(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
   else if(caseName==='overlap') {{ const first=p.timer.callback(); const second=p.timer.callback(); p.resolve(); await Promise.all([first,second]); }}
   else if(caseName==='badge-failure') {{ const first=p.timer.callback(); p.resolve(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
-  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='profile-transition') context.S.activeProfile='profile-b'; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
-  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls}};
+  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable'||caseName==='after-unavailable-muted') window._notificationsEnabled=false; if(caseName==='profile-transition') context.S.activeProfile='profile-b'; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{firstTick={{since:context._cronPollSince,ids:[...context._cronNewJobIds],marks:marks.length}}; failPresentation=false;const retry=p.timer.callback();p.resolve();await retry; }} }}
+  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls,ownerCalls,getNotificationCalls,firstTick}};
 }}
 main().then(v=>process.stdout.write(JSON.stringify(v))).catch(e=>{{console.error(e);process.exit(1)}});
 """
@@ -194,7 +199,7 @@ async function main() {{const a=makeRealm('realm-a'),b=makeRealm('realm-b');
  process.stdout.write(JSON.stringify({{first,second,entered,audible,alerts,records:[...registry.values()]}}));}}
 main().catch(e=>{{console.error(e);process.exit(1)}});
 """
-    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True).stdout)
+    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=True).stdout)
 
 
 def test_issue_repro_hidden_completion_reaches_presentation_owner():
@@ -278,6 +283,7 @@ def test_worker_failure_falls_back_to_direct_notification():
 
 def test_failed_presentation_retries_without_cursor_advance():
     result = _run("failure")
+    assert result["firstTick"] == {"since": 0, "ids": [], "marks": 0}
     assert result["since"] == 42 and result["alerts"] == 1
 
 

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -1,0 +1,152 @@
+"""Behavioral coverage for cron-origin browser notifications in hidden tabs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+def _function_source(name: str) -> str:
+    marker = f"function {name}("
+    start = PANELS_JS.find(marker)
+    assert start >= 0, f"{name} not found"
+    brace = PANELS_JS.find("{", PANELS_JS.find(")", start))
+    depth = 0
+    for index in range(brace, len(PANELS_JS)):
+        if PANELS_JS[index] == "{":
+            depth += 1
+        elif PANELS_JS[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return PANELS_JS[start : index + 1]
+    raise AssertionError(f"{name} body did not terminate")
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for the behavioral harness")
+def _run_node(case: str) -> dict:
+    helper = _function_source("_cronBrowserNotificationsDeliverable")
+    poller = _function_source("startCronPolling")
+    script = f"""
+const caseName = {json.dumps(case)};
+const helperSource = {json.dumps(helper)};
+const pollerSource = {json.dumps(poller)};
+
+async function runCase() {{
+  let _cronPollSince = 0;
+  let _cronPollTimer = null;
+  let _cronPollInFlight = false;
+  let _cronPollGeneration = 0;
+  const _cronNewJobIds = new Set();
+  const toasts = [];
+  const notifications = [];
+  let apiCalls = 0;
+  let resolveApi;
+  const document = {{
+    hidden: caseName !== 'visible',
+    querySelector: () => ({{
+      querySelector: () => null,
+      appendChild: () => {{}},
+      style: {{}},
+    }}),
+  }};
+  const window = {{_notificationsEnabled: caseName !== 'unavailable'}};
+  globalThis.Notification = {{permission: caseName === 'unavailable' ? 'default' : 'granted'}};
+  const t = (key, ...args) => key + ':' + args.join('|');
+  const showToast = (message) => toasts.push(message);
+  const sendBrowserNotification = (title, body, options) => notifications.push({{title, body, options}});
+  const updateCronBadge = () => {{}};
+  const _markSessionCompletionUnreadIfBackground = () => {{}};
+  const completions = [{{name: 'Nightly', status: 'success', completed_at: 42, job_id: 'job-1', session_id: 'sid-1', message_count: 7, toast_notifications: caseName !== 'muted'}}];
+  const api = () => {{
+    apiCalls += 1;
+    return new Promise(resolve => {{ resolveApi = () => resolve({{completions}}); }});
+  }};
+  const setInterval = callback => {{ _cronPollTimer = {{callback}}; return _cronPollTimer; }};
+  const clearInterval = () => {{}};
+  eval(helperSource);
+  eval(pollerSource);
+  startCronPolling();
+  if (caseName === 'unavailable') {{
+    await _cronPollTimer.callback();
+  }} else if (caseName === 'stale') {{
+    const pending = _cronPollTimer.callback();
+    await Promise.resolve();
+    _cronPollGeneration += 1;
+    resolveApi();
+    await pending;
+  }} else if (caseName === 'overlap') {{
+    const first = _cronPollTimer.callback();
+    await Promise.resolve();
+    const second = _cronPollTimer.callback();
+    resolveApi();
+    await Promise.all([first, second]);
+  }} else {{
+    const pending = _cronPollTimer.callback();
+    resolveApi();
+    await pending;
+  }}
+  process.stdout.write(JSON.stringify({{apiCalls, toasts, notifications, since: _cronPollSince, ids: [..._cronNewJobIds]}}));
+}}
+runCase().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    result = subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+def test_hidden_tab_cron_completion_fires_browser_notification():
+    result = _run_node("hidden")
+    assert result["apiCalls"] == 1
+    assert result["toasts"] == []
+    assert result["notifications"] == [{
+        "title": "Nightly",
+        "body": "cron_completion_status:Nightly|status_completed:",
+        "options": {"forceHidden": True, "sid": "sid-1"},
+    }]
+
+
+def test_hidden_completion_preserves_cursor_unread_and_badge():
+    result = _run_node("hidden")
+    assert result["since"] == 42
+    assert result["ids"] == ["job-1"]
+
+
+def test_visible_completion_keeps_toast_only():
+    result = _run_node("visible")
+    assert result["toasts"] == ["cron_completion_status:Nightly|status_completed:"]
+    assert result["notifications"] == []
+
+
+def test_muted_completion_keeps_unread_without_alert():
+    result = _run_node("muted")
+    assert result["toasts"] == []
+    assert result["notifications"] == []
+    assert result["since"] == 42
+    assert result["ids"] == ["job-1"]
+
+
+def test_hidden_without_permission_or_setting_preserves_backlog():
+    result = _run_node("unavailable")
+    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "since": 0, "ids": []}
+
+
+def test_stale_generation_drops_completion():
+    result = _run_node("stale")
+    assert result["apiCalls"] == 1
+    assert result["notifications"] == []
+    assert result["since"] == 0
+    assert result["ids"] == []
+
+
+def test_overlapping_polls_do_not_duplicate_completion():
+    result = _run_node("overlap")
+    assert result["apiCalls"] == 1
+    assert len(result["notifications"]) == 1

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -14,7 +14,39 @@ MESSAGES = (ROOT / "static/messages.js").read_text(encoding="utf-8")
 PANELS = (ROOT / "static/panels.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node is required")
-BASE_PANELS = subprocess.check_output(["git", "show", "origin/master:static/panels.js"], cwd=ROOT, text=True)
+
+# This is the exact hidden-document guard from origin/master at the respec base.
+# Pinning the small reproduction fixture keeps CI independent of git ref depth.
+BASE_POLLER = """function startCronPolling(){
+    if(_cronPollTimer) return;
+    _cronPollTimer=setInterval(async()=>{
+      if(document.hidden) return;  // don't poll when tab is in background
+      try{
+        const pollGeneration=_cronPollGeneration;
+        const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
+        if(pollGeneration!==_cronPollGeneration) return;
+        if(data.completions&&data.completions.length>0){
+          for(const c of data.completions){
+            if(c.toast_notifications !== false){
+              showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') :
+t('status_completed')),4000);
+            }
+            _cronPollSince=Math.max(_cronPollSince,c.completed_at);
+            if(c.job_id) _cronNewJobIds.add(String(c.job_id));
+            if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
+              const activeProfile=(typeof S!=='undefined'&&S&&S.activeProfile)||'default';
+              _markSessionCompletionUnreadIfBackground(c.session_id, c.message_count, {
+                source:'cron',
+                profile:activeProfile,
+              });
+            }
+          }
+          // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
+          updateCronBadge();
+        }
+      }catch(e){}
+    },30000);
+  }"""
 
 
 def _function(source: str, name: str) -> str:
@@ -36,7 +68,6 @@ OWNER = "const _STREAM_NOTIFICATION_BACKGROUND={};" + MESSAGES[_owner_start:_own
     for name in ("_isBrowserNotificationReady", "_notificationOptions", "_showPwaNotification", "sendBrowserNotification")
 )
 POLLER = _function(PANELS, "startCronPolling")
-BASE_POLLER = _function(BASE_PANELS, "startCronPolling")
 
 
 def _run_base_head_reproduction() -> dict:
@@ -65,14 +96,15 @@ const owner={json.dumps(OWNER)};
 const poller={json.dumps(POLLER)};
 const caseName={json.dumps(case)};
 const registry=new Map(),shown=[],toasts=[],marks=[];
-let badgeCalls=0,enteredQueries=0,releaseQueries;
+let badgeCalls=0;
 let alertCount=0,failPresentation=caseName==='failure'||caseName==='ordered';
-function Notification(title,options) {{ if(failPresentation) throw new Error('native seam failed'); shown.push({{title,options}}); alertCount++; }}
+const shouldFail=options=>failPresentation&&(caseName!=='ordered'||String(options&&options.tag).endsWith('-42'));
+function Notification(title,options) {{ if(shouldFail(options)) throw new Error('native seam failed'); shown.push({{title,options}}); alertCount++; }}
 Notification.permission='granted';
 const registration={{active:null}}; registration.active=registration;
 registration.getNotifications=({{tag}})=>Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);
 registration.showNotification=(title,options)=>{{
-  if(failPresentation) return Promise.reject(new Error('worker failed'));
+  if(shouldFail(options)) return Promise.reject(new Error('worker failed'));
   const existing=registry.get(options.tag); registry.set(options.tag,{{title,options}}); shown.push({{title,options}});
   if(caseName==='stale-after-notification') context._cronPollGeneration++;
   if(caseName==='partial-failure') failPresentation=true;
@@ -87,7 +119,7 @@ const context={{window,document,Notification,navigator:{{serviceWorker:{{getRegi
 context.globalThis=context; context.window.Notification=Notification; vm.createContext(context); vm.runInContext(owner,context);
 function setupPoller(completions) {{
   let timer=null,apiCalls=0,resolveApi,rejectApi;
-  context._cronPollSince=0; context._cronPollTimer=null; context._cronPollGeneration=0; context._cronNewJobIds=new Set(); context.updateCronBadge=()=>{{badgeCalls++;}};
+  context._cronPollSince=0; context._cronPollTimer=null; context._cronPollGeneration=0; context._cronNewJobIds=new Set(); context.updateCronBadge=()=>{{badgeCalls++;if(caseName==='badge-failure')throw new Error('badge failed');}};
   context._markSessionCompletionUnreadIfBackground=(...args)=>marks.push(args);
   context.api=()=>{{apiCalls++;return new Promise((resolve,reject)=>{{resolveApi=()=>resolve({{completions}});rejectApi=()=>reject(new Error('rejected api'));}});}};
   context.setInterval=cb=>{{timer={{callback:cb}};context._cronPollTimer=timer;return timer;}};
@@ -107,6 +139,7 @@ async function main() {{
   if(caseName==='unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}}; }}
   if(caseName==='no-query') delete registration.getNotifications;
   if(caseName==='rejected-api') {{ const first=p.timer.callback(); await Promise.resolve(); p.reject(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
+  else if(caseName==='badge-failure') {{ const first=p.timer.callback(); p.resolve(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
   else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable') window._notificationsEnabled=false; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
   return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}};
 }}
@@ -250,10 +283,6 @@ def test_stale_generation_after_presentation_drops_local_effects():
     assert result["shown"] and result["since"] == 0 and result["ids"] == [] and result["marks"] == []
 
 
-def test_rejected_poll_releases_in_flight():
-    assert _run("hidden")["apiCalls"] == 1
-
-
 def test_sessionless_poller_uses_root_url_and_no_session_unread():
     result = _run("sessionless")
     options = result["shown"][0]["options"]
@@ -278,3 +307,8 @@ def test_omitted_sid_without_active_session_uses_current_location():
 
 def test_explicit_renotify_false_is_preserved():
     assert _run("owner-false")["result"]["renotify"] is False
+
+
+def test_badge_failure_does_not_stick_in_flight_guard():
+    result = _run("badge-failure")
+    assert result["apiCalls"] == 2 and result["since"] == 42

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -44,7 +44,6 @@ const pollerSource = {json.dumps(poller)};
 async function runCase() {{
   let _cronPollSince = 0;
   let _cronPollTimer = null;
-  let _cronPollInFlight = false;
   let _cronPollGeneration = 0;
   const _cronNewJobIds = new Set();
   const toasts = [];
@@ -59,25 +58,47 @@ async function runCase() {{
       style: {{}},
     }}),
   }};
-  const window = {{_notificationsEnabled: caseName !== 'unavailable'}};
-  globalThis.Notification = {{permission: caseName === 'unavailable' ? 'default' : 'granted'}};
+  const unavailableCases = new Set(['unavailable', 'setting-off', 'permission-denied', 'permission-default', 'missing-api']);
+  const window = {{_notificationsEnabled: !['unavailable', 'setting-off'].includes(caseName)}};
+  if(caseName !== 'missing-api') {{
+    const permission = caseName === 'permission-denied' ? 'denied' : caseName === 'permission-default' ? 'default' : 'granted';
+    globalThis.Notification = {{permission}};
+  }} else delete globalThis.Notification;
   const t = (key, ...args) => key + ':' + args.join('|');
   const showToast = (message) => toasts.push(message);
   const sendBrowserNotification = (title, body, options) => notifications.push({{title, body, options}});
   const updateCronBadge = () => {{}};
   const _markSessionCompletionUnreadIfBackground = () => {{}};
-  const completions = [{{name: 'Nightly', status: 'success', completed_at: 42, job_id: 'job-1', session_id: 'sid-1', message_count: 7, toast_notifications: caseName !== 'muted'}}];
+  const completions = [{{name: 'Nightly', status: 'success', completed_at: 42, job_id: 'job-1', session_id: caseName === 'no-session' ? '' : 'sid-1', message_count: 7, toast_notifications: caseName !== 'muted'}}];
+  let rejectApi;
   const api = () => {{
     apiCalls += 1;
-    return new Promise(resolve => {{ resolveApi = () => resolve({{completions}}); }});
+    return new Promise((resolve, reject) => {{
+      if(caseName === 'reject' && apiCalls === 1) rejectApi = () => reject(new Error('poll failed'));
+      else resolveApi = () => resolve({{completions}});
+    }});
   }};
   const setInterval = callback => {{ _cronPollTimer = {{callback}}; return _cronPollTimer; }};
   const clearInterval = () => {{}};
   eval(helperSource);
   eval(pollerSource);
   startCronPolling();
-  if (caseName === 'unavailable') {{
+  if (unavailableCases.has(caseName)) {{
     await _cronPollTimer.callback();
+  }} else if (caseName === 'transition') {{
+    const pending = _cronPollTimer.callback();
+    await Promise.resolve();
+    window._notificationsEnabled = false;
+    resolveApi();
+    await pending;
+  }} else if (caseName === 'reject') {{
+    const failed = _cronPollTimer.callback();
+    await Promise.resolve();
+    rejectApi();
+    await failed;
+    const recovered = _cronPollTimer.callback();
+    resolveApi();
+    await recovered;
   }} else if (caseName === 'stale') {{
     const pending = _cronPollTimer.callback();
     await Promise.resolve();
@@ -137,6 +158,31 @@ def test_muted_completion_keeps_unread_without_alert():
 def test_hidden_without_permission_or_setting_preserves_backlog():
     result = _run_node("unavailable")
     assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "since": 0, "ids": []}
+
+
+@pytest.mark.parametrize("case", ["setting-off", "permission-denied", "permission-default", "missing-api"])
+def test_hidden_unavailable_delivery_modes_preserve_backlog(case):
+    result = _run_node(case)
+    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "since": 0, "ids": []}
+
+
+def test_hidden_transition_to_unavailable_preserves_backlog():
+    result = _run_node("transition")
+    assert result == {"apiCalls": 1, "toasts": [], "notifications": [], "since": 0, "ids": []}
+
+
+def test_rejected_poll_clears_in_flight_guard():
+    result = _run_node("reject")
+    assert result["apiCalls"] == 2
+    assert len(result["notifications"]) == 1
+    assert result["since"] == 42
+
+
+def test_hidden_completion_without_session_id_skips_origin_notification():
+    result = _run_node("no-session")
+    assert result["notifications"] == []
+    assert result["since"] == 42
+    assert result["ids"] == ["job-1"]
 
 
 def test_stale_generation_drops_completion():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -1,4 +1,4 @@
-"""Behavioral coverage for cron-origin browser notifications in hidden tabs."""
+"""Composed owner and cron-poller proof for issue #7257."""
 
 from __future__ import annotations
 
@@ -9,205 +9,272 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
-PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+MESSAGES = (ROOT / "static/messages.js").read_text(encoding="utf-8")
+PANELS = (ROOT / "static/panels.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required")
+BASE_PANELS = subprocess.check_output(["git", "show", "origin/master:static/panels.js"], cwd=ROOT, text=True)
 
 
-def _function_source(name: str) -> str:
-    marker = f"function {name}("
-    start = PANELS_JS.find(marker)
-    assert start >= 0, f"{name} not found"
-    brace = PANELS_JS.find("{", PANELS_JS.find(")", start))
+def _function(source: str, name: str) -> str:
+    start = source.index(f"function {name}(")
+    brace = source.index("{", source.index(")", start))
     depth = 0
-    for index in range(brace, len(PANELS_JS)):
-        if PANELS_JS[index] == "{":
-            depth += 1
-        elif PANELS_JS[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return PANELS_JS[start : index + 1]
-    raise AssertionError(f"{name} body did not terminate")
+    for index in range(brace, len(source)):
+        depth += source[index] == "{"
+        depth -= source[index] == "}"
+        if depth == 0:
+            return source[start : index + 1]
+    raise AssertionError(name)
 
 
-def _run_node(case: str) -> dict:
-    if NODE is None:
-        pytest.skip("node is required for the behavioral harness")
-    helper = _function_source("_cronBrowserNotificationsDeliverable")
-    poller = _function_source("startCronPolling")
+_owner_start = MESSAGES.index("let _desktopBackgroundedForNotifications=false;")
+_owner_end = MESSAGES.index("function _isSessionCurrentPane", _owner_start)
+OWNER = "const _STREAM_NOTIFICATION_BACKGROUND={};" + MESSAGES[_owner_start:_owner_end] + "\n" + "\n".join(
+    _function(MESSAGES, name)
+    for name in ("_isBrowserNotificationReady", "_notificationOptions", "_showPwaNotification", "sendBrowserNotification")
+)
+POLLER = _function(PANELS, "startCronPolling")
+BASE_POLLER = _function(BASE_PANELS, "startCronPolling")
+
+
+def _run_base_head_reproduction() -> dict:
     script = f"""
-const caseName = {json.dumps(case)};
-const helperSource = {json.dumps(helper)};
-const pollerSource = {json.dumps(poller)};
-
-async function runCase() {{
-  let _cronPollSince = 0;
-  let _cronPollTimer = null;
-  let _cronPollGeneration = 0;
-  const _cronNewJobIds = new Set();
-  const toasts = [];
-  const notifications = [];
-  const markCalls = [];
-  let apiCalls = 0;
-  let resolveApi;
-  const document = {{
-    hidden: caseName !== 'visible',
-    querySelector: () => ({{
-      querySelector: () => null,
-      appendChild: () => {{}},
-      style: {{}},
-    }}),
-  }};
-  const unavailableCases = new Set(['unavailable', 'setting-off', 'permission-denied', 'permission-default', 'missing-api']);
-  const window = {{_notificationsEnabled: !['unavailable', 'setting-off'].includes(caseName)}};
-  if(caseName !== 'missing-api') {{
-    const permission = caseName === 'permission-denied' ? 'denied' : caseName === 'permission-default' ? 'default' : 'granted';
-    globalThis.Notification = {{permission}};
-  }} else delete globalThis.Notification;
-  const t = (key, ...args) => key + ':' + args.join('|');
-  const showToast = (message) => toasts.push(message);
-  const sendBrowserNotification = (title, body, options) => notifications.push({{title, body, options}});
-  const updateCronBadge = () => {{}};
-  const _markSessionCompletionUnreadIfBackground = (...args) => markCalls.push(args);
-  const completions = [{{name: 'Nightly', status: 'success', completed_at: 42, job_id: 'job-1', session_id: caseName === 'no-session' ? '' : 'sid-1', message_count: 7, toast_notifications: caseName !== 'muted'}}];
-  let rejectApi;
-  const api = () => {{
-    apiCalls += 1;
-    return new Promise((resolve, reject) => {{
-      if(caseName === 'reject' && apiCalls === 1) rejectApi = () => reject(new Error('poll failed'));
-      else resolveApi = () => resolve({{completions}});
-    }});
-  }};
-  const setInterval = callback => {{ _cronPollTimer = {{callback}}; return _cronPollTimer; }};
-  const clearInterval = () => {{}};
-  eval(helperSource);
-  eval(pollerSource);
-  startCronPolling();
-  if (unavailableCases.has(caseName)) {{
-    await _cronPollTimer.callback();
-  }} else if (caseName === 'transition') {{
-    const pending = _cronPollTimer.callback();
-    await Promise.resolve();
-    window._notificationsEnabled = false;
-    resolveApi();
-    await pending;
-  }} else if (caseName === 'reject') {{
-    const failed = _cronPollTimer.callback();
-    await Promise.resolve();
-    rejectApi();
-    await failed;
-    const recovered = _cronPollTimer.callback();
-    resolveApi();
-    await recovered;
-  }} else if (caseName === 'stale') {{
-    const pending = _cronPollTimer.callback();
-    await Promise.resolve();
-    _cronPollGeneration += 1;
-    resolveApi();
-    await pending;
-  }} else if (caseName === 'overlap') {{
-    const first = _cronPollTimer.callback();
-    await Promise.resolve();
-    const second = _cronPollTimer.callback();
-    resolveApi();
-    await Promise.all([first, second]);
-  }} else {{
-    const pending = _cronPollTimer.callback();
-    resolveApi();
-    await pending;
-  }}
-  process.stdout.write(JSON.stringify({{apiCalls, toasts, notifications, markCalls, since: _cronPollSince, ids: [..._cronNewJobIds]}}));
+const vm=require('vm'),base={json.dumps(BASE_POLLER)},head={json.dumps(POLLER)};
+async function run(source,isHead) {{
+  let timer,apiCalls=0,presentations=0;
+  const context={{document:{{hidden:true}},window:{{_notificationsEnabled:true}},Notification:{{permission:'granted'}},
+    _cronPollTimer:null,_cronPollSince:0,_cronPollGeneration:0,_cronNewJobIds:new Set(),
+    S:{{activeProfile:'profile-a',session:null}},setInterval:cb=>{{timer=cb;return 1;}},
+    api:async()=>{{apiCalls++;return {{completions:[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',toast_notifications:true}}]}};}},
+    sendBrowserNotification:async()=>{{presentations++;return {{delivered:true,alreadyDisplayed:false}};}},showToast:()=>{{}},updateCronBadge:()=>{{}},
+    t:(key,...args)=>key+':'+args.join('|'),
+    _isBackgroundedForBrowserNotification:()=>true,_isBrowserNotificationReady:()=>true,Promise,console}};
+  vm.createContext(context);vm.runInContext(source,context);vm.runInContext('startCronPolling()',context);await timer();return {{apiCalls,presentations}};
 }}
-runCase().catch(error => {{ console.error(error); process.exit(1); }});
+Promise.all([run(base,false),run(head,true)]).then(([baseResult,headResult])=>process.stdout.write(JSON.stringify({{base:baseResult,head:headResult}}))).catch(e=>{{console.error(e);process.exit(1)}});
+"""
+    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True).stdout)
+
+
+def _run(case: str) -> dict:
+    script = f"""
+const vm=require('vm');
+const owner={json.dumps(OWNER)};
+const poller={json.dumps(POLLER)};
+const caseName={json.dumps(case)};
+const registry=new Map(),shown=[],toasts=[],marks=[];
+let badgeCalls=0,enteredQueries=0,releaseQueries;
+let alertCount=0,failPresentation=caseName==='failure'||caseName==='ordered';
+function Notification(title,options) {{ if(failPresentation) throw new Error('native seam failed'); shown.push({{title,options}}); alertCount++; }}
+Notification.permission='granted';
+const registration={{active:null}}; registration.active=registration;
+registration.getNotifications=({{tag}})=>Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);
+registration.showNotification=(title,options)=>{{
+  if(failPresentation) return Promise.reject(new Error('worker failed'));
+  const existing=registry.get(options.tag); registry.set(options.tag,{{title,options}}); shown.push({{title,options}});
+  if(caseName==='stale-after-notification') context._cronPollGeneration++;
+  if(caseName==='partial-failure') failPresentation=true;
+  if(!existing || options.renotify) alertCount++; return Promise.resolve();
+}};
+const document={{hidden:!['foreground','desktop'].includes(caseName),baseURI:'https://example.test/',hasFocus:()=>false}};
+const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},addEventListener:()=>{{}}}};
+const context={{window,document,Notification,navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(registration)}}}},location:window.location,
+  S:{{activeProfile:'profile-a',session:{{session_id:'sess-active'}}}},_sessionUrlForSid:sid=>'/session/'+sid,_appRootPath:()=>'/app/',assistantDisplayName:()=> 'Hermes',
+  t:(key,...args)=>key+':'+args.join('|'),showToast:msg=>toasts.push(msg),updateNotificationPermissionStatus:()=>{{}},requestNotificationPermission:()=>caseName==='permission-reject'?Promise.reject(new Error('permission request failed')):Promise.resolve('granted'),
+  setTimeout,clearTimeout,Promise,console,globalThis:null}};
+context.globalThis=context; context.window.Notification=Notification; vm.createContext(context); vm.runInContext(owner,context);
+function setupPoller(completions) {{
+  let timer=null,apiCalls=0,resolveApi,rejectApi;
+  context._cronPollSince=0; context._cronPollTimer=null; context._cronPollGeneration=0; context._cronNewJobIds=new Set(); context.updateCronBadge=()=>{{badgeCalls++;}};
+  context._markSessionCompletionUnreadIfBackground=(...args)=>marks.push(args);
+  context.api=()=>{{apiCalls++;return new Promise((resolve,reject)=>{{resolveApi=()=>resolve({{completions}});rejectApi=()=>reject(new Error('rejected api'));}});}};
+  context.setInterval=cb=>{{timer={{callback:cb}};context._cronPollTimer=timer;return timer;}};
+  vm.runInContext(poller,context); return {{get timer(){{return timer;}},get apiCalls(){{return apiCalls;}},resolve:()=>resolveApi(),reject:()=>rejectApi()}};
+}}
+async function main() {{
+  if(caseName==='permission-reject') {{ Notification.permission='default'; return {{result:await vm.runInContext("sendBrowserNotification('title','body',{{forceHidden:true}})",context)}}; }}
+  if(caseName.startsWith('owner-')) {{
+    if(caseName==='owner-no-session') context.S.session=null;
+    const options=caseName==='owner-empty'?{{sid:'',tag:'hermes-cron-profile-a-job-1-42',renotify:false}}:caseName==='owner-false'?{{renotify:false}}:{{}};
+    return {{result:vm.runInContext(`_notificationOptions('body',${{JSON.stringify(options)}})`,context)}};
+  }}
+  const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
+  const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure')?2:1);
+  const p=setupPoller(completions); vm.runInContext('startCronPolling()',context);
+  if(caseName==='desktop') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable') window._notificationsEnabled=false;
+  if(caseName==='unavailable') {{ await p.timer.callback(); return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}}; }}
+  if(caseName==='no-query') delete registration.getNotifications;
+  if(caseName==='rejected-api') {{ const first=p.timer.callback(); await Promise.resolve(); p.reject(); await first; const second=p.timer.callback(); p.resolve(); await second; }}
+  else {{ const pending=p.timer.callback(); await Promise.resolve(); if(caseName==='desktop-transition') window.__hermesSetBackgrounded(true); if(caseName==='after-unavailable') window._notificationsEnabled=false; if(caseName==='stale') context._cronPollGeneration++; p.resolve(); await pending; if(caseName==='failure') {{failPresentation=false;const retry=p.timer.callback();p.resolve();await retry;}} }}
+  return {{apiCalls:p.apiCalls,shown,toasts,marks,since:context._cronPollSince,ids:[...context._cronNewJobIds],registry:[...registry.keys()],alerts:alertCount,badgeCalls}};
+}}
+main().then(v=>process.stdout.write(JSON.stringify(v))).catch(e=>{{console.error(e);process.exit(1)}});
 """
     result = subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True)
     return json.loads(result.stdout)
 
 
-def test_hidden_tab_cron_completion_fires_browser_notification():
-    result = _run_node("hidden")
-    assert result["apiCalls"] == 1
-    assert result["toasts"] == []
-    assert result["notifications"] == [{
-        "title": "Nightly",
-        "body": "cron_completion_status:Nightly|status_completed:",
-        "options": {"forceHidden": True, "sid": "sid-1"},
-    }]
+def _run_two_realms(simultaneous: bool) -> dict:
+    script = f"""
+const vm=require('vm'),owner={json.dumps(OWNER)},registry=new Map(),alerts=[];const simultaneous={json.dumps(simultaneous)};let audible=0;
+let entered=0,release;
+const bothEntered=new Promise(resolve=>release=resolve);
+function makeRealm(id) {{
+  const Notification=function(){{}}; Notification.permission='granted';
+  const reg={{active:null}}; reg.active=reg;
+  reg.getNotifications=({{tag}})=>{{entered++;if(!simultaneous)return Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);if(entered===2) release();return bothEntered.then(()=>registry.has(tag)?[registry.get(tag)]:[]);}};
+  reg.showNotification=(title,options)=>{{const existed=registry.has(options.tag);registry.set(options.tag,{{title,options,realm:id}});alerts.push({{id,options}});if(!existed) audible++;return Promise.resolve();}};
+  const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},Notification}};
+  const context={{window,document:{{hidden:true}},Notification,navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(reg)}}}},location:window.location,S:{{session:null}},assistantDisplayName:()=> 'Hermes',_appRootPath:()=>'/app/',_sessionUrlForSid:s=>'/session/'+s,setTimeout,Promise,console}};
+  context.globalThis=context;vm.createContext(context);vm.runInContext(owner,context);return context;
+}}
+async function main() {{const a=makeRealm('realm-a'),b=makeRealm('realm-b');
+ const opts={{forceHidden:true,sid:'',tag:'hermes-cron-profile-a-job-1-42',renotify:false,dedupe:true}};
+ let first,second;
+ if(simultaneous) {{
+   const firstPromise=vm.runInContext(`sendBrowserNotification('Nightly','done',${{JSON.stringify(opts)}})`,a);
+   const secondPromise=vm.runInContext(`sendBrowserNotification('Nightly','done',${{JSON.stringify(opts)}})`,b);
+   [first,second]=await Promise.all([firstPromise,secondPromise]);
+ }} else {{
+   first=await vm.runInContext(`sendBrowserNotification('Nightly','done',${{JSON.stringify(opts)}})`,a);
+   second=await vm.runInContext(`sendBrowserNotification('Nightly','done',${{JSON.stringify(opts)}})`,b);
+ }}
+ process.stdout.write(JSON.stringify({{first,second,entered,audible,alerts,records:[...registry.values()]}}));}}
+main().catch(e=>{{console.error(e);process.exit(1)}});
+"""
+    return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, check=True).stdout)
 
 
-def test_hidden_completion_preserves_cursor_unread_and_badge():
-    result = _run_node("hidden")
-    assert result["since"] == 42
-    assert result["ids"] == ["job-1"]
+def test_issue_repro_hidden_completion_reaches_presentation_owner():
+    result = _run("hidden")
+    assert result["since"] == 42 and result["toasts"] == [] and result["shown"]
+    assert result["shown"][0]["options"]["renotify"] is False
 
 
-def test_visible_completion_keeps_toast_only():
-    result = _run_node("visible")
-    assert result["toasts"] == ["cron_completion_status:Nightly|status_completed:"]
-    assert result["notifications"] == []
+def test_issue_reproduction_base_fails_head_reaches_presentation_owner():
+    result = _run_base_head_reproduction()
+    assert result == {"base": {"apiCalls": 0, "presentations": 0}, "head": {"apiCalls": 1, "presentations": 1}}
 
 
-def test_muted_completion_keeps_unread_without_alert():
-    result = _run_node("muted")
-    assert result["toasts"] == []
-    assert result["notifications"] == []
-    assert result["since"] == 42
-    assert result["ids"] == ["job-1"]
+def test_desktop_background_recomputed_before_and_after_await():
+    result = _run("desktop")
+    assert result["toasts"] == [] and result["since"] == 42
 
 
-def test_hidden_without_permission_or_setting_preserves_backlog():
-    result = _run_node("unavailable")
-    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
+def test_desktop_background_transition_after_await_uses_canonical_state():
+    result = _run("desktop-transition")
+    assert result["toasts"] == [] and result["since"] == 42 and result["shown"]
 
 
-@pytest.mark.parametrize("case", ["setting-off", "permission-denied", "permission-default", "missing-api"])
-def test_hidden_unavailable_delivery_modes_preserve_backlog(case):
-    result = _run_node(case)
-    assert result == {"apiCalls": 0, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
+def test_after_await_readiness_loss_preserves_backlog_and_badge():
+    result = _run("after-unavailable")
+    assert result["since"] == 0 and result["ids"] == [] and result["marks"] == [] and result["badgeCalls"] == 0
 
 
-def test_hidden_transition_to_unavailable_preserves_backlog():
-    result = _run_node("transition")
-    assert result == {"apiCalls": 1, "toasts": [], "notifications": [], "markCalls": [], "since": 0, "ids": []}
+def test_background_delivery_unavailable_preserves_backlog():
+    result = _run("unavailable")
+    assert result["apiCalls"] == 0 and result["since"] == 0 and result["ids"] == []
 
 
-def test_rejected_poll_clears_in_flight_guard():
-    result = _run_node("reject")
-    assert result["apiCalls"] == 2
-    assert len(result["notifications"]) == 1
-    assert result["since"] == 42
+def test_explicit_empty_sid_never_inherits_active_session():
+    result = _run("owner-empty")["result"]
+    assert result["data"]["url"] == "https://example.test/app/" and result["renotify"] is False
+    assert result["tag"] == "hermes-cron-profile-a-job-1-42"
 
 
-def test_hidden_sessionless_completion_hands_off_without_session_unread_mark():
-    result = _run_node("no-session")
-    assert result["notifications"] == [{
-        "title": "Nightly",
-        "body": "cron_completion_status:Nightly|status_completed:",
-        "options": {"forceHidden": True, "sid": ""},
-    }]
-    assert result["markCalls"] == []
-    assert result["since"] == 42
-    assert result["ids"] == ["job-1"]
+def test_truthy_session_keeps_deep_link_and_unread_boundary():
+    result = _run("hidden")
+    assert result["marks"][0][0] == "sid-1" and result["marks"][0][2]["profile"] == "profile-a"
+    assert "/session/sid-1" in result["shown"][0]["options"]["data"]["url"]
 
 
-def test_hidden_session_bound_completion_marks_session_unread():
-    result = _run_node("hidden")
-    assert result["markCalls"] == [["sid-1", 7, {
-        "source": "cron",
-        "profile": "default",
-    }]]
+def test_two_realms_same_identity_short_circuit_displayed_record():
+    result = _run_two_realms(False)
+    assert result["first"]["delivered"] is True and result["second"]["alreadyDisplayed"] is True
+    assert len(result["records"]) == 1 and len(result["alerts"]) == 1
 
 
-def test_stale_generation_drops_completion():
-    result = _run_node("stale")
-    assert result["apiCalls"] == 1
-    assert result["notifications"] == []
-    assert result["since"] == 0
-    assert result["ids"] == []
+def test_two_realms_same_identity_replace_silently():
+    result = _run_two_realms(True)
+    assert result["audible"] == 1 and len(result["records"]) == 1
+    assert all(row["options"]["renotify"] is False for row in result["alerts"])
 
 
-def test_overlapping_polls_do_not_duplicate_completion():
-    result = _run_node("overlap")
-    assert result["apiCalls"] == 1
-    assert len(result["notifications"]) == 1
+def test_later_completed_at_remains_presentable():
+    result = _run("later")
+    assert result["since"] == 43 and len(result["registry"]) == 2
+
+
+def test_get_notifications_absent_falls_through_to_show():
+    assert _run("no-query")["shown"]
+
+
+def test_failed_presentation_retries_without_cursor_advance():
+    result = _run("failure")
+    assert result["since"] == 42 and result["alerts"] == 1
+
+
+def test_successful_completion_updates_badge_before_later_retryable_failure():
+    result = _run("partial-failure")
+    assert result["since"] == 42 and result["badgeCalls"] == 1
+
+
+def test_rejected_api_clears_in_flight_and_next_request_succeeds():
+    result = _run("rejected-api")
+    assert result["apiCalls"] == 2 and result["since"] == 42
+
+
+def test_earlier_failure_blocks_later_completion():
+    assert _run("ordered")["since"] == 0
+
+
+def test_muted_completion_consumes_without_alert():
+    result = _run("muted")
+    assert result["shown"] == [] and result["since"] == 42
+
+
+def test_foreground_completion_keeps_toast_only():
+    result = _run("foreground")
+    assert result["shown"] == [] and result["toasts"]
+
+
+def test_stale_generation_drops_every_effect():
+    result = _run("stale")
+    assert result["shown"] == [] and result["since"] == 0 and result["ids"] == []
+
+
+def test_stale_generation_after_presentation_drops_local_effects():
+    result = _run("stale-after-notification")
+    assert result["shown"] and result["since"] == 0 and result["ids"] == [] and result["marks"] == []
+
+
+def test_rejected_poll_releases_in_flight():
+    assert _run("hidden")["apiCalls"] == 1
+
+
+def test_sessionless_poller_uses_root_url_and_no_session_unread():
+    result = _run("sessionless")
+    options = result["shown"][0]["options"]
+    assert options["data"]["url"] == "https://example.test/app/"
+    assert options["tag"] == "hermes-cron-profile-a-job-1-42" and result["marks"] == []
+
+
+def test_request_permission_rejection_is_retryable_outcome():
+    result = _run("permission-reject")["result"]
+    assert result == {"delivered": False, "alreadyDisplayed": False, "retryable": True, "reason": "permission-request-failed"}
+
+
+def test_existing_caller_defaults_preserve_omitted_sid_and_renotify():
+    result = _run("owner-omitted")["result"]
+    assert result["tag"] == "hermes-sess-active" and result["renotify"] is True
+
+
+def test_omitted_sid_without_active_session_uses_current_location():
+    result = _run("owner-no-session")["result"]
+    assert result["data"]["url"] == "https://example.test/"
+
+
+def test_explicit_renotify_false_is_preserved():
+    assert _run("owner-false")["result"]["renotify"] is False

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -215,7 +215,7 @@ def test_issue_reproduction_base_fails_head_reaches_presentation_owner():
 
 def test_desktop_background_recomputed_before_and_after_await():
     result = _run("desktop")
-    assert result["toasts"] == [] and result["since"] == 42
+    assert result["toasts"] == [] and result["since"] == 42 and result["alerts"] == 1
 
 
 def test_desktop_background_transition_after_await_uses_canonical_state():
@@ -251,8 +251,9 @@ def test_explicit_empty_sid_never_inherits_active_session():
 
 def test_truthy_session_keeps_deep_link_and_unread_boundary():
     result = _run("hidden")
-    assert result["marks"][0][0] == "sid-1" and result["marks"][0][2]["profile"] == "profile-a"
+    assert len(result["marks"]) == 1 and result["marks"][0][0] == "sid-1" and result["marks"][0][2]["profile"] == "profile-a"
     assert "/session/sid-1" in result["shown"][0]["options"]["data"]["url"]
+    assert result["shown"][0]["options"]["tag"] == "hermes-cron-profile-a-job-1-42"
 
 
 def test_two_realms_same_identity_short_circuit_displayed_record():

--- a/tests/test_issue7257_cron_origin_browser_notification.py
+++ b/tests/test_issue7257_cron_origin_browser_notification.py
@@ -6,10 +6,15 @@ OS delivery, and OS-level tag collapse remain unreached.
 
 from __future__ import annotations
 
+import io
 import json
+import os
 import shutil
 import subprocess
+import sys
+import types
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -69,7 +74,7 @@ _owner_start = MESSAGES.index("let _desktopBackgroundedForNotifications=false;")
 _owner_end = MESSAGES.index("function _isSessionCurrentPane", _owner_start)
 OWNER = "const _STREAM_NOTIFICATION_BACKGROUND={};" + MESSAGES[_owner_start:_owner_end] + "\n" + "\n".join(
     _function(MESSAGES, name)
-    for name in ("_isBrowserNotificationReady", "_notificationOptions", "_showPwaNotification", "sendBrowserNotification")
+    for name in ("_isBrowserNotificationReady", "_notificationOptions", "_completionNotificationPreviewText", "_showPwaNotification", "sendBrowserNotification")
 )
 POLLER = _function(PANELS, "startCronPolling")
 
@@ -98,6 +103,63 @@ async function run(source,isHead) {{
 Promise.all([run(base,false),run(head,true)]).then(([baseResult,headResult])=>process.stdout.write(JSON.stringify({{base:baseResult,head:headResult}}))).catch(e=>{{console.error(e);process.exit(1)}});
 """
     return json.loads(subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=True).stdout)
+
+
+def _run_equal_timestamp_cursor(include_earlier: bool = False) -> dict:
+    earlier = "  {name:'Earlier',status:'success',completed_at:99,job_id:'job-earlier',session_id:'',message_count:0,toast_notifications:true},\n" if include_earlier else ""
+    script = f"""
+const vm=require('vm'),owner={json.dumps(OWNER)},poller={json.dumps(POLLER)};
+const rows=[
+{earlier}  {{name:'Job A',status:'success',completed_at:100,job_id:'job-a',session_id:'',message_count:0,toast_notifications:true}},
+  {{name:'Job B',status:'success',completed_at:100,job_id:'job-b',session_id:'',message_count:0,toast_notifications:true}},
+  {{name:'Job C',status:'success',completed_at:101,job_id:'job-c',session_id:'',message_count:0,toast_notifications:true}},
+];
+const registry=new Map(),queries=[],responses=[],outcomes=[],alerts=[];
+let failedWorker=false,failedDirect=false;
+function Notification(title,options) {{
+  if(options.tag.endsWith('-job-b-100')&&!failedDirect) {{ failedDirect=true; throw new Error('direct failed'); }}
+  alerts.push({{title,options}});
+}}
+Notification.permission='granted';
+const registration={{active:null}}; registration.active=registration;
+registration.getNotifications=({{tag}})=>Promise.resolve(registry.has(tag)?[registry.get(tag)]:[]);
+registration.showNotification=(title,options)=>{{
+  if(options.tag.endsWith('-job-b-100')&&!failedWorker) {{ failedWorker=true; return Promise.reject(new Error('worker failed')); }}
+  registry.set(options.tag,{{title,options}}); alerts.push({{title,options}}); return Promise.resolve();
+}};
+const window={{_notificationsEnabled:true,location:{{origin:'https://example.test',href:'https://example.test/'}},Notification,addEventListener:()=>{{}}}};
+const context={{window,document:{{hidden:true,baseURI:'https://example.test/'}},Notification,
+  navigator:{{serviceWorker:{{getRegistration:()=>Promise.resolve(registration)}}}},location:window.location,
+  S:{{activeProfile:'profile-a',session:null}},_cronPollTimer:null,_cronPollSince:0,_cronPollGeneration:0,_cronNewJobIds:new Set(),
+  _sessionUrlForSid:s=>'/session/'+s,_appRootPath:()=>'/app/',assistantDisplayName:()=> 'Hermes',
+  t:(key,...args)=>key+':'+args.join('|'),showToast:()=>{{}},updateCronBadge:()=>{{}},
+  _markSessionCompletionUnreadIfBackground:()=>{{}},setInterval:cb=>{{context.timer=cb;return 1;}},
+  setTimeout,clearTimeout,Promise,console,globalThis:null}};
+context.globalThis=context; context.window.Notification=Notification; vm.createContext(context);
+vm.runInContext(owner,context);
+const realSend=context.sendBrowserNotification;
+context.sendBrowserNotification=(...args)=>realSend(...args).then(outcome=>{{outcomes.push({{tag:args[2].tag,outcome}});return outcome;}});
+vm.runInContext(poller,context);
+vm.runInContext('startCronPolling()',context);
+context.api=async url=>{{
+  const since=Number(new URL(url,'https://example.test').searchParams.get('since'));
+  queries.push(since);
+  const completions=rows.filter(row=>row.completed_at>since);
+  responses.push(completions.length);
+  return {{completions}};
+}};
+async function main() {{
+  await context.timer();
+  const afterFirst={{since:context._cronPollSince,queries:queries.slice(),responses:responses.slice(),alerts:alerts.length}};
+  await context.timer();
+  process.stdout.write(JSON.stringify({{afterFirst,queries,responses,alerts,outcomes,since:context._cronPollSince,tags:[...registry.keys()]}}));
+}}
+main().catch(e=>{{console.error(e);process.exit(1)}});
+    """
+    result = subprocess.run([NODE, "-e", script], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=False)
+    if result.returncode:
+        raise AssertionError(result.stderr)
+    return json.loads(result.stdout)
 
 
 def _run(case: str) -> dict:
@@ -154,7 +216,7 @@ async function main() {{
     const result=await vm.runInContext("sendBrowserNotification('title','body',{{force:true}})",context);
     return {{result,ownerCalls,getNotificationCalls,shown}};
   }}
-  const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'&&caseName!=='after-unavailable-muted'}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
+  const all=[{{name:'Nightly',status:'success',completed_at:42,job_id:'job-1',session_id:caseName==='sessionless'?'':'sid-1',message_count:7,toast_notifications:caseName!=='muted'&&caseName!=='after-unavailable-muted',output_preview:caseName==='preview'?'  Preview   text\\nwith   spacing   '+'x'.repeat(150):caseName==='empty-preview'?'':undefined}},{{name:'Later',status:'success',completed_at:43,job_id:'job-1',session_id:'',message_count:0,toast_notifications:true}}];
   const completions=caseName==='ordered'?all.slice().reverse():all.slice(0,(caseName==='later'||caseName==='partial-failure'||caseName==='force-hidden-transition'||caseName==='permission-transition')?2:1);
   const p=setupPoller(completions); vm.runInContext('startCronPolling()',context);
   if(caseName==='desktop'||caseName==='desktop-unavailable') {{ document.hidden=false; window.__hermesSetBackgrounded(true); }} if(caseName==='unavailable'||caseName==='desktop-unavailable') window._notificationsEnabled=false;
@@ -212,6 +274,32 @@ def test_issue_repro_hidden_completion_reaches_presentation_owner():
 def test_issue_reproduction_base_fails_head_reaches_presentation_owner():
     result = _run_base_head_reproduction()
     assert result == {"base": {"apiCalls": 0, "presentations": 0}, "head": {"apiCalls": 1, "presentations": 1}}
+
+
+def test_equal_timestamp_failure_keeps_the_group_eligible_for_retry():
+    result = _run_equal_timestamp_cursor()
+    assert result["afterFirst"] == {"since": 0, "queries": [0], "responses": [3], "alerts": 1}
+    assert result["queries"] == [0, 0]
+    assert result["responses"] == [3, 3]
+    assert result["since"] == 101
+    assert len(result["tags"]) == 3 and len(result["alerts"]) == 3
+    assert sum(item["options"]["tag"].endswith("-job-a-100") for item in result["alerts"]) == 1
+    assert any(
+        item["tag"].endswith("-job-a-100") and item["outcome"].get("alreadyDisplayed") is True
+        for item in result["outcomes"]
+    )
+    assert all(
+        any(item["tag"].endswith(f"-{job_id}-{timestamp}") and item["outcome"].get("delivered") is True for item in result["outcomes"])
+        for job_id, timestamp in (("job-b", 100), ("job-c", 101))
+    )
+
+
+def test_completed_group_progress_survives_a_later_equal_timestamp_failure():
+    result = _run_equal_timestamp_cursor(include_earlier=True)
+    assert result["afterFirst"]["since"] == 99
+    assert result["queries"] == [0, 99]
+    assert result["since"] == 101
+    assert len(result["tags"]) == 4 and len(result["alerts"]) == 4
 
 
 def test_desktop_background_recomputed_before_and_after_await():
@@ -335,9 +423,9 @@ def test_sessionless_poller_uses_root_url_and_no_session_unread():
     assert options["tag"] == "hermes-cron-profile-a-job-1-42" and result["marks"] == []
 
 
-def test_request_permission_rejection_is_retryable_outcome():
+def test_request_permission_rejection_returns_reduced_outcome():
     result = _run("permission-reject")["result"]
-    assert result == {"delivered": False, "alreadyDisplayed": False, "retryable": True, "reason": "permission-request-failed"}
+    assert result == {"delivered": False, "alreadyDisplayed": False}
 
 
 def test_existing_caller_defaults_preserve_omitted_sid_and_renotify():
@@ -356,7 +444,7 @@ def test_explicit_renotify_false_is_preserved():
 
 def test_owner_without_dedupe_does_not_query_displayed_records():
     result = _run("owner-no-dedupe")
-    assert result["result"] == {"delivered": True, "alreadyDisplayed": False, "retryable": False, "reason": "delivered"}
+    assert result["result"] == {"delivered": True, "alreadyDisplayed": False}
     assert result["getNotificationCalls"] == 0
 
 
@@ -379,3 +467,163 @@ def test_mid_batch_permission_loss_preserves_backlog_without_prompting():
 def test_badge_failure_does_not_stick_in_flight_guard():
     result = _run("badge-failure")
     assert result["apiCalls"] == 2 and result["since"] == 42
+
+
+def test_completion_preview_uses_owner_shaping_and_status_fallback():
+    preview = _run("preview")["shown"][0]
+    empty = _run("empty-preview")["shown"][0]
+    absent = _run("hidden")["shown"][0]
+    expected_preview = ("Preview text with spacing " + "x" * 150)[:100] + "…"
+    assert preview["title"] == "Nightly" and preview["options"]["body"] == expected_preview
+    assert empty["title"] == "Nightly" and empty["options"]["body"].startswith("cron_completion_status:")
+    assert absent["title"] == "Nightly" and absent["options"]["body"].startswith("cron_completion_status:")
+
+
+class _JSONHandler:
+    def __init__(self):
+        self.status = None
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        pass
+
+    def end_headers(self):
+        pass
+
+
+def _payload(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _stub_cron_jobs(monkeypatch, *, output_dir=None, jobs=None):
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    if output_dir is not None:
+        cron_jobs.OUTPUT_DIR = output_dir
+    if jobs is not None:
+        cron_jobs.list_jobs = lambda include_disabled=True: jobs
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+
+def test_recent_success_preview_uses_latest_output_at_or_before_completion(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    out_dir = tmp_path / "cron-out" / "job42"
+    out_dir.mkdir(parents=True)
+    files = {
+        "old.md": (90, "## Response\nold response\n"),
+        "new.md": (100, "## Response\nnew response\n"),
+        "later.md": (110, "## Response\nlater response\n"),
+    }
+    for name, (mtime, content) in files.items():
+        output = out_dir / name
+        output.write_text(content, encoding="utf-8")
+        os.utime(output, (mtime, mtime))
+    jobs = [{"id": "job42", "name": "Job 42", "last_run_at": 100, "last_status": "ok"}]
+    _stub_cron_jobs(monkeypatch, output_dir=tmp_path / "cron-out", jobs=jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    assert handler.status == 200
+    completion = _payload(handler)["completions"][0]
+    assert completion["output_preview"] == "new response"
+    assert "later response" not in completion["output_preview"]
+    assert set(completion) == {
+        "job_id",
+        "name",
+        "status",
+        "completed_at",
+        "toast_notifications",
+        "session_id",
+        "output_preview",
+    }
+
+
+@pytest.mark.parametrize("case", ["missing", "unreadable", "empty", "metadata"])
+def test_recent_preview_omits_unsafe_or_empty_output(monkeypatch, tmp_path, case):
+    import api.routes as routes
+
+    output_dir = tmp_path / "cron-out"
+    output_file = output_dir / "job42" / "run.md"
+    if case != "missing":
+        output_file.parent.mkdir(parents=True)
+        if case == "empty":
+            content = "## Response\n"
+        elif case == "metadata":
+            content = "# Cron Job: Job 42\n\n**Job ID:** job42\n**Status:** ok\n"
+        else:
+            content = "## Response\nbody\n"
+        output_file.write_text(content, encoding="utf-8")
+        os.utime(output_file, (100, 100))
+    if case == "unreadable":
+        original_read_text = Path.read_text
+
+        def unreadable(path, *args, **kwargs):
+            if path == output_file:
+                raise OSError("permission denied")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+    jobs = [{"id": "job42", "name": "Job 42", "last_run_at": 100, "last_status": "ok"}]
+    _stub_cron_jobs(monkeypatch, output_dir=output_dir, jobs=jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    assert handler.status == 200
+    completion = _payload(handler)["completions"][0]
+    assert "output_preview" not in completion
+
+
+def test_recent_preview_reads_no_agent_output_after_separator(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    output_dir = tmp_path / "cron-out" / "job42"
+    output_dir.mkdir(parents=True)
+    output = output_dir / "run.md"
+    output.write_text(
+        "# Cron Job: Job 42\n\n**Job ID:** job42\n**Mode:** no_agent (script)\n\n---\n\nscript output\n",
+        encoding="utf-8",
+    )
+    os.utime(output, (100, 100))
+    jobs = [{"id": "job42", "name": "Job 42", "last_run_at": 100, "last_status": "ok"}]
+    _stub_cron_jobs(monkeypatch, output_dir=tmp_path / "cron-out", jobs=jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    assert handler.status == 200
+    completion = _payload(handler)["completions"][0]
+    assert completion["output_preview"] == "script output"
+
+
+def test_recent_error_completion_keeps_projected_fields_without_preview(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    output_dir = tmp_path / "cron-out" / "job42"
+    output_dir.mkdir(parents=True)
+    output = output_dir / "run.md"
+    output.write_text("## Response\nold output\n", encoding="utf-8")
+    os.utime(output, (100, 100))
+    jobs = [{"id": "job42", "name": "Job 42", "last_run_at": 100, "last_status": "error", "toast_notifications": False}]
+    _stub_cron_jobs(monkeypatch, output_dir=tmp_path / "cron-out", jobs=jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    assert handler.status == 200
+    completion = _payload(handler)["completions"][0]
+    assert completion == {
+        "job_id": "job42",
+        "name": "Job 42",
+        "status": "error",
+        "completed_at": 100.0,
+        "toast_notifications": False,
+        "session_id": "",
+    }

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -81,10 +81,10 @@ def test_completion_notification_fires_when_tab_was_hidden_during_stream():
     # sendBrowserNotification honors forceHidden but still respects the
     # notifications-enabled setting (forceHidden is NOT the test-button force).
     assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS
-    assert "if(!force&&!window._notificationsEnabled) return;" in MESSAGES_JS
+    assert "const settingGateSatisfied=()=>" in MESSAGES_JS
     assert "function _isBackgroundedForBrowserNotification(){" in MESSAGES_JS
     assert "window.__hermesSetBackgrounded=(value)=>{" in MESSAGES_JS
-    assert "if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;" in MESSAGES_JS
+    assert "const visibilityGateSatisfied=()=>" in MESSAGES_JS
 
 
 def test_desktop_background_notification_signal_stays_out_of_stream_visibility():

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -81,10 +81,10 @@ def test_completion_notification_fires_when_tab_was_hidden_during_stream():
     # sendBrowserNotification honors forceHidden but still respects the
     # notifications-enabled setting (forceHidden is NOT the test-button force).
     assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS
-    assert "const settingGateSatisfied=()=>" in MESSAGES_JS
+    assert "if(!force&&!window._notificationsEnabled) return outcome('setting-disabled');" in MESSAGES_JS
     assert "function _isBackgroundedForBrowserNotification(){" in MESSAGES_JS
     assert "window.__hermesSetBackgrounded=(value)=>{" in MESSAGES_JS
-    assert "const visibilityGateSatisfied=()=>" in MESSAGES_JS
+    assert "if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return outcome('foreground');" in MESSAGES_JS
 
 
 def test_desktop_background_notification_signal_stays_out_of_stream_visibility():

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -81,10 +81,10 @@ def test_completion_notification_fires_when_tab_was_hidden_during_stream():
     # sendBrowserNotification honors forceHidden but still respects the
     # notifications-enabled setting (forceHidden is NOT the test-button force).
     assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS
-    assert "if(!force&&!window._notificationsEnabled) return outcome('setting-disabled');" in MESSAGES_JS
+    assert "if(!force&&!window._notificationsEnabled) return skip();" in MESSAGES_JS
     assert "function _isBackgroundedForBrowserNotification(){" in MESSAGES_JS
     assert "window.__hermesSetBackgrounded=(value)=>{" in MESSAGES_JS
-    assert "if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return outcome('foreground');" in MESSAGES_JS
+    assert "if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return skip();" in MESSAGES_JS
 
 
 def test_desktop_background_notification_signal_stays_out_of_stream_visibility():


### PR DESCRIPTION
## Thinking Path

- Cron jobs that deliver to the WebUI land in the transcript, but a backgrounded tab gets no browser notification. Scheduled alerts therefore never reach the desktop or the Android relay that mirrors WebUI notifications. The cron poller was the only consumer that could notify about a completion, and it stopped early while the document was hidden.
- The existing browser notification owner handles this path. The per-session event stream closes while hidden, and relabelling a cron delivery as a background-task event would give cron jobs different dedupe and acknowledgement rules.
- Delivering while hidden exposed a second problem in the poller's cursor. `startCronPolling` advanced `_cronPollSince` per completion but returned early when a presentation failed. Two jobs can share a `completed_at`, while `mark_job_run` stamps each job's `last_run_at` independently. A successful earlier item moved the cursor onto that timestamp before its sibling failed. `/api/crons/recent` filters with strict `ts > since` (`api/routes.py:21930`), so the failed sibling could never be queried again. The cursor now advances past a `completed_at` only after every completion with that timestamp was delivered or already displayed. A partial group therefore returns as a whole on the next poll. The stable per-completion tag and displayed-record check make a retry of the successful sibling a silent no-op.
- The notification body carries the job's output preview, as the issue asks. `/api/crons/recent` now projects one bounded plain-text `output_preview` built with the same `_cron_output_snippet` extraction the run-detail endpoint already uses. The browser shapes it with `_completionNotificationPreviewText`, the helper that builds the "Response complete" body.
- The preview applies only to a successful completion. The scheduler writes a run's output file before it records `last_run_at`, so the newest output file at or before `completed_at` belongs to that successful run. A run that failed before producing output has no file of its own. Those completions keep the localized status body.
- The delivery result was also carrying `retryable` and `reason` fields that no call site reads. They are gone; the poller reads `delivered` and `alreadyDisplayed`, which is all any consumer ever used. The response sort likewise dropped an alphabetical `job_id` tie-break the endpoint has no ordering contract for.

## What Changed

- `static/panels.js`: `startCronPolling` commits `_cronPollSince` at the end of each `completed_at` group instead of per item, so a failure inside a group leaves the cursor below that group's timestamp; the notification body prefers the completion's `output_preview` shaped through the notification owner's preview helper and falls back to the localized status text; the sort is numeric on `completed_at` only. Per-item unread markers, the badge refresh, the readiness gates, the generation fence, and the visible-tab toast are unchanged.
- `static/messages.js`: `sendBrowserNotification` and `_showPwaNotification` return `{delivered, alreadyDisplayed}` on every path, dropping the two unread diagnostic fields. Gate order, `force`/`forceHidden` semantics, the service-worker-then-direct fallback, the displayed-record check, and the notification identity and URL rules are unchanged.
- `api/routes.py`: `_handle_cron_recent` projects an optional bounded `output_preview` for successful completions, produced by a new `_cron_completion_output_preview` helper that selects the job's newest output file at or before `completed_at` and extracts its response body with the existing `_cron_output_snippet`. The helper never raises; a missing directory, unreadable file, or empty response section simply omits the key. The `since` parsing, the strict `ts > since` filter, the existing fields, and the session join are untouched.
- `tests/test_issue7257_cron_origin_browser_notification.py`: adds an equal-`completed_at` partial-failure case driven through an endpoint seam that honors strict `ts > since`, group-progress coverage, route-level preview provenance tests, and body-composition coverage for preview versus status fallback.
- `tests/test_pwa_notification_controls.py`: updates two source assertions for the reduced outcome shape.

## Why It Matters

A cron job that finishes while the tab is backgrounded now raises a browser notification titled with the job name and filled with the run's own output. The Android app relays that content to a native notification. A completion that shares a second with another job also remains eligible for retry when its first delivery attempt fails.

## Verification

The equal-timestamp regression fails on the unfixed poller because the first tick commits the cursor onto the shared timestamp. The next strict `since` query excludes the failed sibling, so the poller never presents it. The fixed poller delivers both jobs without duplicating the sibling that already succeeded. Preview provenance tests pin the run correspondence, reject a later run's file, and keep the status body for failed completions. The composed poller and owner harness covers muted, foreground, sessionless, desktop-backgrounded, stale-generation, overlapping-poll, permission-loss, and worker-fallback paths. Existing cron polling, cron toast, cron badge, cron unread, and notification suites also ran unchanged. ESLint's runtime-guard config passes over the browser sources. CI runs the full matrix.

## Risks / Follow-ups

- The harness stubs the final presentation layer, so local runs don't exercise real service-worker registration, OS-level delivery, or native tag collapse. Cross-tab suppression is proven at the displayed-record layer and still depends on the browser for OS delivery.
- Output previews are attached to successful completions only. The scheduler writes a run's output before recording its completion, which is what makes the association safe; a run that failed before producing output has no file of its own, so those notifications keep the localized status body rather than borrow an earlier run's text. If a future run record carries its own output filename, the preview could cover failed runs too.
- The preview lookup reads at most one output file per reported completion, and a poll normally reports none, so the endpoint's steady-state cost is unchanged.
- No security-sensitive behavior changes: the new helper reuses the existing cron job-id validation and reads only within the cron output directory the run-detail and output endpoints already serve.
- Release note: cron completions now raise a browser notification with the job name and an output preview when the tab is backgrounded, and same-second completions are no longer dropped when one delivery attempt fails.

## Contract Routing

- Task type: bug fix with a small additive API projection field.
- Touched areas: cron completion polling in the browser, browser notification delivery, `/api/crons/recent`.
- Relevant public docs: `docs/CONTRACTS.md`, `ARCHITECTURE.md`, `TESTING.md`.
- Scope boundaries: no new endpoint, no server event, no persistence, no change to the endpoint's strict `since` filter or to notification identity; `CHANGELOG.md` untouched.
- Evidence needed before claiming done: equal-timestamp partial-failure regression failing on the unfixed poller and passing here; preview provenance tests pinning run correspondence and the status fallback; existing cron and notification suites green.

## Contract Change

- Previous contract: `/api/crons/recent` returned `job_id`, `name`, `status`, `completed_at`, `toast_notifications`, `session_id`, and `message_count` per completion.
- New contract: the same fields, plus an optional `output_preview` string present only for a successful completion whose run output could be located. Absent or empty means no preview is available and consumers should fall back to status text.
- Affected docs and tests: `tests/test_issue7257_cron_origin_browser_notification.py` covers the new field's provenance, boundaries, and consumption; the existing cron endpoint tests cover the unchanged fields.
- Compatibility: purely additive and optional. Existing consumers that ignore the field are unaffected, and the client keeps a complete status-only body path.

## Upstream

Closes #7257.

## Model Used

OpenAI GPT-6 via Codex.


