### PR TITLE
perf(run-journal): stop journaling metering telemetry; filter it from replay

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -9927,6 +9927,7 @@ from api.run_journal import (
     _parse_run_journal_event_id as _shared_parse_run_journal_event_id,
     bound_run_journal_snapshot_args,
     find_run_summary,
+    journal_replay_visible,
     read_run_events,
     read_session_run_events,
     session_journal_fingerprint,
@@ -17717,6 +17718,10 @@ def _replay_run_journal(
         max_seq=max_seq,
     )
     for entry in journal.get("events") or []:
+        # Legacy journals contain metering rows (write-time skip landed
+        # later); never replay transient telemetry to a reconnecting client.
+        if not journal_replay_visible(entry):
+            continue
         _sse_with_id(
             handler,
             entry.get("event") or entry.get("type") or "message",
@@ -18252,6 +18257,10 @@ def _handle_session_run_journal_stream_for_session(handler, parsed, session_id):
 
     def emit_replay(events, stream_id, cutoff_seq):
         for entry in events:
+            # Legacy journals contain metering rows; never replay transient
+            # telemetry to a reconnecting client.
+            if not journal_replay_visible(entry):
+                continue
             event_id = str(entry.get("event_id") or "")
             event_seq = _run_journal_same_run_seq(event_id, stream_id)
             if cutoff_seq is not None and event_seq is not None and event_seq > cutoff_seq:

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -43,6 +43,28 @@ TERMINAL_SSE_EVENTS = frozenset({"done", "cancel", "apperror", "error", "stream_
 # `done`, and breaking early would drop them. `apperror` is included because
 # it terminates with no trailing `stream_end`.
 SSE_RELAY_CLOSE_EVENTS = frozenset({"stream_end", "cancel", "apperror", "error"})
+# Transient live-UI telemetry. Journaled historically, but with no recovery
+# value: nothing reconstructs transcript state from a metering row, and their
+# ~10 Hz emit rate made long reasoning-heavy runs produce journals that were
+# overwhelmingly telemetry (observed: 18 MB / 39k events, 97% metering +
+# reasoning deltas) — the replay of that backlog to a reconnecting tab OOMs
+# the browser. Write-time paths skip journaling them; replay readers skip any
+# metering rows still present in legacy journals.
+REPLAY_SKIPPED_SSE_EVENTS = frozenset({"metering"})
+
+
+def journal_replay_visible(event: "dict | Any") -> bool:
+    """Return True when a journal row should be replayed to a reconnecting client.
+
+    ``metering`` rows (legacy journals only — new writes skip them) are dropped:
+    they are point-in-time live-UI telemetry whose only replay effect is
+    re-painting a stale TPS label while multiplying the reconnect burst size.
+    Unknown/missing event names stay visible (fail open to content).
+    """
+    if not isinstance(event, dict):
+        return True
+    name = str(event.get("event") or event.get("type") or "")
+    return name not in REPLAY_SKIPPED_SSE_EVENTS
 # Back-compat alias used by older call sites / tests.
 _TERMINAL_SSE_EVENTS = TERMINAL_SSE_EVENTS
 _FSYNC_MODE_ENV = "HERMES_WEBUI_RUN_JOURNAL_FSYNC"
@@ -446,10 +468,21 @@ class RunJournalWriter:
         self._path = _run_path(self.session_id, self.run_id, session_dir=self.session_dir)
         self._lock = _lock_for(self._path)
 
-    def append_sse_event(self, event_name: str, payload=None) -> dict:
+    def append_sse_event(self, event_name: str, payload=None) -> "dict | None":
         # Draw from the shared module-level seq cache under the per-path lock so
-        # this writer and any direct append_run_event() call on the same path
+        # this writer and any direct append_run_event call on the same path
         # agree on one monotonic, gapless sequence.
+        if event_name in REPLAY_SKIPPED_SSE_EVENTS:
+            # Transient telemetry (metering) is never journaled. Emitted at
+            # ~10 Hz during active streams, it turned long reasoning-heavy
+            # runs into multi-MB journals that were ~65% telemetry by bytes
+            # (observed: 18 MB / 39k events), and the replay of that backlog
+            # to a reconnecting tab OOMs the browser. No recovery consumer
+            # reads metering rows, so skipping them has no behavioral cost.
+            # Return a falsy marker so put() callers leave their journal-id
+            # plumbing untouched (event_id stays None → frame is delivered
+            # id-less, same as pre-journal legacy events).
+            return None
         with self._lock:
             seq = _reserve_next_seq(self._path)
         return append_run_event(

--- a/tests/test_metering_journal_bloat.py
+++ b/tests/test_metering_journal_bloat.py
@@ -1,0 +1,174 @@
+"""Run-journal telemetry bloat regression tests.
+
+A long, reasoning-heavy live run journals ``metering`` snapshots at ~10 Hz.
+Because every journaled frame is later replayed to a reconnecting browser
+(hard refresh mid-run), a 40-minute run can produce a multi-MB journal that is
+overwhelmingly transient telemetry — the replay burst then kills the tab
+(observed in production: 18 MB / 39k events, 97% metering + reasoning deltas;
+browser OOM on refresh while the server stayed up).
+
+The fix has two halves, each with a pinned invariant:
+
+1. **Write time** — ``RunJournalWriter.append_sse_event`` (the shared
+   chokepoint for every SSE frame streamed.py / gateway_chat.py journal via
+   ``put()``) skips ``metering`` frames entirely. Metering is live-UI
+   telemetry (TPS label, usage indicator): nothing reconstructs transcript
+   state from it, so journaling it has no recovery value.
+2. **Replay time** — legacy journals already contain metering rows, and the
+   replay readers' cursor/coverage math MUST keep seeing them (filtering
+   inside the readers would break ``_run_journal_covers_offline_gap``'s seq
+   counting and ``read_session_run_events``' ``cursor_event_missing`` bound).
+   So filtering happens at the SSE emit sites only.
+
+This suite pins: the writer skip, the replay-visible predicate, the
+readers-must-not-filter contract (cursor math on a legacy journal), and the
+emit-site filters.
+"""
+from pathlib import Path
+
+from api.run_journal import (
+    RunJournalWriter,
+    journal_replay_visible,
+    read_run_events,
+    read_session_run_events,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_SRC = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def _write_legacy_journal_with_metering(tmp_path) -> Path:
+    """Hand-write a journal shaped like pre-fix production data: metering
+    rows interleaved with token rows, contiguous seqs."""
+    import json
+
+    journal_dir = tmp_path / "_run_journal" / "session_1"
+    journal_dir.mkdir(parents=True)
+    rows = []
+    for seq in range(1, 7):
+        if seq % 2 == 0:
+            rows.append(
+                {"event": "metering", "seq": seq, "event_id": f"run_1:{seq}",
+                 "run_id": "run_1", "session_id": "session_1", "payload": {"tps": 1}}
+            )
+        else:
+            rows.append(
+                {"event": "token", "seq": seq, "event_id": f"run_1:{seq}",
+                 "run_id": "run_1", "session_id": "session_1", "payload": {"text": f"t{seq}"}}
+            )
+    path = journal_dir / "run_1.jsonl"
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+    return path
+
+
+# ── Write-time skip ──────────────────────────────────────────────────────────
+
+
+def test_writer_does_not_journal_metering(tmp_path):
+    writer = RunJournalWriter("session_1", "run_1", session_dir=tmp_path)
+
+    journaled_metering = writer.append_sse_event("metering", {"tps": 12.5})
+    first = writer.append_sse_event("token", {"text": "hello"})
+    journaled_metering_2 = writer.append_sse_event("metering", {"tps": 10.1})
+    second = writer.append_sse_event("token", {"text": "world"})
+    done = writer.append_sse_event("done", {"session": {"session_id": "session_1"}})
+
+    # Metering frames return a not-journaled marker (falsy, no event_id) so
+    # put() callers leave their journal-id plumbing untouched.
+    assert not journaled_metering
+    assert not journaled_metering_2
+    assert first["seq"] == 1
+    assert second["seq"] == 2
+    assert done["seq"] == 3
+    assert done["terminal"] is True
+
+    journal = read_run_events("session_1", "run_1", session_dir=tmp_path)
+    names = [event["event"] for event in journal["events"]]
+
+    # Content and terminal events survive; telemetry does not.
+    assert names == ["token", "token", "done"]
+    # Seqs stay gapless and contiguous after the skips.
+    assert [event["seq"] for event in journal["events"]] == [1, 2, 3]
+
+
+# ── Replay-visible predicate ─────────────────────────────────────────────────
+
+
+def test_journal_replay_visible_skips_only_metering():
+    assert journal_replay_visible({"event": "metering"}) is False
+    assert journal_replay_visible({"event": "token"}) is True
+    assert journal_replay_visible({"event": "reasoning"}) is True
+    assert journal_replay_visible({"event": "done"}) is True
+    # Fail open to content: unknown / missing names stay visible.
+    assert journal_replay_visible({"event": "future_event"}) is True
+    assert journal_replay_visible({}) is True
+    assert journal_replay_visible("not-a-dict") is True
+
+
+# ── Readers must NOT filter (cursor + coverage contract) ─────────────────────
+
+
+def test_per_run_reader_keeps_metering_rows_for_cursor_math(tmp_path):
+    """read_run_events feeds _run_journal_covers_offline_gap, which counts
+    seqs in (floor, cutoff] to prove an offline gap is backfilled. Filtering
+    metering rows here would make coverage falsely fail on legacy journals."""
+    _write_legacy_journal_with_metering(tmp_path)
+
+    journal = read_run_events("session_1", "run_1", session_dir=tmp_path)
+    assert [event["seq"] for event in journal["events"]] == [1, 2, 3, 4, 5, 6]
+    assert journal["events"][1]["event"] == "metering"
+
+
+def test_session_replay_reader_keeps_metering_rows_for_cursor_math(tmp_path):
+    """read_session_run_events must resolve a cursor pointing at a HIGH seq
+    even when most rows below it are metering (the production fat journal:
+    18k metering rows interleaved with content). Filtering would trip
+    cursor_event_missing and break resume entirely."""
+    _write_legacy_journal_with_metering(tmp_path)
+
+    result = read_session_run_events(
+        "session_1", after_event_id="run_1:5", session_dir=tmp_path
+    )
+    assert result["status"] == "ok"
+    assert [event["seq"] for event in result["events"]] == [6]
+
+
+# ── Emit-site filters (static contract, mirrors repo's static-test style) ────
+
+
+def test_per_run_replay_emitter_filters_metering():
+    """_replay_run_journal serves the dead-stream replay and the offline-gap
+    replay; its emit loop must skip metering rows."""
+    replay_idx = ROUTES_SRC.index("def _replay_run_journal(")
+    replay_end = ROUTES_SRC.index("def _run_journal_same_run_seq(", replay_idx)
+    replay_block = ROUTES_SRC[replay_idx:replay_end]
+    assert "journal_replay_visible" in replay_block, (
+        "_replay_run_journal must filter rows via journal_replay_visible"
+    )
+
+
+def test_cross_run_replay_emitter_filters_metering():
+    """emit_replay (cross-run session replay in the session-events SSE
+    handler) must skip metering rows before writing SSE frames."""
+    emit_idx = ROUTES_SRC.index("def emit_replay(")
+    emit_end = ROUTES_SRC.index("def emit_session_snapshot(", emit_idx)
+    emit_block = ROUTES_SRC[emit_idx:emit_end]
+    assert "journal_replay_visible" in emit_block, (
+        "emit_replay must filter rows via journal_replay_visible"
+    )
+
+
+def test_writer_skip_is_in_the_shared_chokepoint():
+    """The write-time skip must live in RunJournalWriter.append_sse_event —
+    the one place both streaming.put() and gateway_chat.put_gateway_event()
+    journal through — not duplicated at each producer."""
+    journal_src = (ROOT / "api" / "run_journal.py").read_text(encoding="utf-8")
+    append_idx = journal_src.index("def append_sse_event(self, event_name")
+    body_end = journal_src.index("def read_run_events(", append_idx)
+    append_block = journal_src[append_idx:body_end]
+    assert "REPLAY_SKIPPED_SSE_EVENTS" in append_block, (
+        "append_sse_event must skip journaling REPLAY_SKIPPED_SSE_EVENTS"
+    )


### PR DESCRIPTION
## What

Stop journaling `metering` telemetry, and filter it from journal replay. Fixes the browser-tab OOM crash-loop on mid-run refresh described in #7272.

## Why

Observed in production (single 40-minute reasoning-heavy run): an 18 MB / 39k-event run journal that was **97% transient telemetry** — 18.5k `metering` rows (12.4 MB, journaled at ~10 Hz per the 100ms throttle in `_emit_metering`) + 18k `reasoning` deltas, vs 650 KB of actual token content. Because every journaled frame replays to a reconnecting client, the hard-refresh burst delivered ~39k unpaced SSE frames to the tab and OOMed it — repeatedly — while the server stayed up. It also made every `/api/session` poll re-parse and re-compact the growing journal (`[SLOW] ... compact=1800-2600ms` per poll).

Metering has no recovery value: `_run_journal_has_visible_output` counts only token/interim/reasoning/tool rows; the live-snapshot builder ignores metering; the SSE taxonomy carries it as live-UI payload (TPS/usage indicator). A replayed metering snapshot's only effect is re-painting a stale TPS number while multiplying the reconnect burst ~50x by row count.

## The change

**Write time — the chokepoint, not the instances:** `RunJournalWriter.append_sse_event` skips `REPLAY_SKIPPED_SSE_EVENTS = {"metering"}` and returns `None`. Every SSE producer (`api/streaming.py` `put()`, `api/gateway_chat.py` `put_gateway_event()`) journals through this one method, so a single guard covers all of them; callers' journal-id plumbing is untouched (a `None` return leaves `event_id` falsy, so the frame is delivered id-less exactly like pre-journal legacy events — no queue-shape or drain-loop changes).

**Replay time — emit sites only:** the two SSE emit loops (`_replay_run_journal` for dead-stream/gap replay, `emit_replay` for cross-run session replay) skip metering rows via the new `journal_replay_visible()` predicate, so legacy journals that already contain the telemetry backlog never stream it to a reconnecting client.

**Readers deliberately do NOT filter.** `read_run_events` / `read_session_run_events` keep returning every row: `read_session_run_events`' `cursor_event_missing` bound compares the cursor seq against the full row count, and routes.py's `_run_journal_covers_offline_gap` counts journal seqs in `(floor, cutoff]` to prove an offline gap was backfilled — filtering inside the readers would break cursor resolution and falsely report uncovered gaps on legacy journals. This contract is pinned by test.

## Siblings checked (GUIDELINES #1: fix the class)

- `append_run_event` (the free function) is only called by `RunJournalWriter.append_sse_event` itself in production paths; the writer guard therefore covers it. The turn journal (`worker_started` events) is a separate file and never carries metering.
- The 4 other `put('metering', ...)` call sites in streaming.py all flow through `put()` → writer; no direct `append_run_event('metering')` exists anywhere.
- Gateway-side `put_gateway_event` mirrors `put()` and journals through the same writer — covered.
- Frontend `runJournalEventName` listener list includes `metering`, which is harmless: with the emit-site filters, replayed journals contain no metering frames at all, and live metering frames are delivered as before (id-less).

## Tests

New `tests/test_metering_journal_bloat.py` (TDD — written first, all 8 initial assertions failed against `master`, then green after the fix):

- writer skip: metering returns falsy, seqs stay gapless, content + terminal events survive
- `journal_replay_visible` predicate: skips only `metering`, fails open to unknown events
- readers-keep-rows contract: legacy journal with interleaved metering keeps all 6 rows; high-seq cursor resolves (`run_1:5` → resumes at 6, no `cursor_event_missing`)
- emit-site filters at both replay paths (static contract, matching the repo's existing static-test style for these loops)

Regression sweep (repo `.venv`, Python 3.11): run-journal family + stage-364 id contract + metering/TPS instrumentation + reasoning/recovered-context replay + gateway SSE reconnect dedupe + turn-journal lifecycle — **404 tests, all green**. Not run: full browser suite (`tests/browser_*.py` needs a live browser environment); the changed code paths are all server-side Python.

## Verification I could not do

No live mid-run refresh test in a real browser against a legacy fat journal (needs a marathon reasoning run to reproduce). The emit-site filter is exercised by unit test only; the write-time skip will be verified in production after deploy by inspecting the next run's journal composition.

Closes #7272
