### PR TITLE
docs: add optional Parallel Search MCP setup

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -218,7 +218,9 @@ URLs, and any supplied objective or context go to Parallel. This adds MCP tools;
 it does not replace the built-in web tools or change their provider settings.
 
 In the same profile, run `/reload-mcp` in chat, then check **MCP Servers** and
-**MCP Tools** in Settings. A configured server is not proof of a working
+**MCP Tools** in Settings. If `parallel` initially appears unavailable while
+reload is still running, wait for it to finish discovering tools, then refresh
+the panel. A configured server is not proof of a working
 connection: confirm that `parallel` is active and that `web_search` and
 `web_fetch` appear under it (Hermes prefixes their registered names with
 `mcp__parallel__`). Try asking Hermes to use Parallel to find a public

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -191,6 +191,48 @@ State normally lives outside the repository. By default:
 Override these with `HERMES_HOME` and `HERMES_WEBUI_STATE_DIR` when you need an
 isolated test install.
 
+## Optional web search with Parallel Search MCP
+
+After onboarding, you can add [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+for web search and page extraction without a Parallel account or API key.
+This uses Hermes Agent's existing remote MCP client over Streamable HTTP.
+Free access is rate limited.
+
+Choose the profile you want to use, then edit that profile's `config.yaml` on
+the machine running Hermes. The default profile normally uses
+`~/.hermes/config.yaml`; named profiles use their own config files. Add this
+entry under the existing `mcp_servers` mapping, keeping other servers and
+settings intact. If you already have a server named `parallel`, choose another
+name instead of overwriting it.
+
+```yaml
+mcp_servers:
+  parallel:
+    url: https://search.parallel.ai/mcp
+```
+
+No authorization headers are needed for this anonymous endpoint. Adding the
+entry enables the server on the next MCP discovery or reload, and the agent may
+call its tools during a conversation. Search queries, requested
+URLs, and any supplied objective or context go to Parallel. This adds MCP tools;
+it does not replace the built-in web tools or change their provider settings.
+
+In the same profile, run `/reload-mcp` in chat, then check **MCP Servers** and
+**MCP Tools** in Settings. A configured server is not proof of a working
+connection: confirm that `parallel` is active and that `web_search` and
+`web_fetch` appear under it (Hermes prefixes their registered names with
+`mcp__parallel__`). Try asking Hermes to use Parallel to find a public
+documentation page and fetch its contents. Existing toolset selections still
+apply, so include the server's MCP toolset if your conversation restricts tools.
+
+To stop using it, disable the server in **MCP Servers** or remove only its entry
+from the profile config, then run `/reload-mcp` again. Reload reconnects MCP
+servers, so wait for active tool calls to finish first.
+
+If reload reports `MCP runtime unavailable`, check the Hermes Agent installation
+using [Troubleshooting](troubleshooting.md). Docker users should also check the
+Agent source mount and dependency setup in the [Docker guide](docker.md).
+
 ## When to file an issue
 
 File an issue when the diagnostics point to WebUI rather than local


### PR DESCRIPTION
## Thinking Path

Hermes WebUI already supports remote MCP servers, but its onboarding guide has no example connecting one. This adds a small, optional web-search setup through the existing profile config and reload path.

## What Changed

Added a Parallel Search MCP example to `docs/onboarding.md`, including profile selection, preserving existing config, activation, tool inventory checks, disabling, and runtime troubleshooting.

## Why It Matters

Hermes WebUI uses the installed Agent's search tools. There isn't one provider enabled for everyone: [the runtime honors explicit settings, then detects available backends](https://github.com/NousResearch/hermes-agent/blob/79445a496c86a19332ad786494b8384d2167e2d0/tools/web_tools.py#L102-L163). In the current Agent, the [automatic no-key fallback rotates among Exa, Parallel, Firecrawl, and Keenable](https://github.com/NousResearch/hermes-agent/blob/79445a496c86a19332ad786494b8384d2167e2d0/plugins/web/keyless_mcp.py#L298-L336). Agent 0.21.0 also exposes [a selectable Parallel free tier](https://github.com/NousResearch/hermes-agent/blob/79445a496c86a19332ad786494b8384d2167e2d0/plugins/web/parallel/provider.py#L44-L88), using the same anonymous MCP endpoint. Free Parallel search and extraction are already available there. This PR only documents an alternative: separately named MCP tools alongside the existing web backend. Users who just want free Parallel search can use the built-in path.

There's a useful reason to make that choice easy. [Artificial Analysis' Search API results](https://artificialanalysis.ai/agents/search-api#details), dated August 31, show these wins against the other supported providers:

| Comparison | Parallel | Other provider |
| --- | --- | --- |
| BrowseComp accuracy | Advanced: 77 | Tavily basic: 59 |
| DeepSearchQA F1 | Advanced: 81 | Brave web: 62; LLM context: 78 |
| BrowseComp accuracy | Advanced: 77 | Exa fast: 61; instant: 65; auto: 74 |
| DeepSearchQA F1 | Advanced: 81 | Firecrawl: 74 |
| BrowseComp accuracy | Advanced: 77 | Keenable realtime: 64; pro: 66 |
| Total cost per 1,000 benchmark tasks | Fast: $68.08 | Perplexity medium: $91.39 |

The quality scores are out of 100. Parallel fast's total task cost is about 26% lower than Perplexity medium's, including search and answer-model costs. Perplexity medium does lead the overall index, 80 versus Parallel advanced's 75, so the cost comparison is a tradeoff. These are [API results in Artificial Analysis' fixed test setup](https://artificialanalysis.ai/methodology/search-api), not measured scores for this free MCP connection. They give users a reason to try Parallel on their own work; they don't prove that every Hermes setup will get the same gains.

Adding the documented config enables the MCP server on the next discovery or reload. The agent may then send queries, URLs, and supplied context to Parallel. Free access is rate limited. Existing built-in web tools and provider settings are unchanged.

I work at Parallel, which operates this service.

## Verification

Used existing prebuilt Python dependencies, isolated Hermes home and WebUI state, and an environment without credentials:

- Loaded the exact documented YAML through WebUI's `get_config_for_profile_home` and the Agent's MCP config loader.
- Executed WebUI's `_run_reload_mcp_command`, which called the real Agent discovery client and registered `mcp__parallel__web_search` and `mcp__parallel__web_fetch`.
- Called both through the Agent tool registry: search returned 10 results; fetch returned the public Search MCP documentation with no per-URL errors.
- Set the server to disabled and reloaded: no MCP servers remained connected.
- `git diff --check` passed.

Live check: 2026-09-05 UTC, with the existing prebuilt Hermes Agent 0.20.4 environment and source at `73141f4d02c3eb5da91b15c9f6f372d1a33749cd` (August 19). WebUI baseline: `e168b67e4278df618d1cab61fdb3a8dc55b29a81`, exp-v0.52.264. WebUI discovers an installed Agent or runs the installer from Agent main; it does not pin one Agent revision. The newer 0.21.0 source linked above was inspected for availability, not run in this smoke check. Initial check assertions needed correction for the Agent's tool-name prefix and result wrapper; the completed check passed without product changes.

## Risks / Follow-ups

Documentation only. No build, full test suite, browser flow, container setup, or full chat turn was run. The native check covers the loader, reload implementation, and tool calls, not every deployment or Agent version. Reload reconnects MCP servers; the guide tells users to let active tool calls finish first.

## Contract Routing

Setup/onboarding documentation. Checked `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, the onboarding safety checklist, and the existing profile config, MCP inventory, and reload implementations. No runtime contract changes.

## Model Used

AI-assisted with OpenAI. Tools used: repository inspection, GitHub CLI, and a lightweight native MCP smoke check.
