### PR TITLE
fix(pwa): bust service-worker cache when static bundles change

### DIFF
--- a/api/asset_identity_cache.py
+++ b/api/asset_identity_cache.py
@@ -1,0 +1,188 @@
+"""Bounded, process-local freshness for mutable static-tree content identity.
+
+The owner is one instance shared by the shell and worker token helper. This
+cache does not authorize immutable responses or replace per-response byte ETags.
+Filesystem work is supplied by the existing strict inventory function and runs
+outside the coordination lock. There are no background threads or exporters.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+import math
+from pathlib import Path
+import threading
+import time
+from typing import Callable
+
+
+@dataclass
+class _Flight:
+    key: str
+    done: bool = False
+    value: str | None = None
+
+
+class AssetIdentityCache:
+    """Share success and failure outcomes with one global in-flight scan.
+
+    Limits are per instance/process, not per root or per HTTP route. A slow
+    scanner cannot spawn replacement scanners: excess or timed-out followers
+    receive None (identity unavailable), never a stale successful identity.
+    """
+
+    def __init__(
+        self,
+        *,
+        freshness_seconds: float = 1.0,
+        failure_seconds: float = 0.25,
+        max_entries: int = 4,
+        max_waiters: int = 32,
+        wait_seconds: float = 2.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        for value in (freshness_seconds, failure_seconds, wait_seconds):
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError("cache durations must be finite and positive")
+        if not isinstance(max_entries, int) or max_entries < 1:
+            raise ValueError("max_entries must be a positive integer")
+        if not isinstance(max_waiters, int) or max_waiters < 1:
+            raise ValueError("max_waiters must be a positive integer")
+        self._freshness_seconds = freshness_seconds
+        self._failure_seconds = failure_seconds
+        self._max_entries = max_entries
+        self._max_waiters = max_waiters
+        self._wait_seconds = wait_seconds
+        self._clock = clock
+        self._condition = threading.Condition(threading.Lock())
+        self._entries: OrderedDict[str, tuple[str | None, float]] = OrderedDict()
+        self._flight: _Flight | None = None
+        self._waiters = 0
+        self._stats: dict[str, int | float] = {
+            "requests": 0,
+            "cache_hits": 0,
+            "negative_hits": 0,
+            "refreshes": 0,
+            "refresh_successes": 0,
+            "refresh_failures": 0,
+            "shared_results": 0,
+            "wait_timeouts": 0,
+            "wait_rejections": 0,
+            "peak_waiters": 0,
+            "evictions": 0,
+            "last_refresh_seconds": 0.0,
+            "total_refresh_seconds": 0.0,
+            "max_refresh_seconds": 0.0,
+        }
+
+    def get(self, static_root: Path, compute: Callable[[Path], str]) -> str | None:
+        # Lexical absolute identity only: resolve()/stat() here would let warm
+        # requests repeat filesystem work before reaching the shared flight.
+        # Resolve symlinks inside compute, where the original inventory does it.
+        key = str(Path(static_root).absolute())
+        # Waiting has its own real monotonic deadline, independent of a test's
+        # injected freshness clock, and spans waits for *different* root flights.
+        deadline = time.monotonic() + self._wait_seconds
+        with self._condition:
+            self._stats["requests"] += 1
+            while True:
+                cached = self._entries.get(key)
+                if cached is not None and self._clock() < cached[1]:
+                    self._entries.move_to_end(key)
+                    self._stats["cache_hits"] += 1
+                    if cached[0] is None:
+                        self._stats["negative_hits"] += 1
+                    return cached[0]
+                flight = self._flight
+                if flight is None:
+                    flight = _Flight(key)
+                    self._flight = flight
+                    self._stats["refreshes"] += 1
+                    break
+                if self._waiters >= self._max_waiters:
+                    self._stats["wait_rejections"] += 1
+                    return None
+                self._waiters += 1
+                self._stats["peak_waiters"] = max(
+                    self._stats["peak_waiters"], self._waiters
+                )
+                try:
+                    completed = self._condition.wait_for(
+                        lambda flight=flight: flight.done,
+                        timeout=max(0.0, deadline - time.monotonic()),
+                    )
+                finally:
+                    self._waiters -= 1
+                if not completed:
+                    self._stats["wait_timeouts"] += 1
+                    return None
+                if flight.key == key:
+                    # Consume this generation's result even if a later flight
+                    # has already begun. Never turn awakened followers into a
+                    # second burst of scans after a slow refresh or failure.
+                    self._stats["shared_results"] += 1
+                    return flight.value
+                # A changed server-selected root may wait behind another root,
+                # but must never consume the other root's content identity.
+
+        value = None
+        started = time.monotonic()
+        try:
+            try:
+                candidate = compute(Path(key))
+                if isinstance(candidate, str) and candidate:
+                    value = candidate
+            except Exception:
+                # Do not retain exception objects, paths or tracebacks. Unknown
+                # identity is a short-lived result, not a successful fallback.
+                pass
+            return value
+        finally:
+            # Also release/notify after BaseException (which still propagates
+            # to the leader). The failed generation is briefly shared as None.
+            elapsed = time.monotonic() - started
+            with self._condition:
+                try:
+                    lifetime = (
+                        self._freshness_seconds if value is not None
+                        else self._failure_seconds
+                    )
+                    self._entries[key] = (value, self._clock() + lifetime)
+                    self._entries.move_to_end(key)
+                    while len(self._entries) > self._max_entries:
+                        self._entries.popitem(last=False)
+                        self._stats["evictions"] += 1
+                    self._stats[
+                        "refresh_successes" if value is not None else "refresh_failures"
+                    ] += 1
+                    self._stats["last_refresh_seconds"] = elapsed
+                    self._stats["total_refresh_seconds"] += elapsed
+                    self._stats["max_refresh_seconds"] = max(
+                        self._stats["max_refresh_seconds"], elapsed
+                    )
+                    flight.value = value
+                except BaseException:
+                    self._entries.pop(key, None)
+                    raise
+                finally:
+                    flight.done = True
+                    self._flight = None
+                    self._condition.notify_all()
+
+    def snapshot(self) -> dict[str, int | float]:
+        """Return fixed-cardinality diagnostics, with no keys or user data.
+
+        This is an in-process accessor, not a public HTTP metrics endpoint.
+        Taking a snapshot must remain possible while filesystem I/O is blocked.
+        """
+        with self._condition:
+            return {
+                **self._stats,
+                "current_waiters": self._waiters,
+                "in_flight": int(self._flight is not None),
+                "entries": len(self._entries),
+            }
+
+
+# One owner for all shell/worker callers, including server-selected root changes.
+ASSET_IDENTITY_CACHE = AssetIdentityCache()

--- a/api/asset_identity_cache.py
+++ b/api/asset_identity_cache.py
@@ -21,6 +21,7 @@ class _Flight:
     key: str
     done: bool = False
     value: str | None = None
+    expires_at: float | None = None
 
 
 class AssetIdentityCache:
@@ -44,9 +45,9 @@ class AssetIdentityCache:
         for value in (freshness_seconds, failure_seconds, wait_seconds):
             if not math.isfinite(value) or value <= 0:
                 raise ValueError("cache durations must be finite and positive")
-        if not isinstance(max_entries, int) or max_entries < 1:
+        if isinstance(max_entries, bool) or not isinstance(max_entries, int) or max_entries < 1:
             raise ValueError("max_entries must be a positive integer")
-        if not isinstance(max_waiters, int) or max_waiters < 1:
+        if isinstance(max_waiters, bool) or not isinstance(max_waiters, int) or max_waiters < 1:
             raise ValueError("max_waiters must be a positive integer")
         self._freshness_seconds = freshness_seconds
         self._failure_seconds = failure_seconds
@@ -66,6 +67,7 @@ class AssetIdentityCache:
             "refresh_successes": 0,
             "refresh_failures": 0,
             "shared_results": 0,
+            "expired_shared_results": 0,
             "wait_timeouts": 0,
             "wait_rejections": 0,
             "peak_waiters": 0,
@@ -113,13 +115,18 @@ class AssetIdentityCache:
                     )
                 finally:
                     self._waiters -= 1
-                if not completed:
+                # Notification is not timely delivery. A follower may only
+                # regain this lock after its original waiting budget expired.
+                if not completed or time.monotonic() >= deadline:
                     self._stats["wait_timeouts"] += 1
                     return None
                 if flight.key == key:
-                    # Consume this generation's result even if a later flight
-                    # has already begun. Never turn awakened followers into a
-                    # second burst of scans after a slow refresh or failure.
+                    # Share only a still-fresh published generation. A delayed
+                    # follower must not return expired bytes or become another
+                    # scanner merely because its original flight completed.
+                    if flight.expires_at is None or self._clock() >= flight.expires_at:
+                        self._stats["expired_shared_results"] += 1
+                        return None
                     self._stats["shared_results"] += 1
                     return flight.value
                 # A changed server-selected root may wait behind another root,
@@ -147,7 +154,8 @@ class AssetIdentityCache:
                         self._freshness_seconds if value is not None
                         else self._failure_seconds
                     )
-                    self._entries[key] = (value, self._clock() + lifetime)
+                    expires_at = self._clock() + lifetime
+                    self._entries[key] = (value, expires_at)
                     self._entries.move_to_end(key)
                     while len(self._entries) > self._max_entries:
                         self._entries.popitem(last=False)
@@ -161,6 +169,7 @@ class AssetIdentityCache:
                         self._stats["max_refresh_seconds"], elapsed
                     )
                     flight.value = value
+                    flight.expires_at = expires_at
                 except BaseException:
                     self._entries.pop(key, None)
                     raise

--- a/api/routes.py
+++ b/api/routes.py
@@ -12802,9 +12802,9 @@ def _save_saved_prompts(prompts: list) -> None:
 # `/session/<id>` routes are the hottest navigations and each re-read the
 # ~190 KB static/index.html from disk and re-ran the two process-constant
 # substitutions (__WEBUI_VERSION__, __MAX_UPLOAD_BYTES__) on every request.
-# Those values are fixed for the process lifetime, so we cache the partially
-# rendered template here, keyed by (size, nanosecond mtime) exactly like
-# _STATIC_CACHE so a redeploy is picked up without a restart. The two values
+# The version token also includes the byte identity of every static resource,
+# and that identity is checked *before* this cache lookup so a bundle edit
+# invalidates the shell even when index.html itself is unchanged. The values
 # that genuinely vary per request — the per-session CSRF token and the runtime
 # extension tags (inject_extension_tags) — are still applied on each request
 # against the cached base, so caching changes no observable output.
@@ -12812,11 +12812,36 @@ _INDEX_SHELL_CACHE: dict = {}
 _INDEX_SHELL_CACHE_LOCK = threading.Lock()
 
 
+def _static_content_identity(static_root: Path) -> str:
+    """Hash normalized paths and current bytes for every static resource.
+
+    The recursive walk is the one authoritative shell inventory: it includes
+    nested vendor assets, the worker itself, index/manifest resources, and PWA
+    icons without maintaining a second top-level list that can drift. File
+    metadata is deliberately excluded because a replacement can preserve it.
+    """
+    root = Path(static_root).resolve()
+    fingerprint = hashlib.sha256()
+    paths = sorted(
+        (path for path in root.rglob("*") if path.is_file()),
+        key=lambda path: path.relative_to(root).as_posix(),
+    )
+    for path in paths:
+        relative_path = path.relative_to(root).as_posix().encode("utf-8")
+        content_digest = hashlib.sha256(path.read_bytes()).digest()
+        # Length framing prevents adjacent path/content fields from being
+        # interpreted as another normalized resource boundary.
+        fingerprint.update(len(relative_path).to_bytes(8, "big"))
+        fingerprint.update(relative_path)
+        fingerprint.update(content_digest)
+    return fingerprint.hexdigest()
+
+
 def _assets_cache_bust_token(static_root: Path) -> str:
     """Return a cache token covering the WebUI's served static shell.
 
-    The token changes whenever any bundle under static_root changes (name,
-    size, or mtime), even when WEBUI_VERSION stays constant (non-git
+    The token changes whenever any recursive static resource changes by byte
+    identity, even when WEBUI_VERSION or file metadata stays constant (non-git
     installs). Cache name must change on bundle edits or the service-worker
     cache serves stale bundles indefinitely; hard refresh does not bypass
     service-worker caches.
@@ -12825,19 +12850,9 @@ def _assets_cache_bust_token(static_root: Path) -> str:
     from api.updates import WEBUI_VERSION
 
     try:
-        fingerprint = hashlib.sha256()
-        paths = (
-            sorted(static_root.glob("*.js"))
-            + sorted(static_root.glob("*.css"))
-            + [static_root / "index.html"]
+        fingerprint = hashlib.sha256(
+            _static_content_identity(static_root).encode("ascii")
         )
-        for path in paths:
-            if not path.exists():
-                continue
-            stat = path.stat()
-            fingerprint.update(
-                f"{path.name}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8")
-            )
         return quote(f"{WEBUI_VERSION}+a{fingerprint.hexdigest()[:10]}", safe="")
     except Exception:
         return quote(WEBUI_VERSION, safe="")
@@ -12846,18 +12861,18 @@ def _assets_cache_bust_token(static_root: Path) -> str:
 def _render_index_shell_base() -> str:
     """Return static/index.html with the process-constant tokens substituted.
 
-    Cached and invalidated on (size, mtime_ns) change. The CSRF token and
-    extension-tag injection are intentionally NOT applied here — they vary per
-    request and are applied by the caller against this base string.
+    Cached and invalidated on index metadata and asset-byte identity. The CSRF
+    token and extension-tag injection are intentionally NOT applied here — they
+    vary per request and are applied by the caller against this base string.
     """
     index_path = api_config.get_index_html_path()
+    version_token = _assets_cache_bust_token(api_config.get_static_root())
     st = index_path.stat()
-    sig = (index_path, st.st_size, st.st_mtime_ns)
+    sig = (index_path, version_token, st.st_size, st.st_mtime_ns)
     with _INDEX_SHELL_CACHE_LOCK:
         cached = _INDEX_SHELL_CACHE.get("base")
         if cached and cached[0] == sig:
             return cached[1]
-    version_token = _assets_cache_bust_token(api_config.get_static_root())
     base = (
         index_path.read_text(encoding="utf-8")
         .replace("__WEBUI_VERSION__", version_token)
@@ -17751,10 +17766,10 @@ _COMPRESSIBLE_MIME = {
     "application/json", "text/plain",
 }
 
-# In-process cache for raw bytes, compressed bytes, and ETag. The cache is keyed
-# by absolute path and invalidated on (size, high-precision mtime) change, so a
-# redeploy is picked up without a process restart. Missing/random paths never
-# enter the cache; memory cost is bounded by the static/ tree's served files.
+# In-process cache for compressed representations keyed by absolute path and
+# the digest of the bytes just read. Every request reads and hashes the file
+# before selecting a representation, so metadata-preserving replacements cannot
+# reuse stale bytes or a stale ETag. Missing/random paths never enter the cache.
 _STATIC_CACHE: dict = {}
 _STATIC_CACHE_LOCK = threading.Lock()
 
@@ -17780,36 +17795,28 @@ def _serve_static(handler, parsed):
         ct = guessed_type if guessed_type and not content_encoding else "application/octet-stream"
     ct_header = f"{ct}; charset=utf-8" if ct in _TEXT_MIME_TYPES else ct
 
-    # Look up or populate the per-file cache (raw, optional gzip, ETag).
-    # Keyed by absolute path; invalidated by (size, nanosecond mtime).
-    st = static_file.stat()
-    sig = (st.st_size, st.st_mtime_ns)
+    # Read once, then derive the ETag and cache lookup from that exact buffer.
+    # Separate stat/read sequences are not coherent enough to identify content.
+    raw = static_file.read_bytes()
+    content_digest = hashlib.sha256(raw).hexdigest()
     cache_key = str(static_file)
-    raw = gz = etag = None
+    gz = None
+    etag = f'W/"{content_digest}"'
     with _STATIC_CACHE_LOCK:
         cached = _STATIC_CACHE.get(cache_key)
-        if cached and cached[0] == sig:
-            _, raw, gz, etag = cached
-    if raw is None:
-        raw = static_file.read_bytes()
-        # Weak ETag: equality semantics, derived from filesystem identity.
-        etag = f'W/"{sig[0]:x}-{sig[1]:x}"'
-        gz = (gzip.compress(raw, compresslevel=6)
-              if ct in _COMPRESSIBLE_MIME and len(raw) > 1024
-              else None)
-        with _STATIC_CACHE_LOCK:
-            _STATIC_CACHE[cache_key] = (sig, raw, gz, etag)
+        if cached and cached[0] == content_digest:
+            gz = cached[1]
+        else:
+            gz = (gzip.compress(raw, compresslevel=6)
+                  if ct in _COMPRESSIBLE_MIME and len(raw) > 1024
+                  else None)
+            _STATIC_CACHE[cache_key] = (content_digest, gz)
 
-    # The page template substitutes __WEBUI_VERSION__ at request time (see the
-    # `/`/`/index.html`/`/session/` branch above), and static/sw.js's
-    # SHELL_ASSETS list relies on the same convention. So a fingerprinted URL
-    # is safe to cache aggressively: any redeploy changes the URL.
-    version_values = parse_qs(parsed.query, keep_blank_values=True).get("v", [""])
-    has_fingerprint = bool(version_values[0])
-    cache_control = (
-        "public, max-age=31536000, immutable" if has_fingerprint
-        else "public, max-age=300"
-    )
+    # The static tree is mutable in-place and ?v= is client-controlled. Matching
+    # a token at request time still does not prove that these exact bytes belong
+    # to a coherent snapshot across the separate inventory/read operations, so
+    # every URL must revalidate; byte ETags keep that inexpensive.
+    cache_control = "public, max-age=0, must-revalidate"
 
     # 304 short-circuit on conditional GET.
     if handler.headers.get("If-None-Match") == etag:

--- a/api/routes.py
+++ b/api/routes.py
@@ -12682,6 +12682,22 @@ def _serve_shell_unavailable(handler, exc: Exception) -> bool:
     return True
 
 
+def _serve_worker_identity_unavailable(handler) -> bool:
+    """Refuse a worker update when complete static-byte identity is unavailable."""
+    data = (
+        "// Hermes static asset identity is unavailable; "
+        "service-worker update refused.\n"
+    ).encode("utf-8")
+    handler.send_response(503)
+    handler.send_header("Content-Type", "application/javascript; charset=utf-8")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("Service-Worker-Allowed", "/")
+    handler.send_header("Content-Length", str(len(data)))
+    handler.end_headers()
+    handler.wfile.write(data)
+    return True
+
+
 _SHUTDOWN_LOG_VALUE_RE = re.compile(r"[\x00-\x1f\x7f]+")
 
 
@@ -12812,6 +12828,14 @@ _INDEX_SHELL_CACHE: dict = {}
 _INDEX_SHELL_CACHE_LOCK = threading.Lock()
 
 
+_ASSET_IDENTITY_UNAVAILABLE_SUFFIX = "%2Fidentity-unavailable"
+_ASSET_IDENTITY_UNAVAILABLE_TOKEN = "asset-identity-unavailable"
+
+
+def _asset_identity_is_available(version_token: str) -> bool:
+    return not version_token.endswith(_ASSET_IDENTITY_UNAVAILABLE_SUFFIX)
+
+
 def _static_content_identity(static_root: Path) -> str:
     """Hash normalized paths and current bytes for every static resource.
 
@@ -12855,7 +12879,10 @@ def _assets_cache_bust_token(static_root: Path) -> str:
         )
         return quote(f"{WEBUI_VERSION}+a{fingerprint.hexdigest()[:10]}", safe="")
     except Exception:
-        return quote(WEBUI_VERSION, safe="")
+        # Preserve the historical string-returning helper for callers that only
+        # need a display/version fallback, while marking that identity is absent.
+        # Cache consumers must reject this explicit suffix as a cache signature.
+        return quote(WEBUI_VERSION, safe="") + _ASSET_IDENTITY_UNAVAILABLE_SUFFIX
 
 
 def _render_index_shell_base() -> str:
@@ -12867,6 +12894,14 @@ def _render_index_shell_base() -> str:
     """
     index_path = api_config.get_index_html_path()
     version_token = _assets_cache_bust_token(api_config.get_static_root())
+    if not _asset_identity_is_available(version_token):
+        # Metadata cannot authorize reuse when some inventoried bytes could not
+        # be read. Read the current index every time and never cache this path.
+        return (
+            index_path.read_text(encoding="utf-8")
+            .replace("__WEBUI_VERSION__", _ASSET_IDENTITY_UNAVAILABLE_TOKEN)
+            .replace("__MAX_UPLOAD_BYTES__", str(MAX_UPLOAD_BYTES))
+        )
     st = index_path.stat()
     sig = (index_path, version_token, st.st_size, st.st_mtime_ns)
     with _INDEX_SHELL_CACHE_LOCK:
@@ -13681,10 +13716,11 @@ def handle_get(handler, parsed) -> bool:
         static_root = api_config.get_static_root()
         sw_path = (static_root / "sw.js").resolve()
         if sw_path.exists():
-            # Inject the current git-derived version as the cache name so the
-            # service worker cache busts automatically on every new deploy.
+            # Inject a cache name covering both version and bundle bytes.
             # The token also changes for bundle edits via _assets_cache_bust_token, not only for a new WEBUI_VERSION deploy.
             version_token = _assets_cache_bust_token(static_root)
+            if not _asset_identity_is_available(version_token):
+                return _serve_worker_identity_unavailable(handler)
             text = sw_path.read_text(encoding="utf-8").replace(
                 "__WEBUI_VERSION__", version_token
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -12812,6 +12812,37 @@ _INDEX_SHELL_CACHE: dict = {}
 _INDEX_SHELL_CACHE_LOCK = threading.Lock()
 
 
+def _assets_cache_bust_token(static_root: Path) -> str:
+    """Return a cache token covering the WebUI's served static shell.
+
+    The token changes whenever any bundle under static_root changes (name,
+    size, or mtime), even when WEBUI_VERSION stays constant (non-git
+    installs). Cache name must change on bundle edits or the service-worker
+    cache serves stale bundles indefinitely; hard refresh does not bypass
+    service-worker caches.
+    """
+    from urllib.parse import quote
+    from api.updates import WEBUI_VERSION
+
+    try:
+        fingerprint = hashlib.sha256()
+        paths = (
+            sorted(static_root.glob("*.js"))
+            + sorted(static_root.glob("*.css"))
+            + [static_root / "index.html"]
+        )
+        for path in paths:
+            if not path.exists():
+                continue
+            stat = path.stat()
+            fingerprint.update(
+                f"{path.name}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8")
+            )
+        return quote(f"{WEBUI_VERSION}+a{fingerprint.hexdigest()[:10]}", safe="")
+    except Exception:
+        return quote(WEBUI_VERSION, safe="")
+
+
 def _render_index_shell_base() -> str:
     """Return static/index.html with the process-constant tokens substituted.
 
@@ -12819,8 +12850,6 @@ def _render_index_shell_base() -> str:
     extension-tag injection are intentionally NOT applied here — they vary per
     request and are applied by the caller against this base string.
     """
-    from api.updates import WEBUI_VERSION
-
     index_path = api_config.get_index_html_path()
     st = index_path.stat()
     sig = (index_path, st.st_size, st.st_mtime_ns)
@@ -12828,9 +12857,7 @@ def _render_index_shell_base() -> str:
         cached = _INDEX_SHELL_CACHE.get("base")
         if cached and cached[0] == sig:
             return cached[1]
-    from urllib.parse import quote
-
-    version_token = quote(WEBUI_VERSION, safe="")
+    version_token = _assets_cache_bust_token(api_config.get_static_root())
     base = (
         index_path.read_text(encoding="utf-8")
         .replace("__WEBUI_VERSION__", version_token)
@@ -13641,9 +13668,8 @@ def handle_get(handler, parsed) -> bool:
         if sw_path.exists():
             # Inject the current git-derived version as the cache name so the
             # service worker cache busts automatically on every new deploy.
-            from urllib.parse import quote
-            from api.updates import WEBUI_VERSION
-            version_token = quote(WEBUI_VERSION, safe="")
+            # The token also changes for bundle edits via _assets_cache_bust_token, not only for a new WEBUI_VERSION deploy.
+            version_token = _assets_cache_bust_token(static_root)
             text = sw_path.read_text(encoding="utf-8").replace(
                 "__WEBUI_VERSION__", version_token
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -12890,19 +12890,21 @@ def _static_content_identity(static_root: Path) -> str:
 def _assets_cache_bust_token(static_root: Path) -> str:
     """Return a cache token covering the WebUI's served static shell.
 
-    The token changes whenever any recursive static resource changes by byte
-    identity, even when WEBUI_VERSION or file metadata stays constant (non-git
+    After bounded freshness expiry, changes to any recursive static resource
+    change its byte identity, even with stable version or metadata (non-git
     installs). Cache name must change on bundle edits or the service-worker
     cache serves stale bundles indefinitely; hard refresh does not bypass
     service-worker caches.
     """
     from urllib.parse import quote
     from api.updates import WEBUI_VERSION
+    from api.asset_identity_cache import ASSET_IDENTITY_CACHE
 
     try:
-        fingerprint = hashlib.sha256(
-            _static_content_identity(static_root).encode("ascii")
-        )
+        identity = ASSET_IDENTITY_CACHE.get(static_root, _static_content_identity)
+        if identity is None:
+            return quote(WEBUI_VERSION, safe="") + _ASSET_IDENTITY_UNAVAILABLE_SUFFIX
+        fingerprint = hashlib.sha256(identity.encode("ascii"))
         return quote(f"{WEBUI_VERSION}+a{fingerprint.hexdigest()[:10]}", safe="")
     except Exception:
         # Preserve the historical string-returning helper for callers that only

--- a/api/routes.py
+++ b/api/routes.py
@@ -12845,9 +12845,35 @@ def _static_content_identity(static_root: Path) -> str:
     metadata is deliberately excluded because a replacement can preserve it.
     """
     root = Path(static_root).resolve()
+
+    def inventory_files():
+        # Path.rglob() can silently omit a directory whose listing fails (for
+        # example a POSIX 0111 directory). Enumerate explicitly and let both
+        # scandir() and entry classification raise so identity becomes unknown.
+        pending = [root]
+        while pending:
+            directory = pending.pop()
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    entry_mode = entry.stat(follow_symlinks=False).st_mode
+                    if _stat.S_ISDIR(entry_mode):
+                        pending.append(Path(entry.path))
+                    elif _stat.S_ISREG(entry_mode):
+                        yield Path(entry.path)
+                    elif _stat.S_ISLNK(entry_mode):
+                        # rglob()+is_file() followed file symlinks. Preserve
+                        # that inventory behavior; an unresolvable symlink is
+                        # an unclassifiable entry and therefore fails closed.
+                        target_mode = entry.stat(follow_symlinks=True).st_mode
+                        if _stat.S_ISREG(target_mode):
+                            yield Path(entry.path)
+                    # Other classified non-directory, non-file entries are not
+                    # servable static resources and intentionally do not enter
+                    # the byte identity.
+
     fingerprint = hashlib.sha256()
     paths = sorted(
-        (path for path in root.rglob("*") if path.is_file()),
+        inventory_files(),
         key=lambda path: path.relative_to(root).as_posix(),
     )
     for path in paths:
@@ -12896,7 +12922,10 @@ def _render_index_shell_base() -> str:
     version_token = _assets_cache_bust_token(api_config.get_static_root())
     if not _asset_identity_is_available(version_token):
         # Metadata cannot authorize reuse when some inventoried bytes could not
-        # be read. Read the current index every time and never cache this path.
+        # be read. Evict any earlier shell, read the current index every time,
+        # and never cache this path.
+        with _INDEX_SHELL_CACHE_LOCK:
+            _INDEX_SHELL_CACHE.pop("base", None)
         return (
             index_path.read_text(encoding="utf-8")
             .replace("__WEBUI_VERSION__", _ASSET_IDENTITY_UNAVAILABLE_TOKEN)

--- a/docs/static-asset-freshness.md
+++ b/docs/static-asset-freshness.md
@@ -30,6 +30,10 @@ scanner resolves symlinks inside the single-flight callback; lexical `..` is
 not collapsed before symlink resolution.
 
 At most **32 followers** wait, with a **2-second** monotonic waiting budget.
+The original absolute deadline is checked again after a notified follower
+reacquires the lock. A completed generation is shared only while its own
+completion-based expiry remains valid. A delayed follower fails closed and
+never starts a replacement scan just because its generation has expired.
 Extra or timed-out callers receive unavailable identity, rather than stale
 success or permission to launch another scan. Existing route behavior then
 keeps shell output out of its cache and returns a no-store 503 for the worker.
@@ -48,7 +52,8 @@ release their slot. Coordination cleanup also runs if publication fails.
 
 `ASSET_IDENTITY_CACHE.snapshot()` returns an independent, fixed-key in-process
 snapshot. It includes requests, warm/negative hits, refresh attempts/successes/
-failures, shared results, waiter rejections/timeouts, current and peak waiters,
+failures, shared results, expired shared results, waiter rejections/timeouts,
+current and peak waiters,
 entry/eviction counts, in-flight state, and last/total/maximum refresh seconds.
 
 There are no request identifiers, paths, roots, tokens, digests, exception

--- a/docs/static-asset-freshness.md
+++ b/docs/static-asset-freshness.md
@@ -1,0 +1,75 @@
+# Static asset identity: bounded freshness
+
+The shell and service-worker routes share one `AssetIdentityCache` instance at
+`api.asset_identity_cache.ASSET_IDENTITY_CACHE`, through the existing
+`_assets_cache_bust_token()` helper. The strict recursive inventory and actual
+content digests remain authoritative. Semantic bundle identity is unchanged.
+
+## Contract change
+
+Previously each token request rescanned the entire static tree. The new policy
+shares a successful completed scan for **1 second**, measured with a monotonic
+clock from completion, and shares unavailable identity for **0.25 seconds**.
+After expiry, same-size/same-nanosecond-mtime replacements, nested assets, added
+or removed files, worker resources and icons are detected by content hashing.
+A metadata touch alone does not change the identity.
+
+This is bounded staleness, not an atomic filesystem snapshot. An edit during
+freshness can retain the preceding asset token until the next refresh. This is
+why served static responses must continue reading exact bytes, deriving their
+ETags from that same buffer, and returning `public, max-age=0, must-revalidate`
+for every query token. No `immutable` permission is granted by this cache.
+The existing semantic-version bridge is unchanged; it still distinguishes the
+release version from the fingerprinted asset token.
+
+There is **at most one active scan per process**, including across root changes,
+and at most **four retained root entries**, including failures. Root identity
+is server-selected, never taken from a URL query or request header. Warm hits
+perform no static-tree traversal, resolution, stat or byte reads. The original
+scanner resolves symlinks inside the single-flight callback; lexical `..` is
+not collapsed before symlink resolution.
+
+At most **32 followers** wait, with a **2-second** monotonic waiting budget.
+Extra or timed-out callers receive unavailable identity, rather than stale
+success or permission to launch another scan. Existing route behavior then
+keeps shell output out of its cache and returns a no-store 503 for the worker.
+Other healthy cached roots can still be reused while a scan is in progress.
+The scanning leader can remain blocked in filesystem I/O: this mechanism bounds
+scan fan-out, not OS call duration or all HTTP server request threads. It does
+not attempt to kill threads or spawn replacement scans. Bounds are per process;
+multiple server processes each own their own cache.
+
+Filesystem work never holds the coordination lock. Ordinary exceptions become
+short-lived unavailable results. A leader's `BaseException` still propagates,
+but followers are released with unavailable identity. Interrupted follower waits
+release their slot. Coordination cleanup also runs if publication fails.
+
+## Diagnostics
+
+`ASSET_IDENTITY_CACHE.snapshot()` returns an independent, fixed-key in-process
+snapshot. It includes requests, warm/negative hits, refresh attempts/successes/
+failures, shared results, waiter rejections/timeouts, current and peak waiters,
+entry/eviction counts, in-flight state, and last/total/maximum refresh seconds.
+
+There are no request identifiers, paths, roots, tokens, digests, exception
+strings, per-key labels, exporters, log floods, new dependencies, new HTTP
+endpoints, or background threads. An exporter would be a separate scoped task.
+
+For a same-root burst within freshness, `refreshes` should increase once;
+`in_flight` is 0 or 1; `entries <= 4`; `current_waiters <= 32`. Repeated inventory
+errors should increase negative hits rather than refreshes until failure expiry.
+Timeouts and rejections are fail-closed availability signals, not proof of a
+healthy cache. Timing values describe this process, not production-wide SLOs.
+
+## Verification
+
+Run the new unit, byte-identity, and full-router tests along with the existing
+static cache, static resolver, PWA, semantic bridge and index-template tests
+through `./scripts/test.sh`. Legacy mutation tests must explicitly advance a
+fake monotonic clock past freshness rather than disabling the cache. Retain the
+non-root POSIX directory-permission regression and exact nanosecond assertions.
+
+Then run the complete repository suite and credential-free browser smoke on the
+rebased head. A source-helper replay does not validate HTTP middleware, browser
+service-worker lifecycle, subpath installation, authentication, gzip/304 routes,
+or the maintainer's private gate. These remain separate certification steps.

--- a/static/pwa-startup.js
+++ b/static/pwa-startup.js
@@ -5,6 +5,32 @@
   'use strict';
   var root=document.documentElement;
 
+  // The server stamps one asset fingerprint token into shell URLs and this page,
+  // but stale-client detection compares a semantic WebUI version. Keep those
+  // identities separate: retain the raw asset token for cache/debug consumers
+  // while exposing only the release version through the historical bundle
+  // global consumed by checkWebUIVersionSkew().
+  function semanticBundleVersion(value){
+    if(value===null||value===undefined) return '';
+    var raw=String(value);
+    var decoded=raw;
+    try{decoded=decodeURIComponent(raw);}catch(_){}
+    return decoded.replace(/\+a[0-9a-f]{10}$/i,'');
+  }
+  try{
+    var bundleVersion='';
+    Object.defineProperty(window,'__HERMES_WEBUI_BUNDLE_VERSION__',{
+      configurable:true,
+      enumerable:true,
+      get:function(){return bundleVersion;},
+      set:function(value){
+        var raw=value===null||value===undefined?'':String(value);
+        window.__HERMES_WEBUI_ASSET_VERSION__=raw;
+        bundleVersion=semanticBundleVersion(raw);
+      }
+    });
+  }catch(_){}
+
   function mql(query){
     try{return window.matchMedia&&window.matchMedia(query).matches;}catch(_){return false;}
   }

--- a/tests/test_asset_identity_cache.py
+++ b/tests/test_asset_identity_cache.py
@@ -1,0 +1,444 @@
+"""Deterministic state/lifecycle coverage for shared static-tree freshness."""
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import os
+from queue import Queue
+import tempfile
+import threading
+import unittest
+from unittest.mock import patch
+
+from api.asset_identity_cache import AssetIdentityCache
+
+
+class Clock:
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds=1.0):
+        self.now += seconds
+
+
+class ObservedCondition(threading.Condition):
+    """Observe actual waiter registration rather than guessing with sleeps."""
+    def __init__(self):
+        super().__init__(threading.Lock())
+        self.wait_started = Queue()
+
+    def wait(self, timeout=None):
+        self.wait_started.put(threading.get_ident())
+        return super().wait(timeout)
+
+    def registered(self, count):
+        seen = set()
+        while len(seen) < count:
+            seen.add(self.wait_started.get(timeout=5))
+
+
+class AssetIdentityCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = Clock()
+        self.cache = AssetIdentityCache(clock=self.clock, wait_seconds=5)
+        self.root = Path("static")
+
+    def test_warm_result_reuses_completed_content_identity(self):
+        calls = []
+        compute = lambda root: calls.append(root) or "first"
+        self.assertEqual(self.cache.get(self.root, compute), "first")
+        for _ in range(100):
+            self.assertEqual(self.cache.get(self.root, compute), "first")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(self.cache.snapshot()["cache_hits"], 100)
+
+    def test_expiry_boundary_recomputes(self):
+        self.assertEqual(self.cache.get(self.root, lambda _: "first"), "first")
+        self.clock.advance(0.999)
+        self.assertEqual(self.cache.get(self.root, lambda _: "second"), "first")
+        self.clock.advance(0.001)
+        self.assertEqual(self.cache.get(self.root, lambda _: "second"), "second")
+
+    def test_freshness_starts_at_completion_not_scan_start(self):
+        def slow_scan(_):
+            self.clock.advance(30)
+            return "first"
+        self.cache.get(self.root, slow_scan)
+        self.clock.advance(0.5)
+        self.assertEqual(self.cache.get(self.root, lambda _: "second"), "first")
+        self.assertEqual(self.cache.snapshot()["refreshes"], 1)
+
+    def test_failure_is_shared_until_short_expiry_then_recovers(self):
+        calls = []
+        def fail(_):
+            calls.append(1)
+            raise PermissionError("do-not-export-this-path")
+        self.assertIsNone(self.cache.get(self.root, fail))
+        self.clock.advance(0.249)
+        self.assertIsNone(self.cache.get(self.root, lambda _: "repaired"))
+        self.clock.advance(0.001)
+        self.assertEqual(self.cache.get(self.root, lambda _: "repaired"), "repaired")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(self.cache.snapshot()["refresh_failures"], 1)
+
+    def test_ordinary_exception_classes_all_fail_closed(self):
+        for error in (PermissionError, FileNotFoundError, OSError, RuntimeError):
+            with self.subTest(error=error):
+                cache = AssetIdentityCache()
+                def fail(_, error=error):
+                    raise error("private-detail")
+                self.assertIsNone(cache.get(self.root, fail))
+                self.assertEqual(cache.snapshot()["in_flight"], 0)
+                self.assertEqual(cache.snapshot()["refresh_failures"], 1)
+
+    def test_invalid_compute_result_cannot_authorize_identity(self):
+        for value in (None, "", 10, {}, b"digest"):
+            with self.subTest(value=value):
+                cache = AssetIdentityCache()
+                self.assertIsNone(cache.get(self.root, lambda _, value=value: value))
+                self.assertEqual(cache.snapshot()["refresh_failures"], 1)
+
+    def _burst(self, *, failure=False, expired=False):
+        cache = self.cache
+        observed = ObservedCondition()
+        cache._condition = observed
+        if expired:
+            cache.get(self.root, lambda _: "old")
+            self.clock.advance(1)
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        def scan(_):
+            calls.append(1)
+            started.set()
+            if not release.wait(5):
+                raise AssertionError("scan was not released")
+            if failure:
+                raise PermissionError("private-path")
+            return "fresh"
+        with ThreadPoolExecutor(max_workers=17) as pool:
+            leader = pool.submit(cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                followers = [pool.submit(cache.get, self.root, scan) for _ in range(16)]
+                observed.registered(16)
+                self.assertEqual(cache.snapshot()["current_waiters"], 16)
+                self.assertEqual(len(calls), 1)
+            finally:
+                release.set()
+            expected = None if failure else "fresh"
+            self.assertEqual(leader.result(5), expected)
+            for future in followers:
+                self.assertEqual(future.result(5), expected)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(cache.snapshot()["shared_results"], 16)
+        self.assertEqual(cache.snapshot()["current_waiters"], 0)
+        self.assertEqual(cache.snapshot()["in_flight"], 0)
+
+    def test_cold_burst_has_exactly_one_scan(self):
+        self._burst()
+
+    def test_expired_burst_has_exactly_one_scan(self):
+        self._burst(expired=True)
+
+    def test_failed_burst_has_exactly_one_scan(self):
+        self._burst(failure=True)
+
+    def test_hashing_runs_outside_coordination_lock(self):
+        started, release = threading.Event(), threading.Event()
+        def scan(_):
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "fresh"
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            leader = pool.submit(self.cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                # This thread must acquire the same non-reentrant lock while
+                # the scanning thread is still inside the filesystem callback.
+                snap = pool.submit(self.cache.snapshot).result(2)
+                self.assertEqual(snap["in_flight"], 1)
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "fresh")
+
+    def test_waiter_cap_fails_closed_without_extra_scan(self):
+        cache = AssetIdentityCache(max_waiters=2, wait_seconds=5)
+        observed = ObservedCondition()
+        cache._condition = observed
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        def scan(_):
+            calls.append(1)
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "fresh"
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            leader = pool.submit(cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                followers = [pool.submit(cache.get, self.root, scan) for _ in range(2)]
+                observed.registered(2)
+                self.assertIsNone(pool.submit(cache.get, self.root, scan).result(2))
+                self.assertEqual(cache.snapshot()["peak_waiters"], 2)
+                self.assertEqual(cache.snapshot()["wait_rejections"], 1)
+                self.assertEqual(calls, [1])
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "fresh")
+            self.assertEqual([f.result(5) for f in followers], ["fresh"] * 2)
+
+    def test_wait_timeout_never_starts_a_replacement_scan(self):
+        cache = AssetIdentityCache(wait_seconds=0.02, clock=self.clock)
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        def scan(_):
+            calls.append(1)
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "fresh"
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            leader = pool.submit(cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                self.assertIsNone(cache.get(self.root, scan))
+                self.assertIsNone(cache.get(Path("other-root"), scan))
+                self.assertEqual(cache.snapshot()["wait_timeouts"], 2)
+                self.assertEqual(cache.snapshot()["current_waiters"], 0)
+                self.assertEqual(cache.snapshot()["in_flight"], 1)
+                self.assertEqual(calls, [1])
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "fresh")
+        self.assertEqual(cache.get(self.root, lambda _: "wrong"), "fresh")
+
+    def test_expired_success_is_not_served_on_timeout(self):
+        cache = AssetIdentityCache(wait_seconds=0.02, clock=self.clock)
+        cache.get(self.root, lambda _: "old")
+        self.clock.advance(1)
+        started, release = threading.Event(), threading.Event()
+        def scan(_):
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "new"
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            leader = pool.submit(cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                self.assertIsNone(cache.get(self.root, scan))
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "new")
+
+    def test_base_exception_releases_waiters_and_allows_retry(self):
+        observed = ObservedCondition()
+        self.cache._condition = observed
+        started, release = threading.Event(), threading.Event()
+        def abort(_):
+            started.set()
+            self.assertTrue(release.wait(5))
+            raise KeyboardInterrupt("test-only cancellation")
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            leader = pool.submit(self.cache.get, self.root, abort)
+            try:
+                self.assertTrue(started.wait(5))
+                follower = pool.submit(self.cache.get, self.root, lambda _: "bad")
+                observed.registered(1)
+            finally:
+                release.set()
+            with self.assertRaises(KeyboardInterrupt):
+                leader.result(5)
+            self.assertIsNone(follower.result(5))
+        self.assertEqual(self.cache.snapshot()["in_flight"], 0)
+        self.assertEqual(self.cache.snapshot()["current_waiters"], 0)
+        self.clock.advance(0.25)
+        self.assertEqual(self.cache.get(self.root, lambda _: "recovered"), "recovered")
+
+    def test_different_roots_serialize_without_identity_leak(self):
+        observed = ObservedCondition()
+        self.cache._condition = observed
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        def first(_):
+            calls.append("first-start")
+            started.set()
+            self.assertTrue(release.wait(5))
+            calls.append("first-end")
+            return "identity-a"
+        def second(_):
+            calls.append("second")
+            return "identity-b"
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            a = pool.submit(self.cache.get, Path("a"), first)
+            try:
+                self.assertTrue(started.wait(5))
+                b = pool.submit(self.cache.get, Path("b"), second)
+                observed.registered(1)
+                self.assertEqual(calls, ["first-start"])
+            finally:
+                release.set()
+            self.assertEqual(a.result(5), "identity-a")
+            self.assertEqual(b.result(5), "identity-b")
+        self.assertEqual(calls, ["first-start", "first-end", "second"])
+
+    def test_spurious_wakeup_does_not_start_another_scan(self):
+        observed = ObservedCondition()
+        self.cache._condition = observed
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        def scan(_):
+            calls.append(1)
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "fresh"
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            leader = pool.submit(self.cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                follower = pool.submit(self.cache.get, self.root, scan)
+                observed.registered(1)
+                with observed:
+                    observed.notify_all()
+                observed.registered(1)
+                self.assertFalse(follower.done())
+                self.assertEqual(calls, [1])
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "fresh")
+            self.assertEqual(follower.result(5), "fresh")
+
+    def test_bounded_root_entries(self):
+        for index in range(100):
+            self.cache.get(Path(f"root-{index}"), lambda root: str(root))
+            self.assertLessEqual(self.cache.snapshot()["entries"], 4)
+        self.assertEqual(self.cache.snapshot()["evictions"], 96)
+
+    def test_failure_entries_also_obey_capacity(self):
+        def fail(_):
+            raise FileNotFoundError("no file")
+        for index in range(100):
+            self.cache.get(Path(f"missing-{index}"), fail)
+        self.assertEqual(self.cache.snapshot()["entries"], 4)
+        self.assertEqual(self.cache.snapshot()["evictions"], 96)
+
+    def test_lru_reuse_and_eviction(self):
+        cache = AssetIdentityCache(max_entries=2, clock=self.clock)
+        for root in ("a", "b", "a", "c"):
+            cache.get(Path(root), lambda root: str(root))
+        self.assertEqual(cache.snapshot()["refreshes"], 3)
+        cache.get(Path("a"), lambda _: "wrong")
+        self.assertEqual(cache.snapshot()["refreshes"], 3)
+        cache.get(Path("b"), lambda _: "b-again")
+        self.assertEqual(cache.snapshot()["refreshes"], 4)
+
+    def test_root_change_never_reuses_another_roots_identity(self):
+        a, b = Path("a"), Path("b")
+        self.assertEqual(self.cache.get(a, lambda _: "A"), "A")
+        self.assertEqual(self.cache.get(b, lambda _: "B"), "B")
+        self.assertEqual(self.cache.get(a, lambda _: "bad"), "A")
+
+    def test_wall_clock_changes_do_not_affect_freshness(self):
+        self.cache.get(self.root, lambda _: "A")
+        with patch("time.time", return_value=-1e20):
+            self.assertEqual(self.cache.get(self.root, lambda _: "bad"), "A")
+        self.clock.advance(1)
+        with patch("time.time", return_value=1e20):
+            self.assertEqual(self.cache.get(self.root, lambda _: "B"), "B")
+
+    def test_warm_hit_has_no_static_filesystem_operations(self):
+        self.cache.get(self.root, lambda _: "A")
+        with patch.object(Path, "resolve", side_effect=AssertionError("resolve")), \
+             patch.object(Path, "stat", side_effect=AssertionError("stat")), \
+             patch.object(Path, "read_bytes", side_effect=AssertionError("read")), \
+             patch("os.scandir", side_effect=AssertionError("walk")):
+            self.assertEqual(self.cache.get(self.root, lambda _: "bad"), "A")
+
+    def test_relative_and_absolute_paths_share(self):
+        self.cache.get(self.root, lambda _: "A")
+        self.assertEqual(self.cache.get(self.root.absolute(), lambda _: "bad"), "A")
+        self.assertEqual(self.cache.snapshot()["refreshes"], 1)
+
+    @unittest.skipUnless(os.name == "posix", "symlink traversal requires POSIX")
+    def test_symlink_parent_traversal_is_not_lexically_collapsed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / "a" / "assets").mkdir(parents=True)
+            (base / "b" / "nested").mkdir(parents=True)
+            (base / "b" / "assets").mkdir()
+            (base / "a" / "link").symlink_to(base / "b" / "nested", target_is_directory=True)
+            root = base / "a" / "link" / ".." / "assets"
+            actual = self.cache.get(root, lambda path: str(path.resolve()))
+            self.assertEqual(actual, str(base / "b" / "assets"))
+
+    def test_telemetry_is_fixed_cardinality_and_detached(self):
+        self.cache.get(Path("private-root-not-for-metrics"), lambda _: "private-digest")
+        snap = self.cache.snapshot()
+        self.assertEqual(snap["requests"], 1)
+        self.assertEqual(snap["refresh_successes"], 1)
+        self.assertEqual(snap["entries"], 1)
+        self.assertGreaterEqual(snap["total_refresh_seconds"], 0)
+        self.assertNotIn("private", repr(snap))
+        self.assertTrue(all(isinstance(v, (int, float)) for v in snap.values()))
+        snap["requests"] = -1
+        self.assertEqual(self.cache.snapshot()["requests"], 1)
+        keys = set(snap)
+        for index in range(20):
+            self.cache.get(Path(str(index)), lambda _: "digest")
+        self.assertEqual(set(self.cache.snapshot()), keys)
+
+    def test_failed_root_does_not_poison_another_completed_root(self):
+        self.cache.get(Path("healthy"), lambda _: "healthy-digest")
+        def fail(_):
+            raise OSError("failure")
+        self.assertIsNone(self.cache.get(Path("failed"), fail))
+        self.assertEqual(self.cache.get(Path("healthy"), lambda _: "wrong"), "healthy-digest")
+
+    def test_publication_failure_also_releases_the_flight(self):
+        calls = [0]
+        def broken_clock():
+            calls[0] += 1
+            if calls[0] == 1:
+                raise RuntimeError("clock failed during publication")
+            return 100.0
+        cache = AssetIdentityCache(clock=broken_clock)
+        with self.assertRaisesRegex(RuntimeError, "clock failed"):
+            cache.get(self.root, lambda _: "unpublished")
+        self.assertEqual(cache.snapshot()["in_flight"], 0)
+        self.assertEqual(cache.snapshot()["entries"], 0)
+        self.assertEqual(cache.get(self.root, lambda _: "retry"), "retry")
+
+    def test_interrupted_wait_releases_waiter_slot_not_leader(self):
+        class InterruptedCondition(threading.Condition):
+            def wait(self, timeout=None):
+                raise KeyboardInterrupt("follower interrupted")
+        self.cache._condition = InterruptedCondition(threading.Lock())
+        started, release = threading.Event(), threading.Event()
+        def scan(_):
+            started.set()
+            self.assertTrue(release.wait(5))
+            return "finished"
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            leader = pool.submit(self.cache.get, self.root, scan)
+            try:
+                self.assertTrue(started.wait(5))
+                with self.assertRaises(KeyboardInterrupt):
+                    self.cache.get(self.root, lambda _: "wrong")
+                self.assertEqual(self.cache.snapshot()["current_waiters"], 0)
+                self.assertEqual(self.cache.snapshot()["in_flight"], 1)
+            finally:
+                release.set()
+            self.assertEqual(leader.result(5), "finished")
+
+    def test_invalid_limits_rejected(self):
+        for option in ("freshness_seconds", "failure_seconds", "wait_seconds"):
+            for value in (0, -1, float("nan"), float("inf")):
+                with self.subTest(option=option, value=value), self.assertRaises(ValueError):
+                    AssetIdentityCache(**{option: value})
+        for option in ("max_entries", "max_waiters"):
+            for value in (0, -1, 1.5):
+                with self.subTest(option=option, value=value), self.assertRaises(ValueError):
+                    AssetIdentityCache(**{option: value})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_asset_identity_deadlines.py
+++ b/tests/test_asset_identity_deadlines.py
@@ -1,0 +1,125 @@
+"""Delayed follower freshness and absolute-wait-deadline regressions."""
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import threading
+import unittest
+from unittest.mock import patch
+
+from api.asset_identity_cache import AssetIdentityCache
+
+
+class Clock:
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds=1.0):
+        self.now += seconds
+
+
+class AssetIdentityDeadlineTests(unittest.TestCase):
+    """Model a notified follower not being scheduled until after a deadline."""
+
+    def delayed_follower(self, *, other_root=False, expire_freshness=False,
+                         expire_wait=False, failure=False):
+        from types import SimpleNamespace
+        import api.asset_identity_cache as cache_module
+
+        fresh_clock, wait_clock = Clock(), Clock()
+        cache = AssetIdentityCache(clock=fresh_clock, wait_seconds=5)
+        started, release, waiting = (threading.Event() for _ in range(3))
+        calls = []
+
+        class DelayedCondition(threading.Condition):
+            def wait(self, timeout=None):
+                waiting.set()
+                return super().wait(timeout)
+
+            def wait_for(self, predicate, timeout=None):
+                completed = super().wait_for(predicate, timeout)
+                if completed:
+                    # Completion really happened. Advance the clocks to model
+                    # scheduling/lock contention before this follower resumes.
+                    if expire_freshness:
+                        fresh_clock.advance(2)
+                    if expire_wait:
+                        wait_clock.advance(6)
+                return completed
+
+        cache._condition = DelayedCondition(threading.Lock())
+
+        def compute(root):
+            calls.append(root.name)
+            started.set()
+            if not release.wait(5):
+                raise AssertionError("test failed to release leader")
+            if failure:
+                raise PermissionError("controlled scan failure")
+            return "fresh"
+
+        # Patch this module's clock handle, not threading's real timeout clock.
+        with patch.object(cache_module, "time", SimpleNamespace(monotonic=wait_clock)):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                leader = pool.submit(cache.get, Path("a"), compute)
+                try:
+                    self.assertTrue(started.wait(5))
+                    follower = pool.submit(cache.get, Path("b" if other_root else "a"), compute)
+                    self.assertTrue(waiting.wait(5))
+                finally:
+                    release.set()
+                self.assertEqual(leader.result(5), None if failure else "fresh")
+                result = follower.result(5)
+        return result, calls, cache.snapshot()
+
+    def test_completed_generation_cannot_bypass_freshness(self):
+        result, calls, stats = self.delayed_follower(expire_freshness=True)
+        self.assertIsNone(result, "a delayed follower received an expired identity")
+        self.assertEqual(calls, ["a"], "expiry must not turn followers into new scans")
+        self.assertEqual(stats.get("expired_shared_results", 0), 1)
+        self.assertEqual(stats["current_waiters"], 0)
+        self.assertEqual(stats["in_flight"], 0)
+
+    def test_completed_generation_cannot_bypass_wait_budget(self):
+        result, calls, stats = self.delayed_follower(expire_wait=True)
+        self.assertIsNone(result, "completion must not erase the follower deadline")
+        self.assertEqual(calls, ["a"])
+        self.assertEqual(stats["wait_timeouts"], 1)
+
+    def test_other_root_cannot_start_hashing_after_wait_budget(self):
+        result, calls, stats = self.delayed_follower(other_root=True, expire_wait=True)
+        self.assertIsNone(result, "expired cross-root follower must not become a leader")
+        self.assertEqual(calls, ["a"], "a second root scanned after its wait deadline")
+        self.assertEqual(stats["wait_timeouts"], 1)
+
+    def test_unexpired_completed_generation_is_shared(self):
+        result, calls, stats = self.delayed_follower()
+        self.assertEqual(result, "fresh")
+        self.assertEqual(calls, ["a"])
+        self.assertEqual(stats["shared_results"], 1)
+
+    def test_cross_root_follower_with_budget_can_scan_its_own_root(self):
+        result, calls, stats = self.delayed_follower(other_root=True)
+        self.assertEqual(result, "fresh")
+        self.assertEqual(calls, ["a", "b"])
+        self.assertEqual(stats["refreshes"], 2)
+
+    def test_delayed_negative_generation_still_fails_closed(self):
+        result, calls, stats = self.delayed_follower(expire_freshness=True, failure=True)
+        self.assertIsNone(result)
+        self.assertEqual(calls, ["a"])
+        self.assertEqual(stats.get("expired_shared_results", 0), 1)
+        self.assertEqual(stats["refresh_failures"], 1)
+
+    def test_boolean_entry_limit_is_rejected(self):
+        with self.assertRaises(ValueError):
+            AssetIdentityCache(max_entries=True)
+
+    def test_boolean_waiter_limit_is_rejected(self):
+        with self.assertRaises(ValueError):
+            AssetIdentityCache(max_waiters=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_index_shell_template_cache.py
+++ b/tests/test_index_shell_template_cache.py
@@ -15,19 +15,18 @@ from __future__ import annotations
 import json
 import os
 import time
-from urllib.parse import quote
 
 import api.config as api_config
 import api.routes as routes
-from api.updates import WEBUI_VERSION
 
 
 def _old_inline_render(csrf_token: str) -> str:
     """Reproduce the pre-cache inline render exactly, for equivalence checks."""
     index_path = api_config.get_index_html_path()
+    version_token = routes._assets_cache_bust_token(api_config.get_static_root())
     return (
         index_path.read_text(encoding="utf-8")
-        .replace("__WEBUI_VERSION__", quote(WEBUI_VERSION, safe=""))
+        .replace("__WEBUI_VERSION__", version_token)
         .replace("__MAX_UPLOAD_BYTES__", str(routes.MAX_UPLOAD_BYTES))
         .replace("__CSRF_TOKEN_JSON__", json.dumps(csrf_token))
     )

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -175,9 +175,19 @@ class TestPWARoutes:
         idx = src.find('"/sw.js"')
         assert idx != -1, "routes.py must handle /sw.js"
         block = src[idx:idx + 1200]
-        assert "quote(WEBUI_VERSION, safe=\"\")" in block, (
-            "sw.js route must URL-encode the injected cache version so unusual git tags "
-            "cannot break the JavaScript string literal"
+        assert "_assets_cache_bust_token" in block, (
+            "sw.js route must derive the cache version from _assets_cache_bust_token, "
+            "which URL-encodes this version"
+        )
+        helper_idx = src.find("def _assets_cache_bust_token")
+        assert helper_idx != -1, "routes.py must define _assets_cache_bust_token"
+        helper_block = src[helper_idx:helper_idx + 1200]
+        assert 'quote(f"{WEBUI_VERSION}+a{fingerprint.hexdigest()[:10]}", safe="")' in helper_block, (
+            "the helper must URL-encode the cache-busting version token before "
+            "it is injected into the service-worker cache name"
+        )
+        assert 'return quote(WEBUI_VERSION, safe="")' in helper_block, (
+            "the helper must fail soft to the plain URL-encoded version token"
         )
 
     def test_sw_route_sets_service_worker_allowed(self):
@@ -361,9 +371,10 @@ class TestIndexHtmlIntegration:
                 idx = src.find('parsed.path.startswith("/session/")')
             assert idx != -1, "routes.py must handle /, /index.html, and /session/<id>"
             block = src[idx:idx + 800]
-        assert "quote(WEBUI_VERSION, safe=\"\")" in block, (
-            "the app-shell render must URL-encode the cache-busting version token before "
-            "injecting it into script src attributes and service worker registration"
+        assert "_assets_cache_bust_token" in block, (
+            "the app-shell render must derive the cache-busting version token from "
+            "_assets_cache_bust_token (URL-encoded) before injecting it into script src "
+            "attributes and service worker registration"
         )
 
     def test_index_sw_registration_uses_relative_path(self):

--- a/tests/test_pwa_semantic_version_bridge.py
+++ b/tests/test_pwa_semantic_version_bridge.py
@@ -1,0 +1,83 @@
+"""Behavioral regression coverage for semantic bundle version vs asset fingerprint."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PWA_STARTUP = ROOT / "static" / "pwa-startup.js"
+
+
+def _run_stamp(stamp: str) -> dict[str, str]:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is required for PWA startup behavior tests")
+    source = PWA_STARTUP.read_text(encoding="utf-8")
+    script = f"""
+const vm = require('vm');
+const source = {json.dumps(source)};
+const classes = {{ toggle(){{}}, add(){{}}, remove(){{}} }};
+global.document = {{
+  documentElement: {{ classList: classes, dataset: {{}} }},
+  addEventListener() {{}},
+  visibilityState: 'visible',
+}};
+global.window = {{
+  navigator: {{
+    standalone: false,
+    userAgent: '',
+    platform: '',
+    maxTouchPoints: 0,
+    onLine: true,
+  }},
+  matchMedia() {{
+    return {{ matches: false, addEventListener() {{}}, addListener() {{}} }};
+  }},
+  addEventListener() {{}},
+  dispatchEvent() {{}},
+  setTimeout() {{}},
+}};
+global.CustomEvent = function() {{}};
+vm.runInThisContext(source);
+window.__HERMES_WEBUI_BUNDLE_VERSION__ = {json.dumps(stamp)};
+process.stdout.write(JSON.stringify({{
+  bundle: String(window.__HERMES_WEBUI_BUNDLE_VERSION__ || ''),
+  asset: String(window.__HERMES_WEBUI_ASSET_VERSION__ || ''),
+}}));
+"""
+    proc = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_asset_fingerprint_does_not_change_semantic_bundle_version():
+    result = _run_stamp("v0.52.294%2Ba0123456789")
+    assert result == {
+        "bundle": "v0.52.294",
+        "asset": "v0.52.294%2Ba0123456789",
+    }
+
+
+def test_plain_release_version_keeps_existing_semantics():
+    result = _run_stamp("v0.52.294")
+    assert result == {
+        "bundle": "v0.52.294",
+        "asset": "v0.52.294",
+    }
+
+
+def test_unrelated_semver_build_metadata_is_not_stripped():
+    result = _run_stamp("v0.52.294%2Blinux")
+    assert result == {
+        "bundle": "v0.52.294+linux",
+        "asset": "v0.52.294%2Blinux",
+    }

--- a/tests/test_static_asset_compression_and_cache.py
+++ b/tests/test_static_asset_compression_and_cache.py
@@ -7,11 +7,11 @@ Pre-fix shape:
   static/index.html and static/sw.js carries `?v=__WEBUI_VERSION__`
   fingerprinting that already guarantees a fresh URL on redeploy.
 
-Fix: _serve_static now negotiates gzip when the client opts in, emits
-weak ETags for conditional GETs, and sends `max-age=31536000, immutable`
-when the request URL carries a `?v=…` fingerprint (`max-age=300`
-otherwise). Bytes + headers are cached in-process and invalidated on
-(size, mtime) change so a redeploy is picked up without a restart.
+Fix: _serve_static now negotiates gzip when the client opts in and emits
+byte-derived weak ETags for conditional GETs. Because this checkout is mutable
+in place and `?v=` is client-controlled, every static URL uses conservative
+revalidation. Bytes are read and hashed on each request so metadata-preserving
+replacements cannot reuse stale cache entries.
 
 These tests pin both halves — header policy AND the cache-invalidation
 contract — so future refactors of _serve_static cannot silently
@@ -19,6 +19,9 @@ re-introduce no-store or break the gzip/304 path.
 """
 
 import gzip
+import hashlib
+import os
+import threading
 from types import SimpleNamespace
 from urllib.parse import urlparse
 
@@ -101,7 +104,7 @@ def test_plain_get_returns_raw_bytes_with_etag(isolated_static):
     assert h.header("Content-Type") == "application/javascript; charset=utf-8"
     assert h.header("Content-Encoding") is None  # no gzip without Accept-Encoding
     assert h.header("ETag") is not None and h.header("ETag").startswith('W/"')
-    assert h.header("Cache-Control") == "public, max-age=300"  # no fingerprint
+    assert h.header("Cache-Control") == "public, max-age=0, must-revalidate"
     assert bytes(h.body) == payload
 
 
@@ -118,29 +121,29 @@ def test_gzip_negotiated_when_client_accepts(isolated_static):
     assert int(h.header("Content-Length")) == len(h.body) < len(payload)
 
 
-def test_fingerprinted_url_gets_immutable_cache(isolated_static):
+def test_fingerprinted_url_still_revalidates(isolated_static):
     from api import routes
     _make_static_file(isolated_static, "ui.js", b"x" * 2000)
 
     h = _serve(routes, "/static/ui.js", query="v=abc1234")
-    assert h.header("Cache-Control") == "public, max-age=31536000, immutable"
+    assert h.header("Cache-Control") == "public, max-age=0, must-revalidate"
 
 
-def test_empty_fingerprint_value_gets_short_cache(isolated_static):
-    """Only a non-empty version token is an immutable-cache fingerprint."""
+def test_empty_fingerprint_value_gets_revalidation(isolated_static):
+    """Client-controlled query values never make mutable bytes immutable."""
     from api import routes
     _make_static_file(isolated_static, "ui.js", b"x" * 2000)
 
     h = _serve(routes, "/static/ui.js", query="v=")
-    assert h.header("Cache-Control") == "public, max-age=300"
+    assert h.header("Cache-Control") == "public, max-age=0, must-revalidate"
 
 
-def test_unfingerprinted_url_gets_short_cache(isolated_static):
+def test_unfingerprinted_url_gets_revalidation(isolated_static):
     from api import routes
     _make_static_file(isolated_static, "ui.js", b"x" * 2000)
 
     h = _serve(routes, "/static/ui.js")
-    assert h.header("Cache-Control") == "public, max-age=300"
+    assert h.header("Cache-Control") == "public, max-age=0, must-revalidate"
 
 
 def test_conditional_get_returns_304(isolated_static):
@@ -155,7 +158,7 @@ def test_conditional_get_returns_304(isolated_static):
                     request_headers={"If-None-Match": etag})
     assert second.status == 304
     assert second.header("ETag") == etag
-    assert second.header("Cache-Control") == "public, max-age=31536000, immutable"
+    assert second.header("Cache-Control") == "public, max-age=0, must-revalidate"
     assert second.header("Vary") == "Accept-Encoding"
     assert bytes(second.body) == b""
 
@@ -200,6 +203,113 @@ def test_etag_changes_for_same_size_edits_within_same_second(isolated_static):
     second_response = _serve(routes, "/static/ui.js")
     assert second_response.header("ETag") != etag_v1
     assert bytes(second_response.body) == b"b" * 2048
+
+
+def test_same_size_same_mtime_replacement_returns_new_bytes(isolated_static):
+    """A metadata-equal replacement cannot reuse the prior buffer or ETag."""
+    import os
+    from api import routes
+
+    (isolated_static / "nested").mkdir()
+    path = _make_static_file(isolated_static, "nested/ui.js", b"a" * 512)
+    stamp_ns = 1_900_000_000_123_456_789
+    os.utime(path, ns=(stamp_ns, stamp_ns))
+    first = _serve(routes, "/static/nested/ui.js")
+
+    path.write_bytes(b"b" * 512)
+    os.utime(path, ns=(stamp_ns, stamp_ns))
+    second = _serve(routes, "/static/nested/ui.js")
+
+    assert bytes(second.body) == b"b" * 512
+    assert second.header("ETag") != first.header("ETag")
+    stale = _serve(
+        routes,
+        "/static/nested/ui.js",
+        request_headers={"If-None-Match": first.header("ETag")},
+    )
+    assert stale.status == 200
+    assert bytes(stale.body) == b"b" * 512
+
+
+def test_update_after_identity_returns_current_revalidated_bytes(
+    isolated_static, monkeypatch
+):
+    """A stale revision cannot make an interleaved replacement immutable.
+
+    The shell inventory and a later static read are necessarily separate
+    filesystem operations in a mutable checkout. This coordinates an update
+    between them, after first populating the gzip cache with the old bytes,
+    and proves that the static response still describes the bytes it read.
+    """
+    from api import routes
+
+    index_path = isolated_static / "index.html"
+    index_path.write_text("__WEBUI_VERSION__", encoding="utf-8")
+    monkeypatch.setattr(api_config, "get_index_html_path", lambda: index_path)
+    monkeypatch.setattr(routes, "_INDEX_SHELL_CACHE", {})
+
+    path = _make_static_file(isolated_static, "ui.js", b"a" * 4096)
+    first = _serve(
+        routes,
+        "/static/ui.js",
+        request_headers={"Accept-Encoding": "gzip"},
+    )
+    old_etag = first.header("ETag")
+
+    real_token = routes._assets_cache_bust_token
+    identity_captured = threading.Event()
+    replacement_written = threading.Event()
+
+    def token_captured_before_replacement(static_root):
+        token = real_token(static_root)
+        identity_captured.set()
+        assert replacement_written.wait(timeout=2), "test update did not run"
+        return token
+
+    monkeypatch.setattr(
+        routes, "_assets_cache_bust_token", token_captured_before_replacement
+    )
+    rendered: dict[str, str] = {}
+
+    def render_shell():
+        rendered["base"] = routes._render_index_shell_base()
+
+    shell_thread = threading.Thread(target=render_shell)
+    shell_thread.start()
+    assert identity_captured.wait(timeout=2), "identity scan did not run"
+
+    stat = path.stat()
+    path.write_bytes(b"b" * 4096)
+    os.utime(path, (stat.st_atime, stat.st_mtime))
+    replacement_written.set()
+    shell_thread.join(timeout=2)
+    assert not shell_thread.is_alive()
+    stale_token = rendered["base"]
+
+    current = _serve(
+        routes,
+        "/static/ui.js",
+        query=f"v={stale_token}",
+        request_headers={"Accept-Encoding": "gzip"},
+    )
+    expected_digest = hashlib.sha256(b"b" * 4096).hexdigest()
+    assert current.status == 200
+    assert gzip.decompress(bytes(current.body)) == b"b" * 4096
+    assert current.header("ETag") == f'W/"{expected_digest}"'
+    assert current.header("Cache-Control") == "public, max-age=0, must-revalidate"
+    assert current.header("Vary") == "Accept-Encoding"
+
+    stale = _serve(
+        routes,
+        "/static/ui.js",
+        query=f"v={stale_token}",
+        request_headers={
+            "Accept-Encoding": "gzip",
+            "If-None-Match": old_etag,
+        },
+    )
+    assert stale.status == 200
+    assert gzip.decompress(bytes(stale.body)) == b"b" * 4096
 
 
 def test_image_is_not_gzipped(isolated_static):

--- a/tests/test_static_asset_resolver.py
+++ b/tests/test_static_asset_resolver.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from urllib.parse import quote
 
 import api.config as api_config
 import api.routes as routes
-from api.updates import WEBUI_VERSION
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -82,7 +80,7 @@ def test_service_worker_and_favicon_follow_selected_static_root(tmp_path, monkey
 
     sw_handler = _get("/sw.js")
     expected = sw_path.read_text(encoding="utf-8").replace(
-        "__WEBUI_VERSION__", quote(WEBUI_VERSION, safe="")
+        "__WEBUI_VERSION__", routes._assets_cache_bust_token(static_root)
     ).encode("utf-8")
     assert sw_handler.status == 200
     assert sw_handler.header("Service-Worker-Allowed") == "/"

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -1,0 +1,67 @@
+"""Regression coverage for the static-shell cache-bust token.
+
+The token is derived from bundle (name, size, mtime_ns) and must change when
+any static shell asset changes, even when WEBUI_VERSION is a constant string
+(non-git installs). Without it, the service-worker cache name never changes
+and stale bundles survive indefinitely; hard refresh does not bypass
+service-worker caches.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def asset_token():
+    """Return the real _assets_cache_bust_token bound to this worktree."""
+    from api import routes
+
+    return routes._assets_cache_bust_token
+
+
+def test_token_does_not_raise_on_missing_static_root(tmp_path, asset_token):
+    """Fail-soft: a missing or empty static root returns a string, not an error."""
+    token = asset_token(tmp_path / "does-not-exist")
+    assert isinstance(token, str)
+    assert token != ""
+
+
+def test_token_changes_when_bundle_mtime_changes(tmp_path, asset_token):
+    """A bundle edit (mtime change) must produce a different cache token."""
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    bundle = static_root / "ui.js"
+    bundle.write_text("console.log(1)", encoding="utf-8")
+    first = asset_token(static_root)
+    time.sleep(0.02)
+    bundle.touch()
+    second = asset_token(static_root)
+    assert first != second, "token must change when a bundle file changes"
+
+
+def test_token_carries_fingerprint_suffix(tmp_path, asset_token):
+    """The token must differ from the bare constant version value."""
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    (static_root / "ui.js").write_text("x", encoding="utf-8")
+    (static_root / "index.html").write_text("<html></html>", encoding="utf-8")
+    token = asset_token(static_root)
+    assert "%2Ba" in token, "token must carry the asset fingerprint suffix (URL-encoded)"
+    assert token != "unknown", "token must not be the bare constant version"
+
+
+def test_sw_route_uses_bundle_fingerprint_token():
+    """Source anchor: the /sw.js route must derive its cache name from the token."""
+    routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    idx = routes_src.find('"/sw.js"')
+    assert idx != -1
+    block = routes_src[idx:idx + 1000]
+    assert "_assets_cache_bust_token(static_root)" in block, (
+        "sw.js route must derive its cache name from the bundle fingerprint"
+    )

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -320,14 +320,3 @@ def test_search_only_vendor_directory_fails_closed(tmp_path, monkeypatch):
         ).decode("utf-8")
     finally:
         vendor.chmod(0o755)
-
-
-def test_sw_route_uses_bundle_fingerprint_token():
-    """Source anchor: the /sw.js route must derive its cache name from the token."""
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
-    idx = routes_src.find('"/sw.js"')
-    assert idx != -1
-    block = routes_src[idx:idx + 1000]
-    assert "_assets_cache_bust_token(static_root)" in block, (
-        "sw.js route must derive its cache name from the bundle fingerprint"
-    )

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -42,6 +42,24 @@ def _one_pixel_png(pixel: bytes) -> bytes:
     )
 
 
+@pytest.fixture(autouse=True)
+def asset_clock(monkeypatch):
+    """Isolate real cache state and advance its monotonic freshness explicitly."""
+    from api import asset_identity_cache
+
+    now = [100.0]
+    monkeypatch.setattr(
+        asset_identity_cache,
+        "ASSET_IDENTITY_CACHE",
+        asset_identity_cache.AssetIdentityCache(clock=lambda: now[0]),
+    )
+
+    def expire():
+        now[0] += 1.0
+
+    return expire
+
+
 @pytest.fixture()
 def asset_token():
     """Return the real _assets_cache_bust_token bound to this worktree."""
@@ -57,7 +75,7 @@ def test_token_does_not_raise_on_missing_static_root(tmp_path, asset_token):
     assert token != ""
 
 
-def test_token_is_stable_for_metadata_only_touch(tmp_path, asset_token):
+def test_token_is_stable_for_metadata_only_touch(tmp_path, asset_token, asset_clock):
     """A touch without a byte edit is not a new content revision."""
     static_root = tmp_path / "static"
     static_root.mkdir()
@@ -66,6 +84,7 @@ def test_token_is_stable_for_metadata_only_touch(tmp_path, asset_token):
     first = asset_token(static_root)
     time.sleep(0.02)
     bundle.touch()
+    asset_clock()
     second = asset_token(static_root)
     assert second == first, "metadata alone must not create a new revision"
 
@@ -85,7 +104,7 @@ def test_token_is_stable_for_metadata_only_touch(tmp_path, asset_token):
     ],
 )
 def test_token_changes_for_shell_bytes_with_stable_metadata(
-    tmp_path, asset_token, relative_path, first_bytes, second_bytes
+    tmp_path, asset_token, relative_path, first_bytes, second_bytes, asset_clock
 ):
     """Byte identity—not metadata—must govern the shell revision."""
     static_root = tmp_path / "static"
@@ -102,6 +121,7 @@ def test_token_changes_for_shell_bytes_with_stable_metadata(
     restored_stat = bundle.stat()
     assert restored_stat.st_size == stat.st_size
     assert restored_stat.st_mtime_ns == stat.st_mtime_ns
+    asset_clock()
     assert asset_token(static_root) != first
 
 
@@ -138,7 +158,7 @@ class _RouteHandler:
 
 
 def test_shell_cache_and_worker_agree_after_nested_bundle_mutation(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, asset_clock
 ):
     """A bundle edit invalidates the shell even when index.html is unchanged."""
     static_root = tmp_path / "static"
@@ -172,7 +192,10 @@ def test_shell_cache_and_worker_agree_after_nested_bundle_mutation(
 
     stat = bundle.stat()
     bundle.write_bytes(b"export const value = 'bravo';\n")
-    os.utime(bundle, (stat.st_atime, stat.st_mtime))
+    os.utime(bundle, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    assert bundle.stat().st_size == stat.st_size
+    assert bundle.stat().st_mtime_ns == stat.st_mtime_ns
+    asset_clock()
 
     second_shell_token = shell_token()
     handler = _RouteHandler()
@@ -244,7 +267,7 @@ def test_unavailable_identity_does_not_authorize_cached_shell_reuse(
     )
 
 
-def test_search_only_vendor_directory_fails_closed(tmp_path, monkeypatch):
+def test_search_only_vendor_directory_fails_closed(tmp_path, monkeypatch, asset_clock):
     """A still-servable leaf beneath an unlistable vendor directory fails closed."""
     if os.name != "posix":
         pytest.skip("real 0111 directory semantics require POSIX")
@@ -302,6 +325,7 @@ def test_search_only_vendor_directory_fails_closed(tmp_path, monkeypatch):
         assert static_handler.status == 200
         assert bytes(static_handler.body) == b"export const value = 'bravo';\n"
 
+        asset_clock()
         second_token = routes._assets_cache_bust_token(static_root)
         assert not routes._asset_identity_is_available(second_token)
         assert second_token.endswith(routes._ASSET_IDENTITY_UNAVAILABLE_SUFFIX)

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -14,10 +14,11 @@ import struct
 import time
 import zlib
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import api.config as api_config
 import api.routes as routes
+from api.updates import WEBUI_VERSION
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -177,6 +178,67 @@ def test_shell_cache_and_worker_agree_after_nested_bundle_mutation(
     second_worker_token = worker_text.rsplit("hermes-shell-", 1)[1].rstrip("';\n")
     assert second_shell_token != first_shell_token
     assert second_worker_token == second_shell_token
+
+
+def test_unavailable_identity_does_not_authorize_cached_shell_reuse(
+    tmp_path, monkeypatch
+):
+    """An unreadable inventoried asset must not make version-only metadata stable."""
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    index_path = static_root / "index.html"
+    index_path.write_text(
+        'old <script src="static/ui.js?v=__WEBUI_VERSION__"></script>',
+        encoding="utf-8",
+    )
+    bundle = static_root / "ui.js"
+    bundle.write_bytes(b"alpha")
+    (static_root / "sw.js").write_text(
+        "const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';",
+        encoding="utf-8",
+    )
+    unavailable = static_root / "unreadable.txt"
+    unavailable.write_bytes(b"identity input")
+
+    monkeypatch.setattr(api_config, "get_static_root", lambda: static_root)
+    monkeypatch.setattr(api_config, "get_index_html_path", lambda: index_path)
+    monkeypatch.setattr(routes, "_INDEX_SHELL_CACHE", {})
+    real_read_bytes = Path.read_bytes
+
+    def fail_unavailable_read(path):
+        if path == unavailable:
+            raise PermissionError("controlled inventory failure")
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fail_unavailable_read)
+
+    first = routes._render_index_shell_base()
+    assert first.startswith("old ")
+    assert "base" not in routes._INDEX_SHELL_CACHE
+
+    index_stat = index_path.stat()
+    index_path.write_text(
+        'new <script src="static/ui.js?v=__WEBUI_VERSION__"></script>',
+        encoding="utf-8",
+    )
+    os.utime(index_path, ns=(index_stat.st_atime_ns, index_stat.st_mtime_ns))
+    bundle.write_bytes(b"bravo")
+    assert index_path.stat().st_mtime_ns == index_stat.st_mtime_ns
+    second = routes._render_index_shell_base()
+
+    assert second.startswith("new ")
+    assert second != first
+    assert routes._ASSET_IDENTITY_UNAVAILABLE_TOKEN in second
+    assert quote(WEBUI_VERSION, safe="") not in second
+    assert "base" not in routes._INDEX_SHELL_CACHE
+
+    worker_handler = _RouteHandler()
+    assert routes.handle_get(worker_handler, urlparse("http://test/sw.js")) is True
+    assert worker_handler.status == 503
+    assert ("Cache-Control", "no-store") in worker_handler.sent_headers
+    assert quote(WEBUI_VERSION, safe="") not in bytes(worker_handler.body).decode(
+        "utf-8"
+    )
 
 
 def test_sw_route_uses_bundle_fingerprint_token():

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -96,9 +96,12 @@ def test_token_changes_for_shell_bytes_with_stable_metadata(
     first = asset_token(static_root)
 
     bundle.write_bytes(second_bytes)
-    os.utime(bundle, (stat.st_atime, stat.st_mtime))
+    os.utime(bundle, ns=(stat.st_atime_ns, stat.st_mtime_ns))
 
     assert len(second_bytes) == len(first_bytes)
+    restored_stat = bundle.stat()
+    assert restored_stat.st_size == stat.st_size
+    assert restored_stat.st_mtime_ns == stat.st_mtime_ns
     assert asset_token(static_root) != first
 
 
@@ -239,6 +242,84 @@ def test_unavailable_identity_does_not_authorize_cached_shell_reuse(
     assert quote(WEBUI_VERSION, safe="") not in bytes(worker_handler.body).decode(
         "utf-8"
     )
+
+
+def test_search_only_vendor_directory_fails_closed(tmp_path, monkeypatch):
+    """A still-servable leaf beneath an unlistable vendor directory fails closed."""
+    if os.name != "posix":
+        pytest.skip("real 0111 directory semantics require POSIX")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("real 0111 directory semantics do not deny listing to root")
+
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    index_path = static_root / "index.html"
+    index_path.write_text(
+        '<html><script src="static/ui.js?v=__WEBUI_VERSION__"></script></html>',
+        encoding="utf-8",
+    )
+    (static_root / "ui.js").write_bytes(b"shell")
+    (static_root / "sw.js").write_text(
+        "const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';",
+        encoding="utf-8",
+    )
+    vendor = static_root / "vendor" / "private"
+    vendor.mkdir(parents=True)
+    leaf = vendor / "known-leaf.js"
+    leaf.write_bytes(b"export const value = 'alpha';\n")
+
+    monkeypatch.setattr(api_config, "get_static_root", lambda: static_root)
+    monkeypatch.setattr(api_config, "get_index_html_path", lambda: index_path)
+    monkeypatch.setattr(routes, "_INDEX_SHELL_CACHE", {})
+
+    # Prime the cache while the complete tree is readable, exactly as a process
+    # would do before a deployment directory is made search-only.
+    first_token = routes._assets_cache_bust_token(static_root)
+    assert routes._asset_identity_is_available(first_token)
+    first_shell = routes._render_index_shell_base()
+    assert "base" in routes._INDEX_SHELL_CACHE
+
+    vendor.chmod(0o111)
+    try:
+        try:
+            os.listdir(vendor)
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("0111 did not deny directory listing to this runner")
+
+        leaf_stat = leaf.stat()
+        leaf.write_bytes(b"export const value = 'bravo';\n")
+        os.utime(leaf, ns=(leaf_stat.st_atime_ns, leaf_stat.st_mtime_ns))
+        assert leaf.stat().st_size == leaf_stat.st_size
+        assert leaf.stat().st_mtime_ns == leaf_stat.st_mtime_ns
+
+        static_handler = _RouteHandler()
+        assert routes._serve_static(
+            static_handler,
+            urlparse("http://test/static/vendor/private/known-leaf.js"),
+        )
+        assert static_handler.status == 200
+        assert bytes(static_handler.body) == b"export const value = 'bravo';\n"
+
+        second_token = routes._assets_cache_bust_token(static_root)
+        assert not routes._asset_identity_is_available(second_token)
+        assert second_token.endswith(routes._ASSET_IDENTITY_UNAVAILABLE_SUFFIX)
+
+        second_shell = routes._render_index_shell_base()
+        assert routes._ASSET_IDENTITY_UNAVAILABLE_TOKEN in second_shell
+        assert second_shell is not first_shell
+        assert "base" not in routes._INDEX_SHELL_CACHE
+
+        worker_handler = _RouteHandler()
+        assert routes.handle_get(worker_handler, urlparse("http://test/sw.js")) is True
+        assert worker_handler.status == 503
+        assert ("Cache-Control", "no-store") in worker_handler.sent_headers
+        assert quote(WEBUI_VERSION, safe="") not in bytes(
+            worker_handler.body
+        ).decode("utf-8")
+    finally:
+        vendor.chmod(0o755)
 
 
 def test_sw_route_uses_bundle_fingerprint_token():

--- a/tests/test_static_cache_bust_token.py
+++ b/tests/test_static_cache_bust_token.py
@@ -1,20 +1,44 @@
 """Regression coverage for the static-shell cache-bust token.
 
-The token is derived from bundle (name, size, mtime_ns) and must change when
-any static shell asset changes, even when WEBUI_VERSION is a constant string
-(non-git installs). Without it, the service-worker cache name never changes
-and stale bundles survive indefinitely; hard refresh does not bypass
-service-worker caches.
+The token is derived from normalized resource paths and actual content bytes.
+It must change when any recursive shell resource changes, even when
+WEBUI_VERSION, file size, or mtime stays constant (non-git installs). Without
+it, the service-worker cache name never changes and stale bundles survive
+indefinitely; hard refresh does not bypass service-worker caches.
 """
 
 from __future__ import annotations
 
+import os
+import struct
 import time
+import zlib
 from pathlib import Path
+from urllib.parse import urlparse
 
+import api.config as api_config
+import api.routes as routes
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _one_pixel_png(pixel: bytes) -> bytes:
+    """Return a valid PNG so icon fixtures exercise real binary resources."""
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + kind
+            + data
+            + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"\x00" + pixel))
+        + chunk(b"IEND", b"")
+    )
 
 
 @pytest.fixture()
@@ -32,8 +56,8 @@ def test_token_does_not_raise_on_missing_static_root(tmp_path, asset_token):
     assert token != ""
 
 
-def test_token_changes_when_bundle_mtime_changes(tmp_path, asset_token):
-    """A bundle edit (mtime change) must produce a different cache token."""
+def test_token_is_stable_for_metadata_only_touch(tmp_path, asset_token):
+    """A touch without a byte edit is not a new content revision."""
     static_root = tmp_path / "static"
     static_root.mkdir()
     bundle = static_root / "ui.js"
@@ -42,7 +66,39 @@ def test_token_changes_when_bundle_mtime_changes(tmp_path, asset_token):
     time.sleep(0.02)
     bundle.touch()
     second = asset_token(static_root)
-    assert first != second, "token must change when a bundle file changes"
+    assert second == first, "metadata alone must not create a new revision"
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "first_bytes", "second_bytes"),
+    [
+        ("vendor/example/example.min.js", b"console.log('a');", b"console.log('b');"),
+        ("vendor/example/example.css", b".old{color:red}", b".new{color:tan}"),
+        ("manifest.json", b'{"name":"aaaaaa"}', b'{"name":"bbbbbb"}'),
+        ("favicon.svg", b"<svg>a</svg>", b"<svg>b</svg>"),
+        (
+            "favicon-32.png",
+            _one_pixel_png(b"\x01\x02\x03\xff"),
+            _one_pixel_png(b"\x04\x05\x06\xff"),
+        ),
+    ],
+)
+def test_token_changes_for_shell_bytes_with_stable_metadata(
+    tmp_path, asset_token, relative_path, first_bytes, second_bytes
+):
+    """Byte identity—not metadata—must govern the shell revision."""
+    static_root = tmp_path / "static"
+    bundle = static_root / relative_path
+    bundle.parent.mkdir(parents=True)
+    bundle.write_bytes(first_bytes)
+    stat = bundle.stat()
+    first = asset_token(static_root)
+
+    bundle.write_bytes(second_bytes)
+    os.utime(bundle, (stat.st_atime, stat.st_mtime))
+
+    assert len(second_bytes) == len(first_bytes)
+    assert asset_token(static_root) != first
 
 
 def test_token_carries_fingerprint_suffix(tmp_path, asset_token):
@@ -54,6 +110,73 @@ def test_token_carries_fingerprint_suffix(tmp_path, asset_token):
     token = asset_token(static_root)
     assert "%2Ba" in token, "token must carry the asset fingerprint suffix (URL-encoded)"
     assert token != "unknown", "token must not be the bare constant version"
+
+
+class _RouteHandler:
+    def __init__(self):
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.headers = {}
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+
+def test_shell_cache_and_worker_agree_after_nested_bundle_mutation(
+    tmp_path, monkeypatch
+):
+    """A bundle edit invalidates the shell even when index.html is unchanged."""
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+    index_path = static_root / "index.html"
+    index_path.write_text(
+        '<html><script src="static/ui.js?v=__WEBUI_VERSION__"></script></html>',
+        encoding="utf-8",
+    )
+    (static_root / "sw.js").write_text(
+        "const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';",
+        encoding="utf-8",
+    )
+    bundle = static_root / "vendor" / "nested.js"
+    bundle.parent.mkdir()
+    bundle.write_bytes(b"export const value = 'alpha';\n")
+    monkeypatch.setattr(api_config, "get_static_root", lambda: static_root)
+    monkeypatch.setattr(api_config, "get_index_html_path", lambda: index_path)
+    monkeypatch.setattr(routes, "_INDEX_SHELL_CACHE", {})
+
+    def shell_token() -> str:
+        shell_handler = _RouteHandler()
+        routes.handle_get(shell_handler, urlparse("http://test/"))
+        assert shell_handler.status == 200
+        html = bytes(shell_handler.body).decode("utf-8")
+        start = html.index("static/ui.js?v=") + len("static/ui.js?v=")
+        return html[start:html.index('"', start)]
+
+    first_shell_token = shell_token()
+    assert "base" in routes._INDEX_SHELL_CACHE
+
+    stat = bundle.stat()
+    bundle.write_bytes(b"export const value = 'bravo';\n")
+    os.utime(bundle, (stat.st_atime, stat.st_mtime))
+
+    second_shell_token = shell_token()
+    handler = _RouteHandler()
+    assert routes.handle_get(handler, urlparse("http://test/sw.js")) is True
+    worker_text = bytes(handler.body).decode("utf-8")
+    second_worker_token = worker_text.rsplit("hermes-shell-", 1)[1].rstrip("';\n")
+    assert second_shell_token != first_shell_token
+    assert second_worker_token == second_shell_token
 
 
 def test_sw_route_uses_bundle_fingerprint_token():

--- a/tests/test_static_identity_freshness.py
+++ b/tests/test_static_identity_freshness.py
@@ -1,0 +1,218 @@
+"""Byte-integrity and scan-amplification regressions at the real token helper.
+
+Use ./scripts/test.sh in a complete checkout. Fixtures advance monotonic
+freshness explicitly; they never disable the production cache or weaken hashes.
+"""
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from queue import Queue
+import os
+import tempfile
+import threading
+import unittest
+from unittest.mock import patch
+from urllib.parse import unquote
+
+import api.asset_identity_cache as identity_cache
+import api.routes as routes
+import api.updates as updates
+
+
+class StaticIdentityFreshnessTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.now = 100.0
+        self.cache = identity_cache.AssetIdentityCache(clock=lambda: self.now, wait_seconds=5)
+        self.cache_patch = patch.object(identity_cache, "ASSET_IDENTITY_CACHE", self.cache)
+        self.cache_patch.start()
+        self.addCleanup(self.cache_patch.stop)
+        self.version_patch = patch.object(updates, "WEBUI_VERSION", "v0.52.294")
+        self.version_patch.start()
+        self.addCleanup(self.version_patch.stop)
+        (self.root / "ui.js").write_bytes(b"export const value = 'alpha';\n")
+        (self.root / "sw.js").write_bytes(b"worker __WEBUI_VERSION__")
+
+    def token(self):
+        return routes._assets_cache_bust_token(self.root)
+
+    def test_repeated_calls_share_one_real_recursive_hash(self):
+        with patch.object(routes, "_static_content_identity", wraps=routes._static_content_identity) as scan:
+            first = self.token()
+            for _ in range(40):
+                self.assertEqual(self.token(), first)
+            self.assertEqual(scan.call_count, 1)
+
+    def _concurrent_scan(self, *, failure=False, expired=False):
+        if expired:
+            self.token()
+            self.now += 1
+        arrivals = Queue()
+        class ObservedCondition(threading.Condition):
+            def wait(self, timeout=None):
+                arrivals.put(threading.get_ident())
+                return super().wait(timeout)
+        self.cache._condition = ObservedCondition(threading.Lock())
+        release = threading.Event()
+        calls = []
+        count_lock = threading.Lock()
+        real_scan = routes._static_content_identity
+        def scan(root):
+            with count_lock:
+                calls.append(root)
+            arrivals.put(threading.get_ident())
+            if not release.wait(5):
+                raise AssertionError("scan release timed out")
+            if failure:
+                raise PermissionError("controlled strict-inventory failure")
+            return real_scan(root)
+        with patch.object(routes, "_static_content_identity", side_effect=scan):
+            with ThreadPoolExecutor(max_workers=16) as pool:
+                futures = [pool.submit(self.token) for _ in range(16)]
+                try:
+                    seen = set()
+                    while len(seen) < 16:
+                        seen.add(arrivals.get(timeout=5))
+                    self.assertEqual(len(calls), 1, "public callers amplified the recursive scan")
+                finally:
+                    release.set()
+                tokens = [future.result(5) for future in futures]
+        self.assertEqual(len(set(tokens)), 1)
+        self.assertEqual(routes._asset_identity_is_available(tokens[0]), not failure)
+
+    def test_cold_public_token_burst_has_one_scan(self):
+        self._concurrent_scan()
+
+    def test_expired_public_token_burst_has_one_scan(self):
+        self._concurrent_scan(expired=True)
+
+    def test_failed_public_token_burst_has_one_scan(self):
+        self._concurrent_scan(failure=True)
+
+    def test_missing_root_is_negatively_cached_then_recovers(self):
+        self.root = self.root / "not-created-yet"
+        with patch.object(routes, "_static_content_identity", wraps=routes._static_content_identity) as scan:
+            tokens = [self.token() for _ in range(30)]
+            self.assertTrue(all(not routes._asset_identity_is_available(token) for token in tokens))
+            self.assertEqual(scan.call_count, 1)
+            self.root.mkdir()
+            (self.root / "ui.js").write_bytes(b"repaired")
+            self.now += 0.25
+            self.assertTrue(routes._asset_identity_is_available(self.token()))
+            self.assertEqual(scan.call_count, 2)
+
+    def test_same_size_same_nanosecond_mtime_edits_change_identity_after_expiry(self):
+        resources = {
+            "ui.js": (b"alpha", b"bravo"),
+            "vendor/nested/code.js": (b"alpha", b"bravo"),
+            "vendor/nested/style.css": (b".aa{}", b".bb{}"),
+            "manifest.json": (b'{"n":"a"}', b'{"n":"b"}'),
+            "favicon.svg": (b"<svg>a</svg>", b"<svg>b</svg>"),
+            "favicon-32.png": (b"\x89PNG\r\n\x1a\na", b"\x89PNG\r\n\x1a\nb"),
+            "sw.js": (b"worker-a", b"worker-b"),
+            "index.html": (b"<p>a</p>", b"<p>b</p>"),
+        }
+        # Binary bytes matter to the hasher regardless of MIME validity. The
+        # neighboring existing regression retains its valid one-pixel PNG fixture.
+        for relative, (before, after) in resources.items():
+            with self.subTest(relative=relative):
+                path = self.root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(before)
+                self.now += 1
+                first = self.token()
+                stamp = path.stat()
+                path.write_bytes(after)
+                os.utime(path, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+                self.assertEqual(path.stat().st_size, stamp.st_size)
+                self.assertEqual(path.stat().st_mtime_ns, stamp.st_mtime_ns)
+                self.now += 1
+                self.assertNotEqual(self.token(), first)
+
+    def test_metadata_only_touch_is_stable_after_real_refresh(self):
+        first = self.token()
+        (self.root / "ui.js").touch()
+        self.now += 1
+        with patch.object(routes, "_static_content_identity", wraps=routes._static_content_identity) as scan:
+            self.assertEqual(self.token(), first)
+            self.assertEqual(scan.call_count, 1)
+
+    def test_path_rename_is_part_of_byte_identity(self):
+        first = self.token()
+        (self.root / "ui.js").rename(self.root / "renamed.js")
+        self.now += 1
+        self.assertNotEqual(self.token(), first)
+
+    def test_add_and_remove_are_part_of_inventory(self):
+        first = self.token()
+        added = self.root / "extra"
+        added.write_bytes(b"additional resource")
+        self.now += 1
+        second = self.token()
+        self.assertNotEqual(second, first)
+        added.unlink()
+        self.now += 1
+        self.assertEqual(self.token(), first)
+
+    def test_permission_error_never_reuses_stale_success(self):
+        first = self.token()
+        self.assertTrue(routes._asset_identity_is_available(first))
+        self.now += 1
+        with patch("os.scandir", side_effect=PermissionError("unlistable")):
+            second = self.token()
+            self.assertFalse(routes._asset_identity_is_available(second))
+            self.assertTrue(second.endswith(routes._ASSET_IDENTITY_UNAVAILABLE_SUFFIX))
+        self.now += 0.25
+        self.assertEqual(self.token(), first)
+
+    @unittest.skipUnless(os.name == "posix" and os.geteuid() != 0, "requires non-root POSIX")
+    def test_search_only_directory_remains_fail_closed(self):
+        vendor = self.root / "vendor"
+        vendor.mkdir()
+        leaf = vendor / "known.js"
+        leaf.write_bytes(b"alpha")
+        first = self.token()
+        self.assertTrue(routes._asset_identity_is_available(first))
+        vendor.chmod(0o111)
+        try:
+            with self.assertRaises(PermissionError):
+                os.listdir(vendor)
+            stamp = leaf.stat()
+            leaf.write_bytes(b"bravo")
+            os.utime(leaf, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+            self.assertEqual(leaf.read_bytes(), b"bravo")
+            self.assertEqual(leaf.stat().st_size, stamp.st_size)
+            self.assertEqual(leaf.stat().st_mtime_ns, stamp.st_mtime_ns)
+            self.now += 1
+            self.assertFalse(routes._asset_identity_is_available(self.token()))
+        finally:
+            vendor.chmod(0o755)
+
+    @unittest.skipUnless(os.name == "posix", "requires symlink support")
+    def test_broken_symlink_makes_inventory_unavailable(self):
+        self.token()
+        (self.root / "broken.js").symlink_to(self.root / "missing.js")
+        self.now += 1
+        self.assertFalse(routes._asset_identity_is_available(self.token()))
+
+    def test_semantic_version_changes_do_not_force_a_new_tree_scan(self):
+        with patch.object(routes, "_static_content_identity", wraps=routes._static_content_identity) as scan:
+            first = self.token()
+            with patch.object(updates, "WEBUI_VERSION", "v0.52.295+build.meta"):
+                second = self.token()
+            self.assertNotEqual(first, second)
+            self.assertTrue(unquote(second).startswith("v0.52.295+build.meta+a"))
+            self.assertEqual(scan.call_count, 1)
+
+    def test_empty_tree_is_a_complete_stable_inventory(self):
+        empty = self.root / "empty"
+        empty.mkdir()
+        first = routes._assets_cache_bust_token(empty)
+        self.assertTrue(routes._asset_identity_is_available(first))
+        self.now += 1
+        self.assertEqual(routes._assets_cache_bust_token(empty), first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_static_identity_public_routes.py
+++ b/tests/test_static_identity_public_routes.py
@@ -1,0 +1,202 @@
+"""Full-router regressions for the shared shell/worker freshness boundary.
+
+These tests require the complete repository and its test runner. A token-helper
+replay is not a substitute for executing these route and exact-byte assertions.
+"""
+from concurrent.futures import ThreadPoolExecutor
+import hashlib
+import os
+from pathlib import Path
+from queue import Queue
+import re
+import tempfile
+import threading
+import unittest
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import api.asset_identity_cache as identity_cache
+import api.config as api_config
+import api.routes as routes
+
+
+class Handler:
+    def __init__(self, headers=None):
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.headers = headers or {}
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+
+class StaticIdentityPublicRoutesTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.index = self.root / "index.html"
+        self.index.write_text('<html>old <script src="static/ui.js?v=__WEBUI_VERSION__"></script></html>', encoding="utf-8")
+        (self.root / "sw.js").write_text("const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';", encoding="utf-8")
+        self.bundle = self.root / "ui.js"
+        self.bundle.write_bytes(b"alpha")
+        self.now = 100.0
+        self.cache = identity_cache.AssetIdentityCache(clock=lambda: self.now, wait_seconds=5)
+        for target, name, value in (
+            (identity_cache, "ASSET_IDENTITY_CACHE", self.cache),
+            (api_config, "get_static_root", lambda: self.root),
+            (api_config, "get_index_html_path", lambda: self.index),
+            (routes, "_INDEX_SHELL_CACHE", {}),
+            (routes, "_STATIC_CACHE", {}),
+        ):
+            replacement = patch.object(target, name, value)
+            replacement.start()
+            self.addCleanup(replacement.stop)
+
+    def request(self, path, headers=None):
+        handler = Handler(headers)
+        # server.py treats only an exact False as 404; the response writers
+        # return None, so truthiness is not the handled contract here.
+        self.assertIsNot(routes.handle_get(handler, urlparse("http://test" + path)), False)
+        return handler
+
+    def shell_token(self):
+        handler = self.request("/")
+        self.assertEqual(handler.status, 200)
+        match = re.search(r'static/ui.js\?v=([^"\s]+)', bytes(handler.body).decode())
+        self.assertIsNotNone(match)
+        return match.group(1)
+
+    def test_shell_worker_and_query_variants_reuse_one_scan(self):
+        with patch.object(routes, "_static_content_identity", wraps=routes._static_content_identity) as scan:
+            token = self.shell_token()
+            for path in ("/", "/index.html?v=arbitrary", "/sw.js?v=old", "/sw.js?v=other"):
+                handler = self.request(path)
+                self.assertEqual(handler.status, 200)
+                self.assertIn(token.encode(), bytes(handler.body))
+            self.assertEqual(scan.call_count, 1)
+
+    def test_shell_and_worker_turn_over_together_after_expiry(self):
+        first = self.shell_token()
+        stamp = self.bundle.stat()
+        self.bundle.write_bytes(b"bravo")
+        os.utime(self.bundle, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+        self.assertEqual(self.bundle.stat().st_size, stamp.st_size)
+        self.assertEqual(self.bundle.stat().st_mtime_ns, stamp.st_mtime_ns)
+        self.now += 1
+        second = self.shell_token()
+        self.assertNotEqual(second, first)
+        worker = self.request("/sw.js")
+        self.assertEqual(worker.status, 200)
+        self.assertIn(second.encode(), bytes(worker.body))
+        self.assertIn(("Cache-Control", "no-store"), worker.sent_headers)
+
+    def test_negative_reuse_never_authorizes_shell_cache_or_worker(self):
+        with patch.object(routes, "_static_content_identity", side_effect=PermissionError("unreadable")) as scan:
+            first = self.request("/")
+            self.assertIn(b"old ", bytes(first.body))
+            self.assertNotIn("base", routes._INDEX_SHELL_CACHE)
+            stamp = self.index.stat()
+            self.index.write_text(self.index.read_text().replace("old ", "new "), encoding="utf-8")
+            os.utime(self.index, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+            self.assertEqual(self.index.stat().st_size, stamp.st_size)
+            self.assertEqual(self.index.stat().st_mtime_ns, stamp.st_mtime_ns)
+            second = self.request("/")
+            self.assertIn(b"new ", bytes(second.body))
+            self.assertNotIn("base", routes._INDEX_SHELL_CACHE)
+            self.assertIn(routes._ASSET_IDENTITY_UNAVAILABLE_TOKEN.encode(), bytes(second.body))
+            worker = self.request("/sw.js")
+            self.assertEqual(worker.status, 503)
+            self.assertIn(("Cache-Control", "no-store"), worker.sent_headers)
+            self.assertEqual(scan.call_count, 1)
+
+    def test_mixed_public_request_burst_uses_one_flight(self):
+        arrivals = Queue()
+        class ObservedCondition(threading.Condition):
+            def wait(self, timeout=None):
+                arrivals.put(threading.get_ident())
+                return super().wait(timeout)
+        self.cache._condition = ObservedCondition(threading.Lock())
+        release = threading.Event()
+        original = routes._static_content_identity
+        calls = []
+        def scan(root):
+            calls.append(root)
+            arrivals.put(threading.get_ident())
+            if not release.wait(5):
+                raise AssertionError("scan release timed out")
+            return original(root)
+        with patch.object(routes, "_static_content_identity", side_effect=scan):
+            with ThreadPoolExecutor(max_workers=16) as pool:
+                futures = [pool.submit(self.request, "/" if i % 2 else "/sw.js") for i in range(16)]
+                try:
+                    seen = set()
+                    while len(seen) < 16:
+                        seen.add(arrivals.get(timeout=5))
+                    self.assertEqual(len(calls), 1)
+                finally:
+                    release.set()
+                handlers = [future.result(5) for future in futures]
+        token = routes._assets_cache_bust_token(self.root).encode()
+        self.assertTrue(all(handler.status == 200 and token in bytes(handler.body) for handler in handlers))
+        self.assertEqual(len(calls), 1)
+
+    def test_timed_out_worker_fails_closed_without_replacement_scan(self):
+        cache = identity_cache.AssetIdentityCache(wait_seconds=0.02)
+        started, release = threading.Event(), threading.Event()
+        original = routes._static_content_identity
+        calls = []
+        def scan(root):
+            calls.append(root)
+            started.set()
+            if not release.wait(5):
+                raise AssertionError("scan release timed out")
+            return original(root)
+        with patch.object(identity_cache, "ASSET_IDENTITY_CACHE", cache), \
+             patch.object(routes, "_static_content_identity", side_effect=scan):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                leader = pool.submit(self.request, "/")
+                try:
+                    self.assertTrue(started.wait(5))
+                    worker = self.request("/sw.js")
+                    self.assertEqual(worker.status, 503)
+                    self.assertIn(("Cache-Control", "no-store"), worker.sent_headers)
+                    self.assertEqual(len(calls), 1)
+                finally:
+                    release.set()
+                self.assertEqual(leader.result(5).status, 200)
+
+    def test_freshness_never_weakens_exact_byte_etags_or_cache_headers(self):
+        token = self.shell_token()
+        first = self.request("/static/ui.js?v=" + token)
+        self.assertEqual(bytes(first.body), b"alpha")
+        old_etag = dict(first.sent_headers)["ETag"]
+        stamp = self.bundle.stat()
+        self.bundle.write_bytes(b"bravo")
+        os.utime(self.bundle, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+        self.assertEqual(self.bundle.stat().st_size, stamp.st_size)
+        self.assertEqual(self.bundle.stat().st_mtime_ns, stamp.st_mtime_ns)
+        # Deliberately stay INSIDE the identity freshness window. Even an old
+        # URL must return current bytes and may never claim immutable caching.
+        for version in (token, "arbitrary"):
+            response = self.request("/static/ui.js?v=" + version, {"If-None-Match": old_etag})
+            self.assertEqual(response.status, 200)
+            self.assertEqual(bytes(response.body), b"bravo")
+            headers = dict(response.sent_headers)
+            self.assertEqual(headers["ETag"], 'W/"' + hashlib.sha256(b"bravo").hexdigest() + '"')
+            self.assertEqual(headers["Cache-Control"], "public, max-age=0, must-revalidate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Status

**Not ready to merge.** The semantic-version false-positive from the latest maintainer gate is now repaired on head `252e6cfbfeb4a48f466404a65d3bb2cea866cb2a`, but the separate unbounded whole-tree hashing / concurrent fan-out blocker still needs a bounded shared single-flight cache before this PR should be merged.

## Thinking Path

- A mutable/non-git WebUI install needs cache identity tied to static bytes, not only `WEBUI_VERSION` or file metadata.
- The worker, rendered shell and static responses must agree on that byte identity without ever granting immutable caching to arbitrary `?v=` values.
- The stale-client banner has a different contract: it compares the semantic WebUI release version from `/api/settings`, not the asset fingerprint.
- Therefore asset identity and semantic bundle identity must stay separate even though the current HTML template has one `__WEBUI_VERSION__` substitution point.
- The remaining recursive fingerprint scan also needs bounded shared refresh work; that part is still open.

## What Changed

The current branch now:

- computes recursive static-tree identity from normalized paths plus actual content digests, so same-size/same-mtime byte replacements change identity;
- includes nested vendor/PWA resources in that identity and fails closed when complete identity cannot be established;
- keys rendered-shell reuse on the asset identity and makes `/sw.js` use the same token;
- derives static ETags from the exact bytes read and requires revalidation instead of treating arbitrary non-empty `?v=` values as immutable snapshots;
- keeps the stronger behavior-level shell/worker mutation coverage and removed the earlier source-string assertion;
- **new on `252e6cf`:** `static/pwa-startup.js` intercepts the later bundle-version stamp, preserves the raw fingerprinted token as `window.__HERMES_WEBUI_ASSET_VERSION__`, and exposes only the decoded semantic release as `window.__HERMES_WEBUI_BUNDLE_VERSION__` for the existing stale-client skew checker. Only the exact `+a<10 hex>` asset suffix is stripped; unrelated SemVer build metadata is preserved.
- adds `tests/test_pwa_semantic_version_bridge.py` with behavioral Node coverage for fingerprinted tags, plain release tags, and unrelated build metadata.

## Why It Matters

The content-based identity fixes the original stale-service-worker class without trusting forgeable metadata. The latest semantic bridge fixes the maintainer-reproduced tagged-install regression where a client such as `v0.52.294+a<fingerprint>` was compared against server `v0.52.294` and permanently shown the hard-refresh banner.

The PR is still incomplete because computing the recursive content identity independently on every public shell/worker request creates avoidable concurrent filesystem/CPU amplification.

## Verification

Current head: `252e6cfbfeb4a48f466404a65d3bb2cea866cb2a`.

New semantic-identity regression was exercised in an isolated focused replay using the fetched current `pwa-startup.js` source and the exact new test logic:

```text
before semantic bridge: 3 failed
  - fingerprinted asset token remained the bundle version
  - no separate asset token was retained
  - percent-encoded non-fingerprint build metadata was not decoded

after semantic bridge: 3 passed in 0.60s
```

That replay was **not** `./scripts/test.sh` in a complete repository checkout, so it is not presented as repository-suite validation. The pre-existing maintainer gate on the prior product head reported its focused static/PWA/cache matrix as 81/81 and independently confirmed the byte-identity / recursive-inventory fixes, but that gate explicitly remained RED on semantic identity and scan fan-out. Exact-head hosted CI for `252e6cf` is running as of this update and is not claimed green here until it completes.

## Risks / Follow-ups

One maintainer-gate blocker remains:

- Recursive `_static_content_identity()` work is still performed before shell-cache reuse and on `/sw.js`; concurrent unauthenticated requests can multiply a full static-tree scan. This needs one shared bounded single-flight freshness cache (including short-lived identity-unavailable results), with filesystem I/O outside the coordination lock and exception-safe waiter cleanup.

The branch also still needs integration onto current upstream before final certification. `api/routes.py` changed upstream after this branch's merge base, so that integration must preserve current upstream router changes rather than overlaying an older whole-file blob.

## Contract Routing

Task type: PWA/static-cache correctness and stale-client version-identity repair.

Touched areas: static asset identity, rendered shell/service-worker cache token, static HTTP cache semantics, and the existing stale-client version comparison input.

Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `TESTING.md`.

Scope boundaries: no API/schema/config change, no auth relaxation, no workflow change, no new dependency, and no change to the stale-client comparison policy itself. The semantic release value and asset revision are separated before that existing policy runs.

## Model Used

OpenAI GPT-5.6 Sol via ChatGPT with the GitHub integration for repository inspection and writes.
