### PR TITLE
feat(ui): animated kaomoji busy indicator during agent turns

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3630,6 +3630,11 @@ body.resizing .sidebar{transition:none!important;}
   animation:wlpulse 1.3s ease-in-out infinite;
 }
 .tl-rundot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex-shrink:0;animation:wlpulse 1.3s ease-in-out infinite;}
+/* ── Kaomoji busy indicator (ported from hermes-cli TUI) ── */
+.kaomoji-busy{display:inline-block;font-family:inherit;line-height:1;vertical-align:middle;opacity:.85;min-width:2.2em;text-align:center;}
+.thinking-card-icon.kaomoji-busy{font-size:15px;}
+.agent-kaomoji{font-size:12px;}
+.tool-card-kaomoji{font-size:12px;margin-right:4px;}
 /* Show more button inside tool card result */
 .tool-card-more{background:none;border:none;color:var(--blue);font-size:10px;cursor:pointer;padding:3px 0 0;opacity:.7;display:block;}
 .tool-card-more:hover{opacity:1;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -23,6 +23,26 @@ const MAX_UPLOAD_MB=Math.round(MAX_UPLOAD_BYTES/1024/1024);
 // single-threaded so only one done event fires at a time in practice.
 let _queueDrainSid=null;
 const $=id=>document.getElementById(id);
+
+// ── Kaomoji busy indicator (ported from hermes-cli TUI) ──────────────────
+// Animated faces that cycle during S.busy (turn in progress), replacing
+// the static lightbulb / running-dot with the same kaomoji the CLI shows.
+const _KAOMOJI_FACES=['(｡•́︿•̀｡)','(◔_◔)','(¬‿¬)','( •_•)>⌐■-■','(⌐■_■)','(´･_･`)','◉_◉','(°ロ°)','( ˘⌣˘)♡','ヽ(>∀<☆)☆','٩(๑❛ᴗ❛๑)۶','(⊙_⊙)','(¬_¬)','( ͡° ͜ʖ ͡°)','ಠ_ಠ'];
+let _kaomojiTick=0;
+let _kaomojiTimer=null;
+function _kaomojiTickFn(){
+  _kaomojiTick++;
+  const face=_KAOMOJI_FACES[_kaomojiTick%_KAOMOJI_FACES.length];
+  document.querySelectorAll('[data-kaomoji="1"]').forEach(el=>{el.textContent=face;});
+}
+function _kaomojiStart(){
+  if(_kaomojiTimer)return;
+  _kaomojiTickFn();
+  _kaomojiTimer=setInterval(_kaomojiTickFn,800);
+}
+function _kaomojiStop(){
+  if(_kaomojiTimer){clearInterval(_kaomojiTimer);_kaomojiTimer=null;}
+}
 const OFFLINE_RECHECK_MS=2500;
 const OFFLINE_HEALTH_TIMEOUT_MS=10000;
 const OFFLINE_FETCH_FAILURES_BEFORE_BANNER=2;
@@ -6702,7 +6722,7 @@ function _activityStatusNode({kind='info',label='',detail='',status='done',ts=nu
   row.className=`agent-activity-status agent-activity-status-${kind} agent-activity-status-${status}`;
   if(id) row.setAttribute('data-activity-event-id',id);
   if(ts) row.setAttribute('data-activity-at',String(ts));
-  const iconMap={run:li('play',13),model:li('bot',13),waiting:'<span class="tool-card-running-dot"></span>',thinking:li('lightbulb',13),tool:li('wrench',13),done:li('check',13),warning:li('alert-triangle',13)};
+  const iconMap={run:li('play',13),model:li('bot',13),waiting:'<span class="kaomoji-busy agent-kaomoji" data-kaomoji="1">'+_KAOMOJI_FACES[0]+'</span>',thinking:'<span class="kaomoji-busy agent-kaomoji" data-kaomoji="1">'+_KAOMOJI_FACES[0]+'</span>',tool:li('wrench',13),done:li('check',13),warning:li('alert-triangle',13)};
   row.innerHTML=`<span class="agent-activity-status-icon">${iconMap[kind]||li('clock',13)}</span><span class="agent-activity-status-copy"><span class="agent-activity-status-label">${esc(label)}</span>${detail?`<span class="agent-activity-status-detail">${esc(detail)}</span>`:''}</span><span class="agent-activity-status-time">${esc(_activityClockLabel(ts))}</span>`;
   return row;
 }
@@ -8351,6 +8371,7 @@ async function handleComposerPrimaryAction(){
 
 function setBusy(v){
   S.busy=v;
+  if(v)_kaomojiStart();else _kaomojiStop();
   updateSendBtn();
   if(!v){
     if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();
@@ -11559,7 +11580,7 @@ function _thinkingCardHtml(text, open){
   const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}" aria-label="${t('copy')}">${li('copy',12)}</button>`;
   const shouldOpen=!!open||_worklogDetailsExpandedDefault();
   const classes=`thinking-card${shouldOpen?' open':''}`;
-  return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
+  return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon kaomoji-busy" data-kaomoji="1">${_KAOMOJI_FACES[0]}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
 }
 function isSimplifiedToolCalling(){
   return window._simplifiedToolCalling!==false;
@@ -18744,7 +18765,7 @@ function buildToolCard(tc){
   const hasMore=tc.snippet&&tc.snippet.length>displaySnippet.length;
   const moreLabel=tc.is_diff?'Show diff':'Show more';
   const lessLabel=tc.is_diff?'Hide diff':'Show less';
-  const runIndicator=tc.done===false?'<span class="tool-card-running-dot"></span>':'';
+  const runIndicator=tc.done===false?'<span class="kaomoji-busy tool-card-kaomoji" data-kaomoji="1">'+_KAOMOJI_FACES[0]+'</span>':'';
   const isSubagent=tc.name==='subagent_progress';
   const isDelegation=tc.name==='delegate_task';
   const openClass='';
@@ -20090,7 +20111,7 @@ function _thinkingMarkup(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
   const openClass=_worklogDetailsExpandedDefault()?' open':'';
   return (clean&&String(clean).trim())
-    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
+    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon kaomoji-busy" data-kaomoji="1">${_KAOMOJI_FACES[0]}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
 }
 function _renderThinkingInto(row,text=''){


### PR DESCRIPTION
## Summary

Ports the CLI TUI's kaomoji busy faces (`ui-tui/src/content/faces.ts` from hermes-agent) into the web dashboard. While a turn is in flight, the busy/thinking indicators now cycle through the same kaomoji faces the terminal UI shows, instead of static icons.

## Changes

- **Thinking/reasoning card** — rotating kaomoji replaces the static lightbulb icon in the card header (both `_thinkingCardHtml` and the legacy path)
- **Activity status rows** — `waiting` and `thinking` kinds now render a rotating kaomoji instead of the pulsing dot / lightbulb
- **Running tool cards** — the pulsing `.tool-card-running-dot` is replaced by a rotating kaomoji

A single global interval (`_kaomojiStart`/`_kaomojiStop`, hooked into `setBusy`) cycles the 15 faces every 800ms while busy and stops when the turn completes, so all live indicators animate in sync. CSS in `style.css` sizes the faces appropriately per context.

## Verification

- `node --check static/ui.js` passes
- Hard-refreshed the dashboard while the agent worked — faces rotate in thinking cards, activity rows, and tool cards, and stop when the turn finishes

## Notes

Pure frontend change — no API/state layer touched, no tests affected.