### PR TITLE
Web Push notifications to wake a backgrounded PWA for approvals

### DIFF
--- a/api/push_notifications.py
+++ b/api/push_notifications.py
@@ -1,0 +1,209 @@
+"""Web Push notifications for the WebUI PWA.
+
+Local `Notification`/`reg.showNotification()` calls (see messages.js
+`_showPwaNotification`) only fire while the page or its service worker is
+actively alive -- on iOS specifically, a backgrounded/locked PWA gets no
+wake-up at all, so a time-sensitive prompt (an execute_code approval, most
+notably) can sit unseen until it times out no matter how long the timeout is.
+Web Push (RFC 8030 + VAPID) is the only mechanism that can wake a fully
+closed PWA, because delivery goes through the OS's own push service instead
+of the page's JS.
+
+OPTIONAL, same convention as edge-tts/psutil/docx in requirements.txt: needs
+`pywebpush` (`pip install pywebpush`). Absent, every function here degrades
+to a no-op -- approval flow and the existing foreground notifications are
+completely unaffected either way. VAPID keypair generation only needs
+`cryptography`, already a hard requirement, so the public-key endpoint works
+even without pywebpush installed; only the actual send is gated on it.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pywebpush import webpush, WebPushException
+    _HAVE_PYWEBPUSH = True
+except ImportError:
+    _HAVE_PYWEBPUSH = False
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+_vapid_lock = threading.Lock()
+_subs_lock = threading.Lock()
+
+
+def _webui_home() -> Path:
+    """Install-wide state dir -- deliberately NOT get_active_hermes_home().
+
+    That helper resolves per-request against whichever profile is currently
+    active (issue #798 per-request TLS context) -- fine for profile-owned
+    data, wrong here. A push subscription belongs to the physical
+    device/browser install, not to whatever profile happened to be active
+    in the tab when the user clicked "Enable notifications"; a subscription
+    filed under one profile's dir would be invisible to send_push_to_all()
+    when a *different* profile's session is the one raising the approval
+    that's supposed to wake the phone. Same fix api/extensions.py already
+    uses for its own profile-independent state.
+    """
+    try:
+        from api.config import STATE_DIR
+        return Path(STATE_DIR)
+    except Exception:
+        return Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(Path.home() / ".hermes" / "webui"))).expanduser()
+
+
+def _vapid_private_key_path() -> Path:
+    return _webui_home() / "push_vapid_private_key.pem"
+
+
+def _subscriptions_path() -> Path:
+    return _webui_home() / "push_subscriptions.json"
+
+
+def _generate_vapid_keypair_pem() -> bytes:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _public_b64url_from_pem(private_pem: bytes) -> str:
+    private_key = serialization.load_pem_private_key(private_pem, password=None)
+    public_raw = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.UncompressedPoint,
+    )
+    return base64.urlsafe_b64encode(public_raw).rstrip(b"=").decode("ascii")
+
+
+def ensure_vapid_keys() -> dict | None:
+    """Return {"private_key_path": str, "public_key": b64url str}.
+
+    Generates and persists a keypair on first call (0600, matching the
+    other secret-bearing files this profile writes). A stable keypair is
+    required -- the browser's PushSubscription is bound to the public key
+    it subscribed with, so rotating keys silently would orphan every
+    existing subscription.
+    """
+    path = _vapid_private_key_path()
+    if not path.exists():
+        with _vapid_lock:
+            if not path.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                pem = _generate_vapid_keypair_pem()
+                path.write_bytes(pem)
+                try:
+                    path.chmod(0o600)
+                except Exception:
+                    pass
+    try:
+        pem = path.read_bytes()
+        return {"private_key_path": str(path), "public_key": _public_b64url_from_pem(pem)}
+    except Exception:
+        logger.warning("Failed to load/derive VAPID keys", exc_info=True)
+        return None
+
+
+def _load_subscriptions() -> list:
+    p = _subscriptions_path()
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _save_subscriptions(subs: list) -> None:
+    p = _subscriptions_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(subs, ensure_ascii=False, indent=2), encoding="utf-8")
+    try:
+        p.chmod(0o600)
+    except Exception:
+        pass
+
+
+def add_subscription(subscription: dict) -> None:
+    """Store a PushSubscription.toJSON() payload, de-duped by endpoint."""
+    endpoint = str((subscription or {}).get("endpoint") or "").strip()
+    if not endpoint:
+        return
+    with _subs_lock:
+        subs = [s for s in _load_subscriptions() if s.get("endpoint") != endpoint]
+        subs.append(subscription)
+        _save_subscriptions(subs)
+
+
+def remove_subscription(endpoint: str) -> None:
+    endpoint = str(endpoint or "").strip()
+    if not endpoint:
+        return
+    with _subs_lock:
+        subs = [s for s in _load_subscriptions() if s.get("endpoint") != endpoint]
+        _save_subscriptions(subs)
+
+
+def _remove_subscriptions(endpoints: list) -> None:
+    if not endpoints:
+        return
+    dead = set(endpoints)
+    with _subs_lock:
+        subs = [s for s in _load_subscriptions() if s.get("endpoint") not in dead]
+        _save_subscriptions(subs)
+
+
+def send_push_to_all(title: str, body: str, *, url: str = "./", tag: str | None = None) -> None:
+    """Best-effort push to every stored subscription. Never raises.
+
+    A subscription answering 404/410 (Gone) means the browser/OS dropped it
+    -- pywebpush surfaces that as WebPushException with response.status_code
+    set, and it's the standard signal to stop sending to that endpoint
+    rather than retry it forever.
+    """
+    if not _HAVE_PYWEBPUSH:
+        return
+    subs = _load_subscriptions()
+    if not subs:
+        return
+    keys = ensure_vapid_keys()
+    if not keys:
+        return
+    payload = json.dumps({"title": title, "body": body, "url": url, "tag": tag or "hermes-push"})
+    stale: list[str] = []
+    for sub in subs:
+        try:
+            webpush(
+                subscription_info=sub,
+                data=payload,
+                vapid_private_key=keys["private_key_path"],
+                # Apple's push service (web.push.apple.com) is documented to be
+                # stricter than other push services about `sub`: it must be a
+                # genuine, reachable contact per RFC 8292's intent (so the push
+                # service operator can reach the sender about abuse), not just
+                # syntactically mailto-shaped. A fake, non-resolvable domain
+                # (e.g. the previous "hermes.local") gets rejected as
+                # BadJwtToken even though the JWT is otherwise well-formed.
+                vapid_claims={"sub": "mailto:dgzap111@gmail.com"},
+            )
+        except WebPushException as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in (404, 410):
+                stale.append(sub.get("endpoint"))
+            else:
+                logger.warning("Push send failed (%s): %s", status, exc)
+        except Exception:
+            logger.warning("Push send failed", exc_info=True)
+    if stale:
+        _remove_subscriptions(stale)

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -3,12 +3,15 @@
 State-extraction prelude to the routes.py split tracked in #1907.
 Extracts approval state, not handlers, by design.
 """
+import logging
 import queue
 import threading
 import uuid
 from contextlib import contextmanager
 
 from api.session_events import publish_session_list_changed
+
+logger = logging.getLogger(__name__)
 
 # Approval system (optional -- graceful fallback if agent not available)
 try:
@@ -945,6 +948,26 @@ def submit_pending(session_key: str, approval: dict) -> None:
         # notify arriving before T1's earlier notify with a stale count).
         _approval_sse_notify_locked(session_key, head, total)
     publish_session_list_changed("attention_pending")
+    # Web Push, in addition to the SSE notify above: SSE only reaches an
+    # already-open, already-connected tab. On iOS specifically a
+    # backgrounded/locked PWA has no live SSE connection and the existing
+    # local Notification()/showNotification() path (messages.js
+    # sendBrowserNotification) can't fire either -- both require the page or
+    # its service worker to be actively alive. Web Push is delivered by the
+    # OS's own push service instead, so it's the only path that can wake a
+    # fully closed install. No-ops entirely if pywebpush isn't installed or
+    # no device has subscribed -- see api/push_notifications.py.
+    try:
+        from api.push_notifications import send_push_to_all
+        from urllib.parse import quote
+        send_push_to_all(
+            "Approval required",
+            entry.get("description") or "Tool approval needed",
+            url=f"session/{quote(session_key, safe='')}",
+            tag=f"hermes-{session_key}",
+        )
+    except Exception:
+        logger.warning("Web Push notify failed", exc_info=True)
     # NOTE: We do NOT call _submit_pending_raw here — that function overwrites
     # _pending[session_key] with a single dict, which would undo the list we just
     # built. The gateway blocking path uses _gateway_queues (a separate mechanism

--- a/api/routes.py
+++ b/api/routes.py
@@ -14422,6 +14422,19 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/approval/stream":
         return _handle_approval_sse_stream(handler, parsed)
 
+    if parsed.path == "/api/push/vapid-public-key":
+        return _handle_push_vapid_public_key(handler, parsed)
+
+    if parsed.path == "/api/push/debug-ack":
+        # Temporary delivery-diagnostic beacon (see static/sw.js's push
+        # handler) -- fired first thing, before showNotification(), so a hit
+        # in the access log proves the push event actually reached the
+        # device's service worker, isolating that from whether iOS then
+        # chose to display it. Safe to remove once push delivery is a known
+        # quantity; every hit is already visible in the normal request log
+        # via its ?tag= query string, so no bespoke logging needed here.
+        return j(handler, {"ok": True})
+
     if parsed.path == "/api/approval/inject_test":
         # Loopback-only: used by automated tests; blocked from any remote client
         if handler.client_address[0] != "127.0.0.1":
@@ -16531,6 +16544,13 @@ def handle_post(handler, parsed) -> bool:
     # ── Approval (POST) ──
     if parsed.path == "/api/approval/respond":
         return _handle_approval_respond(handler, body)
+
+    # ── Web Push subscriptions (POST) ──
+    if parsed.path == "/api/push/subscribe":
+        return _handle_push_subscribe(handler, body)
+
+    if parsed.path == "/api/push/unsubscribe":
+        return _handle_push_unsubscribe(handler, body)
 
     # ── Clarify (POST) ──
     if parsed.path == "/api/clarify/respond":
@@ -26625,6 +26645,38 @@ def _handle_approval_respond(handler, body):
             else {}
         ),
     })
+
+
+def _handle_push_vapid_public_key(handler, parsed):
+    """Return the VAPID public key so the frontend can call pushManager.subscribe().
+
+    Generates the keypair on first call (see api/push_notifications.py).
+    Works even without pywebpush installed -- keygen only needs `cryptography`,
+    already a hard requirement; only the send path needs pywebpush.
+    """
+    from api.push_notifications import ensure_vapid_keys
+    keys = ensure_vapid_keys()
+    if not keys:
+        return j(handler, {"error": "push notifications unavailable"}, status=503)
+    return j(handler, {"key": keys["public_key"]})
+
+
+def _handle_push_subscribe(handler, body):
+    endpoint = str((body or {}).get("endpoint") or "").strip()
+    if not endpoint:
+        return bad(handler, "endpoint is required")
+    from api.push_notifications import add_subscription
+    add_subscription(body)
+    return j(handler, {"ok": True})
+
+
+def _handle_push_unsubscribe(handler, body):
+    endpoint = str((body or {}).get("endpoint") or "").strip()
+    if not endpoint:
+        return bad(handler, "endpoint is required")
+    from api.push_notifications import remove_subscription
+    remove_subscription(endpoint)
+    return j(handler, {"ok": True})
 
 
 def _resolve_clarify_legacy(sid: str, clarify_id: str, response: str) -> bool:

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -23,7 +23,7 @@ from api.agent_sessions import normalize_agent_session_source
 
 logger = logging.getLogger(__name__)
 
-AUTO_TITLE_LABELS = {'untitled', 'new chat'}
+AUTO_TITLE_LABELS = {'untitled', 'new chat', 'bot chat'}
 
 
 class RegenerationUnavailable(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,12 @@ cryptography>=42.0
 # The workspace file routes return 503 with an install hint when they are absent.
 # Install them only if you want .docx/.xlsx/.pptx preview support:
 #   pip install python-docx>=1.1.2 openpyxl>=3.1.5 python-pptx>=1.0.2
+#
+# OPTIONAL: Web Push notifications (wakes a backgrounded/closed PWA install for
+# a time-sensitive prompt, e.g. an execute_code approval -- local
+# Notification()/showNotification() calls can't do this, they need the page or
+# its service worker to already be alive) need `pywebpush`. VAPID keypair
+# generation alone only needs `cryptography` above, already required; only the
+# actual send (api/push_notifications.py) is gated on this and no-ops silently
+# without it. Install it only if you want push-woken approval alerts:
+#   pip install pywebpush>=2.0

--- a/static/messages.js
+++ b/static/messages.js
@@ -9179,6 +9179,7 @@ function requestNotificationPermission(){
   if(Notification.permission==='granted'){
     if(typeof updateNotificationPermissionStatus==='function') updateNotificationPermissionStatus();
     if(typeof showToast==='function') showToast(t('notifications_enabled_toast'),3000);
+    _ensurePushSubscription();
     return Promise.resolve('granted');
   }
   if(Notification.permission==='denied'){
@@ -9189,8 +9190,67 @@ function requestNotificationPermission(){
   return Notification.requestPermission().then(p=>{
     if(typeof showToast==='function') showToast(p==='granted'?t('notifications_enabled_toast'):t('notifications_denied'),3000,p==='granted'?undefined:'error');
     if(typeof updateNotificationPermissionStatus==='function') updateNotificationPermissionStatus();
+    if(p==='granted') _ensurePushSubscription();
     return p;
   });
+}
+
+// Web Push registration: local Notification()/showNotification() (above)
+// only fire while this page or its service worker is actively alive, which
+// a backgrounded/locked PWA (notably on iOS) never is. Web Push is the only
+// path that can wake a fully closed install -- delivery goes through the
+// OS's own push service, driven server-side (api/push_notifications.py)
+// instead of by this page's JS. Best-effort and silent: a device that can't
+// or won't subscribe just keeps the existing foreground-only behavior.
+function _urlBase64ToUint8Array(base64String){
+  const padding='='.repeat((4-base64String.length%4)%4);
+  const base64=(base64String+padding).replace(/-/g,'+').replace(/_/g,'/');
+  const rawData=atob(base64);
+  const outputArray=new Uint8Array(rawData.length);
+  for(let i=0;i<rawData.length;++i) outputArray[i]=rawData.charCodeAt(i);
+  return outputArray;
+}
+async function _ensurePushSubscription(){
+  try{
+    if(!('serviceWorker' in navigator)||!('PushManager' in window)) return;
+    if(!('Notification' in window)||Notification.permission!=='granted') return;
+    const reg=await navigator.serviceWorker.ready;
+    const {key}=await api('api/push/vapid-public-key',{timeoutToast:false});
+    if(!key) return;
+    const desiredKey=_urlBase64ToUint8Array(key);
+    let sub=await reg.pushManager.getSubscription();
+    // A PushSubscription is bound to the VAPID public key it was created
+    // with -- if the server's key ever changes (key file regenerated, or
+    // -- the actual bug this guards against -- an earlier bad build served
+    // a profile-scoped key instead of the one true server-wide key) an
+    // existing subscription silently stops being deliverable-to without
+    // ever erroring here. Re-subscribing against a mismatched key is the
+    // only fix; detect it and self-heal instead of staying silently stale.
+    if(sub){
+      const existingKey=new Uint8Array(sub.options.applicationServerKey);
+      const sameKey=existingKey.length===desiredKey.length&&existingKey.every((b,i)=>b===desiredKey[i]);
+      if(!sameKey){
+        await sub.unsubscribe().catch(()=>{});
+        sub=null;
+      }
+    }
+    if(!sub){
+      sub=await reg.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:desiredKey});
+    }
+    await api('api/push/subscribe',{method:'POST',body:JSON.stringify(sub.toJSON()),timeoutToast:false});
+  }catch(e){console.warn('Push subscription failed:',e);}
+}
+async function _unsubscribeFromPush(){
+  try{
+    if(!('serviceWorker' in navigator)) return;
+    const reg=await navigator.serviceWorker.getRegistration();
+    if(!reg) return;
+    const sub=await reg.pushManager.getSubscription();
+    if(!sub) return;
+    const endpoint=sub.endpoint;
+    await sub.unsubscribe();
+    await api('api/push/unsubscribe',{method:'POST',body:JSON.stringify({endpoint}),timeoutToast:false});
+  }catch(e){console.warn('Push unsubscribe failed:',e);}
 }
 function sendBrowserNotification(title,body,options={}){
   const force=!!(options&&options.force);

--- a/static/panels.js
+++ b/static/panels.js
@@ -13464,6 +13464,11 @@ function updateNotificationPermissionStatus(){
   const perm=Notification.permission||'default';
   const label=t('notifications_permission_status', perm);
   el.textContent=label;
+  // Opportunistic re-check for a returning session where permission was
+  // already granted earlier: requestNotificationPermission() only runs on
+  // an explicit click, so this is what catches a device whose push
+  // subscription needs (re)registering without one.
+  if(perm==='granted'&&typeof _ensurePushSubscription==='function') _ensurePushSubscription();
   if(btn){
     const granted=perm==='granted';
     btn.disabled=granted;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7671,6 +7671,15 @@ function _attachProjectQuickCreateButton(chip, project){
 }
 
 
+// Always-visible quick-switch roster, rendered between the Profiles tab
+// (full list) and the Projects filter bar in the chat sidebar.
+const PINNED_BOTS=[
+  {name:'diana',label:'Diana'},
+  {name:'lamb',label:'Lamb'},
+  {name:'scout-deep',label:'Scout'},
+  {name:'techops',label:'TechOps'},
+];
+
 function renderSessionListFromCache(){
   // #4671: while a profile-switch skeleton is up, bail — _allSessions still holds the
   // PREVIOUS profile's rows until /api/sessions resolves, so any unrelated caller
@@ -7781,6 +7790,22 @@ function renderSessionListFromCache(){
       sourceTabs.appendChild(btn);
     }
     list.appendChild(sourceTabs);
+  }
+  // Pinned bots — always-visible quick switch for the core bot roster,
+  // between the Profiles tab (full list) and the Projects filter below.
+  {
+    const pinnedBar=document.createElement('div');
+    pinnedBar.className='pinned-bots-bar';
+    for(const bot of PINNED_BOTS){
+      const chip=document.createElement('button');
+      chip.type='button';
+      chip.className='pinned-bot-chip'+(bot.name===S.activeProfile?' active':'');
+      chip.textContent=bot.label;
+      chip.title='Switch to '+bot.label;
+      chip.onclick=()=>{ if(bot.name!==S.activeProfile) switchToProfile(bot.name); };
+      pinnedBar.appendChild(chip);
+    }
+    list.appendChild(pinnedBar);
   }
   // Project filter bar — show when there are real projects OR there are
   // unassigned sessions (so the Unassigned chip has something to filter to).

--- a/static/style.css
+++ b/static/style.css
@@ -5737,6 +5737,13 @@ main.main > #mainPlugin{display:none;}
 .session-list-error-retry:hover:not(:disabled):not([aria-busy="true"]):not([aria-disabled="true"]){background:var(--hover-bg);border-color:var(--accent-bg-strong);color:var(--text);}
 .session-list-error-retry:focus-visible{outline:2px solid var(--focus-ring);outline-offset:2px;}
 .session-list-error-retry:disabled,.session-list-error-retry[aria-busy="true"],.session-list-error-retry[aria-disabled="true"]{background:var(--surface);border-color:var(--border2);color:var(--muted);cursor:wait;opacity:1;}
+.pinned-bots-bar{display:flex;gap:4px;padding:8px 10px 4px;flex-wrap:wrap;align-items:center;flex-shrink:0;}
+.pinned-bot-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none;touch-action:manipulation;}
+.pinned-bot-chip:hover{background:rgba(255,255,255,.08);color:var(--text);}
+.pinned-bot-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg);}
+:root:not(.dark) .pinned-bot-chip{border-color:rgba(0,0,0,.12);background:rgba(0,0,0,.04);}
+:root:not(.dark) .pinned-bot-chip:hover{background:var(--hover-bg);color:var(--text);}
+:root:not(.dark) .pinned-bot-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);}
 .project-bar{display:flex;gap:4px;padding:4px 10px 8px;flex-wrap:wrap;align-items:center;flex-shrink:0;}
 .project-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none;touch-action:manipulation;}
 .project-chip:hover{background:rgba(255,255,255,.08);color:var(--text);}

--- a/static/sw.js
+++ b/static/sw.js
@@ -174,6 +174,33 @@ self.addEventListener('fetch', (event) => {
 });
 
 
+// Web Push: the only path that can wake a fully backgrounded/closed PWA
+// (notably on iOS). Delivered by the OS's push service, so this fires even
+// when no tab is open and no page JS is running -- unlike the local
+// Notification()/showNotification() calls in messages.js, which need the
+// page or this worker to already be alive. Payload shape is set server-side
+// in api/push_notifications.py: {title, body, url, tag}.
+self.addEventListener('push', (event) => {
+  let data = {};
+  try { data = event.data ? event.data.json() : {}; } catch (_e) {}
+  const title = data.title || 'Hermes';
+  const options = {
+    body: data.body || '',
+    tag: data.tag || 'hermes-push',
+    renotify: true,
+    icon: 'static/favicon-192.png',
+    badge: 'static/favicon-32.png',
+    data: { url: data.url || './' },
+  };
+  // TEMPORARY delivery diagnostic (see api/routes.py /api/push/debug-ack):
+  // fired first, before showNotification, so a hit in the server's access
+  // log proves this handler actually ran on-device -- isolates "push never
+  // reached the phone" from "it arrived but iOS didn't display it". Remove
+  // once push delivery is a known quantity.
+  const ack = fetch('api/push/debug-ack?tag=' + encodeURIComponent(options.tag)).catch(() => {});
+  event.waitUntil(Promise.all([ack, self.registration.showNotification(title, options)]));
+});
+
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const rawUrl = (event.notification.data && event.notification.data.url) || './';


### PR DESCRIPTION
## Summary
- Adds Web Push (RFC 8030 + VAPID) so a pending tool approval — an `execute_code` approval, most notably — can wake a locked/backgrounded iOS PWA. Local `Notification()`/`showNotification()` calls only fire while the page or its service worker is already alive, which a locked phone never is, so a time-sensitive approval could sit unseen until it timed out.
- Adds VAPID keypair generation, `/api/push/subscribe` + `/api/push/unsubscribe` + `/api/push/vapid-public-key` endpoints, a `push` handler in the service worker, and self-healing re-subscribe if the server's VAPID key ever changes underneath an existing subscription.
- Entirely optional: everything degrades to a silent no-op without `pywebpush` installed, and existing foreground notifications are unaffected either way.
- Also includes an always-visible pinned bot quick-switch bar in the chat sidebar (diana/lamb/scout-deep/techops), and treats "bot chat" as an auto-title placeholder alongside the existing "untitled"/"new chat" labels.

## Test plan
- [x] Rebased cleanly onto latest `master`
- [x] Confirmed the server starts cleanly with the new code (`/api/push/vapid-public-key` responds correctly, no import errors)
- [ ] Confirm actual push delivery on a real iOS device (a temporary `/api/push/debug-ack` beacon in `static/sw.js` is included to verify this before it's removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)