### PR TITLE
fix(docker): env reload must not strip trailing = from secrets (#7432)

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -169,7 +169,23 @@ load_env() {
   obfuscate_part="${ENV_OBFUSCATE_PART}"
   if [ -f "$tocheck" ]; then
     echo "-- Loading environment variables from $tocheck (overwrite existing: $overwrite_if_different) (ignorelist: $ignore_list) (obfuscate: $obfuscate_part)"
-    while IFS='=' read -r key value; do
+    # Read whole lines, then split at the FIRST '=' only. Splitting on every
+    # '=' (IFS='=' read -r key value) makes read drop a single trailing '='
+    # from values, corrupting secrets such as openssl rand -base64 32 output
+    # (44 chars ending in '=').
+    while IFS= read -r line; do
+      # Skip empty lines and comment lines.
+      case "$line" in
+        ''|\#*) continue ;;
+      esac
+      if [[ "$line" == *=* ]]; then
+        key=${line%%=*}
+        value=${line#*=}
+      else
+        # Line without '=': whole line is the key with an empty value.
+        key=$line
+        value=
+      fi
       doit=false
       # checking if the key is in the ignorelist
       for i in $ignore_list; do


### PR DESCRIPTION
Closes #7432

## Problem

`load_env()` in `docker_init.bash` re-reads the environment snapshot written
by `save_env()` (as the root phase) after the script restarts via `su` (as the
unprivileged runtime user). The loop used `while IFS='=' read -r key value`,
and in Bash a `read` split on every `=` drops a single trailing `=` from the
last field. Any secret whose value ends in one `=` — e.g. `openssl rand
-base64 32` output, which is always 44 chars ending in `=` — was reloaded with
43 chars, breaking shared-secret auth and `HERMES_WEBUI_PASSWORD` matching.

## Fix

Read each line whole (`IFS= read -r line`), then split at the **first** `=`
only:

- `key=${line%%=*}`
- `value=${line#*=}`

so embedded and trailing `=` in values are preserved. Empty lines and comment
lines are skipped; lines without `=` keep their previous behavior (whole line
as the key with an empty value). Single-padding (`abc=`), double-padding
(`abc==`), embedded `=` (`a=b=c`), and plain values are all covered.

## Verification

`bash -n docker_init.bash` passes. No shellcheck/shfmt CI or lint config
exists in the repo (checked `.github/workflows`).

Extracted the real `load_env()` from `HEAD` (buggy) and from the fix, and ran
both against the same temp env file, including a genuine `openssl rand
-base64 32` token:

```
=== BEFORE (HEAD load_env, buggy) ===
API_SERVER_KEY=<abc>
REAL_TOKEN_len=43
REAL_TOKEN_ends_with_eq=no

=== AFTER (fixed load_env) ===
API_SERVER_KEY=<abc=>
REAL_TOKEN_len=44
REAL_TOKEN_ends_with_eq=yes
```

Behavior preserved for the other cases (identical before/after):
`PLAIN_KEY=<value>`, `PADDED2=<abc==>`, `EMBEDDED=<a=b=c>`, `NOVALUE=<>`,
`EMPTYVAL=<>`. A file with blank and `#` comment lines sets only the real
variable and keeps `SOME_KEY=<xyz=>` intact.

Issue's minimal repro:

```
$ bash -c 'printf "%s\n" "API_SERVER_KEY=abc=" | while IFS="=" read -r key value; do printf "<%s> <%s>\n" "$key" "$value"; done'
<API_SERVER_KEY> <abc>          # Bash drops the single trailing =

$ printf "%s\n" "API_SERVER_KEY=abc=" | while IFS= read -r line; do key=${line%%=*}; value=${line#*=}; printf "<%s> <%s>\n" "$key" "$value"; done
<API_SERVER_KEY> <abc=>         # fixed parse preserves it
```