### PR TITLE
fix: resolve composer chip and sidebar model label on direct-provider fallback

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1248,6 +1248,7 @@ class Session:
                  clear_generation=None,
                  intentional_shrink_generation=None,
                  gateway_routing=None, gateway_routing_history=None,
+                 last_used_model=None,
                  llm_title_generated: bool=False,
                  manual_title: bool=False,
                 parent_session_id: str=None,
@@ -1346,6 +1347,7 @@ class Session:
         self.intentional_shrink_generation = intentional_shrink_generation
         self.gateway_routing = gateway_routing if isinstance(gateway_routing, dict) else None
         self.gateway_routing_history = gateway_routing_history if isinstance(gateway_routing_history, list) else []
+        self.last_used_model = str(last_used_model).strip()[:240] if last_used_model else None
         self.llm_title_generated = bool(llm_title_generated)
         self.manual_title = bool(manual_title)
         self.parent_session_id = parent_session_id
@@ -1430,7 +1432,7 @@ class Session:
             'truncation_boundary',
             'clear_generation',
             'intentional_shrink_generation',
-            'gateway_routing', 'gateway_routing_history', 'llm_title_generated', 'manual_title',
+            'gateway_routing', 'gateway_routing_history', 'last_used_model', 'llm_title_generated', 'manual_title',
             'parent_session_id',
             'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
             'is_cli_session', 'source_tag', 'raw_source', 'session_source', 'source_label', 'read_only',
@@ -1796,6 +1798,7 @@ class Session:
             'recommended_recovery_action': self.recommended_recovery_action,
             'gateway_routing': self.gateway_routing,
             'gateway_routing_history': self.gateway_routing_history,
+            'last_used_model': self.last_used_model,
             'manual_title': self.manual_title,
             # Only emit 'parent_session_id' when set (the /branch fork link, #1342).
             # Sessions without a fork must not leak None — see test_session_lineage_metadata_api.

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -105,6 +105,7 @@ _SIDEBAR_SESSION_RESPONSE_FIELDS = {
     "read_only",
     "is_read_only",
     "gateway_routing",
+    "last_used_model",
 }
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -15824,6 +15824,9 @@ def handle_post(handler, parsed) -> bool:
                     str(old_model or "") != str(getattr(s, "model", "") or "")
                     or str(old_provider or "") != str(getattr(s, "model_provider", "") or "")
                 ):
+                    s.last_used_model = None
+                    s.gateway_routing = None
+                    s.gateway_routing_history = []
                     s.context_length = _resolve_context_length_for_session_model(
                         getattr(s, "model", None),
                         getattr(s, "model_provider", None),

--- a/api/routes.py
+++ b/api/routes.py
@@ -8030,6 +8030,52 @@ def _session_model_state_from_request(
     return model_value, provider
 
 
+def _invalidate_session_route_state_if_changed(
+    session,
+    *,
+    model: str | None,
+    provider: str | None = None,
+    provider_specified: bool = True,
+) -> bool:
+    """Normalize and update requested route, clearing route-derived state if changed.
+
+    Preserves gateway_routing_history. When the normalized model or provider
+    differs from the session's existing route, clears last_used_model,
+    gateway_routing, context_length, threshold_tokens, and last_prompt_tokens.
+    Returns True if a real route change occurred, False otherwise.
+    """
+    old_model = getattr(session, "model", None)
+    old_provider = getattr(session, "model_provider", None)
+
+    norm_model, norm_provider = _session_model_state_from_request(
+        model,
+        provider if provider_specified else None,
+        current_provider=old_provider if not provider_specified else None,
+    )
+    if norm_model is not None:
+        session.model = norm_model
+    session.model_provider = norm_provider
+
+    # Compare normalized values to avoid spurious invalidation on whitespace/case drift
+    old_norm_model = str(old_model or "").strip()
+    new_norm_model = str(session.model or "").strip()
+    old_norm_provider = _clean_session_model_provider(old_provider) or ""
+    new_norm_provider = _clean_session_model_provider(session.model_provider) or ""
+
+    changed = (old_norm_model != new_norm_model) or (old_norm_provider != new_norm_provider)
+    if changed:
+        session.last_used_model = None
+        session.gateway_routing = None
+        session.context_length = _resolve_context_length_for_session_model(
+            session.model,
+            session.model_provider,
+        )
+        session.threshold_tokens = 0
+        session.last_prompt_tokens = 0
+
+    return changed
+
+
 def _lookup_gateway_session_identity(session_id: str) -> dict:
     if not session_id:
         return {}
@@ -15803,8 +15849,6 @@ def handle_post(handler, parsed) -> bool:
         except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be updated from WebUI", 403)
         old_ws = getattr(s, "workspace", "")
-        old_model = getattr(s, "model", None)
-        old_provider = getattr(s, "model_provider", None)
         try:
             new_ws = str(resolve_trusted_workspace(body.get("workspace", s.workspace)))
         except ValueError as e:
@@ -15812,26 +15856,13 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(body["session_id"]):
             s.workspace = new_ws
             if "model" in body or "model_provider" in body:
-                model, provider = _session_model_state_from_request(
-                    body.get("model", s.model),
-                    body.get("model_provider") if "model_provider" in body else None,
-                    getattr(s, "model_provider", None),
+                changed = _invalidate_session_route_state_if_changed(
+                    s,
+                    model=body.get("model", s.model),
+                    provider=body.get("model_provider") if "model_provider" in body else None,
+                    provider_specified="model_provider" in body,
                 )
-                if model is not None:
-                    s.model = model
-                s.model_provider = provider
-                if (
-                    str(old_model or "") != str(getattr(s, "model", "") or "")
-                    or str(old_provider or "") != str(getattr(s, "model_provider", "") or "")
-                ):
-                    s.last_used_model = None
-                    s.gateway_routing = None
-                    s.context_length = _resolve_context_length_for_session_model(
-                        getattr(s, "model", None),
-                        getattr(s, "model_provider", None),
-                    )
-                    s.threshold_tokens = 0
-                    s.last_prompt_tokens = 0
+                if changed:
                     from api.config import _evict_session_agent
 
                     _evict_session_agent(body["session_id"])
@@ -22563,8 +22594,12 @@ def _prepare_chat_start_session_for_stream(
         else source
     )
     s.workspace = workspace
-    s.model = model
-    s.model_provider = model_provider
+    _invalidate_session_route_state_if_changed(
+        s,
+        model=model,
+        provider=model_provider,
+        provider_specified=True,
+    )
     s.active_stream_id = stream_id
     register_session_writeback_owner(s.session_id, stream_id)
     s.post_compression_context_tokens_estimate = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -15826,7 +15826,6 @@ def handle_post(handler, parsed) -> bool:
                 ):
                     s.last_used_model = None
                     s.gateway_routing = None
-                    s.gateway_routing_history = []
                     s.context_length = _resolve_context_length_for_session_model(
                         getattr(s, "model", None),
                         getattr(s, "model_provider", None),

--- a/api/routes.py
+++ b/api/routes.py
@@ -10706,6 +10706,7 @@ _SIDEBAR_SESSION_RESPONSE_FIELDS = (
 )
 
 
+
 def _sidebar_session_response_item(session: dict, *, redact_enabled: bool | None = None) -> dict:
     """Return the bounded /api/sessions row shape used by the sidebar.
 
@@ -15405,6 +15406,7 @@ def handle_post(handler, parsed) -> bool:
                 # the duplicate should behave identically.
                 gateway_routing=copy.deepcopy(getattr(session, "gateway_routing", None)),
                 gateway_routing_history=copy.deepcopy(getattr(session, "gateway_routing_history", None) or []),
+                last_used_model=getattr(session, "last_used_model", None),
                 # Preserve LLM-generated title flag so we don't regenerate title on duplicate.
                 llm_title_generated=getattr(session, "llm_title_generated", False),
                 manual_title=getattr(session, "manual_title", False),
@@ -16258,6 +16260,7 @@ def handle_post(handler, parsed) -> bool:
             context_messages=copy.deepcopy(forked_context),
             # Gateway routing — inherit from source
             gateway_routing=copy.deepcopy(getattr(source, "gateway_routing", None)),
+            last_used_model=getattr(source, "last_used_model", None),
             # Context engine — inherit state so branch's context engine starts correctly
             context_engine=getattr(source, "context_engine", None),
             context_engine_state=copy.deepcopy(getattr(source, "context_engine_state", None) or {}),
@@ -23773,6 +23776,7 @@ def _handle_session_compression_recovery_start(handler, body):
                 threshold_tokens=getattr(source, "threshold_tokens", None),
                 gateway_routing=copy.deepcopy(getattr(source, "gateway_routing", None)),
                 gateway_routing_history=copy.deepcopy(getattr(source, "gateway_routing_history", None) or []),
+                last_used_model=getattr(source, "last_used_model", None),
                 parent_session_id=getattr(source, "session_id", sid),
                 worktree_path=getattr(source, "worktree_path", None),
                 worktree_branch=getattr(source, "worktree_branch", None),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11947,6 +11947,8 @@ def _run_agent_streaming(
                 # resolved_model would mis-attribute exactly the turns where
                 # attribution matters most.
                 _used_model = getattr(agent, 'model', None) or resolved_model or model
+                if _used_model:
+                    s.last_used_model = str(_used_model).strip()[:240]
                 if _gateway_routing:
                     s.gateway_routing = _gateway_routing
                     _history = list(getattr(s, 'gateway_routing_history', None) or [])

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10317,6 +10317,7 @@ def _run_agent_streaming(
             # detached worker for a NAMED profile paired that profile's endpoint
             # with the DEFAULT profile's API key (finding #3). No-op for the
             # default/root profile.
+            _session_requested_provider = None
             with profiles_api.profile_scope_for_detached_worker(
                 _resolved_profile_name, "model + credential resolution", logger_override=logger
             ):
@@ -11940,7 +11941,7 @@ def _run_agent_streaming(
                     agent,
                     result,
                     requested_model=resolved_model or model,
-                    requested_provider=resolved_provider,
+                    requested_provider=_session_requested_provider or resolved_provider,
                 )
                 # #6068: the served model must be read AFTER agent.run — the agent
                 # mutates agent.model when a fallback fires, so the pre-run

--- a/static/boot.js
+++ b/static/boot.js
@@ -2287,7 +2287,6 @@ $('modelSelect').onchange=async()=>{
   if(routeChanged){
     S.session.last_used_model = null;
     S.session.gateway_routing = null;
-    S.session.gateway_routing_history = [];
   }
   S.session.model=modelState.model;
   S.session.model_provider=modelState.model_provider||null;

--- a/static/boot.js
+++ b/static/boot.js
@@ -2242,6 +2242,15 @@ function _applySessionContextMetadataUpdate(data){
   S.session.threshold_tokens=data.session.threshold_tokens||0;
   S.session.last_prompt_tokens=data.session.last_prompt_tokens||0;
   S.session.post_compression_context_tokens_estimate=data.session.post_compression_context_tokens_estimate||null;
+  if('last_used_model' in data.session){
+    S.session.last_used_model=data.session.last_used_model||null;
+  }
+  if('gateway_routing' in data.session){
+    S.session.gateway_routing=data.session.gateway_routing||null;
+  }
+  if('gateway_routing_history' in data.session){
+    S.session.gateway_routing_history=data.session.gateway_routing_history||[];
+  }
   if(typeof _syncCtxIndicator==='function'){
     const u=S.lastUsage||{};
     const _pick=(latest,stored,dflt=0)=>latest!=null?latest:(stored!=null?stored:dflt);
@@ -2273,6 +2282,13 @@ $('modelSelect').onchange=async()=>{
     return;
   }
   if(typeof _rememberPendingSessionModel==='function') _rememberPendingSessionModel(S.session.session_id,modelState.model,modelState.model_provider);
+  const routeChanged = String(S.session.model || '') !== String(modelState.model || '')
+    || String(S.session.model_provider || '') !== String(modelState.model_provider || '');
+  if(routeChanged){
+    S.session.last_used_model = null;
+    S.session.gateway_routing = null;
+    S.session.gateway_routing_history = [];
+  }
   S.session.model=modelState.model;
   S.session.model_provider=modelState.model_provider||null;
   if(typeof syncModelChip==='function') syncModelChip();
@@ -2294,6 +2310,7 @@ $('modelSelect').onchange=async()=>{
   // re-reverts a cross-family pick (the #3737 bug, Codex catch). send() clears it
   // after reading a matching pending pick. (#3739/#3737)
   _applySessionContextMetadataUpdate(data);
+  if(typeof syncModelChip==='function') syncModelChip();
   // Warn if selected model belongs to a different provider than what Hermes is configured for
   if(typeof _checkProviderMismatch==='function'){
     const warn=_checkProviderMismatch(selectedModel);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -422,7 +422,7 @@ function _formatSessionModelWithGateway(s){
   const routing=(typeof _latestGatewayRoutingForSession==='function')?_latestGatewayRoutingForSession(s):(s.gateway_routing||null);
   const fallbackModel=s.last_used_model||s.model;
   if(typeof _formatGatewayModelLabel==='function'){
-    return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(fallbackModel);
+    return _formatGatewayModelLabel(fallbackModel,getModelLabel(fallbackModel),routing)||getModelLabel(fallbackModel);
   }
   return fallbackModel;
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -420,10 +420,11 @@ async function _manualTitleRegenerateTimeoutMs(){
 function _formatSessionModelWithGateway(s){
   if(!s||!s.model)return'';
   const routing=(typeof _latestGatewayRoutingForSession==='function')?_latestGatewayRoutingForSession(s):(s.gateway_routing||null);
+  const fallbackModel=s.last_used_model||s.model;
   if(typeof _formatGatewayModelLabel==='function'){
-    return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(s.model);
+    return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(fallbackModel);
   }
-  return s.model;
+  return fallbackModel;
 }
 
 function _getSessionViewedCounts() {

--- a/static/ui.js
+++ b/static/ui.js
@@ -7551,10 +7551,10 @@ function _latestGatewayRoutingForSession(session){
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
     return null;
   }
-  // ponytail: canonical route dimension matching covers explicit, legacy, and bare routes in 3 lines
-  const reqProvider=String(routing.requested_provider||'').trim();
-  const sessProvider=String(session.model_provider||'').trim();
-  if(reqProvider!==sessProvider) return null;
+  // Canonical provider identity matching: case-insensitive, preserves legacy/empty
+  const reqProvider=String(routing.requested_provider||'').trim().toLowerCase();
+  const sessProvider=String(session.model_provider||'').trim().toLowerCase();
+  if(reqProvider && sessProvider && reqProvider !== sessProvider) return null;
   return routing;
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -4897,7 +4897,6 @@ async function selectModelFromDropdown(value){
     if(sessionModelChanged){
       S.session.last_used_model = null;
       S.session.gateway_routing = null;
-      S.session.gateway_routing_history = [];
     }
   }
   // Resolve the provider-specific option so duplicate bare IDs (e.g. gpt-5.5

--- a/static/ui.js
+++ b/static/ui.js
@@ -7546,6 +7546,7 @@ function _gatewayModelWarningText(routing){
 }
 function _latestGatewayRoutingForSession(session){
   if(!session)return null;
+  const fromHistory=!session.gateway_routing;
   const routing=session.gateway_routing||(Array.isArray(session.gateway_routing_history)&&session.gateway_routing_history.length?session.gateway_routing_history[session.gateway_routing_history.length-1]:null);
   if(!routing)return null;
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
@@ -7554,6 +7555,8 @@ function _latestGatewayRoutingForSession(session){
   // Canonical provider identity matching: case-insensitive, preserves legacy/empty
   const reqProvider=String(routing.requested_provider||'').trim().toLowerCase();
   const sessProvider=String(session.model_provider||'').trim().toLowerCase();
+  // Fail closed on provider-less history candidate when active route has an explicit provider
+  if(fromHistory && sessProvider && !reqProvider) return null;
   if(reqProvider && sessProvider && reqProvider !== sessProvider) return null;
   return routing;
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -4018,7 +4018,11 @@ function syncModelChip(){
   const text=opt?opt.textContent:getModelLabel(sel.value||'');
   const compactText=_compactComposerModelChipLabel(sel.value||'', text);
   const gatewayRouting=_latestGatewayRoutingForSession(S.session);
-  const fallbackText=(S.session&&S.session.last_used_model)?_compactComposerModelChipLabel(S.session.last_used_model,getModelLabel(S.session.last_used_model)):compactText;
+  // ponytail: live manual dropdown pick takes precedence over historical served model
+  const manualPick = String(sel.value||'') !== String((S.session&&S.session.model)||'');
+  const fallbackText = (!manualPick && S.session && S.session.last_used_model)
+    ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
+    : compactText;
   const displayText=_formatGatewayModelLabel(sel.value||'',compactText,gatewayRouting)||fallbackText;
   label.textContent=displayText;
   if(mobileLabel) mobileLabel.textContent=displayText;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7551,8 +7551,8 @@ function _latestGatewayRoutingForSession(session){
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
     return null;
   }
-  // Canonical provider identity matching: case-insensitive, preserves legacy/empty
-  const reqProvider=String(routing.requested_provider||'').trim().toLowerCase();
+  // Canonical provider identity matching: case-insensitive, falls back to legacy provider attribution
+  const reqProvider=String(routing.requested_provider||routing.provider||routing.used_provider||'').trim().toLowerCase();
   const sessProvider=String(session.model_provider||'').trim().toLowerCase();
   if(reqProvider && sessProvider && reqProvider !== sessProvider) return null;
   return routing;

--- a/static/ui.js
+++ b/static/ui.js
@@ -4018,7 +4018,8 @@ function syncModelChip(){
   const text=opt?opt.textContent:getModelLabel(sel.value||'');
   const compactText=_compactComposerModelChipLabel(sel.value||'', text);
   const gatewayRouting=_latestGatewayRoutingForSession(S.session);
-  const displayText=_formatGatewayModelLabel(sel.value||'',compactText,gatewayRouting)||compactText;
+  const fallbackText=(S.session&&S.session.last_used_model)?_compactComposerModelChipLabel(S.session.last_used_model,getModelLabel(S.session.last_used_model)):compactText;
+  const displayText=_formatGatewayModelLabel(sel.value||'',compactText,gatewayRouting)||fallbackText;
   label.textContent=displayText;
   if(mobileLabel) mobileLabel.textContent=displayText;
   chip.title=gatewayRouting?`${sel.value||'Conversation model'} ${_gatewayRoutingLabel(gatewayRouting)}`:(sel.value||'Conversation model');

--- a/static/ui.js
+++ b/static/ui.js
@@ -7551,8 +7551,8 @@ function _latestGatewayRoutingForSession(session){
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
     return null;
   }
-  // Canonical provider identity matching: case-insensitive, falls back to legacy provider attribution
-  const reqProvider=String(routing.requested_provider||routing.provider||routing.used_provider||'').trim().toLowerCase();
+  // Canonical provider identity matching: case-insensitive, preserves legacy/empty
+  const reqProvider=String(routing.requested_provider||'').trim().toLowerCase();
   const sessProvider=String(session.model_provider||'').trim().toLowerCase();
   if(reqProvider && sessProvider && reqProvider !== sessProvider) return null;
   return routing;

--- a/static/ui.js
+++ b/static/ui.js
@@ -4018,11 +4018,10 @@ function syncModelChip(){
   const text=opt?opt.textContent:getModelLabel(sel.value||'');
   const compactText=_compactComposerModelChipLabel(sel.value||'', text);
   const gatewayRouting=_latestGatewayRoutingForSession(S.session);
-  // ponytail: live manual dropdown pick takes precedence over historical routing/fallback
-  const manualPick = String(sel.value||'') !== String((S.session&&S.session.model)||'');
-  const activeRouting = manualPick ? null : gatewayRouting;
-  const fallbackModel = (!manualPick && S.session && S.session.last_used_model) ? S.session.last_used_model : (sel.value || '');
-  const fallbackText = (!manualPick && S.session && S.session.last_used_model)
+  const routeMatches=!S.session||!S.session.model||String(sel.value||'')===String(S.session.model||'');
+  const activeRouting=routeMatches?gatewayRouting:null;
+  const fallbackModel=(routeMatches&&S.session&&S.session.last_used_model)?S.session.last_used_model:(sel.value||'');
+  const fallbackText=(routeMatches&&S.session&&S.session.last_used_model)
     ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
     : compactText;
   const displayText=_formatGatewayModelLabel(fallbackModel,fallbackText,activeRouting)||fallbackText;
@@ -4892,6 +4891,15 @@ async function selectModelFromDropdown(value){
   const sameModel=String(currentState.model||'')===String(value||'');
   const sameProvider=String(currentState.model_provider||'')===String(provider||'');
   if(sameModel&&sameProvider){ closeModelDropdown(); return; }
+  if(S.session){
+    const sessionModelChanged = String(S.session.model || '') !== String(value || '')
+      || String(S.session.model_provider || '') !== String(provider || '');
+    if(sessionModelChanged){
+      S.session.last_used_model = null;
+      S.session.gateway_routing = null;
+      S.session.gateway_routing_history = [];
+    }
+  }
   // Resolve the provider-specific option so duplicate bare IDs (e.g. gpt-5.5
   // under OpenAI Codex vs OpenRouter) update session model_provider correctly.
   if(typeof _ensureModelOptionInDropdown==='function'){
@@ -7539,9 +7547,12 @@ function _gatewayModelWarningText(routing){
 }
 function _latestGatewayRoutingForSession(session){
   if(!session)return null;
-  if(session.gateway_routing)return session.gateway_routing;
-  const history=Array.isArray(session.gateway_routing_history)?session.gateway_routing_history:[];
-  return history.length?history[history.length-1]:null;
+  const routing=session.gateway_routing||(Array.isArray(session.gateway_routing_history)&&session.gateway_routing_history.length?session.gateway_routing_history[session.gateway_routing_history.length-1]:null);
+  if(!routing)return null;
+  if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
+    return null;
+  }
+  return routing;
 }
 
 function _stripXmlToolCallsDisplay(s){

--- a/static/ui.js
+++ b/static/ui.js
@@ -4018,15 +4018,16 @@ function syncModelChip(){
   const text=opt?opt.textContent:getModelLabel(sel.value||'');
   const compactText=_compactComposerModelChipLabel(sel.value||'', text);
   const gatewayRouting=_latestGatewayRoutingForSession(S.session);
-  // ponytail: live manual dropdown pick takes precedence over historical served model
+  // ponytail: live manual dropdown pick takes precedence over historical routing/fallback
   const manualPick = String(sel.value||'') !== String((S.session&&S.session.model)||'');
+  const activeRouting = manualPick ? null : gatewayRouting;
   const fallbackText = (!manualPick && S.session && S.session.last_used_model)
     ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
     : compactText;
-  const displayText=_formatGatewayModelLabel(sel.value||'',compactText,gatewayRouting)||fallbackText;
+  const displayText=_formatGatewayModelLabel(sel.value||'',compactText,activeRouting)||fallbackText;
   label.textContent=displayText;
   if(mobileLabel) mobileLabel.textContent=displayText;
-  chip.title=gatewayRouting?`${sel.value||'Conversation model'} ${_gatewayRoutingLabel(gatewayRouting)}`:(sel.value||'Conversation model');
+  chip.title=activeRouting?`${sel.value||'Conversation model'} ${_gatewayRoutingLabel(activeRouting)}`:(sel.value||'Conversation model');
   chip.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
   if(mobileAction) mobileAction.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7551,18 +7551,10 @@ function _latestGatewayRoutingForSession(session){
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
     return null;
   }
+  // ponytail: canonical route dimension matching covers explicit, legacy, and bare routes in 3 lines
   const reqProvider=String(routing.requested_provider||'').trim();
   const sessProvider=String(session.model_provider||'').trim();
-  if(routing.requested_provider&&session.model_provider&&reqProvider!==sessProvider){
-    return null;
-  }
-  if(sessProvider&&!routing.requested_provider){
-    // Legacy history lacking requested_provider cannot be assumed to belong to an explicit provider route
-    return null;
-  }
-  if(reqProvider&&!sessProvider){
-    return null;
-  }
+  if(reqProvider!==sessProvider) return null;
   return routing;
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -4021,13 +4021,14 @@ function syncModelChip(){
   // ponytail: live manual dropdown pick takes precedence over historical routing/fallback
   const manualPick = String(sel.value||'') !== String((S.session&&S.session.model)||'');
   const activeRouting = manualPick ? null : gatewayRouting;
+  const fallbackModel = (!manualPick && S.session && S.session.last_used_model) ? S.session.last_used_model : (sel.value || '');
   const fallbackText = (!manualPick && S.session && S.session.last_used_model)
     ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
     : compactText;
-  const displayText=_formatGatewayModelLabel(sel.value||'',compactText,activeRouting)||fallbackText;
+  const displayText=_formatGatewayModelLabel(fallbackModel,fallbackText,activeRouting)||fallbackText;
   label.textContent=displayText;
   if(mobileLabel) mobileLabel.textContent=displayText;
-  chip.title=activeRouting?`${sel.value||'Conversation model'} ${_gatewayRoutingLabel(activeRouting)}`:(sel.value||'Conversation model');
+  chip.title=activeRouting?`${fallbackModel||'Conversation model'} ${_gatewayRoutingLabel(activeRouting)}`:(fallbackModel||'Conversation model');
   chip.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
   if(mobileAction) mobileAction.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7551,6 +7551,18 @@ function _latestGatewayRoutingForSession(session){
   if(routing.requested_model&&session.model&&String(routing.requested_model)!==String(session.model)){
     return null;
   }
+  const reqProvider=String(routing.requested_provider||'').trim();
+  const sessProvider=String(session.model_provider||'').trim();
+  if(routing.requested_provider&&session.model_provider&&reqProvider!==sessProvider){
+    return null;
+  }
+  if(sessProvider&&!routing.requested_provider){
+    // Legacy history lacking requested_provider cannot be assumed to belong to an explicit provider route
+    return null;
+  }
+  if(reqProvider&&!sessProvider){
+    return null;
+  }
   return routing;
 }
 

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -80,8 +80,10 @@ def test_frontend_formatters_resolve_precedence():
 
 
 def test_composer_chip_manual_pick_overrides_last_used_model():
-    """Manual dropdown pick takes precedence over historical fallback."""
+    """Manual dropdown pick takes precedence over historical fallback and routing."""
     assert "manualPick" in UI_JS
     assert "!manualPick&&S.session&&S.session.last_used_model" in UI_JS.replace(" ", "")
+    assert "activeRouting=manualPick?null:gatewayRouting" in UI_JS.replace(" ", "")
+    assert "_formatGatewayModelLabel(sel.value||'',compactText,activeRouting)" in UI_JS.replace(" ", "")
 
 

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -77,3 +77,11 @@ def test_frontend_formatters_resolve_precedence():
 
     # ui.js: composer chip label resolution
     assert "S.session.last_used_model" in UI_JS
+
+
+def test_composer_chip_manual_pick_overrides_last_used_model():
+    """Manual dropdown pick takes precedence over historical fallback."""
+    assert "manualPick" in UI_JS
+    assert "!manualPick&&S.session&&S.session.last_used_model" in UI_JS.replace(" ", "")
+
+

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -328,6 +328,123 @@ def test_server_session_update_clears_stale_fallback_and_routing():
     assert resp_session.get("gateway_routing_history") == [{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}]
 
 
+def test_chat_start_preparation_route_invalidation_scenarios():
+    """Verify chat-start preparation route invalidation and preservation:
+    1. An existing fallback plus a different incoming model/provider clears current attribution but preserves history.
+    2. The same requested route preserves attribution.
+    3. A failed/interrupted turn after the route switch cannot expose the old last_used_model through the session-list projection.
+    """
+    from unittest.mock import MagicMock, patch
+    from api import routes
+    from api.helpers import public_session_projection
+    from api.route_session_list_cache import _session_list_cache_bounded_payload
+
+    # 1. Existing fallback + different incoming model/provider clears current attribution but preserves history
+    s1 = Session(
+        session_id="chat_start_switch_test",
+        title="Chat Start Switch",
+        model="claude-3-5-sonnet",
+        model_provider="anthropic",
+        last_used_model="claude-3-haiku",
+        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"},
+        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}],
+    )
+    s1.save = MagicMock()
+    with patch("api.routes.register_session_writeback_owner"):
+        routes._prepare_chat_start_session_for_stream(
+            s1,
+            msg="Hello from new model",
+            attachments=[],
+            workspace="/tmp",
+            model="gpt-4o",
+            model_provider="openai",
+            stream_id="stream_switch_1",
+            defer_save=True,
+        )
+    assert s1.model == "gpt-4o"
+    assert s1.model_provider == "openai"
+    assert s1.last_used_model is None
+    assert s1.gateway_routing is None
+    assert s1.gateway_routing_history == [{
+        "used_model": "claude-3-haiku",
+        "provider": "anthropic",
+        "requested_model": "claude-3-5-sonnet",
+    }]
+
+    # 2. Same requested route preserves attribution
+    s2 = Session(
+        session_id="chat_start_same_route_test",
+        title="Chat Start Same Route",
+        model="claude-3-5-sonnet",
+        model_provider="anthropic",
+        last_used_model="claude-3-haiku",
+        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"},
+        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}],
+    )
+    s2.save = MagicMock()
+    with patch("api.routes.register_session_writeback_owner"):
+        routes._prepare_chat_start_session_for_stream(
+            s2,
+            msg="Followup on same route",
+            attachments=[],
+            workspace="/tmp",
+            model="claude-3-5-sonnet",
+            model_provider="anthropic",
+            stream_id="stream_same_1",
+            defer_save=True,
+        )
+    assert s2.model == "claude-3-5-sonnet"
+    assert s2.model_provider == "anthropic"
+    assert s2.last_used_model == "claude-3-haiku"
+    assert s2.gateway_routing == {
+        "used_model": "claude-3-haiku",
+        "provider": "anthropic",
+        "requested_model": "claude-3-5-sonnet",
+    }
+    assert s2.gateway_routing_history == [{
+        "used_model": "claude-3-haiku",
+        "provider": "anthropic",
+        "requested_model": "claude-3-5-sonnet",
+    }]
+
+    # 3. Failed/interrupted turn after route switch cannot expose old last_used_model through session-list projection
+    s3 = Session(
+        session_id="chat_start_interrupted_test",
+        title="Interrupted Turn Test",
+        model="claude-3-5-sonnet",
+        model_provider="anthropic",
+        last_used_model="claude-3-haiku",
+        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"},
+        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}],
+    )
+    s3.save = MagicMock()
+    with patch("api.routes.register_session_writeback_owner"):
+        routes._prepare_chat_start_session_for_stream(
+            s3,
+            msg="Start turn that fails",
+            attachments=[],
+            workspace="/tmp",
+            model="gpt-4o",
+            model_provider="openai",
+            stream_id="stream_failed_1",
+            defer_save=True,
+        )
+    # Simulate turn failure/interruption before any post-run settlement
+    payload = {"sessions": [dict(s3.__dict__)]}
+    projected = _session_list_cache_bounded_payload(payload)
+    proj_session = projected["sessions"][0]
+
+    assert proj_session["model"] == "gpt-4o"
+    assert proj_session.get("last_used_model") is None
+    assert proj_session.get("gateway_routing") is None
+
+    # Also verify public_session_projection matches
+    pub_proj = public_session_projection(dict(s3.__dict__))
+    assert pub_proj["model"] == "gpt-4o"
+    assert pub_proj.get("last_used_model") is None
+    assert pub_proj.get("gateway_routing") is None
+
+
 def test_production_model_selection_lifecycle_observable_behavior():
     """Test full production sequence: selectModelFromDropdown -> modelSelect.onchange -> syncModelChip -> session update -> in flight."""
     raw_output = _production_event_harness("""

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -1,0 +1,79 @@
+"""Regression tests for issue #6594:
+Composer chip and sidebar model resolution during direct-provider fallback.
+
+Verifies:
+1. session.model is NOT overwritten during direct fallback (preserves requested route).
+2. session.last_used_model is persisted on Session and serialized in compact/metadata.
+3. _SIDEBAR_SESSION_RESPONSE_FIELDS allowlists last_used_model.
+4. Frontend resolution precedence: gateway_routing.used_model -> last_used_model -> session.model.
+5. Multi-turn route stability (subsequent turns still target requested session.model).
+"""
+
+from pathlib import Path
+from api.models import Session
+from api.routes import _SIDEBAR_SESSION_RESPONSE_FIELDS, _sidebar_session_response_item
+
+ROOT = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+STREAMING_PY = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+def test_session_model_preserved_and_last_used_model_persisted():
+    """session.model must not be overwritten; last_used_model must be persisted."""
+    session = Session(
+        session_id="6594fallback",
+        title="Direct Fallback Test",
+        model="claude-3-5-sonnet",
+        last_used_model="claude-3-haiku",
+    )
+    session.save()
+
+    loaded = Session.load("6594fallback")
+    assert loaded is not None
+    # Requested route preserved
+    assert loaded.model == "claude-3-5-sonnet"
+    # Fallback model captured separately
+    assert loaded.last_used_model == "claude-3-haiku"
+
+    # Verify compact representation
+    compact = loaded.compact()
+    assert compact["model"] == "claude-3-5-sonnet"
+    assert compact["last_used_model"] == "claude-3-haiku"
+
+    # Verify load_metadata_only
+    meta = Session.load_metadata_only("6594fallback")
+    assert meta is not None
+    assert meta.model == "claude-3-5-sonnet"
+    assert meta.last_used_model == "claude-3-haiku"
+
+
+def test_sidebar_session_response_fields_allowlists_last_used_model():
+    """Sidebar session serialization must include last_used_model."""
+    assert "last_used_model" in _SIDEBAR_SESSION_RESPONSE_FIELDS
+
+    raw_session = {
+        "session_id": "sid6594",
+        "title": "Conversation",
+        "model": "gpt-4o",
+        "last_used_model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    sidebar_item = _sidebar_session_response_item(raw_session)
+    assert sidebar_item.get("last_used_model") == "gpt-4o-mini"
+    assert sidebar_item.get("model") == "gpt-4o"
+
+
+def test_streaming_updates_last_used_model_without_mutating_session_model():
+    """Post-run hook updates s.last_used_model from post-run agent.model."""
+    assert "s.last_used_model = str(_used_model).strip()[:240]" in STREAMING_PY
+    assert "s.model = " not in STREAMING_PY.split("if _used_model:")[1].split("if _gateway_routing:")[0]
+
+
+def test_frontend_formatters_resolve_precedence():
+    """Frontend must resolve gateway_routing -> last_used_model -> session.model."""
+    # sessions.js: _formatSessionModelWithGateway
+    assert "fallbackModel=s.last_used_model||s.model" in SESSIONS_JS.replace(" ", "")
+
+    # ui.js: composer chip label resolution
+    assert "S.session.last_used_model" in UI_JS

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -11,14 +11,15 @@ from api.routes import _SIDEBAR_SESSION_RESPONSE_FIELDS, _sidebar_session_respon
 ROOT = Path(__file__).resolve().parent.parent
 SESSIONS_JS = ROOT / "static" / "sessions.js"
 UI_JS = ROOT / "static" / "ui.js"
+BOOT_JS = ROOT / "static" / "boot.js"
 NODE = shutil.which("node")
 
 
-def _extract_function(source: str, name: str) -> str:
-    start = source.find(f"function {name}(")
-    assert start != -1, f"Could not find function {name}"
+def _extract_block(source: str, prefix: str) -> str:
+    start = source.find(prefix)
+    assert start != -1, f"Could not find {prefix}"
     brace = source.find("{", start)
-    assert brace != -1, f"Could not find opening brace for {name}"
+    assert brace != -1, f"Could not find opening brace for {prefix}"
     depth = 0
     for idx in range(brace, len(source)):
         ch = source[idx]
@@ -28,7 +29,14 @@ def _extract_function(source: str, name: str) -> str:
             depth -= 1
             if depth == 0:
                 return source[start : idx + 1]
-    pytest.fail(f"Could not extract complete function body for {name}")
+    pytest.fail(f"Could not extract complete block for {prefix}")
+
+
+def _extract_function(source: str, name: str) -> str:
+    for prefix in (f"async function {name}(", f"function {name}("):
+        if prefix in source:
+            return _extract_block(source, prefix)
+    pytest.fail(f"Could not find function {name}")
 
 
 def _run_node(script: str) -> str:
@@ -40,53 +48,113 @@ def _run_node(script: str) -> str:
     try:
         proc = subprocess.run(
             [NODE, script_path],
-            check=True,
             capture_output=True,
             text=True,
         )
+        if proc.returncode != 0:
+            raise RuntimeError(f"Node execution failed (code {proc.returncode}):\n{proc.stderr}")
         return proc.stdout.strip()
     finally:
         Path(script_path).unlink(missing_ok=True)
 
 
-def _frontend_harness(eval_code: str) -> str:
+def _sidebar_harness(eval_code: str) -> str:
     sessions_source = SESSIONS_JS.read_text(encoding="utf-8")
     ui_source = UI_JS.read_text(encoding="utf-8")
 
     fn_gateway_routing_label = _extract_function(ui_source, "_gatewayRoutingLabel")
     fn_format_gateway_model_label = _extract_function(ui_source, "_formatGatewayModelLabel")
+    fn_latest_gateway_routing = _extract_function(ui_source, "_latestGatewayRoutingForSession")
     fn_format_session_model_with_gateway = _extract_function(sessions_source, "_formatSessionModelWithGateway")
 
     header = """
 function _gatewayProviderName(p) { return p ? String(p) : ''; }
 function _compactComposerModelChipLabel(id, label) { return label || id; }
 function getModelLabel(id) { return id ? ('Model(' + id + ')') : ''; }
-function _latestGatewayRoutingForSession(s) {
-  if(!s) return null;
-  if(s.gateway_routing) return s.gateway_routing;
-  const history = Array.isArray(s.gateway_routing_history) ? s.gateway_routing_history : [];
-  return history.length ? history[history.length - 1] : null;
-}
-function _selectedModelOption() { return null; }
-
-function resolveComposerChip(selVal, session) {
-  const S = { session: session };
-  const sel = { value: selVal };
-  const text = getModelLabel(sel.value || '');
-  const compactText = _compactComposerModelChipLabel(sel.value || '', text);
-  const gatewayRouting = _latestGatewayRoutingForSession(S.session);
-  const manualPick = String(sel.value || '') !== String((S.session && S.session.model) || '');
-  const activeRouting = manualPick ? null : gatewayRouting;
-  const fallbackModel = (!manualPick && S.session && S.session.last_used_model) ? S.session.last_used_model : (sel.value || '');
-  const fallbackText = (!manualPick && S.session && S.session.last_used_model)
-    ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
-    : compactText;
-  const displayText = _formatGatewayModelLabel(fallbackModel, fallbackText, activeRouting) || fallbackText;
-  return displayText;
-}
 """
-    full_script = f"{header}\n{fn_gateway_routing_label}\n{fn_format_gateway_model_label}\n{fn_format_session_model_with_gateway}\n{eval_code}"
+    full_script = f"{header}\n{fn_gateway_routing_label}\n{fn_format_gateway_model_label}\n{fn_latest_gateway_routing}\n{fn_format_session_model_with_gateway}\n{eval_code}"
     return _run_node(full_script)
+
+
+def _production_event_harness(eval_code: str) -> str:
+    ui_source = UI_JS.read_text(encoding="utf-8")
+    boot_source = BOOT_JS.read_text(encoding="utf-8")
+
+    fn_gateway_routing_label = _extract_function(ui_source, "_gatewayRoutingLabel")
+    fn_format_gateway_model_label = _extract_function(ui_source, "_formatGatewayModelLabel")
+    fn_latest_gateway_routing = _extract_function(ui_source, "_latestGatewayRoutingForSession")
+    fn_sync_model_chip = _extract_function(ui_source, "syncModelChip")
+    fn_select_model = _extract_function(ui_source, "selectModelFromDropdown")
+    fn_apply_ctx = _extract_function(boot_source, "_applySessionContextMetadataUpdate")
+    onchange_block = _extract_block(boot_source, "$('modelSelect').onchange=")
+
+    harness = f"""
+const elements = {{
+  modelSelect: {{ id: 'modelSelect', value: 'claude-3-5-sonnet', onchange: null }},
+  composerModelChip: {{ title: '', classList: {{ toggle: () => {{}}, contains: () => false }} }},
+  composerModelLabel: {{ textContent: '' }},
+  composerMobileModelLabel: {{ textContent: '' }},
+  composerMobileModelAction: {{ classList: {{ toggle: () => {{}}, contains: () => false }} }},
+  composerModelDropdown: {{ classList: {{ toggle: () => {{}}, contains: () => false }} }}
+}};
+
+function $(id) {{ return elements[id] || null; }}
+
+const S = {{
+  _bootReady: true,
+  session: {{
+    session_id: 'test-session-1',
+    workspace: 'default',
+    model: 'claude-3-5-sonnet',
+    model_provider: null,
+    last_used_model: 'claude-3-haiku',
+    gateway_routing: null,
+    gateway_routing_history: []
+  }}
+}};
+
+function _gatewayProviderName(p) {{ return p ? String(p) : ''; }}
+function _compactComposerModelChipLabel(id, label) {{ return label || id; }}
+function getModelLabel(id) {{ return id ? ('Model(' + id + ')') : ''; }}
+function _selectedModelOption() {{ return null; }}
+function _modelStateForSelect(sel, v) {{ return {{ model: v, model_provider: null }}; }}
+function closeModelDropdown() {{}}
+function clearProfileTransitionReasoningContext() {{}}
+function _writePersistedModelState() {{}}
+function _rememberPendingSessionModel() {{}}
+function syncReasoningChip() {{}}
+function syncTopbar() {{}}
+function showToast() {{}}
+function t() {{ return ''; }}
+
+async function api(endpoint, opts) {{
+  if (endpoint === '/api/session/update') {{
+    const body = JSON.parse(opts.body);
+    return {{
+      session: {{
+        session_id: body.session_id,
+        model: body.model,
+        model_provider: body.model_provider,
+        last_used_model: null,
+        gateway_routing: null,
+        gateway_routing_history: []
+      }}
+    }};
+  }}
+  return {{}};
+}}
+
+{fn_gateway_routing_label}
+{fn_format_gateway_model_label}
+{fn_latest_gateway_routing}
+{fn_sync_model_chip}
+{fn_select_model}
+{fn_apply_ctx}
+{onchange_block}
+
+{eval_code}
+"""
+    return _run_node(harness)
 
 
 def test_session_model_preserved_and_last_used_model_persisted():
@@ -156,14 +224,14 @@ def test_streaming_post_run_hook_updates_last_used_model_without_mutating_sessio
 def test_sidebar_model_resolution_observable_precedence():
     """Sidebar formatter returns observable string according to precedence hierarchy."""
     # Case 1: Direct fallback (last_used_model takes precedence over requested model)
-    out1 = _frontend_harness("""
+    out1 = _sidebar_harness("""
 const s = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku', gateway_routing: null };
 console.log(_formatSessionModelWithGateway(s));
 """)
     assert out1 == "Model(claude-3-haiku)"
 
     # Case 2: Gateway fallback with explicit used_model (routing.used_model takes precedence)
-    out2 = _frontend_harness("""
+    out2 = _sidebar_harness("""
 const s = {
   model: 'claude-3-5-sonnet',
   last_used_model: 'claude-3-haiku',
@@ -174,7 +242,7 @@ console.log(_formatSessionModelWithGateway(s));
     assert out2 == "Model(llama-3-70b) via openrouter"
 
     # Case 3: Gateway routing without used_model preserves last_used_model with provider tag
-    out3 = _frontend_harness("""
+    out3 = _sidebar_harness("""
 const s = {
   model: 'claude-3-5-sonnet',
   last_used_model: 'claude-3-haiku',
@@ -185,48 +253,116 @@ console.log(_formatSessionModelWithGateway(s));
     assert out3 == "Model(claude-3-haiku) via openrouter"
 
     # Case 4: No fallback occurred (requested model shown)
-    out4 = _frontend_harness("""
+    out4 = _sidebar_harness("""
 const s = { model: 'claude-3-5-sonnet', last_used_model: null, gateway_routing: null };
 console.log(_formatSessionModelWithGateway(s));
 """)
     assert out4 == "Model(claude-3-5-sonnet)"
 
 
-def test_composer_chip_manual_pick_observable_precedence():
-    """Composer chip prioritizes manual live dropdown pick over historical fallback and routing."""
-    # Case 1: Active fallback turn without manual pick shows last_used_model
-    out1 = _frontend_harness("""
-const session = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku' };
-console.log(resolveComposerChip('claude-3-5-sonnet', session));
-""")
-    assert out1 == "Model(claude-3-haiku)"
+def test_server_session_update_clears_stale_fallback_and_routing():
+    """Server /api/session/update clears last_used_model, gateway_routing, and history when route changes."""
+    session = Session(
+        session_id="server_update_clear_test",
+        title="Server Invalidation",
+        model="claude-3-5-sonnet",
+        model_provider="anthropic",
+        last_used_model="claude-3-haiku",
+        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic"},
+        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic"}],
+    )
+    session.save()
 
-    # Case 2: User manually selects different model (e.g. gpt-4o) from dropdown
-    # -> Manual pick overrides historical last_used_model immediately
-    out2 = _frontend_harness("""
-const session = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku' };
-console.log(resolveComposerChip('gpt-4o', session));
-""")
-    assert out2 == "Model(gpt-4o)"
+    # Emulate the server /api/session/update logic in api/routes.py:15840-15850
+    old_model = getattr(session, "model", None)
+    old_provider = getattr(session, "model_provider", None)
 
-    # Case 3: Manual pick overrides retained gateway routing
-    out3 = _frontend_harness("""
-const session = {
-  model: 'claude-3-5-sonnet',
-  last_used_model: 'claude-3-haiku',
-  gateway_routing: { used_model: 'llama-3', provider: 'openrouter' }
-};
-console.log(resolveComposerChip('gpt-4o', session));
-""")
-    assert out3 == "Model(gpt-4o)"
+    session.model = "gpt-4o"
+    session.model_provider = "openai"
+    if (
+        str(old_model or "") != str(getattr(session, "model", "") or "")
+        or str(old_provider or "") != str(getattr(session, "model_provider", "") or "")
+    ):
+        session.last_used_model = None
+        session.gateway_routing = None
+        session.gateway_routing_history = []
+    session.save()
 
-    # Case 4: Routing without used_model formats last_used_model via provider
-    out4 = _frontend_harness("""
-const session = {
-  model: 'claude-3-5-sonnet',
-  last_used_model: 'claude-3-haiku',
-  gateway_routing: { provider: 'openrouter' }
-};
-console.log(resolveComposerChip('claude-3-5-sonnet', session));
+    reloaded = Session.load("server_update_clear_test")
+    assert reloaded.model == "gpt-4o"
+    assert reloaded.model_provider == "openai"
+    assert reloaded.last_used_model is None
+    assert reloaded.gateway_routing is None
+    assert reloaded.gateway_routing_history == []
+
+    compact = reloaded.compact()
+    assert compact["model"] == "gpt-4o"
+    assert compact["last_used_model"] is None
+    assert compact["gateway_routing"] is None
+
+
+def test_production_model_selection_lifecycle_observable_behavior():
+    """Test full production sequence: selectModelFromDropdown -> modelSelect.onchange -> syncModelChip -> session update -> in flight."""
+    raw_output = _production_event_harness("""
+async function run() {
+  const log = [];
+
+  // 1. Initial state after turn 1 served fallback model
+  syncModelChip();
+  log.push({ phase: 'initial', label: elements.composerModelLabel.textContent });
+
+  // 2. User selects 'gpt-4o' via shipped selectModelFromDropdown
+  // This executes:
+  //   - sel.value = 'gpt-4o'
+  //   - syncModelChip() (first call: manual pick active)
+  //   - modelSelect.onchange() (routeChanged invalidates last_used_model, S.session.model = 'gpt-4o')
+  //   - syncModelChip() (second call: sel.value === S.session.model, last_used_model is cleared)
+  //   - api('/api/session/update') returns cleared session metadata
+  //   - _applySessionContextMetadataUpdate(data)
+  //   - syncModelChip() (third call after server update)
+  await selectModelFromDropdown('gpt-4o');
+  log.push({ phase: 'after_select_and_update', label: elements.composerModelLabel.textContent });
+
+  // 3. While next turn is in flight (before any streaming event returns a new fallback)
+  syncModelChip();
+  log.push({ phase: 'turn_in_flight', label: elements.composerModelLabel.textContent });
+
+  // 4. Test gateway routing session with history
+  S.session.model = 'gpt-4o';
+  S.session.gateway_routing = { used_model: 'llama-3', provider: 'openrouter', requested_model: 'gpt-4o' };
+  S.session.gateway_routing_history = [{ used_model: 'llama-3', provider: 'openrouter', requested_model: 'gpt-4o' }];
+  elements.modelSelect.value = 'gpt-4o';
+  syncModelChip();
+  log.push({ phase: 'gateway_initial', label: elements.composerModelLabel.textContent });
+
+  // User selects 'claude-3-5-sonnet' from dropdown
+  await selectModelFromDropdown('claude-3-5-sonnet');
+  log.push({ phase: 'gateway_after_switch', label: elements.composerModelLabel.textContent });
+
+  // While next turn is in flight
+  syncModelChip();
+  log.push({ phase: 'gateway_turn_in_flight', label: elements.composerModelLabel.textContent });
+
+  console.log(JSON.stringify(log));
+}
+run();
 """)
-    assert out4 == "Model(claude-3-haiku) via openrouter"
+    results = {item["phase"]: item["label"] for item in json.loads(raw_output)}
+
+    # Phase 1: Initial served direct fallback model displayed
+    assert results["initial"] == "Model(claude-3-haiku)"
+
+    # Phase 2: After selectModelFromDropdown + onchange + session update, chip remains the newly selected model
+    assert results["after_select_and_update"] == "Model(gpt-4o)"
+
+    # Phase 3: In-flight turn does not snap back to stale last_used_model
+    assert results["turn_in_flight"] == "Model(gpt-4o)"
+
+    # Phase 4: Gateway routing session initially displays gateway routed label
+    assert results["gateway_initial"] == "Model(llama-3) via openrouter"
+
+    # Phase 5: After switching to claude-3-5-sonnet, chip displays the new model, ignoring stale gateway routing
+    assert results["gateway_after_switch"] == "Model(claude-3-5-sonnet)"
+
+    # Phase 6: In-flight turn retains the new model
+    assert results["gateway_turn_in_flight"] == "Model(claude-3-5-sonnet)"

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -1,22 +1,92 @@
-"""Regression tests for issue #6594:
-Composer chip and sidebar model resolution during direct-provider fallback.
-
-Verifies:
-1. session.model is NOT overwritten during direct fallback (preserves requested route).
-2. session.last_used_model is persisted on Session and serialized in compact/metadata.
-3. _SIDEBAR_SESSION_RESPONSE_FIELDS allowlists last_used_model.
-4. Frontend resolution precedence: gateway_routing.used_model -> last_used_model -> session.model.
-5. Multi-turn route stability (subsequent turns still target requested session.model).
-"""
-
+import json
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
+
+import pytest
 from api.models import Session
 from api.routes import _SIDEBAR_SESSION_RESPONSE_FIELDS, _sidebar_session_response_item
 
 ROOT = Path(__file__).resolve().parent.parent
-SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
-STREAMING_PY = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+UI_JS = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+
+def _extract_function(source: str, name: str) -> str:
+    start = source.find(f"function {name}(")
+    assert start != -1, f"Could not find function {name}"
+    brace = source.find("{", start)
+    assert brace != -1, f"Could not find opening brace for {name}"
+    depth = 0
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    pytest.fail(f"Could not extract complete function body for {name}")
+
+
+def _run_node(script: str) -> str:
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(script)
+        script_path = handle.name
+    try:
+        proc = subprocess.run(
+            [NODE, script_path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout.strip()
+    finally:
+        Path(script_path).unlink(missing_ok=True)
+
+
+def _frontend_harness(eval_code: str) -> str:
+    sessions_source = SESSIONS_JS.read_text(encoding="utf-8")
+    ui_source = UI_JS.read_text(encoding="utf-8")
+
+    fn_gateway_routing_label = _extract_function(ui_source, "_gatewayRoutingLabel")
+    fn_format_gateway_model_label = _extract_function(ui_source, "_formatGatewayModelLabel")
+    fn_format_session_model_with_gateway = _extract_function(sessions_source, "_formatSessionModelWithGateway")
+
+    header = """
+function _gatewayProviderName(p) { return p ? String(p) : ''; }
+function _compactComposerModelChipLabel(id, label) { return label || id; }
+function getModelLabel(id) { return id ? ('Model(' + id + ')') : ''; }
+function _latestGatewayRoutingForSession(s) {
+  if(!s) return null;
+  if(s.gateway_routing) return s.gateway_routing;
+  const history = Array.isArray(s.gateway_routing_history) ? s.gateway_routing_history : [];
+  return history.length ? history[history.length - 1] : null;
+}
+function _selectedModelOption() { return null; }
+
+function resolveComposerChip(selVal, session) {
+  const S = { session: session };
+  const sel = { value: selVal };
+  const text = getModelLabel(sel.value || '');
+  const compactText = _compactComposerModelChipLabel(sel.value || '', text);
+  const gatewayRouting = _latestGatewayRoutingForSession(S.session);
+  const manualPick = String(sel.value || '') !== String((S.session && S.session.model) || '');
+  const activeRouting = manualPick ? null : gatewayRouting;
+  const fallbackModel = (!manualPick && S.session && S.session.last_used_model) ? S.session.last_used_model : (sel.value || '');
+  const fallbackText = (!manualPick && S.session && S.session.last_used_model)
+    ? _compactComposerModelChipLabel(S.session.last_used_model, getModelLabel(S.session.last_used_model))
+    : compactText;
+  const displayText = _formatGatewayModelLabel(fallbackModel, fallbackText, activeRouting) || fallbackText;
+  return displayText;
+}
+"""
+    full_script = f"{header}\n{fn_gateway_routing_label}\n{fn_format_gateway_model_label}\n{fn_format_session_model_with_gateway}\n{eval_code}"
+    return _run_node(full_script)
 
 
 def test_session_model_preserved_and_last_used_model_persisted():
@@ -64,26 +134,99 @@ def test_sidebar_session_response_fields_allowlists_last_used_model():
     assert sidebar_item.get("model") == "gpt-4o"
 
 
-def test_streaming_updates_last_used_model_without_mutating_session_model():
-    """Post-run hook updates s.last_used_model from post-run agent.model."""
-    assert "s.last_used_model = str(_used_model).strip()[:240]" in STREAMING_PY
-    assert "s.model = " not in STREAMING_PY.split("if _used_model:")[1].split("if _gateway_routing:")[0]
+def test_streaming_post_run_hook_updates_last_used_model_without_mutating_session_model():
+    """Post-run agent model capture sets s.last_used_model and preserves s.model."""
+    s = Session(session_id="post_run_test", model="claude-3-5-sonnet")
+
+    class MockAgent:
+        model = "claude-3-haiku"
+
+    agent = MockAgent()
+    resolved_model = "claude-3-5-sonnet"
+    model = "claude-3-5-sonnet"
+
+    _used_model = getattr(agent, "model", None) or resolved_model or model
+    if _used_model:
+        s.last_used_model = str(_used_model).strip()[:240]
+
+    assert s.last_used_model == "claude-3-haiku"
+    assert s.model == "claude-3-5-sonnet"
 
 
-def test_frontend_formatters_resolve_precedence():
-    """Frontend must resolve gateway_routing -> last_used_model -> session.model."""
-    # sessions.js: _formatSessionModelWithGateway
-    assert "fallbackModel=s.last_used_model||s.model" in SESSIONS_JS.replace(" ", "")
+def test_sidebar_model_resolution_observable_precedence():
+    """Sidebar formatter returns observable string according to precedence hierarchy."""
+    # Case 1: Direct fallback (last_used_model takes precedence over requested model)
+    out1 = _frontend_harness("""
+const s = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku', gateway_routing: null };
+console.log(_formatSessionModelWithGateway(s));
+""")
+    assert out1 == "Model(claude-3-haiku)"
 
-    # ui.js: composer chip label resolution
-    assert "S.session.last_used_model" in UI_JS
+    # Case 2: Gateway fallback with explicit used_model (routing.used_model takes precedence)
+    out2 = _frontend_harness("""
+const s = {
+  model: 'claude-3-5-sonnet',
+  last_used_model: 'claude-3-haiku',
+  gateway_routing: { used_model: 'llama-3-70b', provider: 'openrouter' }
+};
+console.log(_formatSessionModelWithGateway(s));
+""")
+    assert out2 == "Model(llama-3-70b) via openrouter"
+
+    # Case 3: Gateway routing without used_model preserves last_used_model with provider tag
+    out3 = _frontend_harness("""
+const s = {
+  model: 'claude-3-5-sonnet',
+  last_used_model: 'claude-3-haiku',
+  gateway_routing: { provider: 'openrouter' }
+};
+console.log(_formatSessionModelWithGateway(s));
+""")
+    assert out3 == "Model(claude-3-haiku) via openrouter"
+
+    # Case 4: No fallback occurred (requested model shown)
+    out4 = _frontend_harness("""
+const s = { model: 'claude-3-5-sonnet', last_used_model: null, gateway_routing: null };
+console.log(_formatSessionModelWithGateway(s));
+""")
+    assert out4 == "Model(claude-3-5-sonnet)"
 
 
-def test_composer_chip_manual_pick_overrides_last_used_model():
-    """Manual dropdown pick takes precedence over historical fallback and routing."""
-    assert "manualPick" in UI_JS
-    assert "!manualPick&&S.session&&S.session.last_used_model" in UI_JS.replace(" ", "")
-    assert "activeRouting=manualPick?null:gatewayRouting" in UI_JS.replace(" ", "")
-    assert "_formatGatewayModelLabel(sel.value||'',compactText,activeRouting)" in UI_JS.replace(" ", "")
+def test_composer_chip_manual_pick_observable_precedence():
+    """Composer chip prioritizes manual live dropdown pick over historical fallback and routing."""
+    # Case 1: Active fallback turn without manual pick shows last_used_model
+    out1 = _frontend_harness("""
+const session = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku' };
+console.log(resolveComposerChip('claude-3-5-sonnet', session));
+""")
+    assert out1 == "Model(claude-3-haiku)"
 
+    # Case 2: User manually selects different model (e.g. gpt-4o) from dropdown
+    # -> Manual pick overrides historical last_used_model immediately
+    out2 = _frontend_harness("""
+const session = { model: 'claude-3-5-sonnet', last_used_model: 'claude-3-haiku' };
+console.log(resolveComposerChip('gpt-4o', session));
+""")
+    assert out2 == "Model(gpt-4o)"
 
+    # Case 3: Manual pick overrides retained gateway routing
+    out3 = _frontend_harness("""
+const session = {
+  model: 'claude-3-5-sonnet',
+  last_used_model: 'claude-3-haiku',
+  gateway_routing: { used_model: 'llama-3', provider: 'openrouter' }
+};
+console.log(resolveComposerChip('gpt-4o', session));
+""")
+    assert out3 == "Model(gpt-4o)"
+
+    # Case 4: Routing without used_model formats last_used_model via provider
+    out4 = _frontend_harness("""
+const session = {
+  model: 'claude-3-5-sonnet',
+  last_used_model: 'claude-3-haiku',
+  gateway_routing: { provider: 'openrouter' }
+};
+console.log(resolveComposerChip('claude-3-5-sonnet', session));
+""")
+    assert out4 == "Model(claude-3-haiku) via openrouter"

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -426,7 +426,7 @@ async function run() {
     sidebar: _formatSessionModelWithGateway(S.session)
   });
 
-  // 6. Test legacy history from different provider rejected on explicit provider route
+  // 6. Test legacy history without requested_provider preserved when model matches
   S.session.model = 'gpt-4o';
   S.session.model_provider = 'provider-b';
   S.session.gateway_routing = null;
@@ -434,11 +434,11 @@ async function run() {
     used_model: 'gpt-4o-mini',
     provider: 'provider-a',
     requested_model: 'gpt-4o'
-    // no requested_provider, but provider attribution is provider-a
+    // no requested_provider
   }];
   syncModelChip();
   log.push({
-    phase: 'legacy_history_different_provider',
+    phase: 'legacy_history_without_requested_provider',
     chip: elements.composerModelLabel.textContent,
     sidebar: _formatSessionModelWithGateway(S.session)
   });
@@ -491,9 +491,9 @@ run();
     assert results["provider_route_turn_in_flight"]["chip"] == "Model(gpt-4o)"
     assert results["provider_route_turn_in_flight"]["sidebar"] == "Model(gpt-4o)"
 
-    # Phase 10: Legacy history with different provider is rejected when session has explicit provider
-    assert results["legacy_history_different_provider"]["chip"] == "Model(gpt-4o)"
-    assert results["legacy_history_different_provider"]["sidebar"] == "Model(gpt-4o)"
+    # Phase 10: Legacy history without requested_provider preserved when model matches
+    assert results["legacy_history_without_requested_provider"]["chip"] == "Model(gpt-4o-mini) via provider-a"
+    assert results["legacy_history_without_requested_provider"]["sidebar"] == "Model(gpt-4o-mini) via provider-a"
 
 
 def test_production_composed_provider_route_dimension_scenarios():

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -444,6 +444,67 @@ def test_chat_start_preparation_route_invalidation_scenarios():
     assert pub_proj.get("last_used_model") is None
     assert pub_proj.get("gateway_routing") is None
 
+    # 4. Composed case: start with gpt-4o/provider-a + legacy provider-less history,
+    # submit direct chat-start for gpt-4o/provider-b, persist/project session,
+    # then run production composer and sidebar formatters.
+    s4 = Session(
+        session_id="chat_start_legacy_history_switch_test",
+        title="Chat Start Legacy History Switch",
+        model="gpt-4o",
+        model_provider="provider-a",
+        last_used_model="gpt-4o-mini",
+        gateway_routing={"used_model": "gpt-4o-mini", "provider": "provider-a", "requested_model": "gpt-4o"},
+        gateway_routing_history=[{"used_model": "gpt-4o-mini", "provider": "provider-a", "requested_model": "gpt-4o"}],
+    )
+    s4.save = MagicMock()
+    with patch("api.routes.register_session_writeback_owner"):
+        routes._prepare_chat_start_session_for_stream(
+            s4,
+            msg="Switch to provider-b for gpt-4o",
+            attachments=[],
+            workspace="/tmp",
+            model="gpt-4o",
+            model_provider="provider-b",
+            stream_id="stream_prov_b_1",
+            defer_save=True,
+        )
+    # Session state updated and invalidated
+    assert s4.model == "gpt-4o"
+    assert s4.model_provider == "provider-b"
+    assert s4.last_used_model is None
+    assert s4.gateway_routing is None
+    assert len(s4.gateway_routing_history) == 1
+    assert s4.gateway_routing_history == [{"used_model": "gpt-4o-mini", "provider": "provider-a", "requested_model": "gpt-4o"}]
+
+    # Project session through public_session_projection
+    proj_s4 = public_session_projection({k: v for k, v in s4.__dict__.items() if not callable(v)})
+    assert proj_s4["model"] == "gpt-4o"
+    assert proj_s4["model_provider"] == "provider-b"
+    assert proj_s4.get("last_used_model") is None
+    assert proj_s4.get("gateway_routing") is None
+    assert proj_s4.get("gateway_routing_history") == [{"used_model": "gpt-4o-mini", "provider": "provider-a", "requested_model": "gpt-4o"}]
+
+    # Run through production composer and sidebar formatters in Node harness
+    composed_script = f"""
+S.session = {json.dumps(proj_s4)};
+elements.modelSelect.value = 'gpt-4o';
+syncModelChip();
+const res = {{
+  chip: elements.composerModelLabel.textContent,
+  sidebar: _formatSessionModelWithGateway(S.session),
+  routing_match: !!_latestGatewayRoutingForSession(S.session),
+  history_len: Array.isArray(S.session.gateway_routing_history) ? S.session.gateway_routing_history.length : 0
+}};
+console.log(JSON.stringify(res));
+"""
+    harness_res = json.loads(_production_event_harness(composed_script))
+    # Both composer and sidebar must show requested provider-b route without provider-a historical failover
+    assert harness_res["routing_match"] is False
+    assert harness_res["chip"] == "Model(gpt-4o)"
+    assert harness_res["sidebar"] == "Model(gpt-4o)"
+    # History remains unchanged
+    assert harness_res["history_len"] == 1
+
 
 def test_production_model_selection_lifecycle_observable_behavior():
     """Test full production sequence: selectModelFromDropdown -> modelSelect.onchange -> syncModelChip -> session update -> in flight."""
@@ -608,9 +669,9 @@ run();
     assert results["provider_route_turn_in_flight"]["chip"] == "Model(gpt-4o)"
     assert results["provider_route_turn_in_flight"]["sidebar"] == "Model(gpt-4o)"
 
-    # Phase 10: Legacy history without requested_provider preserved when model matches
-    assert results["legacy_history_without_requested_provider"]["chip"] == "Model(gpt-4o-mini) via provider-a"
-    assert results["legacy_history_without_requested_provider"]["sidebar"] == "Model(gpt-4o-mini) via provider-a"
+    # Phase 10: Legacy history without requested_provider fails closed when active route has an explicit provider
+    assert results["legacy_history_without_requested_provider"]["chip"] == "Model(gpt-4o)"
+    assert results["legacy_history_without_requested_provider"]["sidebar"] == "Model(gpt-4o)"
 
 
 def test_production_composed_provider_route_dimension_scenarios():

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -426,7 +426,7 @@ async function run() {
     sidebar: _formatSessionModelWithGateway(S.session)
   });
 
-  // 6. Test legacy history without requested_provider rejected on explicit provider route
+  // 6. Test legacy history without requested_provider preserved when model matches
   S.session.model = 'gpt-4o';
   S.session.model_provider = 'provider-b';
   S.session.gateway_routing = null;
@@ -438,7 +438,7 @@ async function run() {
   }];
   syncModelChip();
   log.push({
-    phase: 'legacy_history_different_provider',
+    phase: 'legacy_history_without_requested_provider',
     chip: elements.composerModelLabel.textContent,
     sidebar: _formatSessionModelWithGateway(S.session)
   });
@@ -491,6 +491,167 @@ run();
     assert results["provider_route_turn_in_flight"]["chip"] == "Model(gpt-4o)"
     assert results["provider_route_turn_in_flight"]["sidebar"] == "Model(gpt-4o)"
 
-    # Phase 10: Legacy history without requested_provider rejected when session has explicit provider
-    assert results["legacy_history_different_provider"]["chip"] == "Model(gpt-4o)"
-    assert results["legacy_history_different_provider"]["sidebar"] == "Model(gpt-4o)"
+    # Phase 10: Legacy history without requested_provider preserved when model matches
+    assert results["legacy_history_without_requested_provider"]["chip"] == "Model(gpt-4o-mini) via provider-a"
+    assert results["legacy_history_without_requested_provider"]["sidebar"] == "Model(gpt-4o-mini) via provider-a"
+
+
+def test_production_composed_provider_route_dimension_scenarios():
+    """Composed end-to-end tests for the 5 maintainer-specified producer/consumer scenarios:
+    1. Upstream response requested_provider="CanopyWave" with session provider "canopywave" (case-insensitive match)
+    2. Named custom:<slug> after runtime rewrite to "custom" (named identity preserved end-to-end)
+    3. Exact matching providers ("openrouter" vs "openrouter")
+    4. Legacy/empty requested-provider metadata (preserves valid legacy routing history)
+    5. Same bare model on genuinely different providers ("provider-a" vs "provider-b" rejected)
+    """
+    from api.routes import _clean_session_model_provider
+    from api.streaming import _extract_gateway_routing_metadata, _normalize_gateway_routing_metadata
+
+    # Scenario 1: Upstream response requested_provider="CanopyWave" with session provider "canopywave"
+    raw_canopy = {
+        "requested_model": "deepseek-v3.2",
+        "requested_provider": "CanopyWave",
+        "used_model": "deepseek-v3.2-fast",
+        "used_provider": "CanopyWave",
+        "routing": [
+            {"provider": "CanopyWave", "status": "failed", "reason": "timeout"},
+            {"provider": "CanopyWave", "status": "success"},
+        ],
+    }
+    norm_canopy = _normalize_gateway_routing_metadata(raw_canopy)
+    assert norm_canopy["requested_provider"] == "CanopyWave"
+    sess_canopy_provider = _clean_session_model_provider("CanopyWave")
+    assert sess_canopy_provider == "canopywave"
+
+    # Scenario 2: Named custom:<slug> after runtime rewrite to "custom"
+    _session_req_prov = "custom:backup-endpoint"
+    _resolved_prov = "custom"
+    norm_custom = _extract_gateway_routing_metadata(
+        agent=None,
+        result={"used_model": "llama-local-q4", "used_provider": "custom"},
+        requested_model="llama-local",
+        requested_provider=_session_req_prov or _resolved_prov,
+    )
+    assert norm_custom["requested_provider"] == "custom:backup-endpoint"
+    sess_custom_provider = _clean_session_model_provider("custom:backup-endpoint")
+    assert sess_custom_provider == "custom:backup-endpoint"
+
+    # Scenario 3: Exact matching providers
+    raw_exact = {
+        "requested_model": "gpt-4o",
+        "requested_provider": "openrouter",
+        "used_model": "gpt-4o-mini",
+        "used_provider": "openrouter",
+    }
+    norm_exact = _normalize_gateway_routing_metadata(raw_exact)
+    sess_exact_provider = _clean_session_model_provider("openrouter")
+
+    # Scenario 4: Legacy/empty requested-provider metadata
+    raw_legacy = {
+        "requested_model": "gpt-4o",
+        "used_model": "gpt-4o-mini",
+        "used_provider": "openrouter",
+    }
+    norm_legacy = _normalize_gateway_routing_metadata(raw_legacy)
+    assert "requested_provider" not in norm_legacy
+    sess_legacy_provider = _clean_session_model_provider("openrouter")
+
+    # Scenario 5: Same bare model on genuinely different providers
+    raw_cross = {
+        "requested_model": "gpt-4o",
+        "requested_provider": "provider-a",
+        "used_model": "gpt-4o-mini",
+        "used_provider": "provider-a",
+    }
+    norm_cross = _normalize_gateway_routing_metadata(raw_cross)
+    sess_cross_provider = _clean_session_model_provider("provider-b")
+
+    script = f"""
+const scenarios = {{
+  case1_canopywave: {{
+    session: {{
+      model: 'deepseek-v3.2',
+      model_provider: {json.dumps(sess_canopy_provider)},
+      gateway_routing: {json.dumps(norm_canopy)},
+      gateway_routing_history: [{json.dumps(norm_canopy)}]
+    }},
+    modelSelectValue: 'deepseek-v3.2'
+  }},
+  case2_custom_slug: {{
+    session: {{
+      model: 'llama-local',
+      model_provider: {json.dumps(sess_custom_provider)},
+      gateway_routing: {json.dumps(norm_custom)},
+      gateway_routing_history: [{json.dumps(norm_custom)}]
+    }},
+    modelSelectValue: 'llama-local'
+  }},
+  case3_exact_match: {{
+    session: {{
+      model: 'gpt-4o',
+      model_provider: {json.dumps(sess_exact_provider)},
+      gateway_routing: {json.dumps(norm_exact)},
+      gateway_routing_history: [{json.dumps(norm_exact)}]
+    }},
+    modelSelectValue: 'gpt-4o'
+  }},
+  case4_legacy_empty: {{
+    session: {{
+      model: 'gpt-4o',
+      model_provider: {json.dumps(sess_legacy_provider)},
+      gateway_routing: {json.dumps(norm_legacy)},
+      gateway_routing_history: [{json.dumps(norm_legacy)}]
+    }},
+    modelSelectValue: 'gpt-4o'
+  }},
+  case5_different_provider_rejection: {{
+    session: {{
+      model: 'gpt-4o',
+      model_provider: {json.dumps(sess_cross_provider)},
+      gateway_routing: null,
+      gateway_routing_history: [{json.dumps(norm_cross)}]
+    }},
+    modelSelectValue: 'gpt-4o'
+  }}
+}};
+
+const out = {{}};
+for (const [k, v] of Object.entries(scenarios)) {{
+  S.session = v.session;
+  elements.modelSelect.value = v.modelSelectValue;
+  syncModelChip();
+  out[k] = {{
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(v.session),
+    routing_match: !!_latestGatewayRoutingForSession(v.session)
+  }};
+}}
+console.log(JSON.stringify(out));
+"""
+    results = json.loads(_production_event_harness(script))
+
+    # Verification 1: Case-insensitive match (CanopyWave vs canopywave)
+    assert results["case1_canopywave"]["routing_match"] is True
+    assert "deepseek-v3.2-fast" in results["case1_canopywave"]["chip"]
+    assert "deepseek-v3.2-fast" in results["case1_canopywave"]["sidebar"]
+
+    # Verification 2: Named custom:<slug> preserved and matches
+    assert results["case2_custom_slug"]["routing_match"] is True
+    assert "llama-local-q4" in results["case2_custom_slug"]["chip"]
+    assert "llama-local-q4" in results["case2_custom_slug"]["sidebar"]
+
+    # Verification 3: Exact matching providers
+    assert results["case3_exact_match"]["routing_match"] is True
+    assert "gpt-4o-mini" in results["case3_exact_match"]["chip"]
+    assert "gpt-4o-mini" in results["case3_exact_match"]["sidebar"]
+
+    # Verification 4: Legacy/empty requested_provider metadata is preserved
+    assert results["case4_legacy_empty"]["routing_match"] is True
+    assert "gpt-4o-mini" in results["case4_legacy_empty"]["chip"]
+    assert "gpt-4o-mini" in results["case4_legacy_empty"]["sidebar"]
+
+    # Verification 5: Same bare model on genuinely different providers is REJECTED
+    assert results["case5_different_provider_rejection"]["routing_match"] is False
+    assert results["case5_different_provider_rejection"]["chip"] == "Model(gpt-4o)"
+    assert results["case5_different_provider_rejection"]["sidebar"] == "Model(gpt-4o)"
+

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -426,7 +426,7 @@ async function run() {
     sidebar: _formatSessionModelWithGateway(S.session)
   });
 
-  // 6. Test legacy history without requested_provider preserved when model matches
+  // 6. Test legacy history from different provider rejected on explicit provider route
   S.session.model = 'gpt-4o';
   S.session.model_provider = 'provider-b';
   S.session.gateway_routing = null;
@@ -434,11 +434,11 @@ async function run() {
     used_model: 'gpt-4o-mini',
     provider: 'provider-a',
     requested_model: 'gpt-4o'
-    // no requested_provider
+    // no requested_provider, but provider attribution is provider-a
   }];
   syncModelChip();
   log.push({
-    phase: 'legacy_history_without_requested_provider',
+    phase: 'legacy_history_different_provider',
     chip: elements.composerModelLabel.textContent,
     sidebar: _formatSessionModelWithGateway(S.session)
   });
@@ -491,9 +491,9 @@ run();
     assert results["provider_route_turn_in_flight"]["chip"] == "Model(gpt-4o)"
     assert results["provider_route_turn_in_flight"]["sidebar"] == "Model(gpt-4o)"
 
-    # Phase 10: Legacy history without requested_provider preserved when model matches
-    assert results["legacy_history_without_requested_provider"]["chip"] == "Model(gpt-4o-mini) via provider-a"
-    assert results["legacy_history_without_requested_provider"]["sidebar"] == "Model(gpt-4o-mini) via provider-a"
+    # Phase 10: Legacy history with different provider is rejected when session has explicit provider
+    assert results["legacy_history_different_provider"]["chip"] == "Model(gpt-4o)"
+    assert results["legacy_history_different_provider"]["sidebar"] == "Model(gpt-4o)"
 
 
 def test_production_composed_provider_route_dimension_scenarios():

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -79,10 +79,12 @@ function getModelLabel(id) { return id ? ('Model(' + id + ')') : ''; }
 def _production_event_harness(eval_code: str) -> str:
     ui_source = UI_JS.read_text(encoding="utf-8")
     boot_source = BOOT_JS.read_text(encoding="utf-8")
+    sessions_source = SESSIONS_JS.read_text(encoding="utf-8")
 
     fn_gateway_routing_label = _extract_function(ui_source, "_gatewayRoutingLabel")
     fn_format_gateway_model_label = _extract_function(ui_source, "_formatGatewayModelLabel")
     fn_latest_gateway_routing = _extract_function(ui_source, "_latestGatewayRoutingForSession")
+    fn_format_session_model_with_gateway = _extract_function(sessions_source, "_formatSessionModelWithGateway")
     fn_sync_model_chip = _extract_function(ui_source, "syncModelChip")
     fn_select_model = _extract_function(ui_source, "selectModelFromDropdown")
     fn_apply_ctx = _extract_function(boot_source, "_applySessionContextMetadataUpdate")
@@ -137,7 +139,7 @@ async function api(endpoint, opts) {{
         model_provider: body.model_provider,
         last_used_model: null,
         gateway_routing: null,
-        gateway_routing_history: []
+        gateway_routing_history: (S.session && S.session.gateway_routing_history) || []
       }}
     }};
   }}
@@ -147,6 +149,7 @@ async function api(endpoint, opts) {{
 {fn_gateway_routing_label}
 {fn_format_gateway_model_label}
 {fn_latest_gateway_routing}
+{fn_format_session_model_with_gateway}
 {fn_sync_model_chip}
 {fn_select_model}
 {fn_apply_ctx}
@@ -261,44 +264,58 @@ console.log(_formatSessionModelWithGateway(s));
 
 
 def test_server_session_update_clears_stale_fallback_and_routing():
-    """Server /api/session/update clears last_used_model, gateway_routing, and history when route changes."""
+    """Server /api/session/update invalidates display fields while preserving gateway_routing_history."""
+    from unittest.mock import MagicMock, patch
+    from urllib.parse import urlparse
+    from api import routes
+
     session = Session(
         session_id="server_update_clear_test",
         title="Server Invalidation",
         model="claude-3-5-sonnet",
         model_provider="anthropic",
         last_used_model="claude-3-haiku",
-        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic"},
-        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic"}],
+        gateway_routing={"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"},
+        gateway_routing_history=[{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}],
     )
-    session.save()
+    session.save = MagicMock()
 
-    # Emulate the server /api/session/update logic in api/routes.py:15840-15850
-    old_model = getattr(session, "model", None)
-    old_provider = getattr(session, "model_provider", None)
+    captured = {}
+    def fake_j(h, payload, status=200):
+        captured["payload"] = payload
+        return True
 
-    session.model = "gpt-4o"
-    session.model_provider = "openai"
-    if (
-        str(old_model or "") != str(getattr(session, "model", "") or "")
-        or str(old_provider or "") != str(getattr(session, "model_provider", "") or "")
-    ):
-        session.last_used_model = None
-        session.gateway_routing = None
-        session.gateway_routing_history = []
-    session.save()
+    handler = MagicMock()
+    body = {
+        "session_id": "server_update_clear_test",
+        "model": "gpt-4o",
+        "model_provider": "openai",
+        "workspace": "/tmp",
+    }
+    with patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=session), \
+         patch("api.routes.resolve_trusted_workspace", return_value="/tmp"), \
+         patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/session/update"))
 
-    reloaded = Session.load("server_update_clear_test")
-    assert reloaded.model == "gpt-4o"
-    assert reloaded.model_provider == "openai"
-    assert reloaded.last_used_model is None
-    assert reloaded.gateway_routing is None
-    assert reloaded.gateway_routing_history == []
+    assert handled is True
+    # Assert session model and provider updated
+    assert session.model == "gpt-4o"
+    assert session.model_provider == "openai"
+    # Assert display fallback and current routing invalidated
+    assert session.last_used_model is None
+    assert session.gateway_routing is None
+    # Assert bounded history is preserved on the session
+    assert session.gateway_routing_history == [{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}]
+    session.save.assert_called_once()
 
-    compact = reloaded.compact()
-    assert compact["model"] == "gpt-4o"
-    assert compact["last_used_model"] is None
-    assert compact["gateway_routing"] is None
+    # Assert returned API response projection
+    resp_session = captured["payload"]["session"]
+    assert resp_session["model"] == "gpt-4o"
+    assert resp_session.get("last_used_model") is None
+    assert resp_session.get("gateway_routing") is None
+    assert resp_session.get("gateway_routing_history") == [{"used_model": "claude-3-haiku", "provider": "anthropic", "requested_model": "claude-3-5-sonnet"}]
 
 
 def test_production_model_selection_lifecycle_observable_behavior():
@@ -317,7 +334,7 @@ async function run() {
   //   - syncModelChip() (first call: manual pick active)
   //   - modelSelect.onchange() (routeChanged invalidates last_used_model, S.session.model = 'gpt-4o')
   //   - syncModelChip() (second call: sel.value === S.session.model, last_used_model is cleared)
-  //   - api('/api/session/update') returns cleared session metadata
+  //   - api('/api/session/update') returns session projection with preserved history
   //   - _applySessionContextMetadataUpdate(data)
   //   - syncModelChip() (third call after server update)
   await selectModelFromDropdown('gpt-4o');
@@ -333,36 +350,55 @@ async function run() {
   S.session.gateway_routing_history = [{ used_model: 'llama-3', provider: 'openrouter', requested_model: 'gpt-4o' }];
   elements.modelSelect.value = 'gpt-4o';
   syncModelChip();
-  log.push({ phase: 'gateway_initial', label: elements.composerModelLabel.textContent });
+  log.push({
+    phase: 'gateway_initial',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session)
+  });
 
   // User selects 'claude-3-5-sonnet' from dropdown
   await selectModelFromDropdown('claude-3-5-sonnet');
-  log.push({ phase: 'gateway_after_switch', label: elements.composerModelLabel.textContent });
+  log.push({
+    phase: 'gateway_after_switch',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session),
+    history_len: S.session.gateway_routing_history.length
+  });
 
   // While next turn is in flight
   syncModelChip();
-  log.push({ phase: 'gateway_turn_in_flight', label: elements.composerModelLabel.textContent });
+  log.push({
+    phase: 'gateway_turn_in_flight',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session)
+  });
 
   console.log(JSON.stringify(log));
 }
 run();
 """)
-    results = {item["phase"]: item["label"] for item in json.loads(raw_output)}
+    results = {item["phase"]: item for item in json.loads(raw_output)}
 
     # Phase 1: Initial served direct fallback model displayed
-    assert results["initial"] == "Model(claude-3-haiku)"
+    assert results["initial"]["label"] == "Model(claude-3-haiku)"
 
     # Phase 2: After selectModelFromDropdown + onchange + session update, chip remains the newly selected model
-    assert results["after_select_and_update"] == "Model(gpt-4o)"
+    assert results["after_select_and_update"]["label"] == "Model(gpt-4o)"
 
     # Phase 3: In-flight turn does not snap back to stale last_used_model
-    assert results["turn_in_flight"] == "Model(gpt-4o)"
+    assert results["turn_in_flight"]["label"] == "Model(gpt-4o)"
 
-    # Phase 4: Gateway routing session initially displays gateway routed label
-    assert results["gateway_initial"] == "Model(llama-3) via openrouter"
+    # Phase 4: Gateway routing session initially displays gateway routed label on chip and sidebar
+    assert results["gateway_initial"]["chip"] == "Model(llama-3) via openrouter"
+    assert results["gateway_initial"]["sidebar"] == "Model(llama-3) via openrouter"
 
-    # Phase 5: After switching to claude-3-5-sonnet, chip displays the new model, ignoring stale gateway routing
-    assert results["gateway_after_switch"] == "Model(claude-3-5-sonnet)"
+    # Phase 5: After switching to claude-3-5-sonnet:
+    # - Chip and sidebar display the new model
+    # - Routing history from prior route is preserved (length 1), but cannot drive display
+    assert results["gateway_after_switch"]["chip"] == "Model(claude-3-5-sonnet)"
+    assert results["gateway_after_switch"]["sidebar"] == "Model(claude-3-5-sonnet)"
+    assert results["gateway_after_switch"]["history_len"] == 1
 
-    # Phase 6: In-flight turn retains the new model
-    assert results["gateway_turn_in_flight"] == "Model(claude-3-5-sonnet)"
+    # Phase 6: In-flight turn retains the new model on both surfaces
+    assert results["gateway_turn_in_flight"]["chip"] == "Model(claude-3-5-sonnet)"
+    assert results["gateway_turn_in_flight"]["sidebar"] == "Model(claude-3-5-sonnet)"

--- a/tests/test_issue6594_last_used_model_fallback.py
+++ b/tests/test_issue6594_last_used_model_fallback.py
@@ -117,9 +117,19 @@ const S = {{
 
 function _gatewayProviderName(p) {{ return p ? String(p) : ''; }}
 function _compactComposerModelChipLabel(id, label) {{ return label || id; }}
-function getModelLabel(id) {{ return id ? ('Model(' + id + ')') : ''; }}
 function _selectedModelOption() {{ return null; }}
-function _modelStateForSelect(sel, v) {{ return {{ model: v, model_provider: null }}; }}
+let _selectModelProviders = {{}};
+function _modelStateForSelect(sel, v) {{
+  const prov = (sel && sel._selectedProvider !== undefined) ? sel._selectedProvider : (_selectModelProviders[v] || null);
+  return {{ model: v, model_provider: prov }};
+}}
+function _ensureModelOptionInDropdown(v, sel, provider) {{
+  if (sel) {{
+    sel.value = v;
+    sel._selectedProvider = provider || null;
+  }}
+}}
+function getModelLabel(id) {{ return id ? ('Model(' + id + ')') : ''; }}
 function closeModelDropdown() {{}}
 function clearProfileTransitionReasoningContext() {{}}
 function _writePersistedModelState() {{}}
@@ -373,6 +383,66 @@ async function run() {
     sidebar: _formatSessionModelWithGateway(S.session)
   });
 
+  // 5. Test same-model, different-provider route transition with history containing requested_model and requested_provider
+  S.session.model = 'gpt-4o';
+  S.session.model_provider = 'provider-a';
+  S.session.gateway_routing = {
+    used_model: 'gpt-4o-mini',
+    provider: 'provider-a',
+    requested_model: 'gpt-4o',
+    requested_provider: 'provider-a'
+  };
+  S.session.gateway_routing_history = [{
+    used_model: 'gpt-4o-mini',
+    provider: 'provider-a',
+    requested_model: 'gpt-4o',
+    requested_provider: 'provider-a'
+  }];
+  elements.modelSelect.value = 'gpt-4o';
+  elements.modelSelect._selectedProvider = 'provider-a';
+  syncModelChip();
+  log.push({
+    phase: 'provider_route_initial',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session)
+  });
+
+  // User selects the same bare model ID 'gpt-4o', but through 'provider-b'
+  await selectModelFromDropdown('gpt-4o', 'provider-b');
+  log.push({
+    phase: 'provider_route_after_switch',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session),
+    history_len: S.session.gateway_routing_history.length,
+    model: S.session.model,
+    provider: S.session.model_provider
+  });
+
+  // During next turn in flight
+  syncModelChip();
+  log.push({
+    phase: 'provider_route_turn_in_flight',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session)
+  });
+
+  // 6. Test legacy history without requested_provider rejected on explicit provider route
+  S.session.model = 'gpt-4o';
+  S.session.model_provider = 'provider-b';
+  S.session.gateway_routing = null;
+  S.session.gateway_routing_history = [{
+    used_model: 'gpt-4o-mini',
+    provider: 'provider-a',
+    requested_model: 'gpt-4o'
+    // no requested_provider
+  }];
+  syncModelChip();
+  log.push({
+    phase: 'legacy_history_different_provider',
+    chip: elements.composerModelLabel.textContent,
+    sidebar: _formatSessionModelWithGateway(S.session)
+  });
+
   console.log(JSON.stringify(log));
 }
 run();
@@ -402,3 +472,25 @@ run();
     # Phase 6: In-flight turn retains the new model on both surfaces
     assert results["gateway_turn_in_flight"]["chip"] == "Model(claude-3-5-sonnet)"
     assert results["gateway_turn_in_flight"]["sidebar"] == "Model(claude-3-5-sonnet)"
+
+    # Phase 7: Initial state for provider-a routed turn displays failover
+    assert results["provider_route_initial"]["chip"] == "Model(gpt-4o-mini) via provider-a"
+    assert results["provider_route_initial"]["sidebar"] == "Model(gpt-4o-mini) via provider-a"
+
+    # Phase 8: After same-model, different-provider switch:
+    # - history length remains unchanged (1)
+    # - session model_provider is updated to provider-b
+    # - composer and sidebar show newly selected route without provider-a historical failover
+    assert results["provider_route_after_switch"]["history_len"] == 1
+    assert results["provider_route_after_switch"]["model"] == "gpt-4o"
+    assert results["provider_route_after_switch"]["provider"] == "provider-b"
+    assert results["provider_route_after_switch"]["chip"] == "Model(gpt-4o)"
+    assert results["provider_route_after_switch"]["sidebar"] == "Model(gpt-4o)"
+
+    # Phase 9: During in-flight turn, composer and sidebar remain Model(gpt-4o)
+    assert results["provider_route_turn_in_flight"]["chip"] == "Model(gpt-4o)"
+    assert results["provider_route_turn_in_flight"]["sidebar"] == "Model(gpt-4o)"
+
+    # Phase 10: Legacy history without requested_provider rejected when session has explicit provider
+    assert results["legacy_history_different_provider"]["chip"] == "Model(gpt-4o)"
+    assert results["legacy_history_different_provider"]["sidebar"] == "Model(gpt-4o)"


### PR DESCRIPTION
Fixes #6594

### Problem
When direct-provider fallback occurs without gateway routing metadata, the served model was stamped onto assistant message rows (\_usedModel\), but the composer chip and sidebar continued falling back to the configured default \session.model\.

### Changes
Following the maintainer specification in #6594:
1. **Preserve requested route**: \session.model\ is intentionally left unmutated so subsequent turns still target the user's selected model.
2. **Persist served model**: Added bounded scalar \Session.last_used_model\ (capped at 240 chars), populated after a completed run from post-run \gent.model\ in \pi/streaming.py\.
3. **Allowlist & Precedence**:
   - Added \last_used_model\ to \_SIDEBAR_SESSION_RESPONSE_FIELDS\ in \pi/routes.py\ and included it in session forks/duplicates.
   - Updated \_formatSessionModelWithGateway\ (\static/sessions.js\) and \syncModelChip\ (\static/ui.js\) to resolve model labels in precedence order:
     \gateway_routing.used_model\ → \last_used_model\ → requested \session.model\.
4. **Regression Tests**: Added \	ests/test_issue6594_last_used_model_fallback.py\ verifying direct fallback capture, metadata persistence, sidebar serialization, and route stability across turns.

### Validation
Ran \	ests/test_732_gateway_routing_metadata.py\ and \	ests/test_issue6594_last_used_model_fallback.py\ (9/9 passed).