### PR TITLE
Add gateway supervisor for single-container deployments (Refs #6730)

### DIFF
--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+__all__ = [
+    "restart_active_profile_gateway",
+    "_GATEWAY_RESTART_LOCK",
+    "_resolve_hermes_command",
+    "_consume_stream",
+]
+
 import logging
 import os
 import shutil

--- a/api/gateway_supervisor.py
+++ b/api/gateway_supervisor.py
@@ -1,0 +1,377 @@
+"""Gateway supervisor for single-container Docker deployments.
+
+This module provides automatic gateway process supervision when Hermes WebUI
+runs in a single-container configuration. In multi-container deployments with
+s6-overlay, the external supervisor handles gateway lifecycle and this module
+automatically disables itself.
+
+The supervisor monitors gateway health and automatically restarts the process
+when crashes are detected, using exponential backoff to prevent rapid restart
+loops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+logger = logging.getLogger(__name__)
+
+# States that indicate the gateway should be (re)started automatically.
+# Matches container_boot.py's _AUTOSTART_STATES plus transient running states.
+_AUTOSTART_STATES = frozenset({"running"})
+_TRANSIENT_RUNNING_STATES = frozenset({"draining", "degraded"})
+
+# Module-level singleton for integration with server.py
+_supervisor: "GatewaySupervisor | None" = None
+_supervisor_lock = threading.Lock()
+
+
+def _find_supervised_profiles() -> list[tuple[str, Path]]:
+    """Find profiles whose gateway should be supervised.
+
+    Unlike ``get_active_profile_name()`` (which requires a request context
+    via cookie), this works at server startup by scanning the profiles
+    directory.  Returns a list of ``(profile_name, profile_home)`` tuples
+    for every profile whose ``gateway_state.json`` indicates the gateway
+    was running.
+
+    In single-container mode there is typically exactly one such profile.
+    Multi-profile multiplexing is handled by the agent itself; we just
+    ensure the running one stays alive.
+    """
+    results: list[tuple[str, Path]] = []
+    try:
+        # The agent home root (where profiles/ lives) is HERMES_REAL_HOME/.hermes
+        # in the container. HERMES_WEBUI_STATE_DIR points at the WebUI's own
+        # state subdirectory (.hermes/webui), NOT the agent root.
+        real_home = os.environ.get("HERMES_REAL_HOME", "")
+        candidates = []
+        if real_home:
+            candidates.append(Path(real_home) / ".hermes")
+        # Also check $HOME/.hermes for non-container dev environments
+        home_dir = os.environ.get("HOME", "")
+        if home_dir:
+            candidates.append(Path(home_dir) / ".hermes")
+        # Fall back to the standard location
+        candidates.append(Path("/home/hermeswebui/.hermes"))
+
+        profiles_root = None
+        for candidate in candidates:
+            if (candidate / "profiles").is_dir():
+                profiles_root = candidate / "profiles"
+                break
+
+        if profiles_root is None:
+            return results
+
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            state_file = entry / "gateway_state.json"
+            if not state_file.exists():
+                continue
+            try:
+                data = json.loads(state_file.read_text())
+                state = data.get("desired_state") or data.get("gateway_state")
+                if state in _AUTOSTART_STATES or state in _TRANSIENT_RUNNING_STATES:
+                    results.append((entry.name, entry))
+            except (json.JSONDecodeError, OSError):
+                continue
+    except Exception:
+        logger.debug("Error scanning profiles for supervision", exc_info=True)
+    return results
+
+
+def should_enable_supervisor() -> bool:
+    """Check if gateway supervisor should be enabled.
+    
+    Returns:
+        True if supervisor should run, False otherwise.
+        
+    Logic:
+        1. If HERMES_GATEWAY_SUPERVISOR_ENABLED is set, respect it explicitly.
+        2. If running under s6-overlay (multi-container), disable supervisor.
+        3. Default to True in single-container environments.
+    """
+    env_val = os.environ.get("HERMES_GATEWAY_SUPERVISOR_ENABLED", "").strip().lower()
+    
+    # Explicit enable/disable via environment variable
+    if env_val in ("true", "1", "yes"):
+        return True
+    if env_val in ("false", "0", "no"):
+        return False
+    
+    # Auto-detect s6-overlay presence (multi-container mode)
+    if Path("/run/service").exists():
+        logger.debug("s6-overlay detected via /run/service - disabling supervisor")
+        return False
+    
+    if os.environ.get("S6_STAGE2_HOOK"):
+        logger.debug("s6-overlay detected via S6_STAGE2_HOOK - disabling supervisor")
+        return False
+    
+    # Default: enable in single-container mode
+    return True
+
+
+class CrashLoopBackoff:
+    """Exponential backoff tracker for gateway crash recovery.
+    
+    Tracks consecutive failures and calculates exponentially increasing
+    wait times to prevent rapid restart loops while still recovering
+    quickly from transient failures.
+    """
+    
+    def __init__(self) -> None:
+        self.consecutive_failures: int = 0
+        self.backoff_seconds: float = 5.0
+        self.last_start_time: float | None = None
+        self._min_backoff: float = 5.0
+        self._max_backoff: float = 300.0
+        self._successful_run_threshold: float = 600.0
+    
+    def record_start(self) -> None:
+        """Record a successful gateway start."""
+        self.last_start_time = time.time()
+    
+    def record_crash(self) -> float:
+        """Record a gateway crash and return the backoff wait time in seconds.
+        
+        Returns:
+            Number of seconds to wait before next restart attempt.
+        """
+        # Reset backoff if the gateway ran successfully for a while
+        if self.last_start_time is not None:
+            uptime = time.time() - self.last_start_time
+            if uptime > self._successful_run_threshold:
+                logger.info(
+                    "Gateway ran for %.1fs before crash - resetting backoff",
+                    uptime
+                )
+                self.consecutive_failures = 0
+                self.backoff_seconds = self._min_backoff
+        
+        self.consecutive_failures += 1
+        current_backoff = self.backoff_seconds
+        
+        # Double the backoff for next time, capped at max
+        self.backoff_seconds = min(self.backoff_seconds * 2, self._max_backoff)
+        
+        logger.warning(
+            "Gateway crash #%d - waiting %.1fs before restart (next backoff: %.1fs)",
+            self.consecutive_failures,
+            current_backoff,
+            self.backoff_seconds
+        )
+        
+        return current_backoff
+
+
+class GatewaySupervisor:
+    """Daemon thread that supervises the Hermes gateway process.
+    
+    Monitors gateway health via HTTP health checks and automatically
+    restarts the process when failures are detected, coordinating with
+    the WebUI's restart lock to prevent conflicts.
+    """
+    
+    def __init__(self, check_interval: float = 30.0) -> None:
+        """Initialize the gateway supervisor.
+        
+        Args:
+            check_interval: Seconds between health checks (default 30s)
+        """
+        self._check_interval = check_interval
+        self._stop_event = threading.Event()
+        self._supervisor_thread: threading.Thread | None = None
+        self._backoff = CrashLoopBackoff()
+    
+    def start(self) -> None:
+        """Start the supervisor daemon thread."""
+        if self._supervisor_thread is not None:
+            logger.warning("Supervisor already started")
+            return
+        
+        self._supervisor_thread = threading.Thread(
+            target=self._supervisor_loop,
+            name="gateway-supervisor",
+            daemon=True
+        )
+        self._supervisor_thread.start()
+        logger.info("Gateway supervisor started (check_interval=%.1fs)", self._check_interval)
+    
+    def stop(self) -> None:
+        """Stop the supervisor daemon thread."""
+        self._stop_event.set()
+        if self._supervisor_thread is not None:
+            self._supervisor_thread.join(timeout=5.0)
+    
+    def _supervisor_loop(self) -> None:
+        """Main supervisor loop: check health and restart on failure."""
+        try:
+            # Check if we should auto-start the gateway on supervisor initialization
+            if self._should_auto_start():
+                logger.info("Gateway auto-start enabled - checking initial health")
+                if not self._is_gateway_healthy():
+                    logger.info("Gateway not healthy on startup - initiating start")
+                    self._start_gateway()
+            else:
+                logger.info("Gateway auto-start disabled or stopped state detected")
+            
+            # Main monitoring loop
+            while not self._stop_event.wait(self._check_interval):
+                if not self._is_gateway_healthy():
+                    logger.warning("Gateway health check failed")
+                    wait_seconds = self._backoff.record_crash()
+                    
+                    # Wait with ability to be interrupted by stop event
+                    if self._stop_event.wait(wait_seconds):
+                        break
+                    
+                    self._start_gateway()
+        except Exception:
+            logger.exception("Gateway supervisor loop crashed")
+    
+    def _should_auto_start(self) -> bool:
+        """Check if any profile's gateway should be auto-started.
+
+        Scans the profiles directory for gateway_state.json files rather
+        than relying on request-context profile resolution, so this works
+        during server startup (no cookie / no request thread).
+
+        Returns:
+            True if at least one profile has gateway_state == running.
+        """
+        profiles = _find_supervised_profiles()
+        if profiles:
+            names = ", ".join(name for name, _ in profiles)
+            logger.info("Found %d profile(s) with running gateway: %s", len(profiles), names)
+            return True
+        return False
+    
+    def _is_gateway_healthy(self) -> bool:
+        """Check if the gateway process is healthy via HTTP health check.
+        
+        Returns:
+            True if gateway responds with HTTP 200, False otherwise.
+        """
+        try:
+            req = Request("http://127.0.0.1:8642/health")
+            with urlopen(req, timeout=5.0) as response:
+                return response.status == 200
+        except URLError:
+            return False
+        except Exception:
+            logger.debug("Gateway health check error", exc_info=True)
+            return False
+    
+    def _start_gateway(self) -> None:
+        """Start the gateway process for the first running profile.
+
+        Scans profiles (works without request context), acquires the
+        restart lock to coordinate with WebUI-initiated restarts, then
+        launches ``hermes --profile <name> gateway run --no-supervise``
+        as a detached process.
+        """
+        try:
+            from api.gateway_restart import (
+                _GATEWAY_RESTART_LOCK,
+                _resolve_hermes_command,
+                _consume_stream,
+            )
+
+            # Find the profile whose gateway should be running.
+            profiles = _find_supervised_profiles()
+            if not profiles:
+                logger.info("No profiles with running gateway state - not starting")
+                return
+
+            profile_name, profile_home = profiles[0]
+
+            # Try to acquire restart lock - skip if WebUI is restarting
+            if not _GATEWAY_RESTART_LOCK.acquire(blocking=False):
+                logger.info("Restart lock held by WebUI - skipping supervisor restart")
+                return
+
+            try:
+                hermes_cmd = _resolve_hermes_command()
+                cmd = [hermes_cmd, "--profile", profile_name, "gateway", "run", "--no-supervise"]
+
+                env = os.environ.copy()
+                env["HERMES_HOME"] = str(profile_home)
+
+                logger.info(
+                    "Starting gateway: %s (HERMES_HOME=%s)",
+                    " ".join(cmd),
+                    profile_home,
+                )
+
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    start_new_session=True,
+                )
+
+                time.sleep(3.0)
+                returncode = proc.poll()
+
+                if returncode is None:
+                    self._backoff.record_start()
+                    logger.info("Gateway process started successfully (pid=%s)", proc.pid)
+
+                    threading.Thread(
+                        target=_consume_stream, args=(proc.stdout,), daemon=True,
+                    ).start()
+                    threading.Thread(
+                        target=_consume_stream, args=(proc.stderr,), daemon=True,
+                    ).start()
+                else:
+                    stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
+                    stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+                    logger.error(
+                        "Gateway exited immediately (code=%s)\nstdout: %s\nstderr: %s",
+                        returncode, stdout, stderr,
+                    )
+            finally:
+                try:
+                    _GATEWAY_RESTART_LOCK.release()
+                except RuntimeError:
+                    pass
+
+        except Exception:
+            logger.exception("Failed to start gateway process")
+
+
+def stop_supervisor() -> None:
+    """Stop the global supervisor instance if running.
+    
+    Called from server.py shutdown sequence.
+    """
+    global _supervisor
+    with _supervisor_lock:
+        if _supervisor is not None:
+            _supervisor.stop()
+            _supervisor = None
+
+
+def start_supervisor() -> None:
+    """Start the global supervisor instance.
+    
+    Called from server.py startup sequence.
+    """
+    global _supervisor
+    with _supervisor_lock:
+        if _supervisor is None:
+            _supervisor = GatewaySupervisor()
+            _supervisor.start()

--- a/api/gateway_supervisor.py
+++ b/api/gateway_supervisor.py
@@ -279,8 +279,11 @@ class GatewaySupervisor:
 
         Scans profiles (works without request context), acquires the
         restart lock to coordinate with WebUI-initiated restarts, then
-        launches ``hermes --profile <name> gateway run --no-supervise``
-        as a detached process.
+        launches ``hermes --profile <name> gateway run --no-supervise --replace``
+        as a detached process. ``--replace`` lets the supervisor recover
+        from a half-dead previous instance without a separate ``stop``
+        round-trip (which would block on systemd/s6 detection in
+        single-container mode where neither exists).
         """
         try:
             from api.gateway_restart import (
@@ -304,7 +307,7 @@ class GatewaySupervisor:
 
             try:
                 hermes_cmd = _resolve_hermes_command()
-                cmd = [hermes_cmd, "--profile", profile_name, "gateway", "run", "--no-supervise"]
+                cmd = [hermes_cmd, "--profile", profile_name, "gateway", "run", "--no-supervise", "--replace"]
 
                 env = os.environ.copy()
                 env["HERMES_HOME"] = str(profile_home)
@@ -315,10 +318,19 @@ class GatewaySupervisor:
                     profile_home,
                 )
 
+                # Redirect to log file so a stuck / conflicting process leaves evidence
+                # and the supervisor's Popen never blocks on a full PIPE buffer.
+                log_path = Path(profile_home) / "logs" / "gateway-supervisor.log"
+                try:
+                    log_path.parent.mkdir(parents=True, exist_ok=True)
+                except OSError:
+                    pass
+                log_fp = open(log_path, "ab", buffering=0)
                 proc = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=log_fp,
+                    stderr=log_fp,
+                    stdin=subprocess.DEVNULL,
                     env=env,
                     start_new_session=True,
                 )
@@ -330,18 +342,22 @@ class GatewaySupervisor:
                     self._backoff.record_start()
                     logger.info("Gateway process started successfully (pid=%s)", proc.pid)
 
-                    threading.Thread(
-                        target=_consume_stream, args=(proc.stdout,), daemon=True,
-                    ).start()
-                    threading.Thread(
-                        target=_consume_stream, args=(proc.stderr,), daemon=True,
-                    ).start()
+                    # Streams already redirected to log file (gateway-supervisor.log);
+                    # no Popen pipes to drain.
                 else:
-                    stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
-                    stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+                    # Proc died in 3s — read tail of the log file to surface the cause
+                    tail = b""
+                    try:
+                        with open(log_path, "rb") as f:
+                            f.seek(0, 2)
+                            size = f.tell()
+                            f.seek(max(0, size - 4096))
+                            tail = f.read()
+                    except OSError:
+                        pass
                     logger.error(
-                        "Gateway exited immediately (code=%s)\nstdout: %s\nstderr: %s",
-                        returncode, stdout, stderr,
+                        "Gateway exited immediately (code=%s). See %s. Tail: %s",
+                        returncode, log_path, tail.decode("utf-8", errors="replace"),
                     )
             finally:
                 try:

--- a/server.py
+++ b/server.py
@@ -649,6 +649,16 @@ def main() -> None:
         print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
 
     try:
+        from api.gateway_supervisor import should_enable_supervisor, start_supervisor
+        if should_enable_supervisor():
+            start_supervisor()
+            print('[ok] Gateway supervisor started', flush=True)
+        else:
+            print('[tip] Gateway supervisor disabled (multi-container or explicit config)', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: Gateway supervisor failed to start: {e}', flush=True)
+
+    try:
         from api.background_process import start_drain_thread
         if start_drain_thread():
             print('[ok] bg_task_complete drain thread started', flush=True)
@@ -730,6 +740,11 @@ def main() -> None:
             stop_watcher()
         except Exception:
             logger.debug("Failed to stop gateway watcher during shutdown")
+        try:
+            from api.gateway_supervisor import stop_supervisor
+            stop_supervisor()
+        except Exception:
+            logger.debug("Failed to stop gateway supervisor during shutdown", exc_info=True)
         try:
             from api.session_lifecycle import drain_all_on_shutdown
             drain_all_on_shutdown()


### PR DESCRIPTION
## Problem

In single-container Docker deployments, the Hermes Agent gateway process has **no external process supervisor**. When the gateway crashes (OOM, SIGKILL, unexpected exit), nothing restarts it. The WebUI then shows "Gateway sync unavailable" banners, SSE streams break, and chat sessions become unusable until manual intervention.

### Root cause

The single-container init script (`docker_init.bash`) only starts `server.py` — it never starts the gateway. The gateway is only started on-demand (by clicking "Restart Service" or by the agent's fallback path). Multi-container deployments use s6-overlay to supervise the gateway (via `container_boot.py` + s6 service slots); the single-container image has no equivalent.

This is the architectural gap identified in #5231. The distinct 240s kill-loop / process-ownership bug (#6730) is addressed by #6733; this PR is complementary supervision work — it does **not** modify `_wait_and_release` or the restart-button path.

### Log evidence

```
09:52:08  gateway exits code 1 (SIGTERM from 240s timeout)
09:52:32  new gateway started (pid=4061)
10:01:14  pid=4061 UNCLEANLY exited (SIGKILL/OOM/VM death)
          <- nothing restarts it ->
10:05:15  restart failed, gateway stays dead, WebUI unusable
```

## Solution

Add a lightweight Python supervisor thread inside `server.py` that:

1. **Auto-starts gateway on boot** — reads `gateway_state.json`; if state is `running`/`draining`/`degraded`, starts the gateway (reuses `container_boot.py`'s state machine semantics)
2. **Health checks every 30s** — HTTP GET `http://127.0.0.1:8642/health`
3. **Restarts crashed gateways** — uses `hermes --profile <name> gateway run --no-supervise --replace`. The `--replace` flag is required: a half-dead previous instance still holds the recorded PID, so a plain `gateway run` fails with *"Another gateway instance is already running (PID NNNN)"* and silently exits. `--replace` lets the supervisor recover in one round-trip without a separate `stop` (which would block in single-container mode where neither systemd nor launchd exists to handle the stop).
4. **Exponential backoff** — 5s to 300s, resets after 10min of stable uptime
5. **Coordinates with WebUI restarts** — shares `_GATEWAY_RESTART_LOCK` with `gateway_restart.py` to avoid double-restart conflicts
6. **Auto-disables in multi-container** — detects `/run/service/` or `S6_STAGE2_HOOK` and stays out of the way
7. **Configurable** — `HERMES_GATEWAY_SUPERVISOR_ENABLED=false` to explicitly disable
8. **Logs to file, not PIPE** — gateway stdout/stderr redirected to `$HERMES_HOME/logs/gateway-supervisor.log` so the supervisor's Popen never blocks on a full pipe buffer (a real failure mode: the gateway's startup banner + MCP discovery + scheduler boot can flood stderr faster than the supervisor drains it, making the new gateway look dead before it finishes initializing). On early-exit detection the supervisor reads the last 4KB of that log to surface the cause.

## Files changed

| File | Change | Lines |
|------|--------|-------|
| `api/gateway_supervisor.py` | **New** - supervisor implementation (with `--replace` and log redirects) | +393 |
| `server.py` | Start/stop supervisor in `main()` | +15 |
| `api/gateway_restart.py` | Export `__all__` for symbol reuse | +7 |

## Design decisions

- **Python thread, not bash/s6**: minimal change, no Dockerfile modification, no new dependencies. The supervisor runs in the same process as server.py. If server.py itself is OOM-killed, Docker's `restart: unless-stopped` restarts the container and the supervisor comes back with it.
- **`gateway run --no-supervise --replace`, not `gateway start`**: `hermes gateway start` is explicitly rejected inside Docker containers ("Service start is not applicable inside a Docker container"). `gateway run` is the correct foreground mode. `--replace` is required to recover from half-dead previous instances.
- **Profile scanning, not request context**: `get_active_profile_name()` requires a cookie/request context which doesn't exist at server startup. The supervisor scans the profiles directory directly (like `container_boot.py` does).
- **Independent of #6733**: This PR doesn't touch `_wait_and_release` or the restart path. #6733 fixes the restart button's 240s kill-loop; this PR ensures gateways that crash independently get restarted. They coexist cleanly. Note: if #6733 lands and the ownership bug is fixed, the supervisor will simply observe a stable gateway and not need to restart it; if #6733 does not land, the supervisor's retry may mask the kill-loop symptom, which is why the two fixes remain tracked separately.

## Testing

- Syntax check passes for all 3 files (`py_compile`)
- Import check: `should_enable_supervisor()`, `start_supervisor()`, `stop_supervisor()` all importable
- s6 detection correctly returns False in single-container (no `/run/service/`)
- Profile scanning finds the active profile from `gateway_state.json`
- Health check correctly returns False when gateway is down
- Backoff logic: 5s → 10s → 20s, caps at 300s, resets after 10min uptime
- **Live dry-run**: confirmed `--replace` cleanly cycles a stale gateway (pid 1216 → SIGTERM → pid 1365 → healthy in ~15s)
- No new dependencies (stdlib only)

## Related issues

- Refs #6730 (the 240s ownership bug is tracked separately, fixed by #6733)
- Related to #5231 (long-term single-container supervisor follow-up)
- Coexists with #6733 (240s restart kill-loop fix)