### PR TITLE
fix(sessions): warn once per state.db when 'source' column is missing

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -6,6 +6,17 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# state.db paths that already produced the "no 'source' column" warning below.
+# ``get_cli_sessions(all_profiles=True)`` re-reads every profile DB on every
+# sidebar poll (behind a 5 s cache), so a single pre-``source`` profile DB would
+# otherwise re-emit the identical WARNING line every ~15 s for the life of the
+# process. The condition is a property of the DB file, not of the poll, so it
+# is reported once per path. Process-lifetime only: a restart warns again,
+# which is the desired behaviour (the log line is the operator's cue that the
+# agent still needs upgrading). Plain ``set`` mutation under the GIL is
+# sufficient here; a duplicate line from two racing first calls is harmless.
+_SOURCE_COLUMN_WARNED_DB_PATHS: set[str] = set()
+
 
 def open_state_db_readonly(db_path: Path, log: logging.Logger | None = None) -> sqlite3.Connection:
     """Open the live agent ``state.db`` read-only for a pure-read projection.
@@ -562,12 +573,15 @@ def read_importable_agent_session_rows(
         cur.execute("PRAGMA table_info(messages)")
         message_cols = {row[1] for row in cur.fetchall()}
         if 'source' not in session_cols:
-            log.warning(
-                "agent session listing skipped: state.db at %s has no 'source' column "
-                "(older hermes-agent?). Agent sessions unavailable. "
-                "Upgrade hermes-agent to fix this.",
-                db_path,
-            )
+            warned_key = str(db_path.resolve())
+            if warned_key not in _SOURCE_COLUMN_WARNED_DB_PATHS:
+                _SOURCE_COLUMN_WARNED_DB_PATHS.add(warned_key)
+                log.warning(
+                    "agent session listing skipped: state.db at %s has no 'source' column "
+                    "(older hermes-agent?). Agent sessions unavailable. "
+                    "Upgrade hermes-agent to fix this.",
+                    db_path,
+                )
             return []
 
         parent_expr = _optional_col('parent_session_id', session_cols)

--- a/tests/test_issue634.py
+++ b/tests/test_issue634.py
@@ -77,3 +77,74 @@ class TestCliSessionsErrorSurface:
         assert select_pos != -1, "SELECT query not found"
         assert pragma_pos < select_pos, \
             "Schema introspection must run before the main SQL query"
+
+
+# ---------------------------------------------------------------------------
+# Follow-up: the warning must fire once per state.db, not once per poll.
+#
+# get_cli_sessions(all_profiles=True) calls read_importable_agent_session_rows()
+# for every profile on every sidebar poll (behind a 5 s cache). On an install
+# with one pre-``source`` profile DB that produced one identical WARNING line
+# every ~15 s in errors.log. The message is correct; its repetition is not.
+# ---------------------------------------------------------------------------
+import logging
+import sqlite3
+
+import pytest
+
+from api import agent_sessions
+
+
+def _make_pre_source_state_db(path):
+    """Build a state.db whose ``sessions`` table predates the ``source`` column."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, model TEXT, "
+        "message_count INTEGER, started_at REAL)"
+    )
+    conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, timestamp REAL)")
+    conn.commit()
+    conn.close()
+
+
+def _source_column_warnings(caplog):
+    return [
+        rec for rec in caplog.records
+        if rec.levelno == logging.WARNING and "has no 'source' column" in rec.getMessage()
+    ]
+
+
+class TestMissingSourceColumnWarnsOncePerDb:
+    @pytest.fixture(autouse=True)
+    def _fresh_dedupe_state(self, monkeypatch):
+        # The dedupe set is process-lifetime state; give each test its own.
+        monkeypatch.setattr(agent_sessions, "_SOURCE_COLUMN_WARNED_DB_PATHS", set(), raising=False)
+
+    def test_same_db_path_twice_logs_once(self, tmp_path, caplog):
+        db = tmp_path / "state.db"
+        _make_pre_source_state_db(db)
+        with caplog.at_level(logging.WARNING, logger="api.agent_sessions"):
+            first = agent_sessions.read_importable_agent_session_rows(db, exclude_sources=None)
+            second = agent_sessions.read_importable_agent_session_rows(db, exclude_sources=None)
+        assert first == [] and second == []
+        warnings = _source_column_warnings(caplog)
+        assert len(warnings) == 1, [w.getMessage() for w in warnings]
+        # Message text is unchanged: still names the path and the upgrade hint.
+        assert str(db) in warnings[0].getMessage()
+        assert "Upgrade hermes-agent" in warnings[0].getMessage()
+
+    def test_different_db_path_logs_again(self, tmp_path, caplog):
+        db_a = tmp_path / "planner" / "state.db"
+        db_b = tmp_path / "coder" / "state.db"
+        db_a.parent.mkdir()
+        db_b.parent.mkdir()
+        _make_pre_source_state_db(db_a)
+        _make_pre_source_state_db(db_b)
+        with caplog.at_level(logging.WARNING, logger="api.agent_sessions"):
+            agent_sessions.read_importable_agent_session_rows(db_a, exclude_sources=None)
+            agent_sessions.read_importable_agent_session_rows(db_b, exclude_sources=None)
+            agent_sessions.read_importable_agent_session_rows(db_a, exclude_sources=None)
+        warnings = _source_column_warnings(caplog)
+        assert len(warnings) == 2, [w.getMessage() for w in warnings]
+        assert str(db_a) in warnings[0].getMessage()
+        assert str(db_b) in warnings[1].getMessage()


### PR DESCRIPTION
## Thinking Path

On an operator stack (2026-09-08) with several Hermes profiles, `errors.log` gained one identical line every ~15 s — 276 lines in ~70 min:

```
api.models WARNING agent session listing skipped: state.db at /data/hermes/profiles/planner/state.db has no 'source' column (older hermes-agent?). Agent sessions unavailable. Upgrade hermes-agent to fix this.
```

The warning itself is correct (added in #769 for #634 so a missing `source` column is no longer swallowed silently). The problem is its cadence: the condition is a property of one DB file, but it is reported once per sidebar poll.

Mechanism: `api/agent_sessions.py` `read_importable_agent_session_rows()` runs `PRAGMA table_info(sessions)` and warns unconditionally when `source` is absent. `api/models.py` `get_cli_sessions(all_profiles=True)` calls it for every profile on every sidebar poll behind only the 5 s `_CLI_SESSIONS_CACHE_TTL_SECONDS` cache, so every cache miss re-emits the same line for the same DB.

Siblings checked: the other two warnings in this function (read-only open fallback) and the exception-path warning in `get_cli_sessions()` fire on transient conditions and are left as-is. `_cheap_change_fingerprint` (#3536) already handles the pre-`source` schema by returning `None` without logging, so it is not a second emitter.

## What Changed

- `api/agent_sessions.py`: module-level `_SOURCE_COLUMN_WARNED_DB_PATHS: set[str]` keyed by the resolved `db_path`. The "no 'source' column" warning fires the first time a path is seen in the process and is suppressed after that; a different path warns on its own. Message text unchanged; return value unchanged (`[]`).
- `tests/test_issue634.py`: two behavioural tests using real pre-`source` sqlite DBs under `tmp_path` and asserting on captured log records (not source strings).

Process-lifetime only: a restart warns again, which is intended — the line remains the operator's cue that the agent still needs upgrading. Plain `set` mutation under the GIL is sufficient; a duplicate line from two racing first calls is harmless.

## Why It Matters

`errors.log` is the operator's signal channel. One correct line per affected DB is diagnosable; the same line every 15 s buries everything else and inflates log volume for the life of the process.

## Verification

Test failed before the fix, passes after (`./scripts/test.sh tests/test_issue634.py`):

- `test_same_db_path_twice_logs_once` — before: `assert 2 == 1`; after: pass
- `test_different_db_path_logs_again` — before: `assert 3 == 2`; after: pass
- The seven existing #634 tests still pass (9 passed total).

Neighbouring files exercising the same function, each run separately through `./scripts/test.sh`:

- `tests/test_issue3762_importable_rows_schema_guard.py` — 6 passed
- `tests/test_issue3930_source_filter_pushdown.py` — 7 passed
- `tests/test_issue5455_listing_readonly_connection.py` — 5 passed
- `tests/test_issue1494_state_db_fd_leak.py` — 4 passed

Lint: `python3 scripts/ruff_lint.py --diff upstream/master` clean; `ruff check` on both changed files clean.

Not verified: a live multi-profile stack run after the change (the operator stack pins an older WebUI SHA). The behaviour is fully covered by the unit tests, which drive the real function against real sqlite files.

## Risks / Follow-ups

- Root cause on the operator side is the agent reconciler creating a pre-`source` `state.db` for a profile; that is a separate upstream fix in hermes-agent. This PR only stops the repetition in WebUI.
- Deliberately not changed: the `get_cli_sessions()` exception-path warning, the read-only-open fallback warning, and the 5 s cache TTL.
- No contract or doc changes: the warning text, level, and logger are unchanged.

Release-note wording: "Sidebar: the 'state.db has no source column' warning is now logged once per database per process instead of on every poll."

## Model Used

Not applicable.
