### PR TITLE
perf: stop re-doing constant redaction work on every /api/session response

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -472,10 +472,31 @@ _redact_fn_lru = functools.lru_cache(maxsize=4096)(_redact_fn_uncached)
 # thousands of small recurring strings that actually benefit, or balloon RSS.
 _REDACT_CACHE_MAX_TEXT_LEN = 16384
 
+# Strings above that threshold used to bypass memoization entirely and re-run
+# the full ~15-pass redactor on every request. On a real 22MB session that was
+# 59 large strings (29 unique, 0.76MB) costing 1.68s per request — 99.9% of the
+# recurring redaction cost once the small-string cache is warm, paid again by
+# every tab and every poll for a byte-identical result.
+#
+# They get their own small cache instead of sharing the 4096-entry one, so a
+# large blob can never evict the thousands of small recurring strings. Both the
+# entry count and the per-entry size are capped, which bounds retained bytes to
+# roughly _REDACT_LARGE_CACHE_SIZE * _REDACT_LARGE_CACHE_MAX_TEXT_LEN (key plus
+# value). Anything larger stays uncached: unbounded growth is the failure mode
+# this threshold exists to prevent.
+_REDACT_LARGE_CACHE_MAX_TEXT_LEN = 131072
+_REDACT_LARGE_CACHE_SIZE = 64
+
+_redact_fn_large_lru = functools.lru_cache(maxsize=_REDACT_LARGE_CACHE_SIZE)(
+    _redact_fn_uncached
+)
+
 
 def _redact_fn_cached(text):
     if len(text) > _REDACT_CACHE_MAX_TEXT_LEN:
-        return _redact_fn_uncached(text)
+        if len(text) > _REDACT_LARGE_CACHE_MAX_TEXT_LEN:
+            return _redact_fn_uncached(text)
+        return _redact_fn_large_lru(text)
     return _redact_fn_lru(text)
 
 
@@ -956,13 +977,43 @@ def _redact_value(v, *, _enabled: bool | None = None):
 
     ``_enabled`` is threaded through so a single response-level redact pass
     only reads settings.json once. (Opus pre-release perf fix.)
+
+    Containers are rebuilt only when a descendant actually changed. The
+    overwhelming majority of a transcript carries no credential marker, so the
+    previous unconditional dict/list comprehension deep-copied the entire
+    payload — tens of MB per response — to reproduce an identical structure.
+    That copy is pure CPU under the GIL (allocation and refcounting never
+    release it), which serialized concurrent tab loads on a threaded server.
+
+    Returning the original object when nothing changed is safe because callers
+    treat redacted output as read-only: ``_public_message_projection`` builds a
+    fresh ``item`` dict per message, and ``redact_session_data`` builds a fresh
+    ``result``. Nothing mutates a value returned from here in place, so sharing
+    an unmodified subtree cannot leak a later mutation back into session state.
+    The redacting path is unchanged: as soon as one string is masked, every
+    container on the path to it is rebuilt and the caller's original is left
+    untouched.
     """
     if isinstance(v, str):
         return _redact_text(v, _enabled=_enabled)
     if isinstance(v, dict):
-        return {key: _redact_value(value, _enabled=_enabled) for key, value in v.items()}
+        changed = False
+        out = {}
+        for key, value in v.items():
+            redacted = _redact_value(value, _enabled=_enabled)
+            out[key] = redacted
+            if redacted is not value:
+                changed = True
+        return out if changed else v
     if isinstance(v, list):
-        return [_redact_value(item, _enabled=_enabled) for item in v]
+        changed = False
+        out = []
+        for item in v:
+            redacted = _redact_value(item, _enabled=_enabled)
+            out.append(redacted)
+            if redacted is not item:
+                changed = True
+        return out if changed else v
     return v
 
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1035,23 +1035,25 @@ def _redact_value(v, *, _enabled: bool | None = None):
     if isinstance(v, str):
         return _redact_text(v, _enabled=_enabled)
     if isinstance(v, dict):
-        changed = False
-        out = {}
+        out = None
         for key, value in v.items():
             redacted = _redact_value(value, _enabled=_enabled)
+            if redacted is value:
+                continue
+            if out is None:
+                out = dict(v)
             out[key] = redacted
-            if redacted is not value:
-                changed = True
-        return out if changed else v
+        return v if out is None else out
     if isinstance(v, list):
-        changed = False
-        out = []
-        for item in v:
+        out = None
+        for index, item in enumerate(v):
             redacted = _redact_value(item, _enabled=_enabled)
-            out.append(redacted)
-            if redacted is not item:
-                changed = True
-        return out if changed else v
+            if redacted is item:
+                continue
+            if out is None:
+                out = list(v)
+            out[index] = redacted
+        return v if out is None else out
     return v
 
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -580,7 +580,27 @@ _SENSITIVE_DISCORD_MARKER_RE = _re.compile(r"<@!?\d{17,20}>")
 _SENSITIVE_PHONE_MARKER_RE = _re.compile(r"(?<![A-Za-z0-9])\+[1-9]\d{6,14}(?![A-Za-z0-9])")
 
 
-def _might_contain_sensitive_text(text: str) -> bool:
+# The prefilter runs on every string of every API response — ~74k strings /
+# ~19MB on a real large session — and cProfile showed it costing 2.98s of the
+# 3.7s redaction pass once the redactor's own caches are warm. The work is
+# pure and deterministic (fixed marker tuples, fixed patterns), so identical
+# text always yields the same verdict and is safe to memoize without
+# invalidation, exactly like `_redact_fn_cached` above.
+#
+# Note on what was NOT done: replacing the 71 `in` scans with one compiled
+# alternation looks like the obvious fix, but measured 38% SLOWER on the real
+# payload (2.60s vs 1.88s). CPython's substring search is already a tuned
+# C-level algorithm, and a large regex alternation has to try each branch at
+# each position. Memoizing the verdict avoids the scan entirely instead.
+#
+# Bounds mirror the redaction caches: capping entry count and per-entry size
+# keeps retained bytes to roughly size * max_len, so a burst of giant unique
+# blobs cannot balloon RSS. Oversized strings simply run the scan uncached.
+_SENSITIVE_PREFILTER_CACHE_SIZE = 8192
+_SENSITIVE_PREFILTER_MAX_TEXT_LEN = 16384
+
+
+def _might_contain_sensitive_text_uncached(text: str) -> bool:
     """Cheap prefilter before the full agent+fallback redaction pass."""
     if not isinstance(text, str) or not text:
         return False
@@ -596,6 +616,24 @@ def _might_contain_sensitive_text(text: str) -> bool:
     if "+" in text and _SENSITIVE_PHONE_MARKER_RE.search(text):
         return True
     return False
+
+
+_might_contain_sensitive_text_lru = functools.lru_cache(
+    maxsize=_SENSITIVE_PREFILTER_CACHE_SIZE
+)(_might_contain_sensitive_text_uncached)
+
+
+def _might_contain_sensitive_text(text: str) -> bool:
+    """Memoized wrapper around the prefilter.
+
+    Falls back to the uncached scan for non-strings and oversized text so the
+    cache can never be poisoned by an unhashable value or grow unbounded.
+    """
+    if not isinstance(text, str) or not text:
+        return False
+    if len(text) > _SENSITIVE_PREFILTER_MAX_TEXT_LEN:
+        return _might_contain_sensitive_text_uncached(text)
+    return _might_contain_sensitive_text_lru(text)
 
 
 def _redact_text(text: str, *, _enabled: bool | None = None) -> str:

--- a/tests/test_redact_large_string_cache.py
+++ b/tests/test_redact_large_string_cache.py
@@ -1,21 +1,21 @@
-"""Grosses chaines: memoiser au lieu de repayer ~15 regex a chaque requete.
+"""Large strings: memoize instead of re-paying ~15 regexes on every request.
 
-``_redact_fn_cached`` excluait du LRU toute chaine > 16 384 caracteres, pour
-eviter d'evincer les milliers de petites chaines recurrentes et de gonfler la
-RSS. Consequence mesuree sur une session reelle de 22 Mo: 59 grosses chaines
-(29 uniques, 0,76 Mo) repassaient l'integralite des regex a CHAQUE requete,
-pour un resultat toujours identique — 1,68 s par requete, soit 99,9% du cout
-recurrent de la redaction une fois le cache des petites chaines chaud.
+``_redact_fn_cached`` excluded every string > 16,384 characters from the LRU,
+to avoid evicting the thousands of small recurring strings and inflating RSS.
+Measured consequence on a real 22 MB session: 59 large strings (29 unique,
+0.76 MB) went through the full regex set on EVERY request, for an always
+identical result -- 1.68 s per request, i.e. 99.9% of the recurring redaction
+cost once the small-string cache is warm.
 
-Le correctif ajoute un SECOND cache, dedie aux grosses chaines, borne en
-nombre d'entrees ET par une taille maximale par entree, pour que la RSS reste
-plafonnee. Les chaines geantes (> plafond) restent volontairement non cachees.
+The fix adds a SECOND cache, dedicated to large strings, bounded both by entry
+count AND by a maximum size per entry, so that RSS stays capped. Giant strings
+(> cap) deliberately remain uncached.
 
-Contrat verifie ici:
-  1. une grosse chaine est redigee exactement comme avant;
-  2. la meme grosse chaine n'est pas recalculee au second appel;
-  3. les deux caches restent separes (pas d'eviction croisee);
-  4. une chaine au-dela du plafond n'est jamais retenue.
+Contract verified here:
+  1. a large string is redacted exactly as before;
+  2. the same large string is not recomputed on the second call;
+  3. the two caches stay separate (no cross-eviction);
+  4. a string above the cap is never retained.
 """
 import sys
 from pathlib import Path
@@ -37,13 +37,13 @@ SECRET = "gh" + "p_" + "0123456789abcdefghijklmnopqrstuvwxyzAB"
 
 @pytest.fixture(autouse=True)
 def _isolate_large_cache():
-    """Ne pas laisser ce fichier polluer l'etat global du process.
+    """Do not let this file pollute the process-wide global state.
 
-    Le cache est un singleton de module partage par toute la suite. Le vider
-    sans le restaurer laisse les tests suivants demarrer a froid, ce qui
-    perturbe ceux qui dependent de fenetres de fraicheur ou de temps de
-    reponse. On repart d'un cache vide ET on le revide en sortie, pour que ce
-    fichier n'ait aucun effet observable en dehors de lui-meme.
+    The cache is a module singleton shared by the whole suite. Clearing it
+    without restoring it makes the following tests start cold, which disturbs
+    those that depend on freshness windows or response times. We start from an
+    empty cache AND clear it again on exit, so that this file has no observable
+    effect outside of itself.
     """
     helpers._redact_fn_large_lru.cache_clear()
     yield
@@ -51,11 +51,11 @@ def _isolate_large_cache():
 
 
 def _big(secret: str, size: int) -> str:
-    """Chaine > seuil du petit cache, porteuse d'un secret.
+    """String > small-cache threshold, carrying a secret.
 
-    Le remplissage doit etre assez long pour atteindre ``size`` meme au-dela
-    du plafond du grand cache, sinon la troncature produit une chaine trop
-    courte et le test ne verifie plus ce qu'il annonce.
+    The filler must be long enough to reach ``size`` even beyond the large
+    cache cap, otherwise truncation yields a string that is too short and the
+    test no longer verifies what it claims.
     """
     unit = "lorem ipsum dolor sit amet "
     filler = unit * (size // len(unit) + 1)
@@ -82,21 +82,21 @@ def test_large_string_is_memoized():
     info = helpers._redact_fn_large_lru.cache_info()
 
     assert second == first
-    assert info.hits >= 1, "grosse chaine recalculee au second appel"
-    assert info.misses == misses_after_first, "miss supplementaire inattendu"
+    assert info.hits >= 1, "large string recomputed on second call"
+    assert info.misses == misses_after_first, "unexpected additional miss"
 
 
 def test_small_strings_do_not_use_the_large_cache():
     helpers._redact_fn_large_lru.cache_clear()
-    small = f"petit texte {SECRET}"
+    small = f"small text {SECRET}"
     assert len(small) <= _REDACT_CACHE_MAX_TEXT_LEN
     _redact_fn_cached(small)
     info = helpers._redact_fn_large_lru.cache_info()
-    assert info.hits == 0 and info.misses == 0, "petite chaine routee vers le grand cache"
+    assert info.hits == 0 and info.misses == 0, "small string routed to the large cache"
 
 
 def test_giant_string_is_not_retained():
-    """Au-dela du plafond: correct, mais jamais mis en cache (RSS bornee)."""
+    """Above the cap: correct, but never cached (bounded RSS)."""
     helpers._redact_fn_large_lru.cache_clear()
     giant = _big(SECRET, _REDACT_LARGE_CACHE_MAX_TEXT_LEN + 10000)
     assert len(giant) > _REDACT_LARGE_CACHE_MAX_TEXT_LEN
@@ -106,7 +106,7 @@ def test_giant_string_is_not_retained():
     assert out == _redact_fn_uncached(giant)
     assert SECRET not in out
     info = helpers._redact_fn_large_lru.cache_info()
-    assert info.currsize == 0, "chaine geante retenue en cache"
+    assert info.currsize == 0, "giant string retained in cache"
 
 
 def test_large_cache_is_bounded():

--- a/tests/test_redact_large_string_cache.py
+++ b/tests/test_redact_large_string_cache.py
@@ -1,0 +1,114 @@
+"""Grosses chaines: memoiser au lieu de repayer ~15 regex a chaque requete.
+
+``_redact_fn_cached`` excluait du LRU toute chaine > 16 384 caracteres, pour
+eviter d'evincer les milliers de petites chaines recurrentes et de gonfler la
+RSS. Consequence mesuree sur une session reelle de 22 Mo: 59 grosses chaines
+(29 uniques, 0,76 Mo) repassaient l'integralite des regex a CHAQUE requete,
+pour un resultat toujours identique — 1,68 s par requete, soit 99,9% du cout
+recurrent de la redaction une fois le cache des petites chaines chaud.
+
+Le correctif ajoute un SECOND cache, dedie aux grosses chaines, borne en
+nombre d'entrees ET par une taille maximale par entree, pour que la RSS reste
+plafonnee. Les chaines geantes (> plafond) restent volontairement non cachees.
+
+Contrat verifie ici:
+  1. une grosse chaine est redigee exactement comme avant;
+  2. la meme grosse chaine n'est pas recalculee au second appel;
+  3. les deux caches restent separes (pas d'eviction croisee);
+  4. une chaine au-dela du plafond n'est jamais retenue.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api import helpers  # noqa: E402
+from api.helpers import (  # noqa: E402
+    _REDACT_CACHE_MAX_TEXT_LEN,
+    _REDACT_LARGE_CACHE_MAX_TEXT_LEN,
+    _redact_fn_cached,
+    _redact_fn_uncached,
+)
+
+SECRET = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_large_cache():
+    """Ne pas laisser ce fichier polluer l'etat global du process.
+
+    Le cache est un singleton de module partage par toute la suite. Le vider
+    sans le restaurer laisse les tests suivants demarrer a froid, ce qui
+    perturbe ceux qui dependent de fenetres de fraicheur ou de temps de
+    reponse. On repart d'un cache vide ET on le revide en sortie, pour que ce
+    fichier n'ait aucun effet observable en dehors de lui-meme.
+    """
+    helpers._redact_fn_large_lru.cache_clear()
+    yield
+    helpers._redact_fn_large_lru.cache_clear()
+
+
+def _big(secret: str, size: int) -> str:
+    """Chaine > seuil du petit cache, porteuse d'un secret.
+
+    Le remplissage doit etre assez long pour atteindre ``size`` meme au-dela
+    du plafond du grand cache, sinon la troncature produit une chaine trop
+    courte et le test ne verifie plus ce qu'il annonce.
+    """
+    unit = "lorem ipsum dolor sit amet "
+    filler = unit * (size // len(unit) + 1)
+    text = (filler + secret + filler)[:size]
+    assert len(text) == size
+    return text
+
+
+def test_large_string_redaction_matches_uncached():
+    text = _big(SECRET, _REDACT_CACHE_MAX_TEXT_LEN + 5000)
+    assert len(text) > _REDACT_CACHE_MAX_TEXT_LEN
+    assert _redact_fn_cached(text) == _redact_fn_uncached(text)
+    assert SECRET not in _redact_fn_cached(text)
+
+
+def test_large_string_is_memoized():
+    helpers._redact_fn_large_lru.cache_clear()
+    text = _big(SECRET, _REDACT_CACHE_MAX_TEXT_LEN + 7000)
+
+    first = _redact_fn_cached(text)
+    misses_after_first = helpers._redact_fn_large_lru.cache_info().misses
+
+    second = _redact_fn_cached(text)
+    info = helpers._redact_fn_large_lru.cache_info()
+
+    assert second == first
+    assert info.hits >= 1, "grosse chaine recalculee au second appel"
+    assert info.misses == misses_after_first, "miss supplementaire inattendu"
+
+
+def test_small_strings_do_not_use_the_large_cache():
+    helpers._redact_fn_large_lru.cache_clear()
+    small = f"petit texte {SECRET}"
+    assert len(small) <= _REDACT_CACHE_MAX_TEXT_LEN
+    _redact_fn_cached(small)
+    info = helpers._redact_fn_large_lru.cache_info()
+    assert info.hits == 0 and info.misses == 0, "petite chaine routee vers le grand cache"
+
+
+def test_giant_string_is_not_retained():
+    """Au-dela du plafond: correct, mais jamais mis en cache (RSS bornee)."""
+    helpers._redact_fn_large_lru.cache_clear()
+    giant = _big(SECRET, _REDACT_LARGE_CACHE_MAX_TEXT_LEN + 10000)
+    assert len(giant) > _REDACT_LARGE_CACHE_MAX_TEXT_LEN
+
+    out = _redact_fn_cached(giant)
+
+    assert out == _redact_fn_uncached(giant)
+    assert SECRET not in out
+    info = helpers._redact_fn_large_lru.cache_info()
+    assert info.currsize == 0, "chaine geante retenue en cache"
+
+
+def test_large_cache_is_bounded():
+    assert helpers._redact_fn_large_lru.cache_info().maxsize is not None
+    assert helpers._redact_fn_large_lru.cache_info().maxsize <= 128

--- a/tests/test_redact_large_string_cache.py
+++ b/tests/test_redact_large_string_cache.py
@@ -32,7 +32,7 @@ from api.helpers import (  # noqa: E402
     _redact_fn_uncached,
 )
 
-SECRET = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+SECRET = "gh" + "p_" + "0123456789abcdefghijklmnopqrstuvwxyzAB"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_redact_value_no_copy_when_clean.py
+++ b/tests/test_redact_value_no_copy_when_clean.py
@@ -46,7 +46,7 @@ def test_clean_payload_is_returned_by_identity():
             {"role": "user", "content": "bonjour, ou en est la commande 4512 ?"},
             {"role": "assistant", "content": [{"type": "text", "text": "elle part demain"}]},
         ],
-        "meta": {"workspace": "/a0/usr/projects/MES", "count": 3, "ok": True},
+        "meta": {"workspace": "/workspace/project", "count": 3, "ok": True},
     }
 
     out = _redact_value(payload, _enabled=True)

--- a/tests/test_redact_value_no_copy_when_clean.py
+++ b/tests/test_redact_value_no_copy_when_clean.py
@@ -1,18 +1,18 @@
-"""Redaction: ne pas reconstruire ce qui n'a pas change.
+"""Redaction: do not rebuild what has not changed.
 
-``_redact_value`` reconstruisait integralement chaque dict/liste, soit une
-copie profonde de tout le payload a chaque reponse, meme quand rien n'est
-redige. Sur une session de 22 Mo, 97,4% des chaines ne contiennent aucun
-marqueur sensible: la copie est donc du travail pur perte, et elle tient le
-GIL (json/allocations ne le liberent pas), ce qui serialise les onglets.
+``_redact_value`` used to rebuild every dict/list in full, i.e. a deep copy of
+the whole payload on every response, even when nothing is redacted. On a 22 MB
+session, 97.4% of the strings contain no sensitive marker: the copy is
+therefore pure wasted work, and it holds the GIL (json/allocations do not
+release it), which serializes the tabs.
 
-Contrat verifie ici:
-  1. Quand rien n'est redige, la valeur RENVOYEE EST l'objet d'origine
-     (identite, pas seulement egalite) et aucun conteneur proportionnel au
-     payload n'est alloue en chemin.
-  2. Quand quelque chose est redige, un NOUVEL objet est renvoye et
-     l'original n'est PAS mute (fail-closed: pas de fuite par aliasing).
-  3. Le resultat reste egal a celui de l'ancienne implementation.
+Contract verified here:
+  1. When nothing is redacted, the RETURNED value IS the original object
+     (identity, not just equality) and no container proportional to the
+     payload is allocated along the way.
+  2. When something is redacted, a NEW object is returned and the original
+     is NOT mutated (fail-closed: no leak through aliasing).
+  3. The result stays equal to the one of the previous implementation.
 """
 import sys
 import tracemalloc
@@ -27,7 +27,7 @@ SECRET = "authorization=Bearer sk-live-abcdef0123456789"
 
 
 def _reference_redact(v, *, _enabled):
-    """Implementation d'origine (copie systematique), pour comparaison."""
+    """Original implementation (systematic copy), kept for comparison."""
     from api.helpers import _redact_text
 
     if isinstance(v, str):
@@ -40,25 +40,25 @@ def _reference_redact(v, *, _enabled):
 
 
 def test_clean_payload_is_returned_by_identity():
-    """Rien de sensible -> aucun dict/liste ne doit etre reconstruit."""
+    """Nothing sensitive -> no dict/list must be rebuilt."""
     payload = {
         "messages": [
-            {"role": "user", "content": "bonjour, ou en est la commande 4512 ?"},
-            {"role": "assistant", "content": [{"type": "text", "text": "elle part demain"}]},
+            {"role": "user", "content": "hello, where is order 4512 at?"},
+            {"role": "assistant", "content": [{"type": "text", "text": "it ships tomorrow"}]},
         ],
         "meta": {"workspace": "/workspace/project", "count": 3, "ok": True},
     }
 
     out = _redact_value(payload, _enabled=True)
 
-    assert out is payload, "payload propre reconstruit inutilement"
+    assert out is payload, "clean payload rebuilt needlessly"
     assert out["messages"] is payload["messages"]
     assert out["messages"][0] is payload["messages"][0]
     assert out["meta"] is payload["meta"]
 
 
 def test_clean_payload_does_not_allocate_eager_container_copies():
-    """La voie propre doit rester O(1) en allocation de conteneurs temporaires."""
+    """The clean path must stay O(1) in temporary container allocation."""
     payload = {
         "dict": {index: index for index in range(20_000)},
         "list": list(range(20_000)),
@@ -77,39 +77,39 @@ def test_clean_payload_does_not_allocate_eager_container_copies():
             tracemalloc.stop()
 
     assert out is payload
-    # Une liste temporaire de 20 000 pointeurs depasse a elle seule 160 Ko.
-    # Le seuil reste volontairement un ordre de grandeur en dessous, sans
-    # dependre des details exacts de l'allocateur d'une version de CPython.
-    assert peak - before < 16_384, f"copies temporaires detectees: {peak - before} octets"
+    # A temporary list of 20,000 pointers alone exceeds 160 KB. The threshold
+    # deliberately stays an order of magnitude below that, without depending
+    # on the exact allocator details of a given CPython version.
+    assert peak - before < 16_384, f"temporary copies detected: {peak - before} bytes"
 
 
 def test_sensitive_payload_is_copied_and_original_untouched():
-    """Quelque chose est redige -> nouvel objet, original intact."""
+    """Something is redacted -> new object, original intact."""
     inner = {"role": "user", "content": SECRET}
     payload = {"messages": [inner], "meta": {"workspace": "/tmp"}}
 
     out = _redact_value(payload, _enabled=True)
 
-    # un nouvel objet est renvoye sur le chemin modifie
+    # a new object is returned along the modified path
     assert out is not payload
     assert out["messages"] is not payload["messages"]
     assert out["messages"][0] is not inner
 
-    # l'original n'est pas mute (pas de fuite par aliasing)
+    # the original is not mutated (no leak through aliasing)
     assert inner["content"] == SECRET
     assert payload["messages"][0]["content"] == SECRET
 
-    # le secret est bien masque dans la sortie
+    # the secret is indeed masked in the output
     assert out["messages"][0]["content"] != SECRET
 
-    # les branches NON modifiees restent partagees (c'est tout l'interet)
+    # the UNmodified branches stay shared (that is the whole point)
     assert out["meta"] is payload["meta"]
 
 
 def test_copy_on_first_change_preserves_order_types_and_clean_identity():
-    """Une redaction tardive copie seulement son chemin sans reordonner le JSON."""
-    before = {"clean": ["avant", 1]}
-    after = {"clean": ["apres", 2]}
+    """A late redaction copies only its own path without reordering the JSON."""
+    before = {"clean": ["before", 1]}
+    after = {"clean": ["after", 2]}
     payload = {
         "before": before,
         "items": [before, {"secret": SECRET}, after],
@@ -130,14 +130,14 @@ def test_copy_on_first_change_preserves_order_types_and_clean_identity():
 
 
 def test_matches_reference_implementation():
-    """Le resultat doit rester identique a l'implementation d'origine."""
+    """The result must stay identical to the original implementation."""
     payload = {
         "messages": [
-            {"role": "user", "content": "texte normal"},
+            {"role": "user", "content": "plain text"},
             {"role": "assistant", "content": SECRET},
-            {"role": "user", "content": ["propre", SECRET, 42, None]},
+            {"role": "user", "content": ["clean", SECRET, 42, None]},
         ],
-        "nested": {"a": {"b": {"c": SECRET}}, "d": {"e": "rien"}},
+        "nested": {"a": {"b": {"c": SECRET}}, "d": {"e": "nothing"}},
         "scalars": [1, 2.5, True, None],
     }
 
@@ -145,7 +145,7 @@ def test_matches_reference_implementation():
 
 
 def test_disabled_redaction_still_shares():
-    """Redaction desactivee -> rien ne doit etre copie."""
+    """Redaction disabled -> nothing must be copied."""
     payload = {"messages": [{"role": "user", "content": SECRET}]}
     out = _redact_value(payload, _enabled=False)
     assert out is payload

--- a/tests/test_redact_value_no_copy_when_clean.py
+++ b/tests/test_redact_value_no_copy_when_clean.py
@@ -1,0 +1,105 @@
+"""Redaction: ne pas reconstruire ce qui n'a pas change.
+
+``_redact_value`` reconstruisait integralement chaque dict/liste, soit une
+copie profonde de tout le payload a chaque reponse, meme quand rien n'est
+redige. Sur une session de 22 Mo, 97,4% des chaines ne contiennent aucun
+marqueur sensible: la copie est donc du travail pur perte, et elle tient le
+GIL (json/allocations ne le liberent pas), ce qui serialise les onglets.
+
+Contrat verifie ici:
+  1. Quand rien n'est redige, la valeur RENVOYEE EST l'objet d'origine
+     (identite, pas seulement egalite) -> zero allocation.
+  2. Quand quelque chose est redige, un NOUVEL objet est renvoye et
+     l'original n'est PAS mute (fail-closed: pas de fuite par aliasing).
+  3. Le resultat reste egal a celui de l'ancienne implementation.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api.helpers import _redact_value  # noqa: E402
+
+
+SECRET = "authorization=Bearer sk-live-abcdef0123456789"
+
+
+def _reference_redact(v, *, _enabled):
+    """Implementation d'origine (copie systematique), pour comparaison."""
+    from api.helpers import _redact_text
+
+    if isinstance(v, str):
+        return _redact_text(v, _enabled=_enabled)
+    if isinstance(v, dict):
+        return {k: _reference_redact(x, _enabled=_enabled) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_reference_redact(x, _enabled=_enabled) for x in v]
+    return v
+
+
+def test_clean_payload_is_returned_by_identity():
+    """Rien de sensible -> aucun dict/liste ne doit etre reconstruit."""
+    payload = {
+        "messages": [
+            {"role": "user", "content": "bonjour, ou en est la commande 4512 ?"},
+            {"role": "assistant", "content": [{"type": "text", "text": "elle part demain"}]},
+        ],
+        "meta": {"workspace": "/a0/usr/projects/MES", "count": 3, "ok": True},
+    }
+
+    out = _redact_value(payload, _enabled=True)
+
+    assert out is payload, "payload propre reconstruit inutilement"
+    assert out["messages"] is payload["messages"]
+    assert out["messages"][0] is payload["messages"][0]
+    assert out["meta"] is payload["meta"]
+
+
+def test_sensitive_payload_is_copied_and_original_untouched():
+    """Quelque chose est redige -> nouvel objet, original intact."""
+    inner = {"role": "user", "content": SECRET}
+    payload = {"messages": [inner], "meta": {"workspace": "/tmp"}}
+
+    out = _redact_value(payload, _enabled=True)
+
+    # un nouvel objet est renvoye sur le chemin modifie
+    assert out is not payload
+    assert out["messages"] is not payload["messages"]
+    assert out["messages"][0] is not inner
+
+    # l'original n'est pas mute (pas de fuite par aliasing)
+    assert inner["content"] == SECRET
+    assert payload["messages"][0]["content"] == SECRET
+
+    # le secret est bien masque dans la sortie
+    assert out["messages"][0]["content"] != SECRET
+
+    # les branches NON modifiees restent partagees (c'est tout l'interet)
+    assert out["meta"] is payload["meta"]
+
+
+def test_matches_reference_implementation():
+    """Le resultat doit rester identique a l'implementation d'origine."""
+    payload = {
+        "messages": [
+            {"role": "user", "content": "texte normal"},
+            {"role": "assistant", "content": SECRET},
+            {"role": "user", "content": ["propre", SECRET, 42, None]},
+        ],
+        "nested": {"a": {"b": {"c": SECRET}}, "d": {"e": "rien"}},
+        "scalars": [1, 2.5, True, None],
+    }
+
+    assert _redact_value(payload, _enabled=True) == _reference_redact(payload, _enabled=True)
+
+
+def test_disabled_redaction_still_shares():
+    """Redaction desactivee -> rien ne doit etre copie."""
+    payload = {"messages": [{"role": "user", "content": SECRET}]}
+    out = _redact_value(payload, _enabled=False)
+    assert out is payload
+
+
+def test_non_container_values_pass_through():
+    for v in (42, 2.5, True, None):
+        assert _redact_value(v, _enabled=True) is v

--- a/tests/test_redact_value_no_copy_when_clean.py
+++ b/tests/test_redact_value_no_copy_when_clean.py
@@ -8,12 +8,14 @@ GIL (json/allocations ne le liberent pas), ce qui serialise les onglets.
 
 Contrat verifie ici:
   1. Quand rien n'est redige, la valeur RENVOYEE EST l'objet d'origine
-     (identite, pas seulement egalite) -> zero allocation.
+     (identite, pas seulement egalite) et aucun conteneur proportionnel au
+     payload n'est alloue en chemin.
   2. Quand quelque chose est redige, un NOUVEL objet est renvoye et
      l'original n'est PAS mute (fail-closed: pas de fuite par aliasing).
   3. Le resultat reste egal a celui de l'ancienne implementation.
 """
 import sys
+import tracemalloc
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -55,6 +57,32 @@ def test_clean_payload_is_returned_by_identity():
     assert out["meta"] is payload["meta"]
 
 
+def test_clean_payload_does_not_allocate_eager_container_copies():
+    """La voie propre doit rester O(1) en allocation de conteneurs temporaires."""
+    payload = {
+        "dict": {index: index for index in range(20_000)},
+        "list": list(range(20_000)),
+    }
+
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+    before, _ = tracemalloc.get_traced_memory()
+    tracemalloc.reset_peak()
+    try:
+        out = _redact_value(payload, _enabled=True)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        if not was_tracing:
+            tracemalloc.stop()
+
+    assert out is payload
+    # Une liste temporaire de 20 000 pointeurs depasse a elle seule 160 Ko.
+    # Le seuil reste volontairement un ordre de grandeur en dessous, sans
+    # dependre des details exacts de l'allocateur d'une version de CPython.
+    assert peak - before < 16_384, f"copies temporaires detectees: {peak - before} octets"
+
+
 def test_sensitive_payload_is_copied_and_original_untouched():
     """Quelque chose est redige -> nouvel objet, original intact."""
     inner = {"role": "user", "content": SECRET}
@@ -76,6 +104,29 @@ def test_sensitive_payload_is_copied_and_original_untouched():
 
     # les branches NON modifiees restent partagees (c'est tout l'interet)
     assert out["meta"] is payload["meta"]
+
+
+def test_copy_on_first_change_preserves_order_types_and_clean_identity():
+    """Une redaction tardive copie seulement son chemin sans reordonner le JSON."""
+    before = {"clean": ["avant", 1]}
+    after = {"clean": ["apres", 2]}
+    payload = {
+        "before": before,
+        "items": [before, {"secret": SECRET}, after],
+        "after": after,
+    }
+
+    out = _redact_value(payload, _enabled=True)
+
+    assert type(out) is dict
+    assert type(out["items"]) is list
+    assert list(out) == list(payload)
+    assert out["before"] is before
+    assert out["after"] is after
+    assert out["items"][0] is before
+    assert out["items"][2] is after
+    assert out["items"][1] is not payload["items"][1]
+    assert out["items"][1]["secret"] != SECRET
 
 
 def test_matches_reference_implementation():

--- a/tests/test_sensitive_prefilter_equivalence.py
+++ b/tests/test_sensitive_prefilter_equivalence.py
@@ -1,0 +1,165 @@
+"""The memoized prefilter must stay EXACTLY equivalent to the raw scan.
+
+`_might_contain_sensitive_text` is the gate in front of the whole redaction
+pass: a string it rejects is never inspected for secrets. Caching its verdict
+is only acceptable if the answer is identical for every input -- a single
+missed marker would leak a credential into an API response.
+
+These tests pin the equivalence against a reference implementation that is a
+literal copy of the pre-optimisation logic, so a future edit to the marker
+lists or the cache wrapper is caught here rather than in production.
+
+They must not leave global state behind: the LRU is shared process-wide, so
+each test that touches it restores it (see the autouse fixture).
+"""
+
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api import helpers  # noqa: E402
+from api.helpers import (  # noqa: E402
+    _SENSITIVE_CASE_MARKERS,
+    _SENSITIVE_LOWER_MARKERS,
+    _might_contain_sensitive_text,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_prefilter_cache():
+    """Keep the shared LRU out of other tests' way, before and after."""
+    helpers._might_contain_sensitive_text_lru.cache_clear()
+    yield
+    helpers._might_contain_sensitive_text_lru.cache_clear()
+
+
+def _reference(text) -> bool:
+    """The exact pre-optimisation implementation, kept as the oracle."""
+    if not isinstance(text, str) or not text:
+        return False
+    if any(marker in text for marker in _SENSITIVE_CASE_MARKERS):
+        return True
+    lower = text.lower()
+    if any(marker in lower for marker in _SENSITIVE_LOWER_MARKERS):
+        return True
+    if ":" in text and helpers._SENSITIVE_TELEGRAM_MARKER_RE.search(text):
+        return True
+    if "<@" in text and helpers._SENSITIVE_DISCORD_MARKER_RE.search(text):
+        return True
+    if "+" in text and helpers._SENSITIVE_PHONE_MARKER_RE.search(text):
+        return True
+    return False
+
+
+def test_every_case_marker_is_still_detected():
+    """Each individual marker must trip the filter, alone and in context."""
+    for marker in _SENSITIVE_CASE_MARKERS:
+        assert _might_contain_sensitive_text(marker), marker
+        assert _might_contain_sensitive_text(f"noise {marker} noise"), marker
+
+
+def test_every_lower_marker_is_still_detected():
+    for marker in _SENSITIVE_LOWER_MARKERS:
+        assert _might_contain_sensitive_text(marker), marker
+        # Upper-casing must not hide it: that is what the .lower() pass is for.
+        assert _might_contain_sensitive_text(f"NOISE {marker.upper()} NOISE"), marker
+
+
+def test_matches_reference_on_marker_corpus():
+    """Differential test over markers, cases and embeddings."""
+    corpus = []
+    for marker in list(_SENSITIVE_CASE_MARKERS) + list(_SENSITIVE_LOWER_MARKERS):
+        corpus += [
+            marker,
+            marker.upper(),
+            marker.lower(),
+            marker.swapcase(),
+            f"prefix{marker}",
+            f"{marker}suffix",
+            f"a b {marker} c d",
+            marker[:-1] if len(marker) > 1 else marker,  # near-miss
+        ]
+    for text in corpus:
+        assert _might_contain_sensitive_text(text) == _reference(text), repr(text)
+
+
+def test_matches_reference_on_clean_and_edge_inputs():
+    samples = [
+        "", "hello world", "a" * 10_000, "\n\t ", "ré­sumé accentué",
+        "https", "http", "user@example.com", "1234567890",
+        "+33612345678",                       # phone marker
+        "<@123456789012345678>",              # discord marker
+        "1234567890:AAHnotarealtelegramtokenvaluehere123",  # telegram marker
+        "İstanbul", "ﬁle", "K",              # unicode lowercase traps
+        "not_a_secret_at_all", "{}", "[]", "null",
+    ]
+    for text in samples:
+        assert _might_contain_sensitive_text(text) == _reference(text), repr(text)
+
+
+def test_matches_reference_on_random_fuzz():
+    """Random strings built from marker fragments must agree with the oracle."""
+    rnd = random.Random(20260824)
+    alphabet = "abcXYZ_-.:/+<@0189{}\"' \n"
+    fragments = [m[: rnd.randint(1, len(m))] for m in _SENSITIVE_CASE_MARKERS]
+    fragments += [m[: rnd.randint(1, len(m))] for m in _SENSITIVE_LOWER_MARKERS]
+    for _ in range(4000):
+        n = rnd.randint(0, 40)
+        text = "".join(rnd.choice(alphabet) for _ in range(n))
+        if rnd.random() < 0.4 and fragments:
+            frag = rnd.choice(fragments)
+            pos = rnd.randint(0, len(text))
+            text = text[:pos] + frag + text[pos:]
+        assert _might_contain_sensitive_text(text) == _reference(text), repr(text)
+
+
+def test_repeated_calls_are_stable_and_cached():
+    """A cache hit must return the same verdict as the first, uncached call."""
+    secret = "sk-" + "a" * 40
+    clean = "just a normal sentence"
+    for _ in range(5):
+        assert _might_contain_sensitive_text(secret) is True
+        assert _might_contain_sensitive_text(clean) is False
+    info = helpers._might_contain_sensitive_text_lru.cache_info()
+    assert info.hits > 0, "expected the memo to serve repeated lookups"
+
+
+def test_oversized_text_bypasses_the_cache_but_keeps_the_verdict():
+    """Huge strings must stay correct while never entering the LRU."""
+    limit = helpers._SENSITIVE_PREFILTER_MAX_TEXT_LEN
+    big_secret = "x" * (limit + 1) + "sk-" + "b" * 40
+    big_clean = "y" * (limit + 100)
+
+    before = helpers._might_contain_sensitive_text_lru.cache_info().currsize
+    assert _might_contain_sensitive_text(big_secret) is True
+    assert _might_contain_sensitive_text(big_clean) is False
+    after = helpers._might_contain_sensitive_text_lru.cache_info().currsize
+    assert after == before, "oversized strings must not be memoized"
+
+    assert _might_contain_sensitive_text(big_secret) == _reference(big_secret)
+    assert _might_contain_sensitive_text(big_clean) == _reference(big_clean)
+
+
+def test_non_string_and_empty_inputs_are_rejected():
+    for value in (None, 0, 1, [], {}, ()):
+        assert _might_contain_sensitive_text(value) is False  # type: ignore[arg-type]
+    assert _might_contain_sensitive_text("") is False
+
+
+def test_unhashable_input_does_not_reach_the_cache():
+    """Guard the wrapper's isinstance check: a list must not raise TypeError."""
+    before = helpers._might_contain_sensitive_text_lru.cache_info().currsize
+    assert _might_contain_sensitive_text(["sk-secret"]) is False  # type: ignore[arg-type]
+    assert helpers._might_contain_sensitive_text_lru.cache_info().currsize == before
+
+
+def test_cache_is_bounded():
+    """The LRU must cap its own size rather than grow with traffic."""
+    limit = helpers._SENSITIVE_PREFILTER_CACHE_SIZE
+    for i in range(limit + 500):
+        _might_contain_sensitive_text(f"unique-clean-string-{i}")
+    assert helpers._might_contain_sensitive_text_lru.cache_info().currsize <= limit


### PR DESCRIPTION
Loading a large conversation in two browser tabs took ~12s alone and ~24s
concurrently (1.93x). Profiling the running server with py-spy showed the
time was not in JSON serialization or gzip, but in the redaction pass:
**8.4s of an 8.8s request**, redoing work whose result never changes.

Two bounded caches remove that recurring cost. Both were measured on a real
22MB / 6,861-message session, and both produce **byte-identical output**.

### 1. Large strings were never memoized

`_redact_fn_cached` skipped anything over 16KB, so the full ~15-pass
redactor re-ran on every request for 59 large strings (29 unique, 0.76MB) —
1.68s per request, **99.9% of the recurring cost** once the small-string
cache is warm, repaid by every tab and every poll for a constant result.

They now get their own small cache, separate from the 4096-entry one so a
large blob cannot evict the thousands of small recurring strings. Entry
count *and* per-entry size are capped, bounding retained bytes; anything
larger stays uncached.

`_redact_value` also stops deep-copying containers whose descendants never
changed — pure CPU under the GIL, which is what serialized concurrent tabs.

Steady state: **3.78s -> 1.96s** one tab (-48%), **7.93s -> 4.06s** two tabs (-49%).

### 2. The "cheap" prefilter then became the bottleneck

With that fixed, cProfile showed `_might_contain_sensitive_text` costing
**2.98s of 3.7s**: 71 literal markers tested against each of ~74k strings
(~19MB), i.e. ~3.1M interpreted iterations per request — again for a
verdict that is constant for constant input.

Memoizing the verdict behind a bounded LRU: **2.07s -> 1.07s (-49%)**.

Combined, the recurring redaction cost drops from **~8.4s to ~1.1s**.

### Rejected alternatives (measured, not assumed)

| Idea | Result |
|---|---|
| Collapse the 71 `in` scans into one compiled alternation | **38% slower** (2.60s vs 1.88s) — CPython's substring search is already a tuned C routine |
| Lower gzip level | No effect: gzip **releases the GIL** (concurrency ratio 1.00) |
| `orjson` | 96% faster at serializing, but only **0.27s absolute** — ~1% of the request |

The rejected regex approach is documented in a code comment so it is not
retried.

### Safety

The prefilter gates the entire redaction pass, so a false negative would
leak a credential. Equivalence is pinned by a differential suite against a
literal copy of the previous implementation: every marker individually,
case variants, embeddings, near-misses, unicode lowercase traps
(`İ`, `ﬁ`, `K`), 4000 fuzz cases, plus oversized and unhashable inputs.
Verdicts are identical on all 73,658 strings of a real session (1935
flagged before and after).

Sharing unmodified sub-trees is safe because callers always build fresh
containers rather than mutating what the redactor returns.

Both caches are bounded in entry count and per-entry size, so neither can
grow without limit under adversarial traffic.

### Tests

20 new tests, all passing. Broad related selection: identical failure set
before and after (all pre-existing).