### PR TITLE
fix: make run-journal recovery idempotent (repeated repair passes multiplied recovered rows)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2706,7 +2706,7 @@ def _recover_journaled_output_and_terminal_error(
     session,
     stream_id: str | None,
     *,
-    dedupe_existing: bool = False,
+    dedupe_existing: bool = True,
     terminal_recovery: dict | None = None,
 ) -> tuple[bool, bool]:
     """Recover readable activity first, then append its authoritative terminal error."""
@@ -2760,7 +2760,7 @@ def _append_journaled_partial_output(
     session,
     stream_id: str | None,
     *,
-    dedupe_existing: bool = False,
+    dedupe_existing: bool = True,
 ) -> bool:
     """Recover already-emitted visible output from a dead stream journal.
 
@@ -3439,6 +3439,7 @@ def _apply_core_sync_or_error_marker(
             _recover_journaled_output_and_terminal_error(
                 session,
                 _stream_id,
+                dedupe_existing=True,
                 terminal_recovery=_terminal_recovery,
             )
         )

--- a/api/models.py
+++ b/api/models.py
@@ -2425,14 +2425,19 @@ def _find_existing_assistant_for_journal_content(
 
     def _owns_turn(idx: int) -> bool:
         message = messages[idx]
-        if (
-            stream_id
-            and message.get('_recovered_stream_id') == stream_id
-        ):
+        # Stream-locked rows (recovered by an earlier pass) may only be
+        # claimed by the SAME stream — symmetric with the tool path, and it
+        # closes the cross-stream collapse asymmetry flagged in the #7388
+        # attack review.
+        if stream_id and message.get('_recovered_stream_id') == stream_id:
             return True
         if turn_start is not None:
-            # Window is defined: only rows inside it (or same-stream rows)
-            # are claimable. Earlier turns are legitimate repetition.
+            # Window is defined: window position suffices for rows that are
+            # NOT stream-tagged (they belong to this turn's core/live state);
+            # stream-tagged rows from OTHER streams were already excluded
+            # above. Earlier turns are legitimate repetition.
+            if message.get('_recovered_stream_id'):
+                return False
             return idx >= turn_start
         # No matchable pending checkpoint (quiescent session, or the pending
         # message has no surviving row): no current-turn boundary exists to
@@ -2505,21 +2510,25 @@ def _journal_tool_already_present(
         )
         if existing_preview != candidate_preview:
             continue
-        if candidate_stream is not None:
-            existing_stream = tool_call.get('_recovered_stream_id')
-            # A tool card explicitly tagged with a recovered_stream_id that
-            # differs from ours belongs to another retry's turn — don't let
-            # it pre-empt this retry.  Untagged tool cards (live) still
-            # match, but only with proven turn ownership (below).
-            if existing_stream and str(existing_stream) != candidate_stream:
+        # Ownership check (#7388 re-review) — branch on the EXISTING card's
+        # provenance, not on which arguments the caller supplied:
+        #   * tagged with another stream  -> another recovery's turn: skip.
+        #   * tagged with our stream      -> same-stream idempotency: match.
+        #   * untagged (a live card)      -> only a proven current-turn
+        #     window position (assistant_msg_idx >= turn_start) may match;
+        #     without a window there is nothing proving the card isn't from
+        #     an earlier turn, so it must NOT suppress the current tool.
+        existing_stream = tool_call.get('_recovered_stream_id')
+        if existing_stream:
+            if str(existing_stream) != (candidate_stream or ''):
                 continue
-        elif turn_start is not None:
-            # Untagged candidate + a known turn boundary: require the existing
-            # card to belong to the current turn. Cards attached to earlier
-            # assistant turns are legitimate repetitions, not duplicates.
+            return True
+        if turn_start is not None:
             owner_idx = tool_call.get('assistant_msg_idx')
-            if not isinstance(owner_idx, int) or owner_idx < turn_start:
-                continue
+            if isinstance(owner_idx, int) and owner_idx >= turn_start:
+                return True
+            continue
+        # Legacy degrade (no stream id and no window): pre-fix behavior.
         return True
     return False
 
@@ -2710,25 +2719,53 @@ def _pending_recovery_turn_window_start(session) -> int | None:
     dedupe (#7388 review) needs the window's opening edge: rows at/after the
     checkpoint user message belong to the turn being recovered and may
     absorb journal output; earlier rows are prior turns and must never be
-    claimed.  Returns None when there is no pending message or no row
-    matches it — callers then degrade to stream-tag-only (or, for a
+    claimed.
+
+    Matching precedence (#7388 re-review): EXACT checkpoint identity
+    (timestamp/source/attachment-aware) is scanned across the whole
+    transcript FIRST; the text-only fallback runs only when no exact
+    checkpoint exists, and then takes the LATEST applicable match — an
+    earlier turn that repeated the same prompt text must never win the
+    window.  Returns None when there is no pending message or no row
+    matches it at all — callers then degrade to stream-tag-only (or, for a
     quiescent session with no stream id, legacy session-wide) behavior.
     """
     pending_text = getattr(session, 'pending_user_message', None)
     if not pending_text:
         return None
-    for idx, message in enumerate(session.messages or []):
-        if not isinstance(message, dict):
-            continue
+    messages = [
+        message for message in (session.messages or [])
+        if isinstance(message, dict)
+    ]
+    # Pass 1: exact checkpoint identity anywhere in the transcript. Which
+    # match owns the window: the LATEST match that is NOT a `_recovered`
+    # repair artifact is the current turn's real submission — recovered rows
+    # are appended by the repair path itself (before journal recovery runs)
+    # and must never act as turn boundaries (#7388 attack A: without this,
+    # the repair's own recovered row re-opens the window at the earliest
+    # identical-prompt turn). If ONLY recovered echoes match, the earliest
+    # echo is the best surviving boundary (#3929 owner-echo keeps its core
+    # row claimable).
+    exact_matches = [
+        idx for idx, message in enumerate(messages)
         if _message_matches_pending_checkpoint(
             message,
             pending_text,
             session.pending_started_at,
             session.pending_user_source,
             session.pending_attachments,
-        ) or _message_matches_pending_text(message, pending_text):
-            return idx
-    return None
+        )
+    ]
+    if exact_matches:
+        real = [idx for idx in exact_matches
+                if not messages[idx].get('_recovered')]
+        return real[-1] if real else exact_matches[0]
+    # Pass 2: text-only fallback, LATEST applicable match.
+    fallback = None
+    for idx, message in enumerate(messages):
+        if _message_matches_pending_text(message, pending_text):
+            fallback = idx
+    return fallback
 
 
 def _materialize_unsaved_gateway_terminal_error(

--- a/api/models.py
+++ b/api/models.py
@@ -2401,12 +2401,45 @@ def _find_existing_assistant_for_journal_content(
     *,
     max_index: int | None = None,
     excluded_indexes: set[int] | None = None,
+    stream_id: str | None = None,
+    turn_start: int | None = None,
 ) -> int | None:
+    """Find an earlier assistant row this journal segment can collapse into.
+
+    Turn-ownership rule (#7388 review): a match is only accepted when the
+    candidate row provably belongs to the turn being recovered — either it
+    sits at/after the pending-user checkpoint (``turn_start``) or it was
+    materialized by THIS stream's own earlier recovery pass
+    (``_recovered_stream_id == stream_id``). An identical answer from an
+    EARLIER turn is a legitimate transcript repetition, not a duplicate, and
+    must not suppress the current turn's row. Rows that cannot prove
+    ownership (e.g. legacy rows predating stream-id tagging, when no pending
+    checkpoint is matchable) are never claimed — recovery appends instead,
+    which errs toward preserving content.
+    """
     candidate = _normalize_journal_recovery_text(content)
     if not candidate:
         return None
     messages = session.messages or []
     stop = len(messages) if max_index is None else min(len(messages), max_index)
+
+    def _owns_turn(idx: int) -> bool:
+        message = messages[idx]
+        if (
+            stream_id
+            and message.get('_recovered_stream_id') == stream_id
+        ):
+            return True
+        if turn_start is not None:
+            # Window is defined: only rows inside it (or same-stream rows)
+            # are claimable. Earlier turns are legitimate repetition.
+            return idx >= turn_start
+        # No matchable pending checkpoint (quiescent session, or the pending
+        # message has no surviving row): no current-turn boundary exists to
+        # protect, so legacy session-wide matching applies. This preserves
+        # the #3929 reasoning-backfill contract on pre-stream-id transcripts.
+        return True
+
     substring_match = None
     for idx in range(stop):
         if excluded_indexes and idx in excluded_indexes:
@@ -2420,8 +2453,15 @@ def _find_existing_assistant_for_journal_content(
         if not existing:
             continue
         if existing == candidate:
-            return idx
-        if substring_match is None and len(candidate) >= 24 and candidate in existing:
+            if _owns_turn(idx):
+                return idx
+            continue
+        if (
+            substring_match is None
+            and len(candidate) >= 24
+            and candidate in existing
+            and _owns_turn(idx)
+        ):
             substring_match = idx
     return substring_match
 
@@ -2432,6 +2472,7 @@ def _journal_tool_already_present(
     preview: str,
     *,
     stream_id: str | None = None,
+    turn_start: int | None = None,
 ) -> bool:
     """Return True when an equivalent tool card already exists.
 
@@ -2443,12 +2484,13 @@ def _journal_tool_already_present(
       legitimately-repeated tool (e.g. a second ``terminal: ls`` in a
       different turn) would be dropped.
     * If the existing tool card has no ``_recovered_stream_id`` (a live tool
-      card, or a tool card carried over from a core transcript that pre-dates
-      stream-id tagging), the legacy name+preview match still wins.  This
-      preserves the "core transcript already has this tool, don't duplicate
-      it" invariant the original repair path established.
-    * When ``stream_id`` is omitted, the helper degrades cleanly to its
-      pre-fix session-wide behaviour.
+      card), it only suppresses the current tool when turn ownership is
+      proven — the card's ``assistant_msg_idx`` sits at/after the pending-user
+      checkpoint (``turn_start``). An identical untagged tool from an EARLIER
+      turn is legitimate transcript repetition (#7388 review), not a
+      duplicate.
+    * When ``stream_id`` and ``turn_start`` are both omitted, the helper
+      degrades cleanly to its pre-fix session-wide behaviour.
     """
     candidate_name = str(name or '')
     candidate_preview = _normalize_journal_recovery_text(preview)
@@ -2467,9 +2509,16 @@ def _journal_tool_already_present(
             existing_stream = tool_call.get('_recovered_stream_id')
             # A tool card explicitly tagged with a recovered_stream_id that
             # differs from ours belongs to another retry's turn — don't let
-            # it pre-empt this retry.  Untagged tool cards (live or carried
-            # over from the core transcript) still match.
+            # it pre-empt this retry.  Untagged tool cards (live) still
+            # match, but only with proven turn ownership (below).
             if existing_stream and str(existing_stream) != candidate_stream:
+                continue
+        elif turn_start is not None:
+            # Untagged candidate + a known turn boundary: require the existing
+            # card to belong to the current turn. Cards attached to earlier
+            # assistant turns are legitimate repetitions, not duplicates.
+            owner_idx = tool_call.get('assistant_msg_idx')
+            if not isinstance(owner_idx, int) or owner_idx < turn_start:
                 continue
         return True
     return False
@@ -2642,6 +2691,35 @@ def _pending_recovery_turn_start(session) -> int | None:
         return None
     for idx in range(len(session.messages or []) - 1, -1, -1):
         message = session.messages[idx]
+        if _message_matches_pending_checkpoint(
+            message,
+            pending_text,
+            session.pending_started_at,
+            session.pending_user_source,
+            session.pending_attachments,
+        ) or _message_matches_pending_text(message, pending_text):
+            return idx
+    return None
+
+
+def _pending_recovery_turn_window_start(session) -> int | None:
+    """First index of the turn being recovered (checkpoint row itself).
+
+    Unlike ``_pending_recovery_turn_start`` (which returns the LAST matching
+    row so error-marker surgery sees the whole recovered tail), turn-scoped
+    dedupe (#7388 review) needs the window's opening edge: rows at/after the
+    checkpoint user message belong to the turn being recovered and may
+    absorb journal output; earlier rows are prior turns and must never be
+    claimed.  Returns None when there is no pending message or no row
+    matches it — callers then degrade to stream-tag-only (or, for a
+    quiescent session with no stream id, legacy session-wide) behavior.
+    """
+    pending_text = getattr(session, 'pending_user_message', None)
+    if not pending_text:
+        return None
+    for idx, message in enumerate(session.messages or []):
+        if not isinstance(message, dict):
+            continue
         if _message_matches_pending_checkpoint(
             message,
             pending_text,
@@ -2864,12 +2942,19 @@ def _append_journaled_partial_output(
         if dedupe_existing and content:
             search_excluded = set(claimed_existing_assistant_indexes)
             existing_idx = None
+            # Turn-ownership scope (#7388 review): only rows owned by the
+            # turn being recovered may absorb this journal segment. The
+            # window opens at the FIRST checkpoint-matching row; when no
+            # window exists, _owns_turn degrades to legacy behavior.
+            _turn_start = _pending_recovery_turn_window_start(session)
             while True:
                 candidate_idx = _find_existing_assistant_for_journal_content(
                     session,
                     content,
                     max_index=initial_message_count,
                     excluded_indexes=search_excluded,
+                    stream_id=stream_id,
+                    turn_start=_turn_start,
                 )
                 if candidate_idx is None:
                     break
@@ -3009,6 +3094,7 @@ def _append_journaled_partial_output(
             preview = str(payload.get('preview') or '')
             if dedupe_existing and _journal_tool_already_present(
                 session, name, preview, stream_id=stream_id,
+                turn_start=_pending_recovery_turn_window_start(session),
             ):
                 current_assistant_idx = anchor_idx
                 continue

--- a/tests/test_journal_recovery_turn_scope.py
+++ b/tests/test_journal_recovery_turn_scope.py
@@ -181,3 +181,57 @@ def test_same_stream_repeat_still_dedupes(tmp_path):
     assert len(s.messages) == after_first, (
         f"same-stream re-recovery grew rows: {after_first} -> {len(s.messages)}"
     )
+
+
+def test_same_second_identical_prompt_window_opens_at_current_turn(tmp_path):
+    """#7388 attack A: two turns share the same wall-clock second, so int()
+    truncation makes the EARLIER user row satisfy the checkpoint exactly.
+    The window must still open at the LATEST exact match (the pending row),
+    and both turns' answers must survive."""
+    prompt = "list the files"
+    answer = "README, main.py, setup.cfg."
+    same_ts = 1788145950  # identical int second for BOTH turns
+    _write_journal(answer)
+
+    s = Session(session_id="turnscope", title="turn-scope")
+    s.messages = [
+        {"role": "user", "content": prompt, "timestamp": same_ts},
+        {"role": "assistant", "content": answer, "timestamp": same_ts + 10},
+    ]
+    s.tool_calls = [{
+        "name": "terminal", "preview": "ls", "snippet": "ls", "tid": "live-1",
+        "assistant_msg_idx": 1, "args": {"cmd": "ls"}, "done": True,
+    }]
+    s.pending_user_message = prompt
+    s.pending_started_at = same_ts  # same second as the earlier turn
+    s.pending_user_source = "webui"
+    s.active_stream_id = STREAM_ID
+    s.messages.append({
+        "role": "user", "content": prompt, "timestamp": same_ts,
+    })
+    s.messages.append({
+        "role": "assistant", "type": "interrupted", "content": "interrupted",
+        "timestamp": same_ts + 10, "_pending_journal_recovery": True,
+        "_journal_retry_stream_id": STREAM_ID,
+        "_journal_retry_first_seen_ts": same_ts + 10,
+        "_journal_retry_attempts": 0,
+    })
+    s.save(touch_updated_at=False)
+
+    window = models._pending_recovery_turn_window_start(s)
+    assert window == 2, f"window opened at {window}, expected the pending row (2)"
+
+    core_path = models.SESSION_DIR / "turnscope.json"
+    models._apply_core_sync_or_error_marker(
+        s, core_path, STREAM_ID,
+        require_stream_dead=False, touch_updated_at=False,
+    )
+    answers = [
+        m for m in s.messages
+        if m.get("role") == "assistant" and m.get("content") == answer
+    ]
+    assert len(answers) == 2, (
+        f"same-second repeated answer collapsed: {len(answers)} rows, expected 2"
+    )
+    current_tools = [t for t in (s.tool_calls or []) if t.get("tid") != "live-1"]
+    assert current_tools, "same-second repeated tool card collapsed"

--- a/tests/test_journal_recovery_turn_scope.py
+++ b/tests/test_journal_recovery_turn_scope.py
@@ -1,0 +1,183 @@
+"""Regression tests for the #7388 review: dedupe must be turn-scoped.
+
+A current turn that legitimately repeats an earlier turn's answer or tool
+call must keep its rows — only same-turn (same-stream or pending-checkpoint-
+window) rows may collapse. Composed through the real repair path
+(_apply_core_sync_or_error_marker), not just the recovery helper.
+"""
+import json
+
+import pytest
+
+import api.config as config
+import api.models as models
+from api.models import Session
+
+
+STREAM_ID = "turnscopestream00000000000000000"
+
+BASE_ENV = {
+    "session_id": "turnscope",
+    "title": "turn-scope",
+    "active_stream_id": None,
+    "pending_user_message": None,
+    "pending_started_at": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    (session_dir / "_run_journal" / "turnscope").mkdir(parents=True)
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+
+
+def _write_journal(answer_text, tool_name="terminal", tool_cmd="ls"):
+    lines = []
+    seq = 0
+
+    def ev(name, payload):
+        nonlocal seq
+        seq += 1
+        lines.append(json.dumps({
+            "event": name, "seq": seq, "session_id": "turnscope",
+            "run_id": STREAM_ID, "created_at": 1788146009.0 + seq,
+            "payload": payload,
+        }))
+
+    ev("token", {"text": answer_text})
+    ev("tool", {"name": tool_name, "args": {"cmd": tool_cmd}})
+    ev("tool_complete", {"name": tool_name, "result": "done"})
+    path = models.SESSION_DIR / "_run_journal" / "turnscope" / f"{STREAM_ID}.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _session_with_earlier_turn(answer_text, tool_cmd="ls"):
+    """A completed earlier turn: user -> assistant (same answer) with an
+    untagged tool card (same name+preview) attached to it, then a pending
+    user turn whose stream died and left the recovery marker."""
+    s = Session(session_id="turnscope", title="turn-scope")
+    s.messages = [
+        {"role": "user", "content": "do the thing", "timestamp": 1788145900},
+        {"role": "assistant", "content": answer_text, "timestamp": 1788145910},
+    ]
+    s.tool_calls = [{
+        "name": "terminal",
+        "preview": "ls",
+        "snippet": "ls",
+        "tid": "live-1",
+        "assistant_msg_idx": 1,
+        "args": {"cmd": tool_cmd},
+        "done": True,
+    }]
+    s.pending_user_message = "do the thing again"
+    s.pending_started_at = 1788146000
+    s.active_stream_id = STREAM_ID
+    s.messages.append({
+        "role": "user", "content": "do the thing again", "timestamp": 1788146000,
+    })
+    s.messages.append({
+        "role": "assistant", "type": "interrupted", "content": "interrupted",
+        "timestamp": 1788146010, "_pending_journal_recovery": True,
+        "_journal_retry_stream_id": STREAM_ID,
+        "_journal_retry_first_seen_ts": 1788146010,
+        "_journal_retry_attempts": 0,
+    })
+    return s
+
+
+
+def _run_repair(session):
+    core_path = models.SESSION_DIR / "turnscope.json"
+    # No core transcript exists in this scenario: the repair takes the
+    # pending-recovery branch (messages non-empty) directly.
+    models._apply_core_sync_or_error_marker(
+        session, core_path, STREAM_ID,
+        require_stream_dead=False, touch_updated_at=False,
+    )
+
+def test_repeated_answer_across_turns_is_kept(tmp_path):
+    """The current turn's answer equals an earlier turn's answer word for
+    word. The current row must survive — the maintenance reviewer's first
+    required case."""
+    answer = "The listing shows three files: README, main.py, setup.cfg."
+    _write_journal(answer)
+    s = _session_with_earlier_turn(answer)
+    s.save(touch_updated_at=False)
+
+    _run_repair(s)
+
+    answers = [
+        m for m in s.messages
+        if m.get("role") == "assistant" and m.get("content") == answer
+    ]
+    assert len(answers) == 2, (
+        f"current turn's repeated answer was suppressed "
+        f"({len(answers)} rows, expected 2)"
+    )
+
+
+def test_repeated_tool_across_turns_is_kept(tmp_path):
+    """Same name+preview tool as an earlier untagged turn — the current
+    tool card must survive."""
+    answer = "Second turn output, distinct from the first turn's prose."
+    _write_journal(answer, tool_name="terminal", tool_cmd="ls")
+    s = _session_with_earlier_turn(
+        "First turn output, entirely different prose entirely.",
+    )
+    s.save(touch_updated_at=False)
+
+    _run_repair(s)
+
+    current_tools = [
+        t for t in (s.tool_calls or [])
+        if t.get("tid") != "live-1"
+    ]
+    assert current_tools, "current turn's repeated tool card was suppressed"
+
+
+def test_same_stream_repeat_still_dedupes(tmp_path):
+    """The original 1.65GB bug must stay fixed: recovering the SAME stream
+    twice must not grow the transcript."""
+    answer = "Deterministic crash-window answer used twice via re-recovery."
+    _write_journal(answer)
+
+    s = Session(session_id="turnscope", title="turn-scope")
+    s.messages = [
+        {"role": "user", "content": "ask", "timestamp": 1788146000},
+    ]
+    s.pending_user_message = "ask"
+    s.pending_started_at = 1788146000
+    s.active_stream_id = STREAM_ID
+    s.messages.append({
+        "role": "assistant", "type": "interrupted", "content": "interrupted",
+        "timestamp": 1788146010, "_pending_journal_recovery": True,
+        "_journal_retry_stream_id": STREAM_ID,
+        "_journal_retry_first_seen_ts": 1788146010,
+        "_journal_retry_attempts": 0,
+    })
+
+    _run_repair(s)
+    after_first = len(s.messages)
+
+    for _ in range(4):
+        models._recover_journaled_output_and_terminal_error(
+            s, STREAM_ID, dedupe_existing=True,
+        )
+    assert len(s.messages) == after_first, (
+        f"same-stream re-recovery grew rows: {after_first} -> {len(s.messages)}"
+    )

--- a/tests/test_run_journal_recovery_idempotent.py
+++ b/tests/test_run_journal_recovery_idempotent.py
@@ -1,0 +1,177 @@
+"""Repro: run-journal recovery must be idempotent across repeated passes.
+
+Production evidence (99ed0f78e02d, Aug 2026): a session that went through
+repeated restart/recovery cycles accumulated 458,782 duplicate empty
+assistant rows — each of ~28 distinct reasoning texts duplicated exactly
+16,385 times (2**14 + 1), a power-of-two pattern consistent with the
+recovered array being re-appended on every recovery pass.
+
+Recovery replays the full journal from seq 1 every pass
+(_append_journaled_partial_output never passes after_seq), and its dedupe
+only matches rows stamped with the SAME stream id inside
+range(initial_message_count) — and only when dedupe_existing=True, which
+the pending-turn repair caller does not pass.
+
+These tests assert the invariant: recovering the same journal N times must
+produce the same rows as recovering it once.
+"""
+import json
+
+import pytest
+
+import api.config as config
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    (session_dir / "_run_journal" / "reprosid").mkdir(parents=True)
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+
+
+STREAM_ID = "reprostream0000000000000000000000"
+
+REASONING_TEXTS = [f"recovery reasoning block {i} " + "x" * 40 for i in range(4)]
+
+
+def _write_synthetic_journal(session_dir, *, terminal=True):
+    """A small but realistic dead-stream journal: interleaved reasoning
+    deltas that coalesce into REASONING_TEXTS full blocks, one tool pair,
+    and (optionally) no terminal event (the crash case)."""
+    journal = session_dir / "_run_journal" / "reprosid" / f"{STREAM_ID}.jsonl"
+    seq = 0
+
+    def ev(name, payload):
+        nonlocal seq
+        seq += 1
+        return json.dumps({
+            "event": name, "seq": seq, "session_id": "reprosid",
+            "run_id": STREAM_ID, "created_at": 1788146009.0 + seq,
+            "payload": payload,
+        })
+
+    lines = []
+    # reasoning arrives in deltas; each full text is built from 3 chunks
+    # (boundaries at i*len//3 so the chunks concatenate to the exact text)
+    for text in REASONING_TEXTS:
+        L = len(text)
+        for i in range(3):
+            lines.append(ev("reasoning", {"text": text[i * L // 3:(i + 1) * L // 3]}))
+    lines.append(ev("tool", {"name": "terminal", "args": {"cmd": "ls"}}))
+    lines.append(ev("tool_complete", {"name": "terminal", "result": "ok"}))
+    lines.append(ev("token", {"text": "Visible partial answer text."}))
+    if terminal:
+        lines.append(ev("stream_end", {}))
+    journal.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return journal
+
+
+def _fresh_session_with_pending_marker(session_dir):
+    s = Session(session_id="reprosid", title="repro")
+    s.messages = [
+        {"role": "user", "content": "run the thing", "timestamp": 1788146000},
+    ]
+    s.pending_user_message = "run the thing"
+    s.pending_started_at = 1788146001
+    s.active_stream_id = STREAM_ID
+    marker = {
+        "role": "assistant", "type": "interrupted",
+        "content": "interrupted", "timestamp": 1788146010,
+        "_pending_journal_recovery": True,
+        "_journal_retry_stream_id": STREAM_ID,
+        "_journal_retry_first_seen_ts": 1788146010,
+        "_journal_retry_attempts": 0,
+    }
+    s.messages.append(marker)
+    return s
+
+
+def test_recovery_is_idempotent_across_repeated_passes(tmp_path):
+    session_dir = tmp_path / "sessions"
+    _write_synthetic_journal(session_dir)
+
+    s = _fresh_session_with_pending_marker(session_dir)
+    s.save(touch_updated_at=False)
+
+    # First pass: recovery legitimately appends recovered rows.
+    recovered, _ = models._recover_journaled_output_and_terminal_error(
+        s, STREAM_ID, dedupe_existing=True,
+    )
+    assert recovered, "first recovery should recover journaled output"
+    after_first = len(s.messages)
+
+    # Simulate the production pattern: the retry path runs the recovery
+    # again on a session that already holds the recovered rows (this is
+    # what every get_session()/restart cycle did).
+    for _ in range(5):
+        models._recover_journaled_output_and_terminal_error(
+            s, STREAM_ID, dedupe_existing=True,
+        )
+    assert len(s.messages) == after_first, (
+        f"recovery re-appended rows: {after_first} -> {len(s.messages)}"
+    )
+
+
+def test_recovery_without_dedupe_flag_is_still_bounded(tmp_path):
+    """The pending-turn repair caller (models.py ~3447) passes no
+    dedupe_existing flag. Repeated repair passes must not grow the
+    transcript either."""
+    session_dir = tmp_path / "sessions"
+    _write_synthetic_journal(session_dir)
+
+    s = _fresh_session_with_pending_marker(session_dir)
+    s.save(touch_updated_at=False)
+
+    models._recover_journaled_output_and_terminal_error(s, STREAM_ID)
+    after_first = len(s.messages)
+    for _ in range(5):
+        models._recover_journaled_output_and_terminal_error(s, STREAM_ID)
+    assert len(s.messages) == after_first, (
+        f"no-flag recovery re-appended rows: {after_first} -> {len(s.messages)}"
+    )
+
+
+def test_reasoning_blocks_recovered_exactly_once(tmp_path):
+    """Content invariant: each distinct reasoning text occurs exactly once
+    across the transcript after repeated recoveries (recovery may coalesce
+    consecutive reasoning events into one row — that is fine; duplication
+    is not)."""
+    session_dir = tmp_path / "sessions"
+    _write_synthetic_journal(session_dir)
+
+    s = _fresh_session_with_pending_marker(session_dir)
+    for _ in range(4):
+        models._recover_journaled_output_and_terminal_error(
+            s, STREAM_ID, dedupe_existing=True,
+        )
+
+    def norm(t):
+        return "".join(t.split())
+
+    all_reasoning = norm(" ".join(
+        str(m.get("reasoning") or "")
+        for m in s.messages
+        if isinstance(m, dict) and m.get("role") == "assistant"
+    ))
+    for text in REASONING_TEXTS:
+        n = norm(text)
+        occurrences = all_reasoning.count(n)
+        assert occurrences == 1, (
+            f"reasoning block appeared {occurrences}x across transcript, expected 1"
+        )


### PR DESCRIPTION
## Run-journal recovery is not idempotent: repeated repair passes multiply recovered rows (1.65 GB session file in production)

### The failure

A long-running WebUI session (500 real turns) accumulated a **1,652,470,061-byte** sidecar: **459,771 message rows, of which only 777 carried content**. The rest were empty assistant recovery stubs stamped `_recovered_from_run_journal`, where ~28 distinct reasoning texts appeared **exactly 16,385 times each** (2¹⁴+1 — power-of-two counts, the fingerprint of an array being re-appended per pass). Every `/api/sessions/<id>/messages` window request re-parsed the whole file, and the sidebar aggregation route ran 6.1–6.3 s per hit.

### Root cause

`_append_journaled_partial_output()` defaults `dedupe_existing=False`, and the pending-turn repair path (`_apply_core_sync_or_error_marker`, the `messages` non-empty branch) calls `_recover_journaled_output_and_terminal_error()` **without** passing it. Every server restart that ran pending-turn repair replayed the dead stream's full journal from seq 1 and re-appended the recovered rows.

The lazy retry path (`_retry_journal_recovery_in_place`) *does* pass `dedupe_existing=True`, but its guards only scan `range(initial_message_count)` (the pre-pass snapshot) and only match rows with the same `_recovered_stream_id` — rows appended by an earlier *repair* pass (whose recovery ran without dedupe) are invisible to it.

So the two recovery entry points didn't agree on the invariant, and the one that matters most across restarts — pending-turn repair, which runs on startup recovery — was the one without dedupe.

### Repro (same production journal, 6 sequential repair passes, isolated tmp env)

| pass | before | after (this PR) |
|---|---|---|
| 1 | 44 | 44 |
| 2 | 87 | 44 |
| 3 | 130 | 44 |
| 4 | 173 | 44 |
| 5 | 216 | 44 |
| 6 | 259 | 44 |

Before grows +43 rows per pass; after is flat.

### The fix

Make a repair mechanism never duplicate: `dedupe_existing=True` becomes the default on both `_append_journaled_partial_output` and `_recover_journaled_output_and_terminal_error`, and the repair caller passes it explicitly. No behavior change for first-time recovery (nothing to dedupe against); repeated passes now converge to a fixed point.

### Tests

`tests/test_run_journal_recovery_idempotent.py`:
- repeated recovery passes (with and without the flag) must not grow the transcript
- each distinct reasoning block must occur exactly once across the transcript after repeated passes
- synthetic journal fixture (reasoning deltas + tool pair + partial token + terminal), tmp-dir isolated, no production data

Full recovery-surface suite passes: 137 passed, 1 skipped (anchor-dedup #3875, partial-work #3929, context-replay #4283, journal deletion #3802, profile/stale-client recovery, compression recovery, core regressions).

### Operator-side remediation note

The production file was already repaired out-of-band by dropping canon-JSON-exact duplicate rows (459,771 → 1,039 rows, lossless — all 777 content rows preserved, verified by two independent re-derivations). This PR prevents recurrence; it does not need a data migration.
