### PR TITLE
fix(api): stop /api/session wedging the server on huge sessions

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -309,6 +309,14 @@ MAX_BODY_BYTES = 20 * 1024 * 1024  # 20MB limit for non-upload POST bodies
 # Firefox reopened a 33MB session; GET /api/session spent ~117s in
 # redact_sensitive_text and even GET / timed out. Above this cap, only the
 # cheap local fallback runs (still catches ghp_/sk-/AKIA/headers/keys).
+#
+# Residual gap above the cap: the fallback is prefix/keyword-based, so the
+# *prefix-less* agent-only shapes are NOT masked in a single field larger than
+# this cap — specifically bare JWTs (eyJ…), Telegram bot tokens
+# (<digits>:<token>), and DB connection-string passwords (postgres://u:pw@host).
+# This is an accepted trade-off (a multi-MB single field is a tool dump, not a
+# credential store); pinned by test_residual_shapes_leak_above_agent_cap so a
+# future reader isn't surprised. Raising the cap trades latency for coverage.
 _REDACT_AGENT_MAX_TEXT_LEN = 16384
 
 def _build_redact_fn():

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -310,13 +310,15 @@ MAX_BODY_BYTES = 20 * 1024 * 1024  # 20MB limit for non-upload POST bodies
 # redact_sensitive_text and even GET / timed out. Above this cap, only the
 # cheap local fallback runs (still catches ghp_/sk-/AKIA/headers/keys).
 #
-# Residual gap above the cap: the fallback is prefix/keyword-based, so the
-# *prefix-less* agent-only shapes are NOT masked in a single field larger than
-# this cap — specifically bare JWTs (eyJ…), Telegram bot tokens
-# (<digits>:<token>), and DB connection-string passwords (postgres://u:pw@host).
-# This is an accepted trade-off (a multi-MB single field is a tool dump, not a
-# credential store); pinned by test_residual_shapes_leak_above_agent_cap so a
-# future reader isn't surprised. Raising the cap trades latency for coverage.
+# The fallback now also masks the three prefix-less agent-only shapes that used
+# to leak above this cap — bare JWTs (eyJ…), DB connection-string passwords
+# (postgres://u:***@host), and Telegram bot tokens (<digits>:<token>) — via the
+# cheap _JWT_RE/_URI_USERINFO_RE/_TELEGRAM_RE passes in _fallback_redact. So a
+# huge single field degrades only in that it skips the *expensive* agent pattern
+# set (Stripe/Slack/Google/… prefixes are still covered by the fallback's own
+# prefix list); the common credential shapes stay masked. Pinned both ways by
+# test_residual_shapes_masked_above_agent_cap. Raising the cap trades latency for
+# the remaining long-tail agent-only patterns.
 _REDACT_AGENT_MAX_TEXT_LEN = 16384
 
 def _build_redact_fn():
@@ -384,6 +386,18 @@ def _build_redact_fn():
         r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----"
     )
 
+    # Prefix-less shapes the agent redactor covers but the prefix/keyword-based
+    # fallback historically did not. Added so the >16KB agent-pass bypass
+    # (see _REDACT_AGENT_MAX_TEXT_LEN) no longer leaks these in a huge single
+    # field — the exact incident class where a multi-MB config dump can carry a
+    # DB URL or JWT. All three are cheap and structure-preserving (they keep the
+    # non-secret context — botid, scheme/user/host — and mask only the secret).
+    _JWT_RE = _re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}")
+    # scheme://user:PASSWORD@host — keep scheme/user/host, mask the password.
+    _URI_USERINFO_RE = _re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://[^/:@\s]+:)([^@/\s]+)(@)")
+    # Telegram bot token <botid>:<token> — keep the numeric botid, mask token.
+    _TELEGRAM_RE = _re.compile(r"(\b\d{5,}:)([A-Za-z0-9_-]{20,})")
+
     def _mask(token: str) -> str:
         return f"{token[:6]}...{token[-4:]}" if len(token) >= 18 else "***"
 
@@ -446,6 +460,10 @@ def _build_redact_fn():
         text = _AUTH_HDR_RE.sub(lambda m: m.group(1) + _mask(m.group(2)), text)
         text = _ENV_RE.sub(_env_replacement, text)
         text = _PRIVKEY_RE.sub("[REDACTED PRIVATE KEY]", text)
+        # Prefix-less agent-only shapes — closes the documented >16KB residual.
+        text = _JWT_RE.sub("[REDACTED JWT]", text)
+        text = _URI_USERINFO_RE.sub(lambda m: m.group(1) + _mask(m.group(2)) + m.group(3), text)
+        text = _TELEGRAM_RE.sub(lambda m: m.group(1) + _mask(m.group(2)), text)
         return text
 
     try:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -304,6 +304,12 @@ MAX_BODY_BYTES = 20 * 1024 * 1024  # 20MB limit for non-upload POST bodies
 
 
 # ── Credential redaction ──────────────────────────────────────────────────────
+# Agent redact (~15 regexes, including Telegram) is catastrophic on megabyte
+# tool dumps and wedges ThreadingHTTPServer behind the GIL. After a VM crash
+# Firefox reopened a 33MB session; GET /api/session spent ~117s in
+# redact_sensitive_text and even GET / timed out. Above this cap, only the
+# cheap local fallback runs (still catches ghp_/sk-/AKIA/headers/keys).
+_REDACT_AGENT_MAX_TEXT_LEN = 16384
 
 def _build_redact_fn():
     """Return a redactor backed by hermes-agent plus local fallback patterns."""
@@ -448,10 +454,16 @@ def _build_redact_fn():
         # HERMES_REDACT_SECRETS opt-in. The local fallback then handles the
         # common short-prefix shapes the agent omits (ghp_, sk-, hf_, AKIA).
         try:
-            agent_redacted = redact_sensitive_text(text, force=True)
+            if len(text) > _REDACT_AGENT_MAX_TEXT_LEN:
+                agent_redacted = text
+            else:
+                agent_redacted = redact_sensitive_text(text, force=True)
         except TypeError:
             # Older hermes-agent builds that predate the force kwarg.
-            agent_redacted = redact_sensitive_text(text)
+            if len(text) > _REDACT_AGENT_MAX_TEXT_LEN:
+                agent_redacted = text
+            else:
+                agent_redacted = redact_sensitive_text(text)
         agent_redacted = _restore_code_env_key_literals(text, agent_redacted)
         return _fallback_redact(agent_redacted)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -8812,6 +8812,12 @@ _LIMITED_TOOL_CONTENT_MAX_CHARS = 4096
 # exceeds the ceiling the response is silently clamped and _messages_truncated
 # is set (the existing truncation signal already covers "more rows exist").
 _MAX_MSG_LIMIT = 500
+# Default visible-row tail when a caller omits ?msg_limit= on a huge sidecar.
+# Matches the frontend's initial window (_INITIAL_MSG_LIMIT = 30). Without this,
+# cancel/restore/refresh hit the bare full-transcript path and serialize a
+# 30MB+ session (this chat: 2ecefb602e66) — redact + json_write wedges the GIL
+# and the rest of :8787 looks crashed. Opt out with ?full=1.
+_DEFAULT_DISPLAY_MSG_LIMIT = 30
 
 
 def _parse_msg_limit(raw):
@@ -8829,6 +8835,20 @@ def _parse_msg_limit(raw):
     except (TypeError, ValueError):
         return None
     return max(1, min(value, _MAX_MSG_LIMIT))
+
+
+def _parse_full_transcript_flag(raw) -> bool:
+    """Return True when the caller explicitly wants the unwindowed transcript."""
+    return str(raw or "").strip() in ("1", "true", "True")
+
+
+def _auto_msg_limit_for_huge_sidecar(session_id, msg_limit, full_transcript: bool):
+    """Bound omitted ?msg_limit= on huge sidecars unless ?full=1 is set."""
+    if msg_limit is not None or full_transcript or not session_id:
+        return msg_limit
+    if _sidecar_file_exceeds_threshold(session_id, _SIDECAR_BYTE_TAIL_THRESHOLD):
+        return _DEFAULT_DISPLAY_MSG_LIMIT
+    return msg_limit
 
 
 # If a sidecar JSON file exceeds this threshold, the display-path tail
@@ -13476,7 +13496,14 @@ def handle_get(handler, parsed) -> bool:
         # case (the client sees there are more rows than returned). Parsing +
         # clamping live in _parse_msg_limit so the expression has direct test
         # coverage; None means the bare no-msg_limit path (full transcript).
-        msg_limit = _parse_msg_limit(query.get("msg_limit", [None])[0])
+        # Huge sidecars without an explicit ?full=1 are forced onto the same
+        # 30-row tail the frontend uses for first paint — otherwise a 30MB
+        # session JSON redact/serialize wedges ThreadingHTTPServer.
+        msg_limit = _auto_msg_limit_for_huge_sidecar(
+            sid,
+            _parse_msg_limit(query.get("msg_limit", [None])[0]),
+            _parse_full_transcript_flag(query.get("full", [None])[0]),
+        )
         # ?msg_before=N — 0-based index into the full message array.
         # Returns messages before this index (for scroll-to-top lazy loading).
         # Combined with msg_limit for paging.

--- a/docs/PRELAUNCH-FIXES.md
+++ b/docs/PRELAUNCH-FIXES.md
@@ -1,0 +1,28 @@
+# hermes-webui (fork) — required fixes
+
+**Path:** `/home/alex/hermes-webui`  
+**Remotes:** `nesquena/hermes-webui` + public fork `Alextechgamer/hermes-webui`  
+**Branch:** `fix/session-endpoint-redact-gil-wedge` (`334eb105` 2026-09-01), clean
+
+**Verdict:** not a money product. Redaction branch is the point. Do not market as Tillpress.
+
+---
+
+## Do not do
+
+- Copy tokens into `~/.claude/.credentials.json`
+- Dump session transcripts with secrets into issues
+- Treat this fork as a launch SKU
+
+---
+
+## High
+
+### H1 — Stay on the redact branch until upstream merge
+HEAD: mask JWT / URI-userinfo / Telegram in the >16KB redact fallback. Public-release readiness = upstream’s, plus this leak fix.
+
+**Fix:** do not mix Tillpress/Batchideo work here. Merge/PR to upstream when you want it public; this audit did not re-pentest.
+
+## Next action
+
+None in the money queue.

--- a/static/commands.js
+++ b/static/commands.js
@@ -965,14 +965,14 @@ async function _runManualCompression(focusTopic){
     // Preflight: verify the viewed session still exists before compressing.
     // This avoids a confusing "not found" toast when the UI is stale.
     try{
-      const live=await api(`/api/session?session_id=${encodeURIComponent(sid)}`);
+      const live=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=30`);
       if(!live||!live.session||live.session.session_id!==sid){
         throw new Error('session no longer available');
       }
       S.session=live.session;
       S.messages=live.session.messages||[];
       S.toolCalls=live.session.tool_calls||[];
-      if(typeof _messagesTruncated!=='undefined') _messagesTruncated=false;
+      if(typeof _messagesTruncated!=='undefined') _messagesTruncated=!!live.session._messages_truncated;
     }catch(preflightErr){
       if(typeof clearCompressionUi==='function') clearCompressionUi();
       if(typeof _setCompressionSessionLock==='function') _setCompressionSessionLock(null);
@@ -1748,11 +1748,11 @@ async function cmdRetry(){
     const r=await api('/api/session/retry',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
+    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid)+'&messages=1&resolve_model=0&msg_limit=30');
     // #5924 SILENT-race guard: a session switch during the GET await must not let
     // this recovery apply session A's intent to whatever session is now visible.
     if(!S.session||S.session.session_id!==activeSid)return;
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!data.session._messages_truncated;renderMessages();}
     $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();
     // Re-arm the single-shot explicit-pick marker from the captured non-default
     // pick — but only if it's still safe at fire time (session unchanged, current
@@ -1770,8 +1770,8 @@ async function cmdUndo(){
     const r=await api('/api/session/undo',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
+    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid)+'&messages=1&resolve_model=0&msg_limit=30');
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!data.session._messages_truncated;renderMessages();}
     showToast(`↩ ${t('undid_n_messages')} ${r.removed_count} ${t('undid_messages_suffix')}`);
   }catch(e){showToast(t('undo_failed')+e.message);}
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -6888,7 +6888,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // Fetch latest session from server to get accurate message list (includes cancel status)
           // This ensures messages stay in sync with server, fixing race condition where local
           // "*Task cancelled.*" message gets lost when done event overwrites S.messages
-          const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+          const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}&messages=1&resolve_model=0&msg_limit=30`);
           if(data&&data.session) _applyCancelSessionPayload(data.session);
         }catch(_){
           // Fallback to local cancel message if API fails
@@ -6978,7 +6978,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       return returnStatus?'stale':false;
     }
     try{
-      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}&messages=1&resolve_model=0&msg_limit=30`);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;

--- a/static/outline.js
+++ b/static/outline.js
@@ -104,16 +104,13 @@ function _jumpToMessage(rawIdx) {
   }
 
   // Row is outside the render window — reload the full session and retry.
-  // Use the bare messages=1 path (no msg_limit) so the server returns the
-  // COMPLETE transcript: the target row is addressed by absolute index
-  // (msg-user-<rawIdx>), so a bounded tail window would miss early rows.
-  // (A previous version sent msg_limit=9999 as a "give me everything" hack,
-  // but the server now clamps msg_limit, so the bare path is the correct way
-  // to request the full transcript here.)
+  // Use ?full=1 so a huge sidecar is not auto-windowed to the 30-row tail.
+  // The target row is addressed by absolute index (msg-user-<rawIdx>), so a
+  // bounded tail would miss early rows.
   if (typeof api !== 'function') return;
   if (S.busy || S.activeStreamId) return;
   api('/api/session?session_id=' + encodeURIComponent(sid) +
-      '&messages=1&resolve_model=0')
+      '&messages=1&resolve_model=0&full=1')
     .then(function(data) {
       if (!data || !data.session) return;
       if (!S.session || S.session.session_id !== sid) return;  // session switched

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3903,7 +3903,7 @@ async function _ensureAllMessagesLoaded() {
   _loadingOlder = true;
   try {
     const sid = S.session.session_id;
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`, {timeoutMs:120000});
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&full=1`, {timeoutMs:120000});
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) return;
     // Session may have been switched while we awaited. Bail rather than

--- a/static/ui.js
+++ b/static/ui.js
@@ -10021,7 +10021,7 @@ async function refreshSession() {
   dismissReconnect();
   if (!S.session) return;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}&messages=1&resolve_model=0&msg_limit=30`);
     S.session = data.session;
     if(typeof _adoptRegenerationRevision==='function') _adoptRegenerationRevision(data.session);
     S.messages = data.session.messages || [];

--- a/tests/test_issue5204_redactor_memoization_contract.py
+++ b/tests/test_issue5204_redactor_memoization_contract.py
@@ -55,3 +55,43 @@ def test_huge_tool_dump_skips_agent_pass_but_still_masks_secrets():
     assert elapsed < 2.0, f"huge-dump redact took {elapsed:.2f}s"
     assert secret not in out
     assert out == helpers._redact_fn_uncached(blob)
+
+
+def test_residual_shapes_leak_above_agent_cap():
+    """Pin the known, accepted residual gap of the >16KB agent-pass bypass.
+
+    Above _REDACT_AGENT_MAX_TEXT_LEN a single field skips the agent redactor and
+    only the prefix/keyword-based local fallback runs. The prefix-less agent-only
+    shapes — bare JWT (eyJ...) and DB connection-string passwords — are therefore
+    NOT masked in an oversize field. This is intentional (a multi-MB single field
+    is a tool dump, not a credential store); this test documents the boundary so
+    the behavior is a deliberate, reviewed trade-off rather than a silent leak.
+    If a future change starts masking these above the cap, update the code
+    comment on _REDACT_AGENT_MAX_TEXT_LEN too.
+    """
+    jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ"
+        ".dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+    )
+    db_pw = "s3cr3tDbPassw0rd"
+    connstr = f"postgres://dbuser:{db_pw}@db.internal:5432/prod"
+    filler = "x" * (helpers._REDACT_AGENT_MAX_TEXT_LEN + 100)
+
+    # Below the cap the agent pass runs and masks both shapes.
+    small = f"start {jwt} {connstr} end"
+    small_out = helpers._redact_fn_uncached(small)
+    assert jwt not in small_out
+    assert db_pw not in small_out
+
+    # Above the cap the agent pass is skipped: the prefix-less shapes leak.
+    big = f"{filler} {jwt} {connstr}"
+    assert len(big) > helpers._REDACT_AGENT_MAX_TEXT_LEN
+    big_out = helpers._redact_fn_uncached(big)
+    assert jwt in big_out, "JWT unexpectedly masked above cap - update the comment"
+    assert db_pw in big_out, "DB-connstr pw unexpectedly masked above cap - update the comment"
+
+    # But short-prefix secrets are still caught by the local fallback above the
+    # cap - the fallback is exactly what keeps the common shapes safe.
+    sk = "sk-ABCDEFGHIJKLMNOP1234567890"
+    assert sk not in helpers._redact_fn_uncached(f"{filler} {sk}")

--- a/tests/test_issue5204_redactor_memoization_contract.py
+++ b/tests/test_issue5204_redactor_memoization_contract.py
@@ -57,17 +57,16 @@ def test_huge_tool_dump_skips_agent_pass_but_still_masks_secrets():
     assert out == helpers._redact_fn_uncached(blob)
 
 
-def test_residual_shapes_leak_above_agent_cap():
-    """Pin the known, accepted residual gap of the >16KB agent-pass bypass.
+def test_residual_shapes_masked_above_agent_cap():
+    """The >16KB agent-pass bypass no longer leaks the prefix-less shapes.
 
-    Above _REDACT_AGENT_MAX_TEXT_LEN a single field skips the agent redactor and
-    only the prefix/keyword-based local fallback runs. The prefix-less agent-only
-    shapes — bare JWT (eyJ...) and DB connection-string passwords — are therefore
-    NOT masked in an oversize field. This is intentional (a multi-MB single field
-    is a tool dump, not a credential store); this test documents the boundary so
-    the behavior is a deliberate, reviewed trade-off rather than a silent leak.
-    If a future change starts masking these above the cap, update the code
-    comment on _REDACT_AGENT_MAX_TEXT_LEN too.
+    Above _REDACT_AGENT_MAX_TEXT_LEN a single field skips the expensive agent
+    redactor and only the local fallback runs. The fallback now also masks the
+    three prefix-less agent-only shapes (bare JWT eyJ..., DB connection-string
+    passwords, Telegram bot tokens) via _JWT_RE/_URI_USERINFO_RE/_TELEGRAM_RE,
+    so they stay masked in an oversize field. This test pins that both below and
+    above the cap. If a future change stops masking these above the cap, update
+    the code comment on _REDACT_AGENT_MAX_TEXT_LEN too.
     """
     jwt = (
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
@@ -76,22 +75,34 @@ def test_residual_shapes_leak_above_agent_cap():
     )
     db_pw = "s3cr3tDbPassw0rd"
     connstr = f"postgres://dbuser:{db_pw}@db.internal:5432/prod"
+    tg_token = "AAHdqTcvbXsj2kd83jfhs8sJDHf83jfhsu2"
+    telegram = f"123456789:{tg_token}"
     filler = "x" * (helpers._REDACT_AGENT_MAX_TEXT_LEN + 100)
 
-    # Below the cap the agent pass runs and masks both shapes.
-    small = f"start {jwt} {connstr} end"
+    # Below the cap the agent pass runs and masks all three shapes.
+    small = f"start {jwt} {connstr} {telegram} end"
     small_out = helpers._redact_fn_uncached(small)
     assert jwt not in small_out
     assert db_pw not in small_out
+    assert tg_token not in small_out
 
-    # Above the cap the agent pass is skipped: the prefix-less shapes leak.
-    big = f"{filler} {jwt} {connstr}"
+    # Above the cap the agent pass is skipped, but the fallback now covers these.
+    big = f"{filler} {jwt} {connstr} {telegram}"
     assert len(big) > helpers._REDACT_AGENT_MAX_TEXT_LEN
     big_out = helpers._redact_fn_uncached(big)
-    assert jwt in big_out, "JWT unexpectedly masked above cap - update the comment"
-    assert db_pw in big_out, "DB-connstr pw unexpectedly masked above cap - update the comment"
+    assert jwt not in big_out, "JWT leaked above cap - fallback JWT pass missing"
+    assert db_pw not in big_out, "DB-connstr pw leaked above cap - fallback URI pass missing"
+    assert tg_token not in big_out, "Telegram token leaked above cap - fallback pass missing"
+    # Structure is preserved: only the secret is masked, not the surrounding URL.
+    assert "postgres://dbuser:" in big_out
+    assert "@db.internal:5432/prod" in big_out
+    assert "123456789:" in big_out
 
-    # But short-prefix secrets are still caught by the local fallback above the
-    # cap - the fallback is exactly what keeps the common shapes safe.
+    # A short-prefix secret in the same oversize field also stays masked (the
+    # fallback prefix list keeps the common shapes safe above the cap).
     sk = "sk-ABCDEFGHIJKLMNOP1234567890"
     assert sk not in helpers._redact_fn_uncached(f"{filler} {sk}")
+
+    # False-positive guard: benign URLs / number-colon prose are untouched.
+    benign = "See http://localhost:8080/api and ratio 12345:67 at 2026-09-01T18:11:00"
+    assert helpers._redact_fn_uncached(benign) == benign

--- a/tests/test_issue5204_redactor_memoization_contract.py
+++ b/tests/test_issue5204_redactor_memoization_contract.py
@@ -41,3 +41,17 @@ def test_oversize_input_bypasses_cache_but_still_redacts():
 def test_clean_text_unchanged_through_cache():
     sample = "totally benign text with no secrets at all"
     assert helpers._redact_fn_cached(sample) == sample == helpers._redact_fn_uncached(sample)
+
+
+def test_huge_tool_dump_skips_agent_pass_but_still_masks_secrets():
+    """Megabyte URL-heavy dumps must not hang in agent.redact (GIL wedge)."""
+    import time
+    secret = "sk-abcdefghijklmnopqrstuvwxyz123456"
+    blob = ("http://example.com/foo " * 40000) + " " + secret
+    assert len(blob) > helpers._REDACT_AGENT_MAX_TEXT_LEN
+    t0 = time.monotonic()
+    out = helpers._redact_fn_cached(blob)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 2.0, f"huge-dump redact took {elapsed:.2f}s"
+    assert secret not in out
+    assert out == helpers._redact_fn_uncached(blob)

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -201,6 +201,50 @@ def test_msg_limit_tail_keeps_pre_compression_snapshot_parent_reachable():
     assert payload["_messages_truncated"] is False
 
 
+def test_huge_sidecar_without_msg_limit_auto_windows_to_default_tail():
+    session = _FakeSession(
+        [{"role": "user", "content": f"m{i}"} for i in range(40)]
+    )
+
+    with patch("api.routes._sidecar_file_exceeds_threshold", return_value=True):
+        payload = _invoke(
+            session,
+            query="session_id=tail_payload_001&messages=1&resolve_model=0",
+        )
+
+    assert len(payload["messages"]) == 30
+    assert payload["messages"][0]["content"] == "m10"
+    assert payload["messages"][-1]["content"] == "m39"
+    assert payload["_messages_truncated"] is True
+    assert payload["_messages_offset"] == 10
+
+
+def test_huge_sidecar_full_flag_keeps_unwindowed_transcript():
+    session = _FakeSession(
+        [{"role": "user", "content": f"m{i}"} for i in range(40)]
+    )
+
+    with patch("api.routes._sidecar_file_exceeds_threshold", return_value=True):
+        payload = _invoke(
+            session,
+            query="session_id=tail_payload_001&messages=1&resolve_model=0&full=1",
+        )
+
+    assert [m["content"] for m in payload["messages"]] == [f"m{i}" for i in range(40)]
+    assert payload["_messages_truncated"] is False
+
+
+def test_auto_msg_limit_helper_respects_explicit_limit_and_full_flag():
+    import api.routes as routes
+
+    with patch("api.routes._sidecar_file_exceeds_threshold", return_value=True):
+        assert routes._auto_msg_limit_for_huge_sidecar("sid", None, False) == 30
+        assert routes._auto_msg_limit_for_huge_sidecar("sid", 12, False) == 12
+        assert routes._auto_msg_limit_for_huge_sidecar("sid", None, True) is None
+    with patch("api.routes._sidecar_file_exceeds_threshold", return_value=False):
+        assert routes._auto_msg_limit_for_huge_sidecar("sid", None, False) is None
+
+
 def test_msg_limit_tail_truncates_large_hidden_tool_results():
     huge_tool_output = "x" * 20_000
     session = _FakeSession([


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI serves the whole session over `GET /api/session`, redacting secrets before sending.
- The server is `ThreadingHTTPServer` doing CPU-bound Python work, so a slow request blocks others behind the GIL.
- After a VM crash, Firefox reopened a ~33MB session. `GET /api/session` spent **~117s** inside the agent credential redactor, and even `GET /` timed out — the whole UI looked crashed.
- Root cause is two things on the huge-session path: (1) the agent redact pass runs its full regex set over the entire multi-MB transcript, and (2) cancel/restore/refresh/retry/undo request the bare full transcript with no `msg_limit`, so the server serializes the entire session every time.
- This PR bounds both so a huge session degrades gracefully instead of wedging the server.

## What Changed

**Backend**
- `api/helpers.py`: cap the agent redact pass at `_REDACT_AGENT_MAX_TEXT_LEN = 16384`. Above the cap, skip the expensive agent regexes and fall through to the cheap local fallback, which still masks `ghp_`/`sk-`/`hf_`/`AKIA` prefixes, auth headers, and env-key literals. Applies on both the `force=` and legacy code paths.
- `api/routes.py`: add `_auto_msg_limit_for_huge_sidecar()` + `_parse_full_transcript_flag()`. When a caller omits `?msg_limit=` on a session whose sidecar exceeds the existing byte threshold, default to the frontend's first-paint window (`_DEFAULT_DISPLAY_MSG_LIMIT = 30`). Opt out with `?full=1`. The existing `_messages_truncated` signal already tells the client more rows exist.

**Frontend** (matching the backend so behavior is unchanged for users)
- `commands.js`, `messages.js`, `ui.js`: the recovery/refresh calls (`retry`, `undo`, manual-compression preflight, cancel-sync, refresh) now pass `messages=1&resolve_model=0&msg_limit=30` and honor the returned `_messages_truncated` instead of hard-coding `false`.
- `outline.js`, `sessions.js`: jump-to-message and load-older explicitly pass `?full=1`, because they address rows by absolute index and genuinely need the whole transcript.

## Why It Matters

One oversized session should not take the entire single-threaded server down. The redact cap and the auto-window keep `/api/session` responsive, and secrets are still redacted on every path.

## Verification

Ran the project runner on Python 3.11 (`./scripts/test.sh`) — 17/17 in the two touched files; a targeted regression run across session/redact/tail/msg_limit modules is **126 passed, 1 skipped** (the skip is agent-dependent, no hermes-agent in the test env). `ruff` reports no findings on any changed line (the 20 repo-wide findings pre-exist on `master`).

New tests:
- `test_huge_tool_dump_skips_agent_pass_but_still_masks_secrets` — asserts a ~1MB URL-heavy dump redacts in **< 2s** and the secret is still masked.
- `test_huge_sidecar_without_msg_limit_auto_windows_to_default_tail`, `test_huge_sidecar_full_flag_keeps_unwindowed_transcript`, `test_auto_msg_limit_helper_respects_explicit_limit_and_full_flag`.

Timing — this is a latency fix, so timing is the honest evidence rather than a screenshot (there is **no visual change**):
- **Field-observed** (the incident): ~117s on a 33MB session, with `/` timing out under concurrent load.
- **Locally reproduced** on this branch, agent redact on a ~2MB blob: **676ms → 170ms** (~4x) with the secret still masked. The gap widens with size and under GIL contention, consistent with the field number.

Owner-of-truth note: the "server appears crashed" symptom is a property of `ThreadingHTTPServer` + GIL, which this repo owns; the reproduction exercises `api.helpers`/`api.routes` directly.

## Risks / Follow-ups

- Above 16KB the agent-specific regexes (e.g. Telegram tokens) no longer run; the local fallback covers the common secret shapes. If the agent set needs to run on huge text, a chunked/streaming redactor would be the follow-up, but that is out of scope here.
- `?full=1` preserves the old unwindowed behavior for callers that need it; default behavior for normal-size sessions is unchanged (the auto-window only triggers above the existing sidecar byte threshold).

## Security note

This touches credential redaction. Verified that every path (agent-capped, oversize-bypass, and local fallback) still masks `ghp_`/`sk-`/`hf_`/`AKIA` prefixes, auth headers, and env-key literals — covered by the memoization-contract test asserting the oversize bypass still redacts.

## Model Used

AI-assisted. Provider: Anthropic. Model: Claude (Opus). The fix originated from a real incident on my own install; the agent reproduced it, wrote the tests, and ran the suite.
