### PR TITLE
fix(picker): dedupe plain provider/model badge keys for slash-bearing model ids (#7290)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3927,6 +3927,15 @@ function _normalizeConfiguredModelKey(modelId){
 function _isEquivalentConfiguredModelEntry(modelId,badge,entries){
   const normalized=_normalizeConfiguredModelKey(modelId);
   const provider=String(badge&&badge.provider||'').toLowerCase();
+  // A row synthesized from an ungrouped top-level OPTION (temporary/custom
+  // entries added by _ensureModelOptionInDropdown) is stored with providerId:''
+  // even when the option carries provider identity, so that row's provider
+  // authority has to fall back to its badge provider (same fallback already
+  // used by _modelProviderForSelectedBadge below). Without it the routed
+  // spellings cannot see the row as belonging to that provider (#7290).
+  const _entryProvider=(entry)=>String(
+    (entry&&entry.providerId)||(entry&&entry.badge&&entry.badge.provider)||''
+  ).toLowerCase();
   const matchingEntries=(entries||[]).filter(existing=>
     _normalizeConfiguredModelKey(existing.value)===normalized
   );
@@ -3943,7 +3952,7 @@ function _isEquivalentConfiguredModelEntry(modelId,badge,entries){
   if(prefix&&rawId.toLowerCase().startsWith(prefix)){
     const routedId=rawId.slice(prefix.length);
     return (entries||[]).some(entry=>
-      String(entry.providerId||'').toLowerCase()===provider
+      _entryProvider(entry)===provider
       &&_normalizeConfiguredModelKey(entry.value)===_normalizeConfiguredModelKey(routedId)
     );
   }
@@ -3958,7 +3967,7 @@ function _isEquivalentConfiguredModelEntry(modelId,badge,entries){
   if(slashPrefix&&rawId.toLowerCase().startsWith(slashPrefix)){
     const routedId=rawId.slice(slashPrefix.length);
     return (entries||[]).some(entry=>
-      String(entry.providerId||'').toLowerCase()===provider
+      _entryProvider(entry)===provider
       &&_normalizeConfiguredModelKey(entry.value)===_normalizeConfiguredModelKey(routedId)
     );
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -3940,12 +3940,29 @@ function _isEquivalentConfiguredModelEntry(modelId,badge,entries){
   // different providers.
   const rawId=String(modelId||'');
   const prefix=provider?`@${provider}:`:'';
-  if(!prefix||!rawId.toLowerCase().startsWith(prefix)) return false;
-  const routedId=rawId.slice(prefix.length);
-  return (entries||[]).some(entry=>
-    String(entry.providerId||'').toLowerCase()===provider
-    &&_normalizeConfiguredModelKey(entry.value)===_normalizeConfiguredModelKey(routedId)
-  );
+  if(prefix&&rawId.toLowerCase().startsWith(prefix)){
+    const routedId=rawId.slice(prefix.length);
+    return (entries||[]).some(entry=>
+      String(entry.providerId||'').toLowerCase()===provider
+      &&_normalizeConfiguredModelKey(entry.value)===_normalizeConfiguredModelKey(routedId)
+    );
+  }
+  // Plain `provider/model` badge keys (produced by the backend alongside
+  // `@provider:model`) must dedupe the same way when an existing picker row
+  // belongs to that provider. For single-slash model ids the primary
+  // normalization already strips the prefix; this branch matters for
+  // slash-bearing model ids where the prefixed key keeps vendor hierarchy
+  // (e.g. commandcode/deepseek/deepseek-v4-flash vs deepseek/deepseek-v4-flash)
+  // and would otherwise leak as a duplicate selectable entry (#7290).
+  const slashPrefix=provider?`${provider}/`:'';
+  if(slashPrefix&&rawId.toLowerCase().startsWith(slashPrefix)){
+    const routedId=rawId.slice(slashPrefix.length);
+    return (entries||[]).some(entry=>
+      String(entry.providerId||'').toLowerCase()===provider
+      &&_normalizeConfiguredModelKey(entry.value)===_normalizeConfiguredModelKey(routedId)
+    );
+  }
+  return false;
 }
 
 function _getConfiguredModelBadge(modelId,badgeMap,providerId){

--- a/tests/test_configured_model_picker_dedup.py
+++ b/tests/test_configured_model_picker_dedup.py
@@ -85,6 +85,53 @@ def test_named_custom_provider_routing_id_does_not_duplicate_picker_row(tmp_path
     assert results == [True, True]
 
 
+def test_plain_provider_prefix_slash_model_id_does_not_duplicate_picker_row(tmp_path):
+    """#7290: a `provider/model` badge key for a slash-bearing model id
+    (e.g. commandcode/deepseek/deepseek-v4-flash) must dedupe against the bare
+    model row of the same provider, instead of leaking as a duplicate entry."""
+    ui = UI_JS_PATH.read_text(encoding="utf-8")
+
+    assert "const slashPrefix=provider?`${provider}/`:'';" in ui, (
+        "_isEquivalentConfiguredModelEntry must route plain `provider/model` "
+        "badge keys like the @-prefixed spelling (#7290)"
+    )
+
+    entries = [{"value": "deepseek/deepseek-v4-flash", "providerId": "commandcode"}]
+    results = _equivalent_cases(
+        tmp_path,
+        [
+            {
+                "modelId": "commandcode/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": entries,
+            },
+            {
+                "modelId": "@commandcode:deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": entries,
+            },
+        ],
+    )
+    assert results == [True, True]
+
+
+def test_plain_provider_prefix_same_model_other_provider_remains_distinct(tmp_path):
+    """#7290 guard: the plain `provider/model` routing dedup must NOT collapse
+    the same model id from a different provider (#3360 family)."""
+    entries = [{"value": "deepseek/deepseek-v4-flash", "providerId": "other-provider"}]
+    results = _equivalent_cases(
+        tmp_path,
+        [
+            {
+                "modelId": "commandcode/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": entries,
+            },
+        ],
+    )
+    assert results == [False]
+
+
 def test_same_model_id_from_another_provider_remains_distinct(tmp_path):
     entries = [{"value": "model-a", "providerId": "custom:primary"}]
     results = _equivalent_cases(

--- a/tests/test_configured_model_picker_dedup.py
+++ b/tests/test_configured_model_picker_dedup.py
@@ -89,30 +89,91 @@ def test_plain_provider_prefix_slash_model_id_does_not_duplicate_picker_row(tmp_
     """#7290: a `provider/model` badge key for a slash-bearing model id
     (e.g. commandcode/deepseek/deepseek-v4-flash) must dedupe against the bare
     model row of the same provider, instead of leaking as a duplicate entry."""
-    ui = UI_JS_PATH.read_text(encoding="utf-8")
-
-    assert "const slashPrefix=provider?`${provider}/`:'';" in ui, (
-        "_isEquivalentConfiguredModelEntry must route plain `provider/model` "
-        "badge keys like the @-prefixed spelling (#7290)"
-    )
-
-    entries = [{"value": "deepseek/deepseek-v4-flash", "providerId": "commandcode"}]
+    grouped_row = [{"value": "deepseek/deepseek-v4-flash", "providerId": "commandcode"}]
+    # A temporary/custom row synthesized from an ungrouped top-level OPTION
+    # (`_ensureModelOptionInDropdown`): renderModelDropdown stores it with
+    # providerId:'' and only the badge carries the provider identity, which is
+    # exactly the shape that used to leak the duplicate.
+    top_level_row = [
+        {
+            "value": "@commandcode:deepseek/deepseek-v4-flash",
+            "providerId": "",
+            "badge": {"provider": "commandcode"},
+        }
+    ]
+    badgeless_top_level_row = [
+        {
+            "value": "deepseek/deepseek-v4-flash",
+            "providerId": "",
+            "badge": {"provider": "commandcode"},
+        }
+    ]
     results = _equivalent_cases(
         tmp_path,
         [
             {
                 "modelId": "commandcode/deepseek/deepseek-v4-flash",
                 "badge": {"provider": "commandcode"},
-                "entries": entries,
+                "entries": grouped_row,
             },
             {
                 "modelId": "@commandcode:deepseek/deepseek-v4-flash",
                 "badge": {"provider": "commandcode"},
-                "entries": entries,
+                "entries": grouped_row,
+            },
+            {
+                "modelId": "commandcode/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": top_level_row,
+            },
+            {
+                "modelId": "@commandcode:deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": top_level_row,
+            },
+            {
+                "modelId": "commandcode/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": badgeless_top_level_row,
             },
         ],
     )
-    assert results == [True, True]
+
+    assert results == [True, True, True, True, True]
+
+
+def test_plain_provider_prefix_top_level_row_other_provider_remains_distinct(tmp_path):
+    """#7290 guard: reaching the top-level row's provider through its badge must
+    not collapse the same model id from a different provider (#3360 family)."""
+    results = _equivalent_cases(
+        tmp_path,
+        [
+            {
+                "modelId": "otherprovider/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "otherprovider"},
+                "entries": [
+                    {
+                        "value": "@commandcode:deepseek/deepseek-v4-flash",
+                        "providerId": "",
+                        "badge": {"provider": "commandcode"},
+                    }
+                ],
+            },
+            {
+                "modelId": "commandcode/deepseek/deepseek-v4-flash",
+                "badge": {"provider": "commandcode"},
+                "entries": [
+                    {
+                        "value": "@otherprovider:deepseek/deepseek-v4-flash",
+                        "providerId": "",
+                        "badge": {"provider": "otherprovider"},
+                    }
+                ],
+            },
+        ],
+    )
+
+    assert results == [False, False]
 
 
 def test_plain_provider_prefix_same_model_other_provider_remains_distinct(tmp_path):
@@ -151,3 +212,266 @@ def test_same_model_id_from_another_provider_remains_distinct(tmp_path):
     )
 
     assert results == [False, False]
+
+
+_TOP_LEVEL_OPTION_DRIVER = r"""
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunc(name) {
+  const re = new RegExp('(?:async\\s+)?function\\s+' + name + '\\s*\\(');
+  const start = ui.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let openParen = ui.indexOf('(', start);
+  let i = openParen + 1;
+  let parenDepth = 1;
+  while (parenDepth > 0 && i < ui.length) {
+    if (ui[i] === '(') parenDepth++;
+    else if (ui[i] === ')') parenDepth--;
+    i++;
+  }
+  let depth = 1;
+  i = ui.indexOf('{', i);
+  if (i < 0) throw new Error(name + ' body not found');
+  i++;
+  while (depth > 0 && i < ui.length) {
+    if (ui[i] === '{') depth++;
+    else if (ui[i] === '}') depth--;
+    i++;
+  }
+  if (ui[i] === ';') i++;
+  return ui.slice(start, i);
+}
+
+function makeClassList(initial) {
+  const set = new Set(initial || []);
+  return {
+    _set: set,
+    add(cls) { set.add(cls); },
+    remove(cls) { set.delete(cls); },
+    contains(cls) { return set.has(cls); },
+    toggle(cls, force) {
+      if (force === true) { set.add(cls); return true; }
+      if (force === false) { set.delete(cls); return false; }
+      if (set.has(cls)) { set.delete(cls); return false; }
+      set.add(cls);
+      return true;
+    },
+  };
+}
+
+function defineClassName(node) {
+  Object.defineProperty(node, 'className', {
+    get() { return [...node.classList._set].join(' '); },
+    set(v) { node.classList = makeClassList(String(v || '').split(/\s+/).filter(Boolean)); },
+  });
+}
+
+function makeNode(tag) {
+  const node = {
+    tagName: String(tag || '').toUpperCase(),
+    children: [],
+    dataset: {},
+    style: {},
+    parentElement: null,
+    textContent: '',
+    value: '',
+    tabIndex: 0,
+    onclick: null,
+    _listeners: {},
+    _innerHTML: '',
+    appendChild(child) {
+      child.parentElement = this;
+      this.children.push(child);
+      if (this.tagName === 'OPTGROUP' && this._ownerSelect && child.tagName === 'OPTION') {
+        this._ownerSelect.options.push(child);
+      }
+      return child;
+    },
+    addEventListener(type, handler) { this._listeners[type] = handler; },
+    querySelector(selector) { return this._qs ? this._qs[selector] || null : null; },
+    setAttribute(name, value) { this[name] = value; },
+    focus() { this._focused = true; },
+  };
+  node.classList = makeClassList();
+  defineClassName(node);
+  Object.defineProperty(node, 'innerHTML', {
+    get() { return this._innerHTML; },
+    set(v) {
+      this._innerHTML = String(v || '');
+      this.children = [];
+      this._qs = {};
+      if (this.tagName === 'DIV' && this._innerHTML.includes('model-search-input')) {
+        const input = makeNode('input');
+        input.className = 'model-search-input';
+        const clear = makeNode('button');
+        clear.className = 'model-search-clear';
+        this._qs['.model-search-input'] = input;
+        this._qs['.model-search-clear'] = clear;
+      } else if (this.tagName === 'DIV' && this._innerHTML.includes('model-custom-input')) {
+        const input = makeNode('input');
+        input.className = 'model-custom-input';
+        const btn = makeNode('button');
+        btn.className = 'model-custom-btn';
+        this._qs['.model-custom-input'] = input;
+        this._qs['.model-custom-btn'] = btn;
+      }
+    },
+  });
+  return node;
+}
+
+function makeOption(value, label, parent) {
+  const opt = makeNode('option');
+  opt.value = value;
+  opt.textContent = label || value;
+  opt.parentElement = parent || null;
+  return opt;
+}
+
+function makeSelect(groups, selectedValue) {
+  const sel = { id: 'modelSelect', children: [], options: [], _value: selectedValue || '' };
+  Object.defineProperty(sel, 'value', {get(){return sel._value;}, set(v){sel._value=String(v||'');}});
+  Object.defineProperty(sel, 'selectedOptions', {get(){const o=sel.options.find(x=>x.value===sel._value);return o?[o]:[];}});
+  // _ensureModelOptionInDropdown appends a direct child OPTION to the select and
+  // renderModelDropdown walks select.children, so keep it in both collections.
+  sel.appendChild=function(option){option.parentElement=sel;sel.children.push(option);sel.options.push(option);};
+  sel.querySelectorAll=function(){return [];};
+  for (const group of groups || []) {
+    const og = makeNode('optgroup');
+    og.label = group.provider || '';
+    og.dataset.provider = group.provider_id || '';
+    og._ownerSelect = sel;
+    if (group.extra_models) og.dataset.extraModels = JSON.stringify(group.extra_models);
+    for (const model of group.models || []) og.appendChild(makeOption(model.id, model.label || model.id, og));
+    sel.children.push(og);
+    sel.options.push(...og.children);
+  }
+  return sel;
+}
+
+function walk(dd) {
+  const out = [];
+  const stack = [...(dd.children || [])];
+  while (stack.length) {
+    const n = stack.shift();
+    out.push(n);
+    if (n.children && n.children.length) stack.push(...n.children);
+  }
+  return out;
+}
+
+const payload = JSON.parse(process.argv[3]);
+const dropdown = makeNode('div');
+dropdown.classList.add('open');
+const modelSelect = makeSelect(payload.groups, payload.selectedValue);
+
+function $(id) {
+  if (id === 'composerModelDropdown') return dropdown;
+  if (id === 'modelSelect') return modelSelect;
+  return null;
+}
+const window = { _configuredModelBadges: payload.configuredBadges || {} };
+const document = { createElement(tag) { return makeNode(tag); } };
+function esc(v) { return String(v || ''); }
+function t(key, ...args) {
+  if (key === 'model_show_all_models') return `Show all ${args[0]} models`;
+  return key;
+}
+function li() { return 'x'; }
+function getModelLabel(v) { return String(v || ''); }
+function closeModelDropdown() {}
+function syncModelChip() {}
+function _refreshOpenModelDropdown() {}
+function _deduplicateModelPickerOptions() { return 0; }
+
+for (const name of [
+  '_normalizeConfiguredModelKey',
+  '_getConfiguredModelBadge',
+  '_providerFromModelValue',
+  '_readModelOverflowData',
+  '_appendOverflowOptionsToGroup',
+  '_isEquivalentConfiguredModelEntry',
+  '_getOptionProviderId',
+  '_modelStateForSelect',
+  '_findModelInDropdown',
+  '_applyModelToDropdown',
+  '_ensureModelOptionInDropdown',
+  'renderModelDropdown',
+]) {
+  eval(extractFunc(name));
+}
+
+_ensureModelOptionInDropdown(payload.requested, modelSelect, payload.requestedProvider);
+renderModelDropdown();
+
+const nodes = walk(dropdown);
+const rowIds = [];
+for (const n of nodes) {
+  const html = String(n._innerHTML || '');
+  if (typeof n.onclick !== 'function' || !html.includes('model-opt-id')) continue;
+  const match = html.match(/class="model-opt-id">([^<]*)</);
+  if (match) rowIds.push(match[1]);
+}
+process.stdout.write(JSON.stringify({
+  rowIds,
+  selected: modelSelect.value,
+  optionValues: modelSelect.options.map((o) => o.value),
+  markup: nodes.map((n) => String(n._innerHTML || '')).join('\n'),
+}));
+"""
+
+
+def _render_top_level_option(tmp_path, payload):
+    driver = tmp_path / "driver_top.js"
+    driver.write_text(_TOP_LEVEL_OPTION_DRIVER, encoding="utf-8")
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, str(driver), str(UI_JS_PATH), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_temporary_top_level_option_row_does_not_duplicate_configured_entry(tmp_path):
+    """#7290 (temporary/custom row path): a top-level OPTION synthesized by
+    `_ensureModelOptionInDropdown` is stored with providerId:'' and its provider
+    identity only lives on the badge. Rendering the picker afterwards must not
+    add the plain `provider/model` configured key as a second row."""
+    data = _render_top_level_option(
+        tmp_path,
+        {
+            "groups": [
+                {
+                    "provider": "OpenRouter",
+                    "provider_id": "openrouter",
+                    "models": [{"id": "other-model"}],
+                }
+            ],
+            "selectedValue": "@commandcode:deepseek/deepseek-v4-flash",
+            "requested": "@commandcode:deepseek/deepseek-v4-flash",
+            "requestedProvider": "commandcode",
+            "configuredBadges": {
+                "@commandcode:deepseek/deepseek-v4-flash": {
+                    "provider": "commandcode",
+                    "role": "fallback",
+                    "label": "Fallback 1",
+                },
+                "commandcode/deepseek/deepseek-v4-flash": {
+                    "provider": "commandcode",
+                    "role": "fallback",
+                    "label": "Fallback 1",
+                },
+            },
+        },
+    )
+
+    model_rows = [row_id for row_id in data["rowIds"] if "deepseek-v4-flash" in row_id]
+    assert model_rows == ["@commandcode:deepseek/deepseek-v4-flash"]
+    assert "commandcode/deepseek/deepseek-v4-flash" not in data["markup"]
+    # The temporary/custom option the user picked survives the re-render.
+    assert data["selected"] == "@commandcode:deepseek/deepseek-v4-flash"
+    assert "@commandcode:deepseek/deepseek-v4-flash" in data["optionValues"]


### PR DESCRIPTION
## Summary

The model dropdown shows duplicate entries when the active provider is a built-in plugin provider (e.g. `commandcode`) and the configured default model id itself contains a slash (e.g. `deepseek/deepseek-v4-flash`): the bare id and a `provider/model`-prefixed variant (`commandcode/deepseek/deepseek-v4-flash`) both appear as selectable options. Picking the prefixed entry persists it as the session model and the request is sent with the literal prefixed name, which the endpoint rejects with HTTP 400.

## Root Cause

`_configured_model_badges_from_static_catalog()` in `api/config.py` stores three key variants for the primary model: `model`, `{provider}/{model}`, and `@{provider}:{model}`. `_buildModelPicker()` drops badge keys that `_isEquivalentConfiguredModelEntry()` deems equivalent to an existing row.

- For the `@{provider}:{model}` variant, the routing check strips the `@provider:` prefix and compares the routed id against rows of the same provider → equivalent, correctly deduped.
- For the plain `{provider}/{model}` variant, `_normalizeConfiguredModelKey()` strips only the first slash segment. When the model id itself contains a slash, `commandcode/deepseek/deepseek-v4-flash` normalizes to `deepseek/deepseek.v4.flash` while the bare `deepseek/deepseek-v4-flash` normalizes to `deepseek.v4.flash` — not equal, so the prefixed variant leaks into the dropdown as a duplicate selectable entry. (The `provider/` prefix is only stripped for single-slash model ids, which is why the plain-prefix path appeared to work before.)

## Change

`static/ui.js` — `_isEquivalentConfiguredModelEntry()` now routes plain `provider/model` badge keys the same way it routes `@provider:model`: when the raw key starts with `<provider>/`, strip that prefix and compare the routed id against existing picker rows that belong to that same provider. If no row of that provider matches, the prefixed key is NOT considered equivalent (so same model id from another provider stays distinct — the #3360 collision guard is preserved).

## Verification

- Reproduced the leak on `master` with the real JS functions via Node: `_isEquivalentConfiguredModelEntry("commandcode/deepseek/deepseek-v4-flash", {provider:"commandcode"}, [{value:"deepseek/deepseek-v4-flash", providerId:"commandcode"}])` → `false` before, `true` after.
- After the fix: prefixed key dedupes (`true`), `@provider:model` still dedupes (`true`), same model id under a different provider remains distinct (`false`), and unrelated multi-slash ids do not collapse.
- Added regression tests to `tests/test_configured_model_picker_dedup.py` (node driver against the live `static/ui.js`).
- `pytest tests/test_configured_model_picker_dedup.py tests/test_issue3360_multi_slash_model_collision.py` → 14 passed; `pytest tests/test_model_picker_badges.py tests/test_configured_model_picker_provider_routing.py tests/test_issue3959_model_suffix_dedup.py tests/test_issue3429_uri_scheme_model_ids.py` → 20 passed.

## Closes

Closes #7290
