### PR TITLE
fix(models): honor models_discovered flag as metadata, not allowlist

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -120,3 +120,7 @@ jobs:
       - name: Run browser smoke
         if: needs.changes.outputs.docs_only != 'true'
         run: python tests/browser_smoke.py
+
+      - name: Run live-model policy regression
+        if: needs.changes.outputs.docs_only != 'true'
+        run: python tests/browser_live_model_policy.py

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -744,12 +744,18 @@ limits) and never a picker pin.
 One shared resolver applies this policy for both `providers{}` and matching
 `custom_providers[]` entries: `_live_models_policy_for_provider()` in
 `api/config.py`. A pin stored in either location restricts; a discovery marker
-in either location is metadata. The policy is applied on the main catalog build
-in `get_available_models()` — including its network-free static fallback,
-`_static_models_catalog_without_live_probes()` — and on `/api/models/live`. The
-same provider-config resolution and sentinel filtering back the Settings provider
-list in `api/providers.py`, the provider credential helpers, the reasoning-effort
-config lookup, and the onboarding readiness check in `api/onboarding.py`.
+in either location is metadata. That resolver is the authority used by the live
+route, `/api/models/live`. The main catalog path — `get_available_models()` and
+its network-free static fallback,
+`_static_models_catalog_without_live_probes()` — does not call the resolver; it
+mirrors the same policy with its own `_models_config_is_discovered()` checks.
+That duplication is deliberate (those paths carry their own admission gating and
+produce a different catalog shape), but it means the resolver and the mirrored
+checks must be kept in sync whenever the discovered-versus-pinned policy
+changes. The same provider-config resolution and sentinel filtering back the
+Settings provider list in `api/providers.py`, the provider credential helpers,
+the reasoning-effort config lookup, and the onboarding readiness check in
+`api/onboarding.py`.
 
 ### Live-model response caching
 
@@ -762,9 +768,12 @@ configured model IDs. It never includes credential values such as `api_key` or
 `key_env`. This is what stops a discovered catalog being replayed after the same
 profile and provider are switched to a pin.
 
-The browser mirrors this: `_liveModelCache` in `static/ui.js` is keyed by profile
-and provider, with the key captured at fetch start so a mid-flight profile switch
-cannot file one profile's catalog under another profile's key.
+The browser keeps no response cache of its own. `static/ui.js` always fetches
+`/api/models/live` and relies on the policy-keyed server cache above, because a
+profile-and-provider-only browser copy would go stale on a same-profile policy
+change. It captures the active profile at fetch start and re-checks it before
+applying a response, so a mid-flight profile switch cannot file one profile's
+catalog under another profile's view.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -702,6 +702,70 @@ Default toolset list (hardcoded fallback):
 The web UI always runs with the full CLI toolset. There is no per-session toolset
 restriction from the UI yet (see ROADMAP.md Wave 4 for the plan).
 
+### Provider identity resolution
+
+`config.yaml` stores `providers:` entries under the raw key the user wrote, so
+those keys legitimately vary: `z-ai`, `CLIPpoxy` and `opencode_go` all occur.
+Most call sites instead hold an already-canonicalized id, with aliases resolved
+by `_resolve_provider_alias()` (`z-ai` -> `zai`, `google` -> `gemini`, `github`
+-> `copilot`). A plain `providers.get(canonical)` therefore misses an aliased,
+mixed-case or underscore-named entry and silently skips that provider's
+configuration — its pins, `api_key`, reasoning efforts and readiness.
+
+`_resolve_raw_provider_key(provider_id, providers_cfg=None)` in `api/config.py`
+maps any id form back to the raw key. An exact raw-key hit wins first; otherwise
+it matches on any of the key, its lowercased form, `_canonicalise_provider_id(key)`
+and `_resolve_provider_alias(key)`. It matches on any candidate form rather than
+one shared normal form because `_canonicalise_provider_id` deliberately preserves
+`x-ai` instead of folding it to `xai`. Unknown ids pass through unchanged; the
+helper does not guess. `_get_provider_cfg_for_id()` is the convenience wrapper
+that returns the resolved config dict.
+
+### Discovered model catalogs vs. pinned allowlists
+
+A `providers.<id>.models` mapping has two meanings, and the code must not
+conflate them: a user pin / allowlist that restricts which models the picker
+offers, or per-model metadata Hermes itself persisted after a successful live
+`/v1/models` probe.
+
+A mapping is metadata, not a pin, when the entry carries `models_discovered: true`
+or the legacy in-mapping sentinel `__discovered_model_catalog__: true`; detect
+it with `_models_config_is_discovered()`. In that case the live catalog stays
+authoritative and the persisted IDs are only a probe-failure fallback. An
+unflagged mapping stays a strict allowlist — the historic behavior, which must
+not regress.
+
+`__discovered_model_catalog__` and `__explicit_model_allowlist__` are
+compatibility metadata keys, never model IDs. `_configured_model_ids()` filters
+both centrally so they cannot leak into any model list. The exception is
+`providers.copilot.models`, which is a per-model settings map (reasoning effort,
+limits) and never a picker pin.
+
+One shared resolver applies this policy for both `providers{}` and matching
+`custom_providers[]` entries: `_live_models_policy_for_provider()` in
+`api/config.py`. A pin stored in either location restricts; a discovery marker
+in either location is metadata. The policy is applied on the main catalog build
+in `get_available_models()` — including its network-free static fallback,
+`_static_models_catalog_without_live_probes()` — and on `/api/models/live`. The
+same provider-config resolution and sentinel filtering back the Settings provider
+list in `api/providers.py`, the provider credential helpers, the reasoning-effort
+config lookup, and the onboarding readiness check in `api/onboarding.py`.
+
+### Live-model response caching
+
+`/api/models/live` caches responses for 60 seconds (`_LIVE_MODELS_CACHE_TTL`),
+keyed by `(profile, provider, policy fingerprint)` — see `_live_models_cache_key()`
+and `_live_models_policy_fingerprint()` in `api/routes.py`. The fingerprint
+covers only the inputs the discovered-vs-pinned decision reads: the matched
+source, the discovery marker, the Copilot settings-map flag, and the sanitized
+configured model IDs. It never includes credential values such as `api_key` or
+`key_env`. This is what stops a discovered catalog being replayed after the same
+profile and provider are switched to a pin.
+
+The browser mirrors this: `_liveModelCache` in `static/ui.js` is keyed by profile
+and provider, with the key captured at fetch start so a mid-flight profile switch
+cannot file one profile's catalog under another profile's key.
+
 ---
 
 ## 9. Known Bugs and Technical Debt Summary

--- a/api/config.py
+++ b/api/config.py
@@ -2676,6 +2676,72 @@ def _get_provider_cfg(provider_id) -> dict:
     return provider_cfg if isinstance(provider_cfg, dict) else {}
 
 
+def _resolve_raw_provider_key(provider_id, providers_cfg=None):
+    """Map a provider id back to its RAW key in ``config.yaml`` ``providers:``.
+
+    Most call sites hold an already-canonicalised provider id (aliases resolved
+    by ``_resolve_provider_alias``), but ``config.yaml`` stores the entry under
+    whatever key the user wrote — e.g. ``z-ai``, ``CLIPpoxy`` or
+    ``opencode_go``.  A plain ``providers.get(canonical)`` therefore misses an
+    aliased / mixed-case / underscore-named entry, silently skipping the
+    per-provider config (pins, api_key, reasoning efforts).
+
+    Matching accepts any of the candidate forms the main catalog path builds
+    inline: the exact key, its lowercased form, ``_canonicalise_provider_id``
+    and ``_resolve_provider_alias``.  The comparison is an intersection on ANY
+    form (rather than a single shared normal form) because
+    ``_canonicalise_provider_id`` deliberately preserves ``x-ai`` instead of
+    folding it to ``xai``.
+
+    An exact raw-key hit wins first so behaviour for existing non-aliased
+    configs is unchanged.  The request is returned unchanged when no key
+    matches.  Cheap, side-effect free, no config writes.
+    """
+    if provider_id is None:
+        return provider_id
+    if providers_cfg is None:
+        providers_cfg = _get_providers_cfg()
+    if not isinstance(providers_cfg, dict) or not providers_cfg:
+        return provider_id
+    if provider_id in providers_cfg:
+        return provider_id
+
+    def _match_forms(value):
+        text = str(value)
+        forms = {text, text.strip().lower()}
+        try:
+            forms.add(_canonicalise_provider_id(text))
+        except Exception:
+            pass
+        try:
+            forms.add(_resolve_provider_alias(text.strip().lower()))
+        except Exception:
+            pass
+        forms.discard("")
+        return forms
+
+    requested_forms = _match_forms(provider_id)
+    for key in providers_cfg:
+        if requested_forms & _match_forms(key):
+            return key
+    return provider_id
+
+
+def _get_provider_cfg_for_id(provider_id, providers_cfg=None) -> dict:
+    """Return the ``providers.<raw key>`` config dict for *provider_id*.
+
+    Like ``_get_provider_cfg`` but first resolves alias / mixed-case /
+    underscore ids back to the raw key the user actually wrote, so an aliased
+    provider's config is not silently missed.
+    """
+    if providers_cfg is None:
+        providers_cfg = _get_providers_cfg()
+    if not isinstance(providers_cfg, dict):
+        return {}
+    provider_cfg = providers_cfg.get(_resolve_raw_provider_key(provider_id, providers_cfg), {})
+    return provider_cfg if isinstance(provider_cfg, dict) else {}
+
+
 class AmbiguousCustomProviderError(ValueError):
     """Raised when two+ custom_providers[] entries normalize to the same slug.
 
@@ -4243,7 +4309,7 @@ def _resolve_model_reasoning_efforts_impl(
                     )
                     break
         elif provider:
-            _prov_entry = (cfg.get("providers") or {}).get(provider, {})
+            _prov_entry = _get_provider_cfg_for_id(provider, cfg.get("providers") or {})
             if isinstance(_prov_entry, dict):
                 _re_lists = _configured_reasoning_effort_lists(
                     _prov_entry, hinted_model
@@ -7586,7 +7652,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 providers_cfg = cfg.get("providers", {})
                 if isinstance(providers_cfg, dict):
                     for provider_key in filter(None, [active_provider, "custom"]):
-                        provider_cfg = providers_cfg.get(provider_key, {})
+                        # ``active_provider`` is already alias-resolved, but
+                        # config.yaml stores the entry under the RAW key the user
+                        # wrote (``z-ai``, ``CLIPpoxy``, ``opencode_go``). Resolve
+                        # it back so an aliased provider's api_key is not missed
+                        # (same class as the /api/models/live alias gap).
+                        provider_cfg = _get_provider_cfg_for_id(provider_key, providers_cfg)
                         if isinstance(provider_cfg, dict):
                             api_key = (provider_cfg.get("api_key") or "").strip()
                             if api_key:

--- a/api/config.py
+++ b/api/config.py
@@ -2742,6 +2742,102 @@ def _get_provider_cfg_for_id(provider_id, providers_cfg=None) -> dict:
     return provider_cfg if isinstance(provider_cfg, dict) else {}
 
 
+def _matching_custom_provider_entries(provider_id, config_obj=None) -> list[dict]:
+    """Return ``custom_providers[]`` entries matching a requested provider id.
+
+    Mirrors the collection ``_handle_live_models`` performs: a ``custom:<slug>``
+    id matches the entry whose name normalizes to that slug, and the bare
+    ``custom`` id matches unnamed entries.  Kept here so the live-model policy
+    resolver and the live route agree on which entry a request maps to.
+    """
+    raw = str(provider_id or "").strip().lower()
+    if not raw:
+        return []
+    entries = _custom_provider_entries(config_obj)
+    if not entries:
+        return []
+    if raw.startswith("custom:"):
+        return [
+            entry
+            for entry in entries
+            if _custom_provider_slug_from_name(entry.get("name", "")) == raw
+        ]
+    if raw == "custom":
+        return [
+            entry
+            for entry in entries
+            if not _custom_provider_slug_from_name(entry.get("name", ""))
+        ]
+    return []
+
+
+def _live_models_policy_for_provider(provider_id, config_obj=None) -> dict:
+    """Resolve the discovered-vs-pinned live-model policy for *provider_id*.
+
+    One shared resolver for both ``providers{}`` and matching
+    ``custom_providers[]`` entries, so a genuine pin stored in either location
+    restricts the live catalog and a Hermes-persisted discovery catalog stays
+    per-model metadata (live authoritative).  ``provider_id`` may be canonical
+    or raw; the ``providers{}`` lookup resolves alias / mixed-case / underscore
+    ids via ``_resolve_raw_provider_key``.
+
+    Returns a dict:
+
+    - ``source``: ``"providers"``, ``"custom"`` or ``None``.
+    - ``entry``: the matched config mapping (or ``{}``).
+    - ``models``: sanitized configured model IDs (``_configured_model_ids``);
+      for a custom entry the singular ``model`` is prepended.
+    - ``discovered``: ``_models_config_is_discovered(entry)``.
+    - ``settings_map``: True for Copilot, whose ``models`` mapping is per-model
+      settings rather than a picker allowlist.
+    - ``has_models``: True when the matched entry carries a ``models`` key.
+    """
+    result = {
+        "source": None,
+        "entry": {},
+        "models": [],
+        "discovered": False,
+        "settings_map": False,
+        "has_models": False,
+    }
+    if config_obj is None:
+        config_obj = cfg
+    if not isinstance(config_obj, dict):
+        return result
+    requested = str(provider_id or "").strip()
+    providers_cfg = config_obj.get("providers") or {}
+    if isinstance(providers_cfg, dict):
+        provider_cfg = _get_provider_cfg_for_id(requested, providers_cfg)
+        if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+            result.update(
+                source="providers",
+                entry=provider_cfg,
+                models=_configured_model_ids(provider_cfg.get("models")),
+                discovered=_models_config_is_discovered(provider_cfg),
+                settings_map=(
+                    requested.lower() == "copilot"
+                    or _resolve_raw_provider_key(requested, providers_cfg) == "copilot"
+                ),
+                has_models=True,
+            )
+            return result
+    for entry in _matching_custom_provider_entries(requested, config_obj):
+        models = _configured_model_ids(entry.get("models"))
+        singular = str(entry.get("model") or "").strip()
+        if singular and singular not in models:
+            models = [singular] + models
+        result.update(
+            source="custom",
+            entry=entry,
+            models=models,
+            discovered=_models_config_is_discovered(entry),
+            settings_map=False,
+            has_models="models" in entry,
+        )
+        return result
+    return result
+
+
 class AmbiguousCustomProviderError(ValueError):
     """Raised when two+ custom_providers[] entries normalize to the same slug.
 

--- a/api/config.py
+++ b/api/config.py
@@ -1418,6 +1418,29 @@ def _configured_model_options(raw_models: object) -> list[dict[str, str]]:
     ]
 
 
+def _models_config_is_discovered(provider_cfg: object) -> bool:
+    """True when a provider's ``models`` mapping is an auto-discovered catalog.
+
+    Mirrors upstream Hermes Agent's ``_entry_models_discovered``: the current
+    shape is an entry-level ``models_discovered: true`` sibling of ``models``,
+    and older Hermes versions wrote an in-mapping
+    ``__discovered_model_catalog__: true`` sentinel instead (accepted on read
+    for backward compatibility). A catalog Hermes itself persisted after a
+    successful ``/v1/models`` probe is never a user pin, so ``models`` must
+    not be treated as a restricting picker allowlist — the live catalog is
+    authoritative.
+    """
+    if not isinstance(provider_cfg, dict):
+        return False
+    if provider_cfg.get("models_discovered") is True:
+        return True
+    models = provider_cfg.get("models")
+    return (
+        isinstance(models, dict)
+        and models.get("__discovered_model_catalog__") is True
+    )
+
+
 def _named_custom_provider_slugs(config_obj: dict | None = None) -> set[str]:
     return {
         slug
@@ -8143,9 +8166,14 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     # whichever model had local settings. Only Copilot skips the
                     # config-models allowlist branch and asks Hermes CLI for the
                     # live catalog first (static _PROVIDER_MODELS is fallback only).
+                    # A provider whose ``models`` was persisted by live discovery
+                    # (``models_discovered: true``) is the same class of case:
+                    # the mapping is per-model metadata, not a user pin, so the
+                    # live /v1/models catalog stays authoritative (#7404).
                     _uses_models_as_settings_map = pid == "copilot"
                     if (
                         not _uses_models_as_settings_map
+                        and not _models_config_is_discovered(provider_cfg)
                         and isinstance(provider_cfg, dict)
                         and "models" in provider_cfg
                     ):

--- a/api/config.py
+++ b/api/config.py
@@ -1379,9 +1379,21 @@ def _custom_provider_entries(config_obj: dict | None = None) -> list[dict]:
 
 
 def _configured_model_ids(raw_models: object) -> list[str]:
-    """Return ordered model IDs from supported config allowlist shapes."""
+    """Return ordered model IDs from supported config allowlist shapes.
+
+    Sentinel keys that Hermes persists inside a user-facing ``models`` mapping
+    (``__discovered_model_catalog__``, ``__explicit_model_allowlist__``) are
+    config metadata, never model IDs. Filter them out centrally here (mirroring
+    upstream Hermes Agent's ``_declared_model_ids``) so no downstream model
+    list, static group, provenance path, or fallback path can surface them.
+    """
+    sentinel_keys = {"__discovered_model_catalog__", "__explicit_model_allowlist__"}
     if isinstance(raw_models, dict):
-        candidates = (key for key in raw_models if isinstance(key, str))
+        candidates = (
+            key
+            for key in raw_models
+            if isinstance(key, str) and key not in sentinel_keys
+        )
     elif isinstance(raw_models, list):
         candidates = raw_models
     else:
@@ -5764,7 +5776,18 @@ def _static_models_catalog_without_live_probes() -> dict:
             raw_key = canonical_to_raw_provider_key.get(pid, pid)
             provider_cfg = _get_provider_cfg(raw_key)
             raw_models = []
-            if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+            # A provider whose ``models`` was persisted by live discovery
+            # (``models_discovered: true`` or the legacy in-mapping sentinel) is
+            # a per-model metadata catalog, not a user pin — never treat it as
+            # the complete static picker allowlist. Start from the broader
+            # static/plugin fallback catalog and let persisted model IDs be
+            # merged in below as fallback metadata (mirrors the live-rebuild
+            # chokepoint in _build_available_models_uncached, #7404).
+            if (
+                isinstance(provider_cfg, dict)
+                and "models" in provider_cfg
+                and not _models_config_is_discovered(provider_cfg)
+            ):
                 raw_models = _configured_model_options(provider_cfg["models"])
             if not raw_models:
                 raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))

--- a/api/config.py
+++ b/api/config.py
@@ -7673,6 +7673,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _cp_has_configured_models = (
                         isinstance(_cp_configured_models, (dict, list))
                         and len(_cp_configured_models) > 0
+                        # A mapping Hermes persisted after a live /v1/models
+                        # probe is per-model metadata, not a user pin. Exclude
+                        # it so the provider still probes (and the live catalog
+                        # stays authoritative) instead of treating the
+                        # discovered catalog as a restricting allowlist (#7404).
+                        and not _models_config_is_discovered(_cp)
                     )
                     _live_models = auto_detected_models_by_provider.get(_slug)
                     _live_error = None
@@ -8219,6 +8225,27 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
                     if not raw_models:
                         raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
+                        # A discovered catalog is per-model metadata, not a
+                        # user pin: when the live probe returns nothing the
+                        # broader static catalog is the base, and the persisted
+                        # (sanitized) model IDs are MERGED in as fallback
+                        # metadata so a probe failure does not silently drop a
+                        # discovered-only model from the picker (#7404).
+                        if _models_config_is_discovered(provider_cfg):
+                            for model_id in _configured_model_ids(
+                                provider_cfg.get("models")
+                            ):
+                                if not any(
+                                    m.get("id") == model_id for m in raw_models
+                                ):
+                                    raw_models.append(
+                                        {
+                                            "id": model_id,
+                                            "label": _get_label_for_model(
+                                                model_id, groups
+                                            ),
+                                        }
+                                    )
 
                     detected_models = auto_detected_models_by_provider.get(pid, [])
                     if detected_models and not raw_models:

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -18,6 +18,7 @@ from api.config import (
     _FALLBACK_MODELS,
     _HERMES_FOUND,
     invalidate_models_cache,
+    _get_provider_cfg_for_id,
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
     _get_config_path,
@@ -609,7 +610,11 @@ def _provider_api_key_present(
     # ``... or {}`` degrades that null to an empty mapping (salvage of #3967).
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
-        provider_cfg = providers_cfg.get(provider, {})
+        # ``provider`` is a canonical setup id (``zai``), but config.yaml stores
+        # the entry under the RAW user key (``z-ai``, ``CLIPpoxy``). Resolve it
+        # back so an aliased provider is not reported as unconfigured (same
+        # class as the /api/models/live alias gap).
+        provider_cfg = _get_provider_cfg_for_id(provider, providers_cfg)
         if (
             isinstance(provider_cfg, dict)
             and str(provider_cfg.get("api_key") or "").strip()

--- a/api/providers.py
+++ b/api/providers.py
@@ -2776,15 +2776,18 @@ def get_providers() -> dict[str, Any]:
                     pid,
                     exc_info=True,
                 )
-        # Also include models from config.yaml providers section
+        # Also include models from config.yaml providers section. Route the
+        # mapping through _configured_model_ids so metadata sentinels Hermes
+        # persists inside a discovered catalog
+        # (__discovered_model_catalog__ / __explicit_model_allowlist__) never
+        # surface as visible model rows (#7404 review).
         if isinstance(providers_cfg, dict):
             provider_cfg = providers_cfg.get(pid, {})
             if isinstance(provider_cfg, dict) and "models" in provider_cfg:
-                cfg_models = provider_cfg["models"]
-                if isinstance(cfg_models, dict):
-                    models = models + [{"id": k, "label": k} for k in cfg_models.keys()]
-                elif isinstance(cfg_models, list):
-                    models = models + [{"id": k, "label": k} for k in cfg_models]
+                models = models + [
+                    {"id": model_id, "label": model_id}
+                    for model_id in _configured_model_ids(provider_cfg["models"])
+                ]
                 # Recompute models_total when config.yaml contributes additional
                 # entries on top of the live/static catalog. For non-Nous
                 # providers models_total still equals len(models); for Nous

--- a/api/providers.py
+++ b/api/providers.py
@@ -39,6 +39,7 @@ from api.config import (
     _configured_model_ids,
     _custom_provider_slug_from_name,
     _get_label_for_model,
+    _get_provider_cfg_for_id,
     _models_from_live_provider_ids,
     _pool_entry_payloads,
     _read_live_provider_model_ids,
@@ -1153,7 +1154,7 @@ def _provider_has_shadowed_codex_oauth_value(provider_id: str) -> bool:
             values.append(model_cfg.get("api_key"))
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
-        provider_cfg = providers_cfg.get(provider_id, {})
+        provider_cfg = _get_provider_cfg_for_id(provider_id, providers_cfg)
         if isinstance(provider_cfg, dict):
             values.append(provider_cfg.get("api_key"))
     custom_providers = cfg.get("custom_providers", [])
@@ -1321,7 +1322,7 @@ def _provider_has_key(provider_id: str) -> bool:
     # Check providers.<id>.api_key
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
-        provider_cfg = providers_cfg.get(provider_id, {})
+        provider_cfg = _get_provider_cfg_for_id(provider_id, providers_cfg)
         if isinstance(provider_cfg, dict) and str(provider_cfg.get("api_key") or "").strip():
             if _provider_value_counts_as_api_key(provider_id, provider_cfg.get("api_key")):
                 return True
@@ -1367,7 +1368,7 @@ def _get_provider_api_key(provider_id: str) -> str | None:
 
     providers_cfg = cfg.get("providers") or {}
     if isinstance(providers_cfg, dict):
-        provider_cfg = providers_cfg.get(provider_id, {})
+        provider_cfg = _get_provider_cfg_for_id(provider_id, providers_cfg)
         if isinstance(provider_cfg, dict):
             provider_key = str(provider_cfg.get("api_key") or "").strip()
             if _provider_value_counts_as_api_key(provider_id, provider_key):
@@ -3026,7 +3027,7 @@ def _clean_provider_key_from_config(provider_id: str) -> None:
             # 1. Clean providers.<id>.api_key
             providers_cfg = cfg.get("providers") or {}
             if isinstance(providers_cfg, dict):
-                provider_cfg = providers_cfg.get(provider_id, {})
+                provider_cfg = _get_provider_cfg_for_id(provider_id, providers_cfg)
                 if isinstance(provider_cfg, dict) and provider_cfg.get("api_key"):
                     del provider_cfg["api_key"]
                     changed = True

--- a/api/routes.py
+++ b/api/routes.py
@@ -21370,6 +21370,7 @@ def _handle_live_models(handler, parsed):
     try:
         from api.config import get_config as _gc
         from api.config import _configured_model_ids, _models_config_is_discovered
+        from api.config import _get_provider_cfg_for_id
         cfg = _gc()
         if not provider:
             provider = cfg.get("model", {}).get("provider") or ""
@@ -21572,7 +21573,7 @@ def _handle_live_models(handler, parsed):
                 try:
                     import urllib.request
                     _providers_cfg = cfg.get("providers") or {}
-                    _prov = _providers_cfg.get(provider, {}) if isinstance(_providers_cfg, dict) else {}
+                    _prov = _get_provider_cfg_for_id(provider, _providers_cfg)
                     # Only use a provider-scoped key.  A top-level model.api_key
                     # is safe here only when it belongs to the requested provider;
                     # otherwise /api/models/live?provider=<other> could forward
@@ -21612,7 +21613,7 @@ def _handle_live_models(handler, parsed):
         try:
             _providers_cfg = cfg.get("providers") or {}
             if isinstance(_providers_cfg, dict):
-                _provider_cfg = _providers_cfg.get(provider, {})
+                _provider_cfg = _get_provider_cfg_for_id(provider, _providers_cfg)
         except Exception:
             _provider_cfg = {}
         if (

--- a/api/routes.py
+++ b/api/routes.py
@@ -1895,7 +1895,7 @@ _OPENAI_COMPAT_ENDPOINTS = {
 # specific model filtering happens downstream in hermes_cli.
 #
 _LIVE_MODELS_CACHE_TTL = 60.0
-_LIVE_MODELS_CACHE: dict[tuple[str, str], tuple[float, dict]] = {}
+_LIVE_MODELS_CACHE: dict[tuple[str, str, str], tuple[float, dict]] = {}
 _LIVE_MODELS_CACHE_LOCK = threading.RLock()
 
 
@@ -1912,11 +1912,44 @@ def _active_profile_for_live_models_cache() -> str:
         return "default"
 
 
-def _live_models_cache_key(provider: str) -> tuple[str, str]:
-    return (_active_profile_for_live_models_cache(), provider)
+def _live_models_policy_fingerprint(provider: str) -> str:
+    """Stable, secret-free fingerprint of a provider's live-model policy.
+
+    Folds the INPUTS the discovered-vs-pinned decision reads — whether a
+    matching config entry exists, its discovery marker(s), whether it is a
+    Copilot settings map, and its sanitized configured model IDs — into the
+    live-models cache key.  Without this a discovered catalog could be replayed
+    for up to 60s after the profile is changed to a pin.  Never includes
+    ``api_key`` / ``key_env`` values.
+    """
+    try:
+        from api.config import _live_models_policy_for_provider, get_config
+
+        policy = _live_models_policy_for_provider(provider, get_config())
+        payload = {
+            "source": policy.get("source"),
+            "discovered": bool(policy.get("discovered")),
+            "settings_map": bool(policy.get("settings_map")),
+            "has_models": bool(policy.get("has_models")),
+            "models": list(policy.get("models") or []),
+        }
+    except Exception as _e:
+        logger.debug("_live_models_policy_fingerprint fell back for %s: %s", provider, _e)
+        payload = {"error": "policy_unavailable"}
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
 
 
-def _get_cached_live_models(key: tuple[str, str]) -> dict | None:
+def _live_models_cache_key(provider: str) -> tuple[str, str, str]:
+    return (
+        _active_profile_for_live_models_cache(),
+        provider,
+        _live_models_policy_fingerprint(provider),
+    )
+
+
+def _get_cached_live_models(key: tuple[str, str, str]) -> dict | None:
     now = time.monotonic()
     with _LIVE_MODELS_CACHE_LOCK:
         cached = _LIVE_MODELS_CACHE.get(key)
@@ -1929,7 +1962,7 @@ def _get_cached_live_models(key: tuple[str, str]) -> dict | None:
         return copy.deepcopy(payload)
 
 
-def _set_cached_live_models(key: tuple[str, str], payload: dict) -> None:
+def _set_cached_live_models(key: tuple[str, str, str], payload: dict) -> None:
     with _LIVE_MODELS_CACHE_LOCK:
         _LIVE_MODELS_CACHE[key] = (time.monotonic(), copy.deepcopy(payload))
 
@@ -21369,8 +21402,8 @@ def _handle_live_models(handler, parsed):
 
     try:
         from api.config import get_config as _gc
-        from api.config import _configured_model_ids, _models_config_is_discovered
-        from api.config import _get_provider_cfg_for_id
+        from api.config import _configured_model_ids
+        from api.config import _get_provider_cfg_for_id, _live_models_policy_for_provider
         cfg = _gc()
         if not provider:
             provider = cfg.get("model", {}).get("provider") or ""
@@ -21606,23 +21639,17 @@ def _handle_live_models(handler, parsed):
         # discovered catalog stays live-authoritative and falls back to the
         # persisted (sanitized) IDs only when the probe returned nothing;
         # Copilot's models mapping is per-model settings, never a pin. Route
-        # everything through _configured_model_ids so metadata sentinels never
-        # surface as selectable models (#7404 review).
-        _uses_models_as_settings_map = provider == "copilot"
-        _provider_cfg = {}
+        # everything through the shared policy resolver so a pin stored in a
+        # ``custom_providers[]`` entry (not just ``providers.<id>``) is
+        # honoured, and always via _configured_model_ids so metadata sentinels
+        # never surface as selectable models (#7404 review).
         try:
-            _providers_cfg = cfg.get("providers") or {}
-            if isinstance(_providers_cfg, dict):
-                _provider_cfg = _get_provider_cfg_for_id(provider, _providers_cfg)
+            _policy = _live_models_policy_for_provider(provider, cfg)
         except Exception:
-            _provider_cfg = {}
-        if (
-            not _uses_models_as_settings_map
-            and isinstance(_provider_cfg, dict)
-            and "models" in _provider_cfg
-        ):
-            _configured_ids = _configured_model_ids(_provider_cfg.get("models"))
-            if _models_config_is_discovered(_provider_cfg):
+            _policy = {}
+        if _policy.get("has_models") and not _policy.get("settings_map"):
+            _configured_ids = list(_policy.get("models") or [])
+            if _policy.get("discovered"):
                 if not ids:
                     ids = list(_configured_ids)
             else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -21369,6 +21369,7 @@ def _handle_live_models(handler, parsed):
 
     try:
         from api.config import get_config as _gc
+        from api.config import _configured_model_ids, _models_config_is_discovered
         cfg = _gc()
         if not provider:
             provider = cfg.get("model", {}).get("provider") or ""
@@ -21443,17 +21444,11 @@ def _handle_live_models(handler, parsed):
                         _ids.append(_mid)
 
                 _append(_cp.get("model", ""))
-                _models = _cp.get("models")
-                if isinstance(_models, dict):
-                    for _mid in _models:
-                        if isinstance(_mid, str):
-                            _append(_mid)
-                elif isinstance(_models, list):
-                    for _item in _models:
-                        if isinstance(_item, str):
-                            _append(_item)
-                        elif isinstance(_item, dict):
-                            _append(_item.get("id") or _item.get("model") or _item.get("name"))
+                # Go through _configured_model_ids so the metadata sentinels
+                # Hermes persists in a discovered catalog never surface as
+                # selectable model IDs (#7404 review).
+                for _mid in _configured_model_ids(_cp.get("models")):
+                    _append(_mid)
                 return _ids
 
             def _custom_provider_api_key(_cp):
@@ -21603,6 +21598,34 @@ def _handle_live_models(handler, parsed):
                 except Exception as _fetch_err:
                     logger.debug("Live fetch from %s failed: %s", provider, _fetch_err)
                     # Fall through to static list below
+
+        # ── Config allowlist / discovery policy ────────────────────────────
+        # Mirror get_available_models() so this enrichment surface agrees with
+        # the picker: a genuine user pin restricts the returned IDs; a
+        # discovered catalog stays live-authoritative and falls back to the
+        # persisted (sanitized) IDs only when the probe returned nothing;
+        # Copilot's models mapping is per-model settings, never a pin. Route
+        # everything through _configured_model_ids so metadata sentinels never
+        # surface as selectable models (#7404 review).
+        _uses_models_as_settings_map = provider == "copilot"
+        _provider_cfg = {}
+        try:
+            _providers_cfg = cfg.get("providers") or {}
+            if isinstance(_providers_cfg, dict):
+                _provider_cfg = _providers_cfg.get(provider, {})
+        except Exception:
+            _provider_cfg = {}
+        if (
+            not _uses_models_as_settings_map
+            and isinstance(_provider_cfg, dict)
+            and "models" in _provider_cfg
+        ):
+            _configured_ids = _configured_model_ids(_provider_cfg.get("models"))
+            if _models_config_is_discovered(_provider_cfg):
+                if not ids:
+                    ids = list(_configured_ids)
+            else:
+                ids = list(_configured_ids)
 
         # Static fallback — only reached when live fetch also failed.
         if not ids:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -77,7 +77,10 @@ The first screen reports the runtime state WebUI can see:
 
 - Hermes Agent importability: whether WebUI can import and run `AIAgent`.
 - Provider status: whether `config.yaml` and credential state are enough for a
-  chat request.
+  chat request. Provider readiness resolves the configured provider key through
+  its alias, mixed-case, and underscore forms before checking credentials, so an
+  entry written under an alias (for example `providers: {z-ai: ...}` while the
+  selected provider is `zai`) is still detected as configured.
 - Password status: whether WebUI password protection is enabled.
 - Config paths: the active `config.yaml` and `.env` locations for this profile.
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -9264,6 +9264,13 @@ async function loadSettingsPanel(){
     // Populate model dropdown from /api/models + live model fetch (#872)
     const modelSel=$('settingsModel');
     if(modelSel){
+      // #7404 review: this is an authoritative settings rebuild. Advance the
+      // policy generation and this select's owner identity before the
+      // unrequestSeq'd _fetchLiveModels() call below so a live response held
+      // from a previous settings open cannot append stale models to the
+      // rebuilt list.
+      if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
+      if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
       modelSel.innerHTML='';
       let models=null;
       try{
@@ -11874,6 +11881,10 @@ async function _saveSelfHostedProvider(providerId){
 // loaded yet (e.g. during early Settings open) cannot break the save flow.
 function _refreshModelDropdownsAfterProviderChange(){
   try{
+    // #7404 review: a provider add/remove/refresh is an authoritative policy
+    // change, so advance the live-model generation. Any in-flight response for
+    // the previous provider policy is rejected at apply time.
+    if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
     if(typeof window._invalidateSlashModelCache==='function'){
       window._invalidateSlashModelCache();
     }
@@ -12855,6 +12866,10 @@ async function saveSettings(andClose){
         await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
         body.default_model=model;
         body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
+        // #7404 review: the model policy changed for the same profile. Advance
+        // the live-model generation so any in-flight broad-discovered response
+        // is rejected before it can re-append a model the new pin excludes.
+        if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
         }catch(_modelErr){
           // A 400 here (e.g. an ambiguous custom-provider slug collision: rename
           // one provider) is user-fixable, not a partial success. Surface the
@@ -12891,6 +12906,10 @@ async function saveSettings(andClose){
         await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
         body.default_model=model;
         body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
+        // #7404 review: the model policy changed for the same profile. Advance
+        // the live-model generation so any in-flight broad-discovered response
+        // is rejected before it can re-append a model the new pin excludes.
+        if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
         }catch(_modelErr){
           // A 400 here (e.g. an ambiguous custom-provider slug collision: rename
           // one provider) is user-fixable, not a partial success. Surface the

--- a/static/panels.js
+++ b/static/panels.js
@@ -9264,13 +9264,14 @@ async function loadSettingsPanel(){
     // Populate model dropdown from /api/models + live model fetch (#872)
     const modelSel=$('settingsModel');
     if(modelSel){
-      // #7404 review: this is an authoritative settings rebuild. Advance the
-      // policy generation and this select's owner identity before the
-      // unrequestSeq'd _fetchLiveModels() call below so a live response held
-      // from a previous settings open cannot append stale models to the
-      // rebuilt list. Starts its own replacement fetch below, so do NOT route
-      // through _liveModelPolicyChanged() (that would double-fetch).
-      if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
+      // #7404 review: this is an authoritative rebuild of the Settings select
+      // ONLY. Advance ITS per-target latest-request sequence, never the global
+      // policy generation: the composer is an independent publisher, so a
+      // Settings rebuild must not invalidate a composer live-model request that
+      // is already in flight (nor vice versa). The unrequestSeq'd
+      // _fetchLiveModels() call below starts its own replacement for
+      // settingsModel, so do NOT route through _liveModelPolicyChanged() (that
+      // would double-fetch).
       if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
       modelSel.innerHTML='';
       let models=null;

--- a/static/panels.js
+++ b/static/panels.js
@@ -9271,7 +9271,7 @@ async function loadSettingsPanel(){
       // is already in flight (nor vice versa). The unrequestSeq'd
       // _fetchLiveModels() call below starts its own replacement for
       // settingsModel, so do NOT route through _liveModelPolicyChanged() (that
-      // would double-fetch).
+      // drives the composer and would double-fetch here).
       if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
       modelSel.innerHTML='';
       let models=null;
@@ -11883,23 +11883,17 @@ async function _saveSelfHostedProvider(providerId){
 // loaded yet (e.g. during early Settings open) cannot break the save flow.
 function _refreshModelDropdownsAfterProviderChange(){
   try{
-    // #7404 review: a provider add/remove/refresh is an authoritative policy
-    // change, so advance the live-model generation. Any in-flight response for
-    // the previous provider policy is rejected at apply time. Already starts a
-    // replacement rebuild below, so do NOT route through
-    // _liveModelPolicyChanged() (that would double-fetch).
-    if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
     if(typeof window._invalidateSlashModelCache==='function'){
       window._invalidateSlashModelCache();
     }
-    // Fire-and-forget: don't block the providers panel refresh on a
-    // dropdown rebuild. The composer/Settings dropdowns will catch up
-    // on the very next paint frame.
-    if(typeof window._ensureModelDropdownReady==='function'){
-      window._modelDropdownReady=null;
-      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
-    }else if(typeof populateModelDropdown==='function'){
-      Promise.resolve(populateModelDropdown()).catch(()=>{});
+    // #7404 review: a provider add/remove/refresh is an authoritative policy
+    // change. Route through _liveModelPolicyChanged() so the generation advance
+    // and the replacement rebuild share one owner: it synchronously retains the
+    // composer's pending entry across the generation change (no visibility gap)
+    // and starts the replacement rebuild exactly once. Do NOT rebuild here as
+    // well -- that would double-fetch.
+    if(typeof _liveModelPolicyChanged==='function'){
+      _liveModelPolicyChanged();
     }
   }catch(_e){
     // Swallow — dropdown refresh is best-effort, providers panel must still update.

--- a/static/panels.js
+++ b/static/panels.js
@@ -9033,6 +9033,69 @@ function _syncSettingsMaxTokensPlaceholder(field, fallbackValue){
     : 'No override';
 }
 
+// Authoritative rebuild of the Settings -> Default Model select (#872).
+//
+// Shared by loadSettingsPanel() (panel open) and _liveModelPolicyChanged()
+// (default-model save / provider add-remove-refresh) so this target has ONE
+// implementation. The chokepoint used to know only about the composer, so a
+// policy change invalidated an in-flight Settings live fetch without starting
+// a replacement -- the Settings picker then lost its live-only models until the
+// panel was next rebuilt (#7404 review).
+//
+// Advances ONLY the Settings select's per-target latest-request sequence, never
+// the global policy generation: the composer is an independent publisher, so a
+// Settings rebuild must not invalidate an in-flight composer live-model request
+// (nor vice versa). Clears innerHTML before repopulating, so a replacement
+// REPLACES the live catalog instead of accumulating entries across policy saves.
+async function _rebuildSettingsModelSelect(){
+  const modelSel=$('settingsModel');
+  // Settings never opened -- nothing to rebuild, and no throw for the caller.
+  if(!modelSel) return null;
+  if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
+  modelSel.innerHTML='';
+  let models=null;
+  try{
+    models=await api('/api/models');
+    for(const g of ((models||{}).groups||[])){
+      const og=document.createElement('optgroup');
+      og.label=g.provider;
+      if(g.provider_id) og.dataset.provider=g.provider_id;
+      for(const m of [...(g.models||[]),...(g.extra_models||[])]){
+        const opt=document.createElement('option');
+        opt.value=m.id;opt.textContent=m.label;
+        if(m && (m.supports_fast_tier === true || String(m.supports_fast_tier).toLowerCase()==='true')){
+          opt.dataset.fast='1';
+        }else if(m && (m.supports_fast_tier === false || String(m.supports_fast_tier).toLowerCase()==='false')){
+          opt.dataset.fast='0';
+        }
+        og.appendChild(opt);
+      }
+      modelSel.appendChild(og);
+    }
+    // Append live-fetched models for the active provider, same as the
+    // chat-header dropdown does via _fetchLiveModels() (#872).
+    if(models.active_provider && typeof _fetchLiveModels==='function'){
+      _fetchLiveModels(models.active_provider, modelSel);
+    }
+  }catch(e){}
+  _settingsHermesDefaultModelOnOpen=(models&&models.default_model)||'';
+  _settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;
+  // Use the smart matcher so a saved bare form like "anthropic/claude-opus-4.6"
+  // (what the CLI's `hermes model` command writes) still selects the matching
+  // `@nous:anthropic/claude-opus-4.6` option on a Nous setup. Without this, the
+  // picker renders blank for any user whose default was persisted without the
+  // @-prefix — CLI-first users, legacy installs, etc.
+  if(typeof _applyModelToDropdown==='function'){
+    _applyModelToDropdown(_settingsHermesDefaultModelOnOpen, modelSel, (models&&models.active_provider)||window._activeProvider||null);
+  }else{
+    modelSel.value=_settingsHermesDefaultModelOnOpen;
+  }
+  if(typeof closeSettingsModelDropdown==='function') closeSettingsModelDropdown();
+  if(typeof mountSettingsModelPicker==='function') mountSettingsModelPicker();
+  return models;
+}
+if(typeof window!=='undefined') window._rebuildSettingsModelSelect=_rebuildSettingsModelSelect;
+
 async function loadSettingsPanel(){
   try{
     const settings=await api('/api/settings');
@@ -9264,55 +9327,9 @@ async function loadSettingsPanel(){
     // Populate model dropdown from /api/models + live model fetch (#872)
     const modelSel=$('settingsModel');
     if(modelSel){
-      // #7404 review: this is an authoritative rebuild of the Settings select
-      // ONLY. Advance ITS per-target latest-request sequence, never the global
-      // policy generation: the composer is an independent publisher, so a
-      // Settings rebuild must not invalidate a composer live-model request that
-      // is already in flight (nor vice versa). The unrequestSeq'd
-      // _fetchLiveModels() call below starts its own replacement for
-      // settingsModel, so do NOT route through _liveModelPolicyChanged() (that
-      // drives the composer and would double-fetch here).
-      if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
-      modelSel.innerHTML='';
-      let models=null;
-      try{
-        models=await api('/api/models');
-        for(const g of ((models||{}).groups||[])){
-          const og=document.createElement('optgroup');
-          og.label=g.provider;
-          if(g.provider_id) og.dataset.provider=g.provider_id;
-          for(const m of [...(g.models||[]),...(g.extra_models||[])]){
-            const opt=document.createElement('option');
-            opt.value=m.id;opt.textContent=m.label;
-            if(m && (m.supports_fast_tier === true || String(m.supports_fast_tier).toLowerCase()==='true')){
-              opt.dataset.fast='1';
-            }else if(m && (m.supports_fast_tier === false || String(m.supports_fast_tier).toLowerCase()==='false')){
-              opt.dataset.fast='0';
-            }
-            og.appendChild(opt);
-          }
-          modelSel.appendChild(og);
-        }
-        // Append live-fetched models for the active provider, same as the
-        // chat-header dropdown does via _fetchLiveModels() (#872).
-        if(models.active_provider && typeof _fetchLiveModels==='function'){
-          _fetchLiveModels(models.active_provider, modelSel);
-        }
-      }catch(e){}
-      _settingsHermesDefaultModelOnOpen=(models&&models.default_model)||'';
-      _settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;
-      // Use the smart matcher so a saved bare form like "anthropic/claude-opus-4.6"
-      // (what the CLI's `hermes model` command writes) still selects the matching
-      // `@nous:anthropic/claude-opus-4.6` option on a Nous setup. Without this, the
-      // picker renders blank for any user whose default was persisted without the
-      // @-prefix — CLI-first users, legacy installs, etc.
-      if(typeof _applyModelToDropdown==='function'){
-        _applyModelToDropdown(_settingsHermesDefaultModelOnOpen, modelSel, (models&&models.active_provider)||window._activeProvider||null);
-      }else{
-        modelSel.value=_settingsHermesDefaultModelOnOpen;
-      }
-      if(typeof closeSettingsModelDropdown==='function') closeSettingsModelDropdown();
-      if(typeof mountSettingsModelPicker==='function') mountSettingsModelPicker();
+      // Shared rebuild -- the same chokepoint `_liveModelPolicyChanged()`
+      // drives, so this target has ONE implementation (#7404 review).
+      await _rebuildSettingsModelSelect();
       modelSel.addEventListener('change',_markSettingsDirty,{once:false});
       if(!modelSel._settingsChipSyncBound){
         modelSel._settingsChipSyncBound=true;

--- a/static/panels.js
+++ b/static/panels.js
@@ -9268,7 +9268,8 @@ async function loadSettingsPanel(){
       // policy generation and this select's owner identity before the
       // unrequestSeq'd _fetchLiveModels() call below so a live response held
       // from a previous settings open cannot append stale models to the
-      // rebuilt list.
+      // rebuilt list. Starts its own replacement fetch below, so do NOT route
+      // through _liveModelPolicyChanged() (that would double-fetch).
       if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
       if(typeof _liveModelAdvanceSelectIdentity==='function') _liveModelAdvanceSelectIdentity(modelSel);
       modelSel.innerHTML='';
@@ -11883,7 +11884,9 @@ function _refreshModelDropdownsAfterProviderChange(){
   try{
     // #7404 review: a provider add/remove/refresh is an authoritative policy
     // change, so advance the live-model generation. Any in-flight response for
-    // the previous provider policy is rejected at apply time.
+    // the previous provider policy is rejected at apply time. Already starts a
+    // replacement rebuild below, so do NOT route through
+    // _liveModelPolicyChanged() (that would double-fetch).
     if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
     if(typeof window._invalidateSlashModelCache==='function'){
       window._invalidateSlashModelCache();
@@ -12868,8 +12871,9 @@ async function saveSettings(andClose){
         body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
         // #7404 review: the model policy changed for the same profile. Advance
         // the live-model generation so any in-flight broad-discovered response
-        // is rejected before it can re-append a model the new pin excludes.
-        if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
+        // is rejected before it can re-append a model the new pin excludes, and
+        // start a replacement request so the live catalog is not dropped.
+        if(typeof _liveModelPolicyChanged==='function') _liveModelPolicyChanged();
         }catch(_modelErr){
           // A 400 here (e.g. an ambiguous custom-provider slug collision: rename
           // one provider) is user-fixable, not a partial success. Surface the
@@ -12908,8 +12912,9 @@ async function saveSettings(andClose){
         body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
         // #7404 review: the model policy changed for the same profile. Advance
         // the live-model generation so any in-flight broad-discovered response
-        // is rejected before it can re-append a model the new pin excludes.
-        if(typeof _liveModelAdvancePolicyGeneration==='function') _liveModelAdvancePolicyGeneration();
+        // is rejected before it can re-append a model the new pin excludes, and
+        // start a replacement request so the live catalog is not dropped.
+        if(typeof _liveModelPolicyChanged==='function') _liveModelPolicyChanged();
         }catch(_modelErr){
           // A 400 here (e.g. an ambiguous custom-provider slug collision: rename
           // one provider) is user-fixable, not a partial success. Surface the

--- a/static/ui.js
+++ b/static/ui.js
@@ -3601,6 +3601,21 @@ function _isLiveModelOwnerCurrent(token){
   }
   return true;
 }
+function _liveModelPolicyChanged(){
+  _liveModelAdvancePolicyGeneration();
+  // A policy change invalidates any in-flight response. Start a replacement
+  // request so the live catalog is not dropped: without this, advancing the
+  // generation rejects the in-flight response and nothing re-fetches, leaving
+  // live-only models absent from the dropdown (#7404 review).
+  try{
+    if(typeof window._ensureModelDropdownReady==='function'){
+      window._modelDropdownReady=null;
+      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
+    }else if(typeof populateModelDropdown==='function'){
+      Promise.resolve(populateModelDropdown()).catch(()=>{});
+    }
+  }catch(_e){}
+}
 
 function _applySessionModelFallback(sel){
   if(!sel) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3730,10 +3730,20 @@ async function populateModelDropdown(opts={}){
 // suppress another profile's fetch. Used by syncTopbar() to defer model
 // corrections until the fetch completes, preventing premature fallback to the
 // first static model (#1169).
-const _liveModelFetchPending=new Set();
+const _liveModelFetchPending=new Map();
 function _liveModelFetchKey(provider){
   const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
   return profile+'\u0000'+String(provider||'');
+}
+function _liveModelFetchBegin(provider){
+  const key=_liveModelFetchKey(provider);
+  _liveModelFetchPending.set(key,(_liveModelFetchPending.get(key)||0)+1);
+  return key;
+}
+function _liveModelFetchEnd(key){
+  const remaining=(_liveModelFetchPending.get(key)||0)-1;
+  if(remaining>0)_liveModelFetchPending.set(key,remaining);
+  else _liveModelFetchPending.delete(key);
 }
 
 function _addLiveModelsToSelect(provider, models, sel){
@@ -3841,8 +3851,7 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
   // Capture the profile at fetch start so a mid-flight profile switch cannot
   // apply this catalog to a different profile's dropdown.
   const _fetchProfile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
-  const fetchKey=_liveModelFetchKey(provider);
-  _liveModelFetchPending.add(fetchKey);
+  const fetchKey=_liveModelFetchBegin(provider);
   try{
     const url=new URL('api/models/live',document.baseURI||location.href);
     url.searchParams.set('provider',provider);
@@ -3864,7 +3873,7 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
   }catch(e){
     console.debug('[hermes] Live model fetch failed for',provider,e.message);
   }finally{
-    _liveModelFetchPending.delete(fetchKey);
+    _liveModelFetchEnd(fetchKey);
   }
 }
 
@@ -11191,7 +11200,9 @@ function syncTopbar(){
         const missingModelIsRoutable=_providerDefersMissingModelFallback(S.session.model_provider||window._activeProvider||null);
         // Also defer if a live model fetch is still in flight — the model may be
         // in the list once the fetch completes. Persisting now would corrupt the
-        // session with the wrong model before live models arrive (#1169).
+        // session with the wrong model before live models arrive (#1169). The
+        // entry is reference-counted, so it persists until the LAST in-flight
+        // request for this key completes (overlapping fetches share one key).
         const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(_liveModelFetchKey(window._activeProvider));
         if(liveStillPending||missingModelIsRoutable){
           // Live fetch in flight — don't touch sel.value or S.session.model yet.

--- a/static/ui.js
+++ b/static/ui.js
@@ -3561,16 +3561,24 @@ function _persistSessionModelCorrection(model, provider, opts){
 let _modelDropdownRequestSeq=0;
 let _modelCatalogFallbackRetried=false;
 
-// #7404 review: every live-model response is fenced by an immutable latest-owner
-// token. The active profile alone cannot distinguish two requests issued under
-// the same profile but different model policies (a broad discovered catalog vs
-// a strict pin) -- and `_addLiveModelsToSelect()` is additive, so a late broad
-// response would otherwise re-append a model the newer strict policy removed.
-// `generation` advances on same-profile policy saves and authoritative
-// dropdown/settings refreshes; `selectIdentity` advances whenever the target
-// <select> is authoritatively rebuilt. Both halves are read from live state at
-// check time (the select identity off the element itself, never a WeakMap), so
-// a stale request can neither mutate the list nor re-sync the chip.
+// #7404 review: live-model applicability has TWO independent authorities.
+//
+//  * `_liveModelPolicyGeneration` is GLOBAL and advances ONLY on a genuine
+//    provider/model policy change (a default-model save or a provider
+//    add/remove/refresh). A policy change invalidates every in-flight response
+//    captured before it, across all selects.
+//  * Each <select> owns a per-target latest-request sequence
+//    (`sel.__liveModelOwnerSeq`). Rebuilding one select (composer or Settings)
+//    advances only ITS sequence, so it supersedes its own older requests and
+//    never the other select's. `_fetchLiveModels()` claims a fresh sequence at
+//    request start, so "the newest request for a target wins" is intrinsic to
+//    the request rather than dependent on every caller.
+//
+// A response is applied only while its immutable owner token still matches the
+// live profile, the live policy generation, and its target's latest sequence.
+// Both halves are read from live state at check time (the sequence off the
+// element itself, never a WeakMap), so a stale request can neither mutate the
+// list nor re-sync the chip.
 let _liveModelPolicyGeneration=0;
 function _liveModelAdvancePolicyGeneration(){
   _liveModelPolicyGeneration++;
@@ -3581,11 +3589,17 @@ function _liveModelAdvanceSelectIdentity(sel){
   _liveModelOwnerSeq++;
   sel.__liveModelOwnerSeq=_liveModelOwnerSeq;
 }
+function _liveModelTargetIdentity(sel){
+  if(sel&&sel.id) return String(sel.id);
+  const fallback=(typeof $==='function')?$('modelSelect'):null;
+  return (fallback&&fallback.id)?String(fallback.id):'';
+}
 function _liveModelOwnerToken(provider, sel){
   return {
     profile:(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default',
     provider:String(provider||''),
     generation:_liveModelPolicyGeneration,
+    targetId:_liveModelTargetIdentity(sel),
     selectIdentity:(sel&&typeof sel.__liveModelOwnerSeq==='number')?sel.__liveModelOwnerSeq:null,
     sel:sel||null,
   };
@@ -3712,11 +3726,10 @@ async function populateModelDropdown(opts={}){
       return; // no server groups and no configured fallback
     }
     const previousSelection=_captureModelDropdownSelection(sel);
-    // Authoritative rebuild of this select: bump the policy generation and the
-    // select's owner identity so any live-model response captured before this
-    // render (under a now-superseded policy) is rejected before it can mutate
-    // the fresh list.
-    _liveModelAdvancePolicyGeneration();
+    // Authoritative rebuild of THIS select (the composer). Advance only its
+    // per-target latest-request sequence, never the global policy generation:
+    // the Settings select is an independent publisher, so a composer rebuild
+    // must not invalidate its in-flight live request (#7404 review).
     _liveModelAdvanceSelectIdentity(sel);
     // Clear existing options
     sel.innerHTML='';
@@ -3787,22 +3800,23 @@ async function populateModelDropdown(opts={}){
 // discovered catalog after the same profile switched to a strict model pin and
 // never reach the policy-aware server cache (#7404 review). Always fetch.
 //
-// Tracks profile+provider+policy-generation triples with a live-model fetch in
-// flight. Keyed by the same authority as the request so a pending fetch for one
-// profile/generation cannot suppress another's (and so an older generation's
-// completion decrements its own counter, never a newer generation's). Used by
-// syncTopbar() to defer model corrections until the fetch completes, preventing
-// premature fallback to the first static model (#1169). Calling this without an
-// explicit generation resolves to the CURRENT generation, so `has()` there still
-// means "at least one in-flight request for the current authority".
+// Tracks profile+provider+policy-generation+target-select tuples with a
+// live-model fetch in flight. Carrying the target identity keeps the composer
+// and Settings pending states independent: syncTopbar() observes only the
+// composer key, so a Settings-only fetch cannot make the composer look pending
+// (nor hide a composer fetch behind a Settings one). Keyed by the same
+// authority as the request so an older generation's completion decrements its
+// own counter, never a newer generation's. Calling this without an explicit
+// select resolves to the composer select, so `has()` there still means "at
+// least one in-flight request for the current composer authority".
 const _liveModelFetchPending=new Map();
-function _liveModelFetchKey(provider, generation){
+function _liveModelFetchKey(provider, generation, sel){
   const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
   const policyGeneration=(typeof generation==='number')?generation:_liveModelPolicyGeneration;
-  return profile+'\u0000'+String(provider||'')+'\u0000'+String(policyGeneration);
+  return profile+'\u0000'+String(provider||'')+'\u0000'+String(policyGeneration)+'\u0000'+_liveModelTargetIdentity(sel);
 }
 function _liveModelFetchBegin(provider, ownerToken){
-  const key=_liveModelFetchKey(provider, ownerToken?ownerToken.generation:undefined);
+  const key=_liveModelFetchKey(provider, ownerToken?ownerToken.generation:undefined, ownerToken?ownerToken.sel:undefined);
   _liveModelFetchPending.set(key,(_liveModelFetchPending.get(key)||0)+1);
   return key;
 }
@@ -3914,9 +3928,17 @@ function _addLiveModelsToSelect(provider, models, sel){
 async function _fetchLiveModels(provider, sel, requestSeq=null){
   if(!provider||!sel) return;
   if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+  // Claim a FRESH per-target latest-request token at fetch start. This makes
+  // "the newest request for this select wins" intrinsic to the request instead
+  // of relying on every caller to advance identity first -- the recurring
+  // source of cross-target stale-rejection bugs. An older overlapping request
+  // for the same select becomes stale and cannot re-append its catalog after
+  // the newer one.
+  _liveModelAdvanceSelectIdentity(sel);
   // Capture an immutable latest-owner token at fetch start: active profile,
-  // provider, model-policy generation, and target-select identity. See
-  // _isLiveModelOwnerCurrent() for the full staleness contract.
+  // provider, model-policy generation, target identity, and this request's own
+  // per-target sequence. See _isLiveModelOwnerCurrent() for the staleness
+  // contract.
   const ownerToken=_liveModelOwnerToken(provider, sel);
   const fetchKey=_liveModelFetchBegin(provider, ownerToken);
   try{
@@ -11272,7 +11294,7 @@ function syncTopbar(){
         // session with the wrong model before live models arrive (#1169). The
         // entry is reference-counted, so it persists until the LAST in-flight
         // request for this key completes (overlapping fetches share one key).
-        const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(_liveModelFetchKey(window._activeProvider));
+        const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(_liveModelFetchKey(window._activeProvider, undefined, $('modelSelect')));
         if(liveStillPending||missingModelIsRoutable){
           // Live fetch in flight — don't touch sel.value or S.session.model yet.
           // _addLiveModelsToSelect() will re-apply S.session.model once done (#1169).

--- a/static/ui.js
+++ b/static/ui.js
@@ -3619,49 +3619,90 @@ function _liveModelPolicyChanged(){
   // Best-effort by contract: this is a dropdown refresh, so nothing here may
   // throw into the caller. saveSettings() wraps its call in a catch that treats
   // a throw as "failed to update default model" and ABORTS the save, so an
-  // unexpected error while resolving the composer target must not escape.
-  let sel=null;
+  // unexpected error while resolving either target must not escape.
+  //
+  // There are exactly TWO live-model targets in this codebase: the composer
+  // (`modelSelect`) and Settings -> Default Model (`settingsModel`). A genuine
+  // policy change invalidates in-flight responses for BOTH, so the replacement
+  // must cover both as well; starting one only for the composer leaves the
+  // Settings picker without its live-only models (#7404 review).
+  let composerSel=null;
+  let settingsSel=null;
   try{
-    sel=(typeof $==='function')?$('modelSelect'):null;
+    composerSel=(typeof $==='function')?$('modelSelect'):null;
+    settingsSel=(typeof $==='function')?$('settingsModel'):null;
   }catch(_e){
-    sel=null;
+    composerSel=null;
+    settingsSel=null;
   }
-  // Resolve the composer target and its provider BEFORE advancing so the
-  // placeholder below is retained under the replacement's own authority.
+  // Resolve the provider BEFORE advancing so both placeholders below are
+  // retained under the replacement's own authority.
   const provider=window._activeProvider||null;
+  // The global policy generation is real policy authority: advance it ONCE.
   _liveModelAdvancePolicyGeneration();
-  // Gap-free transition: advancing the generation changes the composer's
-  // pending key, but the replacement rebuild only re-registers that key after
-  // an asynchronous /api/models round-trip. Retain a placeholder SYNCHRONOUSLY
-  // -- before any promise is created -- so `has()` on the current composer key
-  // is never false across the transition. syncTopbar() defers a model
-  // correction while that key is pending, so without this the in-flight live
-  // fetch window would persist a static fallback (#7404 review).
-  const retainedKey=_liveModelFetchKey(provider, undefined, sel);
-  _liveModelFetchRetain(retainedKey);
-  let released=false;
-  const release=()=>{
-    if(released) return;
-    released=true;
-    _liveModelFetchEnd(retainedKey);
+  // Gap-free transition for the COMPOSER: advancing the generation changes the
+  // composer's pending key, but the replacement rebuild only re-registers that
+  // key after an asynchronous /api/models round-trip. Retain a placeholder
+  // SYNCHRONOUSLY -- before any promise is created -- so `has()` on the current
+  // composer key is never false across the transition. syncTopbar() defers a
+  // model correction while that key is pending, so without this the in-flight
+  // live fetch window would persist a static fallback (#7404 review).
+  const composerRetainedKey=_liveModelFetchKey(provider, undefined, composerSel);
+  _liveModelFetchRetain(composerRetainedKey);
+  let composerReleased=false;
+  const releaseComposer=()=>{
+    if(composerReleased) return;
+    composerReleased=true;
+    _liveModelFetchEnd(composerRetainedKey);
   };
+  // The SETTINGS select is an independent publisher with its own per-target
+  // identity, so it gets its own placeholder under the SAME key function and a
+  // replacement through the SHARED rebuild. Retained synchronously here for the
+  // same gap-free reason as the composer; release() is idempotent so overlap
+  // decrements the refcount once.
+  let settingsRetainedKey=null;
+  let settingsReleased=true;
+  const releaseSettings=()=>{
+    if(settingsReleased) return;
+    settingsReleased=true;
+    _liveModelFetchEnd(settingsRetainedKey);
+  };
+  if(settingsSel){
+    settingsRetainedKey=_liveModelFetchKey(provider, undefined, settingsSel);
+    _liveModelFetchRetain(settingsRetainedKey);
+    settingsReleased=false;
+  }
   // A policy change invalidates any in-flight response. Start a replacement
-  // request so the live catalog is not dropped: without this, advancing the
-  // generation rejects the in-flight response and nothing re-fetches, leaving
-  // live-only models absent from the dropdown (#7404 review). Fire-and-forget:
-  // callers must not await the rebuild. The placeholder is released on EVERY
-  // exit: the settled promise, the no-rebuild-available path, and the catch.
+  // request for the composer so its live catalog is not dropped. Fire-and-
+  // forget: callers must not await the rebuild. The placeholder is released on
+  // EVERY exit: the settled promise, the no-rebuild-available path, and the
+  // catch.
   try{
     if(typeof window._ensureModelDropdownReady==='function'){
       window._modelDropdownReady=null;
-      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{}).finally(release);
+      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{}).finally(releaseComposer);
     }else if(typeof populateModelDropdown==='function'){
-      Promise.resolve(populateModelDropdown()).catch(()=>{}).finally(release);
+      Promise.resolve(populateModelDropdown()).catch(()=>{}).finally(releaseComposer);
     }else{
-      release();
+      releaseComposer();
     }
   }catch(_e){
-    release();
+    releaseComposer();
+  }
+  // Symmetric replacement for the SETTINGS target. Route through the shared
+  // `_rebuildSettingsModelSelect()` so both call sites have ONE implementation.
+  // That helper clears the select first, so this REPLACES the live catalog; a
+  // bare `_fetchLiveModels()` re-append would accumulate entries on every
+  // policy save. Guarded so a missing panels.js helper cannot throw into
+  // saveSettings().
+  try{
+    if(typeof window._rebuildSettingsModelSelect==='function'){
+      Promise.resolve(window._rebuildSettingsModelSelect()).catch(()=>{}).finally(releaseSettings);
+    }else{
+      releaseSettings();
+    }
+  }catch(_e){
+    releaseSettings();
   }
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -3719,19 +3719,22 @@ async function populateModelDropdown(opts={}){
   }
 }
 
-// Cache so we don't re-fetch on every page load.
-// Keyed by profile + provider: the endpoint response depends on the active
-// profile, so a profile switch must not append profile A's catalog to profile
-// B's freshly-rendered pinned list (#7404 review).
-const _liveModelCache={};
-function _liveModelCacheKey(provider){
+// No client-side response cache for live models. The server-side
+// /api/models/live cache is keyed by (profile, provider, policy fingerprint),
+// so a browser copy keyed only by profile+provider would replay a broad
+// discovered catalog after the same profile switched to a strict model pin and
+// never reach the policy-aware server cache (#7404 review). Always fetch.
+//
+// Tracks profile+provider pairs with a live-model fetch in flight. Keyed by the
+// same authority as the request so a pending fetch for one profile cannot
+// suppress another profile's fetch. Used by syncTopbar() to defer model
+// corrections until the fetch completes, preventing premature fallback to the
+// first static model (#1169).
+const _liveModelFetchPending=new Set();
+function _liveModelFetchKey(provider){
   const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
   return profile+'\u0000'+String(provider||'');
 }
-// Tracks providers for which a live-model fetch is in flight.
-// Used by syncTopbar() to defer model corrections until the fetch completes,
-// preventing premature fallback to the first static model (#1169).
-const _liveModelFetchPending=new Set();
 
 function _addLiveModelsToSelect(provider, models, sel){
   if(!provider||!models||!models.length||!sel) return 0;
@@ -3836,16 +3839,10 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
   if(!provider||!sel) return;
   if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
   // Capture the profile at fetch start so a mid-flight profile switch cannot
-  // file this catalog under the new profile's key.
-  const cacheKey=_liveModelCacheKey(provider);
-  // Already fetched — apply cached models to this select element (#872)
-  if(_liveModelCache[cacheKey]){
-    if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
-    const added=_addLiveModelsToSelect(provider,_liveModelCache[cacheKey],sel);
-    if(added>0 && typeof syncModelChip==='function') syncModelChip();
-    return;
-  }
-  _liveModelFetchPending.add(provider);
+  // apply this catalog to a different profile's dropdown.
+  const _fetchProfile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
+  const fetchKey=_liveModelFetchKey(provider);
+  _liveModelFetchPending.add(fetchKey);
   try{
     const url=new URL('api/models/live',document.baseURI||location.href);
     url.searchParams.set('provider',provider);
@@ -3855,8 +3852,10 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
     const data=await _liveRes.json();
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
     if(!data.models||!data.models.length) return;
-    _liveModelCache[cacheKey]=data.models;
-    if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+    // Re-verify the profile captured before the await: if the active profile
+    // changed mid-flight this catalog no longer belongs to the current view.
+    const _currentProfile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
+    if(_currentProfile!==_fetchProfile) return;
     const added=_addLiveModelsToSelect(provider,data.models,sel);
     if(added>0){
       if(typeof syncModelChip==='function') syncModelChip();
@@ -3865,7 +3864,7 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
   }catch(e){
     console.debug('[hermes] Live model fetch failed for',provider,e.message);
   }finally{
-    _liveModelFetchPending.delete(provider);
+    _liveModelFetchPending.delete(fetchKey);
   }
 }
 
@@ -11193,7 +11192,7 @@ function syncTopbar(){
         // Also defer if a live model fetch is still in flight — the model may be
         // in the list once the fetch completes. Persisting now would corrupt the
         // session with the wrong model before live models arrive (#1169).
-        const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(window._activeProvider);
+        const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(_liveModelFetchKey(window._activeProvider));
         if(liveStillPending||missingModelIsRoutable){
           // Live fetch in flight — don't touch sel.value or S.session.model yet.
           // _addLiveModelsToSelect() will re-apply S.session.model once done (#1169).

--- a/static/ui.js
+++ b/static/ui.js
@@ -3561,6 +3561,47 @@ function _persistSessionModelCorrection(model, provider, opts){
 let _modelDropdownRequestSeq=0;
 let _modelCatalogFallbackRetried=false;
 
+// #7404 review: every live-model response is fenced by an immutable latest-owner
+// token. The active profile alone cannot distinguish two requests issued under
+// the same profile but different model policies (a broad discovered catalog vs
+// a strict pin) -- and `_addLiveModelsToSelect()` is additive, so a late broad
+// response would otherwise re-append a model the newer strict policy removed.
+// `generation` advances on same-profile policy saves and authoritative
+// dropdown/settings refreshes; `selectIdentity` advances whenever the target
+// <select> is authoritatively rebuilt. Both halves are read from live state at
+// check time (the select identity off the element itself, never a WeakMap), so
+// a stale request can neither mutate the list nor re-sync the chip.
+let _liveModelPolicyGeneration=0;
+function _liveModelAdvancePolicyGeneration(){
+  _liveModelPolicyGeneration++;
+}
+let _liveModelOwnerSeq=0;
+function _liveModelAdvanceSelectIdentity(sel){
+  if(!sel) return;
+  _liveModelOwnerSeq++;
+  sel.__liveModelOwnerSeq=_liveModelOwnerSeq;
+}
+function _liveModelOwnerToken(provider, sel){
+  return {
+    profile:(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default',
+    provider:String(provider||''),
+    generation:_liveModelPolicyGeneration,
+    selectIdentity:(sel&&typeof sel.__liveModelOwnerSeq==='number')?sel.__liveModelOwnerSeq:null,
+    sel:sel||null,
+  };
+}
+function _isLiveModelOwnerCurrent(token){
+  if(!token) return false;
+  const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
+  if(profile!==token.profile) return false;
+  if(_liveModelPolicyGeneration!==token.generation) return false;
+  if(token.sel){
+    const selectIdentity=(typeof token.sel.__liveModelOwnerSeq==='number')?token.sel.__liveModelOwnerSeq:null;
+    if(selectIdentity!==token.selectIdentity) return false;
+  }
+  return true;
+}
+
 function _applySessionModelFallback(sel){
   if(!sel) return null;
   const configuredDefault=String(window._defaultModel||'').trim();
@@ -3656,6 +3697,12 @@ async function populateModelDropdown(opts={}){
       return; // no server groups and no configured fallback
     }
     const previousSelection=_captureModelDropdownSelection(sel);
+    // Authoritative rebuild of this select: bump the policy generation and the
+    // select's owner identity so any live-model response captured before this
+    // render (under a now-superseded policy) is rejected before it can mutate
+    // the fresh list.
+    _liveModelAdvancePolicyGeneration();
+    _liveModelAdvanceSelectIdentity(sel);
     // Clear existing options
     sel.innerHTML='';
     _dynamicModelLabels={};
@@ -3725,18 +3772,22 @@ async function populateModelDropdown(opts={}){
 // discovered catalog after the same profile switched to a strict model pin and
 // never reach the policy-aware server cache (#7404 review). Always fetch.
 //
-// Tracks profile+provider pairs with a live-model fetch in flight. Keyed by the
-// same authority as the request so a pending fetch for one profile cannot
-// suppress another profile's fetch. Used by syncTopbar() to defer model
-// corrections until the fetch completes, preventing premature fallback to the
-// first static model (#1169).
+// Tracks profile+provider+policy-generation triples with a live-model fetch in
+// flight. Keyed by the same authority as the request so a pending fetch for one
+// profile/generation cannot suppress another's (and so an older generation's
+// completion decrements its own counter, never a newer generation's). Used by
+// syncTopbar() to defer model corrections until the fetch completes, preventing
+// premature fallback to the first static model (#1169). Calling this without an
+// explicit generation resolves to the CURRENT generation, so `has()` there still
+// means "at least one in-flight request for the current authority".
 const _liveModelFetchPending=new Map();
-function _liveModelFetchKey(provider){
+function _liveModelFetchKey(provider, generation){
   const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
-  return profile+'\u0000'+String(provider||'');
+  const policyGeneration=(typeof generation==='number')?generation:_liveModelPolicyGeneration;
+  return profile+'\u0000'+String(provider||'')+'\u0000'+String(policyGeneration);
 }
-function _liveModelFetchBegin(provider){
-  const key=_liveModelFetchKey(provider);
+function _liveModelFetchBegin(provider, ownerToken){
+  const key=_liveModelFetchKey(provider, ownerToken?ownerToken.generation:undefined);
   _liveModelFetchPending.set(key,(_liveModelFetchPending.get(key)||0)+1);
   return key;
 }
@@ -3848,10 +3899,11 @@ function _addLiveModelsToSelect(provider, models, sel){
 async function _fetchLiveModels(provider, sel, requestSeq=null){
   if(!provider||!sel) return;
   if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
-  // Capture the profile at fetch start so a mid-flight profile switch cannot
-  // apply this catalog to a different profile's dropdown.
-  const _fetchProfile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
-  const fetchKey=_liveModelFetchBegin(provider);
+  // Capture an immutable latest-owner token at fetch start: active profile,
+  // provider, model-policy generation, and target-select identity. See
+  // _isLiveModelOwnerCurrent() for the full staleness contract.
+  const ownerToken=_liveModelOwnerToken(provider, sel);
+  const fetchKey=_liveModelFetchBegin(provider, ownerToken);
   try{
     const url=new URL('api/models/live',document.baseURI||location.href);
     url.searchParams.set('provider',provider);
@@ -3861,12 +3913,14 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
     const data=await _liveRes.json();
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
     if(!data.models||!data.models.length) return;
-    // Re-verify the profile captured before the await: if the active profile
-    // changed mid-flight this catalog no longer belongs to the current view.
-    const _currentProfile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
-    if(_currentProfile!==_fetchProfile) return;
+    // Require the captured owner token to remain current before any UI
+    // mutation. A profile switch, a newer policy save/refresh, or a rebuilt
+    // target select all invalidate it -- the last one is what stops an older
+    // broad response from being appended after a newer strict result.
+    if(!_isLiveModelOwnerCurrent(ownerToken)) return;
     const added=_addLiveModelsToSelect(provider,data.models,sel);
     if(added>0){
+      if(!_isLiveModelOwnerCurrent(ownerToken)) return;
       if(typeof syncModelChip==='function') syncModelChip();
       console.debug('[hermes] Live models loaded for',provider+':',added,'new models added');
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -3719,8 +3719,15 @@ async function populateModelDropdown(opts={}){
   }
 }
 
-// Cache so we don't re-fetch on every page load
+// Cache so we don't re-fetch on every page load.
+// Keyed by profile + provider: the endpoint response depends on the active
+// profile, so a profile switch must not append profile A's catalog to profile
+// B's freshly-rendered pinned list (#7404 review).
 const _liveModelCache={};
+function _liveModelCacheKey(provider){
+  const profile=(typeof S!=='undefined'&&S&&S.activeProfile)?String(S.activeProfile):'default';
+  return profile+'\u0000'+String(provider||'');
+}
 // Tracks providers for which a live-model fetch is in flight.
 // Used by syncTopbar() to defer model corrections until the fetch completes,
 // preventing premature fallback to the first static model (#1169).
@@ -3828,10 +3835,13 @@ function _addLiveModelsToSelect(provider, models, sel){
 async function _fetchLiveModels(provider, sel, requestSeq=null){
   if(!provider||!sel) return;
   if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
+  // Capture the profile at fetch start so a mid-flight profile switch cannot
+  // file this catalog under the new profile's key.
+  const cacheKey=_liveModelCacheKey(provider);
   // Already fetched — apply cached models to this select element (#872)
-  if(_liveModelCache[provider]){
+  if(_liveModelCache[cacheKey]){
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
-    const added=_addLiveModelsToSelect(provider,_liveModelCache[provider],sel);
+    const added=_addLiveModelsToSelect(provider,_liveModelCache[cacheKey],sel);
     if(added>0 && typeof syncModelChip==='function') syncModelChip();
     return;
   }
@@ -3845,7 +3855,7 @@ async function _fetchLiveModels(provider, sel, requestSeq=null){
     const data=await _liveRes.json();
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
     if(!data.models||!data.models.length) return;
-    _liveModelCache[provider]=data.models;
+    _liveModelCache[cacheKey]=data.models;
     if(requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq) return;
     const added=_addLiveModelsToSelect(provider,data.models,sel);
     if(added>0){

--- a/static/ui.js
+++ b/static/ui.js
@@ -3616,19 +3616,53 @@ function _isLiveModelOwnerCurrent(token){
   return true;
 }
 function _liveModelPolicyChanged(){
+  // Best-effort by contract: this is a dropdown refresh, so nothing here may
+  // throw into the caller. saveSettings() wraps its call in a catch that treats
+  // a throw as "failed to update default model" and ABORTS the save, so an
+  // unexpected error while resolving the composer target must not escape.
+  let sel=null;
+  try{
+    sel=(typeof $==='function')?$('modelSelect'):null;
+  }catch(_e){
+    sel=null;
+  }
+  // Resolve the composer target and its provider BEFORE advancing so the
+  // placeholder below is retained under the replacement's own authority.
+  const provider=window._activeProvider||null;
   _liveModelAdvancePolicyGeneration();
+  // Gap-free transition: advancing the generation changes the composer's
+  // pending key, but the replacement rebuild only re-registers that key after
+  // an asynchronous /api/models round-trip. Retain a placeholder SYNCHRONOUSLY
+  // -- before any promise is created -- so `has()` on the current composer key
+  // is never false across the transition. syncTopbar() defers a model
+  // correction while that key is pending, so without this the in-flight live
+  // fetch window would persist a static fallback (#7404 review).
+  const retainedKey=_liveModelFetchKey(provider, undefined, sel);
+  _liveModelFetchRetain(retainedKey);
+  let released=false;
+  const release=()=>{
+    if(released) return;
+    released=true;
+    _liveModelFetchEnd(retainedKey);
+  };
   // A policy change invalidates any in-flight response. Start a replacement
   // request so the live catalog is not dropped: without this, advancing the
   // generation rejects the in-flight response and nothing re-fetches, leaving
-  // live-only models absent from the dropdown (#7404 review).
+  // live-only models absent from the dropdown (#7404 review). Fire-and-forget:
+  // callers must not await the rebuild. The placeholder is released on EVERY
+  // exit: the settled promise, the no-rebuild-available path, and the catch.
   try{
     if(typeof window._ensureModelDropdownReady==='function'){
       window._modelDropdownReady=null;
-      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
+      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{}).finally(release);
     }else if(typeof populateModelDropdown==='function'){
-      Promise.resolve(populateModelDropdown()).catch(()=>{});
+      Promise.resolve(populateModelDropdown()).catch(()=>{}).finally(release);
+    }else{
+      release();
     }
-  }catch(_e){}
+  }catch(_e){
+    release();
+  }
 }
 
 function _applySessionModelFallback(sel){
@@ -3824,6 +3858,15 @@ function _liveModelFetchEnd(key){
   const remaining=(_liveModelFetchPending.get(key)||0)-1;
   if(remaining>0)_liveModelFetchPending.set(key,remaining);
   else _liveModelFetchPending.delete(key);
+}
+// Retain an EXPLICIT key without owning a request. Used by
+// _liveModelPolicyChanged() to hold a placeholder across the async
+// advance-then-rebuild window so the composer never observes `has()===false`
+// between generations (#7404 review). The refcount overlaps the replacement
+// fetch's own begin/end; _liveModelFetchEnd() releases it.
+function _liveModelFetchRetain(key){
+  if(!key) return;
+  _liveModelFetchPending.set(key,(_liveModelFetchPending.get(key)||0)+1);
 }
 
 function _addLiveModelsToSelect(provider, models, sel){

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -73,6 +73,11 @@ PROFILE_INFLIGHT_RACED = "policy-profile-inflight-raced"
 PROFILE_CONCURRENT = "policy-profile-concurrent"
 CONCURRENT_CATALOG = [{"id": "concurrent-live-1", "label": "Concurrent Live 1"}]
 PROFILE_SAME_PROFILE_RACE = "policy-profile-same-race"
+# #7404 review P1 regression: advancing the policy generation without starting a
+# replacement request drops the live catalog. Distinct catalog so the
+# replacement's models are distinguishable from the held broad response's.
+PROFILE_SAVE_POLICY = "policy-profile-save"
+AFTER_POLICY_CATALOG = [{"id": "after-policy-live-1", "label": "After Policy Live 1"}]
 
 BENIGN = [
     "favicon",
@@ -174,9 +179,10 @@ def _wait_for_held_routes(stub: "LiveModelStub", count: int, page, timeout: floa
 
     Uses ``page.wait_for_timeout`` so each iteration advances Playwright's event
     loop (which is what actually dispatches route handlers); a Python
-    ``time.sleep`` would deadlock the interception.
+    ``time.sleep`` would deadlock the interception. ``timeout`` is in
+    milliseconds, matching the other helpers and Playwright's own API.
     """
-    deadline = time.time() + timeout
+    deadline = time.time() + timeout / 1000.0
     while len(stub.held_routes) < count:
         if time.time() > deadline:
             return False
@@ -591,6 +597,102 @@ def main() -> int:
             "OK  older broad response rejected after newer strict result:",
             ids_after_race,
             f"(live requests {broad_requests}->{stub.live_request_count})",
+        )
+
+        # --- Case 6: saveSettings policy change invalidates AND re-requests ----
+        #
+        # #7404 review P1: saveSettings() advanced the live-model policy
+        # generation on a changed default-model save but started no replacement
+        # request. The in-flight live-model response was then rejected as stale,
+        # so live-only models silently disappeared from the dropdown. The fix
+        # routes both save branches through _liveModelPolicyChanged(), which
+        # BOTH invalidates the in-flight response AND starts a replacement.
+        #
+        # This case drives that production chokepoint. Pre-fix the symbol does
+        # not exist, so fall back to the real pre-fix helper (advance only),
+        # which reproduces the dropped-catalog defect without a missing-symbol
+        # error.
+        page.evaluate(f"S.activeProfile = {PROFILE_SAVE_POLICY!r}")
+        stub.live_models = list(BROAD_DISCOVERED)
+        stub.hold_live = True
+        stub.held_routes = []
+        # In-flight request captured under the pre-save policy (the Settings open
+        # path starts one with an unrequestSeq'd _fetchLiveModels call). Held so
+        # it arrives AFTER the save's policy change.
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError(
+                "save-policy: in-flight broad request was never held; "
+                f"held={len(stub.held_routes)} total={stub.live_request_count}"
+            )
+        requests_before_save = stub.live_request_count
+
+        # The replacement request will carry this catalog. Responses are
+        # generated at release time, so the held broad route is re-armed with
+        # BROAD_DISCOVERED again just before it is released below.
+        stub.live_models = list(AFTER_POLICY_CATALOG)
+        page.evaluate(
+            "() => {"
+            "  if (typeof _liveModelPolicyChanged === 'function') {"
+            "    _liveModelPolicyChanged();"
+            "  } else if (typeof _liveModelAdvancePolicyGeneration === 'function') {"
+            "    _liveModelAdvancePolicyGeneration();"
+            "  }"
+            "}"
+        )
+
+        # Wait for the replacement request. Pre-fix none is issued, so this
+        # returns False after the timeout and the stale response below is still
+        # released to prove the invalidation half.
+        replacement_held = _wait_for_held_routes(stub, 2, page)
+        if replacement_held:
+            # Release the replacement (newer) response first and let it apply.
+            stub.release_live(stub.held_routes[1])
+            _wait_for_option(page, "after-policy-live-1")
+
+        # Release the held broad (older, now stale) response LAST. Its stale
+        # token must be rejected so its broad-only model never lands.
+        stub.live_models = list(BROAD_DISCOVERED)
+        stub.release_live(stub.held_routes[0])
+        page.wait_for_timeout(300)
+        ids_after_save = _option_values(page)
+
+        # Half 1 (stale rejected).
+        if "broad-live-1" in ids_after_save:
+            raise AssertionError(
+                "save-policy: the stale in-flight broad response re-appended "
+                f"'broad-live-1' after the policy change; options={ids_after_save!r}"
+            )
+        # Half 2 (catalog not dropped). Assert the live models are present
+        # BEFORE the request-count check so the pre-fix failure reports the
+        # dropped catalog (missing models), not merely a missing call.
+        if "after-policy-live-1" not in ids_after_save:
+            raise AssertionError(
+                "save-policy dropped the live catalog: after the policy change "
+                "the in-flight response was rejected and no replacement live "
+                "models ever landed, so live-only models are MISSING from the "
+                f"dropdown; options={ids_after_save!r}; "
+                f"requests before={requests_before_save} "
+                f"after={stub.live_request_count}; "
+                f"replacement_held={replacement_held}"
+            )
+        if stub.live_request_count <= requests_before_save:
+            raise AssertionError(
+                "save-policy: the policy change did not re-request "
+                f"/api/models/live; before={requests_before_save} "
+                f"after={stub.live_request_count}"
+            )
+        print(
+            "OK  saveSettings policy change invalidated the in-flight response "
+            "AND restored the live catalog:",
+            ids_after_save,
+            f"(live requests {requests_before_save}->{stub.live_request_count}, "
+            f"replacement_held={replacement_held})",
         )
 
         if errors:

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -91,6 +91,9 @@ AFTER_POLICY_CATALOG = [{"id": "after-policy-live-1", "label": "After Policy Liv
 PROFILE_TARGET_A = "policy-profile-target-a"
 PROFILE_TARGET_B = "policy-profile-target-b"
 PROFILE_TARGET_PENDING = "policy-profile-target-pending"
+# #7404 review: the policy-change pending-visibility gap. The composer key must
+# never be absent across _liveModelPolicyChanged()'s generation advance.
+PROFILE_POLICY_GAP = "policy-profile-gap"
 COMPOSER_CATALOG = [{"id": "composer-live-1", "label": "Composer Live 1"}]
 SETTINGS_CATALOG = [{"id": "settings-live-1", "label": "Settings Live 1"}]
 
@@ -911,6 +914,75 @@ def main() -> int:
         if not _wait_for_js(page, "() => !" + composer_pending_expr):
             raise AssertionError("pending isolation: composer pending key never cleared")
         print("OK  composer and Settings pending state are independent")
+
+        # --- Case 10: policy change never leaves the composer unpending ------
+        #
+        # #7404 review: _liveModelPolicyChanged() advances the global policy
+        # generation, which changes the composer's pending key. The replacement
+        # rebuild only re-registers that key after an asynchronous /api/models
+        # round-trip, so without a synchronous placeholder there is a window in
+        # which `has()` on the CURRENT composer key is false. syncTopbar() runs
+        # from boot/messages/commands/session-loads and defers a model correction
+        # only while that key is pending, so in that window it would persist a
+        # static fallback for a fetch whose live catalog may yet arrive (#1169).
+        #
+        # The assertion reads the composer key in the SAME tick as the
+        # chokepoint call, so it observes the transition itself rather than a
+        # later rebuild. Pre-fix the value is False (the gap); post-fix the
+        # synchronous retain makes it True.
+        page.evaluate(f"S.activeProfile = {PROFILE_POLICY_GAP!r}")
+        page.evaluate(f"window._activeProvider = {PROVIDER!r}")
+        stub.live_models = list(COMPOSER_CATALOG)
+        stub.hold_live = True
+        stub.held_routes = []
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("policy-gap: composer fetch was never held")
+        composer_key_expr = (
+            "_liveModelFetchKey("
+            f"{PROVIDER!r}, undefined, document.getElementById('modelSelect'))"
+        )
+        pending_in_change_tick = page.evaluate(
+            "() => {"
+            "  if (typeof _liveModelPolicyChanged === 'function') {"
+            "    _liveModelPolicyChanged();"
+            "  }"
+            "  return _liveModelFetchPending.has(" + composer_key_expr + ");"
+            "}"
+        )
+        if not pending_in_change_tick:
+            raise AssertionError(
+                "policy-gap: the composer pending entry vanished in the tick the "
+                "policy changed (`has()` on the current composer key was false); "
+                "a syncTopbar() in that window would persist a static fallback "
+                "for the in-flight live fetch"
+            )
+        # The replacement live fetch is held too; release every held route, then
+        # assert the composer key eventually clears. That proves the placeholder
+        # retained by the chokepoint is released on its settle path (no leak).
+        if not _wait_for_held_routes(stub, 2, page):
+            raise AssertionError(
+                "policy-gap: the replacement composer fetch was never held; "
+                f"held={len(stub.held_routes)} total={stub.live_request_count}"
+            )
+        while stub.held_routes:
+            stub.release_live(stub.held_routes.pop(0))
+        if not _wait_for_js(
+            page, "key => !_liveModelFetchPending.has(key)", composer_key_expr
+        ):
+            raise AssertionError(
+                "policy-gap: the composer pending key never cleared after the "
+                "replacement settled — the retained placeholder leaked"
+            )
+        print(
+            "OK  composer stayed pending in the policy-change tick and the "
+            "placeholder was released after settle"
+        )
 
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Headless browser regression for the live-model discovered-vs-pinned policy.
+
+WHY THIS EXISTS
+  `static/ui.js` used to keep a browser response cache for `/api/models/live`,
+  keyed by profile + provider. That cache could replay a broad *discovered*
+  catalog after the same profile switched to a strict model pin, because the
+  client copy never consulted the policy-keyed server cache. The server fix
+  (60s TTL keyed by profile, provider, and a discovered-vs-pinned policy
+  fingerprint) cannot help if the browser short-circuits on a local hit.
+  #7404 review removed the browser cache; this gate locks that in behaviourally.
+
+  It is a regression guard, not a unit test: it boots the real `server.py`
+  agent-free and drives the real `populateModelDropdown()` entry point, stubbing
+  `/api/models/live` with Playwright so no provider, credential, or agent is
+  needed. Two assertions are the required regressions:
+    1. Same-profile discovered -> strict pin: the stale unpinned model must not
+       be re-applied, AND the endpoint must actually be re-requested (proving
+       the browser did not short-circuit).
+    2. Profile switch: a catalog served for profile A must not be applied when
+       the active profile is B.
+  A third case exercises the in-flight profile re-verification: a response for
+  the profile captured at fetch start must be dropped if the profile changed
+  before it was applied.
+
+USAGE
+  python tests/browser_live_model_policy.py
+  (Requires: playwright + chromium. Boots server.py on an ephemeral port with an
+  isolated temp state dir and no agent.)
+
+EXIT CODES
+  0 — all policy regressions held
+  1 — a regression was observed (stale model re-applied, no re-fetch, or
+      cross-profile leak)
+  2 — environment/setup failure (server didn't boot, playwright missing, etc.)
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+# 'openrouter' avoids the `@provider:` ID prefixing `_addLiveModelsToSelect`
+# applies to portal-style providers, keeping option values easy to assert.
+PROVIDER = "openrouter"
+
+BROAD_DISCOVERED = [
+    {"id": "broad-live-1", "label": "Broad Live 1"},
+    {"id": "broad-live-2", "label": "Broad Live 2"},
+    {"id": "broad-live-3", "label": "Broad Live 3"},
+]
+STRICT_PIN = [{"id": "strict-pin-1", "label": "Strict Pin 1"}]
+PROFILE_A_CATALOG = [{"id": "a-live-1", "label": "A Live 1"}]
+PROFILE_B_CATALOG = [{"id": "b-live-1", "label": "B Live 1"}]
+INFLIGHT_CATALOG = [{"id": "inflight-live-1", "label": "Inflight Live 1"}]
+
+PROFILE_A = "policy-profile-a"
+PROFILE_B = "policy-profile-b"
+PROFILE_INFLIGHT = "policy-profile-inflight"
+PROFILE_INFLIGHT_RACED = "policy-profile-inflight-raced"
+
+BENIGN = [
+    "favicon",
+    "manifest.json",
+    "serviceworker",
+    "sw.js",
+    "the server responded with a status of 404",
+]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(base_url: str, timeout: float = 30.0, proc: subprocess.Popen | None = None) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(base_url + "/health", timeout=2) as response:
+                if response.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(0.25)
+    return False
+
+
+def _terminate_process(proc: subprocess.Popen | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _option_values(page) -> list[str]:
+    return page.evaluate(
+        "Array.from(document.querySelectorAll('#modelSelect option')).map(o => o.value)"
+    )
+
+
+def _wait_for_option(page, model_id: str, timeout: float = 8000.0) -> bool:
+    try:
+        page.wait_for_function(
+            "id => Array.from(document.querySelectorAll('#modelSelect option'))"
+            ".some(o => o.value === id)",
+            arg=model_id,
+            timeout=timeout,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _wait_for_live_requests(page, count: int, timeout: float = 8000.0) -> bool:
+    """Wait for the browser to issue more than *count* live-model fetches.
+
+    MUST go through a Playwright call (``wait_for_function``) rather than a
+    Python ``time.sleep`` busy-wait: route handlers are dispatched on
+    Playwright's event loop, which only advances while a Playwright API call is
+    pumping. A pure-Python poll never lets the intercepted request be fulfilled,
+    so the counter would never move and the wait would hang until the CI job
+    timeout. ``wait_for_function`` also measures the app's own fetch call, which
+    is exactly the "did the browser really re-request?" property under test.
+    """
+    try:
+        page.wait_for_function(
+            "n => (window.__liveFetchCount || 0) > n",
+            arg=count,
+            timeout=timeout,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _capture_page_errors(page) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+
+    def on_console(message):
+        if message.type != "error":
+            return
+        text = message.text
+        if not any(needle in text.lower() for needle in BENIGN):
+            errors.append(("console", text))
+
+    page.on("console", on_console)
+    page.on("pageerror", lambda error: errors.append(("pageerror", str(error))))
+    return errors
+
+
+class LiveModelStub:
+    """Serves deterministic `/api/models` and `/api/models/live` payloads."""
+
+    def __init__(self) -> None:
+        self.active_provider = PROVIDER
+        self.live_models: list[dict] = []
+        self.live_request_count = 0
+        self.live_requests: list[str] = []
+
+    @staticmethod
+    def _is_live_url(url: str) -> bool:
+        return url.split("?", 1)[0].endswith("/api/models/live")
+
+    def _models_payload(self) -> dict:
+        return {
+            "active_provider": self.active_provider,
+            "default_model": "static-base",
+            "configured_model_badges": {},
+            "groups": [
+                {
+                    "provider": "OpenRouter",
+                    "provider_id": self.active_provider,
+                    "models": [{"id": "static-base", "label": "Static Base"}],
+                }
+            ],
+        }
+
+    def _live_payload(self) -> dict:
+        return {"provider": self.active_provider, "models": self.live_models}
+
+    def handle_live(self, route) -> None:
+        self.live_request_count += 1
+        self.live_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(self._live_payload()),
+        )
+
+    def handle_models(self, route) -> None:
+        if self._is_live_url(route.request.url):
+            self.handle_live(route)
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(self._models_payload()),
+        )
+
+
+def _install_flip_on_live_fetch(page) -> None:
+    """Test harness hook: flip the active profile when the next live fetch runs.
+
+    Runs in the page before app scripts. `_fetchLiveModels()` captures the
+    profile before awaiting `fetch`; this hook changes it synchronously inside
+    that call so the captured value and the post-await value differ.
+    """
+    page.add_init_script(
+        """
+        (() => {
+          const realFetch = window.fetch.bind(window);
+          window.__flipProfileOnNextLiveFetch = null;
+          window.__liveFetchCount = 0;
+          window.fetch = function(input, init) {
+            const url = (typeof input === 'string') ? input : (input && input.url) || '';
+            if (url.includes('/api/models/live')) {
+              window.__liveFetchCount += 1;
+              if (window.__flipProfileOnNextLiveFetch) {
+                const target = window.__flipProfileOnNextLiveFetch;
+                window.__flipProfileOnNextLiveFetch = null;
+                S.activeProfile = target;
+              }
+            }
+            return realFetch(input, init);
+          };
+        })();
+        """
+    )
+
+
+def main() -> int:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("SETUP FAIL: playwright is not installed", file=sys.stderr)
+        return 2
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    server_py = os.path.join(repo_root, "server.py")
+    if not os.path.exists(server_py):
+        print(f"SETUP FAIL: server.py not found at {server_py}", file=sys.stderr)
+        return 2
+
+    port = int(os.getenv("HERMES_LIVE_MODEL_POLICY_PORT", "") or _free_port())
+    base_url = f"http://127.0.0.1:{port}"
+    state_dir = tempfile.mkdtemp(prefix="hermes-live-model-policy-")
+    env = os.environ.copy()
+    for key in list(env):
+        if key.endswith("_API_KEY"):
+            env.pop(key, None)
+    env.update({
+        "HERMES_WEBUI_PORT": str(port),
+        "HERMES_WEBUI_HOST": "127.0.0.1",
+        "HERMES_WEBUI_STATE_DIR": state_dir,
+        "HERMES_HOME": state_dir,
+        "HERMES_BASE_HOME": state_dir,
+        "HERMES_WEBUI_SKIP_ONBOARDING": "1",
+        "HERMES_WEBUI_AGENT_DIR": os.path.join(state_dir, "no-agent"),
+    })
+
+    log_path = os.path.join(state_dir, "server.log")
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        [sys.executable, server_py],
+        cwd=repo_root,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
+    )
+    browser = None
+    playwright = None
+    try:
+        if not _wait_for_health(base_url, timeout=30, proc=proc):
+            print("SETUP FAIL: server did not become healthy in 30s", file=sys.stderr)
+            log.flush()
+            with open(log_path) as handle:
+                print(handle.read()[-2000:], file=sys.stderr)
+            return 2
+
+        stub = LiveModelStub()
+        stub.live_models = list(BROAD_DISCOVERED)
+        errors: list[tuple[str, str]] = []
+        playwright = sync_playwright().start()
+        browser = playwright.chromium.launch(
+            headless=True, args=["--no-sandbox", "--disable-dev-shm-usage"]
+        )
+        context = browser.new_context(base_url=base_url)
+        page = context.new_page()
+        _install_flip_on_live_fetch(page)
+        page.route("**/api/models**", stub.handle_models)
+        page.route("**/api/models/live**", stub.handle_live)
+        errors = _capture_page_errors(page)
+        page.goto("/", wait_until="domcontentloaded")
+        page.wait_for_selector("#modelSelect", state="attached", timeout=15000)
+
+        # Seed the dropdown with the broad discovered catalog (the app's own
+        # boot hydration does this; wait for it to land).
+        if not _wait_for_option(page, "broad-live-1"):
+            raise AssertionError(
+                "setup: discovered catalog was never applied on boot; "
+                f"observed options={_option_values(page)!r}; "
+                f"live requests={stub.live_request_count}; errors={errors!r}"
+            )
+        print("OK  discovered catalog applied:", _option_values(page))
+        baseline_requests = stub.live_request_count
+
+        # --- Regression 1: same-profile discovered -> strict pin --------------
+        stub.live_models = list(STRICT_PIN)
+        page.evaluate("void populateModelDropdown()")
+        applied_pin = _wait_for_option(page, "strict-pin-1")
+        ids_after_pin = _option_values(page)
+        if not applied_pin:
+            raise AssertionError(
+                "same-profile discovered->pin: strict pin 'strict-pin-1' was never "
+                f"applied; observed options={ids_after_pin!r}; "
+                f"live requests before={baseline_requests} after={stub.live_request_count}"
+            )
+        if stub.live_request_count <= baseline_requests:
+            raise AssertionError(
+                "same-profile discovered->pin: browser did not re-request "
+                f"/api/models/live after the policy change; observed requests="
+                f"{stub.live_request_count} (baseline={baseline_requests}); "
+                f"options={ids_after_pin!r}"
+            )
+        if "broad-live-1" in ids_after_pin:
+            raise AssertionError(
+                "same-profile discovered->pin: stale unpinned model 'broad-live-1' "
+                f"was re-applied; observed options={ids_after_pin!r}"
+            )
+        print(
+            "OK  same-profile pin replaced discovered catalog:",
+            ids_after_pin,
+            f"(live requests {baseline_requests}->{stub.live_request_count})",
+        )
+
+        # --- Regression 2: profile switch ------------------------------------
+        page.evaluate(f"S.activeProfile = {PROFILE_A!r}")
+        stub.live_models = list(PROFILE_A_CATALOG)
+        page.evaluate("void populateModelDropdown()")
+        if not _wait_for_option(page, "a-live-1"):
+            raise AssertionError(
+                "profile switch: catalog for profile A was never applied; "
+                f"observed options={_option_values(page)!r}"
+            )
+        page.evaluate(f"S.activeProfile = {PROFILE_B!r}")
+        stub.live_models = list(PROFILE_B_CATALOG)
+        page.evaluate("void populateModelDropdown()")
+        applied_b = _wait_for_option(page, "b-live-1")
+        ids_after_switch = _option_values(page)
+        if not applied_b:
+            raise AssertionError(
+                "profile switch: catalog for profile B was never applied; "
+                f"observed options={ids_after_switch!r}"
+            )
+        if "a-live-1" in ids_after_switch:
+            raise AssertionError(
+                "profile switch: profile A catalog 'a-live-1' leaked into profile "
+                f"B; observed options={ids_after_switch!r}"
+            )
+        print("OK  profile switch dropped the previous profile catalog:", ids_after_switch)
+
+        # --- Case 3: in-flight profile re-verification -----------------------
+        page.evaluate(f"S.activeProfile = {PROFILE_INFLIGHT!r}")
+        stub.live_models = list(INFLIGHT_CATALOG)
+        before_inflight = page.evaluate("window.__liveFetchCount || 0")
+        page.evaluate(f"window.__flipProfileOnNextLiveFetch = {PROFILE_INFLIGHT_RACED!r}")
+        page.evaluate("void populateModelDropdown()")
+        if not _wait_for_live_requests(page, before_inflight):
+            raise AssertionError(
+                "in-flight profile check: /api/models/live was never requested; "
+                f"observed requests={stub.live_request_count}"
+            )
+        page.wait_for_function(
+            "profile => typeof S !== 'undefined' && S.activeProfile === profile",
+            arg=PROFILE_INFLIGHT_RACED,
+            timeout=5000,
+        )
+        page.wait_for_timeout(500)
+        ids_after_inflight = _option_values(page)
+        if "inflight-live-1" in ids_after_inflight:
+            raise AssertionError(
+                "in-flight profile check: catalog captured for profile "
+                f"{PROFILE_INFLIGHT!r} was applied after the active profile changed "
+                f"to {PROFILE_INFLIGHT_RACED!r}; observed options={ids_after_inflight!r}"
+            )
+        print("OK  in-flight response dropped after profile changed:", ids_after_inflight)
+
+        if errors:
+            raise AssertionError(f"unexpected browser errors: {errors!r}")
+        print("\nLIVE MODEL POLICY GATE PASSED")
+        return 0
+    except Exception as error:
+        print(f"\nLIVE MODEL POLICY GATE FAILED: {error}", file=sys.stderr)
+        return 1
+    finally:
+        if browser is not None:
+            browser.close()
+        if playwright is not None:
+            playwright.stop()
+        _terminate_process(proc)
+        log.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -72,6 +72,7 @@ PROFILE_INFLIGHT = "policy-profile-inflight"
 PROFILE_INFLIGHT_RACED = "policy-profile-inflight-raced"
 PROFILE_CONCURRENT = "policy-profile-concurrent"
 CONCURRENT_CATALOG = [{"id": "concurrent-live-1", "label": "Concurrent Live 1"}]
+PROFILE_SAME_PROFILE_RACE = "policy-profile-same-race"
 
 BENIGN = [
     "favicon",
@@ -510,6 +511,87 @@ def main() -> int:
                 "overlapping request completed; still pending"
             )
         print("OK  pending key cleared after the last overlapping request")
+
+        # --- Case 5: older broad response cannot win a same-profile race -------
+        #
+        # #7404 review blocking finding: response applicability was fenced only
+        # by the active profile (and an optional requestSeq). The Settings caller
+        # (`_fetchLiveModels(provider, modelSel)` with no requestSeq) is
+        # unowned, so an older broad-discovered response could reach the
+        # additive `_addLiveModelsToSelect()` AFTER a newer strict-pin refresh
+        # already applied, re-adding a model the strict policy excludes. The fix
+        # attaches an immutable owner token (profile + generation + select
+        # identity) to every request and rejects it before DOM mutation.
+        #
+        # Sequence is the maintainer's exact ordering:
+        #   broad-old held -> strict pin saved + refreshed -> release strict
+        #   first -> release broad last -> broad-only model must be absent.
+        page.evaluate(f"S.activeProfile = {PROFILE_SAME_PROFILE_RACE!r}")
+        stub.live_models = list(BROAD_DISCOVERED)
+        stub.hold_live = True
+        stub.held_routes = []
+        # Start the OLD broad request exactly the way loadSettingsPanel() does:
+        # no requestSeq, so the pre-fix code fences it on the profile alone.
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError(
+                "same-profile race: broad request was never held; "
+                f"held={len(stub.held_routes)} total={stub.live_request_count}"
+            )
+        broad_requests = stub.live_request_count
+
+        # Same-profile policy change through the production save-refresh path
+        # the provider key save (`_saveProviderKey`) invokes. This advances the
+        # live-model generation and starts the strict refresh (held below).
+        stub.live_models = list(STRICT_PIN)
+        page.evaluate("() => _refreshModelDropdownsAfterProviderChange()")
+        if not _wait_for_held_routes(stub, 2, page):
+            raise AssertionError(
+                "same-profile race: strict refresh was never held; "
+                f"held={len(stub.held_routes)} total={stub.live_request_count}"
+            )
+        if stub.live_request_count <= broad_requests:
+            raise AssertionError(
+                "same-profile race: the endpoint was not re-requested after the "
+                f"policy change; before={broad_requests} "
+                f"after={stub.live_request_count}"
+            )
+
+        # Release the STRICT (newer) response first and let it apply.
+        stub.release_live(stub.held_routes[1])
+        if not _wait_for_option(page, "strict-pin-1"):
+            raise AssertionError(
+                "same-profile race: strict pin was never applied after its "
+                f"response was released; options={_option_values(page)!r}"
+            )
+
+        # Release the BROAD (older) response last. Its stale token must be
+        # rejected so its broad-only model never lands.
+        stub.live_models = list(BROAD_DISCOVERED)
+        stub.release_live(stub.held_routes[0])
+        page.wait_for_timeout(300)
+        ids_after_race = _option_values(page)
+        if "strict-pin-1" not in ids_after_race:
+            raise AssertionError(
+                "same-profile race: strict pin disappeared after the stale broad "
+                f"response completed; options={ids_after_race!r}"
+            )
+        if "broad-live-1" in ids_after_race:
+            raise AssertionError(
+                "same-profile race: older broad-discovered response re-appended "
+                "'broad-live-1' after the newer strict result; "
+                f"options={ids_after_race!r}"
+            )
+        print(
+            "OK  older broad response rejected after newer strict result:",
+            ids_after_race,
+            f"(live requests {broad_requests}->{stub.live_request_count})",
+        )
 
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -96,6 +96,14 @@ PROFILE_TARGET_PENDING = "policy-profile-target-pending"
 PROFILE_POLICY_GAP = "policy-profile-gap"
 COMPOSER_CATALOG = [{"id": "composer-live-1", "label": "Composer Live 1"}]
 SETTINGS_CATALOG = [{"id": "settings-live-1", "label": "Settings Live 1"}]
+# #7404 review P1 (Settings target): a settingsModel live request in flight when
+# a changed default model is saved is invalidated by the global generation
+# advance; the replacement must rebuild the Settings picker, not just the
+# composer, or live-only models vanish from Settings until the panel is rebuilt.
+PROFILE_SETTINGS_POLICY = "policy-profile-settings-save"
+SETTINGS_BEFORE_CATALOG = [{"id": "settings-before-1", "label": "Settings Before 1"}]
+SETTINGS_AFTER_CATALOG = [{"id": "settings-after-1", "label": "Settings After 1"}]
+SETTINGS_AFTER_CATALOG_2 = [{"id": "settings-after-2", "label": "Settings After 2"}]
 
 BENIGN = [
     "favicon",
@@ -705,7 +713,12 @@ def main() -> int:
         # live-model generation and starts the strict refresh (held below).
         stub.live_models = list(STRICT_PIN)
         page.evaluate("() => _refreshModelDropdownsAfterProviderChange()")
-        if not _wait_for_held_routes(stub, 2, page):
+        # A policy change now drives BOTH live-model targets, so collect both
+        # replacements before releasing them. Pre-fix (Settings target absent)
+        # only the composer replacement exists; the wait is best-effort and the
+        # assertions below are authoritative.
+        _wait_for_held_routes(stub, 3, page, timeout=4000)
+        if len(stub.held_routes) < 2:
             raise AssertionError(
                 "same-profile race: strict refresh was never held; "
                 f"held={len(stub.held_routes)} total={stub.live_request_count}"
@@ -717,8 +730,10 @@ def main() -> int:
                 f"after={stub.live_request_count}"
             )
 
-        # Release the STRICT (newer) response first and let it apply.
-        stub.release_live(stub.held_routes[1])
+        # Release the STRICT (newer) replacements first and let them apply. All
+        # routes after index 0 are replacements (composer and/or Settings).
+        for _route in stub.held_routes[1:]:
+            stub.release_live(_route)
         if not _wait_for_option(page, "strict-pin-1"):
             raise AssertionError(
                 "same-profile race: strict pin was never applied after its "
@@ -795,13 +810,16 @@ def main() -> int:
             "}"
         )
 
-        # Wait for the replacement request. Pre-fix none is issued, so this
-        # returns False after the timeout and the stale response below is still
-        # released to prove the invalidation half.
-        replacement_held = _wait_for_held_routes(stub, 2, page)
+        # Wait for the replacements (composer and/or Settings). Pre-fix none is
+        # issued, so this returns False after the timeout and the stale response
+        # below is still released to prove the invalidation half.
+        replacement_held = _wait_for_held_routes(stub, 2, page, timeout=4000)
         if replacement_held:
-            # Release the replacement (newer) response first and let it apply.
-            stub.release_live(stub.held_routes[1])
+            # Give BOTH targets' replacements a chance to arrive before draining
+            # them all with the post-save catalog.
+            _wait_for_held_routes(stub, 3, page, timeout=2000)
+            for _route in stub.held_routes[1:]:
+                stub.release_live(_route)
             _wait_for_option(page, "after-policy-live-1")
 
         # Release the held broad (older, now stale) response LAST. Its stale
@@ -970,6 +988,9 @@ def main() -> int:
                 "policy-gap: the replacement composer fetch was never held; "
                 f"held={len(stub.held_routes)} total={stub.live_request_count}"
             )
+        # Give the Settings replacement (now also driven by the chokepoint) a
+        # chance to arrive too, then drain every held route.
+        _wait_for_held_routes(stub, 3, page, timeout=2000)
         while stub.held_routes:
             stub.release_live(stub.held_routes.pop(0))
         if not _wait_for_js(
@@ -983,6 +1004,140 @@ def main() -> int:
             "OK  composer stayed pending in the policy-change tick and the "
             "placeholder was released after settle"
         )
+
+        # --- Case 11: Settings replacement on a policy change (new P1) --------
+        #
+        # Greptile P1: when a settingsModel live request is still in flight as
+        # the user saves a changed default model, _liveModelPolicyChanged()
+        # invalidated that response globally but started a replacement only for
+        # modelSelect, leaving live-only models absent from the Settings picker
+        # until it was rebuilt. This drives the real Settings open path
+        # (loadSettingsPanel) and the real policy chokepoint, then requires the
+        # Settings picker to end up with the replacement's live-only catalog.
+        #
+        # The second half is the no-accumulation guarantee: a second policy save
+        # must REPLACE the Settings live catalog. A bare _fetchLiveModels()
+        # re-append (no innerHTML clear) would leave the previous policy's
+        # live-only model behind, so the stale-model assertion has teeth.
+        while stub.held_routes:
+            stub.release_live(stub.held_routes.pop(0))
+        page.wait_for_timeout(50)
+        page.evaluate(f"S.activeProfile = {PROFILE_SETTINGS_POLICY!r}")
+        stub.live_models = list(SETTINGS_BEFORE_CATALOG)
+        stub.hold_live = True
+        stub.held_routes = []
+        # Open Settings through its production loader so settingsModel is
+        # populated and its live request is in flight under the pre-save policy.
+        page.evaluate("void loadSettingsPanel()")
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("settings-policy: the Settings live fetch was never held")
+        stale_settings_route = stub.held_routes[0]
+        requests_before = stub.live_request_count
+
+        # A changed default-model save through the production chokepoint.
+        stub.live_models = list(SETTINGS_AFTER_CATALOG)
+        page.evaluate(
+            "() => {"
+            "  if (typeof _liveModelPolicyChanged === 'function') {"
+            "    _liveModelPolicyChanged();"
+            "  }"
+            "}"
+        )
+        # Give the replacements (composer + Settings) a chance to be issued.
+        # Deliberately do NOT fail here: a pre-fix run must fail on the missing
+        # Settings catalog below, not on a missing request symbol.
+        _wait_for_held_routes(stub, 3, page, timeout=3000)
+        # The held pre-save Settings response is now stale; its generation is
+        # gone, so releasing it must NOT append its catalog.
+        stub.live_models = list(SETTINGS_BEFORE_CATALOG)
+        stub.release_live(stale_settings_route)
+        # Every replacement carries the post-save catalog.
+        stub.live_models = list(SETTINGS_AFTER_CATALOG)
+        for route in list(stub.held_routes):
+            if route is stale_settings_route:
+                continue
+            stub.release_live(route)
+        stub.held_routes = []
+
+        if not _wait_for_settings_option(page, "settings-after-1"):
+            raise AssertionError(
+                "settings-policy dropped the live catalog: after the policy change "
+                "the in-flight Settings response was rejected and no replacement "
+                "live models ever landed, so live-only models are MISSING from the "
+                f"Settings picker; settings options={_settings_option_values(page)!r}; "
+                f"requests before={requests_before} after={stub.live_request_count}"
+            )
+        settings_ids = _settings_option_values(page)
+        if "settings-before-1" in settings_ids:
+            raise AssertionError(
+                "settings-policy: the stale pre-save Settings response was applied "
+                f"after the policy change; settings options={settings_ids!r}"
+            )
+        if settings_ids.count("settings-after-1") != 1:
+            raise AssertionError(
+                "settings-policy duplicated the replacement's live model; "
+                f"settings options={settings_ids!r}"
+            )
+        # The composer replacement is released with the same catalog; proving it
+        # also published shows the chokepoint drives BOTH targets, not one.
+        if not _wait_for_option(page, "settings-after-1"):
+            raise AssertionError(
+                "settings-policy: the composer replacement did not publish while "
+                f"Settings was rebuilt; composer options={_option_values(page)!r}"
+            )
+        print(
+            "OK  Settings policy change invalidated the in-flight response AND "
+            "restored the Settings live catalog:",
+            settings_ids,
+            f"(live requests {requests_before}->{stub.live_request_count})",
+        )
+
+        # Second policy save: the Settings rebuild must clear the previous live
+        # catalog rather than accumulate it.
+        while stub.held_routes:
+            stub.release_live(stub.held_routes.pop(0))
+        stub.held_routes = []
+        stub.live_models = list(SETTINGS_AFTER_CATALOG_2)
+        page.evaluate(
+            "() => {"
+            "  if (typeof _liveModelPolicyChanged === 'function') {"
+            "    _liveModelPolicyChanged();"
+            "  }"
+            "}"
+        )
+        _wait_for_held_routes(stub, 2, page, timeout=3000)
+        for route in list(stub.held_routes):
+            stub.release_live(route)
+        stub.held_routes = []
+        if not _wait_for_settings_option(page, "settings-after-2"):
+            raise AssertionError(
+                "settings-policy: the second policy change did not publish its "
+                f"live catalog; settings options={_settings_option_values(page)!r}"
+            )
+        settings_ids = _settings_option_values(page)
+        if "settings-after-1" in settings_ids:
+            raise AssertionError(
+                "settings-policy accumulated the previous policy's live model "
+                "instead of replacing it (bare re-append, no innerHTML clear); "
+                f"settings options={settings_ids!r}"
+            )
+        if settings_ids.count("settings-after-2") != 1:
+            raise AssertionError(
+                "settings-policy duplicated the second replacement's live model; "
+                f"settings options={settings_ids!r}"
+            )
+        print(
+            "OK  second Settings policy save replaced (did not accumulate) the "
+            "live catalog:",
+            settings_ids,
+        )
+
+        # Drain any still-held live routes so browser.close() does not abort
+        # them (an intercepted-but-unreleased route surfaces as a Playwright
+        # teardown traceback even when the gate itself passed).
+        while stub.held_routes:
+            stub.release_live(stub.held_routes.pop(0))
+        page.wait_for_timeout(100)
 
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -23,6 +23,11 @@ WHY THIS EXISTS
   A third case exercises the in-flight profile re-verification: a response for
   the profile captured at fetch start must be dropped if the profile changed
   before it was applied.
+  A fourth case exercises the reference-counted pending entry (#7404 review):
+  two overlapping fetches for the same profile+provider share one key, and the
+  key must stay pending until the older one has resolved and only clear when the
+  last one resolves. The route handler is put in "hold" mode so response timing
+  is released deterministically from the test (never with a blocking sleep).
 
 USAGE
   python tests/browser_live_model_policy.py
@@ -65,6 +70,8 @@ PROFILE_A = "policy-profile-a"
 PROFILE_B = "policy-profile-b"
 PROFILE_INFLIGHT = "policy-profile-inflight"
 PROFILE_INFLIGHT_RACED = "policy-profile-inflight-raced"
+PROFILE_CONCURRENT = "policy-profile-concurrent"
+CONCURRENT_CATALOG = [{"id": "concurrent-live-1", "label": "Concurrent Live 1"}]
 
 BENIGN = [
     "favicon",
@@ -148,6 +155,34 @@ def _wait_for_live_requests(page, count: int, timeout: float = 8000.0) -> bool:
         return False
 
 
+def _wait_for_js(page, expression: str, arg=None, timeout: float = 8000.0) -> bool:
+    """Return True once *expression* is truthy in the page, else False.
+
+    ``wait_for_function`` raises on timeout; this normalises that to a bool and
+    always pumps Playwright's event loop until the condition holds.
+    """
+    try:
+        page.wait_for_function(expression, arg=arg, timeout=timeout)
+        return True
+    except Exception:
+        return False
+
+
+def _wait_for_held_routes(stub: "LiveModelStub", count: int, page, timeout: float = 8000.0) -> bool:
+    """Pump Playwright until *count* live routes are held by the stub.
+
+    Uses ``page.wait_for_timeout`` so each iteration advances Playwright's event
+    loop (which is what actually dispatches route handlers); a Python
+    ``time.sleep`` would deadlock the interception.
+    """
+    deadline = time.time() + timeout
+    while len(stub.held_routes) < count:
+        if time.time() > deadline:
+            return False
+        page.wait_for_timeout(25)
+    return True
+
+
 def _capture_page_errors(page) -> list[tuple[str, str]]:
     errors: list[tuple[str, str]] = []
 
@@ -171,6 +206,11 @@ class LiveModelStub:
         self.live_models: list[dict] = []
         self.live_request_count = 0
         self.live_requests: list[str] = []
+        # When set, live responses are held instead of fulfilled so the test can
+        # release overlapping requests one at a time, deterministically.
+        self.hold_live = False
+        self.held_routes: list = []
+        self.fulfilled_count = 0
 
     @staticmethod
     def _is_live_url(url: str) -> bool:
@@ -196,6 +236,13 @@ class LiveModelStub:
     def handle_live(self, route) -> None:
         self.live_request_count += 1
         self.live_requests.append(route.request.url)
+        if self.hold_live:
+            self.held_routes.append(route)
+            return
+        self.release_live(route)
+
+    def release_live(self, route) -> None:
+        self.fulfilled_count += 1
         route.fulfill(
             status=200,
             content_type="application/json",
@@ -400,6 +447,69 @@ def main() -> int:
                 f"to {PROFILE_INFLIGHT_RACED!r}; observed options={ids_after_inflight!r}"
             )
         print("OK  in-flight response dropped after profile changed:", ids_after_inflight)
+
+        # --- Case 4: overlapping requests must keep the pending key alive -----
+        #
+        # syncTopbar() defers a model correction while a fetch is pending, so the
+        # observable requirement is: while ANY request for a key is in flight,
+        # _liveModelFetchPending.has(key) must be true. This case asserts on
+        # .has() only — .has() exists on both a Set (the pre-fix shape, which
+        # cleared the key as soon as ANY request finished) and the current
+        # reference-counted Map. That way it fails pre-fix for the RACE rather
+        # than for an API mismatch (e.g. .get is not a function on a Set).
+        page.evaluate(f"S.activeProfile = {PROFILE_CONCURRENT!r}")
+        stub.live_models = list(CONCURRENT_CATALOG)
+        pending_key = page.evaluate(f"() => _liveModelFetchKey({PROVIDER!r})")
+        # Hold live responses so both fetches are genuinely in flight at once.
+        # They are released explicitly below; no blocking sleep is used.
+        stub.hold_live = True
+        stub.held_routes = []
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 2, page):
+            raise AssertionError(
+                "concurrency: expected two overlapping /api/models/live "
+                f"requests to be held; held={len(stub.held_routes)} "
+                f"total={stub.live_request_count}"
+            )
+        if not page.evaluate("key => _liveModelFetchPending.has(key)", pending_key):
+            raise AssertionError(
+                "concurrency: key must be pending while both requests are in flight"
+            )
+
+        # Release ONLY the older response. Its completion is observable: the
+        # catalog it carries reaches the dropdown. The newer request is still
+        # held, so the key MUST still be pending afterwards.
+        stub.release_live(stub.held_routes[0])
+        if not _wait_for_option(page, "concurrent-live-1"):
+            raise AssertionError(
+                "concurrency: the first (older) request never completed after "
+                f"being released; options={_option_values(page)!r}"
+            )
+        if not page.evaluate("key => _liveModelFetchPending.has(key)", pending_key):
+            raise AssertionError(
+                "concurrency: pending entry cleared after the FIRST of two "
+                "overlapping requests completed while a newer request for the same "
+                "profile+provider is still in flight — syncTopbar() would now "
+                "persist a static fallback over the session's intended model"
+            )
+        print("OK  pending key survived the first of two overlapping requests")
+
+        # Release the last response; only now may the key clear.
+        stub.release_live(stub.held_routes[1])
+        if not _wait_for_js(
+            page, "key => !_liveModelFetchPending.has(key)", pending_key
+        ):
+            raise AssertionError(
+                "concurrency: pending entry did not clear after the LAST "
+                "overlapping request completed; still pending"
+            )
+        print("OK  pending key cleared after the last overlapping request")
 
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")

--- a/tests/browser_live_model_policy.py
+++ b/tests/browser_live_model_policy.py
@@ -29,6 +29,13 @@ WHY THIS EXISTS
   last one resolves. The route handler is put in "hold" mode so response timing
   is released deterministically from the test (never with a blocking sleep).
 
+  Two more cases lock in the #7404 separation of policy authority from
+  per-target authority: the composer (`#modelSelect`) and Settings
+  (`#settingsModel`) selects are independent live-model publishers, so a rebuild
+  of one must not reject an in-flight request for the other, and the pending
+  projection must be per-target. Both directions are driven through the real
+  production entry points (`loadSettingsPanel()` and `populateModelDropdown()`).
+
 USAGE
   python tests/browser_live_model_policy.py
   (Requires: playwright + chromium. Boots server.py on an ephemeral port with an
@@ -78,6 +85,14 @@ PROFILE_SAME_PROFILE_RACE = "policy-profile-same-race"
 # replacement's models are distinguishable from the held broad response's.
 PROFILE_SAVE_POLICY = "policy-profile-save"
 AFTER_POLICY_CATALOG = [{"id": "after-policy-live-1", "label": "After Policy Live 1"}]
+# #7404 review: composer (modelSelect) and Settings (settingsModel) are
+# independent live-model publishers. Their own catalogs make a cross-target
+# rebuild that drops one of them observable.
+PROFILE_TARGET_A = "policy-profile-target-a"
+PROFILE_TARGET_B = "policy-profile-target-b"
+PROFILE_TARGET_PENDING = "policy-profile-target-pending"
+COMPOSER_CATALOG = [{"id": "composer-live-1", "label": "Composer Live 1"}]
+SETTINGS_CATALOG = [{"id": "settings-live-1", "label": "Settings Live 1"}]
 
 BENIGN = [
     "favicon",
@@ -130,6 +145,25 @@ def _wait_for_option(page, model_id: str, timeout: float = 8000.0) -> bool:
     try:
         page.wait_for_function(
             "id => Array.from(document.querySelectorAll('#modelSelect option'))"
+            ".some(o => o.value === id)",
+            arg=model_id,
+            timeout=timeout,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _settings_option_values(page) -> list[str]:
+    return page.evaluate(
+        "Array.from(document.querySelectorAll('#settingsModel option')).map(o => o.value)"
+    )
+
+
+def _wait_for_settings_option(page, model_id: str, timeout: float = 8000.0) -> bool:
+    try:
+        page.wait_for_function(
+            "id => Array.from(document.querySelectorAll('#settingsModel option'))"
             ".some(o => o.value === id)",
             arg=model_id,
             timeout=timeout,
@@ -455,7 +489,94 @@ def main() -> int:
             )
         print("OK  in-flight response dropped after profile changed:", ids_after_inflight)
 
-        # --- Case 4: overlapping requests must keep the pending key alive -----
+        # --- Case 4: composer held, Settings rebuild (direction A) -------------
+        #
+        # The reported bug: loadSettingsPanel() advanced the GLOBAL policy
+        # generation, so a valid composer request already in flight was then
+        # rejected as stale with no replacement. A Settings rebuild must only
+        # supersede settingsModel; the composer must still publish its catalog.
+        page.evaluate(f"S.activeProfile = {PROFILE_TARGET_A!r}")
+        stub.live_models = list(COMPOSER_CATALOG)
+        stub.hold_live = True
+        stub.held_routes = []
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("direction A: composer fetch was never held")
+        # Rebuild the Settings dropdown through its production path while the
+        # composer request is in flight.
+        stub.live_models = list(SETTINGS_CATALOG)
+        page.evaluate("void loadSettingsPanel()")
+        if not _wait_for_held_routes(stub, 2, page):
+            raise AssertionError("direction A: Settings fetch was never held")
+        # Release both: the composer (older, held across the Settings rebuild)
+        # first, then the Settings response.
+        stub.live_models = list(COMPOSER_CATALOG)
+        stub.release_live(stub.held_routes[0])
+        stub.live_models = list(SETTINGS_CATALOG)
+        stub.release_live(stub.held_routes[1])
+        if not _wait_for_option(page, "composer-live-1"):
+            raise AssertionError(
+                "direction A: the composer catalog was dropped when Settings was "
+                "rebuilt — its in-flight request was rejected with no "
+                f"replacement; composer options={_option_values(page)!r}"
+            )
+        if not _wait_for_settings_option(page, "settings-live-1"):
+            raise AssertionError(
+                "direction A: the Settings catalog did not publish; "
+                f"settings options={_settings_option_values(page)!r}"
+            )
+        print(
+            "OK  Settings rebuild left the composer catalog intact:",
+            _option_values(page),
+            "settings:",
+            _settings_option_values(page),
+        )
+
+        # --- Case 5: Settings held, composer rebuild (direction B) -------------
+        #
+        # The reverse: a composer/session refresh (populateModelDropdown) advanced
+        # the global generation, rejecting an in-flight settingsModel request.
+        # A composer rebuild must only supersede the composer.
+        page.evaluate(f"S.activeProfile = {PROFILE_TARGET_B!r}")
+        stub.live_models = list(SETTINGS_CATALOG)
+        stub.hold_live = True
+        stub.held_routes = []
+        page.evaluate("void loadSettingsPanel()")
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("direction B: Settings fetch was never held")
+        # Production composer rebuild while the Settings request is in flight.
+        stub.live_models = list(COMPOSER_CATALOG)
+        page.evaluate("void populateModelDropdown()")
+        if not _wait_for_held_routes(stub, 2, page):
+            raise AssertionError("direction B: composer fetch was never held")
+        stub.live_models = list(SETTINGS_CATALOG)
+        stub.release_live(stub.held_routes[0])
+        stub.live_models = list(COMPOSER_CATALOG)
+        stub.release_live(stub.held_routes[1])
+        if not _wait_for_settings_option(page, "settings-live-1"):
+            raise AssertionError(
+                "direction B: the Settings catalog was dropped when the composer "
+                "was rebuilt — its in-flight request was rejected with no "
+                f"replacement; settings options={_settings_option_values(page)!r}"
+            )
+        if not _wait_for_option(page, "composer-live-1"):
+            raise AssertionError(
+                "direction B: the composer catalog did not publish; "
+                f"composer options={_option_values(page)!r}"
+            )
+        print(
+            "OK  composer rebuild left the Settings catalog intact:",
+            _settings_option_values(page),
+            "composer:",
+            _option_values(page),
+        )
+
+        # --- Case 6: overlapping requests must keep the pending key alive -----
         #
         # syncTopbar() defers a model correction while a fetch is pending, so the
         # observable requirement is: while ANY request for a key is in flight,
@@ -488,27 +609,52 @@ def main() -> int:
             raise AssertionError(
                 "concurrency: key must be pending while both requests are in flight"
             )
+        # Two overlapping requests for the same target must share ONE
+        # reference-counted key (2), not two per-request keys.
+        if not _wait_for_js(
+            page, "key => _liveModelFetchPending.get(key) === 2", pending_key
+        ):
+            raise AssertionError(
+                "concurrency: expected two overlapping same-target requests to "
+                "share one pending reference count of 2"
+            )
 
-        # Release ONLY the older response. Its completion is observable: the
-        # catalog it carries reaches the dropdown. The newer request is still
-        # held, so the key MUST still be pending afterwards.
+        # Under the per-target latest-request authority (#7404 review), the
+        # SECOND request supersedes the first. Releasing the OLDER response must
+        # therefore NOT apply its catalog, while the shared key decays 2 -> 1
+        # because the newer request is still in flight. Pre-fix the older one
+        # was still applicable, so the drop assertion below is the behavioural
+        # delta (the 2 -> 1 decay is orthogonal and unchanged).
         stub.release_live(stub.held_routes[0])
+        if not _wait_for_js(
+            page,
+            "key => _liveModelFetchPending.has(key) && _liveModelFetchPending.get(key) === 1",
+            pending_key,
+        ):
+            raise AssertionError(
+                "concurrency: pending entry did not decay 2 -> 1 after the older "
+                "of two overlapping same-target requests completed while the "
+                "newer was still in flight"
+            )
+        if "concurrent-live-1" in _option_values(page):
+            raise AssertionError(
+                "concurrency: the superseded older response applied its catalog "
+                f"after a newer same-target request had claimed the target; "
+                f"options={_option_values(page)!r}"
+            )
+        print(
+            "OK  pending key decayed 2 -> 1 and the superseded response was "
+            "rejected"
+        )
+
+        # Release the last (newest) response; now the catalog lands and only
+        # then may the key clear.
+        stub.release_live(stub.held_routes[1])
         if not _wait_for_option(page, "concurrent-live-1"):
             raise AssertionError(
-                "concurrency: the first (older) request never completed after "
-                f"being released; options={_option_values(page)!r}"
+                "concurrency: the newest overlapping request never applied its "
+                f"catalog after being released; options={_option_values(page)!r}"
             )
-        if not page.evaluate("key => _liveModelFetchPending.has(key)", pending_key):
-            raise AssertionError(
-                "concurrency: pending entry cleared after the FIRST of two "
-                "overlapping requests completed while a newer request for the same "
-                "profile+provider is still in flight — syncTopbar() would now "
-                "persist a static fallback over the session's intended model"
-            )
-        print("OK  pending key survived the first of two overlapping requests")
-
-        # Release the last response; only now may the key clear.
-        stub.release_live(stub.held_routes[1])
         if not _wait_for_js(
             page, "key => !_liveModelFetchPending.has(key)", pending_key
         ):
@@ -518,7 +664,7 @@ def main() -> int:
             )
         print("OK  pending key cleared after the last overlapping request")
 
-        # --- Case 5: older broad response cannot win a same-profile race -------
+        # --- Case 7: older broad response cannot win a same-profile race -------
         #
         # #7404 review blocking finding: response applicability was fenced only
         # by the active profile (and an optional requestSeq). The Settings caller
@@ -599,7 +745,7 @@ def main() -> int:
             f"(live requests {broad_requests}->{stub.live_request_count})",
         )
 
-        # --- Case 6: saveSettings policy change invalidates AND re-requests ----
+        # --- Case 8: saveSettings policy change invalidates AND re-requests ----
         #
         # #7404 review P1: saveSettings() advanced the live-model policy
         # generation on a changed default-model save but started no replacement
@@ -694,6 +840,77 @@ def main() -> int:
             f"(live requests {requests_before_save}->{stub.live_request_count}, "
             f"replacement_held={replacement_held})",
         )
+
+        # --- Case 9: pending ownership is per-target --------------------------
+        #
+        # #7404 review: _liveModelFetchKey() carried profile+provider+policy
+        # generation but no target identity, so a settingsModel fetch and a
+        # modelSelect fetch shared one pending key. syncTopbar() queries that key
+        # to defer a composer model correction, so a Settings-only fetch made
+        # the composer look pending (and could hide a real composer fetch).
+        # Assert the two targets keep independent pending state in both
+        # directions. The composer/settings key expressions work pre-fix too
+        # (the extra select arg is just ignored by the old two-arg signature),
+        # so a pre-fix failure reports the collision rather than a missing API.
+        page.evaluate(f"S.activeProfile = {PROFILE_TARGET_PENDING!r}")
+        stub.live_models = list(SETTINGS_CATALOG)
+        stub.hold_live = True
+        stub.held_routes = []
+        settings_pending_expr = (
+            "_liveModelFetchPending.has(_liveModelFetchKey("
+            "window._activeProvider, undefined, document.getElementById('settingsModel')))"
+        )
+        composer_pending_expr = (
+            "_liveModelFetchPending.has(_liveModelFetchKey("
+            "window._activeProvider, undefined, document.getElementById('modelSelect')))"
+        )
+        # Settings-only fetch in flight: the composer must NOT look pending.
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('settingsModel');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("pending isolation: Settings fetch was never held")
+        if page.evaluate("() => " + composer_pending_expr):
+            raise AssertionError(
+                "pending isolation: a Settings-only live fetch is reported as "
+                "composer pending — syncTopbar() would defer the composer's model "
+                "correction and hide a real composer fetch"
+            )
+        if not page.evaluate("() => " + settings_pending_expr):
+            raise AssertionError(
+                "pending isolation: the in-flight Settings fetch should be pending"
+            )
+        stub.release_live(stub.held_routes[0])
+        if not _wait_for_js(page, "() => !" + settings_pending_expr):
+            raise AssertionError("pending isolation: Settings pending key never cleared")
+        stub.held_routes = []
+
+        # Composer-only fetch in flight: Settings must NOT look pending.
+        stub.live_models = list(COMPOSER_CATALOG)
+        page.evaluate(
+            "() => {"
+            "  const sel = document.getElementById('modelSelect');"
+            f"  void _fetchLiveModels({PROVIDER!r}, sel);"
+            "}"
+        )
+        if not _wait_for_held_routes(stub, 1, page):
+            raise AssertionError("pending isolation: composer fetch was never held")
+        if page.evaluate("() => " + settings_pending_expr):
+            raise AssertionError(
+                "pending isolation: a composer-only live fetch is reported as "
+                "Settings pending"
+            )
+        if not page.evaluate("() => " + composer_pending_expr):
+            raise AssertionError(
+                "pending isolation: the in-flight composer fetch should be pending"
+            )
+        stub.release_live(stub.held_routes[0])
+        if not _wait_for_js(page, "() => !" + composer_pending_expr):
+            raise AssertionError("pending isolation: composer pending key never cleared")
+        print("OK  composer and Settings pending state are independent")
 
         if errors:
             raise AssertionError(f"unexpected browser errors: {errors!r}")

--- a/tests/test_4737_first_tab_model_catalog_refresh.py
+++ b/tests/test_4737_first_tab_model_catalog_refresh.py
@@ -147,6 +147,15 @@ function buildHarness(currentScenario) {
   globalThis._configuredModelBadges = {};
   globalThis._modelDropdownRequestSeq = 0;
   globalThis._modelCatalogFallbackRetried = false;
+  // Mirror the production latest-owner helpers populateModelDropdown() now calls
+  // (#7404 review). _fetchLiveModels is stubbed below, so only the generation
+  // and select-identity advances are needed here.
+  globalThis._liveModelPolicyGeneration = 0;
+  globalThis._liveModelAdvancePolicyGeneration = () => { globalThis._liveModelPolicyGeneration++; };
+  globalThis._liveModelAdvanceSelectIdentity = (sel) => {
+    if (!sel) return;
+    sel.__liveModelOwnerSeq = (typeof sel.__liveModelOwnerSeq === 'number' ? sel.__liveModelOwnerSeq : 0) + 1;
+  };
   globalThis.$ = (id) => {
     if (id === 'modelSelect') return select;
     if (id === 'composerModelDropdown') return dropdown;

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -206,6 +206,15 @@ function installGlobals(select, redirects, fetchQueue, jsonCalls) {
   globalThis._refreshOpenModelDropdown = () => {};
   globalThis._modelDropdownRequestSeq = 0;
   globalThis._fetchLiveModels = () => {};
+  // Mirror the production latest-owner helpers populateModelDropdown() now calls
+  // (#7404 review). _fetchLiveModels is stubbed above, so only the generation
+  // and select-identity advances are needed here.
+  globalThis._liveModelPolicyGeneration = 0;
+  globalThis._liveModelAdvancePolicyGeneration = () => { globalThis._liveModelPolicyGeneration++; };
+  globalThis._liveModelAdvanceSelectIdentity = (sel) => {
+    if (!sel) return;
+    sel.__liveModelOwnerSeq = (typeof sel.__liveModelOwnerSeq === 'number' ? sel.__liveModelOwnerSeq : 0) + 1;
+  };
   globalThis.console = { warn() {}, debug() {}, log() {} };
   globalThis.fetch = async () => {
     if (!fetchQueue.length) throw new Error('unexpected fetch');

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -40,7 +40,10 @@ function extractFunction(source, name) {
   const marker = `async function ${name}`;
   const start = source.indexOf(marker);
   if (start < 0) throw new Error(`missing function: ${name}`);
-  const end = source.indexOf("\n// Cache so we don't re-fetch on every page load", start);
+  // Anchor on the next top-level declaration rather than on a prose comment:
+  // the previous marker was the "Cache so we don't re-fetch" comment, which
+  // disappeared when the browser live-model response cache was removed (#7406).
+  const end = source.indexOf("\nconst _liveModelFetchPending", start);
   if (end < 0) throw new Error(`missing end marker after: ${name}`);
   return source.slice(start, end);
 }

--- a/tests/test_batch_fixes.py
+++ b/tests/test_batch_fixes.py
@@ -247,9 +247,26 @@ class TestSystemTheme:
         src = read("static/panels.js")
         # PR #2799 (v0.51.119): skin precedence now prefers localStorage over settings.skin
         # so the inline-gate-resolved DOM skin survives the picker hydration.
-        skin_idx = src.index("const skinVal=(localStorage.getItem('hermes-skin')||settings.skin||'default').toLowerCase();")
-        # models is now declared as let models=null before the try block
-        models_idx = src.index("models=await api('/api/models');")
+        #
+        # #7404 review: the Settings-select rebuild -- and therefore the
+        # /api/models await -- moved into the shared _rebuildSettingsModelSelect()
+        # helper, which is defined earlier in the file. A file-global index()
+        # would therefore compare this function's skin hydration against the
+        # helper's own definition. Scope the search to loadSettingsPanel and
+        # compare against whichever construct performs the await, so the
+        # guarantee is unchanged: theme/skin must be hydrated before the models
+        # fetch is awaited, otherwise a slow model fetch can clobber an
+        # in-progress skin selection.
+        start = src.index("async function loadSettingsPanel(){")
+        end = src.index("\nasync function ", start + 10)
+        body = src[start:end]
+        skin_idx = body.index(
+            "const skinVal=(localStorage.getItem('hermes-skin')||settings.skin||'default').toLowerCase();"
+        )
+        if "models=await api('/api/models');" in body:
+            models_idx = body.index("models=await api('/api/models');")
+        else:
+            models_idx = body.index("await _rebuildSettingsModelSelect();")
         assert skin_idx < models_idx, (
             "loadSettingsPanel must hydrate theme/skin before awaiting /api/models, "
             "otherwise a slow model fetch can clobber an in-progress skin selection"

--- a/tests/test_issue1539_provider_removal_dropdown_invalidation.py
+++ b/tests/test_issue1539_provider_removal_dropdown_invalidation.py
@@ -42,6 +42,35 @@ def _read_static(name: str) -> str:
     return (REPO / "static" / name).read_text(encoding="utf-8")
 
 
+def _strip_line_comments(src: str) -> str:
+    """Drop ``// ...`` line comments, respecting string literals.
+
+    Source-presence assertions must not be satisfiable by a COMMENT that merely
+    mentions the symbol — otherwise deleting the real call still passes. Applied
+    to the extracted function bodies before asserting (#7404 review).
+    """
+    out = []
+    for line in src.splitlines():
+        quote = None
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            if quote:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == quote:
+                    quote = None
+            elif ch in "\"'`":
+                quote = ch
+            elif ch == "/" and i + 1 < len(line) and line[i + 1] == "/":
+                line = line[:i]
+                break
+            i += 1
+        out.append(line)
+    return "\n".join(out)
+
+
 def _extract_function_body(src: str, signature: str) -> str:
     """Return the source of a top-level ``async function NAME(...)`` /
     ``function NAME(...)`` declaration via brace-balance — robust to nested
@@ -154,41 +183,87 @@ class TestProviderRemoveInvalidatesDropdowns:
         )
 
     def test_dropdown_flush_calls_populate_model_dropdown(self):
-        src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
-        assert "populateModelDropdown" in body, (
-            "_refreshModelDropdownsAfterProviderChange must call "
-            "populateModelDropdown() so the composer model picker, Settings → "
-            "Default Model dropdown, _dynamicModelLabels, and "
-            "_configuredModelBadges all rebuild from a fresh /api/models "
-            "response (covers the dropdown + badge surfaces from #1539)."
+        """#1539's guarantee — a provider change must rebuild every dropdown
+        surface from a fresh /api/models response — is now provided by the
+        shared policy chokepoint.
+
+        ``_liveModelPolicyChanged()`` (``static/ui.js``) owns the rebuild: it
+        calls ``_ensureModelDropdownReady()`` (or ``populateModelDropdown()``)
+        so the composer picker, Settings → Default Model dropdown,
+        ``_dynamicModelLabels`` and ``_configuredModelBadges`` all rebuild. The
+        panels.js helper delegates to it. Assert BOTH halves so removing either
+        the delegation or the mechanics fails here (#1539, #7404 review).
+        """
+        body = _strip_line_comments(
+            _extract_function_body(
+                _read_static("panels.js"),
+                "function _refreshModelDropdownsAfterProviderChange(",
+            )
+        )
+        assert "_liveModelPolicyChanged()" in body, (
+            "_refreshModelDropdownsAfterProviderChange must delegate to "
+            "_liveModelPolicyChanged() so the dropdown/badge surfaces from "
+            "#1539 still rebuild from a fresh /api/models response."
+        )
+        chokepoint = _strip_line_comments(
+            _extract_function_body(
+                _read_static("ui.js"), "function _liveModelPolicyChanged("
+            )
+        )
+        assert "populateModelDropdown" in chokepoint, (
+            "_liveModelPolicyChanged() must call populateModelDropdown() (directly "
+            "or via _ensureModelDropdownReady) so the composer model picker, "
+            "Settings → Default Model dropdown, _dynamicModelLabels, and "
+            "_configuredModelBadges all rebuild (#1539)."
         )
 
     def test_dropdown_flush_reuses_shared_model_ready_promise(self):
-        src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
-        ensure_pos = body.index("typeof window._ensureModelDropdownReady")
-        reset_pos = body.index("window._modelDropdownReady=null", ensure_pos)
-        call_pos = body.index("window._ensureModelDropdownReady()", reset_pos)
+        """The rebuild must reset and reuse the shared ``_modelDropdownReady``
+        promise rather than firing a second, unshared fetch. The mechanics moved
+        into ``_liveModelPolicyChanged()``; the ordering assertion is unchanged
+        there (#1539, #7404 review)."""
+        chokepoint = _strip_line_comments(
+            _extract_function_body(
+                _read_static("ui.js"), "function _liveModelPolicyChanged("
+            )
+        )
+        ensure_pos = chokepoint.index("typeof window._ensureModelDropdownReady")
+        reset_pos = chokepoint.index("window._modelDropdownReady=null", ensure_pos)
+        call_pos = chokepoint.index("window._ensureModelDropdownReady()", reset_pos)
 
         assert ensure_pos < reset_pos < call_pos
 
     def test_dropdown_flush_is_resilient_to_missing_modules(self):
         """If commands.js or ui.js failed to load, the providers panel must
-        still update — the dropdown flush is best-effort (#1539)."""
-        src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
-        # Outer try/catch wraps the whole helper so a runtime error inside
-        # populateModelDropdown / cache flush cannot surface as an unhandled
-        # rejection that breaks the surrounding save/remove flow.
+        still update — the dropdown flush is best-effort (#1539).
+
+        Both halves are asserted: the panels.js helper keeps its own try/catch
+        and typeof guard, and the delegated chokepoint in ui.js is itself
+        resilient (try/catch + typeof guards) so a missing module cannot surface
+        as an unhandled rejection in the save/remove flow (#7404 review)."""
+        body = _strip_line_comments(
+            _extract_function_body(
+                _read_static("panels.js"),
+                "function _refreshModelDropdownsAfterProviderChange(",
+            )
+        )
         assert re.search(r"\btry\s*\{", body), (
             "_refreshModelDropdownsAfterProviderChange must wrap its work in "
             "try/catch — if commands.js or ui.js failed to load, a missing "
             "function should not break the providers panel update (#1539)."
         )
-        # And the populateModelDropdown call must be guarded by typeof — the
-        # dropdown rebuild is best-effort.
-        assert "typeof populateModelDropdown" in body, (
+        chokepoint = _strip_line_comments(
+            _extract_function_body(
+                _read_static("ui.js"), "function _liveModelPolicyChanged("
+            )
+        )
+        assert re.search(r"\btry\s*\{", chokepoint), (
+            "_liveModelPolicyChanged must be best-effort: saveSettings() treats a "
+            "throw from it as a failed model save and aborts (#7404 review)."
+        )
+        # The populateModelDropdown call must be guarded by typeof — the dropdown
+        # rebuild is best-effort.
+        assert "typeof populateModelDropdown" in chokepoint, (
             "populateModelDropdown lookup must use typeof so it gracefully "
             "skips when ui.js hasn't loaded yet."
         )

--- a/tests/test_issue1743_model_picker_race.py
+++ b/tests/test_issue1743_model_picker_race.py
@@ -26,7 +26,10 @@ def test_model_picker_opens_before_async_model_catalog_finishes():
 
 def test_populate_model_dropdown_rerenders_if_picker_is_already_open():
     """If the async catalog finishes while open, refresh the visible custom rows."""
-    body = _body_between(UI_JS, "async function populateModelDropdown", "// Cache so we don't re-fetch")
+    # End anchor is the next top-level declaration, not a prose comment: the
+    # old "// Cache so we don't re-fetch" marker vanished when the browser
+    # live-model response cache was removed (#7406).
+    body = _body_between(UI_JS, "async function populateModelDropdown", "const _liveModelFetchPending")
 
     assert "composerModelDropdown" in body
     assert "classList.contains('open')" in body or 'classList.contains("open")' in body

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -667,7 +667,23 @@ def test_populate_model_dropdown_accepts_session_visit_freshness_and_guards_stal
     assert "const requestSeq=++_modelDropdownRequestSeq" in body
     assert body.count("requestSeq!==_modelDropdownRequestSeq") >= 3
     assert "_fetchLiveModels(data.active_provider, sel, requestSeq)" in body
-    assert live_tail.count("requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq") >= 4
+    # `_fetchLiveModels` must re-check the request sequence at every async
+    # boundary before touching the DOM. The count was calibrated at 4 when a
+    # redundant duplicate guard sat after the client-side cache assignment; the
+    # browser response cache was removed (#7406), taking its guard with it, so 3
+    # covers the remaining boundaries (entry, post-fetch, post-json).
+    assert live_tail.count("requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq") >= 3
+    # The removed cache also lost its "this cached payload is still current"
+    # protection, so the profile captured before the await must be re-verified
+    # before the response is applied (#7406).
+    assert "_fetchProfile" in live_tail, (
+        "_fetchLiveModels must capture the active profile before awaiting so a "
+        "mid-flight profile switch cannot apply the response (#7406)"
+    )
+    assert "_currentProfile!==_fetchProfile" in live_tail, (
+        "_fetchLiveModels must re-verify the captured profile before applying a "
+        "response to the DOM (#7406)"
+    )
 
 
 def test_load_session_schedules_session_visit_model_refresh_before_message_load():

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -674,15 +674,18 @@ def test_populate_model_dropdown_accepts_session_visit_freshness_and_guards_stal
     # covers the remaining boundaries (entry, post-fetch, post-json).
     assert live_tail.count("requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq") >= 3
     # The removed cache also lost its "this cached payload is still current"
-    # protection, so the profile captured before the await must be re-verified
-    # before the response is applied (#7406).
-    assert "_fetchProfile" in live_tail, (
-        "_fetchLiveModels must capture the active profile before awaiting so a "
-        "mid-flight profile switch cannot apply the response (#7406)"
+    # protection, so the owner token captured before the await must be
+    # re-verified before the response is applied (#7406). The token subsumes the
+    # earlier profile-only re-check by capturing the active profile alongside the
+    # model-policy generation and the target select identity (#7404 review).
+    assert "_liveModelOwnerToken(provider, sel)" in live_tail, (
+        "_fetchLiveModels must capture an owner token (active profile + policy "
+        "generation + select identity) before awaiting so a mid-flight profile "
+        "switch or policy change cannot apply the response (#7406)"
     )
-    assert "_currentProfile!==_fetchProfile" in live_tail, (
-        "_fetchLiveModels must re-verify the captured profile before applying a "
-        "response to the DOM (#7406)"
+    assert live_tail.count("_isLiveModelOwnerCurrent(ownerToken)") >= 2, (
+        "_fetchLiveModels must re-verify the captured owner token before "
+        "mutating the DOM and before syncing the chip (#7406, #7404 review)"
     )
 
 

--- a/tests/test_issues_373_374_375.py
+++ b/tests/test_issues_373_374_375.py
@@ -193,10 +193,31 @@ class TestLiveModelFetching:
             "ui.js must define _fetchLiveModels() function (#375)"
         )
 
-    def test_frontend_live_models_cache_exists(self):
-        """ui.js must cache live model responses to avoid redundant API calls (#375)."""
-        assert "_liveModelCache" in UI_JS, (
-            "ui.js must use _liveModelCache to avoid re-fetching on every dropdown open (#375)"
+    def test_frontend_has_no_client_live_models_cache(self):
+        """#375 required avoiding redundant live-model fetches. That intent is now
+        served by the SERVER: /api/models/live caches for 60s keyed by
+        (profile, provider, policy fingerprint).
+
+        The client-side response cache was deliberately removed. Keyed only by
+        profile+provider it replayed a broad discovered catalog after the same
+        profile switched to a strict model pin, short-circuiting before the
+        policy-aware server cache could answer (#7406 review). This pins the
+        frontend half of that contract; the server half is asserted below.
+        """
+        assert "_liveModelCache" not in UI_JS, (
+            "ui.js must not keep a client-side live-model response cache — it goes "
+            "stale on a same-profile policy change and bypasses the server cache (#7406)"
+        )
+        assert "_fetchLiveModels" in UI_JS, (
+            "ui.js must still fetch live models on every dropdown population — the "
+            "policy-keyed server cache is the only cache (#375, #7406)"
+        )
+
+    def test_server_live_models_cache_preserves_375_intent(self):
+        """The #375 no-redundant-fetch guarantee now lives in the server cache."""
+        assert "_LIVE_MODELS_CACHE_TTL" in ROUTES_PY, (
+            "the server-side live-model cache must exist — it is what preserves the "
+            "#375 intent now that the browser keeps no response cache (#7406)"
         )
 
     def test_frontend_calls_live_models_after_static_load(self):

--- a/tests/test_model_default_boot_precedence.py
+++ b/tests/test_model_default_boot_precedence.py
@@ -124,6 +124,15 @@ const window = {_defaultModel: null, _activeProvider: null, _configuredModelBadg
 let _dynamicModelLabels = {};
 let _liveModelFetchPending = new Set();
 let _liveModelCache = {};
+// Mirror the production latest-owner helpers populateModelDropdown() now calls
+// (#7404 review). _fetchLiveModels is stubbed above, so only the generation and
+// select-identity advances are needed here.
+let _liveModelPolicyGeneration = 0;
+function _liveModelAdvancePolicyGeneration() { _liveModelPolicyGeneration++; }
+function _liveModelAdvanceSelectIdentity(sel) {
+  if (!sel) return;
+  sel.__liveModelOwnerSeq = (typeof sel.__liveModelOwnerSeq === 'number' ? sel.__liveModelOwnerSeq : 0) + 1;
+}
 
 for (const name of [
   '_getOptionProviderId', '_providerFromModelValue', '_modelStateForSelect',

--- a/tests/test_models_discovered_not_allowlist.py
+++ b/tests/test_models_discovered_not_allowlist.py
@@ -135,3 +135,197 @@ def test_legacy_discovered_sentinel_is_also_not_an_allowlist(monkeypatch, tmp_pa
 
     assert set(ids) == set(live_models), f"expected full live catalog, got {ids}"
     assert "__discovered_model_catalog__" not in ids
+
+
+# ── Network-free / static-catalog consistency (review #7406) ───────────────
+
+
+def _static_catalog_setup(monkeypatch, tmp_path, providers_cfg, *, default="claude-sonnet-4.6"):
+    """Drive _static_models_catalog_without_live_probes() offline against a
+    temp config with a single known provider (anthropic)."""
+    import api.config as config
+    from api import providers as prov
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: {}\n", encoding="utf-8")
+    auth_store_path = tmp_path / "auth.json"
+    auth_store_path.write_text("{}", encoding="utf-8")
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir(exist_ok=True)
+    (hermes_home / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(config, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(config, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: auth_store_path)
+    monkeypatch.setattr(config, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(config, "_save_models_cache_to_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(config.os, "getenv", lambda key, default=None: default or "", raising=False)
+
+    # Config: active provider is the known anthropic provider, with its
+    # configured models mapping (the per-case flag shape drives the assertion).
+    config.cfg = {
+        "model": {"provider": "anthropic", "default": default},
+        "providers": providers_cfg,
+    }
+    # Only anthropic has a key, so the static catalog stays hermetic.
+    monkeypatch.setattr(prov, "_provider_has_key", lambda pid: pid == "anthropic")
+    if hasattr(prov, "invalidate_providers_cache"):
+        prov.invalidate_providers_cache()
+
+    from api.plugin_providers import invalidate_plugin_model_provider_cache
+
+    invalidate_plugin_model_provider_cache()
+    return config
+
+
+def _static_group_ids(config, provider_id="anthropic"):
+    catalog = config._static_models_catalog_without_live_probes()
+    for group in catalog["groups"]:
+        if group.get("provider_id") == provider_id:
+            return [m["id"] for m in group["models"]]
+    raise AssertionError(f"anthropic group not in static catalog: {catalog['groups']!r}")
+
+
+def _all_static_ids(config):
+    catalog = config._static_models_catalog_without_live_probes()
+    ids = [m["id"] for group in catalog["groups"] for m in group["models"]]
+    return ids
+
+
+def test_static_catalog_models_discovered_keeps_broader_static_catalog(monkeypatch, tmp_path):
+    """models_discovered: true must NOT clamp the offline static catalog to the
+    persisted subset — the broader _PROVIDER_MODELS list stays authoritative
+    (review #7406, fix 2)."""
+    providers_cfg = {
+        "anthropic": {
+            "name": "Anthropic",
+            "api_key": "sk-ant-test",
+            "models_discovered": True,
+            "models": {
+                "claude-sonnet-4.6": {"context_length": 200000},
+                "claude-haiku-4-5": {},
+                "claude-for-editing": {},  # persisted-only: absent from static catalog
+            },
+        }
+    }
+    config = _static_catalog_setup(monkeypatch, tmp_path, providers_cfg)
+    ids = _static_group_ids(config)
+    # The broader static catalog (5 claude models) must be retained, not clamped
+    # to the 3 persisted keys above.
+    assert "claude-opus-4.7" in ids
+    assert "claude-opus-4.6" in ids
+    assert "claude-sonnet-4-5" in ids
+    assert len(ids) >= 5, f"expected broad static catalog, got {ids}"
+    # Persisted model IDs are merged in as fallback metadata (not dropped),
+    # including persisted-only IDs absent from the static catalog.
+    assert "claude-sonnet-4.6" in ids
+    assert "claude-haiku-4-5" in ids
+    assert "claude-for-editing" in ids
+
+
+def test_static_catalog_legacy_sentinel_keeps_broader_static_catalog(monkeypatch, tmp_path):
+    """The legacy in-mapping __discovered_model_catalog__ sentinel must behave
+    the same as models_discovered: true in the offline static catalog."""
+    providers_cfg = {
+        "anthropic": {
+            "name": "Anthropic",
+            "api_key": "sk-ant-test",
+            "models": {
+                "__discovered_model_catalog__": True,
+                "claude-sonnet-4.6": {},
+                "claude-sonnet-4-5": {},
+            },
+        }
+    }
+    config = _static_catalog_setup(monkeypatch, tmp_path, providers_cfg)
+    ids = _static_group_ids(config)
+    assert "claude-opus-4.7" in ids
+    assert "claude-haiku-4-5" in ids
+    assert "claude-sonnet-4.6" in ids
+    assert len(ids) >= 5, f"expected broad static catalog, got {ids}"
+
+
+def test_static_catalog_unflagged_mapping_is_strict_allowlist(monkeypatch, tmp_path):
+    """Without the discovered flag, a configured models mapping stays a strict
+    allowlist — the intentional #644 user-pin behavior must not regress."""
+    providers_cfg = {
+        "anthropic": {
+            "name": "Anthropic",
+            "api_key": "sk-ant-test",
+            "models": {
+                "claude-sonnet-4.6": {"context_length": 200000},
+                "claude-haiku-4-5": {},
+            },
+        }
+    }
+    config = _static_catalog_setup(monkeypatch, tmp_path, providers_cfg)
+    ids = _static_group_ids(config)
+    assert set(ids) == {"claude-sonnet-4.6", "claude-haiku-4-5"}, (
+        f"unflagged mapping must pin the allowlist, got {ids}"
+    )
+
+
+def test_configured_model_ids_filters_both_sentinels(monkeypatch):
+    """Central filter: neither compatibility sentinel may surface as a model id
+    from any supported mapping shape (review #7406, fix 1)."""
+    import api.config as config
+
+    mapping = {
+        "__discovered_model_catalog__": True,
+        "__explicit_model_allowlist__": True,
+        "claude-sonnet-4.6": {"context_length": 200000},
+        "claude-haiku-4-5": {},
+    }
+    ids = config._configured_model_ids(mapping)
+    assert "__discovered_model_catalog__" not in ids
+    assert "__explicit_model_allowlist__" not in ids
+    assert "claude-sonnet-4.6" in ids
+    assert "claude-haiku-4-5" in ids
+    # Only the legacy sentinel present (no explicit-allowlist key).
+    legacy_only = {
+        "__discovered_model_catalog__": True,
+        "deepseek-v4-flash": {},
+    }
+    legacy_ids = config._configured_model_ids(legacy_only)
+    assert legacy_ids == ["deepseek-v4-flash"]
+    # No sentinels at all — plain allowlist preserved as before.
+    plain = {"deepseek-v4-flash": {}, "deepseek-v4-pro": {}}
+    assert config._configured_model_ids(plain) == ["deepseek-v4-flash", "deepseek-v4-pro"]
+
+
+def test_static_catalog_no_sentinel_in_models_or_extra_models(monkeypatch, tmp_path):
+    """Neither sentinel may leak into the static catalog models or the picker
+    overflow bucket for either discovery shape."""
+    provider_configs = [
+        {
+            # Discovery shape (a): entry-level models_discovered flag.
+            "anthropic": {
+                "name": "Anthropic",
+                "api_key": "sk-ant-test",
+                "models_discovered": True,
+                "models": {
+                    "claude-sonnet-4.6": {"context_length": 200000},
+                    "claude-haiku-4-5": {},
+                },
+            }
+        },
+        {
+            # Discovery shape (b): legacy in-mapping sentinel.
+            "anthropic": {
+                "name": "Anthropic",
+                "api_key": "sk-ant-test",
+                "models": {
+                    "__discovered_model_catalog__": True,
+                    "claude-sonnet-4.6": {},
+                    "claude-haiku-4-5": {},
+                },
+            }
+        },
+    ]
+    for providers_cfg in provider_configs:
+        config = _static_catalog_setup(monkeypatch, tmp_path, providers_cfg)
+        ids = _all_static_ids(config)
+        assert "__discovered_model_catalog__" not in ids
+        assert "__explicit_model_allowlist__" not in ids

--- a/tests/test_models_discovered_not_allowlist.py
+++ b/tests/test_models_discovered_not_allowlist.py
@@ -819,3 +819,168 @@ def test_pinned_custom_provider_skips_live_probe(monkeypatch, tmp_path):
     assert not calls, f"pinned custom provider probed live: {calls}"
     assert "acme-pinned" in ids
     assert "should-not-appear" not in ids
+
+
+# ── Named custom_providers[] pins + cache authority (#7406 review) ──────────
+#
+# The live route used to merge every ID the custom endpoint returned and only
+# clamped against ``providers{}`` pins, so a pin stored in a matching
+# ``custom_providers[]`` entry was silently widened.  These drive the REAL
+# handler (``routes._handle_live_models``), not the helper functions.
+
+
+def _live_ids_via_handler(monkeypatch, cfg, live_models_by_provider, query_provider,
+                          *, stub_alias=True):
+    from urllib.parse import urlparse
+
+    routes, _ = _live_models_setup(
+        monkeypatch, cfg, live_models_by_provider, stub_alias=stub_alias
+    )
+    parsed = urlparse(f"/api/models/live?provider={query_provider}")
+    payload = routes._handle_live_models(object(), parsed)
+    return routes, [m["id"] for m in payload.get("models", [])]
+
+
+def test_live_models_custom_provider_pin_restricts_live_catalog(monkeypatch, tmp_path):
+    """A pin in a matching ``custom_providers[]`` entry must restrict the
+    returned IDs exactly like a ``providers.<id>`` pin: an unpinned live ID must
+    not leak (maintainer's ``custom:acme`` repro)."""
+    cfg = {
+        "model": {"provider": "custom:acme"},
+        "custom_providers": [
+            {
+                "name": "Acme",
+                "base_url": "http://127.0.0.1:9999/v1",
+                "api_key": "sk-acme",
+                "models": {"pinned-only": {}},
+            }
+        ],
+    }
+    calls = []
+    routes, config = _live_models_setup(monkeypatch, cfg, {})
+    _patch_custom_endpoint_urlopen(
+        monkeypatch,
+        config,
+        {"data": [{"id": "pinned-only"}, {"id": "unpinned-live"}]},
+        calls,
+    )
+    from urllib.parse import urlparse
+
+    payload = routes._handle_live_models(
+        object(), urlparse("/api/models/live?provider=custom:acme")
+    )
+    ids = [m["id"] for m in payload.get("models", [])]
+    assert calls, "expected the custom endpoint probe to run"
+    assert set(ids) == {"pinned-only"}, ids
+    assert "unpinned-live" not in ids
+
+
+def test_live_models_custom_provider_discovery_stays_live_authoritative(monkeypatch, tmp_path):
+    """Over-correction guard: a discovery marker on a ``custom_providers[]``
+    entry makes its ``models`` mapping metadata, so the live catalog stays
+    authoritative (persisted IDs are a probe-failure fallback only)."""
+    cfg = {
+        "model": {"provider": "custom:acme"},
+        "custom_providers": [
+            {
+                "name": "Acme",
+                "base_url": "http://127.0.0.1:9999/v1",
+                "api_key": "sk-acme",
+                "models_discovered": True,
+                "models": {"acme-cached": {}},
+            }
+        ],
+    }
+    calls = []
+    routes, config = _live_models_setup(monkeypatch, cfg, {})
+    _patch_custom_endpoint_urlopen(
+        monkeypatch,
+        config,
+        {"data": [{"id": "acme-live-1"}, {"id": "acme-live-2"}]},
+        calls,
+    )
+    from urllib.parse import urlparse
+
+    payload = routes._handle_live_models(
+        object(), urlparse("/api/models/live?provider=custom:acme")
+    )
+    ids = [m["id"] for m in payload.get("models", [])]
+    assert calls, "expected the custom endpoint probe to run"
+    assert {"acme-live-1", "acme-live-2"}.issubset(set(ids)), ids
+    assert "acme-cached" in ids
+
+
+def test_live_models_cache_invalidated_when_discovered_flips_to_pin(monkeypatch):
+    """A catalog cached while the provider was discovered must not be replayed
+    after the same profile+provider is changed to a strict pin.  The policy
+    fingerprint in the cache key must force a re-evaluation."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models_discovered": True,
+                "models": {"gpt-4o": {}},
+            }
+        },
+    }
+    routes, _ = _live_models_setup(
+        monkeypatch, cfg, {"openai": ["gpt-4o", "gpt-5-discovered"]}
+    )
+    from urllib.parse import urlparse
+
+    parsed = urlparse("/api/models/live?provider=openai")
+    first = routes._handle_live_models(object(), parsed)
+    first_ids = [m["id"] for m in first["models"]]
+    assert "gpt-5-discovered" in first_ids
+
+    # Same profile + provider, but the entry is now a genuine pin.
+    cfg["providers"]["openai"] = {"models": {"gpt-4o": {}}}
+    second = routes._handle_live_models(object(), parsed)
+    second_ids = [m["id"] for m in second["models"]]
+    assert set(second_ids) == {"gpt-4o"}, second_ids
+    assert "gpt-5-discovered" not in second_ids
+
+
+def test_live_models_cache_scoped_by_profile(monkeypatch):
+    """A catalog cached for profile A must not be served for profile B."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models_discovered": True,
+                "models": {"gpt-4o": {}},
+            }
+        },
+    }
+    live = {"openai": ["gpt-4o", "gpt-5-profile-a"]}
+    routes, _ = _live_models_setup(monkeypatch, cfg, live)
+    monkeypatch.setattr(routes, "_active_profile_for_live_models_cache", lambda: "profile-a")
+    from urllib.parse import urlparse
+
+    parsed = urlparse("/api/models/live?provider=openai")
+    ids_a = [m["id"] for m in routes._handle_live_models(object(), parsed)["models"]]
+    assert "gpt-5-profile-a" in ids_a
+
+    live["openai"] = ["gpt-4o", "gpt-5-profile-b"]
+    monkeypatch.setattr(routes, "_active_profile_for_live_models_cache", lambda: "profile-b")
+    ids_b = [m["id"] for m in routes._handle_live_models(object(), parsed)["models"]]
+    assert "gpt-5-profile-b" in ids_b
+    assert "gpt-5-profile-a" not in ids_b
+
+
+def test_live_models_discovered_control_still_broad(monkeypatch):
+    """Control: the unchanged ``providers{}`` discovered path still returns the
+    broad live catalog."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models_discovered": True,
+                "models": {"gpt-4o": {}},
+            }
+        },
+    }
+    _, ids = _live_ids_via_handler(
+        monkeypatch, cfg, {"openai": ["gpt-4o", "gpt-5-discovered"]}, "openai"
+    )
+    assert {"gpt-4o", "gpt-5-discovered"}.issubset(set(ids)), ids

--- a/tests/test_models_discovered_not_allowlist.py
+++ b/tests/test_models_discovered_not_allowlist.py
@@ -1,0 +1,137 @@
+"""Regression coverage for providers with ``models_discovered: true``.
+
+Upstream Hermes Agent treats a ``models`` mapping as per-model metadata, not a
+picker allowlist, when the entry carries ``models_discovered: true`` (a catalog
+Hermes itself persisted after a successful /v1/models probe). WebUI must do the
+same: the live /v1/models catalog stays authoritative and the configured subset
+must not clamp the dropdown to its own keys (#7404).
+"""
+
+
+def _provider_group(payload: dict, provider_id: str) -> dict:
+    for group in payload.get("groups", []):
+        if group.get("provider_id") == provider_id:
+            return group
+    raise AssertionError(f"provider group {provider_id!r} not found: {payload.get('groups')!r}")
+
+
+def _ids_from_group(group: dict) -> list[str]:
+    return [m["id"] for m in group["models"]]
+
+
+def _setup(monkeypatch, tmp_path, cfg, live_models):
+    import api.config as config
+
+    monkeypatch.setattr(config, "cfg", cfg, raising=False)
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
+    monkeypatch.setattr(config, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_models_cache_source_fingerprint", lambda: {"test": "fingerprint"})
+    monkeypatch.setattr(config, "reload_config_if_stale", lambda: None)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0, raising=False)
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(
+        config,
+        "_read_live_provider_model_ids",
+        lambda pid: live_models if pid == cfg["model"]["provider"] else [],
+    )
+    config.invalidate_models_cache()
+    return config
+
+
+def test_models_discovered_catalog_is_not_a_picker_allowlist(monkeypatch, tmp_path):
+    """models_discovered: true must surface the full live catalog, not just the
+    configured subset."""
+    live_models = [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-lite",
+        "deepseek-r1-0706",
+        "deepseek-v4-reasoner",
+    ]
+    cfg = {
+        "model": {"default": "deepseek-v4-pro", "provider": "deepseek"},
+        "providers": {
+            "deepseek": {
+                "name": "DeepSeek",
+                "models_discovered": True,
+                "models": {
+                    "deepseek-v4-pro": {"context_length": 65536},
+                    "deepseek-v4-flash": {"context_length": 32768},
+                },
+            }
+        },
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, live_models)
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "deepseek")
+    ids = _ids_from_group(group)
+
+    assert set(ids) == set(live_models), f"expected full live catalog, got {ids}"
+    assert "deepseek-v4-lite" in ids
+    assert "deepseek-r1-0706" in ids
+
+
+def test_models_discovered_false_keeps_configured_allowlist(monkeypatch, tmp_path):
+    """Without the discovered flag the configured models remain a strict
+    allowlist (existing behavior must not regress)."""
+    live_models = [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-lite",
+        "deepseek-r1-0706",
+    ]
+    cfg = {
+        "model": {"default": "deepseek-v4-pro", "provider": "deepseek"},
+        "providers": {
+            "deepseek": {
+                "name": "DeepSeek",
+                "models_discovered": False,
+                "models": {
+                    "deepseek-v4-pro": {"context_length": 65536},
+                    "deepseek-v4-flash": {"context_length": 32768},
+                },
+            }
+        },
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, live_models)
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "deepseek")
+    ids = _ids_from_group(group)
+
+    assert set(ids) == {"deepseek-v4-pro", "deepseek-v4-flash"}, f"expected configured allowlist, got {ids}"
+
+
+def test_legacy_discovered_sentinel_is_also_not_an_allowlist(monkeypatch, tmp_path):
+    """The legacy in-mapping ``__discovered_model_catalog__`` sentinel written
+    by older Hermes versions must behave like ``models_discovered: true``."""
+    live_models = [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-lite",
+        "deepseek-r1-0706",
+    ]
+    cfg = {
+        "model": {"default": "deepseek-v4-pro", "provider": "deepseek"},
+        "providers": {
+            "deepseek": {
+                "name": "DeepSeek",
+                "models": {
+                    "__discovered_model_catalog__": True,
+                    "deepseek-v4-pro": {"context_length": 65536},
+                    "deepseek-v4-flash": {"context_length": 32768},
+                },
+            }
+        },
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, live_models)
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "deepseek")
+    ids = _ids_from_group(group)
+
+    assert set(ids) == set(live_models), f"expected full live catalog, got {ids}"
+    assert "__discovered_model_catalog__" not in ids

--- a/tests/test_models_discovered_not_allowlist.py
+++ b/tests/test_models_discovered_not_allowlist.py
@@ -351,7 +351,7 @@ def _install_fake_provider_model_ids(monkeypatch, fn):
     monkeypatch.setitem(sys.modules, "hermes_cli.models", models)
 
 
-def _live_models_setup(monkeypatch, cfg, live_models_by_provider):
+def _live_models_setup(monkeypatch, cfg, live_models_by_provider, *, stub_alias=True):
     import api.config as config
     import api.routes as routes
 
@@ -362,7 +362,8 @@ def _live_models_setup(monkeypatch, cfg, live_models_by_provider):
         lambda _handler, payload, status=200, extra_headers=None: payload,
     )
     monkeypatch.setattr(config, "get_config", lambda: cfg)
-    monkeypatch.setattr(config, "_resolve_provider_alias", lambda provider: provider)
+    if stub_alias:
+        monkeypatch.setattr(config, "_resolve_provider_alias", lambda provider: provider)
     _install_fake_provider_model_ids(
         monkeypatch,
         lambda provider: list(live_models_by_provider.get(provider, [])),
@@ -370,10 +371,12 @@ def _live_models_setup(monkeypatch, cfg, live_models_by_provider):
     return routes, config
 
 
-def _live_ids(monkeypatch, cfg, live_models_by_provider, query_provider):
+def _live_ids(monkeypatch, cfg, live_models_by_provider, query_provider, *, stub_alias=True):
     from urllib.parse import urlparse
 
-    routes, _ = _live_models_setup(monkeypatch, cfg, live_models_by_provider)
+    routes, _ = _live_models_setup(
+        monkeypatch, cfg, live_models_by_provider, stub_alias=stub_alias
+    )
     parsed = urlparse(f"/api/models/live?provider={query_provider}")
     payload = routes._handle_live_models(object(), parsed)
     return [m["id"] for m in payload.get("models", [])]
@@ -473,6 +476,147 @@ def test_live_models_copilot_settings_map_is_not_a_pin(monkeypatch):
     ids = _live_ids(monkeypatch, cfg, {"copilot": live}, "copilot")
     assert set(ids) == set(live)
     assert "__explicit_model_allowlist__" not in ids
+
+
+# ── Aliased config keys must still hit the pin policy (#7406 alias gap) ─────
+#
+# ``/api/models/live`` resolves the requested provider id to its canonical slug
+# (``z-ai`` -> ``zai``, ``google`` -> ``gemini``) but config.yaml stores the
+# entry under the RAW key the user wrote.  The old lookup keyed straight off the
+# canonical slug, missed the entry, skipped the discovered-vs-pinned block, and
+# returned the full live catalog -- bypassing a genuine pin.  These tests must
+# NOT stub ``_resolve_provider_alias`` to identity (which is what hid the bug).
+
+
+def test_live_models_aliased_config_key_genuine_pin_restricts(monkeypatch):
+    """The exact P1: ``providers: {"z-ai": ...}`` queried as canonical ``zai``
+    must apply the user's allowlist, not return the whole live catalog."""
+    cfg = {
+        "model": {"provider": "zai"},
+        "providers": {
+            "z-ai": {"models": {"glm-4": {}, "glm-4-air": {}}},
+        },
+    }
+    ids = _live_ids(
+        monkeypatch,
+        cfg,
+        {"zai": ["glm-4", "glm-4-air", "glm-4-unpinned"]},
+        "zai",
+        stub_alias=False,
+    )
+    assert set(ids) == {"glm-4", "glm-4-air"}
+    assert "glm-4-unpinned" not in ids
+
+
+def test_live_models_aliased_config_key_discovered_is_live_authoritative(monkeypatch):
+    """The alias fix must not over-correct: a discovered aliased entry keeps the
+    live catalog authoritative."""
+    cfg = {
+        "model": {"provider": "zai"},
+        "providers": {
+            "z-ai": {
+                "models_discovered": True,
+                "models": {"glm-4": {}},
+            },
+        },
+    }
+    ids = _live_ids(
+        monkeypatch,
+        cfg,
+        {"zai": ["glm-4", "glm-4-discovered"]},
+        "zai",
+        stub_alias=False,
+    )
+    assert set(ids) == {"glm-4", "glm-4-discovered"}
+
+
+def test_live_models_mixed_case_config_key_pin_restricts(monkeypatch):
+    """A mixed-case raw key (``CLIPpoxy``) must resolve to its config entry."""
+    cfg = {
+        "model": {"provider": "clippoxy"},
+        "providers": {
+            "CLIPpoxy": {"models": {"clip-model-a": {}}},
+        },
+    }
+    ids = _live_ids(
+        monkeypatch,
+        cfg,
+        {"clippoxy": ["clip-model-a", "clip-model-b"]},
+        "clippoxy",
+        stub_alias=False,
+    )
+    assert set(ids) == {"clip-model-a"}
+
+
+def test_live_models_underscore_config_key_pin_restricts(monkeypatch):
+    """An underscore raw key (``opencode_go``) must resolve to its config entry
+    when queried in the canonical hyphenated form."""
+    cfg = {
+        "model": {"provider": "opencode-go"},
+        "providers": {
+            "opencode_go": {"models": {"oc-model-a": {}}},
+        },
+    }
+    ids = _live_ids(
+        monkeypatch,
+        cfg,
+        {"opencode-go": ["oc-model-a", "oc-model-b"]},
+        "opencode-go",
+        stub_alias=False,
+    )
+    assert set(ids) == {"oc-model-a"}
+
+
+def test_resolve_raw_provider_key_maps_aliases_and_case():
+    """Direct unit coverage for the shared raw-key resolver."""
+    from api import config
+
+    providers = {
+        "z-ai": {"models": {"glm-4": {}}},
+        "google": {"models": {"gemini-2.5-pro": {}}},
+        "CLIPpoxy": {"models": {"clip-model-a": {}}},
+        "opencode_go": {"models": {"oc-model-a": {}}},
+        "openai": {"models": {"gpt-4o": {}}},
+    }
+    resolver = config._resolve_raw_provider_key
+    assert resolver("zai", providers) == "z-ai"
+    assert resolver("z-ai", providers) == "z-ai"
+    assert resolver("gemini", providers) == "google"
+    assert resolver("CLIPpoxy", providers) == "CLIPpoxy"
+    assert resolver("clippoxy", providers) == "CLIPpoxy"
+    assert resolver("opencode-go", providers) == "opencode_go"
+    assert resolver("openai", providers) == "openai"
+    assert resolver("mystery", providers) == "mystery"
+    assert resolver("mystery", None) == "mystery"
+
+    assert config._get_provider_cfg_for_id("zai", providers) == providers["z-ai"]
+    assert config._get_provider_cfg_for_id("mystery", providers) == {}
+
+
+def test_provider_api_key_resolves_aliased_config_key(monkeypatch):
+    """``api.providers`` credential resolution must find an aliased entry."""
+    from api import providers as prov
+
+    monkeypatch.setattr(prov, "_provider_env_var_for", lambda _pid: None)
+    monkeypatch.setattr(prov, "_pool_entry_payloads", lambda _pid: [])
+    monkeypatch.setattr(
+        prov,
+        "get_config",
+        lambda: {"providers": {"z-ai": {"api_key": "sk-zai-alias-test"}}},
+    )
+    assert prov._get_provider_api_key("zai") == "sk-zai-alias-test"
+
+
+def test_onboarding_provider_key_present_resolves_aliased_config_key():
+    """Onboarding readiness must not report an aliased provider as
+    unconfigured.  Same class as the /api/models/live alias gap: the setup id
+    is canonical (``zai``) while config.yaml keys the entry ``z-ai``."""
+    from api.onboarding import _provider_api_key_present
+
+    aliased = {"providers": {"z-ai": {"api_key": "sk-test-123"}}}
+    assert _provider_api_key_present("zai", aliased, {}) is True
+    # Control: an entry the user genuinely has not configured stays False.
+    assert _provider_api_key_present("zai", {"providers": {"openai": {"api_key": "x"}}}, {}) is False
 
 
 # ── Settings provider list (review #7406, fix 2) ───────────────────────────

--- a/tests/test_models_discovered_not_allowlist.py
+++ b/tests/test_models_discovered_not_allowlist.py
@@ -165,10 +165,15 @@ def _static_catalog_setup(monkeypatch, tmp_path, providers_cfg, *, default="clau
 
     # Config: active provider is the known anthropic provider, with its
     # configured models mapping (the per-case flag shape drives the assertion).
-    config.cfg = {
-        "model": {"provider": "anthropic", "default": default},
-        "providers": providers_cfg,
-    }
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {
+            "model": {"provider": "anthropic", "default": default},
+            "providers": providers_cfg,
+        },
+        raising=False,
+    )
     # Only anthropic has a key, so the static catalog stays hermetic.
     monkeypatch.setattr(prov, "_provider_has_key", lambda pid: pid == "anthropic")
     if hasattr(prov, "invalidate_providers_cache"):
@@ -329,3 +334,344 @@ def test_static_catalog_no_sentinel_in_models_or_extra_models(monkeypatch, tmp_p
         ids = _all_static_ids(config)
         assert "__discovered_model_catalog__" not in ids
         assert "__explicit_model_allowlist__" not in ids
+
+
+# ── /api/models/live policy (review #7406, fix 1) ──────────────────────────
+
+
+def _install_fake_provider_model_ids(monkeypatch, fn):
+    import sys
+    import types
+
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.__path__ = []
+    models = types.ModuleType("hermes_cli.models")
+    models.provider_model_ids = fn
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", models)
+
+
+def _live_models_setup(monkeypatch, cfg, live_models_by_provider):
+    import api.config as config
+    import api.routes as routes
+
+    routes._clear_live_models_cache()
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, extra_headers=None: payload,
+    )
+    monkeypatch.setattr(config, "get_config", lambda: cfg)
+    monkeypatch.setattr(config, "_resolve_provider_alias", lambda provider: provider)
+    _install_fake_provider_model_ids(
+        monkeypatch,
+        lambda provider: list(live_models_by_provider.get(provider, [])),
+    )
+    return routes, config
+
+
+def _live_ids(monkeypatch, cfg, live_models_by_provider, query_provider):
+    from urllib.parse import urlparse
+
+    routes, _ = _live_models_setup(monkeypatch, cfg, live_models_by_provider)
+    parsed = urlparse(f"/api/models/live?provider={query_provider}")
+    payload = routes._handle_live_models(object(), parsed)
+    return [m["id"] for m in payload.get("models", [])]
+
+
+def test_live_models_custom_provider_filters_sentinel_keys(monkeypatch):
+    """A legacy custom provider's persisted sentinels must never surface as
+    selectable models on /api/models/live (#7406 fix 1)."""
+    cfg = {
+        "model": {"provider": "custom:acme"},
+        "custom_providers": [
+            {
+                "name": "Acme",
+                "models": {
+                    "__discovered_model_catalog__": True,
+                    "__explicit_model_allowlist__": True,
+                    "acme-real-model": {},
+                },
+            }
+        ],
+    }
+    ids = _live_ids(monkeypatch, cfg, {}, "custom:acme")
+    assert "__discovered_model_catalog__" not in ids
+    assert "__explicit_model_allowlist__" not in ids
+    assert "acme-real-model" in ids
+
+
+def test_live_models_genuine_pin_restricts_catalog(monkeypatch):
+    """Without a discovery marker, the configured models stay a strict
+    allowlist — an unpinned live model must not leak into the response."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models": {"gpt-4o": {}, "gpt-4o-mini": {}},
+            }
+        },
+    }
+    ids = _live_ids(
+        monkeypatch,
+        cfg,
+        {"openai": ["gpt-4o", "gpt-4o-mini", "gpt-5-unpinned"]},
+        "openai",
+    )
+    assert set(ids) == {"gpt-4o", "gpt-4o-mini"}
+    assert "gpt-5-unpinned" not in ids
+
+
+def test_live_models_discovered_catalog_stays_live_authoritative(monkeypatch):
+    """A discovered catalog is metadata, not a pin: the live /v1/models list is
+    authoritative even when it is broader than the persisted subset."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models_discovered": True,
+                "models": {"gpt-4o": {}, "gpt-4o-mini": {}},
+            }
+        },
+    }
+    ids = _live_ids(monkeypatch, cfg, {"openai": ["gpt-4o", "gpt-5-discovered"]}, "openai")
+    assert set(ids) == {"gpt-4o", "gpt-5-discovered"}
+
+
+def test_live_models_discovered_probe_failure_falls_back_to_configured(monkeypatch):
+    """When discovery probe returns nothing, the persisted (sanitized) catalog
+    is the fallback — not an empty list."""
+    cfg = {
+        "model": {"provider": "openai"},
+        "providers": {
+            "openai": {
+                "models_discovered": True,
+                "models": {"gpt-4o": {}, "account-only-model": {}},
+            }
+        },
+    }
+    ids = _live_ids(monkeypatch, cfg, {}, "openai")
+    assert "gpt-4o" in ids
+    assert "account-only-model" in ids
+
+
+def test_live_models_copilot_settings_map_is_not_a_pin(monkeypatch):
+    """Copilot's models mapping is per-model settings, so it must not clamp the
+    live catalog, and sentinel metadata must not leak (#7406 fix 1)."""
+    cfg = {
+        "model": {"provider": "copilot"},
+        "providers": {
+            "copilot": {
+                "models": {
+                    "gpt-5": {"reasoning_effort": "high"},
+                    "__explicit_model_allowlist__": True,
+                },
+            }
+        },
+    }
+    live = ["gpt-5", "gpt-5-mini", "claude-opus-4.7"]
+    ids = _live_ids(monkeypatch, cfg, {"copilot": live}, "copilot")
+    assert set(ids) == set(live)
+    assert "__explicit_model_allowlist__" not in ids
+
+
+# ── Settings provider list (review #7406, fix 2) ───────────────────────────
+
+
+def _providers_module_setup(monkeypatch):
+    import sys
+    import types
+
+    from api import providers as prov
+
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda _pid: []
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+    monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"anthropic": "Anthropic"})
+    monkeypatch.setattr(
+        prov,
+        "_PROVIDER_MODELS",
+        {"anthropic": [{"id": "claude-static", "label": "Claude Static"}]},
+    )
+    monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+    monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+    monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+    if hasattr(prov, "invalidate_providers_cache"):
+        prov.invalidate_providers_cache()
+    return prov
+
+
+def test_provider_list_filters_sentinel_keys(monkeypatch):
+    """The Settings provider card must not show discovery sentinels as model
+    tags for either discovery shape (#7406 fix 2)."""
+    from api import providers as prov
+
+    _providers_module_setup(monkeypatch)
+    monkeypatch.setattr(
+        prov,
+        "get_config",
+        lambda: {
+            "model": {"provider": "anthropic"},
+            "providers": {
+                "anthropic": {
+                    "models_discovered": True,
+                    "models": {
+                        "__discovered_model_catalog__": True,
+                        "__explicit_model_allowlist__": True,
+                        "claude-real": {},
+                    },
+                }
+            },
+        },
+    )
+    try:
+        result = prov.get_providers()
+        anthropic = next(p for p in result["providers"] if p["id"] == "anthropic")
+        ids = [m["id"] for m in anthropic["models"]]
+        assert "__discovered_model_catalog__" not in ids
+        assert "__explicit_model_allowlist__" not in ids
+        assert "claude-real" in ids
+        assert "claude-static" in ids
+    finally:
+        if hasattr(prov, "invalidate_providers_cache"):
+            prov.invalidate_providers_cache()
+
+
+# ── Live-rebuild merge-on-probe-failure (review #7406, fix 3) ──────────────
+
+
+def test_live_rebuild_discovered_probe_failure_merges_persisted_ids(monkeypatch, tmp_path):
+    """A discovered-only persisted id must survive a live probe failure: the
+    broader static catalog is retained and the persisted ids are MERGED in
+    (#7406 fix 3 regression)."""
+    live_models = []  # probe failed / returned nothing
+    cfg = {
+        "model": {"default": "claude-sonnet-4.6", "provider": "anthropic"},
+        "providers": {
+            "anthropic": {
+                "name": "Anthropic",
+                "api_key": "sk-ant-test",
+                "models_discovered": True,
+                "models": {
+                    "claude-sonnet-4.6": {"context_length": 200000},
+                    "account-only-model": {},
+                },
+            }
+        },
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, live_models)
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "anthropic")
+    ids = _ids_from_group(group)
+
+    assert "account-only-model" in ids, f"discovered-only id dropped: {ids}"
+    assert "claude-opus-4.7" in ids, f"static catalog was replaced, not merged: {ids}"
+
+
+# ── Custom-provider discovery probe (review #7406, fix 4) ──────────────────
+
+
+def _patch_custom_endpoint_urlopen(monkeypatch, config, payload, calls):
+    import json
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+    def _fake_urlopen(req, timeout=None):
+        calls.append(getattr(req, "full_url", str(req)))
+        return _FakeResponse()
+
+    monkeypatch.setattr(config.urllib.request, "urlopen", _fake_urlopen)
+
+
+def _bare_id(model_id):
+    """Strip the ``@provider_id:`` routing prefix the picker adds when the
+    custom provider is not the active provider."""
+    text = str(model_id or "")
+    if text.startswith("@") and ":" in text:
+        return text.rsplit(":", 1)[1]
+    return text
+
+
+def test_discovered_custom_provider_still_probes_live(monkeypatch, tmp_path):
+    """A custom_providers[] entry carrying a discovery marker is metadata, not
+    an allowlist, so it must still probe /v1/models (#7406 fix 4)."""
+    calls = []
+    cfg = {
+        "model": {"default": "claude-sonnet-4.6", "provider": "anthropic"},
+        "providers": {"anthropic": {"api_key": "sk-ant-test"}},
+        "custom_providers": [
+            {
+                "name": "Acme",
+                "base_url": "http://127.0.0.1:9999/v1",
+                "api_key": "sk-acme",
+                "models_discovered": True,
+                "models": {"acme-cached": {}},
+            }
+        ],
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, [])
+    _patch_custom_endpoint_urlopen(
+        monkeypatch,
+        config,
+        {"data": [{"id": "acme-live-1"}, {"id": "acme-live-2"}]},
+        calls,
+    )
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "custom:acme")
+    ids = [_bare_id(mid) for mid in _ids_from_group(group)]
+
+    assert calls, "discovered custom provider did not probe /v1/models"
+    assert "acme-live-1" in ids
+    assert "acme-live-2" in ids
+    assert "acme-cached" in ids
+
+
+def test_pinned_custom_provider_skips_live_probe(monkeypatch, tmp_path):
+    """Control: a genuine custom-provider pin stays an allowlist and does not
+    probe /v1/models (#7404 user-pin behavior preserved)."""
+    calls = []
+    cfg = {
+        "model": {"default": "claude-sonnet-4.6", "provider": "anthropic"},
+        "providers": {"anthropic": {"api_key": "sk-ant-test"}},
+        "custom_providers": [
+            {
+                "name": "Acme",
+                "base_url": "http://127.0.0.1:9999/v1",
+                "api_key": "sk-acme",
+                "models": {"acme-pinned": {}},
+            }
+        ],
+    }
+    config = _setup(monkeypatch, tmp_path, cfg, [])
+    _patch_custom_endpoint_urlopen(
+        monkeypatch,
+        config,
+        {"data": [{"id": "should-not-appear"}]},
+        calls,
+    )
+
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "custom:acme")
+    ids = [_bare_id(mid) for mid in _ids_from_group(group)]
+
+    assert not calls, f"pinned custom provider probed live: {calls}"
+    assert "acme-pinned" in ids
+    assert "should-not-appear" not in ids


### PR DESCRIPTION
## Thinking Path

The WebUI model picker must agree with Hermes Agent about which models a provider offers.

Hermes persists a `providers.<id>.models` mapping after a successful live `/v1/models` probe. That mapping is **per-model metadata** — the catalog Hermes itself discovered — not a user pin. The WebUI treated any `models` mapping as a strict picker allowlist, so the live catalog was clamped to the persisted subset and most of the provider's models never appeared in the dropdown (#7404).

Fixing that distinction on the primary path exposed the same conflation on the other paths that read the same config, so this PR establishes one policy and applies it everywhere rather than patching the one reported site.

## What Changed

Thirteen commits (SHAs below are post-rebase; the branch was rebased onto current `master`, so SHAs quoted in earlier review rounds and comments refer to pre-rebase commits):



1. **`e4440d52`** — main catalog path (`get_available_models()`): honour `models_discovered: true` and the legacy in-mapping `__discovered_model_catalog__` sentinel as metadata, so the live catalog stays authoritative.
2. **`5482478e`** — the same policy in the network-free `_static_models_catalog_without_live_probes()` path (merge persisted IDs into the broader static catalog instead of replacing it), plus central filtering of both compatibility sentinels (`__discovered_model_catalog__`, `__explicit_model_allowlist__`) in `_configured_model_ids()` so they can never surface as model IDs.
3. **`43a6ee65`** — route the remaining paths through the policy: `/api/models/live`, the Settings provider list, the probe-failure regression (sanitized configured options are now merged into the static fallback, not replaced), and `custom_providers[]` entries carrying a discovery marker (so they still probe `/v1/models`).
4. **`2a0f35e9`** — provider identity resolution. `/api/models/live` canonicalizes the requested provider via `_resolve_provider_alias()` and then looked that canonical slug up in `providers:`, missing entries keyed by the raw user-written form (`z-ai`, `CLIPpoxy`, `opencode_go`) and skipping the policy entirely. Adds `_resolve_raw_provider_key()` / `_get_provider_cfg_for_id()` and applies them to every `providers.<key>` lookup that was indexing by an alias-resolved id: the live route (both the policy lookup and the OpenAI-compat probe's provider-scoped api_key lookup), the `api/providers.py` credential helpers, the reasoning-effort lookup, and the onboarding readiness check.
5. **`83904d30`** — one shared policy resolver (`_live_models_policy_for_provider()`) covering **both** `providers{}` and matching `custom_providers[]` entries, so a pin stored in a named custom-provider entry restricts the catalog instead of being widened. Also binds the route cache to policy: the `/api/models/live` cache key becomes `(profile, provider, policy fingerprint)` and the browser `_liveModelCache` is namespaced by profile + provider.
6. **`c8225c98`** — documentation (`ARCHITECTURE.md` §8, `docs/onboarding.md`).
7. **`a98d69bc`** — removed the browser live-model response cache. `_fetchLiveModels()` always requests `/api/models/live`, so a policy change can no longer be short-circuited by a local hit; the policy-keyed server cache is the only cache. Captures the active profile before the await and re-verifies it before applying to the DOM, and keys `_liveModelFetchPending` to profile **and** provider (all four sites, including the `syncTopbar()` read). Adds `tests/browser_live_model_policy.py` — a real-Chromium behavioural regression wired into CI — plus the corresponding doc and test-contract updates.
8. **`37c193a2`** — closes a P1 from the next review round on `a98d69bc`: `_liveModelFetchPending` was cleared by whichever overlapping request finished first, so `syncTopbar()` could see no pending fetch and persist a static fallback over the session's intended model before the newer catalog arrived. The key is now reference-counted (`Set` → `Map` with `_liveModelFetchBegin`/`_liveModelFetchEnd`), released in `finally` on every exit path, so the entry persists until the LAST in-flight request for that key completes. Adds a deterministic overlapping-request case to the browser gate.

9. **`8d45099a`** — fences live-model response applicability with a **policy-generation owner token**. An older broad-discovered response could still apply after a newer strict-pin response for the SAME profile: `_fetchLiveModels()` was fenced only by the active profile plus an optional `requestSeq`, and the Settings caller passed no `requestSeq` at all — so every `requestSeq!==null && ...` guard was a no-op there, leaving only the profile comparison, which a same-profile policy change passes by definition. Because `_addLiveModelsToSelect()` is additive, the late response re-appended a model the new pin excluded. Each request now captures an immutable owner token (profile + provider + policy generation + target-select identity), re-verified before any DOM mutation and before `syncModelChip()`; the generation advances on same-profile policy saves and authoritative dropdown/settings refreshes (which is what makes the previously-unowned Settings caller owned); and the pending map is keyed by the captured authority so an old generation cannot clear a newer one. Also rebased onto current `master`.

10. **`358f2ffe`** — a **policy save must also start a replacement request**. Greptile P1: `saveSettings()` advanced the policy generation on a changed default-model save but started no replacement, so the in-flight response was rejected as stale and live-only models silently disappeared until some later rebuild. Adds `_liveModelPolicyChanged()` — one chokepoint that both invalidates in-flight responses and starts a replacement — and routes both `saveSettings()` branches through it; the two sites that already rebuild keep the bare advance and are annotated so they are not later "unified" into a double fetch.
11. **`9430fec1`** — **separate policy authority from per-target authority.** Maintainer review: `_liveModelPolicyGeneration` was page-global while `modelSelect` and `settingsModel` are independent publishers, so rebuilding one select advanced the global generation and rejected the OTHER select's valid in-flight request with no replacement. The same "advance without replacement" defect, reappearing across targets. The generation is now global for **genuine policy changes only**; each select owns a per-target latest-request sequence, and `_fetchLiveModels()` claims a fresh one at request start so newest-wins is intrinsic to the request. The pending key carries target identity, so `syncTopbar()` observes only composer pending state.

12. **`bde406eb`** — **keep the composer fetch visible across a policy change.** `syncTopbar()` defers a model correction while a composer live-model fetch is pending (the #1169 guard), but the pending key carries the policy generation, so advancing it made an already in-flight composer request invisible until the replacement's async `/api/models` round-trip resolved — a window as long as that request, not a single tick. A `syncTopbar()` landing in it persisted a static fallback over a live-only session model: the exact corruption the guard exists to prevent. `_liveModelPolicyChanged()` now retains a placeholder pending entry under the new generation synchronously, before any promise is created, releasing it on every exit path; `release()` is idempotent so overlap decrements once. The composer target resolution is guarded because `saveSettings()` treats a throw from this path as a failed model save and aborts.

13. **`ef451e7b`** — **drive every live-model target from the chokepoint.** Greptile P1 on `9430fec1`: a policy save invalidated an in-flight `settingsModel` response but started a replacement only for `modelSelect`, so the Settings picker lost its live-only models until rebuilt. Same root cause as #11 one level out — the chokepoint knew about one target, because the Settings rebuild was inlined in `loadSettingsPanel()` where the chokepoint could not reach it. The rebuild is extracted into a shared `_rebuildSettingsModelSelect()` (a faithful move; `loadSettingsPanel()` now simply awaits it, so no double fetch and no behaviour change), and the chokepoint now retains a placeholder and starts a replacement for **each** target. The Settings replacement goes through the rebuild path, which clears the select first — `_addLiveModelsToSelect()` is additive, so a bare `_fetchLiveModels()` re-append would accumulate duplicates on every policy save. A no-accumulation regression covers that.


Behaviour summary:

- A mapping with a discovery marker → live catalog authoritative; persisted IDs are a **probe-failure fallback only**.
- An unflagged mapping → strict allowlist, unchanged (regression-guarded by tests).
- `providers.copilot.models` → per-model settings map, never a picker pin.
- A pin in `providers{}` **or** `custom_providers[]` restricts identically.

## Why It Matters

The reported bug hid models a user had access to. The follow-on fixes close the inverse and more dangerous direction: paths that skipped the policy returned models the user had deliberately pinned away, including via `custom_providers[]` and aliased config keys. One shared resolver means the picker, the live enrichment route, the Settings list and the onboarding readiness check now answer the same question the same way.

## Verification

All commands run in the repo checkout on this branch.

**Targeted:** `./scripts/test.sh tests/test_models_discovered_not_allowlist.py` → **29 passed** (17 at the start of the branch).

**Fail-before-fix, verified in an isolated worktree** (`api/*.py` + `static/*.js` at the base, new tests applied):

| Round | Result |
|---|---|
| alias fix | `6 failed, 18 passed` |
| custom-provider pin + cache | `2 failed, 27 passed` |

The maintainer's own reproduction, before and after, for the custom-provider pin:

```
pre-fix : ['pinned-only', 'unpinned-live']
post-fix: {'pinned-only'}
```

**Browser gates** (real headless Chromium against the real `server.py`):

| Gate | Result |
|---|---|
| `python tests/browser_live_model_policy.py` (new) | 14/14 cases pass, exit 0 (~9s) |
| `python tests/browser_smoke.py` (existing) | exit 0 — unchanged by the JS edit |

The new gate **fails before the fix** when only `static/ui.js` is reverted:

```
LIVE MODEL POLICY GATE FAILED: same-profile discovered->pin: strict pin 'strict-pin-1'
was never applied; observed options=['static-base','broad-live-1','broad-live-2','broad-live-3'];
live requests before=1 after=1
```

`before=1 after=1` is the reported short-circuit: the endpoint was never reached, so the policy-aware server cache never answered. Post-fix: `live requests 1->2`, options `['static-base','strict-pin-1']`.

**Full suite:** `./scripts/test.sh` → **3 failed, 15303 passed**, 121 skipped, 1 xfailed, 2 xpassed.

- 2 are `tests/test_tls_aware_probe.py::test_helper_self_signed_warns_and_succeeds` and `::test_helper_insecure_optin_is_silent` — both reproduce on a **clean checkout of the base commit** (`2 failed, 12 passed`), environmental.
- The third is `tests/test_issue5932_kanban_board_default_workdir_layout.py::test_board_modal_default_workdir_layout[1280-800-en]` — an order-dependent layout flake. It passes in isolation (12 passed, twice), does not reference `ui.js`/`panels.js` live-model code, and also failed on this branch before the round-12/13 commits existed.

**Baseline confirming all three are pre-existing.** Full suite on a clean `master` worktree (`2ad70a28`, no PR code, same venv and same `./scripts/test.sh`):

```
= 3 failed, 15273 passed, 121 skipped, 1 xfailed, 2 xpassed ... in 1280.63s
```

The failure set is **identical** on `master` and on this branch — the same kanban layout case and the same two TLS-helper cases:

| | base `2ad70a28` | this branch |
|---|---|---|
| failed | 3 | 3 |
| passed | 15273 | 15303 |
| failure set | kanban 1280-800-en, TLS ×2 | kanban 1280-800-en, TLS ×2 |

So the branch adds 30 passing cases and introduces no new failure. The three are environmental/order-dependent and reproduce without this change.

The overlapping-request case in the browser gate fails **before** the reference-count fix, with the race rather than an API mismatch:

```
LIVE MODEL POLICY GATE FAILED: concurrency: pending entry cleared after the FIRST of two
overlapping requests completed while a newer request for the same profile+provider is still
in flight — syncTopbar() would now persist a static fallback over the session's intended model
```

(Assertions deliberately use only `Map.has()`, which exists on the pre-fix `Set` too, so the pre-fix failure is the race itself and not `_liveModelFetchPending.get is not a function`.)

Two further rounds of regressions, each failing **before** its fix with the defect rather than a symbol error:

```
# round 8 — a policy save advanced the generation but started no replacement
LIVE MODEL POLICY GATE FAILED: save-policy dropped the live catalog: ... live-only models
are MISSING from the dropdown; options=['static-base', 'strict-pin-1'];
requests before=10 after=10; replacement_held=False

# round 9 — a view rebuild advanced the GLOBAL generation, dropping the other select's catalog
direction A: the composer catalog was dropped when Settings was rebuilt — its in-flight
request was rejected with no replacement; composer options=['static-base']
direction B: the Settings catalog was dropped when the composer was rebuilt — its in-flight
request was rejected with no replacement; settings options=['static-base']
```



The owner-token case fails **before** that fix (reverting only `static/ui.js` + `static/panels.js`), with the race rather than a missing-symbol error:

```
LIVE MODEL POLICY GATE FAILED: same-profile race: older broad-discovered response
re-appended 'broad-live-1' after the newer strict result;
options=['static-base', 'strict-pin-1', 'broad-live-1', 'broad-live-2', 'broad-live-3']
```


Two further cases, same discipline:

```
# round 12 — the pending entry vanished in the tick the policy changed
LIVE MODEL POLICY GATE FAILED: policy-gap: the composer pending entry vanished in the tick
the policy changed (`has()` on the current composer key was false); a syncTopbar() in that
window would persist a static fallback for the in-flight live fetch

# round 13 — a policy save left the SETTINGS catalog without a replacement
LIVE MODEL POLICY GATE FAILED: settings-policy dropped the live catalog: after the policy
change the in-flight Settings response was rejected and no replacement live models ever
landed, so live-only models are MISSING from the Settings picker;
settings options=['static-base']; requests before=20 after=21
```

Both exit non-zero from the assertion itself, not a missing symbol. Each fix also has a teeth-check on its specific guard: removing only the `innerHTML=''` clear from the shared Settings rebuild makes the new **no-accumulation** row fail (13/14), and moving the skin hydration after the models await makes the re-homed appearance-ordering assertion fail.


**Lint:** `python3 scripts/ruff_lint.py` → 0 findings on added/modified lines. `node --check static/ui.js` and `node --check static/panels.js` → clean.

**Doc identifiers:** all 13 identifiers named in the new documentation confirmed present in `api/*.py` / `static/ui.js`. Doc-adjacent contract tests (`test_contract_review_gate`, `test_agent_source_dependency_audit`, `test_canonical_session_resolution_rfc`, `test_issue4812_session_sse_contract_rfc`, `test_v050260_docker_invariants`) → **65 passed**.

## Documentation

- `ARCHITECTURE.md` §8 (Configuration Loading) — three new subsections: *Provider identity resolution*, *Discovered model catalogs vs. pinned allowlists*, *Live-model response caching*. The last of these was corrected in `a98d69bc` to describe the server cache as the only cache, and the resolver subsection now states plainly that the catalog paths mirror the policy rather than calling the resolver (Greptile P2).
- `docs/onboarding.md` — one sentence in "What the wizard checks" noting that provider readiness resolves the configured key through its alias / mixed-case / underscore forms before checking credentials.
- `CHANGELOG.md` not edited, per repo policy.

Release-note wording: *"The model picker now respects provider model pins stored under aliased or mixed-case config keys and in `custom_providers[]`, and no longer treats a Hermes-discovered model catalog as a restricting allowlist."*

## Contract Change

The browser live-model cache that `a98d69bc` removes was a test-pinned contract, so per `docs/CONTRACTS.md` the docs and the tests moved with the code in that commit.

- **Previous contract:** `tests/test_issues_373_374_375.py::test_frontend_live_models_cache_exists` asserted `_liveModelCache` must exist in `ui.js` — #375's "avoid re-fetching on every dropdown open" was implemented client-side.
- **New contract:** that intent is served by the **server** cache (`_LIVE_MODELS_CACHE_TTL`, keyed by profile, provider and a secret-free policy fingerprint). The test now asserts the frontend keeps **no** response cache and still fetches, with a companion `test_server_live_models_cache_preserves_375_intent` pinning the server half.
- **Affected docs and tests:** `ARCHITECTURE.md` ("Live-model response caching"), `tests/test_issues_373_374_375.py`, `tests/test_issue4756_session_visit_model_refresh.py`, `tests/test_5021_boot_model_redirect_budget.py`, `tests/test_issue1743_model_picker_race.py`.

Two further test-pinned source shapes moved with the code when the Settings-select rebuild was extracted into a shared helper (`ef451e7b`), both re-homed onto the real contract rather than loosened:

- **`tests/test_batch_fixes.py::test_panels_hydrates_appearance_before_models_fetch`** — a file-global `index()` compared `loadSettingsPanel`'s skin hydration against the shared helper's earlier `/api/models` await (which is now defined above it). Scoped to `loadSettingsPanel` and compared against whichever construct performs the await. The guarantee is unchanged: theme/skin is hydrated before the models fetch is awaited, so a slow fetch cannot clobber an in-progress skin selection.
- **`tests/test_sprint9.py::test_no_duplicate_function_definitions`** — its regex matches the literal text `function <name>(`, which a comment of mine contained. Comment reworded; the test is unchanged.
- **`tests/test_issue1539_provider_removal_dropdown_invalidation.py`** — #1539's "a provider change rebuilds every dropdown surface" now lives one level down (the panels.js helper delegates to the chokepoint), so its three source-presence assertions cover **both** halves: the delegation and the rebuild mechanics. Extracted bodies are comment-stripped first, so a comment mentioning a symbol cannot satisfy an assertion.
- **Reason:** a profile+provider client copy cannot observe a same-profile policy change; the server key carries the policy fingerprint, so cache correctness has one owner instead of two.
- **Compatibility:** no user-facing config change and no endpoint contract change. The browser always calls the endpoint; the cost is one request per dropdown population, absorbed by the existing 60s server cache.

## Risks / Follow-ups

- **Correction to an earlier statement in this PR.** A previous version of this description claimed the repository has no JS test harness for `static/ui.js`. That was wrong: `tests/browser_smoke.py` is a real Playwright gate that boots `server.py` and runs in CI. The browser-side change now **does** have a behavioural regression (`tests/browser_live_model_policy.py`, wired into CI alongside the smoke gate), so the earlier "verified by inspection only" caveat no longer applies.
- `_canonical_to_raw_provider_key`'s inline construction inside `_build_available_models_uncached` is left in place — it carries admission gating and moving it is not obviously behaviour-preserving.
- `resolve_custom_provider_connection()`'s `providers_cfg.get(pid, {})` is deliberately unchanged: it indexes a `custom:<slug>` id, which never matches a config key. Pre-existing, not this bug class.
- **Out of scope, for the maintainer's product call:** whether a discovered catalog should widen picker selectability at all. This PR only makes every path honour whichever policy is chosen.
- The two `test_tls_aware_probe` failures are pre-existing and untouched by this PR; the `test_issue5932_kanban_board_default_workdir_layout` failure is an order-dependent flake that passes in isolation and does not reference `ui.js`. Both are documented under Verification rather than hidden.

## Contract Routing

- **Task type:** bug fix + consistency fix + docs.
- **Touched areas:** model catalog policy, provider identity resolution, live-model response caching, onboarding readiness detection, credential resolution.
- **Relevant public docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `ARCHITECTURE.md` §8, `docs/onboarding.md`.
- **Scope boundaries:** does not decide whether discovery should widen selectability (maintainer's call); does not convert the main/static catalog paths to the shared resolver (they mirror the policy deliberately — see the Contract Change section); does not refactor unrelated provider code.
- **Evidence needed before claiming done:** targeted tests pass; new tests demonstrably fail pre-fix; full-suite failures attributed to a clean base; lint clean; docs updated in the same PR.

## Model Used

- **Provider:** Command Code
- **Model:** `deepseek/deepseek-v4.1-flash` (earlier commits on the branch used `deepseek/deepseek-v4-flash`)
- **Notable tool use:** implementation via the OpenCode CLI driven headlessly from the workflow; diffs were reviewed and independently re-verified before each push, including fail-before-fix runs in isolated git worktrees and clean-base reproduction of pre-existing failures. No commit, push or comment was made without human approval at each stage.

Fixes #7404
