### PR TITLE
fix(cron): render Last/Next run in the configured Hermes timezone

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -770,6 +770,38 @@ def _worktree_retained_payload_for_session_id(sid: str) -> dict:
         return {}
 
 
+def _server_tz_offset() -> str:
+    """Return the server's configured timezone as a "+HHMM"/"-HHMM" offset string.
+
+    The agent resolves its timezone as: ``HERMES_TIMEZONE`` env var (highest
+    priority) -> ``timezone`` key in the active profile's config.yaml ->
+    server local time. ``time.strftime("%z")`` alone returns the *process*
+    timezone, which is typically UTC inside a container even when Hermes is
+    configured for a different zone — so the cron panel would show UTC times
+    for anyone not on the server's zone (#7140).
+
+    Falls back to the process offset on any failure; never raises.
+    """
+    tz_name = os.getenv("HERMES_TIMEZONE", "").strip()
+    if not tz_name:
+        try:
+            config_path = _active_profile_config_path()
+            if config_path.exists():
+                cfg = _load_yaml_config_file(config_path)
+                if isinstance(cfg, dict):
+                    tz_name = str(cfg.get("timezone") or "").strip()
+        except Exception:
+            tz_name = ""
+    if tz_name:
+        try:
+            from datetime import datetime
+            from zoneinfo import ZoneInfo
+            return datetime.now(ZoneInfo(tz_name)).strftime("%z")
+        except Exception:
+            pass
+    return time.strftime("%z")
+
+
 def _active_profile_config_path() -> Path:
     """Return config.yaml for the request's active WebUI profile.
 
@@ -2650,7 +2682,7 @@ def _session_list_payload_to_response(payload: dict) -> dict:
         "active_profile": payload.get("active_profile"),
         "other_profile_count": int(payload.get("other_profile_count", 0)),
         "server_time": time.time(),
-        "server_tz": time.strftime("%z"),
+        "server_tz": _server_tz_offset(),
     }
     if "webui_session_count" in payload:
         response["webui_session_count"] = int(payload.get("webui_session_count", 0))

--- a/static/panels.js
+++ b/static/panels.js
@@ -1232,8 +1232,12 @@ function _renderCronDetail(job){
   if (!title || !body) return;
   title.textContent = job.name || job.schedule_display || '(unnamed)';
   const status = _cronStatusMeta(job);
-  const nextRun = job.next_run_at ? new Date(job.next_run_at).toLocaleString() : t('not_available');
-  const lastRun = job.last_run_at ? new Date(job.last_run_at).toLocaleString() : t('never');
+  // Format in the server's configured timezone (#7140): the agent stores
+  // last_run_at/next_run_at in Hermes time, and plain toLocaleString() would
+  // render the browser's zone (UTC for most operators) instead.
+  const _fmtTz = (typeof _formatInServerTz === 'function') ? _formatInServerTz : null;
+  const nextRun = job.next_run_at ? (_fmtTz ? _fmtTz(new Date(job.next_run_at)) : new Date(job.next_run_at).toLocaleString()) : t('not_available');
+  const lastRun = job.last_run_at ? (_fmtTz ? _fmtTz(new Date(job.last_run_at)) : new Date(job.last_run_at).toLocaleString()) : t('never');
   const schedule = job.schedule_display || (job.schedule && job.schedule.expression) || '';
   const skills = Array.isArray(job.skills) && job.skills.length ? job.skills.join(', ') : '—';
   const deliver = job.deliver || 'local';
@@ -1361,7 +1365,10 @@ async function _loadCronDetailRuns(jobId, detailKey){
     const rows = data.runs.map((run, i) => {
       const ts = run.filename.replace('.md','').replace(/_/g,' ');
       const sizeStr = run.size > 1024 ? (run.size/1024).toFixed(1)+' KB' : run.size+' B';
-      const dateStr = new Date(run.modified * 1000).toLocaleString();
+      // Server-time formatting (#7140): run files are written by the agent in
+      // Hermes time; plain toLocaleString() would render the browser's zone.
+      const _fmtTz = (typeof _formatInServerTz === 'function') ? _formatInServerTz : null;
+      const dateStr = (_fmtTz ? _fmtTz(new Date(run.modified * 1000)) : new Date(run.modified * 1000).toLocaleString());
       const rid = `cron-det-run-${jobId}-${i}`;
       const usageStrip = isScriptJob ? '' : _formatCronRunUsageStrip(run.usage);
       const runExpanded = _cronExpansionGet(_cronRunExpandKey(jobId, run.filename));

--- a/tests/test_issue7140_cron_timezone.py
+++ b/tests/test_issue7140_cron_timezone.py
@@ -1,0 +1,98 @@
+"""Regression tests for issue #7140 — cron panel timezone.
+
+Root cause: ``api/routes.py`` sent ``"server_tz": time.strftime("%z")``, which
+returns the *process* timezone (UTC inside a typical container) rather than
+the configured Hermes timezone. The cron detail panel also formatted
+``Last run``/``Next run`` with a raw ``toLocaleString()``, so a job firing at
+08:00 server-local read as 1:35 AM UTC on the operator's screen.
+
+Fix:
+- ``_server_tz_offset()`` resolves the zone exactly like the agent:
+  ``HERMES_TIMEZONE`` env var -> ``timezone`` key in the active profile's
+  config.yaml -> process offset fallback.
+- ``static/panels.js`` cron detail and run-history rows use
+  ``_formatInServerTz()`` (guarded) instead of plain ``toLocaleString()``.
+"""
+
+import os
+import pathlib
+import re
+
+import pytest
+
+import api.routes as routes  # noqa: E402  — mirrors other WebUI test modules
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Backend: _server_tz_offset() resolves the configured Hermes timezone
+# ---------------------------------------------------------------------------
+
+def _server_tz_offset():
+    return routes._server_tz_offset()
+
+
+def test_server_tz_uses_hermes_timezone_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TIMEZONE", "America/Sao_Paulo")
+    offset = _server_tz_offset()
+    assert re.fullmatch(r"[+-]\d{4}", offset)
+    assert offset in ("-0300", "-0200")  # São Paulo DST range
+
+
+def test_server_tz_falls_back_to_config_timezone(monkeypatch, tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("timezone: Asia/Kolkata\n")
+    monkeypatch.setattr(routes, "_active_profile_config_path", lambda: config)
+    monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+    assert _server_tz_offset() == "+0530"
+
+
+def test_server_tz_falls_back_to_process_offset(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+    config = tmp_path / "config.yaml"
+    config.write_text("timezone: ''\n")
+    monkeypatch.setattr(routes, "_active_profile_config_path", lambda: config)
+    assert re.fullmatch(r"[+-]\d{4}", _server_tz_offset())
+
+
+def test_server_tz_invalid_zone_falls_back_safely(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TIMEZONE", "Not/AZone")
+    assert re.fullmatch(r"[+-]\d{4}", _server_tz_offset())
+
+
+def test_sessions_response_uses_server_tz_offset(monkeypatch):
+    """The sessions response must call _server_tz_offset(), not raw strftime."""
+    assert re.search(
+        r'"server_tz"\s*:\s*_server_tz_offset\(\)', ROUTES_PY
+    ), "routes.py must use _server_tz_offset() for server_tz"
+
+
+def test_routes_has_server_tz_helper():
+    """_server_tz_offset() must consult HERMES_TIMEZONE then config.yaml."""
+    assert "_server_tz_offset" in ROUTES_PY
+    assert 'os.getenv("HERMES_TIMEZONE"' in ROUTES_PY
+    assert 'cfg.get("timezone")' in ROUTES_PY
+
+
+# ---------------------------------------------------------------------------
+# Frontend: cron detail + run history use _formatInServerTz
+# ---------------------------------------------------------------------------
+
+def test_cron_detail_uses_format_in_server_tz():
+    """Cron detail 'Last run'/'Next run' must use _formatInServerTz (guarded)."""
+    assert "_formatInServerTz" in PANELS_JS
+    # The detail panel's nextRun/lastRun lines must route through _fmtTz.
+    detail_block = PANELS_JS[
+        PANELS_JS.index("const status = _cronStatusMeta(job);"):
+        PANELS_JS.index("const schedule = job.schedule_display")
+    ]
+    assert "_fmtTz(new Date(job.next_run_at))" in detail_block
+    assert "_fmtTz(new Date(job.last_run_at))" in detail_block
+
+
+def test_cron_run_history_uses_format_in_server_tz():
+    """Cron run-history timestamps must use _formatInServerTz (guarded)."""
+    assert "_fmtTz(new Date(run.modified * 1000))" in PANELS_JS


### PR DESCRIPTION
## Problem
The cron detail panel rendered **Last run**/**Next run** in the *browser's* timezone (UTC for most operators) instead of the configured Hermes timezone. A job firing at `08:00` server-local showed `1:35 AM` UTC — the cron fires correctly; only the displayed timestamp was wrong.

## Root cause
1. `api/routes.py` sent `"server_tz": time.strftime("%z")` — the **process** timezone (UTC in a typical container), not the configured Hermes zone. So `_serverTz` was always `+0000` and `_formatInServerTz` treated it as absent.
2. `static/panels.js` cron detail formatted with raw `toLocaleString()` and never called the existing `_formatInServerTz()` helper (other panels already use it).

## Fix
- New `_server_tz_offset()` in `api/routes.py` resolving the zone exactly like the agent: `HERMES_TIMEZONE` env → `timezone` key in the active profile's `config.yaml` → process offset fallback. Never raises.
- `/api/sessions` now sends `_server_tz_offset()`.
- Cron detail (Next/Last run) and cron run-history rows use `_formatInServerTz()` with the standard `typeof` guard.

## Tests
New `tests/test_issue7140_cron_timezone.py`: env override, config.yaml fallback (Asia/Kolkata → `+0530`), process fallback, invalid-zone safety, plus static checks that the panel routes through the helper. Full run: 42 passed.

Fixes #7140