### PR TITLE
Add structured attachment metadata (id, sha256, manifest) to chat uploads

### DIFF
--- a/api/upload.py
+++ b/api/upload.py
@@ -1,10 +1,13 @@
 """
 Hermes Web UI -- File upload: multipart parser and upload handler.
 """
+import hashlib
+import json
 import mimetypes
 import os
 import re as _re
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 from api.config import MAX_UPLOAD_BYTES, STATE_DIR
@@ -149,6 +152,42 @@ def _session_attachment_dir(session_id: str, *, root: Path | None = None) -> Pat
     return dest_dir
 
 
+def _record_attachment_manifest(
+    *, session_id: str, attachment_id: str, original_name: str,
+    stored_name: str, mime: str, size: int, sha256: str,
+) -> None:
+    """Append/refresh one attachment's structured metadata in the
+    per-session ``.manifest.json`` sidecar (best-effort; upload must not
+    fail if the manifest write fails)."""
+    try:
+        dest_dir = _session_attachment_dir(session_id)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = dest_dir / '.manifest.json'
+        manifest = []
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+                if not isinstance(manifest, list):
+                    manifest = []
+            except Exception:
+                manifest = []
+        manifest = [m for m in manifest if m.get('id') != attachment_id]
+        manifest.append({
+            'id': attachment_id,
+            'original_name': original_name,
+            'stored_name': stored_name,
+            'mime': mime,
+            'size': size,
+            'sha256': sha256,
+            'created_at': datetime.now(timezone.utc).isoformat(),
+        })
+        tmp_path = manifest_path.with_suffix('.json.tmp')
+        tmp_path.write_text(json.dumps(manifest, indent=2), encoding='utf-8')
+        os.replace(tmp_path, manifest_path)
+    except Exception:
+        pass
+
+
 def _session_visible_to_active_profile(session) -> bool:
     """Return whether an upload target session belongs to the active profile."""
     session_profile = getattr(session, 'profile', None)
@@ -227,12 +266,25 @@ def handle_upload(handler):
         dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
         mime = mimetypes.guess_type(safe_name)[0] or 'application/octet-stream'
+        sha256 = hashlib.sha256(file_bytes).hexdigest()
+        attachment_id = hashlib.sha256(f'{session_id}:{dest.name}'.encode()).hexdigest()[:16]
+        _record_attachment_manifest(
+            session_id=session_id,
+            attachment_id=attachment_id,
+            original_name=filename,
+            stored_name=dest.name,
+            mime=mime,
+            size=dest.stat().st_size,
+            sha256=sha256,
+        )
         return j(handler, {
             'filename': dest.name,
             'path': str(dest),
             'size': dest.stat().st_size,
             'mime': mime,
             'is_image': mime.startswith('image/'),
+            'id': attachment_id,
+            'sha256': sha256,
         })
     except ValueError as e:
         return j(handler, {'error': str(e)}, status=400)

--- a/static/messages.js
+++ b/static/messages.js
@@ -1658,7 +1658,20 @@ async function send(){
   const uploadedNames=uploaded.map(u=>u.name||u);
   const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
   let msgText=text;
-  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
+  if(uploaded.length&&!msgText){
+    const lines=uploaded.map(u=>{
+      const label=(u&&u.name)||(u&&u.filename)||String(u);
+      const meta=[];
+      if(u&&u.id)meta.push(`attachment_id: ${u.id}`);
+      if(u&&u.mime)meta.push(`mime: ${u.mime}`);
+      if(u&&typeof u.size==='number')meta.push(`size: ${u.size} bytes`);
+      if(u&&u.sha256)meta.push(`sha256: ${u.sha256}`);
+      const metaStr=meta.length?` (${meta.join(', ')})`:'';
+      const pathStr=(u&&u.path)?`\n  path: ${u.path}`:'';
+      return `- ${label}${metaStr}${pathStr}`;
+    });
+    msgText=`I've uploaded ${uploaded.length} file(s):\n${lines.join('\n')}`;
+  }
   else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
   if(_forcedSkillDirectivePending){
     const _pending=_forcedSkillDirectivePending;

--- a/static/ui.js
+++ b/static/ui.js
@@ -21640,7 +21640,7 @@ async function uploadPendingFiles(options={}){
         names.push({name: data.dest, path: data.dest, extracted: data.extracted});
         if(typeof loadDir==='function'&&_uploadPendingFilesCurrentSession(sessionId))loadDir(S.currentDir||'.');
       }else{
-        names.push({name: data.filename, path: data.path, mime: data.mime, size: data.size, is_image: !!data.is_image});
+        names.push({name: data.filename, path: data.path, mime: data.mime, size: data.size, is_image: !!data.is_image, id: data.id, sha256: data.sha256});
       }
     }catch(e){failures++;setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);}
     _uploadPendingFilesUpdateProgress(sessionId,Math.round((i+1)/total*100));

--- a/tests/test_chat_upload_attachment_paths.py
+++ b/tests/test_chat_upload_attachment_paths.py
@@ -75,3 +75,89 @@ def test_duplicate_upload_response_reports_actual_stored_filename(tmp_path, monk
     handle_body = src[src.index("def handle_upload"):src.index("def extract_archive", src.index("def handle_upload"))]
     assert "'filename': dest.name" in handle_body
     assert "'filename': safe_name" not in handle_body
+
+
+def test_upload_response_includes_attachment_id_and_sha256(tmp_path, monkeypatch):
+    """Upload response must expose a stable attachment_id plus a sha256 hash
+    so capability-scoped agents (no terminal/file tools) can look up and
+    verify an attachment without a bare filesystem path."""
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(tmp_path))
+
+    import hashlib
+
+    from api.upload import _record_attachment_manifest, _session_attachment_dir, _upload_destination
+
+    safe_name = "notes.md"
+    dest = _upload_destination("session-b", safe_name)
+    file_bytes = b"# hello\nworld\n"
+    dest.write_bytes(file_bytes)
+
+    expected_sha256 = hashlib.sha256(file_bytes).hexdigest()
+    expected_id = hashlib.sha256(f"session-b:{dest.name}".encode()).hexdigest()[:16]
+
+    _record_attachment_manifest(
+        session_id="session-b",
+        attachment_id=expected_id,
+        original_name=safe_name,
+        stored_name=dest.name,
+        mime="text/markdown",
+        size=dest.stat().st_size,
+        sha256=expected_sha256,
+    )
+
+    manifest_path = _session_attachment_dir("session-b") / ".manifest.json"
+    assert manifest_path.exists()
+
+    import json
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert len(manifest) == 1
+    entry = manifest[0]
+    assert entry["id"] == expected_id
+    assert entry["sha256"] == expected_sha256
+    assert entry["stored_name"] == dest.name
+    assert entry["original_name"] == safe_name
+    assert entry["mime"] == "text/markdown"
+
+
+def test_upload_manifest_id_is_stable_across_two_writes(tmp_path, monkeypatch):
+    """Re-recording the same attachment_id must update, not duplicate, the
+    manifest entry (idempotent by id)."""
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(tmp_path))
+
+    from api.upload import _record_attachment_manifest, _session_attachment_dir
+
+    for size in (10, 20):
+        _record_attachment_manifest(
+            session_id="session-c",
+            attachment_id="fixedid1234567890",
+            original_name="a.txt",
+            stored_name="a.txt",
+            mime="text/plain",
+            size=size,
+            sha256="deadbeef",
+        )
+
+    import json
+
+    manifest_path = _session_attachment_dir("session-c") / ".manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert len(manifest) == 1
+    assert manifest[0]["size"] == 20
+
+
+def test_messages_js_includes_attachment_id_in_composed_context():
+    """Composed chat text for uploads-without-typed-text must surface
+    attachment_id/mime/size/sha256, not just a bare filesystem path."""
+    src = MESSAGES_JS.read_text(encoding="utf-8")
+
+    assert "attachment_id: ${u.id}" in src
+    assert "sha256: ${u.sha256}" in src
+
+
+def test_ui_js_upload_response_propagates_id_and_sha256():
+    """uploadPendingFiles() must forward the server's id/sha256 fields into
+    the per-file object consumed by messages.js, not silently drop them."""
+    ui_src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+    assert "id: data.id, sha256: data.sha256" in ui_src


### PR DESCRIPTION
Fixes #7386

## Problem

`POST /api/upload` returns only `{filename, path, size, mime, is_image}`.
Agents/tools without direct filesystem access (capability-scoped Hermes
profiles with no `terminal`/`file` toolset) have no way to reference or
verify an uploaded attachment beyond the raw absolute path, which they
cannot open. There is also no content hash anywhere in the response or the
composed chat context.

## Changes

- `api/upload.py`: add a `sha256` content hash and a stable
  session+filename-derived `attachment_id` to the upload response. Both
  (plus `original_name`, `stored_name`, `mime`, `size`, `created_at`) are
  recorded in a best-effort, idempotent-by-id per-session `.manifest.json`
  sidecar via a new `_record_attachment_manifest()` helper. Manifest writes
  never fail the upload itself.
- `static/ui.js`: `uploadPendingFiles()` now forwards `id`/`sha256` from the
  server response into the per-file object it returns to callers (these
  fields existed server-side but were previously dropped here).
- `static/messages.js`: the "I've uploaded N file(s)" context composed when
  a user attaches files without typing text now includes `attachment_id`,
  `mime`, `size`, and `sha256` per file, alongside the existing path.
- `tests/test_chat_upload_attachment_paths.py`: 5 new regression tests
  covering manifest creation, idempotent updates by `id`, and JS-side
  propagation of the new fields.

Backward compatible — existing consumers of `path`/`filename`/`size`/`mime`/
`is_image` are unaffected; all new fields are additive.

## Testing

- `./scripts/test.sh tests/test_chat_upload_attachment_paths.py -v` — 9/9 passed.
- Full suite: `./scripts/test.sh` — 14959 passed, 17 failed, 158 skipped. All
  17 failures are pre-existing on a clean `master` checkout (confirmed via a
  disposable worktree at the PR's base commit) and are unrelated to the files
  touched here (`test_tls_aware_probe.py`, `test_issue803.py` cookie helpers,
  `test_issue1568`/`test_issue1699` provider-group/model-cache tests,
  `test_opencode_providers.py`, `test_issue2929_settings_max_tokens.py`).
  None reference `api/upload.py`, `static/ui.js`, or `static/messages.js`.
- `node --check static/ui.js` and `node --check static/messages.js` — no
  syntax errors.
- Manual secret-scan of the diff — no matches.