### PR TITLE
fix: keep model-provider transitions atomic (OPS-359)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8629,6 +8629,34 @@ def _models_cache_file_age_seconds(cache_path: Path, now: float) -> float | None
         return None
 
 
+def get_nonblocking_available_models_snapshot() -> dict | None:
+    """Return immediate complete catalog evidence without waiting for a rebuild.
+
+    The chat-start send path must never queue behind
+    ``_available_models_cache_lock``. Try the current validated memory snapshot
+    with a nonblocking lock acquisition; if memory is unavailable or busy, use
+    only the strict validated disk snapshot. Never build, wait, or substitute a
+    minimal/static catalog, because incomplete evidence must preserve an
+    explicit model/provider pair.
+    """
+    acquired = _available_models_cache_lock.acquire(blocking=False)
+    if acquired:
+        try:
+            try:
+                cached = _get_fresh_memory_models_cache(time.monotonic())
+            except Exception:
+                cached = None
+        finally:
+            _available_models_cache_lock.release()
+        if cached is not None:
+            return cached
+
+    try:
+        return _load_models_cache_from_disk()
+    except Exception:
+        return None
+
+
 def warm_models_catalog_provenance_if_cold() -> None:
     """Best-effort, NON-BLOCKING, disk-only publish of catalog provenance.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2868,6 +2868,7 @@ from api.config import (
     SERVER_START_TIME,
     _resolve_cli_toolsets,
     get_available_models,
+    get_nonblocking_available_models_snapshot,
     get_available_models_for_session_visit,
     _provider_is_known_or_configured,
     IMAGE_EXTS,
@@ -6500,6 +6501,58 @@ def _catalog_group_owns_exact_model(group: dict, model: str) -> bool:
     return False
 
 
+def _repair_explicit_model_provider_from_cached_catalog(
+    model: str,
+    requested_provider: str,
+) -> tuple[str, bool]:
+    """Repair a stale explicit pair only from complete, unique cached ownership."""
+    try:
+        catalog = get_nonblocking_available_models_snapshot()
+    except Exception:
+        return requested_provider, False
+    if not isinstance(catalog, dict) or catalog.get("error"):
+        return requested_provider, False
+    groups = [group for group in catalog.get("groups") or [] if isinstance(group, dict)]
+    if not groups or any(group.get("models_endpoint_error") for group in groups):
+        return requested_provider, False
+    exact_requested_groups = [
+        group
+        for group in groups
+        if _clean_session_model_provider(group.get("provider_id")) == requested_provider
+    ]
+    requested_groups = exact_requested_groups
+    if not requested_groups:
+        requested_canonical = _normalize_provider_id(requested_provider)
+        canonical_groups = [
+            group
+            for group in groups
+            if requested_canonical
+            and requested_canonical != "custom"
+            and _normalize_provider_id(group.get("provider_id")) == requested_canonical
+        ]
+        canonical_group_ids = {
+            provider
+            for group in canonical_groups
+            if (provider := _clean_session_model_provider(group.get("provider_id")))
+        }
+        if len(canonical_group_ids) == 1:
+            requested_groups = canonical_groups
+    if not requested_groups:
+        return requested_provider, False
+    if any(_catalog_group_owns_exact_model(group, model) for group in requested_groups):
+        return requested_provider, False
+    owners = {
+        provider
+        for group in groups
+        if (provider := _clean_session_model_provider(group.get("provider_id")))
+        and provider != requested_provider
+        and _catalog_group_owns_exact_model(group, model)
+    }
+    if len(owners) != 1:
+        return requested_provider, False
+    return owners.pop(), True
+
+
 def _repair_foreign_session_model_provider(
     session,
     *,
@@ -6538,8 +6591,10 @@ def _repair_foreign_session_model_provider(
         return resolved_provider
 
     try:
-        catalog = get_available_models(prefer_cache=True)
+        catalog = get_nonblocking_available_models_snapshot()
     except Exception:
+        return resolved_provider
+    if not isinstance(catalog, dict) or catalog.get("error"):
         return resolved_provider
     groups = [group for group in catalog.get("groups") or [] if isinstance(group, dict)]
     stored_groups = [
@@ -7306,28 +7361,21 @@ def _resolve_compatible_session_model_state(
 
     Fast path (#1855): when the caller supplies both a model and an explicit
     ``model_provider`` AND the model is not itself ``@provider:model``-qualified,
-    we can return the inputs verbatim without calling ``get_available_models()``.
-    The slow path below would arrive at the same answer via
-    ``if requested_provider and not explicit_provider: return model, requested_provider, False``
-    after paying the full catalog-build cost. Avoiding the catalog here keeps
-    ``POST /api/chat/start`` snappy even when the model catalog is cold and the
-    rebuild has to make network calls (custom OpenAI-compat endpoints,
-    OpenRouter ``/models``, LM Studio ``/models``, credential pool refresh),
-    those used to wedge the handler for >100s and trigger 502s on default-60s
-    reverse proxies, even though the WebUI itself eventually responded.
+    avoid a live catalog rebuild. Before returning the pair, use only the cached
+    catalog to repair a provider that provably does not own the model when one
+    and only one other provider does. Ambiguous, incomplete, or failed catalog
+    evidence preserves the requested pair.
 
-    ``prefer_cached_catalog=True`` (ours-original) makes the catalog lookup
-    non-blocking: it resolves from the warm/disk cache or a network-free
-    minimal catalog and NEVER triggers a live per-provider rebuild (the
-    Copilot token-exchange HTTPS call that hangs a server-initiated wakeup
-    turn, see rebase report §1/§3/model-resolve-hang). Human-initiated
-    chat/start leaves this False to keep full live discovery; a session that
-    already has a persisted model still resolves correctly because the
-    persisted model wins over the catalog and the catalog is only consulted
-    for the default-model backstop.
+    ``prefer_cached_catalog=True`` (ours-original) prevents the slow-path
+    lookup from triggering a live per-provider rebuild: it resolves from the
+    warm/disk cache or a network-free minimal catalog. Explicit model/provider
+    pairs never enter that lookup; their ownership repairs use only
+    ``get_nonblocking_available_models_snapshot()`` and preserve the pair when
+    no immediate complete evidence exists.
     """
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    catalog_override = None
     if model and requested_provider == "moa":
         return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
@@ -7340,15 +7388,19 @@ def _resolve_compatible_session_model_state(
         if isinstance(providers_cfg, dict) and requested_provider in providers_cfg:
             return model, requested_provider, False
     if model and requested_provider:
-        # Only safe when the model itself does not carry an ``@provider:model``
-        # qualifier — qualified strings require the catalog to decide whether
-        # the qualifier matches the active provider (see slow path below).
         bare_model, explicit_provider = _split_provider_qualified_model(model)
         model_prefix = model.split("/", 1)[0].strip().lower() if "/" in model else ""
         stale_codex_openai_slash_id = (
             requested_provider == "openai-codex"
             and model_prefix == "openai"
         )
+        if explicit_provider or stale_codex_openai_slash_id:
+            try:
+                catalog_override = get_nonblocking_available_models_snapshot()
+            except Exception:
+                catalog_override = None
+            if not isinstance(catalog_override, dict) or catalog_override.get("error"):
+                return model, requested_provider, False
         if not explicit_provider and not stale_codex_openai_slash_id:
             _profile_default = str(profile_default_model or "").strip()
             _profile_prov = _clean_session_model_provider(profile_provider)
@@ -7376,6 +7428,15 @@ def _resolve_compatible_session_model_state(
             if _repaired_model:
                 return _repaired_model, requested_provider, True
 
+            _catalog_provider, _provider_repaired = (
+                _repair_explicit_model_provider_from_cached_catalog(
+                    model,
+                    requested_provider,
+                )
+            )
+            if _provider_repaired:
+                return model, _catalog_provider, True
+
             return model, requested_provider, False
 
     # Default (human chat/start) path calls get_available_models() with NO
@@ -7388,7 +7449,9 @@ def _resolve_compatible_session_model_state(
     # genuine TypeError raised *inside* get_available_models(prefer_cache=True)
     # and silently fall back to the slow live provider rebuild that
     # prefer_cached_catalog=True is meant to avoid.
-    if prefer_cached_catalog:
+    if catalog_override is not None:
+        catalog = catalog_override
+    elif prefer_cached_catalog:
         import inspect as _inspect
 
         try:

--- a/static/ui.js
+++ b/static/ui.js
@@ -3089,8 +3089,6 @@ function _captureModelDropdownSelection(sel){
   return {model:String(sel.value||''),model_provider:null};
 }
 function _modelProviderForSend(modelId){
-  const sessionProvider=(S&&S.session&&S.session.model_provider)||null;
-  if(sessionProvider) return sessionProvider;
   const model=String(modelId||'').trim();
   if(!model) return null;
   const explicitProvider=typeof _providerFromModelValue==='function'
@@ -3114,6 +3112,9 @@ function _modelProviderForSend(modelId){
       }
     }catch(_){}
   }
+  const sessionModel=String((S&&S.session&&S.session.model)||'').trim();
+  const sessionProvider=(S&&S.session&&S.session.model_provider)||null;
+  if(sessionProvider&&sessionModel===model) return sessionProvider;
   return null;
 }
 function _reconcileModelDropdownSelection(sel,data,previousState,opts){

--- a/tests/test_chat_start_provider_fallback.py
+++ b/tests/test_chat_start_provider_fallback.py
@@ -60,7 +60,7 @@ function extractFunc(name) {
 let modelSelect;
 function $(id) { return id === 'modelSelect' ? modelSelect : null; }
 
-function makeSelect(options, initialValue) {
+function makeSelect(options, initialValue, selectedIndex) {
   const sel = {options: [], selectedIndex: -1, selectedOptions: []};
   Object.defineProperty(sel, 'value', {
     get() { return this._value || ''; },
@@ -78,6 +78,10 @@ function makeSelect(options, initialValue) {
     sel.options.push(opt);
   }
   sel.value = initialValue || '';
+  if (Number.isInteger(selectedIndex) && sel.options[selectedIndex]) {
+    sel.selectedIndex = selectedIndex;
+    sel.selectedOptions = [sel.options[selectedIndex]];
+  }
   return sel;
 }
 
@@ -100,9 +104,12 @@ for (const name of [
 }
 
 const args = JSON.parse(process.argv[3]);
-modelSelect = makeSelect(args.options || [], args.initialValue || '');
+modelSelect = makeSelect(args.options || [], args.initialValue || '', args.selectedIndex);
 if (args.persisted) localStorage.setItem(MODEL_STATE_KEY, JSON.stringify(args.persisted));
-var S = {session: {model_provider: args.sessionProvider || null}};
+var S = {session: {
+  model: args.sessionModel || null,
+  model_provider: args.sessionProvider || null,
+}};
 
 if (args.mode === 'modelState') {
   process.stdout.write(JSON.stringify(_modelStateForSelect(modelSelect, args.model)));
@@ -150,12 +157,61 @@ def _run_model_state_helper(driver_path, payload):
 def test_model_provider_for_send_preserves_session_provider(driver_path):
     provider = _run_helper(driver_path, {
         "model": "grok-4.3",
+        "sessionModel": "grok-4.3",
         "sessionProvider": "session-provider",
-        "initialValue": "grok-4.3",
-        "options": [{"provider": "xai-oauth", "value": "grok-4.3"}],
+        "initialValue": "claude-sonnet-4.6",
+        "options": [{"provider": "anthropic", "value": "claude-sonnet-4.6"}],
     })
 
     assert provider == "session-provider"
+
+
+@node_test
+@pytest.mark.parametrize(
+    ("model", "provider"),
+    [("grok-4.3", "xai-oauth"), ("gpt-5.6-terra", "openai-codex")],
+)
+def test_model_provider_for_send_preserves_correct_session_pair(driver_path, model, provider):
+    resolved = _run_helper(driver_path, {
+        "model": model,
+        "sessionModel": model,
+        "sessionProvider": provider,
+        "initialValue": model,
+        "options": [{"provider": provider, "value": model}],
+    })
+
+    assert resolved == provider
+
+
+@node_test
+def test_model_provider_for_send_preserves_selected_same_model_collision(driver_path):
+    provider = _run_helper(driver_path, {
+        "model": "shared-model",
+        "sessionModel": "shared-model",
+        "sessionProvider": "provider-a",
+        "initialValue": "shared-model",
+        "selectedIndex": 1,
+        "options": [
+            {"provider": "provider-a", "value": "shared-model"},
+            {"provider": "provider-b", "value": "shared-model"},
+        ],
+    })
+
+    assert provider == "provider-b"
+
+
+@node_test
+@pytest.mark.parametrize("model", ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol"])
+def test_model_provider_for_send_does_not_reuse_stale_session_provider(driver_path, model):
+    provider = _run_helper(driver_path, {
+        "model": model,
+        "sessionModel": "grok-4.3",
+        "sessionProvider": "xai-oauth",
+        "initialValue": model,
+        "options": [{"provider": "openai-codex", "value": model}],
+    })
+
+    assert provider == "openai-codex"
 
 
 @node_test
@@ -198,6 +254,43 @@ def test_model_provider_for_send_uses_only_matching_persisted_state(driver_path)
 
     assert matching == "xai-oauth"
     assert unrelated is None
+
+
+@node_test
+def test_model_provider_for_send_uses_persisted_pair_after_model_transition(driver_path):
+    provider = _run_helper(driver_path, {
+        "model": "gpt-5.6-terra",
+        "sessionModel": "grok-4.3",
+        "sessionProvider": "xai-oauth",
+        "initialValue": "",
+        "persisted": {"model": "gpt-5.6-terra", "model_provider": "openai-codex"},
+    })
+
+    assert provider == "openai-codex"
+
+
+@node_test
+def test_model_provider_for_send_prefers_matching_persisted_collision(driver_path):
+    provider = _run_helper(driver_path, {
+        "model": "shared-model",
+        "sessionModel": "shared-model",
+        "sessionProvider": "provider-a",
+        "initialValue": "",
+        "persisted": {"model": "shared-model", "model_provider": "provider-b"},
+    })
+
+    assert provider == "provider-b"
+
+
+@node_test
+def test_model_provider_for_send_preserves_explicit_qualified_selection(driver_path):
+    provider = _run_helper(driver_path, {
+        "model": "@openai-codex:gpt-5.6-terra",
+        "sessionModel": "grok-4.3",
+        "sessionProvider": "xai-oauth",
+    })
+
+    assert provider == "openai-codex"
 
 
 @node_test

--- a/tests/test_issue1855_resolve_model_provider_fast_path.py
+++ b/tests/test_issue1855_resolve_model_provider_fast_path.py
@@ -11,14 +11,15 @@ saw 502 Proxy Error while WebUI eventually started the run anyway, creating
 a duplicate-send risk if the user retried.
 
 The fix: when the caller supplies an explicit model_provider AND the model is
-not an @provider:model-qualified string, skip the catalog build entirely and
-return (model, requested_provider, False) verbatim. The slow path would have
-reached the same answer; we just avoid paying for the cold catalog.
+not an @provider:model-qualified string, skip the live catalog build and use
+only the cache before returning the pair. The cache-only check can repair a
+provably stale provider without paying for cold provider discovery.
 
 Coverage:
 
-1. The fast path returns without calling get_available_models() when both
-   inputs are present and the model has no @-prefix.
+1. The fast path reads only the nonblocking catalog snapshot when both inputs
+   are present and the model has no @-prefix; it never calls the blocking
+   catalog builder.
 2. The fast path correctly preserves the model and provider unchanged.
 3. The slow path still fires for @provider:model qualified IDs (those need
    the catalog to validate the qualifier against the active provider).
@@ -41,26 +42,31 @@ def _read(rel_path: str) -> str:
 
 
 class TestFastPathInvocation:
-    """The fast path must skip get_available_models() in the happy case."""
+    """The fast path must use only cached catalog data in the happy case."""
 
-    def test_fast_path_with_bare_model_and_provider_skips_catalog(self):
-        """Caller-supplied (model, model_provider) returns without catalog."""
+    def test_fast_path_with_bare_model_and_provider_uses_cached_catalog(self):
+        """Caller-supplied (model, model_provider) avoids live discovery."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        cached_catalog = {
+            "groups": [
+                {"provider_id": "openai-codex", "models": [{"id": "gpt-5.5"}]}
+            ]
+        }
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=cached_catalog,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "gpt-5.5",
                 "openai-codex",
             )
 
-        assert mock_catalog.call_count == 0, (
-            "get_available_models() must not be called when both model and "
-            "model_provider are supplied and the model has no @provider:model "
-            "qualifier — that's the point of the fast path."
-        )
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("gpt-5.5", "openai-codex", False)
 
-    def test_fast_path_with_openrouter_slash_qualified_model_skips_catalog(self):
+    def test_fast_path_with_openrouter_slash_qualified_model_uses_cached_catalog(self):
         """OpenRouter slash-qualified IDs still hit the fast path.
 
         Slash-qualified IDs are valid picker output for OpenRouter and a stored
@@ -69,17 +75,29 @@ class TestFastPathInvocation:
         """
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        cached_catalog = {
+            "groups": [
+                {
+                    "provider_id": "openrouter",
+                    "models": [{"id": "anthropic/claude-opus-4.7"}],
+                }
+            ]
+        }
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=cached_catalog,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "anthropic/claude-opus-4.7",
                 "openrouter",
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("anthropic/claude-opus-4.7", "openrouter", False)
 
-    def test_codex_with_stale_openai_slash_id_uses_catalog_repair(self):
-        """Codex must repair stale OpenRouter-shaped OpenAI IDs.
+    def test_codex_with_stale_openai_slash_id_uses_nonblocking_catalog_repair(self):
+        """Codex repairs stale OpenRouter-shaped IDs without live discovery.
 
         Browser/localStorage state can submit ``openai/gpt-...`` while the
         session/provider is ``openai-codex``. If the fast path preserves that
@@ -89,21 +107,42 @@ class TestFastPathInvocation:
         """
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
-            mock_catalog.return_value = {
+        cached_catalog = {
                 "active_provider": "openai-codex",
                 "default_model": "gpt-5.5",
                 "groups": [
                     {"provider_id": "openai-codex", "models": [{"id": "gpt-5.5"}]}
                 ],
             }
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=cached_catalog,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "openai/gpt-5.4-mini",
                 "openai-codex",
             )
 
-        assert mock_catalog.call_count == 1
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("gpt-5.5", "openai-codex", True)
+
+    def test_qualified_explicit_pair_never_waits_for_live_catalog(self):
+        """An @provider:model pair preserves intent when the snapshot is absent."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
+            result = _resolve_compatible_session_model_state(
+                "@openrouter:anthropic/claude-opus-4.7",
+                "openrouter",
+            )
+
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
+        assert result == ("@openrouter:anthropic/claude-opus-4.7", "openrouter", False)
 
     def test_fast_path_normalizes_provider_default_alias(self):
         """`'default'` is treated as None by _clean_session_model_provider.
@@ -133,7 +172,18 @@ class TestFastPathInvocation:
         """Caller's explicit provider passes through verbatim, no aliasing."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        cached_catalog = {
+            "groups": [
+                {
+                    "provider_id": "custom:siliconflow",
+                    "models": [{"id": "GLM-4.5-Air-FP8"}],
+                }
+            ]
+        }
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=cached_catalog,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             # Even a non-canonical provider slug must pass through — this is
             # the contract that resolve_model_provider() in config.py relies on
             # to route through custom: providers.
@@ -142,7 +192,8 @@ class TestFastPathInvocation:
                 "custom:siliconflow",
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result[0] == "GLM-4.5-Air-FP8"
         assert result[1] == "custom:siliconflow"
         assert result[2] is False  # model_was_normalized=False
@@ -155,24 +206,25 @@ class TestSlowPathStillFires:
         """`@openrouter:foo/bar` strings need the catalog to validate the qualifier."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
-            mock_catalog.return_value = {
+        cached_catalog = {
                 "active_provider": "openrouter",
                 "default_model": "anthropic/claude-opus-4.7",
                 "groups": [
                     {"provider_id": "openrouter", "models": [{"id": "anthropic/claude-opus-4.7"}]}
                 ],
             }
+        with patch("api.routes.get_nonblocking_available_models_snapshot", return_value=cached_catalog) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             _resolve_compatible_session_model_state(
                 "@openrouter:anthropic/claude-opus-4.7",
                 "openrouter",
             )
 
-        assert mock_catalog.call_count == 1, (
+        assert mock_snapshot.call_count == 1, (
             "@provider:model qualified strings need the catalog to verify "
             "the qualifier matches the active provider and to detect stale "
             "cross-provider artifacts (#1253)."
         )
+        mock_catalog.assert_not_called()
 
     def test_configured_provider_qualified_model_skips_catalog(self):
         """Configured providers already carry trusted routing context."""

--- a/tests/test_issue2518_active_provider_fallback.py
+++ b/tests/test_issue2518_active_provider_fallback.py
@@ -21,8 +21,8 @@ Coverage:
 
 1. newSession() source carries the active-provider fallback chain.
 2. End-to-end: when client sends ``model_provider`` (either explicit or via
-   the new fallback), /api/session/new's resolve step does NOT call
-   ``get_available_models()``.
+   the new fallback), /api/session/new's resolve step reads the nonblocking
+   snapshot exactly once and never calls the catalog builder.
 3. Negative: client sends ``model_provider: null`` (no fallback available) —
    resolve step still works via the slow path and returns the catalog's
    default.
@@ -100,44 +100,78 @@ class TestClientFallbackSourceShape:
 
 
 # ---------------------------------------------------------------------------
-# End-to-end: with model_provider, /api/session/new skips the cold catalog.
+# End-to-end: with model_provider, /api/session/new uses the cached catalog once.
 # ---------------------------------------------------------------------------
 
 
 class TestSessionNewFastPathWithProvider:
-    """When client supplies a real model_provider, no catalog rebuild."""
+    """A real model_provider uses one cached lookup, never live discovery."""
 
-    def test_explicit_provider_skips_get_available_models(self):
-        """The headline fix: client-supplied provider → fast path."""
+    def test_explicit_provider_uses_cached_catalog_once(self):
+        """An explicit pair validates against cached catalog data exactly once."""
         from api.routes import _session_model_state_from_request
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        cached_catalog = {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.5"}],
+                }
+            ],
+        }
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=cached_catalog,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             model, provider = _session_model_state_from_request(
                 "gpt-5.5",
                 "openai-codex",
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert model == "gpt-5.5"
         assert provider == "openai-codex"
 
-    def test_active_provider_fallback_does_not_double_invoke_catalog(self):
-        """Sanity: the fast path is shared between the explicit and fallback
-        cases on the client. As long as the client sent a truthy
-        model_provider, the server stays on the fast path. The actual
-        fallback selection happens client-side; this test pins that the
-        server side is invariant under the two client strategies."""
+    def test_active_provider_fallback_uses_cached_catalog_once(self):
+        """Explicit and fallback wire pairs each use one cached-only lookup."""
         from api.routes import _session_model_state_from_request
 
         # Simulate the two client strategies (explicit vs active-provider
-        # fallback) producing the same wire shape.
-        for client_provider in ("openai-codex", "anthropic", "openrouter"):
-            with patch("api.routes.get_available_models") as mock_catalog:
-                _session_model_state_from_request("claude-opus-4.7", client_provider)
-            assert mock_catalog.call_count == 0, (
-                f"client_provider={client_provider!r} must hit the fast path; "
-                f"otherwise the #2518 fallback is invisible to the server."
-            )
+        # fallback) producing the same wire shape with realistic provider-owned
+        # models. A concrete dict is required here: a bare MagicMock is truthy
+        # and can accidentally exercise catalog-repair branches.
+        cached_catalog = {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {"provider_id": "openai-codex", "models": [{"id": "gpt-5.5"}]},
+                {"provider_id": "anthropic", "models": [{"id": "claude-opus-4.7"}]},
+                {
+                    "provider_id": "openrouter",
+                    "models": [{"id": "google/gemini-2.5-pro"}],
+                },
+            ],
+        }
+        client_pairs = (
+            ("gpt-5.5", "openai-codex"),
+            ("claude-opus-4.7", "anthropic"),
+            ("google/gemini-2.5-pro", "openrouter"),
+        )
+        for client_model, client_provider in client_pairs:
+            with patch(
+                "api.routes.get_nonblocking_available_models_snapshot",
+                return_value=cached_catalog,
+            ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
+                model, provider = _session_model_state_from_request(
+                    client_model,
+                    client_provider,
+                )
+            mock_snapshot.assert_called_once_with()
+            mock_catalog.assert_not_called()
+            assert (model, provider) == (client_model, client_provider)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue3405_profile_provider_resolution.py
+++ b/tests/test_issue3405_profile_provider_resolution.py
@@ -137,10 +137,13 @@ class TestProfileProviderResolution:
         assert mock_catalog.call_count == 1
 
     def test_explicit_provider_still_uses_fast_path(self):
-        """Explicit model_provider must still take the fast path per #1855."""
+        """Explicit model_provider must still avoid live discovery per #1855."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "gpt-5.5",
                 "openai-codex",
@@ -148,7 +151,8 @@ class TestProfileProviderResolution:
                 profile_default_model="claude-sonnet-4.6",
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("gpt-5.5", "openai-codex", False)
 
     def test_at_qualified_model_wins_over_profile(self):

--- a/tests/test_issue5127_process_wakeup_bare_model.py
+++ b/tests/test_issue5127_process_wakeup_bare_model.py
@@ -12,7 +12,10 @@ class TestIssue5127CustomProviderBareSuffixRepair:
     def test_fast_path_repairs_bare_suffix_to_profile_default(self):
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "grok-composer-2.5-fast",
                 "custom:my-proxy",
@@ -21,14 +24,18 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_not_called()
+        mock_catalog.assert_not_called()
         assert result == ("x-ai/grok-composer-2.5-fast", "custom:my-proxy", True)
 
     def test_fast_path_skips_repair_when_profile_provider_mismatches(self):
         """Regression: custom:other-proxy must not inherit my-proxy's qualified default."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "grok-composer-2.5-fast",
                 "custom:other-proxy",
@@ -37,13 +44,17 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("grok-composer-2.5-fast", "custom:other-proxy", False)
 
     def test_fast_path_repairs_generic_custom_provider(self):
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "some-model",
                 "custom",
@@ -51,13 +62,17 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_not_called()
+        mock_catalog.assert_not_called()
         assert result == ("vendor/some-model", "custom", True)
 
     def test_fast_path_does_not_rewrite_unrelated_bare_model(self):
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "other-model",
                 "custom:my-proxy",
@@ -65,13 +80,17 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("other-model", "custom:my-proxy", False)
 
     def test_fast_path_keeps_qualified_model_unchanged(self):
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value=None,
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "x-ai/grok-composer-2.5-fast",
                 "custom:my-proxy",
@@ -79,7 +98,8 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count == 0
+        mock_snapshot.assert_called_once_with()
+        mock_catalog.assert_not_called()
         assert result == ("x-ai/grok-composer-2.5-fast", "custom:my-proxy", False)
 
     def test_slow_path_repairs_bare_suffix_to_profile_default_for_custom_provider(self):
@@ -194,12 +214,14 @@ class TestIssue5127CustomProviderBareSuffixRepair:
         """Regression: openai/... under openai-codex must not take bare fast return."""
         from api.routes import _resolve_compatible_session_model_state
 
-        with patch("api.routes.get_available_models") as mock_catalog:
-            mock_catalog.return_value = {
+        with patch(
+            "api.routes.get_nonblocking_available_models_snapshot",
+            return_value={
                 "active_provider": "openai-codex",
                 "default_model": "gpt-5.5",
                 "groups": [],
-            }
+            },
+        ) as mock_snapshot, patch("api.routes.get_available_models") as mock_catalog:
             result = _resolve_compatible_session_model_state(
                 "openai/gpt-5.4-mini",
                 "openai-codex",
@@ -207,7 +229,8 @@ class TestIssue5127CustomProviderBareSuffixRepair:
                 prefer_cached_catalog=True,
             )
 
-        assert mock_catalog.call_count >= 1
+        assert mock_snapshot.call_count == 1
+        mock_catalog.assert_not_called()
         assert result[0] == "gpt-5.5"
         assert result[2] is True
 

--- a/tests/test_issue5731_session_model_provider_repair.py
+++ b/tests/test_issue5731_session_model_provider_repair.py
@@ -74,9 +74,9 @@ def test_poisoned_pair_repairs_at_chat_start(monkeypatch, tmp_path):
     monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _p: (None, None, {"model": {"provider": "kilocode"}}))
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: (
-            catalog_calls.append(prefer_cache)
+        "get_nonblocking_available_models_snapshot",
+        lambda: (
+            catalog_calls.append(True)
             or _catalog(
                 _group("ollama", "llama3.2"),
                 _group("kilocode", "@kilocode:kilo/minimax/minimax-m3"),
@@ -98,8 +98,8 @@ def test_catalog_equivalent_owner_repairs_poisoned_pair(monkeypatch):
     session = _session(model="gpt-4o-mini", provider="ollama")
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: _catalog(
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
             _group("ollama", "llama3.2"),
             _group("kilocode", "GPT.4O.MINI"),
         ),
@@ -112,8 +112,8 @@ def test_equivalent_request_model_repairs_poisoned_pair(monkeypatch):
     session = _session(model="GPT.4O.MINI", provider="ollama")
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: _catalog(
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
             _group("ollama", "llama3.2"),
             _group("kilocode", "gpt-4o-mini"),
         ),
@@ -132,8 +132,8 @@ def test_self_hosted_exact_owner_is_preserved(monkeypatch, provider):
     session = _session(model="vendor/model/with/slashes", provider=provider)
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: _catalog(
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
             _group(provider, "vendor/model/with/slashes"),
             _group("kilocode", "other-model"),
         ),
@@ -148,8 +148,8 @@ def test_stored_owner_in_extra_models_is_preserved(monkeypatch):
     stored_group["extra_models"] = [{"id": "kilo/minimax/minimax-m3"}]
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: _catalog(
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
             stored_group,
             _group("kilocode", "kilo/minimax/minimax-m3"),
         ),
@@ -164,8 +164,8 @@ def test_stored_provider_discovery_failure_is_preserved(monkeypatch):
     stored_group["models_endpoint_error"] = "catalog unavailable"
     monkeypatch.setattr(
         routes,
-        "get_available_models",
-        lambda *, prefer_cache=False: _catalog(
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
             stored_group,
             _group("kilocode", "kilo/minimax/minimax-m3"),
         ),
@@ -183,7 +183,11 @@ def test_stored_provider_discovery_failure_is_preserved(monkeypatch):
 )
 def test_explicit_or_qualified_model_selection_is_preserved(monkeypatch, requested_model, explicit_model_pick):
     session = _session()
-    monkeypatch.setattr(routes, "get_available_models", lambda **_kwargs: pytest.fail("catalog must not be read"))
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: pytest.fail("catalog must not be read"),
+    )
 
     assert _repair(
         session,
@@ -207,14 +211,25 @@ def test_explicit_or_qualified_model_selection_is_preserved(monkeypatch, request
 )
 def test_missing_or_ambiguous_catalog_evidence_is_preserved(monkeypatch, catalog):
     session = _session()
-    monkeypatch.setattr(routes, "get_available_models", lambda *, prefer_cache=False: catalog)
+    monkeypatch.setattr(routes, "get_nonblocking_available_models_snapshot", lambda: catalog)
 
     assert _repair(session, catalog) == "ollama"
 
 
+def test_unavailable_nonblocking_catalog_snapshot_preserves_provider(monkeypatch):
+    session = _session()
+    monkeypatch.setattr(routes, "get_nonblocking_available_models_snapshot", lambda: None)
+
+    assert _repair(session, None) == "ollama"
+
+
 def test_matching_profile_provider_skips_catalog(monkeypatch):
     session = _session()
-    monkeypatch.setattr(routes, "get_available_models", lambda **_kwargs: pytest.fail("catalog must not be read"))
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: pytest.fail("catalog must not be read"),
+    )
 
     assert _repair(session, None, profile_provider="ollama") == "ollama"
 
@@ -249,7 +264,7 @@ def test_preservation_cases_still_reach_chat_start(monkeypatch, tmp_path, body, 
     )
     captured = {}
 
-    def get_catalog(*, prefer_cache=False):
+    def get_catalog():
         if isinstance(catalog, Exception):
             raise catalog
         return catalog
@@ -257,7 +272,7 @@ def test_preservation_cases_still_reach_chat_start(monkeypatch, tmp_path, body, 
     monkeypatch.setattr(routes, "_get_or_materialize_session", lambda _sid, **_kwargs: session)
     monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
     monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _p: (None, None, {"model": {"provider": "kilocode"}}))
-    monkeypatch.setattr(routes, "get_available_models", get_catalog)
+    monkeypatch.setattr(routes, "get_nonblocking_available_models_snapshot", get_catalog)
     monkeypatch.setattr(routes, "_start_run", lambda _s, **kwargs: captured.update(kwargs) or {"ok": True})
     monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200: payload)
 

--- a/tests/test_issue6722_provider_qualified_model_leak.py
+++ b/tests/test_issue6722_provider_qualified_model_leak.py
@@ -112,34 +112,32 @@ class TestSessionModelStatePreservesQualifierForRepair:
     still see the qualified form. The qualifier is stripped to the bare model ONLY
     at the gateway boundary (see TestGatewayModelField)."""
 
-    def test_unavailable_qualified_provider_repairs_to_active_default(self, monkeypatch):
-        """A session pinned to a removed/unconfigured provider must revert to the
-        active default on a non-explicit resolve — the premature strip in the
-        previous revision returned (bare_model, removed) instead."""
+    def test_unavailable_qualified_provider_preserves_pair_without_live_catalog(self, monkeypatch):
+        """Missing catalog evidence preserves the qualified pair without blocking.
+
+        OPS-359 makes this request path latency-safe: an unavailable provider
+        cannot justify a silent model swap, and resolving it must not rebuild the
+        live catalog behind the cache lock.
+        """
         import api.routes as routes
 
         monkeypatch.setattr(
             routes,
+            "get_nonblocking_available_models_snapshot",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            routes,
             "get_available_models",
-            lambda: {
-                "active_provider": "openai-codex",
-                "default_model": "gpt-5.5",
-                "groups": [
-                    {
-                        "provider_id": "openai-codex",
-                        "models": [{"id": "@openai-codex:gpt-5.5"}],
-                    },
-                ],
-            },
+            lambda: (_ for _ in ()).throw(AssertionError("blocking catalog must not be called")),
         )
         model_value, provider = routes._session_model_state_from_request(
             "@removed:mistral-large", None, "removed"
         )
-        assert model_value == "gpt-5.5", (
-            f"removed/unconfigured qualified provider must repair to the active "
-            f"default, got model_value={model_value!r}"
+        assert model_value == "@removed:mistral-large", (
+            f"missing catalog evidence must preserve the explicit model, got {model_value!r}"
         )
-        assert provider == "openai-codex"
+        assert provider == "removed"
 
     def test_active_provider_qualified_model_preserves_qualifier_for_routing(self, monkeypatch):
         """A qualified model naming the active provider is preserved intact so

--- a/tests/test_ops359_model_provider_atomic.py
+++ b/tests/test_ops359_model_provider_atomic.py
@@ -1,0 +1,278 @@
+"""Regression coverage for atomic automated model/provider transitions (OPS-359)."""
+
+import threading
+
+from types import SimpleNamespace
+
+import pytest
+
+import api.config as config
+import api.routes as routes
+
+
+def _catalog(*groups):
+    return {"groups": list(groups)}
+
+
+def _group(provider_id, *models, error=None):
+    group = {
+        "provider_id": provider_id,
+        "models": [{"id": model} for model in models],
+    }
+    if error:
+        group["models_endpoint_error"] = error
+    return group
+
+
+@pytest.mark.parametrize("model", ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol"])
+def test_explicit_pair_repairs_stale_xai_provider_from_unique_cached_owner(monkeypatch, model):
+    calls = []
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: (
+            calls.append(True)
+            or _catalog(
+                _group("xai-oauth", "grok-4.3"),
+                _group("openai-codex", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol"),
+            )
+        ),
+    )
+
+    assert routes._resolve_compatible_session_model_state(model, "xai-oauth") == (
+        model,
+        "openai-codex",
+        True,
+    )
+    assert calls == [True]
+
+
+@pytest.mark.parametrize(
+    ("model", "provider"),
+    [
+        ("gpt-5.6-terra", "openai-codex"),
+        ("grok-4.3", "xai-oauth"),
+    ],
+)
+def test_explicit_pair_preserves_correct_cached_owner(monkeypatch, model, provider):
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
+            _group("xai-oauth", "grok-4.3"),
+            _group("openai-codex", "gpt-5.6-terra"),
+        ),
+    )
+
+    assert routes._resolve_compatible_session_model_state(model, provider) == (
+        model,
+        provider,
+        False,
+    )
+
+
+def test_explicit_pair_preserves_legitimate_shared_model_id(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
+            _group("xai-oauth", "shared-model"),
+            _group("openai-codex", "shared-model"),
+        ),
+    )
+
+    assert routes._resolve_compatible_session_model_state("shared-model", "xai-oauth") == (
+        "shared-model",
+        "xai-oauth",
+        False,
+    )
+
+
+@pytest.mark.parametrize(
+    "catalog",
+    [
+        _catalog(
+            _group("xai-oauth", "grok-4.3"),
+            _group("openai-codex", "gpt-5.6-terra"),
+            _group("openrouter", "gpt-5.6-terra"),
+        ),
+        _catalog(
+            _group("xai-oauth", "grok-4.3", error="catalog unavailable"),
+            _group("openai-codex", "gpt-5.6-terra"),
+        ),
+        _catalog(_group("openai-codex", "gpt-5.6-terra")),
+    ],
+)
+def test_explicit_pair_does_not_infer_without_complete_unique_ownership(monkeypatch, catalog):
+    monkeypatch.setattr(routes, "get_nonblocking_available_models_snapshot", lambda: catalog)
+
+    assert routes._resolve_compatible_session_model_state("gpt-5.6-terra", "xai-oauth") == (
+        "gpt-5.6-terra",
+        "xai-oauth",
+        False,
+    )
+
+
+def test_explicit_pair_does_not_infer_when_cached_catalog_raises(monkeypatch):
+    def unavailable():
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(routes, "get_nonblocking_available_models_snapshot", unavailable)
+
+    assert routes._resolve_compatible_session_model_state("gpt-5.6-terra", "xai-oauth") == (
+        "gpt-5.6-terra",
+        "xai-oauth",
+        False,
+    )
+
+
+def test_chat_start_persists_repaired_model_provider_pair(monkeypatch, tmp_path):
+    saves = []
+    session = SimpleNamespace(
+        session_id="ops-359",
+        workspace=str(tmp_path),
+        model="gpt-5.6-terra",
+        model_provider="xai-oauth",
+        profile="default",
+        messages=[],
+        context_messages=[],
+        pending_user_message=None,
+        title="OPS-359",
+        session_source=None,
+        save=lambda *args, **kwargs: saves.append((args, kwargs)),
+    )
+    captured = {}
+
+    def start_run(current, **kwargs):
+        captured.update(kwargs)
+        routes._prepare_chat_start_session_for_stream(
+            current,
+            msg=kwargs["msg"],
+            attachments=kwargs["attachments"],
+            workspace=kwargs["workspace"],
+            model=kwargs["model"],
+            model_provider=kwargs["model_provider"],
+            stream_id="ops-359-stream",
+        )
+        return {
+            "stream_id": "ops-359-stream",
+            "effective_model_provider": kwargs["model_provider"],
+        }
+
+    monkeypatch.setattr(routes, "_get_or_materialize_session", lambda _sid, **_kwargs: session)
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _p: (None, None, {}))
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
+            _group("xai-oauth", "grok-4.3"),
+            _group("openai-codex", "gpt-5.6-terra"),
+        ),
+    )
+    monkeypatch.setattr(routes, "_start_run", start_run)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200: payload)
+
+    response = routes._handle_chat_start(
+        None,
+        {"session_id": session.session_id, "message": "resume automatically"},
+    )
+
+    assert captured["model"] == "gpt-5.6-terra"
+    assert captured["model_provider"] == "openai-codex"
+    assert session.model == "gpt-5.6-terra"
+    assert session.model_provider == "openai-codex"
+    assert response["effective_model_provider"] == "openai-codex"
+    assert saves
+
+
+@pytest.mark.parametrize(
+    ("model", "provider"),
+    [
+        ("gpt-5.6-terra", "xai-oauth"),
+        ("@openrouter:anthropic/claude-opus-4.7", "openrouter"),
+        ("openai/gpt-5.4-mini", "openai-codex"),
+    ],
+)
+def test_explicit_pair_resolution_never_waits_for_models_cache_lock(monkeypatch, model, provider):
+    """A catalog rebuild cannot delay any explicit-pair chat start."""
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+    builder_called = threading.Event()
+    resolved = []
+    finished = threading.Event()
+
+    def hold_models_cache_lock():
+        with config._available_models_cache_lock:
+            lock_held.set()
+            release_lock.wait(timeout=2.0)
+
+    def blocking_catalog_builder(*, prefer_cache=False):
+        builder_called.set()
+        with config._available_models_cache_lock:
+            return _catalog(_group("openai-codex", "gpt-5.6-terra"))
+
+    def resolve_pair():
+        try:
+            resolved.append(
+                routes._resolve_compatible_session_model_state(
+                    model,
+                    provider,
+                )
+            )
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(routes, "get_available_models", blocking_catalog_builder)
+    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+    holder = threading.Thread(target=hold_models_cache_lock, daemon=True)
+    worker = threading.Thread(target=resolve_pair, daemon=True)
+    holder.start()
+    assert lock_held.wait(timeout=1.0)
+    worker.start()
+    try:
+        assert finished.wait(timeout=0.2), (
+            "explicit-pair resolution waited for _available_models_cache_lock"
+        )
+    finally:
+        release_lock.set()
+        holder.join(timeout=1.0)
+        worker.join(timeout=1.0)
+
+    assert resolved == [(model, provider, False)]
+    assert not builder_called.is_set()
+
+
+def test_requested_provider_alias_matches_single_canonical_catalog_group(monkeypatch):
+    """A unique canonical alias group can prove that the requested owner is stale."""
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
+            _group("anthropic", "claude-sonnet-4.6"),
+            _group("openai-codex", "gpt-5.6-terra"),
+        ),
+    )
+
+    assert routes._resolve_compatible_session_model_state(
+        "gpt-5.6-terra",
+        "claude-code",
+    ) == ("gpt-5.6-terra", "openai-codex", True)
+
+
+def test_requested_provider_canonical_group_ambiguity_preserves_explicit_pair(monkeypatch):
+    """Several groups in one provider family are not ownership proof."""
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: _catalog(
+            _group("openai", "gpt-4.1"),
+            _group("openai-codex", "gpt-5.6-terra"),
+            _group("anthropic", "claude-sonnet-4.6"),
+        ),
+    )
+
+    assert routes._resolve_compatible_session_model_state(
+        "claude-sonnet-4.6",
+        "gpt",
+    ) == ("claude-sonnet-4.6", "gpt", False)

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -1169,6 +1169,11 @@ def test_at_provider_removed_provider_still_reverts_to_default(monkeypatch):
             ],
         },
     )
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: routes.get_available_models(),
+    )
 
     # Non-explicit (2nd+ turn / chat switch): unknown provider -> repair to default.
     model, _provider, changed = routes._resolve_compatible_session_model_state(
@@ -1352,6 +1357,11 @@ def test_at_provider_first_party_named_third_party_model_known_limitation(monkey
                 },
             ],
         },
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_nonblocking_available_models_snapshot",
+        lambda: routes.get_available_models(),
     )
 
     # Non-explicit path: the gpt-prefixed third-party id is (imperfectly) treated


### PR DESCRIPTION
## Summary

Fixes OPS-359 by keeping Hermes WebUI model/provider routing atomic during automated transitions.

- Frontend no longer reuses a session provider when the session model differs from the outgoing model.
- Server validates explicit model/provider pairs only against an immediately available nonblocking catalog snapshot.
- Catalog ownership checks never wait behind `_available_models_cache_lock` and never invoke the blocking catalog builder.
- Missing, ambiguous, incomplete, failed, or unavailable evidence preserves explicit user intent.
- Adds Terra/Luna/Sol, lock-contention, provider-alias, `None` snapshot, queue/start persistence, and adjacent fast-path regression coverage.

## Root cause

Model and provider were maintained as separate mutable fields. A model transition could send a new Codex model with the previous xAI provider. The first server repair attempted a cached catalog call that could still block behind an active rebuild lock.

## Verification

- `127 passed` across focused OPS-359 and changed fast-path/provider suites.
- `92 passed` across adjacent resolver/model-picker suites.
- `71 passed, 3 deselected` in provider-mismatch coverage; the deselected tests require an authenticated live WebUI HTTP context and returned 401 outside browser auth.
- Lock-contention regression holds `_available_models_cache_lock`, proves explicit-pair resolution returns within 0.2 seconds, and proves the blocking catalog builder is never called.
- `py_compile`, `node --check`, and `git diff --check` passed.
- Added-line security scan passed.
- AGY final exact-tree review: **SHIP**.

## Risk and rollback

- Disk fallback uses the existing strict cache validator and does not trigger catalog construction.
- Repair occurs only with complete unique ownership evidence.
- Revert this PR to restore prior routing behavior.

Linear: OPS-359

No deployment is included. Merge and deployment require separate Rand approval.
