### PR TITLE
fix: drain unread request bodies to keep HTTP/1.1 keep-alive in sync

### DIFF
--- a/server.py
+++ b/server.py
@@ -106,6 +106,7 @@ from api.helpers import (
     get_profile_cookie,
     _build_csp_report_only_policy,
     _CLIENT_DISCONNECT_ERRORS,
+    MAX_BODY_BYTES,
 )
 from api.profiles import set_request_profile, clear_request_profile
 from api.routes import handle_delete, handle_get, handle_patch, handle_post, handle_put, apply_cors_preflight_headers
@@ -291,11 +292,15 @@ class QuietHTTPServer(ThreadingHTTPServer):
 
 
 class _BodyTrackingReader:
-    """Counts body bytes read per request so unread bodies can be drained.
+    """Counts body bytes consumed per request so unread bodies can be drained.
 
     Responses that exit before ``read_body`` (401/403/30x) would otherwise
     leave body bytes on the socket, which the keep-alive loop parses as the
     next request line (observed as 400/501 corruption behind reverse proxies).
+
+    Only ``read``/``readinto`` are counted: the request line and headers are
+    read via ``readline`` through the passthrough below and must not count
+    toward the body total.
     """
 
     def __init__(self, inner):
@@ -306,6 +311,11 @@ class _BodyTrackingReader:
         data = self._inner.read(*args)
         self.count += len(data) if data else 0
         return data
+
+    def readinto(self, b):
+        n = self._inner.readinto(b)
+        self.count += n if n else 0
+        return n
 
     def __getattr__(self, name):
         return getattr(self._inner, name)
@@ -418,20 +428,15 @@ class Handler(BaseHTTPRequestHandler):
             clear_request_profile()
 
     def handle_one_request(self) -> None:
-        """Install the body-tracking wrapper and drain unread bodies per request.
+        """Track body bytes per request and drain unread bodies at one chokepoint.
 
-        The wrapper is installed once per connection and its counter reset
-        each request (stale counts made the drain skip later early-exit
-        bodies — review finding, PR #7368). Draining in the finally covers
-        every method at a single chokepoint: responses that exit before
-        ``read_body`` (401/403/30x) would otherwise leave body bytes on the
-        socket, parsed as the next request line (400/501 corruption).
-        ``headers`` is cleared per request so a request that fails before
-        header parsing (e.g. overlong request line) can never inherit the
-        previous request's Content-Length framing — such a connection fails
-        closed instead of draining under stale authority. A bare keep-alive
-        ping returns with no headers and an already-closing connection, so
-        closing on ``headers is None`` is safe there too.
+        The wrapper is installed once per connection with its counter reset
+        each request. Draining in the finally covers every method: responses
+        that exit before ``read_body`` (401/403/30x) would otherwise leave
+        body bytes on the socket, parsed as the next request line (400/501
+        corruption). ``headers`` is cleared per request so a request that
+        fails before header parsing can never inherit the previous request's
+        framing — ``_drain_unread_body`` fails such a connection closed.
         """
         if isinstance(self.rfile, _BodyTrackingReader):
             self.rfile.count = 0
@@ -441,22 +446,27 @@ class Handler(BaseHTTPRequestHandler):
         try:
             super().handle_one_request()
         finally:
-            if getattr(self, "headers", None) is None:
-                self.close_connection = True
-                return
             self._drain_unread_body()
 
     def _drain_unread_body(self) -> None:
-        """Consume any unread request body so keep-alive stays in sync."""
+        """Consume any unread request body so keep-alive stays in sync.
+
+        Fails the connection closed whenever the framing cannot be trusted
+        or the body cannot be drained safely: no current headers, already
+        closing, any Transfer-Encoding (the server implements no transfer
+        framing), malformed length, or a length ``read_body`` itself would
+        refuse (mirrors its MAX_BODY_BYTES cap so a giant claimed body can
+        never pin a thread draining).
+        """
         try:
             if getattr(self, "close_connection", False):
                 return
             if getattr(self, "headers", None) is None:
+                self.close_connection = True
                 return
             # The server implements no transfer framing, so a TE body cannot
             # be drained reliably — treat every nonempty Transfer-Encoding
-            # (chunked or not) as unresynchronizable and fail closed
-            # (review finding, PR #7368).
+            # (chunked or not) as unresynchronizable and fail closed.
             if (self.headers.get("Transfer-Encoding") or "").strip():
                 self.close_connection = True
                 return
@@ -465,9 +475,11 @@ class Handler(BaseHTTPRequestHandler):
             except (TypeError, ValueError):
                 self.close_connection = True
                 return
-            if length < 0:
-                # Malformed framing: some stdlib versions parse it without
-                # rejecting, leaving the connection desynced — fail closed.
+            if length < 0 or length > MAX_BODY_BYTES:
+                # Malformed framing (some stdlib versions parse a negative
+                # length without rejecting), or a body read_body would refuse
+                # to consume — either way the socket cannot be resynced by
+                # draining, so fail closed.
                 self.close_connection = True
                 return
             remaining = length - getattr(self.rfile, "count", 0)

--- a/server.py
+++ b/server.py
@@ -290,11 +290,32 @@ class QuietHTTPServer(ThreadingHTTPServer):
         super().handle_error(request, client_address)
 
 
+class _BodyTrackingReader:
+    """Counts body bytes read per request so unread bodies can be drained.
+
+    Responses that exit before ``read_body`` (401/403/30x) would otherwise
+    leave body bytes on the socket, which the keep-alive loop parses as the
+    next request line (observed as 400/501 corruption behind reverse proxies).
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.count = 0
+
+    def read(self, *args):
+        data = self._inner.read(*args)
+        self.count += len(data) if data else 0
+        return data
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 class Handler(BaseHTTPRequestHandler):
     # HTTP/1.1 keep-alive stays on, so every response must declare framing.
     protocol_version = "HTTP/1.1"
     timeout = 30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
-    
+
     def setup(self):
         """Set socket options for each accepted connection."""
         super().setup()
@@ -395,6 +416,69 @@ class Handler(BaseHTTPRequestHandler):
                 self._safe_webui_print(traceback.format_exc())
         finally:
             clear_request_profile()
+
+    def handle_one_request(self) -> None:
+        """Install the body-tracking wrapper and drain unread bodies per request.
+
+        The wrapper is installed once per connection and its counter reset
+        each request (stale counts made the drain skip later early-exit
+        bodies — review finding, PR #7368). Draining in the finally covers
+        every method at a single chokepoint: responses that exit before
+        ``read_body`` (401/403/30x) would otherwise leave body bytes on the
+        socket, parsed as the next request line (400/501 corruption).
+        ``headers`` is cleared per request so a request that fails before
+        header parsing (e.g. overlong request line) can never inherit the
+        previous request's Content-Length framing — such a connection fails
+        closed instead of draining under stale authority. A bare keep-alive
+        ping returns with no headers and an already-closing connection, so
+        closing on ``headers is None`` is safe there too.
+        """
+        if isinstance(self.rfile, _BodyTrackingReader):
+            self.rfile.count = 0
+        else:
+            self.rfile = _BodyTrackingReader(self.rfile)
+        self.headers = None
+        try:
+            super().handle_one_request()
+        finally:
+            if getattr(self, "headers", None) is None:
+                self.close_connection = True
+                return
+            self._drain_unread_body()
+
+    def _drain_unread_body(self) -> None:
+        """Consume any unread request body so keep-alive stays in sync."""
+        try:
+            if getattr(self, "close_connection", False):
+                return
+            if getattr(self, "headers", None) is None:
+                return
+            # The server implements no transfer framing, so a TE body cannot
+            # be drained reliably — treat every nonempty Transfer-Encoding
+            # (chunked or not) as unresynchronizable and fail closed
+            # (review finding, PR #7368).
+            if (self.headers.get("Transfer-Encoding") or "").strip():
+                self.close_connection = True
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0") or 0)
+            except (TypeError, ValueError):
+                self.close_connection = True
+                return
+            if length < 0:
+                # Malformed framing: some stdlib versions parse it without
+                # rejecting, leaving the connection desynced — fail closed.
+                self.close_connection = True
+                return
+            remaining = length - getattr(self.rfile, "count", 0)
+            while remaining > 0:
+                chunk = self.rfile.read(min(remaining, 65536))
+                if not chunk:
+                    self.close_connection = True  # peer closed mid-body
+                    return
+                remaining -= len(chunk)
+        except Exception:
+            self.close_connection = True
 
     def _handle_write(self, route_func) -> None:
         self._req_t0 = time.time(); reset_trusted_auth_request_state(self)

--- a/tests/test_keepalive_unread_body_drain.py
+++ b/tests/test_keepalive_unread_body_drain.py
@@ -22,12 +22,12 @@ import io
 import json
 import socket
 import threading
-from email.message import Message
 from unittest import mock
 
 import pytest
 
 import api.auth
+from api.helpers import MAX_BODY_BYTES
 from http.server import BaseHTTPRequestHandler
 from server import Handler, QuietHTTPServer, _BodyTrackingReader
 
@@ -213,6 +213,28 @@ def test_negative_content_length_fails_closed(password_auth):
     assert connection_alive is False, (get_status, get_body[:200])
 
 
+def test_oversized_content_length_fails_closed_without_draining():
+    """A Content-Length ``read_body`` would refuse must close, not drain.
+
+    A rejected request claiming more than MAX_BODY_BYTES must fail the
+    connection closed immediately: draining it would burn bandwidth and pin
+    a thread, and ``read_body`` itself closes on such lengths — the drain
+    mirrors that cap so both paths use the same limit. Asserts zero bytes
+    are consumed (pre-cap code would read the buffered bytes first).
+    """
+    body = b"x" * 100
+    handler = Handler.__new__(Handler)
+    handler.rfile = _BodyTrackingReader(io.BytesIO(body))  # type: ignore[assignment]
+    handler.headers = {"Content-Length": str(MAX_BODY_BYTES + 1)}  # type: ignore[assignment]
+    handler.close_connection = False
+
+    handler._drain_unread_body()
+
+    assert handler.close_connection is True
+    assert handler.rfile.count == 0  # type: ignore[attr-defined]
+    assert handler.rfile._inner.getvalue() == body  # type: ignore[attr-defined]
+
+
 def test_body_byte_counter_resets_per_request(password_auth):
     """After a request whose body WAS read, a later early-exit POST must still drain.
 
@@ -380,39 +402,35 @@ def test_stale_headers_fail_closed(password_auth):
 def test_stale_headers_never_authorize_a_drain():
     """The per-request finally must close, never drain, without current headers.
 
-    Pins the fail-closed boundary added for the PR #7368 maintainer review:
-    if a request fails before header parsing assigns current headers while
-    stale request-A framing is still present and the connection is still
-    marked reusable (e.g. a stdlib path that answers an error without
-    closing), the finally must close the connection rather than consume
-    bytes under the stale Content-Length.
+    If a request fails before header parsing assigns current headers while
+    the connection is still marked reusable (e.g. a stdlib path that answers
+    an error without closing), the finally must close the connection rather
+    than consume bytes under any framing. ``handle_one_request`` clears
+    ``headers`` before dispatch, so the stub below sees ``None`` — there is
+    no stale request-A framing left to inherit.
 
-    The stdlib stub simulates exactly that path: it returns without
-    assigning headers and without closing, leaving request A's
-    ``Content-Length: 60`` in place. ``c_bytes`` stands in for bytes after
-    malformed B (pipelined request C): pre-fix the stale drain consumes 60
-    of them as B's "body" and leaves the connection open; fixed, the
-    connection closes and every byte is untouched.
+    ``c_bytes`` stands in for bytes after malformed B (pipelined request C):
+    without the fail-closed boundary the drain would consume bytes as B's
+    "body" and leave the connection open; fixed, the connection closes and
+    every byte is untouched.
     """
-    stale = Message()
-    stale["Content-Length"] = "60"
     c_bytes = (
         b"GET /api/session?session_id=20260827_080609_a123e437 HTTP/1.1\r\n"
         b"Host: 127.0.0.1\r\n"
         b"Connection: keep-alive\r\n"
         b"\r\n"
     )
-    assert len(c_bytes) > 60, len(c_bytes)
 
     handler = Handler.__new__(Handler)
     handler.rfile = _BodyTrackingReader(io.BytesIO(c_bytes))  # type: ignore[assignment]
-    handler.headers = stale
+    handler.headers = None  # type: ignore[assignment]
     handler.close_connection = False
 
     def _return_before_headers(handler_self):
         # Simulates a stdlib path that answers before parse_request assigns
-        # current headers (overlong request line) without closing.
-        assert handler_self.headers is stale
+        # current headers (overlong request line) without closing. The
+        # per-request reset in handle_one_request has already cleared headers.
+        assert handler_self.headers is None
         assert handler_self.close_connection is False
 
     with mock.patch.object(

--- a/tests/test_keepalive_unread_body_drain.py
+++ b/tests/test_keepalive_unread_body_drain.py
@@ -1,0 +1,425 @@
+"""Regression tests for keep-alive connection sync after early-exit requests.
+
+A rejected POST (auth redirect 302 / 401) returns before the route handler
+reads the request body. With HTTP/1.1 keep-alive, those unread body bytes were
+then parsed as the next request line, corrupting the connection — observed in
+production as:
+
+    501 Unsupported method ('{"session_id":"..."}GET')
+
+whenever the browser fired a rejected POST and then a GET on the same
+connection (via a keep-alive reverse proxy). The fix drains any unread
+Content-Length body (or closes the connection when it cannot) before the next
+request is read.
+
+These tests boot the real ``server.Handler`` on a loopback socket and assert
+the connection stays in sync across an early-exit POST.
+"""
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import socket
+import threading
+from email.message import Message
+from unittest import mock
+
+import pytest
+
+import api.auth
+from http.server import BaseHTTPRequestHandler
+from server import Handler, QuietHTTPServer, _BodyTrackingReader
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _ServerRunner:
+    """Boot the real Handler on a loopback port.
+
+    With the ``password_auth`` fixture active, write requests hit the auth
+    gate and are rejected 401 before any route handler reads the request
+    body — the exact early-exit path that poisoned keep-alive connections in
+    production.
+    """
+
+    def __init__(self):
+        self.port = _free_port()
+        self.httpd = QuietHTTPServer(("127.0.0.1", self.port), Handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join(timeout=5)
+
+
+@pytest.fixture()
+def password_auth(monkeypatch):
+    """Enable password auth for the in-process server (auth gate active).
+
+    get_password_hash caches per process; reset the cache so the env var set
+    here is honored, and restore state afterwards.
+    """
+    monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "keepalive-regression-test")
+    monkeypatch.setattr(api.auth, "_AUTH_HASH_COMPUTED", False, raising=False)
+    monkeypatch.setattr(api.auth, "_AUTH_HASH_CACHE", None, raising=False)
+    yield
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+
+
+def _post_then_get_same_connection(port: int) -> tuple[int, bytes, int, bytes]:
+    """POST a body-carrying request that gets rejected early, then GET on the
+    same keep-alive connection. Returns (post_status, post_body, get_status,
+    get_body)."""
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        body = json.dumps({"session_id": "20260827_080609_a123e437"}).encode()
+        conn.request(
+            "POST",
+            "/api/session/import_cli",
+            body=body,
+            headers={
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+            },
+        )
+        resp = conn.getresponse()
+        post_status, post_body = resp.status, resp.read()
+
+        # Second request on the SAME connection. Without the drain fix the
+        # server parses the leftover body bytes as this request's method line.
+        conn.request("GET", "/api/session?session_id=20260827_080609_a123e437")
+        resp2 = conn.getresponse()
+        get_status, get_body = resp2.status, resp2.read()
+        return post_status, post_body, get_status, get_body
+    finally:
+        conn.close()
+
+
+def test_unread_post_body_does_not_poison_next_keepalive_request(password_auth):
+    """A body-carrying POST rejected before read_body must not corrupt the
+    next request on the same keep-alive connection.
+
+    Reproduces the production failure: POST /api/session/import_cli rejected
+    by the auth gate (body never read), then GET /api/session on the same
+    connection parsed the leftover JSON body as the request method → 501 HTML.
+    """
+    with _ServerRunner() as srv:
+        post_status, post_body, get_status, get_body = _post_then_get_same_connection(
+            srv.port
+        )
+
+    # The POST is rejected by the auth gate without its body being read.
+    assert post_status == 401, post_body[:200]
+
+    # The follow-up request must be parsed cleanly: a well-formed 401 JSON
+    # API response, NOT the BaseHTTPRequestHandler HTML error page built from
+    # a corrupted request line.
+    assert get_status != 501, get_body[:200]
+    assert not get_body.lstrip().startswith(b"<!DOCTYPE"), get_body[:200]
+    assert get_status == 401, get_body[:200]
+    assert b"Authentication required" in get_body
+
+
+def _unsupported_te_then_get(
+    port: int, headers: dict, body: bytes, check_post_status: bool = True
+) -> tuple[int, bytes, bool]:
+    """POST with unframable transfer framing (rejected early by the auth gate),
+    then GET on the same keep-alive connection.
+
+    Returns (get_status, get_body, connection_alive) — connection_alive False
+    means the server closed the socket after the rejected request (fail-closed),
+    so the GET was never answered on that connection."""
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request(
+            "POST",
+            "/api/session/import_cli",
+            body=body,
+            headers={"Content-Type": "application/json", **headers},
+        )
+        resp = conn.getresponse()
+        post_status, _ = resp.status, resp.read()
+        if check_post_status:
+            assert post_status == 401, post_status
+
+        # Next request on the same connection: if the server failed closed it
+        # closed the socket (RemoteDisconnected); if it left the body on the
+        # socket, those bytes are parsed as this request line → 501 HTML.
+        conn.request("GET", "/api/session?session_id=20260827_080609_a123e437")
+        resp2 = conn.getresponse()
+        return resp2.status, resp2.read(), True
+    except (http.client.RemoteDisconnected, ConnectionError, OSError):
+        # Server closed the connection after the rejected request: fail-closed.
+        return 0, b"", False
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "te_headers",
+    [
+        {"Transfer-Encoding": "gzip"},  # unsupported TE, no usable framing
+        {"Transfer-Encoding": "gzip", "Content-Length": "43"},  # conflicting TE+CL
+        {"Transfer-Encoding": "chunked"},  # pins existing close behavior
+        {"Transfer-Encoding": "gzip, chunked"},
+    ],
+)
+def test_transfer_encoding_fails_closed(password_auth, te_headers):
+    """Any nonempty Transfer-Encoding must fail closed: the server implements
+    no transfer framing, so the body cannot be drained reliably and keep-alive
+    must not reuse the connection (review finding, PR #7368).
+
+    Reproduces the maintainer-verified desync: POST with ``Transfer-Encoding:
+    gzip`` rejected by the auth gate leaves the body on the socket; the next
+    request line parses those bytes → 501 HTML. The TE+Content-Length case
+    must also close rather than implicitly trusting the content length."""
+    body = b'{"session_id":"20260827_080609_a123e437"}'
+    with _ServerRunner() as srv:
+        get_status, get_body, connection_alive = _unsupported_te_then_get(
+            srv.port,
+            te_headers,
+            body,
+        )
+
+    # Fail-closed: after a TE request the server must close the connection
+    # rather than parsing a following request on it.
+    assert connection_alive is False, (get_status, get_body[:200])
+
+
+def test_negative_content_length_fails_closed(password_auth):
+    """A negative Content-Length must close rather than leave a desynced
+    keep-alive connection. On Python 3.13 parse_request does NOT reject the
+    framing (the drain sees length < 0, skips the loop, keeps the connection):
+    the body then desyncs the next request → 501 HTML (reproduced)."""
+    body = b'{"session_id":"20260827_080609_a123e437"}'
+    with _ServerRunner() as srv:
+        get_status, get_body, connection_alive = _unsupported_te_then_get(
+            srv.port,
+            {"Content-Length": "-5"},
+            body,
+            check_post_status=False,  # stdlib may 400-close before the handler
+        )
+
+    assert connection_alive is False, (get_status, get_body[:200])
+
+
+def test_body_byte_counter_resets_per_request(password_auth):
+    """After a request whose body WAS read, a later early-exit POST must still drain.
+
+    Regression for the review finding on PR #7368: the rfile wrapper persists
+    for the whole keep-alive connection, so a cumulative counter left the
+    drain computing a per-request remainder against a connection-lifetime
+    total — silently skipping the unread body and reproducing the original
+    corruption on the next request.
+
+    Sequence on ONE connection (all bodies exactly 41 bytes so the stale
+    counter would exactly cancel the new body):
+      1. POST /api/auth/login  (public path, body read by route → counter = 41)
+      2. POST /api/session/import_cli (auth gate rejects 401, body UNREAD)
+      3. GET  /api/session     — must be clean JSON 401, not an HTML error page
+    """
+    # Both bodies must be the SAME length so the stale connection-lifetime
+    # counter exactly equals the second request's Content-Length.
+    def _padded(pairs: dict, target: int) -> bytes:
+        probe = json.dumps({**pairs, "pad": ""})
+        n = target - len(probe)  # each extra pad char adds exactly 1 byte
+        assert n >= 0, (probe, target)
+        return json.dumps({**pairs, "pad": "0" * n}).encode()
+
+    cli_body = _padded({"session_id": "20260827_080609_a123e437"}, 60)
+    login_body = _padded({"username": "x", "password": "y"}, 60)
+    assert len(login_body) == len(cli_body)
+
+    with _ServerRunner() as srv:
+        conn = http.client.HTTPConnection("127.0.0.1", srv.port, timeout=5)
+        try:
+            # 1. Body-reading request (public, CSRF-exempt): route consumes the body.
+            conn.request(
+                "POST",
+                "/api/auth/login",
+                body=login_body,
+                headers={"Content-Type": "application/json", "Content-Length": str(len(login_body))},
+            )
+            r1 = conn.getresponse()
+            login_status, login_resp = r1.status, r1.read()
+            assert login_status == 401, login_resp[:200]
+            assert not login_resp.lstrip().startswith(b"<!DOCTYPE"), login_resp[:200]
+
+            # 2. Early-exit request: rejected by the auth gate before read_body.
+            conn.request(
+                "POST",
+                "/api/session/import_cli",
+                body=cli_body,
+                headers={"Content-Type": "application/json", "Content-Length": str(len(cli_body))},
+            )
+            r2 = conn.getresponse()
+            post_status, post_resp = r2.status, r2.read()
+            assert post_status == 401, post_resp[:200]
+
+            # 3. Without a per-request counter reset the stale count (41) cancels
+            # this body (41) and the drain skips it, corrupting this request.
+            conn.request("GET", "/api/session?session_id=20260827_080609_a123e437")
+            r3 = conn.getresponse()
+            get_status, get_body = r3.status, r3.read()
+        finally:
+            conn.close()
+
+    assert get_status != 501, get_body[:200]
+    assert not get_body.lstrip().startswith(b"<!DOCTYPE"), get_body[:200]
+    assert get_status == 401, get_body[:200]
+    assert b"Authentication required" in get_body
+
+
+def _read_raw_response(fp) -> tuple[int, bytes]:
+    """Read one HTTP/1.1 response from a buffered socket file.
+
+    Returns (status, body). Raises on timeout/EOF before the status line.
+    """
+    status_line = fp.readline(8192)
+    assert status_line, "expected an HTTP response status line, got EOF"
+    parts = status_line.split()
+    assert parts[:1] == [b"HTTP/1.1"] and len(parts) >= 2, status_line[:200]
+    status = int(parts[1])
+    length = 0
+    while True:
+        line = fp.readline(8192)
+        assert line, "EOF while reading response headers"
+        if line in (b"\r\n", b"\n", b""):
+            break
+        name, _, value = line.partition(b":")
+        if name.strip().lower() == b"content-length":
+            length = int(value.strip() or 0)
+    body = b""
+    while len(body) < length:
+        chunk = fp.read(length - len(body))
+        if not chunk:
+            break
+        body += chunk
+    return status, body
+
+
+def test_stale_headers_fail_closed(password_auth):
+    """A request that fails before header parsing must not drain under stale framing.
+
+    Regression for the review finding on PR #7368: ``Handler`` is reused for
+    the whole keep-alive connection, so without a per-request ``headers``
+    reset a request B with an overlong request line (stdlib returns before
+    assigning current headers) would inherit request A's ``Content-Length``
+    in the ``finally`` drain and consume bytes belonging to malformed B or
+    pipelined request C (``remaining = L - 0`` after the counter reset).
+
+    Sequence on ONE raw socket:
+      1. POST /api/auth/login with a 60-byte body (route reads it → 401 JSON)
+      2. Overlong request line pipelined with a valid GET (request C)
+    The server must answer the overlong line (414) and then close without
+    ever answering C — C bytes must not be consumed as B's body.
+    """
+    login_body = json.dumps(
+        {"username": "x", "password": "y", "pad": "0" * 15}
+    ).encode()
+    assert len(login_body) == 60, len(login_body)
+
+    with _ServerRunner() as srv:
+        sock = socket.create_connection(("127.0.0.1", srv.port), timeout=5)
+        sock.settimeout(5)
+        try:
+            fp = sock.makefile("rb")
+            # 1. Body-reading request: route consumes the 60-byte body.
+            req_a = (
+                "POST /api/auth/login HTTP/1.1\r\n"
+                "Host: 127.0.0.1\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {len(login_body)}\r\n"
+                "Connection: keep-alive\r\n"
+                "\r\n"
+            ).encode() + login_body
+            sock.sendall(req_a)
+            login_status, login_resp = _read_raw_response(fp)
+            assert login_status == 401, login_resp[:200]
+            assert not login_resp.lstrip().startswith(b"<!DOCTYPE"), login_resp[:200]
+
+            # 2. Overlong request line + pipelined valid GET on the same socket.
+            # The line is sized just over the stdlib 65536-byte limit so the
+            # leftover line tail is SMALLER than request A's Content-Length:
+            # without the headers reset the stale drain (remaining = L - 0)
+            # consumes the tail plus the head of pipelined C as B's "body".
+            req_b = (
+                f"GET /{'A' * 65530} HTTP/1.1\r\n"
+                "Host: 127.0.0.1\r\n"
+                "Connection: keep-alive\r\n"
+                "\r\n"
+            ).encode()
+            req_c = (
+                "GET /api/session?session_id=20260827_080609_a123e437 HTTP/1.1\r\n"
+                "Host: 127.0.0.1\r\n"
+                "Connection: keep-alive\r\n"
+                "\r\n"
+            ).encode()
+            sock.sendall(req_b + req_c)
+            err_status, err_body = _read_raw_response(fp)
+            assert err_status == 414, (err_status, err_body[:200])
+
+            # Fail-closed: the server closes instead of consuming C as B's
+            # body — EOF, never a second HTTP response.
+            tail = fp.read()
+            assert tail == b"", tail[:200]
+        finally:
+            sock.close()
+
+
+def test_stale_headers_never_authorize_a_drain():
+    """The per-request finally must close, never drain, without current headers.
+
+    Pins the fail-closed boundary added for the PR #7368 maintainer review:
+    if a request fails before header parsing assigns current headers while
+    stale request-A framing is still present and the connection is still
+    marked reusable (e.g. a stdlib path that answers an error without
+    closing), the finally must close the connection rather than consume
+    bytes under the stale Content-Length.
+
+    The stdlib stub simulates exactly that path: it returns without
+    assigning headers and without closing, leaving request A's
+    ``Content-Length: 60`` in place. ``c_bytes`` stands in for bytes after
+    malformed B (pipelined request C): pre-fix the stale drain consumes 60
+    of them as B's "body" and leaves the connection open; fixed, the
+    connection closes and every byte is untouched.
+    """
+    stale = Message()
+    stale["Content-Length"] = "60"
+    c_bytes = (
+        b"GET /api/session?session_id=20260827_080609_a123e437 HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Connection: keep-alive\r\n"
+        b"\r\n"
+    )
+    assert len(c_bytes) > 60, len(c_bytes)
+
+    handler = Handler.__new__(Handler)
+    handler.rfile = _BodyTrackingReader(io.BytesIO(c_bytes))  # type: ignore[assignment]
+    handler.headers = stale
+    handler.close_connection = False
+
+    def _return_before_headers(handler_self):
+        # Simulates a stdlib path that answers before parse_request assigns
+        # current headers (overlong request line) without closing.
+        assert handler_self.headers is stale
+        assert handler_self.close_connection is False
+
+    with mock.patch.object(
+        BaseHTTPRequestHandler, "handle_one_request", _return_before_headers
+    ):
+        handler.handle_one_request()
+
+    assert handler.close_connection is True
+    assert handler.rfile.count == 0  # type: ignore[attr-defined]
+    assert handler.rfile._inner.getvalue() == c_bytes  # type: ignore[attr-defined]


### PR DESCRIPTION
### ACTUAL USE CASE

I'm using webui with caddy for proxy with ssl. For me the first `/api/sessions` works, but `/api/session` fails after that. The same url works when opening in a new tab as GET request (with session cookie automatically added by chrome I assume.

### DETAILS FROM AGENT

A write request rejected before its body is read (401 auth gate, 403 CSRF gate, 302 page redirect) left the request body bytes on the socket. With HTTP/1.1 keep-alive, BaseHTTPRequestHandler then parsed those bytes as the next request line, corrupting the connection. Observed in production behind a keep-alive reverse proxy as:

    501 Unsupported method ('{"session_id":"..."}GET')

whenever the browser sent a rejected POST (e.g. /api/session/import_cli) followed by GET /api/session on the same connection.

Fix: wrap rfile with a byte-counting reader and drain any unread Content-Length body in a finally block on both the read and write request paths. If the body cannot be safely resynced (chunked, invalid length, peer disconnect mid-body) the connection is closed instead.

Adds a regression test that boots the real Handler and proves a body-carrying POST rejected by the auth gate no longer poisons the next keep-alive request: fails with the corrupted-request 501 HTML page before the fix, passes after.