### PR TITLE
fix: show Hermes Desktop sessions in the chat sidebar

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -58,6 +58,7 @@ SOURCE_LABELS = {
     'api_server': 'API',
     'cli': 'CLI',
     'cron': 'Cron',
+    'desktop': 'Desktop',
     'discord': 'Discord',
     'email': 'Email',
     'kanban': 'Kanban',
@@ -85,12 +86,12 @@ def normalize_agent_session_source(raw_source: str | None) -> dict:
 
     if raw == 'webui':
         session_source = 'webui'
-    elif raw in {'acp', 'cli', 'tui'}:
-        # 'acp' (Agent Client Protocol adapter — Zed, external device bridges)
-        # is a local interactive agent client like the CLI/TUI: its sessions
-        # live only in state.db, so classifying it 'other' would leave them
-        # invisible in both sidebar buckets (webui skips the state.db
-        # projection; cli keeps only CLI-classified rows).
+    elif raw in {'acp', 'cli', 'desktop', 'tui'}:
+        # ACP adapters and Hermes Desktop are interactive clients like the
+        # CLI/TUI. Their sessions live only in state.db, so classifying them
+        # as 'other' would leave them invisible in both sidebar buckets
+        # (webui skips the state.db projection; cli keeps only interactive
+        # rows).
         session_source = 'cli'
     elif raw in MESSAGING_SOURCES:
         session_source = 'messaging'
@@ -242,10 +243,10 @@ def is_cli_session_row(row: dict) -> bool:
     if source in {"external_agent", "external-agent"}:
         return True
     if (
-        source_tag in {"acp", "cli", "tui"}
-        or raw_source in {"acp", "cli", "tui"}
-        or source_name in {"acp", "cli", "tui"}
-        or source_label in {"acp", "cli", "tui"}
+        source_tag in {"acp", "cli", "desktop", "tui"}
+        or raw_source in {"acp", "cli", "desktop", "tui"}
+        or source_name in {"acp", "cli", "desktop", "tui"}
+        or source_label in {"acp", "cli", "desktop", "tui"}
     ):
         return True
 
@@ -289,11 +290,11 @@ def is_cli_session_row_visible(row: dict) -> bool:
     }
     if "tui" in interactive_sources:
         return True
-    if "acp" in interactive_sources:
-        # Like TUI rows, user-driven ACP sessions stay visible even when
-        # ended/untitled. Unlike TUI, an ACP connection can record only
-        # assistant/tool/system rows (e.g. a replayed or aborted turn), so
-        # require at least one user turn before surfacing the row.
+    if {"acp", "desktop"} & interactive_sources:
+        # Like TUI rows, user-driven ACP/Desktop sessions stay visible even
+        # when ended/untitled. Unlike TUI, these clients can leave connection
+        # records containing only assistant/tool/system rows, so require at
+        # least one user turn before surfacing the row.
         return _count_user_turns(row) > 0
 
     if _has_cli_lineage(row):
@@ -630,7 +631,13 @@ def read_importable_agent_session_rows(
             if 'role' in message_cols:
                 user_message_count_expr = "COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END)"
             else:
-                user_message_count_expr = f"COUNT(m.{count_col})"
+                # Without role metadata we cannot prove a Desktop connection
+                # record contains a user turn. Fail closed for Desktop only;
+                # preserve the legacy count fallback for every existing source.
+                user_message_count_expr = (
+                    "CASE WHEN LOWER(COALESCE(s.source, '')) = 'desktop' THEN 0 "
+                    f"ELSE COUNT(m.{count_col}) END"
+                )
             last_activity_expr = "MAX(m.timestamp)" if messages_has_timestamp else "NULL"
             join_clause = "LEFT JOIN messages m ON m.session_id = s.id"
             group_by_clause = "GROUP BY s.id"
@@ -638,7 +645,10 @@ def read_importable_agent_session_rows(
             # No usable messages table: use the denormalized per-session counts
             # and ``started_at`` so the rows still surface in the sidebar.
             actual_count_expr = "s.message_count"
-            user_message_count_expr = "s.message_count"
+            user_message_count_expr = (
+                "CASE WHEN LOWER(COALESCE(s.source, '')) = 'desktop' THEN 0 "
+                "ELSE s.message_count END"
+            )
             last_activity_expr = "NULL"
             join_clause = ""
             group_by_clause = ""

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2547,7 +2547,7 @@ function _isCliSession(session) {
     || session.source_label
     || ''
   ).toLowerCase();
-  if (raw === 'cli' || raw === 'tui' || raw === 'acp') return true;
+  if (raw === 'cli' || raw === 'tui' || raw === 'acp' || raw === 'desktop') return true;
   // If messaging-like, don't classify as legacy CLI even when is_cli_session is true.
   if (_isMessagingSession(session)) return false;
   return session.is_cli_session === true;

--- a/tests/test_desktop_session_sidebar_visibility.py
+++ b/tests/test_desktop_session_sidebar_visibility.py
@@ -1,0 +1,267 @@
+"""Hermes Desktop state.db sessions must appear in Hermex's sidebar."""
+
+import sqlite3
+import subprocess
+import time
+import unittest.mock
+from pathlib import Path
+
+import api.models as models
+from api.agent_sessions import (
+    is_cli_session_row,
+    is_cli_session_row_visible,
+    normalize_agent_session_source,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_normalizes_to_interactive_family():
+    meta = normalize_agent_session_source("desktop")
+    assert meta["session_source"] == "cli"
+    assert meta["raw_source"] == "desktop"
+    assert meta["source_label"] == "Desktop"
+
+
+def test_raw_desktop_row_is_interactive():
+    assert is_cli_session_row({"id": "desktop-session", "source": "desktop"}) is True
+
+
+def test_ended_desktop_conversation_with_user_turn_stays_visible():
+    row = {
+        "id": "desktop-ended",
+        "source": "desktop",
+        "title": "Desktop Session",
+        "message_count": 4,
+        "actual_message_count": 4,
+        "actual_user_message_count": 1,
+        "ended_at": 1_751_000_000.0,
+        "end_reason": "client_disconnect",
+    }
+    normalized = {**row, **normalize_agent_session_source("desktop")}
+    assert is_cli_session_row(normalized) is True
+    assert is_cli_session_row_visible(normalized) is True
+
+
+def test_desktop_rows_without_user_turns_stay_hidden():
+    for message_count in (0, 3):
+        row = {
+            "id": f"desktop-no-user-{message_count}",
+            "source": "desktop",
+            "title": "Desktop Session",
+            "message_count": message_count,
+            "actual_message_count": message_count,
+            "actual_user_message_count": 0,
+            "ended_at": 1_751_000_000.0,
+            "end_reason": "client_disconnect",
+        }
+        normalized = {**row, **normalize_agent_session_source("desktop")}
+        assert is_cli_session_row(normalized) is True
+        assert is_cli_session_row_visible(normalized) is False
+
+
+def _make_state_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    started = time.time()
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, session_source, title, model, started_at, message_count,
+         parent_session_id, ended_at, end_reason)
+        VALUES (?, 'desktop', NULL, ?, 'openai-codex/gpt-5.6-sol', ?, 3, NULL, NULL, NULL)
+        """,
+        (
+            "20260820_140625_693cd9",
+            "Troubleshoot system issues after rough morning",
+            started,
+        ),
+    )
+    for index, (role, content) in enumerate(
+        (("user", "hello"), ("assistant", "hi"), ("user", "follow-up"))
+    ):
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, ?, ?, ?)",
+            (
+                f"desktop-message-{index}",
+                "20260820_140625_693cd9",
+                role,
+                content,
+                started + index / 10,
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_desktop_session_appears_in_state_db_projection(tmp_path):
+    db = tmp_path / "state.db"
+    _make_state_db(db)
+    with (
+        unittest.mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        unittest.mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+    ):
+        results = models._load_cli_sessions_uncached(tmp_path, db, None)
+
+    row = next(
+        (item for item in results if item["session_id"] == "20260820_140625_693cd9"),
+        None,
+    )
+    assert row is not None, "Desktop session should appear in the sidebar projection"
+    assert row["is_cli_session"] is True
+    assert row["session_source"] == "cli"
+    assert row["source_label"] == "Desktop"
+
+
+def _make_desktop_stub_db(path: Path, *, include_role: bool) -> None:
+    conn = sqlite3.connect(str(path))
+    role_column = ", role TEXT" if include_role else ""
+    conn.executescript(
+        f"""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT{role_column},
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    started = time.time()
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, title, model, started_at, message_count)
+        VALUES ('desktop-stub', 'desktop', 'Connection stub', 'test-model', ?, 2)
+        """,
+        (started,),
+    )
+    if include_role:
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, 'desktop-stub', ?, ?, ?)",
+            [
+                ("stub-assistant", "assistant", "hello", started),
+                ("stub-tool", "tool", "result", started + 0.1),
+            ],
+        )
+    else:
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, content, timestamp) VALUES (?, 'desktop-stub', ?, ?)",
+            [
+                ("stub-message-1", "assistant-shaped legacy row", started),
+                ("stub-message-2", "tool-shaped legacy row", started + 0.1),
+            ],
+        )
+    conn.commit()
+    conn.close()
+
+
+def _load_desktop_stub(tmp_path: Path, *, include_role: bool) -> list[dict]:
+    db = tmp_path / "state.db"
+    _make_desktop_stub_db(db, include_role=include_role)
+    with (
+        unittest.mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        unittest.mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+    ):
+        return models._load_cli_sessions_uncached(tmp_path, db, None)
+
+
+def test_role_aware_state_db_hides_desktop_stub_without_user_turn(tmp_path):
+    results = _load_desktop_stub(tmp_path, include_role=True)
+    assert not any(item["session_id"] == "desktop-stub" for item in results)
+
+
+def test_legacy_state_db_without_message_roles_fails_closed_for_desktop(tmp_path):
+    results = _load_desktop_stub(tmp_path, include_role=False)
+    assert not any(item["session_id"] == "desktop-stub" for item in results)
+
+
+def test_legacy_state_db_without_messages_table_fails_closed_for_desktop(tmp_path):
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, title, model, started_at, message_count)
+        VALUES ('desktop-stub', 'desktop', 'Connection stub', 'test-model', ?, 2)
+        """,
+        (time.time(),),
+    )
+    conn.commit()
+    conn.close()
+
+    with (
+        unittest.mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        unittest.mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+    ):
+        results = models._load_cli_sessions_uncached(tmp_path, db, None)
+
+    assert not any(item["session_id"] == "desktop-stub" for item in results)
+
+
+def test_sessions_js_classifies_raw_desktop_payload_as_interactive():
+    src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.index("function _sourceKeyForSession")
+    end = src.index("function _sessionSourceLabel", start)
+    block = src[start:end]
+    script = f"""
+function _isMessagingSession() {{ return false; }}
+{block}
+if (!_isCliSession({{ source: 'desktop' }})) {{
+  throw new Error('raw Desktop session should be interactive');
+}}
+if (!_isCliSession({{ raw_source: 'desktop' }})) {{
+  throw new Error('raw_source Desktop session should be interactive');
+}}
+if (_isCliSession({{ source: 'telegram', is_cli_session: false }})) {{
+  throw new Error('messaging session should not be interactive');
+}}
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)


### PR DESCRIPTION
## Bug description

Conversations created in Hermes Desktop are persisted in the profile `state.db` with `source=desktop`, but they do not appear in the WebUI/Hermex chat sidebar.

## Root cause

The server-side source normalizer and browser fallback classify `acp`, `cli`, and `tui` sessions as interactive, but not `desktop`. Desktop rows therefore fall into the `other` bucket and are excluded from both normal sidebar views.

## Fix

- Normalize `desktop` into the existing interactive/CLI session family while preserving `raw_source=desktop`.
- Expose the source label as `Desktop`.
- Keep the browser-side fallback consistent with the server classifier.
- Require a provable user turn before showing Desktop rows. Legacy databases without usable role metadata fail closed rather than exposing assistant/tool-only stubs.
- Leave messaging-source classification unchanged.

No database migration is required.

## How to verify

1. Create a conversation from Hermes Desktop.
2. Open the WebUI for the same profile.
3. Confirm the conversation appears in the interactive session list with a `Desktop` source label.
4. Confirm Desktop rows without a user turn remain hidden.

## Test plan

- [x] Added nine focused Desktop-session regression tests.
- [x] Ran 150 related session projection, gateway sync, lineage, and source-filter tests.
- [x] `ruff check api/agent_sessions.py tests/test_desktop_session_sidebar_visibility.py`
- [x] `node --check static/sessions.js`
- [x] `git diff --check origin/master...HEAD`

## Risk assessment

Low. The production change is limited to source classification and Desktop visibility. Messaging sources retain their existing precedence and behavior.

## AI assistance disclosure

This patch was developed, tested, and submitted by Boddicker, an AI coding assistant, under James Dishman's direction and authorization. James reported the user-facing failure and approved the upstream submission.
