### PR TITLE
gateway chat: persist usage and context-window fields on the session

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1465,8 +1465,15 @@ def _run_gateway_chat_streaming(
                 # the real compressor; 75% of the window is the same default
                 # ContextCompressor derives, so the tooltip stops lying about
                 # nothing rather than claiming a precise number we do not have.
+                #
+                # `getattr(..., 0) or 0` treated an authoritative 0 - just
+                # persisted a few lines up when the wire sent
+                # threshold_tokens: 0 - identically to "never set", and
+                # clobbered it with this fabricated default. api/models.py's
+                # Session defaults threshold_tokens to None, so check identity
+                # against that instead of truthiness against 0.
                 _gw_cl_now = getattr(s, "context_length", 0) or 0
-                if _gw_cl_now > 0 and not (getattr(s, "threshold_tokens", 0) or 0):
+                if _gw_cl_now > 0 and getattr(s, "threshold_tokens", None) is None:
                     s.threshold_tokens = int(_gw_cl_now * 0.75)
             except Exception:
                 pass
@@ -1557,7 +1564,12 @@ def _run_gateway_chat_streaming(
         try:
             for _ck in ("context_length", "threshold_tokens"):
                 _cv = getattr(s, _ck, 0) or 0
-                if isinstance(_cv, (int, float)) and _cv > 0 and not usage.get(_ck):
+                # `_ck not in usage`, not `not usage.get(_ck)`: threshold_tokens
+                # can be a real, already-correct 0 in `usage` (the wire wrote it
+                # a few lines up in the try block above), and a truthiness check
+                # would treat that the same as "gateway never sent this field"
+                # and stomp it with the session's fabricated 75% default.
+                if isinstance(_cv, (int, float)) and _cv > 0 and _ck not in usage:
                     usage[_ck] = int(_cv)
         except Exception:
             pass

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -397,6 +398,12 @@ def _gateway_sse_reasoning_delta(payload: dict) -> str:
         return ""
 
 
+# last_prompt_tokens/threshold_tokens: presence, not truthiness, decides
+# whether a frame's value replaces the running one - see the comment in
+# _gateway_stream_usage(). Shared so every merge site agrees with the parser.
+_CONTEXT_RING_PRESENCE_KEYS = frozenset({"last_prompt_tokens", "threshold_tokens"})
+
+
 def _gateway_stream_usage(payload: dict) -> dict:
     usage = payload.get("usage") if isinstance(payload, dict) else None
     if not isinstance(usage, dict):
@@ -418,8 +425,23 @@ def _gateway_stream_usage(payload: dict) -> dict:
         return 0
 
     try:
-        _cost = usage.get("estimated_cost") or usage.get("estimated_cost_usd") or 0
-        if not isinstance(_cost, (int, float)):
+        _cost = usage.get("estimated_cost")
+        if _cost is None:
+            _cost = usage.get("estimated_cost_usd")
+        # Same relayed-provider-JSON trust boundary as _first_int above, but
+        # costs are legitimately floats so int() can't be the sanitizer here.
+        # A non-finite value (e.g. 1e999 -> +inf) used to survive isinstance()
+        # unchanged, get summed into the session total, and get persisted as
+        # `Infinity` - invalid JSON that then fails to json.loads() on session
+        # restore/list, so the session could no longer load at all. Reject
+        # bool (bool is an int subclass), any non-finite float, and negative
+        # values; keep only a real, usable, non-negative cost.
+        if (
+            isinstance(_cost, bool)
+            or not isinstance(_cost, (int, float))
+            or not math.isfinite(_cost)
+            or _cost < 0
+        ):
             _cost = 0
     except Exception:
         _cost = 0
@@ -432,6 +454,13 @@ def _gateway_stream_usage(payload: dict) -> dict:
     # omits them, and a zero here would overwrite a good session value
     # downstream. Routed through _first_int on purpose - this is the same trust
     # boundary where a bare int() used to cost the turn its transcript.
+    #
+    # last_prompt_tokens/threshold_tokens are presence-sensitive rather than
+    # truthiness-sensitive: the producing gateway's ContextCompressor clamps
+    # its post-compaction sentinel to a real 0 (see hermes-agent#105905), so
+    # an explicit 0 is a meaningful "just compacted" signal, not "no data".
+    # `_val:` alone can't tell that apart from "key absent" (also 0), so those
+    # two check `usage` directly for key presence.
     for _extra in (
         "cache_read_tokens",
         "cache_write_tokens",
@@ -439,7 +468,19 @@ def _gateway_stream_usage(payload: dict) -> dict:
         "threshold_tokens",
     ):
         _val = _first_int(_extra)
-        if _val:
+        # "Present" means a real, usable number, not merely a key in the
+        # payload: junk (a string, a nested dict, an overflowing/NaN float)
+        # must be dropped exactly like _first_int already drops it for the
+        # billing counters, not treated as an authoritative explicit-zero.
+        _raw = usage.get(_extra)
+        _explicit_zero = (
+            _extra in _CONTEXT_RING_PRESENCE_KEYS
+            and isinstance(_raw, (int, float))
+            and not isinstance(_raw, bool)
+            and math.isfinite(_raw)
+            and _raw >= 0
+        )
+        if _val or _explicit_zero:
             out[_extra] = _val
     return out
 
@@ -707,7 +748,7 @@ def _run_gateway_runs_api_streaming(
                     final_text = output
                     if stream_id in STREAM_PARTIAL_TEXT:
                         STREAM_PARTIAL_TEXT[stream_id] = output
-                usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
+                usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v or k in _CONTEXT_RING_PRESENCE_KEYS})
                 sse_event = "message"
                 continue
             if payload_event == "run.failed":
@@ -730,7 +771,7 @@ def _run_gateway_runs_api_streaming(
                 if stream_id in STREAM_PARTIAL_TEXT:
                     STREAM_PARTIAL_TEXT[stream_id] += delta
                 put_gateway_event("token", {"text": delta})
-            usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
+            usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v or k in _CONTEXT_RING_PRESENCE_KEYS})
     return final_text, usage
 
 
@@ -1217,8 +1258,8 @@ def _run_gateway_chat_streaming(
                         if stream_id in STREAM_PARTIAL_TEXT:
                             STREAM_PARTIAL_TEXT[stream_id] += delta
                         put_gateway_event("token", {"text": delta})
-                    usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
-            usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
+                    usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v or k in _CONTEXT_RING_PRESENCE_KEYS})
+            usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v or k in _CONTEXT_RING_PRESENCE_KEYS})
         assistant_text = final_text.strip()
         if terminal_error:
             error_payload = _settle_gateway_terminal_error(
@@ -1337,7 +1378,6 @@ def _run_gateway_chat_streaming(
             # fallback further down needs this turn's slice; handing it the
             # cumulative sum makes the context ring climb every turn, which is
             # the exact regression #1436 introduced last_prompt_tokens to stop.
-            _turn_input_tokens = usage.get("input_tokens") or 0
             for _uk in (
                 "input_tokens",
                 "output_tokens",
@@ -1368,25 +1408,31 @@ def _run_gateway_chat_streaming(
             # last_prompt_tokens from the gateway process is the real fix and
             # supersedes this heuristic.
             try:
-                # Preferred: the gateway now reports the compressor's own
-                # last_prompt_tokens - the single most recent real prompt, correct
-                # on tool turns too. Fall back to the tool-free heuristic when
-                # talking to an older gateway that does not send it.
-                _gw_wire = usage.get("last_prompt_tokens") or 0
-                if isinstance(_gw_wire, (int, float)) and _gw_wire > 0:
-                    s.last_prompt_tokens = int(_gw_wire)
-                else:
-                    _gw_prompt = _turn_input_tokens
-                    _gw_tool_calls = STREAM_LIVE_TOOL_CALLS.get(stream_id) or []
-                    if (
-                        isinstance(_gw_prompt, (int, float))
-                        and _gw_prompt > 0
-                        and not _gw_tool_calls
-                    ):
-                        s.last_prompt_tokens = int(_gw_prompt)
-                _gw_thresh = usage.get("threshold_tokens") or 0
-                if isinstance(_gw_thresh, (int, float)) and _gw_thresh > 0:
-                    s.threshold_tokens = int(_gw_thresh)
+                # The gateway reports the compressor's own last_prompt_tokens -
+                # the single most recent real prompt, correct on tool turns too
+                # (hermes-agent#105905). Trust it outright on presence, INCLUDING
+                # an explicit 0 (the compressor's post-compaction clamp) - do not
+                # fall back to a heuristic when the wire value is there.
+                #
+                # An older gateway that omits the key entirely leaves this
+                # branch untaken and the previous numerator stands. There used
+                # to be a tool-free fallback here keyed on "no tool-progress
+                # events observed for this stream_id" - but an empty
+                # STREAM_LIVE_TOOL_CALLS entry only proves no progress events
+                # were *received*; a gateway/proxy that doesn't emit them can
+                # still have run multiple tool calls, and this side has no
+                # authoritative per-turn call count to tell the difference. A
+                # confidently wrong numerator is worse than a stale one, so an
+                # absent key now leaves last_prompt_tokens/threshold_tokens
+                # untouched rather than guess.
+                if "last_prompt_tokens" in usage:
+                    _gw_wire = usage.get("last_prompt_tokens") or 0
+                    if isinstance(_gw_wire, (int, float)):
+                        s.last_prompt_tokens = int(_gw_wire)
+                if "threshold_tokens" in usage:
+                    _gw_thresh = usage.get("threshold_tokens") or 0
+                    if isinstance(_gw_thresh, (int, float)):
+                        s.threshold_tokens = int(_gw_thresh)
             except Exception:
                 pass
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1475,6 +1475,19 @@ def _run_gateway_chat_streaming(
             )
         from api.streaming import _session_payload_with_full_messages
         gateway_session_payload = _session_payload_with_full_messages(s, tool_calls=[])
+        # The context ring reads its denominator off `usage`, not off the
+        # session (static/ui.js: `usage.context_length || DEFAULT_CTX`). It does
+        # try to backfill from the browser's cached session, but on a session's
+        # FIRST turn that cache predates the value we just persisted, so the ring
+        # silently divides by 128K - a 1M model then reads 20% at 26k and crosses
+        # the compress-hint line at 6.5% of its real window. Send it explicitly.
+        try:
+            for _ck in ("context_length", "threshold_tokens"):
+                _cv = getattr(s, _ck, 0) or 0
+                if isinstance(_cv, (int, float)) and _cv > 0 and not usage.get(_ck):
+                    usage[_ck] = int(_cv)
+        except Exception:
+            pass
         put_gateway_event("done", {"session": redact_session_data(gateway_session_payload), "usage": usage})
         put_gateway_event("stream_end", {"session_id": session_id})
     except urllib.error.HTTPError as exc:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -401,11 +401,47 @@ def _gateway_stream_usage(payload: dict) -> dict:
     usage = payload.get("usage") if isinstance(payload, dict) else None
     if not isinstance(usage, dict):
         return {}
-    return {
-        "input_tokens": int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0),
-        "output_tokens": int(usage.get("completion_tokens") or usage.get("output_tokens") or 0),
-        "estimated_cost": usage.get("estimated_cost") or usage.get("estimated_cost_usd") or 0,
+
+    def _first_int(*keys) -> int:
+        # Provider JSON relayed verbatim by the gateway. A string, dict or
+        # overflowing token count used to raise here, inside the SSE read loop,
+        # where the outer `except Exception` turns it into "Gateway request
+        # failed" - the whole turn's transcript discarded over one bad usage
+        # field. Skip the junk, keep the turn.
+        for key in keys:
+            try:
+                value = int(usage.get(key) or 0)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if value:
+                return value
+        return 0
+
+    try:
+        _cost = usage.get("estimated_cost") or usage.get("estimated_cost_usd") or 0
+        if not isinstance(_cost, (int, float)):
+            _cost = 0
+    except Exception:
+        _cost = 0
+    out = {
+        "input_tokens": _first_int("prompt_tokens", "input_tokens"),
+        "output_tokens": _first_int("completion_tokens", "output_tokens"),
+        "estimated_cost": _cost,
     }
+    # Hermes gateway extras, added only when actually sent: an older gateway
+    # omits them, and a zero here would overwrite a good session value
+    # downstream. Routed through _first_int on purpose - this is the same trust
+    # boundary where a bare int() used to cost the turn its transcript.
+    for _extra in (
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "last_prompt_tokens",
+        "threshold_tokens",
+    ):
+        _val = _first_int(_extra)
+        if _val:
+            out[_extra] = _val
+    return out
 
 
 def _gateway_reasoning_delta(payload: dict) -> str:
@@ -1052,6 +1088,15 @@ def _run_gateway_chat_streaming(
                 "stream": True,
                 "messages": [*prefill_messages, {"role": "user", "content": message_content}],
             }
+            # Strip @provider:model prefix (same as runs API path)
+            _body_model = body.get("model", "") or ""
+            if _body_model.startswith("@"):
+                try:
+                    _bare, _provider_hint = _body_model[1:].rsplit(":", 1)
+                    if _provider_hint.strip():
+                        body["model"] = _provider_hint.strip()
+                except ValueError:
+                    pass
             if model_provider:
                 body["provider"] = model_provider
             if reasoning_effort is not None:
@@ -1275,6 +1320,83 @@ def _run_gateway_chat_streaming(
             s.workspace = str(workspace)
             s.model = model
             s.model_provider = model_provider
+            # Gateway turns build no in-process agent/compressor, so nothing else
+            # here ever wrote usage - it persisted 0 for every session. The
+            # terminal SSE chunk already carries it; the agent is fresh per
+            # request, so this is the turn's total and accumulates.
+            for _uk in ("input_tokens", "output_tokens", "estimated_cost"):
+                _uv = usage.get(_uk) or 0
+                if isinstance(_uv, (int, float)) and _uv > 0:
+                    setattr(s, _uk, (getattr(s, _uk, 0) or 0) + _uv)
+                # Report the persisted lifetime total, not this turn's slice:
+                # static/messages.js derives the per-turn badge by subtracting
+                # the pre-turn session total, so it needs cumulative numbers.
+                usage[_uk] = getattr(s, _uk, 0) or 0
+
+            # Context-ring fields (ui.js #1436). Numerator: the gateway sums
+            # usage across the turn's API calls, so it equals the real prompt
+            # size ONLY on a tool-free turn; on a 3-call tool turn it triples
+            # and would light the red "compress now" nag. Hence the gate below.
+            # ponytail: tool turns keep the previous (stale) numerator, and a
+            # tool-using first turn gets none at all - under-reporting, which is
+            # always safe here (never a false nag). Reading the compressor's own
+            # last_prompt_tokens from the gateway process is the real fix and
+            # supersedes this heuristic.
+            try:
+                # Preferred: the gateway now reports the compressor's own
+                # last_prompt_tokens - the single most recent real prompt, correct
+                # on tool turns too. Fall back to the tool-free heuristic when
+                # talking to an older gateway that does not send it.
+                _gw_wire = usage.get("last_prompt_tokens") or 0
+                if isinstance(_gw_wire, (int, float)) and _gw_wire > 0:
+                    s.last_prompt_tokens = int(_gw_wire)
+                else:
+                    _gw_prompt = usage.get("input_tokens") or 0
+                    _gw_tool_calls = STREAM_LIVE_TOOL_CALLS.get(stream_id) or []
+                    if (
+                        isinstance(_gw_prompt, (int, float))
+                        and _gw_prompt > 0
+                        and not _gw_tool_calls
+                    ):
+                        s.last_prompt_tokens = int(_gw_prompt)
+                _gw_thresh = usage.get("threshold_tokens") or 0
+                if isinstance(_gw_thresh, (int, float)) and _gw_thresh > 0:
+                    s.threshold_tokens = int(_gw_thresh)
+            except Exception:
+                pass
+
+            # Denominator: without context_length ui.js divides by
+            # DEFAULT_CTX = 128*1024 and mis-sizes the ring for every 1M model.
+            try:
+                if not (getattr(s, "context_length", 0) or 0):
+                    from api.routes import _resolve_context_length_for_session_model as _gw_ctx_resolve
+                    from api.routes import _session_context_length_lookup_state as _gw_ctx_state
+
+                    _gw_model = (model or "").strip()
+                    if _gw_model.startswith("@"):
+                        # '@openrouter:some/model' resolves to the 256K fallback;
+                        # the bare name does not. Same strip the request body does.
+                        try:
+                            _gw_model = _gw_model[1:].rsplit(":", 1)[-1].strip() or _gw_model
+                        except Exception:
+                            pass
+                    _m, _p, _b, _k = _gw_ctx_state(_gw_model, model_provider or "")
+                    _gw_ctx_len = _gw_ctx_resolve(_m, _p, base_url=_b, api_key=_k) or 0
+                    # 256000 is the resolver's "I do not know this model" default.
+                    # routes.py only re-resolves when context_length is falsy, so
+                    # persisting the fallback would make a wrong window permanent.
+                    if _gw_ctx_len > 0 and _gw_ctx_len != 256_000:
+                        s.context_length = int(_gw_ctx_len)
+                # Compression trigger for the "Auto-compress at X" tooltip
+                # (ui.js hides the line while this is falsy). The gateway owns
+                # the real compressor; 75% of the window is the same default
+                # ContextCompressor derives, so the tooltip stops lying about
+                # nothing rather than claiming a precise number we do not have.
+                _gw_cl_now = getattr(s, "context_length", 0) or 0
+                if _gw_cl_now > 0 and not (getattr(s, "threshold_tokens", 0) or 0):
+                    s.threshold_tokens = int(_gw_cl_now * 0.75)
+            except Exception:
+                pass
 
             def _restore_cancelled_success_writeback():
                 if pending_source == "process_wakeup":

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1088,15 +1088,23 @@ def _run_gateway_chat_streaming(
                 "stream": True,
                 "messages": [*prefill_messages, {"role": "user", "content": message_content}],
             }
-            # Strip @provider:model prefix (same as runs API path)
+            # Strip @provider:model prefix (same as runs API path). The grammar
+            # is delegated to the shared parser rather than split by hand: a
+            # bare rsplit(":", 1) eats the model's own tag
+            # (@openrouter:meta/llama-4:free -> "free") and a bare
+            # split(":", 1) eats a custom provider's host:port
+            # (@custom:myhost:8080:model). _split_provider_qualified_model
+            # already knows both shapes and its docstring names this path (#6722).
             _body_model = body.get("model", "") or ""
             if _body_model.startswith("@"):
                 try:
-                    _bare, _provider_hint = _body_model[1:].rsplit(":", 1)
-                    if _provider_hint.strip():
-                        body["model"] = _provider_hint.strip()
-                except ValueError:
-                    pass
+                    from api.routes import _split_provider_qualified_model
+
+                    _bare_model, _provider_hint = _split_provider_qualified_model(_body_model)
+                    if _provider_hint and _bare_model:
+                        body["model"] = _bare_model
+                except Exception:
+                    logger.debug("provider-qualified model strip failed", exc_info=True)
             if model_provider:
                 body["provider"] = model_provider
             if reasoning_effort is not None:
@@ -1324,7 +1332,24 @@ def _run_gateway_chat_streaming(
             # here ever wrote usage - it persisted 0 for every session. The
             # terminal SSE chunk already carries it; the agent is fresh per
             # request, so this is the turn's total and accumulates.
-            for _uk in ("input_tokens", "output_tokens", "estimated_cost"):
+            # Read the per-turn prompt size BEFORE the loop below rewrites
+            # usage["input_tokens"] into the lifetime total. The tool-free
+            # fallback further down needs this turn's slice; handing it the
+            # cumulative sum makes the context ring climb every turn, which is
+            # the exact regression #1436 introduced last_prompt_tokens to stop.
+            _turn_input_tokens = usage.get("input_tokens") or 0
+            for _uk in (
+                "input_tokens",
+                "output_tokens",
+                "estimated_cost",
+                # The cache split is parsed by _gateway_stream_usage and read by
+                # static/messages.js (6055/6134), which subtracts the pre-turn
+                # session total exactly as it does for input/output - so these
+                # have to be persisted and reported cumulatively too, or they
+                # read as zero after a reload.
+                "cache_read_tokens",
+                "cache_write_tokens",
+            ):
                 _uv = usage.get(_uk) or 0
                 if isinstance(_uv, (int, float)) and _uv > 0:
                     setattr(s, _uk, (getattr(s, _uk, 0) or 0) + _uv)
@@ -1351,7 +1376,7 @@ def _run_gateway_chat_streaming(
                 if isinstance(_gw_wire, (int, float)) and _gw_wire > 0:
                     s.last_prompt_tokens = int(_gw_wire)
                 else:
-                    _gw_prompt = usage.get("input_tokens") or 0
+                    _gw_prompt = _turn_input_tokens
                     _gw_tool_calls = STREAM_LIVE_TOOL_CALLS.get(stream_id) or []
                     if (
                         isinstance(_gw_prompt, (int, float))
@@ -1375,11 +1400,13 @@ def _run_gateway_chat_streaming(
                     _gw_model = (model or "").strip()
                     if _gw_model.startswith("@"):
                         # '@openrouter:some/model' resolves to the 256K fallback;
-                        # the bare name does not. Same strip the request body does.
-                        try:
-                            _gw_model = _gw_model[1:].rsplit(":", 1)[-1].strip() or _gw_model
-                        except Exception:
-                            pass
+                        # the bare name does not. Same shared strip as the
+                        # request body above, so both resolve the same lane.
+                        from api.routes import _split_provider_qualified_model as _gw_split
+
+                        _gw_bare, _gw_provider_hint = _gw_split(_gw_model)
+                        if _gw_provider_hint and _gw_bare:
+                            _gw_model = _gw_bare
                     _m, _p, _b, _k = _gw_ctx_state(_gw_model, model_provider or "")
                     _gw_ctx_len = _gw_ctx_resolve(_m, _p, base_url=_b, api_key=_k) or 0
                     # 256000 is the resolver's "I do not know this model" default.

--- a/docs/advanced-chat-setup.md
+++ b/docs/advanced-chat-setup.md
@@ -120,3 +120,39 @@ locally and want browser-originated chat to use the same runtime/tool path as
 messaging surfaces. Attachments, cancellation, approvals, and clarify prompts
 still follow WebUI's current compatibility path and may not match every messaging
 surface until the runtime-adapter migration is complete.
+
+### Usage and context-window accounting
+
+A gateway-backed session builds no in-process agent or `ContextCompressor`, so
+the only usage data it ever sees is what the OpenAI-compat terminal chunk
+carries. WebUI now persists that into durable per-session totals and forwards
+enough of it for the browser context ring to size itself correctly:
+
+- `input_tokens`, `output_tokens`, `estimated_cost`, `cache_read_tokens`, and
+  `cache_write_tokens` accumulate into session lifetime totals on every
+  terminal chunk. `static/messages.js` derives each turn's own badge by
+  subtracting the pre-turn session totals, so these fields are cumulative by
+  design, not per-turn.
+- `last_prompt_tokens` is the context ring's numerator. When the connected
+  gateway sends its own `last_prompt_tokens` (the compressor's most recent
+  real prompt size), WebUI uses that value directly — correct on tool turns
+  too. Against an older gateway that omits it, WebUI falls back to a
+  tool-free heuristic: this turn's `input_tokens` slice, used only when the
+  turn made no tool calls. A tool-using turn under that fallback leaves the
+  previous numerator in place rather than reporting a wrong one — safe
+  because it can only under-report, never trigger a false "compress now".
+- `context_length` (the ring's denominator) is resolved once per session from
+  the connected model/provider and persisted, so a browser reload does not
+  re-derive it. `256000` is the resolver's "unknown model" fallback and is
+  deliberately never persisted, so an unrecognized model can still resolve
+  correctly once its metadata becomes available instead of being pinned wrong
+  forever. `threshold_tokens` mirrors the gateway's real compression
+  threshold when sent, or defaults to 75% of `context_length` — the same
+  default `ContextCompressor` uses — so the "Auto-compress at X" tooltip has
+  a number instead of hiding.
+- `@provider:model` route hints are parsed with the shared
+  `_split_provider_qualified_model` grammar (`api/routes.py`, #6722) at both
+  the outgoing request body and the context-length lookup, so a model tag
+  with its own colon (`@openrouter:meta/llama-4:free`) or a custom provider
+  slug derived from a host:port authority
+  (`@custom:10.8.71.41:8080:Qwen3`) resolve to the same lane both places.

--- a/docs/advanced-chat-setup.md
+++ b/docs/advanced-chat-setup.md
@@ -133,14 +133,22 @@ enough of it for the browser context ring to size itself correctly:
   terminal chunk. `static/messages.js` derives each turn's own badge by
   subtracting the pre-turn session totals, so these fields are cumulative by
   design, not per-turn.
-- `last_prompt_tokens` is the context ring's numerator. When the connected
-  gateway sends its own `last_prompt_tokens` (the compressor's most recent
-  real prompt size), WebUI uses that value directly — correct on tool turns
-  too. Against an older gateway that omits it, WebUI falls back to a
-  tool-free heuristic: this turn's `input_tokens` slice, used only when the
-  turn made no tool calls. A tool-using turn under that fallback leaves the
-  previous numerator in place rather than reporting a wrong one — safe
-  because it can only under-report, never trigger a false "compress now".
+- `last_prompt_tokens` / `threshold_tokens` are presence-sensitive, not
+  truthiness-sensitive: an explicit `0` from the gateway (the compressor's
+  post-compaction clamp) is trusted outright and overwrites the previous
+  numerator, exactly like any other real value — WebUI can tell "genuinely
+  zero right now" apart from "this gateway never sent the field" only by
+  checking whether the key is present in the payload at all, so a plain
+  falsy check can't be used here the way it is for the billing/cache
+  counters above. A gateway that omits the key entirely (older versions
+  before hermes-agent#105905) leaves the previous numerator exactly where it
+  was; WebUI does not attempt to infer one from `input_tokens` or from
+  whether any tool-progress events were observed for the turn. That
+  inference used to exist and was removed: an empty tool-call list only
+  proves no tool-progress *events* arrived, not that no tools ran — a
+  gateway or intermediate proxy that doesn't emit those optional events
+  would report a multi-call aggregate as if it were a single real prompt,
+  which is a confidently wrong numerator and worse than a stale one.
 - `context_length` (the ring's denominator) is resolved once per session from
   the connected model/provider and persisted, so a browser reload does not
   re-derive it. `256000` is the resolver's "unknown model" fallback and is

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -1647,11 +1647,16 @@ def test_gateway_stream_usage_survives_junk_and_overflow():
     )
 
 
-def _run_gateway_turn(tmp_path, monkeypatch, session, usage_json, *, model="test-model"):
+def _run_gateway_turn(tmp_path, monkeypatch, session, usage_json, *, model="test-model", out=None):
     """Drive one gateway turn against a canned terminal usage block.
 
     Returns the request body the worker actually sent, so the provider-prefix
-    strip can be asserted from the wire rather than from an internal.
+    strip can be asserted from the wire rather than from an internal. Pass a
+    dict as `out` to also get the "done" SSE event's `usage` payload back via
+    out["done_usage"] - what static/ui.js's context ring actually reads on a
+    session's first turn, before the browser has any cached session to
+    backfill from (see the comment above the done-event backfill block in
+    api/gateway_chat.py).
     """
     captured = {}
 
@@ -1685,12 +1690,19 @@ def _run_gateway_turn(tmp_path, monkeypatch, session, usage_json, *, model="test
     session.pending_started_at = 123
     session.save()
     channel = create_stream_channel()
-    channel.subscribe()
+    subscriber = channel.subscribe()
     STREAMS[stream_id] = channel
 
     gateway_chat._run_gateway_chat_streaming(
         session.session_id, "hi", model, str(tmp_path), stream_id, [],
     )
+    if out is not None:
+        out["done_usage"] = None
+        while not subscriber.empty():
+            item = subscriber.get_nowait()
+            event, data = item[0], item[1]
+            if event == "done":
+                out["done_usage"] = (data or {}).get("usage")
     return captured.get("body", "")
 
 
@@ -1881,3 +1893,54 @@ def test_gateway_context_ring_trusts_explicit_zero_and_leaves_absent_field_untou
         "signal - the old numerator must stand, not a guess derived from "
         "input_tokens and an empty tool-call list"
     )
+
+
+def test_gateway_explicit_zero_threshold_survives_the_75_percent_default_and_done_event(
+    tmp_path, monkeypatch
+):
+    """threshold_tokens: 0 on the wire must reach BOTH the saved session and
+    the "done" event's usage payload untouched by the fabricated 75%-of-window
+    default - two separate spots downstream of the presence-sensitive parse
+    fix both re-introduced a truthiness check on an already-correct 0:
+
+      1. The "Auto-compress at X" tooltip default (`not (... or 0)`) treated
+         a persisted 0 as "never set" and overwrote it with
+         int(context_length * 0.75).
+      2. The done-event backfill (`not usage.get(_ck)`) treated a present-but-
+         zero usage["threshold_tokens"] the same way and replaced it with the
+         session's now-fabricated value.
+
+    A resolved positive context_length is required to reproduce both - the
+    75% default is a no-op without one.
+    """
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    s = new_session()
+    s.context_length = 1_000_000  # already resolved, so the denominator block no-ops
+    s.save()
+
+    out = {}
+    _run_gateway_turn(
+        tmp_path, monkeypatch, s,
+        '{"prompt_tokens":1000,"completion_tokens":10,"last_prompt_tokens":1000,"threshold_tokens":0}',
+        out=out,
+    )
+    saved = models.get_session(s.session_id)
+    assert saved.threshold_tokens == 0, "an explicit wire zero must not become the 750000 default"
+    assert out["done_usage"]["threshold_tokens"] == 0, (
+        "the done event ui.js reads on a session's first turn must carry the same "
+        "zero the session persisted, not a value backfilled from a stale default"
+    )
+
+    # Follow-up turn from an older gateway that omits the field entirely: the
+    # persisted zero must stand, not be reinterpreted as "unset" a turn later.
+    _run_gateway_turn(
+        tmp_path, monkeypatch, models.get_session(s.session_id),
+        '{"prompt_tokens":50,"completion_tokens":5}',
+    )
+    saved = models.get_session(s.session_id)
+    assert saved.threshold_tokens == 0, "an omitted field on a later turn must not revive the default"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -1694,16 +1694,18 @@ def _run_gateway_turn(tmp_path, monkeypatch, session, usage_json, *, model="test
     return captured.get("body", "")
 
 
-def test_gateway_tool_free_fallback_uses_this_turns_prompt_not_the_lifetime_total(tmp_path, monkeypatch):
-    """Second tool-free turn must not inherit the accumulated input total.
+def test_gateway_absent_last_prompt_tokens_never_inherits_the_billing_total(tmp_path, monkeypatch):
+    """An older gateway that never sends last_prompt_tokens must leave the
+    context-ring numerator alone across turns - never let it drift to the
+    cumulative billing total (regression #1436 originally introduced
+    last_prompt_tokens to stop this exact failure mode).
 
-    The accumulation loop rewrites usage["input_tokens"] into the session
-    lifetime total so static/messages.js can subtract the pre-turn value. The
-    older-gateway fallback then read that same key as "this turn's prompt", so
-    from turn two onwards the context ring's numerator was a running sum and
-    climbed toward a false "compress now" - the regression #1436 introduced
-    last_prompt_tokens to prevent. Turn one hides it (0 + n == n); turn two is
-    the test.
+    This used to be guarded by a tool-free heuristic keyed on
+    STREAM_LIVE_TOOL_CALLS being empty, which a maintainer re-gate flagged as
+    unreliable: an empty list only proves no tool-progress events were
+    *received*, not that no tools ran, on a gateway/proxy that omits those
+    optional events (defect #3). The fix removes the guess entirely - absent
+    means untouched, full stop.
     """
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
@@ -1712,17 +1714,18 @@ def test_gateway_tool_free_fallback_uses_this_turns_prompt_not_the_lifetime_tota
     monkeypatch.setattr(models, "SESSIONS", OrderedDict())
 
     s = new_session()
-    # No last_prompt_tokens: an older gateway, so the tool-free fallback runs.
+    # No last_prompt_tokens on the wire at all: an older gateway.
     _run_gateway_turn(tmp_path, monkeypatch, s, '{"prompt_tokens":1000,"completion_tokens":10}')
     saved = models.get_session(s.session_id)
-    assert saved.last_prompt_tokens == 1000
-    assert saved.input_tokens == 1000
+    assert saved.last_prompt_tokens is None, "no wire signal means no numerator, not a guess"
+    assert saved.input_tokens == 1000, "the billing total still accumulates independently"
 
     _run_gateway_turn(tmp_path, monkeypatch, saved, '{"prompt_tokens":1200,"completion_tokens":10}')
     saved = models.get_session(s.session_id)
-    assert saved.input_tokens == 2200, "billing total still accumulates"
-    assert saved.last_prompt_tokens == 1200, (
-        "context numerator must be this turn's prompt, not the 2200 lifetime sum"
+    assert saved.input_tokens == 2200, "billing total keeps accumulating"
+    assert saved.last_prompt_tokens is None, (
+        "must never silently become the 2200 lifetime sum just because two "
+        "tool-free-looking turns went by"
     )
 
 
@@ -1778,4 +1781,103 @@ def test_gateway_provider_prefix_strip_keeps_colon_tagged_and_host_port_models(t
     # (host:port) must not be mistaken for an eaten model-tag colon.
     assert _split_provider_qualified_model("@custom:10.8.71.41:8080:Qwen3") == (
         "Qwen3", "custom:10.8.71.41:8080",
+    )
+
+
+def test_gateway_stream_usage_rejects_non_finite_cost():
+    """estimated_cost: 1e999 becomes +inf in JSON, which then can't round-trip
+    through json.dumps for session persistence/restore - a poisoned session
+    that no longer loads in the browser. Reject non-finite, negative, and
+    bool costs at the parse boundary; a normal float still passes through.
+    """
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "estimated_cost": 1e999}}
+    )["estimated_cost"] == 0
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "estimated_cost": float("nan")}}
+    )["estimated_cost"] == 0
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "estimated_cost": -5.0}}
+    )["estimated_cost"] == 0
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "estimated_cost": True}}
+    )["estimated_cost"] == 0
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "estimated_cost": 0.42}}
+    )["estimated_cost"] == 0.42
+
+    import json as _json
+    _json.dumps(_gateway_stream_usage({"usage": {"estimated_cost": 1e999}}))
+
+
+def test_gateway_stream_usage_preserves_explicit_zero_context_ring_fields():
+    """The producing gateway's ContextCompressor clamps its post-compaction
+    sentinel to a real 0 (hermes-agent#105905's max(0, ...)). That 0 must
+    survive parsing as a present key, not collapse into "key absent" the way
+    a falsy check would - otherwise WebUI can't tell "just compacted, numerator
+    is genuinely 0" from "older gateway never sent this field at all".
+    """
+    present_zero = _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "last_prompt_tokens": 0, "threshold_tokens": 0}}
+    )
+    assert "last_prompt_tokens" in present_zero and present_zero["last_prompt_tokens"] == 0
+    assert "threshold_tokens" in present_zero and present_zero["threshold_tokens"] == 0
+
+    absent = _gateway_stream_usage({"usage": {"prompt_tokens": 1}})
+    assert "last_prompt_tokens" not in absent
+    assert "threshold_tokens" not in absent
+
+    # cache tokens keep the old truthy-only behaviour - they are billing
+    # totals accumulated frame-by-frame, not a context-ring presence signal,
+    # and the review didn't flag them.
+    assert "cache_read_tokens" not in _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 1, "cache_read_tokens": 0}}
+    )
+
+
+def test_gateway_context_ring_trusts_explicit_zero_and_leaves_absent_field_untouched(
+    tmp_path, monkeypatch
+):
+    """End-to-end through _run_gateway_chat_streaming: an explicit
+    last_prompt_tokens=0 (post-compaction) must overwrite a stale nonzero
+    numerator; an older gateway that omits the field entirely must leave the
+    previous numerator standing rather than have this side guess at one from
+    an empty tool-call list (defect #3 - unreliable tool-free inference).
+    """
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    s = new_session()
+    _run_gateway_turn(
+        tmp_path, monkeypatch, s,
+        '{"prompt_tokens":1000,"completion_tokens":10,"last_prompt_tokens":26257}',
+    )
+    saved = models.get_session(s.session_id)
+    assert saved.last_prompt_tokens == 26257
+
+    # Post-compaction turn: gateway sends an authoritative 0.
+    _run_gateway_turn(
+        tmp_path, monkeypatch, saved,
+        '{"prompt_tokens":50,"completion_tokens":5,"last_prompt_tokens":0}',
+    )
+    saved = models.get_session(s.session_id)
+    assert saved.last_prompt_tokens == 0, "an explicit 0 must be trusted, not treated as absent"
+
+    # Bump it back up, then simulate an older gateway that omits the field on
+    # a tool-free turn. Old behaviour would have inferred a fresh numerator
+    # from input_tokens using the empty-tool-call-list heuristic (defect #3);
+    # the fix leaves last_prompt_tokens exactly where it was instead.
+    saved.last_prompt_tokens = 26257
+    saved.save()
+    _run_gateway_turn(
+        tmp_path, monkeypatch, saved, '{"prompt_tokens":9000,"completion_tokens":10}',
+    )
+    saved = models.get_session(s.session_id)
+    assert saved.last_prompt_tokens == 26257, (
+        "no last_prompt_tokens on the wire means no authoritative per-turn "
+        "signal - the old numerator must stand, not a guess derived from "
+        "input_tokens and an empty tool-call list"
     )

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -1645,3 +1645,137 @@ def test_gateway_stream_usage_survives_junk_and_overflow():
     assert "threshold_tokens" not in _gateway_stream_usage(
         {"usage": {"prompt_tokens": 7, "threshold_tokens": "lots"}}
     )
+
+
+def _run_gateway_turn(tmp_path, monkeypatch, session, usage_json, *, model="test-model"):
+    """Drive one gateway turn against a canned terminal usage block.
+
+    Returns the request body the worker actually sent, so the provider-prefix
+    strip can be asserted from the wire rather than from an internal.
+    """
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"ok"}}],"usage":' + usage_json.encode() + b'}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = req.data.decode("utf-8")
+        return FakeResponse()
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
+        "status": "not_configured", "source": "none", "label": "",
+        "message_count": 0, "messages": [],
+    })
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+
+    stream_id = f"stream-{id(usage_json)}-{len(session.messages)}"
+    session.active_stream_id = stream_id
+    session.pending_user_message = "hi"
+    session.pending_attachments = []
+    session.pending_started_at = 123
+    session.save()
+    channel = create_stream_channel()
+    channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        session.session_id, "hi", model, str(tmp_path), stream_id, [],
+    )
+    return captured.get("body", "")
+
+
+def test_gateway_tool_free_fallback_uses_this_turns_prompt_not_the_lifetime_total(tmp_path, monkeypatch):
+    """Second tool-free turn must not inherit the accumulated input total.
+
+    The accumulation loop rewrites usage["input_tokens"] into the session
+    lifetime total so static/messages.js can subtract the pre-turn value. The
+    older-gateway fallback then read that same key as "this turn's prompt", so
+    from turn two onwards the context ring's numerator was a running sum and
+    climbed toward a false "compress now" - the regression #1436 introduced
+    last_prompt_tokens to prevent. Turn one hides it (0 + n == n); turn two is
+    the test.
+    """
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    s = new_session()
+    # No last_prompt_tokens: an older gateway, so the tool-free fallback runs.
+    _run_gateway_turn(tmp_path, monkeypatch, s, '{"prompt_tokens":1000,"completion_tokens":10}')
+    saved = models.get_session(s.session_id)
+    assert saved.last_prompt_tokens == 1000
+    assert saved.input_tokens == 1000
+
+    _run_gateway_turn(tmp_path, monkeypatch, saved, '{"prompt_tokens":1200,"completion_tokens":10}')
+    saved = models.get_session(s.session_id)
+    assert saved.input_tokens == 2200, "billing total still accumulates"
+    assert saved.last_prompt_tokens == 1200, (
+        "context numerator must be this turn's prompt, not the 2200 lifetime sum"
+    )
+
+
+def test_gateway_persists_the_cache_token_split_across_turns(tmp_path, monkeypatch):
+    """cache_read/cache_write are parsed, so they must also be persisted.
+
+    static/messages.js:6055/6134 derives the per-turn cache badge by
+    subtracting the pre-turn session totals, exactly as it does for
+    input/output - so these belong in the same cumulative accumulation, or a
+    reload shows zero.
+    """
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    s = new_session()
+    usage = '{"prompt_tokens":10,"completion_tokens":2,"cache_read_tokens":300,"cache_write_tokens":40}'
+    _run_gateway_turn(tmp_path, monkeypatch, s, usage)
+    _run_gateway_turn(tmp_path, monkeypatch, models.get_session(s.session_id), usage)
+
+    saved = models.get_session(s.session_id)
+    assert saved.cache_read_tokens == 600
+    assert saved.cache_write_tokens == 80
+
+
+def test_gateway_provider_prefix_strip_keeps_colon_tagged_and_host_port_models(tmp_path, monkeypatch):
+    """@provider:model must not lose the model's own colon segment.
+
+    rsplit(":", 1) turns "@openrouter:meta/llama-4:free" into "free"; a plain
+    split(":", 1) would instead turn "@custom:myhost:8080:m" into
+    "myhost:8080:m". The shared #6722 parser knows both grammars, so both the
+    request body and the context-length lookup delegate to it.
+    """
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    s = new_session()
+    body = _run_gateway_turn(
+        tmp_path, monkeypatch, s, '{"prompt_tokens":5,"completion_tokens":1}',
+        model="@openrouter:meta/llama-4:free",
+    )
+    assert json.loads(body)["model"] == "meta/llama-4:free"
+
+    from api.routes import _split_provider_qualified_model
+
+    assert _split_provider_qualified_model("@openrouter:meta/llama-4:free")[0] == "meta/llama-4:free"
+    # #1776's example: a custom-provider slug derived from base_url authority
+    # (host:port) must not be mistaken for an eaten model-tag colon.
+    assert _split_provider_qualified_model("@custom:10.8.71.41:8080:Qwen3") == (
+        "Qwen3", "custom:10.8.71.41:8080",
+    )

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -345,6 +345,16 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert isinstance(saved.messages[1]["timestamp"], float)
     assert saved.messages[0]["timestamp"] < saved.messages[1]["timestamp"]
     assert saved.active_stream_id is None
+    # Provider-reported usage must reach the session record; it persisted 0 for
+    # every gateway-backed session before this. last_prompt_tokens stays unset:
+    # gateway usage is summed across the turn's API calls, so it is a billing
+    # total, not the context size ui.js needs for the gauge (#1436).
+    assert saved.input_tokens == 4
+    assert saved.output_tokens == 2
+    # The fixture is a TOOL turn, so the gate deliberately leaves the context
+    # numerator unset: gateway usage is summed across the turn's API calls and
+    # would over-report the prompt size. Tool-free turns do set it.
+    assert not getattr(saved, "last_prompt_tokens", 0)
     assert stream_id not in STREAMS
     assert captured["url"] == "http://gateway.local/v1/chat/completions"
     assert captured["headers"]["Authorization"] == "Bearer secret-token"
@@ -1596,3 +1606,42 @@ def test_gateway_worker_skips_runs_api_when_opt_in_absent():
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
+
+
+def test_gateway_stream_usage_survives_junk_and_overflow():
+    """A bad provider token count must not cost the turn its transcript.
+
+    int() on a string/dict/overflowing usage field used to raise inside the SSE
+    read loop, where the outer `except Exception` converted it into "Gateway
+    request failed" and discarded everything the turn had streamed. Each junk
+    key must be skipped, and a good key later in the same chunk still wins.
+    """
+    from api.gateway_chat import _gateway_stream_usage
+
+    # Junk of every shape the wire can carry, including 1e999 -> inf.
+    assert _gateway_stream_usage({"usage": {"prompt_tokens": "not-a-number"}}) == {
+        "input_tokens": 0, "output_tokens": 0, "estimated_cost": 0,
+    }
+    assert _gateway_stream_usage({"usage": {"prompt_tokens": {"nested": 1}}})["input_tokens"] == 0
+    assert _gateway_stream_usage({"usage": {"prompt_tokens": 1e999}})["input_tokens"] == 0
+    assert _gateway_stream_usage({"usage": {"prompt_tokens": float("nan")}})["input_tokens"] == 0
+    # Junk in the first key must fall through to the good alias, not abort.
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": "junk", "input_tokens": 25546}}
+    )["input_tokens"] == 25546
+    # A non-numeric cost must not poison the whole dict either.
+    assert _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 7, "estimated_cost": "free"}}
+    ) == {"input_tokens": 7, "output_tokens": 0, "estimated_cost": 0}
+    # Hermes gateway extras appear only when sent, so an older gateway keeps the
+    # legacy three-key shape and cannot zero a good session value.
+    assert "last_prompt_tokens" not in _gateway_stream_usage({"usage": {"prompt_tokens": 7}})
+    _rich = _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 7, "last_prompt_tokens": 26194, "threshold_tokens": 750000}}
+    )
+    assert _rich["last_prompt_tokens"] == 26194
+    assert _rich["threshold_tokens"] == 750000
+    # Junk in an extra must be dropped, not raised and not written as garbage.
+    assert "threshold_tokens" not in _gateway_stream_usage(
+        {"usage": {"prompt_tokens": 7, "threshold_tokens": "lots"}}
+    )


### PR DESCRIPTION
## Problem

When `HERMES_WEBUI_CHAT_BACKEND=gateway`, turns are dispatched to `_run_gateway_chat_streaming` in `api/gateway_chat.py`. That path builds no in-process agent and no `ContextCompressor` — so nothing on it ever wrote usage onto the session. `input_tokens`, `last_prompt_tokens`, `threshold_tokens` and `context_length` stayed `0`/`None` for **every** gateway-backed session.

`static/ui.js` needs those to draw the context ring:

```js
const DEFAULT_CTX = 128*1024;
const ctxWindow   = usage.context_length || DEFAULT_CTX;
const rawPct      = hasPromptTok ? Math.round((contextPromptTok/ctxWindow)*100) : 0;
const compressText = pct>=75 ? t('ctx_compress_action') : (pct>=50 ? t('ctx_compress_hint') : '');
```

With `context_length` missing it divides by 128K. On a 1M-context model that means the user is prompted to compress at roughly **6%** of the real window. The reported symptom was *"every new session gets compacted context on the first message"* — no compaction was running; the gauge was measuring against the wrong denominator.

Measured on the affected host, same prompt: **20%** of a 128K default before, **2.62%** of the real 1,000,000 after.

## Changes

**`_gateway_stream_usage`** keeps the terminal chunk's usage and now carries the Hermes extras — cache read/write split, `last_prompt_tokens`, `threshold_tokens` — when the gateway sends them. They're emitted **only when non-zero**, so an older gateway keeps the legacy three-key shape and a zero can never overwrite a good session value.

**Writeback** accumulates the billing counters and reports the persisted lifetime total on the done event, which is what `static/messages.js` subtracts against to render the per-turn badge.

**`last_prompt_tokens`** prefers the gateway's compressor-sourced value, falling back to the turn's usage sum *only on a tool-free turn*, where that sum genuinely is the prompt size. On a tool turn the sum over-reports — measured **52,451 vs a real 26,257** — which is exactly what would light the red compress action.

**`context_length`** is seeded from the resolver `api/routes.py` already uses, with two guards:

- skips the resolver's `256000` unknown-model default, because `routes.py` only re-resolves while the field is falsy — persisting the fallback would make a wrong window **permanent**
- strips an `@provider:` prefix first, since the qualified form resolves to that same fallback while the bare name resolves correctly

## Also fixes live data loss on this path

`int()` on a provider usage field ran **inside the SSE read loop**:

```python
"input_tokens": int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0),
```

A string, dict, or overflowing token count raises there, the outer `except Exception` catches it, and the **entire turn's transcript is discarded** — surfacing to the user as "Gateway request failed". Reproduced by reverting the fix and watching the persistence test fail with `IndexError` on `saved.messages[-1]` (zero messages persisted).

`_first_int` skips the bad key and keeps the turn. `OverflowError` is in the except clause deliberately: `1e999` alone still lost turns without it.

## Tests

`tests/test_webui_gateway_chat_backend.py` — **43 passed**.

New coverage pins the crash class (string, dict, `NaN`, `1e999`), a good alias surviving a junk one, a non-numeric cost not poisoning the dict, and the legacy three-key shape being preserved when the gateway sends no extras.

A broader sweep (`-k "usage or context_length or gateway or session"`) gives 3084 passed / 13 failed, and all 13 fail identically on a pristine tree (`test_provider_mismatch.py` `UnboundLocalError`, plus browser tests needing a Playwright install).

## Note

The producing half — the gateway forwarding `last_prompt_tokens`/`threshold_tokens` on the OpenAI-compat finish chunk — is a separate change in `hermes-agent`. This PR degrades cleanly without it: the tool-free fallback still supplies a correct numerator on non-tool turns, and the extras are simply absent.
