### PR TITLE
fix(profiles): show profile display_name in the WebUI

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2002,6 +2002,7 @@ def _build_profile_rows_fast() -> list | None:
         enabled_count, total_count = _get_profile_skills_stats(home)
         return {
             'name': name,
+            'display_name': _profile_display_name_from_meta(home),
             'path': str(home),
             'is_default': is_default,
             'is_active': False,  # filled in by caller (cheap, varies per request)
@@ -2070,6 +2071,7 @@ def list_profiles_api() -> list:
                     enabled_count, total_count = _get_profile_skills_stats(p.path)
                     return [{
                         'name': p.name,
+                        'display_name': _profile_display_name_from_meta(p.path),
                         'path': str(p.path),
                         'is_default': p.is_default,
                         'is_active': True,  # Always true in isolated mode
@@ -2088,6 +2090,7 @@ def list_profiles_api() -> list:
         enabled_count, total_count = _get_profile_skills_stats(hermes_home)
         return [{
             'name': active,
+            'display_name': _profile_display_name_from_meta(hermes_home),
             'path': str(hermes_home),
             'is_default': active == 'default',
             'is_active': True,
@@ -2135,6 +2138,7 @@ def list_profiles_api() -> list:
             enabled_count, total_count = _get_profile_skills_stats(p.path)
             result.append({
                 'name': p.name,
+                'display_name': _profile_display_name_from_meta(p.path),
                 'path': str(p.path),
                 'is_default': p.is_default,
                 'is_active': p.name == active,
@@ -2166,6 +2170,24 @@ def _profile_visible_from_meta(profile_path: Path) -> bool:
         return True
     visible = data.get('visible')
     return visible is not False
+
+
+def _profile_display_name_from_meta(profile_path: Path) -> str:
+    """Return the profile's ``display_name`` from profile.yaml ('' if unset).
+
+    Mirrors ``_profile_visible_from_meta`` and the agent's own resolution
+    (``hermes_cli.profiles`` reads the same profile.yaml). Never raises.
+    """
+    try:
+        meta_path = Path(profile_path) / 'profile.yaml'
+        if not meta_path.exists():
+            return ''
+        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
+    except Exception:
+        return ''
+    if not isinstance(data, dict):
+        return ''
+    return str(data.get('display_name') or '').strip()
 
 
 def _default_profile_dict() -> dict:

--- a/api/routes.py
+++ b/api/routes.py
@@ -14651,6 +14651,9 @@ def handle_get(handler, parsed) -> bool:
             handler,
             {
                 "name": active_profile_name,
+                "display_name": profiles_api._profile_display_name_from_meta(
+                    profiles_api.get_active_hermes_home()
+                ),
                 "path": str(profiles_api.get_active_hermes_home()),
                 "is_default": profiles_api._is_root_profile(active_profile_name),
                 "default_workspace": _profile_default_workspace,

--- a/static/boot.js
+++ b/static/boot.js
@@ -3585,7 +3585,12 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       if (p && typeof p === 'object' && typeof p.name === 'string') {
         _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
         if (p.default_workspace) S._profileDefaultWorkspace = p.default_workspace;
-        return {status: 'resolved', profile: p.name || 'default', isDefault: !!p.is_default};
+        return {
+          status: 'resolved',
+          profile: p.name || 'default',
+          profileDisplay: (p.display_name && typeof p.display_name === 'string' && p.display_name.trim()) ? p.display_name.trim() : (p.name || 'default'),
+          isDefault: !!p.is_default,
+        };
       }
       if (p === undefined && !alreadyAttempted) {
         if (_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(markerStorage)) {
@@ -3613,13 +3618,14 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const activeProfileState = await _resolveActiveProfileBootstrapState();
   if (activeProfileState.status === 'recovery-redirect') return;
   S.activeProfile = activeProfileState.profile;
+  S.activeProfileDisplay = activeProfileState.profileDisplay || activeProfileState.profile;
   S.activeProfileIsDefault = activeProfileState.isDefault;
   applyBotName();
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
-  if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  if(profileLabel) profileLabel.textContent=S.activeProfileDisplay||S.activeProfile||'default';
   const titleLabel=$('titlebarProfileLabel');
-  if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
+  if(titleLabel) titleLabel.textContent=S.activeProfileDisplay||S.activeProfile||'default';
   const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;
   const _savedLocalBeforeProfileSwitch=localStorage.getItem('hermes-webui-session');
   const _profileSwitchProfileBefore=S.activeProfile||'default';

--- a/static/panels.js
+++ b/static/panels.js
@@ -6871,7 +6871,7 @@ function renderProfileDropdown(data) {
     const gwDot = `<span class="profile-opt-badge ${p.gateway_running ? 'running' : 'stopped'}"></span>`;
     const checkmark = p.name === active ? ' <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--link)" stroke-width="3" style="vertical-align:-1px"><polyline points="20 6 9 17 4 12"/></svg>' : '';
     const defaultBadge = p.is_default ? ` <span style="opacity:.5;font-weight:400">${esc(t('profile_default_label'))}</span>` : '';
-    opt.innerHTML = `<div class="profile-opt-name">${gwDot}${esc(p.name)}${defaultBadge}${checkmark}</div>` +
+    opt.innerHTML = `<div class="profile-opt-name">${gwDot}${esc(p.display_name||p.name)}${defaultBadge}${checkmark}</div>` +
       (meta.length ? `<div class="profile-opt-meta">${esc(meta.join(' \u00b7 '))}</div>` : '');
     opt.onclick = async () => {
       closeProfileDropdown();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4389,7 +4389,7 @@ function _showBatchProjectPicker(){
     const item=document.createElement('div');item.className='project-picker-item';
     if(p.color){const dot=document.createElement('span');dot.className='color-dot';
       dot.style.cssText='width:6px;height:6px;border-radius:50%;background:'+p.color+';flex-shrink:0;';item.appendChild(dot);}
-    const name=document.createElement('span');name.textContent=p.name;item.appendChild(name);
+    const name=document.createElement('span');name.textContent=p.display_name||p.name;item.appendChild(name);
     item.onclick=async()=>{picker.remove();
       try{await Promise.all(ids.map(sid=>api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:sid,project_id:p.project_id})})));
         showToast('Moved to '+p.name);exitSessionSelectMode();await renderSessionList();
@@ -7816,7 +7816,7 @@ function renderSessionListFromCache(){
         chip.appendChild(dot);
       }
       const nameSpan=document.createElement('span');
-      nameSpan.textContent=p.name;
+      nameSpan.textContent=p.display_name||p.name;
       chip.appendChild(nameSpan);
       let _pClickTimer=null;
       chip.onclick=(e)=>{
@@ -9251,7 +9251,7 @@ function _showProjectPicker(session, anchorEl){
       item.appendChild(dot);
     }
     const name=document.createElement('span');
-    name.textContent=p.name;
+    name.textContent=p.display_name||p.name;
     item.appendChild(name);
     item.onclick=async()=>{
       picker.remove();

--- a/static/ui.js
+++ b/static/ui.js
@@ -11005,9 +11005,9 @@ function syncTopbar(){
     if(typeof syncAppTitlebar==='function') syncAppTitlebar();
     // Update profile chip even when no session is active (e.g. right after profile switch)
     const _profileLabel=$('profileChipLabel');
-    if(_profileLabel) _profileLabel.textContent=S.activeProfile||'default';
+    if(_profileLabel) _profileLabel.textContent=S.activeProfileDisplay||S.activeProfile||'default';
     const _titleLabel=$('titlebarProfileLabel');
-    if(_titleLabel) _titleLabel.textContent=S.activeProfile||'default';
+    if(_titleLabel) _titleLabel.textContent=S.activeProfileDisplay||S.activeProfile||'default';
     return;
   }
   const sessionTitle=S.session.title||t('untitled');

--- a/tests/test_issue7151_profile_display_name.py
+++ b/tests/test_issue7151_profile_display_name.py
@@ -1,0 +1,96 @@
+"""Regression tests for issue #7151 — WebUI should show profile display_name.
+
+The agent resolves a profile's friendly name from ``display_name`` in the
+profile's ``profile.yaml`` (the CLI shows e.g. ``programmer (default)``), but
+the WebUI serialized only the canonical ``name`` and rendered it everywhere.
+
+Fix:
+- ``api/profiles.py``: ``_profile_display_name_from_meta()`` reads
+  ``display_name`` from each profile's ``profile.yaml``; every serialization
+  point in ``list_profiles_api()`` now includes ``display_name``.
+- ``api/routes.py``: ``/api/profile/active`` includes ``display_name``.
+- Frontend renders ``display_name || name`` (dropdown, chips, titlebar).
+
+Identity-sensitive spots (profile switching, cache lookups) intentionally keep
+using the canonical ``name`` — only display surfaces changed.
+"""
+
+import pathlib
+import re
+
+import api.profiles as profiles  # noqa: E402
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+PROFILES_PY = (REPO_ROOT / "api" / "profiles.py").read_text(encoding="utf-8")
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Backend: profile rows include display_name
+# ---------------------------------------------------------------------------
+
+def test_profile_rows_include_display_name():
+    """Every serialized profile row must carry display_name."""
+    assert "display_name" in PROFILES_PY
+    # Fast path row builder
+    fast = PROFILES_PY[PROFILES_PY.index("def _build_profile_rows_fast"):]
+    fast_row = fast[fast.index("def _row"):fast.index("rows: list = []")]
+    assert "'display_name': _profile_display_name_from_meta" in fast_row
+    # Slow fallback rows
+    slow = PROFILES_PY[PROFILES_PY.index("def list_profiles_api"):]
+    assert slow.count("'display_name':") >= 1
+
+
+def test_active_profile_endpoint_includes_display_name():
+    """/api/profile/active must include display_name."""
+    active_block = ROUTES_PY[ROUTES_PY.index('"/api/profile/active"'):]
+    assert '"display_name": profiles_api._profile_display_name_from_meta' in active_block
+
+
+def test_display_name_helper_reads_profile_yaml(tmp_path):
+    """_profile_display_name_from_meta reads profile.yaml; never raises."""
+    prof = tmp_path / "prof"
+    prof.mkdir()
+    (prof / "profile.yaml").write_text("display_name: Programmer\nvisible: true\n")
+    assert profiles._profile_display_name_from_meta(prof) == "Programmer"
+
+    # Missing file → ''
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert profiles._profile_display_name_from_meta(empty) == ""
+
+    # Corrupt yaml → ''
+    (prof / "profile.yaml").write_text("::: not yaml")
+    assert profiles._profile_display_name_from_meta(prof) == ""
+
+    # Missing key → ''
+    (prof / "profile.yaml").write_text("visible: false\n")
+    assert profiles._profile_display_name_from_meta(prof) == ""
+
+
+# ---------------------------------------------------------------------------
+# Frontend: display surfaces use display_name || name
+# ---------------------------------------------------------------------------
+
+def test_profile_dropdown_uses_display_name():
+    """The compose-footer profile dropdown renders display_name || name."""
+    assert "esc(p.display_name||p.name)" in PANELS_JS
+
+
+def test_sessions_profile_chip_uses_display_name():
+    """Session profile chips render display_name || name."""
+    assert "p.display_name||p.name" in SESSIONS_JS
+
+
+def test_boot_keeps_canonical_name_for_identity():
+    """Boot must keep canonical name as identity, add profileDisplay for UI."""
+    assert "profile: p.name || 'default'" in BOOT_JS
+    assert "profileDisplay:" in BOOT_JS
+    assert "S.activeProfileDisplay" in BOOT_JS
+    # Chip/titlebar labels must prefer the display name.
+    assert "S.activeProfileDisplay||S.activeProfile||'default'" in BOOT_JS
+    assert "S.activeProfileDisplay||S.activeProfile||'default'" in UI_JS


### PR DESCRIPTION
## Problem
The agent resolves a profile's friendly name from `display_name` in the profile's `profile.yaml` — the CLI shows e.g. `programmer (default)` — but the WebUI serialized only the canonical `name` and rendered it on every surface (dropdown, chips, titlebar).

## Fix
- `api/profiles.py`: new `_profile_display_name_from_meta()` (mirrors `_profile_visible_from_meta`; never raises). Every serialization point in `list_profiles_api()` now includes `display_name`: fast path, isolated mode, both fallbacks.
- `api/routes.py`: `/api/profile/active` includes `display_name`.
- Frontend renders `display_name || name` in the compose-footer profile dropdown, session profile chips/pickers, header chip and titlebar.
- Identity-sensitive spots (profile switching, cache lookups, boot identity) intentionally keep the canonical `name` — only display surfaces changed.

## Tests
New `tests/test_issue7151_profile_display_name.py`: row serialization, `/api/profile/active` payload, helper edge cases (missing file / corrupt yaml / missing key), and static frontend checks. Full run: 63 passed.

Fixes #7151