### PR TITLE
fix(skills): report the total when the skill-not-found reply truncates available_skills

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1007,13 +1007,28 @@ def _find_skill_in_dir(name: str, skills_dir: Path) -> tuple[Path | None, Path |
     return _find_skill_in_dirs(name, [skills_dir])
 
 
+# Cap on the courtesy list of names carried by a skill-not-found reply. The
+# bound stays; what it must never do is present a partial list as the whole
+# set, because a caller that cannot find its skill in `available_skills` will
+# conclude the skill is not installed.
+_SKILL_NOT_FOUND_LIST_LIMIT = 20
+
+
 def _skill_not_found_payload(name: str, skills_dir: Path) -> dict:
-    available = [s["name"] for s in _skills_list_from_dir(skills_dir).get("skills", [])[:20]]
+    all_names = [s["name"] for s in _skills_list_from_dir(skills_dir).get("skills", [])]
+    total = len(all_names)
+    available = all_names[:_SKILL_NOT_FOUND_LIST_LIMIT]
+    truncated = total > len(available)
+    hint = "Use skills_list to see all available skills"
+    if truncated:
+        hint = f"Showing {len(available)} of {total} skills. {hint}"
     return {
         "success": False,
         "error": f"Skill '{name}' not found.",
         "available_skills": available,
-        "hint": "Use skills_list to see all available skills",
+        "available_skills_truncated": truncated,
+        "total_skills": total,
+        "hint": hint,
     }
 
 

--- a/tests/test_issue7426_skill_not_found_listing_truncation.py
+++ b/tests/test_issue7426_skill_not_found_listing_truncation.py
@@ -1,0 +1,70 @@
+"""#7426: the skill-not-found reply must not present a capped list as the whole set.
+
+`_skill_not_found_payload` caps `available_skills` so a large skills tree cannot
+bloat an error payload. The bug was that the cap was silent: with 74 skills
+installed, a caller asking for one that sorts past the 20th got "not found" plus
+a 20-name list that did not contain it and did not say anything was omitted, so
+the only reasonable reading was that the skill is not installed.
+
+These tests pin the honesty of the payload, not the size of the cap.
+"""
+
+import pathlib
+
+import api.routes as routes
+
+
+def _stub_listing(monkeypatch, count):
+    names = [f"skill-{i:03d}" for i in range(count)]
+    monkeypatch.setattr(
+        routes,
+        "_skills_list_from_dir",
+        lambda *args, **kwargs: {
+            "success": True,
+            "skills": [{"name": n} for n in names],
+            "count": len(names),
+        },
+    )
+    return names
+
+
+def test_truncated_listing_reports_the_total_and_says_it_is_truncated(monkeypatch):
+    names = _stub_listing(monkeypatch, 74)
+    payload = routes._skill_not_found_payload("skill-073", pathlib.Path("/nonexistent"))
+
+    assert payload["success"] is False
+    # The cap still applies: the payload does not grow without bound.
+    assert len(payload["available_skills"]) < len(names)
+    # But a caller can now tell a partial list from a complete one.
+    assert payload["available_skills_truncated"] is True
+    assert payload["total_skills"] == 74
+    assert "74" in payload["hint"]
+    assert str(len(payload["available_skills"])) in payload["hint"]
+
+
+def test_untruncated_listing_is_not_flagged_as_truncated(monkeypatch):
+    names = _stub_listing(monkeypatch, 3)
+    payload = routes._skill_not_found_payload("nope", pathlib.Path("/nonexistent"))
+
+    assert payload["available_skills"] == names
+    assert payload["available_skills_truncated"] is False
+    assert payload["total_skills"] == 3
+    assert payload["hint"] == "Use skills_list to see all available skills"
+
+
+def test_empty_skills_tree_reports_zero_and_no_truncation(monkeypatch):
+    _stub_listing(monkeypatch, 0)
+    payload = routes._skill_not_found_payload("nope", pathlib.Path("/nonexistent"))
+
+    assert payload["available_skills"] == []
+    assert payload["available_skills_truncated"] is False
+    assert payload["total_skills"] == 0
+
+
+def test_exactly_at_the_cap_is_not_flagged_as_truncated(monkeypatch):
+    names = _stub_listing(monkeypatch, routes._SKILL_NOT_FOUND_LIST_LIMIT)
+    payload = routes._skill_not_found_payload("nope", pathlib.Path("/nonexistent"))
+
+    assert payload["available_skills"] == names
+    assert payload["available_skills_truncated"] is False
+    assert payload["total_skills"] == len(names)


### PR DESCRIPTION
Fixes #7426.

## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the CLI, and its tool surface is consumed by an agent as much as by a human
- When a tool cannot do what was asked, the error payload is the agent's only map of what it *could* have asked for
- `skill_view` / `GET /api/skills/content` answers a miss with `available_skills` — a courtesy list of names, capped at 20
- The cap was silent: no total, no marker, and a hint that reads as though the list were the whole set
- With 74 skills installed, asking for one that sorts past the 20th returns "not found" plus a list that does not contain it, so the only reasonable reading is that the skill is not installed — and an agent abandons a skill that is present and working
- This PR keeps the bound and stops it lying: the payload now says how many skills exist and whether the list was cut

## What Changed

`api/routes.py` — `_skill_not_found_payload`:

- The bare `[:20]` slice becomes a named `_SKILL_NOT_FOUND_LIST_LIMIT = 20`, so the cap is greppable and the comment explaining *why* it must not be silent lives with it
- Two fields added: `total_skills` (how many exist) and `available_skills_truncated` (whether the list is partial)
- The `hint` gains a prefix only when the list is actually cut: `"Showing 20 of 74 skills. Use skills_list to see all available skills"`. The untruncated hint string is unchanged byte-for-byte

The cap itself is unchanged, and `available_skills` still holds the same first 20 names. This is additive: nothing that reads the existing fields changes behavior. Nothing in `static/` or `tests/` consumed `available_skills`, so there is no frontend counterpart to update, and no UI changes — hence no before/after images.

This matches the shape the repo already uses for capped lists: `api/updates.py:1422-1423` returns `(subjects[:limit], truncated)` for commit subjects, and `_skills_list_from_dir` already computes the `count` this payload was discarding.

## Why It Matters

A bounded list is fine. A bounded list presented as complete is a wrong answer, and it is wrong in the direction that costs the most: the caller concludes an installed skill does not exist and stops looking.

## Verification

`./scripts/test.sh` on Python 3.12.3.

**New test fails before the fix, passes after.** `tests/test_issue7426_skill_not_found_listing_truncation.py`, 4 cases, bound to the shape the issue pins (74 skills, request one that sorts past the cut):

```
# with api/routes.py reverted to master's _skill_not_found_payload
FAILED ...::test_truncated_listing_reports_the_total_and_says_it_is_truncated - KeyError: 'available_skills_truncated'
FAILED ...::test_untruncated_listing_is_not_flagged_as_truncated - KeyError: 'available_skills_truncated'
FAILED ...::test_empty_skills_tree_reports_zero_and_no_truncation - KeyError: 'available_skills_truncated'
FAILED ...::test_exactly_at_the_cap_is_not_flagged_as_truncated - AttributeError: module 'api.routes' has no attribute '_SKILL_NOT_FOUND_LIST_LIMIT'
4 failed in 5.69s

# with the fix
4 passed in 3.33s
```

The tests cover 0 / under-cap / exactly-at-cap / over-cap, and assert the payload's observable fields rather than any source string. They stub the listing rather than the payload builder under test, so they need neither `hermes-agent` nor `node` and actually execute in CI — the `requires_agent_modules` end-to-end route would silently skip there, since CI does not provision `hermes-agent`.

**End-to-end against a real skills tree.** 74 `SKILL.md` directories on disk, through the real `_skills_list_from_dir`:

```
before: {"success": false, "error": "Skill 'skill-073' not found.",
         "available_skills": [20 names], "hint": "Use skills_list to see all available skills"}
        len == 20, 'skill-073' in available_skills == False, no total anywhere

after:  ... "available_skills_truncated": true, "total_skills": 74,
        "hint": "Showing 20 of 74 skills. Use skills_list to see all available skills"
```

**Neighbouring tests.** `test_skill_detail_error_guard`, `test_skills_toggle`, `test_skills_category_collapse`, `test_skill_usage`, `test_profile_skills_stats`, `test_issue1880_profile_scoped_skills` — 41 passed, 12 skipped (the skips are the `requires_agent_modules` ones).

**Lint gates.** `scripts/ruff_lint.py --diff origin/master` — "0 on added/modified lines. OK." `python -m compileall` clean. `ruff format --check` clean on the new test file.

**Full suite.** 13351 passed, 338 failed, 1438 skipped. I could not get the suite fully green in my environment and want to be explicit about why rather than claim a green run: 295 of the 338 failures are `FileNotFoundError: 'node'` (no Node.js on the box, so every JS runtime-guard test fails), and the rest are the private `hermes-agent` package being absent (`tools.approval._ApprovalEntry`) or resolving to `None`. To show none of them are mine, I ran the 8 non-`node` failing files against master's `_skill_not_found_payload` and against the fix: **27 failed / 183 passed / 28 skipped, identical both ways.** They are pre-existing and environmental. CI, which has Node, is the authority on the JS guards — I cannot claim those pass, only that I did not touch any JS.

**Sibling sweep** (guideline 1, fix the class not the instance). `grep -rn "\[:[0-9]\+\]" api/` filtered to not-found / suggestion / options payloads returns exactly one site — `api/routes.py:1011`, the one fixed here. `available_skills` has no other producer and no consumer in `static/` or `tests/`. The same *class* of defect exists at `api/workspace.py::list_dir` (#6645, dir listings silently capped at 200), but that is a different code path with its own open PRs (#6685, #6687) and is deliberately out of scope here.

## Risks / Follow-ups

- **Risk: low.** Purely additive to a JSON error payload with no existing consumers. A client that ignores the new fields sees exactly what it saw before.
- **Deliberately not done: fuzzy "did you mean" matching.** Ranking near-misses ahead of sort order would make the requested name likely to survive the cap, and is arguably a better answer. I left it out because it is a new matching heuristic rather than a fix to the reported defect, and because the honest payload already lets a caller reach the full list via `skills_list`. Happy to add it in a follow-up if you would rather have it.
- **Not verified:** anything requiring `hermes-agent` or Node.js, per the Verification section.
- `total_skills` counts what `_skills_list_from_dir` returns for the active profile's search dirs, including skills marked disabled — the same set `available_skills` was already drawn from. This PR does not change that set, only reports its size.

## Release Note

`skill_view`'s "skill not found" reply no longer presents a truncated list of available skills as the complete set — it now reports the total and flags that the list was cut, so a skill sorting past the cap is no longer mistaken for one that is not installed.

## Model Used

AI-assisted. Provider: Anthropic. Model: Claude Opus 5. Used for investigation, the reproduction, the patch, and the tests; every claim above is backed by a command run in this environment.
