### PR TITLE
feat(sessions): add default-off lifecycle shadow audit

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -398,7 +398,9 @@ _DEFAULT_EXPERIMENTAL_CONFIG = {
     # session call sites must continue using the existing JSON paths unless a
     # later PR deliberately enables and wires this flag.
     "unified_session_db": False,
+    "unified_session_metadata_mode": "off",
 }
+_UNIFIED_SESSION_METADATA_MODES = {"off", "shadow", "sync"}
 _DEFAULT_AGENT_PERSONALITIES = {
     # Mirrors the Hermes Agent CLI built-ins so WebUI's config-derived
     # /personality path is not empty for fresh profiles.
@@ -537,6 +539,31 @@ def is_unified_session_db_enabled(config_data: dict | None = None) -> bool:
     if not isinstance(experimental, dict):
         return False
     return experimental.get("unified_session_db") is True
+
+
+def get_unified_session_metadata_mode(config_data: dict | None = None) -> str:
+    """Return normalized unified lifecycle metadata mode.
+
+    Valid values are ``off``, ``shadow``, ``sync``. Invalid, missing, or
+    non-string values fail closed to ``off``. Whitespace is stripped and
+    comparison is case-insensitive.
+    """
+    active_cfg = config_data if isinstance(config_data, dict) else cfg
+    experimental = active_cfg.get("experimental", {}) if isinstance(active_cfg, dict) else {}
+    if not isinstance(experimental, dict):
+        return "off"
+    raw = experimental.get("unified_session_metadata_mode", "off")
+    if not isinstance(raw, str):
+        return "off"
+    normalized = raw.strip().lower()
+    if normalized in _UNIFIED_SESSION_METADATA_MODES:
+        return normalized
+    return "off"
+
+
+def is_unified_session_metadata_shadow_enabled(config_data: dict | None = None) -> bool:
+    """True only when master flag is on and mode is ``shadow``."""
+    return is_unified_session_db_enabled(config_data) and get_unified_session_metadata_mode(config_data) == "shadow"
 
 
 def _refresh_config_cache(config_path: Path | None = None) -> None:

--- a/api/session_metadata_sync.py
+++ b/api/session_metadata_sync.py
@@ -293,22 +293,46 @@ def _is_trusted_core_source(row: dict) -> bool:
     return str(meta.get("session_source") or "").strip().lower() == "webui"
 
 
-def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict], dict, set[str], bool]:
+def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict], dict, set[str], bool, int]:
     out: dict[str, dict] = {}
     blocked: dict[str, int] = {"malformed": 0, "id_mismatch": 0, "messages_invalid": 0, "profile_mismatch": 0}
     blocked_ids: set[str] = set()
+    unanchorable_blocked = 0
     session_dir = Path(session_dir)
     sidecar_unreadable = False
     entries: list[Path] = []
+
+    def _record_blocked(kind: str, *raw_ids) -> None:
+        """Record rejected inventory evidence without double-counting anchors.
+
+        An admitted raw identity is counted later through its blocked lineage.
+        Only a rejected record with no admissible identity can seed the aggregate
+        ambiguity accumulator directly.
+        """
+        nonlocal sidecar_unreadable, unanchorable_blocked
+        try:
+            blocked[kind] += 1
+            anchors = {
+                raw_id
+                for raw_id in raw_ids
+                if isinstance(raw_id, str) and raw_id and raw_id.strip()
+            }
+            if anchors:
+                blocked_ids.update(anchors)
+            else:
+                unanchorable_blocked += 1
+        except Exception:
+            sidecar_unreadable = True
+
     try:
         if not session_dir.exists() or not session_dir.is_dir():
-            return out, blocked, blocked_ids, True
+            return out, blocked, blocked_ids, True, unanchorable_blocked
         try:
             entries = list(session_dir.glob("*.json"))
         except Exception:
-            return out, blocked, blocked_ids, True
+            return out, blocked, blocked_ids, True, unanchorable_blocked
     except Exception:
-        return out, blocked, blocked_ids, True
+        return out, blocked, blocked_ids, True, unanchorable_blocked
     for p in entries:
         if p.name.startswith("_") or p.name.startswith("."):
             continue
@@ -322,77 +346,35 @@ def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict
         try:
             data = json.loads(text)
         except Exception:
-            try:
-                blocked["malformed"] += 1
-                if file_sid_early:
-                    blocked_ids.add(file_sid_early)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", file_sid_early)
             continue
         if not isinstance(data, dict):
-            try:
-                blocked["malformed"] += 1
-                if file_sid_early:
-                    blocked_ids.add(file_sid_early)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", file_sid_early)
             continue
         file_sid_raw = p.stem
         raw_payload_sid = data.get("session_id")
         if not isinstance(raw_payload_sid, str) or not raw_payload_sid.strip():
-            try:
-                blocked["malformed"] += 1
-                if isinstance(file_sid_raw, str) and file_sid_raw.strip():
-                    blocked_ids.add(file_sid_raw)
-                if isinstance(raw_payload_sid, str) and raw_payload_sid.strip():
-                    blocked_ids.add(raw_payload_sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", file_sid_raw, raw_payload_sid)
             continue
         payload_sid = raw_payload_sid
         file_sid = file_sid_raw if isinstance(file_sid_raw, str) and file_sid_raw.strip() else ""
         if not file_sid:
-            try:
-                blocked["malformed"] += 1
-                if payload_sid:
-                    blocked_ids.add(payload_sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", payload_sid)
             continue
         if payload_sid != file_sid:
-            try:
-                blocked["id_mismatch"] += 1
-                if file_sid:
-                    blocked_ids.add(file_sid)
-                if payload_sid:
-                    blocked_ids.add(payload_sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("id_mismatch", file_sid, payload_sid)
             continue
         sid = payload_sid
         if not sid:
-            try:
-                blocked["malformed"] += 1
-                if file_sid:
-                    blocked_ids.add(file_sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", file_sid)
             continue
         prof = data.get("profile")
         if not isinstance(prof, str) or not prof.strip() or prof != profile:
-            try:
-                blocked["profile_mismatch"] += 1
-                blocked_ids.add(sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("profile_mismatch", sid)
             continue
         msgs = data.get("messages")
         if not isinstance(msgs, list):
-            try:
-                blocked["messages_invalid"] += 1
-                blocked_ids.add(sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("messages_invalid", sid)
             continue
         try:
             pinned = _tri_state_sidecar_flag(data, "pinned")
@@ -410,11 +392,7 @@ def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict
             sidecar_unreadable = True
             continue
         if kind == "malformed":
-            try:
-                blocked["malformed"] += 1
-                blocked_ids.add(sid)
-            except Exception:
-                sidecar_unreadable = True
+            _record_blocked("malformed", sid)
             continue
         out[sid] = {
             "session_id": sid,
@@ -428,8 +406,8 @@ def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict
             "raw_started_at": started_at,
         }
     if sidecar_unreadable:
-        return out, blocked, blocked_ids, True
-    return out, blocked, blocked_ids, False
+        return out, blocked, blocked_ids, True, unanchorable_blocked
+    return out, blocked, blocked_ids, False, unanchorable_blocked
 
 
 def _inventory_core_all(db_path: Path) -> tuple[dict[str, dict], bool, int, set[str]]:
@@ -620,9 +598,12 @@ def compute_aggregate_diagnostics(session_dir: Path, db_path: Path, profile) -> 
     blocked, never compared.
     """
     profile = _validate_profile(profile)
-    inv_result = _inventory_sidecars(session_dir, profile)
+    inv_result: tuple = _inventory_sidecars(session_dir, profile)
     sidecar_unreadable = False
-    if len(inv_result) == 4:
+    unanchorable_sidecar_blocked = 0
+    if len(inv_result) == 5:
+        sidecars, inv_blocked, inv_blocked_ids, sidecar_unreadable, unanchorable_sidecar_blocked = inv_result
+    elif len(inv_result) == 4:
         sidecars, inv_blocked, inv_blocked_ids, sidecar_unreadable = inv_result
     elif len(inv_result) == 3:
         sidecars, inv_blocked, inv_blocked_ids = inv_result
@@ -848,7 +829,10 @@ def compute_aggregate_diagnostics(session_dir: Path, db_path: Path, profile) -> 
     sidecar_only_msgful = 0
     core_only = 0
     blocked_active = 0
-    blocked_ambiguous = inv_blocked_total
+    # Anchored sidecar rejections are counted once when their blocked lineage
+    # is visited below. Only unanchorable sidecar records and invalid core IDs
+    # without an admissible lineage identity seed the aggregate directly.
+    blocked_ambiguous = invalid_core_blocked + unanchorable_sidecar_blocked
 
     effective_unreadable = blocked_unreadable or blocked_unreadable_sidecar
     if sidecar_unreadable:

--- a/api/session_metadata_sync.py
+++ b/api/session_metadata_sync.py
@@ -1,0 +1,985 @@
+"""Pure, read-only aggregate audit for lifecycle metadata (issue #498 shadow slice).
+
+Maintainer-approved slice: disabled-by-default (master flag + mode == shadow),
+aggregate-only, read-only shadow comparison plus offline drift audit. No writes,
+no events, no cache invalidation, no index/state.db mutation, no stream
+behavior, no apply/yes/migration/repair path.
+
+See https://github.com/nesquena/hermes-webui/issues/498#issuecomment-5385677557
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import defaultdict
+from contextlib import closing
+from pathlib import Path
+
+from api.agent_sessions import _is_continuation_session as _canonical_is_continuation
+from api.agent_sessions import normalize_agent_session_source
+from api.agent_sessions import open_state_db_readonly
+
+
+def _strict_lifecycle_value(value) -> bool | None:
+    """Strict tri-state normalizer for untrusted lifecycle inputs.
+
+    Permitted encodings only:
+      - actual bool -> bool(value)
+      - exact int 0/1 -> False/True
+      - exact float 0.0/1.0 -> False/True
+    Everything else (strings including "true"/"false"/"" / whitespace /
+    yes/no/on/off, objects, arrays, null/None, non-0/1 numbers) -> None
+    (unknown, fail-closed). Never uses generic truthiness.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        return None
+    if isinstance(value, float):
+        if value == 1.0:
+            return True
+        if value == 0.0:
+            return False
+        return None
+    return None
+
+
+def provisional_truth(json_pinned, json_archived, core_pinned, core_archived) -> dict:
+    """Pure hypothetical planner per approved truth table.
+
+    archived = json_archived or core_archived
+    pinned   = (json_pinned or core_pinned) and not archived
+
+    Inputs are first strict-normalized to the tri-state contract (bool and
+    exact 0/1 incl. 0.0/1.0 -> False/True; strings/objects/arrays/null and
+    non-0/1 numbers -> None). Unknown (None) is treated as False for the
+    hypothetical only after strict normalization. Never writes.
+    """
+    ja_raw = _strict_lifecycle_value(json_archived)
+    ca_raw = _strict_lifecycle_value(core_archived)
+    jp_raw = _strict_lifecycle_value(json_pinned)
+    cp_raw = _strict_lifecycle_value(core_pinned)
+    ja = ja_raw if ja_raw is not None else False
+    ca = ca_raw if ca_raw is not None else False
+    jp = jp_raw if jp_raw is not None else False
+    cp = cp_raw if cp_raw is not None else False
+    archived = ja or ca
+    pinned = (jp or cp) and not archived
+    return {"archived": archived, "pinned": pinned}
+
+
+def read_core_lifecycle_batch(db_path: Path, sids: set[str]) -> dict[str, dict]:
+    """Read pinned/archived tri-state for exact ids, read-only.
+
+    Preserves distinction:
+      - absent row            -> {"pinned": None, "archived": None, "exists": False}
+      - present row, col absent or NULL -> pinned/archived None, exists True
+      - actual bool, exact int 0/1, exact float 0.0/1.0 -> False/True
+      - any other integer, non-0/1 float, string (including "true"/"false"/""
+        / whitespace / yes/no/on/off), object, array, null -> None
+        (unknown, fail-closed). Never uses generic truthiness.
+      - database/schema/query read failure -> {"unreadable": True} (distinct from ordinary absent row -> {"exists": False, "unreadable": False})
+    Never mutates disk. Uses read-only URI helper.
+    """
+    wanted = {s for s in (sids or set()) if isinstance(s, str) and s.strip()}
+    result: dict[str, dict] = {sid: {"pinned": None, "archived": None, "exists": False, "unreadable": False} for sid in wanted}
+    if not wanted:
+        return result
+    db_path = Path(db_path)
+    if not db_path.exists():
+        for sid in wanted:
+            result[sid]["unreadable"] = True
+        return result
+    try:
+        with closing(open_state_db_readonly(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            try:
+                cur.execute("PRAGMA table_info(sessions)")
+                cols = {row[1] for row in cur.fetchall()}
+            except Exception:
+                for sid in wanted:
+                    result[sid]["unreadable"] = True
+                return result
+            if "id" not in cols:
+                for sid in wanted:
+                    result[sid]["unreadable"] = True
+                return result
+            has_pinned = "pinned" in cols
+            has_archived = "archived" in cols
+            ids = list(wanted)
+            for i in range(0, len(ids), 500):
+                chunk = ids[i : i + 500]
+                placeholders = ",".join("?" * len(chunk))
+                pinned_expr = "s.pinned" if has_pinned else "NULL AS pinned"
+                archived_expr = "s.archived" if has_archived else "NULL AS archived"
+                try:
+                    cur.execute(
+                        f"SELECT s.id, {pinned_expr}, {archived_expr} FROM sessions s WHERE s.id IN ({placeholders})",
+                        chunk,
+                    )
+                except Exception:
+                    for sid in chunk:
+                        if sid in result:
+                            result[sid]["unreadable"] = True
+                    continue
+                try:
+                    rows = cur.fetchall()
+                except Exception:
+                    for sid in chunk:
+                        if sid in result:
+                            result[sid]["unreadable"] = True
+                    continue
+                for row in rows:
+                    sid = row["id"]
+                    if not isinstance(sid, str) or not sid.strip():
+                        continue
+                    if sid not in result:
+                        continue
+                    result[sid]["exists"] = True
+                    for col, has_col in (("pinned", has_pinned), ("archived", has_archived)):
+                        if not has_col:
+                            result[sid][col] = None
+                        else:
+                            result[sid][col] = _strict_lifecycle_value(row[col])
+    except Exception:
+        for sid in wanted:
+            if not result[sid].get("unreadable"):
+                result[sid]["unreadable"] = True
+        pass
+    return result
+
+
+def _tri_state_sidecar_flag(data: dict, key: str):
+    """Read pinned/archived as tri-state via established core sidecar path.
+
+    Permitted encodings only: actual bool and exact numeric 0/1 (including
+    exact 0.0/1.0) -> False/True. Every string -> None (including "true",
+    "false", "", whitespace, yes/no/on/off, arbitrary strings). Objects,
+    arrays, null, and non-0/1 numeric values also -> None (unknown,
+    fail-closed). Preserves absent vs explicit false. Never coerces unknown
+    via bool(raw).
+    """
+    if key not in data:
+        return None
+    return _strict_lifecycle_value(data.get(key))
+
+
+def _classify_pending(data: dict) -> bool | None:
+    """Tri-state pending classification for offline audit (fail-closed).
+
+    Known active (True) -> blocks as active lineage.
+    Known inactive (False) -> allows comparison.
+    Unknown/malformed (None) -> blocks as ambiguous.
+
+    Legitimate indicators preserved without generic truthiness:
+      - active_stream_id: active iff non-empty stripped string; inactive iff
+        absent/None/"" / whitespace; ambiguous for any non-string type.
+      - pending_user_message: same as active_stream_id.
+      - has_pending_user_message: active iff True/1/1.0/"true"/"1";
+        inactive iff absent/None/False/0/0.0/"false"/"0"/""/whitespace;
+        ambiguous otherwise (e.g., "maybe", 2, [], {}).
+    If any field is ambiguous, overall is ambiguous (fail-closed) even if
+    another field is active. This is distinct from lifecycle strict
+    normalization and never uses bool(value) on strings.
+    """
+    has_ambiguous = False
+    has_active = False
+    # active_stream_id
+    if "active_stream_id" in data:
+        v = data.get("active_stream_id")
+        if v is None:
+            pass
+        elif isinstance(v, str):
+            if v.strip():
+                has_active = True
+            else:
+                pass
+        else:
+            has_ambiguous = True
+    # pending_user_message
+    if "pending_user_message" in data:
+        v = data.get("pending_user_message")
+        if v is None:
+            pass
+        elif isinstance(v, str):
+            if v.strip():
+                has_active = True
+            else:
+                pass
+        else:
+            has_ambiguous = True
+    # has_pending_user_message
+    if "has_pending_user_message" in data:
+        v = data.get("has_pending_user_message")
+        if v is None:
+            pass
+        elif isinstance(v, bool):
+            if v is True:
+                has_active = True
+            else:
+                pass
+        elif isinstance(v, int) and not isinstance(v, bool):
+            if v == 1:
+                has_active = True
+            elif v == 0:
+                pass
+            else:
+                has_ambiguous = True
+        elif isinstance(v, float):
+            if v == 1.0:
+                has_active = True
+            elif v == 0.0:
+                pass
+            else:
+                has_ambiguous = True
+        elif isinstance(v, str):
+            s = v.strip().lower()
+            if not s:
+                pass
+            elif s in {"true", "1"}:
+                has_active = True
+            elif s in {"false", "0"}:
+                pass
+            else:
+                has_ambiguous = True
+        else:
+            has_ambiguous = True
+    if has_ambiguous:
+        return None
+    if has_active:
+        return True
+    return False
+
+
+def _is_sidecar_pending(data: dict) -> bool:
+    """Legacy wrapper: returns True only for known active pending state."""
+    state = _classify_pending(data)
+    return state is True
+
+
+def _classify_parent_ref(raw) -> tuple[str, str | None]:
+    """Classify an untrusted parent reference.
+
+    Returns (kind, valid_id):
+      - absent  (raw is None / missing): valid root/no-parent
+      - valid   (non-empty non-whitespace str): exact parent identity (raw exact string)
+      - malformed (empty/whitespace/non-string/BLOB/numeric): fail-closed
+    Callers must treat absent and valid as non-blocking; malformed makes
+    the owning candidate a blocked anchor. Valid ids preserve raw exact string
+    without stripping or coercion.
+    """
+    if raw is None:
+        return ("absent", None)
+    if isinstance(raw, str):
+        if raw and raw.strip():
+            return ("valid", raw)
+        return ("malformed", None)
+    return ("malformed", None)
+
+
+def _is_trusted_core_source(row: dict) -> bool:
+    raw = row.get("source")
+    if raw is None:
+        raw = row.get("raw_source") or row.get("session_source")
+    meta = normalize_agent_session_source(raw)
+    return str(meta.get("session_source") or "").strip().lower() == "webui"
+
+
+def _inventory_sidecars(session_dir: Path, profile: str) -> tuple[dict[str, dict], dict, set[str], bool]:
+    out: dict[str, dict] = {}
+    blocked: dict[str, int] = {"malformed": 0, "id_mismatch": 0, "messages_invalid": 0, "profile_mismatch": 0}
+    blocked_ids: set[str] = set()
+    session_dir = Path(session_dir)
+    sidecar_unreadable = False
+    entries: list[Path] = []
+    try:
+        if not session_dir.exists() or not session_dir.is_dir():
+            return out, blocked, blocked_ids, True
+        try:
+            entries = list(session_dir.glob("*.json"))
+        except Exception:
+            return out, blocked, blocked_ids, True
+    except Exception:
+        return out, blocked, blocked_ids, True
+    for p in entries:
+        if p.name.startswith("_") or p.name.startswith("."):
+            continue
+        file_stem_raw = p.stem
+        file_sid_early = file_stem_raw if isinstance(file_stem_raw, str) and file_stem_raw.strip() else ""
+        try:
+            text = p.read_text(encoding="utf-8")
+        except Exception:
+            sidecar_unreadable = True
+            continue
+        try:
+            data = json.loads(text)
+        except Exception:
+            try:
+                blocked["malformed"] += 1
+                if file_sid_early:
+                    blocked_ids.add(file_sid_early)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        if not isinstance(data, dict):
+            try:
+                blocked["malformed"] += 1
+                if file_sid_early:
+                    blocked_ids.add(file_sid_early)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        file_sid_raw = p.stem
+        raw_payload_sid = data.get("session_id")
+        if not isinstance(raw_payload_sid, str) or not raw_payload_sid.strip():
+            try:
+                blocked["malformed"] += 1
+                if isinstance(file_sid_raw, str) and file_sid_raw.strip():
+                    blocked_ids.add(file_sid_raw)
+                if isinstance(raw_payload_sid, str) and raw_payload_sid.strip():
+                    blocked_ids.add(raw_payload_sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        payload_sid = raw_payload_sid
+        file_sid = file_sid_raw if isinstance(file_sid_raw, str) and file_sid_raw.strip() else ""
+        if not file_sid:
+            try:
+                blocked["malformed"] += 1
+                if payload_sid:
+                    blocked_ids.add(payload_sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        if payload_sid != file_sid:
+            try:
+                blocked["id_mismatch"] += 1
+                if file_sid:
+                    blocked_ids.add(file_sid)
+                if payload_sid:
+                    blocked_ids.add(payload_sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        sid = payload_sid
+        if not sid:
+            try:
+                blocked["malformed"] += 1
+                if file_sid:
+                    blocked_ids.add(file_sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        prof = data.get("profile")
+        if not isinstance(prof, str) or not prof.strip() or prof != profile:
+            try:
+                blocked["profile_mismatch"] += 1
+                blocked_ids.add(sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        msgs = data.get("messages")
+        if not isinstance(msgs, list):
+            try:
+                blocked["messages_invalid"] += 1
+                blocked_ids.add(sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        try:
+            pinned = _tri_state_sidecar_flag(data, "pinned")
+            archived = _tri_state_sidecar_flag(data, "archived")
+            msg_count = len(msgs)
+            pending_state = _classify_pending(data)
+            raw_parent_val = data.get("parent_session_id")
+            started_at = data.get("started_at")
+            if started_at is None:
+                started_at = data.get("created_at")
+            if started_at is None:
+                started_at = 0
+            kind, valid_parent = _classify_parent_ref(raw_parent_val)
+        except Exception:
+            sidecar_unreadable = True
+            continue
+        if kind == "malformed":
+            try:
+                blocked["malformed"] += 1
+                blocked_ids.add(sid)
+            except Exception:
+                sidecar_unreadable = True
+            continue
+        out[sid] = {
+            "session_id": sid,
+            "pinned": pinned,
+            "archived": archived,
+            "message_count": msg_count,
+            "is_active": pending_state,
+            "parent_session_id": valid_parent,
+            "started_at": started_at,
+            "raw_parent": raw_parent_val,
+            "raw_started_at": started_at,
+        }
+    if sidecar_unreadable:
+        return out, blocked, blocked_ids, True
+    return out, blocked, blocked_ids, False
+
+
+def _inventory_core_all(db_path: Path) -> tuple[dict[str, dict], bool, int, set[str]]:
+    """Inventory core rows with strict ID validation and error signaling.
+
+    Returns (out, had_unreadable_error, invalid_id_blocked_count, malformed_parent_anchor_ids).
+    Only non-empty, non-whitespace Python str ids are admitted.
+    NULL, int, BLOB, empty, whitespace are blocked and counted as invalid.
+    Any SELECT/connection failure sets had_unreadable_error True (fail-closed).
+    For a malformed parent reference that survives SQLite retrieval (non-string,
+    empty/whitespace), the owning trusted id is recorded as a blocked anchor so
+    a matching sidecar cannot be classified as matched. Raw values are not
+    surfaced. Note: SQLite TEXT affinity may canonicalize integer literals into
+    text before Python sees them; tests use a no-affinity schema to exercise raw
+    numeric/BLOB rejection.
+    """
+    out: dict[str, dict] = {}
+    invalid_blocked = 0
+    malformed_parent_anchors: set[str] = set()
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return out, False, 0, malformed_parent_anchors
+    try:
+        with closing(open_state_db_readonly(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            try:
+                cur.execute("PRAGMA table_info(sessions)")
+                cols = {row[1] for row in cur.fetchall()}
+            except Exception:
+                return out, True, 0, malformed_parent_anchors
+            if "id" not in cols:
+                return out, False, 0, malformed_parent_anchors
+            has_pinned = "pinned" in cols
+            has_archived = "archived" in cols
+            has_parent = "parent_session_id" in cols
+            has_started = "started_at" in cols
+            has_ended = "ended_at" in cols
+            has_end_reason = "end_reason" in cols
+            has_source = "source" in cols
+            has_session_source = "session_source" in cols
+            pinned_expr = "s.pinned" if has_pinned else "NULL AS pinned"
+            archived_expr = "s.archived" if has_archived else "NULL AS archived"
+            parent_expr = "s.parent_session_id" if has_parent else "NULL AS parent_session_id"
+            started_expr = "s.started_at" if has_started else "NULL AS started_at"
+            ended_expr = "s.ended_at" if has_ended else "NULL AS ended_at"
+            end_reason_expr = "s.end_reason" if has_end_reason else "NULL AS end_reason"
+            source_expr = "s.source" if has_source else "NULL AS source"
+            session_source_expr = "s.session_source" if has_session_source else "NULL AS session_source"
+            try:
+                cur.execute(
+                    f"SELECT s.id, {pinned_expr}, {archived_expr}, {parent_expr}, "
+                    f"{started_expr}, {ended_expr}, {end_reason_expr}, {source_expr}, {session_source_expr} "
+                    f"FROM sessions s"
+                )
+            except Exception:
+                return out, True, 0, malformed_parent_anchors
+            for row in cur.fetchall():
+                raw_id = row["id"]
+                if not isinstance(raw_id, str) or not raw_id.strip():
+                    invalid_blocked += 1
+                    continue
+                sid = raw_id
+                pinned = _strict_lifecycle_value(row["pinned"]) if has_pinned else None
+                if not has_pinned or row["pinned"] is None:
+                    # _strict already handles None -> None, but preserve column absent as None
+                    if not has_pinned:
+                        pinned = None
+                    elif row["pinned"] is None:
+                        pinned = None
+                archived = _strict_lifecycle_value(row["archived"]) if has_archived else None
+                if not has_archived or row["archived"] is None:
+                    if not has_archived:
+                        archived = None
+                    elif row["archived"] is None:
+                        archived = None
+                raw_source = str(row["source"]).strip().lower() if row["source"] else None
+                raw_session_source = str(row["session_source"]).strip().lower() if row["session_source"] else None
+                trusted = _is_trusted_core_source({"source": raw_source, "session_source": raw_session_source})
+                parent_val = row["parent_session_id"]
+                kind, valid_parent = _classify_parent_ref(parent_val)
+                if kind == "malformed":
+                    # Preserve internal blocked anchor for the valid core id; do not surface raw value
+                    malformed_parent_anchors.add(sid)
+                    parent_sid = None
+                else:
+                    parent_sid = valid_parent
+                out[sid] = {
+                    "session_id": sid,
+                    "pinned": pinned,
+                    "archived": archived,
+                    "parent_session_id": parent_sid,
+                    "started_at": row["started_at"],
+                    "ended_at": row["ended_at"],
+                    "end_reason": str(row["end_reason"]).strip().lower() if isinstance(row["end_reason"], str) and row["end_reason"].strip() else (str(row["end_reason"]).strip().lower() if row["end_reason"] else None) if row["end_reason"] else None,
+                    "source": raw_source,
+                    "session_source": raw_session_source,
+                    "trusted": bool(trusted),
+                    "malformed_parent": kind == "malformed",
+                }
+            return out, False, invalid_blocked, malformed_parent_anchors
+    except Exception:
+        return out, True, invalid_blocked, malformed_parent_anchors
+    return out, False, invalid_blocked, malformed_parent_anchors
+
+
+def _rows_for_canonical_continuation(sidecars: dict[str, dict], core_all: dict[str, dict]) -> dict[str, dict]:
+    """Build rows_by_id shape expected by the canonical continuation predicate.
+
+    Core lineage facts (ended_at/end_reason/started_at/source/parent_session_id)
+    are authoritative for continuation checks; a core row's canonical parent
+    (including None) is never overwritten by sidecar evidence. Sidecar values
+    only fill provenance gaps (started_at/ended_at/end_reason/source) and add
+    sidecar-only candidates.
+    """
+    rows: dict[str, dict] = {}
+    for sid, v in core_all.items():
+        rows[sid] = {
+            "id": sid,
+            "parent_session_id": v.get("parent_session_id"),
+            "started_at": v.get("started_at"),
+            "ended_at": v.get("ended_at"),
+            "end_reason": v.get("end_reason"),
+            "source": v.get("source"),
+            "session_source": v.get("session_source"),
+        }
+    for sid, v in sidecars.items():
+        if sid not in rows:
+            rows[sid] = {
+                "id": sid,
+                "parent_session_id": v.get("parent_session_id"),
+                "started_at": v.get("started_at"),
+                "ended_at": None,
+                "end_reason": None,
+                "source": None,
+                "session_source": None,
+            }
+        else:
+            for k in ("started_at", "ended_at", "end_reason", "source", "session_source"):
+                if rows[sid].get(k) is None and v.get(k) is not None:
+                    rows[sid][k] = v.get(k)
+    return rows
+
+
+def _canonical_continuation_root(rows_by_id: dict[str, dict], sid: str) -> str:
+    cur = sid
+    seen: dict[str, int] = {cur: 0}
+    path: list[str] = [cur]
+    for _ in range(len(rows_by_id) + 5):
+        row = rows_by_id.get(cur)
+        parent_id = row.get("parent_session_id") if row else None
+        if not isinstance(parent_id, str) or not parent_id.strip():
+            return cur
+        parent = rows_by_id.get(parent_id)
+        if not parent:
+            return cur
+        try:
+            is_cont = bool(_canonical_is_continuation(parent, row))
+        except Exception:
+            return cur
+        if not is_cont:
+            return cur
+        if parent_id in seen:
+            idx = seen[parent_id]
+            cycle = path[idx:]
+            try:
+                return min(cycle)
+            except Exception:
+                return cur
+        cur = str(parent_id)
+        seen[cur] = len(path)
+        path.append(cur)
+    return cur
+
+
+def _validate_profile(profile) -> str:
+    if not isinstance(profile, str) or not profile.strip():
+        raise ValueError("profile is required: pass a non-empty --profile")
+    return profile
+
+
+def compute_aggregate_diagnostics(session_dir: Path, db_path: Path, profile) -> dict:
+    """Aggregate-only, profile-scoped, fail-closed diagnostics.
+
+    Never surfaces titles, prompts, transcript, or session IDs — only counts
+    and the profile name. Profile is required and must be non-empty; None/empty
+    fails closed. Cross-profile sidecars and unverified core sources are
+    blocked, never compared.
+    """
+    profile = _validate_profile(profile)
+    inv_result = _inventory_sidecars(session_dir, profile)
+    sidecar_unreadable = False
+    if len(inv_result) == 4:
+        sidecars, inv_blocked, inv_blocked_ids, sidecar_unreadable = inv_result
+    elif len(inv_result) == 3:
+        sidecars, inv_blocked, inv_blocked_ids = inv_result
+        sidecar_unreadable = False
+    else:
+        sidecars, inv_blocked = inv_result
+        inv_blocked_ids = set()
+        sidecar_unreadable = False
+    if sidecar_unreadable:
+        blocked_unreadable_sidecar = 1
+    else:
+        blocked_unreadable_sidecar = 0
+    db_path = Path(db_path)
+    db_exists = db_path.exists()
+    core_all: dict[str, dict] = {}
+    blocked_unreadable = 0
+    blocked_ambiguous_schema = 0
+    invalid_core_blocked = 0
+    core_had_error = False
+    if not db_exists:
+        blocked_unreadable = len(sidecars) + sum(inv_blocked.values()) if (sidecars or any(inv_blocked.values())) else 1
+    else:
+        inv_core = _inventory_core_all(db_path)
+        malformed_core_parent_anchors: set[str] = set()
+        if isinstance(inv_core, tuple) and len(inv_core) == 4:
+            core_all, core_had_error, invalid_core_blocked, malformed_core_parent_anchors = inv_core
+        elif isinstance(inv_core, tuple) and len(inv_core) == 3:
+            core_all, core_had_error, invalid_core_blocked = inv_core
+        elif isinstance(inv_core, tuple) and len(inv_core) == 2:
+            core_all, core_had_error = inv_core
+        else:
+            core_all = inv_core if isinstance(inv_core, dict) else {}
+        if core_had_error:
+            blocked_unreadable = len(sidecars) + sum(inv_blocked.values()) + invalid_core_blocked if (sidecars or any(inv_blocked.values()) or invalid_core_blocked) else 1
+        try:
+            with closing(open_state_db_readonly(db_path)) as conn:
+                cur = conn.cursor()
+                cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+                if cur.fetchone() is None:
+                    if not core_had_error:
+                        blocked_unreadable = len(sidecars) + sum(inv_blocked.values()) + invalid_core_blocked if (sidecars or any(inv_blocked.values()) or invalid_core_blocked) else 1
+                else:
+                    cur.execute("PRAGMA table_info(sessions)")
+                    cols = {row[1] for row in cur.fetchall()}
+                    if "id" not in cols:
+                        if not core_had_error:
+                            blocked_ambiguous_schema = len(sidecars) + sum(inv_blocked.values()) + invalid_core_blocked if (sidecars or any(inv_blocked.values()) or invalid_core_blocked) else 1
+        except Exception:
+            if not core_had_error:
+                blocked_unreadable = len(sidecars) + sum(inv_blocked.values()) + invalid_core_blocked if (sidecars or any(inv_blocked.values()) or invalid_core_blocked) else 1
+
+    inv_blocked_total = sum(inv_blocked.values()) + invalid_core_blocked
+
+    # Filter foreign/untrusted core-only rows outside the eligible comparison
+    # domain before lineage construction: a core row with no matching sidecar
+    # and an unverified provenance is not an eligible lineage and must not
+    # inflate totals or blocked counts. A matching unverified row is retained
+    # and blocks fail-closed at the lineage loop below. Rejected/malformed
+    # sidecar identities (inv_blocked_ids) are retained as blocked anchors so a
+    # trusted core row with the same id is not misclassified as core_only.
+    blocked_anchor_ids = set(inv_blocked_ids) | set(malformed_core_parent_anchors if 'malformed_core_parent_anchors' in locals() else set())
+    core_eligible = {
+        sid: row
+        for sid, row in core_all.items()
+        if bool(row.get("trusted")) or sid in sidecars or sid in blocked_anchor_ids
+    }
+    rows_by_id = _rows_for_canonical_continuation(sidecars, core_eligible)
+    _audit_blocked: set[str] = set()
+    for _sid, _row in list(rows_by_id.items()):
+        _pid = _row.get("parent_session_id")
+        if not isinstance(_pid, str) or not _pid.strip():
+            continue
+        _parent = rows_by_id.get(_pid)
+        if not _parent:
+            continue
+        try:
+            if _canonical_is_continuation(_parent, _row) and _parent.get("ended_at") is None:
+                _audit_blocked.add(_sid)
+                _audit_blocked.add(str(_pid))
+        except Exception:
+            # The canonical predicate should receive normalized rows, but an
+            # unexpected malformed value must block rather than split into a
+            # clean comparison bucket.
+            _audit_blocked.add(_sid)
+            _audit_blocked.add(str(_pid))
+    try:
+        _state: dict[str, int] = {}
+        _cycles: list[list[str]] = []
+        for _start in list(rows_by_id.keys()):
+            if _state.get(_start, 0) != 0:
+                continue
+            _stack: list[str] = []
+            _pos: dict[str, int] = {}
+            _cur: str | None = _start
+            while _cur is not None:
+                _st = _state.get(_cur, 0)
+                if _st == 1:
+                    _idx = _pos.get(_cur, 0)
+                    _cycle = _stack[_idx:]
+                    if _cycle:
+                        _cycles.append(list(_cycle))
+                    break
+                if _st == 2:
+                    break
+                _state[_cur] = 1
+                _pos[_cur] = len(_stack)
+                _stack.append(_cur)
+                _row_cur = rows_by_id.get(_cur)
+                _pid_cur = _row_cur.get("parent_session_id") if _row_cur else None
+                _parent_cur = rows_by_id.get(_pid_cur) if isinstance(_pid_cur, str) and _pid_cur.strip() else None
+                _is_cont = False
+                try:
+                    _is_cont = bool(_parent_cur and _canonical_is_continuation(_parent_cur, _row_cur))
+                except Exception:
+                    # Fail closed if a hostile row reaches the canonical
+                    # predicate: both ends of the observed relationship are
+                    # ambiguous audit anchors.
+                    _audit_blocked.add(_cur)
+                    if isinstance(_pid_cur, str):
+                        _audit_blocked.add(_pid_cur)
+                    break
+                if not _is_cont:
+                    break
+                _cur = str(_pid_cur) if isinstance(_pid_cur, str) else None
+                if len(_stack) > len(rows_by_id) + 5:
+                    break
+            for _n in _stack:
+                _state[_n] = 2
+        for _c in _cycles:
+            if not _c:
+                continue
+            _audit_blocked.update(_c)
+    except Exception:
+        # A traversal failure cannot be allowed to downgrade malformed
+        # ancestry into a normal aggregate bucket.
+        _audit_blocked.update(rows_by_id)
+    blocked_anchor_ids = blocked_anchor_ids | _audit_blocked
+    # Build deterministic total order for representatives: (started_at,
+    # continuation depth, stable id tie-break) derived from canonical
+    # rows_by_id facts. Depth is continuation distance from root.
+    def _started_float_for_rank(sid: str) -> float:
+        try:
+            return float((rows_by_id.get(sid) or {}).get("started_at") or 0)
+        except Exception:
+            return 0.0
+
+    def _continuation_depth(sid: str) -> int:
+        depth = 0
+        cur = sid
+        seen = {cur}
+        for _ in range(len(rows_by_id) + 5):
+            row = rows_by_id.get(cur)
+            parent_id = row.get("parent_session_id") if row else None
+            parent = rows_by_id.get(parent_id) if parent_id else None
+            if not parent or not _canonical_is_continuation(parent, row):
+                break
+            if parent_id in seen:
+                break
+            depth += 1
+            cur = str(parent_id)
+            seen.add(cur)
+        return depth
+
+    def _rep_key(sid: str) -> tuple:
+        return (_started_float_for_rank(sid), _continuation_depth(sid), str(sid))
+
+    # Blocked anchors participate in lineage grouping so an exact-ID trusted
+    # core row is grouped with its rejected sidecar and blocked, not counted as
+    # core_only. Anchors never contribute sidecar facts to mismatch counts.
+    # Also propagate blocked ancestry: any valid descendant reached by exact raw
+    # parent references from a blocked anchor must also be blocked, even where
+    # canonical continuation cannot link through the malformed parent.
+    # Union of all valid exact parent_session_id references from both sidecar
+    # and core evidence for each candidate (admission precheck, not canonical
+    # continuation semantics).
+    blocked_expanded: set[str] = set(blocked_anchor_ids)
+    all_candidate_parents: dict[str, set[str]] = defaultdict(set)
+    for sid in set(sidecars.keys()) | set(core_eligible.keys()):
+        if sid in sidecars:
+            p = sidecars[sid].get("parent_session_id")
+            if isinstance(p, str) and p.strip():
+                all_candidate_parents[sid].add(p)
+        if sid in core_eligible:
+            p2 = core_eligible[sid].get("parent_session_id")
+            if isinstance(p2, str) and p2.strip():
+                all_candidate_parents[sid].add(p2)
+    changed = True
+    while changed:
+        changed = False
+        for sid, parents in list(all_candidate_parents.items()):
+            if sid in blocked_expanded:
+                continue
+            if any(pr in blocked_expanded for pr in parents):
+                blocked_expanded.add(sid)
+                changed = True
+    all_ids = set(sidecars.keys()) | set(core_eligible.keys()) | blocked_expanded
+    # Ensure blocked anchors have rows_by_id entries for canonical root calc.
+    for bid in blocked_expanded:
+        if bid not in rows_by_id:
+            rows_by_id[bid] = {
+                "id": bid,
+                "parent_session_id": None,
+                "started_at": 0,
+                "ended_at": None,
+                "end_reason": None,
+                "source": None,
+                "session_source": None,
+            }
+    lineage_roots: dict[str, set[str]] = defaultdict(set)
+    for sid in all_ids:
+        root = _canonical_continuation_root(rows_by_id, sid)
+        lineage_roots[root].add(sid)
+
+    total_lineages = len(lineage_roots)
+    matched = 0
+    pinned_jt_cf = 0
+    pinned_jf_ct = 0
+    pinned_conflict = 0
+    archived_jt_cf = 0
+    archived_jf_ct = 0
+    archived_conflict = 0
+    sidecar_only_empty = 0
+    sidecar_only_msgful = 0
+    core_only = 0
+    blocked_active = 0
+    blocked_ambiguous = inv_blocked_total
+
+    effective_unreadable = blocked_unreadable or blocked_unreadable_sidecar
+    if sidecar_unreadable:
+        return {
+            "profile": profile,
+            "total_lineages": 0,
+            "total_sidecar_lineages": 0,
+            "total_core_lineages": 0,
+            "matched": 0,
+            "pinned_mismatch": {"json_true_core_false": 0, "json_false_core_true": 0, "conflict": 0},
+            "archived_mismatch": {"json_true_core_false": 0, "json_false_core_true": 0, "conflict": 0},
+            "sidecar_only": {"empty": 0, "messageful": 0},
+            "core_only": 0,
+            "blocked": {"active": 0, "unreadable": 1, "ambiguous": 0},
+        }
+    if blocked_unreadable or blocked_ambiguous_schema or core_had_error:
+        return {
+            "profile": profile,
+            "total_lineages": total_lineages if total_lineages else (len(sidecars) + inv_blocked_total if (sidecars or inv_blocked_total) else 1),
+            "total_sidecar_lineages": len({_canonical_continuation_root(rows_by_id, sid) for sid in sidecars.keys()}) if sidecars else 0,
+            "total_core_lineages": len({_canonical_continuation_root(rows_by_id, sid) for sid in core_eligible.keys()}) if core_eligible else 0,
+            "matched": 0,
+            "pinned_mismatch": {"json_true_core_false": 0, "json_false_core_true": 0, "conflict": 0},
+            "archived_mismatch": {"json_true_core_false": 0, "json_false_core_true": 0, "conflict": 0},
+            "sidecar_only": {"empty": 0, "messageful": 0},
+            "core_only": 0,
+            "blocked": {"active": 0, "unreadable": blocked_unreadable, "ambiguous": (blocked_ambiguous_schema or blocked_ambiguous) + (0 if blocked_unreadable else 0)},
+        }
+
+    for _root, members in lineage_roots.items():
+        # Any lineage touching a blocked anchor (malformed sidecar id) is
+        # blocked fail-closed, even if a trusted core row shares that id.
+        if any(mid in blocked_expanded for mid in members):
+            blocked_ambiguous += 1
+            continue
+        side_members = [m for m in members if m in sidecars]
+        core_members = [m for m in members if m in core_eligible]
+        # Tri-state pending: ambiguous -> blocked ambiguous, active -> blocked active
+        has_ambiguous_pending = any(sidecars[mid].get("is_active") is None for mid in side_members)
+        if has_ambiguous_pending:
+            blocked_ambiguous += 1
+            continue
+        is_active = any(sidecars[mid].get("is_active") is True for mid in side_members)
+        if is_active:
+            blocked_active += 1
+            continue
+        has_side = bool(side_members)
+        has_core = bool(core_members)
+        has_trusted_core = any(core_eligible[mid].get("trusted") for mid in core_members)
+        has_untrusted_core = any(not core_eligible[mid].get("trusted") for mid in core_members)
+        if has_untrusted_core:
+            blocked_ambiguous += 1
+            continue
+        has_unknown_lifecycle = False
+        for _mid in side_members:
+            if sidecars[_mid].get("pinned") is None or sidecars[_mid].get("archived") is None:
+                has_unknown_lifecycle = True
+                break
+        if not has_unknown_lifecycle:
+            for _mid in core_members:
+                if core_eligible[_mid].get("trusted") and (core_eligible[_mid].get("pinned") is None or core_eligible[_mid].get("archived") is None):
+                    has_unknown_lifecycle = True
+                    break
+        if has_unknown_lifecycle:
+            blocked_ambiguous += 1
+            continue
+        if has_side and not has_core:
+            max_msgs = max(sidecars[mid].get("message_count", 0) for mid in side_members)
+            if max_msgs == 0:
+                sidecar_only_empty += 1
+            else:
+                sidecar_only_msgful += 1
+            continue
+        if has_core and not has_side:
+            if not has_trusted_core:
+                blocked_ambiguous += 1
+                continue
+            core_only += 1
+            continue
+        if has_side and has_core and not has_trusted_core:
+            blocked_ambiguous += 1
+            continue
+        rep_side_id = max(side_members, key=_rep_key)
+        rep_core_id = max(core_members, key=_rep_key)
+        side_pinned = sidecars[rep_side_id].get("pinned")
+        side_archived = sidecars[rep_side_id].get("archived")
+        core_pinned = core_eligible[rep_core_id].get("pinned")
+        core_archived = core_eligible[rep_core_id].get("archived")
+        if core_pinned is None or core_archived is None or side_pinned is None or side_archived is None:
+            blocked_ambiguous += 1
+            continue
+        pinned_match = side_pinned == core_pinned
+        archived_match = side_archived == core_archived
+        if pinned_match and archived_match:
+            matched += 1
+        else:
+            if not pinned_match:
+                if side_pinned and not core_pinned:
+                    pinned_jt_cf += 1
+                elif not side_pinned and core_pinned:
+                    pinned_jf_ct += 1
+            if not archived_match:
+                if side_archived and not core_archived:
+                    archived_jt_cf += 1
+                elif not side_archived and core_archived:
+                    archived_jf_ct += 1
+            if not pinned_match and not archived_match:
+                pinned_conflict += 1
+                archived_conflict += 1
+
+    return {
+        "profile": profile,
+        "total_lineages": total_lineages,
+        "total_sidecar_lineages": len({_canonical_continuation_root(rows_by_id, sid) for sid in sidecars.keys()}) if sidecars else 0,
+        "total_core_lineages": len({_canonical_continuation_root(rows_by_id, sid) for sid in core_eligible.keys()}) if core_eligible else 0,
+        "matched": matched,
+        "pinned_mismatch": {"json_true_core_false": pinned_jt_cf, "json_false_core_true": pinned_jf_ct, "conflict": pinned_conflict},
+        "archived_mismatch": {"json_true_core_false": archived_jt_cf, "json_false_core_true": archived_jf_ct, "conflict": archived_conflict},
+        "sidecar_only": {"empty": sidecar_only_empty, "messageful": sidecar_only_msgful},
+        "core_only": core_only,
+        "blocked": {"active": blocked_active, "unreadable": blocked_unreadable, "ambiguous": blocked_ambiguous},
+    }
+
+
+def shadow_compare(session_dir: Path, db_path: Path, profile) -> dict:
+    """Explicit/offline alias for the dormant shadow comparison (offline-only).
+
+    Aggregate-only, read-only helper that delegates to
+    compute_aggregate_diagnostics. It is not wired to any runtime path
+    (no sidebar, API, watcher, or stream integration) and has no
+    runtime caller in this slice; it exists solely for explicit offline
+    use via tests and scripts/audit_session_metadata_sync.py.
+    """
+    return compute_aggregate_diagnostics(session_dir, db_path, profile)

--- a/docs/architecture/unified-session-db.md
+++ b/docs/architecture/unified-session-db.md
@@ -1,4 +1,68 @@
-# Unified SessionDB Adapter Spike
+# Unified SessionDB — Scope, Source of Truth, and Issue #498 Shadow Slice
+
+Maintainer response: https://github.com/nesquena/hermes-webui/issues/498#issuecomment-5385677557
+
+## Accepted scope of this PR (#498 shadow slice)
+
+This PR is the dormant, disabled-by-default first slice for unified `state.db`
+lifecycle metadata. It adds a pure, aggregate-only, read-only shadow comparison
+path plus an offline aggregate audit. It does not change runtime behavior,
+ordering, filtering, caching, events, or streaming.
+
+## Full source of truth split (current rule for this slice)
+
+In this slice the JSON sidecar is the comparison input/local existing representation — it is
+not an authority that overrides `state.db` for lifecycle where a row is matched and provenance-
+verified. For matched provenance-verified core-backed rows, `state.db` is authoritative for its
+lifecycle fields (`pinned`/`archived`). Transcripts and WebUI-only metadata remain JSON-owned.
+There is one unambiguous rule, not a dual-authority merge.
+
+| Field / concern | Current authoritative owner in this slice | Notes |
+|---|---|---|
+| `messages`, `tool_calls`, `message_count` | WebUI JSON sidecar | Transcript authority stays with sidecars in this slice. |
+| `title`, `workspace`, `profile`, `project_id`, `model`, token/cost, `pending_*`, `active_stream_id`, `worktree_*`, `composer_draft`, `anchor_activity_scenes` | WebUI JSON sidecar | Display/metadata authority. Only `pinned`/`archived` are compared in this slice; other sidecar fields are not diagnosed. |
+| `pinned`, `archived` (lifecycle) — comparison input | WebUI JSON sidecar (input/existing representation) | Read via established read-only sidecar prefix path; tri-state (absent vs explicit false vs explicit true). This is the local view being compared, not an override authority for matched rows. |
+| `pinned`, `archived` — lifecycle authority (matched, provenance-verified only) | `state.db` `sessions` table | Read via `open_state_db_readonly` URI; tri-state via column presence + NULL vs explicit 0/1. Authoritative for matched, provenance-verified core-backed rows (`source`/`session_source` classified as WebUI via `normalize_agent_session_source`). Foreign/unknown core-only rows are outside the eligible comparison domain and contribute to no totals; a matched pair with an unverified source is `blocked` (fail-closed). |
+| `parent_session_id`, `ended_at`, `end_reason`, `source`/`session_source` lineage facts | `state.db` `sessions` table | Consumed only through the repository's canonical continuation predicate `api.agent_sessions._is_continuation_session` (requires `ended_at` + `end_reason` in {compression, cli_close}, exact source match, `session_source == 'fork'` exclusion; `started_at` is never used as an end boundary). `state.db` is authoritative for `parent_session_id` wherever a core row exists; a sidecar `parent_session_id` establishes lineage only for sidecar-only candidates and never overwrites a core candidate's canonical parent. The union of exact parent references is used solely for blocked-anchor descendant propagation. |
+
+Identity handling (exact raw strings only):
+
+- `session_id` (sidecar filename stem, payload `session_id`, core `id`), `profile`, and `parent_session_id` are compared as raw exact strings after only validating `isinstance(x, str)` and non-empty/non-whitespace. Non-strings are malformed/blocked; whitespace-only is malformed. No `.strip()` normalization into an admitted/comparison identity and no `str(...)` coercion of non-strings. Trailing/leading spaces remain distinct values and never alias their unpadded counterpart. Ordinary categorical normalization of `source`/`session_source` is outside this requirement.
+
+Lifecycle tri-state encodings (applies to both the comparison input and the SQLite reader):
+
+- Permitted: actual `bool`, exact integer `0`/`1`, exact float `0.0`/`1.0` → `False`/`True`.
+- Blocked (unknown/`None`, fail-closed): every string — including `"true"`, `"false"`, `""`, whitespace, `yes`/`no`/`on`/`off`, arbitrary strings — plus objects, arrays, `null`, and any non-`0`/`1` numeric value (`2`, `-1`, `2.5`, …). No generic truthiness is used for untrusted lifecycle inputs.
+
+The hypothetical planner that reasons about a unified outcome is pure:
+`archived = json_archived or core_archived`; `pinned = (json_pinned or core_pinned) and not archived`. Inputs are first strict-normalized as above; unknown (`None`) is then treated as `False` for the hypothetical. There is no write-through.
+
+## Explicit default-off, aggregate-only, read-only restriction
+
+- Master gate: `experimental.unified_session_db` defaults to `false`.
+- Mode: `experimental.unified_session_metadata_mode` defaults to `off` (`off | shadow | sync`). Invalid/missing/master-disabled fails closed to current behavior (`off`).
+- `sync` mode does not write in this PR; it is reserved for a future slice.
+- Shadow mode (`unified_session_db: true` + `unified_session_metadata_mode: shadow`) is an intentionally dormant config surface in this remediation: the flag/mode keys remain valid and default-off, but `all_sessions()` performs no automatic comparison, state-db scan, event, cache invalidation, or stream/poll refresh. Diagnostics are available only through the explicit offline entry points `api.session_metadata_sync.compute_aggregate_diagnostics` / `shadow_compare` and `scripts/audit_session_metadata_sync.py` (which fail closed without an explicit non-empty `--profile`). This removes the prior `all_sessions()` hot-path read on the `static/sessions.js:startStreamingPoll()` 30 s poll that violated the no-stream-driven-refresh contract.
+- The offline audit (`scripts/audit_session_metadata_sync.py`) is the only external surface for diagnostics. It requires explicit `--session-dir` and `--state-db` fixture/test paths (fail-closed); it never targets live user state by default. Default output is aggregate-only human-readable text; `--json` emits machine-readable aggregate JSON. Explicit invocations never output IDs, titles, prompts, messages, or transcript text. Its `--help` contains no `--apply`/`--yes`.
+- There is no `apply`/`yes`/`migration`/`repair`/`tombstone`/`delete`/`write-through` command/mode/behavior in this PR (no prohibited execution path; the document mentions migration only to negate it).
+
+## No write/delete/migration in this PR
+
+No UI/API output is added. No sidecar/index/`state.db` writes, lifecycle events, cache invalidation, stream refresh changes, title/transcript sync, migration, repair, tombstone, delete, or write-through behavior exists in this slice. Unknown or ambiguous field/schema/profile/active-state facts are classified as aggregate `blocked` categories (fail closed). In this slice the single current rule is: JSON is the comparison input/local existing representation; for matched provenance-verified core-backed lifecycle rows `state.db` is authoritative for `pinned`/`archived`; transcripts and WebUI-only compatibility state stay JSON-owned; `all_sessions()` runtime behavior is otherwise unchanged.
+
+## Dormant adapter note — superseded/ historical (retained for context)
+
+The historical adapter description below is retained for context and is superseded by the
+current slice's authority rule above. Where it says "JSON sidecar remains authoritative
+for ... archive and pin state," that is the pre-498 general spike framing; the current
+498 shadow slice narrows it: JSON is the comparison input, and for matched
+provenance-verified core-backed rows `state.db` is authoritative for `pinned`/`archived`.
+`api.webui_session_db.WebUIJsonSessionDB` remains dormant; the feature flag above still
+gates any runtime use.
+
+---
+
+# Unified SessionDB Adapter Spike (prior — historical, superseded by § "Full source of truth split (current rule for this slice)")
 
 WebUI currently persists conversations as JSON files under the WebUI session
 directory, while the CLI uses its own session database. The first safe slice of
@@ -71,12 +135,19 @@ test/migration helpers, not runtime persistence replacements.
 6. Make the unified store authoritative in a later release after import,
    archive, pin, profile, project, and recovery semantics match WebUI JSON.
 
-## Authoritative Fields And Open Questions
+## Authoritative Fields And Open Questions — historical spike framing (superseded for lifecycle)
+
+This section is historical spike framing, superseded for lifecycle by the current rule above
+(§ "Full source of truth split (current rule for this slice)"). The historical text said:
 
 The JSON sidecar remains authoritative for `messages`, `tool_calls`, metadata
 display fields, profile/project ownership, archive and pin state, token/cost
 totals, pending stream recovery fields, worktree metadata, and composer draft
 state during this spike.
+
+In the current 498 slice that archival sentence is narrowed: for matched provenance-verified
+core-backed rows, `state.db` lifecycle (`pinned`/`archived`) authority from the current table
+applies; JSON remains authoritative for transcripts and WebUI-only metadata as described there.
 
 Open questions for later slices:
 

--- a/scripts/audit_session_metadata_sync.py
+++ b/scripts/audit_session_metadata_sync.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Offline aggregate audit for lifecycle metadata drift (issue 498 shadow slice).
+
+Aggregate-only, read-only, fail-closed. Never outputs IDs, titles, prompts,
+transcript, or message content. Requires explicit session-dir and
+state-db to avoid touching live user state; help must not mention
+apply/yes flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from api.session_metadata_sync import compute_aggregate_diagnostics
+
+
+def _nonempty_path(value: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise argparse.ArgumentTypeError("must be non-empty and not whitespace-only")
+    return Path(value)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="audit_session_metadata_sync.py",
+        description=(
+            "Aggregate-only, read-only audit for lifecycle drift between "
+            "WebUI JSON sidecars and agent state.db (pinned/archived). "
+            "Emits only aggregate counts and profile names; never IDs, titles, prompts, or transcript. "
+            "Requires explicit --session-dir and --state-db to avoid live state. "
+            "Default output is aggregate-only human-readable text; --json emits machine-readable aggregate JSON."
+        ),
+    )
+    p.add_argument("--session-dir", required=True, type=_nonempty_path, help="Fixture/test session directory (explicit, fail-closed)")
+    p.add_argument("--state-db", required=True, type=_nonempty_path, help="Fixture/test state.db path (explicit, fail-closed)")
+    p.add_argument("--profile", required=True, help="Profile name to scope sidecars (non-empty, fail-closed)")
+    p.add_argument("--json", action="store_true", help="Emit JSON to stdout")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    profile = args.profile
+    if not isinstance(profile, str) or not profile.strip():
+        print("error: --profile is required and must be non-empty", file=sys.stderr)
+        return 2
+    diag = compute_aggregate_diagnostics(args.session_dir, args.state_db, profile)
+    if args.json:
+        json.dump(diag, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        for k in ("profile", "total_lineages", "matched", "sidecar_only", "core_only", "blocked"):
+            sys.stdout.write(f"{k}: {json.dumps(diag.get(k), sort_keys=True)}\n")
+        sys.stdout.write(f"pinned_mismatch: {json.dumps(diag.get('pinned_mismatch'), sort_keys=True)}\n")
+        sys.stdout.write(f"archived_mismatch: {json.dumps(diag.get('archived_mismatch'), sort_keys=True)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue498_session_lifecycle_shadow.py
+++ b/tests/test_issue498_session_lifecycle_shadow.py
@@ -376,8 +376,31 @@ def test_malformed_sidecar_blocks(tmp_path):
     db_path = tmp_path / "state.db"
     _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
     diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
     assert diag["matched"] == 1
-    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["blocked"]["unreadable"] == 0
+    dumped = json.dumps(diag)
+    assert "bad.json" not in dumped
+    assert "good1" not in dumped
+
+
+def test_unanchorable_malformed_sidecar_seeds_once(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / " .json").write_text("{ not json", encoding="utf-8")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [])
+
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+
+    assert diag["total_lineages"] == 0
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["blocked"]["unreadable"] == 0
+    assert " .json" not in json.dumps(diag)
 
 
 def test_id_mismatch_blocks(tmp_path):
@@ -404,8 +427,14 @@ def test_id_mismatch_blocks(tmp_path):
     db_path = tmp_path / "state.db"
     _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
     diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 3
     assert diag["matched"] == 1
-    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["blocked"]["ambiguous"] == 2
+    assert diag["blocked"]["unreadable"] == 0
+    dumped = json.dumps(diag)
+    assert "payload_id" not in dumped
+    assert "file_id" not in dumped
+    assert "good1" not in dumped
 
 
 def test_messages_invalid_blocks(tmp_path):
@@ -1316,7 +1345,7 @@ def test_core_parent_authority_sidecar_cannot_overwrite_none(tmp_path):
     assert child not in dumped
     from api.session_metadata_sync import _inventory_sidecars, _inventory_core_all
 
-    sidecars, _, _, _ = _inventory_sidecars(session_dir, "default")
+    sidecars, _, _, _, _ = _inventory_sidecars(session_dir, "default")
     core_all, _, _, _ = _inventory_core_all(db_path)
     rows = _rows_for_canonical_continuation(sidecars, {k: v for k, v in core_all.items() if v.get("trusted")})
     assert rows[child]["parent_session_id"] is None
@@ -1891,3 +1920,64 @@ def test_audit_blocks_continuation_cycle_deterministically(tmp_path):
     assert diag3["total_core_lineages"] == 1
     assert child_id not in json.dumps(diag3)
     assert secret_child not in json.dumps(diag3)
+
+
+def test_profile_mismatch_counted_once_via_blocked_lineage_exact(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "good1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, "other1", pinned=False, archived=False, profile="other", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
+    assert diag["matched"] == 1
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["blocked"]["unreadable"] == 0
+    dumped = json.dumps(diag)
+    assert "other1" not in dumped
+    assert "good1" not in dumped
+    assert diag["blocked"]["ambiguous"] != 2
+
+
+def test_invalid_core_id_no_lineage_not_double_counted_exact(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "good1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (42, 'webui', 0, 0, 1000.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('good1', 'webui', 0, 0, 1000.0)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 1
+    assert diag["matched"] == 1
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["blocked"]["unreadable"] == 0
+    assert diag["total_core_lineages"] == 1
+    dumped = json.dumps(diag)
+    assert "good1" not in dumped
+    assert "42" not in dumped
+    assert "exception" not in dumped.lower()
+    assert "traceback" not in dumped.lower()
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "good1b", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db2 = tmp_path / "state2.db"
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (?, 'webui', 0, 0, 1000.0)", (sqlite3.Binary(b"blobid"),))
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('good1b', 'webui', 0, 0, 1000.0)")
+    conn2.commit()
+    conn2.close()
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["total_lineages"] == 1
+    assert diag2["blocked"]["ambiguous"] == 1
+    assert "blobid" not in json.dumps(diag2)
+    assert "good1b" not in json.dumps(diag2)

--- a/tests/test_issue498_session_lifecycle_shadow.py
+++ b/tests/test_issue498_session_lifecycle_shadow.py
@@ -1,0 +1,1893 @@
+import json
+import sqlite3
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+import api.config as config
+import api.models as models
+
+
+def _write_sidecar(session_dir: Path, sid: str, **overrides):
+    payload = {
+        "session_id": sid,
+        "title": overrides.get("title", "Test"),
+        "workspace": str(session_dir.parent),
+        "model": "test-model",
+        "created_at": 1000.0,
+        "updated_at": 1000.0,
+        "pinned": False,
+        "archived": False,
+        "profile": "default",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_calls": [],
+    }
+    payload.update(overrides)
+    if "message_count" not in payload and isinstance(payload.get("messages"), list):
+        payload["message_count"] = len(payload["messages"])
+    path = session_dir / f"{sid}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return payload, path
+
+
+def _make_state_db(path: Path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, pinned INTEGER NOT NULL DEFAULT 0, archived INTEGER NOT NULL DEFAULT 0, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT, message_count INTEGER)"
+    )
+    conn.execute("CREATE TABLE IF NOT EXISTS messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    for r in rows:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (id, source, session_source, title, pinned, archived, started_at, ended_at, parent_session_id, end_reason, message_count) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                r["id"],
+                r.get("source", "webui"),
+                r.get("session_source"),
+                r.get("title", "T"),
+                int(bool(r.get("pinned", 0))),
+                int(bool(r.get("archived", 0))),
+                r.get("started_at", 1000.0),
+                r.get("ended_at"),
+                r.get("parent_session_id"),
+                r.get("end_reason"),
+                r.get("message_count", 1),
+            ),
+        )
+        conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (r["id"], "user", "hi", 1000.0))
+    conn.commit()
+    conn.close()
+
+
+def test_config_defaults_shadow_disabled():
+    from api.config import _apply_config_defaults
+
+    cfg = {}
+    _apply_config_defaults(cfg)
+    assert cfg["experimental"]["unified_session_db"] is False
+    assert cfg["experimental"]["unified_session_metadata_mode"] == "off"
+    assert config.is_unified_session_db_enabled(cfg) is False
+    assert config.is_unified_session_metadata_shadow_enabled(cfg) is False
+    assert config.get_unified_session_metadata_mode(cfg) == "off"
+    # also verify explicit isolated mapping via direct dict
+    isolated = {"experimental": {"unified_session_db": False, "unified_session_metadata_mode": "off"}}
+    assert config.is_unified_session_metadata_shadow_enabled(isolated) is False
+
+
+def test_config_shadow_requires_master_flag(monkeypatch):
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": False, "unified_session_metadata_mode": "shadow"}})
+    assert config.is_unified_session_metadata_shadow_enabled() is False
+    assert config.get_unified_session_metadata_mode() == "shadow"
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "shadow"}})
+    assert config.is_unified_session_metadata_shadow_enabled() is True
+
+
+def test_config_invalid_mode_fails_closed(monkeypatch):
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "bogus"}})
+    assert config.get_unified_session_metadata_mode() == "off"
+    assert config.is_unified_session_metadata_shadow_enabled() is False
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": ""}})
+    assert config.get_unified_session_metadata_mode() == "off"
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": None}})
+    assert config.get_unified_session_metadata_mode() == "off"
+
+
+def test_config_sync_does_not_enable_shadow(monkeypatch):
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "sync"}})
+    assert config.get_unified_session_metadata_mode() == "sync"
+    assert config.is_unified_session_metadata_shadow_enabled() is False
+    assert config.is_unified_session_metadata_shadow_enabled({"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "sync"}}) is False
+
+
+def test_config_case_and_whitespace_normalization(monkeypatch):
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": " SHADOW "}})
+    assert config.get_unified_session_metadata_mode() == "shadow"
+    assert config.is_unified_session_metadata_shadow_enabled() is True
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "Sync"}})
+    assert config.get_unified_session_metadata_mode() == "sync"
+
+
+def test_core_lifecycle_preserves_unknown_vs_false_vs_true(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source) VALUES ('sid1','webui')")
+    conn.commit()
+    conn.close()
+    from api.session_metadata_sync import read_core_lifecycle_batch
+
+    result = read_core_lifecycle_batch(db_path, {"sid1"})
+    assert result["sid1"]["pinned"] is None
+    assert result["sid1"]["archived"] is None
+    assert result["sid1"]["exists"] is True
+
+    db_path2 = tmp_path / "state2.db"
+    _make_state_db(db_path2, [{"id": "sid2", "pinned": 0, "archived": 0}])
+    result2 = read_core_lifecycle_batch(db_path2, {"sid2"})
+    assert result2["sid2"]["pinned"] is False
+    assert result2["sid2"]["archived"] is False
+
+    db_path3 = tmp_path / "state3.db"
+    _make_state_db(db_path3, [{"id": "sid3", "pinned": 1, "archived": 1}])
+    result3 = read_core_lifecycle_batch(db_path3, {"sid3"})
+    assert result3["sid3"]["pinned"] is True
+    assert result3["sid3"]["archived"] is True
+
+    result4 = read_core_lifecycle_batch(db_path3, {"missing"})
+    assert result4["missing"]["pinned"] is None
+    assert result4["missing"]["archived"] is None
+    assert result4["missing"]["exists"] is False
+
+
+def test_core_lifecycle_read_is_readonly_no_mutation(tmp_path):
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 1, "archived": 0}])
+    before_mtime = db_path.stat().st_mtime_ns
+    before_size = db_path.stat().st_size
+    from api.session_metadata_sync import read_core_lifecycle_batch
+
+    read_core_lifecycle_batch(db_path, {"sid1"})
+    assert db_path.stat().st_mtime_ns == before_mtime
+    assert db_path.stat().st_size == before_size
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _, p = _write_sidecar(session_dir, "sid1", pinned=True, archived=False)
+    before = p.read_text(encoding="utf-8")
+    before_stat = p.stat()
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert p.read_text(encoding="utf-8") == before
+    assert p.stat().st_mtime_ns == before_stat.st_mtime_ns
+
+
+def test_shadow_mode_does_not_alter_returned_rows(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sidA", pinned=True, archived=False, messages=[{"role": "user", "content": "hi"}], profile="default")
+    _write_sidecar(session_dir, "sidB", pinned=False, archived=True, messages=[{"role": "user", "content": "hi"}], profile="default")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sidA", "pinned": 0, "archived": 0}, {"id": "sidB", "pinned": 1, "archived": 0}])
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": False, "unified_session_metadata_mode": "off"}})
+    rows_off = models.all_sessions()
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "shadow"}})
+    rows_shadow = models.all_sessions()
+    assert sorted(rows_off, key=lambda r: r["session_id"]) == sorted(rows_shadow, key=lambda r: r["session_id"])
+    for r in rows_shadow:
+        if r["session_id"] == "sidA":
+            assert r["pinned"] is True
+            assert r["archived"] is False
+        if r["session_id"] == "sidB":
+            assert r["pinned"] is False
+            assert r["archived"] is True
+
+
+def test_shadow_enabled_does_not_call_comparator_or_scan(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], profile="default")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+    before_mtime = db_path.stat().st_mtime_ns
+    before_size = db_path.stat().st_size
+    idx_path = session_dir / "_index.json"
+    seed_bytes = json.dumps([{"session_id": "sid1", "pinned": False, "archived": False, "message_count": 1}]).encode()
+    idx_path.write_bytes(seed_bytes)
+    seed_mtime = idx_path.stat().st_mtime_ns
+    import api.session_metadata_sync as sms
+
+    called = {"count": 0}
+    orig = sms.compute_aggregate_diagnostics
+
+    def _wrapped(*a, **k):
+        called["count"] += 1
+        return orig(*a, **k)
+
+    monkeypatch.setattr(sms, "compute_aggregate_diagnostics", _wrapped)
+    monkeypatch.setattr(sms, "shadow_compare", _wrapped)
+    monkeypatch.setattr(models, "clear_cli_sessions_cache", lambda: called.__setitem__("clear", True), raising=False)
+    called["clear"] = False
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "shadow"}})
+    rows = models.all_sessions()
+    assert called["count"] == 0
+    assert called["clear"] is False
+    assert db_path.stat().st_mtime_ns == before_mtime
+    assert db_path.stat().st_size == before_size
+    shadow_bytes = idx_path.read_bytes()
+    shadow_mtime = idx_path.stat().st_mtime_ns
+    assert any(r["session_id"] == "sid1" for r in rows)
+    from api.session_metadata_sync import compute_aggregate_diagnostics as direct
+
+    diag = direct(session_dir, db_path, profile="default")
+    assert diag["matched"] == 1
+    # off vs shadow equivalence: shadow must not mutate index beyond normal all_sessions behavior
+    idx_path.write_bytes(seed_bytes)
+    try:
+        import time
+        time.sleep(0.01)
+    except Exception:
+        pass
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": False, "unified_session_metadata_mode": "off"}})
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    rows_off = models.all_sessions()
+    off_bytes = idx_path.read_bytes()
+    off_mtime = idx_path.stat().st_mtime_ns
+    assert shadow_bytes == off_bytes
+    assert shadow_mtime != seed_mtime or off_mtime != seed_mtime or shadow_bytes == seed_bytes
+    assert sorted(rows, key=lambda r: r["session_id"]) == sorted(rows_off, key=lambda r: r["session_id"])
+
+
+def test_profile_isolation(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    dir_default = tmp_path / "default_sessions"
+    dir_other = tmp_path / "other_sessions"
+    dir_default.mkdir()
+    dir_other.mkdir()
+    _write_sidecar(dir_default, "sid_shared", pinned=True, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(dir_other, "sid_shared", pinned=False, archived=False, profile="other", messages=[{"role": "user", "content": "hi"}])
+    db_default = tmp_path / "default.db"
+    db_other = tmp_path / "other.db"
+    _make_state_db(db_default, [{"id": "sid_shared", "pinned": 0, "archived": 0}])
+    _make_state_db(db_other, [{"id": "sid_shared", "pinned": 0, "archived": 0}])
+    diag_default = compute_aggregate_diagnostics(dir_default, db_default, profile="default")
+    assert diag_default["pinned_mismatch"]["json_true_core_false"] == 1
+    diag_other = compute_aggregate_diagnostics(dir_other, db_other, profile="other")
+    assert diag_other["matched"] == 1
+    assert diag_other["pinned_mismatch"]["json_true_core_false"] == 0
+
+
+def test_cross_profile_sidecars_do_not_compare(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid_default", pinned=True, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, "sid_other", pinned=True, archived=False, profile="other", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid_default", "pinned": 0, "archived": 0}, {"id": "sid_other", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 1
+    assert diag["matched"] == 0
+
+
+def test_profile_binding_fail_closed(tmp_path):
+    import pytest
+
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    for bad in [None, "", "   "]:
+        with pytest.raises(ValueError):
+            compute_aggregate_diagnostics(session_dir, db_path, profile=bad)
+
+
+def test_cli_rejects_missing_empty_profile(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    base = [sys.executable, "scripts/audit_session_metadata_sync.py", "--session-dir", str(session_dir), "--state-db", str(db_path)]
+    r1 = subprocess.run(base, capture_output=True, text=True, cwd=str(Path(__file__).parents[1]))
+    assert r1.returncode != 0
+    r2 = subprocess.run(base + ["--profile", ""], capture_output=True, text=True, cwd=str(Path(__file__).parents[1]))
+    assert r2.returncode != 0
+    r3 = subprocess.run(base + ["--profile", "   "], capture_output=True, text=True, cwd=str(Path(__file__).parents[1]))
+    assert r3.returncode != 0
+    r4 = subprocess.run(base + ["--profile", "default", "--json"], capture_output=True, text=True, cwd=str(Path(__file__).parents[1]))
+    assert r4.returncode == 0
+    diag = json.loads(r4.stdout)
+    assert diag["profile"] == "default"
+    dumped = r4.stdout
+    assert "sid1" not in dumped
+
+
+def test_foreign_source_core_rows_excluded_from_core_only(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "coreForeign1", "pinned": 0, "archived": 0, "source": "cron"}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["core_only"] == 0
+    assert diag["blocked"]["ambiguous"] == 0
+    assert diag["total_lineages"] == 0
+    assert diag["total_core_lineages"] == 0
+
+
+def test_foreign_core_only_yields_zero_eligible_counts(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "coreForeignOnly", "pinned": 0, "archived": 0, "source": "cron"}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 0
+    assert diag["total_core_lineages"] == 0
+    assert diag["total_sidecar_lineages"] == 0
+    assert diag["core_only"] == 0
+    assert diag["blocked"]["ambiguous"] == 0
+    assert diag["blocked"]["active"] == 0
+    assert diag["blocked"]["unreadable"] == 0
+    dumped = json.dumps(diag)
+    assert "coreForeignOnly" not in dumped
+
+
+def test_unverified_matching_core_rows_block(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0, "source": "cron"}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+
+
+def test_malformed_sidecar_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "bad.json").write_text("{ not json", encoding="utf-8")
+    _write_sidecar(session_dir, "good1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 1
+    assert diag["blocked"]["ambiguous"] >= 1
+
+
+def test_id_mismatch_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    payload = {
+        "session_id": "payload_id",
+        "title": "Test",
+        "workspace": str(session_dir.parent),
+        "model": "test-model",
+        "created_at": 1000.0,
+        "updated_at": 1000.0,
+        "pinned": False,
+        "archived": False,
+        "profile": "default",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_calls": [],
+        "message_count": 1,
+    }
+    (session_dir / "file_id.json").write_text(json.dumps(payload), encoding="utf-8")
+    _write_sidecar(session_dir, "good1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 1
+    assert diag["blocked"]["ambiguous"] >= 1
+
+
+def test_messages_invalid_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "badMsgs", pinned=False, archived=False, profile="default", messages=None)
+    (session_dir / "badMsgs.json").write_text(json.dumps({"session_id": "badMsgs", "profile": "default", "messages": "not-a-list", "pinned": False, "archived": False, "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    _write_sidecar(session_dir, "good1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "good1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 1
+    assert diag["blocked"]["ambiguous"] >= 1
+
+
+def test_has_pending_user_message_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "pend1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}], has_pending_user_message=True)
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "pend1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["active"] == 1
+    assert diag["matched"] == 0
+
+
+def test_absent_lifecycle_columns_block(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source) VALUES ('sid1','webui')")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["matched"] == 0
+
+
+def test_canonical_root_tip_identity(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root_id = "root11111111"
+    tip_id = "tip22222222"
+    _write_sidecar(session_dir, root_id, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, tip_id, pinned=False, archived=False, parent_session_id=root_id, messages=[{"role": "user", "content": "hi2"}])
+
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, message_count INTEGER)")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, message_count) VALUES (?,?,?,?,?,?,?,?,?)", (root_id, "webui", 1, 0, 1000.0, 1000.5, None, "compression", 1))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, message_count) VALUES (?,?,?,?,?,?,?,?,?)", (tip_id, "webui", 1, 0, 1001.0, None, root_id, None, 1))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (root_id, "user", "hi", 1000.0))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (tip_id, "user", "hi2", 1001.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 1
+    assert diag["pinned_mismatch"]["json_false_core_true"] == 1
+
+
+def test_exact_identity_not_title(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", title="Same Title", pinned=True, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, "sid2", title="Same Title", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}, {"id": "sid2", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 1
+    assert diag["matched"] == 1
+
+
+def test_sidecar_only_empty_vs_messageful(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "empty1", pinned=False, archived=False, messages=[])
+    _write_sidecar(session_dir, "msgful1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["sidecar_only"]["empty"] == 1
+    assert diag["sidecar_only"]["messageful"] == 1
+
+
+def test_core_only_and_blocked_active(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "active1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], active_stream_id="stream123", pending_user_message="hi")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "active1", "pinned": 1, "archived": 0}, {"id": "coreOnly1", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["active"] == 1
+    assert diag["core_only"] == 1
+
+
+def test_aggregate_output_free_of_titles_and_ids(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sidSecret123", title="Secret Prompt Title", pinned=True, archived=False, messages=[{"role": "user", "content": "super secret transcript"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sidSecret123", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    dumped = json.dumps(diag)
+    assert "Secret Prompt Title" not in dumped
+    assert "super secret transcript" not in dumped
+    assert "sidSecret123" not in dumped
+
+
+def test_pure_truth_table():
+    from api.session_metadata_sync import provisional_truth
+
+    assert provisional_truth(False, False, False, False) == {"archived": False, "pinned": False}
+    assert provisional_truth(False, True, False, False) == {"archived": True, "pinned": False}
+    assert provisional_truth(False, False, False, True) == {"archived": True, "pinned": False}
+    assert provisional_truth(True, False, False, False) == {"archived": False, "pinned": True}
+    assert provisional_truth(False, False, True, False) == {"archived": False, "pinned": True}
+    assert provisional_truth(True, False, True, True) == {"archived": True, "pinned": False}
+    assert provisional_truth(True, False, True, False) == {"archived": False, "pinned": True}
+    assert provisional_truth(True, False, None, None) == {"archived": False, "pinned": True}
+    assert provisional_truth(False, False, None, True) == {"archived": True, "pinned": False}
+    assert provisional_truth(True, False, False, True) == {"archived": True, "pinned": False}
+    assert provisional_truth(False, True, True, False) == {"archived": True, "pinned": False}
+
+
+def test_no_apply_flags_in_audit_help():
+    result = subprocess.run([sys.executable, "scripts/audit_session_metadata_sync.py", "--help"], capture_output=True, text=True, cwd=str(Path(__file__).parents[1]))
+    assert result.returncode == 0
+    help_text = result.stdout + result.stderr
+    assert "--apply" not in help_text
+    assert "--yes" not in help_text
+    assert "aggregate" in help_text.lower()
+
+
+def test_blocked_covers_unreadable_ambiguous(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "nope.db"
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["unreadable"] >= 1
+    db_path2 = tmp_path / "bad.db"
+    conn = sqlite3.connect(str(db_path2))
+    conn.execute("CREATE TABLE something_else (id TEXT)")
+    conn.commit()
+    conn.close()
+    diag2 = compute_aggregate_diagnostics(session_dir, db_path2, profile="default")
+    assert diag2["matched"] == 0
+    assert diag2["blocked"]["unreadable"] >= 1
+
+
+def test_no_event_or_cache_invalidation_on_shadow(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+    called = {"clear": False}
+    monkeypatch.setattr(models, "clear_cli_sessions_cache", lambda: called.__setitem__("clear", True), raising=False)
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "shadow"}})
+    before = db_path.stat().st_mtime_ns
+    models.all_sessions()
+    assert called["clear"] is False
+    assert db_path.stat().st_mtime_ns == before
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": True, "unified_session_metadata_mode": "shadow"}})
+    models.all_sessions()
+    assert db_path.stat().st_mtime_ns == before
+
+
+def test_shadow_comparator_is_exercised_and_pure(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, shadow_compare
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    before_db_mtime = db_path.stat().st_mtime_ns
+    before_db_size = db_path.stat().st_size
+    before_sidecar = (session_dir / "sid1.json").read_text(encoding="utf-8")
+    before_sidecar_mtime = (session_dir / "sid1.json").stat().st_mtime_ns
+    idx = session_dir / "_index.json"
+    idx.write_text(json.dumps([{"session_id": "sid1", "pinned": False, "archived": False, "message_count": 1}]), encoding="utf-8")
+    before_idx_bytes = idx.read_bytes()
+    before_idx_mtime = idx.stat().st_mtime_ns
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    via_shadow = shadow_compare(session_dir, db_path, profile="default")
+    assert diag == via_shadow
+    assert diag["matched"] == 1
+    assert (session_dir / "sid1.json").read_text(encoding="utf-8") == before_sidecar
+    assert (session_dir / "sid1.json").stat().st_mtime_ns == before_sidecar_mtime
+    assert db_path.stat().st_mtime_ns == before_db_mtime
+    assert db_path.stat().st_size == before_db_size
+    assert idx.read_bytes() == before_idx_bytes
+    assert idx.stat().st_mtime_ns == before_idx_mtime
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py", "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", "default", "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    assert result.returncode == 0
+    assert (session_dir / "sid1.json").read_text(encoding="utf-8") == before_sidecar
+    assert db_path.stat().st_mtime_ns == before_db_mtime
+
+
+def test_absent_vs_explicit_false_tri_state(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    p1 = session_dir / "sid_absent.json"
+    p1.write_text(json.dumps({"session_id": "sid_absent", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    _write_sidecar(session_dir, "sid_false", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid_absent", "pinned": 0, "archived": 0}, {"id": "sid_false", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["matched"] == 1
+
+
+def test_cli_rejects_blank_and_whitespace_paths_no_cwd_fallback(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    repo_root = Path(__file__).parents[1]
+    script_path = str(repo_root / "scripts" / "audit_session_metadata_sync.py")
+    for blank in ["", "   ", "\t", "\n"]:
+        isolated = tmp_path / f"cwd_{blank.encode('unicode_escape').decode()}"
+        isolated.mkdir(exist_ok=True)
+        r = subprocess.run([sys.executable, script_path, "--session-dir", blank, "--state-db", str(db_path), "--profile", "default"], capture_output=True, text=True, cwd=str(isolated))
+        assert r.returncode == 2, f"blank session-dir {blank!r} should parser-fail with code 2, got {r.returncode}"
+        assert r.stdout == "", f"blank session-dir {blank!r} must have empty stdout"
+        assert "non-empty" in (r.stderr + r.stdout).lower() or "whitespace" in (r.stderr + r.stdout).lower()
+        r2 = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", blank, "--profile", "default"], capture_output=True, text=True, cwd=str(isolated))
+        assert r2.returncode == 2, f"blank state-db {blank!r} should parser-fail with code 2, got {r2.returncode}"
+        assert r2.stdout == "", f"blank state-db {blank!r} must have empty stdout"
+        assert "non-empty" in (r2.stderr + r2.stdout).lower() or "whitespace" in (r2.stderr + r2.stdout).lower()
+        r3 = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", blank], capture_output=True, text=True, cwd=str(isolated))
+        assert r3.returncode == 2, f"blank profile {blank!r} should parser-fail with code 2, got {r3.returncode}"
+        assert r3.stdout == "", f"blank profile {blank!r} must have empty stdout"
+        assert "non-empty" in (r3.stderr + r3.stdout).lower() or "whitespace" in (r3.stderr + r3.stdout).lower() or "profile" in (r3.stderr + r3.stdout).lower()
+    isolated_good = tmp_path / "cwd_good"
+    isolated_good.mkdir(exist_ok=True)
+    good = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", "default", "--json"], capture_output=True, text=True, cwd=str(isolated_good))
+    assert good.returncode == 0
+    parsed = json.loads(good.stdout)
+    assert parsed["profile"] == "default"
+    assert parsed["matched"] == 1
+
+
+def test_hostile_lifecycle_values_block_not_coerced(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, read_core_lifecycle_batch, _tri_state_sidecar_flag
+
+    assert _tri_state_sidecar_flag({"pinned": []}, "pinned") is None
+    assert _tri_state_sidecar_flag({"archived": {}}, "archived") is None
+    assert _tri_state_sidecar_flag({"pinned": "maybe"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": 2}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": 2.5}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": -1}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": True}, "pinned") is True
+    assert _tri_state_sidecar_flag({"pinned": False}, "pinned") is False
+    assert _tri_state_sidecar_flag({"pinned": 1}, "pinned") is True
+    assert _tri_state_sidecar_flag({"pinned": 0}, "pinned") is False
+    assert _tri_state_sidecar_flag({"pinned": 1.0}, "pinned") is True
+    assert _tri_state_sidecar_flag({"pinned": 0.0}, "pinned") is False
+    assert _tri_state_sidecar_flag({"pinned": "true"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "false"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": ""}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "   "}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "yes"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "no"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "on"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "off"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "1"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "0"}, "pinned") is None
+
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived) VALUES ('sidHostile', 'webui', 2, 2)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived) VALUES ('sidNeg', 'webui', -1, 99)")
+    conn.commit()
+    conn.close()
+    result = read_core_lifecycle_batch(db_path, {"sidHostile", "sidNeg"})
+    assert result["sidHostile"]["pinned"] is None
+    assert result["sidHostile"]["archived"] is None
+    assert result["sidNeg"]["pinned"] is None
+    assert result["sidNeg"]["archived"] is None
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "sidHostile.json").write_text(json.dumps({"session_id": "sidHostile", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": [], "archived": {}, "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    (session_dir / "sidNeg.json").write_text(json.dumps({"session_id": "sidNeg", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": 2, "archived": "maybe", "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    db2 = tmp_path / "state2.db"
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidHostile', 'webui', 0, 0, 1000.0)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidNeg', 'webui', 1, 0, 1000.0)")
+    conn2.commit()
+    conn2.close()
+    diag = compute_aggregate_diagnostics(session_dir, db2, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 2
+    assert diag["matched"] == 0
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+    assert diag["pinned_mismatch"]["json_false_core_true"] == 0
+    dumped = json.dumps(diag)
+    assert "sidHostile" not in dumped
+    assert "sidNeg" not in dumped
+
+
+def test_fork_is_not_continuation_groups_separately(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root = "root_fork_test"
+    child = "child_fork_test"
+    _write_sidecar(session_dir, root, pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, child, pinned=False, archived=False, parent_session_id=root, messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (root, "webui", 0, 0, 1000.0, 1000.5, None, "compression", None))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (child, "webui", 0, 0, 1001.0, None, root, None, "fork"))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (root, "user", "hi", 1000.0))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (child, "user", "hi2", 1001.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
+
+
+def test_started_at_not_used_as_end_boundary(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root = "root_boundary"
+    child = "child_boundary"
+    _write_sidecar(session_dir, root, pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, child, pinned=False, archived=False, parent_session_id=root, messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (root, "webui", 0, 0, 1000.0, 2000.0, None, "compression", None))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (child, "webui", 0, 0, 1500.0, None, root, None, None))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (root, "user", "hi", 1000.0))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (child, "user", "hi2", 1500.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
+
+
+def test_string_and_blank_lifecycle_block_not_merge(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, provisional_truth, _tri_state_sidecar_flag
+
+    assert provisional_truth("true", False, False, False) == {"archived": False, "pinned": False}
+    assert provisional_truth(2, False, False, False) == {"archived": False, "pinned": False}
+    assert provisional_truth("", False, False, False) == {"archived": False, "pinned": False}
+    assert provisional_truth("   ", False, False, False) == {"archived": False, "pinned": False}
+    assert provisional_truth("yes", False, False, False) == {"archived": False, "pinned": False}
+    assert _tri_state_sidecar_flag({"pinned": "true"}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": ""}, "pinned") is None
+    assert _tri_state_sidecar_flag({"pinned": "   "}, "pinned") is None
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "sidStrTrue.json").write_text(json.dumps({"session_id": "sidStrTrue", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": "true", "archived": False, "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    (session_dir / "sidBlank.json").write_text(json.dumps({"session_id": "sidBlank", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": "", "archived": "   ", "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidStrTrue', 'webui', 0, 0, 1000.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidBlank', 'webui', 0, 0, 1001.0)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 2
+    assert diag["matched"] == 0
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+    dumped = json.dumps(diag)
+    assert "sidStrTrue" not in dumped
+    assert "sidBlank" not in dumped
+
+
+def test_malformed_same_id_sidecar_blocks_not_core_only(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "same-id.json").write_text("{ not json", encoding="utf-8")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "same-id", "pinned": 0, "archived": 0, "source": "webui"}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["core_only"] == 0
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 1
+    dumped = json.dumps(diag)
+    assert "same-id" not in dumped
+    # Non-dict JSON payload with same id also blocks, not core_only
+    (session_dir / "same-id.json").write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    diag2 = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag2["core_only"] == 0
+    assert diag2["blocked"]["ambiguous"] >= 1
+    assert "same-id" not in json.dumps(diag2)
+
+
+def test_deterministic_lineage_representatives_across_hash_seeds(tmp_path):
+    """Equal started_at must not produce hash-random aggregate buckets."""
+    import os
+    import textwrap
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root = "root_det_seed"
+    child = "child_det_seed"
+    _write_sidecar(session_dir, root, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}], started_at=1000.0, created_at=1000.0)
+    _write_sidecar(session_dir, child, pinned=True, archived=False, parent_session_id=root, messages=[{"role": "user", "content": "hi2"}], started_at=1000.0, created_at=1000.0)
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (root, "webui", 1, 0, 1000.0, 1000.0, None, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child, "webui", 0, 0, 1000.0, None, root, None))
+    conn.commit()
+    conn.close()
+    runner = tmp_path / "runner.py"
+    runner.write_text(textwrap.dedent("""\
+        import json, pathlib, os, sys
+        sys.path.insert(0, os.environ.get("HERMES_TEST_REPO_ROOT", "."))
+        from api.session_metadata_sync import compute_aggregate_diagnostics
+        sd = pathlib.Path(os.environ["HERMES_TEST_SESSION_DIR"])
+        db = pathlib.Path(os.environ["HERMES_TEST_STATE_DB"])
+        d = compute_aggregate_diagnostics(sd, db, profile="default")
+        print(json.dumps(d, sort_keys=True))
+        """), encoding="utf-8")
+    outputs = []
+    base_env = dict(os.environ)
+    base_env["HERMES_TEST_SESSION_DIR"] = str(session_dir)
+    base_env["HERMES_TEST_STATE_DB"] = str(db_path)
+    base_env["HERMES_TEST_REPO_ROOT"] = str(Path(__file__).parents[1])
+    for seed in ("1", "2"):
+        env = dict(base_env)
+        env["PYTHONHASHSEED"] = seed
+        result = subprocess.run([sys.executable, str(runner)], capture_output=True, text=True, cwd=str(Path(__file__).parents[1]), env=env)
+        assert result.returncode == 0, result.stderr
+        outputs.append(result.stdout.strip())
+    assert outputs[0] == outputs[1]
+    diag = json.loads(outputs[0])
+    dumped = outputs[0]
+    assert "root_det_seed" not in dumped
+    assert "child_det_seed" not in dumped
+    assert diag["total_lineages"] == 1
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 1
+
+
+# ---- Required acceptance coverage: defects 1-6 ----
+
+def test_malformed_core_ids_block_aggregate_only(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    # Use no-affinity id column so numeric/BLOB types are preserved (TEXT affinity would coerce 42 to '42')
+    conn.execute("CREATE TABLE sessions (id PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    # invalid ids
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (NULL, 'webui', 0, 0, 1000.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (42, 'webui', 0, 0, 1001.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (?, 'webui', 0, 0, 1002.0)", (sqlite3.Binary(b"blobid"),))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('', 'webui', 0, 0, 1003.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('   ', 'webui', 0, 0, 1004.0)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["core_only"] == 0
+    assert diag["matched"] == 0
+    assert diag["total_lineages"] == 0
+    assert diag["total_core_lineages"] == 0
+    assert diag["blocked"]["ambiguous"] >= 5
+    dumped = json.dumps(diag)
+    assert "42" not in dumped
+    assert "blobid" not in dumped
+    # positive control: valid string trusted core-only
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    db2 = tmp_path / "state2.db"
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('valid-core-1', 'webui', 0, 0, 1000.0)")
+    conn2.commit()
+    conn2.close()
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["core_only"] == 1
+    assert diag2["total_lineages"] == 1
+
+
+def test_mixed_provenance_canonical_lineage_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root = "root_mixed_prov"
+    child = "child_mixed_prov"
+    _write_sidecar(session_dir, root, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, child, pinned=False, archived=False, parent_session_id=root, messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    # parent trusted (source webui), child untrusted via NULL source + cron session_source but still continuation (source mismatch skipped when child source empty)
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (root, "webui", 0, 0, 1000.0, 1000.5, None, "compression", "webui"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", (child, None, 0, 0, 1001.0, None, root, None, "cron"))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 1
+    dumped = json.dumps(diag)
+    assert root not in dumped
+    assert child not in dumped
+
+
+def test_core_inventory_select_failure_is_unreadable(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    import api.session_metadata_sync as sms
+    orig = sms.open_state_db_readonly
+    call_n = {"c": 0}
+    denial_seen = {"v": False}
+
+    class _FakeCursor:
+        def __init__(self, real_cur):
+            self._real = real_cur
+
+        def execute(self, sql, *a, **k):
+            if "FROM sessions s" in sql and "s.id" in sql:
+                denial_seen["v"] = True
+                raise sqlite3.DatabaseError("authorizer denied")
+            return self._real.execute(sql, *a, **k)
+
+        def fetchall(self):
+            return self._real.fetchall()
+
+        def fetchone(self):
+            return self._real.fetchone()
+
+    class _FakeConn:
+        def __init__(self, real_conn, deny: bool):
+            self._real = real_conn
+            self._deny = deny
+            self.row_factory = real_conn.row_factory
+
+        def cursor(self, *a, **k):
+            real_cur = self._real.cursor(*a, **k)
+            if self._deny:
+                return _FakeCursor(real_cur)
+            return real_cur
+
+        def execute(self, sql, *a, **k):
+            if self._deny and "FROM sessions s" in sql and "s.id" in sql:
+                denial_seen["v"] = True
+                raise sqlite3.DatabaseError("authorizer denied")
+            return self._real.execute(sql, *a, **k)
+
+        def close(self):
+            return self._real.close()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a, **k):
+            return self._real.__exit__(*a, **k) if hasattr(self._real, "__exit__") else False
+
+    def _proxied_open(dbp):
+        call_n["c"] += 1
+        real = orig(dbp)
+        deny = call_n["c"] == 1
+        wrapped = _FakeConn(real, deny=deny)
+        orig_close = real.close
+
+        def _close_and_unwrap(*a, **k):
+            try:
+                return orig_close(*a, **k)
+            finally:
+                pass
+
+        wrapped.close = _close_and_unwrap
+        wrapped._real_close = orig_close
+        wrapped._real_conn = real
+        return wrapped
+
+    import contextlib
+
+    def _closing_proxy(conn):
+        if isinstance(conn, _FakeConn):
+            real = conn._real_conn
+            cm = contextlib.closing(real)
+            orig_exit = cm.__exit__
+
+            class _CM:
+                def __enter__(self):
+                    return conn
+
+                def __exit__(self, *a, **k):
+                    try:
+                        return orig_exit(*a, **k)
+                    finally:
+                        pass
+
+            return _CM()
+        return contextlib.closing(conn)
+
+    import unittest.mock as mock
+
+    with mock.patch.object(sms, "open_state_db_readonly", side_effect=_proxied_open):
+        with mock.patch.object(sms, "closing", side_effect=_closing_proxy):
+            diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert denial_seen["v"] is True
+    assert diag["blocked"]["unreadable"] >= 1
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    dumped = json.dumps(diag)
+    assert "sid1" not in dumped
+
+
+def test_malformed_blocked_parent_blocks_child_match(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    parent_id = "parent_malformed_blocked"
+    child_id = "child_of_blocked_parent"
+    # malformed parent (invalid json)
+    (session_dir / f"{parent_id}.json").write_text("{ not json", encoding="utf-8")
+    # valid child pointing to blocked parent
+    _write_sidecar(session_dir, child_id, pinned=False, archived=False, parent_session_id=parent_id, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": child_id, "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 1
+    # fork separation: unrelated valid fork must still be counted separately when not descendant
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "fork_root", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir2, "fork_child", pinned=False, archived=False, parent_session_id="fork_root", messages=[{"role": "user", "content": "hi2"}])
+    db_fork = tmp_path / "state_fork.db"
+    conn = sqlite3.connect(str(db_fork))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", ("fork_root", "webui", 0, 0, 1000.0, 1000.5, None, "compression", None))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason, session_source) VALUES (?,?,?,?,?,?,?,?,?)", ("fork_child", "webui", 0, 0, 1001.0, None, "fork_root", None, "fork"))
+    conn.commit()
+    conn.close()
+    diag_fork = compute_aggregate_diagnostics(session_dir2, db_fork, profile="default")
+    assert diag_fork["total_lineages"] == 2
+
+
+def test_unknown_pending_blocks_known_controls(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, _classify_pending
+
+    assert _classify_pending({"has_pending_user_message": "maybe"}) is None
+    assert _classify_pending({"has_pending_user_message": 2}) is None
+    assert _classify_pending({"has_pending_user_message": []}) is None
+    assert _classify_pending({"active_stream_id": 123}) is None
+    assert _classify_pending({"pending_user_message": ["hi"]}) is None
+    # known inactive
+    assert _classify_pending({"has_pending_user_message": False}) is False
+    assert _classify_pending({"has_pending_user_message": 0}) is False
+    assert _classify_pending({"has_pending_user_message": "false"}) is False
+    assert _classify_pending({}) is False
+    # known active
+    assert _classify_pending({"has_pending_user_message": True}) is True
+    assert _classify_pending({"active_stream_id": "stream123"}) is True
+    assert _classify_pending({"pending_user_message": "hi"}) is True
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid_unknown", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], has_pending_user_message="maybe")
+    _write_sidecar(session_dir, "sid_bad_type", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], active_stream_id=123)
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid_unknown", "pinned": 0, "archived": 0}, {"id": "sid_bad_type", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 2
+    assert diag["blocked"]["active"] == 0
+    assert diag["matched"] == 0
+    dumped = json.dumps(diag)
+    assert "sid_unknown" not in dumped
+    assert "sid_bad_type" not in dumped
+    # active control still blocks as active
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "sid_active", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], has_pending_user_message=True)
+    db2 = tmp_path / "state2.db"
+    _make_state_db(db2, [{"id": "sid_active", "pinned": 0, "archived": 0}])
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["blocked"]["active"] == 1
+    # inactive control allows match
+    session_dir3 = tmp_path / "sessions3"
+    session_dir3.mkdir()
+    _write_sidecar(session_dir3, "sid_inactive", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], has_pending_user_message=False)
+    db3 = tmp_path / "state3.db"
+    _make_state_db(db3, [{"id": "sid_inactive", "pinned": 0, "archived": 0}])
+    diag3 = compute_aggregate_diagnostics(session_dir3, db3, profile="default")
+    assert diag3["matched"] == 1
+
+
+def test_missing_payload_session_id_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    # missing payload session_id
+    (session_dir / "fileOnly.json").write_text(json.dumps({"profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": False, "archived": False, "created_at": 1000.0}), encoding="utf-8")
+    # blank payload
+    (session_dir / "blankPayload.json").write_text(json.dumps({"session_id": "   ", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": False, "archived": False}), encoding="utf-8")
+    # non-string payload
+    (session_dir / "nonString.json").write_text(json.dumps({"session_id": 12345, "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": False, "archived": False}), encoding="utf-8")
+    # mismatched payload (filename vs payload)
+    (session_dir / "mismatch.json").write_text(json.dumps({"session_id": "other_id", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": False, "archived": False}), encoding="utf-8")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "fileOnly", "pinned": 0, "archived": 0}, {"id": "blankPayload", "pinned": 0, "archived": 0}, {"id": "mismatch", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 3
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    dumped = json.dumps(diag)
+    assert "fileOnly" not in dumped.replace("pinned_mismatch", "").replace("archived_mismatch", "")
+    assert "blankPayload" not in dumped
+    assert "nonString" not in dumped
+    assert "other_id" not in dumped
+    assert "mismatch" not in dumped.replace("pinned_mismatch", "").replace("archived_mismatch", "")
+    # valid payload+filename still works
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "validId", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db2 = tmp_path / "state2.db"
+    _make_state_db(db2, [{"id": "validId", "pinned": 0, "archived": 0}])
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["matched"] == 1
+
+
+def test_aggregate_only_no_leak(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sid = "leakTestId999"
+    _write_sidecar(session_dir, sid, title="LeakTitleXYZ", pinned=True, archived=False, messages=[{"role": "user", "content": "leak transcript content"}], pending_user_message="should not leak")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": sid, "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    dumped = json.dumps(diag)
+    for needle in [sid, "LeakTitleXYZ", "leak transcript", "should not leak"]:
+        assert needle not in dumped
+    # also check error/path not leaked via unreadable path
+    diag2 = compute_aggregate_diagnostics(session_dir, tmp_path / "nonexistent.db", profile="default")
+    dumped2 = json.dumps(diag2)
+    assert "nonexistent" not in dumped2
+    assert sid not in dumped2
+
+
+def test_blocked_parent_core_only_reference_blocks_child(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    parent_id = "blocked-parent"
+    child_id = "child"
+    (session_dir / f"{parent_id}.json").write_text("{ not json", encoding="utf-8")
+    _write_sidecar(session_dir, child_id, pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    for rid, parent in [(parent_id, None), (child_id, parent_id)]:
+        conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, parent_session_id) VALUES (?,?,?,?,?,?)", (rid, "webui", 0, 0, 1000.0, parent))
+        conn.execute("INSERT INTO messages VALUES (?,?,?,?)", (rid, "user", "hi", 1000.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["sidecar_only"]["messageful"] == 0
+    assert diag["core_only"] == 0
+    dumped = json.dumps(diag)
+    assert parent_id not in dumped
+    assert child_id not in dumped
+
+
+def test_malformed_sidecar_parent_blocks_candidate(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, _classify_parent_ref
+
+    assert _classify_parent_ref(None) == ("absent", None)
+    assert _classify_parent_ref("  ") == ("malformed", None)
+    assert _classify_parent_ref("") == ("malformed", None)
+    assert _classify_parent_ref([]) == ("malformed", None)
+    assert _classify_parent_ref({}) == ("malformed", None)
+    assert _classify_parent_ref(123) == ("malformed", None)
+    assert _classify_parent_ref("valid-parent") == ("valid", "valid-parent")
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    for sid, parent in [("sid_ws", "   "), ("sid_list", ["x"]), ("sid_dict", {"a": 1})]:
+        _write_sidecar(session_dir, sid, pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}], parent_session_id=parent)
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    for sid in ["sid_ws", "sid_list", "sid_dict"]:
+        conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (?,?,?,?,?)", (sid, "webui", 0, 0, 1000.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 3
+    dumped = json.dumps(diag)
+    for sid in ["sid_ws", "sid_list", "sid_dict"]:
+        assert sid not in dumped
+
+
+def test_malformed_core_parent_blob_and_numeric_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "child_blob", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, "child_num", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    # No-affinity parent column preserves BLOB/numeric; TEXT affinity would coerce int to text
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, parent_session_id, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, parent_session_id) VALUES ('child_blob','webui',0,0,1000.0,?)", (sqlite3.Binary(b"blob-parent"),))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, parent_session_id) VALUES ('child_num','webui',0,0,1001.0,42)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["blocked"]["ambiguous"] >= 2
+    dumped = json.dumps(diag)
+    assert "child_blob" not in dumped
+    assert "child_num" not in dumped
+
+
+def test_core_parent_authority_sidecar_cannot_overwrite_none(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, _rows_for_canonical_continuation
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root = "root_core_auth"
+    child = "child_core_auth"
+    _write_sidecar(session_dir, root, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, child, pinned=False, archived=False, parent_session_id=root, messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (root, "webui", 0, 0, 1000.0, 1000.5, None, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child, "webui", 0, 0, 1001.0, None, None, None))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
+    assert diag["total_core_lineages"] == 2
+    dumped = json.dumps(diag)
+    assert root not in dumped
+    assert child not in dumped
+    from api.session_metadata_sync import _inventory_sidecars, _inventory_core_all
+
+    sidecars, _, _, _ = _inventory_sidecars(session_dir, "default")
+    core_all, _, _, _ = _inventory_core_all(db_path)
+    rows = _rows_for_canonical_continuation(sidecars, {k: v for k, v in core_all.items() if v.get("trusted")})
+    assert rows[child]["parent_session_id"] is None
+
+
+def test_exact_identity_padded_values_do_not_alias(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, _classify_parent_ref, read_core_lifecycle_batch
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('real-id','webui',0,0,1000.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (' padded','webui',0,0,1001.0)")
+    conn.commit()
+    conn.close()
+    payload_padded = {"session_id": " padded", "title": "Test", "workspace": str(session_dir.parent), "model": "test-model", "created_at": 1000.0, "updated_at": 1000.0, "pinned": False, "archived": False, "profile": "default", "messages": [{"role": "user", "content": "hi"}], "tool_calls": [], "message_count": 1}
+    (session_dir / " padded.json").write_text(json.dumps(payload_padded), encoding="utf-8")
+    _write_sidecar(session_dir, "real-id", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 2
+    assert diag["total_lineages"] == 2
+    dumped = json.dumps(diag)
+    assert "real-id" not in dumped
+    assert " padded" not in dumped
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "sid1", pinned=False, archived=False, profile="default", messages=[{"role": "user", "content": "hi"}])
+    (session_dir2 / "sid1.json").write_text(json.dumps({"session_id": "sid1", "profile": " default", "messages": [{"role": "user", "content": "hi"}], "pinned": False, "archived": False, "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    db2 = tmp_path / "state2.db"
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived) VALUES ('sid1','webui',0,0)")
+    conn2.commit()
+    conn2.close()
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["matched"] == 0
+    assert diag2["blocked"]["ambiguous"] >= 1
+    assert "sid1" not in json.dumps(diag2)
+    assert _classify_parent_ref(" root") == ("valid", " root")
+    assert _classify_parent_ref("root") == ("valid", "root")
+    assert _classify_parent_ref(" root")[1] != _classify_parent_ref("root")[1]
+    db3 = tmp_path / "state3.db"
+    conn3 = sqlite3.connect(str(db3))
+    conn3.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn3.execute("INSERT INTO sessions (id, source, pinned, archived) VALUES ('42','webui',0,0)")
+    conn3.execute("INSERT INTO sessions (id, source, pinned, archived) VALUES (' padded2','webui',0,0)")
+    conn3.commit()
+    conn3.close()
+    assert read_core_lifecycle_batch(db3, {42}) == {}
+    assert read_core_lifecycle_batch(db3, {"42"})["42"]["exists"] is True
+    assert read_core_lifecycle_batch(db3, {" padded2"})[" padded2"]["exists"] is True
+    assert read_core_lifecycle_batch(db3, {"padded2"})["padded2"]["exists"] is False
+    assert read_core_lifecycle_batch(db3, {"   "}) == {}
+
+
+def test_exact_identity_filename_payload_core_alias_blocks(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    payload = {
+        "session_id": "file-id",
+        "title": "Test",
+        "workspace": str(session_dir.parent),
+        "model": "test-model",
+        "created_at": 1000.0,
+        "updated_at": 1000.0,
+        "pinned": False,
+        "archived": False,
+        "profile": "default",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_calls": [],
+        "message_count": 1,
+    }
+    (session_dir / " file-id.json").write_text(json.dumps(payload), encoding="utf-8")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "file-id", "pinned": 0, "archived": 0}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["blocked"]["ambiguous"] >= 1
+    dumped = json.dumps(diag)
+    assert "file-id" not in dumped
+    assert " file-id" not in dumped
+
+
+def test_exact_identity_core_id_alias_separate(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "core-id", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (' core-id','webui',0,0,1000.0)")
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["matched"] == 0
+    assert diag["sidecar_only"]["messageful"] == 1
+    assert diag["core_only"] == 1
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["blocked"]["ambiguous"] == 0
+    dumped = json.dumps(diag)
+    assert "core-id" not in dumped
+    assert " core-id" not in dumped
+
+
+def test_exact_identity_parent_alias_canonical_groups_separate(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    root_id = "root"
+    child_id = "child_parent_alias"
+    _write_sidecar(session_dir, root_id, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, child_id, pinned=False, archived=False, parent_session_id=" root", messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (root_id, "webui", 0, 0, 1000.0, 1000.5, None, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child_id, "webui", 0, 0, 1001.0, None, " root", None))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (root_id, "user", "hi", 1000.0))
+    conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (child_id, "user", "hi2", 1001.0))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 2
+    assert diag["total_core_lineages"] == 2
+    assert diag["total_sidecar_lineages"] == 2
+    dumped = json.dumps(diag)
+    assert root_id not in dumped
+    assert child_id not in dumped
+    assert " root" not in dumped
+
+
+def test_valid_roots_and_canonical_continuation_retained(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "root_valid", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir, "child_valid", pinned=False, archived=False, parent_session_id="root_valid", messages=[{"role": "user", "content": "hi2"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", ("root_valid", "webui", 0, 0, 1000.0, 1000.5, None, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, parent_session_id) VALUES (?,?,?,?,?,?)", ("child_valid", "webui", 0, 0, 1001.0, "root_valid"))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["total_lineages"] == 1
+    assert diag["matched"] == 1
+    # valid root without parent (absent parent) also valid
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    _write_sidecar(session_dir2, "solo_root", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db2 = tmp_path / "state2.db"
+    _make_state_db(db2, [{"id": "solo_root", "pinned": 0, "archived": 0}])
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["matched"] == 1
+    # fork remains separate lineage
+    session_dir3 = tmp_path / "sessions3"
+    session_dir3.mkdir()
+    _write_sidecar(session_dir3, "fork_root", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    _write_sidecar(session_dir3, "fork_child", pinned=False, archived=False, parent_session_id="fork_root", messages=[{"role": "user", "content": "hi2"}])
+    db3 = tmp_path / "state3.db"
+    conn3 = sqlite3.connect(str(db3))
+    conn3.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn3.execute("INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?)", ("fork_root", "webui", 0, 0, 1000.0, 1000.5, None, "compression", None))
+    conn3.execute("INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?)", ("fork_child", "webui", 0, 0, 1001.0, None, "fork_root", None, "fork"))
+    conn3.commit()
+    conn3.close()
+    diag3 = compute_aggregate_diagnostics(session_dir3, db3, profile="default")
+    assert diag3["total_lineages"] == 2
+
+
+def test_missing_session_dir_is_unreadable_block(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    missing_dir = tmp_path / "no_such_sessions_xyz"
+    assert not missing_dir.exists()
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "trustedCore1", "pinned": 0, "archived": 0, "source": "webui"}])
+    diag = compute_aggregate_diagnostics(missing_dir, db_path, profile="default")
+    assert diag["blocked"]["unreadable"] >= 1
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    assert diag["total_lineages"] == 0
+    dumped = json.dumps(diag)
+    assert "trustedCore1" not in dumped
+    assert "no_such_sessions_xyz" not in dumped
+    assert missing_dir.name not in dumped
+    # existing empty session dir is not unreadable
+    empty_dir = tmp_path / "empty_sessions"
+    empty_dir.mkdir()
+    diag2 = compute_aggregate_diagnostics(empty_dir, db_path, profile="default")
+    assert diag2["blocked"]["unreadable"] == 0
+
+
+def test_sidecar_read_oserror_is_unreadable(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sid = "sidOSErrorLeakTest999"
+    _write_sidecar(session_dir, sid, pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": sid, "pinned": 0, "archived": 0}])
+    target = session_dir / f"{sid}.json"
+    orig_read_text = Path.read_text
+
+    def _faulting_read(self, *args, **kwargs):
+        if self == target:
+            raise OSError("injected read failure SECRET_TOKEN_OSERROR_XYZ")
+        return orig_read_text(self, *args, **kwargs)
+
+    import unittest.mock as mock
+
+    with mock.patch.object(Path, "read_text", autospec=True, side_effect=_faulting_read):
+        diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["unreadable"] >= 1
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    dumped = json.dumps(diag)
+    assert sid not in dumped
+    assert "SECRET_TOKEN_OSERROR_XYZ" not in dumped
+    assert "injected" not in dumped
+    assert target.name not in dumped
+    # malformed JSON that was successfully read remains ambiguous (not unreadable)
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    (session_dir2 / "bad.json").write_text("{ not json", encoding="utf-8")
+    _write_sidecar(session_dir2, "good1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db2 = tmp_path / "state2.db"
+    _make_state_db(db2, [{"id": "good1", "pinned": 0, "archived": 0}])
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["matched"] == 1
+    assert diag2["blocked"]["ambiguous"] >= 1
+    assert diag2["blocked"]["unreadable"] == 0
+    # existing empty session dir is not unreadable (positive control)
+    empty_dir = tmp_path / "empty_sessions_positive"
+    empty_dir.mkdir()
+    diag3 = compute_aggregate_diagnostics(empty_dir, db_path, profile="default")
+    assert diag3["blocked"]["unreadable"] == 0
+
+
+def test_read_core_lifecycle_batch_select_denied_is_unreadable(tmp_path):
+    from api.session_metadata_sync import read_core_lifecycle_batch
+    import api.session_metadata_sync as sms
+
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "goodPresent", "pinned": 1, "archived": 0}, {"id": "goodAbsent", "pinned": 0, "archived": 0}])
+    conn_check = sqlite3.connect(str(db_path))
+    conn_check.execute("INSERT OR REPLACE INTO sessions (id, source, pinned, archived, started_at) VALUES ('goodPresent','webui',1,0,1000.0)")
+    conn_check.commit()
+    conn_check.close()
+    orig_open = sms.open_state_db_readonly
+    denial_seen = {"v": False}
+
+    def _proxied_open(dbp):
+        real = orig_open(dbp)
+
+        def _auth(action, a1, a2, dbname, trig):
+            if action == sqlite3.SQLITE_READ and a1 == "sessions":
+                denial_seen["v"] = True
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        try:
+            real.set_authorizer(_auth)
+        except Exception:
+            pass
+        return real
+
+    import unittest.mock as mock
+
+    with mock.patch.object(sms, "open_state_db_readonly", side_effect=_proxied_open):
+        result = read_core_lifecycle_batch(db_path, {"goodPresent", "missingRow"})
+    assert denial_seen["v"] is True
+    assert result["goodPresent"]["unreadable"] is True
+    assert result["missingRow"]["unreadable"] is True
+    assert result["goodPresent"]["exists"] is False
+    assert result["missingRow"]["exists"] is False
+    # absent row without denial is not unreadable (positive control)
+    result2 = read_core_lifecycle_batch(db_path, {"missingRow2"})
+    assert result2["missingRow2"]["exists"] is False
+    assert result2["missingRow2"]["unreadable"] is False
+    assert result2["missingRow2"]["pinned"] is None
+    # present row without denial retains values and not unreadable
+    result3 = read_core_lifecycle_batch(db_path, {"goodPresent"})
+    assert result3["goodPresent"]["exists"] is True
+    assert result3["goodPresent"]["pinned"] is True
+    assert result3["goodPresent"]["unreadable"] is False
+
+
+def test_singleton_unknown_lifecycle_blocked_as_ambiguous(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    sid_mal_side = "sidSidecarMalformedABC123"
+    hostile_mal = "maybeHostile123"
+    sd1 = tmp_path / "sd_mal_side"
+    sd1.mkdir()
+    (sd1 / f"{sid_mal_side}.json").write_text(
+        json.dumps(
+            {
+                "session_id": sid_mal_side,
+                "profile": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "pinned": hostile_mal,
+                "archived": False,
+                "created_at": 1000.0,
+                "updated_at": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    db1 = tmp_path / "db_mal_side.db"
+    conn1 = sqlite3.connect(str(db1))
+    conn1.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn1.commit()
+    conn1.close()
+    d1 = compute_aggregate_diagnostics(sd1, db1, profile="default")
+    assert d1["blocked"]["ambiguous"] >= 1
+    assert d1["matched"] == 0
+    assert d1["core_only"] == 0
+    assert d1["sidecar_only"]["empty"] == 0
+    assert d1["sidecar_only"]["messageful"] == 0
+    dumped1 = json.dumps(d1)
+    assert sid_mal_side not in dumped1
+    assert hostile_mal not in dumped1
+
+    sid_inc_side = "sidSidecarIncompleteXYZ789"
+    sd2 = tmp_path / "sd_inc_side"
+    sd2.mkdir()
+    (sd2 / f"{sid_inc_side}.json").write_text(
+        json.dumps(
+            {
+                "session_id": sid_inc_side,
+                "profile": "default",
+                "messages": [{"role": "user", "content": "hi"}],
+                "archived": False,
+                "created_at": 1000.0,
+                "updated_at": 1000.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    db2 = tmp_path / "db_inc_side.db"
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn2.commit()
+    conn2.close()
+    d2 = compute_aggregate_diagnostics(sd2, db2, profile="default")
+    assert d2["blocked"]["ambiguous"] >= 1
+    assert d2["matched"] == 0
+    assert d2["core_only"] == 0
+    assert d2["sidecar_only"]["empty"] == 0
+    assert d2["sidecar_only"]["messageful"] == 0
+    dumped2 = json.dumps(d2)
+    assert sid_inc_side not in dumped2
+
+    sid_mal_core = "sidCoreMalformedDEF456"
+    hostile_core_val = "coreHostileLifecycleTokenQRS456"
+    sd3 = tmp_path / "sd_mal_core"
+    sd3.mkdir()
+    db3 = tmp_path / "db_mal_core.db"
+    conn3 = sqlite3.connect(str(db3))
+    conn3.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn3.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (?,?,?,?,?)", (sid_mal_core, "webui", hostile_core_val, 0, 1000.0))
+    conn3.commit()
+    conn3.close()
+    d3 = compute_aggregate_diagnostics(sd3, db3, profile="default")
+    assert d3["blocked"]["ambiguous"] >= 1
+    assert d3["matched"] == 0
+    assert d3["core_only"] == 0
+    assert d3["sidecar_only"]["empty"] == 0
+    assert d3["sidecar_only"]["messageful"] == 0
+    dumped3 = json.dumps(d3)
+    assert sid_mal_core not in dumped3
+    assert hostile_core_val not in dumped3
+
+    sid_inc_core = "sidCoreIncompleteGHI789"
+    sd4 = tmp_path / "sd_inc_core"
+    sd4.mkdir()
+    db4 = tmp_path / "db_inc_core.db"
+    conn4 = sqlite3.connect(str(db4))
+    conn4.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT)")
+    conn4.execute("INSERT INTO sessions (id, source) VALUES (?,?)", (sid_inc_core, "webui"))
+    conn4.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    conn4.commit()
+    conn4.close()
+    d4 = compute_aggregate_diagnostics(sd4, db4, profile="default")
+    assert d4["blocked"]["ambiguous"] >= 1
+    assert d4["matched"] == 0
+    assert d4["core_only"] == 0
+    assert d4["sidecar_only"]["empty"] == 0
+    assert d4["sidecar_only"]["messageful"] == 0
+    dumped4 = json.dumps(d4)
+    assert sid_inc_core not in dumped4
+
+    sid_inc_core_null = "sidCoreNullJKL012"
+    sd5 = tmp_path / "sd_inc_core_null"
+    sd5.mkdir()
+    db5 = tmp_path / "db_inc_core_null.db"
+    conn5 = sqlite3.connect(str(db5))
+    conn5.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn5.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES (?,?,?,?,?)", (sid_inc_core_null, "webui", None, None, 1000.0))
+    conn5.commit()
+    conn5.close()
+    d5 = compute_aggregate_diagnostics(sd5, db5, profile="default")
+    assert d5["blocked"]["ambiguous"] >= 1
+    assert d5["matched"] == 0
+    assert d5["core_only"] == 0
+    assert d5["sidecar_only"]["empty"] == 0
+    assert d5["sidecar_only"]["messageful"] == 0
+    dumped5 = json.dumps(d5)
+    assert sid_inc_core_null not in dumped5
+
+    sd_ok = tmp_path / "sd_ok_valid"
+    sd_ok.mkdir()
+    _write_sidecar(sd_ok, "sidValidSidecarOnlyOK", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_ok = tmp_path / "db_ok_valid.db"
+    conn_ok = sqlite3.connect(str(db_ok))
+    conn_ok.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER)")
+    conn_ok.commit()
+    conn_ok.close()
+    dok = compute_aggregate_diagnostics(sd_ok, db_ok, profile="default")
+    assert dok["sidecar_only"]["messageful"] == 1
+    assert dok["blocked"]["ambiguous"] == 0
+
+    sd_ok2 = tmp_path / "sd_ok_core"
+    sd_ok2.mkdir()
+    db_ok2 = tmp_path / "db_ok_core.db"
+    conn_ok2 = sqlite3.connect(str(db_ok2))
+    conn_ok2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL)")
+    conn_ok2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidValidCoreOnlyOK','webui',0,0,1000.0)")
+    conn_ok2.commit()
+    conn_ok2.close()
+    dok2 = compute_aggregate_diagnostics(sd_ok2, db_ok2, profile="default")
+    assert dok2["core_only"] == 1
+    assert dok2["blocked"]["ambiguous"] == 0
+
+
+def test_audit_blocks_missing_ended_at_compression_continuation(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    parent_id = "parentMissingEndedAtCompression999"
+    child_id = "childMissingEndedAtCompression999"
+    secret_parent = "SECRET_PARENT_TOKEN_XYZ_1"
+    secret_child = "SECRET_CHILD_TOKEN_XYZ_1"
+    _write_sidecar(session_dir, parent_id, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}], started_at=1000.0, title=secret_parent)
+    _write_sidecar(session_dir, child_id, pinned=False, archived=False, parent_session_id=parent_id, messages=[{"role": "user", "content": "hi2"}], started_at=1001.0, title=secret_child)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (parent_id, "webui", 0, 0, 1000.0, None, None, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child_id, "webui", 0, 0, 1001.0, None, parent_id, None))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+    assert diag["pinned_mismatch"]["json_false_core_true"] == 0
+    assert diag["archived_mismatch"]["json_true_core_false"] == 0
+    assert diag["archived_mismatch"]["json_false_core_true"] == 0
+    dumped = json.dumps(diag)
+    assert parent_id not in dumped
+    assert child_id not in dumped
+    assert secret_parent not in dumped
+    assert secret_child not in dumped
+    # cli_close variant with same missing ended_at semantics
+    session_dir2 = tmp_path / "sessions2"
+    session_dir2.mkdir()
+    db2 = tmp_path / "state2.db"
+    _write_sidecar(session_dir2, parent_id, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}], started_at=1000.0)
+    _write_sidecar(session_dir2, child_id, pinned=False, archived=False, parent_session_id=parent_id, messages=[{"role": "user", "content": "hi2"}], started_at=1001.0)
+    conn2 = sqlite3.connect(str(db2))
+    conn2.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (parent_id, "webui", 0, 0, 1000.0, None, None, "cli_close"))
+    conn2.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child_id, "webui", 0, 0, 1001.0, None, parent_id, None))
+    conn2.commit()
+    conn2.close()
+    diag2 = compute_aggregate_diagnostics(session_dir2, db2, profile="default")
+    assert diag2["blocked"]["ambiguous"] >= 1
+    assert diag2["matched"] == 0
+    assert parent_id not in json.dumps(diag2)
+    # positive control: valid continuation with real ended_at must still collapse and match
+    session_dir3 = tmp_path / "sessions3"
+    session_dir3.mkdir()
+    db3 = tmp_path / "state3.db"
+    _write_sidecar(session_dir3, parent_id, pinned=False, archived=False, parent_session_id=None, messages=[{"role": "user", "content": "hi"}], started_at=1000.0)
+    _write_sidecar(session_dir3, child_id, pinned=False, archived=False, parent_session_id=parent_id, messages=[{"role": "user", "content": "hi2"}], started_at=1001.0)
+    conn3 = sqlite3.connect(str(db3))
+    conn3.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn3.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (parent_id, "webui", 0, 0, 1000.0, 1000.5, None, "compression"))
+    conn3.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child_id, "webui", 0, 0, 1001.0, None, parent_id, None))
+    conn3.commit()
+    conn3.close()
+    diag3 = compute_aggregate_diagnostics(session_dir3, db3, profile="default")
+    assert diag3["matched"] == 1
+    assert diag3["blocked"]["ambiguous"] == 0
+    assert diag3["total_lineages"] == 1
+
+
+def test_audit_blocks_continuation_cycle_deterministically(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    db_path = tmp_path / "state.db"
+    id_a = "cycleA999"
+    id_b = "cycleB999"
+    secret_a = "SECRET_CYCLE_A_TOKEN_XYZ"
+    secret_b = "SECRET_CYCLE_B_TOKEN_XYZ"
+    _write_sidecar(session_dir, id_a, pinned=False, archived=False, parent_session_id=id_b, messages=[{"role": "user", "content": "hi"}], started_at=1001.0, title=secret_a)
+    _write_sidecar(session_dir, id_b, pinned=False, archived=False, parent_session_id=id_a, messages=[{"role": "user", "content": "hi2"}], started_at=1001.0, title=secret_b)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (id_a, "webui", 0, 0, 1001.0, 1000.0, id_b, "compression"))
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (id_b, "webui", 0, 0, 1001.0, 1000.0, id_a, "compression"))
+    conn.commit()
+    conn.close()
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 1
+    assert diag["matched"] == 0
+    assert diag["core_only"] == 0
+    assert diag["sidecar_only"]["empty"] == 0
+    assert diag["sidecar_only"]["messageful"] == 0
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+    assert diag["archived_mismatch"]["json_true_core_false"] == 0
+    assert diag["total_lineages"] == 1
+    assert diag["total_sidecar_lineages"] == 1
+    assert diag["total_core_lineages"] == 1
+    assert diag["blocked"]["ambiguous"] == 1
+    dumped = json.dumps(diag)
+    assert id_a not in dumped
+    assert id_b not in dumped
+    assert secret_a not in dumped
+    assert secret_b not in dumped
+    diag2 = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag == diag2
+    # descendant of cycle must also be blocked and not form clean lineage
+    child_id = "cycleChild999"
+    secret_child = "SECRET_CYCLE_CHILD_XYZ"
+    _write_sidecar(session_dir, child_id, pinned=False, archived=False, parent_session_id=id_a, messages=[{"role": "user", "content": "hi3"}], started_at=1002.0, title=secret_child)
+    conn2 = sqlite3.connect(str(db_path))
+    conn2.execute("INSERT OR REPLACE INTO sessions (id, source, pinned, archived, started_at, ended_at, parent_session_id, end_reason) VALUES (?,?,?,?,?,?,?,?)", (child_id, "webui", 0, 0, 1002.0, None, id_a, None))
+    conn2.commit()
+    conn2.close()
+    diag3 = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag3["blocked"]["ambiguous"] >= 1
+    assert diag3["matched"] == 0
+    assert diag3["core_only"] == 0
+    assert diag3["sidecar_only"]["messageful"] == 0
+    assert diag3["total_lineages"] == 1
+    assert diag3["total_sidecar_lineages"] == 1
+    assert diag3["total_core_lineages"] == 1
+    assert child_id not in json.dumps(diag3)
+    assert secret_child not in json.dumps(diag3)

--- a/tests/test_session_metadata_sync_audit.py
+++ b/tests/test_session_metadata_sync_audit.py
@@ -1,0 +1,259 @@
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_sidecar(session_dir: Path, sid: str, **overrides):
+    payload = {
+        "session_id": sid,
+        "title": overrides.get("title", "Audit Test"),
+        "workspace": str(session_dir.parent),
+        "model": "test-model",
+        "created_at": 1000.0,
+        "updated_at": 1000.0,
+        "pinned": False,
+        "archived": False,
+        "profile": "default",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_calls": [],
+    }
+    payload.update(overrides)
+    if "message_count" not in payload and isinstance(payload.get("messages"), list):
+        payload["message_count"] = len(payload["messages"])
+    p = session_dir / f"{sid}.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def _make_state_db(path: Path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, pinned INTEGER NOT NULL DEFAULT 0, archived INTEGER NOT NULL DEFAULT 0, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT, message_count INTEGER)"
+    )
+    conn.execute("CREATE TABLE IF NOT EXISTS messages (session_id TEXT, role TEXT, content TEXT, timestamp REAL)")
+    for r in rows:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (id, source, session_source, title, pinned, archived, started_at, ended_at, parent_session_id, end_reason, message_count) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                r["id"],
+                r.get("source", "webui"),
+                r.get("session_source"),
+                r.get("title", "T"),
+                int(bool(r.get("pinned", 0))),
+                int(bool(r.get("archived", 0))),
+                r.get("started_at", 1000.0),
+                r.get("ended_at"),
+                r.get("parent_session_id"),
+                r.get("end_reason"),
+                r.get("message_count", 1),
+            ),
+        )
+        conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)", (r["id"], "user", "hi", 1000.0))
+    conn.commit()
+    conn.close()
+
+
+def test_audit_cli_emits_json_aggregate_only(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=True, archived=False, title="Secret Title AAA", messages=[{"role": "user", "content": "secret transcript BBB"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py", "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", "default", "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    assert result.returncode == 0
+    diag = json.loads(result.stdout)
+    assert diag["profile"] == "default"
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 1
+    dumped = result.stdout
+    assert "Secret Title AAA" not in dumped
+    assert "secret transcript BBB" not in dumped
+    assert "sid1" not in dumped
+
+
+def test_audit_cli_requires_explicit_paths(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    assert result.returncode == 0
+    assert "--session-dir" in result.stdout
+    assert "--state-db" in result.stdout
+    result2 = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    assert result2.returncode != 0
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    repo_root = Path(__file__).parents[1]
+    script_path = str(repo_root / "scripts" / "audit_session_metadata_sync.py")
+    for blank in ["", "   ", "\t"]:
+        isolated = tmp_path / f"audit_cwd_{blank.encode('unicode_escape').decode()}"
+        isolated.mkdir(exist_ok=True)
+        r1 = subprocess.run([sys.executable, script_path, "--session-dir", blank, "--state-db", str(db_path), "--profile", "default"], capture_output=True, text=True, cwd=str(isolated))
+        assert r1.returncode == 2, f"blank session-dir {blank!r} should parser-fail with code 2"
+        assert r1.stdout == ""
+        assert "non-empty" in (r1.stderr + r1.stdout).lower() or "whitespace" in (r1.stderr + r1.stdout).lower()
+        r2 = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", blank, "--profile", "default"], capture_output=True, text=True, cwd=str(isolated))
+        assert r2.returncode == 2, f"blank state-db {blank!r} should parser-fail with code 2"
+        assert r2.stdout == ""
+        assert "non-empty" in (r2.stderr + r2.stdout).lower() or "whitespace" in (r2.stderr + r2.stdout).lower()
+        r3 = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", blank], capture_output=True, text=True, cwd=str(isolated))
+        assert r3.returncode == 2
+        assert r3.stdout == ""
+    good = subprocess.run([sys.executable, script_path, "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", "default", "--json"], capture_output=True, text=True, cwd=str(repo_root))
+    assert good.returncode == 0
+    assert json.loads(good.stdout)["profile"] == "default"
+
+
+def test_audit_cli_no_apply_terminology():
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py", "--help"],
+        capture_output=True, text=True, cwd=str(Path(__file__).parents[1]),
+    )
+    help_text = (result.stdout + result.stderr).lower()
+    assert "--apply" not in help_text
+    assert "--yes" not in help_text
+    src2 = Path("api/session_metadata_sync.py").read_text(encoding="utf-8").lower()
+    assert "tombstone" not in src2
+    lines = [l for l in src2.splitlines() if "migration" in l or "repair" in l]
+    forbidden = [l for l in lines if "no " not in l and "never" not in l]
+    assert not forbidden, f"unexpected migration/repair code: {forbidden[:3]}"
+
+
+def test_audit_does_not_mutate_files(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    p = _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    before_sidecar_bytes = p.read_bytes()
+    before_sidecar_mtime = p.stat().st_mtime_ns
+    before_db_mtime = db_path.stat().st_mtime_ns
+    before_db_size = db_path.stat().st_size
+    idx = session_dir / "_index.json"
+    idx.write_text(json.dumps([{"session_id": "sid1", "pinned": False, "archived": False, "message_count": 1}]), encoding="utf-8")
+    before_idx_mtime = idx.stat().st_mtime_ns
+    before_idx_bytes = idx.read_bytes()
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert p.read_bytes() == before_sidecar_bytes
+    assert p.stat().st_mtime_ns == before_sidecar_mtime
+    assert db_path.stat().st_mtime_ns == before_db_mtime
+    assert db_path.stat().st_size == before_db_size
+    assert idx.read_bytes() == before_idx_bytes
+    assert idx.stat().st_mtime_ns == before_idx_mtime
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_session_metadata_sync.py", "--session-dir", str(session_dir), "--state-db", str(db_path), "--profile", "default", "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    assert result.returncode == 0
+    assert p.read_bytes() == before_sidecar_bytes
+    assert p.stat().st_mtime_ns == before_sidecar_mtime
+    assert db_path.stat().st_mtime_ns == before_db_mtime
+
+
+def test_minimal_schema_blocked_not_crash(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=False, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source) VALUES ('sid1','webui')")
+    conn.commit()
+    conn.close()
+    from api.session_metadata_sync import compute_aggregate_diagnostics
+
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] == 1
+    assert diag["matched"] == 0
+
+
+def test_truth_table_via_audit_counts(tmp_path):
+    from api.session_metadata_sync import compute_aggregate_diagnostics, provisional_truth
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    for a, b in [(False, False), (True, False), (False, True)]:
+        for c, d in [(False, False), (True, False), (False, True)]:
+            expected = provisional_truth(a, b, c, d)
+            assert expected["archived"] == (b or d)
+            assert expected["pinned"] == ((a or c) and not (b or d))
+    _write_sidecar(session_dir, "sid1", pinned=True, archived=False, messages=[{"role": "user", "content": "hi"}])
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": False, "archived": True}])
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 1
+    assert diag["archived_mismatch"]["json_false_core_true"] == 1
+    assert diag["pinned_mismatch"]["conflict"] == 1
+    assert diag["archived_mismatch"]["conflict"] == 1
+
+
+def test_hostile_lifecycle_audit_blocks(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    # sidecar with hostile values: list/object and non-0/1 number
+    (session_dir / "sidList.json").write_text(json.dumps({"session_id": "sidList", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": [], "archived": "maybe", "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    (session_dir / "sidObj.json").write_text(json.dumps({"session_id": "sidObj", "profile": "default", "messages": [{"role": "user", "content": "hi"}], "pinned": {}, "archived": 2, "created_at": 1000.0, "updated_at": 1000.0}), encoding="utf-8")
+    # core with non-0/1 value (2) must be treated as unknown/blocked, not as True via truthiness
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, pinned INTEGER, archived INTEGER, started_at REAL, ended_at REAL, parent_session_id TEXT, end_reason TEXT, session_source TEXT)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidList', 'webui', 2, 0, 1000.0)")
+    conn.execute("INSERT INTO sessions (id, source, pinned, archived, started_at) VALUES ('sidObj', 'webui', 0, 99, 1001.0)")
+    conn.commit()
+    conn.close()
+    # direct tri-state check: hostile core values are None via read_core_lifecycle_batch
+    from api.session_metadata_sync import read_core_lifecycle_batch, compute_aggregate_diagnostics
+
+    batch = read_core_lifecycle_batch(db_path, {"sidList", "sidObj"})
+    assert batch["sidList"]["pinned"] is None
+    assert batch["sidObj"]["archived"] is None
+    # compute_aggregate_diagnostics must block (fail-closed) with no merge on hostile values
+    diag = compute_aggregate_diagnostics(session_dir, db_path, profile="default")
+    assert diag["blocked"]["ambiguous"] >= 2
+    assert diag["matched"] == 0
+    assert diag["pinned_mismatch"]["json_true_core_false"] == 0
+    assert diag["pinned_mismatch"]["json_false_core_true"] == 0
+    assert diag["archived_mismatch"]["json_true_core_false"] == 0
+    dumped = json.dumps(diag)
+    assert "sidList" not in dumped
+    assert "sidObj" not in dumped
+
+
+def test_config_gate_off_does_not_change_rows(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    _write_sidecar(session_dir, "sid1", pinned=True, archived=False, messages=[{"role": "user", "content": "hi"}], profile="default")
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path, [{"id": "sid1", "pinned": 0, "archived": 0}])
+    import api.config as config
+    import api.models as models
+    from collections import OrderedDict
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(config, "cfg", {"experimental": {"unified_session_db": False, "unified_session_metadata_mode": "off"}})
+    rows = models.all_sessions()
+    assert any(r["session_id"] == "sid1" and r["pinned"] is True for r in rows)


### PR DESCRIPTION
## Contract Routing

Task type: Default-off, read-only, offline lifecycle shadow diagnostics for #498.

Touched areas: configuration gates, the offline comparator and audit CLI, aggregate-only regression coverage, and the lifecycle-authority documentation.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/README.md`
- `docs/rfcs/hermes-run-adapter-contract.md`
- `docs/architecture/unified-session-db.md`

Scope boundaries: no runtime caller, UI, route, event, cache invalidation, stream/poll refresh, migration, write-through, delete/tombstone, lock/revision protocol, or `--apply`/`--yes` path. The state layer mutated by this PR is **none**.

Evidence: this implements the maintainer-approved first slice in #498: https://github.com/nesquena/hermes-webui/issues/498#issuecomment-5385677557

## Contract Change

Previous documentation did not establish one current lifecycle authority for the WebUI/core overlap. This PR records that matched, profile-bound, provenance-verified core rows use `state.db` as the shared authority for `pinned` and `archived`, while WebUI JSON remains authoritative for transcripts and WebUI-local metadata. The implementation is only a disabled-by-default, offline aggregate comparison of that rule; it does not synchronize or mutate existing rows.

## Thinking Path

- Desktop and WebUI lifecycle metadata can drift while transcript and local recovery data must remain client-local.
- The approved safe first step is to measure only aggregate drift, using canonical profile/session/lineage identity rather than title matching.
- This PR therefore admits only strict, provenance-verified facts and blocks malformed, unreadable, active, ambiguous, or incomplete input rather than inferring authority.
- Write synchronization, migration, and deletion remain deliberately deferred.

## What Changed

- Added default-off unified-session metadata configuration gates.
- Added an explicit offline comparator plus `scripts/audit_session_metadata_sync.py`; it accepts explicit paths and profile input and emits aggregate-only diagnostics.
- Added strict raw identity/profile/parent handling, lifecycle tri-state admission, provenance checks, canonical-lineage grouping, and fail-closed unreadable/ambiguous handling.
- Corrected aggregate accounting so identity-bearing rejected sidecars are counted only through their blocked lineage, while rejected evidence with no admissible identity contributes exactly one direct ambiguity block.
- Added documentation for lifecycle authority and the deliberately dormant shadow-read boundary.
- Added regression coverage for aggregate privacy, malformed data, profile isolation, lineage behavior, read-only database access, CLI input rejection, deterministic aggregation, and zero mutation.

## Why It Matters

This provides a measurable, privacy-preserving baseline for resolving lifecycle drift without putting production session data, transcripts, or user-facing behavior at risk. It makes the next write-path discussion evidence-led rather than speculative.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 ./scripts/test.sh tests/test_issue498_session_lifecycle_shadow.py tests/test_session_metadata_sync_audit.py tests/test_webui_session_db_adapter.py tests/test_webui_state_db_reconciliation.py -q --timeout=60 -p no:cacheprovider` — `133 passed`.
- Exact regressions cover a valid matched row plus malformed sidecar, filename/payload ID mismatch, profile mismatch, invalid core IDs, and a malformed whitespace-stem sidecar that has no admissible identity.
- Complete suite under CPython 3.11.15 / pytest 9.1.1, compared against a fresh detached `04be6002` worktree using the same command and flags: zero candidate-only failures. Both trees have the same 15 environment baseline failures (13 atomic-config-write tests and 2 TLS-aware-probe tests); this head adds 3 passing regression tests.
- Ruff passed for both changed Python files. In-memory compilation, `git diff --check`, deterministic four-seed accounting probes, and the audit CLI help boundary passed; help exposes neither `--apply` nor `--yes`.
- Two independent exact-tree review gates passed for the frozen remediation patch: specification, then quality/privacy/test adequacy.

## Risks / Follow-ups

- This is intentionally dormant: it does not update live sidebar ordering, UI state, or lifecycle records.
- The audit CLI is for explicit offline inputs only; it does not target a live state directory by default.
- The existing baseline failures above remain upstream work and are unrelated to this slice.
- Follow-up write synchronization must wait for the accepted helper dependencies named in the maintainer guidance and receive separate migration/delete review.

Release-note wording: Add a default-off offline audit for shared lifecycle metadata drift without changing session behavior or writing state.

## Model Used

AI-assisted: Meta CommandCode (`meta/muse-spark-1.2-contributor`) for implementation; OpenAI `gpt-5.6-terra` and `gpt-5.6-luna` for verification.
