### PR TITLE
fix(composer): keep newline-on-Enter on phones with a stylus or BT mouse (S-Pen fine pointer)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -244,6 +244,25 @@ EXPECT:
   - No message is sent (no user message appears in chat)
 FAIL: Message sent on Shift+Enter.
 
+### T2.3b: Phone With Stylus Keeps Enter = Newline
+SETUP: A phone whose digitizer exposes a fine pointer as co-existing —
+Galaxy S23/S24/S25 Ultra with the S-Pen, or any phone with a paired
+Bluetooth mouse (check `matchMedia('(any-pointer:fine)').matches` in the
+browser console: it must return true alongside `(pointer:coarse)` true).
+STEPS:
+  1. Open the WebUI on the phone, focus the composer
+  2. Type "Line one"
+  3. Press the keyboard's newline/Enter key (no Shift, no Ctrl)
+  4. Type "Line two"
+EXPECT:
+  - Two lines of text appear in the input box
+  - No message is sent
+FAIL: Message sent on plain Enter. (The co-existing fine pointer used to be
+read as proof of a hardware keyboard, disabling the mobile Enter=newline
+default; only tablet-class screens should fall back to desktop semantics.)
+Note: a tablet with a hardware keyboard must still send on plain Enter —
+re-run T2.2 there to confirm no regression.
+
 ### T2.4: Reload Restores Session
 SETUP: A session exists with at least one exchange (user + assistant).
 STEPS:

--- a/static/boot.js
+++ b/static/boot.js
@@ -164,7 +164,13 @@ function _isPhoneWidthViewport(){
 }
 
 function _isTouchKeyboardViewport(){
-  try{return matchMedia('(hover:none) and (pointer:coarse)').matches&&!_hasFinePointerCoexisting();}catch(_){return false;}
+  try{
+    if(!matchMedia('(hover:none) and (pointer:coarse)').matches) return false;
+    // Phone-sized touch devices keep virtual-keyboard treatment even
+    // when a stylus (S-Pen) or BT mouse exposes a fine pointer.
+    if(_isPhoneSizedTouchDevice()) return true;
+    return !_hasFinePointerCoexisting();
+  }catch(_){ return false; }
 }
 
 function _syncKeyboardBottomInset(){
@@ -2388,6 +2394,19 @@ window._isImeEnter=_isImeEnter;
 function _hasFinePointerCoexisting(){
   try{ return matchMedia('(any-pointer:fine)').matches; }catch(_){ return false; }
 }
+// A *phone-sized* touch-primary device is never "a tablet with a
+// hardware keyboard" — the fine pointer is a stylus (S-Pen on Galaxy Ultra)
+// or a paired BT mouse, not evidence of a physical keyboard. Only on
+// large-screen (tablet-class) touch devices does a co-existing fine pointer
+// mean desktop semantics are wanted. Without this, the S-Pen alone disabled
+// Enter=newline on Galaxy S23/S24/S25 Ultra phones.
+function _isPhoneSizedTouchDevice(){
+  try{
+    if(!matchMedia('(pointer:coarse)').matches) return false;
+    const w=Math.min(screen.width||0,screen.height||0);
+    return w>0&&w<=500;
+  }catch(_){ return false; }
+}
 function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);
 }
@@ -2421,11 +2440,13 @@ $('msg').addEventListener('keydown',e=>{
   // The 'ctrl+enter' and 'shift+enter' settings also use this behavior
   // (plain Enter = newline).
   // Users can override in Settings by explicitly choosing 'enter' mode.
+  // A phone-sized touch device (S-Pen stylus, BT mouse) is still a
+  // phone — Enter stays newline there even if a fine pointer co-exists.
   if(e.key==='Enter'){
     if(_isImeEnter(e)){return;}
     const isNumpadEnter=_isNumpadEnter(e);
-    const _mobileDefault=matchMedia('(pointer:coarse)').matches
-      &&!_hasFinePointerCoexisting()
+    const _mobileDefault=(matchMedia('(pointer:coarse)').matches
+      &&(_isPhoneSizedTouchDevice()||!_hasFinePointerCoexisting()))
       &&window._sendKey==='enter';
     if(window._sendKey==='shift+enter'){
       if(e.shiftKey){e.preventDefault();send();}

--- a/static/boot.js
+++ b/static/boot.js
@@ -2394,17 +2394,11 @@ window._isImeEnter=_isImeEnter;
 function _hasFinePointerCoexisting(){
   try{ return matchMedia('(any-pointer:fine)').matches; }catch(_){ return false; }
 }
-// A *phone-sized* touch-primary device is never "a tablet with a
-// hardware keyboard" — the fine pointer is a stylus (S-Pen on Galaxy Ultra)
-// or a paired BT mouse, not evidence of a physical keyboard. Only on
-// large-screen (tablet-class) touch devices does a co-existing fine pointer
-// mean desktop semantics are wanted. Without this, the S-Pen alone disabled
-// newline-on-Enter on Galaxy S23/S24/S25 Ultra phones.
-//
-// `screen.width`/`screen.height` are CSS pixels on every mainstream mobile
-// browser (they do NOT scale with devicePixelRatio), so a single px threshold
-// is stable across DPRs. Do not substitute visualViewport geometry here:
-// that changes with the on-screen keyboard and pinch zoom.
+// A fine pointer on a phone-sized touch device is a stylus (S-Pen on
+// Galaxy Ultra) or a paired BT mouse, not a hardware keyboard — phones
+// keep phone behavior. Tablet-class touch screens keep the fine-pointer
+// guard. screen.* is in CSS pixels (stable across devicePixelRatio); do
+// not use visualViewport here — it moves with the keyboard and zoom.
 const _PHONE_MAX_MIN_SIDE_PX=500;
 function _isPhoneSizedTouchDevice(){
   try{
@@ -2436,18 +2430,12 @@ $('msg').addEventListener('keydown',e=>{
     }
   }
   // Send key: respect user preference.
-  // On touch-primary devices (coarse pointer, no fine pointer co-existing),
-  // default to Enter = newline regardless of whether the visual viewport has
-  // shrunk. The viewport-shrink heuristic (_isVirtualKeyboardLikelyOpen) was
-  // unreliable on iOS Safari and some Android browsers where the keyboard
-  // doesn't consistently reduce vv.height by >120px. The pointer media query
-  // pair is a sufficient and more reliable signal for "software keyboard only".
-  // Hardware keyboards on tablets are covered by _hasFinePointerCoexisting.
-  // The 'ctrl+enter' and 'shift+enter' settings also use this behavior
-  // (plain Enter = newline).
-  // Users can override in Settings by explicitly choosing 'enter' mode.
-  // A phone-sized touch device (S-Pen stylus, BT mouse) is still a
-  // phone — Enter stays newline there even if a fine pointer co-exists.
+  // On touch-primary devices plain Enter inserts a newline (software
+  // keyboard); a hardware keyboard on a tablet-class screen exposes a
+  // fine pointer and restores Enter-sends. A phone with a stylus (S-Pen)
+  // or BT mouse still counts as a phone. The 'ctrl+enter'/'shift+enter'
+  // settings also make plain Enter a newline; users can override the
+  // default in Settings.
   if(e.key==='Enter'){
     if(_isImeEnter(e)){return;}
     const isNumpadEnter=_isNumpadEnter(e);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2399,12 +2399,18 @@ function _hasFinePointerCoexisting(){
 // or a paired BT mouse, not evidence of a physical keyboard. Only on
 // large-screen (tablet-class) touch devices does a co-existing fine pointer
 // mean desktop semantics are wanted. Without this, the S-Pen alone disabled
-// Enter=newline on Galaxy S23/S24/S25 Ultra phones.
+// newline-on-Enter on Galaxy S23/S24/S25 Ultra phones.
+//
+// `screen.width`/`screen.height` are CSS pixels on every mainstream mobile
+// browser (they do NOT scale with devicePixelRatio), so a single px threshold
+// is stable across DPRs. Do not substitute visualViewport geometry here:
+// that changes with the on-screen keyboard and pinch zoom.
+const _PHONE_MAX_MIN_SIDE_PX=500;
 function _isPhoneSizedTouchDevice(){
   try{
     if(!matchMedia('(pointer:coarse)').matches) return false;
     const w=Math.min(screen.width||0,screen.height||0);
-    return w>0&&w<=500;
+    return w>0&&w<=_PHONE_MAX_MIN_SIDE_PX;
   }catch(_){ return false; }
 }
 function _isNumpadEnter(e){

--- a/tests/test_mobile_enter_decision_matrix.py
+++ b/tests/test_mobile_enter_decision_matrix.py
@@ -1,0 +1,225 @@
+"""
+Executed decision-matrix tests for the phone-sized touch device Enter/newline
+behavior (companion to the source-contract tests in test_mobile_layout.py).
+
+These run the REAL predicates and keydown branch extracted from static/boot.js
+inside Node, with matchMedia/screen stubs, across a device matrix — so CI
+proves the executed behavior at the phone/tablet boundary, not only that the
+source contains certain strings. Requested in review of PR #7376.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+BOOT_JS = REPO / "static" / "boot.js"
+NODE = shutil.which("node")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+const [bootPath, argsJson] = process.argv.slice(-2);
+const args = JSON.parse(argsJson);
+const src = fs.readFileSync(bootPath, 'utf8');
+
+function extractFunction(source, name) {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(name + ' not found');
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error('function body not closed for ' + name);
+}
+
+// Extract the real production predicates.
+const fns = ['_hasFinePointerCoexisting', '_isPhoneSizedTouchDevice', '_isTouchKeyboardViewport']
+  .map((n) => extractFunction(src, n))
+  .join('\n');
+
+// Extract the keydown handler's Enter decision block: from the
+// "if(e.key==='Enter'){" guard (the send-key one, after the autocomplete
+// dropdown block) to its closing brace.
+const anchor = src.indexOf('// Send key: respect user preference.');
+if (anchor < 0) throw new Error('send-key comment anchor not found');
+const guard = src.indexOf("if(e.key==='Enter'){", anchor);
+if (guard < 0) throw new Error('Enter guard not found after send-key anchor');
+let depth = 0, end = -1;
+for (let i = src.indexOf('{', guard); i < src.length; i++) {
+  if (src[i] === '{') depth += 1;
+  else if (src[i] === '}') {
+    depth -= 1;
+    if (depth === 0) { end = i + 1; break; }
+  }
+}
+if (end < 0) throw new Error('Enter decision block not closed');
+// Wrap in a handler so `return` statements inside the block are legal.
+const enterBlock = 'function __enterHandler(e){ ' + src.slice(guard, end) + ' }';
+
+// Browser environment stubs.
+function makeEnv(profile) {
+  const media = profile.media || {};
+  globalThis.window = globalThis;
+  globalThis.matchMedia = (q) => {
+    const key = String(q).replace(/\s+/g, '');
+    const matches = Object.prototype.hasOwnProperty.call(media, key) ? !!media[key] : false;
+    return { matches, media: q, onchange: null, addListener() {}, removeListener() {},
+             addEventListener() {}, removeEventListener() {}, dispatchEvent() { return false; } };
+  };
+  if (profile.screenThrows) {
+    globalThis.screen = undefined;
+  } else {
+    globalThis.screen = { width: profile.screen[0], height: profile.screen[1] };
+  }
+  globalThis.window._sendKey = profile.sendKey || 'enter';
+}
+
+let sentCount = 0;
+globalThis.send = () => { sentCount += 1; };
+
+// Execute the real code under each profile.
+const results = [];
+for (const profile of args.profiles) {
+  makeEnv(profile);
+  eval(fns);
+  const phone = _isPhoneSizedTouchDevice();
+  const vk = _isTouchKeyboardViewport();
+
+  sentCount = 0;
+  const prevented = [];
+  // Simulate the plain-Enter keydown path through the real branch.
+  const e = {
+    key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false,
+    isComposing: false, keyCode: 13, code: 'Enter', location: 0,
+    preventDefault() { prevented.push(1); },
+  };
+  // `_isImeEnter` and `_isNumpadEnter` are called by the block; define them
+  // as the production ones would behave for this event shape (plain Enter,
+  // not composing, not numpad).
+  globalThis._isImeEnter = () => false;
+  globalThis._isNumpadEnter = () => false;
+  eval(enterBlock);
+  __enterHandler(e);
+
+  results.push({
+    name: profile.name,
+    phone,
+    touchKeyboardViewport: vk,
+    sent: sentCount,
+    prevented: prevented.length,
+  });
+}
+console.log(JSON.stringify(results));
+"""
+
+
+def _run_matrix(profiles):
+    assert NODE is not None, "node not on PATH"
+    result = subprocess.run(
+        [NODE, "-e", _DRIVER, str(BOOT_JS), json.dumps({"profiles": profiles})],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}"
+        )
+    return {
+        row["name"]: row
+        for row in json.loads(result.stdout.strip().splitlines()[-1])
+    }
+
+
+# Device matrix: media keys match the exact strings boot.js queries
+# ('(pointer:coarse)', '(any-pointer:fine)', '(hover:none)', and the combined
+# '(hover:none) and (pointer:coarse)' used by _isTouchKeyboardViewport).
+_PROFILES = [
+    # Phone + S-Pen (the reported bug): coarse touch, fine stylus, phone screen.
+    {"name": "phone_stylus", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": True, "(hover:none)": True, "(hover:none)and(pointer:coarse)": True}, "screen": [384, 800]},
+    # Phone + BT mouse: same as above.
+    {"name": "phone_bt_mouse", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": True, "(hover:none)": True, "(hover:none)and(pointer:coarse)": True}, "screen": [412, 915]},
+    # Plain phone, no fine pointer.
+    {"name": "phone_plain", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": False, "(hover:none)": True, "(hover:none)and(pointer:coarse)": True}, "screen": [390, 844]},
+    # Tablet-class touch device + hardware keyboard: desktop Enter semantics.
+    {"name": "tablet_keyboard", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": True, "(hover:none)": False, "(hover:none)and(pointer:coarse)": False}, "screen": [1024, 1366]},
+    # Desktop: fine pointer only.
+    {"name": "desktop", "media": {"(pointer:coarse)": False, "(any-pointer:fine)": True, "(hover:none)": False, "(hover:none)and(pointer:coarse)": False}, "screen": [1920, 1080]},
+    # Degraded environments must fail closed (not phone, no virtual-keyboard inset).
+    {"name": "screen_zero", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": True, "(hover:none)": True, "(hover:none)and(pointer:coarse)": True}, "screen": [0, 0]},
+    {"name": "screen_throws", "media": {"(pointer:coarse)": True, "(any-pointer:fine)": True, "(hover:none)": True, "(hover:none)and(pointer:coarse)": True}, "screenThrows": True},
+]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_phone_with_fine_pointer_keeps_newline():
+    """Phone-sized touch device + fine pointer (S-Pen / BT mouse): plain Enter
+    must NOT send — the newline default survives the co-existing fine pointer."""
+    rows = _run_matrix(_PROFILES)
+    for name in ("phone_stylus", "phone_bt_mouse"):
+        row = rows[name]
+        assert row["phone"] is True, f"{name}: should classify as phone-sized"
+        assert row["sent"] == 0, f"{name}: plain Enter must not send"
+        assert row["prevented"] == 0, f"{name}: Enter must fall through to the textarea (newline)"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_plain_phone_keeps_newline():
+    rows = _run_matrix(_PROFILES)
+    row = rows["phone_plain"]
+    assert row["phone"] is True
+    assert row["sent"] == 0 and row["prevented"] == 0
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_tablet_with_keyboard_still_sends():
+    """Tablet-class touch device + fine pointer (hardware keyboard) keeps
+    desktop semantics: plain Enter sends."""
+    rows = _run_matrix(_PROFILES)
+    row = rows["tablet_keyboard"]
+    assert row["phone"] is False
+    assert row["sent"] == 1, "tablet + hardware keyboard must send on plain Enter"
+    assert row["prevented"] == 1
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_desktop_still_sends():
+    rows = _run_matrix(_PROFILES)
+    row = rows["desktop"]
+    assert row["sent"] == 1 and row["prevented"] == 1
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_degraded_screen_fails_closed():
+    """Zero-size or unavailable screen dimensions must fail closed: no phone
+    classification, no virtual-keyboard inset, desktop Enter semantics."""
+    rows = _run_matrix(_PROFILES)
+    for name in ("screen_zero", "screen_throws"):
+        row = rows[name]
+        assert row["phone"] is False, f"{name}: must not classify as phone"
+        assert row["touchKeyboardViewport"] is False, f"{name}: must not claim a touch keyboard viewport"
+        assert row["sent"] == 1, f"{name}: must keep desktop Enter semantics (fail closed)"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_decision_matrix_touch_keyboard_viewport_matches_enter_gate():
+    """The virtual-keyboard inset predicate must agree with the Enter gate:
+    phones (with or without fine pointer) keep the inset; tablet-class and
+    desktop do not get it."""
+    rows = _run_matrix(_PROFILES)
+    assert rows["phone_stylus"]["touchKeyboardViewport"] is True
+    assert rows["phone_bt_mouse"]["touchKeyboardViewport"] is True
+    assert rows["phone_plain"]["touchKeyboardViewport"] is True
+    assert rows["tablet_keyboard"]["touchKeyboardViewport"] is False
+    assert rows["desktop"]["touchKeyboardViewport"] is False

--- a/tests/test_mobile_enter_decision_matrix.py
+++ b/tests/test_mobile_enter_decision_matrix.py
@@ -42,10 +42,13 @@ function extractFunction(source, name) {
   throw new Error('function body not closed for ' + name);
 }
 
-// Extract the real production predicates.
+// Extract the real production predicates plus the named phone-size constant.
 const fns = ['_hasFinePointerCoexisting', '_isPhoneSizedTouchDevice', '_isTouchKeyboardViewport']
   .map((n) => extractFunction(src, n))
   .join('\n');
+const constMatch = src.match(/^const _PHONE_MAX_MIN_SIDE_PX\s*=\s*[^;]+;/m);
+if (!constMatch) throw new Error('_PHONE_MAX_MIN_SIDE_PX constant not found');
+const declarations = constMatch[0];
 
 // Extract the keydown handler's Enter decision block: from the
 // "if(e.key==='Enter'){" guard (the send-key one, after the autocomplete
@@ -91,7 +94,7 @@ globalThis.send = () => { sentCount += 1; };
 const results = [];
 for (const profile of args.profiles) {
   makeEnv(profile);
-  eval(fns);
+  eval(declarations + '\n' + fns);
   const phone = _isPhoneSizedTouchDevice();
   const vk = _isTouchKeyboardViewport();
 

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1706,6 +1706,27 @@ def test_mobile_enter_newline_respects_hardware_keyboard_on_touch_devices():
         "mobile Enter newline override must skip touch devices that also expose a fine pointer"
 
 
+def test_mobile_enter_newline_survives_stylus_on_phone():
+    """A phone-sized touch device keeps Enter=newline even when a stylus
+    (S-Pen on Galaxy Ultra) or BT mouse exposes a fine pointer.
+
+    The fine pointer on a phone is not evidence of a physical keyboard; only
+    tablet-class screens should fall back to desktop Enter semantics."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "function _isPhoneSizedTouchDevice()" in boot_js, \
+        "boot.js must define a phone-sized touch-device predicate (min screen side <=500px)"
+    assert "_isPhoneSizedTouchDevice()||!_hasFinePointerCoexisting()" in boot_js, \
+        "the mobile Enter override must apply on phone-sized touch devices even with a co-existing fine pointer"
+
+
+def test_touch_keyboard_viewport_keeps_phone_treatment_with_stylus():
+    """The virtual-keyboard inset must stay active on phone-sized touch devices
+    even when a stylus (S-Pen) or BT mouse exposes a fine pointer."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "if(_isPhoneSizedTouchDevice()) return true;" in boot_js, \
+        "_isTouchKeyboardViewport must keep virtual-keyboard treatment on phone-sized touch devices"
+
+
 def test_mobile_enter_newline_only_overrides_enter_default():
     """Mobile newline override must only apply when _sendKey is the default 'enter'."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI defaults to "Enter inserts a newline" on touch-primary devices (when no fine pointer co-exists), so phone keyboards get a newline from their Enter key
- A Galaxy S23 Ultra owner reported that pressing Enter instead **sent** the message — on the current release, with a fresh cache, and with the send-key setting at its default (`enter`)
- The S23 Ultra's S-Pen digitizer exposes a **fine pointer co-existing** with the coarse touch-primary pointer (`(pointer:coarse)` and `(any-pointer:fine)` are both true)
- `_hasFinePointerCoexisting()` therefore returned true, the code concluded "a hardware keyboard is attached", and desktop semantics ("Enter sends") kicked in — on a phone whose only fine pointer is a stylus. A paired Bluetooth mouse has the same effect.
- The guard exists for the right reason (tablets with real keyboards) but the signal is misread on phone-sized screens: a fine pointer on a phone is not evidence of a physical keyboard

## What Changed

- `static/boot.js`: new `_isPhoneSizedTouchDevice()` — a touch-primary device (`pointer:coarse`) whose smaller screen side is ≤ `_PHONE_MAX_MIN_SIDE_PX` (500 CSS px, named constant), with a comment documenting that `screen.*` is CSS pixels (DPR-stable)
- The composer Enter handling and `_isTouchKeyboardViewport()` now treat a phone-sized touch device as a phone **regardless** of a co-existing fine pointer; larger (tablet-class) touch screens keep the existing fine-pointer guard unchanged
- `tests/test_mobile_layout.py`: two source-contract regression tests — a phone with a stylus keeps newline-on-Enter, and the virtual-keyboard inset stays active on phones with a fine pointer
- `tests/test_mobile_enter_decision_matrix.py`: executed decision matrix (per review) — extracts the real predicates and the actual keydown Enter block from boot.js, runs them in Node with stubbed `matchMedia`/`screen` across 7 device profiles, and asserts the executed outcomes (phone + fine pointer = newline; tablet-class + hardware keyboard and desktop = send; zero/unavailable screen data fails closed; inset predicate agrees with the Enter gate). Mutation-checked: reverting the predicate to always-false fails 3 of the 6 tests
- `TESTING.md`: manual check T2.3b (phone with stylus / BT mouse)

## Why It Matters

Every Galaxy Ultra (S23/S24/S25) and every phone with a paired Bluetooth mouse currently gets "Enter sends the message" behavior from the on-screen keyboard, making multi-line composer input effectively impossible unless you know about the Shift+Enter or Ctrl+Enter settings. This is exactly the case the mobile newline-on-Enter default was built for.

## Verification

Local static suite (via `./scripts/test.sh`): 88/88 passing on `tests/test_mobile_layout.py`, `tests/test_shift_enter_send_key.py`, `tests/test_numpad_enter_submit.py`, `tests/test_ime_composition.py`; full suite: 14,961 passed / 15 failed / 156 skipped — the 15 failures (`test_5774b_atomic_config_writes.py`, `test_tls_aware_probe.py`) were verified to fail identically on clean HEAD without this patch (local-environment failures, unrelated to this change).

Live differential browser proof (headless Chromium 152, DevTools-driven, phone context 384×800, `has_touch`, `(pointer:coarse)`/`(hover:none)` native, `(any-pointer:fine)` forced true to model the S-Pen — CDP cannot emulate `any-pointer`, so matchMedia was stubbed for that single query; every other input is native):

| Scenario | Before (HEAD) | After (this PR) |
|---|---|---|
| Phone (384×800) + S-Pen fine pointer, send-key setting = `enter` | Enter **sends the message** (`/api/chat/start` fired, composer cleared) | `'Line one\nLine two'` stays in the composer, zero API calls — Enter inserts a newline |
| Tablet-class (1280×800) touch + fine pointer (hardware keyboard) | Enter sends | Enter still sends (no regression) |

On the reporter's real device: the bug was live on the phone before the patch (current release, cache verified fresh via server logs showing `boot.js?v=exp-v0.52.264`), and Enter inserted a newline after deploying this change.

Viewport widths tested: 384 (phone), 1280 (tablet-class). Tested states: default send-key setting (`enter`) only; the `ctrl+enter` and `shift+enter` settings were covered by the existing automated tests and are not behaviorally modified by this change.

## Risks / Follow-ups

- A phone-sized touch device with a **real** hardware keyboard attached (a folding Bluetooth keyboard, not a mouse or stylus) will now get "Enter inserts a newline" instead of "Enter sends". That trade-off is deliberate: accidental sends on phones are far more common than physical keyboards that cannot produce Shift+Enter, and users who want Enter to send can still pick that explicitly in Settings, while Ctrl+Enter keeps sending everywhere.
- The 500px phone/tablet boundary matches the repo's own mobile breakpoint direction (`max-width: 640px` is the widest mobile bucket in style.css) with margin for landscape phones; foldables in tablet posture fall on the tablet side, which is the safer side for their larger composers.
- No visual layout change, so no before/after screenshots: the only user-visible difference is keystroke behavior (newline vs send), demonstrated by the differential table above.

Release-note-ready wording: **On phones whose digitizer exposes a fine pointer — Galaxy S23/S24/S25 Ultra with the S-Pen, or any phone with a paired Bluetooth mouse — pressing Enter now reliably inserts a newline instead of sending the message.** A co-existing fine pointer used to be read as a hardware-keyboard signal, which disabled the mobile newline-on-Enter default; it is now only treated that way on tablet-class screens.

## Model Used

- Provider: Z.ai — Model: GLM-5.3 (agent framework: Hermes Agent)
- AI wrote the patch, tests, and this PR body; the human reporter supplied the device (Galaxy S23 Ultra), reproduced the bug on the current release, and confirmed the fix on the real phone after deploy.
