### PR TITLE
fix(streaming): stop hidden-tab polling for missing sessions

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -8035,7 +8035,19 @@ function _startHiddenActiveStreamPoll(sid) {
     if (S.activeStreamId) return; // already rendering; wait it out
     try {
       fetch(_apiUrl('api/session/status?session_id=' + encodeURIComponent(sid)), {credentials: 'same-origin'})
-        .then(r => r.ok ? r.json() : null)
+        .then(r => {
+          if (r && (r.status === 404 || r.status === 410)) {
+            // The session is permanently gone. Stop only when this response
+            // still belongs to the active poll so a late 404 from an older
+            // session cannot tear down its replacement.
+            if (_sessionStreamHiddenPollSid === sid) {
+              if (_sessionStreamHiddenSid === sid) _sessionStreamHiddenSid = null;
+              _stopHiddenActiveStreamPoll();
+            }
+            return null;
+          }
+          return r && r.ok ? r.json() : null;
+        })
         .then(d => {
           if (!d || _sessionStreamHiddenPollSid !== sid) return;
           const streamId = d.active_stream_id;

--- a/tests/test_hidden_tab_server_initiated_turn.py
+++ b/tests/test_hidden_tab_server_initiated_turn.py
@@ -21,7 +21,13 @@ tests pinning the contract:
   tab that transitions to hidden via the ``visibilitychange`` hook.
 """
 
+import json
+import shutil
+import subprocess
+import textwrap
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
@@ -89,7 +95,7 @@ def test_hidden_poll_hits_session_status_and_attaches_as_replay():
     """
     start = MESSAGES_JS.find("function _startHiddenActiveStreamPoll(sid)")
     assert start != -1
-    body = MESSAGES_JS[start:start + 2400]
+    body = MESSAGES_JS[start:start + 3200]
     assert "api/session/status?session_id=" in body
     assert "d.active_stream_id" in body
     # attaches as replay (recovered=true) — turn is already mid-flight
@@ -183,3 +189,151 @@ def test_poll_stops_only_when_attach_succeeds():
     # The bounded-retry give-up: a never-current pane stops after the budget.
     assert "_sessionStreamHiddenPollFalseCount" in body
     assert "_SESSION_STREAM_HIDDEN_POLL_MAX_FALSE" in body
+
+
+# ── Terminal missing-session responses stop the hidden poll ────────────────
+
+NODE = shutil.which("node")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_hidden_poll_stops_only_for_owned_missing_sessions():
+    """404/410 stop a stale poll; transient failures and current owners survive."""
+    start = MESSAGES_JS.index("function _startHiddenActiveStreamPoll(sid)")
+    end = MESSAGES_JS.index("function _chatStreamActiveForSession(sid)", start)
+    functions = MESSAGES_JS[start:end]
+
+    driver = textwrap.dedent(
+        r"""
+        const functions = JSON.parse(process.argv[1]);
+        let _sessionStreamHiddenPollTimer = null;
+        let _sessionStreamHiddenPollSid = null;
+        let _sessionStreamHiddenPollFalseStreamId = null;
+        let _sessionStreamHiddenPollFalseCount = 0;
+        let _sessionStreamHiddenSid = null;
+        const _SESSION_STREAM_HIDDEN_POLL_MAX_FALSE = 20;
+        const document = {hidden: true};
+        const S = {activeStreamId: null};
+        const _apiUrl = value => value;
+        const _attachServerInitiatedStream = () => true;
+        let intervalFn = null;
+        let intervalSeq = 0;
+        let fetchCalls = 0;
+
+        globalThis.setInterval = fn => {
+          intervalFn = fn;
+          return ++intervalSeq;
+        };
+        globalThis.clearInterval = () => { intervalFn = null; };
+        eval(functions);
+
+        const flush = () => new Promise(resolve => setImmediate(resolve));
+        const response = status => ({
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () => ({active_stream_id: null}),
+        });
+
+        async function settle() {
+          await flush();
+          await flush();
+        }
+
+        function reset() {
+          _stopHiddenActiveStreamPoll();
+          _sessionStreamHiddenSid = null;
+          intervalFn = null;
+          fetchCalls = 0;
+        }
+
+        async function runStatus(status, reject = false) {
+          reset();
+          _sessionStreamHiddenSid = 'session-a';
+          globalThis.fetch = () => {
+            fetchCalls += 1;
+            return reject ? Promise.reject(new Error('offline')) : Promise.resolve(response(status));
+          };
+          _startHiddenActiveStreamPoll('session-a');
+          await settle();
+          const nextTick = intervalFn;
+          if (nextTick) {
+            nextTick();
+            await settle();
+          }
+          return {
+            fetchCalls,
+            running: intervalFn !== null,
+            pollSid: _sessionStreamHiddenPollSid,
+            hiddenSid: _sessionStreamHiddenSid,
+          };
+        }
+
+        async function runStaleResponse() {
+          reset();
+          let resolveA;
+          globalThis.fetch = url => {
+            fetchCalls += 1;
+            if (String(url).includes('session-a')) {
+              return new Promise(resolve => { resolveA = resolve; });
+            }
+            return Promise.resolve(response(200));
+          };
+          _sessionStreamHiddenSid = 'session-a';
+          _startHiddenActiveStreamPoll('session-a');
+          _sessionStreamHiddenSid = 'session-b';
+          _startHiddenActiveStreamPoll('session-b');
+          await settle();
+          resolveA(response(404));
+          await settle();
+          return {
+            running: intervalFn !== null,
+            pollSid: _sessionStreamHiddenPollSid,
+            hiddenSid: _sessionStreamHiddenSid,
+          };
+        }
+
+        (async () => {
+          const result = {
+            missing404: await runStatus(404),
+            missing410: await runStatus(410),
+            server500: await runStatus(500),
+            offline: await runStatus(0, true),
+            idle200: await runStatus(200),
+            stale404: await runStaleResponse(),
+          };
+          process.stdout.write(JSON.stringify(result));
+        })().catch(error => {
+          console.error(error);
+          process.exit(1);
+        });
+        """
+    )
+
+    proc = subprocess.run(
+        [NODE, "-e", driver, json.dumps(functions)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(proc.stdout)
+
+    for key in ("missing404", "missing410"):
+        assert result[key] == {
+            "fetchCalls": 1,
+            "running": False,
+            "pollSid": None,
+            "hiddenSid": None,
+        }
+
+    for key in ("server500", "offline", "idle200"):
+        assert result[key]["fetchCalls"] == 2
+        assert result[key]["running"] is True
+        assert result[key]["pollSid"] == "session-a"
+        assert result[key]["hiddenSid"] == "session-a"
+
+    assert result["stale404"] == {
+        "running": True,
+        "pollSid": "session-b",
+        "hiddenSid": "session-b",
+    }

--- a/tests/test_hidden_tab_server_initiated_turn.py
+++ b/tests/test_hidden_tab_server_initiated_turn.py
@@ -198,10 +198,14 @@ NODE = shutil.which("node")
 
 @pytest.mark.skipif(NODE is None, reason="node not available")
 def test_hidden_poll_stops_only_for_owned_missing_sessions():
-    """404/410 stop a stale poll; transient failures and current owners survive."""
+    """Terminal responses stop only their owner and cannot reopen on visibility."""
     start = MESSAGES_JS.index("function _startHiddenActiveStreamPoll(sid)")
-    end = MESSAGES_JS.index("function _chatStreamActiveForSession(sid)", start)
-    functions = MESSAGES_JS[start:end]
+    poll_end = MESSAGES_JS.index("function _chatStreamActiveForSession(sid)", start)
+    stream_end = MESSAGES_JS.index("function stopSessionStream()", poll_end)
+    functions = {
+        "poll": MESSAGES_JS[start:poll_end],
+        "session": MESSAGES_JS[poll_end:stream_end],
+    }
 
     driver = textwrap.dedent(
         r"""
@@ -211,21 +215,53 @@ def test_hidden_poll_stops_only_for_owned_missing_sessions():
         let _sessionStreamHiddenPollFalseStreamId = null;
         let _sessionStreamHiddenPollFalseCount = 0;
         let _sessionStreamHiddenSid = null;
+        let _sessionStreamSessionId = null;
+        let _sessionEventSource = null;
+        let _sessionStreamReconnectTimer = null;
         const _SESSION_STREAM_HIDDEN_POLL_MAX_FALSE = 20;
-        const document = {hidden: true};
-        const S = {activeStreamId: null};
+        let visibilityChange = null;
+        const document = {
+          hidden: true,
+          addEventListener: (type, listener) => {
+            if (type === 'visibilitychange') visibilityChange = listener;
+          },
+        };
+        const S = {
+          activeStreamId: null,
+          messages: [],
+          session: {session_id: 'session-a', message_count: 0},
+        };
         const _apiUrl = value => value;
         const _attachServerInitiatedStream = () => true;
         let intervalFn = null;
         let intervalSeq = 0;
         let fetchCalls = 0;
+        let eventSourceCalls = 0;
+
+        class EventSource {
+          constructor() {
+            eventSourceCalls += 1;
+            this.readyState = 1;
+          }
+          addEventListener() {}
+          close() { this.readyState = 2; }
+        }
 
         globalThis.setInterval = fn => {
           intervalFn = fn;
           return ++intervalSeq;
         };
         globalThis.clearInterval = () => { intervalFn = null; };
-        eval(functions);
+        eval(functions.poll);
+
+        function stopSessionStream() {
+          if (_sessionEventSource) _sessionEventSource.close();
+          _sessionEventSource = null;
+          _sessionStreamSessionId = null;
+          _stopHiddenActiveStreamPoll();
+        }
+
+        eval(functions.session);
 
         const flush = () => new Promise(resolve => setImmediate(resolve));
         const response = status => ({
@@ -240,10 +276,14 @@ def test_hidden_poll_stops_only_for_owned_missing_sessions():
         }
 
         function reset() {
-          _stopHiddenActiveStreamPoll();
+          stopSessionStream();
           _sessionStreamHiddenSid = null;
+          document.hidden = true;
+          document._hermesSessionStreamVisibilityHook = false;
+          visibilityChange = null;
           intervalFn = null;
           fetchCalls = 0;
+          eventSourceCalls = 0;
         }
 
         async function runStatus(status, reject = false) {
@@ -292,6 +332,26 @@ def test_hidden_poll_stops_only_for_owned_missing_sessions():
           };
         }
 
+        async function runVisibilityRecovery(status) {
+          reset();
+          globalThis.fetch = () => {
+            fetchCalls += 1;
+            return Promise.resolve(response(status));
+          };
+          startSessionStream('session-a');
+          await settle();
+          if (!visibilityChange) throw new Error('visibilitychange listener was not installed');
+          document.hidden = false;
+          visibilityChange();
+          await settle();
+          return {
+            eventSourceCalls,
+            running: intervalFn !== null,
+            pollSid: _sessionStreamHiddenPollSid,
+            hiddenSid: _sessionStreamHiddenSid,
+          };
+        }
+
         (async () => {
           const result = {
             missing404: await runStatus(404),
@@ -300,6 +360,8 @@ def test_hidden_poll_stops_only_for_owned_missing_sessions():
             offline: await runStatus(0, true),
             idle200: await runStatus(200),
             stale404: await runStaleResponse(),
+            visible404: await runVisibilityRecovery(404),
+            visible410: await runVisibilityRecovery(410),
           };
           process.stdout.write(JSON.stringify(result));
         })().catch(error => {
@@ -317,6 +379,14 @@ def test_hidden_poll_stops_only_for_owned_missing_sessions():
     )
     assert proc.returncode == 0, proc.stderr
     result = json.loads(proc.stdout)
+
+    for key in ("visible404", "visible410"):
+        assert result[key] == {
+            "eventSourceCalls": 0,
+            "running": False,
+            "pollSid": None,
+            "hiddenSid": None,
+        }
 
     for key in ("missing404", "missing410"):
         assert result[key] == {


### PR DESCRIPTION
## Thinking Path

- Hidden tabs intentionally replace the persistent per-session SSE with a six-second status poll to preserve connection-pool capacity.
- A missing session is terminal for that poll, but the client currently folds every non-2xx response into `null` and keeps its interval alive.
- An isolated current-master reproduction showed the same deleted session returning 404 every six seconds for more than four minutes.
- The smallest safe fix is to stop only on explicit 404/410 responses that still belong to the current poll owner, while preserving retries for transient failures.

## Linked Issue

Closes #7299

## What Changed

- Stop the hidden-tab status poll on `404 Not Found` or `410 Gone`.
- Clear the matching hidden-resume owner so returning to the visible tab does not reopen an SSE for the missing session.
- Fence cleanup by the current poll session ID, preventing a late response from session A from stopping session B's replacement poll.
- Add a Node behavior regression covering terminal, retryable, idle, stale-response, and visible-tab recovery cases.
- Document implemented hidden-tab observation, terminal-response ownership, and visibility recovery in `docs/rfcs/session-sse-contract-v1.md`.

## Why It Matters

A stale background tab previously generated up to ten useless 404 requests per minute whenever browser timer throttling allowed it. Multiple tabs multiplied request-thread usage and log noise without any visible recovery path.

## Contract Routing

- Contract family: per-session live-view/SSE lifecycle (`docs/rfcs/session-sse-contract-v1.md`).
- State owner: browser `_sessionStreamHiddenPoll*` and `_sessionStreamHiddenSid` state only.
- Invariant: terminal missing-session responses stop only their owning poll; successful idle responses, 5xx responses, and network failures remain retryable.
- Public endpoint and SSE wire contracts are unchanged.

## Verification

Current head `13d6ba52`, based on upstream `c367ef3c`:
- Affected and neighboring lifecycle suites plus RFC coverage: **186 passed** through `./scripts/test.sh`.
- Critical Markdown check and `git diff --check` passed.
- This follow-up changes documentation only; the 404/410 implementation and behavior tests are unchanged.
- All five fork workflows passed on this head: [Tests (15 Python shards + lint)](https://github.com/laitekin/hermes-webui/actions/runs/35616342004), [Browser smoke](https://github.com/laitekin/hermes-webui/actions/runs/35616342031), [Conversation lifecycle](https://github.com/laitekin/hermes-webui/actions/runs/35616342016), [Docs CI](https://github.com/laitekin/hermes-webui/actions/runs/35616342143), and [Docker smoke](https://github.com/laitekin/hermes-webui/actions/runs/35616342022).
- Greptile re-reviewed this head at 5/5 and confirmed no outstanding findings; the earlier documentation thread is resolved.


Before the implementation change, the new behavior test failed with 404/410 issuing a second fetch while the timer and both session owners remained active:

```text
1 failed, 8 passed
missing404: fetchCalls=2, running=true, pollSid=session-a, hiddenSid=session-a
```

The visible-tab recovery row was also mutation-checked independently: with only the matching `_sessionStreamHiddenSid` cleanup removed (while terminal poll shutdown remained intact), the focused test failed because returning the tab to visible created a new `EventSource`:

```text
visible404: eventSourceCalls=1 (expected 0)
```

After restoring the owner cleanup, both the 404 and 410 visible-recovery rows create zero `EventSource` instances and the affected plus neighboring regression set passes:

```text
152 passed in 5.30s
```

Command:

```bash
NO_PROXY=127.0.0.1,localhost \
no_proxy=127.0.0.1,localhost \
./scripts/test.sh \
  tests/test_hidden_tab_server_initiated_turn.py \
  tests/test_cancelling_run_not_attachable.py \
  tests/test_issue3996_sse_visibility.py \
  tests/test_issue4151_pwa_focus_sse.py \
  tests/test_session_channel_option_x.py \
  tests/test_optionz_liveview_perf.py \
  tests/test_live_to_final_anchor_visible_order.py
```

Additional checks:

```text
node --check static/messages.js                                   passed
.venv/bin/ruff check tests/test_hidden_tab_server_initiated_turn.py passed
.venv/bin/python scripts/ruff_lint.py --diff origin/master          passed
git diff --check                                                 passed
```

The latest-head workflow mirror is [laitekin/hermes-webui#2](https://github.com/laitekin/hermes-webui/pull/2), covering all pytest shards across Python 3.11/3.12/3.13, lint, browser smoke, docs CI, and all three conversation lifecycle scenarios.

Not locally verifiable: the upstream required workflow run is maintainer-controlled and remains unavailable until approved. The fork mirror exercises the same latest head in the meantime.

## Risks / Follow-ups

The behavior change is limited to HTTP 404/410. Authentication failures, rate limits, server errors, network failures, and successful idle responses retain the existing retry behavior. No visible UI or persistence schema changes are included.

## Docs / Compatibility Impact

The SSE contract now documents implemented hidden-tab polling and recovery: owning 404/410 responses stop the interval and clear the matching resume owner; stale responses cannot clear another session owner; idle, other HTTP errors, and network failures remain retryable. No endpoint, wire-format, or persistence-schema change is introduced. Changelog remains release-workflow owned.

## Model Used

- Provider: OpenAI
- Model: GPT-5
- Notable tools: local shell inspection/tests, GitHub CLI, and an isolated Node behavior harness

## Contract Change

Previously, missing-session responses left hidden-tab polling and automatic visibility recovery active. This PR treats only owning 404/410 responses as terminal for that observation state, while keeping other responses retryable. The public SSE contract records the implemented behavior without changing the broader RFC's proposed status.

Documentation/review follow-up: OpenAI GPT-6 via Codex, local shell, and GitHub CLI.

