### PR TITLE
Reset model picker after deleting final conversation

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2262,6 +2262,9 @@ $('modelSelect').onchange=async()=>{
   const modelState=(typeof _modelStateForSelect==='function')
     ? _modelStateForSelect($('modelSelect'),selectedModel)
     : {model:selectedModel,model_provider:null};
+  if(typeof _rememberComposerModelPick==='function'){
+    _rememberComposerModelPick(modelState.model,modelState.model_provider);
+  }
   if(typeof clearProfileTransitionReasoningContext==='function') clearProfileTransitionReasoningContext();
   if(typeof closeModelDropdown==='function') closeModelDropdown();
   if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1298,12 +1298,10 @@ const _emptyComposerModelOverrideHost=typeof window!=='undefined'?window:globalT
 function _rememberEmptyComposerModelOverride(model, modelProvider){
   const resolvedModel=String(model||'').trim();
   if(!resolvedModel) return;
-  const previous=_emptyComposerModelOverrideHost._emptyComposerModelOverride;
   _emptyComposerModelOverrideHost._emptyComposerModelOverride={
     model:resolvedModel,
     model_provider:modelProvider||null,
     saved_at:Date.now(),
-    revision:(Number(previous&&previous.revision||0)||0)+1,
   };
 }
 
@@ -1314,7 +1312,6 @@ function _readEmptyComposerModelOverride(){
     model:String(state.model||''),
     model_provider:state.model_provider||null,
     saved_at:Number(state.saved_at||0)||0,
-    revision:Number(state.revision||0)||0,
   };
 }
 
@@ -1322,17 +1319,48 @@ function _clearEmptyComposerModelOverride(){
   _emptyComposerModelOverrideHost._emptyComposerModelOverride=null;
 }
 
-function _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete){
-  const currentOverride=typeof _readEmptyComposerModelOverride==='function'
-    ? _readEmptyComposerModelOverride()
+const _composerModelPickHost=typeof window!=='undefined'?window:globalThis;
+
+// Track explicit picker intent independently of S.session. During deletion the
+// picker can change both before and after the active session is cleared.
+function _rememberComposerModelPick(model, modelProvider){
+  const resolvedModel=String(model||'').trim();
+  if(!resolvedModel) return;
+  const previous=_composerModelPickHost._composerModelPick;
+  _composerModelPickHost._composerModelPick={
+    model:resolvedModel,
+    model_provider:modelProvider||null,
+    revision:(Number(previous&&previous.revision||0)||0)+1,
+  };
+}
+
+function _readComposerModelPick(){
+  const state=_composerModelPickHost._composerModelPick;
+  if(!state||!state.model) return null;
+  return {
+    model:String(state.model||''),
+    model_provider:state.model_provider||null,
+    revision:Number(state.revision||0)||0,
+  };
+}
+
+function _settleEmptyComposerModelAfterFinalSessionDelete(modelPickRevisionAtDelete){
+  const currentPick=typeof _readComposerModelPick==='function'
+    ? _readComposerModelPick()
     : null;
-  const currentRevision=Number(currentOverride&&currentOverride.revision||0)||0;
-  if(currentRevision!==(Number(overrideRevisionAtDelete||0)||0)) return null;
-  if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
-  const model=String(window._defaultModel||'').trim();
+  const currentRevision=Number(currentPick&&currentPick.revision||0)||0;
+  const preservePick=currentPick&&currentRevision!==(Number(modelPickRevisionAtDelete||0)||0);
+  const model=String(preservePick?currentPick.model:(window._defaultModel||'')).trim();
+  const provider=preservePick?currentPick.model_provider:(window._activeProvider||null);
+  if(preservePick){
+    if(typeof _rememberEmptyComposerModelOverride==='function'){
+      _rememberEmptyComposerModelOverride(model,provider);
+    }
+  }else if(typeof _clearEmptyComposerModelOverride==='function'){
+    _clearEmptyComposerModelOverride();
+  }
   const modelSel=$('modelSelect');
   if(!model||!modelSel) return null;
-  const provider=window._activeProvider||null;
   const applied=typeof _ensureModelOptionInDropdown==='function'
     ? _ensureModelOptionInDropdown(model,modelSel,provider)
     : (typeof _applyModelToDropdown==='function'?_applyModelToDropdown(model,modelSel,provider):null);
@@ -4374,6 +4402,10 @@ function _renderBatchActionBar(){
       danger:true
     });
     if(!ok)return;
+    const modelPickAtDelete=typeof _readComposerModelPick==='function'
+      ? _readComposerModelPick()
+      : null;
+    const modelPickRevisionAtDelete=Number(modelPickAtDelete&&modelPickAtDelete.revision||0)||0;
     try{
       const results=await Promise.all(ids.map(async sid=>{
         const response=await api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})});
@@ -4383,16 +4415,12 @@ function _renderBatchActionBar(){
       const cleanupFailedCount=results.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
-        const overrideAtDelete=typeof _readEmptyComposerModelOverride==='function'
-          ? _readEmptyComposerModelOverride()
-          : null;
-        const overrideRevisionAtDelete=Number(overrideAtDelete&&overrideAtDelete.revision||0)||0;
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
         else{
-          _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete);
+          _settleEmptyComposerModelAfterFinalSessionDelete(modelPickRevisionAtDelete);
           $('msgInner').innerHTML='';$('emptyState').style.display='';
         }
       }
@@ -9163,6 +9191,10 @@ async function deleteSession(sid, beforeDelete=null){
     danger:true
   });
   if(!ok)return false;
+  const modelPickAtDelete=typeof _readComposerModelPick==='function'
+    ? _readComposerModelPick()
+    : null;
+  const modelPickRevisionAtDelete=Number(modelPickAtDelete&&modelPickAtDelete.revision||0)||0;
   const reflowPositions=_captureSessionReflowPositions();
   const beforeDeleteHold=beforeDelete?Promise.resolve().then(beforeDelete):null;
   const previousSessions=_allSessions;
@@ -9198,10 +9230,6 @@ async function deleteSession(sid, beforeDelete=null){
     _optimisticallyRemoveSessionFromList(sid);
   }
   if(S.session&&S.session.session_id===sid){
-    const overrideAtDelete=typeof _readEmptyComposerModelOverride==='function'
-      ? _readEmptyComposerModelOverride()
-      : null;
-    const overrideRevisionAtDelete=Number(overrideAtDelete&&overrideAtDelete.revision||0)||0;
     S.session=null;S.messages=[];S.entries=[];
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
     localStorage.removeItem('hermes-webui-session');
@@ -9210,7 +9238,7 @@ async function deleteSession(sid, beforeDelete=null){
     if(remaining.sessions&&remaining.sessions.length){
       await loadSession(remaining.sessions[0].session_id);
     }else{
-      _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete);
+      _settleEmptyComposerModelAfterFinalSessionDelete(modelPickRevisionAtDelete);
       const _tt=$('topbarTitle');if(_tt)_tt.textContent=assistantDisplayName();
       const _tm=$('topbarMeta');if(_tm)_tm.textContent='Start a new conversation';
       $('msgInner').innerHTML='';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1298,10 +1298,12 @@ const _emptyComposerModelOverrideHost=typeof window!=='undefined'?window:globalT
 function _rememberEmptyComposerModelOverride(model, modelProvider){
   const resolvedModel=String(model||'').trim();
   if(!resolvedModel) return;
+  const previous=_emptyComposerModelOverrideHost._emptyComposerModelOverride;
   _emptyComposerModelOverrideHost._emptyComposerModelOverride={
     model:resolvedModel,
     model_provider:modelProvider||null,
     saved_at:Date.now(),
+    revision:(Number(previous&&previous.revision||0)||0)+1,
   };
 }
 
@@ -1312,6 +1314,7 @@ function _readEmptyComposerModelOverride(){
     model:String(state.model||''),
     model_provider:state.model_provider||null,
     saved_at:Number(state.saved_at||0)||0,
+    revision:Number(state.revision||0)||0,
   };
 }
 
@@ -1319,7 +1322,12 @@ function _clearEmptyComposerModelOverride(){
   _emptyComposerModelOverrideHost._emptyComposerModelOverride=null;
 }
 
-function _resetEmptyComposerModelToConfiguredDefault(){
+function _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete){
+  const currentOverride=typeof _readEmptyComposerModelOverride==='function'
+    ? _readEmptyComposerModelOverride()
+    : null;
+  const currentRevision=Number(currentOverride&&currentOverride.revision||0)||0;
+  if(currentRevision!==(Number(overrideRevisionAtDelete||0)||0)) return null;
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
   const model=String(window._defaultModel||'').trim();
   const modelSel=$('modelSelect');
@@ -4375,12 +4383,16 @@ function _renderBatchActionBar(){
       const cleanupFailedCount=results.filter(result=>result.response&&result.response.state_db_cleanup_failed).length;
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
+        const overrideAtDelete=typeof _readEmptyComposerModelOverride==='function'
+          ? _readEmptyComposerModelOverride()
+          : null;
+        const overrideRevisionAtDelete=Number(overrideAtDelete&&overrideAtDelete.revision||0)||0;
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
         else{
-          _resetEmptyComposerModelToConfiguredDefault();
+          _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete);
           $('msgInner').innerHTML='';$('emptyState').style.display='';
         }
       }
@@ -9186,6 +9198,10 @@ async function deleteSession(sid, beforeDelete=null){
     _optimisticallyRemoveSessionFromList(sid);
   }
   if(S.session&&S.session.session_id===sid){
+    const overrideAtDelete=typeof _readEmptyComposerModelOverride==='function'
+      ? _readEmptyComposerModelOverride()
+      : null;
+    const overrideRevisionAtDelete=Number(overrideAtDelete&&overrideAtDelete.revision||0)||0;
     S.session=null;S.messages=[];S.entries=[];
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
     localStorage.removeItem('hermes-webui-session');
@@ -9194,7 +9210,7 @@ async function deleteSession(sid, beforeDelete=null){
     if(remaining.sessions&&remaining.sessions.length){
       await loadSession(remaining.sessions[0].session_id);
     }else{
-      _resetEmptyComposerModelToConfiguredDefault();
+      _resetEmptyComposerModelToConfiguredDefault(overrideRevisionAtDelete);
       const _tt=$('topbarTitle');if(_tt)_tt.textContent=assistantDisplayName();
       const _tm=$('topbarMeta');if(_tm)_tm.textContent='Start a new conversation';
       $('msgInner').innerHTML='';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1319,6 +1319,19 @@ function _clearEmptyComposerModelOverride(){
   _emptyComposerModelOverrideHost._emptyComposerModelOverride=null;
 }
 
+function _resetEmptyComposerModelToConfiguredDefault(){
+  if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
+  const model=String(window._defaultModel||'').trim();
+  const modelSel=$('modelSelect');
+  if(!model||!modelSel) return null;
+  const provider=window._activeProvider||null;
+  const applied=typeof _ensureModelOptionInDropdown==='function'
+    ? _ensureModelOptionInDropdown(model,modelSel,provider)
+    : (typeof _applyModelToDropdown==='function'?_applyModelToDropdown(model,modelSel,provider):null);
+  if(applied&&typeof syncReasoningChip==='function') syncReasoningChip();
+  return applied;
+}
+
 let _newSessionWorkspaceAnnouncementClearTimer=null;
 
 function _setNewSessionWorkspaceCue(message){
@@ -4366,7 +4379,10 @@ function _renderBatchActionBar(){
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
-        else{$('msgInner').innerHTML='';$('emptyState').style.display='';}
+        else{
+          _resetEmptyComposerModelToConfiguredDefault();
+          $('msgInner').innerHTML='';$('emptyState').style.display='';
+        }
       }
       if(cleanupFailedCount) showToast(t('delete_failed')+' ('+cleanupFailedCount+'/'+ids.length+')',0,'error');
       else showToast((retainedCount?t('session_deleted_worktree'):t('session_delete'))+' ('+ids.length+')');
@@ -9178,6 +9194,7 @@ async function deleteSession(sid, beforeDelete=null){
     if(remaining.sessions&&remaining.sessions.length){
       await loadSession(remaining.sessions[0].session_id);
     }else{
+      _resetEmptyComposerModelToConfiguredDefault();
       const _tt=$('topbarTitle');if(_tt)_tt.textContent=assistantDisplayName();
       const _tm=$('topbarMeta');if(_tm)_tm.textContent='Start a new conversation';
       $('msgInner').innerHTML='';

--- a/tests/test_final_session_delete_model_reset.py
+++ b/tests/test_final_session_delete_model_reset.py
@@ -8,7 +8,6 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
-SESSIONS_JS = SESSIONS_JS_PATH.read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 
@@ -33,18 +32,43 @@ function extractFunction(src, signature) {
 
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const args = JSON.parse(process.argv[3]);
+
+function makeElement(tag) {
+  const el = {
+    tagName: String(tag || 'div').toUpperCase(),
+    children: [],
+    className: '',
+    style: {display: 'none'},
+    textContent: '',
+    appendChild(child) { this.children.push(child); return child; },
+    querySelectorAll() { return []; },
+  };
+  Object.defineProperty(el, 'innerHTML', {
+    get() { return this._innerHTML || ''; },
+    set(value) {
+      this._innerHTML = value;
+      if (value === '') this.children = [];
+    },
+  });
+  return el;
+}
+
 const elements = {
   modelSelect: {value: args.currentModel, _provider: args.currentProvider},
-  topbarTitle: {textContent: ''},
-  topbarMeta: {textContent: ''},
-  msgInner: {innerHTML: ''},
-  emptyState: {style: {display: 'none'}},
-  fileTree: {innerHTML: ''},
+  topbarTitle: makeElement('div'),
+  topbarMeta: makeElement('div'),
+  msgInner: makeElement('div'),
+  emptyState: makeElement('div'),
+  fileTree: makeElement('div'),
+  batchActionBar: makeElement('div'),
 };
-const calls = {clearOverride: 0, reasoningSync: 0};
+let sessionsRequested = false;
+let resolveSessions;
+const sessionsResponse = new Promise(resolve => { resolveSessions = resolve; });
 
 globalThis.window = globalThis;
 globalThis.$ = id => elements[id] || null;
+globalThis.document = {createElement: makeElement};
 globalThis.S = {
   session: {session_id: 'active-session'},
   messages: [{role: 'user', content: 'hello'}],
@@ -52,16 +76,19 @@ globalThis.S = {
 };
 globalThis._defaultModel = args.defaultModel;
 globalThis._activeProvider = args.defaultProvider;
+globalThis._emptyComposerModelOverrideHost = globalThis;
+globalThis._emptyComposerModelOverride = null;
 globalThis.localStorage = {removeItem() {}};
-globalThis._clearEmptyComposerModelOverride = () => { calls.clearOverride++; };
 globalThis._ensureModelOptionInDropdown = (model, select, provider) => {
   select.value = model;
   select._provider = provider || null;
   return model;
 };
-globalThis.syncReasoningChip = () => { calls.reasoningSync++; };
+globalThis.syncReasoningChip = () => {};
 globalThis.showConfirmDialog = async () => true;
 globalThis._sessionSnapshotById = () => ({session_id: 'active-session'});
+globalThis._worktreeSessionCount = () => 0;
+globalThis._worktreeResponseCount = () => 0;
 globalThis._captureSessionReflowPositions = () => null;
 globalThis._clearHandoffStorageForSession = () => {};
 globalThis._clearPersistedSessionQueue = () => {};
@@ -73,22 +100,57 @@ globalThis.syncAppTitlebar = () => {};
 globalThis.showToast = () => {};
 globalThis._sessionResponseRetainsWorktree = () => false;
 globalThis.renderSessionList = async () => {};
+globalThis.exitSessionSelectMode = () => {};
 globalThis.setStatus = () => {};
-globalThis.t = key => key;
+globalThis.t = (key, value) => value === undefined ? key : key + ':' + value;
 globalThis._optimisticallyRemovedSessionIds = new Set();
 globalThis._allSessions = [{session_id: 'active-session'}];
 globalThis._pendingSessionReflowPositions = null;
+globalThis._selectedSessions = new Set(['active-session']);
 globalThis.api = async url => {
   if (url === '/api/session/delete') return {};
-  if (url === '/api/sessions') return {sessions: []};
+  if (url === '/api/sessions') {
+    sessionsRequested = true;
+    return sessionsResponse;
+  }
   throw new Error('unexpected api call: ' + url);
 };
 
+eval(extractFunction(src, 'function _rememberEmptyComposerModelOverride('));
+eval(extractFunction(src, 'function _readEmptyComposerModelOverride('));
+eval(extractFunction(src, 'function _clearEmptyComposerModelOverride('));
 eval(extractFunction(src, 'function _resetEmptyComposerModelToConfiguredDefault('));
 eval(extractFunction(src, 'async function deleteSession('));
+eval(extractFunction(src, 'function _renderBatchActionBar('));
+
+async function waitForSessionsRequest() {
+  for (let attempt = 0; attempt < 20 && !sessionsRequested; attempt++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  if (!sessionsRequested) throw new Error('session list request was not reached');
+}
 
 (async () => {
-  const deleted = await deleteSession('active-session');
+  let deletion;
+  if (args.mode === 'batch') {
+    _renderBatchActionBar();
+    const deleteButton = elements.batchActionBar.children.find(child =>
+      String(child.className || '').includes('batch-action-btn-danger')
+    );
+    if (!deleteButton) throw new Error('batch delete button not rendered');
+    deletion = deleteButton.onclick();
+  } else {
+    deletion = deleteSession('active-session');
+  }
+
+  await waitForSessionsRequest();
+  if (args.pickWhileSettling) {
+    elements.modelSelect.value = args.settlingModel;
+    elements.modelSelect._provider = args.settlingProvider;
+    _rememberEmptyComposerModelOverride(args.settlingModel, args.settlingProvider);
+  }
+  resolveSessions({sessions: []});
+  const deleted = await deletion;
   process.stdout.write(JSON.stringify({
     deleted,
     session: S.session,
@@ -96,7 +158,7 @@ eval(extractFunction(src, 'async function deleteSession('));
     model: elements.modelSelect.value,
     provider: elements.modelSelect._provider,
     emptyStateDisplay: elements.emptyState.style.display,
-    calls,
+    override: _readEmptyComposerModelOverride(),
   }));
 })().catch(err => {
   process.stderr.write(String(err && err.stack ? err.stack : err));
@@ -112,45 +174,54 @@ def driver_path(tmp_path_factory):
     return str(path)
 
 
-@pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_deleting_active_final_session_resets_empty_composer_to_configured_default(driver_path):
+def _run_case(driver_path, **overrides):
+    payload = {
+        "mode": "single",
+        "currentModel": "GPT-5.6 Ornith",
+        "currentProvider": "openai-codex",
+        "defaultModel": "gpt-5.6-luna",
+        "defaultProvider": "openai-codex",
+        **overrides,
+    }
     result = subprocess.run(
-        [
-            NODE,
-            driver_path,
-            str(SESSIONS_JS_PATH),
-            json.dumps(
-                {
-                    "currentModel": "GPT-5.6 Ornith",
-                    "currentProvider": "openai-codex",
-                    "defaultModel": "gpt-5.6-luna",
-                    "defaultProvider": "openai-codex",
-                }
-            ),
-        ],
+        [NODE, driver_path, str(SESSIONS_JS_PATH), json.dumps(payload)],
         capture_output=True,
         text=True,
         timeout=30,
     )
     assert result.returncode == 0, result.stderr
-    data = json.loads(result.stdout)
+    return json.loads(result.stdout)
 
-    assert data["deleted"] is True
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+@pytest.mark.parametrize("mode", ["single", "batch"])
+def test_deleting_active_final_session_resets_empty_composer_to_configured_default(driver_path, mode):
+    data = _run_case(driver_path, mode=mode)
+
+    if mode == "single":
+        assert data["deleted"] is True
     assert data["session"] is None
     assert data["messages"] == []
     assert data["model"] == "gpt-5.6-luna"
     assert data["provider"] == "openai-codex"
     assert data["emptyStateDisplay"] == ""
-    assert data["calls"] == {"clearOverride": 1, "reasoningSync": 1}
+    assert data["override"] is None
 
 
-def test_single_and_batch_final_session_delete_share_model_reset_helper():
-    single_delete = SESSIONS_JS[
-        SESSIONS_JS.index("async function deleteSession(") : SESSIONS_JS.index("// ── Project helpers", SESSIONS_JS.index("async function deleteSession("))
-    ]
-    batch_delete = SESSIONS_JS[
-        SESSIONS_JS.index("function _renderBatchActionBar(") : SESSIONS_JS.index("function _showBatchProjectPicker(")
-    ]
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+@pytest.mark.parametrize("mode", ["single", "batch"])
+def test_final_session_delete_preserves_model_pick_made_while_session_list_loads(driver_path, mode):
+    data = _run_case(
+        driver_path,
+        mode=mode,
+        pickWhileSettling=True,
+        settlingModel="claude-sonnet-4-5",
+        settlingProvider="anthropic",
+    )
 
-    assert "_resetEmptyComposerModelToConfiguredDefault();" in single_delete
-    assert "_resetEmptyComposerModelToConfiguredDefault();" in batch_delete
+    assert data["session"] is None
+    assert data["model"] == "claude-sonnet-4-5"
+    assert data["provider"] == "anthropic"
+    assert data["override"]["model"] == "claude-sonnet-4-5"
+    assert data["override"]["model_provider"] == "anthropic"
+    assert data["override"]["saved_at"] > 0

--- a/tests/test_final_session_delete_model_reset.py
+++ b/tests/test_final_session_delete_model_reset.py
@@ -8,6 +8,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+BOOT_JS_PATH = REPO_ROOT / "static" / "boot.js"
 NODE = shutil.which("node")
 
 
@@ -30,8 +31,21 @@ function extractFunction(src, signature) {
   throw new Error(signature + ' body not closed');
 }
 
+function extractFunctionIfPresent(src, signature) {
+  return src.indexOf(signature) >= 0 ? extractFunction(src, signature) : '';
+}
+
+function extractStatementBefore(src, startText, endText) {
+  const start = src.indexOf(startText);
+  if (start < 0) throw new Error(startText + ' not found');
+  const end = src.indexOf(endText, start);
+  if (end < 0) throw new Error(endText + ' not found after ' + startText);
+  return src.slice(start, end);
+}
+
 const src = fs.readFileSync(process.argv[2], 'utf8');
-const args = JSON.parse(process.argv[3]);
+const bootSrc = fs.readFileSync(process.argv[3], 'utf8');
+const args = JSON.parse(process.argv[4]);
 
 function makeElement(tag) {
   const el = {
@@ -62,6 +76,9 @@ const elements = {
   fileTree: makeElement('div'),
   batchActionBar: makeElement('div'),
 };
+let deleteRequested = false;
+let resolveDelete;
+const deleteResponse = new Promise(resolve => { resolveDelete = resolve; });
 let sessionsRequested = false;
 let resolveSessions;
 const sessionsResponse = new Promise(resolve => { resolveSessions = resolve; });
@@ -78,13 +95,27 @@ globalThis._defaultModel = args.defaultModel;
 globalThis._activeProvider = args.defaultProvider;
 globalThis._emptyComposerModelOverrideHost = globalThis;
 globalThis._emptyComposerModelOverride = null;
+globalThis._composerModelPickHost = globalThis;
+globalThis._composerModelPick = null;
 globalThis.localStorage = {removeItem() {}};
+globalThis._modelStateForSelect = select => ({
+  model: select.value,
+  model_provider: select._provider || null,
+});
 globalThis._ensureModelOptionInDropdown = (model, select, provider) => {
   select.value = model;
   select._provider = provider || null;
   return model;
 };
 globalThis.syncReasoningChip = () => {};
+globalThis.syncModelChip = () => {};
+globalThis.syncTopbar = () => {};
+globalThis.clearProfileTransitionReasoningContext = () => {};
+globalThis.closeModelDropdown = () => {};
+globalThis._writePersistedModelState = () => {};
+globalThis._rememberPendingSessionModel = () => {};
+globalThis._applySessionContextMetadataUpdate = () => {};
+globalThis._checkProviderMismatch = () => null;
 globalThis.showConfirmDialog = async () => true;
 globalThis._sessionSnapshotById = () => ({session_id: 'active-session'});
 globalThis._worktreeSessionCount = () => 0;
@@ -108,20 +139,40 @@ globalThis._allSessions = [{session_id: 'active-session'}];
 globalThis._pendingSessionReflowPositions = null;
 globalThis._selectedSessions = new Set(['active-session']);
 globalThis.api = async url => {
-  if (url === '/api/session/delete') return {};
+  if (url === '/api/session/delete') {
+    deleteRequested = true;
+    return deleteResponse;
+  }
   if (url === '/api/sessions') {
     sessionsRequested = true;
     return sessionsResponse;
   }
+  if (url === '/api/session/update') return {session: {}};
   throw new Error('unexpected api call: ' + url);
 };
 
 eval(extractFunction(src, 'function _rememberEmptyComposerModelOverride('));
 eval(extractFunction(src, 'function _readEmptyComposerModelOverride('));
 eval(extractFunction(src, 'function _clearEmptyComposerModelOverride('));
-eval(extractFunction(src, 'function _resetEmptyComposerModelToConfiguredDefault('));
+const rememberComposerModelPickSrc=extractFunctionIfPresent(src, 'function _rememberComposerModelPick(');
+if(rememberComposerModelPickSrc) eval(rememberComposerModelPickSrc);
+const readComposerModelPickSrc=extractFunctionIfPresent(src, 'function _readComposerModelPick(');
+if(readComposerModelPickSrc) eval(readComposerModelPickSrc);
+eval(extractFunction(src, 'function _settleEmptyComposerModelAfterFinalSessionDelete('));
 eval(extractFunction(src, 'async function deleteSession('));
 eval(extractFunction(src, 'function _renderBatchActionBar('));
+eval(extractStatementBefore(
+  bootSrc,
+  "$('modelSelect').onchange=async()=>{",
+  "$('msg').addEventListener('input'"
+));
+
+async function waitForDeleteRequest() {
+  for (let attempt = 0; attempt < 20 && !deleteRequested; attempt++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  if (!deleteRequested) throw new Error('delete request was not reached');
+}
 
 async function waitForSessionsRequest() {
   for (let attempt = 0; attempt < 20 && !sessionsRequested; attempt++) {
@@ -143,11 +194,19 @@ async function waitForSessionsRequest() {
     deletion = deleteSession('active-session');
   }
 
+  await waitForDeleteRequest();
+  for (const pick of args.picksWhileDeleting || []) {
+    elements.modelSelect.value = pick.model;
+    elements.modelSelect._provider = pick.provider;
+    await elements.modelSelect.onchange();
+  }
+  resolveDelete({});
+
   await waitForSessionsRequest();
   if (args.pickWhileSettling) {
     elements.modelSelect.value = args.settlingModel;
     elements.modelSelect._provider = args.settlingProvider;
-    _rememberEmptyComposerModelOverride(args.settlingModel, args.settlingProvider);
+    await elements.modelSelect.onchange();
   }
   resolveSessions({sessions: []});
   const deleted = await deletion;
@@ -184,7 +243,7 @@ def _run_case(driver_path, **overrides):
         **overrides,
     }
     result = subprocess.run(
-        [NODE, driver_path, str(SESSIONS_JS_PATH), json.dumps(payload)],
+        [NODE, driver_path, str(SESSIONS_JS_PATH), str(BOOT_JS_PATH), json.dumps(payload)],
         capture_output=True,
         text=True,
         timeout=30,
@@ -225,3 +284,56 @@ def test_final_session_delete_preserves_model_pick_made_while_session_list_loads
     assert data["override"]["model"] == "claude-sonnet-4-5"
     assert data["override"]["model_provider"] == "anthropic"
     assert data["override"]["saved_at"] > 0
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+@pytest.mark.parametrize("mode", ["single", "batch"])
+def test_final_session_delete_preserves_model_pick_made_while_delete_request_is_pending(driver_path, mode):
+    data = _run_case(
+        driver_path,
+        mode=mode,
+        picksWhileDeleting=[
+            {"model": "claude-sonnet-4-5", "provider": "anthropic"},
+        ],
+    )
+
+    assert data["session"] is None
+    assert data["model"] == "claude-sonnet-4-5"
+    assert data["provider"] == "anthropic"
+    assert data["override"]["model"] == "claude-sonnet-4-5"
+    assert data["override"]["model_provider"] == "anthropic"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+@pytest.mark.parametrize("mode", ["single", "batch"])
+def test_final_session_delete_preserves_same_model_pick_from_another_provider(driver_path, mode):
+    data = _run_case(
+        driver_path,
+        mode=mode,
+        currentModel="gpt-5.5",
+        currentProvider="openai-codex",
+        picksWhileDeleting=[
+            {"model": "gpt-5.5", "provider": "openrouter"},
+        ],
+    )
+
+    assert data["model"] == "gpt-5.5"
+    assert data["provider"] == "openrouter"
+    assert data["override"]["model"] == "gpt-5.5"
+    assert data["override"]["model_provider"] == "openrouter"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_final_session_delete_detects_model_pick_even_when_value_returns_to_original(driver_path):
+    data = _run_case(
+        driver_path,
+        picksWhileDeleting=[
+            {"model": "claude-sonnet-4-5", "provider": "anthropic"},
+            {"model": "GPT-5.6 Ornith", "provider": "openai-codex"},
+        ],
+    )
+
+    assert data["model"] == "GPT-5.6 Ornith"
+    assert data["provider"] == "openai-codex"
+    assert data["override"]["model"] == "GPT-5.6 Ornith"
+    assert data["override"]["model_provider"] == "openai-codex"

--- a/tests/test_final_session_delete_model_reset.py
+++ b/tests/test_final_session_delete_model_reset.py
@@ -1,0 +1,156 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+SESSIONS_JS = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+
+function extractFunction(src, signature) {
+  const start = src.indexOf(signature);
+  if (start < 0) throw new Error(signature + ' not found');
+  let depth = 0;
+  let bodyStart = src.indexOf('{', src.indexOf(')', start));
+  for (let i = bodyStart; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(signature + ' body not closed');
+}
+
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const args = JSON.parse(process.argv[3]);
+const elements = {
+  modelSelect: {value: args.currentModel, _provider: args.currentProvider},
+  topbarTitle: {textContent: ''},
+  topbarMeta: {textContent: ''},
+  msgInner: {innerHTML: ''},
+  emptyState: {style: {display: 'none'}},
+  fileTree: {innerHTML: ''},
+};
+const calls = {clearOverride: 0, reasoningSync: 0};
+
+globalThis.window = globalThis;
+globalThis.$ = id => elements[id] || null;
+globalThis.S = {
+  session: {session_id: 'active-session'},
+  messages: [{role: 'user', content: 'hello'}],
+  entries: [{type: 'message'}],
+};
+globalThis._defaultModel = args.defaultModel;
+globalThis._activeProvider = args.defaultProvider;
+globalThis.localStorage = {removeItem() {}};
+globalThis._clearEmptyComposerModelOverride = () => { calls.clearOverride++; };
+globalThis._ensureModelOptionInDropdown = (model, select, provider) => {
+  select.value = model;
+  select._provider = provider || null;
+  return model;
+};
+globalThis.syncReasoningChip = () => { calls.reasoningSync++; };
+globalThis.showConfirmDialog = async () => true;
+globalThis._sessionSnapshotById = () => ({session_id: 'active-session'});
+globalThis._captureSessionReflowPositions = () => null;
+globalThis._clearHandoffStorageForSession = () => {};
+globalThis._clearPersistedSessionQueue = () => {};
+globalThis._optimisticallyRemoveSessionFromList = () => {};
+globalThis._hydrateTodosFromSession = () => {};
+globalThis._sessionListQueryString = () => '';
+globalThis.assistantDisplayName = () => 'Hermes';
+globalThis.syncAppTitlebar = () => {};
+globalThis.showToast = () => {};
+globalThis._sessionResponseRetainsWorktree = () => false;
+globalThis.renderSessionList = async () => {};
+globalThis.setStatus = () => {};
+globalThis.t = key => key;
+globalThis._optimisticallyRemovedSessionIds = new Set();
+globalThis._allSessions = [{session_id: 'active-session'}];
+globalThis._pendingSessionReflowPositions = null;
+globalThis.api = async url => {
+  if (url === '/api/session/delete') return {};
+  if (url === '/api/sessions') return {sessions: []};
+  throw new Error('unexpected api call: ' + url);
+};
+
+eval(extractFunction(src, 'function _resetEmptyComposerModelToConfiguredDefault('));
+eval(extractFunction(src, 'async function deleteSession('));
+
+(async () => {
+  const deleted = await deleteSession('active-session');
+  process.stdout.write(JSON.stringify({
+    deleted,
+    session: S.session,
+    messages: S.messages,
+    model: elements.modelSelect.value,
+    provider: elements.modelSelect._provider,
+    emptyStateDisplay: elements.emptyState.style.display,
+    calls,
+  }));
+})().catch(err => {
+  process.stderr.write(String(err && err.stack ? err.stack : err));
+  process.exit(1);
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("final_session_delete_model_reset") / "driver.js"
+    path.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(path)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_deleting_active_final_session_resets_empty_composer_to_configured_default(driver_path):
+    result = subprocess.run(
+        [
+            NODE,
+            driver_path,
+            str(SESSIONS_JS_PATH),
+            json.dumps(
+                {
+                    "currentModel": "GPT-5.6 Ornith",
+                    "currentProvider": "openai-codex",
+                    "defaultModel": "gpt-5.6-luna",
+                    "defaultProvider": "openai-codex",
+                }
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    assert data["deleted"] is True
+    assert data["session"] is None
+    assert data["messages"] == []
+    assert data["model"] == "gpt-5.6-luna"
+    assert data["provider"] == "openai-codex"
+    assert data["emptyStateDisplay"] == ""
+    assert data["calls"] == {"clearOverride": 1, "reasoningSync": 1}
+
+
+def test_single_and_batch_final_session_delete_share_model_reset_helper():
+    single_delete = SESSIONS_JS[
+        SESSIONS_JS.index("async function deleteSession(") : SESSIONS_JS.index("// ── Project helpers", SESSIONS_JS.index("async function deleteSession("))
+    ]
+    batch_delete = SESSIONS_JS[
+        SESSIONS_JS.index("function _renderBatchActionBar(") : SESSIONS_JS.index("function _showBatchProjectPicker(")
+    ]
+
+    assert "_resetEmptyComposerModelToConfiguredDefault();" in single_delete
+    assert "_resetEmptyComposerModelToConfiguredDefault();" in batch_delete


### PR DESCRIPTION
## Thinking Path

Deleting the final active conversation clears the session but leaves the model picker on the deleted conversation model. The next conversation correctly uses the configured default, so the picker and the actual route disagree.

Reset the empty composer picker only when deletion leaves no conversations.

## What Changed

- Added one helper that clears stale empty-composer model state and applies the configured model and provider.
- Called it from single and batch final-conversation deletion.
- Added a Node-backed regression test against the actual sessions.js behaviour.

## Why It Matters

The empty composer no longer shows Ornith while a new conversation starts on Luna. Picking Ornith after the reset remains an explicit selection.

## Verification

- ./scripts/test.sh tests/test_final_session_delete_model_reset.py tests/test_issue4728_new_chat_default_model.py tests/test_new_chat_default_model_frontend.py tests/test_model_default_boot_precedence.py tests/test_static_js_runtime_lint.py -q
  - 28 passed, 1 skipped
- ./scripts/test.sh tests/test_session_batch_select.py tests/test_session_action_menu_regression.py tests/test_active_empty_session_sidebar.py tests/test_final_session_delete_model_reset.py -q
  - 29 passed
- node --check static/sessions.js
- ruff check tests/test_final_session_delete_model_reset.py

## Risks / Follow-ups

The reset only runs when deletion leaves no conversations. Existing load-session behaviour is unchanged when another conversation remains.

No layout or asset changes. This corrects picker state only.

## Model Used

OpenAI Codex (GPT-5). Used pytest and a Node.js behaviour driver for verification.