### PR TITLE
Fix download 404 when a MEDIA: token is wrapped in an inline-code span

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4801,7 +4801,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _smdMediaTailFlushEntry(entry){
     const chunk=_smdMediaTailEntryChunk(entry);
     if(!chunk) return;
-    const m=/^MEDIA:([^\s\)\]]+)$/.exec(String(chunk));
+    // \x60 excluded from the path class (see renderMd in ui.js): an inline-code
+    // MEDIA token must not swallow its closing backtick.
+    const m=/^MEDIA:([^\s\)\]\x60]+)$/.exec(String(chunk));
     const emitted=!!(m && entry && entry.parent && _smdAppendMediaNode(entry.parent, m[1]));
     if(!emitted && entry) _smdMediaWriteText(entry.parent, entry.data, entry.baseAddText, entry.writeText, chunk);
   }
@@ -4849,7 +4851,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Prose runs go through the owning text writer. MEDIA tokens go through
     // the single-token DOMParser helper only after a delimiter or
     // reliable filename suffix proves the ref is complete.
-    const re=/MEDIA:([^\s\)\]]+)/g;
+    const re=/MEDIA:([^\s\)\]\x60]+)/g;  // \x60 excluded — see renderMd in ui.js
     let last=0, m;
     let unmatchedTail=null;
     while((m=re.exec(combined))){
@@ -4875,7 +4877,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // MEDIA prefix; flush any prose before the partial MEDIA suffix.
     const rest = combined.slice(last);
     if(rest){
-      const tailMatch = /MEDIA:[^\s\)\]]*$/.exec(rest);
+      const tailMatch = /MEDIA:[^\s\)\]\x60]*$/.exec(rest);  // \x60 excluded — see ui.js
       const prefixTail = tailMatch ? '' : _smdMediaPrefixTail(rest);
       const tailValue = tailMatch ? tailMatch[0] : prefixTail;
       if(tailValue && rest.length < _MEDIA_TAIL_MAX){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7591,7 +7591,9 @@ function renderMd(raw){
   // generated images) and replace them with inline <img> or download links.
   // Stashed so the path/URL is never processed as markdown.
   const media_stash=[];
-  s=s.replace(/MEDIA:([^\s\)\]]+)/g,(_,raw_ref)=>{
+  // Exclude the backtick (\x60, not a literal — a literal one breaks text-based
+  // JS extraction in the test suite) so an inline-code MEDIA token keeps it out.
+  s=s.replace(/MEDIA:([^\s\)\]\x60]+)/g,(_,raw_ref)=>{
     media_stash.push(raw_ref);
     return '\x00D'+(media_stash.length-1)+'\x00';
   });

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -216,6 +216,20 @@ class TestRendererSanitization:
         assert 'onclick' not in out
         assert '_openimglightbox' not in out
 
+    def test_media_token_in_code_span_does_not_capture_backtick(self, driver_path):
+        # Regression: agents routinely format the token as an inline-code span,
+        # e.g. `MEDIA:/workspace/report.md`. The closing backtick must NOT be
+        # captured into the path, otherwise the download URL becomes
+        # .../report.md%60 and the server 404s (no file has a backtick in its
+        # name). Guards the MEDIA path class in renderMd().
+        out = _render(
+            driver_path,
+            "**Markdown:** `MEDIA:/workspace/report.md`",
+        )
+        assert "api/media?path=" in out
+        assert "%60" not in out, f"backtick leaked into media path: {out!r}"
+        assert "report.md" in out
+
     def test_incomplete_raw_html_tag_is_escaped_before_paragraph_wrapping(self, driver_path):
         out = _render(driver_path, '<img src=x onerror=alert(1)//').lower()
         assert '&lt;img' in out


### PR DESCRIPTION
## Summary

When the agent references a file with a `MEDIA:<path>` token wrapped in a markdown inline-code span — e.g. a message body containing `` `MEDIA:/workspace/report.md` `` — the token-extraction regex in `renderMd()` captures the **closing backtick** as part of the path. The download link the WebUI builds then points at `/api/media?path=/workspace/report.md%60&download=1` (`%60` = the backtick), which 404s because no file with a trailing backtick exists. From the user's side the file simply "won't download". Models format paths as inline code routinely, so this shows up in normal use.

## Root cause

`renderMd()` stashes `MEDIA:` tokens **before** the inline-code / fence stash (it is documented as needing to run first), so when the token sits inside a code span the closing backtick has not been stripped yet. The regex `MEDIA:([^\s\)\]]+)` excludes whitespace, `)` and `]` (the latter two for markdown link syntax) but not the backtick, so the backtick is consumed into the path. The same character class is used on the streaming path in `messages.js`.

## Fix

Add the backtick to the excluded class at all four call sites — `renderMd()` in `static/ui.js`, and `_smdMediaTailFlushEntry` / `_smdMediaAwareAddText` / the tail matcher in `static/messages.js`:

```diff
- /MEDIA:([^\s\)\]]+)/
+ /MEDIA:([^\s\)\]\x60]+)/
```

`\x60` (hex escape) is used instead of a literal backtick so the source stays free of a stray backtick — a literal one trips the text-based JS extraction in `test_smooth_text_fade` (which scans the source char-by-char, treating the backtick as a string delimiter) and `test_issue342`. Local paths never legitimately contain a backtick, so excluding it is safe.

## Repro

1. Get the agent to emit a MEDIA token formatted as inline code: a message containing `` `MEDIA:/workspace/report.md` ``.
2. Click the resulting file link in the chat (a non-image extension like `.md` renders as a download anchor).
3. Download fails; server access log shows `GET /api/media?path=%2Fworkspace%2Freport.md%60&download=1 -> 404`.

## Tests

- New regression test `test_media_token_in_code_span_does_not_capture_backtick` (`tests/test_renderer_js_behaviour.py`) — drives the real `renderMd()` via node; **fails without the fix** (the link carries `%60`), passes with it.
- Ran the renderer / MEDIA / streaming suites locally, all green (185 tests): `test_renderer_js_behaviour.py`, `test_issue342.py`, `test_smooth_text_fade.py`, `test_smd_media_in_stream.py`, `test_media_inline.py`.

## AI Usage Disclosure

Produced with AI assistance (Claude Code), reviewed by a human before submission.
