### PR TITLE
fix: serve static binaries with correct MIME types

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13,6 +13,7 @@ import gzip
 import json
 from api.sse_chunked import end_sse_headers
 import logging
+import mimetypes
 import os
 import queue
 import re
@@ -17716,6 +17717,9 @@ _STATIC_MIME = {
     "webp": "image/webp",
     "woff": "font/woff",
     "woff2": "font/woff2",
+    # Python's built-in MIME table does not include APK, and platform MIME
+    # databases are not consistent across Linux, macOS, and Windows.
+    "apk": "application/vnd.android.package-archive",
 }
 # MIME types that are text-based and should carry charset=utf-8
 _TEXT_MIME_TYPES = {"text/css", "application/javascript", "text/html", "image/svg+xml", "text/plain"}
@@ -17747,7 +17751,13 @@ def _serve_static(handler, parsed):
     if not static_file.exists() or not static_file.is_file():
         return j(handler, {"error": "not found"}, status=404)
     ext = static_file.suffix.lower()
-    ct = _STATIC_MIME.get(ext.lstrip("."), "text/plain")
+    ct = _STATIC_MIME.get(ext.lstrip("."))
+    if ct is None:
+        guessed_type, content_encoding = mimetypes.guess_type(static_file.name)
+        # Encoded suffixes (for example .svgz/.tgz) need Content-Encoding
+        # semantics this route does not implement. Fail closed instead of
+        # advertising the decoded media type for still-compressed bytes.
+        ct = guessed_type if guessed_type and not content_encoding else "application/octet-stream"
     ct_header = f"{ct}; charset=utf-8" if ct in _TEXT_MIME_TYPES else ct
 
     # Look up or populate the per-file cache (raw, optional gzip, ETag).

--- a/tests/test_static_asset_compression_and_cache.py
+++ b/tests/test_static_asset_compression_and_cache.py
@@ -214,6 +214,62 @@ def test_image_is_not_gzipped(isolated_static):
     assert h.header("Content-Type") == "image/png"
 
 
+def test_standard_binary_extension_uses_system_mime_type(isolated_static):
+    """Known binary formats outside the hand-written map keep their real MIME."""
+    from api import routes
+
+    payload = b"%PDF-1.7\n" + b"\x00" * 128
+    _make_static_file(isolated_static, "manual.pdf", payload)
+
+    h = _serve(routes, "/static/manual.pdf")
+    assert h.status == 200
+    assert h.header("Content-Type") == "application/pdf"
+    assert bytes(h.body) == payload
+
+
+def test_apk_is_served_as_android_package_when_platform_database_lacks_it(
+    isolated_static, monkeypatch
+):
+    """Android package MIME must not depend on the host's MIME database."""
+    from api import routes
+
+    monkeypatch.setattr(routes.mimetypes, "guess_type", lambda _name: (None, None))
+    payload = b"PK\x03\x04" + b"\x00" * 128
+    _make_static_file(isolated_static, "hermes-webui.apk", payload)
+
+    h = _serve(routes, "/static/hermes-webui.apk")
+    assert h.status == 200
+    assert h.header("Content-Type") == "application/vnd.android.package-archive"
+    assert bytes(h.body) == payload
+
+
+def test_unknown_static_extension_falls_back_to_octet_stream(isolated_static):
+    """Unknown files fail closed as downloads instead of being exposed as text."""
+    from api import routes
+
+    payload = b"\x00\xff\x10binary"
+    _make_static_file(isolated_static, "artifact.hermes-unknown", payload)
+
+    h = _serve(routes, "/static/artifact.hermes-unknown")
+    assert h.status == 200
+    assert h.header("Content-Type") == "application/octet-stream"
+    assert bytes(h.body) == payload
+
+
+def test_encoded_static_suffix_falls_back_to_octet_stream(isolated_static):
+    """Do not advertise decoded media types without Content-Encoding support."""
+    from api import routes
+
+    payload = b"\x1f\x8b" + b"compressed-svg"
+    _make_static_file(isolated_static, "diagram.svgz", payload)
+
+    h = _serve(routes, "/static/diagram.svgz")
+    assert h.status == 200
+    assert h.header("Content-Type") == "application/octet-stream"
+    assert h.header("Content-Encoding") is None
+    assert bytes(h.body) == payload
+
+
 def test_tiny_file_is_not_gzipped(isolated_static):
     """Files under 1 KB skip gzip — framing overhead exceeds savings."""
     from api import routes


### PR DESCRIPTION
## Summary
- resolve static-file MIME types outside the small built-in allowlist with Python's standard `mimetypes` database
- serve unknown or pre-encoded suffixes as `application/octet-stream` instead of `text/plain`
- keep APK downloads deterministic across hosts with an explicit Android package MIME entry

## Root cause
`_serve_static()` defaulted every extension missing from `_STATIC_MIME` to `text/plain`. This mislabeled PDFs, APKs, and arbitrary binary artifacts; it also added a text charset to those responses.

## Test proof
Before the fix, the four new regression cases failed with `text/plain; charset=utf-8` for PDF, APK, unknown binary, and `.svgz` assets.

After the fix:
- `HERMES_WEBUI_TLS_CERT= HERMES_WEBUI_TLS_KEY= ./scripts/test.sh tests/test_static_asset_compression_and_cache.py -q` — 15 passed
- affected + neighboring static-route tests — 35 passed
- `python -m py_compile api/routes.py tests/test_static_asset_compression_and_cache.py`
- `git diff --check`

## Scope
No APK binaries, certificates, generated artifacts, dependency changes, or changelog edits are included.

## Release note
Static assets now use correct MIME types for standard binary formats, with a safe octet-stream fallback for unknown or encoded files.
