### PR TITLE
fix(session): reconcile one turn held by both stores in messaging display merge

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8997,6 +8997,46 @@ def _merge_session_display_metadata(target: dict | None, source: dict | None) ->
             target[key] = copy.deepcopy(value)
 
 
+# Agent-store-only semantic payload: the model's actual reasoning/thinking
+# trace and the Codex-specific structured item lists. These are NOT display
+# metadata (_SESSION_MESSAGE_DISPLAY_METADATA_KEYS above) and are deliberately
+# NOT folded into it: that allowlist is reused by several merge paths beyond
+# the gateway dual-store reconciliation this one exists for, and widening it
+# would change behavior in call sites that never asked for reasoning/Codex
+# payload semantics. Kept as its own narrow, explicitly-named list instead.
+# `api_content` is deliberately excluded from both lists — its identity rules
+# elsewhere in this module are stricter for good reason and must not be
+# bypassed by a generic dict merge.
+_AGENT_SEMANTIC_PAYLOAD_KEYS = (
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+    "codex_message_items",
+)
+
+
+def _adopt_agent_semantic_payload(target: dict | None, source: dict | None) -> None:
+    """Copy Agent-store-only semantic payload onto the surviving sidecar row.
+
+    Used when a gateway dual-store reconciliation discards an unidentified
+    Agent-store copy of a turn in favor of the identified WebUI sidecar copy:
+    the discarded row can carry the model's real reasoning trace and Codex
+    item lists that the sidecar copy never received. Same fill-only-if-absent
+    policy as `_merge_session_display_metadata`: a field the survivor already
+    carries a non-empty value for is left alone rather than overwritten, so
+    Agent-side data never silently clobbers a sidecar-authored value.
+    """
+    if not isinstance(target, dict) or not isinstance(source, dict):
+        return
+    for key in _AGENT_SEMANTIC_PAYLOAD_KEYS:
+        if _message_display_metadata_value_present(target.get(key)):
+            continue
+        value = source.get(key)
+        if _message_display_metadata_value_present(value):
+            target[key] = copy.deepcopy(value)
+
+
 def _state_db_row_identity_details(message: dict | None) -> tuple[str | None, bool]:
     """Return ``(row_id, valid)`` for private state.db provenance aliases.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -9791,6 +9791,23 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
             seen_message_keys = set()
             unmatched_identified_queue = {}
             kept_positions = set()
+            # An unidentified row that finds no queued survivor falls back to
+            # this pair of dedup checks instead of the round-to-the-second
+            # `_session_message_merge_key`. That coarse key exists so a
+            # cross-store duplicate of the SAME turn (one copy per store,
+            # sub-second clock drift, no id on either side -- sessions
+            # predating stable-id stamping) still collapses to one row.
+            # Using it directly here would also collapse two textually
+            # identical but genuinely DISTINCT unidentified rows from the
+            # SAME store landing in the same wall-clock second (e.g. two
+            # short repeated assistant replies), silently dropping the
+            # second one and its semantic payload. So: full-precision
+            # `_session_message_dedup_key` decides same-store duplicates (a
+            # store's own clock never needs second-level rounding
+            # tolerance), and the coarse key only collapses a row against a
+            # KEPT row from the OPPOSITE store.
+            seen_unmatched_exact_keys = set()
+            seen_unmatched_cross_store_owner = {}
             # Pass 1 admits every identified row and enqueues it under its
             # visible identity; pass 2 admits the unidentified rows that no
             # identified row already covers.
@@ -9799,20 +9816,30 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                     has_identity = bool(msg.get("id") or msg.get("message_id"))
                     if has_identity != identified_pass:
                         continue
-                    key = _session_message_merge_key(msg)
-                    if key in seen_message_keys:
-                        continue
                     visible_key = _cross_store_visible_key(msg, from_sidecar)
                     if has_identity:
-                        unmatched_identified_queue.setdefault(visible_key, []).append(msg)
-                    else:
-                        queue = unmatched_identified_queue.get(visible_key)
-                        if queue:
-                            survivor = queue.pop(0)
-                            _merge_session_display_metadata(survivor, msg)
-                            _adopt_agent_semantic_payload(survivor, msg)
+                        key = _session_message_merge_key(msg)
+                        if key in seen_message_keys:
                             continue
-                    seen_message_keys.add(key)
+                        unmatched_identified_queue.setdefault(visible_key, []).append(msg)
+                        seen_message_keys.add(key)
+                        kept_positions.add(position)
+                        continue
+                    queue = unmatched_identified_queue.get(visible_key)
+                    if queue:
+                        survivor = queue.pop(0)
+                        _merge_session_display_metadata(survivor, msg)
+                        _adopt_agent_semantic_payload(survivor, msg)
+                        continue
+                    exact_key = (from_sidecar, _session_message_dedup_key(msg))
+                    if exact_key in seen_unmatched_exact_keys:
+                        continue
+                    cross_key = _session_message_merge_key(msg)
+                    owner = seen_unmatched_cross_store_owner.get(cross_key)
+                    if owner is not None and owner != from_sidecar:
+                        continue
+                    seen_unmatched_exact_keys.add(exact_key)
+                    seen_unmatched_cross_store_owner.setdefault(cross_key, from_sidecar)
                     kept_positions.add(position)
             return [
                 msg
@@ -10347,6 +10374,7 @@ from api.models import (
     _merge_session_display_metadata,
     _adopt_agent_semantic_payload,
     _session_message_merge_key,
+    _session_message_dedup_key,
     _session_messages_have_prefix,
     _session_message_visible_key,
     _message_timestamp_as_float,

--- a/api/routes.py
+++ b/api/routes.py
@@ -9774,10 +9774,85 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
             # transcript order in pass 1; pass 2 pops the oldest unmatched
             # entry for a match, so repeats pair up in the order they
             # actually occurred rather than collapsing onto one row.
+            #
+            # Those queues are partitioned by SOURCE STORE as well as visible
+            # key, and a row may only consume a survivor from the OPPOSITE
+            # store. Neither list is homogeneous: `sidecar_messages` comes out
+            # of _webui_sidecar_lineage_messages_for_display() and can mix
+            # id-stamped rows with legacy ones after lineage stitching or an
+            # upgrade, and the Agent store can hold identified rows too.
+            # Without the partition an unidentified row could reconcile
+            # against an identified row from its OWN store — two separate
+            # same-text turns, arbitrarily far apart, since
+            # _session_message_visible_key carries role, content and
+            # tool_calls but neither timestamp nor store — and the later turn
+            # would be dropped as though it were a cross-store twin.
             def _cross_store_visible_key(msg, from_sidecar):
                 return _session_message_visible_key(
                     msg, normalize_workspace_prefix=not from_sidecar
                 )
+
+            # Reconciliation writes onto a COPY of the survivor, never the
+            # caller's dict. `session.messages` rows are shared: they live in
+            # the module-level session cache, and `Session.save()` rewrites the
+            # whole array from that in-memory object, so mutating here would let
+            # a plain GET (or even a metadata-only sidebar poll) seed a payload
+            # that any later unrelated save commits to the sidecar JSON. Rows
+            # reaching this branch are already handed out as copies on the
+            # lineage-cache paths, so copying is the contract callers can
+            # actually rely on -- and it keeps display reconciliation from
+            # durably editing a transcript.
+            row_overrides = {}
+
+            def _survivor_row(position, msg):
+                row = row_overrides.get(position)
+                if row is None:
+                    row = dict(msg)
+                    row_overrides[position] = row
+                return row
+
+            def _cross_store_pairable(survivor, dropped):
+                """Guard the pairing key's blind spot for tool identity.
+
+                `_session_message_visible_key` carries role, content and
+                `tool_calls`, but NOT `tool_call_id` or `tool_name`. Two
+                results from different tool calls that happen to print the
+                same text ("OK", "{}", "Command completed.") therefore share a
+                visible key, and reconciling them would delete a real tool
+                result. Require the tool identity to agree before pairing.
+                """
+                return (
+                    str(survivor.get("tool_call_id") or "")
+                    == str(dropped.get("tool_call_id") or "")
+                    and str(survivor.get("tool_name") or survivor.get("name") or "")
+                    == str(dropped.get("tool_name") or dropped.get("name") or "")
+                )
+
+            def _pop_pairable(queue, dropped):
+                """Take the oldest queued survivor this row may pair with."""
+                for index, entry in enumerate(queue):
+                    if _cross_store_pairable(entry[1], dropped):
+                        del queue[index]
+                        return entry
+                return None
+
+            def _reconcile_cross_store_twin(position, survivor, dropped,
+                                            dropped_from_sidecar):
+                """Carry a discarded cross-store twin's payload to the survivor.
+
+                The two lanes are deliberately NOT symmetric. Display metadata
+                is sidecar-authored, so it travels either way. Semantic payload
+                travels only Agent -> sidecar: the Agent store owns the real
+                reasoning/Codex trace, whereas a sidecar-authored `reasoning`
+                is the unreliable one (it can hold a verbatim copy of the
+                reply -- NousResearch/hermes-agent#13007), so pushing it into
+                an Agent survivor would degrade the better record. That lane
+                keeps the survivor's own values.
+                """
+                row = _survivor_row(position, survivor)
+                _merge_session_display_metadata(row, dropped)
+                if not dropped_from_sidecar:
+                    _adopt_agent_semantic_payload(row, dropped)
 
             ordered = sorted(
                 [(msg, False) for msg in cli_messages]
@@ -9806,8 +9881,27 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
             # store's own clock never needs second-level rounding
             # tolerance), and the coarse key only collapses a row against a
             # KEPT row from the OPPOSITE store.
+            #
+            # That cross-store collapse carries metadata across too, on the
+            # same lanes as the identified path below. Without it the payload
+            # of whichever copy loses the sort is dropped outright, and which
+            # copy that is depends only on sub-second drift between the two
+            # stores' writes: the sidecar copy winning silently discards the
+            # Agent copy's reasoning/Codex trace, the Agent copy winning
+            # silently discards the sidecar's display metadata.
+            #
+            # It is also ONE-TO-ONE, for the same reason the identified lane
+            # is: a coarse key groups every same-second repeat of one text, so
+            # a single "already kept a twin" flag would let one kept row absorb
+            # an unbounded number of opposite-store rows and delete every
+            # additional real turn in that second. Each store keeps a
+            # consumable pool of the rows kept for a coarse key; an
+            # opposite-store row collapses against exactly one pooled entry,
+            # and once the pool is empty the next row is a surplus turn that
+            # survives on its own.
             seen_unmatched_exact_keys = set()
-            seen_unmatched_cross_store_owner = {}
+            # cross_key -> {from_sidecar: deque of (position, row) kept for it}
+            unmatched_kept_pools = {}
             # Pass 1 admits every identified row and enqueues it under its
             # visible identity; pass 2 admits the unidentified rows that no
             # identified row already covers.
@@ -9821,28 +9915,39 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                         key = _session_message_merge_key(msg)
                         if key in seen_message_keys:
                             continue
-                        unmatched_identified_queue.setdefault(visible_key, []).append(msg)
+                        unmatched_identified_queue.setdefault(
+                            (visible_key, from_sidecar), deque()
+                        ).append((position, msg))
                         seen_message_keys.add(key)
                         kept_positions.add(position)
                         continue
-                    queue = unmatched_identified_queue.get(visible_key)
-                    if queue:
-                        survivor = queue.pop(0)
-                        _merge_session_display_metadata(survivor, msg)
-                        _adopt_agent_semantic_payload(survivor, msg)
+                    # Opposite store only — see the partition note above.
+                    queue = unmatched_identified_queue.get(
+                        (visible_key, not from_sidecar)
+                    )
+                    entry = _pop_pairable(queue, msg) if queue else None
+                    if entry is not None:
+                        _reconcile_cross_store_twin(
+                            entry[0], entry[1], msg, from_sidecar
+                        )
                         continue
                     exact_key = (from_sidecar, _session_message_dedup_key(msg))
                     if exact_key in seen_unmatched_exact_keys:
                         continue
                     cross_key = _session_message_merge_key(msg)
-                    owner = seen_unmatched_cross_store_owner.get(cross_key)
-                    if owner is not None and owner != from_sidecar:
+                    pools = unmatched_kept_pools.setdefault(cross_key, {})
+                    opposite = pools.get(not from_sidecar)
+                    entry = _pop_pairable(opposite, msg) if opposite else None
+                    if entry is not None:
+                        _reconcile_cross_store_twin(
+                            entry[0], entry[1], msg, from_sidecar
+                        )
                         continue
                     seen_unmatched_exact_keys.add(exact_key)
-                    seen_unmatched_cross_store_owner.setdefault(cross_key, from_sidecar)
+                    pools.setdefault(from_sidecar, deque()).append((position, msg))
                     kept_positions.add(position)
             return [
-                msg
+                row_overrides.get(position, msg)
                 for position, (msg, _from_sidecar) in enumerate(ordered)
                 if position in kept_positions
             ]

--- a/api/routes.py
+++ b/api/routes.py
@@ -9787,10 +9787,43 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
             # _session_message_visible_key carries role, content and
             # tool_calls but neither timestamp nor store — and the later turn
             # would be dropped as though it were a cross-store twin.
-            def _cross_store_visible_key(msg, from_sidecar):
-                return _session_message_visible_key(
-                    msg, normalize_workspace_prefix=not from_sidecar
+            def _cross_store_pairing_key(msg, from_sidecar):
+                """Visible identity for cross-store twin matching.
+
+                Deliberately narrower than `_session_message_visible_key`: it
+                excludes the `api_content` provider sidecar that key appends
+                via `_session_message_key_with_sidecar`. `api_content` is
+                state.db-only by design (there is a whole
+                `_copy_api_content_sidecar` helper because the sidecar copy
+                usually lacks it), so a gateway turn's Agent copy commonly
+                carries provider bytes its sidecar twin does not have. Keying
+                pairing on that field would give the two copies of ONE turn
+                different keys and let both survive — reproducing the exact
+                duplicate-turn symptom this reconciliation exists to fix.
+                `api_content` instead gets its own directional authority in
+                `_reconcile_cross_store_twin`, once a twin is already matched
+                one-to-one on every other identity component (role, visible
+                content, tool_calls, and tool_call_id/tool_name via
+                `_cross_store_pairable`). The SHARED
+                `_session_message_visible_key` is deliberately left untouched
+                — other merge paths rely on its stricter identity there.
+                """
+                if not isinstance(msg, dict):
+                    return ("non_dict", repr(msg))
+                tool_calls = msg.get("tool_calls")
+                tool_calls_key = (
+                    json.dumps(tool_calls, sort_keys=True, default=str)
+                    if tool_calls else ""
                 )
+                role = str(msg.get("role") or "")
+                content = _normalized_session_message_content(msg)
+                if role == "user" and not from_sidecar:
+                    from api.streaming import _strip_workspace_prefix
+
+                    content = " ".join(
+                        _strip_workspace_prefix(content, include_legacy=True).split()
+                    )
+                return (role, content, tool_calls_key)
 
             # Reconciliation writes onto a COPY of the survivor, never the
             # caller's dict. `session.messages` rows are shared: they live in
@@ -9840,19 +9873,27 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                                             dropped_from_sidecar):
                 """Carry a discarded cross-store twin's payload to the survivor.
 
-                The two lanes are deliberately NOT symmetric. Display metadata
-                is sidecar-authored, so it travels either way. Semantic payload
-                travels only Agent -> sidecar: the Agent store owns the real
-                reasoning/Codex trace, whereas a sidecar-authored `reasoning`
-                is the unreliable one (it can hold a verbatim copy of the
-                reply -- NousResearch/hermes-agent#13007), so pushing it into
-                an Agent survivor would degrade the better record. That lane
+                The lanes are deliberately NOT symmetric. Display metadata is
+                sidecar-authored, so it travels either way. Semantic payload
+                and `api_content` both travel only Agent -> sidecar: the
+                Agent store owns the real reasoning/Codex trace and is the
+                only store `api_content` is ever written to, whereas a
+                sidecar-authored `reasoning` is the unreliable one (it can
+                hold a verbatim copy of the reply --
+                NousResearch/hermes-agent#13007), so pushing either into an
+                Agent survivor would degrade the better record. That lane
                 keeps the survivor's own values.
+
+                `_copy_api_content_sidecar` is fill-only-if-absent on its own
+                (it returns early if the target already carries a non-empty
+                value), so a conflicting non-empty pair fails closed: the
+                identified survivor's own `api_content` is never overwritten.
                 """
                 row = _survivor_row(position, survivor)
                 _merge_session_display_metadata(row, dropped)
                 if not dropped_from_sidecar:
                     _adopt_agent_semantic_payload(row, dropped)
+                    _copy_api_content_sidecar(row, dropped)
 
             ordered = sorted(
                 [(msg, False) for msg in cli_messages]
@@ -9910,7 +9951,7 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                     has_identity = bool(msg.get("id") or msg.get("message_id"))
                     if has_identity != identified_pass:
                         continue
-                    visible_key = _cross_store_visible_key(msg, from_sidecar)
+                    visible_key = _cross_store_pairing_key(msg, from_sidecar)
                     if has_identity:
                         key = _session_message_merge_key(msg)
                         if key in seen_message_keys:
@@ -10482,6 +10523,8 @@ from api.models import (
     _session_message_dedup_key,
     _session_messages_have_prefix,
     _session_message_visible_key,
+    _normalized_session_message_content,
+    _copy_api_content_sidecar,
     _message_timestamp_as_float,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,

--- a/api/routes.py
+++ b/api/routes.py
@@ -9764,6 +9764,16 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
             # reconciled away, and only when an identified row with the same
             # visible identity is still unmatched — the same cross-store
             # identity the append-only merge above uses.
+            #
+            # Pairing is one-to-one, not "every match for this visible key
+            # goes to whichever identified row we saw first": two identical
+            # assistant answers (same visible key, different ids, different
+            # per-turn reasoning) must not have their Agent-store metadata
+            # cross-wired onto the wrong survivor. Each visible key gets its
+            # own FIFO queue of still-unmatched identified rows, built in
+            # transcript order in pass 1; pass 2 pops the oldest unmatched
+            # entry for a match, so repeats pair up in the order they
+            # actually occurred rather than collapsing onto one row.
             def _cross_store_visible_key(msg, from_sidecar):
                 return _session_message_visible_key(
                     msg, normalize_workspace_prefix=not from_sidecar
@@ -9779,12 +9789,11 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                 ),
             )
             seen_message_keys = set()
-            unmatched_identified = {}
-            identified_by_visible_key = {}
+            unmatched_identified_queue = {}
             kept_positions = set()
-            # Pass 1 admits every identified row and records the visible
-            # identity it already accounts for; pass 2 admits the unidentified
-            # rows that no identified row already covers.
+            # Pass 1 admits every identified row and enqueues it under its
+            # visible identity; pass 2 admits the unidentified rows that no
+            # identified row already covers.
             for identified_pass in (True, False):
                 for position, (msg, from_sidecar) in enumerate(ordered):
                     has_identity = bool(msg.get("id") or msg.get("message_id"))
@@ -9795,16 +9804,14 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                         continue
                     visible_key = _cross_store_visible_key(msg, from_sidecar)
                     if has_identity:
-                        unmatched_identified[visible_key] = (
-                            unmatched_identified.get(visible_key, 0) + 1
-                        )
-                        identified_by_visible_key.setdefault(visible_key, msg)
-                    elif unmatched_identified.get(visible_key, 0) > 0:
-                        unmatched_identified[visible_key] -= 1
-                        _merge_session_display_metadata(
-                            identified_by_visible_key.get(visible_key), msg
-                        )
-                        continue
+                        unmatched_identified_queue.setdefault(visible_key, []).append(msg)
+                    else:
+                        queue = unmatched_identified_queue.get(visible_key)
+                        if queue:
+                            survivor = queue.pop(0)
+                            _merge_session_display_metadata(survivor, msg)
+                            _adopt_agent_semantic_payload(survivor, msg)
+                            continue
                     seen_message_keys.add(key)
                     kept_positions.add(position)
             return [
@@ -10338,6 +10345,7 @@ from api.models import (
     _active_stream_ids,
     _evict_sessions_over_cap,
     _merge_session_display_metadata,
+    _adopt_agent_semantic_payload,
     _session_message_merge_key,
     _session_messages_have_prefix,
     _session_message_visible_key,

--- a/api/routes.py
+++ b/api/routes.py
@@ -9749,19 +9749,69 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                     truncation_watermark=getattr(session, "truncation_watermark", None),
                     truncation_boundary=getattr(session, "truncation_boundary", None),
                 )
-            merged_messages = []
+            # _session_message_merge_key cannot reconcile one turn that BOTH
+            # stores hold when only one of the two copies carries a stable id:
+            # the identified copy keys as ("message_id", id) while the other
+            # keys as ("legacy", role, content, timestamp, ...). Two key shapes
+            # never compare equal, so the turn survives twice. Every
+            # gateway-backed browser turn has that shape — WebUI stamps a stable
+            # id on the sidecar row it writes while the agent store holds its
+            # own unidentified copy of the same turn.
+            #
+            # Identified rows stay authoritative: two rows that both carry ids
+            # are distinct messages even when their text matches (a user really
+            # can send the same prompt twice). Only an UNIDENTIFIED row is
+            # reconciled away, and only when an identified row with the same
+            # visible identity is still unmatched — the same cross-store
+            # identity the append-only merge above uses.
+            def _cross_store_visible_key(msg, from_sidecar):
+                return _session_message_visible_key(
+                    msg, normalize_workspace_prefix=not from_sidecar
+                )
+
+            ordered = sorted(
+                [(msg, False) for msg in cli_messages]
+                + [(msg, True) for msg in sidecar_messages],
+                key=lambda pair: (
+                    float(pair[0].get("timestamp") or 0),
+                    str(pair[0].get("role") or ""),
+                    str(pair[0].get("content") or ""),
+                ),
+            )
             seen_message_keys = set()
-            for msg in sorted(list(cli_messages) + list(sidecar_messages), key=lambda m: (
-                float(m.get("timestamp") or 0),
-                str(m.get("role") or ""),
-                str(m.get("content") or ""),
-            )):
-                key = _session_message_merge_key(msg)
-                if key in seen_message_keys:
-                    continue
-                seen_message_keys.add(key)
-                merged_messages.append(msg)
-            return merged_messages
+            unmatched_identified = {}
+            identified_by_visible_key = {}
+            kept_positions = set()
+            # Pass 1 admits every identified row and records the visible
+            # identity it already accounts for; pass 2 admits the unidentified
+            # rows that no identified row already covers.
+            for identified_pass in (True, False):
+                for position, (msg, from_sidecar) in enumerate(ordered):
+                    has_identity = bool(msg.get("id") or msg.get("message_id"))
+                    if has_identity != identified_pass:
+                        continue
+                    key = _session_message_merge_key(msg)
+                    if key in seen_message_keys:
+                        continue
+                    visible_key = _cross_store_visible_key(msg, from_sidecar)
+                    if has_identity:
+                        unmatched_identified[visible_key] = (
+                            unmatched_identified.get(visible_key, 0) + 1
+                        )
+                        identified_by_visible_key.setdefault(visible_key, msg)
+                    elif unmatched_identified.get(visible_key, 0) > 0:
+                        unmatched_identified[visible_key] -= 1
+                        _merge_session_display_metadata(
+                            identified_by_visible_key.get(visible_key), msg
+                        )
+                        continue
+                    seen_message_keys.add(key)
+                    kept_positions.add(position)
+            return [
+                msg
+                for position, (msg, _from_sidecar) in enumerate(ordered)
+                if position in kept_positions
+            ]
         return sidecar_messages if len(sidecar_messages) > len(cli_messages) else cli_messages
     return sidecar_messages
 

--- a/tests/test_gateway_dual_store_duplicate_turn.py
+++ b/tests/test_gateway_dual_store_duplicate_turn.py
@@ -126,12 +126,24 @@ Three further defects, found by probing this branch rather than by review:
    unrelated save committed to the sidecar JSON. Payload now lands on a copy
    and this function mutates nothing it was handed.
 
-Known remaining limitation, NOT fixed here: ``_session_message_key_with_sidecar``
-appends ``api_content`` to every key shape including the visible key, so a
-gateway turn whose Agent copy carries provider bytes the sidecar copy lacks
-gets two different visible keys and still renders twice. Narrowing that is a
-change to shared identity machinery with its own stricter rules, out of scope
-for this fix.
+Fifth review round
+-------------------
+The prior round flagged that ``_session_message_key_with_sidecar`` appends
+``api_content`` to every key shape including the visible key used for
+pairing, so a gateway turn whose Agent copy carries provider bytes the
+sidecar copy lacks got two different visible keys and rendered twice. Per the
+reviewer's own guidance: do NOT widen the shared ``_session_message_visible_key``
+globally (other merge paths rely on its stricter, ``api_content``-aware
+identity there). Instead this reconciliation now builds a LOCAL candidate key,
+``_cross_store_pairing_key``, that keeps role, normalized visible content and
+``tool_calls`` but omits ``api_content`` -- tool identity (``tool_call_id``/
+``tool_name``) is still enforced separately via ``_cross_store_pairable``, as
+before. Once a twin is matched one-to-one on that narrower identity,
+``api_content`` gets its own directional authority through the existing
+``_copy_api_content_sidecar`` helper (Agent -> sidecar only, same lane as the
+semantic payload) rather than a generic dict merge. That helper is
+fill-only-if-absent on its own, so a conflicting non-empty pair on both sides
+fails closed: the identified survivor's own value is never overwritten.
 """
 
 from __future__ import annotations
@@ -206,6 +218,80 @@ def test_gateway_reconciliation_preserves_agent_semantic_payload():
     # api_content has its own stricter identity rules elsewhere; this
     # reconciliation must not fold it through the generic semantic-payload copy.
     assert "api_content" not in survivor
+
+
+def test_gateway_reconciliation_pairs_across_differing_api_content():
+    """The reported production shape: Agent copy carries provider bytes the
+    sidecar copy lacks entirely.
+
+    ``_session_message_visible_key`` appends ``api_content`` to its key via
+    ``_session_message_key_with_sidecar``, so the two copies of one turn get
+    DIFFERENT keys once one side has it and the other doesn't -- neither
+    reconciles, and the turn renders twice. This reconciliation's own
+    ``_cross_store_pairing_key`` excludes that field so the match still
+    happens; `api_content` then gets adopted through the same directional
+    (Agent -> sidecar) lane as the semantic payload.
+    """
+    session = SimpleNamespace(
+        messages=[{"id": 8, "role": "assistant", "content": "answer", "timestamp": 10.5}]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q", "timestamp": 1.0},
+        {
+            "role": "assistant",
+            "content": "answer",
+            "timestamp": 10.4,
+            "api_content": "PROVIDER BYTES",
+            "reasoning": "AGENT REASONING",
+        },
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    answers = [m for m in merged if m.get("content") == "answer"]
+    assert len(answers) == 1, "one gateway turn must not render as two answer rows"
+    survivor = answers[0]
+    assert survivor.get("id") == 8, "the identified sidecar row survives"
+    assert survivor.get("api_content") == "PROVIDER BYTES"
+    assert survivor.get("reasoning") == "AGENT REASONING"
+
+
+def test_conflicting_api_content_keeps_survivors_own_value():
+    """Two non-empty, DIFFERENT api_content values must not clobber each other.
+
+    Mirrors the existing conflicting-semantic-payload contract: when the
+    identified survivor already carries its own non-empty `api_content`, the
+    Agent copy's value must not overwrite it -- fail closed via
+    `_copy_api_content_sidecar`'s own fill-only-if-absent policy.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {
+                "id": 8,
+                "role": "assistant",
+                "content": "answer",
+                "timestamp": 10.5,
+                "api_content": "SIDECAR'S OWN BYTES",
+            }
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q", "timestamp": 1.0},
+        {
+            "role": "assistant",
+            "content": "answer",
+            "timestamp": 10.4,
+            "api_content": "AGENT BYTES",
+            "reasoning": "AGENT REASONING",
+        },
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    survivor = next(m for m in merged if m.get("id") == 8)
+    assert survivor.get("api_content") == "SIDECAR'S OWN BYTES"
+    # Non-conflicting fields still adopt normally on the same pass.
+    assert survivor.get("reasoning") == "AGENT REASONING"
 
 
 def test_gateway_reconciliation_keeps_agent_only_rows_and_order():

--- a/tests/test_gateway_dual_store_duplicate_turn.py
+++ b/tests/test_gateway_dual_store_duplicate_turn.py
@@ -1,0 +1,137 @@
+"""Regression: one turn held by BOTH stores rendered twice in messaging sessions.
+
+Reported shape (gateway-backed browser chat, reproduced on a live deployment
+running exp-v0.52.264)
+----------------------------------------------------------------------------
+With ``HERMES_WEBUI_CHAT_BACKEND=gateway`` the agent executes browser turns, so
+one logical turn is written twice:
+
+* the agent store gets the run's own row — no stable ``id``, its own timestamp,
+  provider payloads such as ``codex_message_items``/``codex_reasoning_items``;
+* ``_run_gateway_chat_streaming`` independently writes the WebUI sidecar row —
+  a stable ``id`` from ``_assign_stable_message_ids`` and a timestamp a few
+  hundred microseconds later.
+
+``GET /api/session`` served that assistant answer as TWO adjacent rows while the
+sidecar JSON on disk held exactly one, so inspecting the session file made the
+bug look like a pure DOM-rendering artifact.
+
+Root cause
+----------
+For a messaging session whose agent store holds more rows than the sidecar,
+``_merged_session_messages_for_display`` takes the chronological-union branch
+and dedupes only on ``_session_message_merge_key``. That key has two shapes: a
+row carrying ``id``/``message_id`` keys as ``("message_id", id)``, an
+unidentified row keys as ``("legacy", role, content, timestamp, ...)``. Two key
+SHAPES never compare equal, so the identified sidecar copy and the
+unidentified agent copy of one turn both survived the union.
+
+Contract
+--------
+Identified rows stay authoritative: two rows that both carry ids are distinct
+messages even when their text matches, because a user really can send the same
+prompt twice (``test_session_endpoint_preserves_distinct_messages_with_different_ids``).
+Only an UNIDENTIFIED row is reconciled away, and only while an identified row
+with the same visible identity is still unmatched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import api.routes as routes
+
+
+def _gateway_turn_session():
+    """Sidecar rows exactly as the gateway chat worker writes them."""
+    return SimpleNamespace(
+        messages=[
+            {"id": 7, "role": "user", "content": "show tomorrow's weather", "timestamp": 100.5},
+            {"id": 8, "role": "assistant", "content": "Tomorrow: sunny, 35C.", "timestamp": 130.542},
+        ]
+    )
+
+
+def _gateway_agent_rows():
+    """Agent-store rows for the same turn: no stable id, earlier timestamps."""
+    return [
+        {"role": "user", "content": "show tomorrow's weather", "timestamp": 100.4},
+        {"role": "assistant", "content": "", "timestamp": 110.0, "tool_calls": [{"id": "c1"}]},
+        {"role": "tool", "content": "{\"temp\": 35}", "timestamp": 120.0, "tool_call_id": "c1"},
+        {
+            "role": "assistant",
+            "content": "Tomorrow: sunny, 35C.",
+            "timestamp": 130.424,
+            "reasoning": "**Composing a concise weather summary**",
+            "codex_message_items": [{"type": "message"}],
+        },
+    ]
+
+
+def test_gateway_turn_present_in_both_stores_renders_once():
+    session = _gateway_turn_session()
+    cli_messages = _gateway_agent_rows()
+    # The branch under test is only reached when the agent store is longer.
+    assert len(cli_messages) > len(session.messages)
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    answers = [m for m in merged if m.get("content") == "Tomorrow: sunny, 35C."]
+    assert len(answers) == 1, "one gateway turn must not render as two assistant rows"
+    prompts = [m for m in merged if m.get("content") == "show tomorrow's weather"]
+    assert len(prompts) == 1, "one gateway turn must not render as two user rows"
+
+
+def test_gateway_reconciliation_keeps_the_identified_sidecar_row():
+    session = _gateway_turn_session()
+
+    merged = routes._merged_session_messages_for_display(session, _gateway_agent_rows())
+
+    # The WebUI-owned copy survives: the frontend slices fork/keep-counts
+    # against this list and matches rows by their stable id.
+    assert [m.get("id") for m in merged if m.get("id")] == [7, 8]
+
+
+def test_gateway_reconciliation_keeps_agent_only_rows_and_order():
+    session = _gateway_turn_session()
+
+    merged = routes._merged_session_messages_for_display(session, _gateway_agent_rows())
+
+    # Tool activity lives only in the agent store and must still merge through.
+    assert [m.get("role") for m in merged] == ["user", "assistant", "tool", "assistant"]
+    timestamps = [float(m.get("timestamp") or 0) for m in merged]
+    assert timestamps == sorted(timestamps)
+
+
+def test_identified_rows_with_matching_text_stay_distinct():
+    """Two ids means two messages — a user can send the same prompt twice."""
+    session = SimpleNamespace(
+        messages=[{"id": "sidecar-retry", "role": "user", "content": "retry", "timestamp": 2.0}]
+    )
+    cli_messages = [
+        {"role": "user", "content": "first", "timestamp": 1.0},
+        {"id": "cli-retry", "role": "user", "content": "retry", "timestamp": 2.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m.get("id") for m in merged if m.get("content") == "retry"] == [
+        "cli-retry",
+        "sidecar-retry",
+    ]
+
+
+def test_unidentified_repeats_within_one_store_are_not_collapsed():
+    """Without any id there is no cross-store twin to reconcile against."""
+    session = SimpleNamespace(
+        messages=[{"role": "user", "content": "ping", "timestamp": 5.0}]
+    )
+    cli_messages = [
+        {"role": "user", "content": "ping", "timestamp": 1.0},
+        {"role": "assistant", "content": "pong", "timestamp": 2.0},
+        {"role": "user", "content": "ping", "timestamp": 3.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m.get("content") for m in merged].count("ping") == 3

--- a/tests/test_gateway_dual_store_duplicate_turn.py
+++ b/tests/test_gateway_dual_store_duplicate_turn.py
@@ -82,10 +82,61 @@ the coarse second-granularity key only collapses a row against a kept row from
 the OPPOSITE store — which is the case that key was introduced for: a legacy
 both-unidentified turn written to both stores with sub-second drift between
 the two writes.
+
+Third review round
+------------------
+The survivor queues were keyed by visible identity alone, so an unidentified
+row could consume an identified row from its OWN store. Neither input list is
+homogeneous: ``sidecar_messages`` is the output of
+``_webui_sidecar_lineage_messages_for_display`` and can mix id-stamped rows
+with legacy ones after lineage stitching or an upgrade, and the Agent store
+can hold identified rows too. Because ``_session_message_visible_key`` carries
+role, content and ``tool_calls`` but neither timestamp nor store, two same-text
+turns arbitrarily far apart in ONE store matched each other and the later one
+was dropped as though it were a cross-store twin.
+
+Fixed by partitioning the queues by ``(visible_key, from_sidecar)`` and
+allowing a row to consume only a survivor from the opposite store. The two
+lanes are not symmetric: display metadata is sidecar-authored so it transfers
+on both, but the semantic payload flows only Agent -> sidecar. A
+sidecar-authored ``reasoning`` is the unreliable one (it can hold a verbatim
+copy of the reply, NousResearch/hermes-agent#13007), so it must not ride into
+an Agent survivor under a helper whose documented policy is Agent authority;
+that lane keeps the survivor's own values.
+
+Fourth round (self-review)
+--------------------------
+Three further defects, found by probing this branch rather than by review:
+
+1. The coarse-key collapse tracked only a single "already kept a twin here"
+   flag per key, so ONE kept row could absorb an unbounded number of
+   opposite-store rows -- deleting every additional real turn that shared the
+   second. It now keeps a consumable per-store pool and collapses exactly one
+   twin per kept row, the same one-to-one discipline as the identified lane.
+2. The pairing key omits ``tool_call_id``/``tool_name`` entirely (only
+   ``tool_calls`` is in it), so two results from DIFFERENT tool calls printing
+   the same text -- ``OK``, ``{}``, ``Command completed.`` -- shared a visible
+   key and one was deleted along with its transcript card. Pairing now
+   requires the tool identity to agree. The underlying key is shared with
+   other merge paths and is deliberately left alone.
+3. The reconciliation wrote onto the caller's own dicts. ``session.messages``
+   rows are shared via the module-level session cache, and ``Session.save()``
+   rewrites the whole array from that in-memory object, so a plain ``GET`` --
+   or a metadata-only sidebar poll -- could seed a payload that any later
+   unrelated save committed to the sidecar JSON. Payload now lands on a copy
+   and this function mutates nothing it was handed.
+
+Known remaining limitation, NOT fixed here: ``_session_message_key_with_sidecar``
+appends ``api_content`` to every key shape including the visible key, so a
+gateway turn whose Agent copy carries provider bytes the sidecar copy lacks
+gets two different visible keys and still renders twice. Narrowing that is a
+change to shared identity machinery with its own stricter rules, out of scope
+for this fix.
 """
 
 from __future__ import annotations
 
+import copy
 from types import SimpleNamespace
 
 import api.routes as routes
@@ -284,6 +335,89 @@ def test_surplus_unidentified_repeats_in_one_second_all_survive():
     assert [m.get("reasoning") for m in surplus] == ["first", "second"]
 
 
+def test_unidentified_sidecar_row_cannot_consume_a_sidecar_survivor():
+    """Reconciliation is cross-store only; a store cannot dedupe against itself.
+
+    ``sidecar_messages`` is the output of
+    ``_webui_sidecar_lineage_messages_for_display``, so it can mix id-stamped
+    rows with legacy ones after lineage stitching or an upgrade. Because
+    ``_session_message_visible_key`` carries role/content/tool identity but
+    neither timestamp nor store, an unidentified sidecar row would otherwise
+    match an identified sidecar row from a completely different turn and be
+    dropped as though it were an Agent twin.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {"id": "s1", "role": "assistant", "content": "same", "timestamp": 10.5},
+            {"role": "assistant", "content": "same", "timestamp": 20.5},
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q1", "timestamp": 1.0},
+        {"role": "user", "content": "q2", "timestamp": 2.0},
+        {"role": "user", "content": "q3", "timestamp": 3.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    same = [m for m in merged if m.get("content") == "same"]
+    assert [m.get("timestamp") for m in same] == [10.5, 20.5], "both turns survive"
+    assert same[0].get("id") == "s1"
+
+
+def test_unidentified_agent_row_cannot_consume_an_agent_survivor():
+    """The symmetric case: the Agent store can also hold identified rows."""
+    session = SimpleNamespace(
+        messages=[{"id": "x9", "role": "user", "content": "unrelated", "timestamp": 0.5}]
+    )
+    cli_messages = [
+        {"id": "a1", "role": "assistant", "content": "same", "timestamp": 10.5},
+        {"role": "assistant", "content": "same", "timestamp": 20.5},
+        {"role": "user", "content": "filler", "timestamp": 30.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    same = [m for m in merged if m.get("content") == "same"]
+    assert [m.get("timestamp") for m in same] == [10.5, 20.5], "both turns survive"
+    assert same[0].get("id") == "a1"
+
+
+def test_semantic_payload_travels_only_from_agent_to_sidecar():
+    """The reverse lane keeps the Agent survivor's own semantic values.
+
+    When the identified survivor is the AGENT row and the row being dropped is
+    its unidentified SIDECAR twin, display metadata still transfers (the
+    sidecar authors it) but the semantic payload must not: a sidecar-authored
+    ``reasoning`` is the unreliable one, so it cannot ride into an Agent
+    survivor under a helper documenting Agent authority.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "answer",
+                "timestamp": 10.6,
+                "reasoning": "sidecar reasoning that must not travel",
+                "_turnDuration": 1234,
+            }
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "the question", "timestamp": 1.0},
+        {"id": "a1", "role": "assistant", "content": "answer", "timestamp": 10.4},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    answers = [m for m in merged if m.get("content") == "answer"]
+    assert len(answers) == 1, "the cross-store twin still collapses"
+    survivor = answers[0]
+    assert survivor.get("id") == "a1", "the identified row survives"
+    assert "reasoning" not in survivor, "semantic payload must not flow sidecar->agent"
+    assert survivor.get("_turnDuration") == 1234, "display metadata still transfers"
+
+
 def test_unidentified_cross_store_twin_still_collapses_within_one_second():
     """The coarse merge key's original job must survive this fix.
 
@@ -338,6 +472,206 @@ def test_conflicting_semantic_payload_keeps_survivors_own_value():
 
     survivor = next(m for m in merged if m.get("id") == 8)
     assert survivor["reasoning"] == "sidecar's own reasoning"
+
+
+def test_both_unidentified_twin_carries_payload_either_way():
+    """A legacy cross-store twin must not lose the loser's payload.
+
+    When neither copy has an id, which one survives the sort is decided by
+    sub-second drift between the two stores' writes. Before this was handled,
+    the outcome depended on that drift: the sidecar copy winning silently
+    discarded the Agent copy's reasoning/Codex trace, and the Agent copy
+    winning silently discarded the sidecar's display metadata. Both
+    orderings must now yield the same content.
+    """
+    def merged_twin(sidecar_ts, agent_ts):
+        session = SimpleNamespace(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": "legacy",
+                    "timestamp": sidecar_ts,
+                    "_turnDuration": 999,
+                }
+            ]
+        )
+        cli_messages = [
+            {"role": "user", "content": "q", "timestamp": 1.0},
+            {
+                "role": "assistant",
+                "content": "legacy",
+                "timestamp": agent_ts,
+                "reasoning": "real agent reasoning",
+                "codex_message_items": [{"type": "message"}],
+            },
+        ]
+        out = routes._merged_session_messages_for_display(session, cli_messages)
+        rows = [m for m in out if m.get("content") == "legacy"]
+        assert len(rows) == 1, "the twin still collapses to one row"
+        return rows[0]
+
+    for label, sidecar_ts, agent_ts in (
+        ("sidecar wins the sort", 10.1, 10.4),
+        ("agent wins the sort", 10.9, 10.4),
+    ):
+        row = merged_twin(sidecar_ts, agent_ts)
+        assert row.get("reasoning") == "real agent reasoning", label
+        assert row.get("codex_message_items") == [{"type": "message"}], label
+        assert row.get("_turnDuration") == 999, label
+
+
+def test_same_second_twin_collapse_is_one_to_one():
+    """One kept row absorbs at most ONE opposite-store twin.
+
+    The coarse key groups every same-second repeat of a text, so a single
+    "already kept a twin here" flag lets one row swallow an unbounded number
+    of opposite-store rows, deleting every additional real turn in that
+    second. Which rows die depends only on sub-second write drift, so both
+    orderings are checked.
+    """
+    def merged_reasonings(sidecar_ts):
+        session = SimpleNamespace(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": "same",
+                    "timestamp": sidecar_ts,
+                    "_turnDuration": 7,
+                }
+            ]
+        )
+        cli_messages = [
+            {"role": "user", "content": "q", "timestamp": 1.0},
+            {"role": "assistant", "content": "same", "timestamp": 10.3, "reasoning": "r1"},
+            {"role": "assistant", "content": "same", "timestamp": 10.6, "reasoning": "r2"},
+        ]
+        out = routes._merged_session_messages_for_display(session, cli_messages)
+        return [m.get("reasoning") for m in out if m.get("content") == "same"]
+
+    # Two real Agent turns plus one sidecar twin => two rows either way.
+    assert merged_reasonings(10.1) == ["r1", "r2"], "sidecar twin sorts first"
+    assert merged_reasonings(10.9) == ["r1", "r2"], "sidecar twin sorts last"
+
+
+def test_surplus_same_second_twins_keep_every_real_turn():
+    """Three Agent turns in one second, one sidecar twin => three rows."""
+    session = SimpleNamespace(
+        messages=[{"role": "assistant", "content": "same", "timestamp": 10.1}]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q", "timestamp": 1.0},
+        {"role": "assistant", "content": "same", "timestamp": 10.3, "reasoning": "r1"},
+        {"role": "assistant", "content": "same", "timestamp": 10.5, "reasoning": "r2"},
+        {"role": "assistant", "content": "same", "timestamp": 10.7, "reasoning": "r3"},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [
+        m.get("reasoning") for m in merged if m.get("content") == "same"
+    ] == ["r1", "r2", "r3"]
+
+
+def test_same_second_twins_pair_metadata_one_to_one():
+    """Two real turns, each with its own twin, keep their own metadata."""
+    session = SimpleNamespace(
+        messages=[
+            {"role": "assistant", "content": "same", "timestamp": 10.1, "_turnDuration": 111},
+            {"role": "assistant", "content": "same", "timestamp": 10.2, "_turnDuration": 222},
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q", "timestamp": 1.0},
+        {"role": "assistant", "content": "same", "timestamp": 10.3, "reasoning": "r1"},
+        {"role": "assistant", "content": "same", "timestamp": 10.4, "reasoning": "r2"},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    rows = [m for m in merged if m.get("content") == "same"]
+    assert [(m.get("_turnDuration"), m.get("reasoning")) for m in rows] == [
+        (111, "r1"),
+        (222, "r2"),
+    ]
+
+
+def test_different_tool_calls_with_identical_output_stay_distinct():
+    """The pairing key omits tool identity, so guard it explicitly.
+
+    ``_session_message_visible_key`` carries role, content and ``tool_calls``
+    but NOT ``tool_call_id``/``tool_name``. Two results from different tool
+    calls that print the same text -- ``OK``, ``{}``, ``Command completed.``
+    -- therefore share a visible key, and reconciling them deletes a real
+    tool result along with its card in the transcript.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {
+                "id": "s-A",
+                "role": "tool",
+                "content": '{"ok":true}',
+                "timestamp": 10.5,
+                "tool_call_id": "callA",
+                "tool_name": "read_file",
+            }
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "q", "timestamp": 1.0},
+        {
+            "role": "tool",
+            "content": '{"ok":true}',
+            "timestamp": 20.4,
+            "tool_call_id": "callB",
+            "tool_name": "write_file",
+        },
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    tool_rows = [m for m in merged if m.get("role") == "tool"]
+    assert [m.get("tool_call_id") for m in tool_rows] == ["callA", "callB"]
+
+
+def test_display_merge_does_not_mutate_its_inputs():
+    """Reconciliation must not durably edit the caller's transcript rows.
+
+    ``session.messages`` rows are shared -- they live in the module-level
+    session cache, and ``Session.save()`` rewrites the whole array from that
+    in-memory object. Mutating here would let a plain ``GET`` (or a
+    metadata-only sidebar poll) seed a payload that any later unrelated save
+    commits to the sidecar JSON on disk.
+    """
+    session = _gateway_turn_session()
+    cli_messages = _gateway_agent_rows()
+    sidecar_before = copy.deepcopy(session.messages)
+    cli_before = copy.deepcopy(cli_messages)
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert session.messages == sidecar_before, "sidecar rows must be untouched"
+    assert cli_messages == cli_before, "agent rows must be untouched"
+    # The payload still reaches the returned transcript -- on a copy.
+    survivor = next(m for m in merged if m.get("id") == 8)
+    assert survivor["reasoning"] == "**Composing a concise weather summary**"
+    assert survivor is not session.messages[1]
+
+
+def test_display_merge_is_idempotent():
+    """Re-running the merge on the same session must not change the result.
+
+    The reconciliation mutates the surviving row in place, so a second call
+    sees fields the first call adopted. Both helpers are fill-only-if-absent,
+    which is what makes that safe -- pin it.
+    """
+    session = _gateway_turn_session()
+    cli_messages = _gateway_agent_rows()
+
+    first = routes._merged_session_messages_for_display(session, cli_messages)
+    snapshot = [dict(m) for m in first]
+    second = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [dict(m) for m in second] == snapshot
 
 
 def test_unidentified_repeats_within_one_store_are_not_collapsed():

--- a/tests/test_gateway_dual_store_duplicate_turn.py
+++ b/tests/test_gateway_dual_store_duplicate_turn.py
@@ -62,6 +62,26 @@ existed:
    survivor reference with a per-visible-key FIFO queue built in transcript
    order; each unidentified match pops the oldest still-unmatched entry, so
    repeats pair up one-to-one in the order they actually occurred.
+
+Second review round
+-------------------
+A follow-up review found the FIFO fix above was still gated behind the
+merge-key suppression that runs before it. ``_session_message_merge_key``
+rounds timestamps to whole seconds, so two unidentified rows with the same
+role/content inside one wall-clock second share a key: the first consumed a
+queued survivor, the second hit ``seen_message_keys`` and returned early
+without ever reaching the queue, so its twin kept none of the agent-only
+payload — and where no survivor was waiting at all, the row vanished from the
+transcript outright.
+
+Fixed by splitting duplicate suppression by store for unidentified rows.
+Cross-store matching now runs first; only a row that finds no survivor falls
+through to dedup, where full-precision ``_session_message_dedup_key`` decides
+same-store duplicates (one store's own clock needs no rounding tolerance) and
+the coarse second-granularity key only collapses a row against a kept row from
+the OPPOSITE store — which is the case that key was introduced for: a legacy
+both-unidentified turn written to both stores with sub-second drift between
+the two writes.
 """
 
 from __future__ import annotations
@@ -195,6 +215,94 @@ def test_repeated_identical_answers_pair_one_to_one_in_order():
     assert set(by_id) == {"a1", "a2"}
     assert by_id["a1"]["reasoning"] == "first reasoning"
     assert by_id["a2"]["reasoning"] == "second reasoning"
+
+
+def test_repeated_answers_inside_one_second_pair_one_to_one():
+    """Repeats within a single wall-clock second must still pair one-to-one.
+
+    ``_session_message_merge_key`` rounds timestamps to whole seconds, so two
+    agent rows with the same role/content landing in one second share a merge
+    key even though their fractional timestamps and payloads differ. Suppressing
+    the second one on that key alone would leave its sidecar twin without the
+    reasoning trace it is the sole owner of.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {"id": "a1", "role": "assistant", "content": "same answer", "timestamp": 10.5},
+            {"id": "a2", "role": "assistant", "content": "same answer", "timestamp": 10.8},
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "ask again", "timestamp": 5.0},
+        {
+            "role": "assistant",
+            "content": "same answer",
+            "timestamp": 10.4,
+            "reasoning": "first reasoning",
+            "codex_reasoning_items": [{"type": "reasoning", "n": 1}],
+        },
+        {
+            "role": "assistant",
+            "content": "same answer",
+            "timestamp": 10.7,
+            "reasoning": "second reasoning",
+            "codex_reasoning_items": [{"type": "reasoning", "n": 2}],
+        },
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    answers = [m for m in merged if m.get("content") == "same answer"]
+    assert [m.get("id") for m in answers] == ["a1", "a2"], "no duplicate visible row"
+    by_id = {m["id"]: m for m in answers}
+    assert by_id["a1"]["reasoning"] == "first reasoning"
+    assert by_id["a2"]["reasoning"] == "second reasoning"
+    assert by_id["a1"]["codex_reasoning_items"] == [{"type": "reasoning", "n": 1}]
+    assert by_id["a2"]["codex_reasoning_items"] == [{"type": "reasoning", "n": 2}]
+
+
+def test_surplus_unidentified_repeats_in_one_second_all_survive():
+    """Unpaired same-second repeats from one store are distinct messages.
+
+    When the agent store holds more copies of a text than the sidecar has
+    identified rows to pair them with, the surplus rows have no cross-store
+    twin — they are genuinely separate turns. Collapsing them on the
+    second-granularity merge key would delete a real message outright, not
+    merely its metadata.
+    """
+    session = SimpleNamespace(
+        messages=[{"id": "z1", "role": "assistant", "content": "unrelated", "timestamp": 1.0}]
+    )
+    cli_messages = [
+        {"role": "assistant", "content": "same answer", "timestamp": 10.2, "reasoning": "first"},
+        {"role": "assistant", "content": "same answer", "timestamp": 10.8, "reasoning": "second"},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    surplus = [m for m in merged if m.get("content") == "same answer"]
+    assert [m.get("reasoning") for m in surplus] == ["first", "second"]
+
+
+def test_unidentified_cross_store_twin_still_collapses_within_one_second():
+    """The coarse merge key's original job must survive this fix.
+
+    Sessions predating stable-id stamping hold the same turn in both stores
+    with neither copy identified and a few hundred microseconds of clock drift
+    between the two writes. Second-level rounding is what collapses those into
+    one row, so it still has to apply across stores — just not within one.
+    """
+    session = SimpleNamespace(
+        messages=[{"role": "assistant", "content": "legacy answer", "timestamp": 10.9}]
+    )
+    cli_messages = [
+        {"role": "user", "content": "the question", "timestamp": 1.0},
+        {"role": "assistant", "content": "legacy answer", "timestamp": 10.4},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m.get("content") for m in merged].count("legacy answer") == 1
 
 
 def test_conflicting_semantic_payload_keeps_survivors_own_value():

--- a/tests/test_gateway_dual_store_duplicate_turn.py
+++ b/tests/test_gateway_dual_store_duplicate_turn.py
@@ -33,6 +33,35 @@ messages even when their text matches, because a user really can send the same
 prompt twice (``test_session_endpoint_preserves_distinct_messages_with_different_ids``).
 Only an UNIDENTIFIED row is reconciled away, and only while an identified row
 with the same visible identity is still unmatched.
+
+Review follow-up (same day)
+----------------------------
+A maintainer review of the first version of this fix found the reconciliation
+above was discarding real data along with the duplicate row, and could
+mis-pair metadata when more than one occurrence of the same visible key
+existed:
+
+1. Dropping the unidentified agent-store row copied only the narrow
+   ``_SESSION_MESSAGE_DISPLAY_METADATA_KEYS`` allowlist onto the survivor.
+   That allowlist never included ``reasoning``, ``reasoning_content``,
+   ``reasoning_details``, ``codex_reasoning_items``, or
+   ``codex_message_items`` — exactly the fields the agent-store copy is the
+   sole owner of in the reported production shape. Fixed by
+   ``_adopt_agent_semantic_payload`` (api/models.py): a second, narrow,
+   explicitly-named allowlist, copied only when the survivor lacks the field
+   (never overwriting an existing sidecar value), kept deliberately separate
+   from the display-metadata allowlist so this reconciliation's semantics
+   don't leak into the other call sites that share it. ``api_content`` is
+   excluded from both allowlists on purpose — its identity rules elsewhere in
+   this module are stricter for good reason.
+2. ``identified_by_visible_key.setdefault(visible_key, msg)`` pointed every
+   unidentified match for a visible key at whichever identified row was seen
+   FIRST, so two occurrences of the same visible key (e.g. two identical
+   assistant answers with distinct ids and distinct reasoning) could
+   cross-wire metadata onto the wrong survivor. Fixed by replacing the single
+   survivor reference with a per-visible-key FIFO queue built in transcript
+   order; each unidentified match pops the oldest still-unmatched entry, so
+   repeats pair up one-to-one in the order they actually occurred.
 """
 
 from __future__ import annotations
@@ -92,6 +121,22 @@ def test_gateway_reconciliation_keeps_the_identified_sidecar_row():
     assert [m.get("id") for m in merged if m.get("id")] == [7, 8]
 
 
+def test_gateway_reconciliation_preserves_agent_semantic_payload():
+    """The discarded agent-store row is the sole owner of the real reasoning
+    trace and Codex item lists in the reported production shape — dropping
+    it must not silently drop that payload along with the duplicate row."""
+    session = _gateway_turn_session()
+
+    merged = routes._merged_session_messages_for_display(session, _gateway_agent_rows())
+
+    survivor = next(m for m in merged if m.get("id") == 8)
+    assert survivor["reasoning"] == "**Composing a concise weather summary**"
+    assert survivor["codex_message_items"] == [{"type": "message"}]
+    # api_content has its own stricter identity rules elsewhere; this
+    # reconciliation must not fold it through the generic semantic-payload copy.
+    assert "api_content" not in survivor
+
+
 def test_gateway_reconciliation_keeps_agent_only_rows_and_order():
     session = _gateway_turn_session()
 
@@ -119,6 +164,72 @@ def test_identified_rows_with_matching_text_stay_distinct():
         "cli-retry",
         "sidecar-retry",
     ]
+
+
+def test_repeated_identical_answers_pair_one_to_one_in_order():
+    """Two occurrences of the same visible key must not cross-wire metadata.
+
+    Two identical-text assistant answers, each with its own id and its own
+    distinct agent-store reasoning, must each recover THEIR OWN reasoning —
+    not both pointing at whichever identified row happened to be seen first.
+    """
+    session = SimpleNamespace(
+        messages=[
+            {"id": "a1", "role": "assistant", "content": "same answer", "timestamp": 10.5},
+            {"id": "a2", "role": "assistant", "content": "same answer", "timestamp": 20.5},
+        ]
+    )
+    cli_messages = [
+        # An agent-only row makes the agent store strictly longer than the
+        # sidecar, which is what routes this scenario into the
+        # chronological-union branch under test rather than the sibling
+        # append-only branch (len(sidecar) >= len(cli) takes that one instead).
+        {"role": "user", "content": "ask again", "timestamp": 5.0},
+        {"role": "assistant", "content": "same answer", "timestamp": 10.4, "reasoning": "first reasoning"},
+        {"role": "assistant", "content": "same answer", "timestamp": 20.4, "reasoning": "second reasoning"},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    by_id = {m["id"]: m for m in merged if m.get("id")}
+    assert set(by_id) == {"a1", "a2"}
+    assert by_id["a1"]["reasoning"] == "first reasoning"
+    assert by_id["a2"]["reasoning"] == "second reasoning"
+
+
+def test_conflicting_semantic_payload_keeps_survivors_own_value():
+    """When BOTH sides already carry a non-empty value, the identified
+    survivor's own value wins — agent-store data must not silently
+    overwrite a value the sidecar copy already authored."""
+    session = SimpleNamespace(
+        messages=[
+            {
+                "id": 8,
+                "role": "assistant",
+                "content": "answer",
+                "timestamp": 10.5,
+                "reasoning": "sidecar's own reasoning",
+            }
+        ]
+    )
+    cli_messages = [
+        # Agent-only filler row so len(cli) > len(sidecar) — routes this
+        # scenario into the chronological-union branch under test rather than
+        # the sibling append-only branch (len(sidecar) >= len(cli) takes that
+        # one instead, which has its own, already-tested, conflict handling).
+        {"role": "user", "content": "the question", "timestamp": 5.0},
+        {
+            "role": "assistant",
+            "content": "answer",
+            "timestamp": 10.4,
+            "reasoning": "agent-store reasoning",
+        },
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    survivor = next(m for m in merged if m.get("id") == 8)
+    assert survivor["reasoning"] == "sidecar's own reasoning"
 
 
 def test_unidentified_repeats_within_one_store_are_not_collapsed():


### PR DESCRIPTION
# fix(session): reconcile one turn held by both stores in messaging display merge

## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in a browser, and `GET /api/session` is the single coordinate space the transcript, pagination and fork keep-counts are all computed against.
- A messaging session can be backed by two stores at once: the WebUI sidecar and the agent store.
- With `HERMES_WEBUI_CHAT_BACKEND=gateway` that dual-write happens on *every* browser turn — the agent executes the run and persists its own row, while `_run_gateway_chat_streaming` independently writes the WebUI sidecar row.
- The two copies of one turn are not identical: only the sidecar copy carries a stable `id`.
- `_merged_session_messages_for_display` deduped the chronological union on `_session_message_merge_key` alone, which has two mutually incomparable shapes — `("message_id", id)` and `("legacy", role, content, timestamp, …)` — so the turn survived twice.
- This PR reconciles the two stores on the visible key, the same cross-store identity the sibling append-only branch already uses, so one turn renders once.

## The bug

In a gateway-backed deployment, some assistant turns render **twice** in the browser transcript — a full duplicate block, identical text, stacked vertically, no separator.

The duplication is served by the API, not produced by the browser:

```
GET /api/session?session_id=…&messages=1   ->  274 rows, adjacent duplicate pairs
sidecar JSON on disk                       ->  250 rows, exactly one copy of each turn
```

That gap is why the bug reads as a DOM artifact: inspecting the session file "proves" the data is clean, because the second copy only exists in the merged payload.

The two rows of one assistant answer differ in every field except `content`:

| field | agent-store copy | WebUI sidecar copy |
|---|---|---|
| `id` | *absent* | `8` (from `_assign_stable_message_ids`) |
| `timestamp` | `…557.424624` | `…557.542284` |
| `reasoning` | the model's reasoning | *(see follow-up)* |
| `codex_message_items` / `codex_reasoning_items` | present | absent |

so their merge keys are:

```
('legacy', 'assistant', '<answer text>', '1787915642', '', '', '')
('message_id', '2')
```

Two key **shapes**. They can never compare equal, and `_merged_session_messages_for_display` had no second identity to fall back on. Their `_session_message_visible_key` values, by contrast, are byte-identical.

### Why only this branch

`_merged_session_messages_for_display` picks between two strategies:

- `len(sidecar) >= len(cli)` → `merge_session_messages_append_only`, which already reconciles the stores on the visible key with per-key counting;
- `len(sidecar) < len(cli)` → a chronological union deduped on the merge key only.

The agent store always holds more rows than the sidecar for a gateway-backed session (tool rows, empty tool-call carriers), so the weaker branch is the one that always runs. Whether you get robust cross-store dedupe depended only on which list happened to be longer.

## What Changed

`api/routes.py` — `_merged_session_messages_for_display`, chronological-union branch only:

- Rows are admitted in two passes. Pass 1 admits every **identified** row (one carrying `id`/`message_id`) and records the visible identity it accounts for. Pass 2 admits the **unidentified** rows that no identified row already covers.
- An unidentified row is dropped only while an identified row with the same visible identity is still unmatched; its display-only metadata is folded into the surviving row via `_merge_session_display_metadata`, exactly as the append-only branch does.
- Output order and the existing merge-key dedupe are unchanged.

Identified rows stay authoritative on purpose: two rows that both carry ids are distinct messages even when their text matches, because a user really can send the same prompt twice. That contract is pinned by the existing `test_session_endpoint_preserves_distinct_messages_with_different_ids` and by a new test here.

The sidecar row is the copy that survives. It is the WebUI-owned row the frontend slices fork/keep-counts against and matches by stable id.

## Why It Matters

For any gateway-backed deployment, every browser turn that the agent also persists is served twice. The transcript grows a duplicate per turn, the message count drifts from the sidecar, and pagination/fork offsets are computed against a coordinate space that contains phantom rows.

It also violates the idempotent-replay requirement in `docs/rfcs/live-to-final-assistant-replies.md` ("Replay must be idempotent. It should not duplicate tokens, progress prose, reasoning, tool rows, compression rows, or terminal cards") at the layer below the renderer, so no amount of frontend hardening can fix it.

## Verification

**Automated.** New `tests/test_gateway_dual_store_duplicate_turn.py`, bound to the reported field-level shape (identified sidecar row + unidentified agent row of the same turn, agent store longer):

- fails on `master` — the assistant answer and the user prompt each render twice;
- passes with the fix, keeping the stable ids, the agent-only tool rows, and chronological order;
- pins both non-collapse contracts: two identified rows with matching text stay distinct, and unidentified repeats within one store are not collapsed.

Full suite on Python 3.13 via `./scripts/test.sh`'s venv: **618 passed, 31 skipped**. The one failure, `test_5774b_atomic_config_writes.py::test_atomic_write_preserves_existing_permissions`, reproduces identically on unmodified `master` on this machine (macOS permission semantics) and is unrelated.

**Against the real deployment.** The fixed `_merged_session_messages_for_display` was run against the live session's actual inputs — the real sidecar rows and the real agent-store rows — in the running container, with the module loaded from a scratch copy so the deployment itself was never modified:

```
before: 274 display rows, 4 duplicated assistant answers
after:  266 display rows, 0 duplicated assistant answers
        stable ids [1..8] preserved, chronological order preserved
```

Ownership note: the duplicate-row claim is about this repo's own merge output, proven by calling the repo's function on captured store contents — not inferred from the rendered page.

## Risks / Follow-ups

- **Scope.** Only the `len(sidecar) < len(cli)` branch changes. The append-only branch, the equal-length branch and the no-cli path are untouched.
- **Behavioral risk.** An unidentified row is now droppable. It is dropped only when an identified row with the same visible identity is unmatched, so a session with no stable ids anywhere (the common CLI/Telegram-only shape, where both stores hold byte-identical imported rows) keeps the previous merge-key-only behavior.
- **Not fixed here — a second, separate defect.** On the same deployment the WebUI sidecar row written by the gateway worker has `reasoning` byte-identical to `content` (427 chars each, `content == reasoning` exactly), i.e. the answer is stored as its own reasoning. That points at the `reasoning.available` handling in `api/gateway_chat.py:699-706`, where `STREAM_REASONING_TEXT[stream_id]` accumulates `event_payload["text"]`. It is a write-path bug with its own blast radius and I did not want to mix it into this diff. Happy to file it separately.
- **Deeper root cause, deliberately not addressed.** The real oddity is that gateway mode dual-writes one turn into two stores with no provenance link between the copies — the sidecar row carries no `_state_db_row_id`. Stamping that link at write time would make this reconciliation unnecessary, but it is a contract change to `api/gateway_chat.py` and should be its own discussion. This PR fixes the read path, which is where the user-visible damage is.

## Contract Routing

- **Touched contract family:** session display coordinate space / live-to-final replay idempotence (`docs/rfcs/live-to-final-assistant-replies.md`, `docs/rfcs/webui-run-state-consistency-contract.md`).
- **Evidence:** the two merge keys and the identical visible keys for one turn, captured from a live gateway-backed session; before/after row counts from running the repo's own merge on those captured inputs.
- **No contract change.** This restores the documented idempotent-replay rule; it does not redefine it. No contract document is edited.

## Release note

Gateway-backed browser chat no longer renders a completed turn twice. A messaging session whose agent store holds more rows than its WebUI sidecar now reconciles the two stores on the visible turn identity, so a turn both stores hold is served once instead of twice.

## AI Usage Disclosure

- Provider: Anthropic
- Model: Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code
- Notable tool use: read-only inspection of a live gateway-backed deployment (session sidecar JSON, agent store, `/api/session` responses) to capture the field-level shape; the fixed function was exercised against those captured inputs in a scratch copy of the app tree. Diagnosis, patch and tests reviewed by the human author before submission.
