### PR TITLE
fix(media): exclude backtick from MEDIA token capture regexes

### DIFF
--- a/api/media_snapshots.py
+++ b/api/media_snapshots.py
@@ -444,7 +444,7 @@ def annotate_media_snapshots(
         resolve_ref = resolve_media_ref
     if allowed_predicate is None:
         allowed_predicate = media_capture_allowed
-    media_re = _re.compile(r"MEDIA:([^\s\)\]]+)")
+    media_re = _re.compile(r"MEDIA:([^\s\)\]`]+)")
     captured = 0
     for msg in messages or []:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":

--- a/api/routes.py
+++ b/api/routes.py
@@ -20241,7 +20241,7 @@ def _serve_inline_html_preview(handler, target: Path, cache_control: str, *, csp
     return True
 
 
-_MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]]+)")
+_MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]`]+)")
 
 
 def _message_content_text(content) -> str:

--- a/static/messages.js
+++ b/static/messages.js
@@ -4801,7 +4801,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _smdMediaTailFlushEntry(entry){
     const chunk=_smdMediaTailEntryChunk(entry);
     if(!chunk) return;
-    const m=/^MEDIA:([^\s\)\]]+)$/.exec(String(chunk));
+    const m=/^MEDIA:([^\s\)\]`]+)$/.exec(String(chunk));
     const emitted=!!(m && entry && entry.parent && _smdAppendMediaNode(entry.parent, m[1]));
     if(!emitted && entry) _smdMediaWriteText(entry.parent, entry.data, entry.baseAddText, entry.writeText, chunk);
   }
@@ -4849,7 +4849,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Prose runs go through the owning text writer. MEDIA tokens go through
     // the single-token DOMParser helper only after a delimiter or
     // reliable filename suffix proves the ref is complete.
-    const re=/MEDIA:([^\s\)\]]+)/g;
+    const re=/MEDIA:([^\s\)\]`]+)/g;
     let last=0, m;
     let unmatchedTail=null;
     while((m=re.exec(combined))){
@@ -4875,7 +4875,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // MEDIA prefix; flush any prose before the partial MEDIA suffix.
     const rest = combined.slice(last);
     if(rest){
-      const tailMatch = /MEDIA:[^\s\)\]]*$/.exec(rest);
+      const tailMatch = /MEDIA:[^\s\)\]`]*$/.exec(rest);
       const prefixTail = tailMatch ? '' : _smdMediaPrefixTail(rest);
       const tailValue = tailMatch ? tailMatch[0] : prefixTail;
       if(tailValue && rest.length < _MEDIA_TAIL_MAX){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7591,7 +7591,7 @@ function renderMd(raw){
   // generated images) and replace them with inline <img> or download links.
   // Stashed so the path/URL is never processed as markdown.
   const media_stash=[];
-  s=s.replace(/MEDIA:([^\s\)\]]+)/g,(_,raw_ref)=>{
+  s=s.replace(/MEDIA:([^\s\)\]`]+)/g,(_,raw_ref)=>{
     media_stash.push(raw_ref);
     return '\x00D'+(media_stash.length-1)+'\x00';
   });

--- a/tests/test_issue7359_media_backtick.py
+++ b/tests/test_issue7359_media_backtick.py
@@ -1,0 +1,118 @@
+"""
+Tests for #7359: MEDIA capture regexes must not swallow a trailing backtick.
+
+The capture character class used across the MEDIA token regexes excluded
+whitespace, `)` and `]` but NOT backticks. When a MEDIA reference appeared
+inside inline code or was followed by a closing backtick (e.g. the path was
+written as `MEDIA:/tmp/file.png` in prose), the regex captured the backtick
+into the reference. The backend then tried to serve a path ending in a
+backtick and the download failed.
+
+This test covers all six capture sites:
+1. api/routes.py        — _MEDIA_TOKEN_RE (backend /media endpoint allowlist)
+2. api/media_snapshots.py — media_re (snapshot cleanup scan)
+3. static/messages.js   — streaming smd MEDIA match (full-chunk form)
+4. static/messages.js   — streaming smd MEDIA match (global form)
+5. static/messages.js   — streaming tailMatch form
+6. static/ui.js         — renderMd() MEDIA restore
+
+Static coverage asserts the char class excludes a backtick at each site;
+behavioural coverage runs the actual regexes against real input.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+MEDIA_SNAPSHOTS_PY = (REPO_ROOT / "api" / "media_snapshots.py").read_text(
+    encoding="utf-8"
+)
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+class TestMediaBacktickStatic(unittest.TestCase):
+    """Each capture site's char class must exclude a backtick."""
+
+    def test_routes_py_media_token_re_excludes_backtick(self):
+        self.assertIn(r"MEDIA:([^\s\)\]`]+)", ROUTES_PY)
+
+    def test_media_snapshots_py_excludes_backtick(self):
+        self.assertIn(r'media_re = _re.compile(r"MEDIA:([^\s\)\]`]+)")', MEDIA_SNAPSHOTS_PY)
+
+    def test_messages_js_full_chunk_excludes_backtick(self):
+        self.assertIn(r"/^MEDIA:([^\s\)\]`]+)$/", MESSAGES_JS)
+
+    def test_messages_js_global_excludes_backtick(self):
+        self.assertIn(r"/MEDIA:([^\s\)\]`]+)/g", MESSAGES_JS)
+
+    def test_messages_js_tail_match_excludes_backtick(self):
+        self.assertIn(r"/MEDIA:[^\s\)\]`]*$/", MESSAGES_JS)
+
+    def test_ui_js_restore_excludes_backtick(self):
+        self.assertIn(r"/MEDIA:([^\s\)\]`]+)/g", UI_JS)
+
+    def test_no_capture_site_left_without_backtick_exclusion(self):
+        """Every MEDIA capture regex must have been migrated."""
+        for src, label in (
+            (ROUTES_PY, "api/routes.py"),
+            (MEDIA_SNAPSHOTS_PY, "api/media_snapshots.py"),
+            (MESSAGES_JS, "static/messages.js"),
+            (UI_JS, "static/ui.js"),
+        ):
+            for m in re.finditer(r"MEDIA:\(\[\^[^\]]+\]\)", src):
+                char_class = m.group(1)
+                self.assertIn(
+                    "`",
+                    char_class,
+                    f"{label}: capture regex {m.group(0)!r} does not exclude backtick",
+                )
+            for m in re.finditer(r"MEDIA:\[\^[^\]]+\]\*", src):
+                char_class = m.group(0).split("[^", 1)[1].rsplit("]", 1)[0]
+                self.assertIn(
+                    "`",
+                    char_class,
+                    f"{label}: tail regex {m.group(0)!r} does not exclude backtick",
+                )
+
+
+class TestMediaBacktickBehaviour(unittest.TestCase):
+    """Run the actual regexes: a trailing backtick must NOT be captured."""
+
+    def setUp(self):
+        routes_match = re.search(
+            r"_MEDIA_TOKEN_RE = re\.compile\((r\".*?\")\)", ROUTES_PY
+        )
+        self.assertIsNotNone(routes_match, "could not locate _MEDIA_TOKEN_RE")
+        self.token_re = re.compile(eval(routes_match.group(1)))  # noqa: S307 — test-only
+
+    def test_backend_regex_strips_trailing_backtick(self):
+        m = self.token_re.search("MEDIA:/tmp/file.png`")
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "/tmp/file.png")
+
+    def test_backend_regex_strips_leading_and_trailing_backticks(self):
+        # Inline-code wrapping: `MEDIA:/tmp/file.png` — no backtick may
+        # leak into the captured reference.
+        m = self.token_re.search("`MEDIA:/tmp/file.png`")
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "/tmp/file.png")
+
+    def test_backend_regex_still_rejects_close_paren(self):
+        m = self.token_re.search("MEDIA:/tmp/file.png)")
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "/tmp/file.png")
+
+    def test_ui_js_restore_regex_strips_trailing_backtick(self):
+        # The JS literal is /MEDIA:([^\s\)\]`]+)/g — strip the delimiters.
+        ui_re = re.compile(r"MEDIA:([^\s\)\]`]+)")
+        m = ui_re.search("`MEDIA:/tmp/file.png`")
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "/tmp/file.png")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Inline code wrapping (`` `MEDIA:/path/file.png` ``) let a trailing backtick leak into the captured reference. The capture character class used across the six MEDIA token regexes excluded whitespace, `)` and `]` but **not** backticks — so links wrapped in backticks broke rendering and downloads.

## Fix
Add the backtick to the excluded character set in all six capture sites:
- `api/routes.py` — `_MEDIA_TOKEN_RE`
- `api/media_snapshots.py` — snapshot regex
- `static/messages.js` — stream chunk, link render, tail-match regexes
- `static/ui.js` — message link restore regex

## Tests
New `tests/test_issue7359_media_backtick.py` (static source checks for all six sites + behavioural regex checks). Full media/stream suite green: 133 passed, 18 subtests.

Fixes #7359