### PR TITLE
fix(config): keep provider hint for slash-id picks when session provider differs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3311,8 +3311,22 @@ def model_with_provider_context(model_id: str, model_provider: str | None = None
 
     # For non-OpenRouter slash IDs without an explicit configured provider,
     # keep the ID intact so existing custom/proxy base_url routing and
-    # portal-provider handling remain in charge.
+    # portal-provider handling remain in charge — UNLESS the session provider
+    # is a known routable provider that differs from the profile default.
+    # Dropping the hint there lets the default provider's base_url win and
+    # 404s (e.g. a Nous portal row `upstage/solar-pro4:free` under an
+    # xai-oauth default gets sent to api.x.ai — #7333). Emit the explicit
+    # hint for known static/portal providers and named custom providers
+    # (including `custom:<slug>` stored as the session provider), and keep
+    # the bare ID only for unknown/ambiguous provider slugs (negative
+    # control) so custom/proxy base_url routing stays in charge.
     if "/" in model:
+        if (
+            provider in _PROVIDER_MODELS
+            or provider in _PROVIDER_DISPLAY
+            or provider.startswith("custom:")
+        ):
+            return f"@{provider}:{model}"
         return model
 
     return f"@{provider}:{model}"

--- a/api/config.py
+++ b/api/config.py
@@ -3321,12 +3321,25 @@ def model_with_provider_context(model_id: str, model_provider: str | None = None
     # the bare ID only for unknown/ambiguous provider slugs (negative
     # control) so custom/proxy base_url routing stays in charge.
     if "/" in model:
-        if (
-            provider in _PROVIDER_MODELS
-            or provider in _PROVIDER_DISPLAY
-            or provider.startswith("custom:")
-        ):
+        if provider in _PROVIDER_MODELS or provider in _PROVIDER_DISPLAY:
             return f"@{provider}:{model}"
+        # A named custom provider is only routable when the slug resolves to a
+        # real, unique custom_providers[] entry. `custom:missing` (stale
+        # session provider, no config entry) must NOT be minted into an
+        # @custom:missing:... route — resolve_model_provider() would take the
+        # named-provider lane and find no matching endpoint. `_unique_custom_provider_entry`
+        # returns None for unknown slugs and raises AmbiguousCustomProviderError
+        # for collisions, matching the point-of-return guard used by
+        # resolve_model_provider. (#7356 maintainer review)
+        if provider.startswith("custom:"):
+            custom_providers = cfg.get("custom_providers") if isinstance(cfg, dict) else []
+            if (
+                _unique_custom_provider_entry(
+                    custom_providers, _custom_provider_slug_key(provider)
+                )
+                is not None
+            ):
+                return f"@{provider}:{model}"
         return model
 
     return f"@{provider}:{model}"

--- a/tests/test_issue7333_slash_id_provider_hint.py
+++ b/tests/test_issue7333_slash_id_provider_hint.py
@@ -23,6 +23,8 @@ request path (api/routes.py) resolve via the same shared boundary:
 so exercising that boundary covers both constructions.
 """
 
+import pytest
+
 import api.config as config
 
 
@@ -241,5 +243,59 @@ def test_bare_custom_provider_slash_id_stays_bare():
         assert encoded == "x-ai/grok-4.5", (
             f"bare custom must keep bare passthrough, got {encoded!r}"
         )
+    finally:
+        _restore(old)
+
+
+def test_unknown_named_custom_slug_slash_id_stays_bare():
+    """A custom:<slug> with NO matching custom_providers[] entry must keep the
+    bare id — it is the custom-provider version of the unknown-slug negative
+    control. Routing it as @custom:missing:vendor/model would send the model
+    down a named-provider lane with no matching endpoint (maintainer review
+    on #7356)."""
+    old = _set_config(
+        provider="custom:proxy-main",
+        base_url="https://main.example/v1",
+        default="upstage/solar-pro4:free",
+        custom_providers=[
+            {
+                "name": "proxy-main",
+                "base_url": "https://main.example/v1",
+                "models": {"upstage/solar-pro4:free": {}},
+            },
+        ],
+    )
+    try:
+        encoded = config.model_with_provider_context(
+            "upstage/solar-pro4:free", "custom:missing"
+        )
+        assert encoded == "upstage/solar-pro4:free", (
+            f"unknown named custom slug must keep bare passthrough, got {encoded!r}"
+        )
+    finally:
+        _restore(old)
+
+
+def test_ambiguous_named_custom_slug_fails_closed():
+    """Two custom_providers[] entries normalizing to the same slug must fail
+    closed (AmbiguousCustomProviderError), matching the point-of-return
+    collision guard in resolve_model_provider — a slug we cannot resolve to
+    one unique endpoint must not be minted into an @custom: route."""
+    old = _set_config(
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        default="upstage/solar-pro4:free",
+        custom_providers=[
+            {"name": "proxy-main", "base_url": "https://main.example/v1"},
+            {"name": "Proxy Main", "base_url": "https://other.example/v1"},
+        ],
+    )
+    # "proxy-main" and "Proxy Main" both normalize to slug "proxy-main".
+    assert config._custom_provider_slug_from_name("Proxy Main") == "custom:proxy-main"
+    try:
+        with pytest.raises(config.AmbiguousCustomProviderError):
+            config.model_with_provider_context(
+                "upstage/solar-pro4:free", "custom:proxy-main"
+            )
     finally:
         _restore(old)

--- a/tests/test_issue7333_slash_id_provider_hint.py
+++ b/tests/test_issue7333_slash_id_provider_hint.py
@@ -1,0 +1,218 @@
+"""
+Regression tests for issue #7333 — slash-id catalog picks drop the session
+provider and hit the profile default base_url (Nous -> xAI 404).
+
+``model_with_provider_context()`` historically passed ANY slash-bearing
+model ID through bare when the session provider was not OpenRouter, not an
+ACP/plugin provider, and not listed under ``config.yaml -> providers:``.
+That dropped the provider hint for portal providers (``nous``, ``nvidia``,
+``opencode-zen``, ``opencode-go``) and named custom providers
+(``custom:<slug>``), so ``resolve_model_provider()`` fell back to the
+profile default provider + base_url and sent a vendor-scoped id to the
+wrong endpoint (HTTP 404, e.g. ``upstage/solar-pro4:free`` to
+``api.x.ai``).
+
+The fix emits an explicit ``@<provider>:<model>`` hint for any KNOWN
+routable provider that differs from the configured default, while keeping
+the bare passthrough for unknown/ambiguous provider slugs (negative
+control) so custom/proxy base_url routing stays in charge.
+
+Both the embedded streaming path (api/streaming.py) and the Gateway
+request path (api/routes.py) resolve via the same shared boundary:
+``model_with_provider_context(...)`` -> ``resolve_model_provider(...)``,
+so exercising that boundary covers both constructions.
+"""
+
+import api.config as config
+
+
+def _set_config(provider, base_url=None, default=None, custom_providers=None):
+    old_cfg = dict(config.cfg)
+    model_cfg = {}
+    if provider:
+        model_cfg["provider"] = provider
+    if base_url:
+        model_cfg["base_url"] = base_url
+    if default:
+        model_cfg["default"] = default
+    config.cfg["model"] = model_cfg
+    config.cfg["providers"] = {}
+    if custom_providers is not None:
+        config.cfg["custom_providers"] = custom_providers
+    return old_cfg
+
+
+def _restore(old_cfg):
+    config.cfg.clear()
+    config.cfg.update(old_cfg)
+
+
+# ── The reported bug: nous pick under an xai-oauth default ───────────────
+
+def test_nous_slash_id_keeps_provider_hint_under_foreign_default():
+    """upstage/solar-pro4:free on nous must NOT fall back to the xAI default."""
+    old = _set_config(provider="xai-oauth", base_url="https://api.x.ai/v1",
+                      default="grok-4.6")
+    try:
+        encoded = config.model_with_provider_context("upstage/solar-pro4:free", "nous")
+        assert encoded == "@nous:upstage/solar-pro4:free", (
+            f"expected explicit nous hint, got {encoded!r}"
+        )
+        model, provider, base_url = config.resolve_model_provider(encoded)
+        assert provider == "nous", (
+            f"session provider must win over xai-oauth default, got {provider!r}"
+        )
+        assert model == "upstage/solar-pro4:free"
+        assert base_url != "https://api.x.ai/v1", (
+            "must not inherit the xAI base_url"
+        )
+    finally:
+        _restore(old)
+
+
+def test_nous_slash_id_roundtrip_via_canonical_lane():
+    """The lane-comparison helper must see nous, not xai-oauth."""
+    old = _set_config(provider="xai-oauth", base_url="https://api.x.ai/v1",
+                      default="grok-4.6")
+    try:
+        lane_model, lane_provider = config.canonical_model_provider_lane(
+            "upstage/solar-pro4:free", "nous"
+        )
+        assert lane_provider == "nous", f"lane provider={lane_provider!r}"
+        assert lane_model == "upstage/solar-pro4:free"
+    finally:
+        _restore(old)
+
+
+# ── Same slash ID when the portal IS the profile default ─────────────────
+
+def test_nous_slash_id_when_nous_is_default_stays_bare_and_routes_nous():
+    """provider == config_provider keeps the bare id; portal handling keeps it on nous."""
+    old = _set_config(provider="nous", default="upstage/solar-pro4:free")
+    try:
+        encoded = config.model_with_provider_context("upstage/solar-pro4:free", "nous")
+        assert encoded == "upstage/solar-pro4:free", (
+            f"same-provider pick must stay bare, got {encoded!r}"
+        )
+        model, provider, _ = config.resolve_model_provider(encoded)
+        assert provider == "nous", f"got {provider!r}"
+        assert model == "upstage/solar-pro4:free"
+    finally:
+        _restore(old)
+
+
+# ── OpenRouter and configured OpenAI-compatible providers (unchanged) ────
+
+def test_openrouter_slash_id_still_gets_hint():
+    old = _set_config(provider="anthropic")
+    try:
+        encoded = config.model_with_provider_context("tencent/hy3-preview:free", "openrouter")
+        assert encoded == "@openrouter:tencent/hy3-preview:free", (
+            f"openrouter hint unchanged, got {encoded!r}"
+        )
+        model, provider, _ = config.resolve_model_provider(encoded)
+        assert provider == "openrouter"
+        assert model == "tencent/hy3-preview:free"
+    finally:
+        _restore(old)
+
+
+def test_provider_declared_in_config_still_gets_hint():
+    """A provider with a config.yaml providers: block keeps its @hint (unchanged)."""
+    old = _set_config(provider="openai", base_url="https://api.openai.com/v1")
+    config.cfg["providers"] = {"lmstudio": {"base_url": "http://localhost:1234/v1"}}
+    try:
+        encoded = config.model_with_provider_context("unsloth/gemma-4-12b-it", "lmstudio")
+        assert encoded == "@lmstudio:unsloth/gemma-4-12b-it", (
+            f"configured provider must keep hint, got {encoded!r}"
+        )
+        model, provider, base_url = config.resolve_model_provider(encoded)
+        assert provider == "lmstudio"
+        assert base_url == "http://localhost:1234/v1"
+        assert model == "unsloth/gemma-4-12b-it"
+    finally:
+        _restore(old)
+
+
+# ── Named custom provider variant (#7346) ────────────────────────────────
+
+def test_named_custom_slash_id_keeps_hint_under_other_custom_default():
+    """custom:proxy-alt slash pick must not fall back to custom:proxy-main."""
+    custom_providers = [
+        {"name": "proxy-main", "base_url": "https://main.example/v1",
+         "models": {"upstage/solar-pro4:free": {}}},
+        {"name": "proxy-alt", "base_url": "https://alt.example/v1",
+         "models": {"upstage/solar-pro4:free": {}}},
+    ]
+    old = _set_config(provider="custom:proxy-main",
+                      base_url="https://main.example/v1",
+                      default="upstage/solar-pro4:free",
+                      custom_providers=custom_providers)
+    try:
+        encoded = config.model_with_provider_context(
+            "upstage/solar-pro4:free", "custom:proxy-alt"
+        )
+        assert encoded == "@custom:proxy-alt:upstage/solar-pro4:free", (
+            f"named custom hint must be preserved, got {encoded!r}"
+        )
+        model, provider, _ = config.resolve_model_provider(encoded)
+        assert provider == "custom:proxy-alt", (
+            f"must route to proxy-alt, got {provider!r}"
+        )
+        assert model == "upstage/solar-pro4:free"
+    finally:
+        _restore(old)
+
+
+def test_named_custom_slash_id_legacy_providers_map_shape():
+    """Legacy shape: providers: map uses plain slugs while the stored
+    session provider identity is custom:<slug> — hint must survive."""
+    old = _set_config(provider="custom:proxy-main",
+                      base_url="https://main.example/v1",
+                      default="x-ai/grok-4.5")
+    # Legacy duplicated providers: map with plain slugs; the stored session
+    # provider is the canonical custom:<slug> identity.
+    config.cfg["providers"] = {"proxy-alt": {"base_url": "https://alt.example/v1"}}
+    config.cfg["custom_providers"] = [
+        {"name": "proxy-alt", "base_url": "https://alt.example/v1",
+         "models": {"x-ai/grok-4.5": {}}},
+    ]
+    try:
+        encoded = config.model_with_provider_context("x-ai/grok-4.5", "custom:proxy-alt")
+        assert encoded == "@custom:proxy-alt:x-ai/grok-4.5", (
+            f"legacy-shape custom hint must be preserved, got {encoded!r}"
+        )
+        model, provider, _ = config.resolve_model_provider(encoded)
+        assert provider == "custom:proxy-alt", f"got {provider!r}"
+        assert model == "x-ai/grok-4.5"
+    finally:
+        _restore(old)
+
+
+# ── Negative control: unknown/ambiguous provider not rewritten ───────────
+
+def test_unknown_provider_slash_id_stays_bare():
+    """An unknown provider slug must NOT be rewritten into an @hint; the
+    bare id keeps existing custom/proxy base_url routing in charge."""
+    old = _set_config(provider="openai", base_url="https://proxy.example/v1")
+    try:
+        encoded = config.model_with_provider_context("vendor/model", "totally-unknown-provider")
+        assert encoded == "vendor/model", (
+            f"unknown provider must keep bare passthrough, got {encoded!r}"
+        )
+    finally:
+        _restore(old)
+
+
+def test_bare_custom_provider_slash_id_stays_bare():
+    """Bare 'custom' (no slug) is a proxy pseudo-provider — it keeps the bare
+    id so the configured base_url routing stays in charge (unchanged)."""
+    old = _set_config(provider="custom", base_url="https://proxy.example/v1",
+                      default="x-ai/grok-4.5")
+    try:
+        encoded = config.model_with_provider_context("x-ai/grok-4.5", "custom")
+        assert encoded == "x-ai/grok-4.5", (
+            f"bare custom must keep bare passthrough, got {encoded!r}"
+        )
+    finally:
+        _restore(old)

--- a/tests/test_issue7333_slash_id_provider_hint.py
+++ b/tests/test_issue7333_slash_id_provider_hint.py
@@ -49,10 +49,12 @@ def _restore(old_cfg):
 
 # ── The reported bug: nous pick under an xai-oauth default ───────────────
 
+
 def test_nous_slash_id_keeps_provider_hint_under_foreign_default():
     """upstage/solar-pro4:free on nous must NOT fall back to the xAI default."""
-    old = _set_config(provider="xai-oauth", base_url="https://api.x.ai/v1",
-                      default="grok-4.6")
+    old = _set_config(
+        provider="xai-oauth", base_url="https://api.x.ai/v1", default="grok-4.6"
+    )
     try:
         encoded = config.model_with_provider_context("upstage/solar-pro4:free", "nous")
         assert encoded == "@nous:upstage/solar-pro4:free", (
@@ -63,17 +65,16 @@ def test_nous_slash_id_keeps_provider_hint_under_foreign_default():
             f"session provider must win over xai-oauth default, got {provider!r}"
         )
         assert model == "upstage/solar-pro4:free"
-        assert base_url != "https://api.x.ai/v1", (
-            "must not inherit the xAI base_url"
-        )
+        assert base_url != "https://api.x.ai/v1", "must not inherit the xAI base_url"
     finally:
         _restore(old)
 
 
 def test_nous_slash_id_roundtrip_via_canonical_lane():
     """The lane-comparison helper must see nous, not xai-oauth."""
-    old = _set_config(provider="xai-oauth", base_url="https://api.x.ai/v1",
-                      default="grok-4.6")
+    old = _set_config(
+        provider="xai-oauth", base_url="https://api.x.ai/v1", default="grok-4.6"
+    )
     try:
         lane_model, lane_provider = config.canonical_model_provider_lane(
             "upstage/solar-pro4:free", "nous"
@@ -85,6 +86,7 @@ def test_nous_slash_id_roundtrip_via_canonical_lane():
 
 
 # ── Same slash ID when the portal IS the profile default ─────────────────
+
 
 def test_nous_slash_id_when_nous_is_default_stays_bare_and_routes_nous():
     """provider == config_provider keeps the bare id; portal handling keeps it on nous."""
@@ -103,10 +105,13 @@ def test_nous_slash_id_when_nous_is_default_stays_bare_and_routes_nous():
 
 # ── OpenRouter and configured OpenAI-compatible providers (unchanged) ────
 
+
 def test_openrouter_slash_id_still_gets_hint():
     old = _set_config(provider="anthropic")
     try:
-        encoded = config.model_with_provider_context("tencent/hy3-preview:free", "openrouter")
+        encoded = config.model_with_provider_context(
+            "tencent/hy3-preview:free", "openrouter"
+        )
         assert encoded == "@openrouter:tencent/hy3-preview:free", (
             f"openrouter hint unchanged, got {encoded!r}"
         )
@@ -122,7 +127,9 @@ def test_provider_declared_in_config_still_gets_hint():
     old = _set_config(provider="openai", base_url="https://api.openai.com/v1")
     config.cfg["providers"] = {"lmstudio": {"base_url": "http://localhost:1234/v1"}}
     try:
-        encoded = config.model_with_provider_context("unsloth/gemma-4-12b-it", "lmstudio")
+        encoded = config.model_with_provider_context(
+            "unsloth/gemma-4-12b-it", "lmstudio"
+        )
         assert encoded == "@lmstudio:unsloth/gemma-4-12b-it", (
             f"configured provider must keep hint, got {encoded!r}"
         )
@@ -136,18 +143,27 @@ def test_provider_declared_in_config_still_gets_hint():
 
 # ── Named custom provider variant (#7346) ────────────────────────────────
 
+
 def test_named_custom_slash_id_keeps_hint_under_other_custom_default():
     """custom:proxy-alt slash pick must not fall back to custom:proxy-main."""
     custom_providers = [
-        {"name": "proxy-main", "base_url": "https://main.example/v1",
-         "models": {"upstage/solar-pro4:free": {}}},
-        {"name": "proxy-alt", "base_url": "https://alt.example/v1",
-         "models": {"upstage/solar-pro4:free": {}}},
+        {
+            "name": "proxy-main",
+            "base_url": "https://main.example/v1",
+            "models": {"upstage/solar-pro4:free": {}},
+        },
+        {
+            "name": "proxy-alt",
+            "base_url": "https://alt.example/v1",
+            "models": {"upstage/solar-pro4:free": {}},
+        },
     ]
-    old = _set_config(provider="custom:proxy-main",
-                      base_url="https://main.example/v1",
-                      default="upstage/solar-pro4:free",
-                      custom_providers=custom_providers)
+    old = _set_config(
+        provider="custom:proxy-main",
+        base_url="https://main.example/v1",
+        default="upstage/solar-pro4:free",
+        custom_providers=custom_providers,
+    )
     try:
         encoded = config.model_with_provider_context(
             "upstage/solar-pro4:free", "custom:proxy-alt"
@@ -167,18 +183,25 @@ def test_named_custom_slash_id_keeps_hint_under_other_custom_default():
 def test_named_custom_slash_id_legacy_providers_map_shape():
     """Legacy shape: providers: map uses plain slugs while the stored
     session provider identity is custom:<slug> — hint must survive."""
-    old = _set_config(provider="custom:proxy-main",
-                      base_url="https://main.example/v1",
-                      default="x-ai/grok-4.5")
+    old = _set_config(
+        provider="custom:proxy-main",
+        base_url="https://main.example/v1",
+        default="x-ai/grok-4.5",
+    )
     # Legacy duplicated providers: map with plain slugs; the stored session
     # provider is the canonical custom:<slug> identity.
     config.cfg["providers"] = {"proxy-alt": {"base_url": "https://alt.example/v1"}}
     config.cfg["custom_providers"] = [
-        {"name": "proxy-alt", "base_url": "https://alt.example/v1",
-         "models": {"x-ai/grok-4.5": {}}},
+        {
+            "name": "proxy-alt",
+            "base_url": "https://alt.example/v1",
+            "models": {"x-ai/grok-4.5": {}},
+        },
     ]
     try:
-        encoded = config.model_with_provider_context("x-ai/grok-4.5", "custom:proxy-alt")
+        encoded = config.model_with_provider_context(
+            "x-ai/grok-4.5", "custom:proxy-alt"
+        )
         assert encoded == "@custom:proxy-alt:x-ai/grok-4.5", (
             f"legacy-shape custom hint must be preserved, got {encoded!r}"
         )
@@ -191,12 +214,15 @@ def test_named_custom_slash_id_legacy_providers_map_shape():
 
 # ── Negative control: unknown/ambiguous provider not rewritten ───────────
 
+
 def test_unknown_provider_slash_id_stays_bare():
     """An unknown provider slug must NOT be rewritten into an @hint; the
     bare id keeps existing custom/proxy base_url routing in charge."""
     old = _set_config(provider="openai", base_url="https://proxy.example/v1")
     try:
-        encoded = config.model_with_provider_context("vendor/model", "totally-unknown-provider")
+        encoded = config.model_with_provider_context(
+            "vendor/model", "totally-unknown-provider"
+        )
         assert encoded == "vendor/model", (
             f"unknown provider must keep bare passthrough, got {encoded!r}"
         )
@@ -207,8 +233,9 @@ def test_unknown_provider_slash_id_stays_bare():
 def test_bare_custom_provider_slash_id_stays_bare():
     """Bare 'custom' (no slug) is a proxy pseudo-provider — it keeps the bare
     id so the configured base_url routing stays in charge (unchanged)."""
-    old = _set_config(provider="custom", base_url="https://proxy.example/v1",
-                      default="x-ai/grok-4.5")
+    old = _set_config(
+        provider="custom", base_url="https://proxy.example/v1", default="x-ai/grok-4.5"
+    )
     try:
         encoded = config.model_with_provider_context("x-ai/grok-4.5", "custom")
         assert encoded == "x-ai/grok-4.5", (

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -553,15 +553,39 @@ def test_bare_codex_gpt_runtime_bridge_routes_to_codex(monkeypatch):
 
 
 def test_non_openrouter_slash_model_provider_context_stays_unqualified():
-    """Portal/custom slash IDs must not be blindly wrapped as @provider:model."""
+    """Portal/custom slash IDs must keep the provider hint when the session
+    provider differs from the profile default (#7333).
+
+    Previously any non-OpenRouter slash ID fell through to a bare passthrough,
+    dropping the session provider — so a Nous portal row
+    (``anthropic/claude-sonnet-4.6`` on the Nous namespace) picked under a
+    foreign default (e.g. xai-oauth) inherited the default provider's base_url
+    and 404'd. The fix emits ``@provider:model`` for known routable providers
+    (portal/static/named-custom) that differ from the configured default.
+    """
     import api.config as config
 
-    runtime_model = config.model_with_provider_context(
-        "anthropic/claude-sonnet-4.6",
-        "nous",
-    )
+    old_cfg = dict(config.cfg)
+    config.cfg["model"] = {
+        "provider": "xai-oauth",
+        "default": "grok-4.6",
+        "base_url": "https://api.x.ai/v1",
+    }
+    config.cfg["providers"] = {}
+    try:
+        runtime_model = config.model_with_provider_context(
+            "anthropic/claude-sonnet-4.6",
+            "nous",
+        )
+        model, provider, base_url = config.resolve_model_provider(runtime_model)
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
 
-    assert runtime_model == "anthropic/claude-sonnet-4.6"
+    assert runtime_model == "@nous:anthropic/claude-sonnet-4.6"
+    assert model == "anthropic/claude-sonnet-4.6"
+    assert provider == "nous"
+    assert base_url != "https://api.x.ai/v1"
 
 
 def test_configured_provider_slash_model_keeps_provider_context():


### PR DESCRIPTION
## Problem

Closes #7333 (confirmed P1 by maintainer). Composer catalog rows that carry a non-default provider (e.g. a **Nous** portal row like `upstage/solar-pro4:free`) run against the **profile default provider** when:

1. the model id is slash-namespaced (`vendor/model` or `vendor/model:free`), and
2. the profile has `model.provider` + `model.base_url` set to a first-party endpoint (e.g. `xai-oauth` + `https://api.x.ai/v1`).

The session sidecar is honest (`model_provider: nous`), but `model_with_provider_context()` passed **any** slash-bearing id through bare when the session provider was not OpenRouter/ACP/plugin and not listed under `config.yaml -> providers:` — dropping the hint. `resolve_model_provider()` then fell back to the profile default provider + `base_url` and sent the vendor-scoped id to the wrong endpoint → HTTP 404. Same class of bug for named custom providers (`custom:proxy-alt` pick under a `custom:proxy-main` default — the #7346 variant confirmed by maintainer).

## Fix

`api/config.py` — `model_with_provider_context()`: when the model id contains `/` and the session provider **differs** from the configured default, emit an explicit `@provider:model` hint for any **known routable** provider:

- static/portal providers in `_PROVIDER_MODELS` / `_PROVIDER_DISPLAY` (nous, nvidia, opencode-zen, opencode-go, …)
- named custom providers (`custom:<slug>`, incl. the legacy `providers:`-map shape where the stored identity is `custom:<slug>`)

The bare passthrough is kept for **unknown/ambiguous provider slugs** (negative control) and for bare `custom` (proxy pseudo-provider) so existing custom/proxy `base_url` routing stays in charge. Same-provider picks, OpenRouter, ACP, plugin, and configured `providers:` entries are all untouched.

Both the embedded streaming path (`api/streaming.py`) and the Gateway request path (`api/routes.py`) resolve through this shared `model_with_provider_context(...)` → `resolve_model_provider(...)` boundary, so the fix covers both constructions.

## Tests

- New `tests/test_issue7333_slash_id_provider_hint.py` (9 tests), covering the maintainer's regression matrix:
  - `nous` + `upstage/solar-pro4:free` under an `xai-oauth` default → resolved provider = `nous`, never the xAI base_url
  - same slash id when `nous` **is** the profile default → stays bare and routes nous (unchanged)
  - OpenRouter + configured OpenAI-compatible provider hints (unchanged)
  - named-custom variants: `custom:proxy-alt` under `custom:proxy-main` default; legacy `providers:`-map shape
  - negative controls: unknown provider slug and bare `custom` stay bare
- **Regression-proven:** all 4 bug-class tests FAIL on pre-fix code (hint dropped → bare id returned), pass with the fix; negative controls pass both ways.
- Updated `tests/test_provider_mismatch.py::test_non_openrouter_slash_model_provider_context_stays_unqualified` — it previously locked in the buggy bare-passthrough for `nous` + slash id; now asserts the corrected `@nous:...` routing per the maintainer's fix directive.

## Verification

- 208 tests pass across the resolver/provider/routing suites (`test_model_resolver`, `test_resolve_model_provider_free_suffix`, `test_issue1894_provider_overlap`, `test_plugin_model_providers`, `test_openai_api_provider_alias`, `test_provider_mismatch`, new file)
- `scripts/ruff_lint.py --diff origin/master`: 0 new violations on added/modified lines
- `python3 -m compileall`: clean
- New test file is `ruff format`-clean

## Notes

- No changes to the picker/UI or to session persistence — the fix is at the shared runtime-encoding boundary, exactly where the maintainer placed it ("The fix belongs at the shared runtime-encoding boundary, not as a Solar-specific exception").

### AI Usage Disclosure

Per CONTRIBUTING.md section 4:

- Provider: DeepSeek
- Model: deepseek-v4-flash (autonomous agent run; analysis, reproduction, fix, and tests executed with terminal + git tooling)

