### PR TITLE
fix(api): create chat-attachment uploads with anchored O_EXCL (TOCTOU)

### DIFF
--- a/api/upload.py
+++ b/api/upload.py
@@ -122,8 +122,8 @@ def _attachment_root() -> Path:
     return (STATE_DIR / 'attachments').resolve()
 
 
-def _upload_destination(session_id: str, safe_name: str) -> Path:
-    dest_dir = _session_attachment_dir(session_id)
+def _upload_destination(session_id: str, safe_name: str, dest_dir: Path | None = None) -> Path:
+    dest_dir = dest_dir if dest_dir is not None else _session_attachment_dir(session_id)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = (dest_dir / safe_name).resolve()
     if not dest.is_relative_to(dest_dir):
@@ -224,8 +224,20 @@ def handle_upload(handler):
         if _reject_invisible_session(handler, s):
             return True
         safe_name = _sanitize_upload_name(filename)
-        dest = _upload_destination(session_id, safe_name)
-        dest.write_bytes(file_bytes)
+        dest_dir = _session_attachment_dir(session_id)
+        dest = _upload_destination(session_id, safe_name, dest_dir)
+        # #3398-style TOCTOU hardening, mirrored from the workspace upload
+        # path: O_CREAT|O_EXCL|O_NOFOLLOW anchored open so a raced duplicate
+        # cannot be silently overwritten and a raced symlink subpath cannot
+        # redirect the write outside the attachment dir.
+        try:
+            _wfd = open_anchored_create_fd(dest_dir, dest)
+        except FileExistsError:
+            return j(handler, {'error': f'Upload destination already exists: {safe_name}'}, status=409)
+        except (ValueError, OSError):
+            return j(handler, {'error': 'Upload destination rejected'}, status=403)
+        with os.fdopen(_wfd, 'wb', closefd=True) as _wfh:
+            _wfh.write(file_bytes)
         mime = mimetypes.guess_type(safe_name)[0] or 'application/octet-stream'
         return j(handler, {
             'filename': dest.name,

--- a/tests/test_attachment_upload_toctou.py
+++ b/tests/test_attachment_upload_toctou.py
@@ -1,0 +1,160 @@
+"""TOCTOU hardening for chat-attachment uploads.
+
+handle_upload deduped filenames with an exists() check and then wrote with
+plain write_bytes — two concurrent uploads of the same name could both pass
+the check and the last writer silently won. These tests pin the #3398-style
+anchored O_CREAT|O_EXCL|O_NOFOLLOW creation semantics (mirrored from the
+workspace upload path): a raced duplicate must 409 instead of overwriting,
+and the non-raced happy path / dedup behavior must stay unchanged.
+
+Test-pattern cribbed from tests/test_raw_audio_upload.py (real multipart body
+through parse_multipart + fake handler) and
+tests/test_session_active_profile_authorization.py (monkeypatched
+get_session / _get_active_profile_name).
+"""
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import api.upload as upload
+from api.upload import handle_upload
+
+
+def _multipart_body(fields=None, files=None, boundary=b"testboundary"):
+    fields = fields or {}
+    files = files or {}
+    body = b""
+    for name, value in fields.items():
+        body += b"--" + boundary + b"\r\n"
+        body += f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+        body += str(value).encode() + b"\r\n"
+    for name, (filename, data, content_type) in files.items():
+        body += b"--" + boundary + b"\r\n"
+        body += (
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        ).encode()
+        body += data + b"\r\n"
+    body += b"--" + boundary + b"--\r\n"
+    return body, f"multipart/form-data; boundary={boundary.decode()}"
+
+
+class _FakeHandler:
+    def __init__(self, body: bytes, content_type: str):
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.headers = {
+            "Content-Type": content_type,
+            "Content-Length": str(len(body)),
+        }
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+@pytest.fixture()
+def attachment_env(tmp_path, monkeypatch):
+    """Isolate the attachment inbox and stub the session lookup."""
+    root = tmp_path / "attachments"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(root))
+    monkeypatch.setattr(
+        upload,
+        "get_session",
+        lambda sid: SimpleNamespace(session_id=sid, profile=None),
+    )
+    monkeypatch.setattr(upload, "_get_active_profile_name", lambda: "default")
+    return root
+
+
+def test_raced_duplicate_returns_409_and_preserves_existing_bytes(attachment_env, monkeypatch):
+    """An attacker winning the exists()-check race must not get its bytes written.
+
+    Simulates the race deterministically: the destination file already exists
+    with known content, and _upload_destination returns that exact path as if
+    the dedup check had just passed. The anchored O_EXCL create must fail with
+    FileExistsError -> 409, and the pre-existing bytes must be untouched.
+    """
+    session_id = "race-sess"
+    dest_dir = upload._session_attachment_dir(session_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    target = dest_dir / "report.txt"
+    target.write_bytes(b"ORIGINAL-CONTENT")
+
+    monkeypatch.setattr(
+        upload,
+        "_upload_destination",
+        lambda session_id, safe_name, dest_dir=None: target,
+    )
+
+    body, content_type = _multipart_body(
+        fields={"session_id": session_id},
+        files={"file": ("report.txt", b"ATTACKER-BYTES", "text/plain")},
+    )
+    handler = _FakeHandler(body, content_type)
+    handle_upload(handler)
+
+    assert handler.status == 409
+    assert handler.payload() == {
+        "error": "Upload destination already exists: report.txt"
+    }
+    assert target.read_bytes() == b"ORIGINAL-CONTENT"
+
+
+def test_new_upload_happy_path_unchanged(attachment_env):
+    """A normal upload of a fresh name keeps the exact response shape."""
+    body, content_type = _multipart_body(
+        fields={"session_id": "happy-sess"},
+        files={"file": ("notes.txt", b"hello world", "text/plain")},
+    )
+    handler = _FakeHandler(body, content_type)
+    handle_upload(handler)
+
+    assert handler.status == 200
+    payload = handler.payload()
+    assert set(payload) == {"filename", "path", "size", "mime", "is_image"}
+    assert payload["filename"] == "notes.txt"
+    assert payload["mime"].startswith("text/")
+    assert payload["is_image"] is False
+    assert payload["size"] == len(b"hello world")
+
+    dest = attachment_env / "happy-sess" / "notes.txt"
+    assert Path(payload["path"]) == dest.resolve()
+    assert dest.read_bytes() == b"hello world"
+
+
+def test_non_raced_dedup_still_suffixed(attachment_env):
+    """Uploading an existing name (no race) still picks the -1 suffixed name."""
+    body1, ctype1 = _multipart_body(
+        fields={"session_id": "dedup-sess"},
+        files={"file": ("dup.txt", b"first", "text/plain")},
+    )
+    h1 = _FakeHandler(body1, ctype1)
+    handle_upload(h1)
+    assert h1.status == 200
+
+    body2, ctype2 = _multipart_body(
+        fields={"session_id": "dedup-sess"},
+        files={"file": ("dup.txt", b"second", "text/plain")},
+    )
+    h2 = _FakeHandler(body2, ctype2)
+    handle_upload(h2)
+    assert h2.status == 200
+    assert h2.payload()["filename"] == "dup-1.txt"
+
+    dest_dir = upload._session_attachment_dir("dedup-sess")
+    assert (dest_dir / "dup.txt").read_bytes() == b"first"
+    assert (dest_dir / "dup-1.txt").read_bytes() == b"second"


### PR DESCRIPTION
## What

`handle_upload` (chat attachments) deduped filenames with an `exists()` check and then wrote with plain `dest.write_bytes` — two concurrent uploads of the same name into the same session inbox both passed the check and the **last writer silently won**, leaving one client with a 200 response naming bytes that no longer exist on disk.

The workspace-upload path already solved this exact class in #3398 (`open_anchored_create_fd`: `O_CREAT|O_EXCL|O_NOFOLLOW` anchored openat-walk). This PR mirrors that hardening for the attachment inbox:

- a raced duplicate now gets **409** `Upload destination already exists: <name>` instead of a silent overwrite
- a symlink raced into the attachment path after the containment checks cannot redirect the write outside the inbox
- `_upload_destination` gains an optional `dest_dir` param so `handle_upload` computes the session dir once and anchors against it (all existing 2-arg callers keep working)

## Siblings checked

- Workspace upload path (`handle_workspace_upload`, the #3398 block) — already hardened, untouched.
- `_upload_destination` callers: `tests/test_chat_upload_attachment_paths.py` (2 positional args, compatible), `tests/test_session_active_profile_authorization.py` (monkeypatch with `*_args, **_kwargs`, compatible), comment-only mention in `api/streaming.py`. No pins on the old `write_bytes` behavior.
- Dedup semantics preserved: the non-raced `-1` suffix loop is unchanged.

## Proof: test fails before, passes after

New `tests/test_attachment_upload_toctou.py` (3 tests).

**RED on master** (deterministic race simulation — pre-create the destination, monkeypatch `_upload_destination` to return it anyway, simulating an attacker winning the `exists()` race):
```
assert handler.status == 409
E  assert 200 == 409
```
The attacker's bytes overwrote the original (silent last-writer-wins confirmed).

**GREEN on this branch**: race → 409 with error JSON and **original bytes preserved**; happy-path response shape unchanged (`filename/path/size/mime/is_image`); non-raced dedup still picks `-1` suffix.

## Verification

- `./scripts/test.sh tests/test_attachment_upload_toctou.py tests/test_workspace_upload.py tests/test_large_text_paste_attachment.py tests/test_native_image_attachments.py` → **85 passed**
- `./scripts/test.sh tests/test_attachment_upload_toctou.py tests/test_workspace_upload.py tests/test_chat_upload_attachment_paths.py` → **35 passed**

CHANGELOG untouched per contributor rules.


## AI Usage Disclosure

- **Provider:** Z.AI
- **Models:** GLM-5.3 (analysis, spec design, code review, verification) and GLM-5.3-Flash (mechanical implementation, delegated per-PR to low-reasoning subagents)
- **Notable mode/tool use:** multi-agent workflow — repository audit via parallel read-only scout agents; per-PR implementation delegated with a full written spec; independent reviewer-agent pass on the diff before push; strict TDD (each test observed failing on master before the fix, passing after); verification via `./scripts/test.sh` (pytest) and a real Chromium run for the browser-proof test where applicable.


## Thinking Path

The audit flagged handle_upload as the one remaining write path using plain write_bytes after an exists()-based dedup. The repo already solved this TOCTOU class for workspace uploads in #3398 (open_anchored_create_fd: O_CREAT|O_EXCL|O_NOFOLLOW anchored openat-walk); this PR reuses that exact mechanism for the attachment inbox rather than adding a new one — same helper, same error mapping shape, same FileExistsError->409 semantics.

## Risks / Follow-ups

New observable behavior: a raced duplicate now returns 409 instead of a silent 200-overwrite (both racing clients previously got 200, one naming bytes that no longer existed). Symlink-in-inbox redirects are now blocked by the anchored open. The non-raced -1 suffix dedup loop is unchanged. If any downstream consumer treated a repeated upload of the same name as last-writer-wins overwrite, they will now see 409 — no such consumer found in the repo.
