### PR TITLE
feat(sessions): middle-click / Ctrl-click a sidebar session opens it in a new tab

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4257,6 +4257,79 @@ function _setActiveSessionUrl(sid){
   }
 }
 
+/**
+ * Middle-click (or Ctrl/Cmd+click) on a sidebar session row opens that
+ * session's deep link (`/session/<id>`) in a new browser tab instead of
+ * switching the current tab. Boot already resolves the id from the URL
+ * (`_sessionIdFromLocation` + `loadSession(saved)`), so the new tab lands
+ * directly on the session. Never fires for the ⋮ action menu, checkboxes,
+ * tag chips, lineage/child toggles, while renaming, or in batch select mode.
+ */
+function _openSessionUrlInNewTab(sid){
+  if(!sid||typeof window==='undefined'||typeof _sessionUrlForSid!=='function') return false;
+  if(typeof _sessionSelectMode!=='undefined'&&_sessionSelectMode) return false;
+  if(typeof _renamingSid!=='undefined'&&_renamingSid) return false;
+  let url=null;
+  try{url=_sessionUrlForSid(sid);}catch(_e){return false;}
+  if(!url) return false;
+  try{
+    window.open(url,'_blank','noopener');
+    return true;
+  }catch(_e){return false;}
+}
+// Shared choke point for the pointer-tap paths below: returns true when the
+// event was consumed as an open-in-new-tab (caller must skip same-tab open).
+function _consumeSessionNewTabClick(e, sid){
+  if(!e||!sid) return false;
+  const isModifiedClick=!!(e.ctrlKey||e.metaKey);
+  const isMiddleClick=(typeof e.button==='number'&&e.button===1)||e.which===2;
+  if(!isModifiedClick&&!isMiddleClick) return false;
+  if(e.target&&e.target.closest){
+    try{
+      if(e.target.closest('.session-actions,.session-select-cb-wrapper,.session-tag,.session-child-count,.session-lineage-count')) return false;
+    }catch(_e){}
+  }
+  if(typeof _isSessionActionTarget==='function'&&_isSessionActionTarget(e.target)) return false;
+  if(typeof _sessionSelectMode!=='undefined'&&_sessionSelectMode) return false;
+  if(typeof _renamingSid!=='undefined'&&_renamingSid) return false;
+  if(typeof e.preventDefault==='function') e.preventDefault();
+  if(typeof e.stopPropagation==='function') e.stopPropagation();
+  return _openSessionUrlInNewTab(sid);
+}
+// `auxclick` fires for the middle button where `click` never does; `mousedown`
+// also preventDefaults button-1 so the browser doesn't start autoscroll.
+function _wireSessionNewTabListeners(node, getSid){
+  if(!node||typeof node.addEventListener!=='function'||typeof getSid!=='function') return;
+  node.addEventListener('auxclick',(e)=>{
+    if(!e) return;
+    const btn=(typeof e.button==='number')?e.button:(e.which===2?1:0);
+    if(btn!==1) return;
+    if(e.target&&e.target.closest){
+      try{
+        if(e.target.closest('.session-actions,.session-select-cb-wrapper,.session-tag,.session-child-count,.session-lineage-count')) return;
+      }catch(_e2){}
+    }
+    if(typeof _isSessionActionTarget==='function'&&_isSessionActionTarget(e.target)) return;
+    if(typeof e.preventDefault==='function') e.preventDefault();
+    if(typeof e.stopPropagation==='function') e.stopPropagation();
+    _openSessionUrlInNewTab(getSid());
+  });
+  node.addEventListener('mousedown',(e)=>{
+    if(!e) return;
+    const btn=(typeof e.button==='number')?e.button:(e.which===2?1:0);
+    if(btn!==1) return;
+    if(e.target&&e.target.closest){
+      try{
+        if(e.target.closest('.session-actions,.session-select-cb-wrapper,.session-tag,.session-child-count,.session-lineage-count')) return;
+      }catch(_e2){}
+    }
+    // Swallow the middle-button default (autoscroll / back-nav chord) without
+    // claiming the gesture: pointerup's _finishSessionGesture still ignores
+    // button!==0, so no swipe/rename/tap side effects can fire from this.
+    if(typeof e.preventDefault==='function') e.preventDefault();
+  });
+}
+
 // ── Batch select mode ──
 function toggleSessionSelectMode(){
   _sessionSelectMode=!_sessionSelectMode;
@@ -8311,8 +8384,10 @@ function renderSessionListFromCache(){
         row.title=t('session_lineage_segment_open');
         row.onclick=async(e)=>{
           e.stopPropagation();
+          if(_consumeSessionNewTabClick(e, seg.session_id)) return;
           await _openSidebarSession(seg, {skipLineageResolve:true});
         };
+        _wireSessionNewTabListeners(row, ()=>seg.session_id);
         lineageList.appendChild(row);
       }
       sessionText.appendChild(lineageList);
@@ -8322,7 +8397,8 @@ function renderSessionListFromCache(){
       childList.className='session-child-sessions';
       ['pointerdown','pointerup','click','touchstart','touchmove','touchend','touchcancel'].forEach(ev=>childList.addEventListener(ev,e=>e.stopPropagation()));
       const sortedChildren=[...s._child_sessions].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a));
-      const openChildSession=async(childSession)=>{
+      const openChildSession=async(childSession, openOpts={})=>{
+        if(openOpts&&openOpts.newTab) return _openSessionUrlInNewTab(childSession.session_id);
         await _openSidebarSession(childSession, {skipLineageResolve:true});
       };
       const childLabelFor=(child)=>{
@@ -8556,8 +8632,10 @@ function renderSessionListFromCache(){
               return;
             }
             e.stopPropagation();
+            if(_consumeSessionNewTabClick(e, child.session_id)) return;
             await openChildSession(child);
           };
+          _wireSessionNewTabListeners(mainBtn, ()=>child.session_id);
           row._startRename=_buildSessionRenameStarter(child, mainBtn, ()=>{
             mainBtn.textContent=childLabelFor(child);
           });
@@ -8608,6 +8686,7 @@ function renderSessionListFromCache(){
             e.stopPropagation();
             _openSessionActionMenu(child, actions||row);
           };
+          _wireSessionNewTabListeners(row, ()=>child.session_id);
           childList.appendChild(row);
           continue;
         }
@@ -8618,8 +8697,10 @@ function renderSessionListFromCache(){
         row.title='Open child session';
         row.onclick=async(e)=>{
           e.stopPropagation();
+          if(_consumeSessionNewTabClick(e, child.session_id)) return;
           await openChildSession(child);
         };
+        _wireSessionNewTabListeners(row, ()=>child.session_id);
         childList.appendChild(row);
       }
       sessionText.appendChild(childList);
@@ -8983,8 +9064,13 @@ function renderSessionListFromCache(){
     el.onpointerup=(e)=>{
       if(e.pointerType==='touch') return;
       if(e.pointerType==='mouse' && e.button!==0) return;  // ignore right/middle click
+      if(e.ctrlKey||e.metaKey){
+        // Ctrl/Cmd+click opens in a new tab; keep the current tab untouched.
+        if(_consumeSessionNewTabClick(e, s.session_id)) return;
+      }
       if(_finishSessionGesture(e.clientX,e.clientY,e.target,e.pointerType)) e.stopPropagation();
     };
+    _wireSessionNewTabListeners(el, ()=>s.session_id);
     // Add ondblclick for more reliable double-click detection
     el.ondblclick=(e)=>{
       if(e.pointerType==='mouse' && e.button!==0) return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -9064,8 +9064,12 @@ function renderSessionListFromCache(){
     el.onpointerup=(e)=>{
       if(e.pointerType==='touch') return;
       if(e.pointerType==='mouse' && e.button!==0) return;  // ignore right/middle click
-      if(e.ctrlKey||e.metaKey){
+      if((e.ctrlKey||e.metaKey) && !_sessionSelectMode && !_renamingSid){
         // Ctrl/Cmd+click opens in a new tab; keep the current tab untouched.
+        // Gated on select/rename mode: _consumeSessionNewTabClick refuses
+        // those modes, and mutating gesture state first would make the
+        // fall-through _finishSessionGesture early-return on 'idle',
+        // breaking the row (de)select toggle.
         // Settle the gesture machine first via the shared choke point: a pen
         // (or touch-emulated) drag may have painted swipe offsets, and a
         // shaky click may have added the 'dragging' class — parking

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -9066,10 +9066,10 @@ function renderSessionListFromCache(){
       if(e.pointerType==='mouse' && e.button!==0) return;  // ignore right/middle click
       if(e.ctrlKey||e.metaKey){
         // Ctrl/Cmd+click opens in a new tab; keep the current tab untouched.
-        // Clear the pending tap first so the deferred single-tap opener from
-        // the FIRST click of a fast Ctrl+click-double-click can't fire after
-        // the new tab opens (same cancel path as the double-tap branch).
+        // Clear the pending tap and active gesture before opening the new tab.
         clearTimeout(_tapTimer);_tapTimer=null;_lastTapTime=0;
+        _clearLongPressTimer();
+        _gestureState='idle';
         el.classList.remove('loading');
         if(_consumeSessionNewTabClick(e, s.session_id)) return;
       }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -9066,10 +9066,14 @@ function renderSessionListFromCache(){
       if(e.pointerType==='mouse' && e.button!==0) return;  // ignore right/middle click
       if(e.ctrlKey||e.metaKey){
         // Ctrl/Cmd+click opens in a new tab; keep the current tab untouched.
-        // Clear the pending tap and active gesture before opening the new tab.
+        // Settle the gesture machine first via the shared choke point: a pen
+        // (or touch-emulated) drag may have painted swipe offsets, and a
+        // shaky click may have added the 'dragging' class — parking
+        // _gestureState alone would leave the row visually displaced.
+        // _clearPointerDragState() parks idle, disarms the long-press timer,
+        // and settles swipe paint when a drag was in flight.
         clearTimeout(_tapTimer);_tapTimer=null;_lastTapTime=0;
-        _clearLongPressTimer();
-        _gestureState='idle';
+        _clearPointerDragState();
         el.classList.remove('loading');
         if(_consumeSessionNewTabClick(e, s.session_id)) return;
       }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4266,7 +4266,7 @@ function _setActiveSessionUrl(sid){
  * tag chips, lineage/child toggles, while renaming, or in batch select mode.
  */
 function _openSessionUrlInNewTab(sid){
-  if(!sid||typeof window==='undefined'||typeof _sessionUrlForSid!=='function') return false;
+  if(!sid||typeof window==='undefined'||typeof window.open!=='function') return false;
   if(typeof _sessionSelectMode!=='undefined'&&_sessionSelectMode) return false;
   if(typeof _renamingSid!=='undefined'&&_renamingSid) return false;
   let url=null;
@@ -9066,6 +9066,11 @@ function renderSessionListFromCache(){
       if(e.pointerType==='mouse' && e.button!==0) return;  // ignore right/middle click
       if(e.ctrlKey||e.metaKey){
         // Ctrl/Cmd+click opens in a new tab; keep the current tab untouched.
+        // Clear the pending tap first so the deferred single-tap opener from
+        // the FIRST click of a fast Ctrl+click-double-click can't fire after
+        // the new tab opens (same cancel path as the double-tap branch).
+        clearTimeout(_tapTimer);_tapTimer=null;_lastTapTime=0;
+        el.classList.remove('loading');
         if(_consumeSessionNewTabClick(e, s.session_id)) return;
       }
       if(_finishSessionGesture(e.clientX,e.clientY,e.target,e.pointerType)) e.stopPropagation();

--- a/tests/test_session_middle_click_new_tab.py
+++ b/tests/test_session_middle_click_new_tab.py
@@ -134,15 +134,13 @@ def test_modified_click_cancels_pending_tap_before_new_tab():
     assert "_lastTapTime=0" in window.replace(" ", "")
     assert "_tapTimer=null" in window.replace(" ", "")
     # The row's gesture machine was armed by pointerdown before this
-    # pointerup fired: the long-press timer must be disarmed and the
-    # gesture parked back to idle BEFORE the early return, or a later
-    # pointermove promotes the stale `pressing` state to `dragging` and a
-    # pending pen long-press opens the action menu behind the new tab.
-    nose = window.replace(" ", "")
-    assert "_clearLongPressTimer()" in window
-    assert "_gestureState='idle'" in nose
-    assert window.index("_clearLongPressTimer()") < consume_idx
-    assert window.index("_gestureState='idle'") < consume_idx
+    # pointerup fired, and a pen drag may have painted swipe offsets
+    # (mouse never paints: `_isSessionSwipeTarget` excludes mouse). The
+    # branch must settle via the shared `_clearPointerDragState()` choke
+    # point BEFORE the early return — parking `_gestureState` alone would
+    # leave pen-painted offsets displaced and the `dragging` class stuck.
+    assert "_clearPointerDragState()" in window
+    assert window.index("_clearPointerDragState()") < consume_idx
 
 
 # ── Behavioral tests via Node VM ─────────────────────────────────────────────
@@ -278,12 +276,11 @@ console.log(JSON.stringify(ret));
         urlfn = _extract_function(SESSIONS_JS, "_sessionUrlForSid")
         # The branch under test runs inside the row's gesture closure, so the
         # harness must stub every closure free-var the branch touches:
-        # _tapTimer/_lastTapTime (pending tap), _clearLongPressTimer +
-        # _longPressTimer/_longPressMenuOpened (pen long-press), _gestureState
-        # (pressing/dragging machine), el (row node), and the new-tab choke
+        # _tapTimer/_lastTapTime (pending tap), _clearPointerDragState
+        # (gesture settle choke point), el (row node), and the new-tab choke
         # point. Missing stubs surface as ReferenceError here by design —
         # that is exactly the CI failure the maintainer reported.
-        assert "_clearLongPressTimer()" in branch and "_gestureState='idle'" in branch.replace(" ", "")
+        assert "_clearPointerDragState()" in branch
         driver = (
             "const fs = require('fs');\n"
             "const branchSrc = fs.readFileSync("
@@ -312,15 +309,27 @@ const runnerSrc =
   'const _isSessionActionTarget = () => false;' +
   'let finisherRan = false;' +
   'const _finishSessionGesture = () => { finisherRan = true; return false; };' +
-  'let _longPressTimer = "ARMED"; let _longPressMenuOpened = false; let longPressCleared = false;' +
-  'const _clearLongPressTimer = () => { _longPressTimer = null; longPressCleared = true; };' +
-  'let _gestureState = "pressing";' +
+  // Pen-drag-painted row state: the gesture is mid-drag with swipe tracking
+  // on (i.e. _paintSessionSwipe already ran and set the offset CSS vars).
+  // The choke-point stub below mirrors the shipped _clearPointerDragState
+  // (idle + long-press disarm + settle swipe paint when a drag was in
+  // flight) so the test observes the same settlement the row gets.
+  'let _gestureState = "dragging"; let _swipeTracking = true;' +
+  'let longPressCleared = false; let settleCalls = 0;' +
+  'const removedClasses = [];' +
+  'const _clearLongPressTimer = () => { longPressCleared = true; };' +
+  'const _settleSessionSwipePaint = () => { settleCalls++; removedClasses.push("dragging"); };' +
+  'const _clearPointerDragState = () => {' +
+  '  const wasDragging = _gestureState === "dragging" || _swipeTracking;' +
+  '  _gestureState = "idle"; _clearLongPressTimer();' +
+  '  if(wasDragging){ settleCalls++; removedClasses.push("dragging"); }' +
+  '};' +
   'let loadingRemoved = false;' +
-  'const el = { classList: { remove(c) { loadingRemoved = true; } } };' +
+  'const el = { classList: { remove(c) { if(c === "loading") loadingRemoved = true; } } };' +
   branchSrc.replace(/(\W)document(\W)/g, '$1doc$2')
   .replace(/if\(_consumeSessionNewTabClick\(e, s\.session_id\)\) return;/,
-    'if(_consumeSessionNewTabClick(e, s.session_id)){ globalThis.__capture = { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, longPressTimer: _longPressTimer, longPressCleared: longPressCleared }; }') +
-  '; globalThis.__capture = globalThis.__capture || { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, longPressTimer: _longPressTimer, longPressCleared: longPressCleared };';
+    'if(_consumeSessionNewTabClick(e, s.session_id)){ globalThis.__capture = { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, settleCalls: settleCalls, longPressCleared: longPressCleared }; }') +
+  '; globalThis.__capture = globalThis.__capture || { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, settleCalls: settleCalls, longPressCleared: longPressCleared };';
 try {
   new Function('ref', runnerSrc)(ref);
   ret.out = globalThis.__capture;
@@ -353,9 +362,12 @@ console.log(JSON.stringify(ret));
         assert out["out"]["opened"] == {"u": "/session/test-session-123", "t": "_blank", "f": "noopener"}
         assert out["out"]["loadingRemoved"] is True
         assert out["out"]["finisherRan"] is False
-        # Gesture machine parked + pen long-press disarmed before the return.
+        # Gesture settled via the shared choke point before the return: parked
+        # to idle, swipe-paint settle ran for the in-flight pen drag,
+        # long-press disarmed. (Row starts `dragging` + swipe-tracking to
+        # emulate the pen-drag-painted state the maintainer identified.)
         assert out["out"]["gestureState"] == "idle"
-        assert out["out"]["longPressTimer"] is None
+        assert out["out"]["settleCalls"] >= 1
         assert out["out"]["longPressCleared"] is True
 
     def test_wirer_opens_on_auxclick_and_swallows_mousedown(self):

--- a/tests/test_session_middle_click_new_tab.py
+++ b/tests/test_session_middle_click_new_tab.py
@@ -123,8 +123,8 @@ def test_modified_click_cancels_pending_tap_before_new_tab():
     fast modified double-click fires after the new tab opens and switches the
     current tab anyway — the exact stale-state class the review flagged.
     """
-    idx = SESSIONS_JS.index("if(e.ctrlKey||e.metaKey){")
-    window = SESSIONS_JS[idx:idx + 900]
+    idx = SESSIONS_JS.index("if((e.ctrlKey||e.metaKey)")
+    window = SESSIONS_JS[idx:idx + 1400]
     assert "_consumeSessionNewTabClick(e, s.session_id)" in window
     clear_idx = window.index("clearTimeout(_tapTimer)")
     consume_idx = window.index("_consumeSessionNewTabClick(e, s.session_id)")
@@ -141,6 +141,13 @@ def test_modified_click_cancels_pending_tap_before_new_tab():
     # leave pen-painted offsets displaced and the `dragging` class stuck.
     assert "_clearPointerDragState()" in window
     assert window.index("_clearPointerDragState()") < consume_idx
+    # Select/rename gate: the branch must not touch gesture state when the
+    # new-tab consumer refuses the event (select mode / mid-rename), or the
+    # fall-through _finishSessionGesture early-returns on 'idle' and the row
+    # (de)select toggle never runs.
+    compact = window.replace(" ", "")
+    assert "!_sessionSelectMode" in compact
+    assert "!_renamingSid" in compact
 
 
 # ── Behavioral tests via Node VM ─────────────────────────────────────────────
@@ -194,7 +201,7 @@ def _helpers() -> str:
 
 def _pointerup_branch() -> str:
     """The Ctrl/Cmd branch of the top-level onpointerup, verbatim."""
-    idx = SESSIONS_JS.index("if(e.ctrlKey||e.metaKey){")
+    idx = SESSIONS_JS.index("if((e.ctrlKey||e.metaKey)")
     end = SESSIONS_JS.index(
         "if(_finishSessionGesture(e.clientX,e.clientY,e.target,e.pointerType))",
         idx,
@@ -369,6 +376,96 @@ console.log(JSON.stringify(ret));
         assert out["out"]["gestureState"] == "idle"
         assert out["out"]["settleCalls"] >= 1
         assert out["out"]["longPressCleared"] is True
+
+    def test_select_mode_ctrl_click_skips_branch_and_runs_finisher(self):
+        """Select-mode regression: Ctrl+click must NOT mutate gesture state.
+
+        _consumeSessionNewTabClick refuses select mode, so the pointerup
+        branch must be skipped entirely — gesture stays 'pressing' and the
+        fall-through _finishSessionGesture runs (row toggles). Before the
+        select/rename gate, the branch parked state to 'idle' first and the
+        finisher early-returned, breaking Ctrl+click (de)select.
+        """
+        branch = _pointerup_branch()
+        consume = _extract_function(SESSIONS_JS, "_consumeSessionNewTabClick")
+        opener = _extract_function(SESSIONS_JS, "_openSessionUrlInNewTab")
+        urlfn = _extract_function(SESSIONS_JS, "_sessionUrlForSid")
+        # The branch under test runs inside the row's gesture closure, so the
+        # harness must stub every closure free-var the branch touches.
+        # Select mode ON: _consumeSessionNewTabClick refuses the event, so
+        # the branch must be skipped — no choke, no timer touch — and the
+        # appended verbatim finisher tail must run with state intact.
+        assert "_sessionSelectMode" in branch
+        driver = (
+            "const fs = require('fs');\n"
+            "const branchSrc = fs.readFileSync("
+            + json.dumps("BRANCH_FILE") + ", 'utf8');\n"
+            "const params = { urlSrc: fs.readFileSync("
+            + json.dumps("URL_FILE") + ", 'utf8'),\n"
+            "  openSrc: fs.readFileSync("
+            + json.dumps("OPEN_FILE") + ", 'utf8'),\n"
+            "  consumeSrc: fs.readFileSync("
+            + json.dumps("CONSUME_FILE") + ", 'utf8') };\n"
+            + r"""
+const ret = {};
+const ref = { v: null };
+const runnerSrc =
+  'let _tapTimer = null; let _lastTapTime = 0;' +
+  'const clearTimeout = (id) => {};' +
+  'const e = { button: 0, ctrlKey: true, metaKey: false, clientX: 10, clientY: 20, pointerType: "mouse", target: null, preventDefault() {}, stopPropagation() {} };' +
+  'const s = { session_id: "test-session-123" };' +
+  'const _sessionUrlForSid = ' + params.urlSrc + ';' +
+  'const _openSessionUrlInNewTab = ' + params.openSrc + ';' +
+  'const _consumeSessionNewTabClick = ' + params.consumeSrc + ';' +
+  'let opened = null; const window = { open: (u,t,f) => { opened = {u,t,f}; return null; } };' +
+  'window.location = { href: "http://127.0.0.1:8787/", pathname: "/", search: "", hash: "", origin: "http://127.0.0.1:8787" };' +
+  'const doc = { baseURI: "http://127.0.0.1:8787/" };' +
+  'const _sessionSelectMode = true; const _renamingSid = null;' +
+  'const _isSessionActionTarget = () => false;' +
+  'let finisherRan = false;' +
+  'const _finishSessionGesture = () => { finisherRan = true; return true; };' +
+  'let _gestureState = "pressing"; let _swipeTracking = false;' +
+  'let chokeRan = false;' +
+  'const _clearLongPressTimer = () => {};' +
+  'const _settleSessionSwipePaint = () => {};' +
+  'const _clearPointerDragState = () => { chokeRan = true; _gestureState = "idle"; };' +
+  'const el = { classList: { remove(c) {} } };' +
+  // Verbatim branch (ends before the finisher tail), then the real
+  // fall-through tail re-attached so the skip path is exercised for real.
+  branchSrc.replace(/(\W)document(\W)/g, '$1doc$2') +
+  '; if(_finishSessionGesture(e.clientX,e.clientY,e.target,e.pointerType)) { globalThis.__stopCalled = true; }' +
+  '; globalThis.__capture = { opened: opened, finisherRan: finisherRan, gestureState: _gestureState, chokeRan: chokeRan, stopCalled: !!globalThis.__stopCalled };';
+try {
+  new Function('ref', runnerSrc)(ref);
+  ret.out = globalThis.__capture;
+  delete globalThis.__capture;
+  delete globalThis.__stopCalled;
+} catch (err) { ret.error = String(err && err.message || err); }
+console.log(JSON.stringify(ret));
+"""
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            files = {
+                "BRANCH_FILE": branch,
+                "URL_FILE": urlfn,
+                "OPEN_FILE": opener,
+                "CONSUME_FILE": consume,
+            }
+            concreto = driver
+            for key, content in files.items():
+                path = str(Path(tmp) / (key.lower() + ".js"))
+                Path(path).write_text(content, encoding="utf-8")
+                concreto = concreto.replace(json.dumps(key), json.dumps(path))
+            r = subprocess.run([NODE, "-e", concreto],
+                               capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                raise RuntimeError(f"node failed: {r.stderr}")
+            out = json.loads(r.stdout.strip().splitlines()[-1])
+        assert "error" not in out, out.get("error")
+        assert out["out"]["opened"] is None
+        assert out["out"]["finisherRan"] is True
+        assert out["out"]["gestureState"] == "pressing"
+        assert out["out"]["chokeRan"] is False
 
     def test_wirer_opens_on_auxclick_and_swallows_mousedown(self):
         """The shared wirer (single choke point for all row kinds): auxclick

--- a/tests/test_session_middle_click_new_tab.py
+++ b/tests/test_session_middle_click_new_tab.py
@@ -19,10 +19,11 @@ Ctrl/Cmd+click on the tap paths, leaving right-click menu, select mode,
 rename, swipe, and single-tap behavior untouched.
 """
 import json
-import re
 import shutil
 import subprocess
 from pathlib import Path
+
+import tempfile
 
 import pytest
 
@@ -132,6 +133,16 @@ def test_modified_click_cancels_pending_tap_before_new_tab():
     )
     assert "_lastTapTime=0" in window.replace(" ", "")
     assert "_tapTimer=null" in window.replace(" ", "")
+    # The row's gesture machine was armed by pointerdown before this
+    # pointerup fired: the long-press timer must be disarmed and the
+    # gesture parked back to idle BEFORE the early return, or a later
+    # pointermove promotes the stale `pressing` state to `dragging` and a
+    # pending pen long-press opens the action menu behind the new tab.
+    nose = window.replace(" ", "")
+    assert "_clearLongPressTimer()" in window
+    assert "_gestureState='idle'" in nose
+    assert window.index("_clearLongPressTimer()") < consume_idx
+    assert window.index("_gestureState='idle'") < consume_idx
 
 
 # ── Behavioral tests via Node VM ─────────────────────────────────────────────
@@ -261,12 +272,18 @@ console.log(JSON.stringify(ret));
         temp files (instead of nested ``json.dumps`` string concatenation)
         to keep quoting levels manageable.
         """
-        import tempfile
-
         branch = _pointerup_branch()
         consume = _extract_function(SESSIONS_JS, "_consumeSessionNewTabClick")
         opener = _extract_function(SESSIONS_JS, "_openSessionUrlInNewTab")
         urlfn = _extract_function(SESSIONS_JS, "_sessionUrlForSid")
+        # The branch under test runs inside the row's gesture closure, so the
+        # harness must stub every closure free-var the branch touches:
+        # _tapTimer/_lastTapTime (pending tap), _clearLongPressTimer +
+        # _longPressTimer/_longPressMenuOpened (pen long-press), _gestureState
+        # (pressing/dragging machine), el (row node), and the new-tab choke
+        # point. Missing stubs surface as ReferenceError here by design —
+        # that is exactly the CI failure the maintainer reported.
+        assert "_clearLongPressTimer()" in branch and "_gestureState='idle'" in branch.replace(" ", "")
         driver = (
             "const fs = require('fs');\n"
             "const branchSrc = fs.readFileSync("
@@ -295,12 +312,15 @@ const runnerSrc =
   'const _isSessionActionTarget = () => false;' +
   'let finisherRan = false;' +
   'const _finishSessionGesture = () => { finisherRan = true; return false; };' +
+  'let _longPressTimer = "ARMED"; let _longPressMenuOpened = false; let longPressCleared = false;' +
+  'const _clearLongPressTimer = () => { _longPressTimer = null; longPressCleared = true; };' +
+  'let _gestureState = "pressing";' +
   'let loadingRemoved = false;' +
   'const el = { classList: { remove(c) { loadingRemoved = true; } } };' +
   branchSrc.replace(/(\W)document(\W)/g, '$1doc$2')
   .replace(/if\(_consumeSessionNewTabClick\(e, s\.session_id\)\) return;/,
-    'if(_consumeSessionNewTabClick(e, s.session_id)){ globalThis.__capture = { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan }; }') +
-  '; globalThis.__capture = globalThis.__capture || { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan };';
+    'if(_consumeSessionNewTabClick(e, s.session_id)){ globalThis.__capture = { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, longPressTimer: _longPressTimer, longPressCleared: longPressCleared }; }') +
+  '; globalThis.__capture = globalThis.__capture || { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan, gestureState: _gestureState, longPressTimer: _longPressTimer, longPressCleared: longPressCleared };';
 try {
   new Function('ref', runnerSrc)(ref);
   ret.out = globalThis.__capture;
@@ -333,6 +353,10 @@ console.log(JSON.stringify(ret));
         assert out["out"]["opened"] == {"u": "/session/test-session-123", "t": "_blank", "f": "noopener"}
         assert out["out"]["loadingRemoved"] is True
         assert out["out"]["finisherRan"] is False
+        # Gesture machine parked + pen long-press disarmed before the return.
+        assert out["out"]["gestureState"] == "idle"
+        assert out["out"]["longPressTimer"] is None
+        assert out["out"]["longPressCleared"] is True
 
     def test_wirer_opens_on_auxclick_and_swallows_mousedown(self):
         """The shared wirer (single choke point for all row kinds): auxclick

--- a/tests/test_session_middle_click_new_tab.py
+++ b/tests/test_session_middle_click_new_tab.py
@@ -1,37 +1,65 @@
-"""Middle-click (auxclick button 1) on a sidebar session row opens that session
-in a new browser tab instead of switching the current tab.
+"""Middle-click (auxclick button 1) or Ctrl/Cmd+click on a sidebar session row
+opens that session in a new browser tab instead of switching the current tab.
 
-Today the top-level `.session-item` rows swallow non-left buttons: the
-`onpointerup` guard returns early for `button !== 0` and there is no
-`auxclick`/`mousedown` middle-button handler anywhere in sessions.js, so a
-middle-click does nothing (or triggers browser autoscroll).
+Covers the P1 from Greptile review on #7429 (modified clicks retaining
+gesture state) via a regression lock, plus behavioral coverage the review
+asked for: the new-tab helpers are extracted from the shipped
+``static/sessions.js`` and driven through a Node VM that dispatches synthetic
+pointer/aux/mouse events against a stub row and observes ``window.open``,
+propagation, exclusions, and gesture cleanup.
 
-The fix wires `_openSessionUrlInNewTab(sid)` into a shared choke point used
-by all three sidebar row kinds (top-level session rows, fork rows, and plain
-child-session buttons) via both `auxclick` (primary) and `mousedown`
-(prevents autoscroll) plus Ctrl/Cmd+click on the click path, while leaving
-right-click (menu), select mode, rename, swipe, and single-tap behavior
-untouched.
+Handler/gesture background: top-level ``.session-item`` rows swallow
+non-left buttons (``onpointerup`` returns early for ``button !== 0`` and no
+``auxclick`` handler existed), so middle-click did nothing or triggered
+autoscroll. The fix wires ``_openSessionUrlInNewTab(sid)`` through the shared
+``_consumeSessionNewTabClick`` choke point into all sidebar row kinds
+(top-level rows, fork rows + main buttons, plain child buttons, lineage
+segments) via ``auxclick`` (open) + ``mousedown`` (kill autoscroll) plus
+Ctrl/Cmd+click on the tap paths, leaving right-click menu, select mode,
+rename, swipe, and single-tap behavior untouched.
 """
+import json
+import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
+
 
 REPO = Path(__file__).parent.parent
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
 
-ROW_KINDS = (
-    ".session-item top-level row",
-    "fork child row (.session-child-session-fork)",
-    "plain child row (.session-child-session button)",
-)
+
+def _extract_function(source: str, name: str) -> str:
+    """Extract ``function name(...)`` with balanced braces (sync or plain)."""
+    for prefix in (f"function {name}(", f"async function {name}("):
+        start = source.find(prefix)
+        if start >= 0:
+            break
+    else:
+        raise AssertionError(f"{name} function not found in static/sessions.js")
+    brace = source.find("{", start)
+    assert brace >= 0, f"{name} opening brace not found"
+    depth = 0
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:idx + 1]
+    raise AssertionError(f"{name} function braces unbalanced")
 
 
 def test_new_tab_helper_exists():
     """A shared `_openSessionUrlInNewTab(sid)` helper builds the deep link."""
-    assert "function _openSessionUrlInNewTab(" in SESSIONS_JS
-    helper = SESSIONS_JS.split(
-        "function _openSessionUrlInNewTab(")[1][:1200]
+    helper = _extract_function(SESSIONS_JS, "_openSessionUrlInNewTab")
     assert "_sessionUrlForSid(" in helper
     assert "window.open(" in helper
+    assert "'_blank'" in helper or '"_blank"' in helper
 
 
 def test_auxclick_wired_for_all_row_kinds():
@@ -54,10 +82,9 @@ def test_middle_mousedown_prevents_autoscroll():
     """`mousedown` on button 1 preventDefaults so the browser doesn't autoscroll."""
     assert "addEventListener('auxclick'" in SESSIONS_JS
     assert "addEventListener('mousedown'" in SESSIONS_JS
-    idx = SESSIONS_JS.index("function _wireSessionNewTabListeners(")
-    window = SESSIONS_JS[idx:idx + 2500]
-    assert "button" in window and "1" in window
-    assert "preventDefault()" in window
+    wire = _extract_function(SESSIONS_JS, "_wireSessionNewTabListeners")
+    assert "button" in wire and "1" in wire
+    assert "preventDefault()" in wire
     # Ctrl/Cmd+click on the tap paths also routes to the new-tab opener.
     assert "_consumeSessionNewTabClick(e, child.session_id)" in SESSIONS_JS
     assert "_consumeSessionNewTabClick(e, s.session_id)" in SESSIONS_JS
@@ -70,17 +97,11 @@ def test_ctrl_click_opens_new_tab():
 
 def test_action_menu_and_select_mode_untouched():
     """New-tab must not fire from the ⋮ menu, checkboxes, or select mode."""
-    assert "_isSessionActionTarget" in SESSIONS_JS
-    assert "_sessionSelectMode" in SESSIONS_JS
-    # The existing guards already cover these paths on the click/pointerup
-    # flow; the shared choke point and the wirer must consult them too.
-    consume_idx = SESSIONS_JS.index("function _consumeSessionNewTabClick(")
-    consume = SESSIONS_JS[consume_idx:consume_idx + 1800]
+    consume = _extract_function(SESSIONS_JS, "_consumeSessionNewTabClick")
     assert "_isSessionActionTarget" in consume
     assert "_sessionSelectMode" in consume
     assert "_renamingSid" in consume
-    wire_idx = SESSIONS_JS.index("function _wireSessionNewTabListeners(")
-    wire = SESSIONS_JS[wire_idx:wire_idx + 2500]
+    wire = _extract_function(SESSIONS_JS, "_wireSessionNewTabListeners")
     assert "_isSessionActionTarget" in wire
     assert "session-actions" in wire
 
@@ -91,3 +112,267 @@ def test_openChildSession_new_tab_flag():
     window = SESSIONS_JS[idx:idx + 400]
     assert "newTab" in window
     assert "_openSessionUrlInNewTab(childSession.session_id)" in window
+
+
+def test_modified_click_cancels_pending_tap_before_new_tab():
+    """P1 (#7429 review): the Ctrl/Cmd+click branch must clear the pending
+    single-tap timer *before* opening the new tab.
+
+    Without this, the deferred single-tap opener from the FIRST click of a
+    fast modified double-click fires after the new tab opens and switches the
+    current tab anyway — the exact stale-state class the review flagged.
+    """
+    idx = SESSIONS_JS.index("if(e.ctrlKey||e.metaKey){")
+    window = SESSIONS_JS[idx:idx + 900]
+    assert "_consumeSessionNewTabClick(e, s.session_id)" in window
+    clear_idx = window.index("clearTimeout(_tapTimer)")
+    consume_idx = window.index("_consumeSessionNewTabClick(e, s.session_id)")
+    assert clear_idx < consume_idx, (
+        "pending-tap cancel must run before the new-tab open, not after"
+    )
+    assert "_lastTapTime=0" in window.replace(" ", "")
+    assert "_tapTimer=null" in window.replace(" ", "")
+
+
+# ── Behavioral tests via Node VM ─────────────────────────────────────────────
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_VM_PRELUDE = r"""
+const ret = {};
+const sandbox = { opened: null, openCalls: 0, stopped: 0, prevented: 0,
+  _sessionSelectMode: false, _renamingSid: null,
+  _isSessionActionTarget: () => false,
+  mkEvent: null };
+sandbox.window = { open: (u, t, f) => { sandbox.opened = { u, t, f }; sandbox.openCalls++; return null; } };
+sandbox.document = { baseURI: 'http://127.0.0.1:8787/' };
+sandbox.location = { href: 'http://127.0.0.1:8787/', pathname: '/', search: '', hash: '', origin: 'http://127.0.0.1:8787' };
+sandbox.window.location = sandbox.location;
+sandbox.URL = URL; sandbox.URLSearchParams = URLSearchParams; sandbox.encodeURIComponent = encodeURIComponent;
+sandbox.mkEvent = (over) => Object.assign(
+  { button: 0, ctrlKey: false, metaKey: false, target: null,
+    preventDefault() { sandbox.prevented++; }, stopPropagation() { sandbox.stopped++; } }, over || {});
+const vm = require('vm');
+vm.createContext(sandbox);
+vm.runInContext(params.helpers, sandbox);
+vm.runInContext('var mkEvent = this.mkEvent; var window = this.window; var document = this.document;', sandbox);
+const sid = 'test-session-123';
+"""
+
+
+def _run_node(payload: dict) -> dict:
+    js = (
+        "const params = " + json.dumps(payload) + ";\n"
+        + _VM_PRELUDE
+        + payload["driver"]
+    )
+    r = subprocess.run([NODE, "-e", js], capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        raise RuntimeError(f"node failed: {r.stderr}")
+    return json.loads(r.stdout.strip().splitlines()[-1])
+
+
+def _helpers() -> str:
+    return "\n".join(
+        _extract_function(SESSIONS_JS, name)
+        for name in (
+            "_sessionUrlForSid",
+            "_openSessionUrlInNewTab",
+            "_consumeSessionNewTabClick",
+        )
+    )
+
+
+def _pointerup_branch() -> str:
+    """The Ctrl/Cmd branch of the top-level onpointerup, verbatim."""
+    idx = SESSIONS_JS.index("if(e.ctrlKey||e.metaKey){")
+    end = SESSIONS_JS.index(
+        "if(_finishSessionGesture(e.clientX,e.clientY,e.target,e.pointerType))",
+        idx,
+    )
+    return SESSIONS_JS[idx:end]
+
+
+class TestNewTabBehavior:
+    def test_helper_opens_deep_link_blank(self):
+        out = _run_node({
+            "helpers": _helpers(),
+            "driver": r"""
+const opened0 = vm.runInContext(`_openSessionUrlInNewTab("test-session-123")`, sandbox);
+ret.opened = sandbox.opened; ret.calls = sandbox.openCalls; ret.ret = opened0;
+console.log(JSON.stringify(ret));
+""",
+        })
+        assert out["calls"] == 1
+        assert out["opened"]["u"] == "/session/test-session-123"
+        assert out["opened"]["t"] == "_blank"
+
+    def test_middle_click_consumed_plain_click_passes_through(self):
+        out = _run_node({
+            "helpers": _helpers(),
+            "driver": r"""
+const mid = vm.runInContext(
+  `_consumeSessionNewTabClick(mkEvent({button:1,target:null}), "test-session-123")`, sandbox);
+const midOpened = sandbox.opened;
+sandbox.opened = null; sandbox.openCalls = 0;
+const plain = vm.runInContext(
+  `_consumeSessionNewTabClick(mkEvent({button:0,target:null}), "test-session-123")`, sandbox);
+ret.mid = mid; ret.midOpened = !!midOpened; ret.plain = plain; ret.plainOpened = !!sandbox.opened;
+console.log(JSON.stringify(ret));
+""",
+        })
+        assert out["mid"] is True and out["midOpened"] is True
+        assert out["plain"] is False and out["plainOpened"] is False
+
+    def test_ctrl_click_consumed_select_mode_and_menu_blocked(self):
+        out = _run_node({
+            "helpers": _helpers(),
+            "driver": r"""
+const ctrl = vm.runInContext(
+  `_consumeSessionNewTabClick(mkEvent({button:0,ctrlKey:true,target:null}), "test-session-123")`, sandbox);
+const ctrlOpened = !!sandbox.opened;
+sandbox.opened = null;
+vm.runInContext(`_sessionSelectMode = true;`, sandbox);
+const blockedSelect = vm.runInContext(
+  `_consumeSessionNewTabClick(mkEvent({button:1,target:null}), "test-session-123")`, sandbox);
+vm.runInContext(`_sessionSelectMode = false; _isSessionActionTarget = () => true;`, sandbox);
+const blockedMenu = vm.runInContext(
+  `_consumeSessionNewTabClick(mkEvent({button:1,target:{}}), "test-session-123")`, sandbox);
+ret.ctrl = ctrl; ret.ctrlOpened = ctrlOpened;
+ret.blockedSelect = blockedSelect; ret.blockedMenu = blockedMenu;
+ret.stillClosed = !sandbox.opened;
+console.log(JSON.stringify(ret));
+""",
+        })
+        assert out["ctrl"] is True and out["ctrlOpened"] is True
+        assert out["blockedSelect"] is False
+        assert out["blockedMenu"] is False
+        assert out["stillClosed"] is True
+
+    def test_modified_pointerup_cancels_pending_tap(self):
+        """Execute the real pointerup branch: pending tap cleared, tab opened,
+        and the same-tab gesture finisher never runs.
+
+        The branch ends in a bare ``return`` (it lives inside the row's
+        ``onpointerup`` closure), so the harness rewrites the verbatim
+        ``if(_consume...) return;`` tail to capture the observation object
+        into ``globalThis`` *before* returning, then observes the timer ref,
+        opened tab, and finisher flag. The branch and helpers travel via
+        temp files (instead of nested ``json.dumps`` string concatenation)
+        to keep quoting levels manageable.
+        """
+        import tempfile
+
+        branch = _pointerup_branch()
+        consume = _extract_function(SESSIONS_JS, "_consumeSessionNewTabClick")
+        opener = _extract_function(SESSIONS_JS, "_openSessionUrlInNewTab")
+        urlfn = _extract_function(SESSIONS_JS, "_sessionUrlForSid")
+        driver = (
+            "const fs = require('fs');\n"
+            "const branchSrc = fs.readFileSync("
+            + json.dumps("BRANCH_FILE") + ", 'utf8');\n"
+            "const params = { urlSrc: fs.readFileSync("
+            + json.dumps("URL_FILE") + ", 'utf8'),\n"
+            "  openSrc: fs.readFileSync("
+            + json.dumps("OPEN_FILE") + ", 'utf8'),\n"
+            "  consumeSrc: fs.readFileSync("
+            + json.dumps("CONSUME_FILE") + ", 'utf8') };\n"
+            + r"""
+const ret = {};
+const ref = { v: 'PENDING-TAP' };
+const runnerSrc =
+  'let _tapTimer = ref.v; let _lastTapTime = 111;' +
+  'const clearTimeout = (id) => { if (id === _tapTimer) { _tapTimer = null; ref.v = null; } };' +
+  'const e = { button: 0, ctrlKey: true, metaKey: false, target: null, preventDefault() {}, stopPropagation() {} };' +
+  'const s = { session_id: "test-session-123" };' +
+  'const _sessionUrlForSid = ' + params.urlSrc + ';' +
+  'const _openSessionUrlInNewTab = ' + params.openSrc + ';' +
+  'const _consumeSessionNewTabClick = ' + params.consumeSrc + ';' +
+  'let opened = null; const window = { open: (u,t,f) => { opened = {u,t,f}; return null; } };' +
+  'window.location = { href: "http://127.0.0.1:8787/", pathname: "/", search: "", hash: "", origin: "http://127.0.0.1:8787" };' +
+  'const doc = { baseURI: "http://127.0.0.1:8787/" };' +
+  'const _sessionSelectMode = false; const _renamingSid = null;' +
+  'const _isSessionActionTarget = () => false;' +
+  'let finisherRan = false;' +
+  'const _finishSessionGesture = () => { finisherRan = true; return false; };' +
+  'let loadingRemoved = false;' +
+  'const el = { classList: { remove(c) { loadingRemoved = true; } } };' +
+  branchSrc.replace(/(\W)document(\W)/g, '$1doc$2')
+  .replace(/if\(_consumeSessionNewTabClick\(e, s\.session_id\)\) return;/,
+    'if(_consumeSessionNewTabClick(e, s.session_id)){ globalThis.__capture = { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan }; }') +
+  '; globalThis.__capture = globalThis.__capture || { tapTimer: _tapTimer, ref: ref.v, lastTap: _lastTapTime, opened: opened, loadingRemoved: loadingRemoved, finisherRan: finisherRan };';
+try {
+  new Function('ref', runnerSrc)(ref);
+  ret.out = globalThis.__capture;
+  delete globalThis.__capture;
+} catch (err) { ret.error = String(err && err.message || err); }
+console.log(JSON.stringify(ret));
+"""
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            files = {
+                "BRANCH_FILE": branch,
+                "URL_FILE": urlfn,
+                "OPEN_FILE": opener,
+                "CONSUME_FILE": consume,
+            }
+            concreto = driver
+            for key, content in files.items():
+                path = str(Path(tmp) / (key.lower() + ".js"))
+                Path(path).write_text(content, encoding="utf-8")
+                concreto = concreto.replace(json.dumps(key), json.dumps(path))
+            r = subprocess.run([NODE, "-e", concreto],
+                               capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                raise RuntimeError(f"node failed: {r.stderr}")
+            out = json.loads(r.stdout.strip().splitlines()[-1])
+        assert "error" not in out, out.get("error")
+        assert out["out"]["tapTimer"] is None
+        assert out["out"]["ref"] is None
+        assert out["out"]["lastTap"] == 0
+        assert out["out"]["opened"] == {"u": "/session/test-session-123", "t": "_blank", "f": "noopener"}
+        assert out["out"]["loadingRemoved"] is True
+        assert out["out"]["finisherRan"] is False
+
+    def test_wirer_opens_on_auxclick_and_swallows_mousedown(self):
+        """The shared wirer (single choke point for all row kinds): auxclick
+        button-1 opens the tab; mousedown button-1 preventDefaults (no
+        autoscroll) without opening; other buttons ignored."""
+        wire = _extract_function(SESSIONS_JS, "_wireSessionNewTabListeners")
+        out = _run_node({
+            "helpers": _helpers(),
+            "driver": (
+                "const wireSrc = " + json.dumps(wire) + r""";
+const seen = {};
+const node = { addEventListener: (t, fn) => { seen[t] = fn; } };
+const getSid = () => "test-session-123";
+const mkLocalEvent = (over) => Object.assign(
+  { button: 0, ctrlKey: false, metaKey: false, target: null,
+    preventDefault() { sandbox.prevented++; }, stopPropagation() { sandbox.stopped++; } }, over || {});
+const runner = new Function('node', 'getSid', 'window', 'document',
+  '_sessionSelectMode', '_renamingSid', '_isSessionActionTarget',
+  '_openSessionUrlInNewTab', '_sessionUrlForSid', '_consumeSessionNewTabClick',
+  wireSrc + '; _wireSessionNewTabListeners(node, getSid);');
+runner(node, getSid, sandbox.window, sandbox.document, false, null, () => false,
+  sandbox._openSessionUrlInNewTab, sandbox._sessionUrlForSid, sandbox._consumeSessionNewTabClick);
+ret.hasAux = typeof seen['auxclick'] === 'function';
+ret.hasDown = typeof seen['mousedown'] === 'function';
+// auxclick middle button opens
+seen['auxclick'](mkLocalEvent({ button: 1, target: null }));
+ret.auxOpened = !!sandbox.opened;
+sandbox.opened = null; sandbox.openCalls = 0; sandbox.prevented = 0;
+// mousedown middle button only swallows default
+seen['mousedown'](mkLocalEvent({ button: 1, target: null }));
+ret.downPrevented = sandbox.prevented === 1;
+ret.downOpened = !!sandbox.opened;
+// left auxclick ignored
+seen['auxclick'](mkLocalEvent({ button: 0, target: null }));
+ret.leftIgnored = sandbox.openCalls === 0;
+console.log(JSON.stringify(ret));
+"""
+            ),
+        })
+        assert out["hasAux"] is True and out["hasDown"] is True
+        assert out["auxOpened"] is True
+        assert out["downPrevented"] is True and out["downOpened"] is False
+        assert out["leftIgnored"] is True

--- a/tests/test_session_middle_click_new_tab.py
+++ b/tests/test_session_middle_click_new_tab.py
@@ -1,0 +1,93 @@
+"""Middle-click (auxclick button 1) on a sidebar session row opens that session
+in a new browser tab instead of switching the current tab.
+
+Today the top-level `.session-item` rows swallow non-left buttons: the
+`onpointerup` guard returns early for `button !== 0` and there is no
+`auxclick`/`mousedown` middle-button handler anywhere in sessions.js, so a
+middle-click does nothing (or triggers browser autoscroll).
+
+The fix wires `_openSessionUrlInNewTab(sid)` into a shared choke point used
+by all three sidebar row kinds (top-level session rows, fork rows, and plain
+child-session buttons) via both `auxclick` (primary) and `mousedown`
+(prevents autoscroll) plus Ctrl/Cmd+click on the click path, while leaving
+right-click (menu), select mode, rename, swipe, and single-tap behavior
+untouched.
+"""
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+ROW_KINDS = (
+    ".session-item top-level row",
+    "fork child row (.session-child-session-fork)",
+    "plain child row (.session-child-session button)",
+)
+
+
+def test_new_tab_helper_exists():
+    """A shared `_openSessionUrlInNewTab(sid)` helper builds the deep link."""
+    assert "function _openSessionUrlInNewTab(" in SESSIONS_JS
+    helper = SESSIONS_JS.split(
+        "function _openSessionUrlInNewTab(")[1][:1200]
+    assert "_sessionUrlForSid(" in helper
+    assert "window.open(" in helper
+
+
+def test_auxclick_wired_for_all_row_kinds():
+    """Each row kind handles middle-click via the shared wiring helper."""
+    # The auxclick/mousedown listeners live once in _wireSessionNewTabListeners;
+    # every row kind (top-level .session-item, fork row, fork main button,
+    # plain child button, lineage segment) must call the wirer.
+    assert "_wireSessionNewTabListeners(el, ()=>s.session_id)" in SESSIONS_JS
+    assert SESSIONS_JS.count("_wireSessionNewTabListeners(row, ()=>child.session_id)") == 2
+    assert "_wireSessionNewTabListeners(mainBtn, ()=>child.session_id)" in SESSIONS_JS
+    assert "_wireSessionNewTabListeners(row, ()=>seg.session_id)" in SESSIONS_JS
+    assert SESSIONS_JS.count("_wireSessionNewTabListeners(") >= 6  # def + 5 call sites
+    # All opens route through the two choke points with the concrete sid.
+    assert "_openSessionUrlInNewTab(getSid())" in SESSIONS_JS
+    assert "_openSessionUrlInNewTab(sid)" in SESSIONS_JS
+    assert "_openSessionUrlInNewTab(childSession.session_id)" in SESSIONS_JS
+
+
+def test_middle_mousedown_prevents_autoscroll():
+    """`mousedown` on button 1 preventDefaults so the browser doesn't autoscroll."""
+    assert "addEventListener('auxclick'" in SESSIONS_JS
+    assert "addEventListener('mousedown'" in SESSIONS_JS
+    idx = SESSIONS_JS.index("function _wireSessionNewTabListeners(")
+    window = SESSIONS_JS[idx:idx + 2500]
+    assert "button" in window and "1" in window
+    assert "preventDefault()" in window
+    # Ctrl/Cmd+click on the tap paths also routes to the new-tab opener.
+    assert "_consumeSessionNewTabClick(e, child.session_id)" in SESSIONS_JS
+    assert "_consumeSessionNewTabClick(e, s.session_id)" in SESSIONS_JS
+
+
+def test_ctrl_click_opens_new_tab():
+    """Ctrl/Cmd+left-click on a row opens the deep link in a new tab."""
+    assert "e.ctrlKey||e.metaKey" in SESSIONS_JS.replace(" ", "")
+
+
+def test_action_menu_and_select_mode_untouched():
+    """New-tab must not fire from the ⋮ menu, checkboxes, or select mode."""
+    assert "_isSessionActionTarget" in SESSIONS_JS
+    assert "_sessionSelectMode" in SESSIONS_JS
+    # The existing guards already cover these paths on the click/pointerup
+    # flow; the shared choke point and the wirer must consult them too.
+    consume_idx = SESSIONS_JS.index("function _consumeSessionNewTabClick(")
+    consume = SESSIONS_JS[consume_idx:consume_idx + 1800]
+    assert "_isSessionActionTarget" in consume
+    assert "_sessionSelectMode" in consume
+    assert "_renamingSid" in consume
+    wire_idx = SESSIONS_JS.index("function _wireSessionNewTabListeners(")
+    wire = SESSIONS_JS[wire_idx:wire_idx + 2500]
+    assert "_isSessionActionTarget" in wire
+    assert "session-actions" in wire
+
+
+def test_openChildSession_new_tab_flag():
+    """Child-row programmatic path supports open-in-new-tab without a same-tab switch."""
+    idx = SESSIONS_JS.index("const openChildSession=async(childSession,")
+    window = SESSIONS_JS[idx:idx + 400]
+    assert "newTab" in window
+    assert "_openSessionUrlInNewTab(childSession.session_id)" in window


### PR DESCRIPTION
## Thinking Path
Middle-click on sidebar sessions did nothing useful: top-level `.session-item` rows return early on `onpointerup` for `button!==0` and there is no `auxclick` handler anywhere, so the browser either autoscrolls or ignores the click. The fix routes middle-click (and Ctrl/Cmd+click) through the existing `/session/<id>` deep link that boot already resolves (`_sessionIdFromLocation` + `loadSession(saved)`), so a new tab lands directly on the session with zero server changes.

## What Changed
- `_openSessionUrlInNewTab(sid)` (static/sessions.js): shared helper, builds the deep link via `_sessionUrlForSid()` + `window.open(url, _blank, noopener)`; no-ops in select mode / while renaming.
- `_consumeSessionNewTabClick(e, sid)`: choke point for tap paths (middle button or Ctrl/Cmd+click); excludes the action menu, checkboxes, tag chips, lineage/child toggles, rename, select mode.
- `_wireSessionNewTabListeners(node, getSid)`: wires `auxclick` (open) + `mousedown` (preventDefault to kill autoscroll) on all five row kinds: top-level `.session-item`, fork row, fork main button, plain child-session button, lineage-segment row.
- Child/fork/lineage `onclick` paths consult the choke point so Ctrl+click no longer also switches the current tab; top-level `onpointerup` consults it for Ctrl/Cmd+click (middle button never reaches pointerup by design).
- `openChildSession(child, {newTab})` escape hatch routes to the same helper without a same-tab switch.
- New tests: `tests/test_session_middle_click_new_tab.py` (6 tests).

Siblings considered: lineage-segment rows and plain child-session buttons use separate `onclick` handlers from the top-level gesture machine, so all five needed wiring; the ⋮ menu, checkboxes, swipe/long-press/rename/touch paths are explicitly excluded. `window.open` (not an `<a target=_blank>`) was chosen because rows are gesture-managed `div`s, and anchor-wrapping would break the swipe/long-press machine.

## Why It Matters
Lets power users compare sessions side-by-side and keep a long-running stream visible while triaging other conversations — standard browser behavior users already expect from any list.

## Verification
- New test file: 6/6 pass.
- Neighbors: `test_3845_keyboard_session_nav`, `test_session_touch_actions`, `test_session_switch_busy_race`, `test_parallel_session_switch` — 69 passed total.
- `node --check static/sessions.js` clean.
- Real-behavior check: extracted the three new functions and ran them under node `vm` — helper opens `/session/<id>` with `_blank`, middle-click consumed, plain left-click untouched, Ctrl+click consumed, select-mode blocks. (5/5 assertions.)
- NOT verified in a live browser: a real middle-click end-to-end (no headed browser in this env); the `mousedown` autoscroll suppression relies on the standard `auxclick`/`mousedown` button-1 contract owned by browser vendors.

## Risks / Follow-ups
- Popup blockers: `window.open` from `auxclick` is a user gesture and normally allowed; if a blocker eats it, the click is still consumed (current tab untouched) — acceptable.
- Read-only/external (CLI/messaging) sessions open the same deep link; boot import flow handles them as usual.
- No server/config changes; no new deps; no build step (vanilla JS per repo norms).

## Model Used
muse-spark (Hermes Agent, openrouter).