### PR TITLE
Fix callable key_cmd credentials in agent cache signatures

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8599,14 +8599,19 @@ def _attempt_credential_self_heal(
 def _agent_cache_api_key_sig(resolved_api_key, credential_pool) -> str:
     """Return the cache-signature component for runtime credentials.
 
-    Credential-pool providers can legitimately hand WebUI a different runtime
-    token on each request (round-robin pools, OAuth refresh, auth self-heal).
-    The AIAgent object is also where cross-turn memory-provider state lives, so
-    using the volatile token itself in the cache signature silently defeats the
-    per-session agent cache and drops warmed Hindsight prefetch results.
+    Credential-pool providers and callable key_cmd sources can legitimately
+    hand WebUI a different runtime token on each request (round-robin pools,
+    OAuth refresh, auth self-heal). The AIAgent object is also where cross-turn
+    memory-provider state lives, so using a volatile token in the cache
+    signature silently defeats the per-session agent cache and drops warmed
+    Hindsight prefetch results.
     """
     if credential_pool is not None:
         return 'credential-pool'
+    if not isinstance(resolved_api_key, str) and callable(resolved_api_key):
+        # key_cmd credentials are resolved by the client at request time; do
+        # not mint or stringify a potentially secret token for cache identity.
+        return 'dynamic-credential'
     import hashlib as _hashlib
     return _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16]
 

--- a/tests/test_issue7396_key_cmd_cache.py
+++ b/tests/test_issue7396_key_cmd_cache.py
@@ -1,0 +1,197 @@
+import hashlib
+import queue
+import sys
+import types
+from unittest import mock
+
+from api import config
+
+
+_MISSING = object()
+
+
+class CommandTokenSource:
+    """Minimal stand-in for hermes-agent's callable key_cmd credential."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return "minted-token"
+
+
+def test_callable_api_key_signature_is_stable_secret_free_and_lazy():
+    """#7396: cache identity must not resolve or stringify dynamic credentials."""
+    import api.streaming as streaming
+
+    source = CommandTokenSource()
+
+    first = streaming._agent_cache_api_key_sig(source, None)
+    second = streaming._agent_cache_api_key_sig(source, None)
+
+    assert first == second == "dynamic-credential"
+    assert source.calls == 0
+    assert streaming._agent_cache_api_key_sig("token-a", None) == hashlib.sha256(
+        b"token-a"
+    ).hexdigest()[:16]
+    assert streaming._agent_cache_api_key_sig("token-b", object()) == "credential-pool"
+
+
+def test_key_cmd_runtime_reaches_agent_construction_without_resolving_token():
+    """A non-ephemeral chat worker must construct AIAgent with callable api_key."""
+    import api.streaming as streaming
+
+    captured = {}
+    source = CommandTokenSource()
+
+    class FakeSession:
+        session_id = "issue7396_key_cmd"
+        title = "key_cmd regression"
+        workspace = "/tmp"
+        model = "gpt-4o"
+        model_provider = None
+        profile = None
+        personality = None
+        messages = []
+        context_messages = []
+        input_tokens = 0
+        output_tokens = 0
+        estimated_cost = None
+        cache_read_tokens = 0
+        cache_write_tokens = 0
+        tool_calls = []
+        gateway_routing = None
+        gateway_routing_history = []
+        active_stream_id = None
+        pending_user_message = None
+        pending_attachments = []
+        pending_started_at = None
+        context_length = 0
+        threshold_tokens = 0
+        last_prompt_tokens = 0
+        llm_title_generated = True
+
+        def save(self, *args, **kwargs):
+            return None
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": self.profile,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "personality": self.personality,
+            }
+
+    class CapturingAgent:
+        def __init__(
+            self,
+            model=None,
+            provider=None,
+            base_url=None,
+            api_key=None,
+            platform=None,
+            quiet_mode=False,
+            enabled_toolsets=None,
+            fallback_model=None,
+            session_id=None,
+            session_db=None,
+            stream_delta_callback=None,
+            reasoning_callback=None,
+            tool_progress_callback=None,
+            clarify_callback=None,
+        ):
+            captured["api_key"] = api_key
+            captured["session_id"] = session_id
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs["persist_user_message"]},
+                    {"role": "assistant", "content": "ok"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    session = FakeSession()
+    stream_id = "stream_issue7396_key_cmd"
+    session.active_stream_id = stream_id
+    event_queue = queue.Queue()
+
+    runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    runtime_module.resolve_runtime_provider = mock.Mock(
+        return_value={
+            "provider": "my-gateway",
+            "base_url": "https://gateway.example.invalid/v1",
+            "api_key": source,
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+    )
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.runtime_provider = runtime_module
+    hermes_state = types.ModuleType("hermes_state")
+    hermes_state.SessionDB = mock.Mock(return_value=None)
+    injected = {
+        "hermes_cli": hermes_cli,
+        "hermes_cli.runtime_provider": runtime_module,
+        "hermes_state": hermes_state,
+    }
+    saved_modules = {name: sys.modules.get(name, _MISSING) for name in injected}
+    sys.modules.update(injected)
+
+    try:
+        with mock.patch.object(streaming, "get_session", return_value=session), \
+             mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent), \
+             mock.patch.object(
+                 streaming,
+                 "resolve_model_provider",
+                 return_value=("gpt-4o", "my-gateway", None),
+             ), \
+             mock.patch("api.config.get_config", return_value={}), \
+             mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+            streaming.STREAMS[stream_id] = event_queue
+            streaming._run_agent_streaming(
+                session_id=session.session_id,
+                msg_text="hello",
+                model="gpt-4o",
+                workspace="/tmp",
+                stream_id=stream_id,
+            )
+    finally:
+        streaming.STREAMS.pop(stream_id, None)
+        streaming.AGENT_INSTANCES.pop(stream_id, None)
+        with config.SESSION_AGENT_CACHE_LOCK:
+            config.SESSION_AGENT_CACHE.pop(session.session_id, None)
+        for name, previous in saved_modules.items():
+            if previous is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    assert captured == {"api_key": source, "session_id": session.session_id}
+    assert source.calls == 0
+    assert any(event == "done" for event, _payload in list(event_queue.queue))


### PR DESCRIPTION
## Thinking Path

- Hermes Agent intentionally resolves `key_cmd` credentials to callable token sources so clients can mint short-lived credentials per request.
- WebUI's per-session agent cache signature treated every non-pool credential as a string and called `.encode()` before agent construction.
- Cache identity must stay stable without resolving or stringifying a dynamic credential, while the existing runtime-refresh path remains responsible for installing the current callable on a reused agent.
- The narrow fix is therefore at `_agent_cache_api_key_sig()`, before the string hash path.

## What Changed

- Return the stable, non-secret `dynamic-credential` cache sentinel for non-string callable API keys.
- Preserve the existing `credential-pool` sentinel and SHA-256 signature behavior for string keys.
- Add focused regression coverage proving signature calculation is stable and never invokes the callable.
- Add a chat-worker regression using the issue's runtime shape (`api_key` callable, no credential pool) and prove the turn reaches `AIAgent` construction and emits `done`.

## Why It Matters

Providers configured with `key_cmd` can now start browser/native chat turns instead of failing before the provider client is constructed. No credential is minted during cache lookup, and no callable representation or token material enters the cache signature.

## Contract Routing

Task type: narrow runtime/streaming bug fix.

Touched areas: per-session `AIAgent` cache identity during WebUI chat-worker startup.

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`
- `docs/rfcs/README.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer/invariant: the runtime provider resolver owns the current credential object; the cache-signature helper only derives stable agent identity, and `_refresh_cached_agent_runtime()` continues to swap the current runtime credential on cache reuse. No transcript, SSE protocol, recovery, or persisted-state contract changes.

## Verification

- Before the fix, both new tests failed with `AttributeError: 'CommandTokenSource' object has no attribute 'encode'`; the worker regression confirmed `AIAgent` was never constructed.
- `./scripts/test.sh tests/test_issue7396_key_cmd_cache.py -q` — 2 passed.
- `./scripts/test.sh tests/test_issue7396_key_cmd_cache.py tests/test_sprint42.py -q` — 42 passed, 11 subtests passed.
- `ruff check tests/test_issue7396_key_cmd_cache.py` — passed.
- `git diff --check` — passed.
- A full `./scripts/test.sh` run was attempted on native Windows. It collected 15,078 tests but was stopped after 6% because unrelated frontend Node harnesses and POSIX permission/symlink tests produced broad platform-specific failures. The repository documents native Windows bootstrap as unsupported; the affected and neighboring suites above are green.

## Risks / Follow-ups

- Risk is limited to cache identity selection for callable API keys. String keys and credential pools have explicit unchanged controls.
- The regression uses a minimal callable matching the issue's pinned `CommandTokenSource` behavior; a live external `key_cmd` helper was not executed because doing so would require external credentials and would violate the no-invocation invariant under test.
- No docs change is needed because this restores the intended existing provider behavior rather than changing a public contract.

Release note: Fix WebUI chat startup for custom providers whose API key is supplied by a callable `key_cmd` token source.

## Model Used

- Provider: OpenAI
- Model: GPT-5 (Codex)
- Notable tools: repository inspection, the project test runner, Git, and GitHub CLI. AI assistance was used for implementation, tests, and PR preparation.

Fixes #7396
