### PR TITLE
fix(#7295): keep scheduled cron runs off the profile lock

### DIFF
--- a/api/cron_runtime.py
+++ b/api/cron_runtime.py
@@ -1,0 +1,194 @@
+"""Process isolation for profile-pinned cron execution."""
+
+import logging
+import json
+import multiprocessing
+import pickle
+import queue
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CRON_SUBPROCESS_POLL_SECONDS = 0.25
+_CRON_SUBPROCESS_CLEANUP_TIMEOUT_SECONDS = 5.0
+
+
+def _serialize_child_request(job, args, kwargs):
+    """Encode only JSON-shaped cron data for the spawned child."""
+    try:
+        return (
+            json.dumps(job, separators=(",", ":"), ensure_ascii=False),
+            json.dumps(tuple(args), separators=(",", ":"), ensure_ascii=False),
+            json.dumps(kwargs, separators=(",", ":"), ensure_ascii=False),
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise RuntimeError(
+            "cron subprocess request contains non-serializable job/context data"
+        ) from exc
+
+
+def _child_kwargs_for_operation(operation, kwargs):
+    """Reject live gateway handles that cannot cross into a spawned interpreter."""
+    child_kwargs = dict(kwargs)
+    if operation == "run_one_job":
+        live_context = [
+            name for name in ("adapters", "loop") if child_kwargs.get(name) is not None
+        ]
+        if live_context:
+            raise RuntimeError(
+                "cron subprocess cannot transfer live gateway handles: "
+                + ", ".join(live_context)
+            )
+    return child_kwargs
+
+
+def _cron_job_subprocess_main(job_json, profile_home, operation, args_json, kwargs_json, result_queue):
+    try:
+        job = json.loads(job_json)
+        args = tuple(json.loads(args_json))
+        kwargs = json.loads(kwargs_json)
+        from api.profiles import _cron_child_execution
+
+        child_token = _cron_child_execution.set(True)
+        if profile_home is None:
+            _run_in_profile = None
+        else:
+            from api.profiles import cron_profile_context_for_home
+
+            _run_in_profile = cron_profile_context_for_home(profile_home)
+
+        try:
+            if _run_in_profile is None:
+                result = _invoke_cron_operation(job, operation, args, kwargs)
+            else:
+                with _run_in_profile:
+                    result = _invoke_cron_operation(job, operation, args, kwargs)
+        finally:
+            _cron_child_execution.reset(child_token)
+        try:
+            result_payload = pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL)
+        except Exception as exc:
+            result_queue.put(("error", f"cron subprocess result was not serializable: {exc}", ""))
+        else:
+            result_queue.put(("ok", result_payload))
+    except BaseException as exc:  # pragma: no cover - surfaced in parent
+        import traceback
+
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}", traceback.format_exc()))
+
+
+def _invoke_cron_operation(job, operation, args, kwargs):
+    if operation not in {"run_job", "run_one_job"}:
+        raise ValueError(f"Unsupported cron operation: {operation}")
+    import cron.scheduler as scheduler
+
+    callable_ = getattr(scheduler, operation, None)
+    if callable_ is None:
+        raise RuntimeError(f"cron.scheduler.{operation} is unavailable")
+    if getattr(callable_, "_webui_profile_isolated", False):
+        callable_ = getattr(callable_, "_webui_original_" + operation, callable_)
+    return callable_(job, *args, **kwargs)
+
+
+def _cron_subprocess_result_timeout_seconds(job):
+    for key in ("timeout_seconds", "max_runtime_seconds", "timeout"):
+        raw = (job or {}).get(key)
+        if raw in (None, ""):
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return max(60.0, value + 30.0)
+    return 6 * 60 * 60.0
+
+
+def run_cron_in_profile_subprocess(
+    job, profile_home, operation, *, args=(), kwargs=None
+):
+    """Run one supported cron operation in a profile-pinned spawned child."""
+    if operation not in {"run_job", "run_one_job"}:
+        raise ValueError(f"Unsupported cron operation: {operation}")
+    args = tuple(args)
+    kwargs = _child_kwargs_for_operation(operation, kwargs or {})
+    job_json, args_json, kwargs_json = _serialize_child_request(job, args, kwargs)
+    profile_home = None if profile_home is None else str(Path(profile_home))
+
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue(maxsize=1)
+    process = ctx.Process(
+        target=_cron_job_subprocess_main,
+        args=(job_json, profile_home, operation, args_json, kwargs_json, result_queue),
+    )
+    result_timeout = _cron_subprocess_result_timeout_seconds(job)
+    status = "error"
+    payload = ["cron run subprocess failed before producing a result", ""]
+    try:
+        try:
+            process.start()
+        except BaseException as exc:
+            raise RuntimeError(f"cron run subprocess failed to start: {exc}") from exc
+        deadline = time.monotonic() + result_timeout
+        try:
+            while True:
+                remaining = max(0.0, deadline - time.monotonic())
+                if remaining == 0:
+                    raise queue.Empty
+                try:
+                    status, *payload = result_queue.get(
+                        timeout=min(_CRON_SUBPROCESS_POLL_SECONDS, remaining)
+                    )
+                    break
+                except queue.Empty:
+                    if not process.is_alive():
+                        try:
+                            status, *payload = result_queue.get(timeout=0)
+                        except queue.Empty:
+                            payload = [
+                                f"cron run subprocess exited with code {process.exitcode} without producing a result",
+                                "",
+                            ]
+                        break
+        except queue.Empty:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=_CRON_SUBPROCESS_CLEANUP_TIMEOUT_SECONDS)
+                payload = [
+                    f"cron run subprocess produced no result within {result_timeout:g}s and was terminated",
+                    "",
+                ]
+            else:
+                payload = [
+                    f"cron run subprocess exited with code {process.exitcode} without producing a result",
+                    "",
+                ]
+        finally:
+            process.join(timeout=_CRON_SUBPROCESS_CLEANUP_TIMEOUT_SECONDS)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=_CRON_SUBPROCESS_CLEANUP_TIMEOUT_SECONDS)
+                if process.is_alive():
+                    status = "error"
+                    payload = [
+                        "cron run subprocess did not terminate within the cleanup bound",
+                        "",
+                    ]
+                elif status == "ok":
+                    status = "error"
+                    payload = ["cron run subprocess did not exit after returning a result", ""]
+    finally:
+        result_queue.close()
+        result_queue.join_thread()
+
+    if status == "ok":
+        try:
+            return pickle.loads(payload[0])
+        except Exception as exc:
+            raise RuntimeError("cron subprocess returned an invalid result payload") from exc
+    message = payload[0]
+    traceback_text = payload[1] if len(payload) > 1 else ""
+    if traceback_text:
+        logger.error("Cron subprocess failed:\n%s", traceback_text)
+    raise RuntimeError(message)

--- a/api/cron_runtime.py
+++ b/api/cron_runtime.py
@@ -29,17 +29,11 @@ def _serialize_child_request(job, args, kwargs):
 
 
 def _child_kwargs_for_operation(operation, kwargs):
-    """Reject live gateway handles that cannot cross into a spawned interpreter."""
+    """Keep process-local scheduler handles out of the child request."""
     child_kwargs = dict(kwargs)
     if operation == "run_one_job":
-        live_context = [
-            name for name in ("adapters", "loop") if child_kwargs.get(name) is not None
-        ]
-        if live_context:
-            raise RuntimeError(
-                "cron subprocess cannot transfer live gateway handles: "
-                + ", ".join(live_context)
-            )
+        for name in ("adapters", "loop", "cancel_event"):
+            child_kwargs.pop(name, None)
     return child_kwargs
 
 
@@ -106,9 +100,14 @@ def _cron_subprocess_result_timeout_seconds(job):
 
 
 def run_cron_in_profile_subprocess(
-    job, profile_home, operation, *, args=(), kwargs=None
+    job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
 ):
-    """Run one supported cron operation in a profile-pinned spawned child."""
+    """Run one supported cron operation in a profile-pinned spawned child.
+
+    ``cancel_event`` stays in the parent because it is a live control object.
+    A set event terminates the child; Agent then recovers the abandoned claim
+    through its normal expiry and takeover path.
+    """
     if operation not in {"run_job", "run_one_job"}:
         raise ValueError(f"Unsupported cron operation: {operation}")
     args = tuple(args)
@@ -137,6 +136,10 @@ def run_cron_in_profile_subprocess(
                 if remaining == 0:
                     raise queue.Empty
                 try:
+                    if cancel_event is not None and cancel_event.is_set():
+                        raise RuntimeError(
+                            "cron run subprocess cancelled and was terminated"
+                        )
                     status, *payload = result_queue.get(
                         timeout=min(_CRON_SUBPROCESS_POLL_SECONDS, remaining)
                     )
@@ -151,6 +154,12 @@ def run_cron_in_profile_subprocess(
                                 "",
                             ]
                         break
+        except RuntimeError as exc:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=_CRON_SUBPROCESS_CLEANUP_TIMEOUT_SECONDS)
+            payload = [str(exc), ""]
+            status = "error"
         except queue.Empty:
             if process.is_alive():
                 process.terminate()

--- a/api/cron_runtime.py
+++ b/api/cron_runtime.py
@@ -29,11 +29,14 @@ def _serialize_child_request(job, args, kwargs):
 
 
 def _child_kwargs_for_operation(operation, kwargs):
-    """Keep process-local scheduler handles out of the child request."""
+    """Reject process-local scheduler handles at the child boundary."""
     child_kwargs = dict(kwargs)
     if operation == "run_one_job":
-        for name in ("adapters", "loop", "cancel_event"):
-            child_kwargs.pop(name, None)
+        for name in ("adapters", "loop"):
+            if child_kwargs.get(name) is not None:
+                raise RuntimeError(
+                    f"run_one_job child request cannot carry live {name}"
+                )
     return child_kwargs
 
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -554,7 +554,8 @@ def get_active_hermes_home() -> Path:
 # below makes the entire context-manager body run-to-completion serially, so
 # all webui access to HERMES_HOME goes through one thread at a time. Any
 # Short metadata operations still need the lock while cached cron module paths
-# and HERMES_HOME are swapped; long lifecycle execution runs in a child.
+# and HERMES_HOME are swapped; handle-free lifecycle execution runs in a child,
+# while adapter-backed execution stays parent-side for live delivery.
 _cron_env_lock = threading.Lock()
 
 
@@ -611,7 +612,7 @@ def _home_for_scheduled_cron_job(job: dict) -> Path:
         return get_active_hermes_home()
     if not raw:
         stack = _cron_context_stack.get()
-        if stack:
+        if _cron_profile_context_depth() > 0 and stack:
             return stack[-1]._home
         return get_active_hermes_home()
     if _is_root_profile(raw):
@@ -638,7 +639,8 @@ def install_cron_scheduler_profile_isolation() -> None:
     Standard WebUI deployments do not start the scheduler thread in-process, but
     if a future/single-process deployment calls cron.scheduler.tick() from the
     WebUI worker, tick's background job path has no request TLS context. Wrap
-    run_one_job so the complete Agent lifecycle runs in a profile-pinned child.
+    run_one_job so handle-free Agent lifecycles run in a profile-pinned child;
+    adapter-backed calls retain the parent path for live delivery.
     """
     try:
         import importlib

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -694,8 +694,13 @@ def install_cron_scheduler_profile_isolation() -> None:
         execution_home = _home_for_scheduled_cron_job(job)
         try:
             if live_gateway_handles:
-                active_context = _cron_context_stack.get()
-                if active_context:
+                if _cron_profile_context_depth() > 0:
+                    active_context = _cron_context_stack.get()
+                    if not active_context:
+                        raise RuntimeError(
+                            "live cron gateway handles require an active "
+                            "profile context"
+                        )
                     pinned_home = Path(active_context[-1]._home)
                     if pinned_home != Path(execution_home):
                         raise RuntimeError(

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -9,6 +9,7 @@ cached paths in hermes-agent modules (skills_tool, skill_manager_tool,
 cron/jobs) that snapshot HERMES_HOME at import time.
 """
 import json
+import contextvars
 import logging
 import os
 import re
@@ -552,14 +553,21 @@ def get_active_hermes_home() -> Path:
 # on exit) are NOT atomic without explicit serialization. The _cron_env_lock
 # below makes the entire context-manager body run-to-completion serially, so
 # all webui access to HERMES_HOME goes through one thread at a time. Any
-# subprocess.Popen() call inside `run_job` inherits the env at fork time,
-# which is also under the lock — so child processes always see a consistent
-# (own-profile) HERMES_HOME, never a half-swapped state.
+# Short metadata operations still need the lock while cached cron module paths
+# and HERMES_HOME are swapped; long lifecycle execution runs in a child.
 _cron_env_lock = threading.Lock()
 
 
 def _cron_profile_context_depth() -> int:
     return int(getattr(_tls, 'cron_profile_depth', 0) or 0)
+
+
+_cron_child_execution = contextvars.ContextVar(
+    "webui_cron_child_execution", default=False
+)
+_cron_context_stack = contextvars.ContextVar(
+    "webui_cron_context_stack", default=()
+)
 
 
 def _push_cron_profile_context_depth() -> None:
@@ -569,6 +577,18 @@ def _push_cron_profile_context_depth() -> None:
 def _pop_cron_profile_context_depth() -> None:
     depth = _cron_profile_context_depth()
     _tls.cron_profile_depth = max(0, depth - 1)
+
+
+def _suspend_active_cron_profile_context_for_child() -> bool:
+    """Release a parent tool-call context before handing execution to a child."""
+    stack = _cron_context_stack.get()
+    if not stack:
+        return False
+    context = stack[-1]
+    context._suspended = True
+    context._restore_and_release()
+    _cron_context_stack.set(stack)
+    return True
 
 
 def _home_for_scheduled_cron_job(job: dict) -> Path:
@@ -590,6 +610,9 @@ def _home_for_scheduled_cron_job(job: dict) -> Path:
             )
         return get_active_hermes_home()
     if not raw:
+        stack = _cron_context_stack.get()
+        if stack:
+            return stack[-1]._home
         return get_active_hermes_home()
     if _is_root_profile(raw):
         return _DEFAULT_HERMES_HOME
@@ -610,47 +633,171 @@ def _home_for_scheduled_cron_job(job: dict) -> Path:
 
 
 def install_cron_scheduler_profile_isolation() -> None:
-    """Patch cron.scheduler.run_job for WebUI in-process scheduler safety.
+    """Patch cron.scheduler.run_one_job for profile-pinned scheduler safety.
 
     Standard WebUI deployments do not start the scheduler thread in-process, but
     if a future/single-process deployment calls cron.scheduler.tick() from the
     WebUI worker, tick's background job path has no request TLS context. Wrap
-    run_job so each auto-fired job's persisted ``profile`` field gets the same
-    HERMES_HOME isolation as the manual /api/crons/run path.
+    run_one_job so the complete Agent lifecycle runs in a profile-pinned child.
     """
     try:
-        import cron.scheduler as _cs
+        import importlib
+
+        _cs = importlib.import_module("cron.scheduler")
     except ImportError:
         logger.debug("install_cron_scheduler_profile_isolation: cron.scheduler unavailable")
         return
 
-    original = getattr(_cs, 'run_job', None)
-    if original is None or getattr(original, '_webui_profile_isolated', False):
+    operation = 'run_one_job'
+    original = getattr(_cs, operation, None)
+    embedded_legacy_compat = False
+    if original is None:
+        legacy = getattr(_cs, 'run_job', None)
+        # A synthetic module with no file identity is used by the isolated-mode
+        # regression harness. Keep that callback-only shape working there, while
+        # refusing every real file-backed legacy Agent that lacks run_one_job.
+        if (
+            callable(legacy)
+            and not getattr(_cs, '__file__', None)
+            and _is_isolated_profile_mode()
+        ):
+            operation = 'run_job'
+            original = legacy
+            embedded_legacy_compat = True
+        else:
+            raise RuntimeError(
+                "unsupported Agent version: cron.scheduler.run_one_job is unavailable; "
+                "refusing to install scheduled cron profile isolation because legacy "
+                "run_job cannot preserve the scheduler lifecycle"
+            )
+    if getattr(original, '_webui_profile_isolated', False):
         return
 
-    def _webui_profile_isolated_run_job(job, *args, **kwargs):
-        # Manual WebUI runs already enter cron_profile_context_for_home before
-        # calling run_job. Avoid nesting the non-reentrant env lock or changing
-        # the explicitly selected manual execution profile.
-        if _cron_profile_context_depth() > 0:
+    def _webui_profile_isolated_run_one_job(job, *args, **kwargs):
+        if _cron_child_execution.get():
             return original(job, *args, **kwargs)
+        if embedded_legacy_compat:
+            try:
+                with cron_profile_context_for_home(_home_for_scheduled_cron_job(job)):
+                    return original(job, *args, **kwargs)
+            finally:
+                event_profile = str((job or {}).get("profile") or "").strip() or None
+                if _is_isolated_profile_mode():
+                    event_profile = _isolated_profile_name()
+                try:
+                    publish_session_list_changed("cron_complete", profile=event_profile)
+                except TypeError:
+                    publish_session_list_changed("cron_complete")
+        from api.cron_runtime import run_cron_in_profile_subprocess
+
+        execution_home = _home_for_scheduled_cron_job(job)
+        if _cron_profile_context_depth() > 0:
+            _suspend_active_cron_profile_context_for_child()
+        live_adapters = kwargs.get("adapters")
+        live_loop = kwargs.get("loop")
+        if live_adapters is not None or live_loop is not None:
+            child_kwargs = {
+                key: value
+                for key, value in kwargs.items()
+                if key not in {"adapters", "loop", "verbose"}
+            }
+            try:
+                from cron.jobs import claim_dispatch
+
+                with cron_profile_context_for_home(execution_home):
+                    if not claim_dispatch(job["id"]):
+                        return True
+                result = run_cron_in_profile_subprocess(
+                    job, execution_home, "run_job", args=args, kwargs=child_kwargs
+                )
+                return _complete_cron_run_with_live_handles(
+                    job, result, live_adapters, live_loop,
+                    verbose=bool(kwargs.get("verbose")),
+                )
+            except Exception as exc:
+                _mark_claimed_cron_failure(job, execution_home, exc)
+                return False
+            finally:
+                if _cron_profile_context_depth() == 0:
+                    stack = _cron_context_stack.get()
+                    if stack and getattr(stack[-1], '_suspended', False):
+                        stack[-1]._resume_after_child()
+                event_profile = str((job or {}).get("profile") or "").strip() or None
+                if _is_isolated_profile_mode():
+                    event_profile = _isolated_profile_name()
+                try:
+                    publish_session_list_changed("cron_complete", profile=event_profile)
+                except TypeError:
+                    publish_session_list_changed("cron_complete")
         try:
-            with cron_profile_context_for_home(_home_for_scheduled_cron_job(job)):
-                return original(job, *args, **kwargs)
+            return run_cron_in_profile_subprocess(
+                job, execution_home, "run_one_job", args=args, kwargs=kwargs
+            )
         finally:
+            if _cron_profile_context_depth() == 0:
+                stack = _cron_context_stack.get()
+                if stack and getattr(stack[-1], '_suspended', False):
+                    stack[-1]._resume_after_child()
             event_profile = str((job or {}).get("profile") or "").strip() or None
             if _is_isolated_profile_mode():
                 event_profile = _isolated_profile_name()
             try:
                 publish_session_list_changed("cron_complete", profile=event_profile)
             except TypeError:
-                # Focused tests and older integrations may patch the publisher
-                # with the historical one-argument shape.
                 publish_session_list_changed("cron_complete")
 
-    _webui_profile_isolated_run_job._webui_profile_isolated = True
-    _webui_profile_isolated_run_job._webui_original_run_job = original
-    _cs.run_job = _webui_profile_isolated_run_job
+    _webui_profile_isolated_run_one_job._webui_profile_isolated = True
+    setattr(_webui_profile_isolated_run_one_job, f"_webui_original_{operation}", original)
+    setattr(_cs, operation, _webui_profile_isolated_run_one_job)
+
+
+def _mark_claimed_cron_failure(job, execution_home, exc) -> None:
+    """Settle a fire claim when the isolated worker cannot return a result."""
+    try:
+        from cron.jobs import mark_job_run
+
+        with cron_profile_context_for_home(execution_home):
+            mark_job_run(job["id"], False, str(exc) or type(exc).__name__)
+    except Exception:
+        logger.exception("Failed to mark isolated cron failure for %s", job.get("id"))
+
+
+def _complete_cron_run_with_live_handles(job, result, adapters, loop, *, verbose=False):
+    """Finish a child run in the parent so gateway-owned handles stay live."""
+    import importlib
+
+    scheduler = importlib.import_module("cron.scheduler")
+    from cron.jobs import mark_job_run, save_job_output
+
+    success, output, final_response, error = result
+    job_id = job["id"]
+    delivery_error = None
+    with cron_profile_context_for_home(_home_for_scheduled_cron_job(job)):
+        save_job_output(job_id, output)
+        if success and not str(final_response or "").strip():
+            success = False
+            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+        deliver_content = (
+            final_response
+            if success
+            else scheduler._summarize_cron_failure_for_delivery(job, error)
+        )
+        should_deliver = bool(str(deliver_content or "").strip())
+        if should_deliver and success and scheduler._is_cron_silence_response(deliver_content):
+            should_deliver = False
+        if should_deliver:
+            try:
+                delivery_error = scheduler._deliver_result(
+                    job, deliver_content, adapters=adapters, loop=loop
+                )
+            except Exception as exc:
+                delivery_error = str(exc)
+                logger.error("Delivery failed for isolated cron job %s: %s", job_id, exc)
+        try:
+            mark_job_run(job_id, success, error, delivery_error=delivery_error)
+        except TypeError:
+            mark_job_run(job_id, success, error)
+    return True
 
 
 class cron_profile_context_for_home:
@@ -701,13 +848,14 @@ class cron_profile_context_for_home:
                 _cs._LOCK_FILE = _cs._LOCK_DIR / '.tick.lock'
             except (ImportError, AttributeError):
                 logger.debug("cron_profile_context_for_home: cron.scheduler unavailable")
+            _cron_context_stack.set((*_cron_context_stack.get(), self))
         except Exception:
             _pop_cron_profile_context_depth()
             _cron_env_lock.release()
             raise
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def _restore_and_release(self):
         try:
             if self._prev_env is None:
                 os.environ.pop('HERMES_HOME', None)
@@ -726,8 +874,28 @@ class cron_profile_context_for_home:
                 except (ImportError, AttributeError):
                     pass
         finally:
+            stack = _cron_context_stack.get()
+            if stack and stack[-1] is self:
+                _cron_context_stack.set(stack[:-1])
             _pop_cron_profile_context_depth()
             _cron_env_lock.release()
+
+    def _resume_after_child(self):
+        if not getattr(self, '_suspended', False):
+            return
+        self._suspended = False
+        stack = _cron_context_stack.get()
+        if stack and stack[-1] is self:
+            _cron_context_stack.set(stack[:-1])
+        try:
+            self.__enter__()
+        except Exception:
+            self._suspended = True
+            raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not getattr(self, '_suspended', False):
+            self._restore_and_release()
         return False
 
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -693,47 +693,27 @@ def install_cron_scheduler_profile_isolation() -> None:
         execution_home = _home_for_scheduled_cron_job(job)
         if _cron_profile_context_depth() > 0:
             _suspend_active_cron_profile_context_for_child()
-        live_adapters = kwargs.get("adapters")
-        live_loop = kwargs.get("loop")
-        if live_adapters is not None or live_loop is not None:
-            child_kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key not in {"adapters", "loop", "verbose"}
-            }
-            try:
-                claim_dispatch = None
-                if getattr(_cs, "__file__", None):
-                    from cron.jobs import claim_dispatch
-
-                with cron_profile_context_for_home(execution_home):
-                    if claim_dispatch is not None and not claim_dispatch(job["id"]):
-                        return True
-                result = run_cron_in_profile_subprocess(
-                    job, execution_home, "run_job", args=args, kwargs=child_kwargs
-                )
-                return _complete_cron_run_with_live_handles(
-                    job, result, live_adapters, live_loop,
-                    verbose=bool(kwargs.get("verbose")),
-                )
-            except Exception as exc:
-                _mark_claimed_cron_failure(job, execution_home, exc)
-                return False
-            finally:
-                if _cron_profile_context_depth() == 0:
-                    stack = _cron_context_stack.get()
-                    if stack and getattr(stack[-1], '_suspended', False):
-                        stack[-1]._resume_after_child()
-                event_profile = str((job or {}).get("profile") or "").strip() or None
-                if _is_isolated_profile_mode():
-                    event_profile = _isolated_profile_name()
-                try:
-                    publish_session_list_changed("cron_complete", profile=event_profile)
-                except TypeError:
-                    publish_session_list_changed("cron_complete")
+        child_kwargs = dict(kwargs)
+        live_context = [
+            name for name in ("adapters", "loop")
+            if child_kwargs.pop(name, None) is not None
+        ]
+        cancel_event = child_kwargs.pop("cancel_event", None)
+        if live_context:
+            logger.info(
+                "Cron job %s is isolated in a child; Agent will use its "
+                "standalone delivery path because live gateway handles cannot "
+                "cross the process boundary",
+                (job or {}).get("id", "?"),
+            )
         try:
             return run_cron_in_profile_subprocess(
-                job, execution_home, "run_one_job", args=args, kwargs=kwargs
+                job,
+                execution_home,
+                "run_one_job",
+                args=args,
+                kwargs=child_kwargs,
+                cancel_event=cancel_event,
             )
         finally:
             if _cron_profile_context_depth() == 0:
@@ -751,55 +731,6 @@ def install_cron_scheduler_profile_isolation() -> None:
     _webui_profile_isolated_run_one_job._webui_profile_isolated = True
     setattr(_webui_profile_isolated_run_one_job, f"_webui_original_{operation}", original)
     setattr(_cs, operation, _webui_profile_isolated_run_one_job)
-
-
-def _mark_claimed_cron_failure(job, execution_home, exc) -> None:
-    """Settle a fire claim when the isolated worker cannot return a result."""
-    try:
-        from cron.jobs import mark_job_run
-
-        with cron_profile_context_for_home(execution_home):
-            mark_job_run(job["id"], False, str(exc) or type(exc).__name__)
-    except Exception:
-        logger.exception("Failed to mark isolated cron failure for %s", job.get("id"))
-
-
-def _complete_cron_run_with_live_handles(job, result, adapters, loop, *, verbose=False):
-    """Finish a child run in the parent so gateway-owned handles stay live."""
-    import importlib
-
-    scheduler = importlib.import_module("cron.scheduler")
-    from cron.jobs import mark_job_run, save_job_output
-
-    success, output, final_response, error = result
-    job_id = job["id"]
-    delivery_error = None
-    with cron_profile_context_for_home(_home_for_scheduled_cron_job(job)):
-        save_job_output(job_id, output)
-        if success and not str(final_response or "").strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-        deliver_content = (
-            final_response
-            if success
-            else scheduler._summarize_cron_failure_for_delivery(job, error)
-        )
-        should_deliver = bool(str(deliver_content or "").strip())
-        if should_deliver and success and scheduler._is_cron_silence_response(deliver_content):
-            should_deliver = False
-        if should_deliver:
-            try:
-                delivery_error = scheduler._deliver_result(
-                    job, deliver_content, adapters=adapters, loop=loop
-                )
-            except Exception as exc:
-                delivery_error = str(exc)
-                logger.error("Delivery failed for isolated cron job %s: %s", job_id, exc)
-        try:
-            mark_job_run(job_id, success, error, delivery_error=delivery_error)
-        except TypeError:
-            mark_job_run(job_id, success, error)
-    return True
 
 
 class cron_profile_context_for_home:
@@ -2836,7 +2767,7 @@ def delete_profile_api(name: str) -> dict:
             raise RuntimeError(
                 f"Cannot delete active profile '{name}' while an agent is running. "
                 "Cancel or wait for it to finish."
-            )
+            ) from None
 
     try:
         from hermes_cli.profiles import delete_profile
@@ -2848,7 +2779,7 @@ def delete_profile_api(name: str) -> dict:
         if profile_dir.is_dir():
             shutil.rmtree(str(profile_dir))
         else:
-            raise ValueError(f"Profile '{name}' does not exist.")
+            raise ValueError(f"Profile '{name}' does not exist.") from None
 
     # Drop cached root-profile-name lookup — list_profiles_api() shape changed.
     _SKILLS_STATS_CACHE.clear()

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -693,8 +693,8 @@ def install_cron_scheduler_profile_isolation() -> None:
         live_gateway_handles = (
             kwargs.get("adapters") is not None or kwargs.get("loop") is not None
         )
-        execution_home = _home_for_scheduled_cron_job(job)
         try:
+            execution_home = _home_for_scheduled_cron_job(job)
             if live_gateway_handles:
                 if _cron_profile_context_depth() > 0:
                     active_context = _cron_context_stack.get()

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -702,10 +702,12 @@ def install_cron_scheduler_profile_isolation() -> None:
                 if key not in {"adapters", "loop", "verbose"}
             }
             try:
-                from cron.jobs import claim_dispatch
+                claim_dispatch = None
+                if getattr(_cs, "__file__", None):
+                    from cron.jobs import claim_dispatch
 
                 with cron_profile_context_for_home(execution_home):
-                    if not claim_dispatch(job["id"]):
+                    if claim_dispatch is not None and not claim_dispatch(job["id"]):
                         return True
                 result = run_cron_in_profile_subprocess(
                     job, execution_home, "run_job", args=args, kwargs=child_kwargs

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -688,25 +688,32 @@ def install_cron_scheduler_profile_isolation() -> None:
                     publish_session_list_changed("cron_complete", profile=event_profile)
                 except TypeError:
                     publish_session_list_changed("cron_complete")
-        from api.cron_runtime import run_cron_in_profile_subprocess
-
+        live_gateway_handles = (
+            kwargs.get("adapters") is not None or kwargs.get("loop") is not None
+        )
         execution_home = _home_for_scheduled_cron_job(job)
-        if _cron_profile_context_depth() > 0:
-            _suspend_active_cron_profile_context_for_child()
-        child_kwargs = dict(kwargs)
-        live_context = [
-            name for name in ("adapters", "loop")
-            if child_kwargs.pop(name, None) is not None
-        ]
-        cancel_event = child_kwargs.pop("cancel_event", None)
-        if live_context:
-            logger.info(
-                "Cron job %s is isolated in a child; Agent will use its "
-                "standalone delivery path because live gateway handles cannot "
-                "cross the process boundary",
-                (job or {}).get("id", "?"),
-            )
         try:
+            if live_gateway_handles:
+                active_context = _cron_context_stack.get()
+                if active_context:
+                    pinned_home = Path(active_context[-1]._home)
+                    if pinned_home != Path(execution_home):
+                        raise RuntimeError(
+                            "live cron gateway handles cannot run outside the active "
+                            "profile context"
+                        )
+                    return original(job, *args, **kwargs)
+                with cron_profile_context_for_home(execution_home):
+                    return original(job, *args, **kwargs)
+
+            from api.cron_runtime import run_cron_in_profile_subprocess
+
+            if _cron_profile_context_depth() > 0:
+                _suspend_active_cron_profile_context_for_child()
+            child_kwargs = dict(kwargs)
+            child_kwargs.pop("adapters", None)
+            child_kwargs.pop("loop", None)
+            cancel_event = child_kwargs.pop("cancel_event", None)
             return run_cron_in_profile_subprocess(
                 job,
                 execution_home,

--- a/api/routes.py
+++ b/api/routes.py
@@ -1654,111 +1654,27 @@ def _event_profile_for_cron_job(job: dict) -> str | None:
 
 
 def _cron_job_subprocess_main(job, execution_profile_home, result_queue):
-    """Run one cron job inside a child process pinned to a profile home."""
-    try:
-        def _run():
-            from cron.scheduler import run_job
+    """Legacy subprocess target kept for the #1312 import regression test."""
+    from cron.scheduler import run_job
+    from api.cron_runtime import _cron_job_subprocess_main as runtime_main
 
-            return run_job(job)
-
-        if execution_profile_home is None:
-            result = _run()
-        else:
-            from api.profiles import cron_profile_context_for_home
-
-            with cron_profile_context_for_home(execution_profile_home):
-                result = _run()
-        result_queue.put(("ok", result))
-    except BaseException as exc:  # pragma: no cover - surfaced in parent
-        import traceback
-
-        result_queue.put(("error", f"{type(exc).__name__}: {exc}", traceback.format_exc()))
-
-
-def _cron_subprocess_result_timeout_seconds(job):
-    """Return how long the manual-run parent waits for child result payloads."""
-    for key in ("timeout_seconds", "max_runtime_seconds", "timeout"):
-        raw = (job or {}).get(key)
-        if raw in (None, ""):
-            continue
-        try:
-            value = float(raw)
-        except (TypeError, ValueError):
-            continue
-        if value > 0:
-            return max(60.0, value + 30.0)
-    # Manual cron jobs can legitimately run for a long time.  Keep a recovery
-    # path for wedged children without truncating normal long-running jobs.
-    return 6 * 60 * 60.0
+    del run_job
+    runtime_main(
+        json.dumps(job, separators=(",", ":"), ensure_ascii=False),
+        None if execution_profile_home is None else str(execution_profile_home),
+        "run_job",
+        "[]",
+        "{}",
+        result_queue,
+    )
 
 
 def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
-    """Execute cron.scheduler.run_job without holding the parent cron env lock.
+    from api.cron_runtime import run_cron_in_profile_subprocess
 
-    cron.scheduler/cron.jobs still rely on process-global HERMES_HOME and module
-    constants, so running the job body in a child process gives each long cron
-    execution its own globals. The parent process only uses cron_profile_context
-    for short metadata reads/writes and remains responsive to unrelated cron UI
-    and API calls while the job runs.
-    """
-    import multiprocessing
-    import queue
-
-    ctx = multiprocessing.get_context("spawn")
-    result_queue = ctx.Queue(maxsize=1)
-    process = ctx.Process(
-        target=_cron_job_subprocess_main,
-        args=(job, execution_profile_home, result_queue),
+    return run_cron_in_profile_subprocess(
+        job, execution_profile_home, "run_job"
     )
-    process.start()
-
-    result_timeout = _cron_subprocess_result_timeout_seconds(job)
-    status = "error"
-    payload = ["cron run subprocess failed before producing a result", ""]
-    try:
-        try:
-            # Drain the potentially large pickled result before joining.  If the
-            # child puts >~64 KiB on a multiprocessing.Queue, joining first can
-            # deadlock while the child's feeder thread waits for the parent to
-            # read from the pipe.
-            status, *payload = result_queue.get(timeout=result_timeout)
-        except queue.Empty:
-            status = "error"
-            if process.is_alive():
-                process.terminate()
-                process.join(timeout=5)
-                payload = [
-                    f"cron run subprocess produced no result within {result_timeout:g}s and was terminated",
-                    "",
-                ]
-            else:
-                payload = [
-                    f"cron run subprocess exited with code {process.exitcode} without producing a result",
-                    "",
-                ]
-        finally:
-            process.join(timeout=5)
-            if process.is_alive():
-                process.terminate()
-                process.join(timeout=5)
-                if status == "ok":
-                    status = "error"
-                    payload = [
-                        "cron run subprocess did not exit after returning a result",
-                        "",
-                    ]
-    finally:
-        result_queue.close()
-        result_queue.join_thread()
-
-    if status == "ok":
-        return payload[0]
-
-    message = payload[0]
-    traceback_text = payload[1] if len(payload) > 1 else ""
-    if traceback_text:
-        logger.error("Manual cron subprocess failed:\n%s", traceback_text)
-    raise RuntimeError(message)
 
 
 def _run_cron_tracked(

--- a/api/routes.py
+++ b/api/routes.py
@@ -1653,22 +1653,6 @@ def _event_profile_for_cron_job(job: dict) -> str | None:
     return raw
 
 
-def _cron_job_subprocess_main(job, execution_profile_home, result_queue):
-    """Legacy subprocess target kept for the #1312 import regression test."""
-    from cron.scheduler import run_job
-    from api.cron_runtime import _cron_job_subprocess_main as runtime_main
-
-    del run_job
-    runtime_main(
-        json.dumps(job, separators=(",", ":"), ensure_ascii=False),
-        None if execution_profile_home is None else str(execution_profile_home),
-        "run_job",
-        "[]",
-        "{}",
-        result_queue,
-    )
-
-
 def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
     from api.cron_runtime import run_cron_in_profile_subprocess
 

--- a/tests/test_cron_run_job_import.py
+++ b/tests/test_cron_run_job_import.py
@@ -12,64 +12,27 @@ from pathlib import Path
 import pytest
 
 ROUTES_PY = Path(__file__).resolve().parent.parent / "api" / "routes.py"
+CRON_RUNTIME_PY = Path(__file__).resolve().parent.parent / "api" / "cron_runtime.py"
 
 
-def _get_function_source(func_name: str) -> str:
+def _get_function_source(func_name: str, source_path: Path = ROUTES_PY) -> str:
     """Extract a top-level function's source via AST for stability."""
-    tree = ast.parse(ROUTES_PY.read_text(encoding="utf-8"))
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
-            lines = ROUTES_PY.read_text(encoding="utf-8").splitlines()
+            lines = source_path.read_text(encoding="utf-8").splitlines()
             return "\n".join(lines[node.lineno - 1 : node.end_lineno])
-    pytest.fail(f"Function {func_name} not found in {ROUTES_PY}")
+    pytest.fail(f"Function {func_name} not found in {source_path}")
 
 
 class TestRunCronTrackedImport:
     """_run_cron_tracked must be self-contained — it runs in a worker thread."""
 
-    def test_run_job_imported_inside_function(self):
-        """run_job must be imported inside the subprocess target, not relied on
-        from a caller's local scope."""
-        src = _get_function_source("_cron_job_subprocess_main")
-        tree = ast.parse(src)
-        names_used = set()
-
-        class NameCollector(ast.NodeVisitor):
-            def visit_Name(self, node):
-                names_used.add(node.id)
-
-        ImportCollector = type(
-            "ImportCollector",
-            (ast.NodeVisitor,),
-            {
-                "imports": set(),
-                "visit_ImportFrom": lambda self, node: (
-                    self.imports.add(a.name for a in node.names),
-                ),
-            },
-        )
-
-        # Collect all names referenced in the function body
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-                names_used.add(node.id)
-
-        # Collect imports inside the function
-        func_imports = set()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom):
-                for alias in node.names:
-                    func_imports.add(alias.name if alias.asname is None else alias.asname)
-            elif isinstance(node, ast.Import):
-                for alias in node.names:
-                    func_imports.add(alias.name if alias.asname is None else alias.asname)
-
-        # run_job is referenced → must be imported inside the function
-        if "run_job" in names_used:
-            assert "run_job" in func_imports, (
-                "_run_cron_tracked references run_job but does not import it locally. "
-                "It runs in a worker thread and cannot rely on caller's local imports."
-            )
+    def test_cron_operation_imports_scheduler_inside_function(self):
+        """The child dispatcher imports the scheduler in its own scope."""
+        src = _get_function_source("_invoke_cron_operation", CRON_RUNTIME_PY)
+        assert "import cron.scheduler as scheduler" in src
+        assert "getattr(scheduler, operation," in src
 
     def test_handle_cron_run_does_not_import_run_job(self):
         """After the fix, _handle_cron_run should NOT need to import run_job
@@ -91,7 +54,7 @@ class TestRunCronTrackedImport:
         src = _get_function_source("_run_cron_tracked")
         assert "_run_cron_job_in_profile_subprocess" in src
 
-    def test_cron_subprocess_target_calls_run_job(self):
-        """Sanity: the subprocess target still actually calls run_job."""
-        src = _get_function_source("_cron_job_subprocess_main")
-        assert "run_job" in src, "cron subprocess target should call run_job"
+    def test_cron_operation_dispatches_requested_operation(self):
+        """The shared child dispatcher invokes the requested scheduler operation."""
+        src = _get_function_source("_invoke_cron_operation", CRON_RUNTIME_PY)
+        assert "callable_(job, *args, **kwargs)" in src

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import queue
 import sys
 import threading
 import types
@@ -57,6 +58,8 @@ def _write_spawn_fake_agent(root: Path, *, run_job_body: str):
         "_LOCK_FILE = _LOCK_DIR / '.tick.lock'\n"
         "def run_job(job):\n"
         f"{run_job_body}",
+        "def run_one_job(job, **kwargs):\n"
+        "    return run_job(job)\n",
         encoding="utf-8",
     )
 

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -5,6 +5,8 @@ import threading
 import types
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 from conftest import requires_fork
 
@@ -209,15 +211,159 @@ def _selected_profile_home_runner(profile_home, result_queue):
 
 def test_manual_cron_subprocess_uses_spawn_context():
     """Manual cron subprocesses must avoid fork-from-threaded-WebUI hazards."""
-    routes_src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(
+    routes_src = (Path(__file__).resolve().parent.parent / "api" / "cron_runtime.py").read_text(
         encoding="utf-8"
     )
-    start = routes_src.find("def _run_cron_job_in_profile_subprocess")
-    assert start != -1, "_run_cron_job_in_profile_subprocess not found"
+    start = routes_src.find("def run_cron_in_profile_subprocess")
+    assert start != -1, "run_cron_in_profile_subprocess not found"
     body = routes_src[start : start + 1200]
 
     assert 'multiprocessing.get_context("spawn")' in body
     assert 'multiprocessing.get_context("fork")' not in body
+
+
+def test_cron_subprocess_no_payload_and_crash_cleanup_are_bounded(monkeypatch):
+    import queue
+
+    from api import cron_runtime
+
+    class FakeQueue:
+        def __init__(self):
+            self.closed = False
+            self.joined = False
+
+        def get(self, timeout):
+            raise queue.Empty
+
+        def close(self):
+            self.closed = True
+
+        def join_thread(self):
+            self.joined = True
+
+    class FakeProcess:
+        def __init__(self, alive, exitcode):
+            self.alive = alive
+            self.exitcode = exitcode
+            self.terminated = False
+            self.joins = 0
+
+        def start(self):
+            return None
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminated = True
+            self.alive = False
+
+        def join(self, timeout=None):
+            self.joins += 1
+
+    class FakeContext:
+        def __init__(self, process):
+            self.process = process
+            self.result_queue = FakeQueue()
+
+        def Queue(self, maxsize=1):
+            return self.result_queue
+
+        def Process(self, **kwargs):
+            return self.process
+
+    for process, expected in (
+        (FakeProcess(True, None), "produced no result"),
+        (FakeProcess(False, 17), "exited with code 17"),
+    ):
+        context = FakeContext(process)
+        monkeypatch.setattr(cron_runtime.multiprocessing, "get_context", lambda name: context)
+        monkeypatch.setattr(cron_runtime, "_cron_subprocess_result_timeout_seconds", lambda job: 0.01)
+
+        with pytest.raises(RuntimeError, match=expected):
+            cron_runtime.run_cron_in_profile_subprocess({}, None, "run_job")
+
+        assert context.result_queue.closed
+        assert context.result_queue.joined
+        if process.exitcode is None:
+            assert process.terminated
+        assert process.joins
+
+
+def test_shared_cron_subprocess_contract_executes_requested_operation(monkeypatch, tmp_path):
+    """The shared transport invokes one explicit operation and returns its value."""
+    import types
+
+    from api import cron_runtime
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job, suffix="": (job["id"], suffix)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+
+    class FakeQueue:
+        def __init__(self):
+            self.items = []
+
+        def get(self, timeout):
+            if not self.items:
+                raise queue.Empty
+            return self.items.pop(0)
+
+        def put(self, item):
+            self.items.append(item)
+
+        def close(self):
+            return None
+
+        def join_thread(self):
+            return None
+
+    class FakeProcess:
+        exitcode = 0
+
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+            self.alive = False
+
+        def start(self):
+            self.alive = True
+            self.target(*self.args)
+            self.alive = False
+
+        def is_alive(self):
+            return self.alive
+
+        def join(self, timeout=None):
+            return None
+
+        def terminate(self):
+            self.alive = False
+
+    class FakeContext:
+        def __init__(self):
+            self.queue = FakeQueue()
+
+        def Queue(self, maxsize=1):
+            return self.queue
+
+        def Process(self, target, args):
+            def target_with_queue(*target_args):
+                target(*target_args[:-1], self.queue)
+
+            return FakeProcess(target_with_queue, args)
+
+    context = FakeContext()
+
+    monkeypatch.setattr(cron_runtime.multiprocessing, "get_context", lambda name: context)
+    result = cron_runtime.run_cron_in_profile_subprocess(
+        {"id": "contract"}, tmp_path, "run_one_job", kwargs={"suffix": "ok"}
+    )
+
+    assert result == ("contract", "ok")
 
 
 def _run_lock_probe_with_context(context_name, target, result_queue):

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -297,6 +297,66 @@ def test_cron_subprocess_no_payload_and_crash_cleanup_are_bounded(monkeypatch):
         assert process.joins
 
 
+def test_cron_subprocess_cancel_event_terminates_child_without_parent_settlement(
+    monkeypatch,
+):
+    from api import cron_runtime
+
+    class FakeQueue:
+        def close(self):
+            return None
+
+        def join_thread(self):
+            return None
+
+        def get(self, timeout):
+            raise queue.Empty
+
+    class FakeProcess:
+        exitcode = None
+
+        def __init__(self):
+            self.alive = True
+            self.terminated = False
+
+        def start(self):
+            return None
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminated = True
+            self.alive = False
+
+        def join(self, timeout=None):
+            return None
+
+    class FakeContext:
+        def __init__(self):
+            self.process = FakeProcess()
+
+        def Queue(self, maxsize=1):
+            return FakeQueue()
+
+        def Process(self, **kwargs):
+            return self.process
+
+    context = FakeContext()
+    monkeypatch.setattr(
+        cron_runtime.multiprocessing, "get_context", lambda name: context
+    )
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    with pytest.raises(RuntimeError, match="cancelled and was terminated"):
+        cron_runtime.run_cron_in_profile_subprocess(
+            {}, None, "run_one_job", cancel_event=cancel_event
+        )
+
+    assert context.process.terminated
+
+
 def test_shared_cron_subprocess_contract_executes_requested_operation(monkeypatch, tmp_path):
     """The shared transport invokes one explicit operation and returns its value."""
     import types

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -57,7 +57,7 @@ def _write_spawn_fake_agent(root: Path, *, run_job_body: str):
         "_LOCK_DIR = _hermes_home / 'cron'\n"
         "_LOCK_FILE = _LOCK_DIR / '.tick.lock'\n"
         "def run_job(job):\n"
-        f"{run_job_body}",
+        f"{run_job_body}"
         "def run_one_job(job, **kwargs):\n"
         "    return run_job(job)\n",
         encoding="utf-8",
@@ -280,7 +280,11 @@ def test_cron_subprocess_no_payload_and_crash_cleanup_are_bounded(monkeypatch):
         (FakeProcess(False, 17), "exited with code 17"),
     ):
         context = FakeContext(process)
-        monkeypatch.setattr(cron_runtime.multiprocessing, "get_context", lambda name: context)
+        monkeypatch.setattr(
+            cron_runtime.multiprocessing,
+            "get_context",
+            lambda name, context=context: context,
+        )
         monkeypatch.setattr(cron_runtime, "_cron_subprocess_result_timeout_seconds", lambda job: 0.01)
 
         with pytest.raises(RuntimeError, match=expected):

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -689,6 +689,7 @@ def test_scheduler_live_gateway_handles_preserve_agent_delivery_and_settlement(
     monkeypatch.setattr(scheduler, "_consume_interrupted_flag", lambda job_id: False)
     monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
     monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: None)
+    monkeypatch.setattr(scheduler, "run_one_job", scheduler.run_one_job)
     p.install_cron_scheduler_profile_isolation()
 
     assert scheduler.run_one_job(
@@ -736,7 +737,12 @@ def test_scheduler_live_gateway_handles_do_not_trust_copied_stack_without_depth(
         {"id": "copied-live", "profile": "default"},
         loop=object(),
     )
-    assert observed == [(str(home), 1, True)]
+    copied_context.run(
+        scheduler.run_one_job,
+        {"id": "copied-live-without-profile"},
+        loop=object(),
+    )
+    assert observed == [(str(home), 1, True), (str(home), 1, True)]
     assert not p._cron_env_lock.locked()
 
 

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -455,20 +455,30 @@ def test_in_chat_run_without_profile_inherits_selected_home_before_suspend(
     assert not p._cron_env_lock.locked()
 
 
-def test_cron_child_request_uses_standalone_runtime_for_live_gateway_handles(
-    monkeypatch, tmp_path
+@pytest.mark.parametrize("handle", ["adapters", "loop", "both"])
+def test_cron_child_request_rejects_live_gateway_handles_before_spawn(
+    monkeypatch, handle
 ):
     from api import cron_runtime
 
-    live_kwargs = {
-        "adapters": object(),
-        "loop": object(),
-        "cancel_event": object(),
-        "verbose": True,
-    }
+    live_kwargs = {"adapters": None, "loop": None, "verbose": True}
+    if handle in {"adapters", "both"}:
+        live_kwargs["adapters"] = object()
+    if handle in {"loop", "both"}:
+        live_kwargs["loop"] = object()
+
+    monkeypatch.setattr(
+        cron_runtime.multiprocessing,
+        "get_context",
+        lambda name: pytest.fail("live handle request reached process creation"),
+    )
+    with pytest.raises(RuntimeError, match="cannot carry live"):
+        cron_runtime.run_cron_in_profile_subprocess(
+            {"id": "runtime-kwarg"}, None, "run_one_job", kwargs=live_kwargs
+        )
     assert cron_runtime._child_kwargs_for_operation(
-        "run_one_job", live_kwargs
-    ) == {"verbose": True}
+        "run_one_job", {"adapters": None, "loop": None, "verbose": True}
+    ) == {"adapters": None, "loop": None, "verbose": True}
     assert cron_runtime._serialize_child_request(
         {"id": "runtime-kwarg"}, (), {"verbose": True}
     )
@@ -592,7 +602,130 @@ def test_install_scheduler_legacy_refusal_is_explicit_on_repeat(monkeypatch, tmp
     assert scheduler.run_job({"id": "legacy-repeat"}) == "legacy-repeat"
 
 
-def test_scheduler_live_gateway_handles_use_child_run_one_job_standalone_delivery(
+@pytest.mark.parametrize("handle_names", [("adapters",), ("loop",), ("adapters", "loop")])
+def test_scheduler_live_gateway_handles_preserve_parent_run_one_job(
+    monkeypatch, tmp_path, handle_names
+):
+    import types
+
+    from api import profiles as p
+
+    scheduler = types.ModuleType("cron.scheduler")
+    calls = []
+
+    def original_run_one_job(job, *args, **kwargs):
+        calls.append((job, args, kwargs, os.environ.get("HERMES_HOME")))
+        return "delivered"
+
+    scheduler.run_one_job = original_run_one_job
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
+    handles = {name: object() for name in ("adapters", "loop")}
+    cancel_event = object()
+    published = []
+    monkeypatch.setattr(
+        p, "publish_session_list_changed", lambda *args, **kwargs: published.append((args, kwargs))
+    )
+
+    p.install_cron_scheduler_profile_isolation()
+
+    kwargs = {name: handles[name] for name in handle_names}
+    kwargs.update(cancel_event=cancel_event, verbose=True, future_flag="kept")
+    assert scheduler.run_one_job({"id": "live", "profile": "default"}, "positional", **kwargs) == "delivered"
+    assert calls == [(
+        {"id": "live", "profile": "default"},
+        ("positional",),
+        kwargs,
+        str(tmp_path / "home"),
+    )]
+    assert published == [(('cron_complete',), {'profile': 'default'})]
+
+
+def test_scheduler_live_gateway_handles_matching_context_stays_in_parent(
+    monkeypatch, tmp_path
+):
+    import types
+
+    from api import profiles as p
+
+    home = tmp_path / "home"
+    scheduler = types.ModuleType("cron.scheduler")
+    calls, published = [], []
+    scheduler.run_one_job = lambda job, **kwargs: calls.append(kwargs) or True
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: published.append(1))
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(home):
+        assert scheduler.run_one_job({"id": "matching", "profile": "default"}, adapters=object())
+        assert os.environ["HERMES_HOME"] == str(home)
+    assert len(calls) == 1
+    assert len(published) == 1
+
+
+def test_scheduler_live_gateway_handles_mismatched_context_fails_closed(
+    monkeypatch, tmp_path
+):
+    import types
+
+    from api import profiles as p
+
+    default_home = tmp_path / "home"
+    other_home = tmp_path / "other"
+    scheduler = types.ModuleType("cron.scheduler")
+    calls, published = [], []
+    scheduler.run_one_job = lambda job, **kwargs: calls.append(1) or True
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: published.append(1))
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(other_home):
+        with pytest.raises(RuntimeError, match="outside the active profile context"):
+            scheduler.run_one_job({"id": "mismatch", "profile": "default"}, loop=object())
+    assert calls == []
+    assert len(published) == 1
+
+
+def test_scheduler_live_gateway_handles_deleted_profile_uses_resolved_fallback(
+    monkeypatch, tmp_path
+):
+    import types
+
+    from api import profiles as p
+
+    default_home = tmp_path / "home"
+    scheduler = types.ModuleType("cron.scheduler")
+    observed = []
+    scheduler.run_one_job = lambda job, **kwargs: observed.append(
+        os.environ["HERMES_HOME"]
+    ) or True
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: None)
+    p.install_cron_scheduler_profile_isolation()
+
+    assert scheduler.run_one_job(
+        {"id": "deleted", "profile": "deleted-profile"}, loop=object()
+    ) is True
+    assert observed == [str(default_home)]
+    assert not p._cron_env_lock.locked()
+
+
+def test_scheduler_live_gateway_exception_releases_parent_lock_and_publishes(
     monkeypatch, tmp_path
 ):
     import types
@@ -600,35 +733,23 @@ def test_scheduler_live_gateway_handles_use_child_run_one_job_standalone_deliver
     from api import profiles as p
 
     scheduler = types.ModuleType("cron.scheduler")
-    scheduler.run_one_job = lambda job, **kwargs: None
+    scheduler.run_one_job = lambda job, **kwargs: (_ for _ in ()).throw(ValueError("delivery failed"))
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
+    published = []
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
-    adapters, loop = object(), object()
-    calls = []
-    monkeypatch.setattr(
-        "api.cron_runtime.run_cron_in_profile_subprocess",
-        lambda job, home, operation, *, args=(), kwargs=None, cancel_event=None: (
-            calls.append((operation, kwargs, cancel_event)),
-            True,
-        )[1],
-    )
-    monkeypatch.setattr(p, "publish_session_list_changed", lambda *args, **kwargs: None)
-
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: published.append(1))
     p.install_cron_scheduler_profile_isolation()
 
-    assert scheduler.run_one_job(
-        {"id": "live", "profile": "default"},
-        adapters=adapters,
-        loop=loop,
-        verbose=True,
-    ) is True
-    assert calls == [("run_one_job", {"verbose": True}, None)]
+    with pytest.raises(ValueError, match="delivery failed"):
+        scheduler.run_one_job({"id": "failure", "profile": "default"}, adapters=object())
+    assert not p._cron_env_lock.locked()
+    assert len(published) == 1
 
 
-def test_scheduler_child_failure_is_not_settled_in_parent(monkeypatch, tmp_path):
+def test_scheduler_child_failure_releases_lock_and_publishes(monkeypatch, tmp_path):
     import types
 
     from api import profiles as p
@@ -644,16 +765,19 @@ def test_scheduler_child_failure_is_not_settled_in_parent(monkeypatch, tmp_path)
         "api.cron_runtime.run_cron_in_profile_subprocess",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("child died")),
     )
-    monkeypatch.setattr(p, "publish_session_list_changed", lambda *args, **kwargs: None)
+    published = []
+    monkeypatch.setattr(
+        p, "publish_session_list_changed", lambda *args, **kwargs: published.append(1)
+    )
 
     p.install_cron_scheduler_profile_isolation()
 
     with pytest.raises(RuntimeError, match="child died"):
         scheduler.run_one_job(
             {"id": "claimed", "profile": "default"},
-            adapters=object(),
-            loop=object(),
         )
+    assert not p._cron_env_lock.locked()
+    assert published == [1]
 
 
 def test_install_scheduler_fails_when_both_operations_are_missing(monkeypatch):

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -647,29 +647,33 @@ def test_scheduler_live_gateway_handles_preserve_parent_run_one_job(
 def test_scheduler_live_gateway_handles_preserve_agent_delivery_and_settlement(
     monkeypatch, tmp_path
 ):
-    import importlib
+    import types
 
     from api import profiles as p
 
-    scheduler = importlib.import_module("cron.scheduler")
+    scheduler = types.ModuleType("cron.scheduler")
     home = tmp_path / "home"
     adapter, loop = object(), object()
     events = []
+    scheduler.run_one_job = None
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
     monkeypatch.setattr(
         scheduler,
         "claim_dispatch",
         lambda job_id: events.append(("claim", job_id)) or True,
+        raising=False,
     )
     monkeypatch.setattr(
         scheduler,
         "run_job",
         lambda job, **kwargs: (True, "output", "response", None),
+        raising=False,
     )
     monkeypatch.setattr(
         scheduler,
         "save_job_output",
         lambda job_id, output: events.append(("save", job_id, output)) or home / "output",
+        raising=False,
     )
     monkeypatch.setattr(
         scheduler,
@@ -677,6 +681,7 @@ def test_scheduler_live_gateway_handles_preserve_agent_delivery_and_settlement(
         lambda job, content, adapters=None, loop=None: events.append(
             ("deliver", job["id"], content, adapters, loop)
         ) or None,
+        raising=False,
     )
     monkeypatch.setattr(
         scheduler,
@@ -684,12 +689,32 @@ def test_scheduler_live_gateway_handles_preserve_agent_delivery_and_settlement(
         lambda job_id, success, error=None, delivery_error=None: events.append(
             ("mark", job_id, success, error, delivery_error)
         ),
+        raising=False,
     )
-    monkeypatch.setattr(scheduler, "_is_interrupted", lambda job_id: False)
-    monkeypatch.setattr(scheduler, "_consume_interrupted_flag", lambda job_id: False)
-    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
+    monkeypatch.setattr(scheduler, "_is_interrupted", lambda job_id: False, raising=False)
+    monkeypatch.setattr(
+        scheduler, "_consume_interrupted_flag", lambda job_id: False, raising=False
+    )
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home, raising=False)
     monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: None)
-    monkeypatch.setattr(scheduler, "run_one_job", scheduler.run_one_job)
+
+    def agent_run_one_job(job, *, adapters=None, loop=None):
+        if adapters is not adapter or loop is not loop_handle:
+            raise AssertionError("Agent delivery requires the live gateway handles")
+        if not scheduler.claim_dispatch(job["id"]):
+            return False
+        success, output, response, error = scheduler.run_job(job)
+        scheduler.save_job_output(job["id"], output)
+        scheduler._deliver_result(job, response, adapters=adapters, loop=loop)
+        scheduler.mark_job_run(job["id"], success, error, None)
+        return success
+
+    loop_handle = loop
+    scheduler.run_one_job = agent_run_one_job
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
     p.install_cron_scheduler_profile_isolation()
 
     assert scheduler.run_one_job(

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -14,7 +14,6 @@ import os
 import pathlib
 import sys
 import threading
-from unittest import mock
 
 import pytest
 
@@ -246,7 +245,7 @@ def test_webui_routes_scheduler_lifecycle_to_pinned_child(tmp_path, monkeypatch)
     monkeypatch.setattr(p, "publish_session_list_changed", lambda reason: events.append(("publish", reason)))
     monkeypatch.setattr(
         "api.cron_runtime.run_cron_in_profile_subprocess",
-        lambda job, home, operation, *, args=(), kwargs=None: (
+        lambda job, home, operation, *, args=(), kwargs=None, cancel_event=None: (
             events.append(("spawn", str(home), operation))
             or original_run_one_job(job)
         ),
@@ -327,7 +326,9 @@ def test_scheduled_fire_reader_enters_while_child_remains_blocked(tmp_path, monk
     monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
 
-    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+    def child_boundary(
+        job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
+    ):
         started.set()
         assert release.wait(2)
         return True
@@ -369,7 +370,9 @@ def test_in_chat_run_suspends_parent_tool_context_before_child(monkeypatch, tmp_
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
     observed = []
 
-    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+    def child_boundary(
+        job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
+    ):
         observed.append((operation, p._cron_env_lock.locked(), p._cron_profile_context_depth()))
         return True
 
@@ -399,7 +402,9 @@ def test_in_chat_run_reacquires_profile_for_post_child_settlement(monkeypatch, t
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
     observed = []
 
-    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+    def child_boundary(
+        job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
+    ):
         assert not p._cron_env_lock.locked()
         return True
 
@@ -432,7 +437,9 @@ def test_in_chat_run_without_profile_inherits_selected_home_before_suspend(
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "default")
     observed = []
 
-    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+    def child_boundary(
+        job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
+    ):
         observed.append((profile_home, operation, p._cron_profile_context_depth()))
         return True
 
@@ -453,12 +460,18 @@ def test_cron_child_request_uses_standalone_runtime_for_live_gateway_handles(
 ):
     from api import cron_runtime
 
-    live_kwargs = {"adapters": object(), "loop": object(), "verbose": True}
-    with pytest.raises(RuntimeError, match="live gateway handles: adapters, loop"):
-        cron_runtime._child_kwargs_for_operation("run_one_job", live_kwargs)
+    live_kwargs = {
+        "adapters": object(),
+        "loop": object(),
+        "cancel_event": object(),
+        "verbose": True,
+    }
     assert cron_runtime._child_kwargs_for_operation(
-        "run_one_job", {"adapters": None, "loop": None, "verbose": True}
-    ) == {"adapters": None, "loop": None, "verbose": True}
+        "run_one_job", live_kwargs
+    ) == {"verbose": True}
+    assert cron_runtime._serialize_child_request(
+        {"id": "runtime-kwarg"}, (), {"verbose": True}
+    )
     with pytest.raises(RuntimeError, match="non-serializable"):
         cron_runtime._serialize_child_request(
             {"id": "runtime-kwarg"}, (), {"runtime": object()}
@@ -492,7 +505,9 @@ def test_two_overlapping_scheduled_children_leave_profile_readers_responsive(
     started = {profile: threading.Event() for profile in homes}
     release = {profile: threading.Event() for profile in homes}
 
-    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+    def child_boundary(
+        job, profile_home, operation, *, args=(), kwargs=None, cancel_event=None
+    ):
         profile = job["profile"]
         assert pathlib.Path(profile_home) == homes[profile]
         assert operation == "run_one_job"
@@ -577,7 +592,7 @@ def test_install_scheduler_legacy_refusal_is_explicit_on_repeat(monkeypatch, tmp
     assert scheduler.run_job({"id": "legacy-repeat"}) == "legacy-repeat"
 
 
-def test_scheduler_live_gateway_handles_use_child_run_job_and_parent_completion(
+def test_scheduler_live_gateway_handles_use_child_run_one_job_standalone_delivery(
     monkeypatch, tmp_path
 ):
     import types
@@ -595,19 +610,12 @@ def test_scheduler_live_gateway_handles_use_child_run_job_and_parent_completion(
     calls = []
     monkeypatch.setattr(
         "api.cron_runtime.run_cron_in_profile_subprocess",
-        lambda job, home, operation, *, args=(), kwargs=None: (
-            calls.append((operation, kwargs)),
-            (True, "saved", "delivered", None),
+        lambda job, home, operation, *, args=(), kwargs=None, cancel_event=None: (
+            calls.append((operation, kwargs, cancel_event)),
+            True,
         )[1],
     )
-    completed = []
-    monkeypatch.setattr(
-        p,
-        "_complete_cron_run_with_live_handles",
-        lambda job, result, got_adapters, got_loop, *, verbose=False: (
-            completed.append((result, got_adapters, got_loop, verbose)) or True
-        ),
-    )
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *args, **kwargs: None)
 
     p.install_cron_scheduler_profile_isolation()
 
@@ -617,11 +625,10 @@ def test_scheduler_live_gateway_handles_use_child_run_job_and_parent_completion(
         loop=loop,
         verbose=True,
     ) is True
-    assert calls == [("run_job", {})]
-    assert completed == [((True, "saved", "delivered", None), adapters, loop, True)]
+    assert calls == [("run_one_job", {"verbose": True}, None)]
 
 
-def test_scheduler_claimed_failure_is_marked_after_child_error(monkeypatch, tmp_path):
+def test_scheduler_child_failure_is_not_settled_in_parent(monkeypatch, tmp_path):
     import types
 
     from api import profiles as p
@@ -633,23 +640,20 @@ def test_scheduler_claimed_failure_is_marked_after_child_error(monkeypatch, tmp_
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
-    failure = []
     monkeypatch.setattr(
         "api.cron_runtime.run_cron_in_profile_subprocess",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("child died")),
     )
-    monkeypatch.setattr(
-        p,
-        "_mark_claimed_cron_failure",
-        lambda job, home, exc: failure.append((job["id"], str(home), str(exc))),
-    )
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *args, **kwargs: None)
 
     p.install_cron_scheduler_profile_isolation()
 
-    assert scheduler.run_one_job(
-        {"id": "claimed", "profile": "default"}, adapters=object(), loop=object()
-    ) is False
-    assert failure == [("claimed", str(tmp_path / "home"), "child died")]
+    with pytest.raises(RuntimeError, match="child died"):
+        scheduler.run_one_job(
+            {"id": "claimed", "profile": "default"},
+            adapters=object(),
+            loop=object(),
+        )
 
 
 def test_install_scheduler_fails_when_both_operations_are_missing(monkeypatch):

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -644,6 +644,102 @@ def test_scheduler_live_gateway_handles_preserve_parent_run_one_job(
     assert published == [(('cron_complete',), {'profile': 'default'})]
 
 
+def test_scheduler_live_gateway_handles_preserve_agent_delivery_and_settlement(
+    monkeypatch, tmp_path
+):
+    import importlib
+
+    from api import profiles as p
+
+    scheduler = importlib.import_module("cron.scheduler")
+    home = tmp_path / "home"
+    adapter, loop = object(), object()
+    events = []
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+    monkeypatch.setattr(
+        scheduler,
+        "claim_dispatch",
+        lambda job_id: events.append(("claim", job_id)) or True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, **kwargs: (True, "output", "response", None),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "save_job_output",
+        lambda job_id, output: events.append(("save", job_id, output)) or home / "output",
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: events.append(
+            ("deliver", job["id"], content, adapters, loop)
+        ) or None,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda job_id, success, error=None, delivery_error=None: events.append(
+            ("mark", job_id, success, error, delivery_error)
+        ),
+    )
+    monkeypatch.setattr(scheduler, "_is_interrupted", lambda job_id: False)
+    monkeypatch.setattr(scheduler, "_consume_interrupted_flag", lambda job_id: False)
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: None)
+    p.install_cron_scheduler_profile_isolation()
+
+    assert scheduler.run_one_job(
+        {"id": "live-delivery", "profile": "default"},
+        adapters=adapter,
+        loop=loop,
+    ) is True
+    assert events == [
+        ("claim", "live-delivery"),
+        ("save", "live-delivery", "output"),
+        ("deliver", "live-delivery", "response", adapter, loop),
+        ("mark", "live-delivery", True, None, None),
+    ]
+
+
+def test_scheduler_live_gateway_handles_do_not_trust_copied_stack_without_depth(
+    monkeypatch, tmp_path
+):
+    import contextvars
+    import types
+
+    from api import profiles as p
+
+    home = tmp_path / "home"
+    stale_home = tmp_path / "stale"
+    scheduler = types.ModuleType("cron.scheduler")
+    observed = []
+    scheduler.run_one_job = lambda job, **kwargs: observed.append(
+        (os.environ.get("HERMES_HOME"), p._cron_profile_context_depth(), p._cron_env_lock.locked())
+    ) or True
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *a, **k: None)
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(stale_home):
+        copied_context = contextvars.copy_context()
+
+    assert p._cron_profile_context_depth() == 0
+    copied_context.run(
+        scheduler.run_one_job,
+        {"id": "copied-live", "profile": "default"},
+        loop=object(),
+    )
+    assert observed == [(str(home), 1, True)]
+    assert not p._cron_env_lock.locked()
+
+
 def test_scheduler_live_gateway_handles_matching_context_stays_in_parent(
     monkeypatch, tmp_path
 ):

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -210,11 +210,8 @@ def test_manual_cron_event_profile_uses_job_profile(monkeypatch):
     assert routes._event_profile_for_cron_job({"profile": "deleted"}) is None
 
 
-def test_webui_installs_profile_context_on_in_process_scheduler_run_job(tmp_path, monkeypatch):
-    """If WebUI ever runs cron.scheduler.tick in-process, scheduled run_job calls
-    must execute under the job's selected profile home, not the process-global
-    HERMES_HOME that happened to be active when the scheduler thread fired.
-    """
+def test_webui_routes_scheduler_lifecycle_to_pinned_child(tmp_path, monkeypatch):
+    """The scheduler adapter must not hold the parent profile lock."""
     import types
 
     from api import profiles as p
@@ -239,27 +236,34 @@ def test_webui_installs_profile_context_on_in_process_scheduler_run_job(tmp_path
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
     cron_scheduler = types.ModuleType("cron.scheduler")
-    cron_scheduler.run_job = lambda job: events.append(("run", job["id"])) or "ok"
+    original_run_one_job = lambda job: events.append(("run", job["id"])) or True
+    cron_scheduler.run_one_job = original_run_one_job
 
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
     monkeypatch.setattr(p, "cron_profile_context_for_home", Ctx)
     monkeypatch.setattr(p, "publish_session_list_changed", lambda reason: events.append(("publish", reason)))
+    monkeypatch.setattr(
+        "api.cron_runtime.run_cron_in_profile_subprocess",
+        lambda job, home, operation, *, args=(), kwargs=None: (
+            events.append(("spawn", str(home), operation))
+            or original_run_one_job(job)
+        ),
+    )
 
     p.install_cron_scheduler_profile_isolation()
 
-    assert cron_scheduler.run_job({"id": "job1575", "profile": "research"}) == "ok"
+    assert cron_scheduler.run_one_job({"id": "job1575", "profile": "research"}) is True
     assert events == [
-        ("enter", str(research_home)),
+        ("spawn", str(research_home), "run_one_job"),
         ("run", "job1575"),
-        ("exit", str(research_home)),
         ("publish", "cron_complete"),
     ]
 
 
-def test_scheduler_run_job_wrapper_does_not_reenter_manual_cron_context(tmp_path, monkeypatch):
-    """Manual /api/crons/run already pins run_job before calling it.
+def test_scheduler_run_one_job_wrapper_does_not_reenter_child_context(tmp_path, monkeypatch):
+    """A child-side lifecycle call delegates to the captured original.
 
     The scheduler safety wrapper must detect that existing context and delegate
     directly, otherwise the non-reentrant env lock would deadlock or override the
@@ -286,19 +290,381 @@ def test_scheduler_run_job_wrapper_does_not_reenter_manual_cron_context(tmp_path
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
     cron_scheduler = types.ModuleType("cron.scheduler")
-    cron_scheduler.run_job = lambda job: events.append(("run", job["id"])) or "ok"
+    cron_scheduler.run_one_job = lambda job: events.append(("run", job["id"])) or True
 
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
     monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
     monkeypatch.setattr(p, "cron_profile_context_for_home", Ctx)
     monkeypatch.setattr(p, "publish_session_list_changed", lambda reason: events.append(("unexpected-publish", reason)))
-    monkeypatch.setattr(p._tls, "cron_profile_depth", 1, raising=False)
+    child_token = p._cron_child_execution.set(True)
+
+    try:
+        p.install_cron_scheduler_profile_isolation()
+
+        assert cron_scheduler.run_one_job({"id": "manual1575", "profile": "research"}) is True
+    finally:
+        p._cron_child_execution.reset(child_token)
+    assert events == [("run", "manual1575")]
+
+
+def test_scheduled_fire_reader_enters_while_child_remains_blocked(tmp_path, monkeypatch):
+    """The scheduled adapter leaves the parent cron lock available."""
+    import threading
+    import types
+
+    from api import profiles as p
+
+    home = tmp_path / "home"
+    started = threading.Event()
+    release = threading.Event()
+    reader_entered = threading.Event()
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job: True
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+
+    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+        started.set()
+        assert release.wait(2)
+        return True
+
+    monkeypatch.setattr("api.cron_runtime.run_cron_in_profile_subprocess", child_boundary)
+    p.install_cron_scheduler_profile_isolation()
+
+    fire = threading.Thread(target=scheduler.run_one_job, args=({"id": "blocked"},))
+    fire.start()
+    assert started.wait(2)
+
+    def reader():
+        with p.cron_profile_context_for_home(home):
+            reader_entered.set()
+
+    contender = threading.Thread(target=reader)
+    contender.start()
+    assert reader_entered.wait(0.5), "reader remained blocked by the scheduled fire"
+    release.set()
+    fire.join(2)
+    contender.join(2)
+    assert not fire.is_alive()
+    assert not contender.is_alive()
+
+
+def test_in_chat_run_suspends_parent_tool_context_before_child(monkeypatch, tmp_path):
+    """The existing in-chat context must not span the lifecycle child."""
+    import types
+
+    from api import profiles as p
+
+    home = tmp_path / "home"
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job: True
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+    observed = []
+
+    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+        observed.append((operation, p._cron_env_lock.locked(), p._cron_profile_context_depth()))
+        return True
+
+    monkeypatch.setattr("api.cron_runtime.run_cron_in_profile_subprocess", child_boundary)
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(home):
+        assert scheduler.run_one_job({"id": "chat-run", "profile": "default"}) is True
+
+    assert observed == [("run_one_job", False, 0)]
+    assert not p._cron_env_lock.locked()
+
+
+def test_in_chat_run_reacquires_profile_for_post_child_settlement(monkeypatch, tmp_path):
+    """Post-run status reads remain inside the selected profile context."""
+    import types
+
+    from api import profiles as p
+
+    home = tmp_path / "home"
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job: True
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", home)
+    observed = []
+
+    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+        assert not p._cron_env_lock.locked()
+        return True
+
+    monkeypatch.setattr("api.cron_runtime.run_cron_in_profile_subprocess", child_boundary)
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(home):
+        assert scheduler.run_one_job({"id": "chat-settle", "profile": "default"}) is True
+        observed.append((os.environ.get("HERMES_HOME"), p._cron_profile_context_depth()))
+
+    assert observed == [(str(home), 1)]
+    assert not p._cron_env_lock.locked()
+
+
+def test_in_chat_run_without_profile_inherits_selected_home_before_suspend(
+    monkeypatch, tmp_path
+):
+    """A no-profile in-chat fire captures the selected home before suspension and restores it."""
+    import types
+
+    from api import profiles as p
+
+    selected_home = tmp_path / "selected"
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job: True
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "default")
+    observed = []
+
+    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+        observed.append((profile_home, operation, p._cron_profile_context_depth()))
+        return True
+
+    monkeypatch.setattr("api.cron_runtime.run_cron_in_profile_subprocess", child_boundary)
+    p.install_cron_scheduler_profile_isolation()
+
+    with p.cron_profile_context_for_home(selected_home):
+        assert scheduler.run_one_job({"id": "chat-no-profile"}) is True
+        assert os.environ["HERMES_HOME"] == str(selected_home)
+        assert p._cron_profile_context_depth() == 1
+
+    assert observed == [(selected_home, "run_one_job", 0)]
+    assert not p._cron_env_lock.locked()
+
+
+def test_cron_child_request_uses_standalone_runtime_for_live_gateway_handles(
+    monkeypatch, tmp_path
+):
+    from api import cron_runtime
+
+    live_kwargs = {"adapters": object(), "loop": object(), "verbose": True}
+    with pytest.raises(RuntimeError, match="live gateway handles: adapters, loop"):
+        cron_runtime._child_kwargs_for_operation("run_one_job", live_kwargs)
+    assert cron_runtime._child_kwargs_for_operation(
+        "run_one_job", {"adapters": None, "loop": None, "verbose": True}
+    ) == {"adapters": None, "loop": None, "verbose": True}
+    with pytest.raises(RuntimeError, match="non-serializable"):
+        cron_runtime._serialize_child_request(
+            {"id": "runtime-kwarg"}, (), {"runtime": object()}
+        )
+
+
+def test_two_overlapping_scheduled_children_leave_profile_readers_responsive(
+    tmp_path, monkeypatch
+):
+    """Two profile-owned child boundaries must not share the parent lock."""
+    import types
+
+    from api import profiles as p
+
+    default_home = tmp_path / "home"
+    homes = {
+        "alpha": default_home / "profiles" / "alpha",
+        "beta": default_home / "profiles" / "beta",
+    }
+    for home in homes.values():
+        home.mkdir(parents=True)
+
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job: True
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", default_home)
+
+    started = {profile: threading.Event() for profile in homes}
+    release = {profile: threading.Event() for profile in homes}
+
+    def child_boundary(job, profile_home, operation, *, args=(), kwargs=None):
+        profile = job["profile"]
+        assert pathlib.Path(profile_home) == homes[profile]
+        assert operation == "run_one_job"
+        started[profile].set()
+        assert release[profile].wait(2)
+        return profile
+
+    monkeypatch.setattr("api.cron_runtime.run_cron_in_profile_subprocess", child_boundary)
+    monkeypatch.setattr(p, "publish_session_list_changed", lambda *args, **kwargs: None)
+    p.install_cron_scheduler_profile_isolation()
+
+    workers = [
+        threading.Thread(
+            target=scheduler.run_one_job,
+            args=({"id": profile, "profile": profile},),
+        )
+        for profile in homes
+    ]
+    for worker in workers:
+        worker.start()
+    assert all(started[profile].wait(2) for profile in homes)
+
+    readers = []
+    reader_entered = {profile: threading.Event() for profile in homes}
+    for profile, home in homes.items():
+        reader = threading.Thread(
+            target=lambda profile=profile, home=home: _read_profile(home, reader_entered[profile])
+        )
+        readers.append(reader)
+        reader.start()
+
+    assert all(reader_entered[profile].wait(0.5) for profile in homes)
+    for event in release.values():
+        event.set()
+    for worker in workers + readers:
+        worker.join(2)
+        assert not worker.is_alive()
+    assert not p._cron_env_lock.locked()
+
+
+def _read_profile(home, entered):
+    from api import profiles as p
+
+    with p.cron_profile_context_for_home(home):
+        entered.set()
+
+
+def test_install_scheduler_refuses_legacy_run_job(monkeypatch, tmp_path):
+    import types
+
+    from api import profiles as p
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_job = lambda job: job["id"]
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
+
+    with pytest.raises(RuntimeError, match="unsupported Agent version"):
+        p.install_cron_scheduler_profile_isolation()
+    assert scheduler.run_job({"id": "legacy"}) == "legacy"
+
+
+def test_install_scheduler_legacy_refusal_is_explicit_on_repeat(monkeypatch, tmp_path):
+    import types
+
+    from api import profiles as p
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_job = lambda job: job["id"]
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
+    with pytest.raises(RuntimeError, match="unsupported Agent version"):
+        p.install_cron_scheduler_profile_isolation()
+    with pytest.raises(RuntimeError, match="unsupported Agent version"):
+        p.install_cron_scheduler_profile_isolation()
+    assert scheduler.run_job({"id": "legacy-repeat"}) == "legacy-repeat"
+
+
+def test_scheduler_live_gateway_handles_use_child_run_job_and_parent_completion(
+    monkeypatch, tmp_path
+):
+    import types
+
+    from api import profiles as p
+
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job, **kwargs: None
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
+    adapters, loop = object(), object()
+    calls = []
+    monkeypatch.setattr(
+        "api.cron_runtime.run_cron_in_profile_subprocess",
+        lambda job, home, operation, *, args=(), kwargs=None: (
+            calls.append((operation, kwargs)),
+            (True, "saved", "delivered", None),
+        )[1],
+    )
+    completed = []
+    monkeypatch.setattr(
+        p,
+        "_complete_cron_run_with_live_handles",
+        lambda job, result, got_adapters, got_loop, *, verbose=False: (
+            completed.append((result, got_adapters, got_loop, verbose)) or True
+        ),
+    )
 
     p.install_cron_scheduler_profile_isolation()
 
-    assert cron_scheduler.run_job({"id": "manual1575", "profile": "research"}) == "ok"
-    assert events == [("run", "manual1575")]
+    assert scheduler.run_one_job(
+        {"id": "live", "profile": "default"},
+        adapters=adapters,
+        loop=loop,
+        verbose=True,
+    ) is True
+    assert calls == [("run_job", {})]
+    assert completed == [((True, "saved", "delivered", None), adapters, loop, True)]
+
+
+def test_scheduler_claimed_failure_is_marked_after_child_error(monkeypatch, tmp_path):
+    import types
+
+    from api import profiles as p
+
+    scheduler = types.ModuleType("cron.scheduler")
+    scheduler.run_one_job = lambda job, **kwargs: None
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path / "home")
+    failure = []
+    monkeypatch.setattr(
+        "api.cron_runtime.run_cron_in_profile_subprocess",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("child died")),
+    )
+    monkeypatch.setattr(
+        p,
+        "_mark_claimed_cron_failure",
+        lambda job, home, exc: failure.append((job["id"], str(home), str(exc))),
+    )
+
+    p.install_cron_scheduler_profile_isolation()
+
+    assert scheduler.run_one_job(
+        {"id": "claimed", "profile": "default"}, adapters=object(), loop=object()
+    ) is False
+    assert failure == [("claimed", str(tmp_path / "home"), "child died")]
+
+
+def test_install_scheduler_fails_when_both_operations_are_missing(monkeypatch):
+    import types
+
+    from api import profiles as p
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    scheduler = types.ModuleType("cron.scheduler")
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", scheduler)
+
+    with pytest.raises(RuntimeError, match="run_one_job is unavailable"):
+        p.install_cron_scheduler_profile_isolation()
 
 
 def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
@@ -310,16 +676,16 @@ def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
     must not continue into run_job outside the requested profile context.
     """
     from pathlib import Path
-    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+    src = (Path(__file__).resolve().parent.parent / "api" / "cron_runtime.py").read_text(encoding="utf-8")
 
     idx = src.find("def _cron_job_subprocess_main(job")
     assert idx != -1, "_cron_job_subprocess_main not found"
     body = src[idx : idx + 2000]
 
-    assert "with cron_profile_context_for_home(execution_profile_home):" in body
-    assert "result = _run()" in body
-    assert "ctx = None" not in body
-    assert "except Exception" not in body[:body.find("with cron_profile_context_for_home")], (
+    assert "with _run_in_profile:" in body
+    assert "result = _invoke_cron_operation" in body
+    assert "_run_in_profile = None" in body
+    assert "except Exception" not in body[:body.find("with _run_in_profile")], (
         "cron subprocess target appears to catch profile-context setup before "
         "entering the context; do not fall back to an unpinned run_job call."
     )


### PR DESCRIPTION
## Thinking Path

- Scheduled fires currently hold WebUI's process-wide cron profile lock through model and tool execution, blocking Tasks and cron readers.
- Handle-free scheduled and in-chat fires move the complete existing Agent `run_one_job` call into a profile-pinned spawned child. Agent remains the only owner of claims, heartbeat, execution records, output, delivery decisions, owner fencing, and completion.
- Gateway ticks with live adapters or an event loop keep the existing profile-pinned parent path and pass those objects to Agent unchanged, preserving relay and encrypted delivery. WebUI does not reconstruct the lifecycle in either mode.
- A separate Agent proposal is tracked at https://github.com/NousResearch/hermes-agent/issues/97475. This PR does not depend on that issue being merged.

## What Changed

- `api/cron_runtime.py` centralizes the spawned profile-pinned operation runner, rejects accidental live scheduler handles at the child boundary, preserves bounded result and cleanup behavior, and terminates the child when the parent cancellation event is set.
- `api/profiles.py` routes handle-free scheduled and in-chat fires through child `run_one_job`, while adapter-backed calls use the existing profile-pinned parent path with the live delivery context intact.
- `api/routes.py` keeps the manual panel path on child `run_job` with its existing parent-side persistence and delivery adapter.
- The regression tests cover both boundary modes, live delivery and settlement, copied-context safety, profile lock responsiveness, overlapping profiles, nested execution, child cancellation, child failure without parent settlement, selected-home execution, large results, and manual compatibility.

## Why It Matters

Handle-free scheduled and in-chat jobs no longer hold the parent cron profile lock, so unrelated Tasks and `/api/crons*` readers can proceed. Adapter-backed jobs retain their existing live delivery behavior and parent lock lifetime. Each path runs the canonical Agent lifecycle once, and a child crash or cancellation does not trigger an unfenced WebUI terminal mark.

## Verification

Focused scheduler, transport, import, and isolated-home coverage passed, 66 tests passed with 3 environment-dependent skips. The tests cover the live parent delivery boundary, handle-free child lifecycle, copied-context safety, parent lock responsiveness, cancellation cleanup, profile selection, overlapping profiles, large results, and manual compatibility.

The adapter-backed regression uses Agent's live delivery inputs and retains the existing delivery path.

## Risks / Follow-ups

- Adapter-backed runs still hold the parent profile lock for their duration. A serializable Agent delivery bridge is still needed to extend lock relief to those runs; the proposal is tracked at https://github.com/NousResearch/hermes-agent/issues/97475.
- Handle-free runs use Agent's standalone delivery path. WebUI does not duplicate Agent lifecycle logic.
- Parent cancellation uses bounded hard child termination. Agent claim expiry and takeover recovery remain authoritative.
- The local base reproduction and live supervisor restart proof were unavailable, so this PR makes no base-failure or supervisor-restart claim.

## Contract Routing

Task type: cron runtime bug fix.

Touched areas: profile isolation, scheduled and manual cron execution, child-process lifecycle.

Relevant public docs:

- `docs/CONTRACTS.md`

Scope boundaries: WebUI owns profile resolution, the handle-free spawned-process boundary, bounded cleanup, and `cron_complete` publication. Adapter-backed runs retain the existing profile-pinned parent path. Hermes Agent owns scheduled and in-chat lifecycle semantics through `cron.scheduler.run_one_job` in both modes. The generic delivery/control seam is proposed separately at https://github.com/NousResearch/hermes-agent/issues/97475.

Evidence needed before claiming done: focused scheduler and transport tests, neighboring cron compatibility tests, scoped lint, whitespace validation, and hosted CI on the pushed head. Adapter-backed delivery remains on the existing parent path until the Agent bridge exists.

## Upstream

Refs #7295.

## Model Used

GPT-5 via Codex CLI
