### PR TITLE
Preserve failed tool state in structured completions

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7460,7 +7460,64 @@ def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
             text = str(preview)
     except Exception:
         pass
-    return text[:limit]
+    # Keep enough lookahead for a credential that starts near the display
+    # boundary, then cap the redacted result to the public preview limit.
+    return _redact_text(text[:limit + 512])[:limit]
+
+
+def _canonical_tool_result_is_error(tool_name, function_result, *, detector=None) -> bool:
+    """Project the Agent's canonical tool-failure classification into WebUI.
+
+    Structured callbacks may carry a result object while the Agent classifier
+    accepts its serialized tool-result form. Preserve multimodal objects as-is
+    (the Agent deliberately treats those as successful) and serialize other
+    JSON-shaped values before classification. A missing or incompatible older
+    Agent must not break completion delivery, so classification failure keeps
+    the historical non-error default.
+    """
+    if detector is None:
+        try:
+            from agent.display import _detect_tool_failure as detector
+        except (ImportError, AttributeError):
+            return False
+
+    candidate = function_result
+    if isinstance(function_result, (dict, list, tuple)) and not (
+        isinstance(function_result, dict) and function_result.get('_multimodal') is True
+    ):
+        try:
+            candidate = json.dumps(function_result, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            candidate = str(function_result)
+
+    try:
+        classified = detector(str(tool_name or ''), candidate)
+        return bool(classified[0] if isinstance(classified, tuple) else classified)
+    except Exception:
+        logger.debug('Failed to classify structured tool result', exc_info=True)
+        return False
+
+
+def _settle_live_tool_completion(
+    tool_calls,
+    *,
+    tool_call_id,
+    name,
+    snippet,
+    is_error,
+) -> bool:
+    """Settle the matching live tool record with one authoritative status."""
+    for tool_call in reversed(tool_calls or []):
+        if not isinstance(tool_call, dict) or tool_call.get('done'):
+            continue
+        if tool_call.get('tid') == tool_call_id or (
+            not tool_call.get('tid') and tool_call.get('name') == name
+        ):
+            tool_call['done'] = True
+            tool_call['snippet'] = snippet
+            tool_call['is_error'] = bool(is_error)
+            return True
+    return False
 
 
 def _truncate_tool_args(args, limit: int = 6) -> dict:
@@ -7545,6 +7602,15 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
             tool_msg_sequence.append(seq)
 
     live = [tc for tc in (live_tool_calls or []) if isinstance(tc, dict) and tc.get('name') and tc.get('name') != 'clarify']
+    live_by_tid = {
+        str(tc.get('tid')): tc
+        for tc in live
+        if tc.get('tid')
+    }
+    for tool_call in tool_calls:
+        live_match = live_by_tid.get(str(tool_call.get('tid') or ''))
+        if live_match is not None and live_match.get('is_error') is not None:
+            tool_call['is_error'] = bool(live_match.get('is_error'))
     if live:
         for seq_idx, seq in enumerate(tool_msg_sequence):
             if seq.get('resolved'):
@@ -7552,13 +7618,16 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
             if seq_idx >= len(live):
                 break
             live_tc = live[seq_idx]
-            tool_calls.append({
+            persisted_call = {
                 'name': live_tc.get('name', 'tool'),
                 'snippet': _tool_result_snippet(seq.get('raw', '')),
                 'tid': live_tc.get('tid', '') or '',
                 'assistant_msg_idx': _nearest_assistant_msg_idx(messages, seq.get('msg_idx', -1)),
                 'args': _truncate_tool_args(live_tc.get('args', {}), limit=4),
-            })
+            }
+            if live_tc.get('is_error') is not None:
+                persisted_call['is_error'] = bool(live_tc.get('is_error'))
+            tool_calls.append(persisted_call)
 
     return tool_calls
 
@@ -9919,21 +9988,22 @@ def _run_agent_streaming(
                     if tool_call_id and tool_call_id not in _live_tool_event_complete_ids:
                         _live_tool_event_complete_ids.add(tool_call_id)
                         result_snippet = _tool_result_snippet(function_result)
-                        for live_tc in reversed(_live_tool_calls):
-                            if live_tc.get('done'):
-                                continue
-                            if live_tc.get('tid') == tool_call_id or (not live_tc.get('tid') and live_tc.get('name') == name):
-                                live_tc['done'] = True
-                                live_tc['snippet'] = result_snippet
-                                break
+                        is_error = _canonical_tool_result_is_error(name, function_result)
+                        _settle_live_tool_completion(
+                            _live_tool_calls,
+                            tool_call_id=tool_call_id,
+                            name=name,
+                            snippet=result_snippet,
+                            is_error=is_error,
+                        )
                         if stream_id in STREAM_LIVE_TOOL_CALLS:
-                            for shared_tc in reversed(STREAM_LIVE_TOOL_CALLS[stream_id]):
-                                if shared_tc.get('done'):
-                                    continue
-                                if shared_tc.get('tid') == tool_call_id or (not shared_tc.get('tid') and shared_tc.get('name') == name):
-                                    shared_tc['done'] = True
-                                    shared_tc['snippet'] = result_snippet
-                                    break
+                            _settle_live_tool_completion(
+                                STREAM_LIVE_TOOL_CALLS[stream_id],
+                                tool_call_id=tool_call_id,
+                                name=name,
+                                snippet=result_snippet,
+                                is_error=is_error,
+                            )
                         _checkpoint_activity[0] += 1
                         put('tool_complete', {
                             'event_type': 'tool.completed',
@@ -9941,7 +10011,7 @@ def _run_agent_streaming(
                             'preview': result_snippet,
                             'args': _tool_args_snapshot(args),
                             'tid': tool_call_id,
-                            'is_error': False,
+                            'is_error': is_error,
                         })
                         # Mirror the todo tool's in-memory state into
                         # a dedicated SSE event so the Todos panel can

--- a/tests/test_issue7358_tool_completion_error_state.py
+++ b/tests/test_issue7358_tool_completion_error_state.py
@@ -1,0 +1,115 @@
+import json
+
+from api import streaming
+
+
+def _structured_failure_detector(_tool_name, result):
+    data = json.loads(result)
+    failed = bool(
+        isinstance(data, dict)
+        and (
+            data.get("success") is False
+            or data.get("ok") is False
+            or data.get("status") in {"error", "failed"}
+        )
+    )
+    return failed, " [error]" if failed else ""
+
+
+def test_object_and_json_string_results_use_the_same_canonical_failure_contract():
+    payload = {"success": False, "error": "HTTP 433: usage allowance exceeded"}
+
+    assert streaming._canonical_tool_result_is_error(
+        "web_search", payload, detector=_structured_failure_detector
+    ) is True
+    assert streaming._canonical_tool_result_is_error(
+        "web_search", json.dumps(payload), detector=_structured_failure_detector
+    ) is True
+
+
+def test_successful_result_with_error_like_prose_is_not_misclassified():
+    payload = {"success": True, "output": "The error budget is healthy"}
+
+    assert streaming._canonical_tool_result_is_error(
+        "status", payload, detector=_structured_failure_detector
+    ) is False
+
+
+def test_classifier_failure_does_not_break_tool_completion():
+    def unavailable_classifier(_tool_name, _result):
+        raise ImportError("agent classifier unavailable")
+
+    assert streaming._canonical_tool_result_is_error(
+        "status", {"success": False}, detector=unavailable_classifier
+    ) is False
+
+
+def test_settle_live_tool_completion_updates_only_the_matching_call():
+    calls = [
+        {"name": "search", "tid": "call-1", "done": False},
+        {"name": "search", "tid": "call-2", "done": False},
+    ]
+
+    assert streaming._settle_live_tool_completion(
+        calls,
+        tool_call_id="call-1",
+        name="search",
+        snippet="HTTP 433",
+        is_error=True,
+    ) is True
+    assert calls == [
+        {
+            "name": "search",
+            "tid": "call-1",
+            "done": True,
+            "snippet": "HTTP 433",
+            "is_error": True,
+        },
+        {"name": "search", "tid": "call-2", "done": False},
+    ]
+
+
+def test_persisted_tool_summary_keeps_structured_completion_error_state():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": '{"success": false, "error": "HTTP 433"}',
+        },
+    ]
+
+    summaries = streaming._extract_tool_calls_from_messages(
+        messages,
+        live_tool_calls=[
+            {
+                "name": "search",
+                "tid": "call-1",
+                "done": True,
+                "is_error": True,
+            }
+        ],
+    )
+
+    assert summaries[0]["is_error"] is True
+
+
+def test_live_result_preview_remains_bounded_and_redacted():
+    preview = streaming._tool_result_snippet(
+        {"error": "API_KEY=result-secret-123 " + ("x" * 3000)},
+        limit=80,
+    )
+
+    assert len(preview) <= 80
+    assert "result-secret-123" not in preview
+    assert "API_KEY=" in preview

--- a/tests/test_live_tool_callback_events.py
+++ b/tests/test_live_tool_callback_events.py
@@ -49,6 +49,8 @@ def test_tool_complete_callback_emits_existing_tool_complete_sse_event_with_tool
         "Tool completion SSE emission should be idempotent per callback id."
     )
     assert "result_snippet = _tool_result_snippet(function_result)" in block
+    assert "is_error = _canonical_tool_result_is_error(name, function_result)" in block
+    assert "'is_error': is_error" in block
     assert "_checkpoint_activity[0] += 1" in block
 
 


### PR DESCRIPTION
Closes #7358.

## Thinking Path

- Direct/local chat wires both progress and structured tool callbacks.
- The progress callback already receives the Agent's canonical `is_error` bit, but WebUI suppresses that event when the structured callback is available so the client keeps the stable tool-call ID.
- The structured callback then replaced the canonical status with a hard-coded `false`.
- This keeps the structured path and its `tid`, while deriving the completion status from the same Agent classifier used by the CLI.

## What Changed

- Classify structured object and JSON-string results through `agent.display._detect_tool_failure`.
- Apply the resulting bit to the local live record, shared cancellation/checkpoint state, emitted `tool.completed` event, run journal, and settled tool summary.
- Keep completion delivery backward-compatible: if an older Agent does not expose the classifier, WebUI retains the previous non-error default instead of breaking the stream.
- Redact the bounded live result preview before it is emitted or persisted.
- Add regression coverage for structured failures, successful error-like prose, compatibility fallback, exact tool-ID settlement, persisted status, and preview bounds/redaction.

## Why It Matters

Clients can now render a recoverable failed tool as **Failed** even when the agent later succeeds through another tool. The earlier failure remains visible instead of being rewritten as a successful completion.

## Verification

- Before the fix: the six new regression tests failed.
- `./scripts/test.sh tests/test_issue7358_tool_completion_error_state.py tests/test_live_tool_callback_events.py tests/test_tool_call_persistence.py tests/test_run_journal_routes.py tests/test_issue1361_cancel_data_loss.py tests/test_issue3929_partial_work_recovery.py -q` — 87 passed.
- `./scripts/test.sh tests/ -q` — 14,839 passed, 282 skipped, 2 xfailed, 1 xpassed, and 45 subtests passed. One unrelated existing test failed on macOS: `test_atomic_write_preserves_existing_permissions` expects a setgid bit that this filesystem clears after rewrite.
- `.venv/bin/ruff check tests/test_issue7358_tool_completion_error_state.py` — passed.
- A full-file Ruff check still reports 11 pre-existing findings in `api/streaming.py`; none are on changed lines.
- `git diff --check` — passed.

I did not run a live provider/tool call because this checkout has no configured Agent or provider credentials. The callback, state, persistence, and replay paths are covered by the targeted tests above.

## Contract Routing

- Contract family: live-to-final assistant activity and run-journal projection.
- Evidence: issue #7358, the Agent's `_detect_tool_failure()` classifier, and the existing Gateway completion translator.
- This does not introduce a new event or change Gateway behavior. It corrects the direct/local projection to honor the existing `is_error` contract.

## Risks / Follow-ups

- Older Agent builds without `_detect_tool_failure` keep the previous `is_error: false` fallback rather than losing completion events.
- There is no visual layout change, so no before/after screenshot is included.

## Model Used

- Provider: OpenAI
- Model: GPT-5 (Codex)
- Notable tools: local shell, Git, GitHub CLI, and the repository test runner
