### PR TITLE
feat(titles): schema-first JSON title generation with reasoning-disable fallback

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4444,12 +4444,17 @@ def generate_title_raw_via_aux(
         reasoning_extra["reasoning"] = {"enabled": False}
     if _is_minimax_route(provider, model, base_url):
         reasoning_extra["reasoning_split"] = True
-    # The reasoning-disable rides along on the schema attempt too, exactly like
-    # the CLI (thinking disabled AND output constrained to the JSON object), so
-    # a reasoning-capable model can't burn the whole budget on hidden thinking
-    # before emitting the object (#2083).  Reject-listed routes (OpenAI/Azure,
-    # #4161) stay schema-only.
-    schema_extra.update(reasoning_extra)
+    # The two modes stay INDEPENDENT (#7417 re-gate): the schema attempt sends
+    # ONLY ``response_format`` — exactly the request shape of the Agent title
+    # generator this path mirrors (agent/title_generator.py). A route that
+    # accepts structured output but rejects the nonstandard ``reasoning``
+    # extension (strict OpenAI-compatible gateways) must not fail the schema
+    # attempt because the extension rode along; schema support would then be
+    # gated behind the old provider whitelist again, and the reasoning fallback
+    # would fail too on such routes. The reasoning-disable shape is reserved
+    # for the compatibility fallback below, still gated by
+    # ``_route_rejects_reasoning_extra()`` (#2083 concern is covered there:
+    # the fallback only runs when the route rejected/ignored the schema).
     try:
         _timeout = _aux_title_timeout()
         from agent.auxiliary_client import call_llm

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4339,6 +4339,65 @@ def _extract_title_response(resp, *, aux: bool = False) -> tuple[str, str]:
         return '', f'llm_empty{suffix}'
 
 
+# Strict-output schema for auxiliary title generation (#7413).  Byte-for-byte
+# the CLI's response_format (agent/title_generator.py): requesting a JSON
+# object of shape ``{"title": "..."}`` works on routes that accept-but-ignore a
+# reasoning-disable (e.g. opencode-go/mimo-v2.5-pro) — those used to answer
+# with long reasoning markdown instead of a short title.
+_TITLE_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "session_title",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def _title_unwrap_schema_content(content: str) -> str:
+    """Unwrap a schema-mode title response to plain text.
+
+    Port of the CLI's ``agent/title_generator._extract_title_text`` for the
+    aux route.  Strict ``json_schema`` responses arrive as
+    ``{"title": "..."}``, sometimes wrapped in a markdown fence by
+    non-compliant gateways; providers that ignore ``response_format`` return
+    prose, which is passed through unchanged for the shared sanitizer.
+
+    Returns '' when the content IS JSON but carries no usable string
+    ``title`` (a different object shape, an array, ...) — the caller then
+    falls back to the reasoning-disable mode instead of storing a JSON blob
+    as the session title.
+    """
+    if not content:
+        return ''
+    raw = content.strip()
+    # Fenced JSON from gateways that wrap structured output in markdown.
+    fenced = re.match(r'^```(?:json)?\s*(.*?)\s*```$', raw, re.DOTALL)
+    if fenced:
+        raw = fenced.group(1).strip()
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict) and isinstance(parsed.get('title'), str):
+            return parsed['title'].strip()
+        # Valid JSON that is not a {"title": ...} object — not prose, unusable.
+        return ''
+    except (ValueError, TypeError):
+        pass
+    # Loose scan: a compliant object embedded in surrounding chatter.
+    match = re.search(r'"title"\s*:\s*"((?:[^"\\]|\\.)*)"', raw)
+    if match:
+        try:
+            return json.loads('"%s"' % match.group(1)).strip()
+        except ValueError:
+            return match.group(1).strip()
+    return raw  # prose: leave to the shared sanitizer
+
+
 def generate_title_raw_via_aux(
     user_text: str,
     assistant_text: str,
@@ -4372,15 +4431,34 @@ def generate_title_raw_via_aux(
     if not caller_supplied_route:
         api_key = str(configured.get('api_key', '') or '').strip()
     base_max_tokens = _title_completion_budget(provider, model, base_url)
+    # Schema-first title generation (#7413): request a strict ``{"title": ...}``
+    # JSON object via ``response_format`` (mirroring the CLI), because routes
+    # that accept-but-ignore a reasoning-disable (e.g. opencode-go/mimo-v2.5-pro)
+    # answer with long reasoning markdown instead of a short title — structured
+    # output works on those routes.  The reasoning-disable mode is kept as the
+    # fallback for routes that reject ``response_format`` (HTTP 400) or answer
+    # with a fully empty response.
+    schema_extra = {"response_format": _TITLE_RESPONSE_FORMAT}
     reasoning_extra = {}
     if not _route_rejects_reasoning_extra(provider, model, base_url):
         reasoning_extra["reasoning"] = {"enabled": False}
     if _is_minimax_route(provider, model, base_url):
         reasoning_extra["reasoning_split"] = True
+    # The reasoning-disable rides along on the schema attempt too, exactly like
+    # the CLI (thinking disabled AND output constrained to the JSON object), so
+    # a reasoning-capable model can't burn the whole budget on hidden thinking
+    # before emitting the object (#2083).  Reject-listed routes (OpenAI/Azure,
+    # #4161) stay schema-only.
+    schema_extra.update(reasoning_extra)
     try:
         _timeout = _aux_title_timeout()
         from agent.auxiliary_client import call_llm
         last_status = 'llm_error_aux'
+        attempted = 0
+        # Schema mode starts alive; once a route proves it can't honor
+        # ``response_format`` (exception or empty answer), switch that route to
+        # the reasoning-disable mode for all remaining attempts.
+        schema_dead = False
         for idx, prompt in enumerate(prompts):
             messages = [
                 {"role": "system", "content": prompt},
@@ -4389,22 +4467,63 @@ def generate_title_raw_via_aux(
             budgets = [base_max_tokens]
             try:
                 for budget_idx, max_tokens in enumerate(budgets):
-                    resp = call_llm(
-                        task='title_generation',
-                        provider=provider or None,
-                        model=model or None,
-                        base_url=base_url or None,
-                        api_key=api_key or None,
-                        messages=messages,
-                        max_tokens=max_tokens,
-                        temperature=0.2,
-                        timeout=_timeout,
-                        extra_body=reasoning_extra or None,
-                    )
-                    raw, empty_status = _extract_title_response(resp, aux=True)
-                    if raw:
-                        return raw, ('llm_aux' if idx == 0 and budget_idx == 0 else 'llm_aux_retry')
-                    last_status = empty_status or 'llm_empty_aux'
+                    # Try the JSON-schema mode first; fall back to the
+                    # reasoning-disable mode for this same slot when the route
+                    # rejected ``response_format`` or returned an empty answer.
+                    modes = ('schema', 'reasoning') if not schema_dead else ('reasoning',)
+                    for mode in modes:
+                        try:
+                            attempted += 1
+                            resp = call_llm(
+                                task='title_generation',
+                                provider=provider or None,
+                                model=model or None,
+                                base_url=base_url or None,
+                                api_key=api_key or None,
+                                messages=messages,
+                                max_tokens=max_tokens,
+                                temperature=0.2,
+                                timeout=_timeout,
+                                extra_body=(
+                                    schema_extra
+                                    if mode == 'schema'
+                                    else (reasoning_extra or None)
+                                ),
+                            )
+                        except Exception as e:
+                            last_status = 'llm_error_aux'
+                            logger.debug(
+                                "Aux title generation attempt %s (%s mode) failed: %s",
+                                idx + 1, mode, e,
+                            )
+                            if mode == 'schema':
+                                schema_dead = True
+                                continue  # try the reasoning-disable mode instead
+                            raise
+                        raw, empty_status = _extract_title_response(resp, aux=True)
+                        if raw:
+                            if mode == 'schema':
+                                # json_schema responses arrive as
+                                # ``{"title": ...}`` (possibly markdown-fenced);
+                                # unwrap before the shared sanitizer runs.
+                                # Returns '' when the JSON object has no usable
+                                # title, so the reasoning-disable mode gets a
+                                # chance instead of storing a JSON blob.
+                                raw = _title_unwrap_schema_content(raw)
+                            if raw:
+                                return raw, ('llm_aux' if attempted == 1 else 'llm_aux_retry')
+                        last_status = empty_status or 'llm_empty_aux'
+                        if mode == 'schema' and last_status == 'llm_empty_aux':
+                            # Route answered with no content at all: it likely
+                            # ignored ``response_format``.  Fall back to the
+                            # reasoning-disable mode for this same slot.
+                            schema_dead = True
+                            continue
+                        # llm_empty_reasoning / llm_length keep today's semantics:
+                        # reasoning-only output short-circuits (#2083) and length
+                        # truncation retries with a doubled budget — in whichever
+                        # mode is active.
+                        break
                     if budget_idx == 0 and _title_retry_status(last_status):
                         budgets.append(_title_retry_completion_budget(provider, model, base_url))
             except Exception as e:

--- a/docs/advanced-chat-setup.md
+++ b/docs/advanced-chat-setup.md
@@ -76,6 +76,16 @@ The WebUI's `auto_title_refresh_every` setting remains a separate control for
 periodic refreshes of already-generated titles; it does not re-enable
 automatic generation when the auxiliary flag is off.
 
+Title-generation LLM requests are schema-first: the WebUI asks the model for a
+strict `{"title": ...}` JSON object via the `response_format` parameter
+(mirroring the Hermes Agent's own title generator). The schema attempt sends
+only `response_format`, never a reasoning extension, so routes that accept
+structured output but reject nonstandard fields work on the first attempt.
+When a route rejects `response_format` (or answers empty/non-object), the
+WebUI falls back to the compatibility shape with reasoning disabled
+(`reasoning: {enabled: false}`) for routes that support it, keeping the
+provider whitelist out of the schema path.
+
 ## Gateway-backed browser chat
 
 By default, browser chat runs through WebUI's in-process legacy runtime. Advanced

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -1315,8 +1315,49 @@ class TestAuxSchemaFirstTitleGeneration(unittest.TestCase):
         self.assertEqual(extra['response_format']['type'], 'json_schema')
         self.assertEqual(extra['response_format']['json_schema']['name'], 'session_title')
         self.assertEqual(extra['response_format']['json_schema']['schema']['required'], ['title'])
-        # Route is not reject-listed: the reasoning-disable rides along, like the CLI.
-        self.assertEqual(extra['reasoning'], {'enabled': False})
+        # The schema attempt is schema-ONLY — exactly the Agent title-generator
+        # request shape it mirrors (parity reference); the reasoning-disable is
+        # reserved for the compatibility fallback (#7417 re-gate).
+        self.assertNotIn('reasoning', extra)
+        self.assertEqual(captured['task'], 'title_generation')
+
+    def test_schema_only_route_rejecting_reasoning_succeeds_on_first_call(self):
+        """A strict route that accepts ``response_format`` but raises whenever
+        the nonstandard ``reasoning`` field is present must succeed on the
+        FIRST schema-only call — exactly one call, payload has
+        ``response_format`` and no ``reasoning`` (#7417 re-gate reproduction
+        of the maintainer's blocker)."""
+        from api.streaming import generate_title_raw_via_aux
+
+        calls = []
+
+        def fake_call_llm(**kwargs):
+            calls.append(kwargs)
+            extra = kwargs.get('extra_body') or {}
+            if 'reasoning' in extra:
+                raise ValueError('Unknown parameter: reasoning')
+            return {
+                'choices': [
+                    {
+                        'message': {'content': '{"title": "Schema Works"}'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'custom', 'model': 'strict-gateway-model', 'base_url': 'https://strict.example.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Strict gateway here',
+                    assistant_text='Strictly titled.',
+                )
+
+        self.assertEqual(result, 'Schema Works')
+        self.assertEqual(status, 'llm_aux')
+        self.assertEqual(len(calls), 1, "the schema-only attempt must not fail on a reasoning-rejecting route")
+        extra = calls[0].get('extra_body') or {}
+        self.assertIn('response_format', extra)
+        self.assertNotIn('reasoning', extra)
 
     def test_schema_first_unwraps_fenced_json(self):
         """Some gateways wrap structured output in a markdown code fence."""

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -1273,5 +1273,269 @@ class TestAuxTitleConversationContext(unittest.TestCase):
         self.assertEqual(mock_aux_title.call_args.kwargs.get('conversation_id'), 'entry-sync-sid')
 
 
+class TestAuxSchemaFirstTitleGeneration(unittest.TestCase):
+    """Schema-first title generation (#7413): the aux route asks for a strict
+    ``{"title": ...}`` JSON object via ``response_format`` (mirroring the CLI's
+    agent/title_generator.py) so routes that accept-but-ignore a
+    reasoning-disable still return a short parseable title, with the
+    reasoning-disable mode kept as the fallback for routes that reject
+    ``response_format`` or answer with an empty/non-object response.
+    """
+
+    def _patch_llm(self, fake):
+        return patch('agent.auxiliary_client.call_llm', side_effect=fake, create=True)
+
+    def test_schema_first_unwraps_json_title(self):
+        """A strict json_schema response unwraps to its title text."""
+        from api.streaming import generate_title_raw_via_aux
+
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return {
+                'choices': [
+                    {
+                        'message': {'content': '{"title": "Weather Report"}'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'openrouter', 'model': 'deepseek/deepseek-chat', 'base_url': 'https://openrouter.ai/api/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='What is the weather?',
+                    assistant_text='It is sunny and warm.',
+                )
+
+        self.assertEqual(result, 'Weather Report')
+        self.assertEqual(status, 'llm_aux')
+        extra = captured.get('extra_body') or {}
+        self.assertEqual(extra['response_format']['type'], 'json_schema')
+        self.assertEqual(extra['response_format']['json_schema']['name'], 'session_title')
+        self.assertEqual(extra['response_format']['json_schema']['schema']['required'], ['title'])
+        # Route is not reject-listed: the reasoning-disable rides along, like the CLI.
+        self.assertEqual(extra['reasoning'], {'enabled': False})
+
+    def test_schema_first_unwraps_fenced_json(self):
+        """Some gateways wrap structured output in a markdown code fence."""
+        from api.streaming import generate_title_raw_via_aux
+
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return {
+                'choices': [
+                    {
+                        'message': {'content': '```json\n{"title": "Fenced Title"}\n```'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'openrouter', 'model': 'deepseek/deepseek-chat', 'base_url': 'https://openrouter.ai/api/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Fence me in',
+                    assistant_text='Done.',
+                )
+
+        self.assertEqual(result, 'Fenced Title')
+        self.assertEqual(status, 'llm_aux')
+        self.assertIn('response_format', captured.get('extra_body') or {})
+
+    def test_reject_listed_route_schema_attempt_sends_no_reasoning(self):
+        """OpenAI/Azure reject the `reasoning` param (#4161) — the schema
+        attempt must stay schema-only on reject-listed routes."""
+        from api.streaming import generate_title_raw_via_aux
+
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return {
+                'choices': [
+                    {
+                        'message': {'content': '{"title": "Gpt Title"}'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'openai', 'model': 'gpt-5.5', 'base_url': 'https://api.openai.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Titrate this session',
+                    assistant_text='Titled.',
+                )
+
+        self.assertEqual(result, 'Gpt Title')
+        self.assertEqual(status, 'llm_aux')
+        extra = captured.get('extra_body') or {}
+        self.assertIn('response_format', extra)
+        self.assertNotIn('reasoning', extra)
+
+    def test_prose_response_accepted_on_schema_attempt(self):
+        """A route that ignores response_format and answers in prose still
+        titles on the first (schema) attempt — no forced fallback."""
+        from api.streaming import generate_title_raw_via_aux
+
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return {
+                'choices': [
+                    {
+                        'message': {'content': 'Prose Session Title'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'custom', 'model': 'ignore-schema-model', 'base_url': 'http://localhost:9999/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Title me plainly',
+                    assistant_text='Plainly titled.',
+                )
+
+        self.assertEqual(result, 'Prose Session Title')
+        self.assertEqual(status, 'llm_aux')
+        self.assertIn('response_format', captured.get('extra_body') or {})
+
+    def test_schema_exception_falls_back_to_reasoning_disable(self):
+        """A route that rejects response_format (HTTP 400) falls back to the
+        reasoning-disable mode for the same slot."""
+        from api.streaming import generate_title_raw_via_aux
+
+        calls = []
+
+        def fake_call_llm(**kwargs):
+            calls.append(kwargs)
+            if 'response_format' in (kwargs.get('extra_body') or {}):
+                raise RuntimeError('400: unsupported response_format json_schema')
+            return {
+                'choices': [
+                    {
+                        'message': {'content': 'Fallback Reasoning Title'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'deepseek', 'model': 'deepseek-chat', 'base_url': 'https://api.deepseek.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Schema rejected here',
+                    assistant_text='Falling back.',
+                )
+
+        self.assertEqual(result, 'Fallback Reasoning Title')
+        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1].get('extra_body'), {'reasoning': {'enabled': False}})
+
+    def test_empty_schema_answer_falls_back_to_reasoning_disable(self):
+        """A fully empty answer on the schema attempt (no reasoning, stop
+        finish) means the route ignored response_format — retry the slot in
+        the reasoning-disable mode."""
+        from api.streaming import generate_title_raw_via_aux
+
+        calls = []
+
+        def fake_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return {'choices': [{'message': {'content': ''}, 'finish_reason': 'stop'}]}
+            return {
+                'choices': [
+                    {
+                        'message': {'content': 'Empty Fallback Title'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'deepseek', 'model': 'deepseek-chat', 'base_url': 'https://api.deepseek.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Empty first try',
+                    assistant_text='Fallback second try.',
+                )
+
+        self.assertEqual(result, 'Empty Fallback Title')
+        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1].get('extra_body'), {'reasoning': {'enabled': False}})
+
+    def test_json_object_without_title_falls_back(self):
+        """A JSON object that is not {"title": ...} is not stored as a session
+        title — the reasoning-disable mode gets a chance instead."""
+        from api.streaming import generate_title_raw_via_aux
+
+        calls = []
+
+        def fake_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return {
+                    'choices': [
+                        {
+                            'message': {'content': '{"topic": "wrong shape"}'},
+                            'finish_reason': 'stop',
+                        }
+                    ]
+                }
+            return {
+                'choices': [
+                    {
+                        'message': {'content': 'Right Shape Title'},
+                        'finish_reason': 'stop',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'deepseek', 'model': 'deepseek-chat', 'base_url': 'https://api.deepseek.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Wrong shape first',
+                    assistant_text='Right shape second.',
+                )
+
+        self.assertEqual(result, 'Right Shape Title')
+        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(len(calls), 2)
+
+    def test_schema_length_truncation_retries_in_schema_mode(self):
+        """Length-truncated schema attempts keep the budget-doubling retry in
+        schema mode (recoverable — the model just needs more headroom to emit
+        the JSON object)."""
+        from api.streaming import generate_title_raw_via_aux
+
+        responses = [
+            {'choices': [{'message': {'content': ''}, 'finish_reason': 'length'}]},
+            {'choices': [{'message': {'content': '{"title": "Retried Json Title"}'}, 'finish_reason': 'stop'}]},
+        ]
+        captured_budgets = []
+
+        def fake_call_llm(**kwargs):
+            captured_budgets.append(kwargs.get('max_tokens'))
+            return responses.pop(0)
+
+        with _patch_tg_config({'provider': 'ollama', 'model': 'kimi-k2.6', 'base_url': 'https://ollama.com/v1'}):
+            with self._patch_llm(fake_call_llm):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Hey nur ein kurzer Test',
+                    assistant_text='Alles klar, ich helfe dir dabei.',
+                )
+
+        self.assertEqual(result, 'Retried Json Title')
+        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(captured_budgets, [512, 1024])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Make WebUI aux title generation **schema-first**: request a strict `{"title": "..."}` JSON object via `response_format: json_schema` (mirroring the CLI's `agent/title_generator.py`), keeping the current reasoning-disable mode as the fallback. This removes the dependency on `_route_rejects_reasoning_extra` for routes that *accept but ignore* the reasoning param.

## Root Cause

`generate_title_raw_via_aux()` (api/streaming.py) sends `extra_body={'reasoning': {'enabled': False}}` whenever the route is not reject-listed. Some providers (e.g. opencode-go/mimo-v2.5-pro) **accept and silently ignore** the param: the model still reasons, burns the completion budget on hidden thinking, and either returns empty or emits long reasoning/markdown preamble instead of a short title. The CLI already solved this class of problem with structured output — `response_format: json_schema` works on every model that honors OpenAI-compatible schemas, including the ones that ignore a reasoning-disable.

## Change

`api/streaming.py`, aux path only (agent path untouched):

- Added `_TITLE_RESPONSE_FORMAT` — byte-for-byte the CLI's strict `json_schema` response format (`session_title`, `{"title": string}`, required, `additionalProperties: false`).
- Added `_title_unwrap_schema_content()` — port of the CLI's `_extract_title_text`: unwraps plain and markdown-fenced JSON objects to the title string, passes prose through unchanged (providers that ignore `response_format` still title on the first attempt), and returns `''` for JSON objects without a usable `title` so the fallback fires instead of storing a JSON blob.
- `generate_title_raw_via_aux()` now tries the **schema mode first** (`extra_body={'response_format': ...}`; reasoning-disable rides along on it like the CLI when the route tolerates it — reject-listed OpenAI/Azure routes stay schema-only, #4161). It **falls back to the reasoning-disable mode** for the same prompt/budget slot when the route rejects `response_format` (exception) or answers with a fully empty response, or when the schema attempt returns a non-`{"title": ...}` JSON object.
- Existing semantics preserved per mode: `llm_empty_reasoning` short-circuits without retry (#2083) and `llm_length` still gets the budget-doubling retry — in whichever mode is active. `_route_rejects_reasoning_extra` remains, but only gates the fallback/riding reasoning-disable, no longer the whole request shape.

`tests/test_title_aux_routing.py` — added `TestAuxSchemaFirstTitleGeneration` (8 tests): JSON unwrap (plain + fenced), reject-listed schema-only extra, prose accepted on the schema attempt, exception → reasoning-disable fallback, empty-answer → fallback, JSON-without-title → fallback, and length-truncation retry in schema mode.

## Verification

```
python3 -m pytest tests/test_title_gen_reasoning_extra_gate.py tests/test_title_aux_routing.py -q -p no:cacheprovider
```
- Before: 59 passed (baseline)
- After: **67 passed** (59 existing unchanged + 8 new)

Closes #7413
