### PR TITLE
fix(webui): glide the streaming chat tail instead of snapping it per tick

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -5238,8 +5238,34 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _drainStreamFadeBeforeDone(onDone){
     const drainStartedAt=performance.now();
     let forcedDone=false;
+    let lastStepMs=0;
+    // The SSE `done` handler already cleared S.activeStreamId, but text is still
+    // being released here. Tell ui.js's tail-follow glide it still owns the
+    // scroll tail for the playout, so the last words of an answer scroll with
+    // the same motion as the rest of it instead of snapping per settle tick.
+    // A self-expiring DEADLINE, not a boolean: an abandoned drain (session
+    // switch, cancel, teardown) must never strand the flag on and permanently
+    // divert scrollIfPinned() away from the late-layout settle.
+    const _markDraining=()=>{
+      if(typeof window!=='undefined') window._streamFadeDrainingUntil=performance.now()+400;
+    };
+    const _endDraining=()=>{
+      if(typeof window!=='undefined') window._streamFadeDrainingUntil=0;
+    };
+    _markDraining();
+    // Vsync-align the drain beat for the same reason as _scheduleRender(): a
+    // setTimeout(33)+rAF pair lands unevenly, which is most visible on the last
+    // words of a reply.
+    const pump=()=>{
+      requestAnimationFrame(()=>{
+        if(performance.now()-lastStepMs<29){pump();return;}
+        lastStepMs=performance.now();
+        step();
+      });
+    };
     const step=()=>{
-      if(!assistantBody){onDone();return;}
+      if(!assistantBody){_endDraining();onDone();return;}
+      _markDraining();
       const target=_streamFadeCurrentDisplayText();
       const caughtUp=_renderStreamingFadeMarkdown(target);
       const anchorProcessText=_streamFadeDomText||target;
@@ -5252,7 +5278,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // Let the last released words visibly finish their stagger + fade before
         // the final renderMessages() DOM replacement removes the live spans.
         const remainingAnimationMs=Math.max(_STREAM_FADE_MS, _streamFadeLatestAnimationEndAt-performance.now());
-        setTimeout(onDone, Math.min(remainingAnimationMs, _STREAM_FADE_DONE_MAX_MS));
+        setTimeout(()=>{_endDraining();onDone();}, Math.min(remainingAnimationMs, _STREAM_FADE_DONE_MAX_MS));
         return;
       }
       // Final SSE `done` means the canonical completed session is available.
@@ -5261,11 +5287,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!forcedDone&&performance.now()-drainStartedAt>=_STREAM_FADE_DONE_DRAIN_MAX_MS){
         forcedDone=true;
         if(_smdParser) _smdEndParser();
+        _endDraining();
         onDone();
         return;
       }
-      setTimeout(()=>requestAnimationFrame(step), 33);
+      pump();
     };
+    lastStepMs=performance.now();
     step();
   }
   function _flushPendingSegmentRender(options={}){
@@ -5640,7 +5668,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const caughtUp=_renderStreamingFadeMarkdown(displayText);
           anchorProcessText=_streamFadeDomText||'';
           if(!caughtUp&&!_streamFinalized){
-            setTimeout(()=>_scheduleRender(), 33);
+            // rAF, not setTimeout(33): _scheduleRender() already gates on the
+            // 33ms fade interval, so a 33ms timer on top of it pushed the next
+            // playout tick out to as much as 66ms whenever tokens had stopped
+            // arriving — a visible hitch in the middle of an answer.
+            if(typeof requestAnimationFrame==='function') requestAnimationFrame(()=>_scheduleRender());
+            else setTimeout(()=>_scheduleRender(), 33);
           }
         } else {
           assistantBody.classList.remove('stream-fade-active');
@@ -5672,6 +5705,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const frameIntervalMs=_shouldUseLiveProseFade()?33:66;
     if(sinceLastMs>=frameIntervalMs){
       _pendingRafHandle=requestAnimationFrame(_doRender);
+    } else if(_shouldUseLiveProseFade()&&typeof requestAnimationFrame==='function'){
+      // Vsync-align the word-fade cadence. A setTimeout(33)+rAF pair fires the
+      // render anywhere between 33ms and 50ms depending on where the timer lands
+      // relative to the next frame, so the released word wave arrives unevenly
+      // and reads as typing stutter even though the pacing math is time-based.
+      // Poll rAF instead and render on the first frame at/after the interval —
+      // a steady 2-frame beat on a 60Hz display, 4 frames at 120Hz.
+      const _poll=()=>{
+        _pendingRafHandle=null;
+        if(_streamFinalized){_renderPending=false;return;}
+        // 4ms tolerance: a frame landing a hair early still counts, otherwise
+        // the tick slips a whole frame whenever vsync drifts under the interval.
+        if(performance.now()-_lastRenderMs>=frameIntervalMs-4){_doRender();return;}
+        _pendingRafHandle=requestAnimationFrame(_poll);
+      };
+      _pendingRafHandle=requestAnimationFrame(_poll);
     } else {
       _pendingRafHandle=setTimeout(()=>requestAnimationFrame(_doRender), frameIntervalMs-sinceLastMs);
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5998,7 +5998,7 @@ let _lastMessageRenderAt=-Infinity;
 function _recentMessageRenderArtifactWindow(ms){
   return performance.now()-_lastMessageRenderAt<(ms||1400);
 }
-function _cancelBottomSettle(){ _cancelMessageJumpScroll(); _bottomSettleToken++; if(_settleRO){ _settleRO.disconnect(); _settleRO=null; } clearTimeout(_settleTimer); clearTimeout(_settleFinalTimer); cancelAnimationFrame(_settleRAF); }
+function _cancelBottomSettle(){ _cancelMessageJumpScroll(); _bottomSettleToken++; if(_settleRO){ _settleRO.disconnect(); _settleRO=null; } clearTimeout(_settleTimer); clearTimeout(_settleFinalTimer); cancelAnimationFrame(_settleRAF); if(typeof _tailFollowStop==='function') _tailFollowStop(); }
 function _markMessageTouchScrollIntent(active=true){
   _messageTouchScrollActive=!!active;
   _lastMessageTouchScrollIntentMs=performance.now();
@@ -7124,6 +7124,9 @@ function _settleMessageScrollToBottom(force, explicit){
   // scrollTop once via rAF (batches multiple resize callbacks per frame into
   // a single write). After 300ms of no resize events, the observer disconnects.
   const token=++_bottomSettleToken;
+  // A settle owns the tail from here on; stop the streaming glide so the two
+  // writers can never fight frame-by-frame.
+  if(typeof _tailFollowStop==='function') _tailFollowStop();
   cancelAnimationFrame(_settleRAF);
   if(_settleRO){ _settleRO.disconnect(); _settleRO=null; }
   clearTimeout(_settleTimer);
@@ -7206,6 +7209,102 @@ function _settleFinalScroll(token){
   _scrollPinned=true;
   _deferClearProgrammaticScroll();
 }
+// ---------------------------------------------------------------------------
+// Continuous tail-follow ("glide") for a live streaming turn.
+//
+// A streamed answer grows a couple of words per render tick, but the scroll
+// position only has to move when a line WRAPS. Snapping scrollTop to
+// scrollHeight on every tick therefore paints nothing for several ticks and
+// then one discrete ~1-line jump — the stutter readers see while the answer
+// types itself. The same path also rebuilt the ResizeObserver settle
+// (disconnect + `new ResizeObserver` + observe + two timers) on every tick,
+// i.e. ~30 observer teardown/rebuild cycles a second on a transcript that can
+// be thousands of nodes deep: the dominant per-frame cost on mobile.
+//
+// While a turn is streaming and the reader is pinned we instead run ONE rAF
+// loop that eases scrollTop toward the bottom — exactly one scrollHeight read
+// and at most one scrollTop write per frame, closing a fixed fraction of the
+// remaining distance so a newly wrapped line arrives as a short glide instead
+// of a jump. The loop parks itself after a stretch of frames with nothing to
+// chase, and refuses on the same signals the settle path refuses on, so the
+// sticky-unpin model (#3343/#4295) is unchanged.
+const _TAIL_FOLLOW_EASE=0.26;        // fraction of the remaining gap per frame
+const _TAIL_FOLLOW_MIN_STEP_PX=0.6;  // floor so the glide always converges
+const _TAIL_FOLLOW_MAX_LAG_PX=36;    // steady-state lag ceiling (~1.5 lines)
+const _TAIL_FOLLOW_SNAP_PX=600;      // beyond this, jump — a glide would lag
+const _TAIL_FOLLOW_QUIET_FRAMES=10;  // ~160ms at 60Hz with nothing to chase
+let _tailFollowRAF=0;
+let _tailFollowQuietFrames=0;
+function _tailFollowStop(){
+  if(_tailFollowRAF){cancelAnimationFrame(_tailFollowRAF);_tailFollowRAF=0;}
+  _tailFollowQuietFrames=0;
+}
+// True while text is still arriving/playing out for the active turn. The word
+// fade keeps releasing text for up to ~1.4s AFTER the SSE `done` clears
+// S.activeStreamId, so the drain flag keeps the glide owning the tail for that
+// playout instead of handing it back to the per-tick settle.
+function _tailFollowStreamLive(){
+  try{
+    if(S&&S.activeStreamId) return true;
+  }catch(_){ }
+  if(typeof window==='undefined') return false;
+  const until=Number(window._streamFadeDrainingUntil)||0;
+  return until>performance.now();
+}
+function _tailFollowFrame(){
+  _tailFollowRAF=0;
+  const el=$('messages');
+  if(!el){ _tailFollowQuietFrames=0; return; }
+  // Same refusal set as the settle-path RO callback (never fight a reader who
+  // scrolled away), plus one mobile addition: yield while a finger is actually
+  // DOWN on the transcript, so a per-frame write can never cancel an in-progress
+  // drag or iOS momentum. Deliberately NOT the 1200ms _recentMessageTouchScroll
+  // Intent() tail — touchstart marks that on any tap (a copy button, expanding a
+  // tool card), and pausing follow for 1.2s after a tap would be a regression
+  // against the current settle path, which does not check it at all. A real
+  // upward drag still stops the glide through the sticky-unpin flag.
+  // A jump-to-question owner deliberately holds the reader at the jump target
+  // across smooth-scroll frames (#6621), so the glide must yield to it for the
+  // same reason scrollIfPinned() returns early on it — otherwise the two write
+  // scrollTop against each other every frame.
+  if(typeof _messageJumpScrollOwner!=='undefined'&&_messageJumpScrollOwner){
+    _tailFollowQuietFrames=0;
+    return;
+  }
+  if(!window._autoScrollFollow||!_scrollPinned||_messageUserUnpinned
+    ||_recentNonMessageScrollIntent()||_messageTouchScrollActive){
+    _tailFollowQuietFrames=0;
+    return;
+  }
+  const max=el.scrollHeight-el.clientHeight;
+  const gap=max-el.scrollTop;
+  if(gap>0.5){
+    _tailFollowQuietFrames=0;
+    _programmaticScroll=true;_programmaticScrollSetAt=performance.now();
+    // Ease by a fixed fraction so a wrapped line arrives as a glide, but never
+    // let the tail sit more than _TAIL_FOLLOW_MAX_LAG_PX behind: with the word
+    // fade off the transcript can grow several lines per render tick, and a pure
+    // proportional ease would park the last lines below the fold.
+    const step=Math.max(_TAIL_FOLLOW_MIN_STEP_PX, gap*_TAIL_FOLLOW_EASE, gap-_TAIL_FOLLOW_MAX_LAG_PX);
+    // Land exactly on the bottom for the last pixel rather than leaving a
+    // fractional residue behind — every near-bottom predicate in this file
+    // measures against scrollHeight-clientHeight.
+    el.scrollTop=(gap>_TAIL_FOLLOW_SNAP_PX||gap-step<1) ? max : Math.min(max, el.scrollTop+step);
+    _lastScrollTop=el.scrollTop;_lastMessageClientHeight=el.clientHeight;
+    _nearBottomCount=2;
+    _deferClearProgrammaticScroll();
+  }else{
+    _tailFollowQuietFrames=_tailFollowQuietFrames+1;
+    if(_tailFollowQuietFrames>=_TAIL_FOLLOW_QUIET_FRAMES){_tailFollowQuietFrames=0;return;}
+  }
+  _tailFollowRAF=requestAnimationFrame(_tailFollowFrame);
+}
+function _tailFollowStart(){
+  _tailFollowQuietFrames=0;
+  if(_tailFollowRAF) return;
+  _tailFollowRAF=requestAnimationFrame(_tailFollowFrame);
+}
+let _scrollIfPinnedCoalesced=false;
 function scrollIfPinned(){
   if(!window._autoScrollFollow) return;
   // A jump-to-question owner is mid-flight: it deliberately holds the reader at
@@ -7234,6 +7333,15 @@ function scrollIfPinned(){
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
   if(_messageBottomDistance()>500) _setMessageScrollToBottom();
+  // Live/playing-out turn: hand the tail to the rAF glide instead of snapping
+  // scrollTop and rebuilding the settle ResizeObserver on every tick. The
+  // completion paths (scrollToBottom(), the DOM-replace follow) still run the
+  // full settle, so late layout — Prism, KaTeX, Mermaid, images — is still
+  // re-anchored once the turn ends.
+  // typeof guard keeps this inert in the unit harnesses that extract this
+  // function body without the tail-follow helpers, matching the guard style the
+  // rest of this function already uses.
+  if(typeof _tailFollowStreamLive==='function'&&_tailFollowStreamLive()){ _tailFollowStart(); return; }
   _settleMessageScrollToBottom(false);
 }
 function scrollToBottom(){

--- a/tests/test_streaming_tail_follow_glide.py
+++ b/tests/test_streaming_tail_follow_glide.py
@@ -1,0 +1,315 @@
+"""Regression tests for the streaming chat auto-scroll stutter.
+
+Symptom: while an assistant reply types itself out, the transcript does not
+follow the text smoothly. It sits still for several render ticks and then jumps
+a whole line, and the jump repeats for the length of the answer.
+
+Root cause: the streaming follow path snapped ``scrollTop = scrollHeight`` on
+every render tick. A tick only adds a couple of words, so the scroll position
+does not change at all until a line WRAPS -- at which point the whole line
+height is applied in one painted step. The same path also rebuilt the settle
+ResizeObserver (disconnect + ``new ResizeObserver`` + observe + two timers) per
+tick, i.e. ~30 observer teardown/rebuild cycles a second on a transcript that
+may be thousands of nodes deep, which is the dominant per-frame cost on mobile.
+
+Fix: while a turn is streaming (or the word-fade is still playing text out after
+the SSE ``done``), ``scrollIfPinned()`` hands the tail to a single rAF loop,
+``_tailFollowFrame()``, that eases ``scrollTop`` toward the bottom -- one
+``scrollHeight`` read and at most one ``scrollTop`` write per frame -- instead
+of snapping and re-arming the settle. The loop bounds how far it may lag, snaps
+when it is hopelessly behind, parks itself when there is nothing to chase, and
+refuses on the same signals the settle path refuses on plus an active finger.
+
+The behavioural tests drive the REAL extracted helpers in Node against a fake
+scroller and a manually pumped frame queue, so they fail on the pre-fix version
+(the helpers do not exist) and pass on the fixed one.
+"""
+
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_fn(src: str, name: str) -> str:
+    marker = re.search(rf"(^|\n)\s*(?:async\s+)?function\s+{re.escape(name)}\(", src)
+    assert marker is not None, f"function {name}() not found"
+    start = marker.start()
+    brace = src.index("{", marker.end())
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function {name}() closing brace not found")
+
+
+def _glide_source() -> str:
+    """The real tail-follow block, lifted verbatim from ui.js."""
+    start = UI_JS.index("const _TAIL_FOLLOW_EASE=")
+    end = UI_JS.index("let _scrollIfPinnedCoalesced=false;")
+    assert start < end
+    return UI_JS[start:end]
+
+
+_HARNESS_PRELUDE = """
+const performance = { now: () => _clock };
+let _clock = 0;
+let _frames = [];
+let _nextRafId = 1;
+const _cancelled = new Set();
+function requestAnimationFrame(cb){ const id = _nextRafId++; _frames.push([id, cb]); return id; }
+function cancelAnimationFrame(id){ _cancelled.add(id); }
+function pumpFrames(n){
+  for(let i=0;i<n;i++){
+    const batch = _frames; _frames = [];
+    _clock += 16;
+    for(const [id, cb] of batch){ if(!_cancelled.has(id)) cb(); }
+  }
+}
+const el = { scrollTop: 0, clientHeight: 500, scrollHeight: 500 };
+function $(id){ return id === 'messages' ? el : null; }
+const window = { _autoScrollFollow: true, _streamFadeDrainingUntil: 0 };
+const S = { activeStreamId: 'stream-1' };
+let _scrollPinned = true;
+let _messageUserUnpinned = false;
+let _messageTouchScrollActive = false;
+let _programmaticScroll = false;
+let _programmaticScrollSetAt = 0;
+let _lastScrollTop = 0;
+let _lastMessageClientHeight = 500;
+let _nearBottomCount = 0;
+function _recentNonMessageScrollIntent(){ return false; }
+function _deferClearProgrammaticScroll(){ }
+"""
+
+
+def _run(scenario: str) -> str:
+    source = _HARNESS_PRELUDE + _glide_source() + "\n" + scenario
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".cjs", encoding="utf-8", dir=ROOT, delete=False
+    ) as script:
+        script.write(source)
+        path = pathlib.Path(script.name)
+    try:
+        result = subprocess.run(
+            [NODE, str(path)], cwd=str(ROOT), capture_output=True, text=True, timeout=30
+        )
+    finally:
+        path.unlink(missing_ok=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+# --------------------------------------------------------------------------
+# behaviour
+# --------------------------------------------------------------------------
+
+
+def test_one_wrapped_line_is_glided_not_snapped():
+    """A single wrapped line (24px) must be crossed over several painted frames.
+
+    This is the stutter itself: the old path wrote the whole 24px in one frame.
+    """
+    out = _run(
+        """
+        el.scrollHeight = 524;            // one wrapped line of growth
+        _tailFollowStart();
+        const seen = [];
+        for(let i=0;i<40;i++){ pumpFrames(1); seen.push(Number(el.scrollTop.toFixed(3))); }
+        const distinct = [...new Set(seen)];
+        console.log(JSON.stringify({
+          first: seen[0],
+          settled: seen[seen.length-1],
+          intermediates: distinct.filter(v => v > 0 && v < 24).length,
+        }));
+        """
+    )
+    import json
+
+    data = json.loads(out)
+    assert 0 < data["first"] < 24, (
+        f"first frame must move part of the line, not all of it (got {data['first']})"
+    )
+    assert data["intermediates"] >= 3, (
+        "a wrapped line must be crossed in several painted steps, "
+        f"got {data['intermediates']} intermediate positions"
+    )
+    assert data["settled"] == 24, "the glide must still land exactly on the bottom"
+
+
+def test_glide_never_overshoots_the_bottom():
+    out = _run(
+        """
+        el.scrollHeight = 560;
+        _tailFollowStart();
+        let maxSeen = 0;
+        for(let i=0;i<60;i++){ pumpFrames(1); maxSeen = Math.max(maxSeen, el.scrollTop); }
+        console.log(String(maxSeen));
+        """
+    )
+    assert float(out) <= 60.0, "scrollTop must never exceed scrollHeight-clientHeight"
+
+
+def test_lag_stays_bounded_under_fast_multi_line_growth():
+    """With the word fade off, a tick can add several lines at once. A purely
+    proportional ease would park the newest lines below the fold."""
+    out = _run(
+        """
+        _tailFollowStart();
+        let worstGap = 0;
+        for(let i=0;i<60;i++){
+          el.scrollHeight += 60;          // ~2.5 lines of growth per frame
+          pumpFrames(1);
+          worstGap = Math.max(worstGap, (el.scrollHeight - el.clientHeight) - el.scrollTop);
+        }
+        console.log(String(worstGap));
+        """
+    )
+    assert float(out) <= 40.0, f"tail lagged {out}px behind the bottom during fast growth"
+
+
+def test_huge_gap_snaps_instead_of_gliding():
+    out = _run(
+        """
+        el.scrollHeight = 2000;           // 1500px behind: a glide would crawl
+        _tailFollowStart();
+        pumpFrames(1);
+        console.log(String(el.scrollTop));
+        """
+    )
+    assert float(out) == 1500.0, "a hopeless gap must snap in one frame, not glide"
+
+
+def test_glide_yields_to_an_unpinned_reader():
+    out = _run(
+        """
+        el.scrollHeight = 900;
+        _tailFollowStart();
+        pumpFrames(1);
+        const afterFirst = el.scrollTop;
+        _messageUserUnpinned = true;      // reader scrolled up mid-stream
+        pumpFrames(10);
+        console.log(JSON.stringify({moved: afterFirst > 0, after: el.scrollTop === afterFirst}));
+        """
+    )
+    import json
+
+    data = json.loads(out)
+    assert data["moved"], "sanity: the glide should have moved before the unpin"
+    assert data["after"], "the glide must not move a reader who scrolled away"
+
+
+def test_glide_yields_while_a_finger_is_down():
+    """touchstart marks the transcript touch-active. A per-frame write during an
+    active drag would cancel the drag / iOS momentum."""
+    out = _run(
+        """
+        el.scrollHeight = 900;
+        _messageTouchScrollActive = true;
+        _tailFollowStart();
+        pumpFrames(10);
+        console.log(String(el.scrollTop));
+        """
+    )
+    assert float(out) == 0.0, "the glide must not write while a finger is on the transcript"
+
+
+def test_glide_parks_itself_when_there_is_nothing_to_chase():
+    """The loop must stop scheduling frames once caught up, so an idle session
+    does not hold a permanent rAF loop."""
+    out = _run(
+        """
+        el.scrollHeight = 524;
+        _tailFollowStart();
+        pumpFrames(60);                   // catch up, then go quiet
+        const before = _frames.length;
+        pumpFrames(5);
+        console.log(JSON.stringify({pendingAfterQuiet: _frames.length, before}));
+        """
+    )
+    import json
+
+    assert json.loads(out)["pendingAfterQuiet"] == 0, (
+        "the tail-follow loop must park itself after a quiet stretch"
+    )
+
+
+def test_drain_deadline_keeps_the_glide_after_the_stream_id_clears():
+    """The SSE `done` handler clears S.activeStreamId while the word fade is
+    still releasing text, so the drain deadline must keep the glide engaged."""
+    out = _run(
+        """
+        S.activeStreamId = null;
+        const off = _tailFollowStreamLive();
+        window._streamFadeDrainingUntil = performance.now() + 400;
+        const during = _tailFollowStreamLive();
+        _clock += 1000;                   // deadline lapses on its own
+        const expired = _tailFollowStreamLive();
+        console.log(JSON.stringify({off, during, expired}));
+        """
+    )
+    import json
+
+    data = json.loads(out)
+    assert data["off"] is False
+    assert data["during"] is True, "the fade drain must keep owning the scroll tail"
+    assert data["expired"] is False, (
+        "an abandoned drain must expire on its own, never strand the glide on"
+    )
+
+
+# --------------------------------------------------------------------------
+# wiring
+# --------------------------------------------------------------------------
+
+
+def test_scroll_if_pinned_routes_a_live_stream_to_the_glide():
+    fn = _extract_fn(UI_JS, "scrollIfPinned")
+    assert "_tailFollowStreamLive()" in fn and "_tailFollowStart();" in fn
+    # The >500px recovery snap still runs first, and the per-tick settle stays as
+    # the non-streaming path (locked by test_issue3319).
+    assert fn.index("_messageBottomDistance()>500") < fn.index("_tailFollowStart();")
+    assert fn.index("_tailFollowStart();") < fn.index("_settleMessageScrollToBottom(false)")
+
+
+def test_settle_and_cancel_take_ownership_back_from_the_glide():
+    """Two writers must never chase the tail at once."""
+    assert "_tailFollowStop()" in _extract_fn(UI_JS, "_settleMessageScrollToBottom")
+    assert "_tailFollowStop()" in _extract_fn(UI_JS, "_cancelBottomSettle")
+
+
+def test_fade_render_cadence_is_vsync_aligned():
+    """setTimeout(33)+rAF lands anywhere in 33-50ms, so the released word wave
+    arrives unevenly and reads as typing stutter."""
+    fn = _extract_fn(MESSAGES_JS, "_scheduleRender")
+    assert "frameIntervalMs-4" in fn, "fade path must poll rAF against the interval"
+    assert "_pendingRafHandle=requestAnimationFrame(_poll);" in fn
+    # The self-reschedule while the fade is still catching up must not stack a
+    # 33ms timer on top of _scheduleRender()'s own 33ms gate; rAF first, with the
+    # timer kept only as the no-rAF fallback.
+    assert "requestAnimationFrame(()=>_scheduleRender());" in fn
+    reschedule = fn[fn.index("if(!caughtUp&&!_streamFinalized){"):]
+    assert reschedule.index("requestAnimationFrame(()=>_scheduleRender());") < reschedule.index(
+        "setTimeout(()=>_scheduleRender(), 33);"
+    ), "rAF must be the primary path, the 33ms timer only the fallback"
+
+
+def test_post_done_fade_drain_is_vsync_aligned_and_marks_ownership():
+    fn = _extract_fn(MESSAGES_JS, "_drainStreamFadeBeforeDone")
+    assert "setTimeout(()=>requestAnimationFrame(step), 33);" not in fn
+    assert "window._streamFadeDrainingUntil=performance.now()+400" in fn
+    assert "window._streamFadeDrainingUntil=0" in fn, "drain must release ownership"


### PR DESCRIPTION
## The problem

While an assistant reply typed itself out, the transcript did not follow the text smoothly. It sat still for several render ticks and then jumped a whole line, and the jump repeated for the length of the answer. Most visible on mobile, but present on desktop too.

## Root cause

The streaming follow path snapped `scrollTop = scrollHeight` on every render tick. A tick only adds a couple of words, so the scroll position does not change at all until a line **wraps** — at which point the whole line height is applied in one painted step. That is the stutter: it is not dropped frames, it is a step function.

The same path also rebuilt the settle `ResizeObserver` (disconnect + `new ResizeObserver` + observe + two timers) per tick, i.e. ~30 observer teardown/rebuild cycles a second on a transcript that may be thousands of nodes deep. That is the dominant per-frame cost on mobile.

## The fix

While a turn is streaming — or the word fade is still playing text out after the SSE `done` — `scrollIfPinned()` hands the tail to a single rAF loop, `_tailFollowFrame()`, that eases `scrollTop` toward the bottom: one `scrollHeight` read and at most one `scrollTop` write per frame, closing 26% of the remaining gap so a newly wrapped line arrives as a short glide.

Bounded on both ends:

- **36px lag ceiling** — with the word fade off a tick can add several lines at once, and a purely proportional ease would park the newest lines below the fold.
- **600px snap threshold** — a hopeless gap jumps rather than crawling.
- Lands exactly on `scrollHeight - clientHeight` for the last pixel, so the near-bottom predicates elsewhere in the file are not left measuring against a fractional residue.
- Parks itself after ten quiet frames rather than holding a permanent rAF loop.

Ownership is single-writer: `_settleMessageScrollToBottom()` and `_cancelBottomSettle()` stop the glide, so the completion and late-layout paths (Prism, KaTeX, Mermaid, images) still re-anchor the bottom exactly as before.

## Invariants preserved

The glide refuses on the same signals the settle path's ResizeObserver callback refuses on, so the sticky-unpin model (#3343 / #4295) is unchanged, plus two additions for this code's neighbours:

- **Mobile:** it yields while a finger is actually *down* on the transcript, so a per-frame write can never cancel an in-progress drag or iOS momentum. Deliberately **not** the 1200ms `_recentMessageTouchScrollIntent()` tail — `touchstart` marks that on any tap (a copy button, expanding a tool card), and pausing follow for 1.2s after a tap would regress against the current settle path, which does not check it at all.
- **Jump-to-question:** it yields to an active `_messageJumpScrollOwner` for the same reason `scrollIfPinned()` returns early on one (#6621) — a jump deliberately holds the reader at its target across smooth-scroll frames, and two writers would fight each frame.

## Siblings found and fixed

Three cadence hitches in the word fade, all the same shape: a `setTimeout(33) + rAF` pair fires anywhere between 33ms and 50ms depending on where the timer lands relative to the next frame, so the released word wave arrived unevenly even though the pacing math is time-based.

1. `_scheduleRender()` now polls rAF against the interval — a steady two-frame beat at 60Hz.
2. The self-reschedule while the fade is catching up no longer stacks a 33ms timer on top of `_scheduleRender()`'s own 33ms gate, which had pushed the next playout tick out to as much as 66ms whenever tokens stopped arriving.
3. The post-`done` drain gets the same vsync-aligned beat — this is where the hitch was most visible, on an answer's last words.

The drain marks a self-expiring **deadline** rather than a boolean, so an abandoned drain (session switch, cancel, teardown) can never strand ownership away from the settle.

## Tests

`tests/test_streaming_tail_follow_glide.py` — 12 tests. The behavioural ones drive the **real extracted helpers** in Node against a fake scroller and a manually pumped frame queue, so they exercise the shipped code, not a replica:

- a single wrapped line is crossed over several painted frames, not one (this is the stutter itself)
- the glide never overshoots the bottom, and lands on it exactly
- lag stays bounded under fast multi-line growth
- a hopeless gap snaps in one frame
- it yields to an unpinned reader, and while a finger is down
- it parks itself when there is nothing to chase
- the drain deadline keeps ownership after `S.activeStreamId` clears, and expires on its own

**Proof they fail before the fix:** stashing the two source files and re-running gives `12 failed`. Restoring gives `12 passed`.

**Verification run on this branch:**

- neighbouring scroll / stream / fade / jitter / anchor suite: `1029 passed`
- full suite: `15082 passed, 119 skipped, 2 failed` — the two failures are `tests/test_tls_aware_probe.py`, which fails on this base before the change and covers `scripts/lib/health_probe.sh`, not this code.

## Verified running

Rebuilt the container image and recreated it, health check green, and confirmed the served `/static/ui.js` and `/static/messages.js` carry the new code. Streaming a long prose reply follows the text continuously instead of stepping a line at a time; scrolling up mid-stream still stops follow dead and keeps it stopped.

## What I could not verify

- **No before/after images.** The change is motion over time — a still frame of a scroll position shows nothing useful, and I had no way to capture video from this environment. The behavioural tests above are the substitute: they assert the intermediate painted positions that a screenshot cannot show.
- **Not tested on real iOS/Android hardware.** The mobile-specific reasoning (finger-down yield, iOS momentum, the `overflow-anchor` interaction that `_fixMobileScrollJank()` already suppresses during streaming renders) is from reading the surrounding code, not from a device. Worth a check on a real handset before merge.
- Only exercised against this repo's own streaming path; no other front end consumes these helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9kbjA9C6YY7f173xr6N6G
