### PR TITLE
fix(spaces): keep path-validation hint readable in the Spaces list

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -295,7 +295,8 @@
         </div>
       </div>
       <div class="panel-head-sub" data-i18n="workspace_desc">Add and switch workspaces for your sessions.</div>
-      <div style="flex:1;overflow-y:auto;padding:8px" id="workspacesPanel"><div style="color:var(--muted);font-size:12px" data-i18n="loading">Loading...</div></div>
+      <div class="workspaces-list" id="workspacesPanel"><div style="color:var(--muted);font-size:12px" data-i18n="loading">Loading...</div></div>
+      <div class="workspaces-hint" id="workspacesHint" data-i18n="workspace_paths_validated_hint">Paths are validated as existing directories before saving.</div>
     </div>
     <!-- Profiles panel -->
     <div class="panel-view" id="panelProfiles">

--- a/static/panels.js
+++ b/static/panels.js
@@ -5555,10 +5555,8 @@ function renderWorkspacesPanel(workspaces){
 
     panel.appendChild(row);
   }
-  const hint=document.createElement('div');
-  hint.style.cssText='font-size:11px;color:var(--muted);padding:8px 0';
-  hint.textContent=t('workspace_paths_validated_hint');
-  panel.appendChild(hint);
+  const hint=$('workspacesHint');
+  if(hint) hint.textContent=t('workspace_paths_validated_hint');
   // Re-render detail if we have one cached and we're not in a form
   if (_currentWorkspaceDetail && _workspaceMode !== 'create' && _workspaceMode !== 'edit') {
     const refreshed = workspaces.find(w => w.path === _currentWorkspaceDetail.path);

--- a/static/style.css
+++ b/static/style.css
@@ -3269,6 +3269,8 @@
 .ws-drag-handle:active{cursor:grabbing;}
 .ws-row.dragging{opacity:.35;border:1px dashed var(--accent-bg-strong);}
 .ws-row.drag-over{border-color:var(--accent-text);background:var(--accent-bg);}
+.workspaces-list{flex:1;overflow-y:auto;padding:8px;min-height:0;}
+.workspaces-hint{flex-shrink:0;font-size:11px;color:var(--muted);padding:8px 12px 10px;line-height:1.4;white-space:normal;overflow-wrap:anywhere;}
 .ws-action-btn{padding:4px 8px;border-radius:6px;font-size:11px;font-weight:600;border:1px solid var(--border2);background:rgba(255,255,255,.05);color:var(--muted);cursor:pointer;transition:all .15s;white-space:nowrap;}
 .ws-action-btn:hover{background:rgba(255,255,255,.1);color:var(--text);}
 /* ── Profile dropdown + management panel ── */

--- a/tests/test_issue492_workspace_reorder.py
+++ b/tests/test_issue492_workspace_reorder.py
@@ -138,3 +138,20 @@ class TestWorkspaceReorderFrontend:
             content = f.read()
         for cls in (".ws-drag-handle", ".ws-row.dragging", ".ws-row.drag-over"):
             assert cls in content, f"Missing CSS: {cls}"
+
+    def test_spaces_hint_is_pinned_footer_not_inside_list(self):
+        """The path-validation hint must wrap as a pinned footer, not clip inside the list."""
+        with open("static/index.html", "r", encoding="utf-8") as f:
+            html = f.read()
+        assert 'id="workspacesHint"' in html
+        assert 'class="workspaces-hint"' in html
+        assert 'data-i18n="workspace_paths_validated_hint"' in html
+        with open("static/style.css", "r", encoding="utf-8") as f:
+            css = f.read()
+        assert ".workspaces-list{flex:1;overflow-y:auto;padding:8px;min-height:0;}" in css
+        assert ".workspaces-hint{flex-shrink:0;" in css
+        assert "overflow-wrap:anywhere" in css
+        with open("static/panels.js", "r", encoding="utf-8") as f:
+            js = f.read()
+        assert "$('workspacesHint')" in js
+        assert "hint.style.cssText='font-size:11px;color:var(--muted);padding:8px 0'" not in js


### PR DESCRIPTION
Pin the workspace path-validation note as a wrapping footer instead of appending it inside the scrolling list, where it was clipped.

Amp-Thread-ID: https://ampcode.com/threads/T-01a079fe-19dd-7490-90bc-88f8e5365a6a