### PR TITLE
fix(workspace): open persistent Docker artifacts

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -18035,12 +18035,12 @@ def _handle_list_dir(handler, parsed):
         rel_path = qs.get("path", ["."])[0]
         listing_root = Path(workspace)
         listing_rel = rel_path
-        try:
-            entries = list_dir(listing_root, listing_rel)
-        except (FileNotFoundError, ValueError):
-            mirror = _docker_sandbox_mirror_target(rel_path)
-            if mirror is None:
-                raise
+        mirror = (
+            _docker_sandbox_mirror_target(rel_path)
+            if str(rel_path).lstrip().startswith("/")
+            else None
+        )
+        if mirror is not None:
             listing_root, mirror_target, container_root = mirror
             listing_rel = mirror_target.relative_to(listing_root).as_posix() or "."
             entries = list_dir(listing_root, listing_rel)
@@ -18049,6 +18049,21 @@ def _handle_list_dir(handler, parsed):
                 listing_root,
                 container_root,
             )
+        else:
+            try:
+                entries = list_dir(listing_root, listing_rel)
+            except FileNotFoundError:
+                mirror = _docker_sandbox_mirror_target(rel_path)
+                if mirror is None:
+                    raise
+                listing_root, mirror_target, container_root = mirror
+                listing_rel = mirror_target.relative_to(listing_root).as_posix() or "."
+                entries = list_dir(listing_root, listing_rel)
+                entries = _virtualize_docker_mirror_entries(
+                    entries,
+                    listing_root,
+                    container_root,
+                )
         return j(
             handler,
             {
@@ -21014,15 +21029,25 @@ def _handle_file_read(handler, parsed):
     if not rel:
         return bad(handler, "path is required")
     try:
-        try:
-            payload = read_file_content(Path(s.workspace), rel)
-        except (FileNotFoundError, ValueError):
-            mirror = _docker_sandbox_mirror_target(rel)
-            if mirror is None:
-                raise
+        mirror = (
+            _docker_sandbox_mirror_target(rel)
+            if str(rel).lstrip().startswith("/")
+            else None
+        )
+        if mirror is not None:
             mirror_root, mirror_target, _container_root = mirror
             mirror_rel = mirror_target.relative_to(mirror_root).as_posix() or "."
             payload = read_file_content(mirror_root, mirror_rel)
+        else:
+            try:
+                payload = read_file_content(Path(s.workspace), rel)
+            except FileNotFoundError:
+                mirror = _docker_sandbox_mirror_target(rel)
+                if mirror is None:
+                    raise
+                mirror_root, mirror_target, _container_root = mirror
+                mirror_rel = mirror_target.relative_to(mirror_root).as_posix() or "."
+                payload = read_file_content(mirror_root, mirror_rel)
         return j(handler, payload)
     except ImportError as e:
         return bad(handler, str(e), 503)

--- a/api/routes.py
+++ b/api/routes.py
@@ -10505,6 +10505,7 @@ from api.workspace import (
     read_file_content,
     read_authorized_escape_file_content,
     safe_resolve_ws,
+    resolve_docker_sandbox_mirror,
     raw_authorized_escape_target,
     resolve_trusted_workspace,
     resolve_implicit_workspace_with_recovery,
@@ -18032,12 +18033,27 @@ def _handle_list_dir(handler, parsed):
                 )
                 workspace = Path(persisted.workspace)
         rel_path = qs.get("path", ["."])[0]
-        entries = list_dir(Path(workspace), rel_path)
+        listing_root = Path(workspace)
+        listing_rel = rel_path
+        try:
+            entries = list_dir(listing_root, listing_rel)
+        except (FileNotFoundError, ValueError):
+            mirror = _docker_sandbox_mirror_target(rel_path)
+            if mirror is None:
+                raise
+            listing_root, mirror_target, container_root = mirror
+            listing_rel = mirror_target.relative_to(listing_root).as_posix() or "."
+            entries = list_dir(listing_root, listing_rel)
+            entries = _virtualize_docker_mirror_entries(
+                entries,
+                listing_root,
+                container_root,
+            )
         return j(
             handler,
             {
                 "entries": serialize_workspace_entries_for_browser(entries),
-                "signature": dir_signature(Path(workspace), rel_path, entries),
+                "signature": dir_signature(listing_root, listing_rel, entries),
                 "path": rel_path,
                 "workspace": str(workspace),
                 "workspace_recovered": recovered,
@@ -20707,6 +20723,44 @@ def _handle_media(handler, parsed):
     return _serve_file_bytes(handler, target, mime, disposition, cache_control, csp=csp)
 
 
+def _docker_sandbox_mirror_target(rel: str) -> tuple[Path, Path, str] | None:
+    """Return a contained host mirror target for an active persistent Docker profile."""
+    try:
+        terminal_cfg = (get_config() or {}).get("terminal", {})
+        return resolve_docker_sandbox_mirror(
+            get_active_hermes_home(),
+            terminal_cfg,
+            rel,
+        )
+    except Exception:
+        logger.debug("Failed to resolve Docker sandbox mirror path", exc_info=True)
+        return None
+
+
+def _virtualize_docker_mirror_entries(
+    entries: list[dict],
+    mirror_root: Path,
+    container_root: str,
+) -> list[dict]:
+    """Translate host mirror paths back to the paths recorded by the container."""
+    virtualized = []
+    for entry in entries:
+        item = dict(entry)
+        entry_path = str(item.get("path") or "").lstrip("/")
+        item["path"] = f"{container_root}/{entry_path}".rstrip("/")
+        target = item.get("target")
+        if target:
+            try:
+                target_rel = Path(str(target)).resolve().relative_to(mirror_root)
+                item["target"] = f"/{container_root}/{target_rel.as_posix()}".rstrip(
+                    "/"
+                )
+            except (OSError, RuntimeError, ValueError):
+                item.pop("target", None)
+        virtualized.append(item)
+    return virtualized
+
+
 def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:
     """Resolve /api/file/raw paths from the workspace or this session's uploads."""
     workspace_root = Path(session.workspace)
@@ -20726,9 +20780,21 @@ def _file_raw_target(session, sid: str, rel: str) -> tuple[Path, Path] | None:
         attachment_root = _session_attachment_dir(sid)
         attachment_target = safe_resolve(attachment_root, rel)
     except Exception:
-        return None
-    if attachment_target.exists() and attachment_target.is_file():
+        attachment_root = None
+        attachment_target = None
+    if (
+        attachment_root is not None
+        and attachment_target is not None
+        and attachment_target.exists()
+        and attachment_target.is_file()
+    ):
         return attachment_root, attachment_target
+
+    mirror = _docker_sandbox_mirror_target(rel)
+    if mirror is not None:
+        mirror_root, mirror_target, _container_root = mirror
+        if mirror_target.exists() and mirror_target.is_file():
+            return mirror_root, mirror_target
     return None
 
 
@@ -20948,7 +21014,16 @@ def _handle_file_read(handler, parsed):
     if not rel:
         return bad(handler, "path is required")
     try:
-        return j(handler, read_file_content(Path(s.workspace), rel))
+        try:
+            payload = read_file_content(Path(s.workspace), rel)
+        except (FileNotFoundError, ValueError):
+            mirror = _docker_sandbox_mirror_target(rel)
+            if mirror is None:
+                raise
+            mirror_root, mirror_target, _container_root = mirror
+            mirror_rel = mirror_target.relative_to(mirror_root).as_posix() or "."
+            payload = read_file_content(mirror_root, mirror_rel)
+        return j(handler, payload)
     except ImportError as e:
         return bad(handler, str(e), 503)
     except (FileNotFoundError, ValueError) as e:

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -1014,6 +1014,70 @@ def safe_resolve_ws(root: Path, requested: str) -> Path:
     return resolved
 
 
+_DOCKER_PERSISTENT_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def resolve_docker_sandbox_mirror(
+    profile_home: Path,
+    terminal_cfg: dict | None,
+    requested: str,
+) -> tuple[Path, Path, str] | None:
+    """Resolve a persistent Docker container path to its host-side mirror.
+
+    Hermes records paths as ``/root/...`` or ``/workspace/...`` while the
+    persistent Docker backend stores those files below the active profile's
+    ``sandboxes/docker/default`` directory. Only those two container roots are
+    mapped, and the returned target is resolved through the normal workspace
+    containment guard so mirror symlinks cannot escape their mount root.
+    """
+    if not isinstance(terminal_cfg, dict):
+        return None
+    backend = str(
+        terminal_cfg.get("backend") or terminal_cfg.get("env_type") or ""
+    ).strip().lower()
+    if backend != "docker":
+        return None
+
+    persistent = terminal_cfg.get("container_persistent", True)
+    if isinstance(persistent, bool):
+        persistent_enabled = persistent
+    elif isinstance(persistent, (int, float)):
+        persistent_enabled = persistent == 1
+    else:
+        persistent_enabled = (
+            str(persistent).strip().lower() in _DOCKER_PERSISTENT_TRUE_VALUES
+        )
+    if not persistent_enabled:
+        return None
+
+    raw = str(requested or "").strip()
+    if not raw or "\x00" in raw or "\\" in raw:
+        return None
+    parts = raw.lstrip("/").split("/")
+    if not parts or parts[0] not in {"root", "workspace"}:
+        return None
+    if any(part == ".." for part in parts[1:]):
+        return None
+    relative_parts = [part for part in parts[1:] if part not in {"", "."}]
+    relative = "/".join(relative_parts) or "."
+
+    mount_name = "home" if parts[0] == "root" else "workspace"
+    configured_sandbox_dir = terminal_cfg.get("sandbox_dir") or os.getenv(
+        "TERMINAL_SANDBOX_DIR"
+    )
+    sandbox_root = (
+        Path(str(configured_sandbox_dir)).expanduser()
+        if configured_sandbox_dir
+        else Path(profile_home).expanduser() / "sandboxes"
+    )
+    mirror_root = (sandbox_root / "docker" / "default" / mount_name).resolve()
+    try:
+        target = safe_resolve_ws(mirror_root, relative)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return mirror_root, target, parts[0]
+
+
 # ── Race-safe (TOCTOU) anchored open ─────────────────────────────────────────
 # safe_resolve_ws() validates a path, but if callers then re-open by pathname a
 # symlink swapped in AFTER the check could still escape the workspace. To close

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -417,6 +417,16 @@ Both are documented in `api/startup.py::fix_credential_permissions()`.
 
 If you must use a bind mount: pick a host path, then mount it to `/opt/hermes` in the agent container AND `/home/hermeswebui/.hermes/hermes-agent` in the WebUI container.
 
+### Docker terminal artifacts outside the session workspace
+
+When the Hermes terminal backend uses persistent Docker storage, artifacts
+recorded under `/root/...` or `/workspace/...` can be opened from the WebUI file
+browser. The file routes map those container paths to the active profile's
+host-side sandbox mirror, including a custom `TERMINAL_SANDBOX_DIR`, while
+preserving the same containment and symlink checks used for ordinary workspace
+files. Other absolute container paths and non-persistent Docker filesystems are
+not exposed through this fallback.
+
 ### 5. "Tools (git, node, etc.) missing in two-container setup" (#681)
 
 **Symptom**: You ask the agent to run `git status` in chat and it errors with `command not found`.
@@ -627,6 +637,7 @@ volumes:
 - #668 — auto-detect UID/GID from mounted volume
 - #569 — UID/GID detection priority order
 - #7027 — state dir probed before `/workspace` in UID/GID detection (see [#9 above](#9-failed-to-verify-state-directory--restart-loop-on-a-bind-mounted-state-dir-7027))
+- #7097 — persistent Docker terminal artifacts outside the session workspace
 
 If you hit a new failure mode not covered here, please [open an issue](https://github.com/nesquena/hermes-webui/issues/new) with:
 

--- a/tests/test_issue7097_docker_artifact_mirror.py
+++ b/tests/test_issue7097_docker_artifact_mirror.py
@@ -1,5 +1,6 @@
 """Regression coverage for Docker-sandbox artifact browsing (#7097)."""
 
+from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import urlencode, urlparse
 
@@ -30,6 +31,11 @@ def _configure_docker_mirror(
 ):
     monkeypatch.delenv("TERMINAL_SANDBOX_DIR", raising=False)
     monkeypatch.setattr(routes, "get_active_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(
+        routes,
+        "resolve_implicit_workspace_with_recovery",
+        lambda stored_workspace, _get_last_workspace: (Path(stored_workspace), False),
+    )
     monkeypatch.setattr(
         routes,
         "get_config",

--- a/tests/test_issue7097_docker_artifact_mirror.py
+++ b/tests/test_issue7097_docker_artifact_mirror.py
@@ -1,0 +1,362 @@
+"""Regression coverage for Docker-sandbox artifact browsing (#7097)."""
+
+from types import SimpleNamespace
+from urllib.parse import urlencode, urlparse
+
+import pytest
+
+from api import routes
+
+
+def _capture_json(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, **_kwargs: (payload, status),
+    )
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, message, status=400, **_kwargs: ({"error": message}, status),
+    )
+
+
+def _configure_docker_mirror(
+    monkeypatch,
+    profile_home,
+    *,
+    backend="docker",
+    persistent=True,
+):
+    monkeypatch.delenv("TERMINAL_SANDBOX_DIR", raising=False)
+    monkeypatch.setattr(routes, "get_active_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(
+        routes,
+        "get_config",
+        lambda: {
+            "terminal": {
+                "backend": backend,
+                "container_persistent": persistent,
+            }
+        },
+    )
+
+
+def _parsed(route_path, **query):
+    return urlparse(f"{route_path}?{urlencode(query)}")
+
+
+@pytest.mark.parametrize("request_path", ["root/subdir", "/root/subdir"])
+def test_list_dir_falls_back_to_default_profile_docker_home_mirror(
+    tmp_path,
+    monkeypatch,
+    request_path,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "home" / "subdir"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "artifact.py").write_text("print('ok')", encoding="utf-8")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session", lambda _sid: session)
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_list_dir(
+        object(),
+        _parsed("/api/list", session_id="session-1", path=request_path),
+    )
+
+    assert status == 200
+    assert [entry["name"] for entry in payload["entries"]] == ["artifact.py"]
+    assert payload["entries"][0]["path"] == "root/subdir/artifact.py"
+    assert payload["path"] == request_path
+
+    opened, opened_status = routes._handle_file_read(
+        object(),
+        _parsed(
+            "/api/file",
+            session_id="session-1",
+            path=payload["entries"][0]["path"],
+        ),
+    )
+    assert opened_status == 200
+    assert opened["content"] == "print('ok')"
+
+
+def test_file_read_uses_named_profile_docker_workspace_mirror(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes" / "profiles" / "work"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "workspace"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "report.md").write_bytes(b"# Docker artifact\n")
+    session = SimpleNamespace(workspace=str(workspace), profile="work")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-2", path="workspace/report.md"),
+    )
+
+    assert status == 200
+    assert payload["content"] == "# Docker artifact\n"
+    assert payload["path"] == "report.md"
+
+
+def test_file_raw_anchors_docker_artifact_to_mirror_root(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_root = profile_home / "sandboxes" / "docker" / "default" / "home"
+    target = mirror_root / "image.png"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"png")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+    monkeypatch.setattr(
+        routes,
+        "_serve_file_bytes",
+        lambda _handler, file_path, *_args, anchor_root=None, **_kwargs: {
+            "target": file_path,
+            "anchor_root": anchor_root,
+        },
+    )
+
+    result = routes._handle_file_raw(
+        object(),
+        _parsed("/api/file/raw", session_id="session-3", path="root/image.png"),
+    )
+
+    assert result["target"] == target.resolve()
+    assert result["anchor_root"] == mirror_root
+
+
+def test_workspace_path_keeps_precedence_over_docker_mirror(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    primary_dir = workspace / "root" / "subdir"
+    primary_dir.mkdir(parents=True)
+    (primary_dir / "primary.txt").write_text("primary", encoding="utf-8")
+    profile_home = tmp_path / "hermes"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "home" / "subdir"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "mirror.txt").write_text("mirror", encoding="utf-8")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session", lambda _sid: session)
+
+    payload, status = routes._handle_list_dir(
+        object(),
+        _parsed("/api/list", session_id="session-4", path="root/subdir"),
+    )
+
+    assert status == 200
+    assert [entry["name"] for entry in payload["entries"]] == ["primary.txt"]
+
+
+@pytest.mark.parametrize(
+    ("backend", "persistent"),
+    [("local", True), ("docker", False)],
+)
+def test_docker_mirror_fallback_requires_persistent_docker_backend(
+    tmp_path,
+    monkeypatch,
+    backend,
+    persistent,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "home"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "secret.txt").write_text("not reachable", encoding="utf-8")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(
+        monkeypatch,
+        profile_home,
+        backend=backend,
+        persistent=persistent,
+    )
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-5", path="root/secret.txt"),
+    )
+
+    assert status == 404
+    assert "error" in payload
+
+
+def test_docker_mirror_symlink_escape_stays_blocked(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_root = profile_home / "sandboxes" / "docker" / "default" / "home"
+    mirror_root.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    link = mirror_root / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session", lambda _sid: session)
+
+    payload, status = routes._handle_list_dir(
+        object(),
+        _parsed("/api/list", session_id="session-6", path="root/escape"),
+    )
+
+    assert status == 404
+    assert "content" not in payload
+
+
+@pytest.mark.parametrize(
+    "terminal_cfg",
+    [
+        {"backend": "docker"},
+        {"env_type": "docker", "container_persistent": "true"},
+    ],
+)
+def test_docker_mirror_accepts_agent_default_and_legacy_backend_key(
+    tmp_path,
+    monkeypatch,
+    terminal_cfg,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "home"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "artifact.txt").write_bytes(b"artifact")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    monkeypatch.setattr(routes, "get_active_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(routes, "get_config", lambda: {"terminal": terminal_cfg})
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-7", path="root/artifact.txt"),
+    )
+
+    assert status == 200
+    assert payload["content"] == "artifact"
+
+
+def test_docker_mirror_respects_configured_sandbox_dir(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    sandbox_dir = tmp_path / "custom-sandboxes"
+    mirror_dir = sandbox_dir / "docker" / "default" / "home"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "artifact.txt").write_bytes(b"custom")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path / "wrong-sandboxes"))
+    monkeypatch.setattr(routes, "get_active_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(
+        routes,
+        "get_config",
+        lambda: {
+            "terminal": {
+                "backend": "docker",
+                "container_persistent": True,
+                "sandbox_dir": str(sandbox_dir),
+            }
+        },
+    )
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-8", path="root/artifact.txt"),
+    )
+
+    assert status == 200
+    assert payload["content"] == "custom"
+
+
+def test_docker_mirror_respects_environment_sandbox_dir(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    sandbox_dir = tmp_path / "environment-sandboxes"
+    mirror_dir = sandbox_dir / "docker" / "default" / "home"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "artifact.txt").write_bytes(b"environment")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(sandbox_dir))
+    monkeypatch.setattr(routes, "get_active_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(
+        routes,
+        "get_config",
+        lambda: {"terminal": {"backend": "docker", "container_persistent": True}},
+    )
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-8b", path="root/artifact.txt"),
+    )
+
+    assert status == 200
+    assert payload["content"] == "environment"
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "root/../workspace/secret.txt",
+        "root/subdir\\secret.txt",
+        "other/secret.txt",
+    ],
+)
+def test_docker_mirror_rejects_ambiguous_or_traversal_paths(
+    tmp_path,
+    monkeypatch,
+    request_path,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_dir = profile_home / "sandboxes" / "docker" / "default" / "workspace"
+    mirror_dir.mkdir(parents=True)
+    (mirror_dir / "secret.txt").write_bytes(b"secret")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-9", path=request_path),
+    )
+
+    assert status == 404
+    assert "content" not in payload

--- a/tests/test_issue7097_docker_artifact_mirror.py
+++ b/tests/test_issue7097_docker_artifact_mirror.py
@@ -165,6 +165,38 @@ def test_workspace_path_keeps_precedence_over_docker_mirror(tmp_path, monkeypatc
     assert [entry["name"] for entry in payload["entries"]] == ["primary.txt"]
 
 
+def test_file_read_does_not_fall_back_after_workspace_validation_error(
+    tmp_path,
+    monkeypatch,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "hermes"
+    mirror_root = profile_home / "sandboxes" / "docker" / "default" / "home"
+    mirror_root.mkdir(parents=True)
+    (mirror_root / "oversized.txt").write_text("mirror", encoding="utf-8")
+    session = SimpleNamespace(workspace=str(workspace), profile="default")
+
+    _capture_json(monkeypatch)
+    _configure_docker_mirror(monkeypatch, profile_home)
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda _sid: session)
+
+    def _read_file_content(root, rel):
+        if str(root) == str(workspace):
+            raise ValueError("File too large")
+        return {"path": rel, "content": "mirror"}
+
+    monkeypatch.setattr(routes, "read_file_content", _read_file_content)
+
+    payload, status = routes._handle_file_read(
+        object(),
+        _parsed("/api/file", session_id="session-validation", path="root/oversized.txt"),
+    )
+
+    assert status == 404
+    assert payload["error"] == "File too large"
+
+
 @pytest.mark.parametrize(
     ("backend", "persistent"),
     [("local", True), ("docker", False)],


### PR DESCRIPTION
Fixes #7097

## Thinking Path
- Persistent Docker stores agent artifacts under host-side mirrors for container paths `/root/...` and `/workspace/...`, while the WebUI file APIs currently resolve only the session workspace.
- The active profile and configured sandbox directory determine the mirror location, and the shared persistent container uses the `default` task directory.
- Add one shared, fail-closed resolver and reuse it across directory listing, text reads, and raw file serving.
- Preserve existing workspace and attachment precedence; rewrite mirrored listing paths back to container-facing paths so list-then-open works.

## What Changed
- Map persistent Docker `/root` and `/workspace` paths to the active profile's host sandbox mirror.
- Honor `terminal.sandbox_dir`, then `TERMINAL_SANDBOX_DIR`, then the profile default.
- Keep ordinary workspace paths and session attachments first in resolution order.
- Virtualize mirrored directory-entry paths and safe in-mirror symlink targets.
- Reuse existing containment, symlink, and anchored-read safeguards; reject traversal, backslash, unsupported roots, and non-persistent Docker storage.
- Add regression coverage for default and named profiles, list-to-open round trips, raw reads, overrides, controls, hostile paths, and symlink escapes.
- Document the behavior in `docs/docker.md`.

## Why It Matters
Agent-generated Docker artifacts are persisted on the host but were previously shown as unreadable 404 entries in the WebUI. This restores the expected file-browser and preview flow without exposing arbitrary container paths or weakening workspace containment.

## Verification
- Baseline issue regression: 4 failed, 3 passed, 1 skipped before the fix.
- Focused regression after the fix: 14 passed, 1 skipped on Windows (the skipped case requires creating a symlink, unavailable under the current Windows permissions).
- Neighboring file/workspace regression suites: 109 passed, 12 skipped, 1 deselected.
- `scripts/ruff_lint.py --diff origin/master`: no new violations on added or modified lines.
- `python -m compileall -q api`: passed.
- `git diff --check origin/master...HEAD`: passed.
- The local Docker daemon was unavailable; Linux anchored symlink coverage remains authoritative in CI.

## Contract Routing
- Task type: bounded Docker/workspace bug fix.
- Touched surfaces: workspace resolution plus read-only file list/text/raw APIs and Docker documentation.
- Relevant guidance: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, and `docs/docker.md`.
- Scope: read-only artifact access; no write or folder-download behavior changed; no new public endpoint added.

## Risks / Follow-ups
- The resolver intentionally targets the profile-shared persistent Docker task mirror (`docker/default`), matching Hermes Agent's current backend behavior.
- Explicit `/workspace` bind mounts continue through the existing session-workspace path; arbitrary custom container volumes are not inferred.
- Hosted CI should validate the Linux anchored-open and symlink-escape paths.

## Model Used
OpenAI GPT-5 (Codex coding agent), with human review of the resulting diff and test output.

## Release Note
Persistent Docker artifacts written under `/root` or `/workspace` can now be opened from the WebUI file browser while preserving path containment protections.