### PR TITLE
fix(auth): redirect /login to the safe next path when already authenticated

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1926,6 +1926,8 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 - Enter wrong password → error message, stay on login page.
 - Settings panel: set password via "Access Password" field. Auth activates.
 - "Sign Out" button visible when auth active. Click → redirected to /login.
+- While signed in, open `/login` directly → 302 back to `/` (or to a safe `?next=` path) instead of the form. Sign out first if you need the form.
+- Behind a trusted-header reverse proxy, open `/login` → 302 to `/`; the installed iOS Home Screen app relaunching on `/login` recovers on its own.
 - API calls without auth cookie → 401 JSON response.
 - Check response headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1926,8 +1926,8 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 - Enter wrong password → error message, stay on login page.
 - Settings panel: set password via "Access Password" field. Auth activates.
 - "Sign Out" button visible when auth active. Click → redirected to /login.
-- While signed in, open `/login` directly → 302 back to `/` (or to a safe `?next=` path) instead of the form. Sign out first if you need the form.
-- Behind a trusted-header reverse proxy, open `/login` → 302 to `/`; the installed iOS Home Screen app relaunching on `/login` recovers on its own.
+- While signed in, open `/login` directly → 302 to the deployment's mount root (`./`, so `/hermes/login` lands on `/hermes/`) or to a safe `?next=` path, instead of the form. Sign out first if you need the form.
+- Behind a trusted-header reverse proxy, open `/login` → 302 to the mount root; the installed iOS Home Screen app relaunching on `/login` recovers on its own.
 - API calls without auth cookie → 401 JSON response.
 - Check response headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -11036,6 +11036,28 @@ def _safe_login_redirect_path(raw_path: str | None) -> str:
     return path
 
 
+def _login_redirect_location(safe_path: str) -> str:
+    """Serialize a `_safe_login_redirect_path()` result as a `Location` value.
+
+    The fallback `/` becomes `./`: from `<mount>/login` that resolves to the
+    mount root, so a subpath deployment such as `/hermes/` is not sent to the
+    site root. This mirrors the `_safeNextPath()` default in static/login.js.
+    A present `next` is emitted as-is — the app's own producers (static/ui.js,
+    workspace.js, boot.js) build it from `window.location.pathname`, which
+    already carries the mount prefix, and login.js navigates to it verbatim;
+    prefixing `./` would double the mount (`/hermes/hermes/session/...`).
+
+    `parse_qs()` has already decoded percent escapes, so a UTF-8 `next` arrives
+    as a Unicode string, and `BaseHTTPRequestHandler.send_header()` encodes
+    header values as strict Latin-1 — `/你好` would raise. Percent-encode
+    anything outside the RFC 3986 reserved/unreserved sets back to an ASCII
+    URI; `%` stays safe so a `%xx` that survived decoding is not doubled.
+    """
+    if safe_path == "/":
+        return "./"
+    return quote(safe_path, safe="/%:@!$&'()*+,;=?#[]~")
+
+
 def _request_base_url(handler) -> str:
     from api.auth import _is_secure_context
 
@@ -12943,8 +12965,10 @@ def handle_get(handler, parsed) -> bool:
             handler.send_response(302)
             handler.send_header(
                 "Location",
-                _safe_login_redirect_path(
-                    parse_qs(parsed.query or "").get("next", [""])[0]
+                _login_redirect_location(
+                    _safe_login_redirect_path(
+                        parse_qs(parsed.query or "").get("next", [""])[0]
+                    )
                 ),
             )
             handler.send_header("Cache-Control", "no-store")

--- a/api/routes.py
+++ b/api/routes.py
@@ -11051,11 +11051,14 @@ def _login_redirect_location(safe_path: str) -> str:
     as a Unicode string, and `BaseHTTPRequestHandler.send_header()` encodes
     header values as strict Latin-1 — `/你好` would raise. Percent-encode
     anything outside the RFC 3986 reserved/unreserved sets back to an ASCII
-    URI; `%` stays safe so a `%xx` that survived decoding is not doubled.
+    URI. A `%` is legal only as the start of a `%HH` triplet: a valid triplet
+    that survived decoding is kept as-is (not doubled to `%25HH`), while a
+    lone or malformed `%` (`100%`, `%Z`) is escaped to `%25`.
     """
     if safe_path == "/":
         return "./"
-    return quote(safe_path, safe="/%:@!$&'()*+,;=?#[]~")
+    path = re.sub(r"%(?![0-9A-Fa-f]{2})", "%25", safe_path)
+    return quote(path, safe="/%:@!$&'()*+,;=?#[]~")
 
 
 def _request_base_url(handler) -> str:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2920,6 +2920,7 @@ from api.helpers import (
     read_body,
     MAX_BODY_BYTES,
     _security_headers,
+    flush_pending_auth_cookies,
     _sanitize_error,
     redact_session_data,
     public_session_projection,
@@ -12928,6 +12929,30 @@ def handle_get(handler, parsed) -> bool:
         )
 
     if parsed.path == "/login":
+        from api.auth import ensure_trusted_auth_session, is_auth_enabled
+
+        # Already signed in — send the browser on instead of rendering a form it
+        # cannot use. `/login` is public (PUBLIC_PATHS), so check_auth() never
+        # reconciles the request's identity here; do it in the route. This
+        # covers both a trusted reverse-proxy header and a valid session
+        # cookie. It matters most for an installed web app: iOS relaunches a
+        # Home Screen app at its last URL, so a device that once landed on
+        # /login stays parked on the password form forever even though every
+        # request it makes is authenticated.
+        if is_auth_enabled() and ensure_trusted_auth_session(handler):
+            handler.send_response(302)
+            handler.send_header(
+                "Location",
+                _safe_login_redirect_path(
+                    parse_qs(parsed.query or "").get("next", [""])[0]
+                ),
+            )
+            handler.send_header("Cache-Control", "no-store")
+            handler.send_header("Content-Length", "0")
+            _security_headers(handler)
+            flush_pending_auth_cookies(handler)
+            handler.end_headers()
+            return True
         _settings = load_settings()
         _bn = _html.escape(_settings.get("bot_name") or "Hermes")
         _lang = _settings.get("language", "en")

--- a/tests/test_login_redirect_when_authenticated.py
+++ b/tests/test_login_redirect_when_authenticated.py
@@ -15,8 +15,9 @@ destination, and still renders the form for everyone else.
 from __future__ import annotations
 
 import io
+import re
 from types import SimpleNamespace
-from urllib.parse import urljoin
+from urllib.parse import parse_qs, urljoin
 
 import pytest
 
@@ -88,6 +89,15 @@ def _get_login(handler, query=""):
 
 def _location(handler):
     return handler.header_values("Location")
+
+
+_PCT_ONLY_TRIPLETS = re.compile(r"^(?:[^%]|%[0-9A-Fa-f]{2})*$")
+
+
+def _assert_ascii_uri(location):
+    """RFC 3986: `%` is legal only as the start of a two-hex-digit triplet."""
+    assert location.isascii(), location
+    assert _PCT_ONLY_TRIPLETS.match(location), location
 
 
 def test_trusted_header_request_redirects_to_safe_next(monkeypatch):
@@ -181,6 +191,7 @@ def test_non_latin1_next_is_percent_encoded_for_the_header(monkeypatch):
     assert _get_login(handler, query="next=%2F%E4%BD%A0%E5%A5%BD") is True
     assert handler.status == 302
     assert _location(handler) == ["/%E4%BD%A0%E5%A5%BD"]
+    _assert_ascii_uri(_location(handler)[0])
 
 
 def test_latin1_encodable_non_ascii_next_is_still_percent_encoded(monkeypatch):
@@ -191,6 +202,7 @@ def test_latin1_encodable_non_ascii_next_is_still_percent_encoded(monkeypatch):
 
     assert _get_login(handler, query="next=%2Fsession%2Fcaf%C3%A9") is True
     assert _location(handler) == ["/session/caf%C3%A9"]
+    _assert_ascii_uri(_location(handler)[0])
 
 
 def test_existing_escapes_and_delimiters_survive_encoding(monkeypatch):
@@ -205,6 +217,36 @@ def test_existing_escapes_and_delimiters_survive_encoding(monkeypatch):
         is True
     )
     assert _location(handler) == ["/session/abc%3Fx?q=1&r=2"]
+    _assert_ascii_uri(_location(handler)[0])
+
+
+@pytest.mark.parametrize(
+    ("query", "decoded", "expected"),
+    [
+        ("next=%2Fsession%2F100%25", "/session/100%", "/session/100%25"),
+        ("next=%2Fa%25Z", "/a%Z", "/a%25Z"),
+        ("next=%2Fa%25ZZ", "/a%ZZ", "/a%25ZZ"),
+        # Mixed: the valid `%3F` survives once, the lone `%` is escaped.
+        ("next=%2Fa%253F%25", "/a%3F%", "/a%3F%25"),
+        ("next=%2Fa%25%253F", "/a%%3F", "/a%25%3F"),
+    ],
+)
+def test_malformed_percent_is_escaped_while_valid_triplets_survive(
+    monkeypatch, query, decoded, expected
+):
+    """A `%` that does not start a `%HH` triplet is not a valid URI character.
+    `parse_qs()` hands the route a decoded string in which a literal `%` may
+    appear; it must go out as `%25` while an existing valid triplet is left
+    alone (not doubled to `%253F`)."""
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert parse_qs(query)["next"][0] == decoded  # pin the route's actual input
+
+    assert _get_login(handler, query=query) is True
+    assert handler.status == 302
+    assert _location(handler) == [expected]
+    _assert_ascii_uri(_location(handler)[0])
 
 
 def test_cookie_authenticated_request_redirects(monkeypatch):

--- a/tests/test_login_redirect_when_authenticated.py
+++ b/tests/test_login_redirect_when_authenticated.py
@@ -1,0 +1,186 @@
+"""`GET /login` must not park an already-authenticated client on the form.
+
+`/login` is in `PUBLIC_PATHS`, so `check_auth()` returns early and never
+reconciles the request's identity — the route used to render the password form
+unconditionally. With trusted-header (reverse-proxy SSO) auth that is a dead
+end: iOS relaunches an installed Home Screen web app at its last URL, so a
+device that once landed on `/login` sits on a form it cannot use forever while
+every request it makes is already authenticated. A cookie-authenticated user
+who navigates to `/login` hit the same dead end.
+
+The route now redirects an authenticated request to its validated `next`
+destination, and still renders the form for everyone else.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+
+import api.auth as auth
+import api.profiles as profiles
+import api.routes as routes
+
+
+class _Handler:
+    def __init__(self, *, headers=None, client_address=("127.0.0.1", 12345)):
+        self.headers = dict(headers or {})
+        self.client_address = client_address
+        self.command = "GET"
+        self.path = "/login"
+        self.request = SimpleNamespace()
+        self.rfile = io.BytesIO(b"")
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = []
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def body_text(self):
+        return self.wfile.getvalue().decode("utf-8")
+
+    def header_values(self, name):
+        return [value for key, value in self.sent_headers if key == name]
+
+
+@pytest.fixture(autouse=True)
+def isolated_auth_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(auth, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(auth, "_SESSIONS_FILE", tmp_path / ".sessions.json")
+    monkeypatch.setattr(auth, "is_password_auth_enabled", lambda: False)
+    monkeypatch.setattr(auth, "are_passkeys_enabled", lambda: False)
+    monkeypatch.setattr(auth, "is_oidc_auth_enabled", lambda: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"bot_name": "Hermes"})
+    for key in (
+        "HERMES_WEBUI_TRUSTED_AUTH_HEADER",
+        "HERMES_WEBUI_TRUSTED_GROUPS_HEADER",
+        "HERMES_WEBUI_TRUSTED_PROXY_CIDRS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    auth._sessions.clear()
+    auth._TRUSTED_AUTH_WARNINGS_EMITTED.clear()
+    profiles.clear_request_profile()
+    yield
+    auth._sessions.clear()
+    auth._TRUSTED_AUTH_WARNINGS_EMITTED.clear()
+    profiles.clear_request_profile()
+
+
+def _get_login(handler, query=""):
+    return routes.handle_get(handler, SimpleNamespace(path="/login", query=query))
+
+
+def _location(handler):
+    return handler.header_values("Location")
+
+
+def test_trusted_header_request_redirects_to_safe_next(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler, query="next=%2Fsession%2Fabc123") is True
+    assert handler.status == 302
+    assert _location(handler) == ["/session/abc123"]
+    assert handler.header_values("Cache-Control") == ["no-store"]
+    assert handler.body_text() == ""
+    # The session minted while reconciling the trusted header must ride along,
+    # or the redirect target bounces the client straight back to /login.
+    assert any(
+        cookie.startswith("hermes_session=")
+        for cookie in handler.header_values("Set-Cookie")
+    )
+
+
+def test_trusted_header_request_without_next_redirects_to_root(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler) is True
+    assert handler.status == 302
+    assert _location(handler) == ["/"]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "next=%2F%2Fevil.example.com%2F",
+        "next=https%3A%2F%2Fevil.example.com%2F",
+        "next=%2Flogin%3Fnext%3D%2Flogin",
+    ],
+)
+def test_unsafe_next_falls_back_to_root(monkeypatch, query):
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler, query=query) is True
+    assert handler.status == 302
+    assert _location(handler) == ["/"]
+
+
+def test_cookie_authenticated_request_redirects(monkeypatch):
+    monkeypatch.setattr(auth, "is_password_auth_enabled", lambda: True)
+    cookie = auth.create_session()
+    handler = _Handler(headers={"Cookie": f"hermes_session={cookie}"})
+
+    assert _get_login(handler, query="next=%2Fsession%2Fabc123") is True
+    assert handler.status == 302
+    assert _location(handler) == ["/session/abc123"]
+
+
+def test_unauthenticated_request_still_renders_the_form(monkeypatch):
+    monkeypatch.setattr(auth, "is_password_auth_enabled", lambda: True)
+    handler = _Handler()
+
+    _get_login(handler, query="next=%2Fsession%2Fabc123")
+
+    assert handler.status == 200
+    assert _location(handler) == []
+    assert "<form" in handler.body_text()
+
+
+def test_untrusted_peer_header_still_renders_the_form(monkeypatch):
+    """A spoofed trusted header from a non-proxy peer must not redirect."""
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(
+        headers={"Remote-User": "alice"},
+        client_address=("10.0.0.5", 12345),
+    )
+
+    _get_login(handler, query="next=%2Fsession%2Fabc123")
+
+    assert handler.status == 200
+    assert _location(handler) == []
+    assert "<form" in handler.body_text()
+
+
+def test_expired_cookie_still_renders_the_form(monkeypatch):
+    monkeypatch.setattr(auth, "is_password_auth_enabled", lambda: True)
+    cookie = auth.create_session()
+    auth.invalidate_session(cookie)
+    handler = _Handler(headers={"Cookie": f"hermes_session={cookie}"})
+
+    _get_login(handler)
+
+    assert handler.status == 200
+    assert _location(handler) == []
+    assert "<form" in handler.body_text()
+
+
+def test_auth_disabled_still_renders_the_form():
+    handler = _Handler()
+
+    _get_login(handler)
+
+    assert auth.is_auth_enabled() is False
+    assert handler.status == 200
+    assert _location(handler) == []
+    assert "<form" in handler.body_text()

--- a/tests/test_login_redirect_when_authenticated.py
+++ b/tests/test_login_redirect_when_authenticated.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 from types import SimpleNamespace
+from urllib.parse import urljoin
 
 import pytest
 
@@ -40,6 +41,12 @@ class _Handler:
         self.status = status
 
     def send_header(self, name, value):
+        # Enforce the production header codec: the stdlib
+        # BaseHTTPRequestHandler.send_header() buffers
+        # ("%s: %s\r\n" % (keyword, value)).encode("latin-1", "strict"), so a
+        # non-Latin-1 Location raises there. A fake that only stores Python
+        # strings cannot see that boundary.
+        ("%s: %s\r\n" % (name, value)).encode("latin-1", "strict")
         self.sent_headers.append((name, value))
 
     def end_headers(self):
@@ -100,13 +107,16 @@ def test_trusted_header_request_redirects_to_safe_next(monkeypatch):
     )
 
 
-def test_trusted_header_request_without_next_redirects_to_root(monkeypatch):
+def test_trusted_header_request_without_next_redirects_to_mount_root(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
     handler = _Handler(headers={"Remote-User": "alice"})
 
     assert _get_login(handler) is True
     assert handler.status == 302
-    assert _location(handler) == ["/"]
+    # `./`, not `/`: from `<mount>/login` it resolves to the mount root, so a
+    # subpath deployment such as `/hermes/` is not sent to the site root.
+    # Mirrors the `_safeNextPath()` default in static/login.js.
+    assert _location(handler) == ["./"]
 
 
 @pytest.mark.parametrize(
@@ -117,13 +127,84 @@ def test_trusted_header_request_without_next_redirects_to_root(monkeypatch):
         "next=%2Flogin%3Fnext%3D%2Flogin",
     ],
 )
-def test_unsafe_next_falls_back_to_root(monkeypatch, query):
+def test_unsafe_next_falls_back_to_mount_root(monkeypatch, query):
     monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
     handler = _Handler(headers={"Remote-User": "alice"})
 
     assert _get_login(handler, query=query) is True
     assert handler.status == 302
-    assert _location(handler) == ["/"]
+    assert _location(handler) == ["./"]
+
+
+@pytest.mark.parametrize(
+    ("page_url", "query", "expected"),
+    [
+        # No `next`: land on the mount root, wherever the app is mounted.
+        ("https://host/login", "", "https://host/"),
+        ("https://host/hermes/login", "", "https://host/hermes/"),
+        # Unsafe `next`: same fallback.
+        ("https://host/login", "next=%2F%2Fevil.example.com%2F", "https://host/"),
+        ("https://host/hermes/login", "next=%2F%2Fevil.example.com%2F", "https://host/hermes/"),
+        # A present `next` is a browser-side root-absolute path: the app's own
+        # producers (static/ui.js, workspace.js, boot.js) build it from
+        # window.location.pathname, which already carries the mount prefix, and
+        # static/login.js navigates to it verbatim. Emit it as-is so it resolves
+        # exactly like the password flow — prefixing `./` would double the
+        # mount (`/hermes/hermes/session/...`).
+        ("https://host/login", "next=%2Fsession%2Fabc123", "https://host/session/abc123"),
+        (
+            "https://host/hermes/login",
+            "next=%2Fhermes%2Fsession%2Fabc123",
+            "https://host/hermes/session/abc123",
+        ),
+    ],
+)
+def test_location_resolves_under_root_and_subpath_mounts(
+    monkeypatch, page_url, query, expected
+):
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler, query=query) is True
+    (location,) = _location(handler)
+    assert urljoin(page_url, location) == expected
+
+
+def test_non_latin1_next_is_percent_encoded_for_the_header(monkeypatch):
+    """`parse_qs()` decodes `%E4%BD%A0%E5%A5%BD` to `/你好`, and the stdlib
+    `send_header()` encodes header values as strict Latin-1, so passing the
+    decoded string through raised `UnicodeEncodeError` (a 500 instead of the
+    redirect). The `Location` must go out as an ASCII URI."""
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler, query="next=%2F%E4%BD%A0%E5%A5%BD") is True
+    assert handler.status == 302
+    assert _location(handler) == ["/%E4%BD%A0%E5%A5%BD"]
+
+
+def test_latin1_encodable_non_ascii_next_is_still_percent_encoded(monkeypatch):
+    """`é` fits Latin-1, so the stdlib does not raise — but a raw non-ASCII
+    byte is not a valid header value either. It must be UTF-8 percent-encoded."""
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    assert _get_login(handler, query="next=%2Fsession%2Fcaf%C3%A9") is True
+    assert _location(handler) == ["/session/caf%C3%A9"]
+
+
+def test_existing_escapes_and_delimiters_survive_encoding(monkeypatch):
+    """Encoding must not double a `%xx` that survived `parse_qs()` (a
+    once-encoded `?` the target page owns) or touch URI delimiters."""
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_AUTH_HEADER", "Remote-User")
+    handler = _Handler(headers={"Remote-User": "alice"})
+
+    # parse_qs() decodes this to `/session/abc%3Fx?q=1&r=2`.
+    assert (
+        _get_login(handler, query="next=%2Fsession%2Fabc%253Fx%3Fq%3D1%26r%3D2")
+        is True
+    )
+    assert _location(handler) == ["/session/abc%3Fx?q=1&r=2"]
 
 
 def test_cookie_authenticated_request_redirects(monkeypatch):


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI is meant to be usable as an installed app, including behind a reverse proxy that handles SSO and forwards a trusted identity header
- `/login` is in `PUBLIC_PATHS`, so `check_auth()` returns before it reconciles who is making the request, and the route renders the password form unconditionally
- iOS relaunches an installed Home Screen web app at its **last URL**, so a device that once landed on `/login` reopens there every single time
- Under trusted-header auth that is a dead end: every request the device makes is authenticated, but it is staring at a password form for a password that does not exist. The only escape is manually editing the URL — which an installed app has no address bar for
- A cookie-authenticated user who navigates to `/login` hits the same dead end
- This PR makes `/login` answer 302 to the validated `next` destination when the request is already authenticated, so the app self-heals on the next launch

## What Changed

`api/routes.py`, the `GET /login` branch of `handle_get()`:

- Reconciles the request's identity in the route (`is_auth_enabled() and ensure_trusted_auth_session(handler)`) — necessary because `/login` is public and `check_auth()` skips it. Covers both a trusted reverse-proxy header and an ordinary valid session cookie.
- When authenticated, answers `302` with `Location` from the existing `_safe_login_redirect_path()` guard applied to `?next=`, framed exactly like the sibling `/api/auth/oidc/start` redirect (`Cache-Control: no-store`, `Content-Length: 0`, `_security_headers()`).
- Flushes pending auth cookies, so a session minted during reconciliation reaches the browser and the redirect target does not bounce straight back to `/login`.
- Everything else — unauthenticated, spoofed header from an untrusted peer, stale/invalid cookie, auth disabled — renders the form exactly as before.

Also adds `tests/test_login_redirect_when_authenticated.py` and two manual-check lines to the `TESTING.md` auth section. No new dependency, no new abstraction, no client-side change.

## Why It Matters

Without it, trusted-header (reverse-proxy SSO) deployments have no working installed-app story on iOS: one accidental landing on `/login` bricks the Home Screen icon permanently from the user's point of view. It also fixes the smaller everyday case of a signed-in user opening a bookmarked `/login`.

## Verification

- The test fails before the fix and passes after: on `origin/master` with only the test applied, 6 failed / 3 passed; with the fix, all pass. It asserts observable response behaviour — status, `Location`, `Set-Cookie`, body.
- Cases covered: trusted header with a safe `next`; trusted header with no `next`; three unsafe `next` shapes (`//evil.example.com/`, absolute `https://evil…`, self-referential `/login?next=/login` from #5578) → `/`; cookie-authenticated; unauthenticated with auth enabled; trusted header spoofed from a non-proxy peer (fails closed to the form); invalidated cookie; auth disabled.
- `./scripts/test.sh tests/test_login_redirect_when_authenticated.py tests/test_trusted_header_auth.py` → 45 passed. All auth/login/passkey/OIDC/subpath test files → 409 passed.
- Full suite `./scripts/test.sh tests/` (Python 3.13) → 14967 passed, 170 skipped, 2 failed — both environment artifacts, not regressions: `test_5774b_atomic_config_writes.py::test_atomic_write_preserves_existing_permissions` fails identically on clean `origin/master` on macOS (umask); `test_static_asset_resolver.py::test_service_worker_and_favicon_follow_selected_static_root` broke only because the commit was amended mid-run, changing the setuptools-scm version hash under the running process — passes in isolation on both branches.
- `python3 scripts/ruff_lint.py --diff origin/master` → no new violations.
- Reproduced and fixed on a real deployment: WebUI behind Tailscale Serve with `HERMES_WEBUI_TRUSTED_AUTH_HEADER=Tailscale-User-Login`, iOS Home Screen install. The iOS relaunch-at-last-URL behaviour is Apple's; the automated tests prove the server contract. No screenshots: the change has no visual surface (a 302 replaces a rendered page).

## Risks / Follow-ups

- Security-sensitive area (auth). The redirect target goes through the existing `_safe_login_redirect_path()`, so scheme-relative, absolute-URL, control-character, over-long, and nested-login `next` values all collapse to `/` — the same guard `/api/auth/oidc/start` and the OIDC callback already use. No new validation logic.
- Calling `ensure_trusted_auth_session()` on `/login` can mint a trusted session on a request that previously did not. That is the same reconciliation every non-public route already performs; it still requires a trusted-proxy peer plus a configured header, and an untrusted peer is covered by a test.
- Unlike `check_auth()`, this branch does not apply the `trusted_session_allows_active_profile()` 403. Deliberate: it serves no data, only a redirect, and the destination is re-checked by `check_auth()` on the very next request. Happy to add the check for symmetry if preferred.
- A user who genuinely wants the password form while signed in must sign out first (noted in `TESTING.md`).
- No issue is open for this; happy to file one if you prefer issue-first.

## Release note wording

(Not editing `CHANGELOG.md`, per CONTRIBUTING.)

**Opening `/login` while already signed in now takes you to the app instead of a password form you cannot use.** `/login` is a public route, so it rendered the sign-in form without checking who was asking — and iOS relaunches an installed Home Screen web app at its last URL, so a device that once landed there stayed parked on the form even though every request it made was already authenticated (trusted reverse-proxy SSO header or a valid session cookie). The route now redirects an authenticated request to its validated `next` destination, falling back to `/` for any unsafe value, and carries along a session cookie minted during the check. Unauthenticated visitors, a spoofed header from an untrusted peer, a stale cookie, and auth-disabled installs still get the form exactly as before.

## Model Used / AI Usage Disclosure

- Provider: Anthropic
- Models: Claude Fable 5 (`claude-fable-5`) orchestrating; implementation and tests by a Claude Opus 5 (`claude-opus-5`) subagent
- Mode/tools: Claude Code — agentic file editing, local test execution via `./scripts/test.sh`. The bug was found and reproduced by a human on a real trusted-header deployment with an iOS Home Screen install; the fix, tests, and this write-up were AI-assisted and human-reviewed.
