### PR TITLE
fix(providers): purge env-seeded credential_pool entry on provider delete

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -2953,6 +2953,15 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
     invalidate_account_usage_status_cache(provider_id)
     invalidate_providers_cache()
 
+    # A prior removal may have suppressed the env:<VAR> pool source (see
+    # remove_provider_key). A plain key save only touches .env, so without
+    # this the pool entry is never re-materialized and the runtime keeps
+    # failing auth after a UI re-add. Lift the suppression and force an
+    # immediate load_pool() — mirroring `hermes auth add` (upstream #96058).
+    # Best-effort: the .env write above has already succeeded.
+    if api_key:
+        _lift_suppressed_pool_source(provider_id, env_var)
+
     return {
         "ok": True,
         "provider": provider_id,
@@ -2964,10 +2973,12 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
 def remove_provider_key(provider_id: str) -> dict[str, Any]:
     """Remove the API key for a provider.
 
-    Removes the key from ``~/.hermes/.env`` (via ``set_provider_key``)
-    and also cleans up ``config.yaml`` if the key is stored there
+    Removes the key from ``~/.hermes/.env`` (via ``set_provider_key``),
+    cleans up ``config.yaml`` if the key is stored there
     (``providers.<id>.api_key`` or top-level ``model.api_key`` when this
-    provider is the active one).
+    provider is the active one), and purges the env-seeded
+    ``credential_pool`` entry from ``auth.json`` (see
+    ``_purge_env_seeded_credential_pool``).
 
     Returns a status dict with the operation result.
     """
@@ -2978,8 +2989,100 @@ def remove_provider_key(provider_id: str) -> dict[str, Any]:
     # Clean those up so _provider_has_key() returns False after removal.
     if result.get("ok"):
         _clean_provider_key_from_config(provider_id)
+        # auth.json credential_pool entries seeded from env:<VAR> are only
+        # removable through an explicit purge (load_pool() is additive-only
+        # for env sources, upstream #9331) — otherwise the provider card
+        # survives the delete across restarts and the runtime can't auth.
+        # Runtime parity: prune the entry and record suppressed_sources
+        # exactly like `hermes auth remove` / remove_provider_env_credential.
+        _purge_env_seeded_credential_pool(provider_id)
 
     return result
+
+
+def _purge_env_seeded_credential_pool(provider_id: str) -> None:
+    """Purge the env-seeded ``credential_pool`` entry for *provider_id*.
+
+    Deleting a provider key previously only removed it from ``.env`` and
+    ``config.yaml``; the ``auth.json`` ``credential_pool`` row (source
+    ``env:<VAR>``) survived and kept the provider card alive across server
+    restarts (#7412). Because the pool loader is deliberately additive-only
+    for ``env:*`` sources (#9331), the stale row can only be removed by an
+    explicit deletion path.
+
+    Mirrors the runtime's own removal surface
+    (``hermes_cli.credential_lifecycle.purge_env_credential_references``):
+    prune env-seeded pool entries AND record ``suppressed_sources`` so a
+    lingering shell export cannot re-seed the entry on the next
+    ``load_pool()``. Only ``env:<VAR>`` rows are touched — OAuth /
+    device-code / manual / borrowed credentials are preserved. Best-effort:
+    a failure here must not change the (already successful) .env/config.yaml
+    removal result.
+    """
+    env_var = _provider_env_var_for(provider_id)
+    if not env_var:
+        return
+    try:
+        from hermes_cli.credential_lifecycle import purge_env_credential_references
+
+        purge_env_credential_references(env_var)
+    except ImportError:
+        # Runtime not installed / stubbed in tests — nothing to purge.
+        logger.debug(
+            "hermes_cli runtime unavailable; skipped credential_pool purge "
+            "for provider %s (env var %s)",
+            provider_id,
+            env_var,
+        )
+    except Exception:
+        logger.exception(
+            "credential_pool purge failed for provider %s (env var %s)",
+            provider_id,
+            env_var,
+        )
+
+
+def _lift_suppressed_pool_source(provider_id: str, env_var: str) -> None:
+    """Lift a prior ``env:<VAR>`` suppression and materialize the pool entry.
+
+    Symmetric side of ``_purge_env_seeded_credential_pool`` (#7412): a key
+    re-added through the UI must behave like ``hermes auth add`` — clear the
+    ``suppressed_sources`` marker written by a previous removal and force an
+    immediate ``load_pool()`` so the env-seeded ``credential_pool`` entry is
+    materialized to auth.json right now (upstream #96058 class). Best-effort:
+    the .env write above has already succeeded.
+    """
+    try:
+        from hermes_cli.auth import unsuppress_credential_source
+
+        unsuppress_credential_source(provider_id, f"env:{env_var}")
+    except ImportError:
+        logger.debug(
+            "hermes_cli runtime unavailable; skipped unsuppress for provider %s",
+            provider_id,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to lift suppressed env source for provider %s",
+            provider_id,
+            exc_info=True,
+        )
+    try:
+        from agent.credential_pool import load_pool
+
+        load_pool(provider_id)
+    except ImportError:
+        logger.debug(
+            "hermes_cli runtime unavailable; skipped pool materialization "
+            "for provider %s",
+            provider_id,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to materialize credential_pool entry for provider %s",
+            provider_id,
+            exc_info=True,
+        )
 
 
 def _clean_provider_key_from_config(provider_id: str) -> None:

--- a/tests/test_provider_delete_credential_pool.py
+++ b/tests/test_provider_delete_credential_pool.py
@@ -1,0 +1,217 @@
+"""Regression tests for #7412: provider delete must purge the env-seeded
+``credential_pool`` entry from ``auth.json``.
+
+Root cause: ``remove_provider_key()`` only removed the key from ``.env`` and
+``config.yaml``. The ``auth.json`` credential_pool row (source
+``env:<VAR>``) survived because ``load_pool()`` is deliberately additive-only
+for ``env:*`` sources (upstream #9331) — so the provider card kept appearing
+after a restart, the live runtime couldn't authenticate, and re-adding the
+key through the UI never lifted ``suppressed_sources``.
+
+Fix: on delete, prune the env-seeded pool entry AND record
+``suppressed_sources`` (same mechanism as the runtime's
+``hermes_cli.credential_lifecycle``); on save, lift the suppression and force
+``load_pool()`` so the entry is materialized immediately (upstream #96058).
+
+These tests exercise the REAL runtime helpers (no fake ``hermes_cli``), so
+``HERMES_HOME`` is pinned to an isolated tmp dir on every test.
+"""
+
+import json
+
+import pytest
+
+from api import profiles
+
+
+def _pin_home(monkeypatch, tmp_path):
+    """Point every home resolution (WebUI profile + runtime env) at tmp_path."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+
+def _write_auth_store(tmp_path, payload: dict):
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps(payload), encoding="utf-8")
+    return auth_path
+
+
+def _read_auth_store(tmp_path) -> dict:
+    auth_path = tmp_path / "auth.json"
+    if not auth_path.exists():
+        return {}
+    return json.loads(auth_path.read_text(encoding="utf-8"))
+
+
+def _pool_sources(pool_entries) -> list:
+    if not isinstance(pool_entries, list):
+        return []
+    return [str(e.get("source") or "") for e in pool_entries]
+
+
+class TestRemoveProviderKeyPurging:
+    """Deleting a provider key must purge the env-seeded pool entry."""
+
+    def test_remove_prunes_env_seeded_entry_and_suppresses_source(
+        self, monkeypatch, tmp_path
+    ):
+        """The exact #7412 repro: env-seeded pool row must not survive delete."""
+        _pin_home(monkeypatch, tmp_path)
+        auth_path = _write_auth_store(
+            tmp_path,
+            {
+                "credential_pool": {
+                    "anthropic": [
+                        {
+                            "source": "env:ANTHROPIC_API_KEY",
+                            "id": "env:ANTHROPIC_API_KEY",
+                            "auth_type": "api_key",
+                            "runtime_api_key": "sk-stale-secret-123456",
+                        }
+                    ]
+                }
+            },
+        )
+
+        from api.providers import remove_provider_key
+
+        result = remove_provider_key("anthropic")
+        assert result["ok"] is True
+        assert result["action"] == "removed"
+
+        store = _read_auth_store(tmp_path)
+        # Env-seeded entry gone: provider key removed entirely (no other lane).
+        pool = store.get("credential_pool", {})
+        assert "anthropic" not in pool or not pool.get("anthropic")
+        # Suppression record written like `hermes auth remove` / the runtime
+        # lifecycle (CLI parity) so a lingering shell export can't re-seed it.
+        suppressed = store.get("suppressed_sources", {})
+        assert "env:ANTHROPIC_API_KEY" in (suppressed.get("anthropic") or [])
+        # auth.json exists and the env var is gone from .env too.
+        assert auth_path.exists()
+        env_path = tmp_path / ".env"
+        content = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+        assert "ANTHROPIC_API_KEY" not in content
+
+    def test_remove_preserves_non_env_pool_entries(self, monkeypatch, tmp_path):
+        """OAuth/manual/borrowed rows must survive — the purge only targets
+        ``env:<VAR>`` sources (OAuth preservation contract)."""
+        _pin_home(monkeypatch, tmp_path)
+        _write_auth_store(
+            tmp_path,
+            {
+                "credential_pool": {
+                    "anthropic": [
+                        {
+                            "source": "env:ANTHROPIC_API_KEY",
+                            "id": "env:ANTHROPIC_API_KEY",
+                            "auth_type": "api_key",
+                            "runtime_api_key": "sk-stale-secret-123456",
+                        },
+                        {
+                            "source": "manual",
+                            "id": "manual-1",
+                            "auth_type": "api_key",
+                            "runtime_api_key": "sk-manual-secret-123456",
+                        },
+                    ],
+                    "openai": [
+                        {
+                            "source": "oauth",
+                            "id": "oauth-grant-1",
+                            "auth_type": "oauth",
+                            "access_token": "tok-123456",
+                        }
+                    ],
+                }
+            },
+        )
+
+        from api.providers import remove_provider_key
+
+        result = remove_provider_key("anthropic")
+        assert result["ok"] is True
+
+        pool = _read_auth_store(tmp_path).get("credential_pool", {})
+        # Same-provider manual row kept; the env row is gone.
+        anthropic_sources = _pool_sources(pool.get("anthropic"))
+        assert "manual" in anthropic_sources
+        assert "env:ANTHROPIC_API_KEY" not in anthropic_sources
+        # Unrelated provider's OAuth grant untouched.
+        assert _pool_sources(pool.get("openai")) == ["oauth"]
+
+    def test_remove_graceful_without_runtime(self, monkeypatch, tmp_path):
+        """When hermes_cli is stubbed/absent (ImportError) the removal must
+        still succeed — the pool purge is strictly best-effort."""
+        import types
+        import sys
+
+        _pin_home(monkeypatch, tmp_path)
+        fake_pkg = types.ModuleType("hermes_cli")
+        fake_pkg.__path__ = []
+        monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+        monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+        monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+        from api.providers import remove_provider_key
+
+        result = remove_provider_key("anthropic")
+        assert result["ok"] is True
+        assert result["action"] == "removed"
+
+    def test_purge_helper_noop_without_env_var(self, monkeypatch, tmp_path):
+        """Providers without an env-var mapping must not invoke the runtime
+        purge (there is nothing env-seeded to prune)."""
+        _pin_home(monkeypatch, tmp_path)
+
+        import api.providers as prov
+
+        calls = []
+        monkeypatch.setattr(prov, "_provider_env_var_for", lambda _pid: None)
+
+        try:
+            from hermes_cli.credential_lifecycle import purge_env_credential_references
+
+            monkeypatch.setattr(
+                "hermes_cli.credential_lifecycle.purge_env_credential_references",
+                lambda env_var, clear_models_cache=True: calls.append(env_var),
+            )
+        except ImportError:
+            pytest.skip("runtime not installed")
+
+        prov._purge_env_seeded_credential_pool("anthropic")
+        assert calls == []
+
+
+class TestReaddLiftsSuppression:
+    """Re-adding a key through the UI must behave like `hermes auth add`."""
+
+    def test_readd_unsuppresses_and_materializes_pool_entry(
+        self, monkeypatch, tmp_path
+    ):
+        """Issue consequence #3: after a removal wrote suppressed_sources, a UI
+        save must lift it and materialize the env-seeded pool entry (#96058)."""
+        _pin_home(monkeypatch, tmp_path)
+        _write_auth_store(
+            tmp_path,
+            {
+                "credential_pool": {},
+                "suppressed_sources": {
+                    "anthropic": ["env:ANTHROPIC_API_KEY"]
+                },
+            },
+        )
+
+        from api.providers import set_provider_key
+
+        result = set_provider_key("anthropic", "sk-test-readd-abcdefghij123456")
+        assert result["ok"] is True
+        assert result["action"] == "updated"
+
+        store = _read_auth_store(tmp_path)
+        # Suppression lifted.
+        suppressed = store.get("suppressed_sources", {})
+        assert "env:ANTHROPIC_API_KEY" not in (suppressed.get("anthropic") or [])
+        # Pool entry materialized right now with the env source.
+        sources = _pool_sources(store.get("credential_pool", {}).get("anthropic"))
+        assert "env:ANTHROPIC_API_KEY" in sources


### PR DESCRIPTION
## Summary

Fixes #7412: removing a provider API key from **Settings → Providers → Remove** only deleted the credential from `~/.hermes/.env` and `config.yaml`. The env-seeded `auth.json` → `credential_pool.<provider>` entry (source `env:<VAR>`) survived — `load_pool()` is deliberately additive-only for `env:*` sources (upstream #9331) — so the provider card persisted across server restarts, the live runtime could not authenticate against the dangling pool row, and re-adding the key never lifted `suppressed_sources`.

## Root Cause

`remove_provider_key()` (api/providers.py:2964) touched exactly two stores:
1. `.env` — via `set_provider_key(provider_id, None)`
2. `config.yaml` — via `_clean_provider_key_from_config(provider_id)`

`auth.json` → `credential_pool` was never consulted on save or delete, and the runtime's suppression record was never written.

## Change

Both provider-credential mutations now go through the upstream runtime helpers (`hermes_cli.credential_lifecycle` / `hermes_cli.auth` / `agent.credential_pool` — the same runtime modules `api/config.py` already uses to read the pool), scoped to the auth.json layer only (no `.env`/`config.yaml` logic touched — those stores are already handled with WebUI profile-scoped paths):

- **`remove_provider_key()`** → new `_purge_env_seeded_credential_pool(provider_id)` calls `hermes_cli.credential_lifecycle.purge_env_credential_references(env_var)`, which:
  - prunes `credential_pool` entries whose source is exactly `env:<VAR>` (OAuth / device-code / manual / borrowed rows are preserved — deleting an API key never revokes an OAuth grant), and
  - records `suppressed_sources` for the affected providers — the same sticky mechanism `hermes auth remove` writes, so a lingering shell export cannot re-seed the entry on the next `load_pool()`.
- **`set_provider_key()`** (save side, symmetric) → new `_lift_suppressed_pool_source(provider_id, env_var)` lifts the `suppressed_sources` marker and forces an immediate `load_pool()` so the env-seeded entry is materialized to `auth.json` right now — a UI re-add now behaves like `hermes auth add` (upstream #96058 class).

Both layers are best-effort and lazy-imported: if the runtime is unavailable (or stubbed in offline tests) the existing `.env`/`config.yaml` removal still succeeds unchanged.

## Verification

New regression suite `tests/test_provider_delete_credential_pool.py` (5 tests, real runtime, isolated `HERMES_HOME`) covering the #7412 repro end-to-end:

- delete prunes the env-seeded entry and writes `suppressed_sources` (CLI parity)
- delete preserves same-provider manual rows and unrelated OAuth grants
- delete stays graceful when the runtime is absent (ImportError)
- purge helper no-ops for providers without an env-var mapping
- re-add lifts the suppression and materializes the pool entry immediately

Focused batch — new suite plus all existing provider key-management suites (`test_provider_management.py`, `test_issue1094_provider_bugs.py`, `test_issue1539_provider_removal_dropdown_invalidation.py`, `test_plugin_model_providers.py`, `test_provider_quota_status.py`):

```
102 passed in 13.63s
```

## Notes

- `api/config.py`'s in-process `_CREDENTIAL_POOL_CACHE` is already flushed by the pre-existing `invalidate_models_cache()` inside `set_provider_key()` (both add and remove flows), which runs before the purge, so the next pool read observes the purged store — no additional cache handling needed.
- No `.env`/`config.yaml` logic was modified; the runtime functions called operate on the auth store only (the same `HERMES_HOME`-scoped store `api/config.py` reads the pool from).

Closes #7412