### PR TITLE
Fix #6799: perf(transcript): virtualization ON + long session = endless scroll to re-render loop (~5-6 re-renders/sec idle), CPU 100%+, text selection broken

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -6364,6 +6364,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }else if(_doneLiveScrollSnapshot&&typeof _restoreMessageScrollSnapshotSameFrame==='function'){
             _restoreMessageScrollSnapshotSameFrame(_doneLiveScrollSnapshot);
           }
+          if(typeof _restoreMessageRenderWindowAfterSettledRender==='function') _restoreMessageRenderWindowAfterSettledRender();
           if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
@@ -7064,6 +7065,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
         }
         syncTopbar();renderMessages({preserveScroll:true});
+        if(typeof _restoreMessageRenderWindowAfterSettledRender==='function') _restoreMessageRenderWindowAfterSettledRender();
         if(typeof projectSessionArtifactsForOwner==='function') projectSessionArtifactsForOwner(completedSid);
       }
       if(_isActiveSession()) _queueDrainSid=activeSid;

--- a/static/ui.js
+++ b/static/ui.js
@@ -609,6 +609,9 @@ function _resetMessageRenderWindow(sid){
   clearVisibleMessageRowCache();
   _clearMessageVirtualHeightCache();
 }
+function _restoreMessageRenderWindowAfterSettledRender(){
+  _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
+}
 function _cancelMessageVirtualizedRender(){
   if(_messageVirtualScrollRaf){
     cancelAnimationFrame(_messageVirtualScrollRaf);
@@ -6345,12 +6348,12 @@ if(typeof window!=='undefined'){
   },{capture:true,passive:true});
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
-    _scheduleMessageVirtualizedRender();
     if(_messageJumpScrollOwner){
       _scheduleMessageJumpScrollReconcile(_messageJumpScrollOwner.generation);
       return;
     }
     if(_freshProgrammaticScrollActive()) return;
+    _scheduleMessageVirtualizedRender();
     _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{

--- a/tests/test_issue6799_virtualization_idle_loop.py
+++ b/tests/test_issue6799_virtualization_idle_loop.py
@@ -1,0 +1,49 @@
+"""Regression coverage for the settled-transcript virtualization loop (#6799)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _scroll_listener_body() -> str:
+    start = UI_JS.index("el.addEventListener('scroll',()=>{")
+    end = UI_JS.index("  },{passive:true});", start)
+    return UI_JS[start:end]
+
+
+def test_programmatic_scroll_cannot_schedule_virtualized_rerender():
+    listener = _scroll_listener_body()
+
+    guard_pos = listener.index("if(_freshProgrammaticScrollActive()) return;")
+    schedule_pos = listener.index("_scheduleMessageVirtualizedRender();")
+
+    assert guard_pos < schedule_pos
+
+
+def test_settled_full_window_is_restored_to_default_after_render():
+    assert "function _restoreMessageRenderWindowAfterSettledRender()" in UI_JS
+
+    first_expand = MESSAGES_JS.index(
+        "_messageRenderWindowSize=Math.max(",
+        MESSAGES_JS.index("// Expand render window to cover all messages"),
+    )
+    first_restore = MESSAGES_JS.index(
+        "_restoreMessageRenderWindowAfterSettledRender();",
+        first_expand,
+    )
+    first_block_end = MESSAGES_JS.index("loadDir('.', { preservePreview: true });", first_expand)
+    assert first_expand < first_restore < first_block_end
+
+    second_expand = MESSAGES_JS.index(
+        "_messageRenderWindowSize=Math.max(",
+        MESSAGES_JS.index("// Expand render window so the settled render"),
+    )
+    second_render = MESSAGES_JS.index("renderMessages({preserveScroll:true});", second_expand)
+    second_restore = MESSAGES_JS.index(
+        "_restoreMessageRenderWindowAfterSettledRender();",
+        second_render,
+    )
+    assert second_expand < second_render < second_restore


### PR DESCRIPTION
Fixes #6799

## Summary

The transcript scroll listener in `static/ui.js` scheduled another virtualized render before checking whether a jump reconciliation or fresh programmatic scroll was active. That allowed settled long sessions to continue feeding scroll-triggered renders while idle.

This moves scheduling after those guards. It also adds a helper in `static/ui.js` that restores the render window to its normal size, and calls it after the two settled-render expansion paths in `static/messages.js`. A focused regression test verifies both ordering invariants.

## Verification

- Patch applies cleanly against base `e168b67e4278df618d1cab61fdb3a8dc55b29a81` (`git apply --check`).
- `git diff --check` is clean.
- JS syntax check passed for both touched JavaScript modules.
- `py_compile` passed for the touched Python regression test.
- Tests were not run locally because this environment has no test virtual environment; CI will run the suite.
