### PR TITLE
worklog: stop reading a placeholder lifecycle row as a compression start

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4135,7 +4135,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         || (text.includes('compressed')&&!text.includes('compressing'))
       ) return 'compressed';
       if(
-        phase==='running'||phase==='compressing'
+        // NOT a bare phase==='running'. routes.py appends a placeholder
+        // "live anchor shell" row (role lifecycle, status running,
+        // source_event_type runtime_journal_snapshot) whenever a stream has
+        // events but no visible rows yet. That falls through the source check
+        // above, and a bare running phase then classified every such shell as
+        // a compression start - a permanent phantom "Compressing context"
+        // divider on sessions that never compressed anything.
+        phase==='compressing'
         || text.includes('compressing context')
         || text.includes('compacting context')
         || text.includes('preflight compression')


### PR DESCRIPTION
## Symptom

A brand-new session shows a **"Compressing context"** worklog divider on its very first message, with nothing being compressed. It survives a hard reload, and reappears on every new chat.

## Cause

`api/routes.py` appends a placeholder "live anchor shell" row whenever a stream has events but no visible rows projected yet:

```python
"row_id":            f"lifecycle:{stream_id}:running",
"role":              "lifecycle",
"status":            "running",
"text":              "Working",
"source_event_type": "runtime_journal_snapshot",
```

`_sourceEventTypeForSnapshotAnchorRow` deliberately skips the `source_event_type` branch for exactly that sentinel value, falls through to the role check, and the bare `phase==='running'` arm then classifies the shell as `'compressing'`:

```js
if(source && source!=='runtime_journal_snapshot') return source;   // falls through
…
if(phase==='running' || phase==='compressing' || …) return 'compressing';
```

So an empty placeholder becomes a compression start.

**It also persists.** That classification is written back into the session's `anchor_activity_scenes` as `source_event_type: "compressing"` — which the *first* branch then returns directly on the next load. The divider therefore survives reloads, which is why it looks permanent.

Measured on the affected host: **46 such rows across 24 sessions**, every one carrying the text `"Working"`, and not one of them a genuine compression notice. The gauge on those same sessions read 2.6% of a 1M window, so nothing was near a threshold.

## Fix

Require an explicit cue — `phase==='compressing'`, or one of the compression text markers already listed immediately below it (`compacting context`, `pre-api compression`, `context too large`, …).

The function's own comment already asked for this:

> `lifecycle_status` is shared by compressing + compressed. Prefer explicit cues; do not default every lifecycle row to a running compress divider.

The bare `phase==='running'` arm did precisely what that comment warns against. Nothing else in the branch changes, so real compression events — which arrive either with `phase: 'compressing'` or with one of those texts — still render exactly as before.

## Tests

`tests/test_compression_phantom_barrier.py` — **8 passed**.

Wider sweep (`-k "compress or lifecycle or anchor"`): 714 passed, 2 failed, and those 2 (`test_static_asset_compression_and_cache.py`, cache-header assertions) fail identically on a pristine tree.

## Note on already-affected sessions

Because the bad value is persisted, existing sessions keep showing the divider until their stored row is corrected — the code fix alone only prevents new ones. Operators can repair them by rewriting `source_event_type` from `"compressing"` back to `"runtime_journal_snapshot"` on rows whose `role` is `lifecycle`, `status` is `running`, and text is `"Working"`.
