### PR TITLE
Add idle-TTL and memory-pressure governance for SESSION_AGENT_CACHE

### DIFF
--- a/api/agent_cache_governance.py
+++ b/api/agent_cache_governance.py
@@ -1,0 +1,402 @@
+"""Agent-cache governance for the WebUI's per-session AIAgent cache.
+
+The WebUI keeps one ``AIAgent`` per session in ``SESSION_AGENT_CACHE`` (an
+OrderedDict LRU) so cross-turn state (``_user_turn_count``, memory-provider
+state) survives between messages.  Each cached agent pins the session's full
+live transcript (``_session_messages``) in RAM — tens of MB on a tool-heavy
+session — so the LRU *count* cap alone does not bound the process's resident
+memory: warm sessions churn, transcripts keep growing, and RSS climbs until an
+operator restarts the service.
+
+The gateway solved exactly this problem with three valves
+(``agent.agent_cache`` in config_defaults.py, issue #80764): an LRU cap, an
+idle TTL, and a memory-pressure pass that soft-evicts LRU transcripts once
+anonymous RSS crosses a budget.  This module ports the latter two to the WebUI:
+
+* ``sweep_idle_cached_agents`` — fully evicts cached agents idle past the TTL.
+* ``sweep_agent_cache_under_pressure`` — soft-evicts the least-recently-used
+  transcripts (drops ``_session_messages`` only, keeping the agent object so
+  cross-turn state survives); the transcript is rebuilt from the persisted
+  session on the next turn.
+
+Both are driven by one daemon thread started from ``server.py``.  Everything
+here is pure/read-only so it can be unit-tested without a running server.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_BYTES_PER_MB = 1024 * 1024
+# Fraction of the resolved memory limit at which we start shedding transcripts.
+# Deliberately well under the limit so eviction happens while the process still
+# has room to breathe (parity with gateway.agent_cache_pressure).
+_AUTO_BUDGET_FRACTION = 0.65
+# Below this a "budget" is noise — tiny boxes would evict on every pass.
+_AUTO_BUDGET_FLOOR_MB = 512
+# Upper bound on soft-evictions per pass, so one pressure burst cannot stall
+# the server tearing down a dozen agents (parity with the gateway).
+_MAX_EVICTIONS_PER_PASS = 16
+
+
+def _positive_int(value: Any, default: int) -> int:
+    """Parse an int >= 0; fall back on anything malformed (0 = disabled)."""
+    if isinstance(value, bool) or value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _cgroup_memory_limit_bytes() -> Optional[int]:
+    """Return the memory limit this process runs under, if cgroup-capped.
+
+    Mirrors gateway/agent_cache_pressure.py: prefers cgroup v2 ``memory.max``
+    (and ``memory.high``) on the process's own cgroup, then the root files.
+    ``max`` / near-2^63 sentinels mean "unlimited" → None.
+    """
+    if not sys_platform_linux():
+        return None
+    candidates: List[str] = []
+    try:
+        own = _own_cgroup_path()
+        if own and own != "/":
+            candidates.extend(
+                (
+                    f"/sys/fs/cgroup{own}/memory.high",
+                    f"/sys/fs/cgroup{own}/memory.max",
+                )
+            )
+    except Exception:
+        pass
+    candidates.extend(
+        (
+            "/sys/fs/cgroup/memory.high",
+            "/sys/fs/cgroup/memory.max",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+        )
+    )
+    for candidate in candidates:
+        try:
+            with open(candidate, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+        except OSError:
+            continue
+        if not raw or raw == "max":
+            continue
+        try:
+            limit = int(raw)
+        except ValueError:
+            continue
+        if limit <= 0 or limit >= (1 << 62):
+            continue
+        return limit
+    return None
+
+
+def sys_platform_linux() -> bool:
+    import sys
+
+    return sys.platform == "linux"
+
+
+def _own_cgroup_path() -> Optional[str]:
+    """Read the process's own cgroup path (v2: single line; v1: pick memory)."""
+    try:
+        with open("/proc/self/cgroup", "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.split(":", 2)
+                if len(parts) == 3 and parts[1] == "memory":
+                    return parts[2]
+                if len(parts) == 3 and parts[2].startswith("/"):
+                    # v2 single hierarchy: controllers field empty.
+                    return parts[2]
+    except OSError:
+        return None
+    return None
+
+
+def read_anon_rss_mb() -> Optional[int]:
+    """Return the process's anonymous resident memory in MB, or None.
+
+    Anonymous pages are the ones cached transcripts live in.  Uses
+    /proc/self/status RssAnon; falls back to psutil total RSS if unavailable.
+    """
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("RssAnon:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1]) // 1024
+    except (OSError, ValueError):
+        pass
+    try:
+        import psutil  # type: ignore
+
+        return int(psutil.Process(os.getpid()).memory_info().rss / _BYTES_PER_MB)
+    except Exception:
+        return None
+
+
+def resolve_memory_high_mb(raw: Any, total_ram_mb: Optional[int] = None) -> Optional[int]:
+    """Resolve the memory-pressure budget in MB.
+
+    ``raw`` accepts:
+      * "auto" — cgroup memory limit × _AUTO_BUDGET_FRACTION (floored at
+        _AUTO_BUDGET_FLOOR_MB), falling back to total RAM × fraction.
+      * a number — the budget in MB.
+      * 0 / "0" / "" / "off" — pressure pass disabled (None).
+
+    ``total_ram_mb`` is injectable for tests; None → read from the system.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if raw == "" or raw.lower() in ("0", "off", "none", "false"):
+            return None
+        if raw.lower() == "auto":
+            limit = _cgroup_memory_limit_bytes()
+            if limit is not None:
+                budget = int(limit * _AUTO_BUDGET_FRACTION / _BYTES_PER_MB)
+                return budget if budget >= _AUTO_BUDGET_FLOOR_MB else _AUTO_BUDGET_FLOOR_MB
+            if total_ram_mb is None:
+                total_ram_mb = _total_ram_mb()
+            if total_ram_mb is None:
+                return None
+            budget = int(total_ram_mb * _AUTO_BUDGET_FRACTION)
+            return budget if budget >= _AUTO_BUDGET_FLOOR_MB else _AUTO_BUDGET_FLOOR_MB
+        try:
+            value = int(raw)
+        except ValueError:
+            return None
+        if value <= 0:
+            return None
+        return value
+    if isinstance(raw, (int, float)):
+        value = int(raw)
+        return value if value > 0 else None
+    return None
+
+
+def _total_ram_mb() -> Optional[int]:
+    try:
+        with open("/proc/meminfo", "r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("MemTotal:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1]) // 1024
+    except (OSError, ValueError):
+        pass
+    try:
+        import os as _os
+
+        pages = _os.sysconf("SC_PHYS_PAGES")
+        page_size = _os.sysconf("SC_PAGE_SIZE")
+        return int(pages * page_size / _BYTES_PER_MB)
+    except Exception:
+        return None
+
+
+def _agent_last_activity(agent: Any) -> Optional[float]:
+    """Return the agent's last-activity timestamp (mirrors gateway semantics).
+
+    Falls back to the attribute the AIAgent maintains on every turn.
+    """
+    if agent is None:
+        return None
+    ts = getattr(agent, "_last_activity_ts", None)
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    return None
+
+
+def plan_pressure_evictions(
+    ordered: List[Tuple[str, Any]],
+    is_evictable,
+    protect_recent: int = 8,
+    max_evictions: int = _MAX_EVICTIONS_PER_PASS,
+) -> List[Tuple[str, Any]]:
+    """Pick LRU sessions to soft-evict under memory pressure.
+
+    ``ordered`` is the cache's LRU order (oldest first).  ``is_evictable(key,
+    agent)`` decides whether a session may be shed (e.g. not mid-turn, live
+    transcript already on disk).  The ``protect_recent`` most-recently-used
+    sessions are never touched — their warm prompt cache is worth the most.
+    """
+    plan: List[Tuple[str, Any]] = []
+    if not ordered:
+        return plan
+    if protect_recent > 0:
+        ordered = ordered[: len(ordered) - protect_recent]
+    for key, agent in ordered:
+        if len(plan) >= max_evictions:
+            break
+        try:
+            if is_evictable(key, agent):
+                plan.append((key, agent))
+        except Exception:
+            logger.debug("pressure evictability check failed for %s", key, exc_info=True)
+    return plan
+
+
+def soft_release_transcript(agent: Any) -> None:
+    """Drop the live transcript from a cached agent without tearing it down.
+
+    The next turn rebuilds messages from the persisted session (the WebUI feeds
+    ``get_state_db_session_messages`` fresh each turn), so dropping the in-RAM
+    list is safe and is the single biggest lever on resident memory.  Keeps the
+    agent object itself so cross-turn state (_user_turn_count, memory-provider
+    state) survives the pressure pass.
+    """
+    if agent is None:
+        return
+    try:
+        if hasattr(agent, "_session_messages"):
+            agent._session_messages = []
+    except Exception:
+        logger.debug("soft-release transcript failed", exc_info=True)
+    # _db_flush_scan_prefix is a shallow copy of the flushed transcript — it
+    # shares every message dict, so leaving it pins the multi-MB content strings
+    # the eviction exists to free (parity with gateway #80764).
+    try:
+        if hasattr(agent, "_db_flush_scan_prefix"):
+            agent._db_flush_scan_prefix = None
+    except Exception:
+        logger.debug("soft-release flush prefix failed", exc_info=True)
+
+
+class AgentCacheGovernor:
+    """One governance pass: idle TTL eviction + memory-pressure soft eviction.
+
+    Holds only a reference to the cache + lock + config snapshot so it can be
+    constructed in-process with zero import cycles (streaming.py owns the
+    cache; the governor is pure orchestration).
+    """
+
+    def __init__(
+        self,
+        cache: Dict[str, Any],
+        lock: threading.Lock,
+        *,
+        idle_ttl_secs: int = 3600,
+        memory_high_mb: Optional[int] = None,
+        protect_recent: int = 8,
+        running_check=None,
+        close_agent_fn=None,
+        eviction_hook=None,
+    ) -> None:
+        self._cache = cache
+        self._lock = lock
+        self.idle_ttl_secs = idle_ttl_secs
+        self.memory_high_mb = memory_high_mb
+        self.protect_recent = protect_recent
+        # running_check(key) → bool: True when the session has a live turn.
+        self._running_check = running_check or (lambda key: False)
+        # close_agent_fn(key, agent) → bool: full teardown of an evicted agent
+        # (commit memory, close session DB).  Used by the idle-TTL pass.
+        self._close_agent_fn = close_agent_fn
+        # eviction_hook(key, agent, soft: bool): observability (counters/logs).
+        self._eviction_hook = eviction_hook
+
+    # ── Idle TTL ────────────────────────────────────────────────────────────
+    def sweep_idle(self, now: Optional[float] = None) -> int:
+        """Fully evict cached agents idle past the TTL (0 = disabled).
+
+        Returns the number of agents evicted.  Runs the close callback outside
+        the cache lock so provider I/O never blocks cache users.
+        """
+        if not self.idle_ttl_secs:
+            return 0
+        if now is None:
+            now = time.time()
+        to_evict: List[Tuple[str, Any]] = []
+        with self._lock:
+            for key, entry in list(self._cache.items()):
+                agent = entry[0] if isinstance(entry, tuple) and entry else None
+                if agent is None:
+                    continue
+                if self._running_check(key):
+                    continue  # mid-turn — don't tear it down
+                last_activity = _agent_last_activity(agent)
+                if last_activity is None:
+                    continue  # unknown — leave it (parity with gateway)
+                if (now - last_activity) > self.idle_ttl_secs:
+                    self._cache.pop(key, None)
+                    to_evict.append((key, agent))
+        for key, agent in to_evict:
+            try:
+                if self._close_agent_fn is not None:
+                    self._close_agent_fn(key, agent)
+                if self._eviction_hook is not None:
+                    self._eviction_hook(key, agent, soft=False)
+                logger.info(
+                    "Agent-cache governor: idle evicted session=%s "
+                    "(idle_ttl=%ss, cache_size=%d)",
+                    key, self.idle_ttl_secs, len(self._cache),
+                )
+            except Exception:
+                logger.debug("idle eviction teardown failed for %s", key, exc_info=True)
+        return len(to_evict)
+
+    # ── Memory pressure ─────────────────────────────────────────────────────
+    def sweep_pressure(self, rss_mb: Optional[int] = None) -> int:
+        """Soft-evict LRU transcripts once anonymous RSS crosses the budget.
+
+        Returns the number of transcripts dropped (0 when memory is fine or the
+        pass is disabled).
+        """
+        if not self.memory_high_mb:
+            return 0
+        if rss_mb is None:
+            rss_mb = read_anon_rss_mb()
+        if rss_mb is None or rss_mb < self.memory_high_mb:
+            return 0
+
+        def _is_evictable(key: str, agent: Any) -> bool:
+            if agent is None:
+                return False
+            if self._running_check(key):
+                return False
+            return True
+
+        plan = plan_pressure_evictions(
+            [
+                (key, entry[0] if isinstance(entry, tuple) and entry else entry)
+                for key, entry in self._cache.items()
+            ],
+            _is_evictable,
+            protect_recent=self.protect_recent,
+        )
+        for key, agent in plan:
+            try:
+                soft_release_transcript(agent)
+                if self._eviction_hook is not None:
+                    self._eviction_hook(key, agent, soft=True)
+                logger.info(
+                    "Agent-cache governor: pressure soft-evicted session=%s "
+                    "(rss=%sMB budget=%sMB, cache_size=%d)",
+                    key, rss_mb, self.memory_high_mb, len(self._cache),
+                )
+            except Exception:
+                logger.debug("pressure soft-evict failed for %s", key, exc_info=True)
+        return len(plan)
+
+    def run_pass(self) -> Dict[str, int]:
+        """Run one full governance pass; returns {idle_evicted, pressure_dropped}."""
+        idle = self.sweep_idle()
+        pressure = self.sweep_pressure()
+        return {"idle_evicted": idle, "pressure_dropped": pressure}

--- a/api/agent_cache_governance.py
+++ b/api/agent_cache_governance.py
@@ -261,6 +261,10 @@ def soft_release_transcript(agent: Any) -> None:
     list is safe and is the single biggest lever on resident memory.  Keeps the
     agent object itself so cross-turn state (_user_turn_count, memory-provider
     state) survives the pressure pass.
+
+    Only safe once the transcript is fully on disk: clearing the sole complete
+    in-memory copy while persistence lags loses history on the next rebuild.
+    Callers must check ``transcript_persistence_caught_up(agent)`` first.
     """
     if agent is None:
         return
@@ -279,6 +283,25 @@ def soft_release_transcript(agent: Any) -> None:
         logger.debug("soft-release flush prefix failed", exc_info=True)
 
 
+def transcript_persistence_caught_up(agent: Any) -> bool:
+    """True when the agent's live transcript is fully on disk (gateway parity).
+
+    Mirrors ``gateway/agent_cache_pressure.py::transcript_persistence_caught_up``:
+    ``_last_flushed_db_idx`` is advanced to ``len(messages)`` by
+    ``AIAgent._flush_messages_to_session_db`` only on a fully successful write,
+    so ``flushed >= len(messages)`` means the in-memory list is exactly what the
+    session DB already has.  Unknown shapes are treated as *not* caught up: a
+    skipped eviction costs memory, a wrong one costs the user their conversation.
+    """
+    messages = getattr(agent, "_session_messages", None)
+    if not isinstance(messages, list):
+        return False
+    flushed = getattr(agent, "_last_flushed_db_idx", None)
+    if not isinstance(flushed, int) or isinstance(flushed, bool):
+        return False
+    return flushed >= len(messages)
+
+
 class AgentCacheGovernor:
     """One governance pass: idle TTL eviction + memory-pressure soft eviction.
 
@@ -295,7 +318,7 @@ class AgentCacheGovernor:
         idle_ttl_secs: int = 3600,
         memory_high_mb: Optional[int] = None,
         protect_recent: int = 8,
-        running_check=None,
+        active_sids_fn=None,
         close_agent_fn=None,
         eviction_hook=None,
     ) -> None:
@@ -304,8 +327,9 @@ class AgentCacheGovernor:
         self.idle_ttl_secs = idle_ttl_secs
         self.memory_high_mb = memory_high_mb
         self.protect_recent = protect_recent
-        # running_check(key) → bool: True when the session has a live turn.
-        self._running_check = running_check or (lambda key: False)
+        # active_sids_fn() → set[str]: session_ids with a live agent worker.
+        # Defaults to snapshotting api.config.ACTIVE_RUNS; injectable for tests.
+        self._active_sids_fn = active_sids_fn or self._snapshot_active_sids
         # close_agent_fn(key, agent) → bool: full teardown of an evicted agent
         # (commit memory, close session DB).  Used by the idle-TTL pass.
         self._close_agent_fn = close_agent_fn
@@ -313,6 +337,32 @@ class AgentCacheGovernor:
         self._eviction_hook = eviction_hook
 
     # ── Idle TTL ────────────────────────────────────────────────────────────
+    def _snapshot_active_sids(self) -> set:
+        """Snapshot the set of session_ids with a live agent worker.
+
+        Taken BEFORE the cache lock (parity with the LRU eviction path in
+        api/streaming.py:10422): the codebase never nests ACTIVE_RUNS_LOCK
+        inside SESSION_AGENT_CACHE_LOCK, to avoid a lock-ordering deadlock.
+        A cancel/reconnect can drop STREAMS while the worker is still
+        unwinding, so ACTIVE_RUNS (worker lifecycle) is the authoritative
+        liveness signal — snapshotting it up front is exactly what the
+        existing eviction path does.
+        """
+        active = set()
+        try:
+            from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK
+
+            with ACTIVE_RUNS_LOCK:
+                for _entry in (ACTIVE_RUNS or {}).values():
+                    sid = (_entry or {}).get("session_id")
+                    if sid:
+                        active.add(sid)
+        except Exception:
+            # No liveness registry available — fall back to not evicting
+            # anything mid-turn (conservative: skip, costs memory not history).
+            pass
+        return active
+
     def sweep_idle(self, now: Optional[float] = None) -> int:
         """Fully evict cached agents idle past the TTL (0 = disabled).
 
@@ -323,13 +373,14 @@ class AgentCacheGovernor:
             return 0
         if now is None:
             now = time.time()
+        active = self._active_sids_fn()
         to_evict: List[Tuple[str, Any]] = []
         with self._lock:
             for key, entry in list(self._cache.items()):
                 agent = entry[0] if isinstance(entry, tuple) and entry else None
                 if agent is None:
                     continue
-                if self._running_check(key):
+                if key in active:
                     continue  # mid-turn — don't tear it down
                 last_activity = _agent_last_activity(agent)
                 if last_activity is None:
@@ -358,6 +409,16 @@ class AgentCacheGovernor:
 
         Returns the number of transcripts dropped (0 when memory is fine or the
         pass is disabled).
+
+        Concurrency: the cache snapshot is taken under ``self._lock`` so the
+        plan is built from a consistent view (no dict-mutation RuntimeError
+        while server threads churn the cache).  Each planned soft-release is
+        then re-validated immediately before clearing the transcript: the entry
+        must still exist, still hold the SAME agent object we planned (a turn
+        could have replaced it), the session must not be mid-turn, and the
+        transcript must be fully persisted.  A new turn can start after the
+        plan but before release; skipping the eviction then costs memory, a
+        wrong release costs the user their conversation.
         """
         if not self.memory_high_mb:
             return 0
@@ -366,24 +427,44 @@ class AgentCacheGovernor:
         if rss_mb is None or rss_mb < self.memory_high_mb:
             return 0
 
+        # Snapshot under the lock: the live OrderedDict is mutated by server
+        # threads on every turn, and iterating it unlocked races an insert or
+        # eviction (RuntimeError: dictionary changed size during iteration).
+        with self._lock:
+            snapshot = [
+                (key, entry[0] if isinstance(entry, tuple) and entry else entry)
+                for key, entry in self._cache.items()
+            ]
+
+        active = self._active_sids_fn()
+
         def _is_evictable(key: str, agent: Any) -> bool:
             if agent is None:
                 return False
-            if self._running_check(key):
+            if key in active:
+                return False
+            if not transcript_persistence_caught_up(agent):
                 return False
             return True
 
         plan = plan_pressure_evictions(
-            [
-                (key, entry[0] if isinstance(entry, tuple) and entry else entry)
-                for key, entry in self._cache.items()
-            ],
+            snapshot,
             _is_evictable,
             protect_recent=self.protect_recent,
         )
+        dropped = 0
         for key, agent in plan:
             try:
-                soft_release_transcript(agent)
+                # Revalidate under the lock immediately before release: the
+                # plan can go stale between planning and execution.
+                with self._lock:
+                    entry = self._cache.get(key)
+                    current = entry[0] if isinstance(entry, tuple) and entry else entry
+                    if current is not agent:
+                        continue  # entry replaced since planning — leave it
+                    if key in active or not transcript_persistence_caught_up(agent):
+                        continue  # went active / not persisted — skip
+                    soft_release_transcript(agent)
                 if self._eviction_hook is not None:
                     self._eviction_hook(key, agent, soft=True)
                 logger.info(
@@ -391,9 +472,10 @@ class AgentCacheGovernor:
                     "(rss=%sMB budget=%sMB, cache_size=%d)",
                     key, rss_mb, self.memory_high_mb, len(self._cache),
                 )
+                dropped += 1
             except Exception:
                 logger.debug("pressure soft-evict failed for %s", key, exc_info=True)
-        return len(plan)
+        return dropped
 
     def run_pass(self) -> Dict[str, int]:
         """Run one full governance pass; returns {idle_evicted, pressure_dropped}."""

--- a/api/agent_cache_governance.py
+++ b/api/agent_cache_governance.py
@@ -335,9 +335,34 @@ class AgentCacheGovernor:
         self._close_agent_fn = close_agent_fn
         # eviction_hook(key, agent, soft: bool): observability (counters/logs).
         self._eviction_hook = eviction_hook
+        # Plan-time liveness snapshot, kept for lease-less entries (legacy
+        # agents / injected test agents).  Refreshed at the top of each sweep;
+        # None until the first sweep (unknown → fail closed).
+        self._last_active_snapshot: Optional[set] = None
+
+    def _entry_turn_active(self, key: str, agent: Any) -> bool:
+        """True when the cached entry is mid-turn (per-entry lease).
+
+        The streaming layer maintains ``agent._turn_active`` at turn
+        boundaries (api.config.register_active_run / unregister_active_run),
+        so reading it here inside the cache lock yields the NEWEST liveness
+        state — the plan-time snapshot can be stale by the time a release
+        runs.  Entries without a lease (pre-lease agents, injected test
+        agents) fall back to the plan-time snapshot for compatibility.  An
+        unknown liveness (no lease AND no snapshot yet) is treated as ACTIVE:
+        never evict an agent whose liveness we cannot determine (fail closed).
+        An EMPTY snapshot is authoritative — "no one is running" really means
+        the pass may evict.
+        """
+        lease = getattr(agent, "_turn_active", None)
+        if lease is not None:
+            return bool(lease)
+        if self._last_active_snapshot is None:
+            return True  # no snapshot yet — fail closed
+        return key in self._last_active_snapshot
 
     # ── Idle TTL ────────────────────────────────────────────────────────────
-    def _snapshot_active_sids(self) -> set:
+    def _snapshot_active_sids(self) -> Optional[set]:
         """Snapshot the set of session_ids with a live agent worker.
 
         Taken BEFORE the cache lock (parity with the LRU eviction path in
@@ -347,6 +372,12 @@ class AgentCacheGovernor:
         unwinding, so ACTIVE_RUNS (worker lifecycle) is the authoritative
         liveness signal — snapshotting it up front is exactly what the
         existing eviction path does.
+
+        Returns None when the liveness registry is unavailable; callers must
+        skip the pass entirely (fail CLOSED).  Returning an empty set here
+        would mark EVERY agent as inactive and soft-release/evict live
+        workers — the exact "can't determine liveness" case that must never
+        evict.
         """
         active = set()
         try:
@@ -358,9 +389,10 @@ class AgentCacheGovernor:
                     if sid:
                         active.add(sid)
         except Exception:
-            # No liveness registry available — fall back to not evicting
-            # anything mid-turn (conservative: skip, costs memory not history).
-            pass
+            # Liveness registry unavailable — fail CLOSED: skip the pass.
+            # An empty set would read as "no one is running" and evict
+            # mid-turn agents (the empty-set fallback was fail-OPEN).
+            return None
         return active
 
     def sweep_idle(self, now: Optional[float] = None) -> int:
@@ -373,14 +405,20 @@ class AgentCacheGovernor:
             return 0
         if now is None:
             now = time.time()
-        active = self._active_sids_fn()
+        try:
+            active = self._active_sids_fn()
+        except Exception:
+            active = None
+        if active is None:
+            return 0  # liveness registry unavailable — skip the pass (fail closed)
+        self._last_active_snapshot = active
         to_evict: List[Tuple[str, Any]] = []
         with self._lock:
             for key, entry in list(self._cache.items()):
                 agent = entry[0] if isinstance(entry, tuple) and entry else None
                 if agent is None:
                     continue
-                if key in active:
+                if self._entry_turn_active(key, agent):
                     continue  # mid-turn — don't tear it down
                 last_activity = _agent_last_activity(agent)
                 if last_activity is None:
@@ -436,7 +474,13 @@ class AgentCacheGovernor:
                 for key, entry in self._cache.items()
             ]
 
-        active = self._active_sids_fn()
+        try:
+            active = self._active_sids_fn()
+        except Exception:
+            active = None
+        if active is None:
+            return 0  # liveness registry unavailable — skip the pass (fail closed)
+        self._last_active_snapshot = active
 
         def _is_evictable(key: str, agent: Any) -> bool:
             if agent is None:
@@ -456,13 +500,16 @@ class AgentCacheGovernor:
         for key, agent in plan:
             try:
                 # Revalidate under the lock immediately before release: the
-                # plan can go stale between planning and execution.
+                # plan can go stale between planning and execution.  The
+                # mid-turn check here uses the per-entry lease (newest state),
+                # NOT the plan-time snapshot — a turn that started after the
+                # snapshot must stop the release.
                 with self._lock:
                     entry = self._cache.get(key)
                     current = entry[0] if isinstance(entry, tuple) and entry else entry
                     if current is not agent:
                         continue  # entry replaced since planning — leave it
-                    if key in active or not transcript_persistence_caught_up(agent):
+                    if self._entry_turn_active(key, agent) or not transcript_persistence_caught_up(agent):
                         continue  # went active / not persisted — skip
                     soft_release_transcript(agent)
                 if self._eviction_hook is not None:

--- a/api/config.py
+++ b/api/config.py
@@ -9463,6 +9463,14 @@ def register_active_run(stream_id: str, **metadata) -> None:
     entry.setdefault("phase", "running")
     with ACTIVE_RUNS_LOCK:
         ACTIVE_RUNS[stream_id] = entry
+    # Per-entry turn lease: the agent-cache governor revalidates mid-turn
+    # state from the cached agent's lease, so keep it in sync with the
+    # registry at the turn boundary.  Outside ACTIVE_RUNS_LOCK on purpose —
+    # the cache lock is taken briefly here and no reverse nesting exists
+    # (streaming.py deliberately snapshots ACTIVE_RUNS before taking the
+    # cache lock).  The agent may not be in the cache yet (it is inserted
+    # later in the turn); insertion initializes the lease, see streaming.py.
+    _set_agent_cache_turn_lease(entry.get("session_id"), True)
 
 
 def update_active_run(stream_id: str, **metadata) -> None:
@@ -9480,10 +9488,43 @@ def unregister_active_run(stream_id: str) -> None:
     if not stream_id:
         return
     global LAST_RUN_FINISHED_AT
+    session_id = None
+    still_active = False
     with ACTIVE_RUNS_LOCK:
-        ACTIVE_RUNS.pop(stream_id, None)
+        entry = ACTIVE_RUNS.pop(stream_id, None)
+        session_id = (entry or {}).get("session_id")
         LAST_RUN_FINISHED_AT = time.time()
+        if session_id:
+            # A different stream may still be running for the same session
+            # (cancel/reconnect): keep the lease until the LAST stream ends.
+            still_active = any(
+                isinstance(e, dict) and e.get("session_id") == session_id
+                for e in ACTIVE_RUNS.values()
+            )
+    _set_agent_cache_turn_lease(session_id, still_active)
     unregister_stream_owner(stream_id)
+
+
+def _set_agent_cache_turn_lease(session_id, active: bool) -> None:
+    """Update a cached agent's per-entry turn lease at a turn boundary.
+
+    The governor reads this inside SESSION_AGENT_CACHE_LOCK at release time,
+    so liveness is atomic with the entry it guards (the plan-time snapshot
+    alone can go stale between planning and release).  Best-effort: a missing
+    cache entry (agent not inserted yet, already evicted) is a no-op.
+    """
+    if not session_id:
+        return
+    try:
+        with SESSION_AGENT_CACHE_LOCK:
+            entry = SESSION_AGENT_CACHE.get(session_id)
+            if not entry:
+                return
+            agent = entry[0] if isinstance(entry, tuple) and entry else entry
+            if agent is not None:
+                agent._turn_active = bool(active)
+    except Exception:
+        logger.debug("turn-lease update failed for session %s", session_id, exc_info=True)
 
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that
 # _user_turn_count survives between turns.  This mirrors the gateway's
@@ -9520,6 +9561,7 @@ _SESSION_AGENT_CACHE_IDLE_TTL_DEFAULT = 3600
 SESSION_AGENT_CACHE_IDLE_TTL = _env_int(
     "HERMES_WEBUI_AGENT_CACHE_IDLE_TTL",
     _SESSION_AGENT_CACHE_IDLE_TTL_DEFAULT,
+    minimum=0,
 )
 SESSION_AGENT_CACHE_MEMORY_HIGH_MB = os.getenv(
     "HERMES_WEBUI_AGENT_CACHE_MEMORY_HIGH_MB", "auto"
@@ -9528,12 +9570,14 @@ _SESSION_AGENT_CACHE_PROTECT_RECENT_DEFAULT = 8
 SESSION_AGENT_CACHE_PROTECT_RECENT = _env_int(
     "HERMES_WEBUI_AGENT_CACHE_PROTECT_RECENT",
     _SESSION_AGENT_CACHE_PROTECT_RECENT_DEFAULT,
+    minimum=0,
 )
 # Seconds between governance passes (idle TTL + memory pressure sweep).
 _SESSION_AGENT_CACHE_GOVERN_INTERVAL_DEFAULT = 60
 SESSION_AGENT_CACHE_GOVERN_INTERVAL = _env_int(
     "HERMES_WEBUI_AGENT_CACHE_GOVERN_INTERVAL",
     _SESSION_AGENT_CACHE_GOVERN_INTERVAL_DEFAULT,
+    minimum=0,
 )
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -1062,11 +1062,13 @@ MIME_MAP = {
 
 # ── Toolsets (from config.yaml or hardcoded default) ─────────────────────────
 _DEFAULT_TOOLSETS = [
+    "browser",
     "clarify",
     "code_execution",
     "cronjob",
     "delegation",
     "file",
+    "image_gen",
     "memory",
     "session_search",
     "skills",

--- a/api/config.py
+++ b/api/config.py
@@ -1062,13 +1062,11 @@ MIME_MAP = {
 
 # ── Toolsets (from config.yaml or hardcoded default) ─────────────────────────
 _DEFAULT_TOOLSETS = [
-    "browser",
     "clarify",
     "code_execution",
     "cronjob",
     "delegation",
     "file",
-    "image_gen",
     "memory",
     "session_search",
     "skills",
@@ -9500,6 +9498,41 @@ SESSION_AGENT_CACHE: collections.OrderedDict = collections.OrderedDict()  # LRU 
 # tune it via HERMES_WEBUI_AGENT_CACHE_MAX without editing source.
 SESSION_AGENT_CACHE_MAX = _env_int("HERMES_WEBUI_AGENT_CACHE_MAX", 25)
 SESSION_AGENT_CACHE_LOCK = threading.Lock()
+
+# ── Agent-cache governance (port of gateway agent_cache_pressure, #80764) ─────
+# The LRU cap above bounds the *number* of cached agents; each agent pins a full
+# live transcript (_session_messages) in RAM, so on a long-running WebUI the
+# process still grows without bound as warm sessions churn.  The gateway solved
+# the same problem with three valves (config_defaults.py agent_cache):
+#   1. idle_ttl_secs  — evict agents that have been idle past the TTL;
+#   2. memory_high_mb — soft-evict LRU transcripts when anonymous RSS crosses a
+#                       budget, dropping _session_messages so the heap shrinks
+#                       and the transcript rebuilds from the persisted session
+#                       on the next turn;
+#   3. protect_recent — MRU sessions the pressure pass never touches.
+# WebUI mirrors those with env-tunable defaults identical to the gateway's.
+# 0 disables the valve (parity with gateway semantics where 0/off switches the
+# pass off).  memory_high_mb accepts an MB number or "auto" (derived from the
+# cgroup memory limit, falling back to total RAM).
+_SESSION_AGENT_CACHE_IDLE_TTL_DEFAULT = 3600
+SESSION_AGENT_CACHE_IDLE_TTL = _env_int(
+    "HERMES_WEBUI_AGENT_CACHE_IDLE_TTL",
+    _SESSION_AGENT_CACHE_IDLE_TTL_DEFAULT,
+)
+SESSION_AGENT_CACHE_MEMORY_HIGH_MB = os.getenv(
+    "HERMES_WEBUI_AGENT_CACHE_MEMORY_HIGH_MB", "auto"
+).strip()
+_SESSION_AGENT_CACHE_PROTECT_RECENT_DEFAULT = 8
+SESSION_AGENT_CACHE_PROTECT_RECENT = _env_int(
+    "HERMES_WEBUI_AGENT_CACHE_PROTECT_RECENT",
+    _SESSION_AGENT_CACHE_PROTECT_RECENT_DEFAULT,
+)
+# Seconds between governance passes (idle TTL + memory pressure sweep).
+_SESSION_AGENT_CACHE_GOVERN_INTERVAL_DEFAULT = 60
+SESSION_AGENT_CACHE_GOVERN_INTERVAL = _env_int(
+    "HERMES_WEBUI_AGENT_CACHE_GOVERN_INTERVAL",
+    _SESSION_AGENT_CACHE_GOVERN_INTERVAL_DEFAULT,
+)
 
 
 def _evict_session_agent(session_id: str) -> None:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10437,6 +10437,12 @@ def _run_agent_streaming(
                     except Exception:
                         _active_sids = set()
                     with SESSION_AGENT_CACHE_LOCK:
+                        # Initialize the per-entry turn lease: insertion happens
+                        # on the turn path, so the fresh entry is live.  The
+                        # governor revalidates mid-turn state from this lease at
+                        # release time (not the stale plan-time snapshot);
+                        # unregister_active_run clears it when the turn ends.
+                        agent._turn_active = True
                         SESSION_AGENT_CACHE[session_id] = (agent, _agent_sig)
                         SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
                         from api.config import SESSION_AGENT_CACHE_MAX

--- a/server.py
+++ b/server.py
@@ -648,6 +648,73 @@ def main() -> None:
     except Exception as e:
         print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
 
+    # Agent-cache governance: idle-TTL eviction + memory-pressure soft eviction.
+    # Port of the gateway's agent_cache pressure valves (#80764) — the LRU cap
+    # bounds the *count* of cached agents but each pins a live transcript in
+    # RAM, so a long-running WebUI grows without bound without these two passes.
+    try:
+        from api.agent_cache_governance import (
+            AgentCacheGovernor, resolve_memory_high_mb,
+        )
+        from api.config import (
+            SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK,
+            SESSION_AGENT_CACHE_IDLE_TTL, SESSION_AGENT_CACHE_MEMORY_HIGH_MB,
+            SESSION_AGENT_CACHE_PROTECT_RECENT, SESSION_AGENT_CACHE_GOVERN_INTERVAL,
+        )
+
+        def _governor_running_check(key: str) -> bool:
+            try:
+                from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK
+                with ACTIVE_RUNS_LOCK:
+                    for _entry in (ACTIVE_RUNS or {}).values():
+                        if (_entry or {}).get('session_id') == key:
+                            return True
+            except Exception:
+                pass
+            return False
+
+        def _governor_close_agent(key: str, agent) -> None:
+            try:
+                from api.streaming import _close_evicted_agent_at_session_boundary
+                _close_evicted_agent_at_session_boundary(key, agent)
+            except Exception as e:
+                print(f'[!!] WARNING: Agent-cache idle eviction teardown failed for {key}: {e}', flush=True)
+
+        _governor = AgentCacheGovernor(
+            SESSION_AGENT_CACHE,
+            SESSION_AGENT_CACHE_LOCK,
+            idle_ttl_secs=SESSION_AGENT_CACHE_IDLE_TTL,
+            memory_high_mb=resolve_memory_high_mb(SESSION_AGENT_CACHE_MEMORY_HIGH_MB),
+            protect_recent=SESSION_AGENT_CACHE_PROTECT_RECENT,
+            running_check=_governor_running_check,
+            close_agent_fn=_governor_close_agent,
+            eviction_hook=None,
+        )
+
+        def _governor_loop():
+            while True:
+                try:
+                    _governor.run_pass()
+                except Exception as e:
+                    print(f'[!!] Agent-cache governance pass failed: {e}', flush=True)
+                time.sleep(SESSION_AGENT_CACHE_GOVERN_INTERVAL)
+
+        _governor_thread = threading.Thread(
+            target=_governor_loop,
+            name='agent-cache-governor',
+            daemon=True,
+        )
+        _governor_thread.start()
+        _mem_budget = _governor.memory_high_mb
+        _budget_disp = f'{_mem_budget}MB' if _mem_budget else 'off'
+        print(
+            f'[ok] Agent-cache governor: idle_ttl={SESSION_AGENT_CACHE_IDLE_TTL}s '
+            f'pressure={_budget_disp} protect_recent={SESSION_AGENT_CACHE_PROTECT_RECENT}',
+            flush=True,
+        )
+    except Exception as e:
+        print(f'[!!] WARNING: Agent-cache governor failed to start: {e}', flush=True)
+
     try:
         from api.background_process import start_drain_thread
         if start_drain_thread():

--- a/server.py
+++ b/server.py
@@ -662,17 +662,6 @@ def main() -> None:
             SESSION_AGENT_CACHE_PROTECT_RECENT, SESSION_AGENT_CACHE_GOVERN_INTERVAL,
         )
 
-        def _governor_running_check(key: str) -> bool:
-            try:
-                from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK
-                with ACTIVE_RUNS_LOCK:
-                    for _entry in (ACTIVE_RUNS or {}).values():
-                        if (_entry or {}).get('session_id') == key:
-                            return True
-            except Exception:
-                pass
-            return False
-
         def _governor_close_agent(key: str, agent) -> None:
             try:
                 from api.streaming import _close_evicted_agent_at_session_boundary
@@ -686,7 +675,6 @@ def main() -> None:
             idle_ttl_secs=SESSION_AGENT_CACHE_IDLE_TTL,
             memory_high_mb=resolve_memory_high_mb(SESSION_AGENT_CACHE_MEMORY_HIGH_MB),
             protect_recent=SESSION_AGENT_CACHE_PROTECT_RECENT,
-            running_check=_governor_running_check,
             close_agent_fn=_governor_close_agent,
             eviction_hook=None,
         )

--- a/tests/concurrency_smoke_governor.py
+++ b/tests/concurrency_smoke_governor.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""并发压测:AgentCacheGovernor.sweep_pressure 在缓存 churn 下不崩(冒烟)。
+
+复现 Manny7717 的条件:2000 条缓存 + churn 线程(并发 insert/evict) +
+governor 反复跑 sweep_pressure。旧代码会抛
+RuntimeError: dictionary changed size during iteration(异常被吞→压力阀静默失效);
+修复后应稳定跑完,且只释放"非活跃 + 已持久化"的转录。
+"""
+import sys
+import threading
+import time
+
+sys.path.insert(0, "/root/hermes-webui")
+
+from api.agent_cache_governance import AgentCacheGovernor, transcript_persistence_caught_up
+
+
+class FakeAgent:
+    """模拟 AIAgent:_session_messages + _last_flushed_db_idx + _db_flush_scan_prefix。"""
+
+    def __init__(self, session_id, flushed=False, activity=0.0):
+        self.session_id = session_id
+        self._session_messages = [{"role": "user", "content": "x" * 100} for _ in range(10)]
+        self._last_flushed_db_idx = len(self._session_messages) if flushed else 3
+        self._db_flush_scan_prefix = list(self._session_messages[:3])
+        self._last_activity_ts = activity
+
+    def __repr__(self):
+        return f"<FakeAgent {self.session_id} flushed={self._last_flushed_db_idx == len(self._session_messages)}>"
+
+
+def main():
+    n = 2000
+    cache = {}
+    for i in range(n):
+        cache[f"s{i}"] = (FakeAgent(f"s{i}", flushed=True), object())
+    lock = threading.Lock()
+
+    gov = AgentCacheGovernor(
+        cache, lock,
+        idle_ttl_secs=0,          # 只测压力路径
+        memory_high_mb=1,         # 强制超预算(实际会读 RSS,但传 rss_mb 覆盖)
+        protect_recent=0,
+    )
+
+    stop = threading.Event()
+    stats = {"churn": 0, "evicted": 0}
+
+    def churn():
+        i = 0
+        while not stop.is_set():
+            with lock:
+                if len(cache) > n:
+                    # 随机逐出
+                    key = next(iter(cache))
+                    cache.pop(key, None)
+                cache[f"churn{i % 500}"] = (FakeAgent(f"churn{i % 500}", flushed=True), object())
+                i += 1
+                stats["churn"] += 1
+
+    t = threading.Thread(target=churn, daemon=True)
+    t.start()
+
+    errors = []
+    start = time.time()
+    passes = 300
+    for p in range(passes):
+        try:
+            dropped = gov.sweep_pressure(rss_mb=2000)  # 强制超预算
+            stats["evicted"] += dropped
+        except RuntimeError as e:
+            errors.append(f"pass {p}: RuntimeError: {e}")
+        except Exception as e:
+            errors.append(f"pass {p}: {type(e).__name__}: {e}")
+
+    stop.set()
+    t.join(timeout=5)
+    elapsed = time.time() - start
+
+    print(f"passes={passes} churn_ops={stats['churn']} dropped_total={stats['evicted']} elapsed={elapsed:.1f}s")
+    if errors:
+        print(f"FAIL: {len(errors)} errors, first: {errors[0]}")
+        sys.exit(1)
+
+    # 校验:被释放的必须是 flushed 的 agent;活跃 agent 不应被释放
+    unflushed_released = 0
+    with lock:
+        for key, entry in cache.items():
+            agent = entry[0] if isinstance(entry, tuple) and entry else entry
+            if agent is not None and hasattr(agent, "_session_messages"):
+                if agent._session_messages == [] and agent._last_flushed_db_idx != len([1] * 10) and agent._last_flushed_db_idx < 10:
+                    # 释放后 messages=[];若释放时未 flushed(flushed idx<10)就是 bug
+                    unflushed_released += 1
+    # 更简单的校验:释放的 agent 的 _session_messages 应为空,且 persistence 当时 caught up(通过记录)
+    # 这里直接检查:没有任何 agent 同时满足"messages 被清 且 原本未 flushed"
+    # 由于我们无法追溯释放瞬间,改为断言:所有仍在缓存中的 agent,若 messages=[] 则其 flush idx 必须 == 10(flushed)
+    bad = 0
+    with lock:
+        for key, entry in cache.items():
+            agent = entry[0] if isinstance(entry, tuple) and entry else entry
+            if agent is not None and getattr(agent, "_session_messages", None) == []:
+                if not transcript_persistence_caught_up(agent):
+                    bad += 1
+    if bad:
+        print(f"FAIL: {bad} released agents were NOT persisted at release time")
+        sys.exit(1)
+
+    print("OK: 300 sweeps under churn, no RuntimeError; all released agents were persisted")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_cache_governance.py
+++ b/tests/test_agent_cache_governance.py
@@ -20,10 +20,13 @@ from api.agent_cache_governance import (
 
 
 class _FakeAgent:
-    def __init__(self, last_activity_ts=None):
+    def __init__(self, last_activity_ts=None, flushed=True):
         self._last_activity_ts = last_activity_ts
         self._session_messages = [{"role": "user", "content": "x" * 1000}]
         self._db_flush_scan_prefix = [{"role": "user", "content": "y" * 1000}]
+        # Persistence parity with AIAgent: _last_flushed_db_idx advances to
+        # len(_session_messages) only on a fully successful DB write.
+        self._last_flushed_db_idx = len(self._session_messages) if flushed else 0
 
 
 def _cache_with(entries):
@@ -35,6 +38,15 @@ def _cache_with(entries):
 
 
 def _governor(cache, **kw):
+    # Accept the old ``running_check`` kwarg for legacy tests; translate to the
+    # new snapshot-based active-sids contract.
+    if "running_check" in kw:
+        rc = kw.pop("running_check")
+
+        def _snapshot():
+            return {k for k in list(cache) if rc(k)}
+
+        kw["active_sids_fn"] = _snapshot
     return AgentCacheGovernor(cache, threading.Lock(), **kw)
 
 
@@ -172,3 +184,121 @@ def test_positive_int_parses():
     assert _positive_int("0", 1) == 0  # 0 allowed = disabled
     assert _positive_int("x", 1) == 1
     assert _positive_int(None, 1) == 1
+
+
+# ── persistence gate (gateway parity) ─────────────────────────────────────
+def test_pressure_sweep_skips_unflushed():
+    """A transcript that has not fully flushed to the session DB must not be
+    dropped — clearing the sole complete in-memory copy loses history."""
+    cache = _cache_with([("k", _FakeAgent(flushed=False))])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+    assert g.sweep_pressure(rss_mb=500) == 0
+    assert cache["k"][0]._session_messages  # still there
+
+
+def test_pressure_sweep_drops_flushed():
+    cache = _cache_with([("k", _FakeAgent(flushed=True))])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+    assert g.sweep_pressure(rss_mb=500) == 1
+    assert cache["k"][0]._session_messages == []
+
+
+def test_pressure_sweep_revalidates_replaced_entry():
+    """A plan entry replaced by a new turn between planning and release must
+    not be released (the current agent object differs from the planned one)."""
+    cache = _cache_with([("k", _FakeAgent(flushed=True))])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+
+    original_agent = cache["k"][0]
+
+    class _ReplacingGovernor(g.__class__):
+        _replaced = False
+
+        def _active_sids_fn(self):
+            # On the second plan (the sweep re-runs inside revalidation? no —
+            # replace the entry once between plan and release via hook):
+            return set()
+
+    # Simulate replacement: plan_pressure_evictions is pure; we intercept by
+    # swapping the cache entry after the snapshot but before release. Easiest
+    # deterministic route: wrap plan_pressure_evictions.
+    import api.agent_cache_governance as gmod
+
+    calls = {"n": 0}
+
+    def _plan_wrapper(ordered, is_evictable, **kw):
+        plan = orig_plan(ordered, is_evictable, **kw)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Between planning and release, a new turn replaces the entry.
+            cache["k"] = (_FakeAgent(flushed=True), "sig")
+        return plan
+
+    orig_plan = gmod.plan_pressure_evictions
+    gmod.plan_pressure_evictions = _plan_wrapper
+    try:
+        dropped = g.sweep_pressure(rss_mb=500)
+    finally:
+        gmod.plan_pressure_evictions = orig_plan
+    # The replaced agent must survive; the ORIGINAL planned one was cleared.
+    assert dropped == 0
+    assert cache["k"][0] is not original_agent
+    assert cache["k"][0]._session_messages  # replacement untouched
+
+
+def test_pressure_sweep_goes_active_between_plan_and_release():
+    """A session that becomes mid-turn after planning must be skipped at
+    release time (no transcript dropped while the agent is running)."""
+    cache = _cache_with([("k", _FakeAgent(flushed=True))])
+    state = {"active": False}
+
+    def _active_fn():
+        return {"k"} if state["active"] else set()
+
+    g = _governor(
+        cache, memory_high_mb=100, protect_recent=0, active_sids_fn=_active_fn
+    )
+    # Flip to active after planning (the revalidation inside sweep_pressure
+    # calls _active_sids_fn again before release).
+    state["active"] = True
+    assert g.sweep_pressure(rss_mb=500) == 0
+    assert cache["k"][0]._session_messages  # not dropped
+
+
+def test_pressure_sweep_concurrent_churn_no_crash():
+    """The snapshot must be taken under the lock; unlocked iteration over a
+    churning OrderedDict races (RuntimeError: dictionary changed size during
+    iteration). Deterministic check: churn from another thread while sweeping."""
+    from collections import OrderedDict
+
+    n = 500
+    cache = OrderedDict(
+        (f"k{i}", (_FakeAgent(flushed=True), "sig")) for i in range(n)
+    )
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+    stop = threading.Event()
+    errors = []
+
+    def churn():
+        i = 0
+        while not stop.is_set():
+            try:
+                if len(cache) > n:
+                    cache.popitem(last=False)
+                cache[f"churn{i % 200}"] = (_FakeAgent(flushed=True), "sig")
+                i += 1
+            except Exception:
+                pass
+
+    t = threading.Thread(target=churn, daemon=True)
+    t.start()
+    try:
+        for _ in range(100):
+            try:
+                g.sweep_pressure(rss_mb=500)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+    finally:
+        stop.set()
+        t.join(timeout=5)
+    assert not errors, f"sweep crashed under churn: {errors[0]}"

--- a/tests/test_agent_cache_governance.py
+++ b/tests/test_agent_cache_governance.py
@@ -1,0 +1,174 @@
+"""Unit tests for api.agent_cache_governance (memory-pressure + idle-TTL valves).
+
+Run: HERMES_WEBUI_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python3.11 \
+     python -m pytest tests/test_agent_cache_governance.py -v
+"""
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+sys.path.insert(0, ".")
+
+from api.agent_cache_governance import (
+    AgentCacheGovernor,
+    _positive_int,
+    plan_pressure_evictions,
+    resolve_memory_high_mb,
+    soft_release_transcript,
+)
+
+
+class _FakeAgent:
+    def __init__(self, last_activity_ts=None):
+        self._last_activity_ts = last_activity_ts
+        self._session_messages = [{"role": "user", "content": "x" * 1000}]
+        self._db_flush_scan_prefix = [{"role": "user", "content": "y" * 1000}]
+
+
+def _cache_with(entries):
+    """entries: list[(key, agent)] — oldest first (LRU front)."""
+    c = {}
+    for k, a in entries:
+        c[k] = (a, "sig")
+    return c
+
+
+def _governor(cache, **kw):
+    return AgentCacheGovernor(cache, threading.Lock(), **kw)
+
+
+# ── resolve_memory_high_mb ────────────────────────────────────────────────
+def test_memory_high_auto_with_total_ram():
+    assert resolve_memory_high_mb("auto", total_ram_mb=2000) == 1300
+    assert resolve_memory_high_mb("auto", total_ram_mb=512) >= 512  # floor
+
+
+def test_memory_high_number():
+    assert resolve_memory_high_mb("512", total_ram_mb=2000) == 512
+    assert resolve_memory_high_mb(400, total_ram_mb=2000) == 400
+
+
+def test_memory_high_disabled():
+    assert resolve_memory_high_mb("0") is None
+    assert resolve_memory_high_mb("off") is None
+    assert resolve_memory_high_mb("") is None
+    assert resolve_memory_high_mb(None) is None
+    assert resolve_memory_high_mb("abc") is None
+
+
+# ── plan_pressure_evictions ───────────────────────────────────────────────
+def test_plan_evicts_lru_skips_recent():
+    agents = [(f"k{i}", _FakeAgent()) for i in range(10)]
+    plan = plan_pressure_evictions(agents, lambda k, a: True, protect_recent=3)
+    keys = [k for k, _ in plan]
+    assert keys == [f"k{i}" for i in range(7)]  # last 3 protected
+
+
+def test_plan_never_evicts_midrun():
+    agents = [(f"k{i}", _FakeAgent()) for i in range(10)]
+    plan = plan_pressure_evictions(
+        agents, lambda k, a: k != "k1", protect_recent=0
+    )
+    keys = [k for k, _ in plan]
+    assert "k1" not in keys
+
+
+def test_plan_max_evictions():
+    agents = [(f"k{i}", _FakeAgent()) for i in range(50)]
+    plan = plan_pressure_evictions(agents, lambda k, a: True, protect_recent=0)
+    assert len(plan) <= 16
+
+
+# ── soft_release_transcript ───────────────────────────────────────────────
+def test_soft_release_drops_transcript_keeps_agent():
+    a = _FakeAgent()
+    soft_release_transcript(a)
+    assert a._session_messages == []
+    assert a._db_flush_scan_prefix is None
+
+
+# ── idle TTL sweep ─────────────────────────────────────────────────────────
+def test_idle_sweep_evicts_stale_keeps_fresh():
+    now = time.time()
+    cache = _cache_with([
+        ("stale", _FakeAgent(last_activity_ts=now - 7200)),
+        ("fresh", _FakeAgent(last_activity_ts=now - 10)),
+    ])
+    closed = []
+
+    def close(key, agent):
+        closed.append(key)
+
+    g = _governor(cache, idle_ttl_secs=3600, close_agent_fn=close)
+    assert g.sweep_idle(now=now) == 1
+    assert closed == ["stale"]
+    assert "stale" not in cache
+    assert "fresh" in cache
+
+
+def test_idle_sweep_skips_running():
+    now = time.time()
+    cache = _cache_with([
+        ("running", _FakeAgent(last_activity_ts=now - 7200)),
+    ])
+    g = _governor(
+        cache, idle_ttl_secs=3600,
+        running_check=lambda k: k == "running",
+        close_agent_fn=lambda k, a: None,
+    )
+    assert g.sweep_idle(now=now) == 0
+    assert "running" in cache
+
+
+def test_idle_sweep_disabled_when_ttl_zero():
+    cache = _cache_with([("k", _FakeAgent(last_activity_ts=0))])
+    g = _governor(cache, idle_ttl_secs=0, close_agent_fn=lambda k, a: None)
+    assert g.sweep_idle(now=time.time()) == 0
+
+
+# ── memory pressure sweep ──────────────────────────────────────────────────
+def test_pressure_sweep_soft_evicts_lru():
+    cache = _cache_with([(f"k{i}", _FakeAgent()) for i in range(5)])
+    g = _governor(
+        cache,
+        memory_high_mb=100,
+        protect_recent=1,
+        running_check=lambda k: False,
+    )
+    dropped = g.sweep_pressure(rss_mb=500)
+    assert dropped == 4  # k0..k3 dropped, k4 protected
+    # agents stay in cache (soft) but transcripts are gone
+    assert set(cache.keys()) == {"k0", "k1", "k2", "k3", "k4"}
+    assert cache["k0"][0]._session_messages == []
+    assert cache["k4"][0]._session_messages  # protected: transcript intact
+
+
+def test_pressure_sweep_noop_below_budget():
+    cache = _cache_with([("k", _FakeAgent())])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+    assert g.sweep_pressure(rss_mb=50) == 0
+    assert cache["k"][0]._session_messages
+
+
+def test_pressure_sweep_skips_running():
+    cache = _cache_with([("busy", _FakeAgent())])
+    g = _governor(
+        cache, memory_high_mb=100, protect_recent=0,
+        running_check=lambda k: k == "busy",
+    )
+    assert g.sweep_pressure(rss_mb=500) == 0
+    assert cache["busy"][0]._session_messages
+
+
+def test_pressure_sweep_disabled_when_budget_none():
+    cache = _cache_with([("k", _FakeAgent())])
+    g = _governor(cache, memory_high_mb=None, protect_recent=0)
+    assert g.sweep_pressure(rss_mb=10 ** 9) == 0
+
+
+def test_positive_int_parses():
+    assert _positive_int("10", 1) == 10
+    assert _positive_int("0", 1) == 0  # 0 allowed = disabled
+    assert _positive_int("x", 1) == 1
+    assert _positive_int(None, 1) == 1

--- a/tests/test_agent_cache_governance.py
+++ b/tests/test_agent_cache_governance.py
@@ -20,13 +20,18 @@ from api.agent_cache_governance import (
 
 
 class _FakeAgent:
-    def __init__(self, last_activity_ts=None, flushed=True):
+    def __init__(self, last_activity_ts=None, flushed=True, turn_active=None):
         self._last_activity_ts = last_activity_ts
         self._session_messages = [{"role": "user", "content": "x" * 1000}]
         self._db_flush_scan_prefix = [{"role": "user", "content": "y" * 1000}]
         # Persistence parity with AIAgent: _last_flushed_db_idx advances to
         # len(_session_messages) only on a fully successful DB write.
         self._last_flushed_db_idx = len(self._session_messages) if flushed else 0
+        # Per-entry turn lease: absent (None) by default so injected agents
+        # exercise the snapshot fallback; tests that simulate a mid-turn
+        # state set it explicitly (streaming.py always initializes it).
+        if turn_active is not None:
+            self._turn_active = turn_active
 
 
 def _cache_with(entries):
@@ -248,21 +253,99 @@ def test_pressure_sweep_revalidates_replaced_entry():
 
 def test_pressure_sweep_goes_active_between_plan_and_release():
     """A session that becomes mid-turn after planning must be skipped at
-    release time (no transcript dropped while the agent is running)."""
-    cache = _cache_with([("k", _FakeAgent(flushed=True))])
-    state = {"active": False}
+    release time (no transcript dropped while the agent is running).
 
-    def _active_fn():
-        return {"k"} if state["active"] else set()
+    This exercises the per-entry lease: the plan-time snapshot is empty (the
+    session looked idle), then the turn starts BETWEEN planning and release.
+    The release-time revalidation reads the agent's lease (newest state) and
+    must skip the soft-release.  The old test flipped the active flag BEFORE
+    calling sweep_pressure, so the single snapshot already saw the session
+    active and no plan was ever built — it could never fail.
+    """
+    cache = _cache_with([("k", _FakeAgent(flushed=True))])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+
+    import api.agent_cache_governance as gmod
+
+    orig_plan = gmod.plan_pressure_evictions
+    calls = {"n": 0}
+
+    def _plan_wrapper(ordered, is_evictable, **kw):
+        plan = orig_plan(ordered, is_evictable, **kw)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Between planning and release the session goes mid-turn: the
+            # streaming layer sets the lease (register_active_run).  This is
+            # the window the old test never opened.
+            cache["k"][0]._turn_active = True
+        return plan
+
+    gmod.plan_pressure_evictions = _plan_wrapper
+    try:
+        dropped = g.sweep_pressure(rss_mb=500)
+    finally:
+        gmod.plan_pressure_evictions = orig_plan
+    # The plan targeted k, but the release-time lease says mid-turn: skip.
+    assert dropped == 0
+    assert cache["k"][0]._session_messages  # transcript intact
+
+
+def test_pressure_sweep_fail_closed_when_registry_unavailable():
+    """An unavailable liveness registry must skip the pass (fail CLOSED).
+
+    The old empty-set fallback read as 'no one is running' and soft-released
+    EVERY transcript — the exact 'can't determine liveness' case that must
+    never evict.
+    """
+    cache = _cache_with([("k", _FakeAgent(flushed=True))])
+
+    def _broken_fn():
+        raise RuntimeError("registry down")
 
     g = _governor(
-        cache, memory_high_mb=100, protect_recent=0, active_sids_fn=_active_fn
+        cache, memory_high_mb=100, protect_recent=0, active_sids_fn=_broken_fn
     )
-    # Flip to active after planning (the revalidation inside sweep_pressure
-    # calls _active_sids_fn again before release).
-    state["active"] = True
     assert g.sweep_pressure(rss_mb=500) == 0
-    assert cache["k"][0]._session_messages  # not dropped
+    assert cache["k"][0]._session_messages  # nothing dropped
+
+
+def test_idle_sweep_fail_closed_when_registry_unavailable():
+    cache = _cache_with([("k", _FakeAgent(last_activity_ts=time.time() - 7200))])
+
+    def _broken_fn():
+        raise RuntimeError("registry down")
+
+    g = _governor(
+        cache, idle_ttl_secs=3600, active_sids_fn=_broken_fn,
+        close_agent_fn=lambda k, a: None,
+    )
+    assert g.sweep_idle(now=time.time()) == 0
+    assert "k" in cache
+
+
+def test_pressure_sweep_respects_lease_at_release():
+    """The lease (per-entry mid-turn marker) overrides a stale empty plan-time
+    snapshot: a session that went active after planning is never released.
+    """
+    cache = _cache_with([("k", _FakeAgent(flushed=True, turn_active=True))])
+    g = _governor(cache, memory_high_mb=100, protect_recent=0)
+    assert g.sweep_pressure(rss_mb=500) == 0
+    assert cache["k"][0]._session_messages
+
+
+def test_idle_sweep_respects_lease():
+    """Idle sweep must not tear down an agent whose lease says mid-turn, even
+    when the plan-time snapshot missed it."""
+    now = time.time()
+    cache = _cache_with([
+        ("busy", _FakeAgent(last_activity_ts=now - 7200, turn_active=True)),
+        ("stale", _FakeAgent(last_activity_ts=now - 7200)),
+    ])
+    closed = []
+    g = _governor(cache, idle_ttl_secs=3600, close_agent_fn=lambda k, a: closed.append(k))
+    assert g.sweep_idle(now=now) == 1
+    assert closed == ["stale"]
+    assert "busy" in cache
 
 
 def test_pressure_sweep_concurrent_churn_no_crash():


### PR DESCRIPTION
WebUI's per-session AIAgent cache is bounded only by an LRU entry cap; each cached agent pins a full live transcript (_session_messages) in RAM, so a long-running process grows without bound as warm sessions churn. The gateway solved the same problem with idle-TTL eviction plus an anonymous-RSS pressure valve that soft-evicts LRU transcripts while keeping the agent in cache (transcript rebuilds from the persisted session on the next turn).

Port those two valves to the WebUI:
- api/agent_cache_governance.py: AgentCacheGovernor with sweep_idle() (full eviction past idle_ttl_secs) and sweep_pressure() (soft-evict LRU transcripts above a memory budget, preserving the agent handle)
- api/config.py: env-tunable HERMES_WEBUI_AGENT_CACHE_IDLE_TTL, HERMES_WEBUI_AGENT_CACHE_MEMORY_HIGH_MB (auto derives from cgroup limit), HERMES_WEBUI_AGENT_CACHE_PROTECT_RECENT, HERMES_WEBUI_AGENT_CACHE_GOVERN_INTERVAL
- server.py: background daemon thread running the governance pass
- tests/test_agent_cache_governance.py: 15 unit tests covering budget resolution, LRU planning, soft-release, idle and pressure sweeps

Eviction reuses the existing _close_evicted_agent_at_session_boundary path so memory lifecycle commits stay intact; active (mid-turn) sessions are never touched, matching gateway semantics.