### PR TITLE
fix(server): register SIGINT handler for graceful shutdown (#7078)

### DIFF
--- a/server.py
+++ b/server.py
@@ -721,6 +721,11 @@ def main() -> None:
         logger.debug("Could not install SIGTERM handler", exc_info=True)
 
     try:
+        signal.signal(signal.SIGINT, _request_shutdown)
+    except (ValueError, OSError):
+        logger.debug("Could not install SIGINT handler", exc_info=True)
+
+    try:
         httpd.serve_forever()
     finally:
         httpd.server_close()


### PR DESCRIPTION
## What Problem This Solves

The **Stop server** button in Settings returns `200 {"status": "shutting_down"}` but the WebUI process keeps running for daemons launched via `./ctl.sh start`. The only way to stop the daemon is `kill <pid>` from a terminal.

## Why This Change Was Made

Three facts combine:

1. `ctl.sh start` spawns the server from a non-interactive bash background job. POSIX/bash rule: asynchronous commands in non-interactive shells ignore SIGINT — the child inherits `SIGINT = SIG_IGN`.
2. CPython preserves an inherited `SIG_IGN` for SIGINT — it does not install its `KeyboardInterrupt` handler when SIGINT was ignored at interpreter startup.
3. `_handle_shutdown` (`api/routes.py`) commits suicide with `os.kill(os.getpid(), signal.SIGINT)` — which is a silent no-op for ctl.sh-managed daemons.

Meanwhile `server.py` only registers a graceful handler for SIGTERM (line 718) — which is why `kill -TERM` stops the daemon cleanly while the button's SIGINT does nothing.

## User Impact

The Stop server button now works for ctl.sh-managed daemons. Also covers edge cases where SIGINT is delivered (e.g. `Ctrl+C` in a terminal that forwards SIGINT to the process group).

## Evidence

- Issue: https://github.com/nesquena/hermes-webui/issues/7078
- Root cause confirmed at `server.py:718` — only SIGTERM registered
- Fix: added `signal.signal(signal.SIGINT, _request_shutdown)` after the SIGTERM registration
- 1 file changed, 5 insertions
