### PR TITLE
fix(streaming): never settle the current user turn at the front of the context

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -23,6 +23,9 @@ _PUBLIC_MESSAGE_INTERNAL_FIELDS = frozenset({
     "_active_turn_token",
     "_active_turn_user",
     "_fork_child_turn",
+    # Producer-owned current-turn row marker (hermes-agent turn-boundary contract v2).
+    # Settlement converts it into the WebUI token and strips it; never public.
+    "_turn_id",
 })
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1715,43 +1715,158 @@ def _coerce_current_turn_user_idx(value):
     return idx if idx >= 0 else None
 
 
-def _resolve_active_turn_authority(identity, *, result=None, agent=None):
+def _callable_boundary_contract(agent):
+    """Turn-boundary contract version declared by the Agent callable (0 = none).
+
+    Read from the callable itself — BEFORE invoking it and again for every
+    replacement Agent a retry lane constructs — never inferred from the keys an
+    individual result envelope happens to carry.
+    """
+    return _coerce_contract_version(getattr(agent, 'TURN_BOUNDARY_CONTRACT', 0))
+
+
+def _coerce_contract_version(value):
+    if isinstance(value, bool):
+        return 0
+    try:
+        version = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return version if version > 0 else 0
+
+
+def _resolve_active_turn_authority(identity, *, result=None, agent=None, contract=None):
+    """Bind the WebUI's pending-turn identity to ONE coherent producer coordinate.
+
+    Contract >= 2 (declared by the callable): the result envelope must carry
+    ``turn_boundary_contract >= 2``, a ``turn_id`` equal to the live Agent's
+    ``_current_turn_id`` (unavailable or different → rejected), and a
+    ``messages_projection``; ``current_turn_user_idx`` is honoured only when the
+    addressed row carries the same ``_turn_id`` marker the Agent stamped on this
+    turn's user row (never validated by prompt text). A missing/None/malformed
+    coordinate leaves the turn capable-but-unproven: consumers fail closed. The
+    mutable Agent-instance index is never combined with a result ``turn_id``.
+
+    Contract < 2: the only coordinate is the Agent-instance pair
+    (``_persist_user_message_idx`` / ``_current_turn_id``), which the lookup honours
+    only while ``previous_context`` is still a prefix of the result. Result keys
+    from such producers are ignored (their index is text-derived).
+    """
     if not isinstance(identity, dict):
         return identity
     resolved = dict(identity)
-    resolved.pop('agent_turn_boundary_resolved', None)
-    resolved.pop('agent_turn_boundary_source', None)
-
-    # Treat the boundary as one coherent pair. In particular, do not retain the
-    # failed Agent instance's index/turn when credential self-heal creates a
-    # fresh Agent whose compacted projection has a different current-user index.
-    # The returned-result pair is authoritative when exported; current paired
-    # Agents keep the same pair on the instance instead.
+    for key in (
+        'agent_turn_boundary_resolved', 'agent_turn_boundary_source',
+        'producer_capability', 'producer_contract', 'messages_projection',
+    ):
+        resolved.pop(key, None)
+    _contract = _callable_boundary_contract(agent) if contract is None else _coerce_contract_version(contract)
+    _live_turn_id = (
+        str(getattr(agent, '_current_turn_id', '') or '').strip() if agent is not None else ''
+    )
+    resolved['producer_contract'] = _contract
+    resolved['producer_capability'] = 'turn_boundary' if _contract >= 2 else 'unproven'
+    resolved['messages_projection'] = None
     _boundary_idx = None
     _boundary_turn_id = ''
     _boundary_source = ''
-    if isinstance(result, dict):
-        _result_idx = _coerce_current_turn_user_idx(result.get('current_turn_user_idx'))
-        _result_turn_id = str(result.get('turn_id') or '').strip()
-        if _result_idx is not None and _result_turn_id:
-            _boundary_idx = _result_idx
-            _boundary_turn_id = _result_turn_id
-            _boundary_source = 'result'
-    if agent is not None:
+    if _contract >= 2:
+        if isinstance(result, dict):
+            _result_turn_id = str(result.get('turn_id') or '').strip()
+            _projection = result.get('messages_projection')
+            _bound = (
+                _coerce_contract_version(result.get('turn_boundary_contract')) >= 2
+                and bool(_result_turn_id)
+                and bool(_live_turn_id)
+                and _result_turn_id == _live_turn_id
+                and _projection in ('full', 'delta')
+            )
+            if _bound:
+                resolved['messages_projection'] = _projection
+                _result_idx = _coerce_current_turn_user_idx(result.get('current_turn_user_idx'))
+                if _result_idx is not None:
+                    _boundary_idx = _result_idx
+                    _boundary_turn_id = _result_turn_id
+                    _boundary_source = 'result'
+    elif agent is not None:
         _agent_idx = _coerce_current_turn_user_idx(
             getattr(agent, '_persist_user_message_idx', None)
         )
-        _agent_turn_id = str(getattr(agent, '_current_turn_id', '') or '').strip()
-        if _agent_idx is not None and _agent_turn_id and not _boundary_source:
+        if _agent_idx is not None and _live_turn_id:
             _boundary_idx = _agent_idx
-            _boundary_turn_id = _agent_turn_id
+            _boundary_turn_id = _live_turn_id
             _boundary_source = 'agent'
     if _boundary_source:
         resolved['current_turn_user_idx'] = _boundary_idx
         resolved['turn_id'] = _boundary_turn_id
         resolved['agent_turn_boundary_resolved'] = True
         resolved['agent_turn_boundary_source'] = _boundary_source
+    if _boundary_source == 'result' and not _stamp_result_exported_checkpoint(
+        result.get('messages'), resolved
+    ):
+        # The producer's index does not address its own marked row: malformed,
+        # so the turn stays capable-but-unproven.
+        for key in ('agent_turn_boundary_resolved', 'agent_turn_boundary_source'):
+            resolved.pop(key, None)
+        resolved['current_turn_user_idx'] = None
     return resolved
+
+
+def _producer_exports_turn_boundary(identity):
+    """True for any resolved pending-turn identity: ownership is proven or not claimed.
+
+    Kept as a named predicate so call sites read as "strict mode"; there is no
+    heuristic mode any more — a caller without an identity is the only path that
+    still uses text/role inference (legacy callers outside the streaming route).
+    """
+    return isinstance(identity, dict)
+
+
+def _result_is_delta_projection(identity, result_messages):
+    """Is ``result_messages`` an output-only delta (no history, no user row)?
+
+    Only a bound contract-v2 envelope can say so (``messages_projection ==
+    'delta'``); ``'full'`` is never a delta, even when it holds only historical
+    assistant/tool rows, and an unbound/unknown projection is never a delta.
+    Role-derived detection survives only for callers without an identity.
+    """
+    if isinstance(identity, dict):
+        return identity.get('messages_projection') == 'delta'
+    return bool(result_messages) and all(
+        _is_context_compression_marker(message)
+        or (isinstance(message, dict) and message.get('role') in ('assistant', 'tool'))
+        for message in result_messages or []
+    )
+
+
+def _stamp_result_exported_checkpoint(result_messages, identity):
+    """Carry the WebUI token onto the row the Agent exported as this turn's user message.
+
+    The row must be a user row carrying the same ``_turn_id`` marker the Agent
+    stamped at append time (contract v2); prompt text plays no part. Stamped in the
+    exact ``result["messages"]`` projection before marker cleaning or dedupe shifts
+    indexes, so every later consumer proves the current turn by token.
+    """
+    if not isinstance(result_messages, list) or not isinstance(identity, dict):
+        return False
+    if not identity.get('token'):
+        return False
+    if _active_turn_has_checkpoint(result_messages, identity):
+        return True
+    idx = identity.get('current_turn_user_idx')
+    if not isinstance(idx, int) or isinstance(idx, bool) or idx < 0 or idx >= len(result_messages):
+        return False
+    row = result_messages[idx]
+    if (
+        not isinstance(row, dict)
+        or row.get('role') != 'user'
+        or _is_synthetic_control_message(row)
+        or not identity.get('turn_id')
+        or row.get('_turn_id') != identity.get('turn_id')
+    ):
+        return False
+    _mark_active_turn_checkpoint(row, identity)
+    return True
 
 
 def _active_turn_boundary_is_valid(identity):
@@ -1829,20 +1944,22 @@ def _owner_projection_current_turn_row(messages, identity):
 def _find_active_turn_checkpoint_index(result_messages, previous_context, identity, msg_text):
     """Locate the current turn's user row inside ``result_messages``.
 
-    Exactly one declared index domain is supported. The WebUI token is the
-    strongest proof and wins when it survives the Agent projection. Otherwise
-    the Agent-resolved ``current_turn_user_idx`` addresses ``result["messages"]``
-    directly, so only that exact index is validated. With a repeated prompt a
-    shifted probe (``current_turn_user_idx - len(previous_context)``) can land
-    on an identical historical user row and leak historical assistant prose
-    into the current turn, so no alternative projection is ever probed. If a
-    shifted projection is ever genuinely required, the Agent must carry an
-    explicit projection-origin/base-length discriminator instead.
+    Only proven coordinates are honoured:
 
-    ``previous_context`` is retained for call-site compatibility only; it does
-    not participate in index resolution.
+    * the WebUI token, stamped on the row the WebUI inserted or on the row the
+      Agent exported for this exact ``result["messages"]`` projection;
+    * an Agent-instance index (``_persist_user_message_idx``) only while
+      ``previous_context`` is still a prefix of ``result_messages``: it was
+      captured before the Agent's iteration-time sequence repair, so after a
+      non-prefix rewrite it can address a different projection.
+
+    Either index is accepted only when the addressed row is a user row carrying
+    this turn's text. There is no text-only or role-only inference: after the
+    Agent rewrote history, a repeated prompt's historical row would otherwise be
+    relabelled as the current turn and its old answer claimed as this turn's.
+    Callers fail closed on ``None``.
     """
-    del previous_context  # single declared index domain: result_messages only
+    previous_context = list(previous_context or [])
     result_messages = list(result_messages or [])
     if not isinstance(identity, dict):
         return None
@@ -1852,18 +1969,28 @@ def _find_active_turn_checkpoint_index(result_messages, previous_context, identi
                 return idx
     if not _active_turn_boundary_is_valid(identity):
         return None
+    if (
+        identity.get('agent_turn_boundary_source') != 'result'
+        and previous_context
+        and not _messages_have_prefix(result_messages, previous_context)
+    ):
+        # A capable producer exports the pair on the envelope when the row is
+        # proven; falling back to its instance index after a non-prefix rewrite
+        # would trust a coordinate captured before the rewrite. Legacy producers
+        # keep the exact-index validation below (their only coordinate).
+        return None
     expected_text = identity.get('text') if identity.get('text') is not None else msg_text
     idx = identity['current_turn_user_idx']
-    if idx < 0 or idx >= len(result_messages):
-        return None
-    message = result_messages[idx]
-    if (
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and _normalize_user_text(_message_text(message.get('content')))
-        == _normalize_user_text(expected_text)
-    ):
-        return idx
+    if 0 <= idx < len(result_messages):
+        message = result_messages[idx]
+        if (
+            isinstance(message, dict)
+            and message.get('role') == 'user'
+            and not _is_synthetic_control_message(message)
+            and _normalize_user_text(_message_text(message.get('content')))
+            == _normalize_user_text(expected_text)
+        ):
+            return idx
     return None
 
 
@@ -1900,7 +2027,22 @@ def _materialize_active_turn_user(identity, msg_text, source):
 
 
 def _settle_current_turn_boundary(previous_context, result_messages, identity, msg_text, source):
-    """Insert the pending turn before assistant/tool output when it is absent."""
+    """Insert the pending turn before assistant/tool output when it is absent.
+
+    Placement is proven or not done at all:
+
+    * a located checkpoint (token, or a validated Agent coordinate) is refreshed
+      in place;
+    * a delta-only result (only assistant/tool rows and compression markers)
+      gets the turn at its front — the Agent index addresses the full history,
+      never a delta;
+    * a full-history result that still carries ``previous_context`` as a prefix
+      gets the turn right after that prefix;
+    * anything else is returned unchanged. No index arithmetic
+      (``idx - len(previous_context)``), no trailing-role inference: both can
+      put the pending user before historical assistant rows and claim them as
+      this turn's output.
+    """
     result_messages = list(result_messages or [])
     if not result_messages or not isinstance(identity, dict):
         return result_messages
@@ -1925,26 +2067,14 @@ def _settle_current_turn_boundary(previous_context, result_messages, identity, m
             _mark_active_turn_checkpoint(existing_checkpoint, identity)
         return result_messages
     previous_context = list(previous_context or [])
-    if _messages_have_prefix(result_messages, previous_context):
-        insert_at = len(previous_context)
-    elif _active_turn_boundary_is_valid(identity):
-        insert_at = identity['current_turn_user_idx'] - len(previous_context)
-        if insert_at < 0 or insert_at > len(result_messages):
-            insert_at = identity['current_turn_user_idx']
-        if insert_at < 0 or insert_at > len(result_messages):
-            insert_at = None
-    else:
-        insert_at = None
-    if insert_at is None and all(
-        _is_context_compression_marker(message)
-        or (isinstance(message, dict) and message.get('role') in ('assistant', 'tool'))
-        for message in result_messages
-    ):
+    if _result_is_delta_projection(identity, result_messages):
         insert_at = 0
         while insert_at < len(result_messages) and _is_context_compression_marker(result_messages[insert_at]):
             insert_at += 1
-    if insert_at is None:
-        return result_messages
+    elif _messages_have_prefix(result_messages, previous_context):
+        insert_at = len(previous_context)
+    else:
+        return result_messages  # fail closed: no proven place for the current turn
     return (
         result_messages[:insert_at]
         + [_materialize_active_turn_user(identity, msg_text, source)]
@@ -1982,15 +2112,45 @@ def _align_current_turn_display(previous_display, previous_context, identity):
     return display, context
 
 
+_PRODUCER_TURN_ROW_MARKER = '_turn_id'
+
+
+def _strip_producer_turn_markers(messages):
+    """Copy rows that carry the producer's ``_turn_id`` marker without it.
+
+    By the time settlement runs, ``_stamp_result_exported_checkpoint`` has
+    converted the producer's authority into the WebUI-owned
+    ``_active_turn_token``; the marker must not reach durable WebUI state
+    (session sidecar) or public projections. Rows are copied, never mutated, so
+    result-envelope consumers that still read ``result["messages"]`` are
+    unaffected.
+    """
+    stripped = []
+    for message in messages or []:
+        if isinstance(message, dict) and _PRODUCER_TURN_ROW_MARKER in message:
+            stripped.append({
+                key: value for key, value in message.items() if key != _PRODUCER_TURN_ROW_MARKER
+            })
+        else:
+            stripped.append(message)
+    return stripped
+
+
 def _prepare_marker_clean_writeback(
     previous_context_messages,
     result_messages,
     active_turn_identity=None,
 ):
-    """Return marker-cleaned rows, next context rows, and nudge provenance."""
+    """Return marker-cleaned rows, next context rows, and nudge provenance.
+
+    Both projections derive from ``cleaned``: synthetic control rows removed and
+    the producer's ``_turn_id`` marker stripped (its authority already lives in
+    the WebUI token stamped by ``_stamp_result_exported_checkpoint``).
+    """
     cleaned, has_verification_nudge = _clean_synthetic_control_messages_with_provenance(
         result_messages
     )
+    cleaned = _strip_producer_turn_markers(cleaned)
     provenance = {
         'verification_nudge_seen': has_verification_nudge,
         'active_turn_identity': copy.deepcopy(active_turn_identity),
@@ -2056,6 +2216,7 @@ def _settle_result_messages(
             previous_context_messages,
             next_context_messages,
             msg_text,
+            active_turn_identity=active_turn_identity,
         )
         next_context_messages = _settle_current_turn_boundary(
             previous_context_messages,
@@ -6128,8 +6289,15 @@ def _strip_replayed_context_items(existing_messages, candidates):
     return cleaned
 
 
-def _dedupe_replayed_context_messages(previous_context, result_messages, msg_text=None):
-    """Keep model context append-only without replayed blocks/summaries."""
+def _dedupe_replayed_context_messages(
+    previous_context, result_messages, msg_text=None, active_turn_identity=None,
+):
+    """Keep model context append-only without replayed blocks/summaries.
+
+    For a capable producer (turn-boundary contract) the repaired boundary row
+    must carry the WebUI token and a delta is only what the producer declared;
+    legacy producers keep the text/role heuristics.
+    """
     previous_context = list(previous_context or [])
     result_messages = list(result_messages or [])
     if not previous_context or not result_messages:
@@ -6165,7 +6333,12 @@ def _dedupe_replayed_context_messages(previous_context, result_messages, msg_tex
                     previous_context=previous_context,
                 )
             )
-            if is_stale_merge or _looks_like_current_user_turn(boundary_row, msg_text):
+            _boundary_proven = (
+                _active_turn_token_matches(boundary_row, active_turn_identity)
+                if _producer_exports_turn_boundary(active_turn_identity)
+                else _looks_like_current_user_turn(boundary_row, msg_text)
+            )
+            if is_stale_merge or _boundary_proven:
                 if is_stale_merge:
                     # Clean only the stale-merged boundary row; leave all prior
                     # history in previous_context untouched.
@@ -6183,13 +6356,8 @@ def _dedupe_replayed_context_messages(previous_context, result_messages, msg_tex
                 if candidates:
                     candidates = _strip_replayed_context_items(previous_context, candidates)
                 return previous_context + candidates
-        assistant_or_tool_only_result = bool(result_messages) and all(
-            _is_context_compression_marker(m)
-            or (
-                isinstance(m, dict)
-                and m.get('role') in ('assistant', 'tool')
-            )
-            for m in result_messages
+        assistant_or_tool_only_result = _result_is_delta_projection(
+            active_turn_identity, result_messages,
         )
         if assistant_or_tool_only_result:
             candidates = _strip_replayed_prefix(previous_context, result_messages)
@@ -6983,14 +7151,19 @@ def _merge_display_messages_after_agent_result(
             candidates = _strip_replayed_prefix(previous_display, candidates)
             candidates = _strip_replayed_prefix(previous_context, candidates)
     else:
-        current_user_idx = _find_current_user_turn(result_messages, msg_text)
-        assistant_or_tool_only_result = bool(result_messages) and all(
-            _is_context_compression_marker(m)
-            or (
-                isinstance(m, dict)
-                and m.get('role') in ('assistant', 'tool')
+        if _producer_exports_turn_boundary(_active_turn_identity):
+            # Rewritten (non-prefix) result from a capable producer: only a
+            # proven boundary — the WebUI token or a validated Agent coordinate —
+            # may claim rows as this turn. A text match would select a repeated
+            # historical prompt and display its old answer as current; fail
+            # closed instead. Legacy producers keep the historical text search.
+            current_user_idx = _find_active_turn_checkpoint_index(
+                result_messages, previous_context, _active_turn_identity, msg_text,
             )
-            for m in result_messages
+        else:
+            current_user_idx = _find_current_user_turn(result_messages, msg_text)
+        assistant_or_tool_only_result = _result_is_delta_projection(
+            _active_turn_identity, result_messages,
         )
         turn_candidates = (
             result_messages[current_user_idx:]
@@ -7129,12 +7302,32 @@ def _stamp_missing_message_timestamps(messages, *, now: float | None = None) -> 
     return stamped
 
 
-def _assistant_reply_added_after_current_turn(result_messages, previous_context, msg_text) -> bool:
-    """Return True only when the just-finished turn produced assistant text."""
+def _assistant_reply_added_after_current_turn(
+    result_messages, previous_context, msg_text, active_turn_identity=None,
+) -> bool:
+    """Return True only when the just-finished turn produced assistant text.
+
+    For a non-prefix (rewritten) result the current turn must be proven by the
+    active-turn identity; without one the answer is ``False`` (fail closed) so a
+    historical assistant row is never classified as this turn's reply.
+    """
     result_messages = list(result_messages or [])
     previous_context = list(previous_context or [])
     if _messages_have_prefix(result_messages, previous_context):
         candidates = result_messages[len(previous_context):]
+    elif _producer_exports_turn_boundary(active_turn_identity):
+        current_user_idx = _find_active_turn_checkpoint_index(
+            result_messages, previous_context, active_turn_identity, msg_text,
+        )
+        if current_user_idx is None:
+            return False
+        candidates = result_messages[current_user_idx + 1:]
+        next_user = next(
+            (i for i, m in enumerate(candidates) if isinstance(m, dict) and m.get('role') == 'user'),
+            None,
+        )
+        if next_user is not None:
+            candidates = candidates[:next_user]
     else:
         current_user_idx = _find_current_user_turn(result_messages, msg_text)
         candidates = result_messages[current_user_idx + 1:] if current_user_idx is not None else result_messages
@@ -7187,7 +7380,11 @@ def _turn_transcript_lacks_final_assistant_answer(
         None,
     )
     current_user_idx = current_user_token_idx
-    if current_user_idx is None:
+    _token_owned = (
+        _producer_exports_turn_boundary(active_turn_identity)
+        and bool(active_turn_identity.get('token'))
+    )
+    if current_user_idx is None and not _token_owned:
         current_user_idx = _find_current_user_turn(merged_messages, msg_text)
     if current_user_idx is None or (
         current_user_token_idx is None
@@ -10737,11 +10934,13 @@ def _run_agent_streaming(
                 )
                 _run_conversation_kwargs["user_message"] = user_message
             _result_partial_pre_call_context = list(_previous_context_messages)
+            _boundary_contract = _callable_boundary_contract(agent)
             result = agent.run_conversation(**_run_conversation_kwargs)
             _active_turn_identity = _resolve_active_turn_authority(
                 _active_turn_identity,
                 result=result,
                 agent=agent,
+                contract=_boundary_contract,
             )
             # #4729: the run is done — flush any reasoning tail still in the coalescing
             # buffer (the agent never calls reasoning_callback(None), and a turn can end on
@@ -11041,6 +11240,7 @@ def _run_agent_streaming(
                     _all_result_messages,
                     _previous_context_messages,
                     msg_text,
+                    active_turn_identity=_active_turn_identity,
                 )
                 _last_err = getattr(agent, '_last_error', None) or result.get('error') or ''
                 # #5940: if the Agent aborted on a non-retryable provider error
@@ -11228,11 +11428,13 @@ def _run_agent_streaming(
                                 _result_partial_pre_call_context = list(
                                     _heal_context_messages
                                 )
+                                _boundary_contract = _callable_boundary_contract(agent)
                                 _heal_result = agent.run_conversation(**_heal_kwargs)
                                 _active_turn_identity = _resolve_active_turn_authority(
                                     _active_turn_identity,
                                     result=_heal_result,
                                     agent=agent,
+                                    contract=_boundary_contract,
                                 )
                                 if _result_reports_compression_snapshot_stale(_heal_result):
                                     _heal_stale_classification = _classify_provider_error(
@@ -12526,11 +12728,13 @@ def _run_agent_streaming(
                         _result_partial_pre_call_context = list(
                             _heal_context_messages
                         )
+                        _boundary_contract = _callable_boundary_contract(_heal_agent)
                         _heal_result = _heal_agent.run_conversation(**_heal_kwargs2)
                         _active_turn_identity = _resolve_active_turn_authority(
                             _active_turn_identity,
                             result=_heal_result,
                             agent=_heal_agent,
+                            contract=_boundary_contract,
                         )
                         _heal_stale_classification = None
                         if _result_reports_compression_snapshot_stale(_heal_result):

--- a/docs/rfcs/webui-run-state-consistency-contract.md
+++ b/docs/rfcs/webui-run-state-consistency-contract.md
@@ -152,6 +152,61 @@ and 5; it does not mark every run-state boundary implemented.
    still owns a live channel. Staleness is measured from the cancellation
    timestamp (falling back to run start), so a long-running turn cancelled
    moments ago is never mistaken for an orphan.
+10. **Current-turn ownership is proven by the producer contract or not claimed.**
+   When an Agent result lacks the WebUI's current user row, settlement
+   (`_settle_current_turn_boundary` in `api/streaming.py`) and every consumer
+   that classifies this turn's output (`_assistant_reply_added_after_current_turn`,
+   `_self_heal_result_succeeded`, `_append_result_partial_on_error`,
+   `_merged_transcript_lacks_final_assistant_answer`, the display merge, the
+   replayed-context dedupe) locate the current turn only through a proven
+   coordinate. There is no text search and no role-derived projection guess.
+
+   **Producer contract v2** (hermes-agent `AIAgent.TURN_BOUNDARY_CONTRACT = 2`).
+   The Agent stamps this turn's user row with a `_turn_id` marker at append time
+   (it survives compaction's deep copies, is carried across user-row merges, is
+   never sent to providers and never persisted to `state.db`) and exports on
+   **every** result envelope — success, partial/error, interrupt, retry-exhausted,
+   tool-limit, preflight timeout, durable-lease early return —
+   `turn_boundary_contract`, `turn_id` (this invocation's), `messages_projection`
+   (`"full"`: the exact final `messages` list; the loop never returns an
+   output-only delta) and `current_turn_user_idx`: the marked row, or `None`.
+
+   **Consumer rules.** `_callable_boundary_contract` reads the capability from
+   the Agent callable BEFORE each invocation, including every replacement Agent
+   a self-heal lane constructs; it is never inferred from the keys an envelope
+   happens to carry. `_resolve_active_turn_authority` then binds ONE coherent
+   coordinate:
+   - contract >= 2: the envelope must carry `turn_boundary_contract >= 2`, a
+     `turn_id` equal to the live Agent's `_current_turn_id` (unavailable or
+     different → rejected) and a projection in `{"full", "delta"}`; the index
+     is honoured only when the addressed row is a user row carrying the same
+     `_turn_id` marker, and the WebUI token is stamped on that exact row before
+     marker cleaning shifts indexes. The producer marker is then stripped from
+     every transcript/context row at writeback (rows copied, never mutated) and
+     is listed among the public-projection internal fields, so it never reaches
+     the session sidecar, the terminal SSE payload or session/export responses.
+     An omitted (`None`) or malformed coordinate leaves the turn
+     capable-but-unproven. The mutable Agent-instance index is never combined
+     with a result `turn_id`;
+   - contract < 2 (legacy callable): result keys are ignored (a text-derived
+     index can address an identical historical prompt); the Agent-instance
+     pair is the only coordinate and is honoured only while `previous_context`
+     is still a prefix of the result.
+   The WebUI token that survived the projection always wins.
+
+   **Fail closed.** Without a proven coordinate on a rewritten (non-prefix)
+   result: the pending prompt stays visible, streamed text is kept as a partial,
+   no historical row receives the live token, no prior answer is settled or
+   classified as current, no `done`, no false tool-limit closure. A full
+   projection holding only historical assistant/tool rows is never a delta;
+   only a bound `messages_projection: "delta"` is inserted at the front after
+   leading compression markers. A full-history result that still carries
+   `previous_context` as a prefix gets the turn right after that prefix;
+   anything else is left unchanged (no `idx - len(previous_context)`, no
+   "before the trailing assistant/tool run", no write at index 0 of a full
+   history — a current turn stored before prior rows is merged into the first
+   user message by the Agent's next repair, rewriting the prompt's leading
+   messages every turn).
 
 ## Review Checklist
 
@@ -175,6 +230,13 @@ context reconstruction, or session metadata:
 - If it introduces or changes a reclamation window, what proves an in-flight
   cancellation is not evicted early, and that a wedged one is eventually freed?
 - Can automatic compression or recovery text become visible active-turn content?
+- If it touches current-turn settlement or classification: is the producer
+  capability read from the callable (replacement Agents included) rather than
+  from envelope keys; is the coordinate bound to the live `turn_id` and
+  validated by the row's `_turn_id` marker rather than prompt text; is the
+  projection shape taken from the envelope rather than row roles; and does a
+  rewritten result with a repeated historical prompt, a foreign turn id, an
+  omitted index or a malformed projection fail closed?
 - What test or manual evidence proves the invariant?
 
 ## Existing Issue Map

--- a/tests/test_compression_snapshot_revision.py
+++ b/tests/test_compression_snapshot_revision.py
@@ -470,16 +470,28 @@ def test_stale_non_prefix_partial_uses_token_and_stops_at_next_user():
     ]
 
 
+class _ContractAgent:
+    """A contract-v2 callable whose live turn id the envelope must match."""
+
+    TURN_BOUNDARY_CONTRACT = 2
+
+    def __init__(self, turn_id):
+        self._current_turn_id = turn_id
+        self._persist_user_message_idx = None
+
+
 def test_non_prefix_partial_uses_agent_turn_boundary_without_webui_token():
     session = Session(session_id="agent-boundary-partial", messages=[], context_messages=[])
     result = {
         "partial": True,
+        "turn_boundary_contract": 2,
         "turn_id": "agent-turn-42",
+        "messages_projection": "full",
         "current_turn_user_idx": 2,
         "messages": [
             {"role": "user", "content": "repeat prompt"},
             {"role": "assistant", "content": "historical answer"},
-            {"role": "user", "content": "  repeat   prompt  "},
+            {"role": "user", "content": "  repeat   prompt  ", "_turn_id": "agent-turn-42"},
             {"role": "assistant", "content": "current partial"},
             {"role": "user", "content": "later turn"},
             {"role": "assistant", "content": "later answer"},
@@ -488,6 +500,7 @@ def test_non_prefix_partial_uses_agent_turn_boundary_without_webui_token():
     identity = streaming._resolve_active_turn_authority(
         {"token": "webui-token", "text": "repeat prompt", "turn_id": "", "current_turn_user_idx": None},
         result=result,
+        agent=_ContractAgent("agent-turn-42"),
     )
 
     appended = streaming._append_result_partial_on_error(
@@ -502,12 +515,14 @@ def test_non_prefix_partial_uses_agent_turn_boundary_without_webui_token():
 def test_non_prefix_self_heal_accepts_agent_turn_boundary_without_webui_token(terminal):
     result = {
         "completed": True,
+        "turn_boundary_contract": 2,
         "turn_id": "agent-turn-43",
+        "messages_projection": "full",
         "current_turn_user_idx": 2,
         "messages": [
             {"role": "user", "content": "repeat prompt"},
             {"role": "assistant", "content": "historical answer"},
-            {"role": "user", "content": " repeat\n prompt "},
+            {"role": "user", "content": " repeat\n prompt ", "_turn_id": "agent-turn-43"},
             {"role": "assistant", "content": f"healed after {terminal}"},
             {"role": "user", "content": "later turn"},
             {"role": "assistant", "content": "later answer"},
@@ -516,6 +531,7 @@ def test_non_prefix_self_heal_accepts_agent_turn_boundary_without_webui_token(te
     identity = streaming._resolve_active_turn_authority(
         {"token": "webui-token", "text": "repeat prompt", "turn_id": "", "current_turn_user_idx": None},
         result=result,
+        agent=_ContractAgent("agent-turn-43"),
     )
 
     assert streaming._self_heal_result_succeeded(
@@ -670,11 +686,13 @@ def test_differing_live_and_result_snapshots_are_exact_once(
     )
     result = {
         "partial": True,
+        "turn_boundary_contract": 2,
         "turn_id": "agent-current-turn",
+        "messages_projection": "full",
         "current_turn_user_idx": 1,
         "messages": [
             {"role": "assistant", "content": "[compacted] history"},
-            {"role": "user", "content": " current\n prompt "},
+            {"role": "user", "content": " current\n prompt ", "_turn_id": "agent-current-turn"},
             {"role": "assistant", "content": result_snapshot},
             {"role": "user", "content": "later turn"},
             {"role": "assistant", "content": "later wrong"},
@@ -683,6 +701,7 @@ def test_differing_live_and_result_snapshots_are_exact_once(
     identity = streaming._resolve_active_turn_authority(
         {"token": token, "text": "current prompt"},
         result=result,
+        agent=_ContractAgent("agent-current-turn"),
     )
     monkeypatch.setitem(streaming.STREAM_PARTIAL_TEXT, stream_id, live_snapshot)
     monkeypatch.setitem(streaming.STREAM_REASONING_TEXT, stream_id, "")
@@ -897,6 +916,10 @@ def test_webui_run_missing_explicit_profile_passes_no_foreign_revision(
                 "completed": True,
                 "final_response": "ok",
                 "messages": [
+                    # Like the real Agent, return the full history plus this turn's rows: a
+                    # rewritten history without an exported turn boundary fails closed (no
+                    # text-based current-turn inference), which is not this test's subject.
+                    *list(kwargs.get("conversation_history") or []),
                     {"role": "user", "content": kwargs["persist_user_message"]},
                     {"role": "assistant", "content": "ok"},
                 ],
@@ -1297,7 +1320,7 @@ def _repeated_prompt_collision_result_messages(prompt, *, current_answer):
         {"role": "assistant", "content": "[compacted] summary of earlier context"},
         {"role": "user", "content": prompt},  # shifted probe target (historical)
         {"role": "assistant", "content": "historical answer"},  # historical-only prose
-        {"role": "user", "content": prompt},  # exact Agent index target (current)
+        {"role": "user", "content": prompt, "_turn_id": "agent-heal-turn"},  # exact target (current, marked)
     ]
     if current_answer is not None:
         rows.append({"role": "assistant", "content": current_answer})
@@ -1350,6 +1373,8 @@ def test_self_heal_repeated_prompt_never_accepts_shifted_historical_row(
 
     class RepeatedPromptAgent:
         runs = 0
+        TURN_BOUNDARY_CONTRACT = 2
+        _current_turn_id = "agent-heal-turn"
 
         def __init__(self, session_id=None, **_kwargs):
             self.session_id = session_id
@@ -1382,7 +1407,9 @@ def test_self_heal_repeated_prompt_never_accepts_shifted_historical_row(
             # Heal retry: the 2-row refreshed baseline makes the legacy
             # shifted probe (3 - 2 = 1) collide with the historical user row.
             heal = {
+                "turn_boundary_contract": 2,
                 "turn_id": "agent-heal-turn",
+                "messages_projection": "full",
                 "current_turn_user_idx": 3,
                 "messages": _repeated_prompt_collision_result_messages(
                     prompt,

--- a/tests/test_current_turn_boundary_fail_closed.py
+++ b/tests/test_current_turn_boundary_fail_closed.py
@@ -1,0 +1,394 @@
+"""Current-turn ownership is proven by the producer contract or not claimed at all.
+
+Contract v2 (declared by the Agent callable as ``TURN_BOUNDARY_CONTRACT``): every
+result envelope carries ``turn_boundary_contract``, ``turn_id`` (this invocation's),
+``messages_projection`` ("full": the exact final ``messages`` list) and a nullable
+``current_turn_user_idx`` that addresses the row the Agent stamped with the same
+``_turn_id`` marker at append time. The WebUI reads the capability from the callable
+before each invocation (replacement Agents included), binds the envelope to the live
+turn id, validates the index by marker — never by prompt text — and otherwise leaves
+the turn capable-but-unproven: no historical row receives the live token, no prior
+answer is persisted or classified as this turn's, no ``done``. Legacy callables
+(no contract) keep only a prefix-intact instance index; rewritten results fail closed.
+"""
+
+import copy
+import types
+
+import pytest
+
+from api import streaming
+from tests.test_tool_limit_terminal_state import _run_streaming_with_fake_agent
+
+PROMPT = "Fix the failing test."
+OLD_ANSWER = "The earlier attempt is complete."
+NEW_ANSWER = "Done: parser fixed, tests green."
+TURN_ID = "turn-current"
+
+
+def _history():
+    return [
+        {"role": "user", "content": PROMPT, "timestamp": 1.0},
+        {"role": "assistant", "content": OLD_ANSWER},
+        {"role": "user", "content": "Also update the docs.", "timestamp": 1.2},
+        {"role": "assistant", "content": "Docs updated."},
+    ]
+
+
+def _rewritten(current=True, answer=NEW_ANSWER):
+    """Compaction dropped the tail; the identical historical prompt survives (unmarked)."""
+    rows = [{"role": "user", "content": PROMPT}, {"role": "assistant", "content": OLD_ANSWER}]
+    if current:
+        rows.append({"role": "user", "content": PROMPT})
+        if answer is not None:
+            rows.append({"role": "assistant", "content": answer})
+    return rows
+
+
+def _envelope(messages, *, turn_id=TURN_ID, marked_idx=None, projection="full", contract=2, **extra):
+    """A producer-conformant envelope: the marked row (if any) carries ``_turn_id``."""
+    messages = copy.deepcopy(messages)
+    if marked_idx is not None:
+        messages[marked_idx]["_turn_id"] = turn_id
+    envelope = {"messages": messages, "turn_boundary_contract": contract, "turn_id": turn_id,
+                "messages_projection": projection, "current_turn_user_idx": marked_idx}
+    envelope.update(extra)
+    return envelope
+
+
+def _identity(token="tok-current"):
+    return {"session_id": "s", "token": token, "text": PROMPT, "timestamp": 1.9, "source": "webui",
+            "attachments": [], "checkpoint": None, "current_turn_user_idx": None, "turn_id": ""}
+
+
+def _agent(idx=0, turn_id=TURN_ID, contract=2):
+    agent = types.SimpleNamespace(_persist_user_message_idx=idx, _current_turn_id=turn_id)
+    if contract is not None:
+        agent.TURN_BOUNDARY_CONTRACT = contract
+    return agent
+
+
+def _resolve(result, agent):
+    return streaming._resolve_active_turn_authority(_identity(), result=result, agent=agent)
+
+
+def _tokened(messages):
+    return [i for i, m in enumerate(messages) if isinstance(m, dict) and m.get("_active_turn_token")]
+
+
+def _assistant_texts(messages):
+    return [m.get("content") for m in messages if m.get("role") == "assistant"]
+
+
+# ── producer-conformance: what the resolver accepts and rejects ────────────
+
+
+def test_conformant_envelope_binds_by_marker_only():
+    result = _envelope(_rewritten(), marked_idx=2, completed=True, final_response=NEW_ANSWER)
+    identity = _resolve(result, _agent(idx=0))  # stale instance index is never consulted
+    assert identity["producer_contract"] == 2 and identity["messages_projection"] == "full"
+    assert identity["agent_turn_boundary_source"] == "result" and identity["current_turn_user_idx"] == 2
+    assert _tokened(result["messages"]) == [2]
+    history = _history()
+    assert streaming._find_active_turn_checkpoint_index(result["messages"], history, identity, PROMPT) == 2
+    assert streaming._assistant_reply_added_after_current_turn(result["messages"], history, PROMPT, active_turn_identity=identity) is True
+    assert streaming._self_heal_result_succeeded(result, history, identity, PROMPT) is True
+    partial = streaming._append_result_partial_on_error(
+        types.SimpleNamespace(messages=list(history)), {**result, "partial": True}, history, PROMPT, active_turn_identity=identity,
+    )
+    assert partial is not None and partial["content"] == NEW_ANSWER
+
+
+@pytest.mark.parametrize("case", [
+    "capable_omission",        # producer could not identify the row: index None
+    "index_on_unmarked_row",   # text-matching row without the marker (the old text-derived export)
+    "index_on_assistant_row",
+    "foreign_turn_id",         # envelope from another invocation
+    "live_turn_id_unavailable",
+    "missing_projection",
+    "unknown_projection",
+    "contract_version_missing",
+])
+def test_unproven_or_malformed_envelopes_fail_closed(case):
+    history = _history()
+    messages = _rewritten(current=False)  # only the identical historical prompt survives
+    agent = _agent(idx=0)
+    if case == "capable_omission":
+        result = _envelope(messages, marked_idx=None)
+    elif case == "index_on_unmarked_row":
+        result = _envelope(messages, marked_idx=None); result["current_turn_user_idx"] = 0
+    elif case == "index_on_assistant_row":
+        result = _envelope(messages, marked_idx=None); result["current_turn_user_idx"] = 1
+    elif case == "foreign_turn_id":
+        result = _envelope(messages, marked_idx=0, turn_id="turn-historical")
+    elif case == "live_turn_id_unavailable":
+        result = _envelope(messages, marked_idx=0); agent = _agent(idx=0, turn_id="")
+    elif case == "missing_projection":
+        result = _envelope(messages, marked_idx=0); del result["messages_projection"]
+    elif case == "unknown_projection":
+        result = _envelope(messages, marked_idx=0, projection="partial")
+    else:
+        result = _envelope(messages, marked_idx=0); del result["turn_boundary_contract"]
+    result.update({"completed": True, "final_response": OLD_ANSWER})
+    identity = _resolve(result, agent)
+    assert identity["producer_capability"] == "turn_boundary"
+    assert identity.get("agent_turn_boundary_source") is None  # never the instance index either
+    assert _tokened(result["messages"]) == []
+    assert streaming._find_active_turn_checkpoint_index(result["messages"], history, identity, PROMPT) is None
+    assert streaming._settle_current_turn_boundary(history, list(result["messages"]), identity, PROMPT, "webui") == result["messages"]
+    assert streaming._assistant_reply_added_after_current_turn(result["messages"], history, PROMPT, active_turn_identity=identity) is False
+    assert streaming._self_heal_result_succeeded(result, history, identity, PROMPT) is False
+    assert streaming._append_result_partial_on_error(
+        types.SimpleNamespace(messages=list(history)), {**result, "partial": True}, history, PROMPT, active_turn_identity=identity,
+    ) is None
+    assert streaming._merged_transcript_lacks_final_assistant_answer(history, history, result["messages"], PROMPT, active_turn_identity=identity) is True
+
+
+def test_full_projection_of_historical_output_rows_is_never_a_delta():
+    rows = [{"role": "assistant", "content": "Docs updated."}, {"role": "tool", "tool_call_id": "c1", "content": "x"}]
+    identity = _resolve(_envelope(rows), _agent())
+    assert streaming._result_is_delta_projection(identity, rows) is False
+    assert streaming._settle_current_turn_boundary(_history(), list(rows), identity, PROMPT, "webui") == rows
+    declared = _resolve(_envelope(rows, projection="delta"), _agent())
+    assert streaming._result_is_delta_projection(declared, rows) is True
+    legacy = _resolve({"messages": rows}, _agent(contract=None))
+    assert streaming._result_is_delta_projection(legacy, rows) is False  # no role inference with an identity
+
+
+def test_legacy_callable_uses_only_a_prefix_intact_instance_index():
+    history = _history()
+    appended = history + [{"role": "user", "content": PROMPT}, {"role": "assistant", "content": NEW_ANSWER}]
+    identity = _resolve({"messages": appended}, _agent(idx=len(history), contract=None))
+    assert identity["producer_capability"] == "unproven" and identity["agent_turn_boundary_source"] == "agent"
+    assert streaming._find_active_turn_checkpoint_index(appended, history, identity, PROMPT) == len(history)
+    # result keys from a legacy callable are ignored (their index is text-derived) ...
+    rewritten = _rewritten(); rewritten[0]["_turn_id"] = TURN_ID
+    identity = _resolve({"messages": rewritten, "turn_id": TURN_ID, "current_turn_user_idx": 0}, _agent(idx=0, contract=None))
+    assert identity["agent_turn_boundary_source"] == "agent"
+    # ... and the instance index is not trusted after a rewrite
+    assert streaming._find_active_turn_checkpoint_index(rewritten, history, identity, PROMPT) is None
+    assert _tokened(rewritten) == []
+
+
+def test_compression_marker_and_unknown_role_history_fail_closed_without_marker():
+    history = _history()
+    rows = [
+        {"role": "assistant", "content": "[Context compressed]", "_compressed_summary": True},
+        {"role": "system", "content": "unknown-role scaffolding"},
+        {"role": "user", "content": PROMPT},
+        {"role": "assistant", "content": OLD_ANSWER},
+    ]
+    identity = _resolve(_envelope(rows, marked_idx=None), _agent(idx=2))
+    assert streaming._find_active_turn_checkpoint_index(rows, history, identity, PROMPT) is None
+    assert streaming._settle_current_turn_boundary(history, list(rows), identity, PROMPT, "webui") == rows
+    proven_env = _envelope(rows, marked_idx=2)
+    proven = _resolve(proven_env, _agent(idx=2))
+    assert streaming._find_active_turn_checkpoint_index(proven_env["messages"], history, proven, PROMPT) == 2
+
+
+# ── production-composed streaming route ───────────────────────────────────
+
+
+def _run(tmp_path, monkeypatch, result, **kw):
+    kw.setdefault("prior_messages", _history())
+    kw.setdefault("prior_context_messages", _history())
+    kw.setdefault("msg_text", PROMPT)
+    kw.setdefault("pending_started_at", 1.9)
+    kw.setdefault("current_turn_user_idx", 0)  # stale instance index; live turn id "turn-current"
+    kw.setdefault("agent_contract", 2)
+    events, payload = _run_streaming_with_fake_agent(tmp_path, monkeypatch, result, **kw)
+    kinds = [event for event, _payload in events]
+    session = streaming.SESSIONS["tool_limit_session"]
+    session._sse_events = events  # raw terminal payloads for public-projection assertions
+    return kinds, payload, session
+
+
+def _prompt_rows(messages):
+    return [i for i, m in enumerate(messages) if m.get("role") == "user" and m.get("content") == PROMPT]
+
+
+def _assert_history_intact_and_unclaimed(kinds, payload, session):
+    assert "done" not in kinds
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+    last_old = max(i for i, m in enumerate(payload["messages"]) if m.get("content") == OLD_ANSWER)
+    assert _prompt_rows(payload["messages"])[-1] > last_old  # pending prompt follows history, unanswered
+    tokened = _tokened(session.context_messages)
+    assert all(session.context_messages[i].get("content") == PROMPT for i in tokened)
+    assert not (session.context_messages and session.context_messages[0].get("_active_turn_token"))
+
+
+def test_streaming_repeated_prompt_rewrite_with_capable_omission_fails_closed(tmp_path, monkeypatch):
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(_rewritten(current=False), completed=True, final_response=OLD_ANSWER))
+    _assert_history_intact_and_unclaimed(kinds, payload, session)
+    assert "apperror" in kinds
+
+
+@pytest.mark.parametrize("callable_contract", [2, 1, None])
+def test_streaming_reviewer_blocker_shape_text_derived_pair_is_rejected(tmp_path, monkeypatch, callable_contract):
+    # The installed pair-only producer's export: live turn id + index 0 pointing at the
+    # identical historical prompt (text-derived, no marker). Never accepted — whether the
+    # callable declares v2 (index on an unmarked row is malformed), pair-only, or nothing.
+    if callable_contract == 2:
+        result = _envelope(_rewritten(current=False), completed=True, final_response=OLD_ANSWER)
+        result["current_turn_user_idx"] = 0
+    else:
+        result = {"messages": _rewritten(current=False), "turn_id": TURN_ID, "current_turn_user_idx": 0,
+                  "completed": True, "final_response": OLD_ANSWER}
+    kinds, payload, session = _run(tmp_path, monkeypatch, result, agent_contract=callable_contract)
+    _assert_history_intact_and_unclaimed(kinds, payload, session)
+
+
+def test_streaming_foreign_turn_id_envelope_fails_closed(tmp_path, monkeypatch):
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(_rewritten(current=False), marked_idx=0, turn_id="turn-historical", completed=True, final_response=OLD_ANSWER))
+    _assert_history_intact_and_unclaimed(kinds, payload, session)
+
+
+def test_streaming_full_projection_of_historical_output_rows_is_not_replayed_or_tool_limit_closed(tmp_path, monkeypatch):
+    rows = [{"role": "assistant", "content": "Docs updated."}, {"role": "tool", "tool_call_id": "c1", "content": "x"}]
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(rows, turn_exit_reason="max_iterations_reached(30/30)"))
+    assert "done" not in kinds
+    assert _assistant_texts(payload["messages"]).count("Docs updated.") == 1
+    assert _prompt_rows(payload["messages"])[-1] > 3
+
+
+@pytest.mark.parametrize("projection", ["missing", "partial", 42])
+def test_streaming_malformed_projection_fails_closed(tmp_path, monkeypatch, projection):
+    result = _envelope(_rewritten(), marked_idx=2, completed=True, final_response=NEW_ANSWER)
+    if projection == "missing":
+        del result["messages_projection"]
+    else:
+        result["messages_projection"] = projection
+    kinds, payload, session = _run(tmp_path, monkeypatch, result)
+    assert "done" not in kinds
+    assert _tokened(session.context_messages) in ([], [len(session.context_messages) - 1])
+
+
+def _contains_key(value, key):
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(v, key) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_key(v, key) for v in value)
+    return False
+
+
+def test_streaming_conformant_envelope_completes_the_turn(tmp_path, monkeypatch):
+    result = _envelope(_rewritten(), marked_idx=2, completed=True, final_response=NEW_ANSWER)
+    assert result["messages"][2]["_turn_id"] == TURN_ID  # marker binding, before cleanup
+    kinds, payload, session = _run(tmp_path, monkeypatch, result)
+    assert "done" in kinds and "apperror" not in kinds
+    assert [(m["role"], m.get("content")) for m in payload["messages"][-2:]] == [("user", PROMPT), ("assistant", NEW_ANSWER)]
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+    assert _tokened(session.context_messages) == [2]
+    # the producer marker converted into the WebUI token and stripped from every
+    # projection: durable session state, saved sidecar, and public SSE payloads
+    for projection in (session.messages, session.context_messages, payload["messages"], payload.get("context_messages") or []):
+        assert not any(isinstance(m, dict) and "_turn_id" in m for m in projection)
+    for event, event_payload in session._sse_events:
+        assert not _contains_key(event_payload, "_turn_id"), event
+        assert not _contains_key(event_payload, "_active_turn_token"), event
+    assert result["messages"][2]["_turn_id"] == TURN_ID  # result-envelope rows are copied, not mutated
+
+
+def test_redact_session_data_strips_the_producer_marker_from_both_projections():
+    from api.helpers import redact_session_data
+
+    row = {"role": "user", "content": PROMPT, "_turn_id": TURN_ID, "_active_turn_token": "tok"}
+    public = redact_session_data({
+        "session_id": "s", "messages": [dict(row), {"role": "assistant", "content": NEW_ANSWER}],
+        "context_messages": [dict(row)],
+    })
+    for projection in ("messages", "context_messages"):
+        assert public[projection][0]["content"] == PROMPT
+        assert "_turn_id" not in public[projection][0] and "_active_turn_token" not in public[projection][0]
+
+
+def test_streaming_legacy_callable_with_intact_prefix_completes(tmp_path, monkeypatch):
+    history = _history()
+    appended = history + [{"role": "user", "content": PROMPT}, {"role": "assistant", "content": NEW_ANSWER}]
+    kinds, payload, session = _run(tmp_path, monkeypatch, {"messages": appended, "completed": True, "final_response": NEW_ANSWER},
+                                   current_turn_user_idx=len(history), agent_contract=None)
+    assert "done" in kinds and "apperror" not in kinds
+    assert payload["messages"][-1]["content"] == NEW_ANSWER
+
+
+def test_streaming_legacy_callable_with_rewritten_result_fails_closed(tmp_path, monkeypatch):
+    kinds, payload, session = _run(tmp_path, monkeypatch, {"messages": _rewritten(), "completed": True, "final_response": NEW_ANSWER},
+                                   current_turn_user_idx=2, agent_contract=None)
+    assert "done" not in kinds
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+
+
+def test_streaming_partial_error_persists_the_current_partial_once(tmp_path, monkeypatch):
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(
+        _rewritten(), marked_idx=2, completed=False, partial=True, failed=False, error="provider hiccup", final_response=NEW_ANSWER,
+    ))
+    assert "done" not in kinds and "apperror" in kinds
+    assert _assistant_texts(payload["messages"]).count(NEW_ANSWER) == 1
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+    assert payload["messages"][-1].get("_error") is True
+    assert any(m.get("_partial") and m.get("content") == NEW_ANSWER for m in payload["messages"])
+
+
+def test_streaming_absent_output_keeps_the_marked_prompt_once_without_done(tmp_path, monkeypatch):
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(_rewritten(answer=None), marked_idx=2, completed=False, final_response=""))
+    assert "done" not in kinds
+    assert len(_prompt_rows(payload["messages"])) == 2  # historical copy + this turn, no extra materialization
+    assert _tokened(session.context_messages) == [2]
+
+
+def _auth_failure():
+    return {"completed": False, "messages": [],
+            "error": {"error": {"type": "authentication_error", "status_code": 401, "code": "auth_unavailable",
+                                "message": "Your authentication token has been invalidated."}}}
+
+
+def _lanes():
+    return [pytest.param(lane, id=lane) for lane in ("result", "exception")]
+
+
+@pytest.mark.parametrize("lane", _lanes())
+def test_streaming_self_heal_replacement_agent_with_conformant_envelope_succeeds(tmp_path, monkeypatch, lane):
+    first = RuntimeError("401 unauthorized") if lane == "exception" else _auth_failure()
+    heal = _envelope(_rewritten(), marked_idx=2, turn_id="turn-heal", completed=True, final_response=NEW_ANSWER)
+    kinds, payload, session = _run(
+        tmp_path, monkeypatch, heal, agent_results=[first, heal], enable_auth_retry=True,
+        agent_profiles=[{"turn_id": TURN_ID, "current_turn_user_idx": 0, "contract": 2},      # failed Agent
+                        {"turn_id": "turn-heal", "current_turn_user_idx": 7, "contract": 2}],  # replacement: new id, stale index
+    )
+    assert "done" in kinds and "apperror" not in kinds
+    assert [(m["role"], m.get("content")) for m in payload["messages"][-2:]] == [("user", PROMPT), ("assistant", NEW_ANSWER)]
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+
+
+@pytest.mark.parametrize("lane", _lanes())
+@pytest.mark.parametrize("variant", ["bound_to_failed_agent", "capable_omission", "legacy_replacement"])
+def test_streaming_self_heal_replacement_agent_fails_closed(tmp_path, monkeypatch, lane, variant):
+    first = RuntimeError("401 unauthorized") if lane == "exception" else _auth_failure()
+    if variant == "bound_to_failed_agent":
+        heal = _envelope(_rewritten(current=False), marked_idx=0, turn_id=TURN_ID, completed=True, final_response=OLD_ANSWER)
+        profiles = [{"turn_id": TURN_ID, "current_turn_user_idx": 0, "contract": 2}, {"turn_id": "turn-heal", "current_turn_user_idx": 0, "contract": 2}]
+    elif variant == "capable_omission":
+        heal = _envelope(_rewritten(current=False), turn_id="turn-heal", completed=True, final_response=OLD_ANSWER)
+        profiles = [{"turn_id": TURN_ID, "current_turn_user_idx": 0, "contract": 2}, {"turn_id": "turn-heal", "current_turn_user_idx": 0, "contract": 2}]
+    else:  # the replacement Agent is a legacy callable; its rewritten result cannot be proven
+        heal = {"messages": _rewritten(current=False), "turn_id": "turn-heal", "current_turn_user_idx": 0, "completed": True, "final_response": OLD_ANSWER}
+        profiles = [{"turn_id": TURN_ID, "current_turn_user_idx": 0, "contract": 2}, {"turn_id": "turn-heal", "current_turn_user_idx": 0, "contract": None}]
+    kinds, payload, session = _run(tmp_path, monkeypatch, heal, agent_results=[first, heal], enable_auth_retry=True, agent_profiles=profiles)
+    assert "done" not in kinds
+    assert _assistant_texts(payload["messages"]).count(OLD_ANSWER) == 1
+    assert payload["messages"][-1].get("_error") or payload["messages"][-1]["role"] == "user"
+
+
+@pytest.mark.parametrize("marker", ["_verification_stop_synthetic", "_pre_verify_synthetic"])
+def test_streaming_tool_limit_settlement_with_conformant_envelope(tmp_path, monkeypatch, marker):
+    old_turn = [{"role": "user", "content": PROMPT, "timestamp": 1.1}, {"role": "assistant", "content": OLD_ANSWER}]
+    corrective = "Verification failed. I fixed the parser and reran the tests."
+    rows = old_turn + [{"role": "user", "content": PROMPT},
+                       {"role": "user", "content": "[System: verify the workspace]", marker: True},
+                       {"role": "assistant", "content": corrective}]
+    kinds, payload, session = _run(tmp_path, monkeypatch, _envelope(rows, marked_idx=2, turn_exit_reason="max_iterations_reached(30/30)"),
+                                   prior_messages=old_turn, prior_context_messages=old_turn, current_turn_user_idx=len(old_turn))
+    assert "done" in kinds
+    assert [(m["role"], m.get("content")) for m in payload["messages"]] == [
+        ("user", PROMPT), ("assistant", OLD_ANSWER), ("user", PROMPT), ("assistant", corrective),
+    ]

--- a/tests/test_settle_current_turn_after_repair_merge.py
+++ b/tests/test_settle_current_turn_after_repair_merge.py
@@ -1,0 +1,100 @@
+"""Regression: after a compaction, the agent's alternation repair merges two adjacent
+user rows at the FRONT of the history in place. The Agent-reported
+``current_turn_user_idx`` (recorded before the merge) then no longer addresses the
+current user row, ``result_messages`` no longer carries ``previous_context`` as a
+prefix, and ``_settle_current_turn_boundary`` fell back to
+``insert_at = current_turn_user_idx - len(previous_context) == 0`` — writing the
+new user turn to the front of the context. Every later turn then merged it into
+the first user message (one message per turn, newest first) and the prompt's
+second message changed on every turn (0% prefix-cache hit at 200K+ tokens).
+"""
+from api import streaming as st
+
+
+def _prev_context():
+    return [
+        {'role': 'assistant', 'content': '**Context snapshot** (compaction)', 'timestamp': 1788641031.5},
+        {'role': 'user', 'content': 'Here is a summary of the conversation so far …'},   # compaction summary, role=user
+        {'role': 'user', 'content': 'first protected user message'},                     # adjacent user row
+        {'role': 'assistant', 'content': 'ok', 'tool_calls': [{'id': 'c1', 'type': 'function', 'function': {'name': 't', 'arguments': '{}'}}]},
+        {'role': 'tool', 'tool_call_id': 'c1', 'content': 'tool output'},
+    ]
+
+
+def _agent_result_after_repair(prev, new_text):
+    # hermes-agent: history + new user, then repair_message_sequence merges the two
+    # adjacent user rows in place (list shrinks by one), then the turn produces rows.
+    merged = {'role': 'user', 'content': prev[1]['content'] + '\n\n' + prev[2]['content']}
+    return [prev[0], merged, prev[3], prev[4],
+            {'role': 'user', 'content': new_text},
+            {'role': 'assistant', 'content': 'answer'}]
+
+
+def _identity(prev, new_text):
+    return {
+        'token': 'tok-1', 'turn_id': 'turn-1', 'text': new_text, 'timestamp': 1788800000.0,
+        'agent_turn_boundary_resolved': True,
+        # recorded by the agent BEFORE the in-place merge: len(history) at that time
+        'current_turn_user_idx': len(prev),
+    }
+
+
+def test_new_user_turn_is_never_settled_at_the_front():
+    prev = _prev_context()
+    new_text = 'NEW TURN question'
+    result = _agent_result_after_repair(prev, new_text)
+    settled = st._settle_current_turn_boundary(prev, result, _identity(prev, new_text), new_text, 'webui')
+    users = [i for i, m in enumerate(settled) if m.get('role') == 'user' and m.get('content') == new_text]
+    assert users, 'the current user turn must be present'
+    assert len(users) == 1, f'current user turn duplicated at {users}'
+    assert users[0] > 0, f'current user turn settled at index {users[0]} (front) — must follow the prior history'
+    assert settled[users[0] - 1].get('role') in ('assistant', 'tool'), 'must be preceded by the prior history tail'
+    assert settled[-1].get('role') == 'assistant', 'turn output must stay after the user turn'
+
+
+def test_first_history_message_is_stable_across_turns():
+    """Turn N+1 must see the same leading rows as turn N (prefix-cache safety)."""
+    prev = _prev_context()
+    ctx = list(prev)
+    heads = []
+    for n in range(3):
+        new_text = f'question {n}'
+        result = _agent_result_after_repair(ctx, new_text) if n == 0 else (
+            list(ctx) + [{'role': 'user', 'content': new_text}, {'role': 'assistant', 'content': 'answer'}]
+        )
+        identity = _identity(ctx, new_text)
+        ctx = st._settle_current_turn_boundary(ctx, result, identity, new_text, 'webui')
+        heads.append(ctx[0].get('content'))
+        assert ctx[0].get('role') != 'user' or ctx[0].get('content') != new_text, 'new turn at front'
+    assert len(set(heads)) == 1, f'leading row changed across turns: {heads}'
+
+
+def test_delta_only_result_keeps_front_insertion():
+    """When the Agent returns only this turn's rows (no user row, no history), the
+    current user turn is still inserted before those rows (legacy delta shape)."""
+    prev = _prev_context()
+    new_text = 'delta question'
+    result = [{'role': 'assistant', 'content': 'answer'}, {'role': 'tool', 'tool_call_id': 'c9', 'content': 'x'}]
+    identity = _identity(prev, new_text)
+    identity['current_turn_user_idx'] = 99  # unresolvable
+    identity['messages_projection'] = 'delta'  # declared by a bound contract-v2 envelope
+    settled = st._settle_current_turn_boundary(prev, result, identity, new_text, 'webui')
+    assert settled[0].get('role') == 'user' and settled[0].get('content') == new_text
+    assert [m.get('role') for m in settled[1:]] == ['assistant', 'tool']
+
+
+def test_delta_only_result_with_in_range_index_still_inserts_at_front():
+    """A delta-only result long enough for the recorded full-history index to be
+    numerically in range must not have the user turn placed after its own output:
+    the index addresses the full Agent history, not the delta."""
+    prev = _prev_context()  # five prior messages
+    new_text = 'delta question'
+    result = [{'role': 'assistant', 'content': f'step {i}', 'tool_calls': [{'id': f'c{i}'}]} if i % 2 == 0
+              else {'role': 'tool', 'tool_call_id': f'c{i - 1}', 'content': 'x'} for i in range(8)]
+    identity = _identity(prev, new_text)
+    identity['current_turn_user_idx'] = len(prev)  # 5: in range of the 8-row delta
+    identity['messages_projection'] = 'delta'  # declared by a bound contract-v2 envelope
+    settled = st._settle_current_turn_boundary(prev, result, identity, new_text, 'webui')
+    assert settled[0].get('role') == 'user' and settled[0].get('content') == new_text
+    assert settled[1:] == result
+    assert sum(1 for m in settled if m.get('role') == 'user') == 1

--- a/tests/test_tool_limit_terminal_state.py
+++ b/tests/test_tool_limit_terminal_state.py
@@ -28,7 +28,13 @@ def _run_streaming_with_fake_agent(
     turn_id="turn-current",
     agent_results=None,
     enable_auth_retry=False,
+    agent_contract=None,
+    agent_profiles=None,
 ):
+    """``agent_contract`` sets ``TURN_BOUNDARY_CONTRACT`` on the fake Agent class (None =
+    legacy callable). ``agent_profiles`` is consumed one dict per constructed Agent —
+    keys ``turn_id``, ``current_turn_user_idx``, ``contract`` — so replacement Agents on
+    the self-heal lanes can vary capability, turn id and index."""
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
@@ -74,9 +80,11 @@ def _run_streaming_with_fake_agent(
     event_queue = queue.Queue()
     streaming.STREAMS[stream_id] = event_queue
     result_queue = list(agent_results or [])
+    profile_queue = list(agent_profiles or [])
 
     class FakeAgent:
         def __init__(self, **kwargs):
+            profile = profile_queue.pop(0) if profile_queue else {}
             self.session_id = kwargs.get("session_id")
             self.stream_delta_callback = kwargs.get("stream_delta_callback")
             self.context_compressor = None
@@ -88,8 +96,13 @@ def _run_streaming_with_fake_agent(
             self.reasoning_config = None
             self.ephemeral_system_prompt = None
             self._last_error = None
-            self._persist_user_message_idx = current_turn_user_idx
-            self._current_turn_id = turn_id if current_turn_user_idx is not None else ""
+            self._persist_user_message_idx = profile.get("current_turn_user_idx", current_turn_user_idx)
+            self._current_turn_id = profile.get(
+                "turn_id", turn_id if current_turn_user_idx is not None else ""
+            )
+            contract = profile.get("contract", agent_contract)
+            if contract is not None:
+                self.TURN_BOUNDARY_CONTRACT = contract
 
         def run_conversation(self, **kwargs):
             if result_queue:
@@ -311,13 +324,24 @@ def test_verification_nudge_is_removed_while_corrective_followup_persists(
         },
         {"role": "assistant", "content": "The failing test is fixed."},
     ]
-    result_messages = [
+    # The verification follow-up continues the SAME turn: its user row is prior_turn[0].
+    # A conformant producer returns the FULL projection with that row marked
+    # ``_turn_id`` ahead of the synthetic verification row; ``delta_only`` selects the
+    # capable (v2) producer, otherwise a legacy callable with an intact prefix.
+    # Output-only deltas are not a shape either producer emits.
+    projected_turn = [dict(message) for message in prior_turn]
+    if delta_only:
+        projected_turn[0]["_turn_id"] = "turn-current"
+    result_messages = projected_turn + [
         {"role": "user", "content": "[System: verify the workspace]", marker: True},
         {"role": "assistant", "content": corrective},
     ]
-    if not delta_only:
-        result_messages = prior_turn + result_messages
     result = {"messages": result_messages}
+    if delta_only:
+        result.update({
+            "turn_boundary_contract": 2, "turn_id": "turn-current",
+            "messages_projection": "full", "current_turn_user_idx": 0,
+        })
 
     _events, payload = _run_streaming_with_fake_agent(
         tmp_path,
@@ -327,6 +351,7 @@ def test_verification_nudge_is_removed_while_corrective_followup_persists(
         prior_context_messages=prior_turn,
         msg_text="Fix the failing test.",
         current_turn_user_idx=0,
+        agent_contract=2 if delta_only else None,
     )
 
     expected_sequence = [
@@ -448,11 +473,15 @@ def test_eager_exact_checkpoint_does_not_duplicate_repeated_prompt(
         },
     ]
     corrective = "Verification failed. I fixed the parser and reran the tests."
+    # conformant full projection: the eager checkpoint row comes back marked as this turn's
     result = {
-        "messages": [
+        "messages": old_turn + [
+            {**current_checkpoint[0], "_turn_id": "turn-current"},
             {"role": "user", "content": "[System: verify the workspace]", marker: True},
             {"role": "assistant", "content": corrective},
-        ]
+        ],
+        "turn_boundary_contract": 2, "turn_id": "turn-current",
+        "messages_projection": "full", "current_turn_user_idx": 2,
     }
 
     _events, payload = _run_streaming_with_fake_agent(
@@ -464,6 +493,7 @@ def test_eager_exact_checkpoint_does_not_duplicate_repeated_prompt(
         msg_text=prompt,
         pending_started_at=2.0,
         current_turn_user_idx=2,
+        agent_contract=2,
     )
 
     expected = [
@@ -496,11 +526,15 @@ def test_eager_checkpoint_reused_by_exact_token(tmp_path, monkeypatch, marker):
         },
     ]
     corrective = "Verification failed. I fixed the parser and reran the tests."
+    # conformant full projection: the eager checkpoint row comes back marked as this turn's
     result = {
-        "messages": [
+        "messages": old_turn + [
+            {**current_checkpoint[0], "_turn_id": "turn-current"},
             {"role": "user", "content": "[System: verify the workspace]", marker: True},
             {"role": "assistant", "content": corrective},
-        ]
+        ],
+        "turn_boundary_contract": 2, "turn_id": "turn-current",
+        "messages_projection": "full", "current_turn_user_idx": 2,
     }
 
     _events, payload = _run_streaming_with_fake_agent(
@@ -512,6 +546,7 @@ def test_eager_checkpoint_reused_by_exact_token(tmp_path, monkeypatch, marker):
         msg_text=prompt,
         pending_started_at=1.9,
         current_turn_user_idx=2,
+        agent_contract=2,
     )
 
     expected = [


### PR DESCRIPTION
## Prove current-turn ownership or fail closed after an Agent history rewrite (post-compaction prefix-cache loss, duplicated question)

### Symptom
In a long session after `/compact`, every user turn re-prefilled the whole prompt on a prefix-caching vLLM backend (0 of 241,917 tokens hit; ~100 s before the first token at 200K+ context), while later calls in the same turn hit 98–100%. The model also received each new question twice.

### Root cause
`context_messages[1]` (first user message after the compaction snapshot) grew by one message per turn — a newest-first blob of every user message since compaction (18,358 → 18,840 chars per turn, measured with a per-call hash probe on the Agent's `pre_api_request` hook).

Mechanism, cross-repo:
1. hermes-agent writes compaction summaries as `role=user` (its fix for NousResearch/hermes-agent#11475), so the summary sits next to the protected first user message — two adjacent user rows at the head of the history.
2. hermes-agent's `repair_message_sequence` merges adjacent user rows in place before each API call; the list shrinks and the `current_turn_user_idx` it recorded at turn start no longer addresses the current user row.
3. `_find_active_turn_checkpoint_index` therefore finds no checkpoint; `_messages_have_prefix(result_messages, previous_context)` fails (the head was merged); `_settle_current_turn_boundary` fell back to `insert_at = current_turn_user_idx - len(previous_context)`, which is **0** — the current user turn was written to the front of `context_messages`.
4. Next turn: that row is an old user message adjacent to the next user row → merged again → the blob. The turn's own copy is also appended at the tail, hence the duplicate.

### Why the closed issues did not cover it
#4029 age-gates stale background-task notifications; #2616/#2027 dedupe by message identity (a merged message is a new identity); hermes-agent#11475 changed what the summary says, not where messages are placed. All four fixes are in `e168b67e4` and the bug reproduces on it.

### Fix — the producer contract, negotiated from the callable
State layer: model context / `context_messages` settlement and current-turn classification. Ownership is proven by the Agent's turn-boundary contract or not claimed; there is no text search and no role-derived projection on the streaming route.

**Producer contract v2** (NousResearch/hermes-agent#108216): the Agent marks this turn's user row with `_turn_id` at append time (survives compaction, carried across user-row merges, never sent to providers, never persisted) and exports `{turn_boundary_contract: 2, turn_id, messages_projection: "full", current_turn_user_idx | None}` on **every** envelope — success, partial/error, interrupt, retry-exhausted, tool-limit, preflight timeout, durable-lease early return — with `AIAgent.TURN_BOUNDARY_CONTRACT = 2` declared on the callable.

**Consumer:**
- `_callable_boundary_contract` reads the capability from the Agent callable **before** each invocation — main lane and both self-heal replacement lanes — never from envelope keys.
- `_resolve_active_turn_authority` binds one coherent coordinate. Contract ≥ 2: the envelope must carry `turn_boundary_contract ≥ 2`, a `turn_id` equal to the live Agent's `_current_turn_id` (unavailable or different → rejected) and a projection in `{full, delta}`; the index is honoured only when the addressed row is a user row carrying the same `_turn_id` marker (prompt text plays no part), and the WebUI token is stamped on that exact row before marker cleaning shifts indexes. `None` or malformed → capable-but-unproven. The mutable Agent-instance index is never combined with a result `turn_id`. Contract < 2 (legacy callable): result keys are ignored (a text-derived index can address an identical historical prompt); the instance pair is honoured only while `previous_context` is still a prefix of the result.
- The same proven boundary is used by `_find_active_turn_checkpoint_index`, `_settle_current_turn_boundary`, `_assistant_reply_added_after_current_turn` (new `active_turn_identity` parameter), `_turn_transcript_lacks_final_assistant_answer`, the display merge and `_dedupe_replayed_context_messages`. `_self_heal_result_succeeded` and `_append_result_partial_on_error` already go through the lookup. A full projection holding only historical assistant/tool rows is never a delta; only a bound `messages_projection: "delta"` is inserted at the front. Placement otherwise: right after an intact `previous_context` prefix, else unchanged — no `idx - len(previous_context)`, no "before the trailing run".
- The producer marker never leaks: once the token holds the authority, `_prepare_marker_clean_writeback` strips `_turn_id` from every transcript/context row (rows copied, never mutated, so result-envelope consumers are unaffected), and `_turn_id` joins `api/helpers.py::_PUBLIC_MESSAGE_INTERNAL_FIELDS` as defense in depth for `redact_session_data` and every session/SSE/export projection.
- Fail closed without a proven coordinate on a rewritten result: pending prompt visible, streamed text kept as a partial, no historical row receives the live token, no prior answer settled or classified as current, no `done`, no false tool-limit closure. This applies to legacy callables too: they cannot prove a rewritten result, so it is not settled (prefix-intact results from them still complete).

### Tests
- `tests/test_current_turn_boundary_fail_closed.py` — **producer conformance**: envelopes built the way contract v2 emits them (marker on the exact row) vs. capable omission, index on an unmarked row (the reviewer's text-derived-pair shape), index on an assistant row, foreign turn id, live turn id unavailable, missing/unknown projection, missing contract version — each asserted through the resolver, the lookup, settlement, the assistant-added check, self-heal, partial-on-error and the transcript check. **Production-composed** `_run_agent_streaming` runs for the ordinary lane and both self-heal lanes (returned auth failure / raised 401): repeated-prompt rewrite with capable omission, the reviewer's blocker shape under v2, pair-only and legacy callables, foreign turn id, assistant/tool-only full projection under a tool-limit exit, malformed projections, conformant completion, legacy callable with an intact prefix (completes) and with a rewritten result (fails closed), partial/error, absent output, tool-limit settlement, and replacement Agents varying capability, turn id and index (bound to the failed Agent, capable omission, legacy replacement) — asserting terminal events, transcript order/counts, persistence and context token ownership.
- Existing fixtures a conformant producer cannot emit (bare pairs, instance indexes trusted on rewritten results, output-only deltas) are converted to conformant envelopes in `tests/test_tool_limit_terminal_state.py` and `tests/test_compression_snapshot_revision.py`; the fake-Agent harness gains `agent_contract` and per-replacement `agent_profiles`.
- The conformant-envelope route regression asserts `_turn_id` (and the token) absent from the terminal SSE payloads, `session.messages`, `session.context_messages` and the saved sidecar, while keeping the marker-binding assertion before cleanup and proving the result-envelope row is not mutated; `redact_session_data` regression for both `messages` and `context_messages`.
- Targeted subset (191 files): 2168 passed, 25 skipped.

### Docs
`docs/rfcs/webui-run-state-consistency-contract.md`: Core Invariant 10 (the producer contract v2 and its row marker; capability read from the callable; coordinate bound to the live turn id and validated by marker; projection from the envelope; fail-closed rules and placement) and a matching Review Checklist question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gp366ijf39n4UUtJhZuMh
