### PR TITLE
fix(cron): preserve canonical schedule values in edit and duplicate forms

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -24735,7 +24735,15 @@ def _handle_cron_update(handler, body):
                 updates[k] = v
     except ValueError as e:
         return bad(handler, str(e))
-    job = update_job(body["job_id"], updates)
+    # update_job() reparses the schedule through the agent's authoritative
+    # parser, so invalid or display-only schedule input (e.g. the human-readable
+    # "once at ..." text derived for the UI) raises ValueError here. Report it
+    # as a 400 with the parser message instead of letting it escape as a 500,
+    # and keep the existing job untouched (issue #7352).
+    try:
+        job = update_job(body["job_id"], updates)
+    except ValueError as e:
+        return bad(handler, str(e), 400)
     if not job:
         return bad(handler, "Job not found", 404)
     return j(handler, {"ok": True, "job": _cron_job_for_api(job)})

--- a/static/panels.js
+++ b/static/panels.js
@@ -490,6 +490,20 @@ function _cronScheduleKindForInput(value) {
   return '';
 }
 
+function _cronScheduleEditableText(job) {
+  // Return the parser-compatible schedule value for the edit/duplicate forms.
+  // The agent stores canonical values in schedule.run_at (one-shot ISO) and
+  // schedule.expr (cron expression); schedule_display is derived human-readable
+  // text ("once at 2026-08-28 16:00") that the agent parser does not accept as
+  // input, so submitting it back makes the update fail (issue #7352).
+  const s = job && job.schedule;
+  if (s) {
+    if (typeof s.run_at === 'string' && s.run_at) return s.run_at;
+    if (typeof s.expr === 'string' && s.expr) return s.expr;
+  }
+  return (job && job.schedule_display) || '';
+}
+
 function _syncCronScheduleWarning() {
   const input = $('cronFormSchedule');
   const warning = $('cronFormScheduleOnceWarning');
@@ -1529,7 +1543,7 @@ function duplicateCurrentCron(){
   }
   _renderCronForm({
     name: dupName,
-    schedule: job.schedule_display || (job.schedule && job.schedule.expression) || '',
+    schedule: _cronScheduleEditableText(job),
     prompt: job.prompt || '',
     deliver: job.deliver || 'local',
     profile: job.profile || '',
@@ -1590,7 +1604,7 @@ function openCronEdit(job){
   _cronSelectedSkills = Array.isArray(job.skills) ? [...job.skills] : [];
   _renderCronForm({
     name: job.name || '',
-    schedule: job.schedule_display || (job.schedule && job.schedule.expression) || '',
+    schedule: _cronScheduleEditableText(job),
     prompt: job.prompt || '',
     deliver: job.deliver || 'local',
     profile: job.profile || '',

--- a/tests/test_issue7352_cron_once_edit_roundtrip.py
+++ b/tests/test_issue7352_cron_once_edit_roundtrip.py
@@ -1,0 +1,254 @@
+"""Regression coverage for #7352: one-shot cron edit/duplicate round-trip.
+
+The edit and duplicate forms previously populated the schedule field from
+``job.schedule_display`` (human-readable text like ``once at 2026-08-28 16:00``)
+and submitted it back as the canonical ``schedule`` value, which the agent's
+parser rejects -> HTTP 500. The forms must instead pre-fill the canonical
+stored value (``schedule.run_at`` for one-shot, ``schedule.expr`` for cron),
+and the update route must turn parser ``ValueError`` into a 400.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PANELS_JS = REPO / "static" / "panels.js"
+ROUTES_PY = REPO / "api" / "routes.py"
+NODE = shutil.which("node")
+
+_ONE_SHOT_JOB = {
+    "id": "once-job",
+    "name": "One shot",
+    "schedule": {
+        "kind": "once",
+        "run_at": "2026-08-28T16:05:00-05:00",
+        "display": "once at 2026-08-28 16:05",
+    },
+    "schedule_display": "once at 2026-08-28 16:05",
+}
+
+_CRON_JOB = {
+    "id": "cron-job",
+    "name": "Daily",
+    "schedule": {"kind": "cron", "expr": "0 9 * * *", "display": "0 9 * * *"},
+    "schedule_display": "0 9 * * *",
+}
+
+
+# ---------------------------------------------------------------------------
+# Frontend: the schedule pre-fill helper
+# ---------------------------------------------------------------------------
+
+
+def _schedule_helper_source() -> str:
+    src = PANELS_JS.read_text(encoding="utf-8")
+    start = src.find("function _cronScheduleEditableText")
+    if start < 0:
+        pytest.fail("_cronScheduleEditableText is missing from static/panels.js")
+    end = src.find("function _syncCronScheduleWarning", start)
+    if end < 0:
+        pytest.fail("_cronScheduleEditableText must stay near the cron schedule helpers")
+    return src[start:end]
+
+
+def _run_node(script: str) -> str:
+    proc = subprocess.run(
+        [NODE, "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_cron_schedule_editable_text_returns_canonical_stored_value():
+    script = _schedule_helper_source() + r"""
+const cases = {
+  once: _cronScheduleEditableText(%s),
+  cron: _cronScheduleEditableText(%s),
+  legacyOnly: _cronScheduleEditableText({ schedule_display: 'once at 2026-08-28 16:05' }),
+  empty: _cronScheduleEditableText({}),
+  noJob: _cronScheduleEditableText(null),
+};
+console.log(JSON.stringify(cases));
+""" % (json.dumps(_ONE_SHOT_JOB), json.dumps(_CRON_JOB))
+    got = json.loads(_run_node(script))
+
+    # One-shot: canonical run_at, NOT the derived display text.
+    assert got["once"] == "2026-08-28T16:05:00-05:00"
+    # Cron: canonical expr (the old code looked for the wrong key,
+    # schedule.expression, and fell back to display text).
+    assert got["cron"] == "0 9 * * *"
+    # Legacy/unknown shapes keep the display text as before.
+    assert got["legacyOnly"] == "once at 2026-08-28 16:05"
+    assert got["empty"] == ""
+    assert got["noJob"] == ""
+
+
+def _form_functions_source() -> str:
+    src = PANELS_JS.read_text(encoding="utf-8")
+    start = src.find("function duplicateCurrentCron")
+    if start < 0:
+        pytest.fail("duplicateCurrentCron is missing")
+    end = src.find("function _renderCronForm", start)
+    if end < 0:
+        pytest.fail("duplicateCurrentCron/_renderCronForm boundary marker missing")
+    helper_start = src.find("function _cronScheduleEditableText")
+    helper_end = src.find("function _syncCronScheduleWarning", helper_start)
+    return src[helper_start:helper_end] + "\n" + src[start:end]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+@pytest.mark.parametrize(
+    "job,expected",
+    [
+        (_ONE_SHOT_JOB, "2026-08-28T16:05:00-05:00"),
+        (_CRON_JOB, "0 9 * * *"),
+    ],
+)
+def test_cron_edit_and_duplicate_forms_prefill_canonical_schedule(job, expected):
+    script = _form_functions_source() + r"""
+const captured = [];
+function _renderCronForm(opts) { captured.push(opts); }
+function _bindCronSkillPicker() {}
+function _refreshCronProfileSelect() {}
+function loadCronProfiles() { return Promise.resolve(); }
+function api() { return { catch: () => {} }; }
+function switchPanel() {}
+function t(key) { return key; }
+function showToast() {}
+let _currentPanel = 'tasks';
+let _cronList = [];
+_cronSkillsCache = true;  // declared by the extracted source; skip api() branch
+let _currentCronDetail = null;
+
+const job = %s;
+_currentCronDetail = job;
+openCronEdit(job);
+duplicateCurrentCron();
+console.log(JSON.stringify({ edit: captured[0].schedule, duplicate: captured[1].schedule }));
+""" % json.dumps(job)
+    got = json.loads(_run_node(script))
+
+    assert got["edit"] == expected
+    assert got["duplicate"] == expected
+
+
+def test_cron_forms_no_longer_read_schedule_display_or_expression():
+    """Guard the exact regression shape: neither form path may pre-fill from
+    schedule_display or the wrong schedule.expression key."""
+    src = PANELS_JS.read_text(encoding="utf-8")
+    edit = src[src.find("function openCronEdit"): src.find("function _renderCronForm")]
+    duplicate = src[src.find("function duplicateCurrentCron"): src.find("function openCronCreate")]
+    for body in (edit, duplicate):
+        assert "_cronScheduleEditableText(job)" in body
+        assert "schedule_display ||" not in body
+        assert "schedule.expression" not in body
+
+
+# ---------------------------------------------------------------------------
+# Backend: the update route must 400 on parser ValueError
+# ---------------------------------------------------------------------------
+
+
+class _JSONHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.response_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+def _payload(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _install_fake_cron_jobs(monkeypatch, update_job):
+    import api.routes as routes
+
+    calls = []
+
+    def _update_job(job_id, updates):
+        calls.append((job_id, updates))
+        return update_job(job_id, updates)
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.update_job = _update_job
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    return routes, calls
+
+
+def test_cron_update_invalid_schedule_returns_400_with_parser_message(monkeypatch):
+    def _reject(job_id, updates):
+        raise ValueError("invalid schedule: 'once at 2026-08-28 16:05'")
+
+    routes_obj, calls = _install_fake_cron_jobs(monkeypatch, _reject)
+
+    handler = _JSONHandler()
+    routes_obj._handle_cron_update(
+        handler,
+        {"job_id": "once-job", "schedule": "once at 2026-08-28 16:05"},
+    )
+
+    assert handler.status == 400
+    assert "invalid schedule" in _payload(handler)["error"]
+    assert calls == [("once-job", {"schedule": "once at 2026-08-28 16:05"})]
+
+
+def test_cron_update_missing_job_still_returns_404(monkeypatch):
+    routes_obj, _ = _install_fake_cron_jobs(monkeypatch, lambda job_id, updates: None)
+
+    handler = _JSONHandler()
+    routes_obj._handle_cron_update(handler, {"job_id": "missing", "schedule": "0 9 * * *"})
+
+    assert handler.status == 404
+    assert "not found" in _payload(handler)["error"].lower()
+
+
+def test_cron_update_valid_one_shot_schedule_persists(monkeypatch):
+    updated = {
+        "id": "once-job",
+        "name": "One shot",
+        "schedule": {
+            "kind": "once",
+            "run_at": "2026-08-28T16:05:00-05:00",
+            "display": "once at 2026-08-28 16:05",
+        },
+        "schedule_display": "once at 2026-08-28 16:05",
+    }
+
+    routes_obj, calls = _install_fake_cron_jobs(
+        monkeypatch, lambda job_id, updates: {**updated, **updates}
+    )
+
+    handler = _JSONHandler()
+    routes_obj._handle_cron_update(
+        handler,
+        {"job_id": "once-job", "schedule": "2026-08-28T16:05:00-05:00"},
+    )
+
+    assert handler.status == 200
+    assert _payload(handler)["ok"] is True
+    assert calls == [("once-job", {"schedule": "2026-08-28T16:05:00-05:00"})]


### PR DESCRIPTION
## Thinking Path

Issue #7352 reports a one-shot cron edit/duplicate round-trip bug. I traced the schedule value end-to-end and found two siblings:

1. `openCronEdit()` and `duplicateCurrentCron()` both prefilled the schedule input from `job.schedule_display` or `job.schedule.expression`, even though the authoritative stored values are `schedule.run_at` for one-shot jobs and `schedule.expr` for cron jobs.
2. `_handle_cron_update()` let the agent parser's `ValueError` escape from `update_job()`, so bad display-only input became an HTTP 500 instead of a user-correctable 400.

That means the right fix is the shared frontend chokepoint plus the backend route boundary, not one caller in isolation.

## What Changed

- Added `_cronScheduleEditableText(job)` in `static/panels.js`.
  - Returns `schedule.run_at` for one-shot jobs.
  - Returns `schedule.expr` for cron jobs.
  - Falls back to `schedule_display` only for legacy/unknown shapes.
- Switched both `duplicateCurrentCron()` and `openCronEdit()` to use that helper.
- Wrapped `update_job()` in `api/routes.py` so parser `ValueError`s return HTTP 400 with the parser message instead of escaping as HTTP 500.
- Added `tests/test_issue7352_cron_once_edit_roundtrip.py` covering:
  - canonical schedule extraction for one-shot + cron jobs,
  - edit/duplicate form prefill behavior,
  - guard against regressing back to `schedule_display` / `schedule.expression`,
  - invalid schedule update -> HTTP 400,
  - missing job -> HTTP 404,
  - valid one-shot update persists.

## Why It Matters

One-shot cron jobs were using a presentation string (`once at ...`) as if it were canonical editable input. Saving that value back through the authoritative schedule parser fails, so a normal edit/duplicate flow could crash the request with a 500. This change keeps the UI bound to parser-compatible schedule values and downgrades bad input to a proper 400 if it still reaches the server.

## Verification

- `HERMES_WEBUI_TEST_PYTHON=.venv/bin/python ./scripts/test.sh tests/test_issue7352_cron_once_edit_roundtrip.py` -> **7 passed**
- `.venv/bin/python -m pytest tests/test_cron_model_override.py tests/test_cron_no_agent_edit.py tests/test_cron_toast_notifications.py tests/test_issue617_cron_profile_selector.py -q` -> **20 passed**
- `.venv/bin/python -m ruff check tests/test_issue7352_cron_once_edit_roundtrip.py` -> **passed**
- `node --check static/panels.js` -> **passed**

Regression proof:
- The frontend tests distinguish canonical stored values from display text (`run_at` vs `schedule_display`, `expr` vs `schedule.expression`).
- The backend test exercises the exact failure shape from the report: display-only one-shot text reaching `_handle_cron_update()` now returns 400 with the parser message instead of 500.

## Risks / Follow-ups

- The helper intentionally keeps `schedule_display` as a final fallback for legacy/unknown job shapes so existing older payloads still open in the form instead of blanking.
- I did not touch unrelated cron form behavior (profile/model/provider/toast controls) beyond the shared schedule chokepoint; neighboring cron tests above cover those surfaces.

## Model Used

OpenAI Codex (`gpt-5.4`) via Hermes Agent, using repository-local test tooling plus `gh`.

## AI Usage Disclosure

AI-assisted. Provider: OpenAI Codex. Exact model: `gpt-5.4`. Notable tooling/mode: Hermes Agent with repo-local test runner (`./scripts/test.sh`), pytest, ruff, node syntax check, and `gh` for issue/PR workflow.
