### PR TITLE
perf: harden WebUI persistence, recovery, and sidebar responsiveness

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -10053,11 +10053,10 @@ def _atomic_write_settings_text(path: Path, text: str) -> None:
     tempfile+fsync+os.replace pattern already used by
     ``webui_session_db.WebUIJsonSessionDB._atomic_write``.
 
-    The existing file's mode is carried onto the replacement: ``os.replace``
-    swaps in the temp file's inode, and a plain ``open`` respects the umask
-    (typically 0644), so without this an operator-hardened ``settings.json``
-    (chmod 0600 because it holds the password hash) would be silently loosened
-    on the next save.  New files fall back to the umask-adjusted default.
+    ``settings.json`` contains the login password hash and is always installed
+    with explicit private mode 0600.  This applies to both new files and
+    replacements, including an existing file that was accidentally loosened
+    by a permissive umask.
 
     A symlinked target is written through to its referent (same follow-through
     as the ``Path.write_text`` this replaces), rather than replacing the link
@@ -10069,15 +10068,14 @@ def _atomic_write_settings_text(path: Path, text: str) -> None:
         f".{write_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
     )
     try:
-        mode = os.stat(write_path).st_mode & 0o777
-    except FileNotFoundError:
-        mode = 0o666 & ~_current_umask()
-    try:
         with open(tmp, "w", encoding="utf-8") as handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        os.chmod(tmp, mode)
+        # chmod the inode before os.replace installs it.  A permissive umask
+        # must never make the password-bearing settings file readable by
+        # group/other, even during an atomic replacement.
+        os.chmod(tmp, 0o600)
         os.replace(tmp, write_path)
     finally:
         try:

--- a/api/models.py
+++ b/api/models.py
@@ -162,10 +162,22 @@ _STALE_TMP_AGE_SECONDS = 3600  # 1 hour
 
 _WINDOWS_REPLACE_MAX_RETRIES = 5
 _WINDOWS_REPLACE_INITIAL_DELAY = 0.05  # 50 ms
+_PRIVATE_STATE_FILE_MODE = 0o600
+
+
+def _set_private_state_file_mode(path: Path) -> None:
+    """Keep persisted session metadata private regardless of the process umask."""
+    os.chmod(path, _PRIVATE_STATE_FILE_MODE)
 
 
 def _safe_replace(src: Path, dst: Path) -> None:
-    """Atomic replace with retries on Windows file-locking errors."""
+    """Private atomic replace with retries on Windows file-locking errors."""
+    # ``os.replace`` installs the source inode as-is.  Set its mode before the
+    # rename so a permissive umask can never expose a session sidecar, backup,
+    # or index with group/other permissions, even for the short replacement
+    # window.  A failed chmod aborts the replacement and callers clean up the
+    # staged file, preserving the old destination.
+    _set_private_state_file_mode(src)
     if os.name != 'nt':
         os.replace(src, dst)
         return
@@ -643,7 +655,7 @@ def _save_webui_zero_message_orphan_tombstone(ids) -> None:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(_tmp, p)
+        _safe_replace(_tmp, p)
     except Exception:
         logger.debug(
             "Failed to save webui zero-message orphan tombstone",
@@ -772,7 +784,7 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(_tmp, p)
+        _safe_replace(_tmp, p)
     except Exception:
         logger.debug("Failed to save webui deleted-session tombstone", exc_info=True)
         if _tmp is not None:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -15,6 +15,8 @@ import re
 import shutil
 import sys
 import threading
+import time
+from collections import OrderedDict
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
@@ -1654,6 +1656,7 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
 
     with _profile_lock:
         _SKILLS_STATS_CACHE.clear()
+        _invalidate_profile_expensive_metadata_cache(home)
         if process_wide:
             global _active_profile
             _active_profile = name
@@ -1951,12 +1954,209 @@ _LIST_PROFILES_CACHE: tuple[list, float] | None = None
 _LIST_PROFILES_CACHE_TTL = 4.0  # seconds. The perf(session-load-latency) pass bumped this to 60s, but that was reverted: profile-row mutations (defaults / providers / skills / gateway config) do NOT invalidate this cache, so a 60s TTL served stale profile rows for too long after such a change. 4s keeps the os.walk frequent enough that mutation→poll staleness is negligible while still making rapid dropdown re-opens free. The create/delete invalidation hooks below clear the cache immediately on those specific mutations.
 _LIST_PROFILES_CACHE_LOCK = threading.Lock()
 
+# Profile discovery and the profile dropdown are on a latency-sensitive path.
+# Keep the cheap row projection independent from gateway health checks and the
+# full skill-tree scan. Each profile refreshes independently so one slow gateway
+# or large skill tree cannot serialize the complete profile response.
+_PROFILE_EXPENSIVE_METADATA_TTL_SECONDS = 60.0
+_PROFILE_EXPENSIVE_METADATA_INITIAL_WAIT_SECONDS = 0.10
+_PROFILE_EXPENSIVE_METADATA_MAX_ENTRIES = 128
+_PROFILE_EXPENSIVE_METADATA_FIELDS = (
+    "gateway_running",
+    "skill_count",
+    "enabled_skills",
+    "total_skills",
+)
+_PROFILE_EXPENSIVE_METADATA_CACHE: OrderedDict[Path, tuple[float, tuple[int, int], dict]] = OrderedDict()
+_PROFILE_EXPENSIVE_METADATA_INFLIGHT: dict[Path, threading.Event] = {}
+_PROFILE_EXPENSIVE_METADATA_PROFILE_VERSION: dict[Path, int] = {}
+_PROFILE_EXPENSIVE_METADATA_GLOBAL_VERSION = 0
+_PROFILE_EXPENSIVE_METADATA_LOCK = threading.RLock()
+
+
+def _profile_expensive_metadata_path(profile_path) -> Path:
+    try:
+        return Path(profile_path).expanduser().resolve()
+    except Exception:
+        return Path(str(profile_path or "")).expanduser()
+
+
+def _profile_expensive_metadata_stamp(profile_path: Path) -> tuple[int, int]:
+    with _PROFILE_EXPENSIVE_METADATA_LOCK:
+        return (
+            _PROFILE_EXPENSIVE_METADATA_GLOBAL_VERSION,
+            _PROFILE_EXPENSIVE_METADATA_PROFILE_VERSION.get(profile_path, 0),
+        )
+
+
+def _invalidate_profile_expensive_metadata_cache(profile_path=None) -> None:
+    """Invalidate profile details without discarding the last-known values."""
+    global _PROFILE_EXPENSIVE_METADATA_GLOBAL_VERSION
+    with _PROFILE_EXPENSIVE_METADATA_LOCK:
+        if profile_path is None:
+            _PROFILE_EXPENSIVE_METADATA_GLOBAL_VERSION += 1
+            return
+        path = _profile_expensive_metadata_path(profile_path)
+        _PROFILE_EXPENSIVE_METADATA_PROFILE_VERSION[path] = (
+            _PROFILE_EXPENSIVE_METADATA_PROFILE_VERSION.get(path, 0) + 1
+        )
+
+
+def _profile_expensive_metadata_cache_get(profile_path: Path) -> dict | None:
+    now = time.monotonic()
+    stamp = _profile_expensive_metadata_stamp(profile_path)
+    with _PROFILE_EXPENSIVE_METADATA_LOCK:
+        entry = _PROFILE_EXPENSIVE_METADATA_CACHE.get(profile_path)
+        if entry is None:
+            return None
+        expiry, cached_stamp, metadata = entry
+        if cached_stamp != stamp or now >= expiry:
+            return None
+        _PROFILE_EXPENSIVE_METADATA_CACHE.move_to_end(profile_path)
+        return dict(metadata)
+
+
+def _compute_profile_expensive_metadata(profile_path: Path) -> dict:
+    """Probe one profile's expensive fields, failing closed per field."""
+    try:
+        from hermes_cli.profiles import _check_gateway_running
+        gateway_running = bool(_check_gateway_running(profile_path))
+    except Exception:
+        gateway_running = False
+    try:
+        enabled_count, total_count = _get_profile_skills_stats(profile_path)
+    except Exception:
+        enabled_count, total_count = 0, 0
+    return {
+        "gateway_running": gateway_running,
+        "skill_count": enabled_count,
+        "enabled_skills": enabled_count,
+        "total_skills": total_count,
+    }
+
+
+def _refresh_profile_expensive_metadata(
+    profile_path: Path,
+    event: threading.Event,
+    requested_stamp: tuple[int, int],
+) -> None:
+    try:
+        metadata = _compute_profile_expensive_metadata(profile_path)
+        with _PROFILE_EXPENSIVE_METADATA_LOCK:
+            if _profile_expensive_metadata_stamp(profile_path) == requested_stamp:
+                _PROFILE_EXPENSIVE_METADATA_CACHE[profile_path] = (
+                    time.monotonic() + _PROFILE_EXPENSIVE_METADATA_TTL_SECONDS,
+                    requested_stamp,
+                    dict(metadata),
+                )
+                _PROFILE_EXPENSIVE_METADATA_CACHE.move_to_end(profile_path)
+                while len(_PROFILE_EXPENSIVE_METADATA_CACHE) > _PROFILE_EXPENSIVE_METADATA_MAX_ENTRIES:
+                    _PROFILE_EXPENSIVE_METADATA_CACHE.popitem(last=False)
+    except Exception:
+        logger.debug(
+            "Profile expensive metadata refresh failed for %s",
+            profile_path,
+            exc_info=True,
+        )
+    finally:
+        with _PROFILE_EXPENSIVE_METADATA_LOCK:
+            if _PROFILE_EXPENSIVE_METADATA_INFLIGHT.get(profile_path) is event:
+                _PROFILE_EXPENSIVE_METADATA_INFLIGHT.pop(profile_path, None)
+        event.set()
+
+
+def _request_profile_expensive_metadata(
+    profile_path: Path,
+    fallback: dict,
+) -> tuple[dict, threading.Event | None]:
+    """Return cached details and ensure at most one refresh is running."""
+    now = time.monotonic()
+    requested_stamp = _profile_expensive_metadata_stamp(profile_path)
+    with _PROFILE_EXPENSIVE_METADATA_LOCK:
+        entry = _PROFILE_EXPENSIVE_METADATA_CACHE.get(profile_path)
+        if entry is not None:
+            expiry, cached_stamp, metadata = entry
+            if cached_stamp == requested_stamp and now < expiry:
+                _PROFILE_EXPENSIVE_METADATA_CACHE.move_to_end(profile_path)
+                return dict(metadata), None
+            # A stale or invalidated entry is still useful while its replacement
+            # is computed. It is intentionally not deleted here.
+            last_known = dict(metadata)
+        else:
+            last_known = dict(fallback)
+        event = _PROFILE_EXPENSIVE_METADATA_INFLIGHT.get(profile_path)
+        if event is None:
+            event = threading.Event()
+            _PROFILE_EXPENSIVE_METADATA_INFLIGHT[profile_path] = event
+            owner = True
+        else:
+            owner = False
+
+    if owner:
+        try:
+            thread = threading.Thread(
+                target=_refresh_profile_expensive_metadata,
+                args=(profile_path, event, requested_stamp),
+                name="profile-metadata-refresh",
+                daemon=True,
+            )
+            thread.start()
+        except Exception:
+            with _PROFILE_EXPENSIVE_METADATA_LOCK:
+                if _PROFILE_EXPENSIVE_METADATA_INFLIGHT.get(profile_path) is event:
+                    _PROFILE_EXPENSIVE_METADATA_INFLIGHT.pop(profile_path, None)
+            event.set()
+    return last_known, event
+
+
+def _profile_expensive_metadata_fallback(row: dict) -> dict:
+    defaults = {
+        "gateway_running": False,
+        "skill_count": 0,
+        "enabled_skills": 0,
+        "total_skills": 0,
+    }
+    return {
+        field: row[field] if field in row else defaults[field]
+        for field in _PROFILE_EXPENSIVE_METADATA_FIELDS
+    }
+
+
+def _rows_with_profile_expensive_metadata(rows: list, active: str) -> list:
+    """Overlay bounded cached detail refreshes onto cheap profile rows."""
+    if not rows:
+        return []
+    requests = []
+    deadline = time.monotonic() + _PROFILE_EXPENSIVE_METADATA_INITIAL_WAIT_SECONDS
+    for raw_row in rows:
+        row = dict(raw_row) if isinstance(raw_row, dict) else {}
+        profile_path = _profile_expensive_metadata_path(row.get("path"))
+        fallback = _profile_expensive_metadata_fallback(row)
+        metadata, event = _request_profile_expensive_metadata(profile_path, fallback)
+        requests.append((row, profile_path, fallback, metadata, event))
+
+    for _row, _path, _fallback, event_metadata, event in requests:
+        if event is None:
+            continue
+        remaining = max(0.0, deadline - time.monotonic())
+        event.wait(remaining)
+
+    result = []
+    for row, profile_path, fallback, initial_metadata, _event in requests:
+        metadata = _profile_expensive_metadata_cache_get(profile_path)
+        merged = dict(row)
+        merged.update(metadata or initial_metadata or fallback)
+        merged["is_active"] = merged.get("name") == active
+        result.append(merged)
+    return result
+
 
 def _invalidate_list_profiles_cache() -> None:
     """Drop the cached profile list (call after create/delete/switch)."""
     global _LIST_PROFILES_CACHE
     with _LIST_PROFILES_CACHE_LOCK:
         _LIST_PROFILES_CACHE = None
+    _invalidate_profile_expensive_metadata_cache()
 
 
 def _build_profile_rows_fast() -> list | None:
@@ -1984,7 +2184,6 @@ def _build_profile_rows_fast() -> list | None:
             _get_default_hermes_home,
             _get_profiles_root,
             _read_config_model,
-            _check_gateway_running,
             _PROFILE_ID_RE as _UPSTREAM_PROFILE_ID_RE,
         )
     except Exception:
@@ -1995,24 +2194,15 @@ def _build_profile_rows_fast() -> list | None:
             model, provider = _read_config_model(home)
         except Exception:
             model, provider = None, None
-        try:
-            gateway_running = _check_gateway_running(home)
-        except Exception:
-            gateway_running = False
-        enabled_count, total_count = _get_profile_skills_stats(home)
         return {
             'name': name,
             'path': str(home),
             'is_default': is_default,
             'is_active': False,  # filled in by caller (cheap, varies per request)
-            'gateway_running': gateway_running,
             'model': model,
             'provider': provider,
             'has_env': (home / '.env').exists(),
             'visible': _profile_visible_from_meta(home),
-            'skill_count': enabled_count,
-            'enabled_skills': enabled_count,
-            'total_skills': total_count,
         }
 
     rows: list = []
@@ -2032,6 +2222,63 @@ def _build_profile_rows_fast() -> list | None:
             rows.append(_row(entry, entry.name, False))
 
     return rows
+
+
+def _profile_info_value(profile, field: str, default=None):
+    if isinstance(profile, dict):
+        return profile.get(field, default)
+    return getattr(profile, field, default)
+
+
+def _profile_row_from_upstream_info(profile) -> dict:
+    """Convert an upstream profile object without re-running expensive probes."""
+    path = _profile_info_value(profile, "path", "")
+    skill_count = _profile_info_value(profile, "skill_count", 0)
+    enabled_skills = _profile_info_value(profile, "enabled_skills", skill_count)
+    total_skills = _profile_info_value(profile, "total_skills", 0)
+    return {
+        "name": _profile_info_value(profile, "name", ""),
+        "path": str(path),
+        "is_default": bool(_profile_info_value(profile, "is_default", False)),
+        "is_active": False,
+        "gateway_running": bool(_profile_info_value(profile, "gateway_running", False)),
+        "model": _profile_info_value(profile, "model"),
+        "provider": _profile_info_value(profile, "provider"),
+        "has_env": bool(_profile_info_value(profile, "has_env", False)),
+        "visible": _profile_visible_from_meta(path),
+        "skill_count": skill_count,
+        "enabled_skills": enabled_skills,
+        "total_skills": total_skills,
+    }
+
+
+def _build_isolated_profile_row_fast(active: str, hermes_home: Path) -> dict | None:
+    """Build isolated-mode metadata without scanning all profiles."""
+    try:
+        from hermes_cli.profiles import _read_config_model
+    except Exception:
+        return None
+    try:
+        model, provider = _read_config_model(hermes_home)
+    except Exception:
+        model, provider = None, None
+    return {
+        "name": active,
+        "path": str(hermes_home),
+        # An isolated path is a named profile directory, even when its display
+        # name is literally ``default``; this matches the upstream path-based
+        # selection used by the compatibility fallback below.
+        "is_default": False,
+        "is_active": True,
+        "gateway_running": False,
+        "model": model,
+        "provider": provider,
+        "has_env": (hermes_home / ".env").exists(),
+        "visible": _profile_visible_from_meta(hermes_home),
+        "skill_count": 0,
+        "enabled_skills": 0,
+        "total_skills": 0,
+    }
 
 
 def list_profiles_api() -> list:
@@ -2055,6 +2302,9 @@ def list_profiles_api() -> list:
     if _is_isolated_profile_mode():
         active = _isolated_profile_name()
         hermes_home = Path(_INITIAL_HERMES_HOME).expanduser()
+        fast_row = _build_isolated_profile_row_fast(active, hermes_home)
+        if fast_row is not None:
+            return _rows_with_profile_expensive_metadata([fast_row], active)
         try:
             from hermes_cli.profiles import list_profiles
             infos = list_profiles()
@@ -2067,39 +2317,29 @@ def list_profiles_api() -> list:
                 except OSError:
                     same_home = False
                 if p.name == active and same_home:
-                    enabled_count, total_count = _get_profile_skills_stats(p.path)
-                    return [{
-                        'name': p.name,
-                        'path': str(p.path),
-                        'is_default': p.is_default,
-                        'is_active': True,  # Always true in isolated mode
-                        'gateway_running': p.gateway_running,
-                        'model': p.model,
-                        'provider': p.provider,
-                        'has_env': p.has_env,
-                        'visible': _profile_visible_from_meta(p.path),
-                        'skill_count': enabled_count,
-                        'enabled_skills': enabled_count,
-                        'total_skills': total_count,
-                    }]
+                    row = _profile_row_from_upstream_info(p)
+                    row["is_active"] = True  # Always true in isolated mode
+                    return _rows_with_profile_expensive_metadata([row], active)
         except (ImportError, OSError, PermissionError):
             pass
         # Fallback: construct profile dict with actual active name and hermes_home path
-        enabled_count, total_count = _get_profile_skills_stats(hermes_home)
-        return [{
-            'name': active,
-            'path': str(hermes_home),
-            'is_default': active == 'default',
-            'is_active': True,
-            'gateway_running': False,
-            'model': None,
-            'provider': None,
-            'has_env': (hermes_home / '.env').exists(),
-            'visible': _profile_visible_from_meta(hermes_home),
-            'skill_count': enabled_count,
-            'enabled_skills': enabled_count,
-            'total_skills': total_count,
-        }]
+        return _rows_with_profile_expensive_metadata(
+            [{
+                'name': active,
+                'path': str(hermes_home),
+                'is_default': False,
+                'is_active': True,
+                'gateway_running': False,
+                'model': None,
+                'provider': None,
+                'has_env': (hermes_home / '.env').exists(),
+                'visible': _profile_visible_from_meta(hermes_home),
+                'skill_count': 0,
+                'enabled_skills': 0,
+                'total_skills': 0,
+            }],
+            active,
+        )
 
     # Single-flight the build (#5364): hold the cache lock across the row build
     # so a cold-startup burst of concurrent requests collapses to ONE build while
@@ -2130,27 +2370,13 @@ def list_profiles_api() -> list:
             return [_default_profile_dict()]
 
         active = get_active_profile_name()
-        result = []
-        for p in infos:
-            enabled_count, total_count = _get_profile_skills_stats(p.path)
-            result.append({
-                'name': p.name,
-                'path': str(p.path),
-                'is_default': p.is_default,
-                'is_active': p.name == active,
-                'gateway_running': p.gateway_running,
-                'model': p.model,
-                'provider': p.provider,
-                'has_env': p.has_env,
-                'visible': _profile_visible_from_meta(p.path),
-                'skill_count': enabled_count,
-                'enabled_skills': enabled_count,
-                'total_skills': total_count,
-            })
-        return result
+        return _rows_with_profile_expensive_metadata(
+            [_profile_row_from_upstream_info(p) for p in infos],
+            active,
+        )
 
     active = get_active_profile_name()
-    return [{**p, 'is_active': p['name'] == active} for p in rows]
+    return _rows_with_profile_expensive_metadata(rows, active)
 
 
 def _profile_visible_from_meta(profile_path: Path) -> bool:
@@ -2170,8 +2396,7 @@ def _profile_visible_from_meta(profile_path: Path) -> bool:
 
 def _default_profile_dict() -> dict:
     """Fallback profile dict when hermes_cli is not importable."""
-    enabled_count, compatible_count = _get_profile_skills_stats(_DEFAULT_HERMES_HOME)
-    return {
+    row = {
         'name': 'default',
         'path': str(_DEFAULT_HERMES_HOME),
         'is_default': True,
@@ -2181,10 +2406,11 @@ def _default_profile_dict() -> dict:
         'provider': None,
         'has_env': (_DEFAULT_HERMES_HOME / '.env').exists(),
         'visible': True,
-        'skill_count': enabled_count,
-        'enabled_skills': enabled_count,
-        'total_skills': compatible_count,
+        'skill_count': 0,
+        'enabled_skills': 0,
+        'total_skills': 0,
     }
+    return _rows_with_profile_expensive_metadata([row], 'default')[0]
 
 
 def _validate_profile_name(name: str):

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2135,7 +2135,7 @@ def _rows_with_profile_expensive_metadata(rows: list, active: str) -> list:
         metadata, event = _request_profile_expensive_metadata(profile_path, fallback)
         requests.append((row, profile_path, fallback, metadata, event))
 
-    for _row, _path, _fallback, event_metadata, event in requests:
+    for _row, _path, _fallback, _event_metadata, event in requests:
         if event is None:
             continue
         remaining = max(0.0, deadline - time.monotonic())

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -36,6 +36,7 @@ _SESSIONS_CACHE_STREAMING_TTL_SECONDS = 45.0
 _SESSIONS_CACHE_MAX_ENTRIES = 64
 _SESSIONS_CACHE_WAIT_SECONDS = 0.25
 _SESSIONS_CACHE_STALE_WAIT_SECONDS = 0.10
+_SESSIONS_CACHE_RUNTIME_LOCK_TIMEOUT_SECONDS = 0.01
 _SESSIONS_CACHE: OrderedDict[tuple, tuple[float, tuple, dict]] = OrderedDict()
 _SESSIONS_CACHE_LOCK = threading.RLock()
 _SESSIONS_CACHE_INFLIGHT: dict[tuple, threading.Event] = {}
@@ -163,16 +164,68 @@ def _session_list_cache_running_cron_jobs() -> dict[str, float]:
         return {}
 
 
+def _session_list_cache_active_run_streams() -> dict[str, str]:
+    """Return the live ``session_id -> stream_id`` worker overlay.
+
+    ``ACTIVE_RUNS`` is the worker-lifecycle truth and can outlive both the
+    in-memory session object and the SSE registry. Snapshot it with a short
+    timeout: a sidebar response must never wait behind a worker registry
+    mutation. An empty result is safe because the regular active-stream and
+    cached-row paths still apply.
+    """
+    try:
+        import api.routes as _routes
+
+        runs = getattr(_routes, "ACTIVE_RUNS", None)
+        lock = getattr(_routes, "ACTIVE_RUNS_LOCK", None)
+        if not isinstance(runs, dict):
+            return {}
+        acquired = False
+        try:
+            if lock is not None:
+                try:
+                    acquired = lock.acquire(
+                        timeout=_SESSIONS_CACHE_RUNTIME_LOCK_TIMEOUT_SECONDS
+                    )
+                except TypeError:
+                    acquired = lock.acquire(False)
+                if not acquired:
+                    return {}
+            snapshot = dict(runs)
+        finally:
+            if acquired:
+                lock.release()
+    except Exception:
+        return {}
+
+    result: dict[str, str] = {}
+    for stream_id, raw in snapshot.items():
+        if not isinstance(raw, dict):
+            continue
+        session_id = str(raw.get("session_id") or "").strip()
+        normalized_stream_id = str(stream_id or "").strip()
+        if session_id and normalized_stream_id:
+            result[session_id] = normalized_stream_id
+    return result
+
+
 def _session_list_cache_resolved_source_stamp(key: tuple):
+    source_stamp = None
     try:
         import api.routes as _routes
 
         override = getattr(_routes, "_session_list_cache_source_stamp", None)
         if callable(override) and override is not _session_list_cache_source_stamp:
-            return override(key)
+            source_stamp = override(key)
     except Exception:
         pass
-    return _session_list_cache_source_stamp(key)
+    if source_stamp is None:
+        source_stamp = _session_list_cache_source_stamp(key)
+    # Keep invalidation separate from the filesystem/source stamp. A structural
+    # mutation must make the entry stale even when it is still within its TTL,
+    # but it must not discard the last-known payload before the background
+    # rebuild can replace it.
+    return (source_stamp, _session_list_cache_invalidation_stamp(key))
 
 
 def _session_list_cache_profile_scope(profile: str | None) -> str:
@@ -311,6 +364,29 @@ def _session_list_cache_clear(profile: str | None = None) -> None:
                 continue
             if _profiles_match(cache_profile, normalized_profile):
                 _SESSIONS_CACHE.pop(cache_key, None)
+
+
+def _session_list_cache_invalidate(profile: str | None = None) -> None:
+    """Mark matching entries stale while retaining their last-known payload.
+
+    ``_session_list_cache_clear`` remains the hard-reset helper used by tests
+    and recovery code. Runtime session-list events use this softer operation so
+    the next sidebar request can return immediately and let the expensive
+    historical projection rebuild in the background.
+    """
+    normalized_profile = _session_list_cache_profile_scope(profile) if profile else None
+    with _SESSIONS_CACHE_LOCK:
+        global _SESSIONS_CACHE_GLOBAL_INVALIDATION_VERSION
+        global _SESSIONS_CACHE_ALL_PROFILES_INVALIDATION_VERSION
+        if not profile:
+            _SESSIONS_CACHE_GLOBAL_INVALIDATION_VERSION += 1
+            _SESSIONS_CACHE_ALL_PROFILES_INVALIDATION_VERSION += 1
+            _SESSIONS_CACHE_PROFILE_INVALIDATION_VERSION.clear()
+            return
+        _SESSIONS_CACHE_ALL_PROFILES_INVALIDATION_VERSION += 1
+        _SESSIONS_CACHE_PROFILE_INVALIDATION_VERSION[normalized_profile] = (
+            _SESSIONS_CACHE_PROFILE_INVALIDATION_VERSION.get(normalized_profile, 0) + 1
+        )
 
 
 def _clear_session_list_cache(profile: str | None = None) -> None:
@@ -495,6 +571,10 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
         running_cron_jobs = _session_list_cache_running_cron_jobs()
     except Exception:
         running_cron_jobs = {}
+    try:
+        active_run_streams = _session_list_cache_active_run_streams()
+    except Exception:
+        active_run_streams = {}
     cron_job_prefixes = [(jid, f"cron_{jid}_", started_at) for jid, started_at in running_cron_jobs.items()]
     session_ids = [
         str(row.get("session_id") or "").strip()
@@ -503,19 +583,35 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
     ]
     live_sessions = {}
     if session_ids:
-        with LOCK:
-            for sid in session_ids:
-                live = SESSIONS.get(sid)
-                if live is not None:
-                    live_sessions[sid] = live
+        acquired = False
+        try:
+            try:
+                acquired = LOCK.acquire(
+                    timeout=_SESSIONS_CACHE_RUNTIME_LOCK_TIMEOUT_SECONDS
+                )
+            except TypeError:
+                acquired = LOCK.acquire(False)
+            if acquired:
+                for sid in session_ids:
+                    live = SESSIONS.get(sid)
+                    if live is not None:
+                        live_sessions[sid] = live
+        finally:
+            if acquired:
+                LOCK.release()
     overlaid = []
     for row in rows:
         item = dict(row) if isinstance(row, dict) else {}
         sid = str(item.get("session_id") or "").strip()
         live = live_sessions.get(sid)
+        active_run_stream_id = active_run_streams.get(sid)
+        if active_run_stream_id:
+            # The active-run registry can be fresher than both the cached row
+            # and the in-memory Session object during worker startup/reconnect.
+            item["active_stream_id"] = active_run_stream_id
         if live is not None:
             live_stream_id = getattr(live, "active_stream_id", None)
-            item["active_stream_id"] = live_stream_id or None
+            item["active_stream_id"] = active_run_stream_id or live_stream_id or None
             item["has_pending_user_message"] = bool(
                 getattr(live, "pending_user_message", None)
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -222,8 +222,12 @@ def _queue_generated_title_for_imported_session(session, cli_meta: dict | None) 
 
 
 def _on_session_list_changed(profile: str | None = None) -> None:
-    """Invalidate in-process /api/sessions cache when sidebar state mutates."""
-    _clear_session_list_cache(profile)
+    """Mark /api/sessions stale when sidebar state mutates.
+
+    Keep the last-known snapshot available to the next poll; the route cache
+    owns the single-flight background rebuild of historical projection data.
+    """
+    _session_list_cache_invalidate(profile)
     # #4842: also drop the inner CLI/cron projection cache. While a turn streams
     # that cache is frozen on a stable streaming marker (so per-token message
     # writes don't bust it), which means it no longer self-invalidates via the
@@ -477,6 +481,7 @@ from api.profiles import (  # noqa: F401, E402  (re-export)
     get_active_hermes_home,
     list_profiles_api,
     profile_scope_for_detached_worker,
+    _invalidate_profile_expensive_metadata_cache,
 )
 
 
@@ -1940,6 +1945,7 @@ _SESSIONS_CACHE_TTL_SECONDS = _route_session_list_cache._SESSIONS_CACHE_TTL_SECO
 _SESSIONS_CACHE_WAIT_SECONDS = _route_session_list_cache._SESSIONS_CACHE_WAIT_SECONDS
 _clear_session_list_cache = _route_session_list_cache._clear_session_list_cache
 _session_list_cache_clear = _route_session_list_cache._session_list_cache_clear
+_session_list_cache_invalidate = _route_session_list_cache._session_list_cache_invalidate
 _session_list_cache_claim_rebuild = _route_session_list_cache._session_list_cache_claim_rebuild
 _session_list_cache_done = _route_session_list_cache._session_list_cache_done
 _session_list_cache_get = _route_session_list_cache._session_list_cache_get
@@ -2731,8 +2737,12 @@ def _get_cached_session_list_payload(
         return cached
 
     stale = cached  # now actually a stale payload when one exists, else None
-    stale_reason = _session_list_cache_stale_reason(key) if stale is not None else None
-    if stale is not None and stale_reason != "source":
+    # Both age and source/invalidation changes are stale-while-revalidate cases.
+    # The source stamp can cover state.db, WAL, and a SQLite fingerprint, so do
+    # not synchronously rebuild merely because it changed. Runtime overlays are
+    # applied below on every response; the historical projection is refreshed
+    # by this single-flight background owner.
+    if stale is not None:
         event, is_owner = _session_list_cache_claim_rebuild(key)
         if is_owner:
             if diag is not None:
@@ -27959,6 +27969,7 @@ def _handle_skill_save(handler, body):
         return bad(handler, "Cannot save to a symlinked skill file")
     skill_file.write_text(body["content"], encoding="utf-8")
     _SKILLS_STATS_CACHE.clear()
+    _invalidate_profile_expensive_metadata_cache(skills_dir.parent)
     return j(handler, {"ok": True, "name": skill_name, "path": str(skill_file)})
 
 
@@ -27979,6 +27990,7 @@ def _handle_skill_delete(handler, body):
     skill_dir = matches[0].parent
     shutil.rmtree(str(skill_dir))
     _SKILLS_STATS_CACHE.clear()
+    _invalidate_profile_expensive_metadata_cache(skills_dir.parent)
     return j(handler, {"ok": True, "name": body["name"]})
 
 
@@ -28054,6 +28066,7 @@ def _handle_skill_toggle(handler, body):
 
     reload_config()  # outside with block — reload_config() acquires the lock itself
     _SKILLS_STATS_CACHE.clear()
+    _invalidate_profile_expensive_metadata_cache(config_path.parent)
     return j(handler, {"ok": True, "name": name, "enabled": enabled})
 
 

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -16,7 +16,7 @@ from typing import Any, Iterable
 
 RUN_JOURNAL_DIR_NAME = "_run_journal"
 _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-_WRITER_LOCKS: dict[tuple[str, str, str], threading.Lock] = {}
+_WRITER_LOCKS: dict[tuple[str, str, str], threading.RLock] = {}
 _WRITER_LOCKS_GUARD = threading.Lock()
 # Next-seq to assign per run-journal file path, kept in memory so repeat appends
 # to the same run do not re-parse the whole file on every call. The per-path
@@ -78,12 +78,14 @@ def _run_path(session_id: str, run_id: str, session_dir: Path | None = None) -> 
     return root / RUN_JOURNAL_DIR_NAME / sid / f"{rid}.jsonl"
 
 
-def _lock_for(path: Path) -> threading.Lock:
+def _lock_for(path: Path) -> threading.RLock:
     key = (str(path.parent), path.name, str(os.getpid()))
     with _WRITER_LOCKS_GUARD:
         lock = _WRITER_LOCKS.get(key)
         if lock is None:
-            lock = threading.Lock()
+            # RunJournalWriter holds this lock while delegating to
+            # append_run_event, which acquires the same per-path lock again.
+            lock = threading.RLock()
             _WRITER_LOCKS[key] = lock
         return lock
 
@@ -452,14 +454,17 @@ class RunJournalWriter:
         # agree on one monotonic, gapless sequence.
         with self._lock:
             seq = _reserve_next_seq(self._path)
-        return append_run_event(
-            self.session_id,
-            self.run_id,
-            event_name,
-            payload or {},
-            session_dir=self.session_dir,
-            seq=seq,
-        )
+            # Keep the reservation and the physical append in one critical
+            # section. append_run_event re-enters this RLock to preserve the
+            # direct-call compatibility of its public API.
+            return append_run_event(
+                self.session_id,
+                self.run_id,
+                event_name,
+                payload or {},
+                session_dir=self.session_dir,
+                seq=seq,
+            )
 
 
 def read_run_events(

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -32,6 +32,7 @@ import os
 import re
 import shutil
 import sqlite3
+import tempfile
 import threading
 from contextlib import closing
 from pathlib import Path
@@ -44,6 +45,23 @@ from api.turn_journal import (
 )
 
 logger = logging.getLogger(__name__)
+
+_PRIVATE_STATE_FILE_MODE = 0o600
+
+
+def _create_private_state_temp(directory: Path, prefix: str) -> tuple[int, Path]:
+    """Create a same-directory private temporary file for recovery output."""
+    fd, raw_path = tempfile.mkstemp(prefix=prefix, dir=str(directory))
+    try:
+        os.fchmod(fd, _PRIVATE_STATE_FILE_MODE)
+    except Exception:
+        os.close(fd)
+        try:
+            Path(raw_path).unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return fd, Path(raw_path)
 
 _INTENTIONAL_SHRINK_GENERATION_RE = re.compile(
     r"^[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}$"
@@ -93,7 +111,7 @@ def _rebuild_recovery_session_index(session_dir: Path) -> None:
     ``Session`` cache entries whose backing JSON files are absent from this
     directory; those would immediately audit as ``index_missing_file`` rows.
     """
-    from api.models import _load_session_from_path
+    from api.models import _load_session_from_path, _safe_replace
 
     entry_map: dict[str, dict] = {}
     for path in sorted(session_dir.glob('*.json')):
@@ -116,16 +134,29 @@ def _rebuild_recovery_session_index(session_dir: Path) -> None:
         reverse=True,
     )
     index_path = session_dir / '_index.json'
-    tmp = index_path.with_suffix(f'.tmp.recovery.{os.getpid()}.{threading.current_thread().ident}')
+    fd = None
+    tmp = None
     try:
-        with open(tmp, 'w', encoding='utf-8') as fh:
+        fd, tmp = _create_private_state_temp(
+            session_dir,
+            prefix=f'.{index_path.name}.recovery.',
+        )
+        handle = os.fdopen(fd, 'w', encoding='utf-8')
+        fd = None
+        with handle as fh:
             fh.write(json.dumps(entries, ensure_ascii=False, indent=2))
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp, index_path)
+        _safe_replace(tmp, index_path)
     except Exception:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
-            tmp.unlink(missing_ok=True)
+            if tmp is not None:
+                tmp.unlink(missing_ok=True)
         except Exception:
             pass
         raise
@@ -408,16 +439,37 @@ def recover_session(session_path: Path) -> dict:
     if status["recommend"] != "restore":
         return {**status, "restored": False}
     bak_path = session_path.with_suffix('.json.bak')
-    # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
-    # cannot leave a half-written session.json.
-    tmp_path = session_path.with_suffix('.json.recover.tmp')
+    # Stage the recovery via a private tmp copy + atomic replace so a crash
+    # mid-restore cannot leave a half-written session.json.
+    tmp_fd = None
+    tmp_path = None
     try:
-        shutil.copyfile(bak_path, tmp_path)
-        tmp_path.replace(session_path)
+        tmp_fd, tmp_path = _create_private_state_temp(
+            session_path.parent,
+            prefix=f'.{session_path.name}.recover.',
+        )
+        # Recovery also repairs legacy backups that were created under a
+        # permissive umask.  Harden the backup before staging the replacement;
+        # _safe_replace hardens the temporary live-sidecar inode before rename.
+        os.chmod(bak_path, 0o600)
+        target = os.fdopen(tmp_fd, 'wb')
+        tmp_fd = None
+        with open(bak_path, 'rb') as source, target:
+            shutil.copyfileobj(source, target)
+            target.flush()
+            os.fsync(target.fileno())
+        from api.models import _safe_replace
+        _safe_replace(tmp_path, session_path)
     except OSError as exc:
         logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
         try:
-            tmp_path.unlink(missing_ok=True)
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
         except OSError:
             pass
         return {**status, "restored": False, "error": str(exc)}
@@ -661,17 +713,25 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         if target.exists():
             continue
         payload = _state_db_row_to_sidecar(row)
-        # Per-process/per-thread tmp suffix to avoid corruption under
-        # concurrent reconciliation calls (matches api/models.py:484
-        # Session.save() convention).
-        tmp_suffix = f".json.reconcile.tmp.{os.getpid()}.{threading.current_thread().ident}"
-        tmp = target.with_suffix(tmp_suffix)
         detail_recorded = False
+        tmp_fd = None
+        tmp = None
         try:
-            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding='utf-8')
+            tmp_fd, tmp = _create_private_state_temp(
+                session_dir,
+                prefix=f'.{target.name}.reconcile.',
+            )
+            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as handle:
+                tmp_fd = None
+                handle.write(json.dumps(payload, ensure_ascii=False, indent=2))
+                handle.flush()
+                os.fsync(handle.fileno())
         except OSError as exc:
             try:
-                tmp.unlink(missing_ok=True)
+                if tmp_fd is not None:
+                    os.close(tmp_fd)
+                if tmp is not None:
+                    tmp.unlink(missing_ok=True)
             except OSError:
                 pass
             details.append({'session_id': sid, 'materialized': False, 'error': str(exc)})
@@ -692,7 +752,8 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
             detail_recorded = True
         finally:
             try:
-                tmp.unlink(missing_ok=True)
+                if tmp is not None:
+                    tmp.unlink(missing_ok=True)
             except OSError:
                 pass
         if materialized_now:

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -38,6 +38,33 @@ from api.config import (
 from api.subprocess_utils import windows_hide_flags
 
 
+_PRIVATE_STATE_FILE_MODE = 0o600
+
+
+def _atomic_write_private_text(path: Path, text: str) -> None:
+    """Atomically write private workspace metadata with an explicit mode."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_path = path.resolve(strict=False) if path.is_symlink() else path
+    tmp = write_path.with_name(
+        f".{write_path.name}.{os.getpid()}.{threading.current_thread().ident}.tmp"
+    )
+    try:
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # The temporary inode is what os.replace installs.  chmod it before
+        # the rename so the process umask cannot briefly expose metadata.
+        os.chmod(tmp, _PRIVATE_STATE_FILE_MODE)
+        os.replace(tmp, write_path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
 # ── Profile-aware path resolution ───────────────────────────────────────────
 
 def _profile_state_dir() -> Path:
@@ -342,8 +369,9 @@ def _migrate_global_workspaces() -> list:
         cleaned = _clean_workspace_list(raw)
         if len(cleaned) != len(raw):
             # Rewrite the cleaned version so future reads are already clean
-            _GLOBAL_WS_FILE.write_text(
-                json.dumps(cleaned, ensure_ascii=False, indent=2), encoding='utf-8'
+            _atomic_write_private_text(
+                _GLOBAL_WS_FILE,
+                json.dumps(cleaned, ensure_ascii=False, indent=2),
             )
         return cleaned
     except Exception:
@@ -359,8 +387,9 @@ def load_workspaces() -> list:
             if len(cleaned) != len(raw):
                 # Persist the cleaned version so stale entries don't keep reappearing
                 try:
-                    ws_file.write_text(
-                        json.dumps(cleaned, ensure_ascii=False, indent=2), encoding='utf-8'
+                    _atomic_write_private_text(
+                        ws_file,
+                        json.dumps(cleaned, ensure_ascii=False, indent=2),
                     )
                 except Exception:
                     logger.debug("Failed to persist cleaned workspace list")
@@ -386,7 +415,10 @@ def load_workspaces() -> list:
 def save_workspaces(workspaces: list) -> None:
     ws_file = _workspaces_file()
     ws_file.parent.mkdir(parents=True, exist_ok=True)
-    ws_file.write_text(json.dumps(workspaces, ensure_ascii=False, indent=2), encoding='utf-8')
+    _atomic_write_private_text(
+        ws_file,
+        json.dumps(workspaces, ensure_ascii=False, indent=2),
+    )
 
 
 def get_profile_default_workspace() -> str:
@@ -468,7 +500,7 @@ def set_last_workspace(path: str) -> None:
     try:
         lw_file = _last_workspace_file()
         lw_file.parent.mkdir(parents=True, exist_ok=True)
-        lw_file.write_text(str(path), encoding='utf-8')
+        _atomic_write_private_text(lw_file, str(path))
     except Exception:
         logger.debug("Failed to set last workspace")
 

--- a/ctl.sh
+++ b/ctl.sh
@@ -17,8 +17,8 @@ Usage: ./ctl.sh <command> [args]
 
 Commands:
   start [bootstrap args...]   Start Hermes WebUI as a background daemon
-  stop                        Stop the daemon started by ctl.sh
-  restart [bootstrap args...] Stop, then start again
+  stop [--force]              Stop the daemon started by ctl.sh
+  restart [--force]           Stop, then start again
   status                      Show daemon, host/port, log, and health status
   logs [--lines N] [--follow|--no-follow]
                               Show the daemon log (defaults to tail -n 100 -f)
@@ -704,6 +704,18 @@ _warn_if_unmanaged_instance_serving() {
 
 stop_cmd() {
   ensure_home
+  local force=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force|-f) force=1 ;;
+      *)
+        echo "[ctl] Unknown stop option: $1" >&2
+        return 2
+        ;;
+    esac
+    shift
+  done
+
   local pid
   if ! pid="$(_pid_from_file 2>/dev/null)"; then
     echo "[ctl] Hermes WebUI is stopped"
@@ -720,10 +732,22 @@ stop_cmd() {
     return 0
   fi
 
+  if (( force )); then
+    echo "[ctl] Force-stopping Hermes WebUI (PID ${pid})"
+    _stop_webui_pid "${pid}" KILL
+    rm -f "${PID_FILE}" "${STATE_FILE}"
+    return 0
+  fi
+
   echo "[ctl] Stopping Hermes WebUI (PID ${pid})"
   _stop_webui_pid "${pid}" TERM
-  local i
-  for i in {1..50}; do
+  # server.py's graceful drain is bounded independently; leave enough time
+  # for its default ten-second deadline while keeping ctl.sh itself bounded.
+  local stop_timeout="${HERMES_WEBUI_STOP_TIMEOUT:-12}"
+  [[ "${stop_timeout}" =~ ^[0-9]+$ ]] || stop_timeout=12
+  (( stop_timeout > 0 )) || stop_timeout=12
+  local stop_steps=$(( stop_timeout * 10 )) i
+  for (( i=0; i<stop_steps; i++ )); do
     if ! _is_alive "${pid}"; then
       rm -f "${PID_FILE}" "${STATE_FILE}"
       echo "[ctl] Stopped"
@@ -853,8 +877,16 @@ fi
 
 case "${cmd}" in
   start) start_cmd "$@" ;;
-  stop) stop_cmd ;;
-  restart) stop_cmd; start_cmd "$@" ;;
+  stop) stop_cmd "$@" ;;
+  restart)
+    if [[ "${1:-}" == "--force" || "${1:-}" == "-f" ]]; then
+      shift
+      stop_cmd --force
+    else
+      stop_cmd
+    fi
+    start_cmd "$@"
+    ;;
   status) status_cmd ;;
   logs) logs_cmd "$@" ;;
   -h|--help|help|"") usage ;;

--- a/docs/plans/2026-08-31-webui-p1-p2-concurrency.md
+++ b/docs/plans/2026-08-31-webui-p1-p2-concurrency.md
@@ -1,0 +1,67 @@
+# Hermes WebUI P1/P2 Concurrency and UX Implementation Plan
+
+> **For Hermes:** Execute with Codex workers in isolated worktrees, then run spec and quality review before merge.
+
+**Goal:** Improve Hermes WebUI responsiveness, replay correctness, durability, and user visibility when multiple long-running conversations are active concurrently.
+
+**Architecture:** Preserve the current Python stdlib + vanilla-JS deployment model and the existing in-process Hermes `AIAgent` execution path. Prefer bounded, keyed, incremental state over broad rebuilds; preserve the existing rAF/incremental streaming renderer. Keep the WebUI launchd service and live user state untouched during development and verification.
+
+**Base:** `origin/master` (`e168b67e4278df618d1cab61fdb3a8dc55b29a81`), repository default branch is `master`.
+
+## Workstreams
+
+### A. Run-journal replay integrity
+
+Files: `api/run_journal.py`, `tests/test_run_journal_seq_cache.py`.
+
+- Make sequence reservation and append atomic under one per-run/path critical section.
+- Preserve compatibility with direct `append_run_event()` callers.
+- Add a deterministic concurrent `RunJournalWriter.append_sse_event()` regression proving on-disk order is gapless and `read_session_run_events()` does not return `replay_noncontiguous`.
+
+### B. Session/state file safety and graceful shutdown
+
+Files: `api/models.py`, `api/workspace.py`, `server.py`, `ctl.sh` only if necessary, focused tests.
+
+- Enforce explicit private permissions for session JSON, backups, indexes, workspace metadata, and settings on create/replacement/recovery paths.
+- Preserve atomicity and existing compatibility; do not modify production state.
+- Add graceful drain semantics for routine supervisor shutdown: stop admission, expose/record draining state, wait for active workers within a bounded deadline, then exit; preserve explicit force behavior.
+- Add tests for permissive umask, replacement, and active-worker shutdown behavior.
+
+### C. Session/profile metadata latency
+
+Files: `api/route_session_list_cache.py`, `api/routes.py`, `api/profiles.py`, `api/models.py`, focused tests.
+
+- Make `/api/sessions` serve a last-known snapshot immediately while stale rebuild runs single-flight in the background.
+- Keep active-run overlay fresh without re-running full CLI/Codex/lineage projection.
+- Separate cheap profile metadata from expensive skill counts/gateway probes; use bounded TTL + background refresh.
+- Keep profile/source scoping and invalidation semantics correct.
+- Add tests for stale-while-revalidate, concurrent callers, cache invalidation, and three-large-session behavior.
+
+### D. In-flight persistence and multi-conversation UX
+
+Files: `static/messages.js`, `static/ui.js`, `static/sessions.js`, tests.
+
+- Replace repeated whole-transcript localStorage serialization with compact recovery metadata/delta or bounded tail while preserving reconnect recovery guarantees.
+- Keep selected conversation fully live; add compact background activity/status projections for other active sessions without rendering all token streams.
+- Preserve current rAF/incremental markdown path and session-switch ownership guards.
+- Add browser/static tests for three sessions, switching, reconnect, cancellation, and bounded persistence bytes.
+
+### E. Client bootstrap/cache and lifecycle efficiency
+
+Files: `static/index.html`, `static/sw.js`, relevant JS/CSS/tests.
+
+- Keep auth/navigation network-first but make version-pinned shell assets cache-first or stale-while-revalidate.
+- Lazy-load non-chat surfaces where compatible with the no-build architecture; split locale loading only if tests prove safe.
+- Remove mobile zoom prohibition while preserving iOS input behavior and touch targets.
+- Reduce duplicate per-tab global refresh work where possible, with explicit lifecycle disposal.
+- Add browser-level/static tests for cache versioning, offline shell integrity, responsive behavior, and timer/EventSource lifecycle.
+
+## Global acceptance gates
+
+- No credentials, production state, or live WebUI process touched.
+- All changes are based on this branch, not the dirty operator checkout.
+- Each workstream adds a focused failing test before implementation and passes its focused suite after implementation.
+- Preserve existing API compatibility and current user-facing behavior outside the targeted fixes.
+- Run focused performance/concurrency/replay/security/browser tests, syntax/lint checks, and the broad suite in an isolated process after integration.
+- Verify with a synthetic three-session stress harness: no replay noncontiguous result, bounded persistence, no cross-session state contamination, bounded sidebar latency, and correct completion visibility.
+- Review the final diff for scope, secrets, generated artifacts, and docs accuracy before opening the PR.

--- a/server.py
+++ b/server.py
@@ -99,6 +99,31 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+_GRACEFUL_DRAIN_DEFAULT_SECONDS = 10.0
+_GRACEFUL_DRAIN_MAX_SECONDS = 30.0
+_GRACEFUL_DRAIN_POLL_SECONDS = 0.05
+
+
+def _bounded_graceful_drain_seconds(value, *, default: float = _GRACEFUL_DRAIN_DEFAULT_SECONDS) -> float:
+    """Return a finite, non-negative drain timeout with a hard upper bound."""
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        seconds = default
+    if seconds != seconds or seconds < 0:  # NaN and negative values
+        seconds = default
+    if seconds == float("inf"):
+        seconds = _GRACEFUL_DRAIN_MAX_SECONDS
+    return min(seconds, _GRACEFUL_DRAIN_MAX_SECONDS)
+
+
+def _configured_graceful_drain_seconds() -> float:
+    raw = os.environ.get(
+        "HERMES_WEBUI_SHUTDOWN_DRAIN_SECONDS",
+        str(_GRACEFUL_DRAIN_DEFAULT_SECONDS),
+    )
+    return _bounded_graceful_drain_seconds(raw)
+
 from api.auth import check_auth, reset_trusted_auth_request_state
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import (
@@ -126,17 +151,159 @@ class QuietHTTPServer(ThreadingHTTPServer):
         b"Content-Length: 0\r\n"
         b"\r\n"
     )
+    _DRAINING_RESPONSE = (
+        b"HTTP/1.1 503 Service Unavailable\r\n"
+        b"Connection: close\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 21\r\n"
+        b"\r\n"
+        b'{"status":"draining"}'
+    )
 
     def __init__(self, *args, **kwargs):
         server_address = args[0] if args else kwargs.get('server_address', None)
         if server_address and ':' in server_address[0]:
             self.address_family = socket.AF_INET6
         self.ssl_context: object | None = None
+        self._drain_lock = threading.RLock()
+        self._drain_wakeup = threading.Event()
+        self._drain_state = "running"
+        self._drain_reason = None
+        self._drain_deadline = None
+        self.graceful_drain_timeout_seconds = _configured_graceful_drain_seconds()
+        self._active_request_workers = 0
+        self._active_request_workers_idle = threading.Event()
+        self._active_request_workers_idle.set()
         super().__init__(*args, **kwargs)
         self._request_worker_slots = threading.BoundedSemaphore(self.max_request_workers)
         self._overflow_reject_slots = threading.BoundedSemaphore(self.max_overflow_reject_workers)
         self.accept_loop_requests_total = 0
         self.accept_loop_last_request_at = 0.0
+
+    @property
+    def is_draining(self) -> bool:
+        with self._drain_lock:
+            return self._drain_state != "running"
+
+    @property
+    def shutdown_state(self) -> str:
+        with self._drain_lock:
+            return self._drain_state
+
+    @property
+    def admission_open(self) -> bool:
+        with self._drain_lock:
+            return self._drain_state == "running"
+
+    def _active_agent_worker_count(self) -> int | None:
+        """Read the authoritative active-run registry, failing closed on error."""
+        try:
+            from api import config as _config
+
+            with _config.ACTIVE_RUNS_LOCK:
+                return len(_config.ACTIVE_RUNS)
+        except Exception:
+            logger.debug("Failed to read active worker registry during shutdown", exc_info=True)
+            return None
+
+    def drain_snapshot(self) -> dict:
+        """Return non-secret shutdown state for health/logging/diagnostics."""
+        with self._drain_lock:
+            state = self._drain_state
+            reason = self._drain_reason
+            active_requests = self._active_request_workers
+            deadline = self._drain_deadline
+        active_runs = self._active_agent_worker_count()
+        active_workers = (
+            active_runs + active_requests if active_runs is not None else None
+        )
+        return {
+            "state": state,
+            "reason": reason,
+            "admission_open": state == "running",
+            "active_workers": active_workers,
+            "active_runs": active_runs,
+            "active_requests": active_requests,
+            "deadline": deadline,
+        }
+
+    def begin_graceful_shutdown(
+        self,
+        *,
+        reason: str = "supervisor",
+        timeout_seconds: float | None = None,
+    ) -> bool:
+        """Close admission and start a bounded graceful drain.
+
+        The caller still owns the final ``shutdown()``/process-exit action;
+        this method only changes admission state and establishes the deadline.
+        """
+        timeout = self.graceful_drain_timeout_seconds if timeout_seconds is None else timeout_seconds
+        timeout = _bounded_graceful_drain_seconds(timeout)
+        with self._drain_lock:
+            if self._drain_state != "running":
+                return False
+            now = time.monotonic()
+            self._drain_state = "draining"
+            self._drain_reason = str(reason or "supervisor")
+            self._drain_deadline = now + timeout
+            self._drain_wakeup.set()
+        snapshot = self.drain_snapshot()
+        logger.info(
+            "[shutdown] state=draining reason=%s active_workers=%s deadline_seconds=%.3f",
+            _shutdown_log_value(reason),
+            snapshot["active_workers"] if snapshot["active_workers"] is not None else "unknown",
+            timeout,
+        )
+        return True
+
+    def force_shutdown(self, *, reason: str = "force") -> bool:
+        """Record an immediate forced shutdown without waiting for workers."""
+        with self._drain_lock:
+            if self._drain_state == "forced":
+                return False
+            self._drain_state = "forced"
+            self._drain_reason = str(reason or "force")
+            self._drain_deadline = time.monotonic()
+            self._drain_wakeup.set()
+        logger.warning("[shutdown] state=forced reason=%s", _shutdown_log_value(reason))
+        return True
+
+    def wait_for_graceful_drain(self) -> dict:
+        """Wait for active requests/runs until the established deadline."""
+        with self._drain_lock:
+            state = self._drain_state
+            deadline = self._drain_deadline
+        if state == "running":
+            return self.drain_snapshot()
+        if state == "forced":
+            return self.drain_snapshot()
+
+        deadline = deadline if deadline is not None else time.monotonic()
+        while True:
+            snapshot = self.drain_snapshot()
+            if snapshot["active_workers"] == 0:
+                with self._drain_lock:
+                    if self._drain_state == "draining":
+                        self._drain_state = "drained"
+                logger.info("[shutdown] state=drained reason=%s", _shutdown_log_value(snapshot["reason"]))
+                return self.drain_snapshot()
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                with self._drain_lock:
+                    if self._drain_state == "draining":
+                        self._drain_state = "timed_out"
+                final = self.drain_snapshot()
+                logger.warning(
+                    "[shutdown] state=timed_out reason=%s active_workers=%s",
+                    _shutdown_log_value(final["reason"]),
+                    final["active_workers"] if final["active_workers"] is not None else "unknown",
+                )
+                return final
+
+            self._drain_wakeup.wait(min(remaining, _GRACEFUL_DRAIN_POLL_SECONDS))
+            self._drain_wakeup.clear()
 
     def server_bind(self):
         if sys.platform == 'win32':
@@ -259,13 +426,68 @@ class QuietHTTPServer(ThreadingHTTPServer):
             self._close_request_quietly(request)
             self._overflow_reject_slots.release()
 
+    def _reject_draining_request(self, request) -> None:
+        if getattr(self, "ssl_context", None) is not None:
+            self._close_request_quietly(request)
+            return
+        if not self._overflow_reject_slots.acquire(blocking=False):
+            self._close_request_quietly(request)
+            return
+        try:
+            threading.Thread(
+                target=self._reject_draining_request_worker,
+                args=(request,),
+                daemon=True,
+            ).start()
+        except Exception:
+            self._overflow_reject_slots.release()
+            self._close_request_quietly(request)
+
+    def _reject_draining_request_worker(self, request) -> None:
+        try:
+            self._drain_request_input_nonblocking(request)
+            try:
+                request.sendall(self._DRAINING_RESPONSE)
+                try:
+                    request.shutdown(socket.SHUT_WR)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        finally:
+            self._close_request_quietly(request)
+            self._overflow_reject_slots.release()
+
+    def _try_admit_request(self) -> bool | None:
+        """Reserve a handler slot unless draining; None means capacity overflow."""
+        with self._drain_lock:
+            if self._drain_state != "running":
+                return False
+            if not self._request_worker_slots.acquire(blocking=False):
+                return None
+            self._active_request_workers += 1
+            self._active_request_workers_idle.clear()
+            return True
+
+    def _release_request_worker(self) -> None:
+        with self._drain_lock:
+            self._active_request_workers = max(0, self._active_request_workers - 1)
+            if self._active_request_workers == 0:
+                self._active_request_workers_idle.set()
+                self._drain_wakeup.set()
+
     def process_request(self, request, client_address):
-        if not self._request_worker_slots.acquire(blocking=False):
+        admission = self._try_admit_request()
+        if admission is False:
+            self._reject_draining_request(request)
+            return
+        if admission is None:
             self._reject_overflow_request(request)
             return
         try:
             return super().process_request(request, client_address)
         except Exception:
+            self._release_request_worker()
             self._request_worker_slots.release()
             self._close_request_quietly(request)
             raise
@@ -274,6 +496,7 @@ class QuietHTTPServer(ThreadingHTTPServer):
         try:
             return super().process_request_thread(request, client_address)
         finally:
+            self._release_request_worker()
             self._request_worker_slots.release()
 
     def handle_error(self, request, client_address):
@@ -708,6 +931,7 @@ def main() -> None:
         if _shutdown_requested.is_set():
             return
         _shutdown_requested.set()
+        httpd.begin_graceful_shutdown(reason=signal.Signals(signum).name)
         threading.Thread(
             target=httpd.shutdown,
             name="webui-sigterm-shutdown",
@@ -723,7 +947,15 @@ def main() -> None:
     try:
         httpd.serve_forever()
     finally:
+        if not httpd.is_draining:
+            httpd.begin_graceful_shutdown(reason="serve_forever_exit")
         httpd.server_close()
+        drain_result = httpd.wait_for_graceful_drain()
+        logger.info(
+            "[shutdown] completed state=%s active_workers=%s",
+            drain_result.get("state"),
+            drain_result.get("active_workers"),
+        )
         _log_shutdown_audit()
         try:
             from api.gateway_watcher import stop_watcher

--- a/static/boot.js
+++ b/static/boot.js
@@ -8,7 +8,145 @@
   try {
     var _stopChan = new BroadcastChannel('hermes-webui-shutdown');
     _stopChan.onmessage = function() { _showServerStopped(); };
+    window.addEventListener('pagehide', function(event){
+      // Keep the channel alive for BFCache restores, but release it when this
+      // document is actually going away so repeat loads do not accumulate tabs.
+      if(event && event.persisted)return;
+      try{_stopChan.close();}catch(_){ }
+      _stopChan=null;
+    });
   } catch(_) {}
+})();
+
+// Lazy client bundles -------------------------------------------------------
+// The HTML keeps non-chat bundles as inert data-only script tags. This small
+// loader preserves the no-build architecture while giving boot and user
+// navigation one shared promise per bundle, so a scheduled warm-up and a
+// first click can never download the same script twice.
+(function(){
+  const _hermesModulePromises = new Map();
+  const _hermesLoadedModules = new Set();
+  const _hermesModuleDeps = {
+    'extension-settings':['extension-settings'],
+    panels:['extension-settings','panels'],
+    onboarding:['onboarding'],
+  };
+  const _hermesScheduledDisposals = new Set();
+
+  function _loadHermesLazyScript(name){
+    if(_hermesLoadedModules.has(name))return Promise.resolve();
+    const placeholder=document.querySelector('script[data-hermes-lazy="'+name+'"]');
+    const src=placeholder&&placeholder.getAttribute('data-src');
+    if(!src||!/[?&]v=/.test(src)){
+      return Promise.reject(new Error('Missing versioned lazy client asset: '+name));
+    }
+    return new Promise((resolve,reject)=>{
+      const script=document.createElement('script');
+      script.src=src;
+      script.async=false;
+      script.dataset.hermesLazyLoaded=name;
+      script.onload=()=>{
+        _hermesLoadedModules.add(name);
+        resolve();
+      };
+      script.onerror=()=>reject(new Error('Failed to load lazy client asset: '+name));
+      document.head.appendChild(script);
+    });
+  }
+
+  function _ensureHermesClientModule(name){
+    const existing=_hermesModulePromises.get(name);
+    if(existing)return existing;
+    const deps=_hermesModuleDeps[name];
+    if(!deps)return Promise.reject(new Error('Unknown lazy client module: '+name));
+    const promise=deps.reduce((ready,dep)=>ready.then(()=>_loadHermesLazyScript(dep)),Promise.resolve())
+      .then(()=>{
+        if(name==='panels'&&typeof window._restoreTabVisibility==='function'){
+          window._restoreTabVisibility();
+        }
+        return true;
+      })
+      .catch(error=>{
+        _hermesModulePromises.delete(name);
+        throw error;
+      });
+    _hermesModulePromises.set(name,promise);
+    return promise;
+  }
+
+  function _scheduleHermesClientModule(name){
+    return new Promise((resolve,reject)=>{
+      let finished=false;
+      let timer=0;
+      let idleId=0;
+      const dispose=()=>{
+        if(finished)return;
+        finished=true;
+        if(timer)clearTimeout(timer);
+        if(idleId&&typeof cancelIdleCallback==='function')cancelIdleCallback(idleId);
+        _hermesScheduledDisposals.delete(dispose);
+        reject(new Error('Lazy client module cancelled during page teardown: '+name));
+      };
+      const start=()=>{
+        if(finished)return;
+        finished=true;
+        _hermesScheduledDisposals.delete(dispose);
+        _ensureHermesClientModule(name).then(resolve,reject);
+      };
+      _hermesScheduledDisposals.add(dispose);
+      if(typeof requestIdleCallback==='function'){
+        idleId=requestIdleCallback(start,{timeout:1500});
+      }else{
+        timer=setTimeout(start,0);
+      }
+    });
+  }
+
+  window._hermesEnsureClientModule=_ensureHermesClientModule;
+  window._hermesScheduleClientModule=_scheduleHermesClientModule;
+  window.addEventListener('pagehide',function(event){
+    if(event&&event.persisted)return;
+    Array.from(_hermesScheduledDisposals).forEach(dispose=>dispose());
+  });
+
+  // Inline rail/mobile handlers predate the loader and call switchPanel by
+  // name. Install a temporary proxy; panels.js replaces the global function
+  // when its classic script executes, while the proxy makes the first click
+  // wait for the same singleton load promise.
+  const _hermesPanelSwitchProxy=function(name,opts){
+    return _ensureHermesClientModule('panels').then(()=>{
+      const implementation=window.switchPanel;
+      if(typeof implementation!=='function'||implementation===_hermesPanelSwitchProxy){
+        throw new Error('panels.js did not expose switchPanel');
+      }
+      return implementation(name,opts);
+    }).catch(error=>{
+      console.warn('[hermes] lazy panel load failed:',error);
+      return false;
+    });
+  };
+  window._hermesSwitchPanel=_hermesPanelSwitchProxy;
+  if(typeof window.switchPanel!=='function')window.switchPanel=_hermesPanelSwitchProxy;
+
+  // These controls are visible from the chat shell before panels.js finishes
+  // loading. Give them the same safe handoff as switchPanel so a fast tap
+  // cannot become an inline-handler ReferenceError during cold boot.
+  ['toggleProfileDropdown','toggleComposerWsDropdown','switchSettingsSection'].forEach(name=>{
+    if(typeof window[name]==='function')return;
+    const proxy=function(...args){
+      return _ensureHermesClientModule('panels').then(()=>{
+        const implementation=window[name];
+        if(typeof implementation!=='function'||implementation===proxy){
+          throw new Error('panels.js did not expose '+name);
+        }
+        return implementation.apply(this,args);
+      }).catch(error=>{
+        console.warn('[hermes] lazy panel control failed:',error);
+        return false;
+      });
+    };
+    window[name]=proxy;
+  });
 })();
 
 // cancelStream: stop the active chat stream.
@@ -576,7 +714,7 @@ function expandSidebar(){
 // before first paint. This IIFE is a secondary fallback: it ensures consistency
 // after panels.js is loaded and handles the active-tab switch. No-op if
 // panels.js hasn't loaded yet (typeof guard).
-(function _restoreTabVisibility(){
+function _restoreTabVisibility(){
   try{
     if(typeof _applyTabOrder==='function'&&typeof _getTabOrder==='function'){
       _applyTabOrder(_getTabOrder());
@@ -592,7 +730,9 @@ function expandSidebar(){
       if(active)active.classList.remove('active');
     }
   }catch(_){}
-})();
+}
+window._restoreTabVisibility=_restoreTabVisibility;
+_restoreTabVisibility();
 function toggleMobileFiles(){
   toggleWorkspacePanel();
 }
@@ -2627,8 +2767,18 @@ if(window.visualViewport){
       _forceMobileViewportReflow();
     },60);
   };
+  const _disposeMobileViewportReflow=(event)=>{
+    if(event&&event.persisted)return;
+    if(_mobileViewportReflowTimer){
+      clearTimeout(_mobileViewportReflowTimer);
+      _mobileViewportReflowTimer=0;
+    }
+    window.visualViewport.removeEventListener('resize', _scheduleMobileViewportReflow);
+    window.visualViewport.removeEventListener('scroll', _scheduleMobileViewportReflow);
+  };
   window.visualViewport.addEventListener('resize', _scheduleMobileViewportReflow);
   window.visualViewport.addEventListener('scroll', _scheduleMobileViewportReflow);
+  window.addEventListener('pagehide', _disposeMobileViewportReflow);
 }
 
 // Boot: restore last session or start fresh
@@ -3719,16 +3869,28 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   setTimeout(()=>{
     try{Promise.resolve(_startBootModelDropdown()).catch(()=>{});}catch(_){}
   },0);
-  // Start independent boot fetches without holding the conversation list behind
-  // them. The sidebar can render from /api/sessions while workspace/onboarding
-  // metadata settles in parallel.
-  const _workspaceListReady=loadWorkspaceList();
-  const _onboardingReady=_bootSettings.onboarding_completed?Promise.resolve(false):loadOnboardingWizard();
   // Render the session list before restoring the saved conversation so a stale
   // saved-session/client-side boot error cannot leave the sidebar empty forever.
   await renderSessionList();
-  await _workspaceListReady;
-  await _onboardingReady;
+
+  // Non-chat bundles are requested after the first session-list paint. A panel
+  // click can start the same singleton promise sooner; either path hydrates the
+  // workspace metadata once the panel module is available.
+  const _panelsReady=window._hermesScheduleClientModule('panels');
+  const _workspaceListReady=_panelsReady.then(()=>{
+    if(typeof loadWorkspaceList!=='function')throw new Error('panels.js did not expose loadWorkspaceList');
+    return loadWorkspaceList();
+  }).catch(error=>{
+    console.warn('[hermes] workspace panel bootstrap deferred:',error);
+    return {workspaces:[],last:''};
+  });
+  void _workspaceListReady;
+  if(!_bootSettings.onboarding_completed){
+    void _panelsReady
+      .then(()=>window._hermesEnsureClientModule('onboarding'))
+      .then(()=>typeof loadOnboardingWizard==='function'?loadOnboardingWizard():false)
+      .catch(error=>console.warn('[hermes] onboarding bootstrap deferred:',error));
+  }
   _initResizePanels();
   // Workspace panel restore happens AFTER loadSession so we know if
   // the session has a workspace — prevents the snap-open-then-closed flash (#576).

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Hermes</title>
 <!-- base href enables subpath mount support; all static paths must stay relative (no leading slash).
      MUST appear before manifest/favicon links so browsers resolve relative URLs against the
@@ -72,14 +72,14 @@
 <link rel="stylesheet" href="static/style.css?v=__WEBUI_VERSION__">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" integrity="sha384-LJcOxlx9IMbNXDqJ2axpfEQKkAYbFjJfhXexLfiRJhjDU81mzgkiQq8rkV0j6dVh" crossorigin="anonymous">
   <!-- KaTeX math rendering CSS (loaded eagerly from vendored assets to prevent font CSP noise) -->
-  <link rel="stylesheet" href="static/vendor/katex/0.16.22/katex.min.css">
+  <link rel="stylesheet" href="static/vendor/katex/0.16.22/katex.min.css?v=__WEBUI_VERSION__">
   <!-- streaming-markdown: incremental DOM-building markdown parser for live streams -->
   <!-- Self-hosted from npm:streaming-markdown@0.2.15 — no CDN dependency.           -->
   <!-- sha384 of smd.min.js @0.2.15: sha384-T6r95ocN9t3W8tUK2Fa6FPaO7bJryyjyW0WCalrUnpgtm2qXr5xcN4vwPYEJ6vHa -->
   <!-- ES module imports do not support the integrity= attribute (W3C limitation);    -->
   <!-- version is pinned in the vendored file path; hash documented above for audit. -->
   <script type="module">
-    import * as smd from './static/vendor/smd.min.js';
+    import * as smd from './static/vendor/smd.min.js?v=__WEBUI_VERSION__';
     // SRI verification happens at the ES module level via importmap or SW; pinning version in URL.
     // sha384 of smd.min.js @0.2.15: sha384-T6r95ocN9t3W8tUK2Fa6FPaO7bJryyjyW0WCalrUnpgtm2qXr5xcN4vwPYEJ6vHa
     window.smd = smd;
@@ -1778,9 +1778,10 @@
 <script src="static/sessions.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/commands.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/messages.js?v=__WEBUI_VERSION__" defer></script>
-<script src="static/extension_settings.js?v=__WEBUI_VERSION__" defer></script>
-<script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>
-<script src="static/onboarding.js?v=__WEBUI_VERSION__" defer></script>
+<!-- Non-chat panels are inert until boot schedules them or the user opens one. -->
+<script type="application/x-hermes-lazy" data-hermes-lazy="extension-settings" data-src="static/extension_settings.js?v=__WEBUI_VERSION__"></script>
+<script type="application/x-hermes-lazy" data-hermes-lazy="panels" data-src="static/panels.js?v=__WEBUI_VERSION__"></script>
+<script type="application/x-hermes-lazy" data-hermes-lazy="onboarding" data-src="static/onboarding.js?v=__WEBUI_VERSION__"></script>
 <script src="static/boot.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/outline.js?v=__WEBUI_VERSION__" defer></script>
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -2079,6 +2079,19 @@ function closeLiveStream(sessionId, streamId, source){
   // already deleted INFLIGHT[sessionId], so this is a safe no-op.
   if(INFLIGHT[sessionId]){
     INFLIGHT[sessionId].reattach=true;
+    if(typeof window!=='undefined'&&typeof window._recordSessionActivityProjection==='function'){
+      const _backgroundInflight=INFLIGHT[sessionId];
+      window._recordSessionActivityProjection(sessionId,{
+        streamId:live.streamId||streamId||'',
+        status:'running',
+        phase:Array.isArray(_backgroundInflight.toolCalls)&&_backgroundInflight.toolCalls.length
+          ? 'tool'
+          : (String(_backgroundInflight.lastAssistantText||'').trim()?'answer':'thinking'),
+        toolCount:Array.isArray(_backgroundInflight.toolCalls)?_backgroundInflight.toolCalls.length:0,
+        assistantChars:String(_backgroundInflight.lastAssistantText||'').length,
+        reasoningChars:String(_backgroundInflight.lastReasoningText||'').length,
+      });
+    }
     // The browser-side INFLIGHT snapshot is only a compact tail cache. After a
     // session switch it cannot be treated as the full live turn; rebuild from
     // the durable run journal instead so earlier prose/tool rows are not lost.
@@ -2208,18 +2221,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const _liveInflightAssistant = _liveInflightAssistantMessages.length===1
     ? _liveInflightAssistantMessages[0]
     : null;
+  const _recoveryNeedsJournalReplay=!!(INFLIGHT[activeSid]&&(
+    INFLIGHT[activeSid].recoveryNeedsJournalReplay||
+    INFLIGHT[activeSid].journalReplayFromStart
+  ));
   const _fullInflightAssistant = (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText) || '';
   const _joinedInflightSegments = _liveInflightAssistantMessages.length>1
     ? _liveInflightAssistantMessages.map(m=>m&&m.content?String(m.content).trim():'').filter(Boolean).join('\n\n')
     : '';
-  const _lastLiveAssistant = reconnecting
+  const _lastLiveAssistant = reconnecting&&!_recoveryNeedsJournalReplay
     ? (_liveInflightAssistantMessages.length>1
       ? (_fullInflightAssistant || _joinedInflightSegments)
       : (_liveInflightAssistant
         ? (_fullInflightAssistant || _liveInflightAssistant.content || '')
         : _fullInflightAssistant))
     : '';
-  const _lastLiveReasoning = reconnecting
+  const _lastLiveReasoning = reconnecting&&!_recoveryNeedsJournalReplay
     ? (_liveInflightAssistant&&_liveInflightAssistant.reasoning)
       || (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastReasoningText)
       || ''
@@ -2267,6 +2284,21 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _ownsActiveStreamOrBackground(){
     return !_isActiveSession() || S.activeStreamId===streamId;
   }
+  function _recordLiveActivityProjection(patch={}){
+    if(typeof window==='undefined'||typeof window._recordSessionActivityProjection!=='function') return;
+    const inflight=INFLIGHT[activeSid];
+    window._recordSessionActivityProjection(activeSid,{
+      streamId,
+      status:'running',
+      toolCount:Array.isArray(inflight&&inflight.toolCalls)?inflight.toolCalls.length:0,
+      assistantChars:String(assistantText||'').length,
+      reasoningChars:String(reasoningText||'').length,
+      ...patch,
+    });
+  }
+  _recordLiveActivityProjection({
+    phase:String(assistantText||'').trim()?'answer':(String(reasoningText||'').trim()?'thinking':'working'),
+  });
   function _bailOutOfTerminalEventsFromStaleStream(source){
     if(_ownsActiveStreamOrBackground()) return false;
     // This stale stream no longer owns the session — schedule cleanup of ITS own
@@ -2454,6 +2486,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _streamFadeCleanupReduceMotionListener();
     _smdEndParser();
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
+    if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'completed',phase:'done'});
     _clearOwnerInflightState();
     _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
     _clearStreamNotificationBackground(activeSid, streamId);
@@ -2535,6 +2568,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(!inflight) return;
     inflight.lastAssistantText=assistantText;
     inflight.lastReasoningText=reasoningText;
+    if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({
+      phase:String(assistantText||'').trim()?'answer':'thinking',
+    });
     if(!Array.isArray(inflight.messages)) inflight.messages=[];
     let assistantIdx=-1;
     for(let i=inflight.messages.length-1;i>=0;i--){
@@ -5581,6 +5617,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
 
     S.toolCalls=inflight.toolCalls;
+    if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({
+      phase:'tool',
+      toolName:name,
+    });
     persistInflightState();
     return tc;
   }
@@ -5963,6 +6003,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('approval',e=>{
       const d=JSON.parse(e.data);
+      if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'waiting',phase:'approval'});
       _applyToAnchor('approval',d,e);
       showApprovalForSession(activeSid, d, d.pending_count || 1);
       playAttentionSound(_attentionSoundKey(activeSid,'approval',1));
@@ -5971,6 +6012,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('clarify',e=>{
       const d=JSON.parse(e.data);
+      if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'waiting',phase:'clarify'});
       _applyToAnchor('clarify',d,e);
       showClarifyForSession(activeSid, d);
       playAttentionSound(_attentionSoundKey(activeSid,'clarify',1));
@@ -6161,6 +6203,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _markSessionCompletionUnread(completedSid, completedMessageCount);
         }
         if(isSessionViewed) _markSessionViewed(completedSid, completedMessageCount);
+        if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'completed',phase:'done'});
         _clearOwnerInflightState();
         if(typeof _markSessionCompletedInList==='function'){
           _markSessionCompletedInList(completedSession, activeSid);
@@ -6569,6 +6612,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Application-level error sent explicitly by the server (rate limit, crash, etc.)
       // This is distinct from the SSE network 'error' event below.
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
+      if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'error',phase:'error'});
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearStreamNotificationBackground(activeSid, streamId);
@@ -6829,6 +6873,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
+      if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'cancelled',phase:'cancelled'});
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearStreamNotificationBackground(activeSid, streamId);
@@ -6993,6 +7038,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _streamFadeCleanupReduceMotionListener();
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
+      if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'completed',phase:'done'});
       _clearOwnerInflightState();
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup();
@@ -7090,6 +7136,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _cancelAnimationFramePendingStreamRender();
     _streamFadeCleanupReduceMotionListener();
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
+    if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'error',phase:'error'});
     _clearOwnerInflightState();
     _closeSource(source);
     _clearApprovalForOwner();
@@ -7159,6 +7206,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(!st.active&&st.replay_available){
           replayOnly=true;
         }else if(!st.active){
+          if(typeof _recordLiveActivityProjection==='function') _recordLiveActivityProjection({status:'error',phase:'error'});
           _clearOwnerInflightState();
           _clearApprovalForOwner();
           _clearClarifyForOwner('terminal');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -363,6 +363,33 @@ let _sessionObservedStreaming = null;
 const _sessionStreamingById = new Map();
 const _sessionListSnapshotById = new Map();
 const _sessionListSourceById = new Map();
+// One selected conversation owns the live token renderer. Other active
+// conversations keep only this small, session-keyed projection in the sidebar
+// so three concurrent runs remain observable without opening/rendering a token
+// stream for every row.
+const SESSION_ACTIVITY_PROJECTION_MAX_ENTRIES = 32;
+const SESSION_ACTIVITY_PROJECTION_TTL_MS = 10 * 60 * 1000;
+const SESSION_ACTIVITY_ALLOWED_STATUSES = Object.freeze({
+  running:true,
+  waiting:true,
+  completed:true,
+  cancelled:true,
+  error:true,
+});
+const SESSION_ACTIVITY_ALLOWED_PHASES = Object.freeze({
+  queued:true,
+  thinking:true,
+  tool:true,
+  answer:true,
+  approval:true,
+  clarify:true,
+  done:true,
+  cancelled:true,
+  error:true,
+  working:true,
+});
+const _sessionActivityById = new Map();
+let _sessionActivityRenderTimer = 0;
 let _sessionListPointerActive = false;
 let _sessionListLastScrollAt = 0;
 let _pendingSessionListPayload = null;
@@ -379,6 +406,111 @@ const SESSION_LONG_PRESS_DELAY_MS = 400;
 const SESSION_ARCHIVE_SWIPE_THRESHOLD_PX = 128;
 const SESSION_DELETE_SWIPE_THRESHOLD_PX = 128;
 const SESSION_SWIPE_CANCEL_RATIO = 0.75;
+
+function _scheduleSessionActivityProjectionRender(){
+  if(_sessionActivityRenderTimer||typeof renderSessionListFromCache!=='function') return;
+  const flush=()=>{
+    _sessionActivityRenderTimer=0;
+    if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
+  };
+  if(typeof requestAnimationFrame==='function') _sessionActivityRenderTimer=requestAnimationFrame(flush);
+  else _sessionActivityRenderTimer=setTimeout(flush,120);
+}
+
+function _recordSessionActivityProjection(sid, patch={}){
+  const resolvedSid=String(sid||'').trim();
+  if(!resolvedSid||!patch||typeof patch!=='object') return null;
+  const previous=_sessionActivityById.get(resolvedSid)||{};
+  const requestedStatus=String(patch.status||previous.status||'running').trim().toLowerCase();
+  const status=SESSION_ACTIVITY_ALLOWED_STATUSES[requestedStatus]?requestedStatus:'running';
+  const requestedPhase=String(patch.phase||previous.phase||'working').trim().toLowerCase();
+  const phase=SESSION_ACTIVITY_ALLOWED_PHASES[requestedPhase]?requestedPhase:'working';
+  const count=(value,fallback=0)=>{
+    const n=Number(value);
+    return Number.isFinite(n)?Math.max(0,Math.min(999999,Math.floor(n))):fallback;
+  };
+  const next={
+    sid:resolvedSid,
+    streamId:String(patch.streamId||previous.streamId||'').slice(0,160),
+    status,
+    phase,
+    toolCount:count(patch.toolCount, count(previous.toolCount)),
+    eventCount:count(patch.eventCount, count(previous.eventCount)),
+    assistantChars:count(patch.assistantChars, count(previous.assistantChars)),
+    reasoningChars:count(patch.reasoningChars, count(previous.reasoningChars)),
+    toolName:String(patch.toolName||previous.toolName||'').slice(0,48),
+    startedAt:Number(patch.startedAt||previous.startedAt||0)||0,
+    updatedAt:Date.now(),
+  };
+  _sessionActivityById.set(resolvedSid,next);
+  if(_sessionActivityById.size>SESSION_ACTIVITY_PROJECTION_MAX_ENTRIES){
+    const oldest=[..._sessionActivityById.entries()]
+      .sort((a,b)=>Number(a[1]&&a[1].updatedAt||0)-Number(b[1]&&b[1].updatedAt||0))[0];
+    if(oldest&&oldest[0]!==resolvedSid) _sessionActivityById.delete(oldest[0]);
+  }
+  _scheduleSessionActivityProjectionRender();
+  return next;
+}
+
+function _getSessionActivityProjection(sid, session=null){
+  const resolvedSid=String(sid||'').trim();
+  if(!resolvedSid) return null;
+  const local=_sessionActivityById.get(resolvedSid);
+  if(local&&local.updatedAt&&Date.now()-local.updatedAt>SESSION_ACTIVITY_PROJECTION_TTL_MS){
+    _sessionActivityById.delete(resolvedSid);
+  }
+  const current=_sessionActivityById.get(resolvedSid);
+  if(current) return {...current};
+  const serverRunning=!!(session&&(
+    session.is_streaming||session.active_stream_id||session.cron_running||
+    session.pending_user_message||session.has_pending_user_message
+  ));
+  if(!serverRunning) return null;
+  return {
+    sid:resolvedSid,
+    streamId:String(session.active_stream_id||'').slice(0,160),
+    status:'running',
+    phase:'working',
+    toolCount:0,
+    eventCount:0,
+    assistantChars:0,
+    reasoningChars:0,
+    toolName:'',
+    startedAt:Number(session.pending_started_at||0)||0,
+    updatedAt:0,
+  };
+}
+
+function _formatSessionActivityProjection(projection){
+  if(!projection) return '';
+  const status=String(projection.status||'').toLowerCase();
+  const phase=String(projection.phase||'').toLowerCase();
+  if(status==='waiting') return phase==='clarify'?'Question needed':'Approval needed';
+  if(status==='completed') return 'Complete';
+  if(status==='cancelled') return 'Cancelled';
+  if(status==='error') return 'Error';
+  if(phase==='tool'){
+    const toolName=String(projection.toolName||'').trim();
+    const count=Number(projection.toolCount||0);
+    return toolName
+      ? `Using ${toolName}${count>1?` · ${count} tools`:''}`
+      : `Tool activity${count>0?` · ${count}`:''}`;
+  }
+  if(phase==='thinking') return 'Thinking';
+  if(phase==='answer') return 'Writing';
+  if(phase==='approval') return 'Approval needed';
+  if(phase==='clarify') return 'Question needed';
+  return 'Working';
+}
+
+// messages.js calls this stable window hook rather than owning sidebar state.
+// Keeping the map here makes its lifecycle and row rendering session-scoped;
+// no transcript text is accepted or retained by the projection contract.
+if(typeof window!=='undefined'){
+  window._recordSessionActivityProjection=_recordSessionActivityProjection;
+  window._getSessionActivityProjection=_getSessionActivityProjection;
+  window._formatSessionActivityProjection=_formatSessionActivityProjection;
+}
 
 function _manualTitleAuxConfigFromPayload(auxData){
   if(!auxData||typeof auxData!=='object'||Array.isArray(auxData)) return null;
@@ -821,11 +953,22 @@ function _isSessionLocallyStreaming(s) {
 }
 
 function _isSessionEffectivelyStreaming(s) {
+  const projection=s&&s.session_id&&typeof _getSessionActivityProjection==='function'
+    ? _getSessionActivityProjection(s.session_id,s)
+    : null;
+  // A locally projected run can fill the short sidebar refresh gap only when
+  // the row does not carry an explicit idle answer. An explicit server idle
+  // row wins so a stale browser projection cannot manufacture a spinner after
+  // completion/cancellation (#2066).
+  const projectedRunning=!!(projection&&projection.status==='running'&&s&&
+    s.is_streaming===undefined&&!s.active_stream_id&&!s.cron_running&&
+    !_hasPendingUserMessageSignal(s));
   return Boolean(s && (
     s.is_streaming ||
     s.cron_running ||
     _hasPendingUserMessageSignal(s) ||
-    _isSessionLocallyStreaming(s)
+    _isSessionLocallyStreaming(s) ||
+    projectedRunning
   ));
 }
 
@@ -1063,6 +1206,8 @@ function _serverLiveSnapshotInflight(snapshot, uploaded){
   const hasAnchorActivityScene=!!(anchorActivityScene&&Array.isArray(anchorActivityScene.activity_rows)&&anchorActivityScene.activity_rows.length);
   if(!messages.length&&!toolCalls.length&&!lastAssistantText&&!lastReasoningText&&!hasAnchorActivityScene) return null;
   return {
+    recoveryVersion:2,
+    recoveryMode:'server-snapshot',
     streamId:String(snapshot.stream_id||snapshot.streamId||''),
     messages,
     uploaded:Array.isArray(uploaded)?[...uploaded]:[],
@@ -1073,6 +1218,13 @@ function _serverLiveSnapshotInflight(snapshot, uploaded){
     journalSnapshot:true,
     lastAssistantText,
     lastReasoningText,
+    assistantTextTail:lastAssistantText,
+    assistantTextLength:lastAssistantText.length,
+    assistantTextTruncated:false,
+    reasoningTextTail:lastReasoningText,
+    reasoningTextLength:lastReasoningText.length,
+    reasoningTextTruncated:false,
+    recoveryNeedsJournalReplay:false,
     lastRunJournalSeq:Number.isFinite(replayAfterSeq)?Math.max(0,replayAfterSeq):0,
     lastRunJournalEventId:String(snapshot.last_event_id||snapshot.lastEventId||''),
     anchorActivityScene,
@@ -1102,6 +1254,15 @@ function _selectLiveRecoveryInflight(localInflight, serverLiveSnapshot, activeSt
     return localId===requestedActiveId?localInflight:null;
   }
   if(activeId&&localId!==activeId) return selectDurableSnapshot();
+
+  // LocalStorage intentionally contains only a bounded suffix. Once a tail is
+  // marked partial, the durable run-journal snapshot is the only safe source
+  // for the prefix; even a newer local cursor must not cause the suffix to be
+  // treated as a complete assistant message. The next SSE attach replays from
+  // the durable cursor and preserves the same selected-pane renderer.
+  if(localInflight.recoveryMode==='journal-tail'||localInflight.assistantTextTruncated||localInflight.recoveryNeedsJournalReplay){
+    return selectDurableSnapshot();
+  }
 
   const localSeq=Math.max(0,Number(localInflight.lastRunJournalSeq)||0);
   const serverSeq=Math.max(0,Number(serverLiveSnapshot.lastRunJournalSeq)||0);
@@ -1239,6 +1400,9 @@ function _markPollingCompletionUnreadTransitions(sessions) {
     );
     const completedPersistedObservedStream = !cronRunning && Boolean(observedStreaming && !isStreaming);
     if (completedObservedStream || completedPersistedObservedStream || completedWithNewMessages) {
+      if(typeof _recordSessionActivityProjection==='function'){
+        _recordSessionActivityProjection(sid,{status:'completed',phase:'done'});
+      }
       if (!_isSessionActivelyViewedForList(sid)) {
         // Tag cron session-list markers with source+profile so profile-switch
         // reset can clear only inactive-profile cron dots (#5960 / #5975 re-gate).
@@ -2078,6 +2242,8 @@ async function loadSession(sid){
     const stored=loadInflightState(sid, activeStreamId);
     if(stored){
       INFLIGHT[sid]={
+        recoveryVersion:Number(stored.recoveryVersion||1)||1,
+        recoveryMode:String(stored.recoveryMode||'legacy'),
         streamId:String(stored.streamId||''),
         messages:Array.isArray(stored.messages)&&stored.messages.length?stored.messages:[],
         uploaded:Array.isArray(stored.uploaded)?stored.uploaded:[],
@@ -2090,8 +2256,15 @@ async function loadSession(sid){
         todos:Array.isArray(stored.todos)?stored.todos:null,
         todoStateMeta:stored.todoStateMeta||null,
         reattach:true,
-        lastAssistantText:String(stored.lastAssistantText||''),
-        lastReasoningText:String(stored.lastReasoningText||''),
+        lastAssistantText:String((stored.assistantTextTail??stored.lastAssistantText)||''),
+        lastReasoningText:String((stored.reasoningTextTail??stored.lastReasoningText)||''),
+        assistantTextTail:String((stored.assistantTextTail??stored.lastAssistantText)||''),
+        assistantTextLength:Number(stored.assistantTextLength||0)||0,
+        assistantTextTruncated:!!stored.assistantTextTruncated,
+        reasoningTextTail:String((stored.reasoningTextTail??stored.lastReasoningText)||''),
+        reasoningTextLength:Number(stored.reasoningTextLength||0)||0,
+        reasoningTextTruncated:!!stored.reasoningTextTruncated,
+        recoveryNeedsJournalReplay:!!stored.assistantTextTruncated||!!stored.journalReplayFromStart,
         lastRunJournalSeq:Number(stored.lastRunJournalSeq||0)||0,
         lastRunJournalEventId:String(stored.lastRunJournalEventId||''),
         journalReplayFromStart:!!stored.journalReplayFromStart,
@@ -2104,8 +2277,12 @@ async function loadSession(sid){
   }
 
   if(INFLIGHT[sid]&&INFLIGHT[sid].journalReplayFromStart&&activeStreamId){
-    delete INFLIGHT[sid];
-    if(typeof clearInflightState==='function') clearInflightState(sid);
+    // Keep the compact entry long enough to select the durable runtime
+    // snapshot below. If that snapshot is unavailable, attachLiveStream()
+    // replays from sequence zero instead of rendering a suffix as a full turn.
+    INFLIGHT[sid].recoveryNeedsJournalReplay=true;
+    INFLIGHT[sid].lastRunJournalSeq=0;
+    INFLIGHT[sid].lastRunJournalEventId='';
   }
 
   if(activeStreamId&&INFLIGHT[sid]&&!_inflightHasVisibleLiveState(INFLIGHT[sid])){
@@ -2129,7 +2306,14 @@ async function loadSession(sid){
 
   if(INFLIGHT[sid]){
     _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);
+    const replayFromJournal=!!INFLIGHT[sid].recoveryNeedsJournalReplay;
     const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);
+    if(replayFromJournal){
+      const journalMessages=Array.isArray(INFLIGHT[sid].messages)
+        ? INFLIGHT[sid].messages.filter(message=>message&&message.role==='user')
+        : [];
+      inflightMessages.splice(0,inflightMessages.length,...journalMessages);
+    }
     S.toolCalls=[];
     // Switching between active sessions should rebuild the live worklog from
     // this session's INFLIGHT snapshot, not leave prior-session rows in place.
@@ -2152,7 +2336,8 @@ async function loadSession(sid){
       S.messages=_dropCurrentTurnAssistantMessages(S.messages);
     }
     S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
-    S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
+    S.toolCalls=replayFromJournal?[]:(INFLIGHT[sid].toolCalls||[]);
+    if(replayFromJournal) INFLIGHT[sid].toolCalls=[];
     if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[sid].messages||[])){
       INFLIGHT[sid].messages=S.messages;
     }
@@ -2197,7 +2382,7 @@ async function loadSession(sid){
       (Array.isArray(INFLIGHT[sid].toolCalls)&&INFLIGHT[sid].toolCalls.length)
     ));
     let restoredLiveTurn=!!restoredAnchorScene;
-    if(!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
+    if(!replayFromJournal&&!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
       if(!hasStructuredLiveState){
         restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
       }else{
@@ -8099,6 +8284,9 @@ function renderSessionListFromCache(){
     const isActive=_sessionLineageContainsSession(s,activeSidForSidebar);
     const ownStreaming=_isSessionEffectivelyStreaming(s);
     const isStreaming=ownStreaming||!!s._child_session_streaming;
+    const activityProjection=typeof _getSessionActivityProjection==='function'
+      ? _getSessionActivityProjection(s.session_id,s)
+      : null;
     _rememberRenderedStreamingState(s, ownStreaming);
     _rememberRenderedSessionSnapshot(s);
     const hasUnread=(_hasUnreadForSession(s)||!!s._child_session_has_unread)&&!isActive;
@@ -8187,6 +8375,23 @@ function renderSessionListFromCache(){
     ts.className='session-time'+(hasAttentionState?' is-hidden':'');
     ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
+    // Background runs expose only a compact status projection. The selected
+    // row remains intentionally quiet because its full live Worklog owns the
+    // detailed activity view; no token text is copied into this sidebar node.
+    const showBackgroundActivity=!!(!isActive&&activityProjection&&(
+      isStreaming||activityProjection.status!=='running'
+    ));
+    if(showBackgroundActivity){
+      const activityStatus=document.createElement('span');
+      activityStatus.className='session-activity-status';
+      activityStatus.dataset.sessionActivityStatus=String(activityProjection.status||'');
+      activityStatus.dataset.sessionActivitySessionId=s.session_id;
+      activityStatus.setAttribute('data-session-activity-status',String(activityProjection.status||''));
+      activityStatus.textContent=_formatSessionActivityProjection(activityProjection);
+      activityStatus.title=activityStatus.textContent;
+      activityStatus.style.cssText='display:inline-block;max-width:112px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:0 1 auto;font-size:10px;color:var(--muted);opacity:.9;';
+      titleRow.appendChild(activityStatus);
+    }
     // Project color dot: placed BETWEEN title and timestamp, not inside the
     // title span. Inside the title span it would be clipped by the ellipsis
     // truncation, becoming invisible exactly when the title is long enough

--- a/static/style.css
+++ b/static/style.css
@@ -6616,15 +6616,16 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
   .queue-pill-count{color:var(--text);}
   .queue-pill-chevron{margin-left:auto;opacity:.5;}
 
-/* ── Mobile: prevent iOS auto-zoom on input focus ─────────────────────────
+/* ── Mobile: preserve the iOS input zoom floor ────────────────────────────
    iOS Safari zooms in when a focused input/select has font-size < 16px.
-   This media query targets touch-primary devices (phones and tablets) and
-   bumps all interactive inputs to the minimum non-zoom threshold.
+   Page zoom remains user-controlled in the viewport meta tag. This media
+   query targets touch-primary devices (phones and tablets) and keeps all
+   interactive inputs at the minimum non-auto-zoom threshold.
    The textarea#msg composer is already 16px; the sidebar search, rename
    inputs, settings selects, and dialog inputs are not.  (#1167)
 ──────────────────────────────────────────────────────────────────────── */
 @media (hover:none) and (pointer:coarse){
-  input,textarea,select{font-size:max(16px,1em)!important;}
+  input,textarea,select{font-size:16px!important;font-size:max(16px,1em)!important;}
 }
 
 /* ── PDF preview ─────────────────────────────────────────────────────────── */

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,9 @@
 
 // Cache version is injected by the server at request time (routes.py /sw.js handler).
 // Bumps automatically whenever the git commit changes — no manual edits needed.
+const CACHE_PREFIX = 'hermes-shell-';
 const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';
+const STAGING_CACHE_NAME = CACHE_NAME + '-staging';
 
 // Static assets that form the app shell.
 //
@@ -16,9 +18,11 @@ const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';
 // here, every cache lookup against `?v=...` URLs would miss and fall through
 // to network, defeating the pre-cache.
 //
-// Do not pre-cache './' or login assets here: under password auth they can be
-// either the authenticated app shell or login code, and stale cached responses
-// can make valid password submits fail until the user clears browser cache.
+// Keep the critical chat shell small enough to pre-cache before first paint.
+// Non-chat/bootstrap-heavy bundles are version-pinned but loaded on demand.
+// Do not pre-cache './', manifest.json, or login assets: under password auth
+// they can be the authenticated app shell or login code, and stale cached
+// responses can make valid password submits fail until the user clears cache.
 // Navigations populate './' only after a successful non-redirect network load.
 const VQ = '?v=__WEBUI_VERSION__';
 const SHELL_ASSETS = [
@@ -29,44 +33,72 @@ const SHELL_ASSETS = [
   './static/ui.js' + VQ,
   './static/messages.js' + VQ,
   './static/sessions.js' + VQ,
-  './static/panels.js' + VQ,
   './static/commands.js' + VQ,
   './static/icons.js' + VQ,
   './static/i18n.js' + VQ,
   './static/workspace.js' + VQ,
   './static/terminal.js' + VQ,
-  './static/onboarding.js' + VQ,
+  './static/outline.js' + VQ,
   './static/vendor/smd.min.js' + VQ,
   './static/vendor/katex/0.16.22/katex.min.css' + VQ,
   './static/vendor/katex/0.16.22/katex.min.js' + VQ,
   './static/favicon.svg',
   './static/favicon-32.png',
-  './manifest.json',
+];
+
+// These assets are cached only after the corresponding inert script in
+// index.html is activated by boot.js. Keeping them out of SHELL_ASSETS avoids
+// making first paint wait on settings/task/workspace code.
+const LAZY_ASSETS = [
+  './static/extension_settings.js' + VQ,
+  './static/panels.js' + VQ,
+  './static/onboarding.js' + VQ,
 ];
 
 function deleteOldShellCaches() {
   return caches.keys().then((keys) =>
     Promise.all(
-      keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
+      keys
+        .filter((k) => k.startsWith(CACHE_PREFIX) && k !== CACHE_NAME)
+        .map((k) => caches.delete(k))
     )
   );
 }
 
-// Install: prune old shell caches first, then pre-cache the app shell. Doing
-// this before caches.open(CACHE_NAME) avoids a temporary double-cache window on
-// quota-sensitive browsers during frequent version bumps.
+// Fill a staging cache first so a failed install cannot leave a partially
+// populated current-version cache. The old version remains available until the
+// new worker activates successfully.
+async function precacheShell() {
+  await caches.delete(STAGING_CACHE_NAME);
+  const stagingCache = await caches.open(STAGING_CACHE_NAME);
+  try {
+    await stagingCache.addAll(SHELL_ASSETS);
+    const stagedRequests = await stagingCache.keys();
+    const currentCache = await caches.open(CACHE_NAME);
+    await Promise.all(stagedRequests.map(async (request) => {
+      const response = await stagingCache.match(request);
+      if (!response || response.status !== 200 || response.redirected) {
+        throw new Error('invalid shell response: ' + request.url);
+      }
+      await currentCache.put(request, response);
+    }));
+    await caches.delete(STAGING_CACHE_NAME);
+  } catch (error) {
+    await caches.delete(STAGING_CACHE_NAME);
+    throw error;
+  }
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    deleteOldShellCaches().then(() =>
-      caches.open(CACHE_NAME).then((cache) => {
-        return cache.addAll(SHELL_ASSETS).catch((err) => {
-          // Non-fatal: if any asset fails, still activate
-          console.warn('[sw] Shell pre-cache partial failure:', err);
-        });
+    precacheShell()
+      .then(() => { self.skipWaiting(); })
+      .catch((err) => {
+        // Reject the install so the existing worker/cache remains usable.
+        console.warn('[sw] Shell pre-cache failed; keeping previous cache:', err);
+        throw err;
       })
-    )
   );
-  self.skipWaiting();
 });
 
 // Activate: keep the old-cache cleanup as a safety net in case install was
@@ -80,7 +112,7 @@ self.addEventListener('activate', (event) => {
 // - API calls (/api/*, /stream) → always network (never cache)
 // - Login assets → always network (never cache stale auth code)
 // - Page navigations → network-first so auth redirects/cookies are honored
-// - Shell assets → network-first with cache fallback
+// - Shell assets → stale-while-revalidate (current version served immediately)
 // - Everything else → network-only
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
@@ -127,11 +159,11 @@ self.addEventListener('fetch', (event) => {
           !response.redirected
         ) {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put('./', clone));
+          caches.open(CACHE_NAME).then((cache) => cache.put('./', clone)).catch(() => {});
         }
         return response;
       }).catch(() => {
-        return caches.match('./').then((cached) => cached || new Response(
+        return caches.match('./', { cacheName: CACHE_NAME }).then((cached) => cached || new Response(
           '<html><body style="font-family:sans-serif;padding:2rem;background:#1a1a1a;color:#ccc">' +
           '<h2>You are offline</h2>' +
           '<p>Hermes requires a server connection. Please check your network and try again.</p>' +
@@ -151,25 +183,63 @@ self.addEventListener('fetch', (event) => {
     ? url.pathname.slice(scopePath.length)
     : url.pathname.replace(/^\/+/, '');
   const shellPath = './' + relPath.replace(/^\/+/, '') + url.search;
-  if (!SHELL_ASSETS.includes(shellPath)) return;
+  const isShellAsset = SHELL_ASSETS.includes(shellPath);
+  const isLazyAsset = LAZY_ASSETS.includes(shellPath);
+  if (!isShellAsset && !isLazyAsset) return;
 
-  // Shell assets: network-first with cache fallback. This keeps offline support
-  // but avoids executing stale JS/CSS after a local hotfix when WEBUI_VERSION
-  // has not changed yet (e.g. before a guarded restart updates the ?v token).
+  if (isShellAsset) {
+    // Shell assets: stale-while-revalidate. The version query makes this safe:
+    // a deployment creates a new cache key, while repeat loads return the
+    // current immutable shell immediately and refresh it in the background.
+    event.respondWith(
+      caches.open(CACHE_NAME).then((cache) => cache.match(event.request).then((cached) => {
+        const refresh = fetch(new Request(event.request, { cache: 'no-store' })).then((response) => {
+          if (
+            event.request.method === 'GET' &&
+            response.status === 200 &&
+            !response.redirected
+          ) {
+            cache.put(event.request, response.clone()).catch(() => {});
+          }
+          return response;
+        });
+        if (cached) {
+          event.waitUntil(refresh.catch(() => {}));
+          return cached;
+        }
+        return refresh;
+      })).catch(() => new Response('Offline', {
+        status: 503,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      }))
+    );
+    return;
+  }
+
+  // Lazy panel bundles use the same versioned key but do not block first paint.
+  // Once requested, return a cached copy immediately and refresh it in the
+  // background for the next panel visit.
   event.respondWith(
-    fetch(new Request(event.request, { cache: 'no-store' })).then((response) => {
-      if (
-        event.request.method === 'GET' &&
-        response.status === 200
-      ) {
-        const clone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+    caches.open(CACHE_NAME).then((cache) => cache.match(event.request).then((cached) => {
+      const refresh = fetch(new Request(event.request, { cache: 'no-store' })).then((response) => {
+        if (
+          event.request.method === 'GET' &&
+          response.status === 200 &&
+          !response.redirected
+        ) {
+          cache.put(event.request, response.clone()).catch(() => {});
+        }
+        return response;
+      });
+      if (cached) {
+        event.waitUntil(refresh.catch(() => {}));
+        return cached;
       }
-      return response;
-    }).catch(() => caches.match(event.request).then((cached) => cached || new Response('Offline', {
+      return refresh;
+    })).catch(() => new Response('Offline', {
       status: 503,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    })))
+    }))
   );
 });
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -9336,6 +9336,25 @@ function autoReadLastAssistant(){
 // ── Reconnect banner (B4/B5: reload resilience) ──
 const INFLIGHT_KEY = 'hermes-webui-inflight'; // localStorage key for in-flight session tracking
 const INFLIGHT_STATE_KEY = 'hermes-webui-inflight-state'; // localStorage snapshots for mid-stream reload recovery
+// The browser cache is only a recovery accelerator. The run journal and the
+// canonical session payload remain authoritative, so the cache must never
+// mirror the whole growing transcript. Keep these hard ceilings independent of
+// the older server-configurable limits: a permissive setting must not turn a
+// token stream into an unbounded localStorage writer.
+const INFLIGHT_STATE_SCHEMA_VERSION = 2;
+const INFLIGHT_STATE_HARD_LIMITS = {
+  maxSessions:8,
+  messages:12,
+  toolCalls:16,
+  uploaded:20,
+  activityBurstAnchors:32,
+  todos:20,
+  textTailChars:8192,
+  fieldChars:512,
+  stringChars:16000,
+  entryJsonChars:76000,
+  jsonChars:262144,
+};
 const INFLIGHT_STATE_DEFAULT_LIMITS = {
   maxSessions:8,
   messages:24,
@@ -9379,10 +9398,13 @@ function _isStorageQuotaError(err){
 }
 function _truncateInflightValue(value, maxChars){
   const limits=_getInflightStateLimits();
-  const stringLimit=_boundedInflightInt(maxChars, limits.stringChars, 1000, 500000);
+  const stringLimit=Math.min(
+    _boundedInflightInt(maxChars, limits.stringChars, 1000, 500000),
+    INFLIGHT_STATE_HARD_LIMITS.stringChars
+  );
   if(typeof value==='string'){
     if(value.length<=stringLimit) return value;
-    return value.slice(0,stringLimit)+'\n\n[truncated for browser recovery storage]';
+    return '[truncated for browser recovery storage]\n\n'+value.slice(-stringLimit);
   }
   if(Array.isArray(value)) return value.map(v=>_truncateInflightValue(v, Math.max(2000, Math.floor(stringLimit/2))));
   if(value&&typeof value==='object'){
@@ -9392,47 +9414,176 @@ function _truncateInflightValue(value, maxChars){
   }
   return value;
 }
+function _inflightRecoveryTail(value, maxChars=INFLIGHT_STATE_HARD_LIMITS.textTailChars){
+  const text=String(value||'');
+  return text.length<=maxChars?text:text.slice(-maxChars);
+}
+function _inflightRecoveryValue(value, maxChars=INFLIGHT_STATE_HARD_LIMITS.fieldChars, depth=0){
+  if(value==null||typeof value==='number'||typeof value==='boolean') return value;
+  if(typeof value==='string') return _inflightRecoveryTail(value,maxChars);
+  if(depth>4) return '[nested recovery value omitted]';
+  if(Array.isArray(value)){
+    return value.slice(-8).map(item=>_inflightRecoveryValue(item,maxChars,depth+1));
+  }
+  if(typeof value==='object'){
+    const out={};
+    Object.entries(value).slice(0,12).forEach(([key,item])=>{
+      out[String(key).slice(0,80)]=_inflightRecoveryValue(item,maxChars,depth+1);
+    });
+    return out;
+  }
+  return String(value).slice(0,maxChars);
+}
+function _compactInflightMessage(message){
+  if(!message||typeof message!=='object'||!message.role) return null;
+  const role=String(message.role);
+  const compact={role};
+  if(message._live) compact._live=true;
+  if(message._ts!=null) compact._ts=message._ts;
+  const rawContent=message.content;
+  if(typeof rawContent==='string'){
+    // A user prompt benefits from its prefix for identity/deduplication; a
+    // live assistant message benefits from its newest suffix. Neither is a
+    // substitute for the canonical transcript or journal replay.
+    compact.content=role==='assistant'
+      ? _inflightRecoveryTail(rawContent,INFLIGHT_STATE_HARD_LIMITS.fieldChars)
+      : String(rawContent).slice(0,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+    if(rawContent.length>INFLIGHT_STATE_HARD_LIMITS.fieldChars) compact._recovery_truncated=true;
+    compact._recovery_text_length=rawContent.length;
+  }else if(Array.isArray(rawContent)){
+    compact.content=rawContent.slice(-8).map(part=>_inflightRecoveryValue(part,INFLIGHT_STATE_HARD_LIMITS.fieldChars));
+  }else if(rawContent!=null){
+    compact.content=_inflightRecoveryValue(rawContent,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+  }
+  if(typeof message.reasoning==='string'&&message.reasoning){
+    compact.reasoning=_inflightRecoveryTail(message.reasoning,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+    if(message.reasoning.length>INFLIGHT_STATE_HARD_LIMITS.fieldChars) compact._recovery_reasoning_truncated=true;
+  }
+  if(Array.isArray(message.attachments)&&message.attachments.length){
+    compact.attachments=message.attachments.slice(-8).map(item=>{
+      if(typeof item==='string') return item.slice(0,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+      const name=item&&typeof item==='object'?(item.name||item.filename||item.path||''):'';
+      return String(name).slice(0,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+    }).filter(Boolean);
+  }
+  return compact;
+}
+function _compactInflightToolCall(toolCall){
+  if(!toolCall||typeof toolCall!=='object') return null;
+  const compact={};
+  for(const key of [
+    'tid','id','tool_call_id','tool_use_id','call_id','name','done','is_error',
+    'started_at','completed_at','assistant_msg_idx','activityBurstId',
+    'activitySegmentSeq',
+  ]){
+    if(toolCall[key]!==undefined&&toolCall[key]!==null) compact[key]=toolCall[key];
+  }
+  if(toolCall.args!==undefined) compact.args=_inflightRecoveryValue(toolCall.args);
+  if(toolCall.snippet!==undefined) compact.snippet=_inflightRecoveryTail(toolCall.snippet,INFLIGHT_STATE_HARD_LIMITS.fieldChars);
+  return compact;
+}
+function _compactInflightTodo(todo){
+  if(!todo||typeof todo!=='object') return null;
+  const compact={};
+  for(const key of ['id','content','text','status','state','priority']){
+    if(todo[key]!==undefined&&todo[key]!==null){
+      compact[key]=typeof todo[key]==='string'
+        ? String(todo[key]).slice(0,INFLIGHT_STATE_HARD_LIMITS.fieldChars)
+        : todo[key];
+    }
+  }
+  return compact;
+}
 function _compactInflightState(state){
   const limits=_getInflightStateLimits();
-  const messages=Array.isArray(state.messages)?state.messages.slice(-limits.messages):[];
-  const toolCalls=Array.isArray(state.toolCalls)?state.toolCalls.slice(-limits.toolCalls):[];
+  const messages=Array.isArray(state.messages)
+    ? state.messages.slice(-limits.messages).slice(-INFLIGHT_STATE_HARD_LIMITS.messages)
+    : [];
+  const toolCalls=Array.isArray(state.toolCalls)
+    ? state.toolCalls.slice(-limits.toolCalls).slice(-INFLIGHT_STATE_HARD_LIMITS.toolCalls)
+    : [];
   // Phase 2: persist the live todo snapshot so reload / SSE reattach
   // restores the panel without waiting for the next live `todo` write.
-  // The list is bounded by the agent (typically <20 items) and each
-  // item is small, so no per-list cap is needed beyond the existing
-  // stringChars truncation in _truncateInflightValue.
-  const todos=Array.isArray(state.todos)?state.todos:null;
+  // Keep only the latest bounded todo items; the canonical session payload is
+  // the source for the complete list after reload.
+  const todos=Array.isArray(state.todos)
+    ? state.todos.slice(-Math.min(limits.messages,INFLIGHT_STATE_HARD_LIMITS.todos)).map(_compactInflightTodo).filter(Boolean)
+    : null;
   const todoStateMeta=(state.todoStateMeta&&typeof state.todoStateMeta==='object')?state.todoStateMeta:null;
+  let assistantText=String(state.lastAssistantText||'');
+  let reasoningText=String(state.lastReasoningText||'');
+  if(!assistantText||!reasoningText){
+    for(let i=messages.length-1;i>=0;i--){
+      const message=messages[i];
+      if(!message||message.role!=='assistant') continue;
+      if(!assistantText&&typeof message.content==='string') assistantText=message.content;
+      if(!reasoningText&&typeof message.reasoning==='string') reasoningText=message.reasoning;
+      if(assistantText&&reasoningText) break;
+    }
+  }
+  const assistantTextTail=_inflightRecoveryTail(assistantText);
+  const reasoningTextTail=_inflightRecoveryTail(reasoningText);
+  const compactMessages=messages.map(_compactInflightMessage).filter(Boolean);
+  const compactToolCalls=toolCalls.map(_compactInflightToolCall).filter(Boolean);
+  const compactAnchors=Array.isArray(state.activityBurstAnchors)
+    ? state.activityBurstAnchors.slice(-Math.min(50,INFLIGHT_STATE_HARD_LIMITS.activityBurstAnchors)).map(anchor=>({
+      id:Number(anchor&&anchor.id)||0,
+      textEnd:Number(anchor&&anchor.textEnd)||0,
+    })).filter(anchor=>anchor.id>0)
+    : [];
   return _truncateInflightValue({
+    recoveryVersion:INFLIGHT_STATE_SCHEMA_VERSION,
+    recoveryMode:'journal-tail',
     streamId:state.streamId||null,
-    messages,
-    uploaded:Array.isArray(state.uploaded)?state.uploaded.slice(-20):[],
-    toolCalls,
-    lastAssistantText:state.lastAssistantText||'',
-    lastReasoningText:state.lastReasoningText||'',
+    // Keep these legacy field names as bounded suffixes so older readers can
+    // still reattach. New readers also use the explicit length/tail metadata
+    // to know that the value is not a complete assistant transcript.
+    messages:compactMessages,
+    uploaded:Array.isArray(state.uploaded)
+      ? state.uploaded.slice(-Math.min(20,INFLIGHT_STATE_HARD_LIMITS.uploaded)).map(item=>String(item).slice(0,INFLIGHT_STATE_HARD_LIMITS.fieldChars))
+      : [],
+    toolCalls:compactToolCalls,
+    lastAssistantText:assistantTextTail,
+    lastReasoningText:reasoningTextTail,
+    assistantTextTail,
+    assistantTextLength:assistantText.length,
+    assistantTextTruncated:assistantText.length>assistantTextTail.length,
+    reasoningTextTail,
+    reasoningTextLength:reasoningText.length,
+    reasoningTextTruncated:reasoningText.length>reasoningTextTail.length,
+    recoveryCursor:{
+      seq:Number(state.lastRunJournalSeq||0)||0,
+      eventId:String(state.lastRunJournalEventId||''),
+    },
     lastRunJournalSeq:state.lastRunJournalSeq||0,
     lastRunJournalEventId:state.lastRunJournalEventId||'',
     journalReplayFromStart:!!state.journalReplayFromStart,
     currentActivityBurstId:state.currentActivityBurstId||0,
     currentLiveSegmentSeq:state.currentLiveSegmentSeq||0,
-    activityBurstAnchors:Array.isArray(state.activityBurstAnchors)?state.activityBurstAnchors.slice(-50):[],
+    activityBurstAnchors:compactAnchors,
     todos,
-    todoStateMeta,
-  }, limits.stringChars);
+    todoStateMeta:todoStateMeta?{
+      ts:Number(todoStateMeta.ts||0)||0,
+      source:String(todoStateMeta.source||'').slice(0,80),
+      version:Number(todoStateMeta.version||1)||1,
+    }:null,
+  }, Math.min(limits.stringChars,INFLIGHT_STATE_HARD_LIMITS.stringChars));
 }
 function _writeInflightStateMap(all){
   const limits=_getInflightStateLimits();
+  const maxSessions=Math.min(limits.maxSessions,INFLIGHT_STATE_HARD_LIMITS.maxSessions);
+  const maxJsonChars=Math.min(limits.jsonChars,INFLIGHT_STATE_HARD_LIMITS.jsonChars);
   const entries=Object.entries(all||{})
     .sort((a,b)=>Number(b[1]&&b[1].updated_at||0)-Number(a[1]&&a[1].updated_at||0))
-    .slice(0,limits.maxSessions);
+    .slice(0,maxSessions);
   const compact={};
   for(const [sid,entry] of entries) compact[sid]=entry;
   let json=JSON.stringify(compact);
-  if(json.length>limits.jsonChars){
+  if(json.length>maxJsonChars){
     const current=entries[0];
     json=JSON.stringify(current?{[current[0]]:current[1]}:{});
   }
-  if(json.length>limits.jsonChars){
+  if(json.length>maxJsonChars){
     localStorage.removeItem(INFLIGHT_STATE_KEY);
     return false;
   }
@@ -9474,7 +9625,7 @@ function clearInflightState(sid){
     const all=_readInflightStateMap();
     if(!(sid in all)) return;
     delete all[sid];
-    if(Object.keys(all).length) localStorage.setItem(INFLIGHT_STATE_KEY, JSON.stringify(all));
+    if(Object.keys(all).length) _writeInflightStateMap(all);
     else localStorage.removeItem(INFLIGHT_STATE_KEY);
   }catch(_){ }
 }

--- a/tests/test_issue2389_storage_pressure.py
+++ b/tests/test_issue2389_storage_pressure.py
@@ -13,18 +13,27 @@ def _function_block(src: str, name: str, window: int = 1600) -> str:
     return src[idx : idx + window]
 
 
-def test_service_worker_install_deletes_old_caches_before_opening_new_cache():
+def test_service_worker_install_stages_before_activation_cleanup():
+    """A failed precache must leave the previous version available."""
     install_idx = SW_SRC.find("self.addEventListener('install'")
     assert install_idx != -1, "service worker must define an install handler"
     install_block = SW_SRC[install_idx : SW_SRC.find("self.addEventListener('activate'", install_idx)]
-    cleanup_idx = install_block.find("deleteOldShellCaches().then")
-    open_idx = install_block.find("caches.open(CACHE_NAME)")
-    assert cleanup_idx != -1, "install must delete stale shell caches before pre-cache"
-    assert open_idx != -1, "install must still pre-cache the current shell cache"
-    assert cleanup_idx < open_idx, (
-        "opening the new shell cache before deleting old ones creates a temporary "
-        "double-cache window that increases quota pressure"
+    precache_idx = install_block.find("precacheShell()")
+    skip_idx = install_block.find("self.skipWaiting()")
+    assert precache_idx != -1, "install must stage the current shell before activation"
+    assert skip_idx > precache_idx, "the worker must not skip waiting before precache succeeds"
+    assert "deleteOldShellCaches().then" not in install_block, (
+        "install must retain the previous cache until the staged worker activates"
     )
+
+    precache_idx = SW_SRC.find("async function precacheShell()")
+    precache_block = SW_SRC[precache_idx:install_idx]
+    staging_idx = precache_block.find("caches.open(STAGING_CACHE_NAME)")
+    current_idx = precache_block.find("caches.open(CACHE_NAME)")
+    assert staging_idx != -1 and current_idx != -1
+    assert staging_idx < current_idx, "current cache may only be populated after staging succeeds"
+    assert "await stagingCache.addAll(SHELL_ASSETS)" in precache_block
+    assert "await caches.delete(STAGING_CACHE_NAME)" in precache_block
 
 
 def test_service_worker_keeps_activate_cleanup_safety_net():

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1020,9 +1020,15 @@ def test_100dvh_viewport_height():
         "style.css must use 100dvh for correct mobile viewport height (100vh hides content under address bar)"
 
 
-def test_viewport_disables_page_zoom_for_native_pwa_shell():
-    """Installed PWA launches should not rubber-band into browser-style page zoom."""
-    assert 'name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"' in HTML
+def test_viewport_allows_page_zoom_for_accessible_mobile_shell():
+    """Mobile users must retain browser zoom controls in the PWA shell."""
+    match = re.search(r'<meta name="viewport" content="([^"]+)">', HTML)
+    assert match
+    content = match.group(1)
+    assert "width=device-width" in content
+    assert "initial-scale=1" in content
+    assert "maximum-scale" not in content
+    assert "user-scalable" not in content
 
 
 def test_pwa_safe_area_top_stays_scoped_to_installed_modes():

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -110,21 +110,16 @@ class TestServiceWorker:
             "sw.js must await/then the caches.match() result before applying the fallback"
         )
 
-    def test_sw_shell_assets_are_network_first_with_cache_fallback(self):
-        """Local hotfixes can change JS/CSS while WEBUI_VERSION stays unchanged.
-
-        If shell assets are cache-first, the browser can keep executing stale
-        sessions.js even though the server/curl already returns patched source.
-        Network-first preserves offline fallback without hiding local fixes.
-        """
+    def test_sw_shell_assets_are_stale_while_revalidate(self):
+        """Version-pinned shell assets should paint from CacheStorage first."""
         src = SW.read_text(encoding="utf-8")
-        assert "Shell assets: network-first with cache fallback" in src
-        assert "fetch(new Request(event.request, { cache: 'no-store' })).then((response)" in src
-        assert "caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))" in src
-        assert ".catch(() => caches.match(event.request)" in src
-        assert "if (cached) return cached;" not in src, (
-            "shell assets must not be cache-first; stale JS can survive hard refresh"
-        )
+        marker = "// Shell assets: stale-while-revalidate"
+        assert marker in src
+        block = src[src.find(marker):src.find("  // Lazy panel bundles", src.find(marker))]
+        assert "cache.match(event.request)" in block
+        assert "fetch(new Request(event.request, { cache: 'no-store' }))" in block
+        assert block.index("cache.match(event.request)") < block.index("fetch(")
+        assert "cache.put(event.request, response.clone())" in block
 
     def test_sw_never_caches_api_responses(self):
         """Defensive: the SW must not cache responses from /api/* paths.
@@ -272,20 +267,16 @@ class TestIndexHtmlIntegration:
                 "?v=__WEBUI_VERSION__ to match the URL the page requests"
             )
 
-    def test_sw_shell_assets_are_network_first(self):
-        """Shell JS/CSS must prefer the network, then fall back to CacheStorage.
-
-        Cache-first with an unchanged local dev version can keep stale boot.js
-        loaded after a hotfix, which is exactly how browser chrome/theme-color
-        regressions survive a patch until someone performs cache exorcism.
-        """
+    def test_sw_shell_assets_are_cache_first_with_background_refresh(self):
+        """Versioned shell JS/CSS should return the current cache before revalidation."""
         src = SW.read_text(encoding="utf-8")
-        marker = "// Shell assets: network-first with cache fallback"
+        marker = "// Shell assets: stale-while-revalidate"
         assert marker in src
-        block = src[src.find(marker):src.find(marker) + 900]
-        assert "fetch(new Request(event.request, { cache: 'no-store' })).then" in block
-        assert "caches.match(event.request)" in block
-        assert "caches.match(event.request).then((cached)" not in block[:250]
+        block = src[src.find(marker):src.find("  // Lazy panel bundles", src.find(marker))]
+        assert "cache.match(event.request)" in block
+        assert "fetch(new Request(event.request, { cache: 'no-store' }))" in block
+        assert block.index("cache.match(event.request)") < block.index("fetch(")
+        assert "event.waitUntil(refresh.catch(() => {}))" in block
 
     def test_index_loads_pwa_startup_helper_early(self):
         """The installed-app shell should classify standalone/offline mode before

--- a/tests/test_run_journal_seq_cache.py
+++ b/tests/test_run_journal_seq_cache.py
@@ -6,6 +6,7 @@ O(n^2) over a run. The cache seeds once per path and then increments in memory
 while staying consistent with ``RunJournalWriter`` (both share one cache under
 the same per-path lock).
 """
+import json
 import threading
 
 import pytest  # noqa: F401  # top-level import keeps pytest collection unambiguous
@@ -173,3 +174,73 @@ def test_concurrent_appends_produce_unique_gapless_seqs(tmp_path):
         t.join()
 
     assert sorted(results) == list(range(1, 41))
+
+
+def test_concurrent_writers_append_in_reserved_order_and_replay_gaplessly(tmp_path, monkeypatch):
+    session_id = "sess_writer_order"
+    run_id = "run_writer_order"
+    writer_a = run_journal.RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer_b = run_journal.RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    first_append_entered = threading.Event()
+    second_append_written = threading.Event()
+    results = {}
+    errors = []
+    results_lock = threading.Lock()
+    real_append = run_journal.append_run_event
+
+    def gated_append(*args, **kwargs):
+        seq = kwargs.get("seq")
+        if seq == 1:
+            first_append_entered.set()
+            lock = run_journal._lock_for(
+                tmp_path / run_journal.RUN_JOURNAL_DIR_NAME / session_id / f"{run_id}.jsonl"
+            )
+            # The pre-fix writer released the per-run lock before calling the
+            # public append function. Hold seq 1 at that boundary so seq 2 can
+            # reserve and append first. The fixed writer owns its re-entrant
+            # lock through the nested append and therefore must not wait here.
+            if not getattr(lock, "_is_owned", lambda: False)():
+                assert second_append_written.wait(timeout=5), "seq 2 did not append"
+        event = real_append(*args, **kwargs)
+        if seq == 2:
+            second_append_written.set()
+        return event
+
+    monkeypatch.setattr(run_journal, "append_run_event", gated_append)
+
+    def append_from(writer, label, text):
+        try:
+            event = writer.append_sse_event("token", {"text": text})
+            with results_lock:
+                results[label] = event
+        except BaseException as exc:  # noqa: BLE001 - report thread failures below
+            with results_lock:
+                errors.append(exc)
+
+    thread_a = threading.Thread(target=append_from, args=(writer_a, "a", "first"))
+    thread_a.start()
+    assert first_append_entered.wait(timeout=5), "seq 1 append did not start"
+
+    thread_b = threading.Thread(target=append_from, args=(writer_b, "b", "second"))
+    thread_b.start()
+    thread_a.join(timeout=10)
+    thread_b.join(timeout=10)
+
+    assert not thread_a.is_alive() and not thread_b.is_alive(), "writer threads did not finish"
+    assert not errors, f"concurrent writer failed: {errors!r}"
+    assert {event["seq"] for event in results.values()} == {1, 2}
+
+    journal_path = tmp_path / run_journal.RUN_JOURNAL_DIR_NAME / session_id / f"{run_id}.jsonl"
+    on_disk = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert [event["seq"] for event in on_disk] == [1, 2]
+    assert [event["payload"]["text"] for event in on_disk] == ["first", "second"]
+
+    replay = run_journal.read_session_run_events(
+        session_id,
+        after_event_id=f"{run_id}:1",
+        session_dir=tmp_path,
+    )
+    assert replay["status"] == "ok"
+    assert [event["event_id"] for event in replay["events"]] == [f"{run_id}:2"]
+    assert [event["payload"]["text"] for event in replay["events"]] == ["second"]

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -198,7 +199,7 @@ def test_session_list_cache_follower_wait_stage_when_rebuild_inflight(monkeypatc
     assert "session_list_cache_hit" in owner_diag.stages or "session_list_cache_stored" in owner_diag.stages
 
 
-def test_session_list_cache_source_changed_owner_rebuilds_while_follower_reuses_stale(monkeypatch):
+def test_session_list_cache_source_changed_callers_reuse_stale_while_rebuilding(monkeypatch):
     routes._session_list_cache_clear()
 
     key = routes._session_list_cache_key(
@@ -217,9 +218,9 @@ def test_session_list_cache_source_changed_owner_rebuilds_while_follower_reuses_
             payload,
         )
     # Simulate state.db/WAL/fingerprint changing after the stale payload was
-    # cached. The owner must rebuild synchronously so committed external state is
-    # visible immediately, but followers can still use stale while that rebuild
-    # is blocked; otherwise sidebar polling can pile up behind a slow rebuild.
+    # cached. Source changes use the same stale-while-revalidate path as TTL
+    # expiry: every caller can reuse the snapshot while one background owner
+    # rebuilds it, so sidebar polling never piles up behind a slow rebuild.
     monkeypatch.setattr(
         routes,
         "_session_list_cache_source_stamp",
@@ -265,10 +266,21 @@ def test_session_list_cache_source_changed_owner_rebuilds_while_follower_reuses_
         owner_thread.join(2.0)
         follower_thread.join(2.0)
 
-    assert owner_result["payload"] == _session_cache_payload("fresh")
+    assert owner_result["payload"] == _session_cache_payload("stale")
     assert follower_result["payload"] == _session_cache_payload("stale")
-    assert "session_list_cache_rebuild_owner" in owner_diag.stages
-    assert "session_list_cache_wait_stale_fallback" in follower_diag.stages
+    assert "session_list_cache_stale_background_rebuild" in owner_diag.stages
+    assert (
+        "session_list_cache_stale_return" in follower_diag.stages
+        or "session_list_cache_stale_background_rebuild" in follower_diag.stages
+    )
+
+    release.set()
+    for _ in range(20):
+        cached, _fresh = routes._session_list_cache_get(key, allow_stale=True)
+        if cached == _session_cache_payload("fresh"):
+            break
+        time.sleep(0.05)
+    assert cached == _session_cache_payload("fresh")
 
 
 def test_session_list_cache_owner_returns_stale_and_rebuilds_in_background(monkeypatch):

--- a/tests/test_workstream_b_shutdown.py
+++ b/tests/test_workstream_b_shutdown.py
@@ -1,0 +1,175 @@
+"""Focused Workstream B regressions for graceful supervisor shutdown."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import socket
+import threading
+import time
+from contextlib import closing
+from http.server import BaseHTTPRequestHandler
+
+
+def test_graceful_shutdown_stops_admission_and_waits_for_active_worker():
+    import api.config as config
+    from server import Handler, QuietHTTPServer
+
+    with closing(socket.socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    worker_released = threading.Event()
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["run-under-test"] = {
+            "stream_id": "run-under-test",
+            "session_id": "session-under-test",
+            "phase": "running",
+        }
+
+    httpd = QuietHTTPServer(("127.0.0.1", port), Handler)
+    try:
+        assert httpd.begin_graceful_shutdown(reason="test", timeout_seconds=0.5) is True
+        assert httpd.is_draining is True
+        assert httpd.shutdown_state == "draining"
+        assert httpd.admission_open is False
+
+        def release_worker():
+            time.sleep(0.05)
+            with config.ACTIVE_RUNS_LOCK:
+                config.ACTIVE_RUNS.pop("run-under-test", None)
+            worker_released.set()
+
+        threading.Thread(target=release_worker, daemon=True).start()
+        result = httpd.wait_for_graceful_drain()
+
+        assert worker_released.is_set()
+        assert result["state"] == "drained"
+        assert result["active_workers"] == 0
+        assert httpd.shutdown_state == "drained"
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.pop("run-under-test", None)
+        httpd.server_close()
+
+
+def test_graceful_shutdown_rejects_new_request_admission():
+    from server import QuietHTTPServer
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_args):
+            pass
+
+        def do_GET(self):  # noqa: N802
+            entered.set()
+            release.wait(timeout=2)
+            body = b"released"
+            self.send_response(200)
+            self.send_header("Connection", "close")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    httpd = QuietHTTPServer(("127.0.0.1", 0), _Handler)
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    first = http.client.HTTPConnection(*httpd.server_address, timeout=2)
+    second = http.client.HTTPConnection(*httpd.server_address, timeout=2)
+    server_thread.start()
+    try:
+        first.request("GET", "/hold")
+        assert entered.wait(timeout=2)
+        assert httpd.begin_graceful_shutdown(reason="test", timeout_seconds=1) is True
+
+        second.request("GET", "/new")
+        response = second.getresponse()
+        assert response.status == 503
+        assert json.loads(response.read()) == {"status": "draining"}
+
+        release.set()
+        first_response = first.getresponse()
+        assert first_response.status == 200
+        assert first_response.read() == b"released"
+        httpd.shutdown()
+        server_thread.join(timeout=2)
+        assert not server_thread.is_alive()
+        assert httpd.wait_for_graceful_drain()["state"] == "drained"
+    finally:
+        release.set()
+        first.close()
+        second.close()
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_graceful_shutdown_has_bounded_deadline_and_force_is_immediate():
+    import api.config as config
+    from server import Handler, QuietHTTPServer
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["stuck-run"] = {
+            "stream_id": "stuck-run",
+            "session_id": "session-under-test",
+            "phase": "running",
+        }
+
+    httpd = QuietHTTPServer(("127.0.0.1", 0), Handler)
+    try:
+        assert httpd.begin_graceful_shutdown(reason="test", timeout_seconds=0.01) is True
+        started = time.monotonic()
+        result = httpd.wait_for_graceful_drain()
+        elapsed = time.monotonic() - started
+
+        assert result["state"] == "timed_out"
+        assert elapsed < 0.5
+
+        forced = QuietHTTPServer(("127.0.0.1", 0), Handler)
+        try:
+            assert forced.force_shutdown(reason="test") is True
+            assert forced.is_draining is True
+            assert forced.shutdown_state == "forced"
+            assert forced.admission_open is False
+        finally:
+            forced.server_close()
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.pop("stuck-run", None)
+        httpd.server_close()
+
+
+def test_ctl_force_stop_is_explicit_and_only_targets_ctl_owned_process(tmp_path):
+    from tests.test_ctl_script import (
+        _kill_tree,
+        assert_process_exits,
+        run_ctl,
+        wait_for_pid_file,
+        write_fake_python,
+    )
+
+    fake_python = tmp_path / "fake-python"
+    fake_log = tmp_path / "fake-python.log"
+    write_fake_python(fake_python)
+    env = {
+        "HERMES_WEBUI_PYTHON": str(fake_python),
+        "FAKE_PYTHON_LOG": str(fake_log),
+        "HERMES_WEBUI_HOST": "127.0.0.1",
+        "HERMES_WEBUI_PORT": "18992",
+        "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
+    }
+
+    started = run_ctl(tmp_path, "start", env=env)
+    assert started.returncode == 0, started.stderr + started.stdout
+    pid = wait_for_pid_file(tmp_path / ".hermes" / "webui.pid")
+    try:
+        stopped = run_ctl(tmp_path, "stop", "--force", env=env)
+        assert stopped.returncode == 0, stopped.stderr + stopped.stdout
+        assert "Force-stopping" in stopped.stdout
+        assert_process_exits(pid)
+    finally:
+        _kill_tree(pid)

--- a/tests/test_workstream_b_state_safety.py
+++ b/tests/test_workstream_b_state_safety.py
@@ -1,0 +1,180 @@
+"""Focused Workstream B regressions for private state-file persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections import OrderedDict
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    import api.config as config
+    import api.models as models
+    import api.workspace as workspace
+
+    state_dir = tmp_path / "webui"
+    session_dir = state_dir / "sessions"
+    session_dir.mkdir(parents=True)
+    index_file = session_dir / "_index.json"
+
+    monkeypatch.setattr(config, "STATE_DIR", state_dir, raising=False)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    monkeypatch.setattr(workspace, "_profile_state_dir", lambda: state_dir)
+    return state_dir, session_dir, index_file
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _with_umask(mask: int):
+    previous = os.umask(mask)
+
+    class _Restore:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            os.umask(previous)
+
+    return _Restore()
+
+
+def test_session_create_replace_and_backup_are_private_under_permissive_umask(
+    isolated_state,
+):
+    from api.models import Session
+
+    _state_dir, session_dir, index_file = isolated_state
+    sid = "private_state"
+    with _with_umask(0o000):
+        first = Session(
+            session_id=sid,
+            workspace="",
+            model="test-model",
+            messages=[{"role": "user", "content": "one"}],
+        )
+        first.save()
+
+    session_path = session_dir / f"{sid}.json"
+    assert _mode(session_path) == 0o600
+    assert _mode(index_file) == 0o600
+
+    session_path.chmod(0o644)
+    index_file.chmod(0o644)
+    replacement = Session(
+        session_id=sid,
+        workspace="",
+        model="test-model",
+        messages=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+        ],
+    )
+    replacement.save()
+    assert _mode(session_path) == 0o600
+    assert _mode(index_file) == 0o600
+
+    session_path.chmod(0o644)
+    shrinking = Session(
+        session_id=sid,
+        workspace="",
+        model="test-model",
+        messages=[{"role": "user", "content": "replacement"}],
+    )
+    shrinking.save()
+    assert _mode(session_path) == 0o600
+    assert _mode(session_path.with_suffix(".json.bak")) == 0o600
+
+
+def test_workspace_metadata_create_and_replace_are_private_under_permissive_umask(
+    isolated_state,
+    tmp_path,
+):
+    import api.workspace as workspace
+
+    state_dir, _session_dir, _index_file = isolated_state
+    target_workspace = tmp_path / "workspace"
+    target_workspace.mkdir()
+
+    with _with_umask(0o000):
+        workspace.save_workspaces([{"path": str(target_workspace), "name": "Home"}])
+        workspace.set_last_workspace(str(target_workspace))
+
+    workspaces_file = state_dir / "workspaces.json"
+    last_workspace_file = state_dir / "last_workspace.txt"
+    assert _mode(workspaces_file) == 0o600
+    assert _mode(last_workspace_file) == 0o600
+
+    workspaces_file.chmod(0o644)
+    last_workspace_file.chmod(0o644)
+    workspace.save_workspaces([{"path": str(target_workspace), "name": "Renamed"}])
+    workspace.set_last_workspace(str(target_workspace))
+    assert _mode(workspaces_file) == 0o600
+    assert _mode(last_workspace_file) == 0o600
+
+
+def test_recovery_replacement_is_private_under_permissive_umask(isolated_state):
+    from api.models import Session
+    from api.session_recovery import recover_all_sessions_on_startup, recover_session
+
+    _state_dir, session_dir, index_file = isolated_state
+    sid = "recover_private"
+    live_path = session_dir / f"{sid}.json"
+    backup_path = live_path.with_suffix(".json.bak")
+    live = Session(
+        session_id=sid,
+        workspace="",
+        model="test-model",
+        messages=[{"role": "user", "content": "short"}],
+    )
+    live.save(skip_index=True)
+    backup_path.write_text(
+        json.dumps(
+            {
+                **json.loads(live_path.read_text(encoding="utf-8")),
+                "messages": [
+                    {"role": "user", "content": "long"},
+                    {"role": "assistant", "content": "answer"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    live_path.chmod(0o644)
+    backup_path.chmod(0o644)
+
+    with _with_umask(0o000):
+        result = recover_session(live_path)
+
+    assert result["restored"] is True
+    assert _mode(live_path) == 0o600
+    assert _mode(backup_path) == 0o600
+
+    recover_all_sessions_on_startup(session_dir, rebuild_index=True)
+    assert _mode(index_file) == 0o600
+
+
+def test_settings_create_is_private_under_permissive_umask(isolated_state):
+    import api.config as config
+
+    state_dir, _session_dir, _index_file = isolated_state
+    settings_path = state_dir / "settings.json"
+
+    with _with_umask(0o000):
+        config._atomic_write_settings_text(settings_path, '{"theme": "dark"}')
+
+    assert _mode(settings_path) == 0o600
+
+    settings_path.chmod(0o644)
+    config._atomic_write_settings_text(settings_path, '{"theme": "light"}')
+    assert _mode(settings_path) == 0o600

--- a/tests/test_workstream_c_session_profile_metadata.py
+++ b/tests/test_workstream_c_session_profile_metadata.py
@@ -1,0 +1,426 @@
+"""Behavioral coverage for Workstream C latency boundaries."""
+
+import re
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+import api.profiles as profiles
+import api.routes as routes
+
+
+@pytest.fixture(autouse=True)
+def _clean_workstream_c_caches():
+    routes._session_list_cache_clear()
+    with routes._SESSIONS_CACHE_LOCK:
+        routes._SESSIONS_CACHE_INFLIGHT.clear()
+    with profiles._PROFILE_EXPENSIVE_METADATA_LOCK:
+        profiles._PROFILE_EXPENSIVE_METADATA_CACHE.clear()
+        profiles._PROFILE_EXPENSIVE_METADATA_INFLIGHT.clear()
+        profiles._PROFILE_EXPENSIVE_METADATA_PROFILE_VERSION.clear()
+        profiles._PROFILE_EXPENSIVE_METADATA_GLOBAL_VERSION = 0
+    profiles._LIST_PROFILES_CACHE = None
+    yield
+    routes._session_list_cache_clear()
+    with routes._SESSIONS_CACHE_LOCK:
+        routes._SESSIONS_CACHE_INFLIGHT.clear()
+    with profiles._PROFILE_EXPENSIVE_METADATA_LOCK:
+        profiles._PROFILE_EXPENSIVE_METADATA_CACHE.clear()
+        profiles._PROFILE_EXPENSIVE_METADATA_INFLIGHT.clear()
+
+
+def _session_key(profile="default", *, all_profiles=False):
+    return routes._session_list_cache_key(
+        active_profile=profile,
+        all_profiles=all_profiles,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+
+def _payload(marker, *, all_profiles=False):
+    return {
+        "sessions": [{"session_id": marker}],
+        "cli_count": 0,
+        "all_profiles": all_profiles,
+        "active_profile": "default",
+        "other_profile_count": 0,
+    }
+
+
+def _wait_until(predicate, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+def _age_session_cache_entry(key, seconds):
+    with routes._SESSIONS_CACHE_LOCK:
+        timestamp, stamp, payload = routes._SESSIONS_CACHE[key]
+        routes._SESSIONS_CACHE[key] = (timestamp - seconds, stamp, payload)
+
+
+def test_stale_source_snapshot_is_singleflight_for_concurrent_callers(monkeypatch):
+    source = ["before"]
+    monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: (source[0],))
+    key = _session_key()
+    stale = _payload("last-known")
+    routes._session_list_cache_set(key, stale)
+    source[0] = "after"
+
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def builder():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        started.set()
+        release.wait(2.0)
+        return _payload("rebuilt")
+
+    n_callers = 12
+    barrier = threading.Barrier(n_callers)
+    results = []
+    errors = []
+    result_lock = threading.Lock()
+
+    def caller():
+        try:
+            barrier.wait()
+            value = routes._get_cached_session_list_payload(key=key, builder=builder)
+            with result_lock:
+                results.append(value)
+        except Exception as exc:  # pragma: no cover - makes thread failures visible
+            with result_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=caller) for _ in range(n_callers)]
+    try:
+        for thread in threads:
+            thread.start()
+        assert started.wait(1.0)
+        for thread in threads:
+            thread.join(1.0)
+            assert not thread.is_alive()
+        assert errors == []
+        assert results == [stale] * n_callers
+        assert calls == 1
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(2.0)
+
+    assert _wait_until(
+        lambda: routes._session_list_cache_get(key, allow_stale=True)[0]
+        == _payload("rebuilt")
+    )
+
+
+def test_profile_invalidation_marks_scoped_snapshot_stale_without_eviction(monkeypatch):
+    monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))
+    key_default = _session_key("default")
+    key_other = _session_key("other")
+    key_all = _session_key("default", all_profiles=True)
+    routes._session_list_cache_set(key_default, _payload("default"))
+    routes._session_list_cache_set(key_other, _payload("other"))
+    routes._session_list_cache_set(key_all, _payload("all", all_profiles=True))
+
+    routes._session_list_cache_invalidate("default")
+
+    cached_default, fresh_default = routes._session_list_cache_get(
+        key_default, allow_stale=True
+    )
+    cached_other, fresh_other = routes._session_list_cache_get(
+        key_other, allow_stale=True
+    )
+    cached_all, fresh_all = routes._session_list_cache_get(key_all, allow_stale=True)
+    assert cached_default == _payload("default")
+    assert fresh_default is False
+    assert cached_other == _payload("other")
+    assert fresh_other is True
+    assert cached_all == _payload("all", all_profiles=True)
+    assert fresh_all is False
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def builder():
+        started.set()
+        release.wait(2.0)
+        return _payload("default-rebuilt")
+
+    begin = time.monotonic()
+    returned = routes._get_cached_session_list_payload(key=key_default, builder=builder)
+    elapsed = time.monotonic() - begin
+    try:
+        assert returned == _payload("default")
+        assert elapsed < 0.15
+        assert started.wait(1.0)
+    finally:
+        release.set()
+
+    assert _wait_until(
+        lambda: routes._session_list_cache_get(key_default, allow_stale=True)[0]
+        == _payload("default-rebuilt")
+    )
+
+
+def test_three_large_stale_sessions_return_before_historical_rebuild(monkeypatch):
+    monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))
+    key = _session_key()
+    snapshot = {
+        "sessions": [
+            {"session_id": f"large-{index}", "title": "x" * 80_000}
+            for index in range(3)
+        ],
+        "cli_count": 3,
+    }
+    routes._session_list_cache_set(key, snapshot)
+    _age_session_cache_entry(key, routes._SESSIONS_CACHE_TTL_SECONDS + 1.0)
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def builder():
+        started.set()
+        release.wait(2.0)
+        return {**snapshot, "sessions": [{"session_id": "fresh"}]}
+
+    begin = time.monotonic()
+    returned = routes._get_cached_session_list_payload(key=key, builder=builder)
+    elapsed = time.monotonic() - begin
+    try:
+        assert returned == snapshot
+        assert elapsed < 0.15
+        assert started.wait(1.0)
+    finally:
+        release.set()
+
+
+def test_active_run_overlay_refreshes_cached_rows_without_projection(monkeypatch):
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: {"stream-live"})
+    monkeypatch.setattr(
+        routes,
+        "ACTIVE_RUNS",
+        {"stream-live": {"session_id": "sid-1", "phase": "running"}},
+    )
+    monkeypatch.setattr(routes, "ACTIVE_RUNS_LOCK", threading.Lock())
+    rows = [
+        {"session_id": "sid-1", "updated_at": 1},
+        {"session_id": "sid-2", "updated_at": 2},
+        {"session_id": "sid-3", "updated_at": 3},
+    ]
+
+    overlaid = routes._session_list_cache_overlay_runtime_rows(rows)
+
+    by_id = {row["session_id"]: row for row in overlaid}
+    assert by_id["sid-1"]["active_stream_id"] == "stream-live"
+    assert by_id["sid-1"]["is_streaming"] is True
+
+
+def test_fast_profile_rows_do_not_run_gateway_or_skill_probes(monkeypatch, tmp_path):
+    default_home = tmp_path / "default"
+    profiles_root = tmp_path / "profiles"
+    default_home.mkdir()
+    profiles_root.mkdir()
+    fake_cli = types.ModuleType("hermes_cli")
+    fake_cli_profiles = types.ModuleType("hermes_cli.profiles")
+    fake_cli.profiles = fake_cli_profiles
+    fake_cli_profiles._get_default_hermes_home = lambda: default_home
+    fake_cli_profiles._get_profiles_root = lambda: profiles_root
+    fake_cli_profiles._read_config_model = lambda _home: ("model", "provider")
+    fake_cli_profiles._PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+    gateway_called = threading.Event()
+    stats_called = threading.Event()
+    release = threading.Event()
+
+    def slow_gateway(_home):
+        gateway_called.set()
+        release.wait(1.0)
+        return True
+
+    def slow_stats(_home):
+        stats_called.set()
+        release.wait(1.0)
+        return (9, 10)
+
+    fake_cli_profiles._check_gateway_running = slow_gateway
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.profiles", fake_cli_profiles)
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", slow_stats)
+
+    finished = threading.Event()
+    result = {}
+
+    def build():
+        try:
+            result["rows"] = profiles._build_profile_rows_fast()
+        finally:
+            finished.set()
+
+    thread = threading.Thread(target=build)
+    thread.start()
+    try:
+        assert finished.wait(0.25), "cheap profile discovery must not wait on probes"
+        assert not gateway_called.is_set()
+        assert not stats_called.is_set()
+        assert result["rows"][0]["name"] == "default"
+    finally:
+        release.set()
+        thread.join(1.0)
+
+
+def test_profile_expensive_metadata_is_bounded_and_singleflight(monkeypatch, tmp_path):
+    rows = [
+        {"name": f"profile-{index}", "path": str(tmp_path / f"p-{index}")}
+        for index in range(3)
+    ]
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "profile-0")
+    monkeypatch.setattr(profiles, "_build_profile_rows_fast", lambda: rows)
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+    calls_lock = threading.Lock()
+
+    def slow_details(path):
+        with calls_lock:
+            calls.append(path)
+        started.set()
+        release.wait(2.0)
+        return {
+            "gateway_running": True,
+            "skill_count": 7,
+            "enabled_skills": 7,
+            "total_skills": 8,
+        }
+
+    monkeypatch.setattr(profiles, "_compute_profile_expensive_metadata", slow_details)
+    n_callers = 8
+    barrier = threading.Barrier(n_callers)
+    results = []
+    result_lock = threading.Lock()
+
+    def caller():
+        barrier.wait()
+        value = profiles.list_profiles_api()
+        with result_lock:
+            results.append(value)
+
+    threads = [threading.Thread(target=caller) for _ in range(n_callers)]
+    begin = time.monotonic()
+    try:
+        for thread in threads:
+            thread.start()
+        assert started.wait(1.0)
+        for thread in threads:
+            thread.join(1.0)
+            assert not thread.is_alive()
+        elapsed = time.monotonic() - begin
+        assert elapsed < 0.5
+        assert len(results) == n_callers
+        assert len(calls) == 3
+        assert all(row["skill_count"] == 0 for result in results for row in result)
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(2.0)
+
+    assert _wait_until(
+        lambda: all(
+            profiles._profile_expensive_metadata_cache_get(
+                profiles._profile_expensive_metadata_path(row["path"])
+            )
+            for row in rows
+        )
+    )
+    refreshed = profiles.list_profiles_api()
+    assert all(row["skill_count"] == 7 for row in refreshed)
+    assert len(calls) == 3
+
+
+def test_profile_metadata_ttl_stale_while_revalidate(monkeypatch, tmp_path):
+    profile_path = profiles._profile_expensive_metadata_path(tmp_path / "profile")
+    calls = []
+    second_started = threading.Event()
+    second_release = threading.Event()
+
+    def details(_path):
+        calls.append(1)
+        if len(calls) == 1:
+            return {
+                "gateway_running": False,
+                "skill_count": 1,
+                "enabled_skills": 1,
+                "total_skills": 2,
+            }
+        second_started.set()
+        second_release.wait(2.0)
+        return {
+            "gateway_running": True,
+            "skill_count": 2,
+            "enabled_skills": 2,
+            "total_skills": 3,
+        }
+
+    monkeypatch.setattr(profiles, "_compute_profile_expensive_metadata", details)
+    _initial, initial_event = profiles._request_profile_expensive_metadata(
+        profile_path,
+        {"gateway_running": False, "skill_count": 0, "enabled_skills": 0, "total_skills": 0},
+    )
+    assert initial_event is not None
+    assert initial_event.wait(1.0)
+    assert _wait_until(
+        lambda: profiles._profile_expensive_metadata_cache_get(profile_path)
+        == {
+            "gateway_running": False,
+            "skill_count": 1,
+            "enabled_skills": 1,
+            "total_skills": 2,
+        }
+    )
+
+    with profiles._PROFILE_EXPENSIVE_METADATA_LOCK:
+        expiry, stamp, cached = profiles._PROFILE_EXPENSIVE_METADATA_CACHE[profile_path]
+        profiles._PROFILE_EXPENSIVE_METADATA_CACHE[profile_path] = (
+            time.monotonic() - 1.0,
+            stamp,
+            cached,
+        )
+
+    begin = time.monotonic()
+    stale, refresh_event = profiles._request_profile_expensive_metadata(
+        profile_path,
+        {"gateway_running": False, "skill_count": 0, "enabled_skills": 0, "total_skills": 0},
+    )
+    elapsed = time.monotonic() - begin
+    try:
+        assert stale["skill_count"] == 1
+        assert elapsed < 0.15
+        assert refresh_event is not None
+        assert second_started.wait(1.0)
+    finally:
+        second_release.set()
+        if refresh_event is not None:
+            refresh_event.wait(2.0)
+
+    assert _wait_until(
+        lambda: profiles._profile_expensive_metadata_cache_get(profile_path)
+        == {
+            "gateway_running": True,
+            "skill_count": 2,
+            "enabled_skills": 2,
+            "total_skills": 3,
+        }
+    )
+    assert len(calls) == 2

--- a/tests/test_workstream_d_concurrency.py
+++ b/tests/test_workstream_d_concurrency.py
@@ -1,0 +1,276 @@
+"""Focused Workstream D coverage for client recovery and multi-session UX."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _function_decl(source: str, name: str) -> str:
+    marker = f"function {name}"
+    start = source.find(marker)
+    assert start >= 0, f"{name} not found"
+    params = source.find("(", start)
+    assert params >= 0, f"{name} parameter list not found"
+    paren_depth = 0
+    close = -1
+    for idx in range(params, len(source)):
+        if source[idx] == "(":
+            paren_depth += 1
+        elif source[idx] == ")":
+            paren_depth -= 1
+            if paren_depth == 0:
+                close = idx
+                break
+    assert close >= 0, f"{name} parameter list did not close"
+    brace = source.find("{", close)
+    assert brace >= 0, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(source)):
+        if source[idx] == "{":
+            depth += 1
+        elif source[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"{name} body did not close")
+
+
+def _run_node(script: str) -> dict:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def _ui_recovery_source() -> str:
+    start = UI_JS.index("const INFLIGHT_KEY")
+    end = UI_JS.index("// ─── Todo state:", start)
+    return UI_JS[start:end]
+
+
+def test_recovery_storage_is_tail_and_cursor_bounded_for_three_active_sessions():
+    """A long live answer must not make the localStorage blob grow per token."""
+    source = _ui_recovery_source()
+    script = """
+const vm = require('vm');
+const source = SOURCE;
+const storage = {
+  values: Object.create(null),
+  getItem(key) { return Object.prototype.hasOwnProperty.call(this.values, key) ? this.values[key] : null; },
+  setItem(key, value) { this.values[key] = String(value); },
+  removeItem(key) { delete this.values[key]; },
+};
+const context = {
+  localStorage: storage,
+  window: { _inflightStateLimits: {
+    maxSessions: 25,
+    messages: 100,
+    toolCalls: 200,
+    stringChars: 500000,
+    jsonChars: 4000000,
+  }},
+  Date,
+  console,
+};
+vm.createContext(context);
+vm.runInContext(source, context);
+const answer = 'A'.repeat(180000) + 'ANSWER-TAIL';
+const reasoning = 'R'.repeat(90000) + 'REASONING-TAIL';
+const state = {
+  streamId: 'stream-a',
+  messages: Array.from({length: 160}, (_, index) => ({
+    role: index % 2 ? 'assistant' : 'user',
+    content: index === 159 ? answer : 'history-' + index + '-'.repeat(12000),
+    _live: index === 159,
+  })),
+  lastAssistantText: answer,
+  lastReasoningText: reasoning,
+  lastRunJournalSeq: 812,
+  lastRunJournalEventId: 'stream-a:812',
+  toolCalls: Array.from({length: 120}, (_, index) => ({
+    tid: 'tool-' + index,
+    name: 'terminal',
+    args: {command: 'x'.repeat(12000)},
+    snippet: 'output-' + 'y'.repeat(12000),
+    done: index < 119,
+  })),
+  activityBurstAnchors: Array.from({length: 200}, (_, index) => ({id: index + 1, textEnd: index * 1000})),
+};
+for (const sid of ['session-a', 'session-b', 'session-c']) {
+  context.saveInflightState(sid, {...state, streamId: 'stream-' + sid});
+}
+const raw = storage.values['hermes-webui-inflight-state'] || '';
+const all = JSON.parse(raw || '{}');
+const entries = Object.values(all);
+const sample = entries[0] || {};
+const live = Array.isArray(sample.messages) ? sample.messages.find(message => message && message._live) : null;
+const tool = Array.isArray(sample.toolCalls) ? sample.toolCalls[0] : null;
+process.stdout.write(JSON.stringify({
+  bytes: raw.length,
+  sessionCount: entries.length,
+  recoveryVersion: sample.recoveryVersion,
+  recoveryMode: sample.recoveryMode,
+  assistantLength: sample.assistantTextLength,
+  assistantTail: sample.assistantTextTail,
+  reasoningLength: sample.reasoningTextLength,
+  reasoningTail: sample.reasoningTextTail,
+  assistantTruncated: sample.assistantTextTruncated,
+  messageCount: Array.isArray(sample.messages) ? sample.messages.length : -1,
+  liveContentLength: live && typeof live.content === 'string' ? live.content.length : -1,
+  liveContentTail: live && typeof live.content === 'string' ? live.content.slice(-32) : '',
+  toolCount: Array.isArray(sample.toolCalls) ? sample.toolCalls.length : -1,
+  toolArgsLength: tool && tool.args && typeof tool.args.command === 'string' ? tool.args.command.length : -1,
+  hasToolOutput: !!(tool && (tool.output || tool.result || tool.preview)),
+  cursor: sample.lastRunJournalSeq,
+}));
+""".replace("SOURCE", json.dumps(source))
+    result = _run_node(script)
+
+    assert result["sessionCount"] == 3
+    assert result["bytes"] <= 262144
+    assert result["recoveryVersion"] == 2
+    assert result["recoveryMode"] in {"journal-tail", "tail-journal"}
+    assert result["assistantLength"] == 180000 + len("ANSWER-TAIL")
+    assert result["assistantTail"].endswith("ANSWER-TAIL")
+    assert len(result["assistantTail"]) <= 8192
+    assert result["reasoningLength"] == 90000 + len("REASONING-TAIL")
+    assert result["reasoningTail"].endswith("REASONING-TAIL")
+    assert len(result["reasoningTail"]) <= 8192
+    assert result["assistantTruncated"] is True
+    assert result["messageCount"] <= 12
+    assert result["liveContentLength"] <= 8192
+    assert result["liveContentTail"].endswith("ANSWER-TAIL")
+    assert result["toolCount"] <= 24
+    assert result["toolArgsLength"] <= 2048
+    assert result["hasToolOutput"] is False
+    assert result["cursor"] == 812
+
+
+def test_background_projection_is_metadata_only_and_keeps_three_sessions_distinct():
+    """Background activity can update the sidebar without carrying token text."""
+    assert "function _recordSessionActivityProjection" in SESSIONS_JS
+    assert "function _getSessionActivityProjection" in SESSIONS_JS
+    assert "session-activity-status" in SESSIONS_JS
+    assert "data-session-activity-status" in SESSIONS_JS
+
+    declarations = "\n".join(
+        [
+            "const SESSION_ACTIVITY_PROJECTION_MAX_ENTRIES = 32;",
+            "const SESSION_ACTIVITY_PROJECTION_TTL_MS = 10 * 60 * 1000;",
+            "const SESSION_ACTIVITY_ALLOWED_STATUSES = Object.freeze({running:true, waiting:true, completed:true, cancelled:true, error:true});",
+            "const SESSION_ACTIVITY_ALLOWED_PHASES = Object.freeze({queued:true, thinking:true, tool:true, answer:true, approval:true, clarify:true, done:true, cancelled:true, error:true, working:true});",
+            "const _sessionActivityById = new Map();",
+            "let _sessionActivityRenderTimer = 0;",
+            _function_decl(SESSIONS_JS, "_scheduleSessionActivityProjectionRender"),
+            _function_decl(SESSIONS_JS, "_recordSessionActivityProjection"),
+            _function_decl(SESSIONS_JS, "_getSessionActivityProjection"),
+            _function_decl(SESSIONS_JS, "_formatSessionActivityProjection"),
+        ]
+    )
+    script = declarations + """
+_recordSessionActivityProjection('session-a', {
+  streamId: 'stream-a', status: 'running', phase: 'answer',
+  assistantChars: 900000, reasoningChars: 30, toolCount: 2,
+  eventCount: 22, tokenText: 'must never be persisted or projected',
+});
+_recordSessionActivityProjection('session-b', {
+  streamId: 'stream-b', status: 'waiting', phase: 'approval', toolCount: 7,
+});
+_recordSessionActivityProjection('session-c', {
+  streamId: 'stream-c', status: 'completed', phase: 'done', toolCount: 1,
+});
+const rows = ['session-a', 'session-b', 'session-c'].map(sid => {
+  const projection = _getSessionActivityProjection(sid);
+  return {
+    sid,
+    projection,
+    label: _formatSessionActivityProjection(projection),
+  };
+});
+process.stdout.write(JSON.stringify(rows));
+"""
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    rows = json.loads(result.stdout)
+
+    assert [row["sid"] for row in rows] == ["session-a", "session-b", "session-c"]
+    assert [row["projection"]["status"] for row in rows] == [
+        "running",
+        "waiting",
+        "completed",
+    ]
+    assert rows[0]["projection"]["phase"] == "answer"
+    assert rows[1]["projection"]["phase"] == "approval"
+    assert rows[0]["projection"]["toolCount"] == 2
+    assert rows[1]["projection"]["toolCount"] == 7
+    assert rows[0]["projection"]["assistantChars"] == 900000
+    assert "must never" not in json.dumps(rows)
+    assert all("tokenText" not in row["projection"] for row in rows)
+    assert all(row["label"] for row in rows)
+
+
+def test_selected_renderer_and_ownership_guards_remain_separate_from_projection():
+    """Projection updates must not weaken the existing selected-pane gates."""
+    token = MESSAGES_JS[MESSAGES_JS.index("source.addEventListener('token'"):]
+    token = token[: token.index("source.addEventListener('interim_assistant'")]
+    assert "assistantText+=d.text" in token
+    assert "syncInflightAssistantMessage();" in token
+    assert "_scheduleRender" in token
+    sync = _function_decl(MESSAGES_JS, "syncInflightAssistantMessage")
+    assert "_recordLiveActivityProjection" in sync
+
+    attach = _function_decl(MESSAGES_JS, "attachLiveStream")
+    assert "closeOtherLiveStreams(activeSid)" in attach
+    assert "existingLive.streamId===streamId" in attach
+    assert "source.readyState===EventSource.OPEN" in attach
+
+    close = _function_decl(MESSAGES_JS, "closeLiveStream")
+    assert "INFLIGHT[sessionId].reattach=true" in close
+    assert "journalReplayFromStart=true" in close
+
+    cancel = MESSAGES_JS[MESSAGES_JS.index("source.addEventListener('cancel'"):]
+    cancel = cancel[: cancel.index("for(const _runJournalEventName")]
+    assert "_clearOwnerInflightState" in cancel
+    assert "_clearApprovalForOwner" in cancel
+    assert "_clearClarifyForOwner('cancelled')" in cancel
+
+    # The background projection is intentionally not allowed to invoke the full
+    # transcript renderer. rAF/incremental rendering stays in messages.js.
+    projection = _function_decl(SESSIONS_JS, "_recordSessionActivityProjection")
+    assert "renderMessages" not in projection
+
+
+def test_background_row_has_compact_status_hook_without_rendering_a_transcript():
+    """The browser-facing row contract exposes status as a small data node."""
+    render_start = SESSIONS_JS.index("function _renderOneSession")
+    render_end = SESSIONS_JS.index("function _showProjectPicker", render_start)
+    row_source = SESSIONS_JS[render_start:render_end]
+    compact = re.sub(r"\s+", "", row_source)
+    assert "session-activity-status" in row_source
+    assert "dataset.sessionActivityStatus" in row_source
+    assert "data-session-activity-status" in row_source
+    assert "renderMessages" not in row_source
+    assert "activity" in compact

--- a/tests/test_workstream_e_client_bootstrap.py
+++ b/tests/test_workstream_e_client_bootstrap.py
@@ -1,0 +1,162 @@
+"""Focused static contracts for Workstream E client bootstrap behavior."""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+SW = (ROOT / "static" / "sw.js").read_text(encoding="utf-8")
+BOOT = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _array_block(source, name):
+    match = re.search(
+        rf"const {re.escape(name)}\s*=\s*\[(?P<body>.*?)\];",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"missing {name} allowlist"
+    return match.group("body")
+
+
+def test_versioned_shell_references_are_pinned_and_heavy_panels_are_inert():
+    """The parser must not fetch non-chat bundles before the loader asks for them."""
+    for asset in (
+        "style.css",
+        "pwa-startup.js",
+        "i18n.js",
+        "ui.js",
+        "workspace.js",
+        "terminal.js",
+        "messages.js",
+        "sessions.js",
+        "commands.js",
+        "boot.js",
+        "outline.js",
+    ):
+        assert f"static/{asset}?v=__WEBUI_VERSION__" in INDEX
+
+    for module, asset in (
+        ("extension-settings", "extension_settings.js"),
+        ("panels", "panels.js"),
+        ("onboarding", "onboarding.js"),
+    ):
+        assert re.search(
+            rf'<script[^>]+data-hermes-lazy="{module}"[^>]+data-src="static/{asset}\?v=__WEBUI_VERSION__"',
+            INDEX,
+        ), f"{module} must be represented by a versioned inert lazy script"
+        assert not re.search(
+            rf'<script[^>]+(?<!data-)src="static/{asset}\?v=__WEBUI_VERSION__"[^>]*>',
+            INDEX,
+        ), f"{asset} must not remain an eager script"
+
+    for asset in ("ui.js", "messages.js", "sessions.js"):
+        assert re.search(
+            rf'<script[^>]+src="static/{asset}\?v=__WEBUI_VERSION__"[^>]+defer',
+            INDEX,
+        ), f"chat-critical {asset} must remain eager/deferred"
+
+
+def test_lazy_module_loader_is_singleton_and_boot_does_not_await_panels():
+    assert "window._hermesEnsureClientModule" in BOOT
+    assert "window._hermesScheduleClientModule" in BOOT
+    assert "const _hermesModulePromises = new Map()" in BOOT
+    assert "data-hermes-lazy" in BOOT
+    assert "window._hermesEnsureClientModule('onboarding')" in BOOT
+    assert "await _workspaceListReady" not in BOOT
+    assert "await _onboardingReady" not in BOOT
+    for name in ("toggleProfileDropdown", "toggleComposerWsDropdown", "switchSettingsSection"):
+        assert name in BOOT, f"cold-boot proxy missing for visible panel control {name}"
+
+
+def test_shell_cache_is_cache_first_but_navigation_and_auth_stay_network_first():
+    shell = _array_block(SW, "SHELL_ASSETS")
+    lazy = _array_block(SW, "LAZY_ASSETS")
+
+    assert "style.css' + VQ" in shell
+    assert "boot.js' + VQ" in shell
+    assert "panels.js' + VQ" not in shell
+    assert "onboarding.js' + VQ" not in shell
+    assert "extension_settings.js' + VQ" not in shell
+    assert "manifest.json" not in shell
+    assert "panels.js' + VQ" in lazy
+    assert "onboarding.js' + VQ" in lazy
+    assert "extension_settings.js' + VQ" in lazy
+
+    shell_marker = "// Shell assets: stale-while-revalidate"
+    shell_start = SW.index(shell_marker)
+    shell_block = SW[shell_start : shell_start + 1400]
+    assert "cache.match(event.request)" in shell_block
+    assert shell_block.index("cache.match(event.request)") < shell_block.index("fetch(")
+    assert "cache.put(event.request, response.clone())" in shell_block
+
+    navigation_start = SW.index("if (event.request.mode === 'navigate')")
+    navigation_block = SW[navigation_start : SW.index("  // Only explicit shell assets", navigation_start)]
+    assert navigation_block.index("fetch(") < navigation_block.index("caches.match")
+    assert "cache: 'no-store'" in navigation_block
+    assert "url.pathname.endsWith('/login')" in SW
+    assert "url.pathname.endsWith('/static/login.js')" in SW
+    assert "url.pathname.endsWith('/sw.js')" in SW
+
+
+def test_service_worker_stages_versioned_cache_before_activation():
+    assert "const CACHE_PREFIX = 'hermes-shell-'" in SW
+    assert "const STAGING_CACHE_NAME = CACHE_NAME + '-staging'" in SW
+    assert "async function precacheShell()" in SW
+    assert "await stagingCache.addAll(SHELL_ASSETS)" in SW
+    assert "self.skipWaiting();" in SW
+    install = SW[SW.index("self.addEventListener('install'") : SW.index("self.addEventListener('activate'")]
+    assert "precacheShell()" in install
+    assert ".then(() => { self.skipWaiting(); })" in install
+    assert "catch" in install
+    assert "keeping previous cache" in install
+    assert "event.waitUntil(deleteOldShellCaches())" in SW
+    assert "k.startsWith(CACHE_PREFIX)" in SW
+    assert "k !== CACHE_NAME" in SW
+
+
+def test_mobile_zoom_is_allowed_without_losing_ios_input_floor_or_targets():
+    viewport = re.search(r'<meta name="viewport" content="([^"]+)">', INDEX)
+    assert viewport, "the shell must declare a mobile viewport"
+    content = viewport.group(1)
+    assert "width=device-width" in content
+    assert "initial-scale=1" in content
+    assert "maximum-scale" not in content
+    assert "user-scalable" not in content
+
+    assert re.search(
+        r"@media\s*\(hover:none\)\s*and\s*\(pointer:coarse\)\s*\{[^}]*"
+        r"input\s*,\s*textarea\s*,\s*select\s*\{[^}]*font-size:\s*16px",
+        CSS,
+        re.DOTALL,
+    ), "touch inputs need an explicit 16px iOS zoom floor"
+    assert re.search(r"min-(?:width|height):44px", CSS)
+
+
+def test_client_lifecycle_releases_mobile_viewport_and_shutdown_channel_resources():
+    assert "window.visualViewport.removeEventListener('resize'" in BOOT
+    assert "window.visualViewport.removeEventListener('scroll'" in BOOT
+    assert "clearTimeout(_mobileViewportReflowTimer)" in BOOT
+    assert "if(event && event.persisted)return" in BOOT
+    assert "_stopChan.close()" in BOOT
+    assert "pagehide" in BOOT
+
+
+@pytest.mark.parametrize("relative_path", ["static/sw.js", "static/boot.js"])
+def test_changed_browser_scripts_parse(relative_path):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    result = subprocess.run(
+        [node, "--check", str(ROOT / relative_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Thinking Path

This change addresses a related set of WebUI reliability and responsiveness problems found during a concurrency and runtime audit. The work was integrated in an isolated worktree so the existing dirty checkout remained untouched. The primary invariants are: concurrent run-journal events remain replayable and ordered; private state files stay private; persistence and shutdown are bounded; expensive sidebar metadata does not block the request path; and the client keeps recovery/background activity bounded and understandable.

## Contract Routing

Task type: runtime, persistence, streaming/recovery, sidebar metadata, and UI reliability.
Touched areas: run journal, state persistence, graceful shutdown, session/profile metadata, client recovery/background activity, bootstrap/static delivery, PWA/mobile behavior, and regression tests.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
Scope boundaries: this PR does not change Hermes core gateway async-delegation delivery or the agent runtime itself; it is limited to the WebUI repository.
Evidence needed before claiming done: focused regression tests, browser smoke, syntax/lint checks, and explicit reporting of the known upstream baseline full-suite failures.

## What Changed

- Make concurrent run-journal sequence reservation and append atomic so replay remains contiguous under concurrent writers.
- Harden state/session persistence permissions and shutdown/cleanup behavior.
- Bound persistence pressure and protect private sidecar/state artifacts.
- Refresh session/profile sidebar metadata asynchronously using last-known data rather than blocking on expensive scans.
- Bound client recovery state and background activity while preserving the selected conversation transcript.
- Improve bootstrap/static cache invalidation and PWA/mobile delivery behavior.
- Add focused regression coverage across journal ordering, state safety, shutdown, metadata latency, concurrency, storage pressure, bootstrap, PWA, and mobile layout.

## Why It Matters

The audit reproduced concurrent journal writes landing out of order, which caused replay to reject the journal and return no events. It also found overly permissive sidecar permissions, very large state artifacts, and severe tail latency in session/profile metadata endpoints. These changes address those failure classes without changing the existing no-build-step architecture or the parent checkout.

## Verification

- Merged focused WebUI suite: **179 passed**.
- Journal sequence/replay subset: **10 passed**.
- Runtime/security regression tests completed successfully.
- Browser smoke passed on `/`, `/#settings`, and `/#sessions` with zero console errors.
- JavaScript syntax checks passed for all changed JavaScript files.
- Changed-line Ruff gate passed.
- `git diff --check` passed.

The full repository suite was also attempted: **14,763 passed, 72 failed, and 240 errors**. The first failure reproduced identically on clean upstream `origin/master`, and the affected change clusters pass independently; this is not being represented as an all-green full-suite result.

## Risks / Follow-ups

- This PR does not fix the separate Hermes-core issue where delayed async-delegation completions can be injected as a new synthetic turn after the foreground turn has visibly settled. That belongs in the Hermes gateway/turn-lifecycle layer, not this WebUI repository.
- Full-suite baseline failures remain upstream-reproducible and should be triaged separately.
- UI verification includes browser smoke and responsive/mobile regression coverage; no before/after screenshots are attached in this automated contribution.

## Model Used

OpenAI Codex provider, GPT-5.6-Luna. Work was orchestrated in isolated worktrees with focused implementation/review agents; final integration, test execution, and verification were performed locally by the coordinator.
