### PR TITLE
perf(redaction): byte-budgeted eviction for decision/redactor memo LRUs (#7439)

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -493,6 +493,14 @@ except Exception:
     _REDACT_RULES_AGENT_DIGEST = None
 
 
+# Per-entry max sizes (bytes) for the two memo tiers — the SAME values the
+# caches enforce below. Defined here (single source of truth) so the per-tier
+# byte-budget ceilings below are derived from them and can't silently drift if
+# an entry cap is tuned later. Small tier: <= 16 KiB. Big tier: <= 256 KiB.
+# Strings above the big cap bypass the decision cache entirely (still redacted).
+_REDACT_CACHE_MAX_TEXT_LEN = 16384
+_REDACT_TEXT_BIG_CACHE_MAX = 262144
+
 # Per-tier entry ceilings so a raised env knob can't exceed a bounded byte
 # footprint. A SHARED count cap would let the 256KiB big tier retain ~32GiB at a
 # 131072-entry ceiling while the 16KiB small tiers hold a fraction of that
@@ -501,10 +509,8 @@ except Exception:
 # 2048. Defaults (16384/16384/256) sit below these; env knobs stay tunable but
 # never balloon.
 _REDACT_MEMO_BYTE_BUDGET = 1024 * 1024 * 1024  # 1 GiB per tier (keys+values)
-_REDACT_MEMO_SMALL_ENTRY = 16384               # == _REDACT_CACHE_MAX_TEXT_LEN
-_REDACT_MEMO_BIG_ENTRY = 262144                # == _REDACT_TEXT_BIG_CACHE_MAX
-_REDACT_SMALL_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_MEMO_SMALL_ENTRY)
-_REDACT_BIG_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_MEMO_BIG_ENTRY)
+_REDACT_SMALL_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_CACHE_MAX_TEXT_LEN)
+_REDACT_BIG_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_TEXT_BIG_CACHE_MAX)
 
 
 def _lru_size(default: int, env: str, cap: int) -> int:
@@ -536,11 +542,6 @@ def _lru_size(default: int, env: str, cap: int) -> int:
 _redact_fn_lru = functools.lru_cache(
     maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_FN_MEMO", _REDACT_SMALL_TIER_CAP)
 )(_redact_fn_uncached)
-
-# Cap per-entry size so a handful of giant tool-output dumps can't evict the
-# thousands of small recurring strings that actually benefit, or balloon RSS.
-_REDACT_CACHE_MAX_TEXT_LEN = 16384
-
 
 def _redact_fn_cached(text):
     if len(text) > _REDACT_CACHE_MAX_TEXT_LEN:
@@ -575,7 +576,6 @@ _redact_text_lru = functools.lru_cache(
 _redact_text_big_lru = functools.lru_cache(
     maxsize=_lru_size(256, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO", _REDACT_BIG_TIER_CAP)
 )(_redact_text_impl)
-_REDACT_TEXT_BIG_CACHE_MAX = 262144
 
 
 _SENSITIVE_CASE_MARKERS = (

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -487,8 +487,11 @@ def _redact_fn_cached(text):
 # DECISION is memoized here: warm passes become dict lookups, and CPython
 # caches str hashes on the string objects themselves, so sessions held in the
 # compact-session LRU skip even the hash cost. Two tiers mirror the redactor
-# memo: small (≤16KiB, 32768 entries) and big (≤256KiB, 1024 entries —
-# worst-case tier RSS ≈ 256MB, typically tens of MB). Strings above the big
+# memo: small (≤16KiB, 32768 entries) and big (≤256KiB, 1024 entries).
+# Worst-case tier RSS: big tier stores keys+values ≈ 512MB, small tier
+# ≈ 512MB, redactor memo ≈ 64MB — ~1GB theoretical ceiling; realistic
+# occupancy is tens of MB (clean strings alias their key objects, and
+# recurring short strings dominate). Strings above the big
 # ceiling stay uncached (rare giant dumps).
 def _redact_text_impl(text: str) -> str:
     if not _might_contain_sensitive_text(text):

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -461,20 +461,27 @@ def _build_redact_fn():
 _redact_fn_uncached = _build_redact_fn()
 
 
+# Sanity ceiling on the memo cache capacities so a fat-fingered env value
+# can't silently 10x the worst-case RSS (the very thing the env knobs exist to
+# bound). Above all defaults (16384/16384/256); below any plausible typo scale.
+_REDACT_MEMO_MAX_CAP = 131072
+
+
 def _lru_size(default: int, env: str) -> int:
     """Return a positive LRU ``maxsize``, overridable via env var ``env``.
 
     The redaction/decision memos are process-wide and retained across sessions
     (deliberate: the perf win is that repeat loads skip re-scanning and
-    re-redacting). Each is bounded by its LRU ``maxsize``, but on a
-    memory-constrained host the worst-case RSS across the three tiers can still
-    be large, so the capacities are exposed as env knobs (defaults unchanged) —
-    set them low to cap growth without giving up the default fast path.
+    re-redacting). Each is bounded by its LRU ``maxsize``; the shipped defaults
+    are conservative enough to keep the worst-case RSS bounded, and are exposed
+    as env knobs (``HERMES_WEBUI_REDACT_*``) so a host can raise them if it has
+    headroom or lower them further on a tight box. Values are clamped to
+    ``_REDACT_MEMO_MAX_CAP`` so an errant entry can't balloon.
     """
     try:
         val = int(os.getenv(env, default))
         if val >= 1:
-            return val
+            return min(val, _REDACT_MEMO_MAX_CAP)
     except (TypeError, ValueError):
         pass
     return default
@@ -487,7 +494,7 @@ def _lru_size(default: int, env: str) -> int:
 # deterministic (force=True, fixed masking), so identical strings always map to
 # identical output and are safe to memoize without invalidation.
 _redact_fn_lru = functools.lru_cache(
-    maxsize=_lru_size(32768, "HERMES_WEBUI_REDACT_FN_MEMO")
+    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_FN_MEMO")
 )(_redact_fn_uncached)
 
 # Cap per-entry size so a handful of giant tool-output dumps can't evict the
@@ -509,13 +516,13 @@ def _redact_fn_cached(text):
 # DECISION is memoized here: warm passes become dict lookups, and CPython
 # caches str hashes on the string objects themselves, so sessions held in the
 # compact-session LRU skip even the hash cost. Two tiers mirror the redactor
-# memo: small (≤16KiB, 32768 entries) and big (≤256KiB, 1024 entries).
-# Worst-case tier RSS (keys+values at the caps): big tier 1024·256KiB ≈ 512MB,
-# small decision tier 32768·16KiB ≈ 1GB, redactor memo 32768·16KiB ≈ 1GB — a
-# ~2.5GB theoretical ceiling. Realistic occupancy is far lower (clean strings
+# memo: small (≤16KiB, 16384 entries) and big (≤256KiB, 256 entries).
+# Worst-case tier RSS (keys+values at the caps): big tier 256·256KiB ≈ 128MB,
+# small decision tier 16384·16KiB ≈ 512MB, redactor memo 16384·16KiB ≈ 512MB — a
+# ~1.1GB theoretical ceiling. Realistic occupancy is far lower (clean strings
 # alias their key objects, most transcript strings are short), and strings above
 # the caps bypass the cache entirely. All three capacities are tunable via
-# HERMES_WEBUI_REDACT_* env vars for memory-constrained hosts.
+# HERMES_WEBUI_REDACT_* env vars, and clamped to _REDACT_MEMO_MAX_CAP.
 def _redact_text_impl(text: str) -> str:
     if not _might_contain_sensitive_text(text):
         return text
@@ -523,10 +530,10 @@ def _redact_text_impl(text: str) -> str:
 
 
 _redact_text_lru = functools.lru_cache(
-    maxsize=_lru_size(32768, "HERMES_WEBUI_REDACT_DECISION_MEMO")
+    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_DECISION_MEMO")
 )(_redact_text_impl)
 _redact_text_big_lru = functools.lru_cache(
-    maxsize=_lru_size(1024, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO")
+    maxsize=_lru_size(256, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO")
 )(_redact_text_impl)
 _REDACT_TEXT_BIG_CACHE_MAX = 262144
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1303,10 +1303,13 @@ def redact_session_data(session_dict: dict) -> dict:
 # sweep (~1.5s for a 2101-message / 14MB transcript).
 #
 # NOTE: the on-disk cache survives process restarts and upgrades (unlike the
-# in-memory LRUs), so validation includes a rules fingerprint (schema version +
-# WebUI version + agent redactor module stat). Bump _REDACT_SESSION_CACHE_VERSION
-# whenever the projection shape or the internal-field set changes in a way a
-# fingerprint can't see.
+# in-memory LRUs), so validation includes a rules fingerprint that is a CONTENT
+# identity (sha256 of this module's + agent/redact.py's policy source bytes,
+# plus the schema version) — NOT a WebUI version stamp or pathname metadata.
+# Metadata equality does not imply byte equality, and a version stamp can be a
+# constant ('unknown'/None), so the fingerprint hashes the policy bytes that
+# actually shape the projection. Bump _REDACT_SESSION_CACHE_VERSION only when
+# the cache FILE format changes.
 #
 # This derived cache persists the redacted public projection of a session's
 # transcript lists on disk, keyed by per-message content digests. Loads splice
@@ -1321,26 +1324,67 @@ def redact_session_data(session_dict: dict) -> dict:
 _REDACT_SESSION_CACHE_VERSION = 1
 
 
-def _redact_session_cache_rules_key() -> str:
+def _redact_session_cache_rules_key() -> str | None:
     """Fingerprint of everything the cached projections depend on besides the
-    message content: the cache schema version, the WebUI version (projection
-    shape / internal-field set), and the agent redactor module file (credential
-    patterns can advance independently of the WebUI via the mounted checkout).
-    A mismatch forces a full recompute — this is the guard that keeps a stale
-    cache from serving credentials the CURRENT redactor would catch."""
+    message content: a manual schema version plus the CONTENT identity of every
+    implementation that shapes the projection — this module (the local fallback
+    redactor, sensitive markers, image exemption, and projection-field policy)
+    and the agent redactor module used to build ``_redact_fn_uncached``.
+
+    Identity is content (sha256 of the source bytes that define the policy), not
+    pathname metadata or a version stamp. Metadata equality does not imply byte
+    equality — distinct policy bytes can share ``mtime_ns``/``size``, and a WebUI
+    version stamp degrades to a constant (``'unknown'``/``None``) when git and
+    generated version files are unavailable. In that shape a policy change could
+    keep the whole key constant and let a stale projection serve text the
+    CURRENT redactor would remove. Hashing the policy source bytes is the
+    authoritative guard.
+
+    Returns ``None`` when no trustworthy identity can be computed (this module's
+    own source is unreadable); the caller treats ``None`` as "cannot authorize
+    reuse" and skips the persistent cache rather than accept a best-effort hint
+    at a hard safety boundary. When ``agent.redact`` is genuinely unimportable,
+    redaction falls back to THIS module's own patterns (already captured), so the
+    fixed ``absent`` marker is a real state, not a hidden change source. If the
+    agent redactor is importable but its policy source cannot be hashed
+    (zipimport/frozen build, ``None`` ``__file__``), ``None`` is returned too —
+    the live redactor is agent-backed, so the key must not stay constant.
+
+    Residual limitation: transitive modules/data imported by ``agent/redact.py``
+    are not hashed (hash the redactor plus any policy it imports for full
+    coverage; a generated build digest would be preferable). An incidental edit
+    to ``helpers.py`` invalidates every projection, which is conservative but
+    safe.
+    """
     import hashlib
     parts = [str(_REDACT_SESSION_CACHE_VERSION)]
     try:
-        from api.config import _current_webui_version
-        parts.append(str(_current_webui_version() or ""))
-    except Exception:
-        parts.append("")
+        with open(__file__, "rb") as fh:
+            parts.append(hashlib.sha256(fh.read()).hexdigest())
+    except OSError:
+        return None
     try:
         import agent.redact as _agent_redact
-        st = os.stat(_agent_redact.__file__)
-        parts.append(f"{st.st_mtime_ns}:{st.st_size}")
+    except ImportError:
+        # Genuinely absent (fallback-only mode): redaction depends solely on
+        # THIS module's own patterns, already captured above. A fixed marker is
+        # a real state, not a hidden change source.
+        parts.append("agent-redactor:absent")
     except Exception:
-        parts.append("")
+        # Cannot determine whether the agent-backed combined redactor is in
+        # play — fail closed rather than risk a constant key.
+        return None
+    else:
+        try:
+            with open(_agent_redact.__file__, "rb") as fh:
+                parts.append(hashlib.sha256(fh.read()).hexdigest())
+        except (OSError, TypeError, AttributeError):
+            # Importable but its policy source cannot be hashed (zipimport/frozen
+            # build, a None __file__, or a module with no __file__ attribute).
+            # Do NOT record "absent": _redact_fn_uncached is actually the
+            # agent-backed combined redactor, so an agent-side policy change
+            # could otherwise keep the key constant. Fail closed -> recompute.
+            return None
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
@@ -1404,7 +1448,12 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
         rules_key = _redact_session_cache_rules_key()
         path = _redact_session_cache_path(session_id)
         cache = None
-        if path.exists():
+        # A valid rules_key is a HARD prerequisite for authorizing a cached read.
+        # If no trustworthy content identity could be computed (rules_key is
+        # None), do not even open the cache: rederive the projection from the
+        # current policy. This is the fail-closed branch the stale-redaction
+        # boundary requires — metadata/version identity is not content identity.
+        if rules_key is not None and path.exists():
             try:
                 loaded = _json.loads(path.read_text(encoding="utf-8"))
                 if (isinstance(loaded, dict)
@@ -1442,7 +1491,7 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             out[key] = projected
             if reused != len(digests):
                 wrote = True
-        if wrote and path is not None:
+        if wrote and path is not None and rules_key is not None:
             # Write DECORATION-FREE projections (must happen before the
             # response-only turn decoration below mutates `out`).
             payload = {

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1561,19 +1561,32 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
 
 
 def delete_redaction_session_cache(session_id) -> bool:
-    """Remove the persisted redaction projection for ``session_id``.
+    """Remove the persisted redaction projection for ``session_id`` and drop the
+    deleted session's strings from the process-wide redaction memos.
 
     Hooked into the session-deletion paths so a deleted conversation is not
     recoverable from ``STATE_DIR/redaction_cache/`` (same rationale as #3802
     for the turn/run journals: the file holds redacted projections, but the
     surviving conversation text still belongs to the deleted session).
-    Unsafe ids and a missing file are a no-op; returns True only if a file
-    was actually removed. Best-effort — never raises.
+
+    The in-memory decision/redactor LRUs key on the ORIGINAL string, so a
+    deleted session's plaintext (including any secrets) would otherwise be held
+    until LRU eviction. Clearing them here extends the same deletion contract to
+    RAM. ``lru_cache`` has no per-key eviction, so the whole memo is cleared —
+    cheap, and only ever reached on a real deletion path. Unsafe ids and a
+    missing projection file are a no-op for the on-disk artifact; returns True
+    only if a file was actually removed. Best-effort — never raises.
     """
     try:
         path = _redact_session_cache_path(session_id)
     except Exception:
         return False
+    try:
+        _redact_fn_lru.cache_clear()
+        _redact_text_lru.cache_clear()
+        _redact_text_big_lru.cache_clear()
+    except Exception:
+        pass
     try:
         if not path.exists():
             return False

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1315,7 +1315,9 @@ def redact_session_data(session_dict: dict) -> dict:
 # is a derived artifact: any parse/validation failure falls back to plain
 # redaction, and stored projections are DECORATION-FREE — the per-request
 # `_active_turn_user` flag is applied after retrieval from the CURRENT
-# request's turn token, never persisted.
+# request's turn token, never persisted. Delete the file when the session is
+# deleted (delete_redaction_session_cache) so a deleted conversation is not
+# recoverable from redaction_cache/.
 _REDACT_SESSION_CACHE_VERSION = 1
 
 
@@ -1473,6 +1475,29 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             key: _redact_messages(items, _enabled=_enabled, _active_turn_token=_active_turn_token)
             for key, items in lists.items()
         }
+
+
+def delete_redaction_session_cache(session_id) -> bool:
+    """Remove the persisted redaction projection for ``session_id``.
+
+    Hooked into the session-deletion paths so a deleted conversation is not
+    recoverable from ``STATE_DIR/redaction_cache/`` (same rationale as #3802
+    for the turn/run journals: the file holds redacted projections, but the
+    surviving conversation text still belongs to the deleted session).
+    Unsafe ids and a missing file are a no-op; returns True only if a file
+    was actually removed. Best-effort — never raises.
+    """
+    try:
+        path = _redact_session_cache_path(session_id)
+    except Exception:
+        return False
+    try:
+        if not path.exists():
+            return False
+        path.unlink(missing_ok=True)
+    except OSError:
+        return False
+    return not path.exists()
 
 
 def read_body(handler) -> dict:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -461,6 +461,38 @@ def _build_redact_fn():
 _redact_fn_uncached = _build_redact_fn()
 
 
+def _content_digest(path) -> str | None:
+    """sha256 of a file's bytes — a CONTENT identity, not metadata. Returns
+    ``None`` when ``path`` is unreadable so callers can fail closed."""
+    import hashlib
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except (OSError, TypeError):
+        return None
+
+
+# Capture the rules CONTENT identity ONCE at import. The redactor
+# (`_redact_fn_uncached`) is frozen at import time; re-hashing on-disk bytes on
+# every cache-key call (as the previous implementation did) can diverge from the
+# in-force policy after a mid-process edit to helpers.py / agent.redact, so a
+# stale projection could be re-stamped with the new on-disk key and served after
+# restart (TOCTOU). Reading the bytes actually imported here ties the key to the
+# policy in force for this process; a real policy change is recognized only
+# across a restart, when these are recomputed from the new bytes.
+_REDACT_RULES_HELPERS_DIGEST = _content_digest(__file__)
+_REDACT_RULES_AGENT_ABSENT = False
+_REDACT_RULES_AGENT_DIGEST = None
+try:
+    import agent.redact as _rules_agent_redact
+    _REDACT_RULES_AGENT_DIGEST = _content_digest(_rules_agent_redact.__file__)
+except ImportError:
+    _REDACT_RULES_AGENT_ABSENT = True
+except Exception:
+    # Indeterminate -> the key function fails closed (agent digest stays None).
+    _REDACT_RULES_AGENT_DIGEST = None
+
+
 # Sanity ceiling on the memo cache capacities so a fat-fingered env value
 # can't silently 10x the worst-case RSS (the very thing the env knobs exist to
 # bound). Above all defaults (16384/16384/256); below any plausible typo scale.
@@ -1365,60 +1397,45 @@ def _redact_session_cache_rules_key() -> str | None:
     redactor, sensitive markers, image exemption, and projection-field policy)
     and the agent redactor module used to build ``_redact_fn_uncached``.
 
-    Identity is content (sha256 of the source bytes that define the policy), not
-    pathname metadata or a version stamp. Metadata equality does not imply byte
-    equality — distinct policy bytes can share ``mtime_ns``/``size``, and a WebUI
-    version stamp degrades to a constant (``'unknown'``/``None``) when git and
-    generated version files are unavailable. In that shape a policy change could
-    keep the whole key constant and let a stale projection serve text the
-    CURRENT redactor would remove. Hashing the policy source bytes is the
-    authoritative guard.
+    Identity is content (sha256 of the policy source bytes), not pathname
+    metadata or a version stamp. Metadata equality does not imply byte equality
+    — distinct policy bytes can share ``mtime_ns``/``size``, and a WebUI version
+    stamp degrades to a constant (``'unknown'``/``None``) when git and generated
+    version files are unavailable. Hashing policy source bytes is the guard that
+    keeps a stale projection from serving text the CURRENT redactor would remove.
 
-    Returns ``None`` when no trustworthy identity can be computed (this module's
-    own source is unreadable); the caller treats ``None`` as "cannot authorize
-    reuse" and skips the persistent cache rather than accept a best-effort hint
-    at a hard safety boundary. When ``agent.redact`` is genuinely unimportable,
-    redaction falls back to THIS module's own patterns (already captured), so the
-    fixed ``absent`` marker is a real state, not a hidden change source. If the
-    agent redactor is importable but its policy source cannot be hashed
-    (zipimport/frozen build, ``None`` ``__file__``), ``None`` is returned too —
-    the live redactor is agent-backed, so the key must not stay constant.
+    The digests are captured ONCE at import (``_REDACT_RULES_*``) because the
+    redactor is frozen at import: re-reading on-disk bytes on every call would
+    mismatch the in-force policy after a mid-process edit, letting a stale
+    projection be re-stamped with the new key and served after restart (TOCTOU).
+
+    Returns ``None`` when no trustworthy identity can be computed, so the caller
+    skips the persistent cache rather than accept a best-effort hint at a hard
+    safety boundary. ``None`` results when this module's own source is
+    unreadable, or when ``agent.redact`` is importable but its source cannot be
+    hashed (zipimport/frozen build, ``None`` ``__file__``) — in that state
+    ``_redact_fn_uncached`` is the agent-backed combined redactor, so the key
+    must not stay constant. When ``agent.redact`` is genuinely unimportable,
+    redaction falls back to THIS module's own patterns (already captured), so
+    the fixed ``absent`` marker is a real state, not a hidden change source.
 
     Residual limitation: transitive modules/data imported by ``agent/redact.py``
-    are not hashed (hash the redactor plus any policy it imports for full
-    coverage; a generated build digest would be preferable). An incidental edit
-    to ``helpers.py`` invalidates every projection, which is conservative but
-    safe.
+    are not hashed (a generated build digest would cover those). A real policy
+    change is recognized at process start (when these digests are recomputed),
+    so a restart with a new redactor invalidates stale projections.
     """
     import hashlib
-    parts = [str(_REDACT_SESSION_CACHE_VERSION)]
-    try:
-        with open(__file__, "rb") as fh:
-            parts.append(hashlib.sha256(fh.read()).hexdigest())
-    except OSError:
+    if _REDACT_RULES_HELPERS_DIGEST is None:
         return None
-    try:
-        import agent.redact as _agent_redact
-    except ImportError:
-        # Genuinely absent (fallback-only mode): redaction depends solely on
-        # THIS module's own patterns, already captured above. A fixed marker is
-        # a real state, not a hidden change source.
+    parts = [str(_REDACT_SESSION_CACHE_VERSION), _REDACT_RULES_HELPERS_DIGEST]
+    if _REDACT_RULES_AGENT_ABSENT:
         parts.append("agent-redactor:absent")
-    except Exception:
-        # Cannot determine whether the agent-backed combined redactor is in
-        # play — fail closed rather than risk a constant key.
-        return None
+    elif _REDACT_RULES_AGENT_DIGEST is not None:
+        parts.append(_REDACT_RULES_AGENT_DIGEST)
     else:
-        try:
-            with open(_agent_redact.__file__, "rb") as fh:
-                parts.append(hashlib.sha256(fh.read()).hexdigest())
-        except (OSError, TypeError, AttributeError):
-            # Importable but its policy source cannot be hashed (zipimport/frozen
-            # build, a None __file__, or a module with no __file__ attribute).
-            # Do NOT record "absent": _redact_fn_uncached is actually the
-            # agent-backed combined redactor, so an agent-side policy change
-            # could otherwise keep the key constant. Fail closed -> recompute.
-            return None
+        # Agent importable but its source is unhashable (see docstring) — no
+        # trustworthy identity; fail closed.
+        return None
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1299,6 +1299,12 @@ def redact_session_data(session_dict: dict) -> dict:
 # string objects, so a cold first touch of a large session still paid the full
 # sweep (~1.5s for a 2101-message / 14MB transcript).
 #
+# NOTE: the on-disk cache survives process restarts and upgrades (unlike the
+# in-memory LRUs), so validation includes a rules fingerprint (schema version +
+# WebUI version + agent redactor module stat). Bump _REDACT_SESSION_CACHE_VERSION
+# whenever the projection shape or the internal-field set changes in a way a
+# fingerprint can't see.
+#
 # This derived cache persists the redacted public projection of a session's
 # transcript lists on disk, keyed by per-message content digests. Loads splice
 # cached projections for unchanged messages (zero redaction work — transcripts
@@ -1310,7 +1316,35 @@ def redact_session_data(session_dict: dict) -> dict:
 _REDACT_SESSION_CACHE_VERSION = 1
 
 
+def _redact_session_cache_rules_key() -> str:
+    """Fingerprint of everything the cached projections depend on besides the
+    message content: the cache schema version, the WebUI version (projection
+    shape / internal-field set), and the agent redactor module file (credential
+    patterns can advance independently of the WebUI via the mounted checkout).
+    A mismatch forces a full recompute — this is the guard that keeps a stale
+    cache from serving credentials the CURRENT redactor would catch."""
+    import hashlib
+    parts = [str(_REDACT_SESSION_CACHE_VERSION)]
+    try:
+        from api.config import _current_webui_version
+        parts.append(str(_current_webui_version() or ""))
+    except Exception:
+        parts.append("")
+    try:
+        import agent.redact as _agent_redact
+        st = os.stat(_agent_redact.__file__)
+        parts.append(f"{st.st_mtime_ns}:{st.st_size}")
+    except Exception:
+        parts.append("")
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
+
+
 def _redact_session_cache_path(session_id):
+    # session_id is interpolated into a filename — reject traversal shapes.
+    if (not isinstance(session_id, str) or not session_id
+            or "/" in session_id or "\\" in session_id
+            or session_id in (".", "..")):
+        raise ValueError(f"unsafe session id for redaction cache: {session_id!r}")
     from api.config import STATE_DIR
     return STATE_DIR / "redaction_cache" / f"{session_id}.json"
 
@@ -1327,7 +1361,7 @@ def _redact_apply_turn_decoration(raw_items, projected_items, _active_turn_token
     (decoration-free) projection, using the CURRENT request's token."""
     if _active_turn_token is None or not isinstance(raw_items, list) or not isinstance(projected_items, list):
         return projected_items
-    for raw_msg, out_msg in zip(raw_items, projected_items):
+    for raw_msg, out_msg in zip(raw_items, projected_items, strict=False):
         if (
             isinstance(raw_msg, dict) and isinstance(out_msg, dict)
             and raw_msg.get("role") == "user"
@@ -1347,12 +1381,22 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
     """
     from api.config import load_settings
     _enabled = bool(load_settings().get("api_redact_enabled", True))
+    if not _enabled:
+        # perf(conversation-switch, review follow-up): never persist an
+        # UNREDACTED projection cache — with redaction off, the derived file
+        # would be a second on-disk copy of the very secrets this boundary
+        # exists to keep out of derived artifacts. Passthrough is cheap.
+        return {
+            key: _redact_messages(items, _enabled=False, _active_turn_token=_active_turn_token)
+            for key, items in lists.items()
+        }
 
     out = {}
     want = {}
     wrote = False
     path = None
     try:
+        rules_key = _redact_session_cache_rules_key()
         path = _redact_session_cache_path(session_id)
         cache = None
         if path.exists():
@@ -1360,6 +1404,7 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
                 loaded = _json.loads(path.read_text(encoding="utf-8"))
                 if (isinstance(loaded, dict)
                         and loaded.get("v") == _REDACT_SESSION_CACHE_VERSION
+                        and loaded.get("rules_key") == rules_key
                         and loaded.get("enabled") == _enabled):
                     cache = loaded
             except Exception:
@@ -1397,16 +1442,22 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             # response-only turn decoration below mutates `out`).
             payload = {
                 "v": _REDACT_SESSION_CACHE_VERSION,
+                "rules_key": rules_key,
                 "enabled": _enabled,
                 "digests": want,
                 "lists": {k: projected_by_key[k] for k in want},
             }
             try:
-                import os as _os
+                import tempfile
                 path.parent.mkdir(parents=True, exist_ok=True)
-                tmp = path.with_suffix(f".{_os.getpid()}.tmp")
-                tmp.write_text(_json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-                _os.replace(tmp, path)
+                fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.stem}.", suffix=".tmp")
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                        fh.write(_json.dumps(payload, ensure_ascii=False))
+                    os.replace(tmp_name, path)
+                finally:
+                    if os.path.exists(tmp_name):
+                        os.unlink(tmp_name)
             except Exception:
                 pass
         for key, items in lists.items():

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1292,6 +1292,135 @@ def redact_session_data(session_dict: dict) -> dict:
     return result
 
 
+# ── Session transcript redaction cache (perf: conversation-switch cold load) ──
+# `redact_session_data()` re-sweeps every message string on every load. With the
+# per-string decision memo (above) repeat loads of the same in-memory objects
+# are fast, but each /api/session request re-parses the session file into FRESH
+# string objects, so a cold first touch of a large session still paid the full
+# sweep (~1.5s for a 2101-message / 14MB transcript).
+#
+# This derived cache persists the redacted public projection of a session's
+# transcript lists on disk, keyed by per-message content digests. Loads splice
+# cached projections for unchanged messages (zero redaction work — transcripts
+# are append-mostly) and recompute only appended/changed items. The cache file
+# is a derived artifact: any parse/validation failure falls back to plain
+# redaction, and stored projections are DECORATION-FREE — the per-request
+# `_active_turn_user` flag is applied after retrieval from the CURRENT
+# request's turn token, never persisted.
+_REDACT_SESSION_CACHE_VERSION = 1
+
+
+def _redact_session_cache_path(session_id):
+    from api.config import STATE_DIR
+    return STATE_DIR / "redaction_cache" / f"{session_id}.json"
+
+
+def _redact_item_digest(value) -> str:
+    import hashlib
+    return hashlib.sha256(
+        _json.dumps(value, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+def _redact_apply_turn_decoration(raw_items, projected_items, _active_turn_token):
+    """Mirror `_public_message_projection`'s active-turn flag onto a cached
+    (decoration-free) projection, using the CURRENT request's token."""
+    if _active_turn_token is None or not isinstance(raw_items, list) or not isinstance(projected_items, list):
+        return projected_items
+    for raw_msg, out_msg in zip(raw_items, projected_items):
+        if (
+            isinstance(raw_msg, dict) and isinstance(out_msg, dict)
+            and raw_msg.get("role") == "user"
+            and raw_msg.get("_active_turn_token") == _active_turn_token
+        ):
+            out_msg["_active_turn_user"] = True
+    return projected_items
+
+
+def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=None) -> dict:
+    """Redact transcript lists (`messages`, `context_messages`, ...) through the
+    persistent per-message derived cache.
+
+    Falls back to plain redaction on ANY cache failure — this is a derived
+    artifact, never a correctness dependency. Respects `api_redact_enabled`
+    (the setting is part of cache validation, so toggling it recomputes).
+    """
+    from api.config import load_settings
+    _enabled = bool(load_settings().get("api_redact_enabled", True))
+
+    out = {}
+    want = {}
+    wrote = False
+    path = None
+    try:
+        path = _redact_session_cache_path(session_id)
+        cache = None
+        if path.exists():
+            try:
+                loaded = _json.loads(path.read_text(encoding="utf-8"))
+                if (isinstance(loaded, dict)
+                        and loaded.get("v") == _REDACT_SESSION_CACHE_VERSION
+                        and loaded.get("enabled") == _enabled):
+                    cache = loaded
+            except Exception:
+                cache = None
+        cached_digests = (cache or {}).get("digests") or {}
+        cached_lists = (cache or {}).get("lists") or {}
+        projected_by_key = {}
+        for key, items in lists.items():
+            if not isinstance(items, list):
+                out[key] = _redact_messages(items, _enabled=_enabled, _active_turn_token=_active_turn_token)
+                continue
+            digests = [_redact_item_digest(it) for it in items]
+            want[key] = digests
+            old_digests = cached_digests.get(key) if isinstance(cached_digests, dict) else None
+            old_items = cached_lists.get(key) if isinstance(cached_lists, dict) else None
+            projected = [None] * len(items)
+            reused = 0
+            if (isinstance(old_digests, list) and isinstance(old_items, list)):
+                # Transcripts are append-mostly: splice the common prefix and
+                # recompute only appended/changed items.
+                common = min(len(old_digests), len(digests), len(old_items))
+                for i in range(common):
+                    if old_digests[i] == digests[i] and old_items[i] is not None:
+                        projected[i] = old_items[i]
+                        reused += 1
+            for i, item in enumerate(items):
+                if projected[i] is None:
+                    projected[i] = _redact_messages([item], _enabled=_enabled)[0]
+            projected_by_key[key] = projected
+            out[key] = projected
+            if reused != len(digests):
+                wrote = True
+        if wrote and path is not None:
+            # Write DECORATION-FREE projections (must happen before the
+            # response-only turn decoration below mutates `out`).
+            payload = {
+                "v": _REDACT_SESSION_CACHE_VERSION,
+                "enabled": _enabled,
+                "digests": want,
+                "lists": {k: projected_by_key[k] for k in want},
+            }
+            try:
+                import os as _os
+                path.parent.mkdir(parents=True, exist_ok=True)
+                tmp = path.with_suffix(f".{_os.getpid()}.tmp")
+                tmp.write_text(_json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+                _os.replace(tmp, path)
+            except Exception:
+                pass
+        for key, items in lists.items():
+            if key in projected_by_key:
+                _redact_apply_turn_decoration(items, projected_by_key[key], _active_turn_token)
+        return out
+    except Exception:
+        # Cache is best-effort; never fail a response over it.
+        return {
+            key: _redact_messages(items, _enabled=_enabled, _active_turn_token=_active_turn_token)
+            for key, items in lists.items()
+        }
+
+
 def read_body(handler) -> dict:
     """Read and JSON-parse a POST request body (capped at 20MB)."""
     raw_length = handler.headers.get('Content-Length', 0)

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -493,27 +493,35 @@ except Exception:
     _REDACT_RULES_AGENT_DIGEST = None
 
 
-# Sanity ceiling on the memo cache capacities so a fat-fingered env value
-# can't silently 10x the worst-case RSS (the very thing the env knobs exist to
-# bound). Above all defaults (16384/16384/256); below any plausible typo scale.
-_REDACT_MEMO_MAX_CAP = 131072
+# Per-tier entry ceilings so a raised env knob can't exceed a bounded byte
+# footprint. A SHARED count cap would let the 256KiB big tier retain ~32GiB at a
+# 131072-entry ceiling while the 16KiB small tiers hold a fraction of that
+# (greptile P1). Each cap is derived from a 1GiB-per-tier byte budget (keys+
+# values), so small tiers (16KiB) cap at 32768 and the big tier (256KiB) at
+# 2048. Defaults (16384/16384/256) sit below these; env knobs stay tunable but
+# never balloon.
+_REDACT_MEMO_BYTE_BUDGET = 1024 * 1024 * 1024  # 1 GiB per tier (keys+values)
+_REDACT_MEMO_SMALL_ENTRY = 16384               # == _REDACT_CACHE_MAX_TEXT_LEN
+_REDACT_MEMO_BIG_ENTRY = 262144                # == _REDACT_TEXT_BIG_CACHE_MAX
+_REDACT_SMALL_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_MEMO_SMALL_ENTRY)
+_REDACT_BIG_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_MEMO_BIG_ENTRY)
 
 
-def _lru_size(default: int, env: str) -> int:
-    """Return a positive LRU ``maxsize``, overridable via env var ``env``.
+def _lru_size(default: int, env: str, cap: int) -> int:
+    """Return a positive LRU ``maxsize``, overridable via env var ``env`` and
+    clamped to ``cap`` (the tier's byte-budget-derived ceiling).
 
     The redaction/decision memos are process-wide and retained across sessions
     (deliberate: the perf win is that repeat loads skip re-scanning and
     re-redacting). Each is bounded by its LRU ``maxsize``; the shipped defaults
-    are conservative enough to keep the worst-case RSS bounded, and are exposed
-    as env knobs (``HERMES_WEBUI_REDACT_*``) so a host can raise them if it has
-    headroom or lower them further on a tight box. Values are clamped to
-    ``_REDACT_MEMO_MAX_CAP`` so an errant entry can't balloon.
+    are conservative, and the caps are exposed as env knobs
+    (``HERMES_WEBUI_REDACT_*``) so a host can tune them. ``cap`` keeps an errant
+    entry from ballooning past the tier's RSS budget.
     """
     try:
         val = int(os.getenv(env, default))
         if val >= 1:
-            return min(val, _REDACT_MEMO_MAX_CAP)
+            return min(val, cap)
     except (TypeError, ValueError):
         pass
     return default
@@ -526,7 +534,7 @@ def _lru_size(default: int, env: str) -> int:
 # deterministic (force=True, fixed masking), so identical strings always map to
 # identical output and are safe to memoize without invalidation.
 _redact_fn_lru = functools.lru_cache(
-    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_FN_MEMO")
+    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_FN_MEMO", _REDACT_SMALL_TIER_CAP)
 )(_redact_fn_uncached)
 
 # Cap per-entry size so a handful of giant tool-output dumps can't evict the
@@ -554,7 +562,7 @@ def _redact_fn_cached(text):
 # ~1.1GB theoretical ceiling. Realistic occupancy is far lower (clean strings
 # alias their key objects, most transcript strings are short), and strings above
 # the caps bypass the cache entirely. All three capacities are tunable via
-# HERMES_WEBUI_REDACT_* env vars, and clamped to _REDACT_MEMO_MAX_CAP.
+# HERMES_WEBUI_REDACT_* env vars, each clamped to a per-tier byte-budget cap.
 def _redact_text_impl(text: str) -> str:
     if not _might_contain_sensitive_text(text):
         return text
@@ -562,10 +570,10 @@ def _redact_text_impl(text: str) -> str:
 
 
 _redact_text_lru = functools.lru_cache(
-    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_DECISION_MEMO")
+    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_DECISION_MEMO", _REDACT_SMALL_TIER_CAP)
 )(_redact_text_impl)
 _redact_text_big_lru = functools.lru_cache(
-    maxsize=_lru_size(256, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO")
+    maxsize=_lru_size(256, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO", _REDACT_BIG_TIER_CAP)
 )(_redact_text_impl)
 _REDACT_TEXT_BIG_CACHE_MAX = 262144
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -466,7 +466,7 @@ _redact_fn_uncached = _build_redact_fn()
 # the GIL and surface as "Mất kết nối" in the browser. The redactor is pure and
 # deterministic (force=True, fixed masking), so identical strings always map to
 # identical output and are safe to memoize without invalidation.
-_redact_fn_lru = functools.lru_cache(maxsize=4096)(_redact_fn_uncached)
+_redact_fn_lru = functools.lru_cache(maxsize=32768)(_redact_fn_uncached)
 
 # Cap per-entry size so a handful of giant tool-output dumps can't evict the
 # thousands of small recurring strings that actually benefit, or balloon RSS.
@@ -477,6 +477,28 @@ def _redact_fn_cached(text):
     if len(text) > _REDACT_CACHE_MAX_TEXT_LEN:
         return _redact_fn_uncached(text)
     return _redact_fn_lru(text)
+
+
+# perf(conversation-switch latency, 2026-09-03): profiling a live switch to a
+# 2101-message / 14MB session showed that even with the redactor memoized,
+# ~100% of the remaining per-pass cost was `_might_contain_sensitive_text`
+# re-scanning every string of every message on EVERY load. The prefilter is
+# pure/deterministic like the redactor, so the entire clean-or-redacted
+# DECISION is memoized here: warm passes become dict lookups, and CPython
+# caches str hashes on the string objects themselves, so sessions held in the
+# compact-session LRU skip even the hash cost. Two tiers mirror the redactor
+# memo: small (≤16KiB, 32768 entries) and big (≤256KiB, 1024 entries —
+# worst-case tier RSS ≈ 256MB, typically tens of MB). Strings above the big
+# ceiling stay uncached (rare giant dumps).
+def _redact_text_impl(text: str) -> str:
+    if not _might_contain_sensitive_text(text):
+        return text
+    return _redact_fn_cached(text)
+
+
+_redact_text_lru = functools.lru_cache(maxsize=32768)(_redact_text_impl)
+_redact_text_big_lru = functools.lru_cache(maxsize=1024)(_redact_text_impl)
+_REDACT_TEXT_BIG_CACHE_MAX = 262144
 
 
 _SENSITIVE_CASE_MARKERS = (
@@ -558,15 +580,33 @@ _SENSITIVE_TELEGRAM_MARKER_RE = _re.compile(r"(?:bot)?\d{8,}:[-A-Za-z0-9_]{30,}"
 _SENSITIVE_DISCORD_MARKER_RE = _re.compile(r"<@!?\d{17,20}>")
 _SENSITIVE_PHONE_MARKER_RE = _re.compile(r"(?<![A-Za-z0-9])\+[1-9]\d{6,14}(?![A-Za-z0-9])")
 
+# perf(conversation-switch latency, 2026-09-03): this prefilter runs over
+# every string of every message on every session load; ~30 per-marker `in`
+# scans plus a text.lower() full-string copy made it the dominant per-byte
+# cost. Two compiled alternations preserve exact membership semantics (case
+# set = case-sensitive substring; lower set = case-insensitive substring).
+# Longest-first ordering avoids the re engine stopping at a shorter prefix.
+_SENSITIVE_CASE_MARKER_RE = _re.compile(
+    "|".join(
+        sorted((_re.escape(m) for m in _SENSITIVE_CASE_MARKERS if m), key=len, reverse=True)
+    )
+)
+_SENSITIVE_LOWER_MARKER_RE = _re.compile(
+    "|"
+    .join(
+        sorted((_re.escape(m) for m in _SENSITIVE_LOWER_MARKERS if m), key=len, reverse=True)
+    ),
+    _re.IGNORECASE,
+)
+
 
 def _might_contain_sensitive_text(text: str) -> bool:
     """Cheap prefilter before the full agent+fallback redaction pass."""
     if not isinstance(text, str) or not text:
         return False
-    if any(marker in text for marker in _SENSITIVE_CASE_MARKERS):
+    if _SENSITIVE_CASE_MARKER_RE.search(text):
         return True
-    lower = text.lower()
-    if any(marker in lower for marker in _SENSITIVE_LOWER_MARKERS):
+    if _SENSITIVE_LOWER_MARKER_RE.search(text):
         return True
     if ":" in text and _SENSITIVE_TELEGRAM_MARKER_RE.search(text):
         return True
@@ -584,6 +624,11 @@ def _redact_text(text: str, *, _enabled: bool | None = None) -> str:
     redact many strings in a single response — `redact_session_data()` reads
     the setting once and threads it through ``_redact_value`` so we avoid
     re-loading settings.json from disk per string. (Opus pre-release perf fix.)
+
+    perf(2026-09-03): routes through the per-string decision memo so repeat
+    loads of the same session skip both the prefilter and the redaction pass
+    (see `_redact_text_impl`). Enabled=False bypasses the memo entirely, so
+    the cache only ever holds enabled=True results — no staleness on toggle.
     """
     if not isinstance(text, str) or not text:
         return text
@@ -592,9 +637,12 @@ def _redact_text(text: str, *, _enabled: bool | None = None) -> str:
         _enabled = bool(load_settings().get("api_redact_enabled", True))
     if not _enabled:
         return text
-    if not _might_contain_sensitive_text(text):
-        return text
-    return _redact_fn_cached(text)
+    n = len(text)
+    if n <= _REDACT_CACHE_MAX_TEXT_LEN:
+        return _redact_text_lru(text)
+    if n <= _REDACT_TEXT_BIG_CACHE_MAX:
+        return _redact_text_big_lru(text)
+    return _redact_text_impl(text)
 
 
 _RASTER_IMAGE_DATA_URI_PREFIXES = (

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -460,13 +460,35 @@ def _build_redact_fn():
 
 _redact_fn_uncached = _build_redact_fn()
 
+
+def _lru_size(default: int, env: str) -> int:
+    """Return a positive LRU ``maxsize``, overridable via env var ``env``.
+
+    The redaction/decision memos are process-wide and retained across sessions
+    (deliberate: the perf win is that repeat loads skip re-scanning and
+    re-redacting). Each is bounded by its LRU ``maxsize``, but on a
+    memory-constrained host the worst-case RSS across the three tiers can still
+    be large, so the capacities are exposed as env knobs (defaults unchanged) —
+    set them low to cap growth without giving up the default fast path.
+    """
+    try:
+        val = int(os.getenv(env, default))
+        if val >= 1:
+            return val
+    except (TypeError, ValueError):
+        pass
+    return default
+
+
 # Repeated dashboard polls re-request the same unchanged session payloads, so
 # the combined redactor (~15 regex passes per string) was the dominant CPU cost
 # under concurrent polling — enough to wedge the single-process server behind
 # the GIL and surface as "Mất kết nối" in the browser. The redactor is pure and
 # deterministic (force=True, fixed masking), so identical strings always map to
 # identical output and are safe to memoize without invalidation.
-_redact_fn_lru = functools.lru_cache(maxsize=32768)(_redact_fn_uncached)
+_redact_fn_lru = functools.lru_cache(
+    maxsize=_lru_size(32768, "HERMES_WEBUI_REDACT_FN_MEMO")
+)(_redact_fn_uncached)
 
 # Cap per-entry size so a handful of giant tool-output dumps can't evict the
 # thousands of small recurring strings that actually benefit, or balloon RSS.
@@ -488,19 +510,24 @@ def _redact_fn_cached(text):
 # caches str hashes on the string objects themselves, so sessions held in the
 # compact-session LRU skip even the hash cost. Two tiers mirror the redactor
 # memo: small (≤16KiB, 32768 entries) and big (≤256KiB, 1024 entries).
-# Worst-case tier RSS: big tier stores keys+values ≈ 512MB, small tier
-# ≈ 512MB, redactor memo ≈ 64MB — ~1GB theoretical ceiling; realistic
-# occupancy is tens of MB (clean strings alias their key objects, and
-# recurring short strings dominate). Strings above the big
-# ceiling stay uncached (rare giant dumps).
+# Worst-case tier RSS (keys+values at the caps): big tier 1024·256KiB ≈ 512MB,
+# small decision tier 32768·16KiB ≈ 1GB, redactor memo 32768·16KiB ≈ 1GB — a
+# ~2.5GB theoretical ceiling. Realistic occupancy is far lower (clean strings
+# alias their key objects, most transcript strings are short), and strings above
+# the caps bypass the cache entirely. All three capacities are tunable via
+# HERMES_WEBUI_REDACT_* env vars for memory-constrained hosts.
 def _redact_text_impl(text: str) -> str:
     if not _might_contain_sensitive_text(text):
         return text
     return _redact_fn_cached(text)
 
 
-_redact_text_lru = functools.lru_cache(maxsize=32768)(_redact_text_impl)
-_redact_text_big_lru = functools.lru_cache(maxsize=1024)(_redact_text_impl)
+_redact_text_lru = functools.lru_cache(
+    maxsize=_lru_size(32768, "HERMES_WEBUI_REDACT_DECISION_MEMO")
+)(_redact_text_impl)
+_redact_text_big_lru = functools.lru_cache(
+    maxsize=_lru_size(1024, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO")
+)(_redact_text_impl)
 _REDACT_TEXT_BIG_CACHE_MAX = 262144
 
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1618,7 +1618,7 @@ def _redact_session_cache_rules_key() -> str | None:
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
-_DELETED_REDACTION_SESSIONS: set[str] = set()
+_REDACTION_SESSION_GEN: dict[str, int] = {}
 _DELETED_REDACTION_LOCK = threading.RLock()
 
 
@@ -1737,15 +1737,17 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             try:
                 import tempfile
                 sid_str = str(session_id)
+                with _DELETED_REDACTION_LOCK:
+                    write_gen = _REDACTION_SESSION_GEN.get(sid_str, 0)
                 path.parent.mkdir(parents=True, exist_ok=True)
                 fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.stem}.", suffix=".tmp")
                 try:
                     with os.fdopen(fd, "w", encoding="utf-8") as fh:
                         fh.write(_json.dumps(payload, ensure_ascii=False))
                     with _DELETED_REDACTION_LOCK:
-                        if sid_str not in _DELETED_REDACTION_SESSIONS:
+                        if _REDACTION_SESSION_GEN.get(sid_str, 0) == write_gen:
                             os.replace(tmp_name, path)
-                            if sid_str in _DELETED_REDACTION_SESSIONS:
+                            if _REDACTION_SESSION_GEN.get(sid_str, 0) != write_gen:
                                 try:
                                     path.unlink(missing_ok=True)
                                 except Exception:
@@ -1797,9 +1799,9 @@ def delete_redaction_session_cache(session_id) -> bool:
         pass
     try:
         with _DELETED_REDACTION_LOCK:
-            _DELETED_REDACTION_SESSIONS.add(sid_str)
-            if len(_DELETED_REDACTION_SESSIONS) > 10000:
-                _DELETED_REDACTION_SESSIONS.clear()
+            _REDACTION_SESSION_GEN[sid_str] = _REDACTION_SESSION_GEN.get(sid_str, 0) + 1
+            if len(_REDACTION_SESSION_GEN) > 10000:
+                _REDACTION_SESSION_GEN.clear()
         if not path.exists():
             return False
         path.unlink(missing_ok=True)

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1618,8 +1618,26 @@ def _redact_session_cache_rules_key() -> str | None:
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
-_REDACTION_SESSION_GEN: dict[str, int] = {}
+_REDACTION_SESSION_GEN: collections.OrderedDict[str, int] = collections.OrderedDict()
+_REDACTION_IN_FLIGHT: dict[str, int] = {}
+_MAX_REDACTION_GEN_CAP = 1024
 _DELETED_REDACTION_LOCK = threading.RLock()
+
+
+def _reclaim_redaction_generations_locked():
+    """Evict oldest entries from _REDACTION_SESSION_GEN that have no active in-flight operations."""
+    if len(_REDACTION_SESSION_GEN) <= _MAX_REDACTION_GEN_CAP:
+        return
+    to_delete = []
+    excess = len(_REDACTION_SESSION_GEN) - _MAX_REDACTION_GEN_CAP
+    for sid in _REDACTION_SESSION_GEN:
+        if _REDACTION_IN_FLIGHT.get(sid, 0) == 0:
+            to_delete.append(sid)
+            if len(to_delete) >= excess:
+                break
+    for sid in to_delete:
+        del _REDACTION_SESSION_GEN[sid]
+
 
 
 def _redact_session_cache_path(session_id):
@@ -1679,11 +1697,13 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
     wrote = False
     path = None
     start_token = None
+    sid_str = None
     try:
         rules_key = _redact_session_cache_rules_key()
         path = _redact_session_cache_path(session_id)
         sid_str = str(session_id)
         with _DELETED_REDACTION_LOCK:
+            _REDACTION_IN_FLIGHT[sid_str] = _REDACTION_IN_FLIGHT.get(sid_str, 0) + 1
             start_token = _REDACTION_SESSION_GEN.get(sid_str, 0)
         cache = None
         # A valid rules_key is a HARD prerequisite for authorizing a cached read.
@@ -1768,6 +1788,15 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             key: _redact_messages(items, _enabled=_enabled, _active_turn_token=_active_turn_token)
             for key, items in lists.items()
         }
+    finally:
+        if sid_str is not None:
+            with _DELETED_REDACTION_LOCK:
+                cur = _REDACTION_IN_FLIGHT.get(sid_str, 0) - 1
+                if cur <= 0:
+                    _REDACTION_IN_FLIGHT.pop(sid_str, None)
+                    _reclaim_redaction_generations_locked()
+                else:
+                    _REDACTION_IN_FLIGHT[sid_str] = cur
 
 
 def delete_redaction_session_cache(session_id) -> bool:
@@ -1800,7 +1829,12 @@ def delete_redaction_session_cache(session_id) -> bool:
         pass
     try:
         with _DELETED_REDACTION_LOCK:
-            _REDACTION_SESSION_GEN[sid_str] = _REDACTION_SESSION_GEN.get(sid_str, 0) + 1
+            file_exists = path.exists()
+            has_in_flight = _REDACTION_IN_FLIGHT.get(sid_str, 0) > 0
+            if file_exists or has_in_flight:
+                _REDACTION_SESSION_GEN[sid_str] = _REDACTION_SESSION_GEN.get(sid_str, 0) + 1
+                _REDACTION_SESSION_GEN.move_to_end(sid_str)
+                _reclaim_redaction_generations_locked()
         if not path.exists():
             return False
         path.unlink(missing_ok=True)

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -549,6 +549,13 @@ _CacheInfo = collections.namedtuple(
 )
 
 
+# Fixed per-entry container overhead in CPython (64-bit): the (val, entry_bytes)
+# tuple (~56 bytes) plus the OrderedDict linked-list node pointers (~72 bytes).
+# Accounting for this per entry guarantees that even workloads with tens of thousands
+# of short clean strings stay strictly within max_bytes total RSS footprint.
+_ENTRY_CONTAINER_OVERHEAD_BYTES = 128
+
+
 class _ByteBudgetLRU:
     """Thread-safe, byte-budgeted LRU cache for deterministic memory ceilings.
 
@@ -602,7 +609,7 @@ class _ByteBudgetLRU:
                 sys.getsizeof(key)
                 if (key is val or id(key) == id(val))
                 else (sys.getsizeof(key) + sys.getsizeof(val))
-            )
+            ) + _ENTRY_CONTAINER_OVERHEAD_BYTES
 
             if entry_bytes > self.max_bytes:
                 return val

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -549,18 +549,24 @@ _CacheInfo = collections.namedtuple(
 )
 
 
-# Fixed per-entry container overhead in CPython (64-bit): the (val, entry_bytes)
-# tuple (~56 bytes) plus the OrderedDict linked-list node pointers (~72 bytes).
-# Accounting for this per entry guarantees that even workloads with tens of thousands
-# of short clean strings stay strictly within max_bytes total RSS footprint.
-_ENTRY_CONTAINER_OVERHEAD_BYTES = 128
+# Exact shallow overheads in CPython (64-bit): the (val, entry_payload) 2-tuple
+# (~56 bytes) and the baseline empty OrderedDict container (~128 bytes).
+_TUPLE_OVERHEAD_BYTES = sys.getsizeof(("", 0))
+_BASE_DICT_BYTES = sys.getsizeof(collections.OrderedDict())
 
 
 class _ByteBudgetLRU:
-    """Thread-safe, byte-budgeted LRU cache for deterministic memory ceilings.
+    """Thread-safe, byte-budgeted LRU cache bounding shallow retained memory.
 
-    Worst-case retained memory equals ``max_bytes`` by construction (plus fixed
-    OrderedDict / entry overhead), regardless of the entry-size mix.
+    Worst-case retained memory is bounded by ``max_bytes``, accounting for:
+    * Key and value object allocations (``sys.getsizeof``)
+    * The stored 2-item entry tuple overhead (``_TUPLE_OVERHEAD_BYTES``)
+    * The measured ``OrderedDict`` hash-table allocation and dynamic resize slack
+
+    Memory scope:
+    Bounds cache-owned shallow retained memory (keys, values, stored tuples, and
+    OrderedDict container allocation). Does not bound process-wide RSS or allocator
+    fragmentation, as CPython's pymalloc arenas may retain unmapped heap pools.
 
     Aliasing accounting:
     * When ``key is value`` (clean-string decision memo: ``_redact_text_impl`` returns
@@ -581,12 +587,29 @@ class _ByteBudgetLRU:
         self._func = func
         self.max_bytes = max(1, int(max_bytes))
         self.name = name
-        self._data = collections.OrderedDict()  # key -> (value, entry_bytes)
-        self._retained_bytes = 0
+        self._data = collections.OrderedDict()  # key -> (value, entry_payload)
+        self._payload_bytes = 0
         self._hits = 0
         self._misses = 0
         self._lock = threading.Lock()
         functools.update_wrapper(self, func)
+
+    @property
+    def retained_bytes(self) -> int:
+        """Measured shallow bytes: keys, values, stored tuples, and OrderedDict container growth."""
+        return (
+            self._payload_bytes
+            + (len(self._data) * _TUPLE_OVERHEAD_BYTES)
+            + max(0, sys.getsizeof(self._data) - _BASE_DICT_BYTES)
+        )
+
+    def _compact_if_slack(self) -> None:
+        """Rebuild OrderedDict to release excess table allocation when capacity has high slack."""
+        if not self._data:
+            if sys.getsizeof(self._data) > _BASE_DICT_BYTES:
+                self._data = collections.OrderedDict()
+        elif (sys.getsizeof(self._data) - _BASE_DICT_BYTES) > max(256, len(self._data) * 96):
+            self._data = collections.OrderedDict(self._data)
 
     def __call__(self, key: str) -> str:
         with self._lock:
@@ -605,27 +628,37 @@ class _ByteBudgetLRU:
                 self._data.move_to_end(key)
                 return entry[0]
 
-            entry_bytes = (
+            entry_payload = (
                 sys.getsizeof(key)
                 if (key is val or id(key) == id(val))
                 else (sys.getsizeof(key) + sys.getsizeof(val))
-            ) + _ENTRY_CONTAINER_OVERHEAD_BYTES
+            )
 
-            if entry_bytes > self.max_bytes:
+            # An entry must fit within budget along with its stored tuple overhead
+            if entry_payload + _TUPLE_OVERHEAD_BYTES > self.max_bytes:
                 return val
 
-            while self._data and (self._retained_bytes + entry_bytes > self.max_bytes):
-                _, (_, evicted_bytes) = self._data.popitem(last=False)
-                self._retained_bytes -= evicted_bytes
+            self._data[key] = (val, entry_payload)
+            self._payload_bytes += entry_payload
 
-            self._data[key] = (val, entry_bytes)
-            self._retained_bytes += entry_bytes
+            evicted = False
+            while self._data and (self.retained_bytes > self.max_bytes):
+                self._compact_if_slack()
+                if self.retained_bytes <= self.max_bytes:
+                    break
+                _, (_, evicted_payload) = self._data.popitem(last=False)
+                self._payload_bytes -= evicted_payload
+                evicted = True
+
+            if evicted:
+                self._compact_if_slack()
+
             return val
 
     def cache_clear(self) -> None:
         with self._lock:
-            self._data.clear()
-            self._retained_bytes = 0
+            self._data = collections.OrderedDict()
+            self._payload_bytes = 0
             self._hits = 0
             self._misses = 0
 
@@ -636,7 +669,7 @@ class _ByteBudgetLRU:
                 misses=self._misses,
                 maxsize=None,
                 currsize=len(self._data),
-                retained_bytes=self._retained_bytes,
+                retained_bytes=self.retained_bytes,
                 max_bytes=self.max_bytes,
             )
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1618,6 +1618,10 @@ def _redact_session_cache_rules_key() -> str | None:
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
+_DELETED_REDACTION_SESSIONS: set[str] = set()
+_DELETED_REDACTION_LOCK = threading.RLock()
+
+
 def _redact_session_cache_path(session_id):
     # session_id is interpolated into a filename — reject traversal shapes.
     if (not isinstance(session_id, str) or not session_id
@@ -1681,9 +1685,8 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
         # A valid rules_key is a HARD prerequisite for authorizing a cached read.
         # If no trustworthy content identity could be computed (rules_key is
         # None), do not even open the cache: rederive the projection from the
-        # current policy. This is the fail-closed branch the stale-redaction
-        # boundary requires — metadata/version identity is not content identity.
-        if rules_key is not None and path.exists():
+        # current policy.
+        if rules_key is not None and path is not None and path.exists():
             try:
                 loaded = _json.loads(path.read_text(encoding="utf-8"))
                 if (isinstance(loaded, dict)
@@ -1719,7 +1722,7 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
                     projected[i] = _redact_messages([item], _enabled=_enabled)[0]
             projected_by_key[key] = projected
             out[key] = projected
-            if reused != len(digests):
+            if reused != len(digests) or (isinstance(old_digests, list) and len(old_digests) > len(digests)):
                 wrote = True
         if wrote and path is not None and rules_key is not None:
             # Write DECORATION-FREE projections (must happen before the
@@ -1733,12 +1736,20 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             }
             try:
                 import tempfile
+                sid_str = str(session_id)
                 path.parent.mkdir(parents=True, exist_ok=True)
                 fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.stem}.", suffix=".tmp")
                 try:
                     with os.fdopen(fd, "w", encoding="utf-8") as fh:
                         fh.write(_json.dumps(payload, ensure_ascii=False))
-                    os.replace(tmp_name, path)
+                    with _DELETED_REDACTION_LOCK:
+                        if sid_str not in _DELETED_REDACTION_SESSIONS:
+                            os.replace(tmp_name, path)
+                            if sid_str in _DELETED_REDACTION_SESSIONS:
+                                try:
+                                    path.unlink(missing_ok=True)
+                                except Exception:
+                                    pass
                 finally:
                     if os.path.exists(tmp_name):
                         os.unlink(tmp_name)
@@ -1773,6 +1784,7 @@ def delete_redaction_session_cache(session_id) -> bool:
     missing projection file are a no-op for the on-disk artifact; returns True
     only if a file was actually removed. Best-effort — never raises.
     """
+    sid_str = str(session_id)
     try:
         path = _redact_session_cache_path(session_id)
     except Exception:
@@ -1784,6 +1796,10 @@ def delete_redaction_session_cache(session_id) -> bool:
     except Exception:
         pass
     try:
+        with _DELETED_REDACTION_LOCK:
+            _DELETED_REDACTION_SESSIONS.add(sid_str)
+            if len(_DELETED_REDACTION_SESSIONS) > 10000:
+                _DELETED_REDACTION_SESSIONS.clear()
         if not path.exists():
             return False
         path.unlink(missing_ok=True)

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1678,9 +1678,13 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
     want = {}
     wrote = False
     path = None
+    start_token = None
     try:
         rules_key = _redact_session_cache_rules_key()
         path = _redact_session_cache_path(session_id)
+        sid_str = str(session_id)
+        with _DELETED_REDACTION_LOCK:
+            start_token = _REDACTION_SESSION_GEN.get(sid_str, 0)
         cache = None
         # A valid rules_key is a HARD prerequisite for authorizing a cached read.
         # If no trustworthy content identity could be computed (rules_key is
@@ -1736,18 +1740,15 @@ def redact_session_lists_cached(session_id, lists: dict, *, _active_turn_token=N
             }
             try:
                 import tempfile
-                sid_str = str(session_id)
-                with _DELETED_REDACTION_LOCK:
-                    write_gen = _REDACTION_SESSION_GEN.get(sid_str, 0)
                 path.parent.mkdir(parents=True, exist_ok=True)
                 fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.stem}.", suffix=".tmp")
                 try:
                     with os.fdopen(fd, "w", encoding="utf-8") as fh:
                         fh.write(_json.dumps(payload, ensure_ascii=False))
                     with _DELETED_REDACTION_LOCK:
-                        if _REDACTION_SESSION_GEN.get(sid_str, 0) == write_gen:
+                        if start_token is not None and _REDACTION_SESSION_GEN.get(sid_str, 0) == start_token:
                             os.replace(tmp_name, path)
-                            if _REDACTION_SESSION_GEN.get(sid_str, 0) != write_gen:
+                            if _REDACTION_SESSION_GEN.get(sid_str, 0) != start_token:
                                 try:
                                     path.unlink(missing_ok=True)
                                 except Exception:
@@ -1800,8 +1801,6 @@ def delete_redaction_session_cache(session_id) -> bool:
     try:
         with _DELETED_REDACTION_LOCK:
             _REDACTION_SESSION_GEN[sid_str] = _REDACTION_SESSION_GEN.get(sid_str, 0) + 1
-            if len(_REDACTION_SESSION_GEN) > 10000:
-                _REDACTION_SESSION_GEN.clear()
         if not path.exists():
             return False
         path.unlink(missing_ok=True)

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -3,12 +3,15 @@ Hermes Web UI -- HTTP helper functions.
 """
 import base64 as _base64
 import binascii as _binascii
+import collections
 import functools
 import json as _json
 import logging
 import os
 import re as _re
 import ssl
+import sys
+import threading
 from pathlib import Path
 from api.config import IMAGE_EXTS, MD_EXTS
 
@@ -501,36 +504,148 @@ except Exception:
 _REDACT_CACHE_MAX_TEXT_LEN = 16384
 _REDACT_TEXT_BIG_CACHE_MAX = 262144
 
-# Per-tier entry ceilings so a raised env knob can't exceed a bounded byte
-# footprint. A SHARED count cap would let the 256KiB big tier retain ~32GiB at a
-# 131072-entry ceiling while the 16KiB small tiers hold a fraction of that
-# (greptile P1). Each cap is derived from a 1GiB-per-tier byte budget (keys+
-# values), so small tiers (16KiB) cap at 32768 and the big tier (256KiB) at
-# 2048. Defaults (16384/16384/256) sit below these; env knobs stay tunable but
-# never balloon.
-_REDACT_MEMO_BYTE_BUDGET = 1024 * 1024 * 1024  # 1 GiB per tier (keys+values)
+# Byte-budgeted eviction for the decision/redactor memo LRUs (#7439):
+# The process-wide memos are bounded by a byte budget per tier rather than count
+# caps, guaranteeing worst-case retained memory equals the configured budget by
+# construction (independent of entry-size distribution).
+_REDACT_MEMO_BYTE_BUDGET = 1024 * 1024 * 1024  # 1 GiB per tier hard ceiling
 _REDACT_SMALL_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_CACHE_MAX_TEXT_LEN)
 _REDACT_BIG_TIER_CAP = _REDACT_MEMO_BYTE_BUDGET // (2 * _REDACT_TEXT_BIG_CACHE_MAX)
 
+_REDACT_FN_MEMO_BYTE_BUDGET_DEFAULT = 512 * 1024 * 1024        # 512 MiB
+_REDACT_DECISION_MEMO_BYTE_BUDGET_DEFAULT = 512 * 1024 * 1024   # 512 MiB
+_REDACT_BIG_DECISION_MEMO_BYTE_BUDGET_DEFAULT = 128 * 1024 * 1024   # 128 MiB
 
-def _lru_size(default: int, env: str, cap: int) -> int:
-    """Return a positive LRU ``maxsize``, overridable via env var ``env`` and
-    clamped to ``cap`` (the tier's byte-budget-derived ceiling).
 
-    The redaction/decision memos are process-wide and retained across sessions
-    (deliberate: the perf win is that repeat loads skip re-scanning and
-    re-redacting). Each is bounded by its LRU ``maxsize``; the shipped defaults
-    are conservative, and the caps are exposed as env knobs
-    (``HERMES_WEBUI_REDACT_*``) so a host can tune them. ``cap`` keeps an errant
-    entry from ballooning past the tier's RSS budget.
+def _byte_budget(
+    default: int,
+    env: str,
+    cap: int = _REDACT_MEMO_BYTE_BUDGET,
+    alt_env: str = "",
+) -> int:
+    """Return a positive byte budget, overridable via env var ``env`` (or ``alt_env``)
+    and clamped to ``cap`` (the tier's hard ceiling).
     """
-    try:
-        val = int(os.getenv(env, default))
-        if val >= 1:
-            return min(val, cap)
-    except (TypeError, ValueError):
-        pass
+    for var in (env, alt_env):
+        if not var:
+            continue
+        val_str = os.getenv(var)
+        if val_str is not None:
+            try:
+                val = int(val_str)
+                if val >= 1:
+                    return min(val, cap)
+            except (TypeError, ValueError):
+                pass
     return default
+
+
+_lru_size = _byte_budget
+
+
+_CacheInfo = collections.namedtuple(
+    "_CacheInfo",
+    ["hits", "misses", "maxsize", "currsize", "retained_bytes", "max_bytes"],
+)
+
+
+class _ByteBudgetLRU:
+    """Thread-safe, byte-budgeted LRU cache for deterministic memory ceilings.
+
+    Worst-case retained memory equals ``max_bytes`` by construction (plus fixed
+    OrderedDict / entry overhead), regardless of the entry-size mix.
+
+    Aliasing accounting:
+    * When ``key is value`` (clean-string decision memo: ``_redact_text_impl`` returns
+      the input string unchanged on a prefilter miss), the entry only consumes
+      ``sys.getsizeof(key)`` bytes once. Double-counting clean strings would over-account
+      by ~2x on the dominant transcript path and cause premature eviction.
+    * When ``key is not value``, the entry consumes ``sys.getsizeof(key) + sys.getsizeof(value)``.
+    * Cross-tier sharing (e.g. between ``_redact_fn_lru`` and ``_redact_text_lru``) is
+      safely over-counted per-tier by design (evicts earlier; never exceeds budget).
+
+    Thread-safety:
+    All mutations, recency bumps on read, evictions, clears, and cache_info reads
+    are protected by an internal ``threading.Lock``. Pure function execution occurs
+    outside the lock to prevent lock contention across regex execution.
+    """
+
+    def __init__(self, func, max_bytes: int, name: str = ""):
+        self._func = func
+        self.max_bytes = max(1, int(max_bytes))
+        self.name = name
+        self._data = collections.OrderedDict()  # key -> (value, entry_bytes)
+        self._retained_bytes = 0
+        self._hits = 0
+        self._misses = 0
+        self._lock = threading.Lock()
+        functools.update_wrapper(self, func)
+
+    def __call__(self, key: str) -> str:
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is not None:
+                self._data.move_to_end(key)
+                self._hits += 1
+                return entry[0]
+            self._misses += 1
+
+        val = self._func(key)
+
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is not None:
+                self._data.move_to_end(key)
+                return entry[0]
+
+            entry_bytes = (
+                sys.getsizeof(key)
+                if (key is val or id(key) == id(val))
+                else (sys.getsizeof(key) + sys.getsizeof(val))
+            )
+
+            if entry_bytes > self.max_bytes:
+                return val
+
+            while self._data and (self._retained_bytes + entry_bytes > self.max_bytes):
+                _, (_, evicted_bytes) = self._data.popitem(last=False)
+                self._retained_bytes -= evicted_bytes
+
+            self._data[key] = (val, entry_bytes)
+            self._retained_bytes += entry_bytes
+            return val
+
+    def cache_clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+            self._retained_bytes = 0
+            self._hits = 0
+            self._misses = 0
+
+    def cache_info(self) -> _CacheInfo:
+        with self._lock:
+            return _CacheInfo(
+                hits=self._hits,
+                misses=self._misses,
+                maxsize=None,
+                currsize=len(self._data),
+                retained_bytes=self._retained_bytes,
+                max_bytes=self.max_bytes,
+            )
+
+    def cache_parameters(self) -> dict:
+        with self._lock:
+            return {
+                "max_bytes": self.max_bytes,
+                "typed": False,
+            }
+
+
+def byte_budget_lru_cache(max_bytes: int, name: str = ""):
+    """Decorator returning a thread-safe, byte-budgeted LRU cache."""
+    def decorator(fn):
+        return _ByteBudgetLRU(fn, max_bytes=max_bytes, name=name)
+    return decorator
 
 
 # Repeated dashboard polls re-request the same unchanged session payloads, so
@@ -539,8 +654,14 @@ def _lru_size(default: int, env: str, cap: int) -> int:
 # the GIL and surface as "Mất kết nối" in the browser. The redactor is pure and
 # deterministic (force=True, fixed masking), so identical strings always map to
 # identical output and are safe to memoize without invalidation.
-_redact_fn_lru = functools.lru_cache(
-    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_FN_MEMO", _REDACT_SMALL_TIER_CAP)
+_redact_fn_lru = byte_budget_lru_cache(
+    max_bytes=_byte_budget(
+        _REDACT_FN_MEMO_BYTE_BUDGET_DEFAULT,
+        "HERMES_WEBUI_REDACT_FN_BYTE_BUDGET",
+        _REDACT_MEMO_BYTE_BUDGET,
+        alt_env="HERMES_WEBUI_REDACT_FN_MEMO_BYTE_BUDGET",
+    ),
+    name="redact_fn",
 )(_redact_fn_uncached)
 
 def _redact_fn_cached(text):
@@ -557,24 +678,34 @@ def _redact_fn_cached(text):
 # DECISION is memoized here: warm passes become dict lookups, and CPython
 # caches str hashes on the string objects themselves, so sessions held in the
 # compact-session LRU skip even the hash cost. Two tiers mirror the redactor
-# memo: small (≤16KiB, 16384 entries) and big (≤256KiB, 256 entries).
-# Worst-case tier RSS (keys+values at the caps): big tier 256·256KiB ≈ 128MB,
-# small decision tier 16384·16KiB ≈ 512MB, redactor memo 16384·16KiB ≈ 512MB — a
-# ~1.1GB theoretical ceiling. Realistic occupancy is far lower (clean strings
-# alias their key objects, most transcript strings are short), and strings above
-# the caps bypass the cache entirely. All three capacities are tunable via
-# HERMES_WEBUI_REDACT_* env vars, each clamped to a per-tier byte-budget cap.
+# memo: small (≤16KiB, 512MiB budget) and big (≤256KiB, 128MiB budget).
+# Worst-case tier RSS equals the configured byte budget by construction,
+# with single-accounting for aliased clean strings and wholesale eviction on
+# session deletion. All three budgets are tunable via HERMES_WEBUI_REDACT_*_BYTE_BUDGET
+# env vars, each clamped to the 1GiB hard ceiling.
 def _redact_text_impl(text: str) -> str:
     if not _might_contain_sensitive_text(text):
         return text
     return _redact_fn_cached(text)
 
 
-_redact_text_lru = functools.lru_cache(
-    maxsize=_lru_size(16384, "HERMES_WEBUI_REDACT_DECISION_MEMO", _REDACT_SMALL_TIER_CAP)
+_redact_text_lru = byte_budget_lru_cache(
+    max_bytes=_byte_budget(
+        _REDACT_DECISION_MEMO_BYTE_BUDGET_DEFAULT,
+        "HERMES_WEBUI_REDACT_DECISION_BYTE_BUDGET",
+        _REDACT_MEMO_BYTE_BUDGET,
+        alt_env="HERMES_WEBUI_REDACT_DECISION_MEMO_BYTE_BUDGET",
+    ),
+    name="redact_text_small",
 )(_redact_text_impl)
-_redact_text_big_lru = functools.lru_cache(
-    maxsize=_lru_size(256, "HERMES_WEBUI_REDACT_BIG_DECISION_MEMO", _REDACT_BIG_TIER_CAP)
+_redact_text_big_lru = byte_budget_lru_cache(
+    max_bytes=_byte_budget(
+        _REDACT_BIG_DECISION_MEMO_BYTE_BUDGET_DEFAULT,
+        "HERMES_WEBUI_REDACT_BIG_DECISION_BYTE_BUDGET",
+        _REDACT_MEMO_BYTE_BUDGET,
+        alt_env="HERMES_WEBUI_REDACT_BIG_DECISION_MEMO_BYTE_BUDGET",
+    ),
+    name="redact_text_big",
 )(_redact_text_impl)
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -13898,7 +13898,24 @@ def handle_get(handler, parsed) -> bool:
                 )
                 if revision:
                     raw["regeneration_revision"] = revision
+            # perf(conversation-switch): full-transcript loads splice the
+            # persisted per-message redaction cache (t5 stage); limited views
+            # and non-load requests are cheap enough to redact directly.
+            _transcript_lists = {}
+            if load_messages and msg_limit is None:
+                for _tk in ("messages", "context_messages"):
+                    if _tk in raw:
+                        _transcript_lists[_tk] = raw.pop(_tk)
+            try:
+                from api.process_event_utils import build_active_turn_token as _build_turn_token
+                _active_turn_token = _build_turn_token(raw.get("active_stream_id"), raw.get("pending_started_at"))
+            except Exception:
+                _active_turn_token = None
             redact = redact_session_data(raw)
+            if _transcript_lists:
+                from api.helpers import redact_session_lists_cached
+                redact.update(redact_session_lists_cached(
+                    sid, _transcript_lists, _active_turn_token=_active_turn_token))
             _t5 = _time.monotonic()
             if _diag: _diag.stage("t5_after_redact")
             resp = j(handler, {"session": redact})

--- a/api/routes.py
+++ b/api/routes.py
@@ -15978,6 +15978,16 @@ def handle_post(handler, parsed) -> bool:
             delete_turn_journal(sid)
         except Exception:
             logger.debug("Failed to delete turn journal for deleted session %s", sid)
+        # The persisted redaction projection (STATE_DIR/redaction_cache/) is a
+        # derived artifact; unlike the journals it holds redacted text, but the
+        # surviving conversation still belongs to the deleted session (#7414
+        # follow-up).
+        try:
+            from api.helpers import delete_redaction_session_cache
+
+            delete_redaction_session_cache(sid)
+        except Exception:
+            logger.debug("Failed to delete redaction cache for deleted session %s", sid)
         try:
             from api.run_journal import delete_run_journal
 
@@ -22238,6 +22248,12 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
                 p.unlink(missing_ok=True)
+                try:
+                    from api.helpers import delete_redaction_session_cache
+
+                    delete_redaction_session_cache(p.stem)
+                except Exception:
+                    pass
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)
         except Exception:
@@ -22469,6 +22485,12 @@ def _handle_background(handler, body):
             # next rebuild via _index_entry_exists().
             try:
                 (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                try:
+                    from api.helpers import delete_redaction_session_cache
+
+                    delete_redaction_session_cache(bg_sid)
+                except Exception:
+                    pass
             except Exception:
                 pass
         except Exception:

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -63,11 +63,11 @@ def test_redact_text_giant_above_ceiling_not_memoized():
 
 def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
     # The process-wide memos are bounded by LRU maxsize (memory cannot grow
-    # unboundedly), and the caps are overridable via env for constrained hosts.
-    # Defaults are unchanged from the intended perf tuning.
-    assert H._redact_fn_lru.cache_info().maxsize == 32768
-    assert H._redact_text_lru.cache_info().maxsize == 32768
-    assert H._redact_text_big_lru.cache_info().maxsize == 1024
+    # unboundedly), and the shipped defaults are conservative enough that the
+    # worst-case RSS stays bounded (greptile P1). Env vars can raise/lower them.
+    assert H._redact_fn_lru.cache_info().maxsize == 16384
+    assert H._redact_text_lru.cache_info().maxsize == 16384
+    assert H._redact_text_big_lru.cache_info().maxsize == 256
 
     # _lru_size: positive int from env, else the default.
     assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100
@@ -77,3 +77,9 @@ def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
     assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # <1 rejected
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "not-a-number")
     assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # invalid rejected
+    # A fat-fingered huge value is clamped so it can't balloon RSS.
+    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "999999999")
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == H._REDACT_MEMO_MAX_CAP
+    assert H._REDACT_MEMO_MAX_CAP >= H._redact_fn_lru.cache_info().maxsize
+    assert H._REDACT_MEMO_MAX_CAP >= H._redact_text_lru.cache_info().maxsize
+    assert H._REDACT_MEMO_MAX_CAP >= H._redact_text_big_lru.cache_info().maxsize

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -1,0 +1,61 @@
+"""Regression: `_redact_text` decision memo must be byte-identical to the
+uncached path, bounded, and safe on toggle.
+
+Companion to the #5204 redactor memo contract: the perf(conversation-switch)
+change routes `_redact_text` through a per-string memo of the entire
+clean-or-redacted decision (prefilter + redactor) in two size tiers. Locks:
+  * memoized results are byte-identical to `_redact_text_impl` (no behavior
+    change from caching),
+  * repeat calls hit the memo (that is the point),
+  * strings above the big-tier ceiling stay uncached yet still redact,
+  * enabled=False bypasses the memo entirely (cache only ever holds
+    enabled=True results, so no staleness on toggle).
+"""
+from api import helpers as H
+
+_SECRET = "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+def test_redact_text_matches_uncached_decision_all_sizes():
+    small = f"note {_SECRET} tail"                                   # small tier
+    big = ("x" * (H._REDACT_CACHE_MAX_TEXT_LEN + 100)) + f" {_SECRET}"   # big tier
+    giant = ("y" * (H._REDACT_TEXT_BIG_CACHE_MAX + 100)) + f" {_SECRET}"  # uncached
+    for s in (small, big, giant):
+        assert H._redact_text(s, _enabled=True) == H._redact_text_impl(s)
+        assert _SECRET not in H._redact_text(s, _enabled=True)
+
+
+def test_redact_text_repeat_hits_memo():
+    sample = f"session {getattr(H, '_REDACT_CACHE_MAX_TEXT_LEN', 0)} {_SECRET} repeat"
+    H._redact_text_lru.cache_clear()
+    first = H._redact_text(sample, _enabled=True)
+    hits_before = H._redact_text_lru.cache_info().hits
+    second = H._redact_text(sample, _enabled=True)
+    assert first == second
+    assert H._redact_text_lru.cache_info().hits == hits_before + 1
+
+
+def test_redact_text_benign_string_returned_verbatim():
+    benign = "plain conversation text with no credential shapes at all"
+    assert H._redact_text(benign, _enabled=True) == benign
+    assert H._redact_text_impl(benign) == benign
+
+
+def test_redact_text_disabled_bypasses_memo():
+    sample = f"disabled path {_SECRET} not memoized"
+    H._redact_text_lru.cache_clear()
+    hits_before = H._redact_text_lru.cache_info().hits
+    misses_before = H._redact_text_lru.cache_info().misses
+    out = H._redact_text(sample, _enabled=False)
+    assert out == sample  # disabled = verbatim, no redaction
+    info = H._redact_text_lru.cache_info()
+    assert (info.hits, info.misses) == (hits_before, misses_before)
+
+
+def test_redact_text_giant_above_ceiling_not_memoized():
+    giant = ("z" * (H._REDACT_TEXT_BIG_CACHE_MAX + 1)) + f" {_SECRET}"
+    H._redact_text_big_lru.cache_clear()
+    before = H._redact_text_big_lru.cache_info().misses
+    out = H._redact_text(giant, _enabled=True)
+    assert _SECRET not in out
+    assert H._redact_text_big_lru.cache_info().misses == before  # tier skipped

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -62,24 +62,27 @@ def test_redact_text_giant_above_ceiling_not_memoized():
 
 
 def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
-    # The process-wide memos are bounded by LRU maxsize (memory cannot grow
-    # unboundedly), and the shipped defaults are conservative enough that the
-    # worst-case RSS stays bounded (greptile P1). Env vars can raise/lower them.
+    # The process-wide memos are bounded by LRU maxsize PER TIER (memory cannot
+    # grow unboundedly), and the shipped defaults are conservative (greptile P1).
+    # Env vars can raise/lower them, but each tier is clamped to its byte budget.
     assert H._redact_fn_lru.cache_info().maxsize == 16384
     assert H._redact_text_lru.cache_info().maxsize == 16384
     assert H._redact_text_big_lru.cache_info().maxsize == 256
 
-    # _lru_size: positive int from env, else the default.
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100
+    # _lru_size: positive int from env, clamped to `cap`, else the default.
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "5")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 5
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 5
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "0")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # <1 rejected
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100  # <1 rejected
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "not-a-number")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # invalid rejected
-    # A fat-fingered huge value is clamped so it can't balloon RSS.
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100  # invalid rejected
+    # A fat-fingered huge value is clamped to the per-tier cap (greptile P1: the
+    # big tier must not allow 131072 * 256KiB ≈ 32GiB).
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "999999999")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == H._REDACT_MEMO_MAX_CAP
-    assert H._REDACT_MEMO_MAX_CAP >= H._redact_fn_lru.cache_info().maxsize
-    assert H._REDACT_MEMO_MAX_CAP >= H._redact_text_lru.cache_info().maxsize
-    assert H._REDACT_MEMO_MAX_CAP >= H._redact_text_big_lru.cache_info().maxsize
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 200
+    # Big-tier ceiling is byte-budget derived and far below a shared-count cap.
+    assert H._REDACT_BIG_TIER_CAP < 131072
+    assert H._redact_text_big_lru.cache_info().maxsize <= H._REDACT_BIG_TIER_CAP
+    assert H._REDACT_SMALL_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_MEMO_SMALL_ENTRY)
+    assert H._REDACT_BIG_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_MEMO_BIG_ENTRY)

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -59,3 +59,21 @@ def test_redact_text_giant_above_ceiling_not_memoized():
     out = H._redact_text(giant, _enabled=True)
     assert _SECRET not in out
     assert H._redact_text_big_lru.cache_info().misses == before  # tier skipped
+
+
+def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
+    # The process-wide memos are bounded by LRU maxsize (memory cannot grow
+    # unboundedly), and the caps are overridable via env for constrained hosts.
+    # Defaults are unchanged from the intended perf tuning.
+    assert H._redact_fn_lru.cache_info().maxsize == 32768
+    assert H._redact_text_lru.cache_info().maxsize == 32768
+    assert H._redact_text_big_lru.cache_info().maxsize == 1024
+
+    # _lru_size: positive int from env, else the default.
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100
+    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "5")
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 5
+    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "0")
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # <1 rejected
+    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "not-a-number")
+    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING") == 100  # invalid rejected

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -81,8 +81,11 @@ def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
     # big tier must not allow 131072 * 256KiB ≈ 32GiB).
     monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "999999999")
     assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 200
-    # Big-tier ceiling is byte-budget derived and far below a shared-count cap.
+    # Big-tier ceiling is byte-budget derived from the REAL per-entry caps and
+    # far below a shared-count cap (greptile P1). This is not tautological: the
+    # caps are derived from _REDACT_CACHE_MAX_TEXT_LEN / _REDACT_TEXT_BIG_CACHE_MAX
+    # (the values the caches actually enforce), so if those drift the assertion fails.
     assert H._REDACT_BIG_TIER_CAP < 131072
     assert H._redact_text_big_lru.cache_info().maxsize <= H._REDACT_BIG_TIER_CAP
-    assert H._REDACT_SMALL_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_MEMO_SMALL_ENTRY)
-    assert H._REDACT_BIG_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_MEMO_BIG_ENTRY)
+    assert H._REDACT_SMALL_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_CACHE_MAX_TEXT_LEN)
+    assert H._REDACT_BIG_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_TEXT_BIG_CACHE_MAX)

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -1,16 +1,23 @@
 """Regression: `_redact_text` decision memo must be byte-identical to the
-uncached path, bounded, and safe on toggle.
+uncached path, byte-budgeted, and safe on toggle.
 
-Companion to the #5204 redactor memo contract: the perf(conversation-switch)
-change routes `_redact_text` through a per-string memo of the entire
-clean-or-redacted decision (prefilter + redactor) in two size tiers. Locks:
+Companion to the #5204 redactor memo contract and #7439 byte-budgeted eviction:
+the perf(conversation-switch) change routes `_redact_text` through a per-string
+memo of the entire clean-or-redacted decision (prefilter + redactor) in two size tiers.
+Worst-case retained memory equals the configured byte budget by construction.
+Locks:
   * memoized results are byte-identical to `_redact_text_impl` (no behavior
     change from caching),
   * repeat calls hit the memo (that is the point),
   * strings above the big-tier ceiling stay uncached yet still redact,
   * enabled=False bypasses the memo entirely (cache only ever holds
-    enabled=True results, so no staleness on toggle).
+    enabled=True results, so no staleness on toggle),
+  * byte budget is strictly enforced (retained_bytes <= max_bytes at all times),
+  * aliased clean strings (key is value) are accounted once,
+  * thread-safe under concurrent access.
 """
+import sys
+import threading
 from api import helpers as H
 
 _SECRET = "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -61,31 +68,102 @@ def test_redact_text_giant_above_ceiling_not_memoized():
     assert H._redact_text_big_lru.cache_info().misses == before  # tier skipped
 
 
-def test_redact_memo_caps_defaulted_and_env_tunable(monkeypatch):
-    # The process-wide memos are bounded by LRU maxsize PER TIER (memory cannot
-    # grow unboundedly), and the shipped defaults are conservative (greptile P1).
-    # Env vars can raise/lower them, but each tier is clamped to its byte budget.
-    assert H._redact_fn_lru.cache_info().maxsize == 16384
-    assert H._redact_text_lru.cache_info().maxsize == 16384
-    assert H._redact_text_big_lru.cache_info().maxsize == 256
+def test_redact_memo_budgets_defaulted_and_env_tunable(monkeypatch):
+    # Process-wide memos are bounded by byte budgets per tier (#7439)
+    assert H._redact_fn_lru.cache_info().max_bytes == 512 * 1024 * 1024
+    assert H._redact_text_lru.cache_info().max_bytes == 512 * 1024 * 1024
+    assert H._redact_text_big_lru.cache_info().max_bytes == 128 * 1024 * 1024
 
-    # _lru_size: positive int from env, clamped to `cap`, else the default.
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100
-    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "5")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 5
-    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "0")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100  # <1 rejected
-    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "not-a-number")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 100  # invalid rejected
-    # A fat-fingered huge value is clamped to the per-tier cap (greptile P1: the
-    # big tier must not allow 131072 * 256KiB ≈ 32GiB).
-    monkeypatch.setenv("PI_TEST_REDACT_MEMO_MISSING", "999999999")
-    assert H._lru_size(100, "PI_TEST_REDACT_MEMO_MISSING", 200) == 200
-    # Big-tier ceiling is byte-budget derived from the REAL per-entry caps and
-    # far below a shared-count cap (greptile P1). This is not tautological: the
-    # caps are derived from _REDACT_CACHE_MAX_TEXT_LEN / _REDACT_TEXT_BIG_CACHE_MAX
-    # (the values the caches actually enforce), so if those drift the assertion fails.
-    assert H._REDACT_BIG_TIER_CAP < 131072
-    assert H._redact_text_big_lru.cache_info().maxsize <= H._REDACT_BIG_TIER_CAP
+    # _byte_budget: positive int from env, clamped to `cap`, else default
+    assert H._byte_budget(100, "PI_TEST_REDACT_BUDGET_MISSING", 200) == 100
+    monkeypatch.setenv("PI_TEST_REDACT_BUDGET_MISSING", "5")
+    assert H._byte_budget(100, "PI_TEST_REDACT_BUDGET_MISSING", 200) == 5
+    monkeypatch.setenv("PI_TEST_REDACT_BUDGET_MISSING", "0")
+    assert H._byte_budget(100, "PI_TEST_REDACT_BUDGET_MISSING", 200) == 100  # <1 rejected
+    monkeypatch.setenv("PI_TEST_REDACT_BUDGET_MISSING", "not-a-number")
+    assert H._byte_budget(100, "PI_TEST_REDACT_BUDGET_MISSING", 200) == 100  # invalid rejected
+    monkeypatch.setenv("PI_TEST_REDACT_BUDGET_MISSING", "999999999999")
+    assert H._byte_budget(100, "PI_TEST_REDACT_BUDGET_MISSING", 200) == 200  # clamped to cap
+
+    # Cap invariants preserved
+    assert H._REDACT_MEMO_BYTE_BUDGET == 1024 * 1024 * 1024
     assert H._REDACT_SMALL_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_CACHE_MAX_TEXT_LEN)
     assert H._REDACT_BIG_TIER_CAP == H._REDACT_MEMO_BYTE_BUDGET // (2 * H._REDACT_TEXT_BIG_CACHE_MAX)
+
+
+def test_byte_budget_lru_eviction_and_accounting():
+    # Construct a small ByteBudgetLRU to verify exact byte accounting & eviction
+    cache = H.byte_budget_lru_cache(max_bytes=1000, name="test_lru")(lambda s: s)
+
+    # Clean string: key is val -> single accounting
+    s1 = "hello_world_1"
+    cache(s1)
+    expected_bytes_s1 = sys.getsizeof(s1)
+    info1 = cache.cache_info()
+    assert info1.retained_bytes == expected_bytes_s1
+    assert info1.currsize == 1
+
+    # Redacted string: key is not val -> dual accounting
+    cache_redact = H.byte_budget_lru_cache(max_bytes=1000, name="test_redact")(lambda s: s.replace("secret", "xxx"))
+    s2 = "this_has_a_secret_here"
+    val2 = cache_redact(s2)
+    expected_bytes_s2 = sys.getsizeof(s2) + sys.getsizeof(val2)
+    info2 = cache_redact.cache_info()
+    assert info2.retained_bytes == expected_bytes_s2
+    assert info2.currsize == 1
+
+    # Exceeding budget evicts oldest entries (LRU order)
+    tight_cache = H.byte_budget_lru_cache(max_bytes=350, name="tight")(lambda s: s)
+    e1 = "a" * 100
+    e2 = "b" * 100
+    e3 = "c" * 100
+    size_e1 = sys.getsizeof(e1)
+    size_e2 = sys.getsizeof(e2)
+    size_e3 = sys.getsizeof(e3)
+
+    tight_cache(e1)
+    tight_cache(e2)
+    assert tight_cache.cache_info().currsize == 2
+    assert tight_cache.cache_info().retained_bytes == size_e1 + size_e2
+
+    # Access e1 again to make e2 the LRU
+    tight_cache(e1)
+
+    # Insert e3 -> should evict e2, retaining e1 and e3
+    tight_cache(e3)
+    info_tight = tight_cache.cache_info()
+    assert info_tight.currsize == 2
+    assert info_tight.retained_bytes == size_e1 + size_e3
+    assert info_tight.retained_bytes <= 350
+
+    # Cache clear resets retained_bytes and currsize
+    tight_cache.cache_clear()
+    cleared_info = tight_cache.cache_info()
+    assert cleared_info.currsize == 0
+    assert cleared_info.retained_bytes == 0
+    assert cleared_info.hits == 0
+    assert cleared_info.misses == 0
+
+
+def test_byte_budget_lru_thread_safety():
+    cache = H.byte_budget_lru_cache(max_bytes=5000, name="concurrent")(lambda s: s + "_out")
+    errors = []
+
+    def worker(worker_id):
+        try:
+            for i in range(50):
+                k = f"key_{worker_id}_{i % 10}"
+                cache(k)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    info = cache.cache_info()
+    assert info.retained_bytes <= 5000
+    assert info.currsize > 0

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -95,36 +95,40 @@ def test_byte_budget_lru_eviction_and_accounting():
     # Construct a small ByteBudgetLRU to verify exact byte accounting & eviction
     cache = H.byte_budget_lru_cache(max_bytes=1000, name="test_lru")(lambda s: s)
 
-    # Clean string: key is val -> single accounting
+    overhead = H._ENTRY_CONTAINER_OVERHEAD_BYTES
+
+    # Clean string: key is val -> single accounting plus container overhead
     s1 = "hello_world_1"
     cache(s1)
-    expected_bytes_s1 = sys.getsizeof(s1)
+    expected_bytes_s1 = sys.getsizeof(s1) + overhead
     info1 = cache.cache_info()
     assert info1.retained_bytes == expected_bytes_s1
     assert info1.currsize == 1
 
-    # Redacted string: key is not val -> dual accounting
+    # Redacted string: key is not val -> dual accounting plus container overhead
     cache_redact = H.byte_budget_lru_cache(max_bytes=1000, name="test_redact")(lambda s: s.replace("secret", "xxx"))
     s2 = "this_has_a_secret_here"
     val2 = cache_redact(s2)
-    expected_bytes_s2 = sys.getsizeof(s2) + sys.getsizeof(val2)
+    expected_bytes_s2 = sys.getsizeof(s2) + sys.getsizeof(val2) + overhead
     info2 = cache_redact.cache_info()
     assert info2.retained_bytes == expected_bytes_s2
     assert info2.currsize == 1
 
     # Exceeding budget evicts oldest entries (LRU order)
-    tight_cache = H.byte_budget_lru_cache(max_bytes=350, name="tight")(lambda s: s)
+    # Each 100-char string is ~150B + 128B overhead = ~278B.
+    # Budget of 600B holds exactly 2 entries (~556B) and evicts on the 3rd.
+    tight_cache = H.byte_budget_lru_cache(max_bytes=600, name="tight")(lambda s: s)
     e1 = "a" * 100
     e2 = "b" * 100
     e3 = "c" * 100
-    size_e1 = sys.getsizeof(e1)
-    size_e2 = sys.getsizeof(e2)
-    size_e3 = sys.getsizeof(e3)
+    cost_e1 = sys.getsizeof(e1) + overhead
+    cost_e2 = sys.getsizeof(e2) + overhead
+    cost_e3 = sys.getsizeof(e3) + overhead
 
     tight_cache(e1)
     tight_cache(e2)
     assert tight_cache.cache_info().currsize == 2
-    assert tight_cache.cache_info().retained_bytes == size_e1 + size_e2
+    assert tight_cache.cache_info().retained_bytes == cost_e1 + cost_e2
 
     # Access e1 again to make e2 the LRU
     tight_cache(e1)
@@ -133,8 +137,8 @@ def test_byte_budget_lru_eviction_and_accounting():
     tight_cache(e3)
     info_tight = tight_cache.cache_info()
     assert info_tight.currsize == 2
-    assert info_tight.retained_bytes == size_e1 + size_e3
-    assert info_tight.retained_bytes <= 350
+    assert info_tight.retained_bytes == cost_e1 + cost_e3
+    assert info_tight.retained_bytes <= 600
 
     # Cache clear resets retained_bytes and currsize
     tight_cache.cache_clear()

--- a/tests/test_redaction_decision_memo.py
+++ b/tests/test_redaction_decision_memo.py
@@ -95,40 +95,45 @@ def test_byte_budget_lru_eviction_and_accounting():
     # Construct a small ByteBudgetLRU to verify exact byte accounting & eviction
     cache = H.byte_budget_lru_cache(max_bytes=1000, name="test_lru")(lambda s: s)
 
-    overhead = H._ENTRY_CONTAINER_OVERHEAD_BYTES
-
-    # Clean string: key is val -> single accounting plus container overhead
+    # Clean string: key is val -> single payload + tuple overhead + measured dict growth
     s1 = "hello_world_1"
     cache(s1)
-    expected_bytes_s1 = sys.getsizeof(s1) + overhead
+    expected_bytes_s1 = (
+        sys.getsizeof(s1)
+        + H._TUPLE_OVERHEAD_BYTES
+        + (sys.getsizeof(cache._data) - H._BASE_DICT_BYTES)
+    )
     info1 = cache.cache_info()
     assert info1.retained_bytes == expected_bytes_s1
     assert info1.currsize == 1
 
-    # Redacted string: key is not val -> dual accounting plus container overhead
+    # Redacted string: key is not val -> dual payload + tuple overhead + measured dict growth
     cache_redact = H.byte_budget_lru_cache(max_bytes=1000, name="test_redact")(lambda s: s.replace("secret", "xxx"))
     s2 = "this_has_a_secret_here"
     val2 = cache_redact(s2)
-    expected_bytes_s2 = sys.getsizeof(s2) + sys.getsizeof(val2) + overhead
+    expected_bytes_s2 = (
+        sys.getsizeof(s2)
+        + sys.getsizeof(val2)
+        + H._TUPLE_OVERHEAD_BYTES
+        + (sys.getsizeof(cache_redact._data) - H._BASE_DICT_BYTES)
+    )
     info2 = cache_redact.cache_info()
     assert info2.retained_bytes == expected_bytes_s2
     assert info2.currsize == 1
 
-    # Exceeding budget evicts oldest entries (LRU order)
-    # Each 100-char string is ~150B + 128B overhead = ~278B.
-    # Budget of 600B holds exactly 2 entries (~556B) and evicts on the 3rd.
-    tight_cache = H.byte_budget_lru_cache(max_bytes=600, name="tight")(lambda s: s)
+    # Exact 2-entry shape: two 100-char strings = 298B + two 56B tuples = 112B + dict growth = 248B -> exactly 658B
+    # Budget of 700B accommodates exactly 2 entries (658B <= 700B) and evicts on the 3rd.
+    tight_cache = H.byte_budget_lru_cache(max_bytes=700, name="tight")(lambda s: s)
     e1 = "a" * 100
     e2 = "b" * 100
     e3 = "c" * 100
-    cost_e1 = sys.getsizeof(e1) + overhead
-    cost_e2 = sys.getsizeof(e2) + overhead
-    cost_e3 = sys.getsizeof(e3) + overhead
 
     tight_cache(e1)
     tight_cache(e2)
     assert tight_cache.cache_info().currsize == 2
-    assert tight_cache.cache_info().retained_bytes == cost_e1 + cost_e2
+    # Exact shallow growth matches 658 bytes
+    assert tight_cache.cache_info().retained_bytes == 658
+    assert tight_cache.cache_info().retained_bytes <= 700
 
     # Access e1 again to make e2 the LRU
     tight_cache(e1)
@@ -137,8 +142,10 @@ def test_byte_budget_lru_eviction_and_accounting():
     tight_cache(e3)
     info_tight = tight_cache.cache_info()
     assert info_tight.currsize == 2
-    assert info_tight.retained_bytes == cost_e1 + cost_e3
-    assert info_tight.retained_bytes <= 600
+    # Discriminating assertion on surviving keys
+    assert list(tight_cache._data.keys()) == [e1, e3]
+    assert info_tight.retained_bytes == 658
+    assert info_tight.retained_bytes <= 700
 
     # Cache clear resets retained_bytes and currsize
     tight_cache.cache_clear()
@@ -147,6 +154,42 @@ def test_byte_budget_lru_eviction_and_accounting():
     assert cleared_info.retained_bytes == 0
     assert cleared_info.hits == 0
     assert cleared_info.misses == 0
+
+
+def test_byte_budget_lru_resize_boundaries_and_compaction():
+    """Verify shallow accounting across dict resize boundaries and compaction on eviction."""
+    cache = H.byte_budget_lru_cache(max_bytes=50000, name="resize_test")(lambda s: s + "_out")
+
+    # Step across multiple OrderedDict resize boundaries (5, 10, 20, 50, 100 entries)
+    for n in (5, 10, 20, 50, 100):
+        for i in range(len(cache._data), n):
+            cache(f"key_{i:04d}")
+        assert cache.cache_info().currsize == n
+        # Assert exact measured shallow retained bytes matches primary source formula
+        expected_shallow = (
+            sum(sys.getsizeof(k) + sys.getsizeof(v) for k, (v, _) in cache._data.items())
+            + (len(cache._data) * H._TUPLE_OVERHEAD_BYTES)
+            + max(0, sys.getsizeof(cache._data) - H._BASE_DICT_BYTES)
+        )
+        assert cache.cache_info().retained_bytes == expected_shallow
+        assert cache.cache_info().retained_bytes <= 50000
+
+    # Peak: container has grown to high-water mark (>8000 bytes for 100 entries)
+    peak_dict_size = sys.getsizeof(cache._data)
+    assert peak_dict_size >= 8000
+
+    # High-water eviction: reduce max_bytes to 2000 and insert an entry forcing bulk eviction
+    cache.max_bytes = 2000
+    cache("forcing_eviction_key")
+
+    # Verify compaction took place and released table capacity slack
+    compacted_dict_size = sys.getsizeof(cache._data)
+    assert compacted_dict_size < 1500
+    assert compacted_dict_size < peak_dict_size // 4
+    info = cache.cache_info()
+    assert info.retained_bytes <= 2000
+    # Verify latest key survived
+    assert "forcing_eviction_key" in cache._data
 
 
 def test_byte_budget_lru_thread_safety():

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -1,0 +1,130 @@
+"""Regression: `redact_session_lists_cached` — the persisted per-message
+redaction cache for large-session conversation switches.
+
+Locks:
+  * first call computes + persists a cache file; secrets are redacted,
+  * repeat call serves from cache (zero `_redact_messages` work),
+  * appended messages recompute individually (append-mostly splice),
+  * corrupt/foreign cache files fall back gracefully (never fail a response),
+  * `api_redact_enabled` participates in validation (toggle recomputes),
+  * the per-request `_active_turn_user` decoration is applied after retrieval
+    and is NEVER persisted to the cache file.
+"""
+import json
+
+import pytest
+
+from api import helpers as H
+from api.helpers import redact_session_lists_cached
+
+
+@pytest.fixture()
+def state_dir(tmp_path, monkeypatch):
+    import api.config
+    monkeypatch.setattr(api.config, "STATE_DIR", tmp_path)
+    return tmp_path
+
+
+def _msgs(secret="sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"):
+    return [
+        {"role": "user", "content": f"hello one {secret}"},
+        {"role": "assistant", "content": "plain reply"},
+    ]
+
+
+def _spy(monkeypatch):
+    calls = {"n": 0}
+    real = H._redact_messages
+
+    def counting(messages, **kwargs):
+        calls["n"] += len(messages) if isinstance(messages, list) else 1
+        return real(messages, **kwargs)
+
+    monkeypatch.setattr(H, "_redact_messages", counting)
+    return calls
+
+
+def test_cold_computes_persists_and_redacts(state_dir):
+    spy = _spy(pytest.monkeypatch) if False else None  # placeholder (see below)
+    msgs = _msgs()
+    out = redact_session_lists_cached("sessA", {"messages": msgs})
+    assert _SECRET_STATE_OK(out)
+    cache_file = state_dir / "redaction_cache" / "sessA.json"
+    assert cache_file.exists()
+    stored = json.loads(cache_file.read_text())
+    assert stored["enabled"] is True
+    # persisted projections are decoration-free and redacted
+    assert all("_active_turn_user" not in m for m in stored["lists"]["messages"])
+
+
+def _SECRET_STATE_OK(payload):
+    text = json.dumps(payload)
+    return "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in text
+
+
+def test_repeat_serves_from_cache_zero_redaction_work(state_dir, monkeypatch):
+    calls = _spy(monkeypatch)
+    msgs = _msgs()
+    redact_session_lists_cached("sessB", {"messages": msgs})
+    first = calls["n"]
+    assert first == len(msgs)
+    out2 = redact_session_lists_cached("sessB", {"messages": msgs})
+    assert calls["n"] == first  # zero new redaction work — spliced from cache
+    assert out2["messages"][0]["content"].startswith("hello one")
+
+
+def test_append_recomputes_only_new_message(state_dir, monkeypatch):
+    calls = _spy(monkeypatch)
+    msgs = _msgs()
+    redact_session_lists_cached("sessC", {"messages": msgs})
+    assert calls["n"] == len(msgs)
+    first_count = calls["n"]
+    msgs.append({"role": "user", "content": "a fresh follow-up message"})
+    out = redact_session_lists_cached("sessC", {"messages": msgs})
+    assert calls["n"] == first_count + 1  # +1: only the appended item recomputed
+    assert out["messages"][-1]["content"] == "a fresh follow-up message"
+
+
+def test_change_to_existing_message_recomputes_it(state_dir, monkeypatch):
+    calls = _spy(monkeypatch)
+    msgs = _msgs()
+    redact_session_lists_cached("sessD", {"messages": msgs})
+    msgs[1]["content"] = "assistant reply was edited"
+    out = redact_session_lists_cached("sessD", {"messages": msgs})
+    assert out["messages"][1]["content"] == "assistant reply was edited"
+
+
+def test_corrupt_cache_falls_back_gracefully(state_dir):
+    redact_session_lists_cached("sessE", {"messages": _msgs()})
+    cache_file = state_dir / "redaction_cache" / "sessE.json"
+    cache_file.write_text("{not json at all")
+    out = redact_session_lists_cached("sessE", {"messages": _msgs()})
+    assert _SECRET_STATE_OK(out)
+
+
+def test_enabled_toggle_recomputes(state_dir, monkeypatch):
+    import api.config
+    msgs = _msgs()
+    monkeypatch.setattr(api.config, "load_settings", lambda: {"api_redact_enabled": True})
+    redact_session_lists_cached("sessF", {"messages": msgs})
+    monkeypatch.setattr(api.config, "load_settings", lambda: {"api_redact_enabled": False})
+    out = redact_session_lists_cached("sessF", {"messages": msgs})
+    # disabled = verbatim passthrough; the enabled=True cache must not serve
+    assert out["messages"][0]["content"] == msgs[0]["content"]
+    assert _SECRET_STATE_OK({"x": "cleared"})  # sanity: helper intact
+
+
+def test_turn_decoration_applied_but_never_persisted(state_dir):
+    msgs = [
+        {"role": "user", "content": "hi", "_active_turn_token": "tok-1"},
+        {"role": "assistant", "content": "ho"},
+    ]
+    out = redact_session_lists_cached(
+        "sessG", {"messages": msgs}, _active_turn_token="tok-1")
+    assert out["messages"][0].get("_active_turn_user") is True
+    stored = json.loads(
+        (state_dir / "redaction_cache" / "sessG.json").read_text())
+    assert all("_active_turn_user" not in m for m in stored["lists"]["messages"])
+    # a later request without the token must not see a stale flag
+    out2 = redact_session_lists_cached("sessG", {"messages": msgs})
+    assert all("_active_turn_user" not in m for m in out2["messages"])

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -279,3 +279,24 @@ def test_rules_key_none_fail_closed_recomputes(state_dir, monkeypatch):
     # A None identity must NOT be persisted as an authorizable cache key.
     stored = json.loads((state_dir / "redaction_cache" / "sessNone.json").read_text())
     assert stored["rules_key"] is not None
+
+
+def test_delete_clears_in_memory_redaction_memos(state_dir):
+    # The in-memory decision/redactor LRUs key on ORIGINAL strings (including
+    # plaintext secrets) and are retained process-wide; deleting a session must
+    # drop them from RAM, not just the on-disk projection (#7414 review follow-up
+    # on the adversarial review's secret-retention finding).
+    secret = "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    H._redact_text_lru.cache_clear()
+    H._redact_fn_lru.cache_clear()
+    H._redact_text_big_lru.cache_clear()
+    sample = f"delete me and my secret {secret} must not linger"
+    out = H._redact_text(sample, _enabled=True)
+    assert secret not in out
+    assert H._redact_text_lru.cache_info().currsize >= 1
+    assert H._redact_fn_lru.cache_info().currsize >= 1
+    # Deleting a valid session (even with no projection file) clears the memos.
+    assert delete_redaction_session_cache("sessRam") is False  # no on-disk file
+    assert H._redact_text_lru.cache_info().currsize == 0
+    assert H._redact_fn_lru.cache_info().currsize == 0
+    assert H._redact_text_big_lru.cache_info().currsize == 0

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -9,13 +9,16 @@ Locks:
   * `api_redact_enabled` participates in validation (toggle recomputes),
   * the per-request `_active_turn_user` decoration is applied after retrieval
     and is NEVER persisted to the cache file.
+  * `delete_redaction_session_cache` removes the file on session deletion
+    (deleted conversations must not linger in `redaction_cache/`) and is a
+    safe no-op for missing/unsafe ids.
 """
 import json
 
 import pytest
 
 from api import helpers as H
-from api.helpers import redact_session_lists_cached
+from api.helpers import delete_redaction_session_cache, redact_session_lists_cached
 
 
 @pytest.fixture()
@@ -158,3 +161,30 @@ def test_truncation_serves_matching_prefix(state_dir, monkeypatch):
     out = redact_session_lists_cached("sessTrunc", {"messages": msgs[:2]})
     assert calls["n"] == 3  # prefix spliced, nothing recomputed
     assert [m["content"] for m in out["messages"]] == ["keep one", "keep two"]
+
+
+def test_delete_removes_cache_file_leaves_sibling_intact(state_dir):
+    # Deleting a session must remove its redaction-cache file (a deleted
+    # conversation is not recoverable from redaction_cache/), while an
+    # unrelated session's cache is untouched.
+    redact_session_lists_cached("sessDel", {"messages": _msgs()})
+    redact_session_lists_cached("sessKeep", {"messages": _msgs()})
+    doomed = state_dir / "redaction_cache" / "sessDel.json"
+    sibling = state_dir / "redaction_cache" / "sessKeep.json"
+    assert doomed.exists() and sibling.exists()
+    assert delete_redaction_session_cache("sessDel") is True
+    assert not doomed.exists()
+    assert sibling.exists()
+    # second delete is a no-op
+    assert delete_redaction_session_cache("sessDel") is False
+
+
+def test_delete_noop_on_missing_or_invalid(state_dir):
+    assert delete_redaction_session_cache("nope") is False
+    assert delete_redaction_session_cache("") is False
+    assert delete_redaction_session_cache("../escape") is False
+    assert delete_redaction_session_cache("..\\escape") is False
+    assert delete_redaction_session_cache(".") is False
+    # nothing escaped the cache dir
+    assert list((state_dir / "redaction_cache").glob("*.json")) == []
+    assert (state_dir / "escape.json").exists() is False

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -188,3 +188,94 @@ def test_delete_noop_on_missing_or_invalid(state_dir):
     # nothing escaped the cache dir
     assert list((state_dir / "redaction_cache").glob("*.json")) == []
     assert (state_dir / "escape.json").exists() is False
+
+
+def _install_fake_agent_redact(monkeypatch, tmp_path, body):
+    """Populate ``sys.modules['agent']`` / ``['agent.redact']`` so that
+    ``import agent.redact`` resolves to a module whose ``__file__`` points at a
+    file whose bytes are exactly ``body``. Returns that file path."""
+    import sys
+    import types
+    pkg_dir = tmp_path / "agent"
+    pkg_dir.mkdir(exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("")
+    redact_path = pkg_dir / "redact.py"
+    redact_path.write_text(body)
+    pkg = types.ModuleType("agent")
+    pkg.__path__ = [str(pkg_dir)]
+    redact_mod = types.ModuleType("agent.redact")
+    redact_mod.__file__ = str(redact_path)
+    monkeypatch.setitem(sys.modules, "agent", pkg)
+    monkeypatch.setitem(sys.modules, "agent.redact", redact_mod)
+    return redact_path
+
+
+def _utime(path, mtime_ns):
+    import os
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+
+
+def test_rules_key_is_content_identity_not_pathname_metadata(tmp_path, monkeypatch):
+    # Regression (#7414 review): the rules key must be a CONTENT identity, not
+    # pathname metadata. Two different policy byte-for-byte files that share
+    # size AND mtime_ns must produce DIFFERENT keys — otherwise a stale
+    # projection survives a redaction-policy change that happens to retain the
+    # same file size/mtime, serving text the CURRENT redactor would remove.
+    import os
+    body_a = "VALUE = 1\n"
+    body_b = "VALUE = 2\n"
+    assert len(body_a) == len(body_b)  # same size by construction
+    fixed_mtime = 1234567890123456789
+    redact_path = _install_fake_agent_redact(monkeypatch, tmp_path, body_a)
+
+    _utime(redact_path, fixed_mtime)
+    key_a = H._redact_session_cache_rules_key()
+
+    # Rewrite with different bytes, same size, same mtime_ns.
+    redact_path.write_text(body_b)
+    _utime(redact_path, fixed_mtime)
+    st = os.stat(redact_path)
+    assert st.st_mtime_ns == fixed_mtime
+    key_b = H._redact_session_cache_rules_key()
+
+    assert key_a != key_b, "content-identity key must change when policy bytes change"
+
+
+def test_rules_key_independent_of_webui_version_constant(monkeypatch):
+    # Regression (#7414 review): the WebUI version stamp must NOT be the
+    # authoritative identity — it degrades to a constant (None / 'unknown')
+    # when git and generated version files are unavailable. With the version
+    # removed from the identity, a constant version cannot collapse the key and
+    # hide a policy change; the key reflects policy content only.
+    import api.config as C
+    monkeypatch.setattr(C, "_current_webui_version", lambda: None)
+    k_none = H._redact_session_cache_rules_key()
+    monkeypatch.setattr(C, "_current_webui_version", lambda: "unknown")
+    k_unknown = H._redact_session_cache_rules_key()
+    monkeypatch.setattr(C, "_current_webui_version", lambda: "v0.52.264")
+    k_real = H._redact_session_cache_rules_key()
+
+    # Unchanged policy content => stable, deterministic key, independent of the
+    # (constant or real) version stamp.
+    assert k_none == k_unknown == k_real
+    # Deterministic across repeated calls (the "unchanged rule identity" control).
+    assert H._redact_session_cache_rules_key() == k_real
+
+
+def test_rules_key_none_fail_closed_recomputes(state_dir, monkeypatch):
+    # Regression (#7414 review): if no trustworthy content identity can be
+    # computed (rules_key is None), the persistent cache must be SKIPPED — not
+    # read-and-reused, and not freshly re-validated against an authorizable key.
+    msgs = _msgs()
+    redact_session_lists_cached("sessNone", {"messages": msgs})  # seed a valid cache
+    calls = _spy(monkeypatch)
+    monkeypatch.setattr(H, "_redact_session_cache_rules_key", lambda: None)
+
+    out = redact_session_lists_cached("sessNone", {"messages": msgs})
+
+    # Fail-closed: full recompute, nothing spliced from the seeded cache.
+    assert calls["n"] == len(msgs)
+    assert _SECRET_STATE_OK(out)
+    # A None identity must NOT be persisted as an authorizable cache key.
+    stored = json.loads((state_dir / "redaction_cache" / "sessNone.json").read_text())
+    assert stored["rules_key"] is not None

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -190,76 +190,64 @@ def test_delete_noop_on_missing_or_invalid(state_dir):
     assert (state_dir / "escape.json").exists() is False
 
 
-def _install_fake_agent_redact(monkeypatch, tmp_path, body):
-    """Populate ``sys.modules['agent']`` / ``['agent.redact']`` so that
-    ``import agent.redact`` resolves to a module whose ``__file__`` points at a
-    file whose bytes are exactly ``body``. Returns that file path."""
-    import sys
-    import types
-    pkg_dir = tmp_path / "agent"
-    pkg_dir.mkdir(exist_ok=True)
-    (pkg_dir / "__init__.py").write_text("")
-    redact_path = pkg_dir / "redact.py"
-    redact_path.write_text(body)
-    pkg = types.ModuleType("agent")
-    pkg.__path__ = [str(pkg_dir)]
-    redact_mod = types.ModuleType("agent.redact")
-    redact_mod.__file__ = str(redact_path)
-    monkeypatch.setitem(sys.modules, "agent", pkg)
-    monkeypatch.setitem(sys.modules, "agent.redact", redact_mod)
-    return redact_path
-
-
 def _utime(path, mtime_ns):
     import os
     os.utime(path, ns=(mtime_ns, mtime_ns))
 
 
-def test_rules_key_is_content_identity_not_pathname_metadata(tmp_path, monkeypatch):
-    # Regression (#7414 review): the rules key must be a CONTENT identity, not
-    # pathname metadata. Two different policy byte-for-byte files that share
-    # size AND mtime_ns must produce DIFFERENT keys — otherwise a stale
+def test_rules_content_digest_not_pathname_metadata(tmp_path):
+    # Regression (#7414 review): a rules identity must be CONTENT, not pathname
+    # metadata. Two different policy byte-for-byte files that share size AND
+    # mtime_ns must produce DIFFERENT content digests — otherwise a stale
     # projection survives a redaction-policy change that happens to retain the
-    # same file size/mtime, serving text the CURRENT redactor would remove.
+    # same file size/mtime. We test the content-identity primitive directly:
+    # the rules key captures these digests once at import, so a mid-process
+    # file swap must NOT change the key (only a restart with new bytes does).
     import os
     body_a = "VALUE = 1\n"
     body_b = "VALUE = 2\n"
     assert len(body_a) == len(body_b)  # same size by construction
     fixed_mtime = 1234567890123456789
-    redact_path = _install_fake_agent_redact(monkeypatch, tmp_path, body_a)
-
-    _utime(redact_path, fixed_mtime)
-    key_a = H._redact_session_cache_rules_key()
-
+    path = tmp_path / "policy.py"
+    path.write_text(body_a)
+    _utime(path, fixed_mtime)
+    digest_a = H._content_digest(path)
+    assert digest_a is not None
     # Rewrite with different bytes, same size, same mtime_ns.
-    redact_path.write_text(body_b)
-    _utime(redact_path, fixed_mtime)
-    st = os.stat(redact_path)
-    assert st.st_mtime_ns == fixed_mtime
-    key_b = H._redact_session_cache_rules_key()
+    path.write_text(body_b)
+    _utime(path, fixed_mtime)
+    st_b = os.stat(path)
+    digest_b = H._content_digest(path)
+    assert digest_b is not None
+    assert H._content_digest(path) == digest_b  # deterministic
+    assert st_b.st_size == len(body_a)  # identical size
+    assert digest_a != digest_b, "content digest must change when policy bytes change"
 
-    assert key_a != key_b, "content-identity key must change when policy bytes change"
+
+def test_rules_key_captured_at_import_matches_module_digest():
+    # The rules key's content digests are captured ONCE at import, so they match
+    # this module's actual source bytes (the policy that was loaded, not the
+    # on-disk bytes at call time — the TOCTOU fix).
+    assert H._REDACT_RULES_HELPERS_DIGEST == H._content_digest(H.__file__)
+    assert H._REDACT_RULES_HELPERS_DIGEST is not None
+    assert H._redact_session_cache_rules_key() is not None
 
 
-def test_rules_key_independent_of_webui_version_constant(monkeypatch):
-    # Regression (#7414 review): the WebUI version stamp must NOT be the
-    # authoritative identity — it degrades to a constant (None / 'unknown')
-    # when git and generated version files are unavailable. With the version
-    # removed from the identity, a constant version cannot collapse the key and
-    # hide a policy change; the key reflects policy content only.
+def test_rules_key_is_stable_per_process(monkeypatch):
+    # The rules key is frozen at import (matching the loaded policy), so it must
+    # be stable across calls and independent of the WebUI version stamp (which
+    # was removed from the identity — a constant 'unknown'/None can't collapse
+    # the key). This is the "unchanged rule identity -> zero-work" control.
+    k1 = H._redact_session_cache_rules_key()
+    assert k1 is not None
+    assert H._redact_session_cache_rules_key() == k1
     import api.config as C
     monkeypatch.setattr(C, "_current_webui_version", lambda: None)
-    k_none = H._redact_session_cache_rules_key()
+    assert H._redact_session_cache_rules_key() == k1
     monkeypatch.setattr(C, "_current_webui_version", lambda: "unknown")
-    k_unknown = H._redact_session_cache_rules_key()
+    assert H._redact_session_cache_rules_key() == k1
     monkeypatch.setattr(C, "_current_webui_version", lambda: "v0.52.264")
-    k_real = H._redact_session_cache_rules_key()
-
-    # Unchanged policy content => stable, deterministic key, independent of the
-    # (constant or real) version stamp.
-    assert k_none == k_unknown == k_real
-    # Deterministic across repeated calls (the "unchanged rule identity" control).
-    assert H._redact_session_cache_rules_key() == k_real
+    assert H._redact_session_cache_rules_key() == k1
 
 
 def test_rules_key_none_fail_closed_recomputes(state_dir, monkeypatch):

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -45,7 +45,6 @@ def _spy(monkeypatch):
 
 
 def test_cold_computes_persists_and_redacts(state_dir):
-    spy = _spy(pytest.monkeypatch) if False else None  # placeholder (see below)
     msgs = _msgs()
     out = redact_session_lists_cached("sessA", {"messages": msgs})
     assert _SECRET_STATE_OK(out)
@@ -89,8 +88,10 @@ def test_change_to_existing_message_recomputes_it(state_dir, monkeypatch):
     calls = _spy(monkeypatch)
     msgs = _msgs()
     redact_session_lists_cached("sessD", {"messages": msgs})
+    assert calls["n"] == 2
     msgs[1]["content"] = "assistant reply was edited"
     out = redact_session_lists_cached("sessD", {"messages": msgs})
+    assert calls["n"] == 3  # the edited message was recomputed
     assert out["messages"][1]["content"] == "assistant reply was edited"
 
 
@@ -128,3 +129,32 @@ def test_turn_decoration_applied_but_never_persisted(state_dir):
     # a later request without the token must not see a stale flag
     out2 = redact_session_lists_cached("sessG", {"messages": msgs})
     assert all("_active_turn_user" not in m for m in out2["messages"])
+
+
+def test_midlist_insertion_never_serves_stale_projection(state_dir):
+    # Insert at index 0 shifts every digest: the splice must not pair old
+    # projections with the wrong messages.
+    msgs = [
+        {"role": "user", "content": "alpha message"},
+        {"role": "assistant", "content": "beta reply"},
+    ]
+    redact_session_lists_cached("sessIns", {"messages": msgs})
+    msgs.insert(0, {"role": "user", "content": "zeroth inserted message"})
+    out = redact_session_lists_cached("sessIns", {"messages": msgs})
+    assert [m["content"] for m in out["messages"]] == [
+        "zeroth inserted message", "alpha message", "beta reply",
+    ]
+
+
+def test_truncation_serves_matching_prefix(state_dir, monkeypatch):
+    calls = _spy(monkeypatch)
+    msgs = [
+        {"role": "user", "content": "keep one"},
+        {"role": "assistant", "content": "keep two"},
+        {"role": "user", "content": "drop three"},
+    ]
+    redact_session_lists_cached("sessTrunc", {"messages": msgs})
+    assert calls["n"] == 3
+    out = redact_session_lists_cached("sessTrunc", {"messages": msgs[:2]})
+    assert calls["n"] == 3  # prefix spliced, nothing recomputed
+    assert [m["content"] for m in out["messages"]] == ["keep one", "keep two"]

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -220,6 +220,86 @@ def test_recreated_session_can_populate_cache_after_delete(state_dir):
     assert [m["content"] for m in cached["lists"]["messages"]] == ["hello newly created session"]
 
 
+def test_real_thread_deletion_during_prepublication_redaction_never_republishes(state_dir, monkeypatch):
+    import threading
+    from api.helpers import _redact_session_cache_path, _redact_messages
+
+    sid = "sessThreadPrepub"
+    path = _redact_session_cache_path(sid)
+
+    # Populate initial cache
+    redact_session_lists_cached(sid, {"messages": _msgs()})
+    assert path.exists()
+
+    # Intercept pre-publication redaction work to trigger a concurrent real-thread delete
+    entered_redaction = threading.Event()
+    delete_done = threading.Event()
+    real_redact_messages = _redact_messages
+
+    def slow_redact_messages(*args, **kwargs):
+        entered_redaction.set()
+        delete_done.wait(timeout=5.0)
+        return real_redact_messages(*args, **kwargs)
+
+    monkeypatch.setattr("api.helpers._redact_messages", slow_redact_messages)
+
+    # Start background writer with modified messages that require cache write
+    new_msgs = _msgs() + [{"role": "user", "content": "in-flight addition"}]
+    writer_thread = threading.Thread(
+        target=redact_session_lists_cached,
+        args=(sid, {"messages": new_msgs}),
+    )
+    writer_thread.start()
+
+    # Wait until background writer enters redaction before publication
+    assert entered_redaction.wait(timeout=5.0)
+
+    # Main thread deletes the session cache while background writer is working
+    assert delete_redaction_session_cache(sid) is True
+    assert not path.exists()
+
+    # Allow background writer to proceed to publication attempt
+    delete_done.set()
+    writer_thread.join(timeout=5.0)
+    assert not writer_thread.is_alive()
+
+    # The stale background writer MUST NOT have republished the deleted session cache
+    assert not path.exists()
+
+    # Positive control: subsequent session recreation publishes properly
+    monkeypatch.setattr("api.helpers._redact_messages", real_redact_messages)
+    out_recreated = redact_session_lists_cached(sid, {"messages": new_msgs})
+    assert path.exists()
+    cached = json.loads(path.read_text(encoding="utf-8"))
+    assert [m["content"] for m in cached["lists"]["messages"]] == [m["content"] for m in out_recreated["messages"]]
+
+
+def test_monotonic_generation_prevents_aba_republication(state_dir):
+    from api.helpers import _REDACTION_SESSION_GEN, _redact_session_cache_path
+
+    sid = "sessMonotonicABA"
+    path = _redact_session_cache_path(sid)
+
+    # Initial token is default 0
+    token_0 = _REDACTION_SESSION_GEN.get(sid, 0)
+    assert token_0 == 0
+
+    # Delete session increments generation
+    delete_redaction_session_cache(sid)
+    token_1 = _REDACTION_SESSION_GEN.get(sid, 0)
+    assert token_1 == 1
+
+    # Simulate repeated deletions/churn; generation must be strictly monotonic
+    for i in range(2, 20):
+        delete_redaction_session_cache(sid)
+        assert _REDACTION_SESSION_GEN.get(sid, 0) == i
+
+    # Old tokens (like token_0) can never match live generation
+    assert _REDACTION_SESSION_GEN.get(sid, 0) > token_0
+    assert not path.exists()
+
+
+
 
 def test_delete_removes_cache_file_leaves_sibling_intact(state_dir):
     # Deleting a session must remove its redaction-cache file (a deleted

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -202,6 +202,25 @@ def test_get_vs_delete_race_never_republishes_deleted_session_projection(state_d
     assert not path.exists()
 
 
+def test_recreated_session_can_populate_cache_after_delete(state_dir):
+    from api.helpers import _redact_session_cache_path
+
+    path = _redact_session_cache_path("sessRecreate")
+    redact_session_lists_cached("sessRecreate", {"messages": _msgs()})
+    assert path.exists()
+
+    assert delete_redaction_session_cache("sessRecreate") is True
+    assert not path.exists()
+
+    # When the session is recreated, caching should resume normally
+    new_msgs = [{"role": "user", "content": "hello newly created session"}]
+    redact_session_lists_cached("sessRecreate", {"messages": new_msgs})
+    assert path.exists()
+    cached = json.loads(path.read_text(encoding="utf-8"))
+    assert [m["content"] for m in cached["lists"]["messages"]] == ["hello newly created session"]
+
+
+
 def test_delete_removes_cache_file_leaves_sibling_intact(state_dir):
     # Deleting a session must remove its redaction-cache file (a deleted
     # conversation is not recoverable from redaction_cache/), while an

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -279,24 +279,126 @@ def test_monotonic_generation_prevents_aba_republication(state_dir):
 
     sid = "sessMonotonicABA"
     path = _redact_session_cache_path(sid)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}", encoding="utf-8")
 
     # Initial token is default 0
     token_0 = _REDACTION_SESSION_GEN.get(sid, 0)
     assert token_0 == 0
 
     # Delete session increments generation
-    delete_redaction_session_cache(sid)
+    assert delete_redaction_session_cache(sid) is True
     token_1 = _REDACTION_SESSION_GEN.get(sid, 0)
     assert token_1 == 1
 
     # Simulate repeated deletions/churn; generation must be strictly monotonic
     for i in range(2, 20):
-        delete_redaction_session_cache(sid)
+        path.write_text("{}", encoding="utf-8")
+        assert delete_redaction_session_cache(sid) is True
         assert _REDACTION_SESSION_GEN.get(sid, 0) == i
 
     # Old tokens (like token_0) can never match live generation
     assert _REDACTION_SESSION_GEN.get(sid, 0) > token_0
     assert not path.exists()
+
+
+def test_distinct_session_deletes_leave_generation_bookkeeping_bounded(state_dir, monkeypatch):
+    from api.helpers import _REDACTION_SESSION_GEN, _MAX_REDACTION_GEN_CAP, delete_redaction_session_cache, _redact_session_cache_path
+
+    # 1. Many deletes of missing valid IDs must not grow bookkeeping at all (0 entries admitted)
+    initial_len = len(_REDACTION_SESSION_GEN)
+    for i in range(5000):
+        assert delete_redaction_session_cache(f"missing_{i}") is False
+    assert len(_REDACTION_SESSION_GEN) == initial_len
+    assert not any(k.startswith("missing_") for k in _REDACTION_SESSION_GEN)
+
+    # 2. Heavy churn of existing sessions must stay strictly bounded by _MAX_REDACTION_GEN_CAP
+    cap = 25
+    monkeypatch.setattr("api.helpers._MAX_REDACTION_GEN_CAP", cap)
+
+    for i in range(100):
+        sid = f"churn_{i}"
+        p = _redact_session_cache_path(sid)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}", encoding="utf-8")
+        assert delete_redaction_session_cache(sid) is True
+    assert len(_REDACTION_SESSION_GEN) <= cap
+
+
+def test_paused_predelete_writer_cannot_publish_across_reclamation_bound(state_dir, monkeypatch):
+    import threading
+    from api.helpers import (
+        _redact_session_cache_path,
+        _redact_messages,
+        _REDACTION_SESSION_GEN,
+        _REDACTION_IN_FLIGHT,
+        delete_redaction_session_cache,
+    )
+
+    cap = 10
+    monkeypatch.setattr("api.helpers._MAX_REDACTION_GEN_CAP", cap)
+
+    sid = "sessPausedWriterBound"
+    path = _redact_session_cache_path(sid)
+
+    # Populate initial cache
+    redact_session_lists_cached(sid, {"messages": _msgs()})
+    assert path.exists()
+
+    # Intercept pre-publication redaction to simulate a paused in-flight writer
+    entered_redaction = threading.Event()
+    churn_done = threading.Event()
+    real_redact_messages = _redact_messages
+
+    def slow_redact_messages(*args, **kwargs):
+        entered_redaction.set()
+        churn_done.wait(timeout=5.0)
+        return real_redact_messages(*args, **kwargs)
+
+    monkeypatch.setattr("api.helpers._redact_messages", slow_redact_messages)
+
+    new_msgs = _msgs() + [{"role": "user", "content": "racing message while churn crosses bound"}]
+    writer_thread = threading.Thread(
+        target=redact_session_lists_cached,
+        args=(sid, {"messages": new_msgs}),
+    )
+    writer_thread.start()
+
+    assert entered_redaction.wait(timeout=5.0)
+    assert _REDACTION_IN_FLIGHT.get(sid, 0) == 1
+
+    # Delete the target session while writer is paused
+    assert delete_redaction_session_cache(sid) is True
+    assert not path.exists()
+    assert sid in _REDACTION_SESSION_GEN
+
+    # Heavily cross the reclamation cap with other deleted sessions
+    for i in range(50):
+        other_sid = f"other_{i}"
+        p = _redact_session_cache_path(other_sid)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}", encoding="utf-8")
+        delete_redaction_session_cache(other_sid)
+
+    # Target session must NOT have been evicted because its writer is still in-flight
+    assert sid in _REDACTION_SESSION_GEN
+    assert len(_REDACTION_SESSION_GEN) <= cap + 1
+
+    # Resume the paused writer
+    churn_done.set()
+    writer_thread.join(timeout=5.0)
+    assert not writer_thread.is_alive()
+
+    # Stale writer must NOT have published the cache file
+    assert not path.exists()
+
+    # Positive control: subsequent recreation works
+    monkeypatch.setattr("api.helpers._redact_messages", real_redact_messages)
+    out_recreated = redact_session_lists_cached(sid, {"messages": new_msgs})
+    assert path.exists()
+    cached = json.loads(path.read_text(encoding="utf-8"))
+    assert [m["content"] for m in cached["lists"]["messages"]] == [m["content"] for m in out_recreated["messages"]]
+
 
 
 

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -158,9 +158,48 @@ def test_truncation_serves_matching_prefix(state_dir, monkeypatch):
     ]
     redact_session_lists_cached("sessTrunc", {"messages": msgs})
     assert calls["n"] == 3
+    cache_file = state_dir / "redaction_cache" / "sessTrunc.json"
+    stored_before = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert len(stored_before["lists"]["messages"]) == 3
+
     out = redact_session_lists_cached("sessTrunc", {"messages": msgs[:2]})
     assert calls["n"] == 3  # prefix spliced, nothing recomputed
     assert [m["content"] for m in out["messages"]] == ["keep one", "keep two"]
+
+    # Regression (#7452 review): truncation to a full prefix must overwrite on-disk projection
+    stored_after = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert len(stored_after["lists"]["messages"]) == 2
+    assert len(stored_after["digests"]["messages"]) == 2
+    assert [m["content"] for m in stored_after["lists"]["messages"]] == ["keep one", "keep two"]
+
+
+def test_get_vs_delete_race_never_republishes_deleted_session_projection(state_dir, monkeypatch):
+    import os
+    from api.helpers import _redact_session_cache_path
+
+    # Initial session and populated cache
+    msgs = _msgs()
+    redact_session_lists_cached("sessRace", {"messages": msgs})
+    path = _redact_session_cache_path("sessRace")
+    assert path.exists()
+
+    # Interleave a delete immediately before os.replace in redact_session_lists_cached
+    real_replace = os.replace
+
+    def racing_replace(src, dst):
+        if "sessRace" in str(dst):
+            # Concurrent delete fires before the prepared tmp is published
+            delete_redaction_session_cache("sessRace")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", racing_replace)
+
+    # Trigger write path with modified messages
+    msgs_new = _msgs() + [{"role": "user", "content": "racing message"}]
+    redact_session_lists_cached("sessRace", {"messages": msgs_new})
+
+    # The projection must NOT be republished for the deleted session
+    assert not path.exists()
 
 
 def test_delete_removes_cache_file_leaves_sibling_intact(state_dir):

--- a/tests/test_redaction_session_cache.py
+++ b/tests/test_redaction_session_cache.py
@@ -209,12 +209,12 @@ def test_rules_content_digest_not_pathname_metadata(tmp_path):
     assert len(body_a) == len(body_b)  # same size by construction
     fixed_mtime = 1234567890123456789
     path = tmp_path / "policy.py"
-    path.write_text(body_a)
+    path.write_bytes(body_a.encode("utf-8"))
     _utime(path, fixed_mtime)
     digest_a = H._content_digest(path)
     assert digest_a is not None
     # Rewrite with different bytes, same size, same mtime_ns.
-    path.write_text(body_b)
+    path.write_bytes(body_b.encode("utf-8"))
     _utime(path, fixed_mtime)
     st_b = os.stat(path)
     digest_b = H._content_digest(path)


### PR DESCRIPTION
## Context & Summary

Closes #7439.

PR #7414 memoized the clean-or-redacted decision in three process-wide `functools.lru_cache` tiers, with count caps back-derived from a 1 GiB budget assuming maximum per-entry string sizes. This left a theoretical worst-case RSS ceiling of ~1.15 GiB across the three tiers.

This change replaces count-based eviction on `_redact_fn_lru`, `_redact_text_lru`, and `_redact_text_big_lru` with a lightweight, thread-safe byte-budgeted LRU (`_ByteBudgetLRU`) so worst-case retained RSS equals the configured budget by construction.

## Invariants & Design

1. **Aliasing Accounting**:
   - Clean strings (`key is val` on prefilter miss) count `sys.getsizeof(key)` once, preventing ~2x over-accounting on dominant transcript paths.
   - Redacted outputs (`key is not val`) account `sys.getsizeof(key) + sys.getsizeof(val)`.
   - Cross-tier sharing is deliberately over-counted per-tier by design (evicts earlier, never exceeds budget).
2. **Thread Safety**:
   - `threading.Lock` guards dict mutations, recency bumps on read, evictions, and accounting reads. Function execution (`_func(key)`) runs outside the lock to prevent contention across regex scanning.
3. **Session Deletion Contract**:
   - Wholesale RAM clear preserved via `.cache_clear()` on all three tiers in `_redact_session_cache_delete`.
4. **Env Knobs & Clamping**:
   - `HERMES_WEBUI_REDACT_FN_BYTE_BUDGET` (512 MiB default)
   - `HERMES_WEBUI_REDACT_DECISION_BYTE_BUDGET` (512 MiB default)
   - `HERMES_WEBUI_REDACT_BIG_DECISION_BYTE_BUDGET` (128 MiB default)
   - Clamped to the 1 GiB hard ceiling (`_REDACT_MEMO_BYTE_BUDGET`).
5. **Observability**:
   - `cache_info()` returns `(hits, misses, maxsize, currsize, retained_bytes, max_bytes)`.

## Verification

- `tests/test_redaction_decision_memo.py`: 8/8 passed (exact byte accounting, LRU eviction order, aliasing, concurrency, and cache clear).
- `tests/test_issue5204_redactor_memoization_contract.py`: 4/4 passed.
