### PR TITLE
fix: stop MEDIA link parser from capturing trailing markdown backtick

### DIFF
--- a/api/media_snapshots.py
+++ b/api/media_snapshots.py
@@ -66,6 +66,14 @@ logger = logging.getLogger("hermes.webui")
 # sneak past the gate; ``fullmatch`` is used at call sites.
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
 
+# MEDIA:<ref> token shape — single source of truth shared with api/routes.py
+# (allowlist) so the two backends cannot drift (#7359). The capture class
+# excludes whitespace plus the markdown delimiters ` ) ] so a token wrapped in
+# inline-code backticks or link parens/brackets never captures the closing
+# delimiter into the path (a trailing backtick used to reach
+# /api/media?path=...%60 and 404).
+MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]`]+)")
+
 # Default caps.  Overridable via env var for operators with unusual disks.
 DEFAULT_MAX_FILE_BYTES = 50 * 1024 * 1024          # 50 MB per snapshot
 DEFAULT_TOTAL_CAP_BYTES = 2 * 1024 * 1024 * 1024   # 2 GB total store
@@ -438,13 +446,11 @@ def annotate_media_snapshots(
 
     Returns the number of new snapshots captured (0 on a repeat settle).
     """
-    import re as _re
-
     if resolve_ref is None:
         resolve_ref = resolve_media_ref
     if allowed_predicate is None:
         allowed_predicate = media_capture_allowed
-    media_re = _re.compile(r"MEDIA:([^\s\)\]]+)")
+    media_re = MEDIA_TOKEN_RE
     captured = 0
     for msg in messages or []:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":

--- a/api/routes.py
+++ b/api/routes.py
@@ -20241,7 +20241,11 @@ def _serve_inline_html_preview(handler, target: Path, cache_control: str, *, csp
     return True
 
 
-_MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]]+)")
+# Shared with api/media_snapshots.py so the capture and allowlist backends
+# cannot drift (#7359). Excludes whitespace plus the markdown delimiters
+# ` ) ] so an inline-code-wrapped `MEDIA:/abs/path.zip` token never captures
+# the closing backtick into the path.
+from api.media_snapshots import MEDIA_TOKEN_RE as _MEDIA_TOKEN_RE
 
 
 def _message_content_text(content) -> str:

--- a/static/messages.js
+++ b/static/messages.js
@@ -4801,7 +4801,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _smdMediaTailFlushEntry(entry){
     const chunk=_smdMediaTailEntryChunk(entry);
     if(!chunk) return;
-    const m=/^MEDIA:([^\s\)\]]+)$/.exec(String(chunk));
+    const m=new RegExp('^MEDIA:(' + MEDIA_REF_CLASS + '+)$').exec(String(chunk));
     const emitted=!!(m && entry && entry.parent && _smdAppendMediaNode(entry.parent, m[1]));
     if(!emitted && entry) _smdMediaWriteText(entry.parent, entry.data, entry.baseAddText, entry.writeText, chunk);
   }
@@ -4849,7 +4849,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Prose runs go through the owning text writer. MEDIA tokens go through
     // the single-token DOMParser helper only after a delimiter or
     // reliable filename suffix proves the ref is complete.
-    const re=/MEDIA:([^\s\)\]]+)/g;
+    const re=new RegExp('MEDIA:(' + MEDIA_REF_CLASS + '+)', 'g');
     let last=0, m;
     let unmatchedTail=null;
     while((m=re.exec(combined))){
@@ -4875,7 +4875,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // MEDIA prefix; flush any prose before the partial MEDIA suffix.
     const rest = combined.slice(last);
     if(rest){
-      const tailMatch = /MEDIA:[^\s\)\]]*$/.exec(rest);
+      const tailMatch = new RegExp('MEDIA:'+MEDIA_REF_CLASS+'*$').exec(rest);
       const prefixTail = tailMatch ? '' : _smdMediaPrefixTail(rest);
       const tailValue = tailMatch ? tailMatch[0] : prefixTail;
       if(tailValue && rest.length < _MEDIA_TAIL_MAX){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7519,6 +7519,14 @@ function _stripVisibleAssistantEchoFromThinking(thinkingText, ...visibleTexts){
   return clean;
 }
 
+// MEDIA:<ref> token shape — single source of truth for every MEDIA capture
+// site in ui.js AND messages.js so they cannot drift (#7359). The capture
+// class excludes whitespace plus the markdown delimiters ` ) ] so a token
+// wrapped in inline-code backticks or link parens/brackets never captures
+// the closing delimiter into the path (a trailing backtick used to reach
+// /api/media?path=...%60 and 404).
+const MEDIA_REF_CLASS = '[^\\s\\)\\]`]';
+
 function renderMd(raw){
   let s=(raw||'').replace(/\r\n/g,'\n').replace(/\r/g,'\n');
   // ── Entity decode: must run FIRST so &gt; lines become > for the blockquote
@@ -7591,7 +7599,7 @@ function renderMd(raw){
   // generated images) and replace them with inline <img> or download links.
   // Stashed so the path/URL is never processed as markdown.
   const media_stash=[];
-  s=s.replace(/MEDIA:([^\s\)\]]+)/g,(_,raw_ref)=>{
+  s=s.replace(new RegExp('MEDIA:(' + MEDIA_REF_CLASS + '+)', 'g'),(_,raw_ref)=>{
     media_stash.push(raw_ref);
     return '\x00D'+(media_stash.length-1)+'\x00';
   });
@@ -8959,7 +8967,7 @@ function _stripForTTS(text){
   // Strip links, keep text
   text=text.replace(/\[([^\]]+)\]\([^)]+\)/g,'$1');
   // Replace MEDIA: paths with a simple label
-  text=text.replace(/MEDIA:[^\s]+/g,'a file');
+  text=text.replace(new RegExp('MEDIA:'+MEDIA_REF_CLASS+'+','g'),'a file');
   // Strip emoji and emoticons
   text=text.replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}]/gu,'');
   // Strip HTML tags that may leak through markdown

--- a/tests/test_data_uri_images.py
+++ b/tests/test_data_uri_images.py
@@ -84,6 +84,17 @@ eval(extractFunc('_mdImageHtml'));
 eval(extractFunc('_inlineMediaHtmlForRef'));
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_fullwidth_autolink_behaviour.py
+++ b/tests/test_fullwidth_autolink_behaviour.py
@@ -72,6 +72,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1154_fenced_code_leak.py
+++ b/tests/test_issue1154_fenced_code_leak.py
@@ -45,6 +45,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1446_glued_heading_lift.py
+++ b/tests/test_issue1446_glued_heading_lift.py
@@ -210,6 +210,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1618_yaml_json_diff_newline_preserve.py
+++ b/tests/test_issue1618_yaml_json_diff_newline_preserve.py
@@ -147,6 +147,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue2428_table_pipe_protection.py
+++ b/tests/test_issue2428_table_pipe_protection.py
@@ -60,6 +60,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue2768_workspace_links.py
+++ b/tests/test_issue2768_workspace_links.py
@@ -42,6 +42,13 @@ def _render(markdown: str) -> str:
         global.document={baseURI:'http://example.test/'};
         '''
     )
+    # #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+    # constant (ui.js top-level). Extract the real constant alongside the
+    # functions so the eval'd body resolves it — keeps the single source of
+    # truth instead of re-deriving the char class here.
+    _mrc = re.search(r"const\s+MEDIA_REF_CLASS\s*=\s*[^;]+;", UI_JS)
+    assert _mrc, "MEDIA_REF_CLASS const not found in ui.js"
+    js += "\n" + _mrc.group(0)
     js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
     js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
     js += "\n" + _extract_function(UI_JS, "renderMd")

--- a/tests/test_issue2881_workspace_chat_links.py
+++ b/tests/test_issue2881_workspace_chat_links.py
@@ -42,6 +42,17 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -53,6 +53,13 @@ def _run_renderers(markdown: str) -> dict:
         global.document={baseURI:'http://example.test/'};
         '''
     )
+    # #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+    # constant (ui.js top-level). Extract the real constant alongside the
+    # functions so the eval'd body resolves it — keeps the single source of
+    # truth instead of re-deriving the char class here.
+    _mrc = re.search(r"const\s+MEDIA_REF_CLASS\s*=\s*[^;]+;", UI_JS)
+    assert _mrc, "MEDIA_REF_CLASS const not found in ui.js"
+    js += "\n" + _mrc.group(0)
     js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
     js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
     js += "\n" + _extract_function(UI_JS, "_renderUserFencedBlocks")

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -670,6 +670,26 @@ class TestMediaEndpointUnit(unittest.TestCase):
                     )
                 )
 
+    def test_session_media_token_allows_backtick_wrapped_html_path(self):
+        # #7359: `MEDIA:<path>` (inline-code backticks) must resolve the
+        # allowlist against the bare path, not path` — the trailing backtick
+        # used to be captured, so the browser requested path%60 and downloaded
+        # the JSON 404 body instead of the file.
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            html = pathlib.Path(tmpd) / "report.html"
+            html.write_text("<h1>Report</h1>", encoding="utf-8")
+            session = SimpleNamespace(
+                messages=[{"role": "assistant", "content": f"see `MEDIA:{html}` below"}]
+            )
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertTrue(
+                    routes._session_media_token_allows_path(
+                        "s-media", html, {"text/html"}
+                    )
+                )
+
     def test_session_media_token_rejects_user_authored_html_path(self):
         from api import routes
 

--- a/tests/test_media_message_snapshots.py
+++ b/tests/test_media_message_snapshots.py
@@ -251,6 +251,27 @@ def test_annotate_stamps_assistant_messages_with_snapshots(snap_dir, tmp_path):
     assert len(stamped[str(target)]) == 64
 
 
+def test_annotate_strips_trailing_backtick_from_inline_code_media_ref(snap_dir, tmp_path):
+    """#7359: `` `MEDIA:/abs/path.zip` `` (inline-code backticks) must snapshot
+    /abs/path.zip, not /abs/path.zip` — the closing backtick used to make the
+    ref unresolvable, so the snapshot was skipped and the browser got a 404.
+    """
+    from api.media_snapshots import annotate_media_snapshots
+
+    target = tmp_path / "report.html"
+    target.write_text("<html>v1</html>")
+
+    messages = [
+        {"role": "assistant", "content": f"see `MEDIA:{target}` below"},
+    ]
+    captured = annotate_media_snapshots(messages)
+    assert captured == 1
+
+    stamped = messages[0]["_media_snapshots"]
+    assert str(target) in stamped
+    assert not any("`" in key for key in stamped)
+
+
 def test_annotate_is_idempotent_across_settles(snap_dir, tmp_path):
     from api.media_snapshots import annotate_media_snapshots
 

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -69,6 +69,17 @@ function extractFunc(name) {
   }
   return src.slice(start, i);
 }
+// #7359: renderMd() captures MEDIA refs with the shared MEDIA_REF_CLASS
+// constant (ui.js top-level). Extract the real constant alongside the function
+// so the eval'd body resolves it — keeps the single source of truth instead of
+// re-deriving the char class here. `var` (not const/let) so the binding leaks
+// out of this eval into the enclosing function scope the renderMd eval shares.
+const _mediaRefConst = /const\s+MEDIA_REF_CLASS\s*=\s*(['"`])(?:(?!\1).|\\.)*\1/.exec(src);
+if (_mediaRefConst) {
+  eval('var MEDIA_REF_CLASS = ' + _mediaRefConst[0].replace(/^const\s+MEDIA_REF_CLASS\s*=\s*/, '') + ';');
+} else {
+  throw new Error('MEDIA_REF_CLASS const not found in ui.js');
+}
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
 eval(extractFunc('renderMd'));
@@ -215,6 +226,28 @@ class TestRendererSanitization:
         assert '<img' in out and 'msg-media-img' in out
         assert 'onclick' not in out
         assert '_openimglightbox' not in out
+
+    def test_media_token_in_code_span_does_not_capture_backtick(self, driver_path):
+        # Regression (#7359): agents routinely format the token as an
+        # inline-code span, e.g. `MEDIA:/workspace/report.md`. The closing
+        # backtick must NOT be captured into the path, otherwise the download
+        # URL becomes .../report.md%60 and the server 404s (no file has a
+        # backtick in its name). Guards the MEDIA path class in renderMd().
+        out = _render(
+            driver_path,
+            "**Markdown:** `MEDIA:/workspace/report.md`",
+        )
+        assert "api/media?path=" in out
+        assert "%60" not in out, f"backtick leaked into media path: {out!r}"
+        assert "report.md" in out
+
+    def test_media_token_in_code_span_does_not_capture_backtick_with_extension(self, driver_path):
+        # Same guard with a bare-path download token (the exact #7359 repro:
+        # a .zip inline-code token used to 404 with a backtick suffix).
+        out = _render(driver_path, "Download: `MEDIA:/abs/path/file.zip`")
+        assert "api/media?path=" in out
+        assert "%60" not in out, f"backtick leaked into media path: {out!r}"
+        assert "file.zip" in out
 
     def test_incomplete_raw_html_tag_is_escaped_before_paragraph_wrapping(self, driver_path):
         out = _render(driver_path, '<img src=x onerror=alert(1)//').lower()

--- a/tests/test_smd_media_in_stream.py
+++ b/tests/test_smd_media_in_stream.py
@@ -93,6 +93,7 @@ def _run_real_smd_media_cases() -> dict:
         "globalThis.requestAnimationFrame = cb => cb();\n"
         "const _MEDIA_TAIL_MAX = 4096;\n"
         "const _SMD_MEDIA_PREFIX = 'MEDIA:';\n"
+        "const MEDIA_REF_CLASS = '[^\\\\s\\\\)\\\\]`]';\n"
         "const _SMD_MEDIA_TAIL = new WeakMap();\n"
         "const __SMD_PARSER_FALLBACK = {};\n"
         "const _SMD_SAFE_URL_RE=/^(?:https?:|mailto:|tel:|message:|\\/|#|\\?|\\.|api|session\\/)/i;\n"
@@ -197,9 +198,24 @@ def _run_real_smd_media_cases() -> dict:
         "const refSplit=renderModes(['MEDIA:C:/tmp/li', 've.png ']);\n"
         "const finalExtensionless=renderModes(['MEDIA:https://fal.media/generated']);\n"
         "const pdf=renderModes(['MEDIA:C:/tmp/report.pdf ']);\n"
+        "const backtickRaw=(()=>{\n"
+        "  const root=document.createElement('div');\n"
+        "  const baseRenderer=_safeSmdRenderer(root);\n"
+        "  const renderer=_smdRendererWithoutUnderscoreEmphasis(baseRenderer);\n"
+        "  const parser=smd.parser(renderer);\n"
+        "  _smdBindParserIdentity(renderer, parser, root);\n"
+        "  const parent=document.createElement('p');\n"
+        "  root.appendChild(parent);\n"
+        "  const data={nodes:[parent], index:0};\n"
+        "  const writeText=(p,d,t)=>{ p.appendChild(document.createTextNode(String(t||''))); };\n"
+        "  _smdMediaAwareAddText((d,t)=>{}, parent, data, 'MEDIA:C:/tmp/live.png`', _SMD_MEDIA_TAIL, parser, writeText);\n"
+        "  _smdMediaTailFlush(parser);\n"
+        "  _smdMediaTailClear(parser);\n"
+        "  return { html: root.outerHTML, text: root.textContent };\n"
+        "})();\n"
         "const falsePrefix=renderModes(['M', 'aybe plain prose ']);\n"
         "const crossParent=renderModes(['- ME', '\\n- ow']);\n"
-        "console.log(JSON.stringify({prefixSplits, refSplit, finalExtensionless, pdf, falsePrefix, crossParent}));\n"
+        "console.log(JSON.stringify({prefixSplits, refSplit, finalExtensionless, pdf, backtickRaw, falsePrefix, crossParent}));\n"
     )
     completed = subprocess.run(
         [NODE, "--input-type=module", "-e", script],
@@ -410,7 +426,7 @@ class TestSmdMediaInStream(unittest.TestCase):
         # boundary check must therefore treat a complete http(s) ref as complete
         # even when it has no filename extension.
         self.assertIn("function _smdMediaTailFlush", MESSAGES_JS)
-        self.assertIn("/^MEDIA:([^", MESSAGES_JS)
+        self.assertIn("new RegExp('^MEDIA:('", MESSAGES_JS)
         self.assertIn("_smdMediaTailFlush(_smdParser)", MESSAGES_JS)
 
     def test_extensionless_https_tail_waits_until_stream_end(self):
@@ -520,6 +536,19 @@ class TestSmdMediaInStream(unittest.TestCase):
         self.assertIn("postProcessRenderedMessages(root)", scheduler)
         self.assertIn("_applyMediaPlaybackPreferences(root)", scheduler)
 
+    def test_media_token_capture_class_excludes_backtick_everywhere(self):
+        # #7359: an inline-code-wrapped `MEDIA:/abs/path.zip` token must never
+        # capture the closing backtick into the path. Every MEDIA capture site
+        # (ui.js stash + preview flatten, messages.js streaming sites) must use
+        # the shared MEDIA_REF_CLASS (which excludes ` ) ]), and the old
+        # backtick-swallowing literals must be gone.
+        self.assertIn("const MEDIA_REF_CLASS", UI_JS)
+        self.assertIn("MEDIA_REF_CLASS", MESSAGES_JS)
+        self.assertNotIn(r"MEDIA:([^\s\)\]]+)", UI_JS)
+        self.assertNotIn(r"MEDIA:([^\s\)\]]+)", MESSAGES_JS)
+        self.assertNotIn(r"MEDIA:[^\s]+", UI_JS)
+        self.assertNotIn(r"MEDIA:[^\s\)\]]*$", MESSAGES_JS)
+
 
 @unittest.skipIf(NODE is None, "node not on PATH")
 class TestSmdMediaRealParserBehaviour(unittest.TestCase):
@@ -559,6 +588,19 @@ class TestSmdMediaRealParserBehaviour(unittest.TestCase):
                 self.assertIn('data-path="C:/tmp/report.pdf"', result["html"])
                 self.assertGreaterEqual(result["postProcessCalls"], 1)
                 self.assertGreaterEqual(result["playbackCalls"], 1)
+
+    def test_real_smd_parser_backtick_wrapped_token_strips_backtick(self):
+        # #7359: when a raw inline-code backtick reaches the streaming
+        # interceptor (`MEDIA:C:/tmp/live.png`), the captured ref must never
+        # include the closing backtick — it used to produce
+        # /api/media?path=...%60 → 404 download. The interceptor must emit a
+        # media node with the clean ref and leave the backtick as plain text.
+        result = self.cases["backtickRaw"]
+        self.assertIn('class="media-node"', result["html"])
+        self.assertIn('data-ref="C:/tmp/live.png"', result["html"])
+        self.assertNotIn('data-ref="C:/tmp/live.png`"', result["html"])
+        self.assertNotIn("MEDIA:", result["text"])
+        self.assertIn("`", result["text"])
 
     def test_real_smd_parser_false_prefix_plain_prose_keeps_fade(self):
         result = self.cases["falsePrefix"]["fade"]


### PR DESCRIPTION
## Summary

Fixes #7359 — when an assistant message references a local file with a bare `MEDIA:<path>` token wrapped in inline-code markdown (`` `MEDIA:/abs/path.zip` ``), the MEDIA link parser captured the **closing backtick** in the path. The browser then requested `/api/media?path=...%60`, the endpoint returned a JSON 404 body, and Chrome saved that JSON body as the download ("Failed - No file").

The capture character class excluded whitespace, `)` and `]` but not backticks, across all six capture sites.

## Fix

Per the issue's recommended approach, the token shape is now defined **once per codebase** so the six sites cannot drift:

- **JS** — new shared `MEDIA_REF_CLASS = '[^\s\)\]`]'` const in `static/ui.js` (excludes whitespace plus the markdown delimiters `` ` `` `)` `]`), now used by:
  - `ui.js` renderMd MEDIA stash (linkification)
  - `ui.js` `_stripForTTS` preview flattening (was `MEDIA:[^\s]+`)
  - `messages.js` streaming tail-flush (`^MEDIA:(...)$`)
  - `messages.js` streaming token walk (`MEDIA:(...)`)
  - `messages.js` streaming partial-tail match (`MEDIA:...*$`)
- **Python** — new module-level `MEDIA_TOKEN_RE` in `api/media_snapshots.py`, imported by `api/routes.py` for the session-token allowlist, replacing the duplicated inline literals (previously two independent copies that could drift).

Streaming partial-tail note from the issue: a trailing backtick arriving with the token is never captured into the buffered ref; the media node is emitted with the clean ref and the backtick is rendered as plain text (covered by a real-parser test driving `_smdMediaAwareAddText` through Node).

## Test Plan

- `tests/test_media_inline.py::test_session_media_token_allows_backtick_wrapped_html_path` — allowlist resolves `` `MEDIA:<path>` `` against the bare path
- `tests/test_media_message_snapshots.py::test_annotate_strips_trailing_backtick_from_inline_code_media_ref` — settle-time snapshot captures the clean ref
- `tests/test_smd_media_in_stream.py::test_media_token_capture_class_excludes_backtick_everywhere` — static guard: every capture site uses the shared class, old backtick-swallowing literals are gone
- `tests/test_smd_media_in_stream.py::test_real_smd_parser_backtick_wrapped_token_strips_backtick` — real smd parser (Node): backtick stays as text, media node gets `data-ref` without the backtick

Full focused run: `139 passed, 18 subtests passed` across the three touched test files. JS syntax verified with `node --check`; ESLint runtime guard not runnable in this environment (no node_modules).

Closes #7359