### PR TITLE
fix: scope run-journal recovery dedupe to the recovering turn (#7388 re-gate)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -44,7 +44,7 @@ from api.agent_sessions import (
     read_importable_agent_session_rows,
     read_session_lineage_metadata,
 )
-from api.process_event_utils import stamp_message_source
+from api.process_event_utils import build_active_turn_token, stamp_message_source
 
 logger = logging.getLogger(__name__)
 CLI_VISIBLE_SESSION_LIMIT = 20
@@ -926,7 +926,14 @@ def _append_recovered_pending_turn(session, *, timestamp: int | None = None) -> 
         '_recovered': True,
     }
     pending_source = getattr(session, 'pending_user_source', None)
-    stamp_message_source(recovered, pending_source)
+    stamp_message_source(
+        recovered,
+        pending_source,
+        active_turn_token=build_active_turn_token(
+            getattr(session, 'active_stream_id', None),
+            getattr(session, 'pending_started_at', None),
+        ),
+    )
     if session.pending_attachments:
         recovered['attachments'] = list(session.pending_attachments)
     session.messages.append(recovered)
@@ -2700,9 +2707,9 @@ _TURN_WINDOW_AMBIGUOUS = _TurnWindowAmbiguous()
 def _pending_recovery_turn_window_start(session):
     """Opening index of the recovering turn, in ORIGINAL message coordinates.
 
-    Opens at the EARLIEST exact checkpoint so a turn's own core output stays
-    claimable (#3929); untimed core rows extend it back, text-only fallback
-    takes the LATEST match, unmatched turns are _TURN_WINDOW_AMBIGUOUS."""
+    One exact match opens there (untimed same-text rows extend back). Several
+    exact matches fail closed unless ``_active_turn_token`` uniquely identifies
+    the current turn; unmatched pending turns are ``_TURN_WINDOW_AMBIGUOUS``."""
     pending_text = getattr(session, 'pending_user_message', None)
     if not pending_text:
         return None
@@ -2715,7 +2722,7 @@ def _pending_recovery_turn_window_start(session):
             return False
         return True
 
-    exact_match = None
+    exact_matches = []
     fallback_match = None
     for idx, message in enumerate(messages):
         if not isinstance(message, dict):
@@ -2727,10 +2734,27 @@ def _pending_recovery_turn_window_start(session):
             session.pending_user_source,
             session.pending_attachments,
         ):
-            if exact_match is None:
-                exact_match = idx
+            exact_matches.append(idx)
         elif _message_matches_pending_text(message, pending_text):
             fallback_match = idx
+    exact_match = None
+    if len(exact_matches) == 1:
+        exact_match = exact_matches[0]
+    elif len(exact_matches) > 1:
+        token = build_active_turn_token(
+            getattr(session, 'active_stream_id', None),
+            getattr(session, 'pending_started_at', None),
+        )
+        token_hits = [
+            idx for idx in exact_matches
+            if token and messages[idx].get('_active_turn_token') == token
+        ]
+        if len(token_hits) == 1:
+            exact_match = token_hits[0]
+        elif len(token_hits) > 1:
+            exact_match = token_hits[0]
+        else:
+            return _TURN_WINDOW_AMBIGUOUS
     if exact_match is not None:
         window = exact_match
         for idx in range(exact_match - 1, -1, -1):
@@ -3110,9 +3134,6 @@ def _append_journaled_partial_output(
             flush_assistant()
             continue
         if event_name == 'tool':
-            anchor_idx = flush_assistant()
-            if anchor_idx is None:
-                anchor_idx = ensure_assistant_anchor(created_at)
             name = str(payload.get('name') or 'tool')
             preview = str(payload.get('preview') or '')
             if dedupe_existing and _journal_tool_already_present(
@@ -3122,8 +3143,13 @@ def _append_journaled_partial_output(
                 stream_id=stream_id,
                 turn_start=_pending_recovery_turn_window_start(session),
             ):
-                current_assistant_idx = anchor_idx
+                # Ownership is already proven; do not allocate an empty
+                # recovered anchor just to discover a duplicate tool.
+                flush_assistant()
                 continue
+            anchor_idx = flush_assistant()
+            if anchor_idx is None:
+                anchor_idx = ensure_assistant_anchor(created_at)
             recovered_tool_calls.append({
                 'name': name,
                 'preview': preview,
@@ -3542,6 +3568,14 @@ def _apply_core_sync_or_error_marker(
                 '_recovered': True,
             }
             pending_source = getattr(session, 'pending_user_source', None)
+            stamp_message_source(
+                recovered,
+                pending_source,
+                active_turn_token=build_active_turn_token(
+                    getattr(session, 'active_stream_id', None),
+                    getattr(session, 'pending_started_at', None),
+                ),
+            )
             if pending_source and pending_source != 'webui':
                 recovered['_source'] = pending_source
             if session.pending_attachments:

--- a/api/models.py
+++ b/api/models.py
@@ -2401,12 +2401,37 @@ def _find_existing_assistant_for_journal_content(
     *,
     max_index: int | None = None,
     excluded_indexes: set[int] | None = None,
+    stream_id: str | None = None,
+    turn_start=None,
 ) -> int | None:
+    """Find an earlier assistant row this segment may collapse into.
+
+    Claimable only with proven ownership: this stream's tag, or at/after
+    ``turn_start``. ``turn_start=None`` is quiescent = legacy session-wide.
+    """
     candidate = _normalize_journal_recovery_text(content)
     if not candidate:
         return None
     messages = session.messages or []
     stop = len(messages) if max_index is None else min(len(messages), max_index)
+    window_ambiguous = turn_start is _TURN_WINDOW_AMBIGUOUS
+    window_index = None if window_ambiguous else turn_start
+    legacy_scope = turn_start is None
+
+    def _owns_turn(idx: int) -> bool:
+        if legacy_scope:
+            return True
+        message = messages[idx]
+        existing_stream = message.get('_recovered_stream_id')
+        if existing_stream:
+            # Only the same stream may collapse onto its own recovered output.
+            return bool(stream_id) and str(existing_stream) == str(stream_id)
+        # Untagged rows are core/live transcript: current-turn only when the
+        # window is known and they sit inside it. Otherwise fail closed.
+        if window_index is None:
+            return False
+        return idx >= window_index
+
     substring_match = None
     for idx in range(stop):
         if excluded_indexes and idx in excluded_indexes:
@@ -2420,8 +2445,15 @@ def _find_existing_assistant_for_journal_content(
         if not existing:
             continue
         if existing == candidate:
-            return idx
-        if substring_match is None and len(candidate) >= 24 and candidate in existing:
+            if _owns_turn(idx):
+                return idx
+            continue
+        if (
+            substring_match is None
+            and len(candidate) >= 24
+            and candidate in existing
+            and _owns_turn(idx)
+        ):
             substring_match = idx
     return substring_match
 
@@ -2432,27 +2464,19 @@ def _journal_tool_already_present(
     preview: str,
     *,
     stream_id: str | None = None,
+    turn_start=None,
 ) -> bool:
     """Return True when an equivalent tool card already exists.
 
-    Matching rule:
-
-    * If the existing tool card carries ``_recovered_stream_id``, that means a
-      previous journal-recovery run materialized it.  The retry can safely
-      collapse against it only when both stream ids match — otherwise a
-      legitimately-repeated tool (e.g. a second ``terminal: ls`` in a
-      different turn) would be dropped.
-    * If the existing tool card has no ``_recovered_stream_id`` (a live tool
-      card, or a tool card carried over from a core transcript that pre-dates
-      stream-id tagging), the legacy name+preview match still wins.  This
-      preserves the "core transcript already has this tool, don't duplicate
-      it" invariant the original repair path established.
-    * When ``stream_id`` is omitted, the helper degrades cleanly to its
-      pre-fix session-wide behaviour.
+    Branches on the EXISTING card: foreign stream never, ours always, untagged
+    only inside ``turn_start``. Legacy scope needs ``turn_start is None``.
     """
     candidate_name = str(name or '')
     candidate_preview = _normalize_journal_recovery_text(preview)
     candidate_stream = str(stream_id) if stream_id else None
+    window_ambiguous = turn_start is _TURN_WINDOW_AMBIGUOUS
+    window_index = None if window_ambiguous else turn_start
+    legacy_scope = turn_start is None
     for tool_call in session.tool_calls or []:
         if not isinstance(tool_call, dict):
             continue
@@ -2463,15 +2487,19 @@ def _journal_tool_already_present(
         )
         if existing_preview != candidate_preview:
             continue
-        if candidate_stream is not None:
-            existing_stream = tool_call.get('_recovered_stream_id')
-            # A tool card explicitly tagged with a recovered_stream_id that
-            # differs from ours belongs to another retry's turn — don't let
-            # it pre-empt this retry.  Untagged tool cards (live or carried
-            # over from the core transcript) still match.
-            if existing_stream and str(existing_stream) != candidate_stream:
+        existing_stream = tool_call.get('_recovered_stream_id')
+        if existing_stream:
+            if candidate_stream is None or str(existing_stream) != candidate_stream:
                 continue
-        return True
+            return True
+        if legacy_scope:
+            return True
+        if window_index is None:
+            # Nothing proves this untagged card belongs to the current turn.
+            continue
+        owner_idx = tool_call.get('assistant_msg_idx')
+        if isinstance(owner_idx, int) and owner_idx >= window_index:
+            return True
     return False
 
 
@@ -2653,6 +2681,80 @@ def _pending_recovery_turn_start(session) -> int | None:
     return None
 
 
+class _TurnWindowAmbiguous:
+    """Sentinel: a turn is recovering but its opening row is not locatable.
+
+    Unlike ``None`` (no pending turn, legacy session-wide scope), nothing may
+    be claimed by position — only a same-stream tag may match.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return '<turn-window-ambiguous>'
+
+
+_TURN_WINDOW_AMBIGUOUS = _TurnWindowAmbiguous()
+
+
+def _pending_recovery_turn_window_start(session):
+    """Opening index of the recovering turn, in ORIGINAL message coordinates.
+
+    Opens at the EARLIEST exact checkpoint so a turn's own core output stays
+    claimable (#3929); untimed core rows extend it back, text-only fallback
+    takes the LATEST match, unmatched turns are _TURN_WINDOW_AMBIGUOUS."""
+    pending_text = getattr(session, 'pending_user_message', None)
+    if not pending_text:
+        return None
+    messages = session.messages or []
+
+    def _has_usable_timestamp(message) -> bool:
+        try:
+            int(message.get('timestamp'))
+        except (TypeError, ValueError):
+            return False
+        return True
+
+    exact_match = None
+    fallback_match = None
+    for idx, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        if _message_matches_pending_checkpoint(
+            message,
+            pending_text,
+            session.pending_started_at,
+            session.pending_user_source,
+            session.pending_attachments,
+        ):
+            if exact_match is None:
+                exact_match = idx
+        elif _message_matches_pending_text(message, pending_text):
+            fallback_match = idx
+    if exact_match is not None:
+        window = exact_match
+        for idx in range(exact_match - 1, -1, -1):
+            message = messages[idx]
+            if not isinstance(message, dict):
+                continue
+            if message.get('role') != 'user':
+                # Assistant/tool rows sit inside the turn being walked back over.
+                continue
+            if (
+                _message_matches_pending_text(message, pending_text)
+                and not _has_usable_timestamp(message)
+            ):
+                # Untimed core row for this same prompt: same turn, keep going.
+                window = idx
+                continue
+            # Any other user row is a provable turn boundary.
+            break
+        return window
+    if fallback_match is not None:
+        return fallback_match
+    return _TURN_WINDOW_AMBIGUOUS
+
+
 def _materialize_unsaved_gateway_terminal_error(
     session,
     stream_id: str | None,
@@ -2706,7 +2808,7 @@ def _recover_journaled_output_and_terminal_error(
     session,
     stream_id: str | None,
     *,
-    dedupe_existing: bool = False,
+    dedupe_existing: bool = True,
     terminal_recovery: dict | None = None,
 ) -> tuple[bool, bool]:
     """Recover readable activity first, then append its authoritative terminal error."""
@@ -2760,7 +2862,7 @@ def _append_journaled_partial_output(
     session,
     stream_id: str | None,
     *,
-    dedupe_existing: bool = False,
+    dedupe_existing: bool = True,
 ) -> bool:
     """Recover already-emitted visible output from a dead stream journal.
 
@@ -2864,12 +2966,18 @@ def _append_journaled_partial_output(
         if dedupe_existing and content:
             search_excluded = set(claimed_existing_assistant_indexes)
             existing_idx = None
+            # Turn-ownership scope: only rows owned by the turn being recovered
+            # may absorb this segment. Without a provable window, matching
+            # degrades to stream-tag-only.
+            turn_start = _pending_recovery_turn_window_start(session)
             while True:
                 candidate_idx = _find_existing_assistant_for_journal_content(
                     session,
                     content,
                     max_index=initial_message_count,
                     excluded_indexes=search_excluded,
+                    stream_id=stream_id,
+                    turn_start=turn_start,
                 )
                 if candidate_idx is None:
                     break
@@ -3008,7 +3116,11 @@ def _append_journaled_partial_output(
             name = str(payload.get('name') or 'tool')
             preview = str(payload.get('preview') or '')
             if dedupe_existing and _journal_tool_already_present(
-                session, name, preview, stream_id=stream_id,
+                session,
+                name,
+                preview,
+                stream_id=stream_id,
+                turn_start=_pending_recovery_turn_window_start(session),
             ):
                 current_assistant_idx = anchor_idx
                 continue
@@ -3439,6 +3551,7 @@ def _apply_core_sync_or_error_marker(
             _recover_journaled_output_and_terminal_error(
                 session,
                 _stream_id,
+                dedupe_existing=True,
                 terminal_recovery=_terminal_recovery,
             )
         )

--- a/tests/test_issue3929_partial_work_recovery.py
+++ b/tests/test_issue3929_partial_work_recovery.py
@@ -11,6 +11,7 @@ from api.models import (
     _append_journaled_partial_output,
     _apply_core_sync_or_error_marker,
 )
+from api.process_event_utils import build_active_turn_token
 from api.run_journal import append_run_event
 import api.streaming as streaming
 from api.streaming import _sanitize_messages_for_api
@@ -540,17 +541,24 @@ def test_reasoning_backfill_accepts_core_row_before_recovered_owner_echo():
     pending_started_at = 3_000
     recovered_text = "The core transcript already contains this partial output."
     core_assistant = {"role": "assistant", "content": recovered_text}
+    turn_token = build_active_turn_token(stream_id, pending_started_at)
     session = Session(
         session_id=session_id,
         title="Core owner echo",
         messages=[
-            {"role": "user", "content": pending_text, "timestamp": pending_started_at},
+            {
+                "role": "user",
+                "content": pending_text,
+                "timestamp": pending_started_at,
+                "_active_turn_token": turn_token,
+            },
             core_assistant,
             {
                 "role": "user",
                 "content": pending_text,
                 "timestamp": pending_started_at,
                 "_recovered": True,
+                "_active_turn_token": turn_token,
             },
         ],
         context_messages=[
@@ -559,6 +567,7 @@ def test_reasoning_backfill_accepts_core_row_before_recovered_owner_echo():
         ],
         pending_user_message=pending_text,
         pending_started_at=pending_started_at,
+        active_stream_id=stream_id,
     )
     append_run_event(
         session_id,

--- a/tests/test_journal_recovery_turn_ownership.py
+++ b/tests/test_journal_recovery_turn_ownership.py
@@ -1,0 +1,461 @@
+"""Turn-ownership gates for run-journal recovery dedupe (#7388 residuals).
+
+1: window picks the current turn, indexed against the ORIGINAL messages array.
+2: with a stream and no window, only a same-stream card may match.
+3: the tool oracle must compare an actually-equal normalized name+preview."""
+from __future__ import annotations
+
+import pytest
+
+import api.models as models
+import api.profiles as profiles
+import api.run_journal as run_journal
+from api.models import (
+    Session,
+    _TURN_WINDOW_AMBIGUOUS,
+    _append_journaled_partial_output,
+    _find_existing_assistant_for_journal_content,
+    _journal_tool_already_present,
+    _pending_recovery_turn_window_start,
+)
+from api.run_journal import append_run_event
+
+STREAM_ID = "stream-current"
+OTHER_STREAM = "stream-foreign"
+PROMPT = "run the report"
+ANSWER = "The report finished with 3 warnings and no errors."
+TOOL_NAME = "terminal"
+TOOL_PREVIEW = "ls"
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME *and* the run-journal root.
+
+    ``run_journal`` resolves its root via the session dir, so patching only the
+    env var lets ``append_run_event`` write into the real ``~/.hermes``.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    sessions = home / "sessions"
+    sessions.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", home)
+    monkeypatch.setattr(run_journal, "_default_session_dir", lambda: sessions)
+    monkeypatch.setattr(models, "SESSION_DIR", sessions)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", sessions / "_index.json")
+    return home
+
+
+def _user(content, ts, **extra):
+    row = {"role": "user", "content": content, "timestamp": ts}
+    row.update(extra)
+    return row
+
+
+def _assistant(content, ts, **extra):
+    row = {"role": "assistant", "content": content, "timestamp": ts}
+    row.update(extra)
+    return row
+
+
+def _session(sid, messages, *, pending_started_at, tool_calls=None):
+    return Session(
+        session_id=sid,
+        title="gate",
+        messages=list(messages),
+        tool_calls=list(tool_calls or []),
+        pending_user_message=PROMPT,
+        pending_started_at=pending_started_at,
+        pending_user_source="webui",
+        pending_attachments=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — turn window selection
+# ---------------------------------------------------------------------------
+
+
+def test_recovered_echo_and_real_submission_open_the_same_turn(hermes_home):
+    """Two checkpoint-identical user rows in one turn open at the EARLIEST.
+
+    The repair path appends a ``_recovered`` echo, so one turn shows both rows;
+    the core output between them must stay claimable (#3929).
+    """
+    ts = 1_700_000_000
+    messages = [
+        _user("an earlier, different prompt", ts - 500),   # 0
+        _assistant(ANSWER, ts - 499),                      # 1 historical answer
+        _user(PROMPT, ts),                                 # 2 real submission
+        _assistant("core output for this turn", ts + 1),   # 3 current-turn core
+        _user(PROMPT, ts, _recovered=True),                # 4 repair echo
+    ]
+    session = _session("gate1-echo", messages, pending_started_at=ts)
+
+    window = _pending_recovery_turn_window_start(session)
+
+    assert window == 2, (
+        f"window opened at {window}; both checkpoint rows belong to the current "
+        "turn, so it must open at the earlier one (index 2) to keep this turn's "
+        "core row at index 3 claimable"
+    )
+    # The historical answer at index 1 sits BEFORE the window and is a
+    # different turn's output — it must not be claimable.
+    assert (
+        _find_existing_assistant_for_journal_content(
+            session, ANSWER, stream_id=STREAM_ID, turn_start=window
+        )
+        is None
+    ), "historical answer was claimed by the current turn — cross-turn data loss"
+
+
+def test_historical_turn_with_different_checkpoint_never_wins_window(hermes_home):
+    """An earlier turn repeating the prompt TEXT must not open the window.
+
+    Only the text-only fallback could match it, and that runs solely when no
+    exact checkpoint exists — here the current turn has one.
+    """
+    ts = 1_700_000_050
+    messages = [
+        _user(PROMPT, ts - 500),        # historical: same text, different ts
+        _assistant(ANSWER, ts - 499),
+        _user(PROMPT, ts),              # current turn: exact checkpoint
+    ]
+    session = _session("gate1-textdupe", messages, pending_started_at=ts)
+
+    window = _pending_recovery_turn_window_start(session)
+
+    assert window == 2, (
+        f"window opened at {window}; the exact checkpoint at index 2 must beat "
+        "the earlier text-only repeat at index 0"
+    )
+    assert (
+        _find_existing_assistant_for_journal_content(
+            session, ANSWER, stream_id=STREAM_ID, turn_start=window
+        )
+        is None
+    ), "the earlier turn's answer must not be claimable"
+
+
+def test_window_index_is_a_coordinate_in_original_messages(hermes_home):
+    """A non-dict row before the checkpoint must not shift the window index.
+
+    Compacting before ``enumerate()`` returns a compacted-list coordinate while
+    ownership compares against the original array.
+    """
+    ts = 1_700_000_100
+    messages = [
+        None,                                   # 0 malformed/legacy row
+        _user(PROMPT, ts - 50),                 # 1 historical submission
+        _assistant(ANSWER, ts - 49),            # 2 historical answer
+        _user(PROMPT, ts),                      # 3 current turn (exact ts)
+    ]
+    session = _session("gate1-nondict", messages, pending_started_at=ts)
+
+    window = _pending_recovery_turn_window_start(session)
+
+    assert window == 3, (
+        f"window index {window} is a compacted-list coordinate; it must address "
+        "the current checkpoint at index 3 of the original session.messages"
+    )
+    assert (
+        _find_existing_assistant_for_journal_content(
+            session, ANSWER, stream_id=STREAM_ID, turn_start=window
+        )
+        is None
+    ), "index shift admitted the historical answer at index 2"
+
+
+def test_ambiguous_boundary_fails_closed_toward_appending(hermes_home):
+    """A pending turn with no matching row reports an AMBIGUOUS boundary.
+
+    Distinct from a quiescent session (``None``), where legacy session-wide
+    matching is still correct.
+    """
+    ts = 1_700_000_200
+    messages = [
+        _user("a completely different prompt", ts - 10),
+        _assistant(ANSWER, ts - 9),
+    ]
+    session = _session("gate1-ambiguous", messages, pending_started_at=ts)
+
+    window = _pending_recovery_turn_window_start(session)
+    assert window is _TURN_WINDOW_AMBIGUOUS, (
+        "a pending turn with no matching row must report an AMBIGUOUS boundary, "
+        "not None — None means 'quiescent' and re-enables session-wide matching"
+    )
+
+    assert (
+        _find_existing_assistant_for_journal_content(
+            session, ANSWER, stream_id=STREAM_ID, turn_start=window
+        )
+        is None
+    ), "an unprovable boundary must not claim a historical assistant row"
+
+
+def test_quiescent_session_keeps_legacy_session_wide_match(hermes_home):
+    """No pending turn: there is no current-turn boundary to protect.
+
+    Legacy session-wide matching must survive here or the #3929
+    reasoning-backfill contract breaks on pre-stream-id transcripts.
+    """
+    session = Session(
+        session_id="gate1-quiescent",
+        title="gate",
+        messages=[
+            _user("earlier", 1_700_000_250),
+            _assistant(ANSWER, 1_700_000_251),
+        ],
+    )
+
+    assert _pending_recovery_turn_window_start(session) is None
+    assert (
+        _find_existing_assistant_for_journal_content(session, ANSWER) == 1
+    ), "a quiescent session must keep the pre-fix session-wide match"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — tool ownership
+# ---------------------------------------------------------------------------
+
+
+def test_untagged_historical_tool_does_not_suppress_with_pending_turn(
+    hermes_home,
+):
+    """Pending turn + unlocatable boundary: an untagged card must NOT match.
+
+    Ownership is keyed on the WINDOW; nothing may be claimed by position.
+    """
+    session = _session(
+        "gate2-untagged",
+        [_user("unrelated", 1_700_000_300)],
+        pending_started_at=1_700_000_300,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 0,
+            }
+        ],
+    )
+    window = _pending_recovery_turn_window_start(session)
+    assert window is _TURN_WINDOW_AMBIGUOUS
+
+    assert not _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=STREAM_ID, turn_start=window
+    ), (
+        "an untagged historical tool card suppressed the current turn's card "
+        "even though no turn window proved ownership"
+    )
+
+
+def test_same_stream_tagged_tool_still_matches(hermes_home):
+    """Same-stream idempotency control: a card tagged with OUR stream matches."""
+    session = _session(
+        "gate2-same-stream",
+        [_user(PROMPT, 1_700_000_400)],
+        pending_started_at=1_700_000_400,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "_recovered_stream_id": STREAM_ID,
+                "assistant_msg_idx": 0,
+            }
+        ],
+    )
+
+    assert _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=STREAM_ID, turn_start=None
+    ), "same-stream replay must collapse onto its own earlier recovered card"
+
+
+def test_foreign_stream_tagged_tool_never_matches(hermes_home):
+    """A card tagged with a DIFFERENT stream belongs to another turn."""
+    session = _session(
+        "gate2-foreign",
+        [_user(PROMPT, 1_700_000_500)],
+        pending_started_at=1_700_000_500,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "_recovered_stream_id": OTHER_STREAM,
+                "assistant_msg_idx": 0,
+            }
+        ],
+    )
+
+    assert not _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=STREAM_ID, turn_start=0
+    ), "a foreign-stream card must never suppress this stream's tool"
+
+
+def test_untagged_tool_inside_current_window_matches(hermes_home):
+    """Untagged card whose owner sits inside the window IS current-turn output."""
+    session = _session(
+        "gate2-in-window",
+        [_user(PROMPT, 1_700_000_600), _assistant("", 1_700_000_601)],
+        pending_started_at=1_700_000_600,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 1,
+            }
+        ],
+    )
+
+    assert _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=STREAM_ID, turn_start=0
+    ), "a card owned by a row inside the window is the current turn's own card"
+
+
+def test_legacy_session_wide_match_only_without_both_inputs(hermes_home):
+    """Both ownership inputs absent -> documented pre-fix session-wide behavior."""
+    session = _session(
+        "gate2-legacy",
+        [_user(PROMPT, 1_700_000_700)],
+        pending_started_at=1_700_000_700,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 0,
+            }
+        ],
+    )
+
+    assert _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=None, turn_start=None
+    ), "legacy callers must keep the pre-fix session-wide match"
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — the oracle must compare an actually-equal normalized preview
+# ---------------------------------------------------------------------------
+
+
+def _write_tool_journal(sid, stream_id, *, preview=TOOL_PREVIEW):
+    """Emit a tool pair whose normalized preview EQUALS the historical card's.
+
+    The prior oracle emitted ``args={"cmd": "ls"}`` with no ``preview``, so the
+    signatures were unequal and the assertion could not fail.
+    """
+    append_run_event(sid, stream_id, "tool", {"name": TOOL_NAME, "preview": preview})
+    append_run_event(
+        sid, stream_id, "tool_complete", {"name": TOOL_NAME, "preview": preview}
+    )
+
+
+def test_oracle_preview_is_actually_equal(hermes_home):
+    """Guard the oracle itself: the emitted preview must match the card."""
+    sid = "gate3-oracle"
+    _write_tool_journal(sid, STREAM_ID)
+    session = _session(
+        sid,
+        [_user(PROMPT, 1_700_000_800)],
+        pending_started_at=1_700_000_800,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 0,
+                "_recovered_stream_id": STREAM_ID,
+            }
+        ],
+    )
+    assert _journal_tool_already_present(
+        session, TOOL_NAME, TOOL_PREVIEW, stream_id=STREAM_ID, turn_start=None
+    ), "fixture preview must be signature-equal or the repeated-tool gate is vacuous"
+
+
+def test_repeated_untagged_tool_survives_then_replay_is_idempotent(hermes_home):
+    """Two turns each keep their own card; replaying the stream adds no third."""
+    sid = "gate3-two-turns"
+    _write_tool_journal(sid, STREAM_ID)
+    ts = 1_700_000_900
+    session = _session(
+        sid,
+        [
+            _user(PROMPT, ts - 100),
+            _assistant("earlier answer", ts - 99),
+            _user(PROMPT, ts),
+        ],
+        pending_started_at=ts,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 1,
+            }
+        ],
+    )
+
+    _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    after_first = [
+        tc for tc in session.tool_calls
+        if tc.get("name") == TOOL_NAME
+    ]
+    assert len(after_first) == 2, (
+        f"expected the historical card plus the current turn's card, got "
+        f"{len(after_first)} — the historical card suppressed current output"
+    )
+
+    for _ in range(3):
+        _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    after_replay = [
+        tc for tc in session.tool_calls
+        if tc.get("name") == TOOL_NAME
+    ]
+    assert len(after_replay) == 2, (
+        f"replaying the same stream grew tool cards to {len(after_replay)}; "
+        "same-stream recovery must be idempotent"
+    )
+
+
+def test_repeated_answer_across_turns_survives(hermes_home):
+    """An identical answer in an earlier turn must not suppress the current one."""
+    sid = "gate3-answer"
+    append_run_event(sid, STREAM_ID, "token", {"text": ANSWER})
+    ts = 1_700_001_000
+    session = _session(
+        sid,
+        [
+            _user(PROMPT, ts - 100),
+            _assistant(ANSWER, ts - 99),
+            _user(PROMPT, ts),
+        ],
+        pending_started_at=ts,
+    )
+
+    _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+
+    answers = [
+        m for m in session.messages
+        if m.get("role") == "assistant"
+        and str(m.get("content") or "").strip() == ANSWER
+    ]
+    assert len(answers) == 2, (
+        f"expected the historical answer plus the recovered current answer, got "
+        f"{len(answers)} — the earlier turn suppressed current recovery output"
+    )
+
+    for _ in range(3):
+        _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    answers_after = [
+        m for m in session.messages
+        if m.get("role") == "assistant"
+        and str(m.get("content") or "").strip() == ANSWER
+    ]
+    assert len(answers_after) == 2, (
+        f"replay grew answers to {len(answers_after)}; recovery must be idempotent"
+    )

--- a/tests/test_journal_recovery_turn_ownership.py
+++ b/tests/test_journal_recovery_turn_ownership.py
@@ -16,8 +16,10 @@ from api.models import (
     _append_journaled_partial_output,
     _find_existing_assistant_for_journal_content,
     _journal_tool_already_present,
+    _normalize_journal_recovery_text,
     _pending_recovery_turn_window_start,
 )
+from api.process_event_utils import build_active_turn_token
 from api.run_journal import append_run_event
 
 STREAM_ID = "stream-current"
@@ -59,7 +61,7 @@ def _assistant(content, ts, **extra):
     return row
 
 
-def _session(sid, messages, *, pending_started_at, tool_calls=None):
+def _session(sid, messages, *, pending_started_at, tool_calls=None, active_stream_id=None):
     return Session(
         session_id=sid,
         title="gate",
@@ -69,6 +71,7 @@ def _session(sid, messages, *, pending_started_at, tool_calls=None):
         pending_started_at=pending_started_at,
         pending_user_source="webui",
         pending_attachments=[],
+        active_stream_id=active_stream_id,
     )
 
 
@@ -84,14 +87,17 @@ def test_recovered_echo_and_real_submission_open_the_same_turn(hermes_home):
     the core output between them must stay claimable (#3929).
     """
     ts = 1_700_000_000
+    token = build_active_turn_token(STREAM_ID, ts)
     messages = [
         _user("an earlier, different prompt", ts - 500),   # 0
         _assistant(ANSWER, ts - 499),                      # 1 historical answer
-        _user(PROMPT, ts),                                 # 2 real submission
+        _user(PROMPT, ts, _active_turn_token=token),       # 2 real submission
         _assistant("core output for this turn", ts + 1),   # 3 current-turn core
-        _user(PROMPT, ts, _recovered=True),                # 4 repair echo
+        _user(PROMPT, ts, _recovered=True, _active_turn_token=token),  # 4 echo
     ]
-    session = _session("gate1-echo", messages, pending_started_at=ts)
+    session = _session(
+        "gate1-echo", messages, pending_started_at=ts, active_stream_id=STREAM_ID,
+    )
 
     window = _pending_recovery_turn_window_start(session)
 
@@ -458,4 +464,103 @@ def test_repeated_answer_across_turns_survives(hermes_home):
     ]
     assert len(answers_after) == 2, (
         f"replay grew answers to {len(answers_after)}; recovery must be idempotent"
+    )
+
+
+def test_same_second_historical_real_and_current_echo_does_not_claim_history(
+    hermes_home,
+):
+    """Same-second historical real + current echo must not claim history."""
+    sid = "gate4-collision"
+    append_run_event(sid, STREAM_ID, "token", {"text": ANSWER})
+    _write_tool_journal(sid, STREAM_ID)
+    ts = 1_700_001_100
+    session = _session(
+        sid,
+        [
+            _user(PROMPT, ts),
+            _assistant(ANSWER, ts),
+            _user(PROMPT, ts, _recovered=True),
+        ],
+        pending_started_at=ts,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 1,
+            }
+        ],
+    )
+    assert _normalize_journal_recovery_text(TOOL_PREVIEW) == (
+        _normalize_journal_recovery_text(session.tool_calls[0].get("preview"))
+    ), "fixture preview must be signature-equal or this gate is vacuous"
+
+    window = _pending_recovery_turn_window_start(session)
+    assert window is _TURN_WINDOW_AMBIGUOUS, (
+        f"window opened at {window}; colliding exact checkpoints must fail closed"
+    )
+
+    _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    answers = [
+        m for m in session.messages
+        if m.get("role") == "assistant"
+        and str(m.get("content") or "").strip() == ANSWER
+    ]
+    tools = [tc for tc in session.tool_calls if tc.get("name") == TOOL_NAME]
+    assert len(answers) == 2, (
+        f"expected historical plus recovered current answer, got {len(answers)}"
+    )
+    assert len(tools) == 2, (
+        f"expected historical plus recovered current tool, got {len(tools)}"
+    )
+
+    for _ in range(3):
+        _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    answers_after = [
+        m for m in session.messages
+        if m.get("role") == "assistant"
+        and str(m.get("content") or "").strip() == ANSWER
+    ]
+    tools_after = [tc for tc in session.tool_calls if tc.get("name") == TOOL_NAME]
+    assert len(answers_after) == 2, (
+        f"replay grew answers to {len(answers_after)}; recovery must be idempotent"
+    )
+    assert len(tools_after) == 2, (
+        f"replay grew tools to {len(tools_after)}; recovery must be idempotent"
+    )
+
+
+def test_tool_only_dedupe_does_not_allocate_blank_anchor(hermes_home):
+    """A current-window untagged tool must not grow messages on replay."""
+    sid = "gate4-tool-anchor"
+    _write_tool_journal(sid, STREAM_ID)
+    ts = 1_700_001_200
+    session = _session(
+        sid,
+        [_user(PROMPT, ts), _assistant("", ts + 1)],
+        pending_started_at=ts,
+        tool_calls=[
+            {
+                "name": TOOL_NAME,
+                "preview": TOOL_PREVIEW,
+                "snippet": TOOL_PREVIEW,
+                "assistant_msg_idx": 1,
+            }
+        ],
+    )
+    assert _normalize_journal_recovery_text(TOOL_PREVIEW) == (
+        _normalize_journal_recovery_text(session.tool_calls[0].get("preview"))
+    ), "fixture preview must be signature-equal or this gate is vacuous"
+
+    before_messages = len(session.messages)
+    before_tools = len(session.tool_calls)
+    for _ in range(4):
+        _append_journaled_partial_output(session, STREAM_ID, dedupe_existing=True)
+    assert len(session.tool_calls) == before_tools, (
+        f"tool cards grew {before_tools} -> {len(session.tool_calls)}"
+    )
+    assert len(session.messages) == before_messages, (
+        f"messages grew {before_messages} -> {len(session.messages)}; "
+        "deduped tool recovery must not allocate a blank assistant anchor"
     )


### PR DESCRIPTION
## Run-journal recovery is not idempotent, and the obvious fix loses data across turns

`_apply_core_sync_or_error_marker()` (the populated-sidecar repair path) calls `_recover_journaled_output_and_terminal_error()` **without** `dedupe_existing`, which defaults to `False`. Every repair pass therefore replays the dead stream's journal from seq 1 and re-appends its recovered rows. Sessions accumulate empty assistant stubs tagged `_recovered_from_run_journal` until the sidecar is too large for the browser to load.

This is the same bug as **#7388**, which flips those defaults to `True`. That PR is blocked at three separate heads (`4134d28`, `baab35b`, `679b7cbd`) because flipping the flag alone reaches the existing **session-wide** deduper: an answer or tool legitimately repeated in a *later* turn collapses onto the earlier one, and the recovering turn's output disappears. The idempotency direction was never the objection — turn ownership was.

This PR takes the same direction and closes the three re-gate residuals.

### The rule

Ownership becomes a precondition, not a heuristic. A row may absorb a journal segment only when it provably belongs to the turn being recovered:

- it carries **this stream's** `_recovered_stream_id` (an earlier pass of the same recovery), or
- it sits at/after the pending-user checkpoint that opens the current turn.

`_pending_recovery_turn_window_start()` resolves that boundary and returns a **tri-state**, which is what keeps the two distinct failure modes apart:

| value | meaning | dedupe scope |
|---|---|---|
| `int` | boundary known | rows at/after it |
| `None` | no turn pending (quiescent) | legacy session-wide — nothing to protect, keeps #3929 green |
| `_TURN_WINDOW_AMBIGUOUS` | a turn IS mid-recovery but no row matches its checkpoint | claim nothing by position; fail closed and append |

Collapsing the last two into a single `None` is what made my first attempt regress `test_reasoning_backfill_is_idempotent_for_existing_recovered_text` — a quiescent session legitimately has no window, and must not be treated as ambiguous.

### Re-gate residuals

**1. Mixed historical/current matches, and the index space.**
Indexes address `session.messages` directly. Compacting non-dict rows before `enumerate()` returns a coordinate in the *compacted* list while ownership compares against the original array — one malformed row shifts the boundary backward and admits a historical assistant row.

The window opens at the **earliest** exact checkpoint match. The repair path appends its own `_recovered` echo *before* journal recovery runs, so a turn can present two checkpoint-identical user rows; both open the same turn, and the core output between them must stay claimable (#3929's `test_reasoning_backfill_accepts_core_row_before_recovered_owner_echo` pins exactly this). Historical turns are excluded by **checkpoint identity** — timestamp, source and attachments compared against `pending_started_at` — not by position, so "earliest" is not a weakening. The text-only fallback is content-equality only, so it stays "latest match, and only when no exact checkpoint exists".

**2. Stream-present/no-window tool matching.**
`_journal_tool_already_present()` now branches on the **existing card's** provenance, never on which arguments the caller supplied. Tagged with another stream → skip. Tagged with ours → match (this is what makes replay idempotent). Untagged → only a proven window position may match. Supplying a `stream_id` no longer bypasses the untagged-card check, and legacy session-wide matching is keyed on the *window* being `None`, not on the stream id being absent.

**3. The tool oracle was false-green.**
The prior fixture emitted `args={"cmd": "ls"}` with no `preview`, so production dedupe compared an empty candidate against `"ls"`; unequal signatures append regardless of the ownership branch, and the assertion could not fail. The journal event here emits a preview that is signature-equal to the historical card, and `test_oracle_preview_is_actually_equal` guards the fixture itself so it cannot silently rot back.

### Also handled: untimed core rows

Core-transcript rows are persisted **without timestamps**, so they can never satisfy the exact checkpoint. When the repair path loads a core transcript and then appends its recovered echo, the echo is the only exact match and the core rows for the same turn sit before it. A same-text user row with no usable timestamp cannot be proven to belong to an earlier turn, so the window extends back across it; a row with a present, different timestamp is a provable boundary and stops the walk. Without this, `test_core_sync_branch_does_not_duplicate_journal_output_already_in_core` regresses.

### Measured

Six repair passes through the real `_apply_core_sync_or_error_marker()` entry point, same journal:

| pass | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| **before** — recovered rows | 2 | 4 | 6 | 8 | 10 | 12 |
| **before** — tool cards | 1 | 2 | 3 | 4 | 5 | 6 |
| **after** — recovered rows | 2 | 2 | 2 | 2 | 2 | 2 |
| **after** — tool cards | 1 | 1 | 1 | 1 | 1 | 1 |

The two cross-turn data-loss cases were verified to **fail on base and pass here**, with same-stream idempotency held as a control:

```
BASE    [FAIL] repeated answer across turns survives      got 1, expected 2
        [FAIL] repeated untagged tool across turns        got 1, expected 2
        [PASS] same-stream replay is idempotent
BRANCH  [PASS] [PASS] [PASS]
```

### Tests

`tests/test_journal_recovery_turn_ownership.py` — 13 tests: window selection (recovered echo + real submission, text-repeat vs exact checkpoint, non-dict index shift, ambiguous boundary, quiescent legacy scope), tool ownership (untagged/tagged/foreign-stream/in-window/legacy), and the two integration cases with the corrected oracle.

Recovery-surface suites run against branch and base in the same harness: **161 passed on branch vs 148 on base, with the same 3 pre-existing failures on both** (`test_recovered_journal_context.py::test_deduped_existing_recovered_assistant_repairs_missing_context` and two in `test_session_lost_response_regression.py` — these need the HTTP `server.py` fixture, which does not boot in my sandbox, and they fail identically on unmodified `origin/master`). No regression is introduced by this change; `#3875`, `#3929`, `#4283`, `#3802` and the sidecar-repair suites are green.

### Relationship to other open PRs

- **#7388** — same bug, same direction, currently blocked on the three residuals above. This PR is a drop-in alternative; if #7388 lands first this becomes the turn-scope follow-up.
- **#7291** / **#7273** — reduce what the journal *records* (metering telemetry). Complementary: they shrink replay input, this makes replay idempotent. No overlap in `models.py`.
- **#7282** — skips replay repair for sidecars already proven clean. Complementary: it avoids the pass, this makes the pass safe when it does run.

### Note on the growth shape

Worth flagging for anyone matching production symptoms: #7388's evidence grows **linearly** (+43 rows/pass), which is what this code path produces. I also have two sessions whose clone blocks grow **geometrically** — 1, 1, 2, 4, 8, 16, 32, 64, 128, where each block is an exact copy of every prior clone plus one new payload. I could not reproduce that doubling in this path and am not claiming this PR explains it; it may be a second mechanism. This PR fixes the linear replay only.
