### PR TITLE
fix(streaming): coalesce live scene paints and own terminal finalization

### DIFF
--- a/.github/workflows/conversation-lifecycle.yml
+++ b/.github/workflows/conversation-lifecycle.yml
@@ -71,6 +71,14 @@ jobs:
           LIFECYCLE_SCENARIO: ${{ matrix.scenario }}
         run: python ${{ matrix.script }}
 
+      - name: Run reasoning-before-prose ownership gate
+        if: matrix.scenario == 'normal' || matrix.scenario == 'terminal-error'
+        env:
+          LIFECYCLE_ARTIFACT_DIR: lifecycle-artifacts
+          LIFECYCLE_SCENARIO: ${{ matrix.scenario }}
+          LIFECYCLE_REASONING_FIRST: '1'
+        run: python tests/browser_conversation_lifecycle.py
+
       - name: Run settlement frame proof
         if: matrix.scenario == 'normal'
         env:

--- a/docs/architecture/incremental-stream-semantics.md
+++ b/docs/architecture/incremental-stream-semantics.md
@@ -99,3 +99,20 @@ error and disposal regressions cover pending delimiter and state-release paths.
 The source-extraction test harnesses execute only in an authorized local test
 sandbox. A maintainer threat-policy NO-RUN classification is not a test failure
 or a product defect, and local results do not imply maintainer approval.
+
+## Legacy segment ownership during incremental paints
+
+A reasoning-only scene can paint before the first prose token arrives. New
+compatibility assistant segments must be hidden at creation when that live scene
+already owns presentation (Compact Worklog or Transparent Stream). They remain
+available to the stream's Markdown/fade and metadata paths; the scene renders the
+visible prose. Final-answer-only mode keeps its compatibility body visible.
+This constant-work handoff avoids restoring a full legacy-node scan on every
+incremental paint. Terminal settlement still renders the canonical final/error
+answer through its existing path.
+
+The lifecycle gate's `LIFECYCLE_REASONING_FIRST=1` waits for the reasoning scene
+before releasing prose/tools. This pins the previously timing-sensitive ordering
+without probabilistic sleeps or retries. It runs for both normal and terminal
+error scenarios; `test_issue7478_live_prose_ownership.py` additionally checks
+visibility at insertion, repeated segments, and the no-scene/hidden-activity modes.

--- a/docs/architecture/incremental-stream-semantics.md
+++ b/docs/architecture/incremental-stream-semantics.md
@@ -1,0 +1,101 @@
+# Incremental live-stream semantics
+
+`attachLiveStream()` owns one incremental semantic state, alongside its raw
+`assistantText` accumulator. The raw accumulator remains the reconnect source
+(`INFLIGHT.lastAssistantText`); Markdown/smd and fade state remain presentation
+only. This does not change transport identity, terminal ownership, scene-cache
+identity or canonical asynchronous cancellation settlement.
+
+## Normal growth
+
+The token producer passes the received delta to `_scheduleSemanticProse(delta)`.
+Its first action consumes that delta. The non-resetting 32 ms timer coalesces
+**publication**, not parsing, including for long replies. Token/fade requests defer
+to this producer drain while publication is pending. Semantic boundaries bypass
+the timer and drain synchronously. Inflight messages, current prose and
+presentation readers use the
+same semantic snapshots. Neither a timer nor a paint callback invokes the
+full-history parser during trusted append-only growth.
+
+The shared thinking-helper layer supplies `_createIncrementalSemanticState()`:
+
+- the existing `_thinkPairs` vocabulary, including both alternate reasoning tags;
+- bounded opener/closer lookahead across chunks;
+- code-fence, inline-backtick and indented-code context;
+- plain and DSML-prefixed XML tool-block exclusion;
+- accumulated visible prose and reasoning, with completed reasoning deduplication;
+- two bounded reasoning views for full-run persistence and current live display;
+- a visible-content offset for the current post-tool segment.
+
+The two views cache derived merges, not independent semantic observations. Each
+view consumes completed reasoning blocks once. Alternating persistence/display
+readers must not invalidate each other's cache on every prose token. Separate
+`reasoning` events feed their authoritative delta and before/after accumulator
+identities into both cached views. Trimming and paragraph recognition advance
+from that delta; completed paragraphs are indexed once, while the growing tail
+is not repeatedly hashed. Normal channel growth retains the cached inline suffix.
+An actual deduplication transition can rebuild that suffix, not the full raw
+assistant history. New/replaced channel bases rebuild a view at the explicit
+reset/recovery boundary; snapshots do not guess append continuity from prefixes.
+The batch-recovery reasoning view uses this same delta-fed machinery.
+
+## Boundaries and recovery
+
+Owned non-token SSE handlers synchronously drain pending semantic publication
+before handling their boundary. Tool start/completion seals current prose before
+the tool observation; segment reset records a semantic-content offset rather
+than parsing a raw suffix on each tick. Interim appends are trusted deltas too.
+
+`_parseStreamState()` is the explicit batch recovery oracle. Rewind, untrusted
+replacement/growth, reconnect and uncertain semantic boundaries may resynchronize
+from raw text. Trusted split delimiters remain buffered across nonterminal
+boundaries; terminal/detach exits settle incomplete delimiters through the oracle.
+A resync rebuilds incremental state and segment offsets, including any leading
+normalization. The same unchanged pending boundary is not rescanned by duplicate
+listeners.
+The recovery oracle supplies extracted reasoning parts to two bounded cached
+views, preserving separate live-channel and durable all-run reasoning. Nested
+XML prefixes and retroactive changes to earlier indented content fail closed
+as uncertainty. The first visible line's indentation is recorded incrementally,
+including after leading blank lines; later XML normalization must not silently
+reclassify an already-published literal thinking tag. Partial code fences do not
+announce reasoning transitions.
+
+DSML permits arbitrarily long whitespace prefixes. Lookahead is capped at 256
+code units (the detecting character can bring the observed maximum to 257).
+An oversized uncertain prefix stops speculative incremental interpretation;
+subsequent tokens retain raw text without repeatedly rescanning. An explicit
+boundary supplies the batch fallback. This is a fail-closed recovery path, not
+a normal token-processing mode.
+
+Terminal/detach drains run before the existing completion/handoff sequence.
+Disposal releases the incremental state, fallback snapshot and raw alias; late
+callbacks retain the existing generation guards. Internal reconnect rehydrates a
+disposed parser even when the old transport failed before the first token; a zero
+raw cursor does not mean parser state survived disposal.
+
+## Long-token presentation cost
+
+The semantic fix does not change the reveal cursor or give fade callbacks any
+semantic ownership. Long text emitted in a single fade frame (128 or more code
+units) shares one inline opacity span: those words previously received identical
+animation timing but retained a node per word. Small emissions, code/media,
+reduced-motion and silent rewind prefixes keep their existing paths. Rewind
+muting splits a grouped span at the previously visible word boundary, preserving
+animation of genuinely new tail words. Existing live nodes remain stable until
+settlement; ordinary animation cleanup does not remove or replace them.
+
+## Verification
+
+`tests/test_issue7478_spaced_semantic.py` advances a virtual clock by 40 ms per
+spaced token, and also covers burst/alternating delivery, split think/XML/DSML
+markers, prose/tool/prose order, real inflight synchronization, terminal drain,
+reconnect, replacement, uncertainty and reasoning-cache work. Work counters use
+UTF-16 code units, matching JavaScript string indexing; they are not heap sizes.
+`test_issue7478_cancel.py` additionally drives the real `_wireSSE` token/cancel
+listeners with spaced delivery and deferred canonical settlement. Application
+error and disposal regressions cover pending delimiter and state-release paths.
+
+The source-extraction test harnesses execute only in an authorized local test
+sandbox. A maintainer threat-policy NO-RUN classification is not a test failure
+or a product defect, and local results do not imply maintainer approval.

--- a/docs/architecture/live-scene-terminal-ownership.md
+++ b/docs/architecture/live-scene-terminal-ownership.md
@@ -1,0 +1,88 @@
+# Live scene ordering and terminal ownership
+
+This note describes the presentation-layer contract for the live scene path.
+It supplements [Stable Assistant Turn Anchors](../rfcs/stable-assistant-turn-anchors.md)
+and [Live-to-Final Assistant Replies](../rfcs/live-to-final-assistant-replies.md).
+It does not change run execution, transcript authority, or server validation.
+
+## Ordering provenance
+
+Journal transport sequences and browser-local producer ordinals are different
+ordering domains. The trusted producer context selects `order_domain`; raw event
+payloads do not get to select it. Regressions within either domain still mark the
+projection uncertain and take the full fail-closed path. Comparing a local ordinal
+against the next journal offset must not mark valid delivery uncertain.
+
+Stable identity and duplicate detection remain separate from order validation.
+The local producer domain must not replace a real journal event identity or
+permit ambiguous identity to take the incremental path. Projected rows retain
+`order_domain` for snapshot hydration. That hydration boundary restores local
+provenance only for rows without a journal event ID; rows with a journal ID and
+legacy rows without provenance retain the transport/fail-closed interpretation.
+The normalized-event replay API preserves its already-normalized provenance.
+
+## Semantic and visual ownership
+
+Synchronous producer callbacks ingest prose, reasoning and tool state into the
+turn's anchor. Normal frame paints and terminal fade steps only project that
+state; they must not upsert semantic prose as a consequence of painting.
+
+The stream closure owns the live scene scheduler, generation, pending terminal
+completion, fade timeout/frame, snapshot/persistence timers and registry cleanup.
+A valid `done` schedules one generation-bound completion. The completion is
+claimed and removed before invocation. A transport close during optional fade
+must complete that pending semantic work before disposing the owner.
+
+Once terminal state is claimed, later live producer events cannot compete with
+it. Already-dispatched callbacks must check the current generation and, where
+applicable, the exact scheduled timer handle. Cancellation alone is not proof
+that a callback cannot execute.
+
+Explicit supersession/disposal invalidates the owner and clears the pending
+completion. It is not permission for an obsolete owner to finalize a successor.
+Page teardown first asks the current owner to complete an already-received
+terminal result, then uses the existing detach/reattach handoff. A bfcache
+`pageshow` uses canonical session loading when an inflight attachment needs
+restoring; it does not revive the disposed owner. Session-switch detachment
+retains the existing journal-replay recovery contract.
+Each recovery rewire re-registers the exact registry and re-arms its backstop.
+Registry removal is conditional on exact registry identity so disposal cannot
+remove a replacement owner's entry. Disposal is idempotent.
+
+## Incremental projection
+
+Known-order changes rebuild only dirty rows. Immutable scene snapshots share a
+private persistent row index rather than copying every historical row reference
+on each paint. Live rendering reads `_activity_rows_view`; this non-enumerable
+view is not a public dense array. The public `activity_rows` getter materializes
+a normal frozen dense array once, retaining native reflection and JSON semantics.
+Persistence/replay use that public boundary. Diagnostic counters distinguish the
+private live path from explicit public materialization.
+Initial construction still uses the full projection. The renderer also retains
+its explicit terminal-row fail-closed branch; terminal settlement is not a
+steady-state paint. Genuine identity/order uncertainty continues to rebuild.
+
+## Settled persistence
+
+Both Compact Worklog and Transparent Stream naturally use
+`POST /api/session/anchor-scene` after settled scene attachment. The endpoint's
+256,000-byte UTF-8 scene limit remains authoritative.
+
+Before sending, the client checks a conservative UTF-8 server-serialization
+bound. It includes Python's extra exponent digit for numeric values serialized
+by JavaScript with `e-7`, `e-8`, or `e-9`; numeric-looking text is not counted as
+a number. A known-oversized scene is not posted or truncated: the full in-memory
+semantic scene is retained,
+a warning is emitted and the existing toast surface reports that persistence
+was skipped. Under-budget scenes retain the normal persistence path. The saved
+transcript remains authoritative; skipping this derived scene is not a claim
+that the anchor cache was saved.
+
+## Verification surfaces
+
+The `test_issue6391_*` tests exercise mixed ordering, real projection work,
+immutable snapshots, producer/paint separation, terminal claims, registry
+cleanup, budget handling and dispatched stale callbacks. Browser validation
+must additionally use real synthetic SSE lifecycles in both display modes,
+observe natural persistence and verify replay/reload and terminal cleanup.
+Unit results alone do not establish browser performance or persistence success.

--- a/docs/architecture/live-scene-terminal-ownership.md
+++ b/docs/architecture/live-scene-terminal-ownership.md
@@ -23,9 +23,12 @@ The normalized-event replay API preserves its already-normalized provenance.
 
 ## Semantic and visual ownership
 
-Synchronous producer callbacks ingest prose, reasoning and tool state into the
-turn's anchor. Normal frame paints and terminal fade steps only project that
-state; they must not upsert semantic prose as a consequence of painting.
+Producer receipt appends token text synchronously. An independent 32 ms semantic
+batch extracts prose/inline thinking and synchronizes inflight messages; every
+non-token event and owner detach drains pending prose before its boundary.
+Reasoning and tool callbacks then ingest their state in receipt order. Normal
+frame paints and terminal fade steps only project existing state; they must not
+upsert semantic prose as a consequence of painting.
 
 The stream closure owns the live scene scheduler, generation, pending terminal
 completion, fade timeout/frame, snapshot/persistence timers and registry cleanup.
@@ -38,10 +41,13 @@ it. Already-dispatched callbacks must check the current generation and, where
 applicable, the exact scheduled timer handle. Cancellation alone is not proof
 that a callback cannot execute.
 
-Explicit supersession/disposal invalidates the owner and clears the pending
-completion. It is not permission for an obsolete owner to finalize a successor.
-Page teardown first asks the current owner to complete an already-received
-terminal result, then uses the existing detach/reattach handoff. A bfcache
+The identity-checked `closeLiveStream` contract is shared by ordinary detach,
+session switch, source supersession and page teardown: finish accepted terminal
+work exactly once, flush, snapshot, dispose, then close. A reentrant terminal
+close leaves this sequence owned by the outer detach. Replaced owners cannot
+finish or dispose successors. A payload-less cancel retains its primary async
+canonical-session settlement owner; cursor capture and queued transport tails
+must not dispose it during the fetch. A bfcache
 `pageshow` uses canonical session loading when an inflight attachment needs
 restoring; it does not revive the disposed owner. Session-switch detachment
 retains the existing journal-replay recovery contract.
@@ -61,6 +67,15 @@ private live path from explicit public materialization.
 Initial construction still uses the full projection. The renderer also retains
 its explicit terminal-row fail-closed branch; terminal settlement is not a
 steady-state paint. Genuine identity/order uncertainty continues to rebuild.
+
+## Projection-cache lifetime
+
+Renderer projection entries retain explicit session, stream and turn identity.
+Only live projections are cached. Settled projections evict the corresponding
+live entry and are rebuilt without historical cache retention. The current
+stream's disposal releases its entries after flush/snapshot; identity-guarded
+callbacks prevent retired sources from releasing a successor's state. Eviction
+changes only acceleration state, never semantic rows or persisted transcripts.
 
 ## Settled persistence
 

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -402,6 +402,8 @@
       run_id:runId,
       stream_id:streamId,
       seq,
+      // Local producer ordinals and server journal offsets are incomparable.
+      order_domain:_own(ctx,'order_domain')==='local'?'local':'transport',
       kind:meta.kind,
       source_event_type:sourceType,
       created_at:_own(event,'created_at')||_own(event,'timestamp')||_own(payload,'created_at')||_own(payload,'ts')||_own(ctx,'created_at')||null,
@@ -640,6 +642,11 @@
     }
     _syncAnchorIdentity(anchor,event);
     _routeAnchorEvent(anchor,item);
+    if(_cleanString(_own(item,'classification'))==='activity'){
+      _activityProjectionMark(registry,event,anchor.activity_events.length-1,'activity');
+    }else{
+      _activityProjectionMark(registry,event,-1,_cleanString(_own(item,'classification')));
+    }
     registry.stats.applied+=1;
     return Object.freeze({applied:true,reason:null,normalized:item});
   }
@@ -1000,6 +1007,7 @@
       run_id:_cleanString(_own(event,'run_id'))||null,
       stream_id:_cleanString(_own(event,'stream_id'))||null,
       seq:_own(event,'seq')??null,
+      order_domain:_own(event,'order_domain')==='local'?'local':'transport',
       status,
       created_at:_own(event,'created_at')??null,
       identity:Object.freeze({
@@ -1018,13 +1026,241 @@
     });
   }
 
+  function _activityProjectionState(registry){
+    if(!registry||typeof registry!=='object') return null;
+    let state=registry._activity_projection_state;
+    if(state&&typeof state==='object') return state;
+    state={
+      revision:0,
+      dirty_full:true,
+      dirty_reason:'initial',
+      dirty_indices:[],
+      dirty_row_keys:[],
+      dirty_metadata:false,
+      dirty_aux:false,
+      last_activity_count:0,
+      last_order_seq:null,
+      cache:null,
+    };
+    Object.defineProperty(registry,'_activity_projection_state',{
+      value:state,
+      enumerable:false,
+      configurable:true,
+      writable:true,
+    });
+    return state;
+  }
+
+  function _activityProjectionEventIdentity(event){
+    if(!event||typeof event!=='object') return '';
+    const eventId=_cleanString(_own(event,'event_id'));
+    if(eventId) return 'event:'+eventId;
+    const runId=_cleanString(_own(event,'run_id'));
+    const seq=_own(event,'seq');
+    if(runId&&seq!==undefined&&seq!==null&&seq!=='') return 'run:'+runId+':'+String(seq);
+    const localId=_cleanString(_own(event,'local_id'));
+    const sourceType=_cleanString(_own(event,'source_event_type'));
+    if(localId&&sourceType&&seq!==undefined&&seq!==null&&seq!==''){
+      return 'local:'+localId+':'+sourceType+':'+String(seq);
+    }
+    return '';
+  }
+
+  function _activityProjectionOrderToken(event){
+    if(!event||typeof event!=='object') return null;
+    const seq=_own(event,'seq');
+    if(seq===undefined||seq===null||seq==='') return null;
+    const numeric=Number(seq);
+    return Number.isFinite(numeric)?numeric:String(seq);
+  }
+
+  function _activityProjectionMark(registry, event, index, classification){
+    const state=_activityProjectionState(registry);
+    if(!state) return;
+    state.revision+=1;
+    if(classification!=='activity'){
+      if(classification==='artifact'||classification==='side_effect') state.dirty_aux=true;
+      if(classification==='metadata') state.dirty_metadata=true;
+      return;
+    }
+    const key=_activityProjectionEventIdentity(event);
+    const orderToken=_activityProjectionOrderToken(event);
+    const domain=event.order_domain==='local'?'local':'transport';
+    if(!state.last_order_by_domain) state.last_order_by_domain=Object.create(null);
+    const priorOrder=state.last_order_by_domain[domain];
+    const knownOrder=typeof orderToken==='number';
+    const numericOrder=knownOrder&&typeof priorOrder==='number';
+    // Stable identity is not evidence of sequence order. Opaque/missing tokens
+    // must fail closed without erasing the last comparable domain sequence.
+    if(!key||!knownOrder|| (numericOrder&&orderToken<priorOrder)){
+      state.dirty_full=true;
+      state.dirty_reason=key?'uncertain_order':'uncertain_identity_or_order';
+    }else if(state.dirty_full!==true){
+      const expectedTail=state.last_activity_count;
+      if(index!==expectedTail){
+        state.dirty_full=true;
+        state.dirty_reason='uncertain_order';
+      }else{
+        state.dirty_indices.push(index);
+        state.dirty_row_keys.push(key);
+      }
+    }
+    state.last_activity_count=index+1;
+    if(knownOrder){
+      state.last_order_seq=orderToken;
+      state.last_order_by_domain[domain]=orderToken;
+    }
+  }
+
+  function invalidateAssistantTurnAnchorActivityProjection(registry, options){
+    const state=_activityProjectionState(registry);
+    if(!state) return Object.freeze({invalidated:false,reason:'missing_registry'});
+    const opts=(options&&typeof options==='object')?options:{};
+    state.revision+=1;
+    const reason=_cleanString(_own(opts,'reason'))||'external_activity_replacement';
+    const indices=Array.isArray(_own(opts,'indices'))?_own(opts,'indices'):[];
+    const orderUncertain=_own(opts,'order_uncertain')===true||_own(opts,'identity_uncertain')===true;
+    if(orderUncertain||!indices.length){
+      state.dirty_full=true;
+      state.dirty_reason=orderUncertain?'uncertain_identity_or_order':reason;
+    }else if(!state.dirty_full){
+      indices.forEach((value)=>{
+        const index=Number(value);
+        if(Number.isInteger(index)&&index>=0){
+          state.dirty_indices.push(index);
+          state.dirty_row_keys.push('external:'+String(index));
+        }else{
+          state.dirty_full=true;
+          state.dirty_reason='uncertain_identity_or_order';
+        }
+      });
+    }
+    return Object.freeze({invalidated:true,reason:state.dirty_reason||reason});
+  }
+
+  function _projectionAuxRows(anchor, key){
+    const events=Array.isArray(anchor&&anchor[key])?anchor[key]:[];
+    return events.map(event=>Object.freeze({
+      ..._copyObject(event),
+      payload:Object.freeze(_copyObject(_own(event,'payload'))),
+    }));
+  }
+
+  // A persistent 32-way row index shares unchanged history between immutable
+  // scene snapshots. Each dirty row copies five small index nodes, not N rows.
+  function _projectionRowIndexSet(node, index, row, level=4){
+    const next=node?node.slice():[];
+    const slot=Math.floor(index/Math.pow(32,level))%32;
+    next[slot]=level===0?row:_projectionRowIndexSet(next[slot],index,row,level-1);
+    return Object.freeze(next);
+  }
+  function _projectionRowSnapshot(cache){
+    const root=cache.row_index;
+    const length=cache.rows.length;
+    if(cache.row_view&&cache.row_view_root===root&&cache.row_view.length===length) return cache.row_view;
+    const indexOf=key=>typeof key==='string'&&/^(0|[1-9][0-9]*)$/.test(key)?Number(key):-1;
+    // Frozen sparse array preserves Array.isArray, length and native iteration.
+    // The get/has view supplies values without copying the historical row list.
+    const view=new Proxy(Object.freeze(new Array(length)),{
+      get(target,key,receiver){
+        const index=indexOf(key);
+        if(index>=0&&index<length){
+          let node=root;
+          for(let level=4;level>=0;level--) node=node[Math.floor(index/Math.pow(32,level))%32];
+          return node;
+        }
+        return Reflect.get(target,key,receiver);
+      },
+      has(target,key){
+        const index=indexOf(key);
+        return index>=0&&index<length||Reflect.has(target,key);
+      },
+    });
+    cache.row_view_root=root;
+    cache.row_view=view;
+    cache.row_view_record={public_rows:null};
+    return view;
+  }
+  function _projectionStats(state, cache, fullRebuild, fallbackReason, eventsScanned, rowsRebuilt){
+    return Object.freeze({
+      revision:state.revision,
+      events_scanned:eventsScanned,
+      rows_rebuilt:rowsRebuilt,
+      historical_rows_copied:0,
+      row_index_nodes_copied:cache.row_index_nodes_copied||0,
+      full_rebuild:!!fullRebuild,
+      fallback_reason:fallbackReason||null,
+      order_uncertain:fallbackReason==='uncertain_order'||fallbackReason==='uncertain_identity_or_order',
+      rows_cached:cache&&cache.rows?cache.rows.length:0,
+    });
+  }
+
+  function _activityProjectionRenderKey(row, index, fallback){
+    if(row&&row.role==='tool'&&_cleanString(_own(row,'tool_call_id'))){
+      return 'tool:call:'+_cleanString(_own(row,'tool_call_id'));
+    }
+    const role=_cleanString(_own(row,'role'))||'activity';
+    const stable=_cleanString(_own(row,'row_id'))||_cleanString(_own(row,'local_id'))||_cleanString(_own(row,'event_id'));
+    return stable?role+':'+stable:String(fallback===undefined?index:fallback);
+  }
+
+  // Live-only diagnostics must not alter serialized activity_scene_v1 payloads.
+  function _freezeActivityProjectionScene(scene){
+    Object.defineProperty(scene,'_activity_rows_view',{value:scene._activity_rows_view,enumerable:false});
+    Object.defineProperty(scene,'projection',{value:scene.projection,enumerable:false});
+    Object.defineProperty(scene,'projection_stats',{value:scene.projection_stats,enumerable:false});
+    return Object.freeze(scene);
+  }
+
+  function _projectionSceneFromCache(anchor, mode, cache, stats){
+    const liveRows=_projectionRowSnapshot(cache);
+    const rowViewRecord=cache.row_view_record;
+    let rowsCopied=0;
+    stats=Object.freeze({...stats,
+      get historical_rows_copied(){return rowsCopied;},
+    });
+    const lifecycle=_copyObject(anchor.lifecycle);
+    const content=anchor.content&&typeof anchor.content==='object'?anchor.content:{};
+    const projection=Object.freeze({
+      revision:stats.revision,
+      full_rebuild:stats.full_rebuild,
+      fallback_reason:stats.fallback_reason,
+      order_uncertain:stats.order_uncertain,
+      changed_row_keys:Object.freeze(cache.changed_row_keys.slice()),
+      changed_row_indices:Object.freeze(cache.changed_row_indices.slice()),
+    });
+    return _freezeActivityProjectionScene({
+      version:'activity_scene_v1',
+      mode,
+      identity:_frozenIdentityCopy(anchor.identity||{}),
+      lifecycle:Object.freeze(lifecycle),
+      final_answer:typeof content.final_answer==='string'?content.final_answer:'',
+      final_message_ref:typeof content.final_message_ref==='string'?content.final_message_ref:null,
+      terminal_state:_cleanString(_own(lifecycle,'terminal_state'))||null,
+      // A private read view is for live rendering only. Public consumers retain
+      // a normal dense immutable array, materialized once when requested.
+      _activity_rows_view:liveRows,
+      get activity_rows(){
+        if(!rowViewRecord.public_rows){
+          rowViewRecord.public_rows=Object.freeze(Array.from(liveRows));
+          rowsCopied=rowViewRecord.public_rows.length;
+        }
+        return rowViewRecord.public_rows;
+      },
+      artifacts:Object.freeze(cache.artifacts),
+      side_effects:Object.freeze(cache.side_effects),
+      projection,
+      projection_stats:stats,
+    });
+  }
+
   function projectAssistantTurnAnchorActivityScene(input, options){
     const anchor=_anchorFromProjectionInput(input);
     const opts=(options&&typeof options==='object')?options:{};
     const requestedMode=_cleanString(_own(opts,'mode'));
     const mode=_activityDisplayMode(requestedMode);
     if(!anchor){
-      return Object.freeze({
+      return _freezeActivityProjectionScene({
         version:'activity_scene_v1',
         mode,
         identity:Object.freeze({source_message_refs:Object.freeze([])}),
@@ -1035,30 +1271,140 @@
         activity_rows:Object.freeze([]),
         artifacts:Object.freeze([]),
         side_effects:Object.freeze([]),
+        projection:Object.freeze({revision:0,full_rebuild:true,fallback_reason:'missing_anchor',order_uncertain:true}),
+        projection_stats:Object.freeze({revision:0,events_scanned:0,rows_rebuilt:0,full_rebuild:true,fallback_reason:'missing_anchor',order_uncertain:true,rows_cached:0}),
       });
     }
-    const rows=(Array.isArray(anchor.activity_events)?anchor.activity_events:[])
-      .map((event,index)=>_activitySceneRow(event,index,mode));
-    const lifecycle=_copyObject(anchor.lifecycle);
-    const content=anchor.content&&typeof anchor.content==='object'?anchor.content:{};
-    return Object.freeze({
-      version:'activity_scene_v1',
-      mode,
-      identity:_frozenIdentityCopy(anchor.identity||{}),
-      lifecycle:Object.freeze(lifecycle),
-      final_answer:typeof content.final_answer==='string'?content.final_answer:'',
-      final_message_ref:typeof content.final_message_ref==='string'?content.final_message_ref:null,
-      terminal_state:_cleanString(_own(lifecycle,'terminal_state'))||null,
-      activity_rows:Object.freeze(rows),
-      artifacts:Object.freeze((Array.isArray(anchor.artifacts)?anchor.artifacts:[]).map(event=>Object.freeze({
-        ..._copyObject(event),
-        payload:Object.freeze(_copyObject(_own(event,'payload'))),
-      }))),
-      side_effects:Object.freeze((Array.isArray(anchor.side_effects)?anchor.side_effects:[]).map(event=>Object.freeze({
-        ..._copyObject(event),
-        payload:Object.freeze(_copyObject(_own(event,'payload'))),
-      }))),
-    });
+    const state=_activityProjectionState(input&&typeof input==='object'?input:null);
+    const events=Array.isArray(anchor.activity_events)?anchor.activity_events:[];
+    let cache=state.cache;
+    const cleanProjection=!!(
+      cache&&cache.scene&&cache.mode===mode&&
+      state.dirty_full!==true&&state.dirty_indices.length===0&&
+      !state.dirty_metadata&&!state.dirty_aux&&cache.event_refs.length===events.length
+    );
+    if(cleanProjection){
+      const cleanStats=_projectionStats(state,cache,false,null,0,0);
+      state.last_stats=cleanStats;
+      if(input&&typeof input==='object') Object.defineProperty(input,'projection_stats',{value:cleanStats,writable:true,configurable:true,enumerable:false});
+      if(cache.scene.projection.full_rebuild||cache.scene.projection_stats.events_scanned!==0){
+        cache.changed_row_keys=[];
+        cache.changed_row_indices=[];
+        cache.scene=_projectionSceneFromCache(anchor,mode,cache,cleanStats);
+      }
+      return cache.scene;
+    }
+    let fullRebuild=!cache||cache.mode!==mode||state.dirty_full===true;
+    let fallbackReason=fullRebuild
+      ? (cache&&cache.mode!==mode?'mode_changed':(state.dirty_reason||'initial'))
+      : null;
+    let eventsScanned=0;
+    let rowsRebuilt=0;
+    const changedIndices=[];
+    const changedKeys=[];
+    if(!fullRebuild&&cache.event_refs.length>events.length){
+      fullRebuild=true;
+      fallbackReason='uncertain_order';
+    }
+    if(!fullRebuild&&state.dirty_indices.length===0&&cache.event_refs.length!==events.length){
+      fullRebuild=true;
+      fallbackReason='uncertain_order';
+    }
+    if(fullRebuild){
+      const rows=[];
+      const refs=[];
+      const keys=[];
+      for(let index=0;index<events.length;index+=1){
+        const event=events[index];
+        rows.push(_activitySceneRow(event,index,mode));
+        refs.push(event);
+        keys.push(_activityProjectionEventIdentity(event)||'');
+      }
+      cache={
+        mode,
+        rows,
+        event_refs:refs,
+        event_keys:keys,
+        artifacts:_projectionAuxRows(anchor,'artifacts'),
+        side_effects:_projectionAuxRows(anchor,'side_effects'),
+        changed_row_keys:[],
+        changed_row_indices:[],
+        scene:null,
+      };
+      state.cache=cache;
+      eventsScanned=events.length;
+      rowsRebuilt=events.length;
+      for(let index=0;index<events.length;index+=1){
+        const row=rows[index];
+        changedIndices.push(index);
+        changedKeys.push(_activityProjectionRenderKey(row,index,keys[index]||index));
+      }
+    }else{
+      const dirtyIndices=Array.from(new Set(state.dirty_indices)).sort((a,b)=>a-b);
+      let validatedLength=cache.rows.length;
+      for(const index of dirtyIndices){
+        if(index<0||index>=events.length||index>validatedLength){
+          fullRebuild=true;
+          fallbackReason='uncertain_order';
+          break;
+        }
+        if(index===validatedLength) validatedLength+=1;
+        const event=events[index];
+        const key=_activityProjectionEventIdentity(event);
+        if(!key||(
+          index<cache.event_keys.length&&cache.event_keys[index]&&cache.event_keys[index]!==key
+        )){
+          fullRebuild=true;
+          fallbackReason='uncertain_identity_or_order';
+          break;
+        }
+      }
+      if(fullRebuild){
+        state.dirty_full=true;
+        state.dirty_reason=fallbackReason;
+        return projectAssistantTurnAnchorActivityScene(input,options);
+      }
+      for(const index of dirtyIndices){
+        const event=events[index];
+        const row=_activitySceneRow(event,index,mode);
+        if(index===cache.rows.length){
+          cache.rows.push(row);
+          cache.event_refs.push(event);
+          cache.event_keys.push(_activityProjectionEventIdentity(event));
+        }else{
+          cache.rows[index]=row;
+          cache.event_refs[index]=event;
+          cache.event_keys[index]=_activityProjectionEventIdentity(event);
+        }
+        changedIndices.push(index);
+        changedKeys.push(_activityProjectionRenderKey(row,index,cache.event_keys[index]||index));
+      }
+      eventsScanned=dirtyIndices.length;
+      rowsRebuilt=dirtyIndices.length;
+    }
+    if(state.dirty_aux&&!fullRebuild){
+      cache.artifacts=_projectionAuxRows(anchor,'artifacts');
+      cache.side_effects=_projectionAuxRows(anchor,'side_effects');
+    }
+    cache.changed_row_keys=changedKeys;
+    cache.changed_row_indices=changedIndices;
+    const snapshotIndices=fullRebuild?cache.rows.map((_,index)=>index):changedIndices;
+    if(fullRebuild) cache.row_index=null;
+    for(const index of snapshotIndices) cache.row_index=_projectionRowIndexSet(cache.row_index,index,cache.rows[index]);
+    cache.row_index_nodes_copied=snapshotIndices.length*5;
+    const stats=_projectionStats(state,cache,fullRebuild,fallbackReason,eventsScanned,rowsRebuilt);
+    state.last_stats=stats;
+    state.last_activity_count=events.length;
+    state.dirty_full=false;
+    state.dirty_reason=null;
+    state.dirty_indices=[];
+    state.dirty_row_keys=[];
+    state.dirty_metadata=false;
+    state.dirty_aux=false;
+    const scene=_projectionSceneFromCache(anchor,mode,cache,stats);
+    cache.scene=scene;
+    if(input&&typeof input==='object') Object.defineProperty(input,'projection_stats',{value:stats,writable:true,configurable:true,enumerable:false});
+    return scene;
   }
 
   function projectAssistantTurnAnchorHistoricalTranscriptScene(input, options){
@@ -1703,6 +2049,7 @@
     applyAssistantTurnAnchorNormalizedEvent,
     applyAssistantTurnAnchorSourceEvent,
     applyAssistantTurnAnchorSourceEvents,
+    invalidateAssistantTurnAnchorActivityProjection,
     createAssistantTurnAnchorShadowSnapshot,
     projectAssistantTurnAnchorSettledMessageFinalAnswer,
     projectAssistantTurnAnchorActivityScene,

--- a/static/messages.js
+++ b/static/messages.js
@@ -2049,9 +2049,7 @@ function _shouldForceCompletionNotification(sid, streamId){
 
 function _disposeLiveScenePaints(){
   for(const [sessionId,live] of Object.entries(LIVE_STREAMS)){
-    // Page teardown is not supersession: complete an already received terminal
-    // result before detaching, otherwise use the existing reattach handoff.
-    if(typeof live?.finishScene==='function') live.finishScene();
+    // All detach paths share the current owner's terminal-first contract.
     if(typeof closeLiveStream==='function') closeLiveStream(sessionId,live.streamId,live.source);
     else if(typeof live?.disposeScene==='function') live.disposeScene();
   }
@@ -2072,6 +2070,12 @@ function closeLiveStream(sessionId, streamId, source){
   if(!live) return;
   if(streamId&&live.streamId!==streamId) return;
   if(source&&live.source!==source) return;
+  // A terminal finish can call _closeSource recursively. The outer detach owns
+  // the ordered teardown, while the finalizer retains its current generation.
+  if(live.closingScene) return;
+  live.closingScene=true;
+  if(typeof live.finishScene==='function') live.finishScene();
+  if(LIVE_STREAMS[sessionId]!==live) return;
   if(typeof live.flushScene==='function') live.flushScene();
   // Snapshot the current live-turn DOM BEFORE tearing the stream down. The
   // per-event snapshot (snapshotLiveTurn) only fires on content/tool_complete
@@ -3010,8 +3014,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _committingLivePaint=false;
   let _livePaintScrollSnapshot=null;
   function _disposeAnchorScenePaint(){
+    if(typeof _releaseAnchorSceneRenderProjections==='function') _releaseAnchorSceneRenderProjections(activeSid,streamId);
     _anchorPaintGeneration++;
     _anchorPaintDisposed=true;
+    if(typeof _semanticProseTimer!=='undefined'&&_semanticProseTimer!==null){
+      clearTimeout(_semanticProseTimer);_semanticProseTimer=null;
+    }
     _cancelAnchorRegistryCleanup();
     _pendingTerminalFinish=null;
     if(_terminalFadeTimer!==null) clearTimeout(_terminalFadeTimer);
@@ -4595,6 +4603,39 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _streamDisplay(){
     return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true}).content;
   }
+  let _semanticProseTimer=null;
+  let _semanticProseDirty=false;
+  function _drainSemanticProse(){
+    if(_semanticProseTimer!==null) clearTimeout(_semanticProseTimer);
+    _semanticProseTimer=null;
+    if(!_semanticProseDirty||_anchorPaintDisposed) return;
+    _semanticProseDirty=false;
+    syncInflightAssistantMessage();
+    const parsed=segmentStart===0||!assistantRow ? _parseStreamState() : null;
+    const prose=segmentStart===0 ? (parsed.displayText||'')
+      : _parseCurrentSegmentDisplayText();
+    if(!assistantRow&&S.session?.session_id===activeSid){
+      if(String(parsed.displayText||'').trim()) ensureAssistantRow();
+      _scheduleRender(parsed);
+    }
+    if(String(prose).trim()) _upsertAnchorProcessProse(prose);
+  }
+  function _scheduleSemanticProse(){
+    _semanticProseDirty=true;
+    if(_semanticProseTimer!==null) return;
+    const timer=setTimeout(()=>{
+      if(_semanticProseTimer!==timer||_anchorPaintDisposed) return;
+      _drainSemanticProse();
+    },32);
+    _semanticProseTimer=timer;
+  }
+  function _parseCurrentSegmentDisplayText(){
+    // Use the same code-aware thinking semantics for post-tool prose as for
+    // the first segment. Never project reasoning tags as raw activity prose.
+    return _extractInlineThinkingFromContent(
+      _stripXmlToolCalls(assistantText.slice(segmentStart)),liveReasoningText,
+      {streaming:true}).displayText||'';
+  }
   function _parseStreamState(){
     return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true});
   }
@@ -5454,7 +5495,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const parsed=_parseStreamState();
     return segmentStart===0
       ? parsed.displayText
-      : _stripXmlToolCalls(assistantText.slice(segmentStart));
+      : _parseCurrentSegmentDisplayText();
   }
   function _drainStreamFadeBeforeDone(onDone){
     const fadeGeneration=_anchorPaintGeneration;
@@ -5504,7 +5545,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(_renderPending) _cancelAnimationFramePendingStreamRender();
     const displayText=segmentStart===0
       ? _parseStreamState().displayText
-      : _stripXmlToolCalls(assistantText.slice(segmentStart));
+      : _parseCurrentSegmentDisplayText();
     if(_smdParser){
       _smdWrite(displayText);
     } else if(window.smd){
@@ -5852,7 +5893,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderLiveThinking(parsed);
       const displayText = segmentStart===0
         ? parsed.displayText                          // first segment: uses think-tag stripping
-        : _stripXmlToolCalls(assistantText.slice(segmentStart));
+        : _parseCurrentSegmentDisplayText();
       let anchorProcessText=displayText;
       if(assistantBody){
         if(_shouldUseLiveProseFade()){
@@ -5878,7 +5919,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             // parsed.displayText and users see unformatted markdown until done.
             const fallbackText = segmentStart===0
               ? parsed.displayText
-              : _stripXmlToolCalls(assistantText.slice(segmentStart));
+              : _parseCurrentSegmentDisplayText();
             assistantBody.innerHTML = renderMd ? renderMd(fallbackText) : esc(fallbackText);
           }
         }
@@ -5912,9 +5953,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _wireSSE(source){
     const existingLive=LIVE_STREAMS[activeSid];
     if(existingLive&&existingLive.source&&existingLive.source!==source){
-      if(typeof existingLive.flushScene==='function') existingLive.flushScene();
-      if(typeof existingLive.disposeScene==='function') existingLive.disposeScene();
-      try{if(existingLive.source.readyState!==2)existingLive.source.close();}catch(_){ }
+      closeLiveStream(activeSid,existingLive.streamId,existingLive.source);
     }
     _anchorPaintDisposed=false;
     if(typeof _activateAnchorRegistry==='function') _activateAnchorRegistry();
@@ -5929,12 +5968,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // First semantic terminal event owns completion. Late producer/cursor
       // callbacks cannot compete while its optional visual fade is pending.
       if(_terminalStateReached){
-        if(type==='stream_end'||type==='error'||type==='apperror'||type==='cancel'){
+        // Only accepted deferred done work may be drained by a transport tail.
+        // Cancel's asynchronous canonical fetch retains its own settlement owner.
+        if(_pendingTerminalFinish&&(type==='stream_end'||type==='error'||type==='apperror'||type==='cancel')){
           _completeOwnedTerminal();
           _closeSource(source);
         }
         return;
       }
+      // Drain receipt-owned prose before any semantic boundary can reorder it.
+      if(type!=='token'&&typeof _drainSemanticProse==='function') _drainSemanticProse();
       // Terminal handlers may dispose synchronously. Preserve their journal
       // cursor before that disposal suppresses the separate cursor listener.
       if(type==='done'||type==='cancel'||type==='apperror') _rememberRunJournalCursor(event);
@@ -5948,7 +5991,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _renderAnchorLiveScene();
         return true;
       },
-      finishScene:()=>{if(isCurrentGeneration()) _completeOwnedTerminal();},
+      finishScene:()=>{if(isCurrentGeneration()){_drainSemanticProse();_completeOwnedTerminal();}},
       flushScene:()=>{if(isCurrentGeneration()) _anchorPaintScheduler?.flush();},
       disposeScene:()=>{if(isCurrentGeneration()) _disposeAnchorScenePaint();},
     };
@@ -5972,29 +6015,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(_terminalStateReached||_streamFinalized) return;
       const d=JSON.parse(e.data);
       assistantText+=d.text;
-      syncInflightAssistantMessage();
+      _scheduleSemanticProse();
       if(!S.session||S.session.session_id!==activeSid) return;
       _completeAutomaticCompressionOnLiveProgress(activeSid);
       if(_freshSegment) appendThinking('', _liveThinkingPlacement());
-      // Once the assistant row exists its creation gate is already satisfied, and
-      // the throttled _doRender re-parses once per frame anyway — so the per-token
-      // full-text parse here is pure waste (O(n)/token -> O(n^2) over the answer).
-      // Still call ensureAssistantRow() every token exactly as before (cheap; it
-      // also starts a new segment on a post-tool _freshSegment). Only the parse is
-      // skipped, and only once the row exists. (#5455 WS2.3)
+      // Creating the first prose row and extracting inline thinking are owned
+      // by the independent semantic batch, not by each token or a paint frame.
       if(assistantRow){
         ensureAssistantRow();
         _scheduleRender();
-      }else{
-        const parsed=_parseStreamState();
-        if(String((parsed&&parsed.displayText)||'').trim()) ensureAssistantRow();
-        _scheduleRender(parsed);
       }
-      // Semantic order is assigned on receipt, never by a later paint callback.
-      const synchronousProse=segmentStart===0
-        ? (_parseStreamState().displayText||'')
-        : _stripXmlToolCalls(assistantText.slice(segmentStart));
-      if(String(synchronousProse).trim()) _upsertAnchorProcessProse(synchronousProse);
     });
 
     source.addEventListener('interim_assistant',e=>{
@@ -6113,7 +6143,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!tc) return;
       const pendingDisplayTextBeforeTool=segmentStart===0
         ? (_parseStreamState().displayText||'')
-        : _stripXmlToolCalls(assistantText.slice(segmentStart));
+        : _parseCurrentSegmentDisplayText();
       if(String(pendingDisplayTextBeforeTool||'').trim()) _upsertAnchorProcessProse(pendingDisplayTextBeforeTool,{sealed:true});
       _applyToAnchor('tool',{...d,...tc},e);
 
@@ -6126,7 +6156,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const oldRow=$('toolRunningRow');if(oldRow)oldRow.remove();
       const pendingDisplayText=segmentStart===0
         ? (_parseStreamState().displayText||'')
-        : _stripXmlToolCalls(assistantText.slice(segmentStart));
+        : _parseCurrentSegmentDisplayText();
       if((assistantRow&&assistantBody)||String(pendingDisplayText||'').trim()){
         ensureAssistantRow(true);
       }
@@ -6150,7 +6180,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       tc.is_error=!!d.is_error;
       const pendingDisplayTextBeforeComplete=segmentStart===0
         ? (_parseStreamState().displayText||'')
-        : _stripXmlToolCalls(assistantText.slice(segmentStart));
+        : _parseCurrentSegmentDisplayText();
       if(String(pendingDisplayTextBeforeComplete||'').trim()) _upsertAnchorProcessProse(pendingDisplayTextBeforeComplete,{sealed:true});
       _applyToAnchor('tool_complete',{...d,...tc,is_error:!!d.is_error},e);
       if(typeof noteWorkspaceMutationsFromToolCall==='function') noteWorkspaceMutationsFromToolCall(tc);
@@ -6161,7 +6191,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(tc._createdByComplete){
         const pendingDisplayText=segmentStart===0
           ? (_parseStreamState().displayText||'')
-          : _stripXmlToolCalls(assistantText.slice(segmentStart));
+          : _parseCurrentSegmentDisplayText();
         if((assistantRow&&assistantBody)||String(pendingDisplayText||'').trim()){
           ensureAssistantRow(true);
           _flushPendingSegmentRender({force:true});
@@ -6845,6 +6875,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _clearClarifyForOwner('terminal');
       let d={};
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
+      let _errorRecoveryPending=false;
       const _extensionErrorType=(d.type==='cancelled'||d.type==='interrupted')?'turn:cancel':'turn:error';
       const currentSid=S.session&&S.session.session_id;
       const eventSid=d.old_session_id||d.session_id||'';
@@ -6926,12 +6957,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           },0);
         }
         if(isRecoveryControlMessage){
+          _errorRecoveryPending=true;
           (async()=>{
-            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
-            if(S.session&&S.session.session_id===activeSid){
-              S.messages=_filterRecoveryControlMessages(S.messages||[]);
-              _markSessionViewed(activeSid, S.messages.length);
-              renderMessages({preserveScroll:true});
+            try{
+              if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+              if(S.session&&S.session.session_id===activeSid){
+                S.messages=_filterRecoveryControlMessages(S.messages||[]);
+                _markSessionViewed(activeSid, S.messages.length);
+                renderMessages({preserveScroll:true});
+              }
+            }finally{
+              closeLiveStream(activeSid,streamId,source);
             }
           })();
         } else {
@@ -6948,6 +6984,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         status:d.status||d.type||(_extensionErrorType==='turn:cancel'?'cancelled':'error'),
         endedAt:Date.now()/1000,
       });
+      // Transport closure alone does not retire the logical owner or its cache.
+      if(!_errorRecoveryPending) closeLiveStream(activeSid,streamId,source);
     });
 
     source.addEventListener('warning',e=>{
@@ -7198,7 +7236,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       })();
     });
 
-    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
+    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
     source.addEventListener=addOwnedListener;

--- a/static/messages.js
+++ b/static/messages.js
@@ -381,8 +381,262 @@ function _extractInlineThinkingFromContent(rawContent, existingReasoning, option
   }
   if(cursor<text.length) visible.push(text.slice(cursor));
   const content=leadingRemoved?visible.join('').replace(/^\s+/,''):visible.join('');
+  if(typeof options?.onExtracted==='function') options.onExtracted(extracted);
   const reasoning=_mergeInlineThinkingReasoning(existingReasoning,extracted);
   return {reasoning,content,thinkingText:reasoning,displayText:content,inThinking};
+}
+
+// Live counterpart of _extractInlineThinkingFromContent. Owned by the stream,
+// never by smd/fade. Each write consumes only its delta; delimiter lookahead is
+// bounded. The batch helper above remains the recovery/settled-content oracle.
+function _createIncrementalSemanticState(extractedParts){
+  let content='',body='',bodySpace='';
+  let pending='',xmlPending='',xml=false,thinking=null;
+  let xmlHasText=false,xmlTrimLeading=false;
+  let xmlKeywordTail='',xmlKeywordSeen=false;
+  let fence='',backtick=false,lineSpaces=0,lineStart=true,indented=false;
+  let seenNonspace=false,leadingRemoved=false,uncertain=false,leadingIndented=false;
+  // Two bounded views: durable all-run reasoning and current live reasoning.
+  // A view consumes each completed block once; alternating readers cannot
+  // invalidate one another and force a full-history merge on every prose tick.
+  const views=[];
+  const parts=Array.from(new Set((extractedParts||[]).filter(Boolean)));
+  const completed=new Set(parts),partLengths=new Set(parts.map(part=>part.length));
+  // Work counters use UTF-16 code units, the JavaScript parser's input unit.
+  const stats={incrementalBytes:0,mergeBytes:0,steps:0,maxPending:0};
+  let prefixTrimmed=0;
+  function trimContentStart(){
+    const trimmed=content.replace(/^\s+/,'');
+    prefixTrimmed+=content.length-trimmed.length;content=trimmed;
+  }
+  function appendReason(text){
+    // Keep trimming local to new text, not the growing reasoning accumulator.
+    if(!body) text=text.replace(/^\s+/,'');
+    const tail=text.match(/\s+$/);
+    const end=tail?tail[0]:'';
+    const core=end?text.slice(0,-end.length):text;
+    if(core){body+=bodySpace+core;bodySpace=end;}else bodySpace+=end;
+  }
+  function closeThinking(){
+    if(body&&!completed.has(body)){
+      completed.add(body);partLengths.add(body.length);parts.push(body);
+    }
+    body='';bodySpace='';thinking=null;
+    // A closing delimiter occupies the current source line. Whitespace after
+    // it is not leading indentation, even when the hidden body contained '\n'.
+    lineStart=false;lineSpaces=0;indented=false;
+  }
+  function visible(text){
+    if(leadingRemoved&&!content) text=text.replace(/^\s+/,'');
+    content+=text;
+  }
+  function thinkWrite(text){
+    text=pending+text;pending='';
+    let i=0,plain='';
+    const flush=()=>{if(plain){if(thinking) appendReason(plain);else visible(plain);plain='';}};
+    while(i<text.length){
+      stats.steps++;
+      const rest=text.slice(i,i+24),ch=text[i];
+      if(thinking){
+        if(text.startsWith(thinking.close,i)){
+          flush();i+=thinking.close.length;closeThinking();seenNonspace=true;continue;
+        }
+        if(ch==='<'&&thinking.close.startsWith(rest)&&rest.length<thinking.close.length){
+          flush();pending=text.slice(i);break;
+        }
+        plain+=ch;i++;continue;
+      }
+      // A possible fence marker at line start needs at most two bytes lookahead.
+      const atFence=lineStart&&lineSpaces<=3;
+      if(atFence&&(ch==='`'||ch==='~')){
+        const marker=ch.repeat(3);
+        if(rest.length<3&&marker.startsWith(rest)){flush();pending=text.slice(i);break;}
+        if(text.startsWith(marker,i)){
+          fence=fence===marker?'':(fence||marker);
+          plain+=marker;i+=3;lineStart=false;seenNonspace=true;continue;
+        }
+      }
+      if(!fence&&ch==='`') backtick=!backtick;
+      if(!fence&&!backtick&&!indented&&ch==='<'){
+        const pair=_thinkPairs.find(p=>text.startsWith(p.open,i));
+        if(pair){
+          flush();
+          if(!seenNonspace){leadingRemoved=true;trimContentStart();}
+          thinking=pair;i+=pair.open.length;continue;
+        }
+        if(_thinkPairs.some(p=>rest.length<p.open.length&&p.open.startsWith(rest))){
+          flush();pending=text.slice(i);break;
+        }
+      }
+      plain+=ch;
+      if(ch==='\n'){lineStart=true;lineSpaces=0;indented=false;}
+      else if(lineStart&&ch===' '){lineSpaces++;if(lineSpaces>=4)indented=true;}
+      else if(lineStart&&ch==='\t'){indented=lineSpaces===0||lineSpaces>=4;lineStart=false;}
+      else lineStart=false;
+      if(/\S/.test(ch)){
+        // Record the first visible line's indentation before a later XML gate
+        // can remove it, including when arbitrary blank lines precede it.
+        if(!seenNonspace)leadingIndented=indented;
+        seenNonspace=true;
+      }
+      i++;
+    }
+    flush();
+  }
+  function write(delta){
+    delta=String(delta||'');stats.incrementalBytes+=delta.length;
+    if(uncertain)return;
+    let plain='';
+    const flush=()=>{if(plain){
+      if(xmlTrimLeading&&!xmlHasText)plain=plain.replace(/^\s+/,'');
+      if(/\S/.test(plain))xmlHasText=true;
+      thinkWrite(plain);plain='';
+    }};
+    for(const ch of delta){
+      stats.steps++;
+      // The batch XML helper lstrips whenever either keyword occurs, even in
+      // literal prose. Recognize that gate with bounded cross-chunk lookbehind.
+      if(!xmlKeywordSeen){
+        xmlKeywordTail=(xmlKeywordTail+ch.toLowerCase()).slice(-14);
+        if(xmlKeywordTail.endsWith('function_calls')||xmlKeywordTail.endsWith('dsml')){
+          flush();xmlKeywordSeen=true;xmlKeywordTail='';
+          if(xmlHasText&&leadingIndented){uncertain=true;xmlPending='';break;}
+          trimContentStart();leadingRemoved=true;xmlTrimLeading=true;
+          if(!xmlHasText){lineStart=true;lineSpaces=0;indented=false;}
+        }
+      }
+      if(!xmlPending){
+        if(ch==='<'){flush();xmlPending='<';}
+        else if(!xml)plain+=ch;
+        continue;
+      }
+      xmlPending+=ch;
+      stats.maxPending=Math.max(stats.maxPending,xmlPending.length);
+      // Whitespace inside a DSML prefix is unbounded in the legacy grammar.
+      // Do not retain it indefinitely or repeatedly rescan on subsequent tokens.
+      if(xmlPending.length>256){uncertain=true;xmlPending='';break;}
+      const candidate=xmlPending;
+      // A nested opener in an unfinished XML/DSML prefix can change which
+      // block the batch stripper removes. Do not publish its possible payload.
+      if(ch==='<'){uncertain=true;xmlPending='';break;}
+      const tool=/^<\/?(?:\s*｜\s*DSML\s*[｜|]\s*)?function_calls>$/i;
+      if(tool.test(candidate)){
+        flush();
+        // The legacy XML stripper removes leading whitespace before thinking
+        // extraction. That can retroactively turn earlier indented literal
+        // tags into reasoning; an append-only parser must not guess here.
+        if(xmlHasText&&leadingIndented){uncertain=true;xmlPending='';break;}
+        xmlTrimLeading=true;
+        if(!xmlHasText){lineStart=true;lineSpaces=0;indented=false;}
+        if(candidate[1]==='/'&&!xml){xmlHasText=true;thinkWrite(candidate);xmlPending='';continue;}
+        xml=candidate[1]!=='/';xmlPending='';
+        trimContentStart();leadingRemoved=true;
+        continue;
+      }
+      const stem=candidate.replace(/^<\/?/,'');
+      const plainPrefix='function_calls>'.startsWith(stem.toLowerCase());
+      const dsmlPrefix=/^\s*｜/.test(stem)||/^\s+$/.test(stem);
+      if(plainPrefix||dsmlPrefix&&ch!=='>')continue;
+      xmlPending='';
+      if(!xml){
+        // Match the batch stripper's malformed DSML prefix removal.
+        plain+=candidate.replace(/<\s*｜\s*DSML\s*[｜|]\s*/gi,'');
+      }else if(ch==='<')xmlPending='<';
+    }
+    flush();
+    stats.maxPending=Math.max(stats.maxPending,pending.length);
+  }
+  function appendTrimmed(view,key,spaceKey,text){
+    if(!view[key])text=text.replace(/^\s+/,'');
+    const tail=text.match(/\s+$/),space=tail?tail[0]:'';
+    const core=space?text.slice(0,-space.length):text;
+    if(core){view[key]+=view[spaceKey]+core;view[spaceKey]=space;}
+    else view[spaceKey]+=space;
+  }
+  function partMatch(text){
+    // Hash only at a possible completed-block length, never every growing tail.
+    return partLengths.has(text.length)&&completed.has(text)?text:null;
+  }
+  function appendBase(view,delta){
+    stats.mergeBytes+=delta.length;
+    const oldTail=partMatch(view.tail),oldWhole=partMatch(view.trimmed);
+    appendTrimmed(view,'trimmed','space',delta);
+    // Paragraphs are indexed once on completion. The growing paragraph remains
+    // an unhashed tail; a delayed newline recognizes split "\n\n" separators.
+    for(const ch of delta){
+      if(ch==='\n'&&view.newline){
+        const tail=view.tail;
+        if(tail){
+          view.paragraphs.add(tail);view.lengths.add(tail.length);
+          if(partMatch(tail))view.dirty=true;
+        }
+        view.tail='';view.tailSpace='';view.newline=false;
+      }else{
+        if(view.newline)appendTrimmed(view,'tail','tailSpace','\n');
+        view.newline=ch==='\n';
+        if(!view.newline)appendTrimmed(view,'tail','tailSpace',ch);
+      }
+    }
+    if(oldTail!==partMatch(view.tail)||oldWhole!==partMatch(view.trimmed))view.dirty=true;
+    view.body=null;
+  }
+  function reasoningView(base){
+    let view=views.find(v=>v.base===base);
+    if(!view){
+      view={base,trimmed:'',space:'',tail:'',tailSpace:'',newline:false,
+        paragraphs:new Set(),lengths:new Set(),suffix:'',suffixParagraphs:new Set(),
+        suffixLengths:new Set(),cursor:0,body:null,duplicate:false,dirty:true};
+      appendBase(view,base);
+      if(views.length===2)views.shift();
+      views.push(view);
+    }
+    return view;
+  }
+  function appendReasoning(delta,updates){
+    // The producer supplies before/after identities and the authoritative delta.
+    // Never discover growth by comparing/scanning the full accumulated prefix.
+    const changed=updates.map(([before,after])=>[reasoningView(before),after]);
+    const seen=new Set();
+    for(const [view,after] of changed){
+      if(seen.has(view))continue;
+      seen.add(view);appendBase(view,delta);view.base=after;
+    }
+  }
+  function snapshot(existingReasoning=''){
+    const view=reasoningView(String(existingReasoning||''));
+    // Only a semantic deduplication transition invalidates the inline suffix.
+    // Ordinary channel growth prepends the new base without replaying blocks.
+    if(view.dirty){
+      view.suffix='';view.suffixParagraphs.clear();view.suffixLengths.clear();
+      view.cursor=0;view.body=null;view.dirty=false;
+    }
+    const mergedText=()=>view.trimmed+(view.suffix?(view.trimmed?'\n\n':'')+view.suffix:'');
+    const isDuplicate=(part)=>{
+      if(view.tail.length===part.length&&view.tail===part)return true;
+      if(view.lengths.has(part.length)&&view.paragraphs.has(part))return true;
+      if(view.suffixLengths.has(part.length)&&view.suffixParagraphs.has(part))return true;
+      const length=view.trimmed.length+view.suffix.length+(view.trimmed&&view.suffix?2:0);
+      return length===part.length&&mergedText()===part;
+    };
+    while(view.cursor<parts.length){
+      const part=parts[view.cursor++];stats.mergeBytes+=part.length;
+      if(!isDuplicate(part)){
+        view.suffix+=(view.suffix?'\n\n':'')+part;
+        for(const paragraph of part.split('\n\n')){
+          const trimmed=paragraph.trim();
+          view.suffixParagraphs.add(trimmed);view.suffixLengths.add(trimmed.length);
+        }
+      }
+      view.body=null;
+    }
+    if(view.body!==body){view.body=body;view.duplicate=!!body&&isDuplicate(body);}
+    const base=mergedText();
+    const merged=base+(body&&!view.duplicate?(base?'\n\n':'')+body:'');
+    return {content,displayText:content,reasoning:merged,thinkingText:merged,
+      inThinking:!!thinking||pending.startsWith('<'),uncertain};
+  }
+  return {write,snapshot,appendReasoning,stats,prefixTrimmed:()=>prefixTrimmed,
+    hasPending:()=>!!pending||!!xmlPending,uncertain:()=>uncertain};
 }
 
 if(typeof window!=='undefined'){
@@ -2601,7 +2855,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const ts=Date.now()/1000;
     // Split inline <think> blocks into m.reasoning so the persisted inflight
     // state stays compact and the thinking card has a proper source field.
-    const split=_splitThinkFromContent(assistantText, reasoningText);
+    _consumeSemanticProse();
+    const split=_semanticSnapshot(reasoningText);
     if(assistantIdx>=0){
       inflight.messages[assistantIdx].content=split.content;
       inflight.messages[assistantIdx].reasoning=split.reasoning||undefined;
@@ -2643,7 +2898,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(!_isActiveSession()) return;
     if(assistantRow&&!assistantRow.isConnected){assistantRow=null;assistantBody=null;}
     if(!force&&!assistantRow){
-      const parsed=_parseStreamState();
+      const parsed=_semanticSnapshot();
       if(!String((parsed&&parsed.displayText)||'').trim()) return;
     }
     let turn=$('liveAssistantTurn');
@@ -3017,6 +3272,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(typeof _releaseAnchorSceneRenderProjections==='function') _releaseAnchorSceneRenderProjections(activeSid,streamId);
     _anchorPaintGeneration++;
     _anchorPaintDisposed=true;
+    if(typeof _semanticState!=='undefined'){_semanticState=null;_semanticFallback=null;_semanticRaw='';}
     if(typeof _semanticProseTimer!=='undefined'&&_semanticProseTimer!==null){
       clearTimeout(_semanticProseTimer);_semanticProseTimer=null;
     }
@@ -4601,26 +4857,71 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return s.replace(/^\s+/, '');
   }
   function _streamDisplay(){
-    return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true}).content;
+    return _semanticSnapshot().content;
   }
   let _semanticProseTimer=null;
   let _semanticProseDirty=false;
-  function _drainSemanticProse(){
+  let _semanticState=_createIncrementalSemanticState();
+  let _semanticCursor=0,_semanticSegmentStart=0,_semanticRaw='';
+  let _semanticFallback=null,_semanticFallbackCursor=-1;
+  const _semanticMetrics={fullParses:0,fullBytes:0,resyncReasons:{}};
+  function _consumeSemanticProse(delta){
+    if(!_semanticState)return;
+    if(assistantText.length<_semanticCursor){_resyncSemanticProse('rewind');return;}
+    if(delta===undefined&&_semanticCursor&&assistantText!==_semanticRaw){_resyncSemanticProse('discontinuity');return;}
+    if(assistantText.length===_semanticCursor)return;
+    if(!_semanticState.uncertain())_semanticFallback=null;
+    const trimmedBefore=_semanticState.prefixTrimmed();
+    _semanticState.write(delta===undefined?assistantText.slice(_semanticCursor):delta);
+    _semanticSegmentStart=Math.max(0,_semanticSegmentStart-(_semanticState.prefixTrimmed()-trimmedBefore));
+    _semanticCursor=assistantText.length;_semanticRaw=assistantText;
+  }
+  function _resyncSemanticProse(reason){
+    _semanticMetrics.resyncReasons[reason]=(_semanticMetrics.resyncReasons[reason]||0)+1;
+    _semanticFallback=_parseStreamState();_semanticFallbackCursor=assistantText.length;
+    _semanticState=_createIncrementalSemanticState();
+    _semanticState.write(assistantText);
+    _semanticCursor=assistantText.length;_semanticRaw=assistantText;
+    // A recovered segment is a boundary, not a per-token prefix comparison.
+    let prefix=_stripXmlToolCalls(assistantText.slice(0,segmentStart));
+    if(/function_calls|dsml/i.test(assistantText))prefix=prefix.replace(/^\s+/,'');
+    const prefixState=_createIncrementalSemanticState();prefixState.write(prefix);
+    _semanticSegmentStart=prefixState.uncertain()
+      ?_extractInlineThinkingFromContent(prefix,'',{streaming:true}).content.length
+      :prefixState.snapshot().content.length;
+  }
+  function _semanticSnapshot(existingReasoning=liveReasoningText){
+    if(!_semanticState)return _semanticFallback||{content:'',displayText:'',reasoning:'',thinkingText:'',inThinking:false};
+    const parsed=_semanticState.snapshot(existingReasoning);
+    if(!_semanticFallback||!(_semanticState.uncertain()||_semanticState.hasPending()))return parsed;
+    const fallback=_semanticFallback;
+    const state=fallback.reasoningState||(fallback.reasoningState=_createIncrementalSemanticState(fallback.extractedParts));
+    const reasoning=state.snapshot(existingReasoning).reasoning;
+    return {content:fallback.content,displayText:fallback.displayText,
+      reasoning,thinkingText:reasoning,inThinking:fallback.inThinking};
+  }
+  _consumeSemanticProse();
+  function _drainSemanticProse(boundary=false){
     if(_semanticProseTimer!==null) clearTimeout(_semanticProseTimer);
     _semanticProseTimer=null;
+    if(boundary&&_semanticState&&(_semanticState.uncertain()||(boundary===true&&_semanticState.hasPending()))&&
+        (!_semanticFallback||_semanticFallbackCursor!==assistantText.length)){
+      _resyncSemanticProse('semantic-boundary');_semanticProseDirty=true;
+    }
     if(!_semanticProseDirty||_anchorPaintDisposed) return;
     _semanticProseDirty=false;
     syncInflightAssistantMessage();
-    const parsed=segmentStart===0||!assistantRow ? _parseStreamState() : null;
+    const parsed=segmentStart===0||!assistantRow ? _semanticSnapshot() : null;
     const prose=segmentStart===0 ? (parsed.displayText||'')
       : _parseCurrentSegmentDisplayText();
     if(!assistantRow&&S.session?.session_id===activeSid){
       if(String(parsed.displayText||'').trim()) ensureAssistantRow();
-      _scheduleRender(parsed);
     }
+    _scheduleRender(parsed);
     if(String(prose).trim()) _upsertAnchorProcessProse(prose);
   }
-  function _scheduleSemanticProse(){
+  function _scheduleSemanticProse(delta){
+    _consumeSemanticProse(delta);
     _semanticProseDirty=true;
     if(_semanticProseTimer!==null) return;
     const timer=setTimeout(()=>{
@@ -4632,12 +4933,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _parseCurrentSegmentDisplayText(){
     // Use the same code-aware thinking semantics for post-tool prose as for
     // the first segment. Never project reasoning tags as raw activity prose.
-    return _extractInlineThinkingFromContent(
-      _stripXmlToolCalls(assistantText.slice(segmentStart)),liveReasoningText,
-      {streaming:true}).displayText||'';
+    return _semanticSnapshot().displayText.slice(_semanticSegmentStart);
   }
   function _parseStreamState(){
-    return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true});
+    _semanticMetrics.fullParses++;_semanticMetrics.fullBytes+=assistantText.length;
+    let extractedParts=[];
+    const parsed=_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText,
+      {streaming:true,onExtracted:parts=>{extractedParts=parts;}});
+    return {...parsed,extractedParts};
   }
   function _renderLiveThinking(parsed){
     if(window._showThinking===false){removeThinking();return;}
@@ -4933,6 +5236,19 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // point must NOT replay their fade animation. They are appended as
       // plain text; only the tail beyond _streamFadeSilentPrefixChars fades.
       let silentLeft=_streamFadeSilentPrefixChars||0;
+      // Words emitted together have the same opacity animation. Keep a long
+      // emission in one inline span rather than retaining a node per word.
+      // The reveal cursor still decides which words arrive in this frame.
+      if(value.length>=128&&!reduceMotion&&!silentLeft){
+        const span=document.createElement('span');
+        span.className='stream-fade-word is-new';
+        span.dataset.streamFadeBatch='1';
+        const fadeMs=_streamFadeCurrentMs||_STREAM_FADE_MS;
+        if(fadeMs!==_STREAM_FADE_MS)span.style.setProperty('--stream-fade-ms',fadeMs+'ms');
+        span.textContent=value;parent.appendChild(span);
+        _streamFadeLatestAnimationEndAt=Math.max(_streamFadeLatestAnimationEndAt,appendStartedAt+fadeMs);
+        return;
+      }
       while((match=wordRe.exec(value))){
         if(match.index>last) frag.appendChild(document.createTextNode(value.slice(last,match.index)));
         if(reduceMotion){
@@ -5259,6 +5575,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // after a rewind-triggered rebuild, words before the rewind point must
     // not replay their fade animation.
     let silentLeft=_streamFadeSilentPrefixChars||0;
+    if(value.length>=128&&!reduceMotion&&!silentLeft){
+      const span=document.createElement('span');
+      span.className='stream-fade-word is-new';
+      span.dataset.streamFadeBatch='1';
+      const fadeMs=_streamFadeCurrentMs||_STREAM_FADE_MS;
+      if(fadeMs!==_STREAM_FADE_MS)span.style.setProperty('--stream-fade-ms',fadeMs+'ms');
+      span.textContent=value;el.appendChild(span);
+      _streamFadeLatestAnimationEndAt=Math.max(_streamFadeLatestAnimationEndAt,appendStartedAt+fadeMs);
+      return;
+    }
     while((match=wordRe.exec(value))){
       if(match.index>last) frag.appendChild(document.createTextNode(value.slice(last,match.index)));
       if(reduceMotion){
@@ -5317,6 +5643,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(start<_common){
           const parent=node.parentNode;
           if(parent&&/\bstream-fade-word\b/.test(parent.className||'')&&/\bis-new\b/.test(parent.className||'')){
+            // A same-frame batch may straddle the rewind prefix. Mute only
+            // words already visible, leaving the new suffix animated.
+            if(parent.dataset?.streamFadeBatch==='1'&&consumed>_common&&parent.parentNode){
+              const text=node.textContent||'';
+              let cut=_common-start;
+              if(cut>0&&/\S/.test(text[cut-1]))while(cut<text.length&&/\S/.test(text[cut]))cut++;
+              if(cut<text.length){
+                parent.parentNode.insertBefore(document.createTextNode(text.slice(0,cut)),parent);
+                node.textContent=text.slice(cut);
+                return;
+              }
+            }
             if(parent.classList&&typeof parent.classList.remove==='function'){
               parent.classList.remove('is-new');
             }else{
@@ -5492,7 +5830,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return next.caughtUp;
   }
   function _streamFadeCurrentDisplayText(){
-    const parsed=_parseStreamState();
+    const parsed=_semanticSnapshot();
     return segmentStart===0
       ? parsed.displayText
       : _parseCurrentSegmentDisplayText();
@@ -5544,7 +5882,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(!_isActiveSession()) return;
     if(_renderPending) _cancelAnimationFramePendingStreamRender();
     const displayText=segmentStart===0
-      ? _parseStreamState().displayText
+      ? _semanticSnapshot().displayText
       : _parseCurrentSegmentDisplayText();
     if(_smdParser){
       _smdWrite(displayText);
@@ -5572,6 +5910,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     assistantRow=null;
     assistantBody=null;
     segmentStart=assistantText.length;
+    _semanticSegmentStart=_semanticSnapshot().displayText.length;
     _freshSegment=true;
     _smdEndParser();
     _resetStreamFadeState();
@@ -5859,6 +6198,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _cachedParsedText='';
   let _cachedParsedReasoning='';
   function _scheduleRender(parsed){
+    // Receipt updates semantics immediately. Publish once from its bounded
+    // drain rather than racing a second token/fade paint with that drain.
+    if(typeof _semanticProseDirty!=='undefined'&&_semanticProseDirty) return;
     if(_anchorPaintDisposed) return;
     const renderGeneration=_anchorPaintGeneration;
     // If caller provides a pre-computed parse result, cache it for _doRender.
@@ -5888,7 +6230,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // writes to suppress Chromium scroll re-anchoring during streaming growth.
       if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
       _lastRenderMs=performance.now();
-      const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _parseStreamState();
+      const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _semanticSnapshot();
       _cachedParsed=null;
       _renderLiveThinking(parsed);
       const displayText = segmentStart===0
@@ -5956,6 +6298,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       closeLiveStream(activeSid,existingLive.streamId,existingLive.source);
     }
     _anchorPaintDisposed=false;
+    // Recovery disposes the parser even if no assistant token has arrived.
+    // Empty content is not evidence that the previous parser still exists.
+    if(typeof _semanticCursor!=='undefined'&&(_semanticCursor||!_semanticState)) _resyncSemanticProse('reconnect');
     if(typeof _activateAnchorRegistry==='function') _activateAnchorRegistry();
     // Every listener belongs to this exact transport generation. Reject queued
     // events before parsing, registry mutation, compatibility DOM or scheduling.
@@ -5977,7 +6322,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         return;
       }
       // Drain receipt-owned prose before any semantic boundary can reorder it.
-      if(type!=='token'&&typeof _drainSemanticProse==='function') _drainSemanticProse();
+      if(type!=='token'&&typeof _drainSemanticProse==='function') {
+        // Trusted delimiter lookahead spans nonterminal events without exposing
+        // a partial tool marker as literal prose. Terminal exits settle it.
+        _drainSemanticProse(['done','cancel','apperror','error','stream_end'].includes(type)?true:'semantic');
+      }
       // Terminal handlers may dispose synchronously. Preserve their journal
       // cursor before that disposal suppresses the separate cursor listener.
       if(type==='done'||type==='cancel'||type==='apperror') _rememberRunJournalCursor(event);
@@ -5991,7 +6340,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _renderAnchorLiveScene();
         return true;
       },
-      finishScene:()=>{if(isCurrentGeneration()){_drainSemanticProse();_completeOwnedTerminal();}},
+      finishScene:()=>{if(isCurrentGeneration()){_drainSemanticProse(true);_completeOwnedTerminal();}},
       flushScene:()=>{if(isCurrentGeneration()) _anchorPaintScheduler?.flush();},
       disposeScene:()=>{if(isCurrentGeneration()) _disposeAnchorScenePaint();},
     };
@@ -6015,7 +6364,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(_terminalStateReached||_streamFinalized) return;
       const d=JSON.parse(e.data);
       assistantText+=d.text;
-      _scheduleSemanticProse();
+      _scheduleSemanticProse(d.text);
       if(!S.session||S.session.session_id!==activeSid) return;
       _completeAutomaticCompressionOnLiveProgress(activeSid);
       if(_freshSegment) appendThinking('', _liveThinkingPlacement());
@@ -6045,7 +6394,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           return;
         }
         _completeAutomaticCompressionOnLiveProgress(activeSid);
-        const parsed=_parseStreamState();
+        const parsed=_semanticSnapshot();
         if(String((parsed&&parsed.displayText)||'').trim()||assistantRow){
           ensureAssistantRow(true);
           _flushPendingSegmentRender({force:true});
@@ -6056,7 +6405,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _resetAssistantSegment();
         return;
       }
-      assistantText += assistantText ? `\n\n${visible}` : visible;
+      const semanticDelta=assistantText ? `\n\n${visible}` : visible;
+      assistantText+=semanticDelta;
+      _consumeSemanticProse(semanticDelta);
       visibleInterimSnippets.push(visible);
       syncInflightAssistantMessage();
       if(!S.session||S.session.session_id!==activeSid){
@@ -6115,8 +6466,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!_ownsActiveStreamOrBackground()) return;
       const d=JSON.parse(e.data);
       const text=d.text||'';
+      const previousReasoning=reasoningText,previousLiveReasoning=liveReasoningText;
       reasoningText += text;
       liveReasoningText += text;
+      const reasoningUpdates=[[previousReasoning,reasoningText],[previousLiveReasoning,liveReasoningText]];
+      _semanticState?.appendReasoning(text,reasoningUpdates);
+      _semanticFallback?.reasoningState?.appendReasoning(text,reasoningUpdates);
       if(d.text&&S.session&&S.session.session_id===activeSid) _completeAutomaticCompressionOnLiveProgress(activeSid);
       syncInflightAssistantMessage();
       if(text&&S.session&&S.session.session_id===activeSid&&S.activeStreamId===streamId){
@@ -6142,7 +6497,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const tc=upsertLiveToolCall(d,'start');
       if(!tc) return;
       const pendingDisplayTextBeforeTool=segmentStart===0
-        ? (_parseStreamState().displayText||'')
+        ? (_semanticSnapshot().displayText||'')
         : _parseCurrentSegmentDisplayText();
       if(String(pendingDisplayTextBeforeTool||'').trim()) _upsertAnchorProcessProse(pendingDisplayTextBeforeTool,{sealed:true});
       _applyToAnchor('tool',{...d,...tc},e);
@@ -6155,7 +6510,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       liveReasoningText='';
       const oldRow=$('toolRunningRow');if(oldRow)oldRow.remove();
       const pendingDisplayText=segmentStart===0
-        ? (_parseStreamState().displayText||'')
+        ? (_semanticSnapshot().displayText||'')
         : _parseCurrentSegmentDisplayText();
       if((assistantRow&&assistantBody)||String(pendingDisplayText||'').trim()){
         ensureAssistantRow(true);
@@ -6179,7 +6534,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!tc) return;
       tc.is_error=!!d.is_error;
       const pendingDisplayTextBeforeComplete=segmentStart===0
-        ? (_parseStreamState().displayText||'')
+        ? (_semanticSnapshot().displayText||'')
         : _parseCurrentSegmentDisplayText();
       if(String(pendingDisplayTextBeforeComplete||'').trim()) _upsertAnchorProcessProse(pendingDisplayTextBeforeComplete,{sealed:true});
       _applyToAnchor('tool_complete',{...d,...tc,is_error:!!d.is_error},e);
@@ -6190,7 +6545,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof refreshOpenPreviewIfMutated==='function') refreshOpenPreviewIfMutated();
       if(tc._createdByComplete){
         const pendingDisplayText=segmentStart===0
-          ? (_parseStreamState().displayText||'')
+          ? (_semanticSnapshot().displayText||'')
           : _parseCurrentSegmentDisplayText();
         if((assistantRow&&assistantBody)||String(pendingDisplayText||'').trim()){
           ensureAssistantRow(true);

--- a/static/messages.js
+++ b/static/messages.js
@@ -2047,11 +2047,32 @@ function _shouldForceCompletionNotification(sid, streamId){
   return wasHidden||wasBackgrounded;
 }
 
+function _disposeLiveScenePaints(){
+  for(const [sessionId,live] of Object.entries(LIVE_STREAMS)){
+    // Page teardown is not supersession: complete an already received terminal
+    // result before detaching, otherwise use the existing reattach handoff.
+    if(typeof live?.finishScene==='function') live.finishScene();
+    if(typeof closeLiveStream==='function') closeLiveStream(sessionId,live.streamId,live.source);
+    else if(typeof live?.disposeScene==='function') live.disposeScene();
+  }
+}
+function _restoreLiveSceneAfterPageShow(event){
+  const sid=S.session&&S.session.session_id;
+  if(!event||!event.persisted||!sid||LIVE_STREAMS[sid]||!INFLIGHT[sid]) return;
+  // A bfcache restore resumes an old document, not an obsolete stream owner.
+  // Canonical session loading decides whether a new attachment is warranted.
+  if(typeof loadSession==='function') Promise.resolve(loadSession(sid)).catch(error=>console.warn('Session restore failed',error));
+}
+if(typeof window!=='undefined'&&typeof window.addEventListener==='function'){
+  window.addEventListener('pagehide',_disposeLiveScenePaints);
+  window.addEventListener('pageshow',_restoreLiveSceneAfterPageShow);
+}
 function closeLiveStream(sessionId, streamId, source){
   const live=LIVE_STREAMS[sessionId];
   if(!live) return;
   if(streamId&&live.streamId!==streamId) return;
   if(source&&live.source!==source) return;
+  if(typeof live.flushScene==='function') live.flushScene();
   // Snapshot the current live-turn DOM BEFORE tearing the stream down. The
   // per-event snapshot (snapshotLiveTurn) only fires on content/tool_complete
   // SSE events, so switching away during a quiet window (mid tool-exec, silent
@@ -2061,6 +2082,7 @@ function closeLiveStream(sessionId, streamId, source){
   // thinking/tool content (only the elapsed clock survives). Capturing here
   // guarantees switch-back restores the exact state shown at switch-away. (#3668)
   if(typeof snapshotLiveTurnHtmlForSession==='function') snapshotLiveTurnHtmlForSession(sessionId);
+  if(typeof live.disposeScene==='function') live.disposeScene();
   // Stop the live footer timer/status for the pane that is being detached; the
   // reattach path will rebuild it from INFLIGHT/server state if the user returns.
   if(typeof _clearLiveRunStatusTimer==='function') _clearLiveRunStatusTimer(sessionId);
@@ -2397,7 +2419,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _snapshotLiveTurnTimer=null;
   function _throttledSnapshotLiveTurn(){
     if(_snapshotLiveTurnTimer) return;
-    _snapshotLiveTurnTimer=setTimeout(()=>{_snapshotLiveTurnTimer=null;snapshotLiveTurn();},700);
+    const generation=_anchorPaintGeneration;
+    const timer=setTimeout(()=>{
+      if(_anchorPaintDisposed||generation!==_anchorPaintGeneration||_snapshotLiveTurnTimer!==timer) return;
+      _snapshotLiveTurnTimer=null;
+      snapshotLiveTurn();
+    },700);
+    _snapshotLiveTurnTimer=timer;
   }
   function _cancelThrottledSnapshotTimer(){
     if(_snapshotLiveTurnTimer){clearTimeout(_snapshotLiveTurnTimer);_snapshotLiveTurnTimer=null;}
@@ -2412,10 +2440,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _persistTimer=null;
   function _throttledPersist(){
     if(_persistTimer) return;
-    _persistTimer=setTimeout(()=>{_persistTimer=null;persistInflightState();},2000);
+    const generation=_anchorPaintGeneration;
+    const timer=setTimeout(()=>{
+      if(_anchorPaintDisposed||generation!==_anchorPaintGeneration||_persistTimer!==timer) return;
+      _persistTimer=null;
+      persistInflightState();
+    },2000);
+    _persistTimer=timer;
   }
   function _closeSource(source){
     closeLiveStream(activeSid, streamId, source);
+  }
+  function _retireSourceForRecovery(source){
+    // Transport callbacks are retired, but recovery itself needs an owned
+    // generation visible to pagehide/session teardown while its request awaits.
+    _disposeAnchorScenePaint();
+    _anchorPaintDisposed=false;
+    try{source.close();}catch(_){}
+    LIVE_STREAMS[activeSid]={streamId,source,disposeScene:_disposeAnchorScenePaint,
+      requestScene:()=>false,deferScroll:()=>true};
+    return _anchorPaintGeneration;
   }
   function _clearStreamEndRecovery(){
     if(_streamEndRecoveryTimer){
@@ -2442,12 +2486,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _scheduleStreamEndRecovery(source, delay=180){
     if(_streamEndRecoveryTimer) clearTimeout(_streamEndRecoveryTimer);
     _pendingStreamEndRecovery=true;
-    _streamEndRecoveryTimer=setTimeout(()=>{void _runStreamEndRecovery(source);},delay);
+    const generation=_anchorPaintGeneration;
+    const timer=setTimeout(()=>{
+      if(_anchorPaintDisposed||generation!==_anchorPaintGeneration||_streamEndRecoveryTimer!==timer) return;
+      void _runStreamEndRecovery(source);
+    },delay);
+    _streamEndRecoveryTimer=timer;
   }
   function _finalizeStreamEndFallback(source){
     _clearStreamEndRecovery();
     if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
     _cancelThrottledSnapshotTimer();
+    _anchorPaintScheduler?.flush();
     _terminalStateReached=true;
     _streamFinalized=true;
     _cancelAnimationFramePendingStreamRender();
@@ -2472,12 +2522,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _closeSource(source);
   }
   async function _runStreamEndRecovery(source){
+    const recoveryGeneration=_anchorPaintGeneration;
+    if(_anchorPaintDisposed) return;
     if(_streamFinalized || _terminalStateReached || !_pendingStreamEndRecovery){
       _clearStreamEndRecovery();
       return;
     }
     _streamEndRecoveryTimer=null;
     const status=await _restoreSettledSession(source,{status:true});
+    if(_anchorPaintDisposed||recoveryGeneration!==_anchorPaintGeneration) return;
     if(status==='restored'){
       _clearStreamEndRecovery();
       return;
@@ -2652,12 +2705,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
 
   function _reattachOrRestoreAfterDeferredStreamError(source){
-    if(_terminalStateReached||_streamFinalized) return;
+    const recoveryGeneration=_anchorPaintGeneration;
+    const recoveryCurrent=()=>!_anchorPaintDisposed&&recoveryGeneration===_anchorPaintGeneration;
+    if(!recoveryCurrent()||_terminalStateReached||_streamFinalized) return;
     if((S.session&&S.session.session_id)!==activeSid) return;
     (async()=>{
       try{
         if(streamId){
           const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+          if(!recoveryCurrent()) return;
           if(st.active){
             setComposerStatus('Reconnected',1000);
             _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -2669,6 +2725,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
       if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      if(!recoveryCurrent()) return;
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup(120000);
       _handleStreamError(source);
@@ -2750,11 +2807,25 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _anchorReasoningFlushed=false;
   let _anchorLocalSeq=0;
   if(_anchorRegistryMap&&_anchorRegistry) _anchorRegistryMap.set(streamId,_anchorRegistry);
+  let _anchorRegistryCleanupTimer=null;
+  function _cancelAnchorRegistryCleanup(){
+    if(_anchorRegistryCleanupTimer!==null) clearTimeout(_anchorRegistryCleanupTimer);
+    _anchorRegistryCleanupTimer=null;
+    if(_anchorRegistryMap&&_anchorRegistryMap.get(streamId)===_anchorRegistry) _anchorRegistryMap.delete(streamId);
+  }
+  function _activateAnchorRegistry(){
+    if(!_anchorRegistryMap||!_anchorRegistry) return;
+    _anchorRegistryMap.set(streamId,_anchorRegistry);
+    _scheduleAnchorRegistryCleanup();
+  }
   function _scheduleAnchorRegistryCleanup(delayMs=600000){
     if(!_anchorRegistryMap||!_anchorRegistry) return;
-    setTimeout(()=>{
-      if(_anchorRegistryMap.get(streamId)===_anchorRegistry) _anchorRegistryMap.delete(streamId);
+    if(_anchorRegistryCleanupTimer!==null) clearTimeout(_anchorRegistryCleanupTimer);
+    const timer=setTimeout(()=>{
+      if(_anchorRegistryCleanupTimer!==timer) return;
+      _cancelAnchorRegistryCleanup();
     },delayMs);
+    _anchorRegistryCleanupTimer=timer;
   }
   // Backstop: schedule an identity-guarded cleanup at creation so this shadow
   // registry self-expires no matter which teardown path the stream takes
@@ -2766,6 +2837,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // optional holder to decide whether a temporary visible fallback is needed.
   function _applyToAnchor(sourceEventType, rawEventData, sseEvent, renderOutcome, options={}){
     if(renderOutcome&&typeof renderOutcome==='object') renderOutcome.rendered=false;
+    if(_anchorPaintDisposed) return null;
     if(!_anchorRegistry||!_anchorApi||typeof _anchorApi.applyAssistantTurnAnchorSourceEvent!=='function') return null;
     const raw=(rawEventData&&typeof rawEventData==='object')?rawEventData:{};
     const eventId=(sseEvent&&sseEvent.lastEventId)||raw.event_id||raw.lastEventId||raw.last_event_id||'';
@@ -2787,7 +2859,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const result=_anchorApi.applyAssistantTurnAnchorSourceEvent(
         _anchorRegistry,
         sourceEvent,
-        {session_id:activeSid,stream_id:streamId}
+        {session_id:activeSid,stream_id:streamId,
+          order_domain:!eventId&&raw.local_id?'local':'transport'}
       );
       const rendered=options&&options.render===false?false:_renderAnchorLiveScene();
       if(renderOutcome&&typeof renderOutcome==='object') renderOutcome.rendered=rendered;
@@ -2858,6 +2931,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return !!(result&&(result.applied||result.reason==='duplicate'));
   }
   function _replaceAnchorActivityEventByLocalId(localId, sourceEventType, patch){
+    if(_anchorPaintDisposed) return null;
     const events=_anchorActivityEvents();
     if(!events||!localId) return null;
     for(let i=events.length-1;i>=0;i--){
@@ -2873,6 +2947,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         },
       };
       events[i]=next;
+      if(typeof _anchorApi.invalidateAssistantTurnAnchorActivityProjection==='function'){
+        _anchorApi.invalidateAssistantTurnAnchorActivityProjection(_anchorRegistry,{indices:[i]});
+      }
       return next;
     }
     return null;
@@ -2910,12 +2987,108 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(sceneMode==='hide_all_activity') return (hints&&hints.hidden_activity)||'hidden_activity';
     return row&&row.display_hint||'activity_row';
   }
-  function _renderAnchorLiveScene(){
-    if(!_anchorRegistry||!_isActiveSession()) return false;
+  let _deferAnchorScenePaint=false;
+  let _anchorPaintScheduler=null;
+  let _anchorPaintGeneration=0;
+  let _anchorPaintDisposed=false;
+  let _pendingTerminalFinish=null;
+  let _terminalFadeTimer=null;
+  let _terminalFadeFrame=null;
+  function _completeOwnedTerminal(){
+    const pending=_pendingTerminalFinish;
+    if(!pending||_anchorPaintDisposed||pending.generation!==_anchorPaintGeneration) return;
+    _pendingTerminalFinish=null;
+    if(_terminalFadeTimer!==null) clearTimeout(_terminalFadeTimer);
+    if(_terminalFadeFrame!==null) cancelAnimationFrame(_terminalFadeFrame);
+    _terminalFadeTimer=null;
+    _terminalFadeFrame=null;
+    pending.finish();
+  }
+  let _pendingProsePaint=null;
+  let _pendingKatexPaint=false;
+  const _pendingMediaPaintRoots=new Set();
+  let _committingLivePaint=false;
+  let _livePaintScrollSnapshot=null;
+  function _disposeAnchorScenePaint(){
+    _anchorPaintGeneration++;
+    _anchorPaintDisposed=true;
+    _cancelAnchorRegistryCleanup();
+    _pendingTerminalFinish=null;
+    if(_terminalFadeTimer!==null) clearTimeout(_terminalFadeTimer);
+    if(_terminalFadeFrame!==null) cancelAnimationFrame(_terminalFadeFrame);
+    _terminalFadeTimer=null;
+    _terminalFadeFrame=null;
+    _pendingProsePaint=null;
+    _pendingKatexPaint=false;
+    _pendingMediaPaintRoots.clear();
+    if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
+    _anchorPaintScheduler?.dispose();
+    _anchorPaintScheduler=null;
+    _cancelThrottledSnapshotTimer();
+    _clearStreamEndRecovery();
+    _cancelAnimationFramePendingStreamRender();
+  }
+  function _withDeferredAnchorScenePaint(handler){
+    const generation=_anchorPaintGeneration;
+    return event=>{
+      // EventSource callbacks already queued at close/pagehide must not revive
+      // a disposed visual owner, even when the same session remains selected.
+      if(_anchorPaintDisposed||generation!==_anchorPaintGeneration) return;
+      const previous=_deferAnchorScenePaint;
+      _deferAnchorScenePaint=true;
+      try{return handler(event);}
+      finally{_deferAnchorScenePaint=previous;}
+    };
+  }
+  function _renderAnchorLiveScene(commit=false){
+    if(_committingLivePaint&&!commit) return true;
+    if(_anchorPaintDisposed||!_anchorRegistry||!_isActiveSession()) return false;
     if(typeof window==='undefined'||typeof window._renderLiveAnchorActivitySceneForStream!=='function') return false;
+    if(!commit&&!_terminalStateReached&&!_streamFinalized&&typeof window._createLiveScenePaintScheduler==='function'&&
+       typeof window.requestAnimationFrame==='function'){
+      if(!_anchorPaintScheduler){
+        const registry=_anchorRegistry;
+        _anchorPaintScheduler=window._createLiveScenePaintScheduler({
+          requestFrame:callback=>window.requestAnimationFrame(callback),
+          cancelFrame:handle=>window.cancelAnimationFrame(handle),
+          isCurrent:()=>!_terminalStateReached&&!_streamFinalized&&_isActiveSession()&&
+            S.activeStreamId===streamId&&window._liveAnchorRegistries?.get(streamId)===registry,
+          paint:()=>{
+            const prosePaint=_pendingProsePaint;
+            _pendingProsePaint=null;
+            _committingLivePaint=true;
+            _livePaintScrollSnapshot=typeof _captureMessageScrollSnapshot==='function'?_captureMessageScrollSnapshot():null;
+            const scrollGuard=typeof _prepareLiveAnchorScrollRebuildGuard==='function'?_prepareLiveAnchorScrollRebuildGuard(_livePaintScrollSnapshot):null;
+            try{
+              if(prosePaint) prosePaint();
+              if(_pendingKatexPaint){
+                _pendingKatexPaint=false;
+                if(assistantBody&&typeof renderKatexBlocks==='function') renderKatexBlocks(assistantBody,{streaming:true});
+              }
+              _renderAnchorLiveScene(true);
+              _flushStreamingMediaPostProcess();
+              snapshotLiveTurn();
+            }finally{
+              if(scrollGuard?.release) scrollGuard.release();
+              if(_livePaintScrollSnapshot&&!_anchorPaintDisposed) _restoreMessageScrollSnapshotSameFrame(_livePaintScrollSnapshot);
+              _livePaintScrollSnapshot=null;
+              _committingLivePaint=false;
+            }
+            if(_pendingProsePaint) _anchorPaintScheduler?.request();
+          },
+        });
+      }
+      _anchorPaintScheduler.request();
+      return _anchorPaintScheduler.pending();
+    }
+    // An immediate boundary paint includes every applied event and supersedes
+    // any older pending visual projection without painting it a second time.
+    if(_anchorPaintScheduler) _anchorPaintScheduler.cancel();
     try{
       return !!window._renderLiveAnchorActivitySceneForStream(streamId, activeSid, {
         mode:_anchorSceneActiveMode(),
+        committed:true,
+        scrollOwned:_committingLivePaint,
       });
     }catch(err){
       if(!_anchorShadowWarned&&typeof console!=='undefined'&&console.warn){
@@ -3771,6 +3944,32 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _persistSettledAnchorScene(message, scene, messageIndex){
     if(!activeSid||!message||!scene||typeof api!=='function') return;
     try{
+      // Match the server's UTF-8 serialized scene budget; never truncate the
+      // semantic scene or send a request that is known to fail validation.
+      const serializedScene=JSON.stringify(scene);
+      let sceneBytes=new TextEncoder().encode(serializedScene).byteLength;
+      if(sceneBytes<=256000){
+        // Python's endpoint serializer pads exponents -7, -8 and -9
+        // (1e-7 becomes 1e-07). Count numeric values, not text that merely
+        // resembles numbers. Other Python formatting can shorten this
+        // encoding, so this remains a conservative server-byte bound.
+        JSON.parse(serializedScene,(_key,value)=>{
+          if(typeof value==='number'){
+            const magnitude=Math.abs(value);
+            if(magnitude>=1e-9&&magnitude<1e-6) sceneBytes+=1;
+          }
+          return value;
+        });
+      }
+      if(sceneBytes>256000){
+        message._anchor_scene_persistence_status='over_budget';
+        if(!_persistAnchorSceneWarned){
+          _persistAnchorSceneWarned=true;
+          console.warn('anchor activity scene persistence skipped: scene exceeds byte budget');
+          if(typeof showToast==='function') showToast('Activity details are too large to save. The response remains available.',5000,'warning');
+        }
+        return;
+      }
       const messageOffset=_anchorSceneMessageOffsetForPersist();
       api('/api/session/anchor-scene',{
         method:'POST',
@@ -4322,7 +4521,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         created_at:payload.created_at??row.created_at??undefined,
       };
       try{
-        _anchorApi.applyAssistantTurnAnchorSourceEvent(_anchorRegistry,sourceEvent,{session_id:activeSid,stream_id:sceneStreamId,run_id:sceneRunId});
+        _anchorApi.applyAssistantTurnAnchorSourceEvent(_anchorRegistry,sourceEvent,{
+          session_id:activeSid,stream_id:sceneStreamId,run_id:sceneRunId,
+          // Persisted presentation provenance is consumed only at hydration;
+          // a real journal identity always retains the transport domain.
+          order_domain:row.order_domain==='local'&&!row.event_id?'local':'transport',
+        });
       }catch(err){
         if(!_anchorShadowWarned&&typeof console!=='undefined'&&console.warn){
           _anchorShadowWarned=true;
@@ -4469,11 +4673,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(typeof _smdMediaTailClear==='function') _smdMediaTailClear(__SMD_PARSER_FALLBACK);
   }
   function _scheduleStreamingKatex(){
-    if(_streamingKatexTimer) return;
-    _streamingKatexTimer=setTimeout(()=>{
-      _streamingKatexTimer=null;
-      if(assistantBody&&typeof renderKatexBlocks==='function') renderKatexBlocks(assistantBody,{streaming:true});
-    },150);
+    if(_anchorPaintDisposed||_streamFinalized) return;
+    _pendingKatexPaint=true;
+    _renderAnchorLiveScene();
   }
   // Helper: feed new displayText delta to the smd parser.
   // Only feeds chars beyond what has already been written (_smdWrittenLen).
@@ -4595,6 +4797,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _streamFadeSilentPrefixChars=0;
   }
   function _cancelAnimationFramePendingStreamRender(){
+    _pendingProsePaint=null;
+    _renderPending=false;
+    if(_anchorPaintDisposed||_streamFinalized) _anchorPaintScheduler?.cancel();
     if(_pendingRafHandle===null) return;
     cancelAnimationFrame(_pendingRafHandle);
     clearTimeout(_pendingRafHandle);
@@ -4919,21 +5124,23 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return true;
   }
   function _smdScheduleMediaPostProcess(root){
-    if(!root) return;
-    if(typeof _postProcessWithAnchorSuppression!=='function'
-      && typeof postProcessRenderedMessages!=='function'
-      && typeof _applyMediaPlaybackPreferences!=='function') return;
-    const run=()=>{
+    if(_anchorPaintDisposed||!root||_pendingMediaPaintRoots.has(root)) return;
+    _pendingMediaPaintRoots.add(root);
+    _renderAnchorLiveScene();
+  }
+  function _flushStreamingMediaPostProcess(){
+    const roots=Array.from(_pendingMediaPaintRoots);
+    _pendingMediaPaintRoots.clear();
+    for(const root of roots){
+      if(_anchorPaintDisposed) return;
       try{
         if(typeof _postProcessWithAnchorSuppression==='function') _postProcessWithAnchorSuppression(root);
         else if(typeof postProcessRenderedMessages==='function') postProcessRenderedMessages(root);
         if(typeof _applyMediaPlaybackPreferences==='function') _applyMediaPlaybackPreferences(root);
       }catch(_){}
-    };
-    if(typeof requestAnimationFrame==='function') requestAnimationFrame(run);
-    else if(typeof setTimeout==='function') setTimeout(run,0);
-    else run();
+    }
   }
+
   // Per-parser tail buffer keyed by parser instance so concurrent
   // smd parsers (live prose + anchor-scene rows + tool-card streams)
   // keep their own pending bytes. Cleared inside _smdEndParser /
@@ -5250,14 +5457,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       : _stripXmlToolCalls(assistantText.slice(segmentStart));
   }
   function _drainStreamFadeBeforeDone(onDone){
+    const fadeGeneration=_anchorPaintGeneration;
+    const finish=onDone;
+    onDone=()=>{if(!_anchorPaintDisposed&&fadeGeneration===_anchorPaintGeneration) finish();};
     const drainStartedAt=performance.now();
     let forcedDone=false;
     const step=()=>{
+      if(_anchorPaintDisposed||fadeGeneration!==_anchorPaintGeneration) return;
       if(!assistantBody){onDone();return;}
       const target=_streamFadeCurrentDisplayText();
       const caughtUp=_renderStreamingFadeMarkdown(target);
       const anchorProcessText=_streamFadeDomText||target;
-      if(anchorProcessText) _upsertAnchorProcessProse(anchorProcessText);
+      // Producer callbacks own semantic prose; fade/paint only project it.
       scrollIfPinned();
       if(caughtUp){
         // parser_end can flush pending markdown text; include that final text in
@@ -5266,7 +5477,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // Let the last released words visibly finish their stagger + fade before
         // the final renderMessages() DOM replacement removes the live spans.
         const remainingAnimationMs=Math.max(_STREAM_FADE_MS, _streamFadeLatestAnimationEndAt-performance.now());
-        setTimeout(onDone, Math.min(remainingAnimationMs, _STREAM_FADE_DONE_MAX_MS));
+        _terminalFadeTimer=setTimeout(onDone, Math.min(remainingAnimationMs, _STREAM_FADE_DONE_MAX_MS));
         return;
       }
       // Final SSE `done` means the canonical completed session is available.
@@ -5278,7 +5489,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         onDone();
         return;
       }
-      setTimeout(()=>requestAnimationFrame(step), 33);
+      _terminalFadeTimer=setTimeout(()=>{if(!_anchorPaintDisposed&&fadeGeneration===_anchorPaintGeneration) _terminalFadeFrame=requestAnimationFrame(step);}, 33);
     };
     step();
   }
@@ -5313,7 +5524,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     } else {
       assistantBody.innerHTML=esc(displayText);
     }
-    if(!skipAnchorProcessProse) _upsertAnchorProcessProse(displayText,{sealed:force});
+    // Prose is ingested synchronously by token/tool producers; paint only reads it.
     if(typeof _syncLiveWorklogReasonsForAnchor==='function') _syncLiveWorklogReasonsForAnchor(assistantRow, displayText);
   }
   function _resetAssistantSegment(){
@@ -5607,6 +5818,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _cachedParsedText='';
   let _cachedParsedReasoning='';
   function _scheduleRender(parsed){
+    if(_anchorPaintDisposed) return;
+    const renderGeneration=_anchorPaintGeneration;
     // If caller provides a pre-computed parse result, cache it for _doRender.
     if(parsed){
       _cachedParsed=parsed;
@@ -5621,16 +5834,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // the rAF/setTimeout window between schedule and execution can outlive a session switch.
     if(!_isActiveSession()) return;
     _renderPending=true;
-    // Cap render rate to ~15fps. The browser's rAF fires at 60fps, but each DOM
-    // update takes 50-150ms on large sessions. During GC pauses, rAF callbacks
-    // accumulate and then execute all at once, blocking the main thread for
-    // multi-second stretches and crashing the renderer (Chrome error code 4/5).
-    // Throttling to 66ms intervals prevents this pileup without noticeable
-    // visual degradation — streaming text updates still feel immediate.
-    // performance.now() is monotonic so tab suspend/resume and NTP adjustments
-    // cannot produce negative or enormous deltas.
-    const sinceLastMs=performance.now()-_lastRenderMs;
     const _doRender=()=>{
+      if(_anchorPaintDisposed||renderGeneration!==_anchorPaintGeneration) return;
       _pendingRafHandle=null;
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
@@ -5654,7 +5859,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const caughtUp=_renderStreamingFadeMarkdown(displayText);
           anchorProcessText=_streamFadeDomText||'';
           if(!caughtUp&&!_streamFinalized){
-            setTimeout(()=>_scheduleRender(), 33);
+            _scheduleRender();
           }
         } else {
           assistantBody.classList.remove('stream-fade-active');
@@ -5679,16 +5884,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(typeof _syncLiveWorklogReasonsForAnchor==='function') _syncLiveWorklogReasonsForAnchor(assistantRow, displayText);
       }
-      if(anchorProcessText) _upsertAnchorProcessProse(anchorProcessText);
+      // Producer callbacks own semantic prose; fade/paint only project it.
       scrollIfPinned();
       _throttledSnapshotLiveTurn();
     };
-    const frameIntervalMs=_shouldUseLiveProseFade()?33:66;
-    if(sinceLastMs>=frameIntervalMs){
-      _pendingRafHandle=requestAnimationFrame(_doRender);
-    } else {
-      _pendingRafHandle=setTimeout(()=>requestAnimationFrame(_doRender), frameIntervalMs-sinceLastMs);
-    }
+    _pendingProsePaint=_doRender;
+    _renderAnchorLiveScene();
   }
 
   function _completeAutomaticCompressionOnLiveProgress(sessionId){
@@ -5711,9 +5912,46 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _wireSSE(source){
     const existingLive=LIVE_STREAMS[activeSid];
     if(existingLive&&existingLive.source&&existingLive.source!==source){
+      if(typeof existingLive.flushScene==='function') existingLive.flushScene();
+      if(typeof existingLive.disposeScene==='function') existingLive.disposeScene();
       try{if(existingLive.source.readyState!==2)existingLive.source.close();}catch(_){ }
     }
-    LIVE_STREAMS[activeSid]={streamId,source};
+    _anchorPaintDisposed=false;
+    if(typeof _activateAnchorRegistry==='function') _activateAnchorRegistry();
+    // Every listener belongs to this exact transport generation. Reject queued
+    // events before parsing, registry mutation, compatibility DOM or scheduling.
+    const generation=_anchorPaintGeneration;
+    const isCurrentGeneration=()=>!_anchorPaintDisposed&&
+      generation===_anchorPaintGeneration&&LIVE_STREAMS[activeSid]?.source===source;
+    const addOwnedListener=source.addEventListener;
+    source.addEventListener=(type,handler)=>addOwnedListener.call(source,type,event=>{
+      if(!isCurrentGeneration()) return;
+      // First semantic terminal event owns completion. Late producer/cursor
+      // callbacks cannot compete while its optional visual fade is pending.
+      if(_terminalStateReached){
+        if(type==='stream_end'||type==='error'||type==='apperror'||type==='cancel'){
+          _completeOwnedTerminal();
+          _closeSource(source);
+        }
+        return;
+      }
+      // Terminal handlers may dispose synchronously. Preserve their journal
+      // cursor before that disposal suppresses the separate cursor listener.
+      if(type==='done'||type==='cancel'||type==='apperror') _rememberRunJournalCursor(event);
+      return handler(event);
+    });
+    LIVE_STREAMS[activeSid]={streamId,source,
+      requestScene:()=>isCurrentGeneration()&&_renderAnchorLiveScene(),
+      deferScroll:()=>{
+        if(!isCurrentGeneration()) return true;
+        if(_terminalStateReached||_streamFinalized) return false;
+        _renderAnchorLiveScene();
+        return true;
+      },
+      finishScene:()=>{if(isCurrentGeneration()) _completeOwnedTerminal();},
+      flushScene:()=>{if(isCurrentGeneration()) _anchorPaintScheduler?.flush();},
+      disposeScene:()=>{if(isCurrentGeneration()) _disposeAnchorScenePaint();},
+    };
 
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
@@ -5752,6 +5990,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(String((parsed&&parsed.displayText)||'').trim()) ensureAssistantRow();
         _scheduleRender(parsed);
       }
+      // Semantic order is assigned on receipt, never by a later paint callback.
+      const synchronousProse=segmentStart===0
+        ? (_parseStreamState().displayText||'')
+        : _stripXmlToolCalls(assistantText.slice(segmentStart));
+      if(String(synchronousProse).trim()) _upsertAnchorProcessProse(synchronousProse);
     });
 
     source.addEventListener('interim_assistant',e=>{
@@ -5860,7 +6103,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
     });
 
-    source.addEventListener('tool',e=>{
+    source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{
       if(_terminalStateReached||_streamFinalized) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
@@ -5888,15 +6131,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         ensureAssistantRow(true);
       }
       _flushPendingSegmentRender({force:true});
-      appendLiveToolCard(tc,{sessionId:activeSid,streamId});
-      snapshotLiveTurn();
+      if(!_anchorPaintScheduler?.pending()) appendLiveToolCard(tc,{sessionId:activeSid,streamId});
+      if(!_anchorPaintScheduler?.pending()) snapshotLiveTurn();
       _freshSegment=true;
       _smdEndParser();
       _resetAssistantSegment();
-      scrollIfPinned();
-    });
+      if(!_anchorPaintScheduler?.pending()) scrollIfPinned();
+    }));
 
-    source.addEventListener('tool_complete',e=>{
+    source.addEventListener('tool_complete',_withDeferredAnchorScenePaint(e=>{
       if(_terminalStateReached||_streamFinalized) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
@@ -5923,16 +6166,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           ensureAssistantRow(true);
           _flushPendingSegmentRender({force:true});
         }
-        appendLiveToolCard(tc,{sessionId:activeSid,streamId});
+        if(!_anchorPaintScheduler?.pending()) appendLiveToolCard(tc,{sessionId:activeSid,streamId});
         _freshSegment=true;
         _smdEndParser();
         _resetAssistantSegment();
       } else {
-        appendLiveToolCard(tc,{sessionId:activeSid,streamId});
+        if(!_anchorPaintScheduler?.pending()) appendLiveToolCard(tc,{sessionId:activeSid,streamId});
       }
-      snapshotLiveTurn();
-      scrollIfPinned();
-    });
+      if(!_anchorPaintScheduler?.pending()) snapshotLiveTurn();
+      if(!_anchorPaintScheduler?.pending()) scrollIfPinned();
+    }));
 
     // Phase 2: dedicated `todo_state` event carries a full snapshot of
     // the upstream TodoStore.  We treat it as the single source of truth
@@ -6120,6 +6363,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // a stream_end event arriving during the fade window sees
       // _streamFinalized=false, calls _restoreSettledSession(), and overwrites
       // S.messages with stale server data (issue #3195).
+      _anchorPaintScheduler?.flush();
       _streamFinalized=true;
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
@@ -6127,6 +6371,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const _doneData=JSON.parse(e.data);
       const _doneEvent=e;
       const _finishDone=()=>{
+        if(!isCurrentGeneration()) return;
         // Bug A fix: cancel any pending rAF and mark stream finalized before
         // the DOM is settled by renderMessages, so no trailing token/reasoning rAF
         // can reintroduce a stale thinking card or duplicate content.
@@ -6140,6 +6385,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _finBody=assistantBody;
           _smdEndParser();
           requestAnimationFrame(()=>{
+            if(!isCurrentGeneration()) return;
             if(typeof highlightCode==='function') highlightCode(_finBody);
             if(typeof addCopyButtons==='function') addCopyButtons(_finBody);
             if(typeof renderKatexBlocks==='function') renderKatexBlocks();
@@ -6420,16 +6666,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         });
         sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid});
       };
+      _pendingTerminalFinish={generation:_anchorPaintGeneration,finish:()=>{
+        _finishDone();
+        if(isCurrentGeneration()) _closeSource(source);
+      }};
       if(_shouldUseLiveProseFade()&&assistantBody){
         _cancelAnimationFramePendingStreamRender();
-        _drainStreamFadeBeforeDone(_finishDone);
+        _drainStreamFadeBeforeDone(_completeOwnedTerminal);
         return;
       }
-      _finishDone();
+      _completeOwnedTerminal();
     });
 
     source.addEventListener('stream_end',async e=>{
       if(_streamFinalized){
+        // Transport exhaustion cannot invalidate required terminal settlement.
+        _completeOwnedTerminal();
         _closeSource(source);
         return;
       }
@@ -6449,6 +6701,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // assistant content until a later session switch. Settle from the persisted
       // session before closing so the pane converges on canonical state.
       const status=await _restoreSettledSession(source,{status:true});
+      if(!isCurrentGeneration()) return;
       if(status==='restored'){
         return;
       }
@@ -6572,6 +6825,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     source.addEventListener('apperror',e=>{
       if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
       _clearStreamEndRecovery();
+      _anchorPaintScheduler?.flush();
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
       _cancelThrottledSnapshotTimer();
@@ -6730,10 +6984,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         return;
       }
       if(typeof recordClientSSEError==='function') recordClientSSEError('chat-response',{ready_state:source?source.readyState:null,session_id:activeSid,stream_id:streamId,reason:'chat EventSource.onerror'});
-      try{if(source&&source.readyState!==2)source.close();}catch(_){ }
+      const recoveryGeneration=_retireSourceForRecovery(source);
+      const recoveryCurrent=()=>!_anchorPaintDisposed&&recoveryGeneration===_anchorPaintGeneration;
       if(_deferStreamErrorIfOffline()) return;
       if(_deferStreamErrorIfPageHidden(source)) return;
-      _closeSource(source);
       // If the user has switched to a different session, don't attempt to
       // reconnect — the old stream's EventSource was closed intentionally
       // during session switch and reconnecting would leak a background stream.
@@ -6754,10 +7008,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _retryDelays=[1500,3000,5000,8000,12000,20000];
         setComposerStatus(`Reconnecting… (1/${_retryDelays.length})`);
         const _probeReconnect=async(attempt=0)=>{
+          if(!recoveryCurrent()) return;
           if(_terminalStateReached || _streamFinalized) return;
           if(!_isSessionCurrentPane(activeSid)) return;
           try{
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+            if(!recoveryCurrent()) return;
             if(st&&st.active){
               setComposerStatus('Reconnected',1000);
               _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -6769,9 +7025,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               return;
             }
           }catch(_){
+            if(!recoveryCurrent()) return;
             if(_deferStreamErrorIfOffline()) return;
           }
           if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+          if(!recoveryCurrent()) return;
           if(_deferStreamErrorIfOffline()) return;
           if(_deferStreamErrorIfPageHidden(source)) return;
           const nextDelay=_retryDelays[attempt+1];
@@ -6788,16 +7046,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           setComposerStatus('Restoring session…');
           let _restoreTimedOut=false;
           const _restoreTimer=setTimeout(()=>{
+            if(!recoveryCurrent()) return;
             // If _restoreSettledSession hangs (flaky Tailscale), don't leave
             // the UI stuck on "Restoring session…" forever. Fall through to
             // _handleStreamError after 8s.
             _restoreTimedOut=true;
             if(!_terminalStateReached&&!_streamFinalized){
+              if(!recoveryCurrent()) return;
               if(_deferStreamErrorIfOffline()) return;
               if(_deferStreamErrorIfPageHidden(source)) return;
               _flushReasoningToAnchor();
               _scheduleAnchorRegistryCleanup(120000);
-              _handleStreamError(source);
+              if(recoveryCurrent()) _handleStreamError(source);
             }
           },8000);
           try{
@@ -6814,11 +7074,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(_restoreTimedOut) return; // timer already fired _handleStreamError
           clearTimeout(_restoreTimer);
           if(_terminalStateReached||_streamFinalized) return;
+          if(!recoveryCurrent()) return;
           if(_deferStreamErrorIfOffline()) return;
           if(_deferStreamErrorIfPageHidden(source)) return;
           _flushReasoningToAnchor();
           _scheduleAnchorRegistryCleanup(120000);
-          _handleStreamError(source);
+          if(recoveryCurrent()) _handleStreamError(source);
         };
         setTimeout(()=>{void _probeReconnect(0);},_retryDelays[0]);
         return;
@@ -6828,12 +7089,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(_deferStreamErrorIfPageHidden(source)) return;
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup(120000);
-      _handleStreamError(source);
+      if(recoveryCurrent()) _handleStreamError(source);
     });
 
     source.addEventListener('cancel',e=>{
       if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
       _clearStreamEndRecovery();
+      _anchorPaintScheduler?.flush();
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
       _cancelThrottledSnapshotTimer();
@@ -6862,6 +7124,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.activeStreamId=null;
       }
       const _applyCancelSessionPayload=(sessionPayload)=>{
+        if(!isCurrentGeneration()) return false;
         if(!sessionPayload||typeof sessionPayload!=='object'||!S.session||S.session.session_id!==activeSid) return false;
         // Belt-and-suspenders: the embedded cancel snapshot must be for THIS session.
         // The GET path guarantees it via the URL; the embedded path via the stream→session
@@ -6899,6 +7162,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _setActivePaneIdleIfOwner();
       (async()=>{
         try{
+          if(!isCurrentGeneration()) return;
           if(_applyCancelSessionPayload(_cancelSessionPayload)) return;
           // Fetch latest session from server to get accurate message list (includes cancel status)
           // This ensures messages stay in sync with server, fixing race condition where local
@@ -6906,6 +7170,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
           if(data&&data.session) _applyCancelSessionPayload(data.session);
         }catch(_){
+          if(!isCurrentGeneration()) return;
           // Fallback to local cancel message if API fails
           if(S.session&&S.session.session_id===activeSid){
             const _wasFollowingAtCancelFb=((typeof _isMessagePaneNearBottom==='function')
@@ -6923,10 +7188,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             _markSessionViewed(activeSid, S.messages.length);
           }
         }finally{
+          if(!isCurrentGeneration()) return;
           _dispatchExtensionTurnLifecycle('turn:cancel',activeSid,streamId,{
             status:_cancelData.status||_cancelData.type||'cancelled',
             endedAt:Date.now()/1000,
           });
+          _closeSource(source);
         }
       })();
     });
@@ -6934,6 +7201,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
+    source.addEventListener=addOwnedListener;
   }
 
   // #3018: per-turn ephemeral fields are computed client-side in _finishDone
@@ -6986,14 +7254,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
 
   async function _restoreSettledSession(source, options=null){
+    const restoreGeneration=_anchorPaintGeneration;
     const returnStatus=!!(options&&options.status);
     const preserveVisibleOnShorterTerminalSnapshot=!!(options&&options.preserveVisibleOnShorterTerminalSnapshot);
+    if(_anchorPaintDisposed) return returnStatus?'stale':false;
     if(_isActiveSession() && S.activeStreamId!==streamId){
       _closeSource(source);
       return returnStatus?'stale':false;
     }
     try{
       const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+      if(_anchorPaintDisposed||restoreGeneration!==_anchorPaintGeneration) return returnStatus?'stale':false;
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;
@@ -7165,6 +7436,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
   }
 
+  // Reserve lifecycle ownership before the reconnect preflight awaits. Pagehide
+  // must be able to invalidate an attachment even before its EventSource exists.
+  LIVE_STREAMS[activeSid]={streamId,source:null,disposeScene:_disposeAnchorScenePaint};
+  const attachGeneration=_anchorPaintGeneration;
   (async()=>{
     // Reattach path can carry stale stream ids after server restart; preflight
     // status avoids opening a dead SSE URL that will 404 in the console.
@@ -7172,6 +7447,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(reconnecting){
       try{
         const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+        if(_anchorPaintDisposed||attachGeneration!==_anchorPaintGeneration) return;
         if(!st.active&&st.replay_available){
           replayOnly=true;
         }else if(!st.active){
@@ -7203,6 +7479,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
       }catch(_){}
     }
+    if(_anchorPaintDisposed||attachGeneration!==_anchorPaintGeneration) return;
     const replayParams=(reconnecting||replayOnly)?_runJournalReplayParams():'';
     _dispatchExtensionTurnLifecycle('turn:start',activeSid,streamId,{
       startedAt:_extensionTurnStartedAt,

--- a/static/messages.js
+++ b/static/messages.js
@@ -2942,6 +2942,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     assistantRow.setAttribute('data-live-segment-seq',String(_assistantSegmentSeq));
     assistantBody=document.createElement('div');assistantBody.className='msg-body';
     assistantRow.appendChild(assistantBody);
+    // A reasoning-only scene may already own presentation before prose arrives.
+    // Incremental scene paints intentionally skip the full legacy-node sweep;
+    // retire this new compatibility anchor at creation, not on a later frame.
+    if(typeof chatActivityMode==='function'&&chatActivityMode()!=='hide_all_activity'&&
+       typeof isLiveAnchorActivitySceneOwner==='function'&&isLiveAnchorActivitySceneOwner(streamId)){
+      assistantRow.classList.add('assistant-segment-worklog-source');
+      assistantRow.setAttribute('aria-hidden','true');
+      assistantRow.hidden=true;
+    }
     blocks.appendChild(assistantRow);
     if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
     if(INFLIGHT[activeSid]){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7235,6 +7235,12 @@ function _settleFinalScroll(token){
 }
 function scrollIfPinned(){
   if(!window._autoScrollFollow) return;
+  // Live producers only request follow work. The owner's scene transaction
+  // captures/restores once, after all visual writes in the shared frame.
+  const liveOwner=typeof LIVE_STREAMS!=='undefined'&&typeof S!=='undefined'&&S.session
+    ? LIVE_STREAMS[S.session.session_id] : null;
+  if(liveOwner&&liveOwner.streamId===S.activeStreamId&&
+     typeof liveOwner.deferScroll==='function'&&liveOwner.deferScroll()) return;
   // A jump-to-question owner is mid-flight: it deliberately holds the reader at
   // the jump target across smooth-scroll frames, so never let a live token
   // reclaim the bottom while it is active (#6621). _finishMessageJumpScroll()
@@ -13030,8 +13036,156 @@ function _appendWorklogStep(group, anchor, cards, thinkingText, opts){
     _syncToolRowsContainer(tools, !!(opts&&opts.live));
   }
 }
+const _anchorSceneRenderProjectionCaches=new Map();
+function _anchorSceneRenderCacheKey(scene, settled){
+  const identity=scene&&scene.identity&&typeof scene.identity==='object'?scene.identity:{};
+  const values=[
+    identity.session_id,
+    identity.turn_id,
+    identity.run_id,
+    identity.stream_id,
+    identity.local_id,
+    Array.isArray(identity.source_message_refs)?identity.source_message_refs:[],
+  ];
+  if(!values.slice(0,5).some((value)=>String(value||'').trim())) return '';
+  return `${settled?'settled':'live'}:${JSON.stringify(values)}`;
+}
+function _anchorSceneRenderOutputKey(row){
+  if(!row||typeof row!=='object') return '';
+  if(row.role==='tool'){
+    const tool=row.tool&&typeof row.tool==='object'?row.tool:{};
+    const payload=row.payload&&typeof row.payload==='object'?row.payload:{};
+    const id=row.tool_call_id||tool.id||tool.tid||payload.id||payload.tid||'';
+    if(id) return `tool:call:${String(id)}`;
+  }
+  const stable=row.row_id||row.local_id||row.event_id||'';
+  return stable?`${String(row.role||'activity')}:${String(stable)}`:'';
+}
+function _anchorSceneAttachIncrementalProjection(rows, projection, state){
+  if(!Array.isArray(rows)||!projection||!state) return rows;
+  const changedKeys=Array.isArray(projection.changed_row_keys)?Array.from(new Set(projection.changed_row_keys)):[];
+  const changedOutputIndices=changedKeys.map(key=>{
+    const value=state.outputIndexByKey.get(String(key||''));
+    return value===undefined?-1:value;
+  });
+  const hasChanges=Array.isArray(projection.changed_row_keys)&&projection.changed_row_keys.length>0;
+  const renderProjection=hasChanges
+    ? {...projection,changed_row_keys:changedKeys,changed_output_indices:changedOutputIndices}
+    : {...projection,full_rebuild:false,changed_row_keys:[],changed_row_indices:[],changed_output_indices:[],fallback_reason:null};
+  try{Object.defineProperty(rows,'_anchorSceneProjection',{value:renderProjection,enumerable:false,configurable:true});}
+  catch(_){rows._anchorSceneProjection=renderProjection;}
+  return rows;
+}
+function _anchorSceneSourceRows(scene){
+  const descriptor=scene&&Object.getOwnPropertyDescriptor(scene,'_activity_rows_view');
+  const view=descriptor&&descriptor.enumerable===false?descriptor.value:null;
+  return Array.isArray(view)?view:(Array.isArray(scene&&scene.activity_rows)?scene.activity_rows:[]);
+}
+function _anchorSceneRowsIncrementalProjection(scene, opts){
+  const projection=scene&&scene.projection&&typeof scene.projection==='object'?scene.projection:null;
+  if(!projection) return null;
+  const settled=!!(opts&&opts.settled);
+  const rows=_anchorSceneSourceRows(scene);
+  const cacheKey=_anchorSceneRenderCacheKey(scene,settled);
+  if(!cacheKey) return null;
+  const state=_anchorSceneRenderProjectionCaches.get(cacheKey);
+  if(state&&state.revision===projection.revision&&state.sourceRows===rows){
+    return _anchorSceneAttachIncrementalProjection(state.outputRows,projection,state);
+  }
+  if(!state||projection.full_rebuild===true||state.mode!==String(scene.mode||'')) return null;
+  const changedIndices=Array.isArray(projection.changed_row_indices)?projection.changed_row_indices.map(Number):[];
+  if(!changedIndices.length){
+    if(rows.length!==state.sourceCount) return null;
+    state.revision=projection.revision;
+    state.sourceRows=rows;
+    return _anchorSceneAttachIncrementalProjection(state.outputRows,projection,state);
+  }
+  // Validate the complete dirty set before mutating the cached projection.
+  // Unknown identities, removals, deduplication or order changes use the full path.
+  let nextAppend=state.sourceCount;
+  const seen=new Set(),newKeys=new Set(),planned=[];
+  for(const index of changedIndices){
+    if(!Number.isInteger(index)||index<0||index>=rows.length||seen.has(index)) return null;
+    seen.add(index);
+    const row=rows[index],key=_anchorSceneRenderOutputKey(row);
+    if(!row||!key||row.role==='terminal'||_anchorSceneIsSettledSuccessfulCompression(row,settled)) return null;
+    const existing=state.outputIndexByKey.get(key);
+    const append=index>=state.sourceCount;
+    if(append){
+      if(index!==nextAppend++) return null;
+      if(row.role!=='tool'&&(existing!==undefined||newKeys.has(key))) return null;
+      newKeys.add(key);
+    }else{
+      if(!state.sourceOutputKeys||state.sourceOutputKeys[index]!==key||existing===undefined) return null;
+      if(row.role!=='prose'&&row.role!=='thinking') return null;
+      if(state.outputRows[existing].role!==row.role) return null;
+    }
+    const textKey=String(row.text||'').replace(/\s+/g,' ').trim();
+    if((row.role==='prose'||row.role==='thinking')&&!textKey) return null;
+    if(row.role==='prose'){
+      const collision=state.proseTextKeys.get(textKey);
+      if(collision!==undefined&&collision!==existing) return null;
+      if(planned.some(item=>item.row.role==='prose'&&item.textKey===textKey&&item.key!==key)) return null;
+    }
+    planned.push({row,key,index,append,textKey});
+  }
+  if(nextAppend!==rows.length) return null;
+  for(const item of planned){
+    const {row,key,index,append,textKey}=item;
+    let outputIndex=state.outputIndexByKey.get(key);
+    if(outputIndex!==undefined){
+      const previous=state.outputRows[outputIndex];
+      if(row.role==='prose'){
+        const oldText=String(previous.text||'').replace(/\s+/g,' ').trim();
+        if(state.proseTextKeys.get(oldText)===outputIndex) state.proseTextKeys.delete(oldText);
+      }
+      state.outputRows[outputIndex]=row.role==='tool'?_anchorSceneMergeToolRows(previous,row):row;
+    }else{
+      outputIndex=state.outputRows.length;
+      state.outputIndexByKey.set(key,outputIndex);
+      state.outputRows.push(row);
+    }
+    if(row.role==='prose') state.proseTextKeys.set(textKey,outputIndex);
+    state.sourceOutputKeys[index]=key;
+  }
+  state.sourceCount=rows.length;
+  state.sourceRows=rows;
+  state.revision=projection.revision;
+  return _anchorSceneAttachIncrementalProjection(state.outputRows,projection,state);
+}
+function _anchorSceneRememberFullProjection(scene, opts, rows){
+  const projection=scene&&scene.projection&&typeof scene.projection==='object'?scene.projection:null;
+  if(!projection||!Array.isArray(rows)) return;
+  const settled=!!(opts&&opts.settled);
+  const cacheKey=_anchorSceneRenderCacheKey(scene,settled);
+  if(!cacheKey) return;
+  const state={
+    mode:String(scene.mode||''),
+    settled,
+    revision:projection.revision,
+    sourceCount:_anchorSceneSourceRows(scene).length,
+    sourceRows:_anchorSceneSourceRows(scene),
+    sourceOutputKeys:_anchorSceneSourceRows(scene).map(_anchorSceneRenderOutputKey),
+    outputRows:rows,
+    outputIndexByKey:new Map(),
+    proseTextKeys:new Map(),
+  };
+  rows.forEach((row,index)=>{
+    const key=_anchorSceneRenderOutputKey(row);
+    if(key&&!state.outputIndexByKey.has(key)) state.outputIndexByKey.set(key,index);
+    if(row&&row.role==='prose'){
+      const textKey=String(row.text||'').replace(/\s+/g,' ').trim();
+      if(textKey&&!state.proseTextKeys.has(textKey)) state.proseTextKeys.set(textKey,index);
+    }
+  });
+  _anchorSceneRenderProjectionCaches.set(cacheKey,state);
+}
 function _anchorSceneRowsForRendering(scene, opts){
-  const rows=Array.isArray(scene&&scene.activity_rows)?scene.activity_rows:[];
+  const incrementalRows=typeof _anchorSceneRowsIncrementalProjection==='function'
+    ? _anchorSceneRowsIncrementalProjection(scene,opts)
+    : null;
+  if(incrementalRows) return incrementalRows;
+  const rows=_anchorSceneSourceRows(scene);
   const settled=!!(opts&&opts.settled);
   const live=!settled;
   const out=[];
@@ -13080,6 +13234,35 @@ function _anchorSceneRowsForRendering(scene, opts){
       out.push(row);
     }
   }
+  const projection=scene&&scene.projection&&typeof scene.projection==='object'?scene.projection:null;
+  if(projection&&Array.isArray(projection.changed_row_keys)){
+    const outputRowKey=(row,index)=>{
+      if(row&&row.role==='tool'){
+        const tool=row.tool&&typeof row.tool==='object'?row.tool:{};
+        const payload=row.payload&&typeof row.payload==='object'?row.payload:{};
+        const id=row.tool_call_id||tool.id||tool.tid||payload.id||payload.tid||'';
+        if(id) return `tool:call:${String(id)}`;
+      }
+      const role=String(row&&row.role||'activity');
+      const stable=String(row&& (row.row_id||row.local_id||row.event_id)||'');
+      return stable?`${role}:${stable}`:'';
+    };
+    const outputIndexByKey=new Map();
+    out.forEach((row,index)=>{
+      const key=outputRowKey(row,index);
+      if(key&&!outputIndexByKey.has(key)) outputIndexByKey.set(key,index);
+    });
+    const changedOutputIndices=projection.changed_row_keys.map((key)=>{
+      const raw=String(key||'');
+      if(outputIndexByKey.has(raw)) return outputIndexByKey.get(raw);
+      const roleKey=out.findIndex((row)=>outputRowKey(row,0)===raw);
+      return roleKey;
+    });
+    const renderProjection={...projection,changed_output_indices:changedOutputIndices};
+    try{Object.defineProperty(out,'_anchorSceneProjection',{value:renderProjection,enumerable:false,configurable:true});}
+    catch(_){out._anchorSceneProjection=renderProjection;}
+  }
+  if(typeof _anchorSceneRememberFullProjection==='function') _anchorSceneRememberFullProjection(scene,opts,out);
   return out;
 }
 function _anchorSceneIsSettledSuccessfulCompression(row, settled){
@@ -13335,6 +13518,7 @@ function _anchorSceneWorklogGroup(blocks, opts){
   const live=!!(opts&&opts.live);
   const activityKey=(opts&&opts.activityKey)||'anchor-scene';
   let group=blocks.querySelector(`.tool-worklog-group[data-anchor-scene-owner="1"][data-tool-worklog-key="${CSS.escape(activityKey)}"]`);
+  const created=!group;
   if(!group){
     group=ensureActivityGroup(blocks,{
       // Respect callers that need the settled activity group open. Round 6:
@@ -13357,35 +13541,291 @@ function _anchorSceneWorklogGroup(blocks, opts){
   if(opts&&opts.streamId) group.setAttribute('data-anchor-stream-id',String(opts.streamId));
   if(opts&&opts.turnDuration!==undefined&&opts.turnDuration!==null) group.setAttribute('data-turn-duration',String(opts.turnDuration));
   if(opts&&opts.turnStartedAt!==undefined&&opts.turnStartedAt!==null) group.setAttribute('data-turn-started-at',String(opts.turnStartedAt));
+  group._anchorSceneWorklogCreated=created;
   return group;
+}
+function _anchorSceneWorklogRowKey(row, index){
+  if(!row||typeof row!=='object') return '';
+  const stable=row.row_id||row.local_id||row.event_id||'';
+  if(row.role==='tool'){
+    const logical=_anchorSceneToolRowLogicalKey(row);
+    if(logical) return `tool:${logical}`;
+  }
+  if(stable) return `${String(row.role||'activity')}:${String(stable)}`;
+  return '';
+}
+function _anchorSceneWorklogState(group){
+  if(!group) return null;
+  if(group._anchorSceneWorklogState&&typeof group._anchorSceneWorklogState==='object') return group._anchorSceneWorklogState;
+  const state={
+    initialized:false,
+    orderKeys:[],
+    entryByKey:new Map(),
+    currentTools:null,
+    rowsLength:0,
+    projectionRevision:null,
+    stats:{rows_scanned:0,rows_rebuilt:0,groups_scanned:0,groups_rebuilt:0,groups_created:0,groups_reused:0},
+  };
+  group._anchorSceneWorklogState=state;
+  group._anchorSceneProjectionStats=state.stats;
+  return state;
+}
+function _anchorWorklogNewCounts(){return {total:0,failed:0,running:{},done:{}};}
+function _anchorWorklogAdjustCounts(counts, part, delta){
+  if(!part) return;
+  const target=part.isDone?counts.done:counts.running;
+  target[part.kind]=(target[part.kind]||0)+delta;
+  counts.total+=delta;
+  if(part.isErr) counts.failed+=delta;
+}
+function _anchorWorklogCountSummary(counts){
+  if(counts.total===1){
+    for(const status of ['running','done']){
+      for(const kind of Object.keys(counts[status])){
+        if(counts[status][kind]===1){
+          const line=_toolWorklogSummaryLine(kind,status,1);
+          return counts.failed?`${line}, 1 failed`:line;
+        }
+      }
+    }
+  }
+  const lines=[];
+  for(const status of ['running','done']){
+    for(const kind of ['shell','read','search','write','skill','memory','web','list','delegate','unknown']){
+      const n=counts[status][kind]||0;
+      if(n>0) lines.push(_toolWorklogSummaryLine(kind,status,n));
+    }
+  }
+  if(counts.failed) lines.push(`${counts.failed} failed`);
+  return lines.length?_toolWorklogJoin(lines):'Running';
+}
+function _anchorSceneWorklogAppendOwnedTool(tools,node,state){
+  if(!state.ownedSummary) state.ownedSummary=_anchorWorklogNewCounts();
+  if(!state.dirtySteps) state.dirtySteps=new Set();
+  let step=tools._anchorOwnedStep;
+  if(!step){
+    step={counts:_anchorWorklogNewCounts(),rows:[],group:null,body:null,index:state.ownedStepCount||0};
+    state.ownedStepCount=(state.ownedStepCount||0)+1;
+    tools._anchorOwnedStep=step;
+  }
+  node._anchorOwnedPart=_toolWorklogActionParts(node);
+  node._anchorOwnedStepEl=tools;
+  node._anchorOwnedStepIndex=step.rows.length;
+  step.rows.push(node);
+  _anchorWorklogAdjustCounts(step.counts,node._anchorOwnedPart,1);
+  _anchorWorklogAdjustCounts(state.ownedSummary,node._anchorOwnedPart,1);
+  (step.body||tools).appendChild(node);
+  state.dirtySteps.add(tools);
+}
+function _anchorSceneWorklogReplaceOwnedTool(state,oldNode,node){
+  const tools=oldNode&&oldNode._anchorOwnedStepEl;
+  const step=tools&&tools._anchorOwnedStep;
+  if(!step||!state.ownedSummary) return;
+  _anchorWorklogAdjustCounts(step.counts,oldNode._anchorOwnedPart,-1);
+  _anchorWorklogAdjustCounts(state.ownedSummary,oldNode._anchorOwnedPart,-1);
+  node._anchorOwnedPart=_toolWorklogActionParts(node);
+  node._anchorOwnedStepEl=tools;
+  node._anchorOwnedStepIndex=oldNode._anchorOwnedStepIndex;
+  step.rows[node._anchorOwnedStepIndex]=node;
+  _anchorWorklogAdjustCounts(step.counts,node._anchorOwnedPart,1);
+  _anchorWorklogAdjustCounts(state.ownedSummary,node._anchorOwnedPart,1);
+  state.dirtySteps.add(tools);
+}
+function _syncAnchorSceneOwnedWorklogSummary(group){
+  const state=group&&group._anchorSceneWorklogState;
+  if(!state||!state.initialized||!state.ownedSummary||group.getAttribute('data-tool-worklog-group')!=='1') return false;
+  for(const tools of state.dirtySteps){
+    const step=tools._anchorOwnedStep;
+    if(step.counts.total<2) continue;
+    if(!step.group){
+      const open=_worklogDetailsExpandedDefault();
+      const nested=document.createElement('div');
+      nested.className='tool-group'+(open?' open':' tool-worklog-tool-group-collapsed');
+      nested.setAttribute('data-tool-worklog-tool-group','1');
+      nested.setAttribute('data-tool-group-disclosure-key',`step:${step.index}`);
+      nested.innerHTML=`<button type="button" class="tool-group-head tool-worklog-tool-group-head" aria-expanded="${open?'true':'false'}" onclick="_toggleToolWorklogGroup(this)"><span class="tool-worklog-tool-group-icon tg-icon"></span><span class="tg-sum tool-worklog-tool-group-label"></span><span class="tool-call-group-chevron tg-caret">${li('chevron-right',12)}</span></button><div class="tool-group-body tool-worklog-tool-group-body"><div class="tg-rows tool-worklog-tool-group-rows"></div></div>`;
+      step.group=nested;step.body=nested.querySelector('.tg-rows');
+      for(const row of step.rows) step.body.appendChild(row);
+      tools.appendChild(nested);
+    }
+    const label=step.group.querySelector('.tool-worklog-tool-group-label');
+    if(label) label.textContent=_anchorWorklogCountSummary(step.counts);
+    const kind=['search','shell','read','write','skill','memory','web','list','delegate','unknown'].find(k=>(step.counts.running[k]||0)+(step.counts.done[k]||0)>0)||'unknown';
+    const icon=step.group.querySelector('.tool-worklog-tool-group-icon');
+    if(icon&&step.iconKind!==kind){icon.innerHTML=_toolKindIcon(kind);step.iconKind=kind;}
+  }
+  state.dirtySteps.clear();
+  const counts=state.ownedSummary;
+  const running=Object.values(counts.running).some(n=>n>0);
+  if(running) group.setAttribute('data-tool-worklog-running','1');else group.removeAttribute('data-tool-worklog-running');
+  const live=group.getAttribute('data-live-tool-worklog-group')==='1'||group.getAttribute('data-live-tool-call-group')==='1';
+  const runGroup=group.getAttribute('data-run-activity-group')==='1';
+  const label=group.querySelector('.tool-worklog-label')||group.querySelector('.tool-call-group-label');
+  if(label){
+    label.textContent=runGroup?_anchorWorklogCountSummary(counts):((live?_activityProcessedElapsedLabel(group):_activitySettledProcessedLabel(group))||t('processed_elapsed',''));
+    label.setAttribute('data-sweep-label',label.textContent);
+  }
+  const duration=group.querySelector('.tool-call-group-duration');
+  if(duration){
+    if(runGroup){
+      const formatted=_formatTurnDuration(group.dataset.turnDuration),elapsed=formatted?'':_activityElapsedLabel(group);
+      duration.textContent=formatted?` Done in ${formatted}`:(elapsed?` Working for ${elapsed}`:'');
+      duration.style.display=duration.textContent?'':'none';
+    }else{
+      if(live){const elapsed=_activityElapsedLabel(group);if(elapsed) group.setAttribute('data-active-turn-elapsed',elapsed);else group.removeAttribute('data-active-turn-elapsed');}
+      duration.textContent='';duration.style.display='none';
+    }
+  }
+  return true;
+}
+function _anchorSceneWorklogAppendRow(list, row, node, state){
+  if(row.role==='tool'){
+    let tools=state.currentTools;
+    if(!tools){
+      tools=document.createElement('div');
+      tools.className='wl-step-tools tool-worklog-tools';
+      tools.setAttribute('data-worklog-tools','1');
+      list.appendChild(tools);
+    }
+    if(typeof _anchorSceneWorklogAppendOwnedTool==='function'&&typeof _toolWorklogActionParts==='function') _anchorSceneWorklogAppendOwnedTool(tools,node,state);
+    else tools.appendChild(node);
+    state.currentTools=tools;
+  }else{
+    state.currentTools=null;
+    list.appendChild(node);
+  }
 }
 function _renderAnchorSceneRowsIntoWorklog(group, rows, opts){
   const list=_toolWorklogListEl(group);
   if(!group||!list) return false;
+  opts=opts||{};
+  const state=_anchorSceneWorklogState(group);
+  const projection=opts.projection&&typeof opts.projection==='object'?opts.projection:null;
+  const sourceRows=Array.isArray(rows)?rows:[];
+  if(state.initialized&&projection&&projection.full_rebuild===false&&projection.revision!==undefined&&
+      projection.revision===state.projectionRevision&&sourceRows.length===state.rowsLength){
+    state.stats.groups_scanned+=1;
+    state.stats.groups_reused+=1;
+    return state.rowsLength>0;
+  }
+  const changedKeys=Array.isArray(projection&&projection.changed_row_keys)?projection.changed_row_keys:[];
+  const changedIndices=Array.isArray(projection&&projection.changed_row_indices)?projection.changed_row_indices:[];
+  const changedOutputIndices=Array.isArray(projection&&projection.changed_output_indices)
+    ? projection.changed_output_indices.map((value)=>Number(value)) : [];
+  const dirtyIndices=changedOutputIndices.length?changedOutputIndices:
+    (changedIndices.length?changedIndices:changedKeys.map((_,offset)=>state.rowsLength+offset));
+  const canPatch=state.initialized&&projection&&projection.full_rebuild===false&&
+    changedKeys.length>0&&dirtyIndices.length===changedKeys.length&&sourceRows.length>=state.rowsLength;
+  if(canPatch){
+    const pairs=dirtyIndices.map((index,offset)=>({index,key:String(changedKeys[offset])})).sort((a,b)=>a.index-b.index);
+    let nextAppend=state.rowsLength;
+    const plans=[];
+    for(const pair of pairs){
+      const index=pair.index;
+      if(!Number.isInteger(index)||index<0||index>=sourceRows.length) break;
+      const row=sourceRows[index],key=_anchorSceneWorklogRowKey(row,index);
+      if(!row||!key||!(key===pair.key||key===`${String(row.role||'activity')}:${pair.key}`)) break;
+      const entry=state.entryByKey.get(key);
+      if(index<state.rowsLength){
+        if(!entry||entry.row.role!==row.role||!entry.node.parentElement||state.orderKeys[index]!==key) break;
+      }else if(index!==nextAppend++||entry) break;
+      plans.push({index,row,key,entry});
+    }
+    if(plans.length!==pairs.length||nextAppend!==sourceRows.length){
+      return _renderAnchorSceneRowsIntoWorklog(group,sourceRows,{...opts,projection:{...projection,full_rebuild:true}});
+    }
+    for(const plan of plans){
+      plan.node=_anchorSceneNodeForRow(plan.row,opts);
+      if(!plan.node) return _renderAnchorSceneRowsIntoWorklog(group,sourceRows,{...opts,projection:{...projection,full_rebuild:true}});
+    }
+    for(const {row,key,entry,node} of plans){
+      if(entry){
+        if(typeof _anchorSceneWorklogReplaceOwnedTool==='function') _anchorSceneWorklogReplaceOwnedTool(state,entry.node,node);
+        const parent=entry.node.parentElement;
+        if(typeof parent.replaceChild==='function') parent.replaceChild(node,entry.node);
+        else if(Array.isArray(parent.children)){
+          const childIndex=parent.children.indexOf(entry.node);
+          if(childIndex>=0){parent.children[childIndex]=node;node.parentElement=parent;entry.node.parentElement=null;}
+        }
+        entry.row=row;entry.node=node;
+      }else{
+        _anchorSceneWorklogAppendRow(list,row,node,state);
+        state.orderKeys.push(key);state.entryByKey.set(key,{row,node});state.rowsLength+=1;
+      }
+    }
+    state.projectionRevision=projection.revision;
+    state.stats.rows_scanned+=plans.length;
+    state.stats.rows_rebuilt+=plans.length;
+    state.stats.groups_reused+=1;state.stats.groups_scanned+=1;
+    if(typeof _syncToolCallGroupSummary==='function') _syncToolCallGroupSummary(group);
+    return state.rowsLength>0;
+  }
+  const canReuseClean=!!(
+    state.initialized&&projection&&projection.full_rebuild===false&&changedKeys.length===0&&
+    projection.revision!==undefined&&projection.revision===state.projectionRevision&&
+    sourceRows.length===state.rowsLength
+  );
+  if(canReuseClean){
+    state.stats.groups_scanned+=1;
+    state.stats.groups_reused+=1;
+    return state.rowsLength>0;
+  }
+  // Full fallback retains the historical for(const row of rows) ordering.
+  // The incremental tail keeps the same currentTools=null; reset boundary as
+  // the full path when prose interrupts a tool run.
   list.innerHTML='';
-  let wrote=false;
-  let currentTools=null;
-  for(const row of rows){
+  if(typeof _anchorWorklogNewCounts==='function'){state.ownedSummary=_anchorWorklogNewCounts();state.dirtySteps=new Set();state.ownedStepCount=0;}
+  state.initialized=true;
+  state.orderKeys=[];
+  state.entryByKey=new Map();
+  state.currentTools=null;
+  state.rowsLength=0;
+  state.projectionRevision=projection&&projection.revision!==undefined?projection.revision:null;
+  state.stats.rows_scanned+=sourceRows.length;
+  state.stats.rows_rebuilt+=sourceRows.length;
+  state.stats.groups_scanned+=1;
+  state.stats.groups_rebuilt+=1;
+  if(group._anchorSceneWorklogCreated) state.stats.groups_created+=1;
+  else state.stats.groups_reused+=1;
+  for(let index=0;index<sourceRows.length;index+=1){
+    const row=sourceRows[index];
     const node=_anchorSceneNodeForRow(row,opts);
     if(!node) continue;
-    if(row.role==='tool'){
-      if(!currentTools){
-        currentTools=document.createElement('div');
-        currentTools.className='wl-step-tools tool-worklog-tools';
-        currentTools.setAttribute('data-worklog-tools','1');
-        list.appendChild(currentTools);
+    const key=_anchorSceneWorklogRowKey(row,index);
+    const storedKey=opts._identityFallback?`fallback:${index}`:key;
+    if(!storedKey||state.entryByKey.has(storedKey)){
+      // Ambiguous identity is a full-path condition. Keep the source order and
+      // visible semantics rather than attempting a keyed partial mutation.
+      state.orderKeys=[];
+      state.entryByKey=new Map();
+      state.currentTools=null;
+      state.rowsLength=0;
+      list.innerHTML='';
+      if(typeof _anchorWorklogNewCounts==='function'){state.ownedSummary=_anchorWorklogNewCounts();state.dirtySteps=new Set();state.ownedStepCount=0;}
+      return _renderAnchorSceneRowsIntoWorklog(group,sourceRows,{...opts,projection:{...(projection||{}),full_rebuild:true},_identityFallback:true});
+    }
+    if(typeof _anchorSceneWorklogAppendRow==='function'){
+      _anchorSceneWorklogAppendRow(list,row,node,state);
+    }else if(row.role==='tool'){
+      let tools=state.currentTools;
+      if(!tools){
+        tools=document.createElement('div');
+        tools.className='wl-step-tools tool-worklog-tools';
+        tools.setAttribute('data-worklog-tools','1');
+        list.appendChild(tools);
       }
-      currentTools.appendChild(node);
+      tools.appendChild(node);
+      state.currentTools=tools;
     }else{
-      currentTools=null;
+      state.currentTools=null;
       list.appendChild(node);
     }
-    wrote=true;
+    state.orderKeys.push(storedKey);
+    state.entryByKey.set(storedKey,{row,node});
+    state.rowsLength+=1;
   }
-  if(wrote){
-    _syncToolCallGroupSummary(group);
-  }
-  return wrote;
+  if(state.rowsLength&&typeof _syncToolCallGroupSummary==='function') _syncToolCallGroupSummary(group);
+  return state.rowsLength>0;
 }
 function _liveProcessedWorklogAnchorScore(group, index){
   if(!group) return -1;
@@ -13620,18 +14060,33 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(S.session) turn.dataset.sessionId=S.session.session_id;
   const blocks=_assistantTurnBlocks(turn);
   if(!blocks) return false;
-  const liveDisclosureState=typeof _captureWorklogDetailDisclosureState==='function'
+  const existingWorklogGroup=blocks.querySelector('.tool-worklog-group[data-anchor-scene-owner="1"]');
+  const incrementalOwned=!!(existingWorklogGroup&&existingWorklogGroup._anchorSceneWorklogState?.initialized&&rows._anchorSceneProjection&&!rows._anchorSceneProjection.full_rebuild);
+  const liveDisclosureState=!incrementalOwned&&typeof _captureWorklogDetailDisclosureState==='function'
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
-  const scrollSnapshot=_captureMessageScrollSnapshot();
+  const scrollSnapshot=opts.scrollOwned?null:_captureMessageScrollSnapshot();
   const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
-  blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
-  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
+  const ownedByExistingGroup=(el)=>!!(
+    existingWorklogGroup&&
+    (el===existingWorklogGroup||
+      (typeof existingWorklogGroup.contains==='function'&&existingWorklogGroup.contains(el)))
+  );
+  // Retire legacy surfaces before resolving the owner. Existing owner
+  // descendants are protected so the Compact Worklog group can be reused.
+  if(!incrementalOwned){
+  blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>{
+    if(!ownedByExistingGroup(el)) el.remove();
+  });
+  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>{
+    if(!ownedByExistingGroup(el)) el.remove();
+  });
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
     el.classList.add('assistant-segment-worklog-source');
     el.setAttribute('aria-hidden','true');
     el.hidden=true;
   });
+  }
   const group=_anchorSceneWorklogGroup(blocks,{
     live:true,
     collapsed:false,
@@ -13639,7 +14094,12 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     streamId:streamId||S.activeStreamId||'',
     turnStartedAt:S.session&&S.session.pending_started_at,
   });
-  const ok=_renderAnchorSceneRowsIntoWorklog(group,rows,{live:true,settled:false});
+  if(!group) return false;
+  const ok=_renderAnchorSceneRowsIntoWorklog(group,rows,{
+    live:true,
+    settled:false,
+    projection:rows&&rows._anchorSceneProjection||scene&&scene.projection,
+  });
   if(!ok){
     const list=_toolWorklogListEl(group);
     if(list) list.innerHTML='';
@@ -13654,6 +14114,73 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }
+function _tryIncrementalTransparentAnchorPaint(turn, blocks, rows, opts){
+  const state=blocks._anchorTransparentProjectionState;
+  const projection=rows&&rows._anchorSceneProjection;
+  const flags=JSON.stringify([window._showThinking,window._fadeTextEffect]);
+  if(!state||!projection||projection.full_rebuild||state.flags!==flags||
+      state.streamId!==String(opts.streamId||'')||state.sessionId!==String(opts.sessionId||'')) return null;
+  if(state.revision===projection.revision&&state.nodes.length===rows.length) return true;
+  const indices=Array.from(new Set(projection.changed_output_indices||[])).sort((a,b)=>a-b);
+  if(!indices.length||rows.length<state.nodes.length) return null;
+  const bar=blocks.querySelector(':scope > .transparent-event-controls');
+  if(!bar) return null;
+  let appendIndex=state.nodes.length;
+  const plans=[];
+  for(const index of indices){
+    if(!Number.isInteger(index)||index<0||index>=rows.length) return null;
+    const row=rows[index],key=_anchorSceneRenderOutputKey(row);
+    if(!row||!key) return null;
+    const existing=state.nodes[index];
+    if(existing){
+      if(state.keys[index]!==key||existing.parentElement!==blocks) return null;
+    }else if(index!==appendIndex++) return null;
+    plans.push({index,row,key,existing});
+  }
+  if(appendIndex!==rows.length) return null;
+  for(const plan of plans){
+    plan.node=_anchorSceneTransparentNodeForRow(plan.row,{live:true,settled:false,...opts});
+    if(!plan.node) return null;
+  }
+  const scroll=opts.scrollOwned?null:_captureMessageScrollSnapshot();
+  const oldCount=state.nodes.length;
+  const footer=blocks.querySelector('#liveRunStatus');
+  let reused=0;
+  for(const plan of plans){
+    const {index,row,key,existing,node}=plan;
+    let mounted=node;
+    if(existing&&_transparentLiveRowsCompatible(existing,node)){
+      mounted=_refreshTransparentLiveRow(existing,node,{});
+      reused+=1;
+    }else if(existing){
+      blocks.replaceChild(node,existing);
+    }else{
+      if(footer&&footer.parentElement===blocks) blocks.insertBefore(node,footer);
+      else blocks.appendChild(node);
+      if(row.role==='tool') state.toolCount+=1;
+    }
+    state.nodes[index]=mounted;
+    state.keys[index]=key;
+  }
+  const label=bar.querySelector('.transparent-event-controls-label');
+  const stashed=Number(turn.getAttribute&&turn.getAttribute('data-transparent-total-tool-count'))||0;
+  const tools=Math.max(stashed,state.toolCount);
+  if(label){label.textContent=_transparentEventCountLabel(tools);label.setAttribute('data-transparent-tool-count',String(tools));}
+  bar.setAttribute('data-tool-count',String(tools));
+  // Only the previous recency tail and dirty/new nodes can change fade level.
+  const fadeIndices=new Set(indices);
+  for(let i=Math.max(0,oldCount-6);i<state.nodes.length;i++) fadeIndices.add(i);
+  for(const index of fadeIndices){
+    const node=state.nodes[index],step=Math.min(5,state.nodes.length-1-index);
+    if(step>0) node.setAttribute('data-transparent-fade',String(step));
+    else node.removeAttribute('data-transparent-fade');
+  }
+  state.revision=projection.revision;
+  state.stats={rows_scanned:indices.length,dirty_rows:indices.length,nodes_created:plans.length,nodes_reused:reused,full_rebuild:false};
+  if(scroll) _restoreMessageScrollSnapshotSameFrame(scroll);
+  return true;
+}
+
 function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   opts=opts||{};
   if(!S.session||!S.activeStreamId) return false;
@@ -13674,7 +14201,14 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   if(S.session) turn.dataset.sessionId=S.session.session_id;
   const blocks=_assistantTurnBlocks(turn);
   if(!blocks) return false;
-  const scrollSnapshot=_captureMessageScrollSnapshot();
+  if(typeof _tryIncrementalTransparentAnchorPaint==='function'){
+    const incremental=_tryIncrementalTransparentAnchorPaint(turn,blocks,rows,{...opts,
+      streamId:String(streamId||S.activeStreamId||''),sessionId:String(S.session.session_id||''),
+    });
+    if(incremental!==null) return incremental;
+  }
+  blocks._anchorTransparentProjectionState=null;
+  const scrollSnapshot=opts.scrollOwned?null:_captureMessageScrollSnapshot();
   const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
   const activeStreamId = String(streamId || S.activeStreamId || '');
   const activeSessionId = String(S.session && S.session.session_id || '');
@@ -13717,6 +14251,18 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   const liveFooter=blocks.querySelector('#liveRunStatus');
   const renderedRows=[];
   for(const row of rows){
+    // Reuse unchanged mounted rows of every role. This avoids historical DOM
+    // rebuilding; event/row projection still needs its separate dirty boundary.
+    const toolKey=(row.row_id||row.local_id)
+      ? `${activeStreamId}\u0000${String(row.row_id||row.local_id).trim()}\u0000${row.role}\u0000${String(row.source_event_type||'').trim()}`
+      : '';
+    const preservedTool=toolKey?preserveByKey.get(toolKey):null;
+    const toolSignature=toolKey?JSON.stringify(row)+(row.role==='tool'?'':JSON.stringify([window._showThinking,window._fadeTextEffect])):null;
+    if(preservedTool&&preservedTool._anchorToolPaintSignature===toolSignature){
+      preserveByKey.delete(toolKey);
+      renderedRows.push(preservedTool);
+      continue;
+    }
     const rowEventTs=typeof _anchorSceneRowTimestampSeconds==='function'?_anchorSceneRowTimestampSeconds(row):null;
     const node=_anchorSceneTransparentNodeForRow(row,{
       live:true,
@@ -13734,6 +14280,7 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
       : node;
     if(existing) preserveByKey.delete(key);
     if(!renderedNode) continue;
+    if(toolKey) renderedNode._anchorToolPaintSignature=toolSignature;
     renderedRows.push(renderedNode);
   }
   const transparentLiveRowAlreadyPositioned=(node, expectedNextSibling)=>!!(
@@ -13755,9 +14302,23 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   preserveByKey.forEach(stale=>stale.remove());
   if(renderedRows.length) _syncTransparentEventControls(turn);
   if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
+  // Keyed reconciliation does not tear down the live container. Release its
+  // temporary height guard and restore once, in this same committed paint;
+  // a second rAF restore both duplicated layout and outlived scene ownership.
+  if(scrollRebuildGuard.release) scrollRebuildGuard.release();
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
-  _restoreLiveAnchorScrollSnapshotAfterRebuild(scrollSnapshot,scrollRebuildGuard);
-  if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();
+  if(rows._anchorSceneProjection&&rows.length===renderedRows.length&&typeof _anchorSceneRenderOutputKey==='function'){
+    const keys=rows.map(_anchorSceneRenderOutputKey);
+    if(keys.every(Boolean)&&new Set(keys).size===keys.length){
+      blocks._anchorTransparentProjectionState={
+        streamId:activeStreamId,sessionId:activeSessionId,
+        flags:JSON.stringify([window._showThinking,window._fadeTextEffect]),
+        revision:rows._anchorSceneProjection.revision,keys,nodes:renderedRows,
+        toolCount:rows.filter(row=>row.role==='tool').length,
+        stats:{rows_scanned:rows.length,dirty_rows:rows.length,full_rebuild:true},
+      };
+    }
+  }
   return !!renderedRows.length;
 }
 
@@ -14075,7 +14636,45 @@ function _refreshTransparentLiveRow(existing, node, opts){
   }
   return existing;
 }
+// One visual projection per frame. Semantic events are applied by the caller
+// before request(); the paint always reads the latest authoritative registry.
+function _createLiveScenePaintScheduler(options){
+  let frame=null;
+  let generation=0;
+  let disposed=false;
+  function cancel(){
+    generation++;
+    if(frame!==null) options.cancelFrame(frame);
+    frame=null;
+  }
+  function flush(){
+    const pending=frame!==null;
+    cancel();
+    if(pending&&!disposed&&options.isCurrent()) options.paint();
+  }
+  function request(){
+    if(disposed||frame!==null||!options.isCurrent()) return;
+    const expected=++generation;
+    frame=options.requestFrame(()=>{
+      if(disposed||generation!==expected) return;
+      frame=null;
+      if(options.isCurrent()) options.paint();
+    });
+  }
+  function dispose(){
+    cancel();
+    disposed=true;
+  }
+  return {request,flush,cancel,dispose,pending:()=>frame!==null};
+}
 function _renderLiveAnchorActivitySceneForStream(streamId, sessionId, opts){
+  // Compatibility producers share the active stream's visual owner. Only that
+  // owner's commit may project; a disposed owner returns false without revival.
+  const sid=String(sessionId||(S.session&&S.session.session_id)||'');
+  const owner=typeof LIVE_STREAMS!=='undefined'?LIVE_STREAMS[sid]:null;
+  if(!(opts&&opts.committed)&&owner&&owner.streamId===streamId&&typeof owner.requestScene==='function'){
+    return owner.requestScene();
+  }
   const requestedMode=opts&&opts.mode;
   const activeMode=chatActivityMode();
   const mode=activeMode==='hide_all_activity'
@@ -19003,6 +19602,7 @@ function _toggleToolDiff(btn){
 
 function _syncToolCallGroupSummary(group){
   if(!group) return;
+  if(typeof _syncAnchorSceneOwnedWorklogSummary==='function'&&_syncAnchorSceneOwnedWorklogSummary(group)) return;
   if(group.getAttribute('data-tool-worklog-group')==='1') _syncToolWorklogToolGroup(group);
   const cards=Array.from((_toolWorklogListEl(group)||group).querySelectorAll('.tool-card-row .tool-card,.tool-card-row.tl'));
   const toolCount=cards.length;

--- a/static/ui.js
+++ b/static/ui.js
@@ -13037,6 +13037,16 @@ function _appendWorklogStep(group, anchor, cards, thinkingText, opts){
   }
 }
 const _anchorSceneRenderProjectionCaches=new Map();
+function _releaseAnchorSceneRenderProjections(sessionId,streamId){
+  let released=0;
+  for(const [key,state] of _anchorSceneRenderProjectionCaches){
+    if(state.sessionId===String(sessionId||'')&&state.streamId===String(streamId||'')){
+      _anchorSceneRenderProjectionCaches.delete(key);
+      released++;
+    }
+  }
+  return released;
+}
 function _anchorSceneRenderCacheKey(scene, settled){
   const identity=scene&&scene.identity&&typeof scene.identity==='object'?scene.identity:{};
   const values=[
@@ -13047,8 +13057,14 @@ function _anchorSceneRenderCacheKey(scene, settled){
     identity.local_id,
     Array.isArray(identity.source_message_refs)?identity.source_message_refs:[],
   ];
-  if(!values.slice(0,5).some((value)=>String(value||'').trim())) return '';
-  return `${settled?'settled':'live'}:${JSON.stringify(values)}`;
+  if(settled){
+    _anchorSceneRenderProjectionCaches.delete(_anchorSceneRenderCacheKey(scene,false));
+    return '';
+  }
+  // Without a stream/session owner there is no lifecycle that can release it.
+  if(!String(identity.session_id||'').trim()||!String(identity.stream_id||'').trim()||
+      !String(identity.turn_id||identity.local_id||'').trim()) return '';
+  return `live:${JSON.stringify(values)}`;
 }
 function _anchorSceneRenderOutputKey(row){
   if(!row||typeof row!=='object') return '';
@@ -13160,6 +13176,9 @@ function _anchorSceneRememberFullProjection(scene, opts, rows){
   const cacheKey=_anchorSceneRenderCacheKey(scene,settled);
   if(!cacheKey) return;
   const state={
+    sessionId:String(scene.identity?.session_id||''),
+    streamId:String(scene.identity?.stream_id||''),
+    turnId:String(scene.identity?.turn_id||scene.identity?.local_id||''),
     mode:String(scene.mode||''),
     settled,
     revision:projection.revision,

--- a/tests/browser_conversation_lifecycle.py
+++ b/tests/browser_conversation_lifecycle.py
@@ -291,6 +291,8 @@ class DeterministicGateway:
 
     def __init__(self, scenario: str) -> None:
         self.scenario = scenario
+        self.reasoning_ready = threading.Event()
+        self.release_reasoning = threading.Event()
         self.activity_ready = threading.Event()
         self.release_settle = threading.Event()
         self.final_prefix_ready = threading.Event()
@@ -354,6 +356,10 @@ class DeterministicGateway:
                         "event": "reasoning.available",
                         "text": REASONING_TEXT,
                     })
+                    if os.environ.get("LIFECYCLE_REASONING_FIRST") == "1":
+                        owner.reasoning_ready.set()
+                        if not owner.release_reasoning.wait(timeout=30):
+                            return
                     if owner.scenario == "terminal-error":
                         self._event("message.delta", {
                             "event": "message.delta",
@@ -419,6 +425,7 @@ class DeterministicGateway:
         self._thread.start()
 
     def close(self) -> None:
+        self.release_reasoning.set()
         self.release_settle.set()
         self.release_terminal.set()
         self._server.shutdown()
@@ -843,6 +850,18 @@ def main() -> int:
         page.wait_for_selector("#msg", state="visible", timeout=15000)
         page.locator("#msg").fill(PROMPT)
         page.locator("#btnSend").click()
+
+        if os.environ.get("LIFECYCLE_REASONING_FIRST") == "1":
+            assert gateway.reasoning_ready.wait(timeout=30), "reasoning fixture checkpoint missing"
+            # Deterministically exercise a scene painted before its first prose
+            # segment exists. No sleep/retry can hide a duplicate final surface.
+            page.wait_for_function(
+                """() => Boolean(document.querySelector(
+                  '#liveAssistantTurn [data-anchor-row-role="thinking"]'
+                ))""",
+                timeout=10000,
+            )
+            gateway.release_reasoning.set()
 
         if not gateway.activity_ready.wait(timeout=GATEWAY_ACTIVITY_TIMEOUT):
             raise AssertionError(

--- a/tests/browser_conversation_lifecycle.py
+++ b/tests/browser_conversation_lifecycle.py
@@ -848,6 +848,9 @@ def main() -> int:
         errors = _capture_page_errors(page)
         page.goto("/", wait_until="domcontentloaded")
         page.wait_for_selector("#msg", state="visible", timeout=15000)
+        # Isolate the lifecycle under test from concurrent first-session boot.
+        # Await real session creation before the real composer starts its run.
+        page.evaluate("async () => { await newSession(); }")
         page.locator("#msg").fill(PROMPT)
         page.locator("#btnSend").click()
 

--- a/tests/browser_issue7478_cancel.py
+++ b/tests/browser_issue7478_cancel.py
@@ -1,0 +1,132 @@
+"""Real isolated Gateway lifecycle: cancel immediately after hidden post-tool prose."""
+import json
+import os
+import tempfile
+import threading
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+import browser_conversation_lifecycle as gate
+
+POST_TOOL = 'Post-tool process checkpoint'
+
+
+class CancelGateway(gate.DeterministicGateway):
+    def __init__(self):
+        super().__init__('terminal-error')
+        self.post_tool = threading.Event()
+
+    def _handler(self):
+        parent = super()._handler()
+        owner = self
+
+        class Handler(parent):
+            def _event(self, name, payload):
+                super()._event(name, payload)
+                if name == 'tool.completed':
+                    if not owner.post_tool.wait(30):
+                        return
+                    super()._event('message.delta', {'event': 'message.delta', 'delta': POST_TOOL})
+
+            def do_POST(self):
+                if self.path.endswith('/stop'):
+                    length = int(self.headers.get('Content-Length', '0'))
+                    self.rfile.read(length)
+                    self._json({'ok': True})
+                    return
+                super().do_POST()
+
+        return Handler
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    out = Path(os.environ['LIFECYCLE_ARTIFACT_DIR'])
+    out.mkdir(parents=True, exist_ok=True)
+    mode = os.environ.get('LIFECYCLE_ACTIVITY_MODE', 'compact_worklog')
+    os.environ['LIFECYCLE_REASONING_FIRST'] = '1'
+    gateway = CancelGateway()
+    gateway.start()
+    proc = log = None
+    try:
+        with tempfile.TemporaryDirectory(prefix='ownership-cancel-') as tmp:
+            state = Path(tmp)
+            agent = state / 'no-agent'
+            agent.mkdir()
+            (agent / 'run_agent.py').write_text('')
+            workspace = state / 'workspace'
+            workspace.mkdir()
+            env = {k: v for k, v in os.environ.items() if not k.endswith('_API_KEY')}
+            env.update(HERMES_WEBUI_HOST='127.0.0.1', HERMES_WEBUI_STATE_DIR=str(state/'state'), HERMES_HOME=str(state/'home'), HERMES_BASE_HOME=str(state/'home'), HERMES_CONFIG_PATH=str(state/'home/config.yaml'), HERMES_WEBUI_SKIP_ONBOARDING='1', HERMES_WEBUI_AGENT_DIR=str(agent), HERMES_WEBUI_DEFAULT_WORKSPACE=str(workspace), HERMES_WEBUI_CHAT_BACKEND='gateway', HERMES_WEBUI_GATEWAY_BASE_URL=gateway.base_url, HERMES_WEBUI_GATEWAY_USE_RUNS_API='1', NO_PROXY='127.0.0.1,localhost', no_proxy='127.0.0.1,localhost')
+            for key in ('API_SERVER_KEY', 'HERMES_WEBUI_PASSWORD', 'HERMES_WEBUI_EXTENSION_DIR', 'HERMES_WEBUI_EXTENSION_MANIFEST'):
+                env.pop(key, None)
+            proc, log, _, base = gate._start_webui_server(root, env, out)
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(headless=True, args=['--no-sandbox', '--disable-dev-shm-usage'])
+                page = browser.new_page(base_url=base)
+                errors = gate._capture_page_errors(page)
+                requests = gate._capture_anchor_scene_requests(page)
+                page.goto('/', wait_until='domcontentloaded')
+                page.wait_for_selector('#msg')
+                # Complete session creation before driving the composer; otherwise
+                # boot/session initialization can supersede the first send.
+                page.evaluate('async () => { await newSession(); }')
+                page.evaluate("""mode => {
+                    window._chatActivityDisplayMode=mode;
+                    window.__cancelEvents=[];
+                    const original=_dispatchExtensionTurnLifecycle;
+                    window._dispatchExtensionTurnLifecycle=function(...args){window.__cancelEvents.push(args[0]);return original(...args);};
+                    window.__insertions=[];
+                    const append=Element.prototype.appendChild;
+                    Element.prototype.appendChild=function(node){
+                        const result=append.call(this,node);
+                        if(node instanceof Element && node.matches('.assistant-segment')){
+                            const record={hidden:node.hidden,classes:node.className};
+                            window.__insertions.push(record);
+                            if(window.__armCancel){window.__armCancel=false;record.cancel=true;queueMicrotask(()=>cancelStream('explicit-cancel'));}
+                        }
+                        return result;
+                    };
+                }""", mode)
+                page.locator('#msg').fill(gate.PROMPT)
+                page.locator('#btnSend').click()
+                page.wait_for_selector('[data-anchor-row-role="thinking"]', timeout=30000)
+                assert gateway.reasoning_ready.is_set()
+                gateway.release_reasoning.set()
+                page.wait_for_selector('[data-anchor-row-role="tool"]')
+                page.evaluate('window.__armCancel=true')
+                gateway.post_tool.set()
+                try:
+                    page.wait_for_function("() => window.__cancelEvents.includes('turn:cancel')", timeout=20000)
+                except Exception:
+                    (out/'failure-state.json').write_text(json.dumps(page.evaluate("() => ({events:window.__cancelEvents,insertions:window.__insertions,armed:window.__armCancel,stream:S.activeStreamId,busy:S.busy,text:document.body.innerText})"), indent=2))
+                    (out/'fixture-events.json').write_text(json.dumps(gateway.emitted_events, indent=2))
+                    (out/'errors.json').write_text(json.dumps(errors))
+                    raise
+                page.wait_for_function("() => !S.busy && !S.activeStreamId && !document.querySelector('#liveAssistantTurn')", timeout=15000)
+                state_after = page.evaluate("""() => ({events:window.__cancelEvents,insertions:window.__insertions,messages:S.messages,streams:Object.keys(LIVE_STREAMS),text:document.querySelector('#msgInner').innerText})""")
+                (out/'cancel-state.json').write_text(json.dumps(state_after, indent=2))
+                assert state_after['events'].count('turn:cancel') == 1, state_after
+                inserted = [r for r in state_after['insertions'] if r.get('cancel')]
+                assert len(inserted) == 1 and inserted[0]['hidden'], state_after
+                assert not state_after['streams'], state_after
+                assert any(POST_TOOL in str(m.get('content', '')) for m in state_after['messages']), state_after
+                sid = page.evaluate('S.session.session_id')
+                scene = gate._wait_for_persisted_scene(base, sid, anchor_scene_requests=requests)
+                page.reload(wait_until='domcontentloaded')
+                page.wait_for_function("() => !S.busy && !S.activeStreamId")
+                assert not page.locator('[data-live-assistant="1"]').count()
+                assert not errors, errors
+                (out/'result.json').write_text(json.dumps({'mode': mode, 'scene': scene, 'requests': requests, 'errors': errors, 'passed': True}, indent=2))
+                browser.close()
+        return 0
+    finally:
+        gateway.post_tool.set()
+        gateway.close()
+        gate._terminate_process(proc)
+        if log:
+            log.close()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -200,7 +200,10 @@ def test_attach_live_stream_registers_one_source_per_session_stream():
     error_body = _event_body("error")
 
     assert "const LIVE_STREAMS={};" in MESSAGES_JS
-    assert "LIVE_STREAMS[activeSid]={streamId,source};" in wire_body
+    registration = _brace_body_after(wire_body, "LIVE_STREAMS[activeSid]=")
+    assert "streamId,source" in registration
+    assert "flushScene:" in registration
+    assert "disposeScene:" in registration
     assert "existingLive.source.close();" in wire_body
     assert "if(source&&live.source!==source) return;" in close_body
     assert "existingLive&&existingLive.streamId===streamId" in attach_body

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -204,7 +204,8 @@ def test_attach_live_stream_registers_one_source_per_session_stream():
     assert "streamId,source" in registration
     assert "flushScene:" in registration
     assert "disposeScene:" in registration
-    assert "existingLive.source.close();" in wire_body
+    assert "closeLiveStream(activeSid,existingLive.streamId,existingLive.source);" in wire_body
+    assert "live.source.close();" in close_body
     assert "if(source&&live.source!==source) return;" in close_body
     assert "existingLive&&existingLive.streamId===streamId" in attach_body
     assert "_closeSource(source);" in error_body

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -208,8 +208,8 @@ def test_load_session_preserves_existing_worklog_content_without_destructive_fal
 
 def test_tool_events_are_guarded_against_stale_session_and_stream():
     """Delayed tool events from an old EventSource must not mutate the current session DOM."""
-    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
-    complete_handler = MESSAGES_JS.split("source.addEventListener('tool_complete',e=>{", 1)[1].split("source.addEventListener('approval'", 1)[0]
+    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
+    complete_handler = MESSAGES_JS.split("source.addEventListener('tool_complete',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('approval'", 1)[0]
     for handler in (tool_handler, complete_handler):
         assert "_terminalStateReached||_streamFinalized" in handler
         assert "S.session.session_id!==activeSid" in handler

--- a/tests/test_issue2713_streaming_segment_flush.py
+++ b/tests/test_issue2713_streaming_segment_flush.py
@@ -188,7 +188,7 @@ class TestInterimAssistantHandlerFlush:
         src = read("static/messages.js")
         fn = _extract_handler(src, "interim_assistant")
         branch_start = fn.index("if(alreadyStreamed)")
-        branch = fn[branch_start : fn.index("assistantText +=", branch_start)]
+        branch = fn[branch_start : fn.index("const semanticDelta=", branch_start)]
         assert "ensureAssistantRow(true)" in branch, (
             "already_streamed interim boundaries must materialize the current "
             "token segment before reset"

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -67,7 +67,7 @@ def test_live_compression_card_replacement_restores_snapshot_before_follow_settl
 def test_live_anchor_worklog_rebuild_restores_snapshot_before_follow_settle():
     body = _function_body(UI_JS, "renderLiveAnchorActivityScene")
 
-    capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    capture_idx = body.index("const scrollSnapshot=opts.scrollOwned?null:_captureMessageScrollSnapshot();")
     guard_idx = body.index("const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);")
     remove_idx = body.index("blocks.querySelectorAll('[data-anchor-scene-owner=\"1\"],[data-anchor-scene-row=\"1\"]')")
     restore_detail_idx = body.index("_restoreWorklogDetailDisclosureState(blocks, liveDisclosureState);")

--- a/tests/test_issue3599_inline_thinking_extraction.py
+++ b/tests/test_issue3599_inline_thinking_extraction.py
@@ -99,8 +99,10 @@ def test_messages_js_live_and_persist_paths_share_extractor():
     parse_state = _function_body(MESSAGES_JS, "function _parseStreamState")
     split_persist = _function_body(MESSAGES_JS, "function _splitThinkFromContent")
 
-    assert "_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true}).content" in stream_display
-    assert "return _extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true});" in parse_state
+    assert "_semanticSnapshot().content" in stream_display
+    assert "_parseStreamState" not in stream_display
+    assert "_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText," in parse_state
+    assert "streaming:true,onExtracted:" in parse_state
     assert "return _extractInlineThinkingFromContent(rawContent, existingReasoning, {streaming:false});" in split_persist
     assert "window._extractInlineThinkingFromContentForRender" in MESSAGES_JS
     assert "_thinkingFenceMarkerAt" in MESSAGES_JS

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -79,6 +79,8 @@ function buildRuntime() {
   const activeSid = scenario.activeSid || 'session-5224';
   const streamId = scenario.streamId || 'stream-5224';
   const calls = [];
+  globalThis._anchorPaintGeneration = 0;
+  globalThis._anchorPaintDisposed = false;
   globalThis.activeSid = activeSid;
   globalThis.streamId = streamId;
   globalThis.assistantText = false;

--- a/tests/test_issue5367_transparent_live_row_reconcile.py
+++ b/tests/test_issue5367_transparent_live_row_reconcile.py
@@ -243,9 +243,11 @@ global.CSS = {{ escape:(value)=>String(value) }};
 global.requestAnimationFrame = (fn)=>fn();
 
 global.S = {{ session:{{ session_id: 'session-1', pending_started_at: 123 }}, activeStreamId:'stream-1' }};
-global._captureMessageScrollSnapshot = () => ({{ scrollHeight: 1000 }});
+let scrollCaptures=0, scrollRestores=0;
+global._captureMessageScrollSnapshot = () => {{ scrollCaptures++; return {{ scrollHeight: 1000, pinned:true }}; }};
 global._prepareLiveAnchorScrollRebuildGuard = () => ({{ readerAwayFromBottom:false, release:null }});
-global._restoreMessageScrollSnapshotSameFrame = () => {{}};
+global._restoreMessageScrollSnapshotSameFrame = () => {{scrollRestores++;}};
+global._restoreMessageScrollSnapshotAfterRebuild = () => {{scrollRestores++;}};
 global.scrollIfPinned = () => {{}};
 global._moveLiveRunStatusToTurnEnd = () => {{}};
 global._messageUserUnpinned = false;
@@ -321,6 +323,26 @@ eval(extractFunc('_refreshTransparentLiveRow'));
 eval(extractFunc('_restoreLiveAnchorScrollSnapshotAfterRebuild'));
 eval(extractFunc('_restoreLiveAnchorScrollSnapshotAfterRebuild'));
 eval(extractFunc('_renderLiveAnchorActivitySceneTransparent'));
+
+const countAssert = require('node:assert/strict');
+const originalBuildToolCard = buildToolCard;
+let toolBuildCount = 0;
+global.buildToolCard = (...args) => {{ toolBuildCount++; return originalBuildToolCard(...args); }};
+const toolScene = {{version:'activity_scene_v1',activity_rows:[
+  {{row_id:'stable-tool',role:'tool',source_event_type:'tool',status:'completed',tool:{{name:'terminal'}}}},
+]}};
+_renderLiveAnchorActivitySceneTransparent('stream-1',toolScene,{{sessionId:'session-1'}});
+const stableToolNode = turn.querySelector('[data-anchor-row-id="stable-tool"]');
+const initialToolBuildCount = toolBuildCount;
+_renderLiveAnchorActivitySceneTransparent('stream-1',toolScene,{{sessionId:'session-1'}});
+countAssert.equal(toolBuildCount,initialToolBuildCount,'unchanged tools must not build replacement candidates');
+countAssert.equal(turn.querySelector('[data-anchor-row-id="stable-tool"]'),stableToolNode);
+toolScene.activity_rows[0].tool.name='changed';
+_renderLiveAnchorActivitySceneTransparent('stream-1',toolScene,{{sessionId:'session-1'}});
+countAssert.equal(toolBuildCount,initialToolBuildCount+1,'changed payload must refresh');
+countAssert.equal(turn.querySelector('[data-anchor-row-id="stable-tool"]'),stableToolNode);
+countAssert.equal(scrollCaptures,3,'one snapshot per committed paint');
+countAssert.equal(scrollRestores,scrollCaptures,'one restore per committed paint');
 
 const firstScene = {{
   version:'activity_scene_v1',
@@ -1580,9 +1602,11 @@ global.CSS = {{ escape:(value)=>String(value) }};
 global.t = (key)=>key;
 global.showToast = () => {{}};
 global.S = {{ session:{{ session_id:'session-1' }}, activeStreamId:'stream-1' }};
-global._captureMessageScrollSnapshot = () => ({{ scrollHeight: 1000 }});
+let scrollCaptures=0, scrollRestores=0;
+global._captureMessageScrollSnapshot = () => {{ scrollCaptures++; return {{ scrollHeight: 1000, pinned:true }}; }};
 global._prepareLiveAnchorScrollRebuildGuard = () => ({{ readerAwayFromBottom:false, release:null }});
-global._restoreMessageScrollSnapshotSameFrame = () => {{}};
+global._restoreMessageScrollSnapshotSameFrame = () => {{scrollRestores++;}};
+global._restoreMessageScrollSnapshotAfterRebuild = () => {{scrollRestores++;}};
 global.scrollIfPinned = () => {{}};
 global._moveLiveRunStatusToTurnEnd = () => {{}};
 global._messageUserUnpinned = false;

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -155,7 +155,7 @@ const turn={{
   setAttribute(){{}},
   querySelectorAll(){{return [];}},
 }};
-const blocks={{querySelectorAll(){{return [];}}}};
+const blocks={{querySelector(){{return null;}},querySelectorAll(){{return [];}}}};
 function $(id){{
   if(id==='messages') return el;
   if(id==='msgInner') return msgInner;

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -466,7 +466,7 @@ global._firstValidTimestampSeconds=()=>null;
 eval(anchorsSrc);
 for(const name of [
   'chatActivityMode','isTransparentStream','isFinalAnswerOnlyMode','isCompactWorklogMode','isSimplifiedToolCalling',
-  '_anchorSceneIsSettledSuccessfulCompression','_anchorSceneRowsForRendering',
+  '_anchorSceneIsSettledSuccessfulCompression','_anchorSceneSourceRows','_anchorSceneRowsForRendering',
   '_anchorSceneRowTimestampSeconds','_anchorSceneTransparentNodeForRow',
   '_transparentLiveRowKey','_transparentLiveRowsCompatible',
   '_transparentLiveRowAttributePairs','_transparentLiveRowInteractiveState',
@@ -474,7 +474,8 @@ for(const name of [
   '_thinkingMarkup','_renderThinkingInto',
   '_resetMismatchedLiveAssistantTurnForSession',
   '_liveAnchorReasoningRowForFallback','_updateLiveAnchorReasoningRowForFallback',
-  '_anchorSceneNodeForRow','_anchorSceneWorklogGroup','_renderAnchorSceneRowsIntoWorklog',
+  '_anchorSceneNodeForRow','_anchorSceneWorklogGroup','_anchorSceneWorklogState',
+  '_anchorSceneWorklogRowKey','_anchorSceneWorklogAppendRow','_renderAnchorSceneRowsIntoWorklog',
   'isLiveAnchorActivitySceneOwner','_projectLiveAnchorActivitySceneForStream',
   '_restoreLiveAnchorScrollSnapshotAfterRebuild',
   '_renderLiveAnchorActivitySceneTransparent','renderLiveAnchorActivityScene',

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -532,6 +532,7 @@ global.EventSource=FakeEventSource;
 const attachStart=messagesSrc.indexOf('function attachLiveStream(');
 const attachEnd=messagesSrc.indexOf('\nfunction transcript(){',attachStart);
 if(attachStart<0||attachEnd<0) throw new Error('attachLiveStream source boundary not found');
+eval(messagesSrc.slice(messagesSrc.indexOf('const _thinkPairs='),messagesSrc.indexOf('function _thinkingFenceMarkerAt('))+extractFunc(messagesSrc,'_createIncrementalSemanticState'));
 eval(extractFunc(messagesSrc,'_dispatchExtensionTurnLifecycle'));
 eval(messagesSrc.slice(attachStart,attachEnd));
 attachLiveStream('sid-1','stream-1');

--- a/tests/test_issue6391_delayed_epoch.py
+++ b/tests/test_issue6391_delayed_epoch.py
@@ -1,0 +1,25 @@
+"""Already dispatched timers cannot mutate a superseding stream generation."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+def test_dispatched_snapshot_and_persist_cannot_clear_new_timer_or_mutate():
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _snapshotLiveTurnTimer=null,_persistTimer=null;
+let snapshots=0,persists=0,id=0;const timers=new Map();
+const setTimeout=fn=>{timers.set(++id,fn);return id;};
+const snapshotLiveTurn=()=>snapshots++;
+const persistInflightState=()=>persists++;
+eval(extract(messageSource,'_throttledSnapshotLiveTurn'));
+eval(extract(messageSource,'_throttledPersist'));
+_throttledSnapshotLiveTurn();_throttledPersist();
+const stale=[...timers.values()];
+_anchorPaintGeneration++;_snapshotLiveTurnTimer=null;_persistTimer=null;
+_throttledSnapshotLiveTurn();_throttledPersist();
+const pending=[_snapshotLiveTurnTimer,_persistTimer];
+for(const fn of stale)fn();
+assert.equal(snapshots,0);assert.equal(persists,0);
+assert.deepEqual([_snapshotLiveTurnTimer,_persistTimer],pending);
+for(const key of pending)timers.get(key)();
+assert.equal(snapshots,1);assert.equal(persists,1);
+""")

--- a/tests/test_issue6391_dirty_projection.py
+++ b/tests/test_issue6391_dirty_projection.py
@@ -1,0 +1,350 @@
+"""Deterministic contracts for bounded live-scene projection and Worklog reuse."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+
+
+def _run_node(body: str) -> None:
+    assert NODE, "node is required for live-scene projection contracts"
+    script = r'''
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const anchors = path.join(path.dirname(process.argv[1]), 'assistant_turn_anchors.js');
+require(anchors);
+const api = globalThis.HermesAssistantTurnAnchors;
+const uiSource = fs.readFileSync(process.argv[1], 'utf8');
+function extract(source, name) {
+  const start = source.indexOf('function ' + name + '(');
+  assert.notEqual(start, -1, name + ' must exist');
+  let cursor = source.indexOf('{', start), depth = 1;
+  for (cursor += 1; depth && cursor < source.length; cursor += 1) {
+    if (source[cursor] === '{') depth += 1;
+    if (source[cursor] === '}') depth -= 1;
+  }
+  return source.slice(start, cursor);
+}
+''' + body
+    result = subprocess.run(
+        [NODE, "-e", script, str(ROOT / "static" / "ui.js")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_live_projection_reuses_clean_prefix_and_scans_only_dirty_tail():
+    _run_node(
+        r'''
+const registry = api.createAssistantTurnAnchorRegistry({session_id: 's', stream_id: 'stream'});
+for (let i = 0; i < 200; i += 1) {
+  const result = api.applyAssistantTurnAnchorSourceEvent(registry, {
+    source_event_type: 'tool',
+    event_id: 'event-' + i,
+    seq: i + 1,
+    payload: {id: 'tool-' + i, name: 'terminal', args: {i}},
+  }, {session_id: 's', stream_id: 'stream'});
+  assert.equal(result.applied, true);
+}
+const first = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+assert.equal(first.activity_rows.length, 200);
+assert.equal(first.projection_stats.events_scanned, 200);
+assert.equal(first.projection_stats.full_rebuild, true);
+assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(registry)),'projection_stats'),false);
+assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(first)),'projection'),false);
+assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(first)),'projection_stats'),false);
+const firstRow = first.activity_rows[0];
+const firstLast = first.activity_rows[199];
+const clean=api.projectAssistantTurnAnchorActivityScene(registry, {mode:'compact_worklog'});
+assert.equal(clean.projection.full_rebuild,false);
+assert.equal(clean.projection_stats.events_scanned,0);
+assert.strictEqual(clean.activity_rows,first.activity_rows);
+const unchanged = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+assert.strictEqual(unchanged, clean, 'repeated clean projection must be returned by identity');
+assert.equal(registry.projection_stats.events_scanned, 0);
+const next = api.applyAssistantTurnAnchorSourceEvent(registry, {
+  source_event_type: 'tool_complete',
+  event_id: 'event-201',
+  seq: 201,
+  payload: {id: 'tool-200', result: 'ok'},
+}, {session_id: 's', stream_id: 'stream'});
+assert.equal(next.applied, true);
+const second = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+assert.equal(second.activity_rows.length, 201);
+assert.strictEqual(second.activity_rows[0], firstRow);
+assert.strictEqual(second.activity_rows[199], firstLast);
+assert.equal(second.projection_stats.events_scanned, 1);
+assert.equal(second.projection_stats.rows_rebuilt, 1);
+assert.equal(second.projection_stats.full_rebuild, false);
+for(let i=202;i<=203;i++) api.applyAssistantTurnAnchorSourceEvent(registry,{
+ source_event_type:'tool',event_id:'event-'+i,seq:i,payload:{id:'tool-'+i,name:'terminal'},
+},{session_id:'s',stream_id:'stream'});
+const burst=api.projectAssistantTurnAnchorActivityScene(registry,{mode:'compact_worklog'});
+assert.equal(burst.projection_stats.events_scanned,2,'a two-event frame must not force full projection');
+assert.equal(burst.projection_stats.full_rebuild,false);
+'''
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_projection_fails_closed_to_full_rebuild_on_uncertain_order_or_identity():
+    _run_node(
+        r'''
+const registry = api.createAssistantTurnAnchorRegistry({session_id: 's', stream_id: 'stream'});
+api.applyAssistantTurnAnchorSourceEvent(registry, {
+  source_event_type: 'tool', event_id: 'known', seq: 1,
+  payload: {id: 'known-tool', name: 'terminal'},
+}, {session_id: 's', stream_id: 'stream'});
+api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+const uncertain = api.applyAssistantTurnAnchorSourceEvent(registry, {
+  source_event_type: 'tool',
+  payload: {name: 'terminal'},
+}, {session_id: 's', stream_id: 'stream'});
+assert.equal(uncertain.applied, true);
+const scene = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+assert.equal(scene.projection_stats.full_rebuild, true);
+assert.equal(scene.projection_stats.fallback_reason, 'uncertain_identity_or_order');
+assert.equal(scene.activity_rows.length, 2);
+'''
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_external_activity_replacement_requires_explicit_projection_invalidation_hook():
+    _run_node(
+        r'''
+const registry = api.createAssistantTurnAnchorRegistry({session_id: 's', stream_id: 'stream'});
+api.applyAssistantTurnAnchorSourceEvent(registry, {
+  source_event_type: 'tool', event_id: 'event-1', seq: 1,
+  payload: {id: 'tool-1', name: 'terminal', preview: 'before'},
+}, {session_id: 's', stream_id: 'stream'});
+const first = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+registry.anchor.activity_events[0] = {
+  ...registry.anchor.activity_events[0],
+  payload: {...registry.anchor.activity_events[0].payload, preview: 'after'},
+};
+api.invalidateAssistantTurnAnchorActivityProjection(registry, {indices: [0]});
+const second = api.projectAssistantTurnAnchorActivityScene(registry, {mode: 'compact_worklog'});
+assert.equal(second.activity_rows[0].payload.preview, 'after');
+assert.strictEqual(second.activity_rows[0].row_id, first.activity_rows[0].row_id);
+assert.equal(second.projection_stats.events_scanned, 1);
+assert.equal(second.projection_stats.rows_rebuilt, 1);
+assert.equal(second.projection_stats.full_rebuild, false);
+'''
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_compact_worklog_reuses_group_and_clean_nodes_without_clearing_list():
+    _run_node(
+        r'''
+const source = fs.readFileSync(process.argv[1], 'utf8');
+const render = extract(source, '_renderAnchorSceneRowsIntoWorklog');
+const list = {
+  children: [],
+  appendChild(node) { this.children.push(node); node.parentElement = this; return node; },
+  querySelector() { return null; },
+};
+const group = {
+  _testList: list,
+  querySelector(selector) { return selector === '.tool-worklog-list' ? this._testList : null; },
+};
+let created = 0;
+function nodeForRow(row) {
+  created += 1;
+  return {
+    dataset: {},
+    parentElement: null,
+    setAttribute(name, value) { this[name] = String(value); },
+    getAttribute(name) { return this[name] || ''; },
+    classList: {contains() { return false;}},
+    rowKey: row.row_id,
+  };
+}
+global._toolWorklogListEl = (value) => value && value._testList;
+global._anchorSceneNodeForRow = nodeForRow;
+global._syncToolCallGroupSummary = () => {};
+global.document = {createElement() { return {
+  children: [],
+  className: '',
+  appendChild(node) { this.children.push(node); node.parentElement = this; return node; },
+  setAttribute() {},
+}; }};
+global._anchorSceneWorklogProjectionStats = null;
+eval(extract(source, '_anchorSceneToolRowLogicalKey'));
+eval(extract(source, '_anchorSceneWorklogRowKey'));
+eval(extract(source, '_anchorSceneWorklogState'));
+eval(extract(source, '_anchorSceneWorklogAppendRow'));
+eval(render);
+const rows = Array.from({length: 100}, (_, i) => ({role: 'prose', row_id: 'row-' + i}));
+assert.equal(_renderAnchorSceneRowsIntoWorklog(group, rows, {
+  live: true, settled: false,
+  projection: {revision: 1, full_rebuild: true, changed_row_keys: rows.map(row => row.row_id)},
+}), true);
+const firstNodes = list.children.slice();
+const firstCreated = created;
+assert.equal(firstCreated, 100);
+assert.equal(_renderAnchorSceneRowsIntoWorklog(group, rows, {
+  live: true, settled: false,
+  projection: {revision: 1, full_rebuild: false, changed_row_keys: []},
+}), true);
+assert.equal(created, firstCreated, 'a clean frame must reuse every existing node');
+assert.deepEqual(list.children, firstNodes, 'a clean frame must not clear or reorder the list');
+assert.equal(_renderAnchorSceneRowsIntoWorklog(group, rows.concat({role: 'tool', row_id: 'row-100'}), {
+  live: true, settled: false,
+  projection: {revision: 2, full_rebuild: false, changed_row_keys: ['row-100']},
+}), true);
+assert.equal(created, firstCreated + 1, 'append must only create the dirty tail node');
+assert.strictEqual(list.children[0], firstNodes[0]);
+assert.equal(list.children.length, 101);
+const updatedRows = rows.concat({role: 'tool', row_id: 'row-100'});
+updatedRows[0] = {role: 'prose', row_id: 'row-0', text: 'updated'};
+assert.equal(_renderAnchorSceneRowsIntoWorklog(group, updatedRows, {
+  live: true, settled: false,
+  projection: {
+    revision: 3,
+    full_rebuild: false,
+    changed_row_keys: ['prose:row-0'],
+    changed_output_indices: [0],
+  },
+}), true);
+assert.equal(created, firstCreated + 2, 'an updated dirty row rebuilds only itself');
+assert.notStrictEqual(list.children[0], firstNodes[0]);
+assert.equal(list.children.length, 101);
+const committedNodes=list.children.slice(),committedCreated=created;
+_renderAnchorSceneRowsIntoWorklog(group,updatedRows,{
+ live:true,settled:false,
+ projection:{revision:3,full_rebuild:false,changed_row_keys:['prose:row-0'],changed_output_indices:[0]},
+});
+assert.equal(created,committedCreated,'a second reader of the same revision must not repaint');
+assert.deepEqual(list.children,committedNodes);
+assert.deepEqual(group._anchorSceneProjectionStats, {
+  rows_scanned: 102,
+  rows_rebuilt: 102,
+  groups_scanned: 5,
+  groups_rebuilt: 1,
+  groups_created: 0,
+  groups_reused: 5,
+});
+'''
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_ui_scene_projection_cache_skips_clean_history_and_reads_only_dirty_tail():
+    _run_node(
+        r'''
+const source = fs.readFileSync(process.argv[1], 'utf8');
+const start = source.indexOf('const _anchorSceneRenderProjectionCaches');
+const end = source.indexOf('function _anchorSceneToolCallFromRow', start);
+assert.notEqual(start, -1);
+assert.notEqual(end, -1);
+eval(source.slice(start, end));
+const rows = Array.from({length: 200}, (_, i) => ({
+  role: 'prose', row_id: 'row-' + i, text: 'text-' + i,
+}));
+const identity = {session_id: 's', turn_id: 't', stream_id: 'stream'};
+const first = _anchorSceneRowsForRendering({
+  identity, mode: 'compact_worklog', activity_rows: rows,
+  projection: {
+    revision: 1, full_rebuild: true,
+    changed_row_keys: rows.map(row => 'prose:' + row.row_id),
+    changed_row_indices: rows.map((_, i) => i),
+  },
+}, {settled: false});
+assert.equal(first.length, 200);
+const clean = _anchorSceneRowsForRendering({
+  identity, mode: 'compact_worklog', activity_rows: rows,
+  projection: {revision: 1, full_rebuild: false, changed_row_keys: []},
+}, {settled: false});
+assert.strictEqual(clean, first, 'clean scene projection must reuse its cached rows');
+assert.deepEqual(clean._anchorSceneProjection.changed_row_keys, []);
+const nextRows = rows.concat({role: 'prose', row_id: 'row-200', text: 'tail'});
+let indexedReads = 0;
+const boundedRows = new Proxy(nextRows, {
+  get(target, property, receiver) {
+    if (/^[0-9]+$/.test(String(property))) indexedReads += 1;
+    return Reflect.get(target, property, receiver);
+  },
+});
+const dirty = _anchorSceneRowsForRendering({
+  identity, mode: 'compact_worklog', activity_rows: boundedRows,
+  projection: {
+    revision: 2, full_rebuild: false,
+    changed_row_keys: ['prose:row-200'], changed_row_indices: [200],
+  },
+}, {settled: false});
+assert.equal(indexedReads, 1, 'dirty tail projection must read only the changed source row');
+assert.equal(dirty.length, 201);
+assert.strictEqual(dirty[0], first[0]);
+assert.strictEqual(dirty[199], first[199]);
+assert.equal(dirty[200].row_id, 'row-200');
+const cleanAgain = _anchorSceneRowsForRendering({
+  identity, mode: 'compact_worklog', activity_rows: boundedRows,
+  projection: {
+    revision: 2, full_rebuild: false,
+    changed_row_keys: ['prose:row-200'], changed_row_indices: [200],
+  },
+}, {settled: false});
+assert.strictEqual(cleanAgain, dirty);
+// Reading a projection must not consume another renderer's pending dirty set.
+assert.deepEqual(cleanAgain._anchorSceneProjection.changed_row_keys, ['prose:row-200']);
+assert.equal(indexedReads, 1, 'clean projection must not rescan the history');
+nextRows[0]={role:'prose',row_id:'row-0',text:'updated prefix'};
+indexedReads=0;
+const prefix = _anchorSceneRowsForRendering({
+ identity,mode:'compact_worklog',activity_rows:boundedRows,
+ projection:{revision:3,full_rebuild:false,changed_row_keys:['prose:row-0'],changed_row_indices:[0]},
+},{settled:false});
+assert.equal(prefix[0].text,'updated prefix');
+assert.equal(indexedReads,1,'known same-key prefix update must not scan historical rows');
+const replacement=_anchorSceneRowsForRendering({
+ identity,mode:'compact_worklog',activity_rows:[{role:'prose',row_id:'replacement',text:'new registry'}],
+ projection:{revision:3,full_rebuild:true,changed_row_keys:['prose:replacement'],changed_row_indices:[0]},
+},{settled:false});
+assert.equal(replacement.length,1,'same stream new registry must invalidate old projection');
+assert.equal(replacement[0].text,'new registry');
+
+'''
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_transparent_mounted_projection_only_touches_dirty_nodes_and_fade_tail():
+    _run_node(r'''
+const source=fs.readFileSync(process.argv[1],'utf8');
+eval(extract(source,'_tryIncrementalTransparentAnchorPaint'));
+globalThis.window={_showThinking:true,_fadeTextEffect:false};
+let captures=0,restores=0,created=0,reads=0;
+function _captureMessageScrollSnapshot(){captures++;return {};}
+function _restoreMessageScrollSnapshotSameFrame(){restores++;}
+function _anchorSceneRenderOutputKey(row){return 'prose:'+row.row_id;}
+function _transparentLiveRowsCompatible(){return true;}
+function _refreshTransparentLiveRow(old,node){old.text=node.text;return old;}
+function _anchorSceneTransparentNodeForRow(row){created++;return node(row.text);}
+function _transparentEventCountLabel(count){return String(count);}
+function node(text){return {text,parentElement:null,setAttribute(){},removeAttribute(){}};}
+const label=node(''),bar={querySelector(){return label;},setAttribute(){}};
+const blocks={querySelector(){return bar;},querySelectorAll(){throw Error('history DOM scan');}};
+const nodes=Array.from({length:200},(_,i)=>node('text-'+i));nodes.forEach(n=>n.parentElement=blocks);
+const turn={};
+blocks._anchorTransparentProjectionState={streamId:'s',sessionId:'a',flags:'[true,false]',revision:1,keys:Array.from({length:200},(_,i)=>'prose:row-'+i),nodes,toolCount:0};
+const values=Array.from({length:200},(_,i)=>({role:'prose',row_id:'row-'+i,text:'text-'+i}));
+values[0]={...values[0],text:'new text'};
+const rows=new Proxy(values,{get(target,key){if(/^\d+$/.test(String(key)))reads++;return target[key];}});
+rows._anchorSceneProjection={revision:2,full_rebuild:false,changed_output_indices:[0]};
+const old=nodes.slice();
+assert.equal(_tryIncrementalTransparentAnchorPaint(turn,blocks,rows,{streamId:'s',sessionId:'a'}),true);
+assert.equal(reads,1);assert.equal(created,1);assert.equal(captures,1);assert.equal(restores,1);
+assert.equal(nodes[0].text,'new text');assert.deepEqual(nodes,old);
+assert.equal(_tryIncrementalTransparentAnchorPaint(turn,blocks,rows,{streamId:'s',sessionId:'a'}),true);
+assert.equal(reads,1);assert.equal(created,1);assert.equal(captures,1);assert.equal(restores,1);
+''')

--- a/tests/test_issue6391_lifecycle_matrix.py
+++ b/tests/test_issue6391_lifecycle_matrix.py
@@ -161,6 +161,7 @@ const _parseStreamState=()=>({displayText:assistantText});
 const ensureAssistantRow=()=>{};
 const _scheduleRender=()=>{};
 const _upsertAnchorProcessProse=()=>{tokenEffects+=1;};
+const _scheduleSemanticProse=()=>{tokenEffects+=1;};
 const _withDeferredAnchorScenePaint=handler=>handler;
 const _renderAnchorLiveScene=()=>true;
 const segmentStart=0;

--- a/tests/test_issue6391_lifecycle_matrix.py
+++ b/tests/test_issue6391_lifecycle_matrix.py
@@ -1,0 +1,352 @@
+"""Real SSE callback lifecycle and producer projection matrices for #6391."""
+
+import pytest
+
+from tests.test_issue6391_dirty_projection import _run_node
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+@pytest.mark.parametrize("mode", ["compact_worklog", "transparent_stream"])
+def test_real_registered_callbacks_claim_done_once_and_reject_late_producers(mode):
+    run_js(
+        r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _anchorPaintScheduler=scheduler;
+let _terminalStateReached=false,_streamFinalized=false;
+let _persistTimer=null;
+const activeSid='session',streamId='stream';
+const LIVE_STREAMS={};
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const INFLIGHT={[activeSid]:{messages:[],toolCalls:[]}};
+let terminalClaims=0,handlerEffects=0,closed=0,cursorEffects=0;
+const _closeSource=()=>{closed+=1;};
+const _completeOwnedTerminal=()=>{
+  const pending=_pendingTerminalFinish;
+  if(!pending||_anchorPaintDisposed||pending.generation!==_anchorPaintGeneration)return;
+  _pendingTerminalFinish=null;
+  terminalClaims+=1;
+};
+const _bailOutOfTerminalEventsFromStaleStream=()=>false;
+const _clearStreamEndRecovery=()=>{};
+const _cancelThrottledSnapshotTimer=()=>{};
+const _shouldUseLiveProseFade=()=>false;
+const _rememberRunJournalCursor=()=>{cursorEffects+=1;};
+const _applyToAnchor=()=>{handlerEffects+=1;};
+const _withDeferredAnchorScenePaint=handler=>handler;
+const _renderAnchorLiveScene=()=>true;
+const _anchorPaintDisposedForTest=()=>_anchorPaintDisposed;
+const _sourceEvents=[];
+function transport(){
+  const source={
+    readyState:1,
+    callbacks:_sourceEvents,
+    addEventListener(type,handler){this.callbacks.push({type,handler});},
+    close(){this.readyState=2;closed+=1;},
+    dispatch(type,payload){
+      const event={data:JSON.stringify(payload||{}),lastEventId:streamId+':'+type};
+      for(const item of this.callbacks.filter(candidate=>candidate.type===type))item.handler(event);
+    },
+  };
+  return source;
+}
+eval(extract(messageSource,'_wireSSE'));
+const source=transport();
+_wireSSE(source);
+for(const type of ['token','interim_assistant','reasoning','tool','tool_complete','done','stream_end','cancel','error','apperror']){
+  assert.ok(source.callbacks.some(item=>item.type===type),type+' callback must be registered');
+}
+source.dispatch('done',{status:'completed'});
+assert.equal(terminalClaims,1,'the first done event must claim terminal ownership');
+assert.equal(_pendingTerminalFinish,null);
+const effectsAfterDone=[handlerEffects,cursorEffects,terminalClaims];
+for(const type of ['done','token','interim_assistant','reasoning','tool','tool_complete','cancel','error','apperror']){
+  source.dispatch(type,{text:'late',status:'error'});
+}
+assert.deepEqual([handlerEffects,cursorEffects,terminalClaims],effectsAfterDone);
+assert.equal(_anchorPaintDisposedForTest(),false);
+""".replace("MODE", repr(mode))
+    )
+
+
+@pytest.mark.parametrize("mode", ["compact_worklog", "transparent_stream"])
+def test_done_fade_then_stream_end_completes_once_before_late_callbacks(mode):
+    run_js(
+        r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _anchorPaintScheduler=scheduler;
+let _terminalStateReached=false,_streamFinalized=false;
+let _persistTimer=null;
+const activeSid='session',streamId='stream';
+const LIVE_STREAMS={};
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const INFLIGHT={[activeSid]:{messages:[],toolCalls:[]}};
+let terminalClaims=0,fadeFinish=null,closed=0;
+const _closeSource=()=>{closed+=1;};
+const _completeOwnedTerminal=()=>{
+  const pending=_pendingTerminalFinish;
+  if(!pending||_anchorPaintDisposed||pending.generation!==_anchorPaintGeneration)return;
+  _pendingTerminalFinish=null;
+  terminalClaims+=1;
+};
+const _bailOutOfTerminalEventsFromStaleStream=()=>false;
+const _clearStreamEndRecovery=()=>{};
+const _cancelThrottledSnapshotTimer=()=>{};
+const _cancelAnimationFramePendingStreamRender=()=>{};
+const _shouldUseLiveProseFade=()=>true;
+const _drainStreamFadeBeforeDone=finish=>{fadeFinish=finish;};
+const _rememberRunJournalCursor=()=>{};
+const _withDeferredAnchorScenePaint=handler=>handler;
+const _renderAnchorLiveScene=()=>true;
+const assistantBody={};
+function transport(){
+  const callbacks=[];
+  return {
+    readyState:1,
+    callbacks,
+    addEventListener(type,handler){callbacks.push({type,handler});},
+    close(){this.readyState=2;closed+=1;},
+    dispatch(type,payload){
+      const event={data:JSON.stringify(payload||{}),lastEventId:streamId+':'+type};
+      for(const item of callbacks.filter(candidate=>candidate.type===type))item.handler(event);
+    },
+  };
+}
+eval(extract(messageSource,'_wireSSE'));
+const source=transport();
+_wireSSE(source);
+source.dispatch('done',{status:'completed'});
+assert.equal(_streamFinalized,true);
+assert.equal(_terminalStateReached,true);
+assert.ok(_pendingTerminalFinish,'done must leave a required finish pending during the fade');
+assert.equal(terminalClaims,0);
+assert.equal(typeof fadeFinish,'function');
+source.dispatch('stream_end',{});
+assert.equal(terminalClaims,1,'stream_end must complete the pending terminal exactly once');
+assert.equal(_pendingTerminalFinish,null);
+fadeFinish();
+for(const type of ['done','token','reasoning','tool','tool_complete','cancel','error','apperror','stream_end']){
+  source.dispatch(type,{text:'late',status:'error'});
+}
+assert.equal(terminalClaims,1,'late producers and terminal signals cannot reclaim completion');
+""".replace("MODE", repr(mode))
+    )
+
+
+def test_same_source_rewire_retires_already_registered_callbacks():
+    run_js(
+        r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _anchorPaintScheduler=scheduler;
+let _pendingProsePaint=null,_pendingKatexPaint=false;
+const _pendingMediaPaintRoots=new Set();
+let _terminalStateReached=false,_streamFinalized=false;
+let _persistTimer=null;
+const activeSid='session',streamId='stream';
+const LIVE_STREAMS={};
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const INFLIGHT={[activeSid]:{messages:[],toolCalls:[]}};
+let assistantText='',tokenEffects=0;
+let _snapshotLiveTurnTimer=null,_streamEndRecoveryTimer=null;
+let _pendingStreamEndRecovery=false,_pendingRafHandle=null;
+const _anchorRegistryCleanupTimer=null;
+const _clearStreamEndRecovery=()=>{_pendingStreamEndRecovery=false;_streamEndRecoveryTimer=null;};
+const _cancelThrottledSnapshotTimer=()=>{_snapshotLiveTurnTimer=null;};
+const _cancelAnimationFramePendingStreamRender=()=>{_pendingRafHandle=null;};
+const _closeSource=()=>{};
+const _bailOutOfTerminalEventsFromStaleStream=()=>false;
+const _rememberRunJournalCursor=()=>{};
+const _completeAutomaticCompressionOnLiveProgress=()=>{};
+const syncInflightAssistantMessage=()=>{};
+const _parseStreamState=()=>({displayText:assistantText});
+const ensureAssistantRow=()=>{};
+const _scheduleRender=()=>{};
+const _upsertAnchorProcessProse=()=>{tokenEffects+=1;};
+const _withDeferredAnchorScenePaint=handler=>handler;
+const _renderAnchorLiveScene=()=>true;
+const segmentStart=0;
+const _freshSegment=false;
+const assistantRow={};
+const assistantBody=null;
+function transport(){
+  const callbacks=[];
+  return {
+    readyState:1,
+    callbacks,
+    addEventListener(type,handler){callbacks.push({type,handler});},
+    close(){this.readyState=2;},
+    dispatch(type,payload){
+      const event={data:JSON.stringify(payload||{}),lastEventId:streamId+':'+type};
+      for(const item of callbacks.filter(candidate=>candidate.type===type))item.handler(event);
+    },
+  };
+}
+const clearTimeout=()=>{};
+const cancelAnimationFrame=()=>{};
+eval(extract(messageSource,'_disposeAnchorScenePaint'));
+eval(extract(messageSource,'_wireSSE'));
+const source=transport();
+_wireSSE(source);
+const firstOwner=LIVE_STREAMS[activeSid];
+const oldCallbacks=source.callbacks.slice();
+firstOwner.disposeScene();
+_wireSSE(source);
+const currentOwner=LIVE_STREAMS[activeSid];
+assert.notStrictEqual(currentOwner,firstOwner);
+for(const item of oldCallbacks.filter(candidate=>['token','reasoning','tool','tool_complete','done','cancel','error'].includes(candidate.type))){
+  item.handler({data:JSON.stringify({text:'stale'}),lastEventId:'stale:1'});
+}
+assert.equal(assistantText,'');
+assert.equal(tokenEffects,0,'same-source callbacks from the retired generation must be inert');
+source.dispatch('token',{text:'fresh'});
+assert.equal(assistantText,'fresh');
+assert.equal(tokenEffects,1);
+assert.equal(firstOwner.requestScene(),false,'retired owner cannot be revived by a same-source rewire');
+assert.equal(currentOwner.requestScene(),true);
+"""
+    )
+
+
+def test_disposal_is_idempotent_without_timer_or_owner_resurrection():
+    run_js(
+        r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _anchorPaintScheduler=null;
+_terminalFadeTimer=11,_terminalFadeFrame=12;
+let _pendingProsePaint=null,_pendingKatexPaint=false;
+const _pendingMediaPaintRoots=new Set();
+let _persistTimer=13,_snapshotLiveTurnTimer=14;
+let _streamEndRecoveryTimer=15,_pendingStreamEndRecovery=true;
+let _pendingRafHandle=16;
+let clearCalls=0,cancelCalls=0,schedulerDisposals=0;
+const activeSid='session',streamId='stream';
+const LIVE_STREAMS={};
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const INFLIGHT={[activeSid]:{messages:[],toolCalls:[]}};
+const _clearStreamEndRecovery=()=>{
+  if(_streamEndRecoveryTimer!==null){clearTimeout(_streamEndRecoveryTimer);_streamEndRecoveryTimer=null;}
+  _pendingStreamEndRecovery=false;
+};
+const _rememberRunJournalCursor=()=>{};
+const _cancelThrottledSnapshotTimer=()=>{
+  if(_snapshotLiveTurnTimer!==null){clearTimeout(_snapshotLiveTurnTimer);_snapshotLiveTurnTimer=null;}
+};
+const _cancelAnimationFramePendingStreamRender=()=>{
+  if(_pendingRafHandle!==null){cancelAnimationFrame(_pendingRafHandle);_pendingRafHandle=null;}
+};
+const clearTimeout=()=>{clearCalls+=1;};
+const cancelAnimationFrame=()=>{cancelCalls+=1;};
+const _renderAnchorLiveScene=()=>true;
+const _withDeferredAnchorScenePaint=handler=>handler;
+function transport(){
+  const callbacks=[];
+  return {
+    readyState:1,
+    callbacks,
+    addEventListener(type,handler){callbacks.push({type,handler});},
+  };
+}
+_anchorPaintScheduler={dispose(){schedulerDisposals+=1;}};
+eval(extract(messageSource,'_disposeAnchorScenePaint'));
+eval(extract(messageSource,'_wireSSE'));
+const source=transport();
+_wireSSE(source);
+const owner=LIVE_STREAMS[activeSid];
+owner.disposeScene();
+const firstCounts=[clearCalls,cancelCalls,schedulerDisposals,source.callbacks.length];
+assert.equal(owner.requestScene(),false);
+owner.disposeScene();
+assert.deepEqual([clearCalls,cancelCalls,schedulerDisposals,source.callbacks.length],firstCounts);
+assert.strictEqual(LIVE_STREAMS[activeSid],owner,'disposal must not replace or resurrect the stream owner');
+assert.equal(_anchorPaintDisposed,true);
+assert.equal(_pendingTerminalFinish,null);
+assert.equal(_persistTimer,null);
+assert.equal(_snapshotLiveTurnTimer,null);
+assert.equal(_streamEndRecoveryTimer,null);
+assert.equal(_pendingStreamEndRecovery,false);
+assert.equal(_pendingRafHandle,null);
+"""
+    )
+
+
+@pytest.mark.parametrize("mode", ["compact_worklog", "transparent_stream"])
+def test_normalizer_projection_covers_prose_reasoning_tools_and_mixed_producers(mode):
+    _run_node(
+        r"""
+const scenarios={
+  prose_only:{
+    events:[
+      {source_event_type:'token',event_id:'prose-1',seq:1,payload:{text:'hello'}},
+      {source_event_type:'token',event_id:'prose-2',seq:2,payload:{text:' world'}},
+      {source_event_type:'interim_assistant',event_id:'prose-3',seq:3,payload:{text:'interim answer'}},
+    ],
+    roles:['prose','prose','prose'],
+  },
+  reasoning:{
+    events:[
+      {source_event_type:'reasoning',event_id:'reason-1',seq:1,payload:{text:'first thought'}},
+      {source_event_type:'reasoning',event_id:'reason-2',seq:2,payload:{reasoning:'second thought'}},
+    ],
+    roles:['thinking','thinking'],
+  },
+  tools:{
+    events:[
+      {source_event_type:'tool',event_id:'tool-1',seq:1,payload:{id:'call-1',name:'terminal',args:{command:'pwd'}}},
+      {source_event_type:'tool_complete',event_id:'tool-2',seq:2,payload:{id:'call-1',result:'ok',done:true}},
+    ],
+    roles:['tool','tool'],
+  },
+  mixed:{
+    events:[
+      {source_event_type:'token',event_id:'mixed-1',seq:1,payload:{text:'before'}},
+      {source_event_type:'reasoning',event_id:'mixed-2',seq:2,payload:{text:'thinking'}},
+      {source_event_type:'tool',event_id:'mixed-3',seq:3,payload:{id:'call-m',name:'search',args:{query:'x'}}},
+      {source_event_type:'tool_complete',event_id:'mixed-4',seq:4,payload:{id:'call-m',result:'found'}},
+      {source_event_type:'token',event_id:'mixed-5',seq:5,payload:{text:'after'}},
+    ],
+    roles:['prose','thinking','tool','tool','prose'],
+  },
+};
+for(const [name,scenario] of Object.entries(scenarios)){
+  const registry=api.createAssistantTurnAnchorRegistry({session_id:'session',stream_id:'stream-'+name});
+  const context={session_id:'session',stream_id:'stream-'+name,order_domain:'transport'};
+  for(const event of scenario.events){
+    const result=api.applyAssistantTurnAnchorSourceEvent(registry,event,context);
+    assert.equal(result.applied,true,name+' event must apply');
+  }
+  const terminal=api.applyAssistantTurnAnchorSourceEvent(registry,{
+    source_event_type:'done',event_id:name+'-done',seq:100,payload:{status:'completed'},
+  },context);
+  assert.equal(terminal.applied,true,name+' terminal event must apply');
+  const duplicate=api.applyAssistantTurnAnchorSourceEvent(registry,scenario.events[0],context);
+  assert.equal(duplicate.applied,false,name+' replayed event must dedupe');
+  assert.equal(duplicate.reason,'duplicate');
+  const scene=api.projectAssistantTurnAnchorActivityScene(registry,{mode:MODE});
+  const rows=scene.activity_rows;
+  assert.equal(rows.length,scenario.roles.length+1,name+' row count');
+  assert.deepEqual(rows.slice(0,-1).map(row=>row.role),scenario.roles,name+' producer order');
+  assert.equal(rows.at(-1).role,'terminal');
+  assert.equal(rows.at(-1).source_event_type,'done');
+  assert.equal(scene.lifecycle.status,'completed');
+  assert.equal(scene.terminal_state,'completed');
+  for(const row of rows.slice(0,-1)){
+    const expectedHint=MODE==='transparent_stream'
+      ? 'chronological_activity'
+      : ({prose:'main_prose',thinking:'collapsed_thinking',tool:'tool_row'}[row.role]);
+    assert.equal(row.display_hint,expectedHint,name+' mode hint');
+  }
+  if(name==='tools'){
+    assert.equal(rows[0].tool_call_id,'call-1');
+    assert.equal(rows[0].tool.done,false);
+    assert.equal(rows[1].tool_call_id,'call-1');
+    assert.equal(rows[1].tool.done,true);
+    assert.equal(rows[0].tool.args.command,'pwd');
+    assert.equal(rows[1].tool.snippet,'ok');
+  }
+  if(name==='mixed'){
+    assert.equal(rows[1].thinking.text,'thinking');
+    assert.equal(rows[2].tool.name,'search');
+    assert.equal(rows[4].text,'after');
+  }
+}
+""".replace("MODE", repr(mode))
+    )

--- a/tests/test_issue6391_live_scene_paint.py
+++ b/tests/test_issue6391_live_scene_paint.py
@@ -113,6 +113,7 @@ let _deferAnchorScenePaint=false, _anchorPaintScheduler=scheduler;
 let _anchorPaintGeneration=0, _anchorPaintDisposed=false;
 let _pendingProsePaint=null,_committingLivePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
 let cancelledSnapshotTimers=0;
+let _semanticState={pending:'<thi',content:'retained'.repeat(10000)},_semanticFallback={content:'fallback'},_semanticRaw='raw';
 const _cancelAnimationFramePendingStreamRender=()=>{};
 const _clearStreamEndRecovery=()=>{};
 const _cancelThrottledSnapshotTimer=()=>{cancelledSnapshotTimers++;};
@@ -122,6 +123,7 @@ const oldHandler=_withDeferredAnchorScenePaint(e=>{events.push(e);scheduler.requ
 oldHandler('start');
 _disposeAnchorScenePaint();
 assert.equal(cancelledSnapshotTimers,1,'dispose must cancel trailing DOM snapshots');
+assert.equal(_semanticState,null);assert.equal(_semanticFallback,null);assert.equal(_semanticRaw,'');
 oldHandler('late-complete');
 frame();
 assert.deepEqual(events,['start'],'disposed source must reject queued tool events');

--- a/tests/test_issue6391_live_scene_paint.py
+++ b/tests/test_issue6391_live_scene_paint.py
@@ -297,6 +297,10 @@ def test_actual_sse_registration_rejects_obsolete_callbacks_before_handlers():
 let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
 let _pendingProsePaint=null,_committingLivePaint=false,_deferAnchorScenePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
 const activeSid='a',streamId='s',LIVE_STREAMS={};
+const INFLIGHT={};
+const _resumeSessionStreamAfterLiveChat=()=>{};
+const _drainSemanticProse=()=>{},_scheduleSemanticProse=()=>{};
+eval(extract(messageSource,'closeLiveStream'));
 let _terminalStateReached=false,_streamFinalized=false,assistantText='',mirrors=0;
 const S={session:{session_id:'background-pane'},activeStreamId:'other'};
 const syncInflightAssistantMessage=()=>mirrors++;
@@ -336,7 +340,7 @@ for(const c of old.callbacks)c.fn({data:'{}',lastEventId:'s:999'});
 assert.equal(mirrors,0);
 fresh.dispatch('token',{text:'new generation'});
 assert.equal(assistantText,'new generation');
-assert.equal(mirrors,2,'new token ingestion and cursor listener both execute');
+assert.equal(mirrors,1,'cursor executes; inflight extraction waits for the semantic batch');
 """)
 
 

--- a/tests/test_issue6391_live_scene_paint.py
+++ b/tests/test_issue6391_live_scene_paint.py
@@ -1,0 +1,403 @@
+"""Executable scheduling contracts for the live scene's visual projection.
+
+The fake frame clock deliberately retains cancelled callbacks so teardown tests
+also exercise a callback that has already been handed to the browser.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE = shutil.which("node")
+
+
+def run_js(body):
+    assert NODE, "node is required for executable frame scheduling contracts"
+    script = r"""
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const src = fs.readFileSync(process.argv[1], 'utf8');
+const name = '_createLiveScenePaintScheduler';
+const start = src.indexOf('function ' + name + '(');
+assert.notEqual(start, -1, 'live scene frame scheduler must exist');
+let end = src.indexOf('{', start), depth = 1;
+for(end++; depth && end < src.length; end++) {
+  if(src[end] === '{') depth++;
+  if(src[end] === '}') depth--;
+}
+    eval(src.slice(start, end));
+    function extract(source, name) {
+      const start=source.indexOf('function '+name+'(');
+      assert.notEqual(start,-1,name+' must exist');
+      let params=source.indexOf('(',start), nesting=1;
+      for(params++; nesting && params<source.length; params++) {
+        if(source[params]==='(') nesting++;
+        if(source[params]===')') nesting--;
+      }
+      let end=source.indexOf('{',params), depth=1;
+      for(end++; depth && end<source.length; end++) {
+        if(source[end]==='{') depth++;
+        if(source[end]==='}') depth--;
+      }
+      return source.slice(start,end);
+    }
+    const messageSource=fs.readFileSync(process.argv[2], 'utf8');
+let _pendingTerminalFinish=null,_terminalFadeTimer=null,_terminalFadeFrame=null;
+function _cancelAnchorRegistryCleanup(){}
+let nextId = 0, frames = new Map(), cancelled = [], current = true;
+const events = [], paints = [];
+const scheduler = _createLiveScenePaintScheduler({
+  requestFrame(fn) { frames.set(++nextId, fn); return nextId; },
+  cancelFrame(id) { cancelled.push(id); },
+  isCurrent() { return current; },
+  paint() { paints.push(events.slice()); },
+});
+function frame() {
+  const batch = [...frames.values()]; frames.clear();
+  for(const fn of batch) fn();
+}
+""" + body
+    result = subprocess.run(
+        [NODE, "-e", script, str(ROOT / "static/ui.js"), str(ROOT / "static/messages.js")],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+@pytest.mark.parametrize("mode", ["compact_worklog", "transparent_stream"])
+def test_real_anchor_ingestion_preserves_750_lifecycles_and_replay_order(mode):
+    run_js("""
+require(require('node:path').join(require('node:path').dirname(process.argv[1]),'assistant_turn_anchors.js'));
+const _anchorApi=globalThis.HermesAssistantTurnAnchors;
+const activeSid='a',streamId='s',_assistantSegmentSeq=1,_currentActivityBurstId=1;
+const _anchorPaintDisposed=false;
+let _anchorShadowWarned=false;
+const _anchorRegistry=_anchorApi.createAssistantTurnAnchorRegistry({session_id:activeSid,stream_id:streamId});
+const _renderAnchorLiveScene=()=>{scheduler.request();return true;};
+eval(extract(messageSource,'_applyToAnchor'));
+const _anchorSceneRenderProjectionCaches=new Map();
+for(const fn of ['_anchorSceneRenderCacheKey','_anchorSceneRenderOutputKey','_anchorSceneAttachIncrementalProjection','_anchorSceneSourceRows','_anchorSceneRowsIncrementalProjection','_anchorSceneRememberFullProjection','_anchorSceneToolRowLogicalKey','_anchorSceneMergeToolRows','_anchorSceneRowsForRendering','_anchorSceneIsSettledSuccessfulCompression']) eval(extract(src,fn));
+for(let i=0;i<750;i++) {
+  const start={id:'tool-'+i,name:'terminal',args:{i},created_at:1};
+  const startEvent={lastEventId:'start-'+i};
+  assert.equal(_applyToAnchor('tool',start,startEvent).applied,true);
+  assert.equal(_applyToAnchor('tool',start,startEvent).reason,'duplicate');
+  assert.equal(_applyToAnchor('tool_complete',{...start,done:true,snippet:'result-'+i},{lastEventId:'end-'+i}).applied,true);
+  events.push(i);
+  if(i%250===249) frame();
+}
+assert.equal(paints.length,3);
+assert.equal(paints[0].length,250);
+assert.equal(paints[1].length,500);
+assert.deepEqual(paints[2],Array.from({length:750},(_,i)=>i));
+assert.equal(_anchorRegistry.stats.skipped_duplicate,750);
+const scene=_anchorApi.projectAssistantTurnAnchorActivityScene(_anchorRegistry,{mode:MODE});
+const rows=_anchorSceneRowsForRendering(scene,{settled:false});
+assert.equal(rows.length,750);
+rows.forEach((row,i)=>{
+ assert.equal(row.tool_call_id,'tool-'+i);
+ assert.equal(row.tool.args.i,i);
+ assert.equal(row.tool.snippet,'result-'+i);
+ assert.equal(row.tool.done,true);
+});
+""".replace("MODE", repr(mode)))
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_disposed_owner_rejects_queued_events_and_replacement_gets_new_generation():
+    run_js("""
+let _deferAnchorScenePaint=false, _anchorPaintScheduler=scheduler;
+let _anchorPaintGeneration=0, _anchorPaintDisposed=false;
+let _pendingProsePaint=null,_committingLivePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
+let cancelledSnapshotTimers=0;
+const _cancelAnimationFramePendingStreamRender=()=>{};
+const _clearStreamEndRecovery=()=>{};
+const _cancelThrottledSnapshotTimer=()=>{cancelledSnapshotTimers++;};
+eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
+eval(extract(messageSource,'_disposeAnchorScenePaint'));
+const oldHandler=_withDeferredAnchorScenePaint(e=>{events.push(e);scheduler.request();});
+oldHandler('start');
+_disposeAnchorScenePaint();
+assert.equal(cancelledSnapshotTimers,1,'dispose must cancel trailing DOM snapshots');
+oldHandler('late-complete');
+frame();
+assert.deepEqual(events,['start'],'disposed source must reject queued tool events');
+assert.equal(paints.length,0);
+assert.equal(scheduler.pending(),false);
+// Reconnection in the same attachment gets a fresh generation, while the
+// callback captured by the old EventSource remains invalid forever.
+_anchorPaintDisposed=false;
+const replacement=_withDeferredAnchorScenePaint(e=>events.push(e));
+oldHandler('obsolete');replacement('current');
+assert.deepEqual(events,['start','current']);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_navigation_disposes_every_live_scene_without_closing_transport():
+    run_js("""
+const disposed=[];
+const LIVE_STREAMS={a:{disposeScene:()=>disposed.push('a')},b:{disposeScene:()=>disposed.push('b')},legacy:{}};
+eval(extract(messageSource,'_disposeLiveScenePaints'));
+_disposeLiveScenePaints();
+assert.deepEqual(disposed,['a','b']);
+assert.equal(Object.keys(LIVE_STREAMS).length,3);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_close_stream_flushes_owned_visual_work_before_snapshot_and_disposes():
+    run_js("""
+const order=[];
+const source={readyState:1,close(){order.push('close');}};
+const LIVE_STREAMS={a:{streamId:'s',source,
+  flushScene(){order.push('flush');scheduler.flush();},
+  disposeScene(){order.push('dispose');scheduler.dispose();},
+}};
+const INFLIGHT={};
+const snapshotLiveTurnHtmlForSession=()=>order.push('snapshot');
+const _resumeSessionStreamAfterLiveChat=()=>{};
+eval(extract(messageSource,'closeLiveStream'));
+events.push('tool');scheduler.request();
+closeLiveStream('a','other',source);
+assert.deepEqual(order,[]);
+closeLiveStream('a','s',{});
+assert.deepEqual(order,[]);
+closeLiveStream('a','s',source);
+assert.deepEqual(order,['flush','snapshot','dispose','close']);
+frame(); assert.equal(paints.length,1);
+assert.equal(scheduler.pending(),false);
+assert.equal(LIVE_STREAMS.a,undefined);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_real_render_request_is_coalesced_and_snapshot_follows_commit():
+    run_js("""
+function _flushStreamingMediaPostProcess(){}
+let _deferAnchorScenePaint=false, _anchorPaintScheduler=null;
+let _anchorPaintGeneration=0, _anchorPaintDisposed=false;
+let _pendingProsePaint=null,_committingLivePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
+let _anchorRegistry={}, _anchorShadowWarned=false;
+let activeSid='a', streamId='s', _terminalStateReached=false, _streamFinalized=false;
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const LIVE_STREAMS={};
+let snapshots=0;const order=[];let _livePaintScrollSnapshot=null;
+const _captureMessageScrollSnapshot=()=>{order.push('capture');return {};};
+const _restoreMessageScrollSnapshotSameFrame=()=>order.push('restore');
+const snapshotLiveTurn=()=>{ snapshots++; };
+const _isActiveSession=()=>current;
+const _anchorSceneActiveMode=()=> 'transparent_stream';
+const window={
+  _createLiveScenePaintScheduler,
+  requestAnimationFrame:fn=>{frames.set(++nextId,fn);return nextId;},
+  cancelAnimationFrame:id=>cancelled.push(id),
+  _renderLiveAnchorActivitySceneForStream:(s,a,opts)=>{if(!opts.scrollOwned)_captureMessageScrollSnapshot();order.push('scene');paints.push(events.slice());if(!opts.scrollOwned)_restoreMessageScrollSnapshotSameFrame();return true;},
+  _liveAnchorRegistries:new Map([[streamId,_anchorRegistry]]),
+};
+eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
+eval(extract(messageSource,'_renderAnchorLiveScene'));
+const handler=_withDeferredAnchorScenePaint(e=>{
+  events.push(e); assert.equal(_renderAnchorLiveScene(),true);
+  assert.equal(_renderAnchorLiveScene(),true);
+});
+handler('start'); handler('complete');
+_pendingProsePaint=()=>order.push('prose');
+assert.equal(paints.length,0);
+assert.equal(frames.size,1);
+frame(); assert.deepEqual(paints,[events]);
+assert.equal(snapshots,1);
+assert.deepEqual(order,['capture','prose','scene','restore']);
+handler('next'); current=false; frame();
+assert.equal(paints.length,1);
+assert.equal(_anchorPaintScheduler.pending(),false);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_event_batch_defers_only_paint_and_restores_scope_on_error():
+    run_js("""
+let _deferAnchorScenePaint=false;
+let _anchorPaintGeneration=0, _anchorPaintDisposed=false;
+let _pendingProsePaint=null,_committingLivePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
+let _anchorPaintScheduler=scheduler;
+eval(extract(messageSource, '_withDeferredAnchorScenePaint'));
+const handler=_withDeferredAnchorScenePaint(event=>{
+  events.push(event);
+  assert.equal(_deferAnchorScenePaint,true);
+  scheduler.request(); scheduler.request();
+});
+handler('tool'); handler('tool_complete');
+assert.deepEqual(events,['tool','tool_complete']);
+assert.equal(_deferAnchorScenePaint,false);
+assert.equal(paints.length,0);
+assert.equal(frames.size,1);
+frame(); assert.deepEqual(paints,[events]);
+assert.throws(_withDeferredAnchorScenePaint(()=>{throw Error('test');}));
+assert.equal(_deferAnchorScenePaint,false);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+@pytest.mark.parametrize("transition", ["switch", "dispose", "flush", "cancel_replace"])
+def test_lifecycle_invalidates_already_dispatched_callbacks(transition):
+    run_js("""
+events.push('start'); scheduler.request();
+const obsolete = [...frames.values()][0];
+""" + {
+        "switch": """
+current=false; frame();
+assert.equal(paints.length, 0);
+assert.equal(scheduler.pending(), false);
+""",
+        "dispose": """
+scheduler.dispose(); obsolete(); scheduler.request();
+assert.equal(paints.length, 0);
+assert.equal(scheduler.pending(), false);
+assert.equal(cancelled.length, 1);
+""",
+        "flush": """
+events.push('complete'); scheduler.flush();
+assert.deepEqual(paints, [events]);
+obsolete(); assert.equal(paints.length, 1);
+assert.equal(scheduler.pending(), false);
+""",
+        "cancel_replace": """
+scheduler.cancel(); events.push('replacement'); scheduler.request();
+obsolete(); assert.equal(paints.length, 0);
+assert.equal(scheduler.pending(), true);
+frame(); assert.deepEqual(paints, [events]);
+assert.equal(scheduler.pending(), false);
+""",
+    }[transition])
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_burst_coalesces_without_deferring_authoritative_state():
+    run_js("""
+for(let i=0; i<100; i++) { events.push(i); scheduler.request(); }
+assert.equal(events.length, 100);
+assert.equal(frames.size, 1);
+assert.equal(paints.length, 0);
+frame();
+assert.deepEqual(paints, [events]);
+assert.equal(scheduler.pending(), false);
+events.push(100); scheduler.request(); frame();
+assert.deepEqual(paints[1], events);
+assert.equal(paints.length, 2);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_actual_sse_registration_rejects_obsolete_callbacks_before_handlers():
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+let _pendingProsePaint=null,_committingLivePaint=false,_deferAnchorScenePaint=false,_pendingKatexPaint=false,_persistTimer=null; const _pendingMediaPaintRoots=new Set();
+const activeSid='a',streamId='s',LIVE_STREAMS={};
+let _terminalStateReached=false,_streamFinalized=false,assistantText='',mirrors=0;
+const S={session:{session_id:'background-pane'},activeStreamId:'other'};
+const syncInflightAssistantMessage=()=>mirrors++;
+const _cancelThrottledSnapshotTimer=()=>{};
+const _clearStreamEndRecovery=()=>{};
+const _cancelAnimationFramePendingStreamRender=()=>{};
+const _rememberRunJournalCursor=()=>mirrors++;
+const _renderAnchorLiveScene=()=>{throw Error('obsolete paint');};
+eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
+eval(extract(messageSource,'_disposeAnchorScenePaint'));
+eval(extract(messageSource,'_wireSSE'));
+function transport(){
+ const callbacks=[];
+ return {readyState:1,callbacks,
+   addEventListener(type,fn){callbacks.push({type,fn});},
+   close(){this.readyState=2;},
+   dispatch(type,data){for(const c of callbacks.filter(x=>x.type===type))c.fn({data:JSON.stringify(data),lastEventId:'s:1'});}
+ };
+}
+const old=transport();_wireSSE(old);
+const oldOwner=LIVE_STREAMS[activeSid];
+assert.ok(old.callbacks.some(c=>c.type==='token'));
+assert.ok(old.callbacks.some(c=>c.type==='interim_assistant'));
+assert.ok(old.callbacks.some(c=>c.type==='reasoning'));
+assert.ok(old.callbacks.some(c=>c.type==='tool'));
+_disposeAnchorScenePaint();
+// These are the real registered production closures, not stand-in handlers.
+for(const c of old.callbacks)c.fn({data:'{}',lastEventId:'s:999'});
+assert.equal(mirrors,0);
+assert.equal(assistantText,'');
+assert.equal(_anchorPaintScheduler,null);
+const fresh=transport();_wireSSE(fresh);
+oldOwner.disposeScene();oldOwner.flushScene();
+assert.equal(oldOwner.requestScene(),false);
+assert.equal(_anchorPaintDisposed,false);
+for(const c of old.callbacks)c.fn({data:'{}',lastEventId:'s:999'});
+assert.equal(mirrors,0);
+fresh.dispatch('token',{text:'new generation'});
+assert.equal(assistantText,'new generation');
+assert.equal(mirrors,2,'new token ingestion and cursor listener both execute');
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_streaming_media_postprocess_uses_shared_owner_and_deduplicates_roots():
+    run_js(r"""
+let _anchorPaintDisposed=false,_pendingMediaPaintRoots=new Set(),requests=0;
+function _renderAnchorLiveScene(){requests++;return true;}
+function postProcessRenderedMessages(){}
+function requestAnimationFrame(){throw new Error('independent media frame');}
+eval(extract(fs.readFileSync('static/messages.js','utf8'),'_smdScheduleMediaPostProcess'));
+const root={};_smdScheduleMediaPostProcess(root);_smdScheduleMediaPostProcess(root);
+assert.equal(_pendingMediaPaintRoots.size,1);
+assert.equal(requests,1);
+_anchorPaintDisposed=true;
+_smdScheduleMediaPostProcess({});
+assert.equal(_pendingMediaPaintRoots.size,1);assert.equal(requests,1);
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_terminal_continuations_reject_disposed_generation_before_state_or_dom():
+    run_js(r"""
+{
+const text=fs.readFileSync('static/messages.js','utf8');
+const isCurrentGeneration=()=>false;
+let _streamFinalized=false;
+const start=text.indexOf('const _finishDone=()=>{')+'const _finishDone=()=>{'.length;
+const end=text.indexOf('\n      };',start);
+assert.ok(start>0&&end>start);
+const finish=eval('(()=>{'+text.slice(start,end)+'})');
+assert.doesNotThrow(()=>finish());assert.equal(_streamFinalized,false);
+const a=text.indexOf('const _applyCancelSessionPayload=(sessionPayload)=>{')+'const _applyCancelSessionPayload=(sessionPayload)=>{'.length;
+const b=text.indexOf('\n      };',a);
+const apply=eval('((sessionPayload)=>{'+text.slice(a,b)+'})');
+assert.equal(apply({session_id:'obsolete'}),false);
+}
+""")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not installed")
+def test_prose_replacement_invalidates_only_its_projection_key():
+    run_js(r"""
+{
+require(process.cwd()+'/static/assistant_turn_anchors.js');
+const _anchorApi=globalThis.HermesAssistantTurnAnchors;
+const _anchorRegistry=_anchorApi.createAssistantTurnAnchorRegistry({session_id:'s',stream_id:'stream'});
+let _anchorPaintDisposed=false;
+_anchorApi.applyAssistantTurnAnchorSourceEvent(_anchorRegistry,{source_event_type:'interim_assistant',event_id:'e',local_id:'prose',seq:1,payload:{text:'before'}},{session_id:'s',stream_id:'stream'});
+const before=_anchorApi.projectAssistantTurnAnchorActivityScene(_anchorRegistry,{mode:'transparent_stream'});
+const src=fs.readFileSync('static/messages.js','utf8');
+eval(extract(src,'_anchorActivityEvents'));
+eval(extract(src,'_replaceAnchorActivityEventByLocalId'));
+const localId=_anchorRegistry.anchor.activity_events[0].local_id;
+const replacement=_replaceAnchorActivityEventByLocalId(localId,'interim_assistant',{payload:{text:'after'}});
+assert.ok(replacement);
+const after=_anchorApi.projectAssistantTurnAnchorActivityScene(_anchorRegistry,{mode:'transparent_stream'});
+assert.equal(after.activity_rows[0].payload.text,'after');
+assert.equal(after.projection_stats.events_scanned,1);
+_anchorPaintDisposed=true;
+assert.equal(_replaceAnchorActivityEventByLocalId(localId,'interim_assistant',{payload:{text:'obsolete'}}),null);
+assert.equal(_anchorRegistry.anchor.activity_events[0].payload.text,'after');
+}
+""")

--- a/tests/test_issue6391_order_domains.py
+++ b/tests/test_issue6391_order_domains.py
@@ -1,0 +1,62 @@
+"""Mixed order domains must retain source identity without false regressions."""
+import pytest
+
+
+@pytest.mark.parametrize('unknown', ['opaque', None, ''])
+def test_stable_identity_does_not_make_unknown_order_incrementally_safe(unknown):
+    import json
+    _run_node(r"""
+for(const mode of ['transparent_stream','compact_worklog']){
+ const identity={session_id:'s',stream_id:'run'};
+ const r=api.createAssistantTurnAnchorRegistry(identity);
+ function feed(id,seq){
+  api.applyAssistantTurnAnchorSourceEvent(r,{source_event_type:'tool',event_id:id,seq,payload:{id,name:'read_file'}},identity);
+  return api.projectAssistantTurnAnchorActivityScene(r,{mode});
+ }
+ feed('first',10);
+ const ambiguous=feed('second',UNKNOWN);
+ assert.equal(ambiguous.projection.full_rebuild,true,'stable event identity cannot prove opaque/missing sequence order');
+ assert.equal(ambiguous.projection.fallback_reason,'uncertain_order');
+ const regression=feed('third',9);
+ assert.equal(regression.projection.full_rebuild,true,'unknown sequence must not erase numeric high-water mark');
+ assert.equal(regression.activity_rows.length,3,'fail closed without dropping semantic rows');
+}
+""".replace('UNKNOWN', json.dumps(unknown)))
+
+from tests.test_issue6391_dirty_projection import _run_node
+
+def test_mixed_local_transport_order_keeps_incremental_and_detects_real_regression():
+    _run_node(r"""
+for(const mode of ['transparent_stream','compact_worklog']){
+ const r=api.createAssistantTurnAnchorRegistry({session_id:'s',stream_id:'run'});
+ const feed=(type,seq,domain,id)=>api.applyAssistantTurnAnchorSourceEvent(r,{
+  source_event_type:type,seq,order_domain:domain,event_id:domain==='transport'?'run:'+seq:null,
+  local_id:id,payload:{local_id:id,id,name:'read_file',text:'prose'},
+ },{session_id:'s',stream_id:'run',order_domain:domain});
+ feed('tool',4,'transport','t0');api.projectAssistantTurnAnchorActivityScene(r,{mode});
+ feed('token',8,'local','p1');feed('tool',7,'transport','t1');
+ const scene=api.projectAssistantTurnAnchorActivityScene(r,{mode});
+ assert.equal(scene.projection.full_rebuild,false,'local8 -> transport7 is valid');
+ assert.equal(scene.activity_rows.length,3);
+ feed('tool',6,'transport','t2');
+ assert.equal(api.projectAssistantTurnAnchorActivityScene(r,{mode}).projection.fallback_reason,'uncertain_order');
+}
+""")
+
+
+def test_normalized_replay_preserves_trusted_domain_but_raw_cannot_opt_out():
+    _run_node(r"""
+const identity={session_id:'s',stream_id:'run'};
+const r=api.createAssistantTurnAnchorRegistry(identity);
+const local=api.normalizeAssistantTurnAnchorSourceEvent({source_event_type:'token',seq:8,payload:{text:'local'}},{...identity,order_domain:'local'});
+const wire=api.normalizeAssistantTurnAnchorSourceEvent({source_event_type:'tool',event_id:'run:7',seq:7,payload:{id:'t',name:'read_file'}},identity);
+api.applyAssistantTurnAnchorNormalizedEvent(r,local);
+api.projectAssistantTurnAnchorActivityScene(r);
+api.applyAssistantTurnAnchorNormalizedEvent(r,wire);
+assert.equal(api.projectAssistantTurnAnchorActivityScene(r).projection_stats.full_rebuild,false);
+const raw=api.createAssistantTurnAnchorRegistry(identity);
+api.applyAssistantTurnAnchorSourceEvent(raw,{source_event_type:'tool',event_id:'run:8',seq:8,payload:{id:'a',name:'read_file'}},identity);
+api.projectAssistantTurnAnchorActivityScene(raw);
+api.applyAssistantTurnAnchorSourceEvent(raw,{source_event_type:'tool',event_id:'run:7',seq:7,order_domain:'local',payload:{id:'b',name:'read_file',order_domain:'local'}},identity);
+assert.equal(api.projectAssistantTurnAnchorActivityScene(raw).projection_stats.order_uncertain,true);
+""")

--- a/tests/test_issue6391_page_lifecycle.py
+++ b/tests/test_issue6391_page_lifecycle.py
@@ -1,0 +1,15 @@
+"""Page lifecycle must complete claimed terminal work or transfer recovery."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_pagehide_finishes_before_detach_and_bfcache_uses_canonical_reload():
+    run_js(r"""
+const order=[],LIVE_STREAMS={s:{streamId:'r',finishScene(){order.push('finish');},disposeScene(){order.push('dispose');}}};
+const INFLIGHT={s:{streamId:'r'}},S={session:{session_id:'s'}};
+const closeLiveStream=(sid,rid,source)=>{order.push('detach');delete LIVE_STREAMS[sid];INFLIGHT[sid].reattach=true;};
+const loadSession=sid=>{order.push('reload:'+sid);return Promise.resolve();};
+eval(extract(messageSource,'_disposeLiveScenePaints'));
+eval(extract(messageSource,'_restoreLiveSceneAfterPageShow'));
+_disposeLiveScenePaints();assert.deepEqual(order,['finish','detach']);assert.equal(Object.keys(LIVE_STREAMS).length,0);
+_restoreLiveSceneAfterPageShow({persisted:true});assert.equal(order.at(-1),'reload:s');
+const count=order.length;_restoreLiveSceneAfterPageShow({persisted:false});assert.equal(order.length,count);
+""")

--- a/tests/test_issue6391_page_lifecycle.py
+++ b/tests/test_issue6391_page_lifecycle.py
@@ -5,11 +5,14 @@ def test_pagehide_finishes_before_detach_and_bfcache_uses_canonical_reload():
     run_js(r"""
 const order=[],LIVE_STREAMS={s:{streamId:'r',finishScene(){order.push('finish');},disposeScene(){order.push('dispose');}}};
 const INFLIGHT={s:{streamId:'r'}},S={session:{session_id:'s'}};
-const closeLiveStream=(sid,rid,source)=>{order.push('detach');delete LIVE_STREAMS[sid];INFLIGHT[sid].reattach=true;};
+const snapshotLiveTurnHtmlForSession=()=>{};
+const _resumeSessionStreamAfterLiveChat=()=>{};
+const saveInflightState=()=>{};
+eval(extract(messageSource,'closeLiveStream'));
 const loadSession=sid=>{order.push('reload:'+sid);return Promise.resolve();};
 eval(extract(messageSource,'_disposeLiveScenePaints'));
 eval(extract(messageSource,'_restoreLiveSceneAfterPageShow'));
-_disposeLiveScenePaints();assert.deepEqual(order,['finish','detach']);assert.equal(Object.keys(LIVE_STREAMS).length,0);
+_disposeLiveScenePaints();assert.deepEqual(order,['finish','dispose']);assert.equal(Object.keys(LIVE_STREAMS).length,0);
 _restoreLiveSceneAfterPageShow({persisted:true});assert.equal(order.at(-1),'reload:s');
 const count=order.length;_restoreLiveSceneAfterPageShow({persisted:false});assert.equal(order.length,count);
 """)

--- a/tests/test_issue6391_paint_readonly.py
+++ b/tests/test_issue6391_paint_readonly.py
@@ -4,7 +4,7 @@ from tests.test_issue6391_live_scene_paint import run_js
 def test_segment_paint_cannot_mutate_anchor_prose():
     run_js(r"""
 let _renderPending=false,assistantBody={innerHTML:''},segmentStart=0,assistantText='owned prose';
-const _isActiveSession=()=>true,_parseStreamState=()=>({displayText:assistantText});
+const _isActiveSession=()=>true,_semanticSnapshot=()=>({displayText:assistantText});
 const _stripXmlToolCalls=x=>x,_smdParser=null,window={},renderMd=x=>x;
 const assistantRow={};let mutations=0;
 const _upsertAnchorProcessProse=()=>mutations++;

--- a/tests/test_issue6391_paint_readonly.py
+++ b/tests/test_issue6391_paint_readonly.py
@@ -1,0 +1,31 @@
+"""Paint consumes producer-owned prose; it cannot reassign semantic ownership."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_segment_paint_cannot_mutate_anchor_prose():
+    run_js(r"""
+let _renderPending=false,assistantBody={innerHTML:''},segmentStart=0,assistantText='owned prose';
+const _isActiveSession=()=>true,_parseStreamState=()=>({displayText:assistantText});
+const _stripXmlToolCalls=x=>x,_smdParser=null,window={},renderMd=x=>x;
+const assistantRow={};let mutations=0;
+const _upsertAnchorProcessProse=()=>mutations++;
+eval(extract(messageSource,'_flushPendingSegmentRender'));
+_flushPendingSegmentRender({force:true});
+assert.equal(assistantBody.innerHTML,'owned prose');
+assert.equal(mutations,0,'render must not own semantic writes');
+""")
+
+
+def test_terminal_fade_reads_producer_state_without_semantic_writes():
+    run_js(r"""
+let _anchorPaintDisposed=false,_anchorPaintGeneration=0,assistantBody={};
+let _streamFadeDomText='visible',_smdParser=null;
+const _streamFadeCurrentDisplayText=()=> 'owned';
+let fadePaints=0,mutations=0;
+const _renderStreamingFadeMarkdown=()=>{fadePaints++;return true;};
+const _upsertAnchorProcessProse=()=>mutations++;
+const scrollIfPinned=()=>{},_STREAM_FADE_MS=100,_STREAM_FADE_DONE_MAX_MS=1000,_streamFadeLatestAnimationEndAt=0;
+const setTimeout=()=>1;
+eval(extract(messageSource,'_drainStreamFadeBeforeDone'));
+_drainStreamFadeBeforeDone(()=>{});
+assert.equal(fadePaints,1);assert.equal(mutations,0);
+""")

--- a/tests/test_issue6391_persistence_budget.py
+++ b/tests/test_issue6391_persistence_budget.py
@@ -1,0 +1,54 @@
+"""Client budget guard executes before any anchor persistence request."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_oversized_scene_is_observable_without_post_or_semantic_truncation():
+    run_js(r"""
+let activeSid='s',streamId='run',_persistAnchorSceneWarned=false;
+let calls=[],warnings=[];
+const api=(url,opts)=>{calls.push({url,opts});return Promise.resolve({ok:true});};
+const _anchorSceneMessageOffsetForPersist=()=>0;
+const _anchorSceneAbsoluteMessageIndexForPersist=i=>i;
+const _anchorSceneMessageRef=()=> 'ref';
+const showToast=(...args)=>warnings.push(args);
+const oldWarn=console.warn;console.warn=(...args)=>warnings.push(args);
+eval(extract(messageSource,'_persistSettledAnchorScene'));
+const scene={activity_rows:[{text:'界'.repeat(100000)}]};
+const before=JSON.stringify(scene);
+_persistSettledAnchorScene({},scene,0);
+assert.equal(calls.length,0,'known oversized UTF8 scene must not be posted');
+assert.equal(JSON.stringify(scene),before,'semantic scene must not be truncated');
+assert.ok(warnings.length,'failure must be observable');
+_persistSettledAnchorScene({}, {activity_rows:[{text:'ok'}]},0);
+assert.equal(calls.length,1,'under-budget scene naturally persists');
+console.warn=oldWarn;
+""")
+
+
+def test_server_exponent_padding_is_budgeted_without_counting_string_text():
+    run_js(r"""
+let activeSid='s',streamId='run',_persistAnchorSceneWarned=false;
+const calls=[],warnings=[];
+const api=(url,opts)=>{calls.push(opts);return Promise.resolve({});};
+const _anchorSceneMessageOffsetForPersist=()=>0;
+const _anchorSceneAbsoluteMessageIndexForPersist=(i)=>i;
+const _anchorSceneMessageRef=()=>({});
+const showToast=()=>{};
+console.warn=(...args)=>warnings.push(args);
+eval(extract(messageSource,'_persistSettledAnchorScene'));
+for(const number of [1e-7,-2.5e-8,9.1e-9]){
+  const scene={version:'activity_scene_v1',mode:'compact_worklog',activity_rows:[{role:'prose',payload:{text:'',numbers:Array(100).fill(number)}}]};
+  scene.activity_rows[0].payload.text='x'.repeat(255999-new TextEncoder().encode(JSON.stringify(scene)).length);
+  const original=JSON.stringify(scene),message={};calls.length=0;
+  _persistSettledAnchorScene(message,scene,0);
+  assert.equal(calls.length,0,'Python pads single-digit exponents, making this scene over the endpoint cap');
+  assert.equal(message._anchor_scene_persistence_status,'over_budget');
+  assert.equal(JSON.stringify(scene),original,'semantic state must not be truncated');
+  scene.activity_rows[0].payload.text=scene.activity_rows[0].payload.text.slice(0,-100);
+  _persistSettledAnchorScene({},scene,0);assert.equal(calls.length,1,'under-budget scientific numbers still persist');
+}
+const stringScene={version:'activity_scene_v1',activity_rows:[{role:'prose',payload:{text:'1e-7 \\" -2e-8 '.repeat(12000)}}]};
+const pad=255999-new TextEncoder().encode(JSON.stringify(stringScene)).length;
+stringScene.activity_rows[0].payload.text+='x'.repeat(pad);calls.length=0;
+_persistSettledAnchorScene({},stringScene,0);
+assert.equal(calls.length,1,'numeric-looking text inside JSON strings must not consume numeric padding');
+""")

--- a/tests/test_issue6391_persistent_rows.py
+++ b/tests/test_issue6391_persistent_rows.py
@@ -1,0 +1,22 @@
+"""Live projections preserve old snapshots without copying historical rows."""
+from tests.test_issue6391_dirty_projection import _run_node
+
+
+def test_projection_uses_bounded_persistent_rows_and_preserves_snapshot():
+    _run_node(r"""
+const r=api.createAssistantTurnAnchorRegistry({session_id:'s',stream_id:'run'});
+for(let i=0;i<100;i++)api.applyAssistantTurnAnchorSourceEvent(r,{source_event_type:'tool',event_id:'run:'+i,seq:i,payload:{id:'t'+i,name:'read_file'}},{session_id:'s',stream_id:'run'});
+const a=api.projectAssistantTurnAnchorActivityScene(r,{mode:'compact_worklog'});
+const old=JSON.stringify(a.activity_rows);
+const rows=r._activity_projection_cache?.rows;
+api.applyAssistantTurnAnchorSourceEvent(r,{source_event_type:'tool',event_id:'run:100',seq:100,payload:{id:'t100',name:'read_file'}},{session_id:'s',stream_id:'run'});
+const b=api.projectAssistantTurnAnchorActivityScene(r,{mode:'compact_worklog'});
+assert.equal(JSON.stringify(a.activity_rows),old);
+assert.equal(b._activity_rows_view.length,101);
+assert.equal(b.projection_stats.historical_rows_copied,0);
+assert.ok(b.projection_stats.row_index_nodes_copied<=5);
+assert.equal(Array.isArray(b.activity_rows),true);
+assert.equal(b.activity_rows.map(x=>x.role).length,101);
+assert.equal(Object.isFrozen(b.activity_rows),true);
+assert.strictEqual(b.activity_rows[0],a.activity_rows[0]);
+""")

--- a/tests/test_issue6391_recovery_epoch.py
+++ b/tests/test_issue6391_recovery_epoch.py
@@ -1,0 +1,16 @@
+"""Recovery scheduling is protected even after a timer dispatches."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_dispatched_recovery_cannot_run_in_replacement_generation():
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false;
+let _streamEndRecoveryTimer=null,_pendingStreamEndRecovery=false;
+let count=0,tid=0;const callbacks=[];
+const clearTimeout=()=>{},setTimeout=fn=>{callbacks.push(fn);return ++tid;};
+const _runStreamEndRecovery=()=>count++;
+eval(extract(messageSource,'_scheduleStreamEndRecovery'));
+_scheduleStreamEndRecovery({});_anchorPaintGeneration++;
+_scheduleStreamEndRecovery({});const replacement=_streamEndRecoveryTimer;
+callbacks[0]();assert.equal(count,0);assert.equal(_streamEndRecoveryTimer,replacement);
+callbacks[1]();assert.equal(count,1);
+""")

--- a/tests/test_issue6391_registry_cleanup.py
+++ b/tests/test_issue6391_registry_cleanup.py
@@ -1,0 +1,28 @@
+"""Shadow registry cleanup must not retain terminal owner/timer closures."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_registry_cleanup_cancels_timer_and_preserves_replacement_identity():
+    run_js(r"""
+let _anchorRegistryCleanupTimer=1;
+const _anchorRegistry={},streamId='s';
+const _anchorRegistryMap=new Map([[streamId,_anchorRegistry]]);
+let cleanupCancelled=0;const clearTimeout=()=>cleanupCancelled++;
+eval(extract(messageSource,'_cancelAnchorRegistryCleanup'));
+_cancelAnchorRegistryCleanup();_cancelAnchorRegistryCleanup();
+assert.equal(cleanupCancelled,1);assert.equal(_anchorRegistryMap.size,0);
+const replacement={};_anchorRegistryMap.set(streamId,replacement);
+_cancelAnchorRegistryCleanup();assert.strictEqual(_anchorRegistryMap.get(streamId),replacement);
+""")
+
+
+def test_recovery_rearms_matching_registry_and_cleanup_timer():
+    run_js(r"""
+const _anchorRegistry={},streamId='r',_anchorRegistryMap=new Map();
+let _anchorRegistryCleanupTimer=null,arms=0;
+const _scheduleAnchorRegistryCleanup=()=>{_anchorRegistryCleanupTimer=++arms;};
+eval(extract(messageSource,'_activateAnchorRegistry'));
+_activateAnchorRegistry();assert.equal(_anchorRegistryMap.get(streamId),_anchorRegistry);
+const first=_anchorRegistryCleanupTimer;_anchorRegistryMap.delete(streamId);_anchorRegistryCleanupTimer=null;
+_activateAnchorRegistry();assert.equal(_anchorRegistryMap.get(streamId),_anchorRegistry);
+assert.ok(_anchorRegistryCleanupTimer>first);
+""")

--- a/tests/test_issue6391_row_boundary.py
+++ b/tests/test_issue6391_row_boundary.py
@@ -1,0 +1,32 @@
+"""Lazy live view must not replace the public dense activity_rows contract."""
+from tests.test_issue6391_dirty_projection import _run_node
+
+def test_live_view_and_public_array_have_separate_materialization_contracts():
+    _run_node(r"""
+const r=api.createAssistantTurnAnchorRegistry({session_id:'s',stream_id:'run'});
+api.applyAssistantTurnAnchorSourceEvent(r,{type:'token',seq:1,payload:{text:'one'}});
+const scene=api.projectAssistantTurnAnchorActivityScene(r,{mode:'transparent_stream'});
+assert.ok(scene._activity_rows_view);
+assert.equal(scene.projection_stats.historical_rows_copied,0);
+assert.equal(scene._activity_rows_view.length,1);
+assert.equal(scene.projection_stats.historical_rows_copied,0);
+const rows=scene.activity_rows;
+assert.deepEqual(Object.keys(rows),['0']);assert.equal(Object.hasOwn(rows,0),true);
+assert.equal(Object.entries(rows).length,1);assert.ok(Object.isFrozen(rows));
+assert.equal(rows,scene.activity_rows);
+assert.equal(scene.projection_stats.historical_rows_copied,1);
+assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(scene)),'_activity_rows_view'),false);
+assert.deepEqual(JSON.parse(JSON.stringify(rows)),JSON.parse(JSON.stringify(scene)).activity_rows);
+""")
+
+
+def test_clean_projection_reuses_private_row_identity_without_weakening_guard():
+    _run_node(r"""
+const r=api.createAssistantTurnAnchorRegistry({session_id:'s',stream_id:'run'});
+api.applyAssistantTurnAnchorSourceEvent(r,{source_event_type:'tool',event_id:'run:1',seq:1,payload:{id:'t',name:'read_file'}});
+const a=api.projectAssistantTurnAnchorActivityScene(r);
+const b=api.projectAssistantTurnAnchorActivityScene(r);
+assert.equal(b.projection_stats.rows_rebuilt,0);
+assert.strictEqual(b._activity_rows_view,a._activity_rows_view);
+assert.equal(b.projection_stats.historical_rows_copied,0);
+""")

--- a/tests/test_issue6391_snapshot_domains.py
+++ b/tests/test_issue6391_snapshot_domains.py
@@ -1,0 +1,27 @@
+"""Persisted scene hydration preserves trusted local ordering provenance."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_real_snapshot_hydration_preserves_domains_without_trusting_wire_payload():
+    run_js(r"""
+require(process.argv[2].replace('messages.js','assistant_turn_anchors.js'));
+const _anchorApi=globalThis.HermesAssistantTurnAnchors;
+const activeSid='s',streamId='run';let _anchorShadowWarned=false;
+const ctx={session_id:activeSid,stream_id:streamId};
+const live=_anchorApi.createAssistantTurnAnchorRegistry(ctx);
+_anchorApi.applyAssistantTurnAnchorSourceEvent(live,{source_event_type:'token',seq:8,local_id:'local:1',payload:{text:'progress'}},{...ctx,order_domain:'local'});
+_anchorApi.applyAssistantTurnAnchorSourceEvent(live,{source_event_type:'tool',event_id:'run:7',seq:7,payload:{id:'t',name:'read_file'}},ctx);
+const scene=JSON.parse(JSON.stringify(_anchorApi.projectAssistantTurnAnchorActivityScene(live)));
+assert.equal(scene.activity_rows[0].order_domain,'local');
+const _anchorRegistry=_anchorApi.createAssistantTurnAnchorRegistry(ctx);
+_anchorApi.projectAssistantTurnAnchorActivityScene(_anchorRegistry);
+eval(extract(messageSource,'_sourceEventTypeForSnapshotAnchorRow'));
+eval(extract(messageSource,'_hydrateAnchorRegistryFromActivityScene'));
+assert.equal(_hydrateAnchorRegistryFromActivityScene(scene),true);
+const rebuilt=_anchorApi.projectAssistantTurnAnchorActivityScene(_anchorRegistry);
+assert.equal(rebuilt.projection_stats.order_uncertain,false);
+assert.equal(rebuilt.activity_rows[0].order_domain,'local');
+assert.equal(rebuilt.activity_rows[1].order_domain,'transport');
+const length=_anchorRegistry.anchor.activity_events.length;
+assert.equal(_hydrateAnchorRegistryFromActivityScene(scene),true);
+assert.equal(_anchorRegistry.anchor.activity_events.length,length);
+""")

--- a/tests/test_issue6391_terminal_competition.py
+++ b/tests/test_issue6391_terminal_competition.py
@@ -6,7 +6,7 @@ def test_registered_callbacks_cannot_override_claimed_terminal():
 let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
 const LIVE_STREAMS={},activeSid='s',streamId='r';
 let _terminalStateReached=true,_streamFinalized=true,finished=0,closed=0;
-const _completeOwnedTerminal=()=>finished++,_closeSource=()=>closed++;
+const _completeOwnedTerminal=()=>{finished++;_pendingTerminalFinish=null;},_closeSource=()=>closed++;
 let _deferAnchorScenePaint=false;
 const _rememberRunJournalCursor=()=>{throw new Error('late cursor callback');};
 eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
@@ -18,8 +18,9 @@ for(const type of ['token','reasoning','interim_assistant','tool','tool_complete
  for(const c of listeners.filter(c=>c.type===type))c.fn({data:'invalid JSON'});
 }
 assert.equal(finished,0);
+_pendingTerminalFinish={generation:0,finish:()=>{}};
 for(const c of listeners.filter(c=>c.type==='error'))c.fn({data:'invalid JSON'});
-assert.ok(finished>=1);assert.ok(closed>=1);
+assert.equal(finished,1);assert.equal(closed,1);
 """)
 
 

--- a/tests/test_issue6391_terminal_competition.py
+++ b/tests/test_issue6391_terminal_competition.py
@@ -1,0 +1,45 @@
+"""Terminal claim rejects competing late events before their handlers."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+def test_registered_callbacks_cannot_override_claimed_terminal():
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+const LIVE_STREAMS={},activeSid='s',streamId='r';
+let _terminalStateReached=true,_streamFinalized=true,finished=0,closed=0;
+const _completeOwnedTerminal=()=>finished++,_closeSource=()=>closed++;
+let _deferAnchorScenePaint=false;
+const _rememberRunJournalCursor=()=>{throw new Error('late cursor callback');};
+eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
+eval(extract(messageSource,'_wireSSE'));
+const listeners=[];
+const source={addEventListener(type,fn){listeners.push({type,fn});}};
+_wireSSE(source);
+for(const type of ['token','reasoning','interim_assistant','tool','tool_complete','done']){
+ for(const c of listeners.filter(c=>c.type===type))c.fn({data:'invalid JSON'});
+}
+assert.equal(finished,0);
+for(const c of listeners.filter(c=>c.type==='error'))c.fn({data:'invalid JSON'});
+assert.ok(finished>=1);assert.ok(closed>=1);
+""")
+
+
+def test_terminal_cursor_is_recorded_before_completion_disposes_source():
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+const LIVE_STREAMS={},activeSid='s',streamId='r',INFLIGHT={s:{}};
+let _terminalStateReached=false,_streamFinalized=false,_deferAnchorScenePaint=false;
+let _lastRunJournalSeq=0,_lastRunJournalEventId='';
+const _throttledPersist=()=>{},_completeOwnedTerminal=()=>{},_closeSource=()=>{},_clearStreamEndRecovery=()=>{};
+eval(extract(messageSource,'_rememberRunJournalCursor'));
+eval(extract(messageSource,'_withDeferredAnchorScenePaint'));
+eval(extract(messageSource,'_wireSSE'));
+const listeners=[];const source={addEventListener(type,fn){listeners.push({type,fn});}};
+_wireSSE(source);
+const _bailOutOfTerminalEventsFromStaleStream=()=>{
+ assert.equal(_lastRunJournalSeq,42);assert.equal(INFLIGHT.s.lastRunJournalSeq,42);
+ _terminalStateReached=true;_anchorPaintDisposed=true;
+ return true;
+};
+listeners.find(x=>x.type==='done').fn({lastEventId:'r:42',data:'{}'});
+assert.equal(_lastRunJournalSeq,42);
+""")

--- a/tests/test_issue6391_terminal_owner.py
+++ b/tests/test_issue6391_terminal_owner.py
@@ -1,0 +1,21 @@
+"""Required terminal completion is claimed once before transport disposal."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+def test_terminal_claim_is_exactly_once_and_stale_generation_cannot_finish():
+    run_js(r"""
+let _anchorPaintDisposed=false,_anchorPaintGeneration=0;
+_pendingTerminalFinish=null;_terminalFadeTimer=null;_terminalFadeFrame=null;
+let finished=0,cleared=0;
+const clearTimeout=()=>cleared++,cancelAnimationFrame=()=>cleared++;
+eval(extract(messageSource,'_completeOwnedTerminal'));
+_pendingTerminalFinish={generation:0,finish:()=>finished++};
+_terminalFadeTimer=1;_terminalFadeFrame=2;
+_completeOwnedTerminal();_completeOwnedTerminal();
+assert.equal(finished,1);assert.equal(cleared,2);
+assert.equal(_pendingTerminalFinish,null);
+assert.equal(_terminalFadeTimer,null);assert.equal(_terminalFadeFrame,null);
+_pendingTerminalFinish={generation:0,finish:()=>finished++};
+_anchorPaintGeneration=1;
+_completeOwnedTerminal();assert.equal(finished,1);
+""")

--- a/tests/test_issue6867_artifacts_settled_recovery.py
+++ b/tests/test_issue6867_artifacts_settled_recovery.py
@@ -183,6 +183,8 @@ def test_restore_settled_session_projects_through_production_path(browser):
               window._closeSource = () => {};
               window._isSessionCurrentPane = sid => !!S.session && S.session.session_id === sid;
               window._streamFinalized = false;
+              window._anchorPaintGeneration = 1;
+              window._anchorPaintDisposed = false;
               window._persistTimer = null;
               window._cancelThrottledSnapshotTimer = () => {};
               window._clearAnchorProseIncrementalNode = () => {};

--- a/tests/test_issue7478_cache.py
+++ b/tests/test_issue7478_cache.py
@@ -1,0 +1,48 @@
+"""Live projection lifetime is bounded by explicit stream ownership."""
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+def test_many_live_identities_release_and_rebuild():
+    run_js(r"""
+const _anchorSceneRenderProjectionCaches=new Map();
+for(const f of ['_anchorSceneRenderCacheKey','_anchorSceneSourceRows','_anchorSceneRenderOutputKey','_anchorSceneRememberFullProjection','_releaseAnchorSceneRenderProjections']) eval(extract(src,f));
+let released=0,peakRows=0;
+for(let i=0;i<200;i++){
+ const rows=Array.from({length:100},(_,n)=>({role:'prose',row_id:'p'+n,text:'x'.repeat(512)+n}));
+ const scene={identity:{session_id:'s'+i,stream_id:'r'+i,turn_id:'t'+i},projection:{revision:1},activity_rows:rows};
+ _anchorSceneRememberFullProjection(scene,{settled:false},rows);
+ assert.equal(_anchorSceneRenderProjectionCaches.size,1);
+ const entry=[..._anchorSceneRenderProjectionCaches.values()][0];
+ peakRows=Math.max(peakRows,entry.sourceCount);
+ assert.equal(entry.sessionId,'s'+i);
+ released+=_releaseAnchorSceneRenderProjections('s'+i,'r'+i);
+ assert.equal(_anchorSceneRenderProjectionCaches.size,0);
+ _anchorSceneRememberFullProjection(scene,{settled:false},rows);
+ assert.equal(_anchorSceneRenderProjectionCaches.size,1,'revisit rebuilds released identity');
+ _anchorSceneRememberFullProjection(scene,{settled:true},rows);
+ assert.equal(_anchorSceneRenderProjectionCaches.size,0,'settled projection evicts live identity');
+}
+assert.equal(released,200);assert.equal(peakRows,100);
+""")
+
+
+def test_ownerless_projection_is_not_retained():
+    run_js(r"""
+const _anchorSceneRenderProjectionCaches=new Map();
+for(const f of ['_anchorSceneRenderCacheKey','_anchorSceneSourceRows','_anchorSceneRenderOutputKey','_anchorSceneRememberFullProjection']) eval(extract(src,f));
+for(const identity of [{session_id:'s'}, {session_id:'s',turn_id:'t'}, {stream_id:'r',turn_id:'t'}]){
+ const scene={identity,projection:{revision:1},activity_rows:[{role:'prose',row_id:'p',text:'text'}]};
+ _anchorSceneRememberFullProjection(scene,{settled:false},scene.activity_rows);
+}
+assert.equal(_anchorSceneRenderProjectionCaches.size,0,'cache admission requires a releasable live owner');
+""")
+
+
+def test_settled_projections_are_not_retained():
+    run_js(r"""
+const _anchorSceneRenderProjectionCaches=new Map();
+for(const f of ['_anchorSceneRenderCacheKey','_anchorSceneSourceRows','_anchorSceneRenderOutputKey','_anchorSceneRememberFullProjection']) eval(extract(src,f));
+const scene={identity:{session_id:'s',stream_id:'r',turn_id:'t'},projection:{revision:1},activity_rows:[]};
+_anchorSceneRememberFullProjection(scene,{settled:true},[]);
+assert.equal(_anchorSceneRenderProjectionCaches.size,0);
+""")

--- a/tests/test_issue7478_cancel.py
+++ b/tests/test_issue7478_cancel.py
@@ -1,25 +1,32 @@
 """Payload-less cancellation keeps its async canonical settlement owner."""
 import pytest
 from tests.test_issue6391_live_scene_paint import run_js
+from tests.test_issue7478_spaced_semantic import helpers as semantic_helpers, runtime
 
 
+@pytest.mark.parametrize('tail', ['', '<thi'])
+@pytest.mark.parametrize('spacing', [0, 40])
 @pytest.mark.parametrize('has_row', [True, False])
-def test_wire_cancel_awaits_canonical_snapshot(has_row):
-    run_js(r"""
+def test_wire_cancel_awaits_canonical_snapshot(has_row, spacing, tail):
+    run_js(semantic_helpers() + r"""
 (async()=>{
+""" + runtime() + r"""
 let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
 let _terminalStateReached=false,_streamFinalized=false,_persistTimer=null;
 const activeSid='s',streamId='r',LIVE_STREAMS={};
 const S={session:{session_id:'s'},messages:[],activeStreamId:'r'};
-let assistantText='partial',closed=0,lifecycle=0,rendered=0;
+let assistantText='',liveReasoningText='',closed=0,lifecycle=0,rendered=0;
 let segmentStart=0,_semanticProseTimer=null,_semanticProseDirty=false,scans=0,semanticText='';
-const setTimeout=()=>1,clearTimeout=()=>{};
+let time=0,timerId=0;const timers=new Map();
+const setTimeout=(fn,ms)=>{timers.set(++timerId,{fn,at:time+ms});return timerId;},clearTimeout=id=>timers.delete(id);
+function advance(){time+=SPACING;for(const [id,t]of [...timers])if(t.at<=time){timers.delete(id);t.fn();}}
 const assistantRow=ASSISTANT_ROW,_freshSegment=false;
 let inflightScans=0;
 const syncInflightAssistantMessage=()=>{inflightScans++;},_completeAutomaticCompressionOnLiveProgress=()=>{};
-const ensureAssistantRow=()=>{},_scheduleRender=()=>{};
-const _parseStreamState=()=>{scans++;return {displayText:assistantText};};
-const _stripXmlToolCalls=x=>x,_upsertAnchorProcessProse=x=>{semanticText=x;};
+const ensureAssistantRow=()=>{};
+eval(extract(messageSource,'_stripXmlToolCalls'));eval(extract(messageSource,'_parseStreamState'));
+const fullParse=_parseStreamState;_parseStreamState=()=>{scans++;return fullParse();};
+const _upsertAnchorProcessProse=x=>{semanticText=x;};
 for(const f of ['_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
 let resolveFetch; const api=()=>new Promise(resolve=>{resolveFetch=resolve;});
 const _bailOutOfTerminalEventsFromStaleStream=()=>false;
@@ -41,12 +48,14 @@ const _closeSource=()=>{_anchorPaintGeneration++;_anchorPaintDisposed=true;delet
 const callbacks=[];
 const source={readyState:1,close(){closed++;this.readyState=2;},addEventListener(type,fn){callbacks.push({type,fn});}};
 eval(extract(messageSource,'_wireSSE')); _wireSSE(source);
-for(let i=0;i<10000;i++) for(const x of callbacks.filter(x=>x.type==='token')) x.fn({data:'{"text":"x"}'});
+for(let i=0;i<10000;i++){for(const x of callbacks.filter(x=>x.type==='token')) x.fn({data:'{"text":"x"}'});advance();}
 assert.equal(scans,0,'the actual token handler must not scan full history');
-assert.equal(inflightScans,0,'inflight thinking extraction must also be batched');
+assert.equal(inflightScans,SPACING?10000:0,'publication follows virtual time, not parsing');
+if(TAIL)for(const x of callbacks.filter(x=>x.type==='token'))x.fn({data:JSON.stringify({text:TAIL})});
 for(const x of callbacks.filter(x=>x.type==='cancel')) x.fn({data:'{}'});
-assert.equal(scans,1,'terminal boundary drains the coalesced semantic state');
-assert.equal(semanticText,assistantText);
+assert.equal(scans,TAIL?1:0,'only terminal partial-delimiter fallback may rescan');
+assert.equal(_semanticState.stats.incrementalBytes,10000+TAIL.length);
+assert.equal(semanticText,'x'.repeat(10000));
 for(const x of callbacks.filter(x=>x.type==='stream_end')) x.fn({data:'{}'});
 assert.equal(_anchorPaintDisposed,false,'auxiliary cancel must not dispose pending canonical settlement');
 assert.equal(typeof resolveFetch,'function');
@@ -56,4 +65,4 @@ assert.equal(S.messages[0].content,'canonical partial');
 assert.equal(rendered,1);assert.equal(lifecycle,1);assert.equal(closed,1);
 assert.equal(LIVE_STREAMS.s,undefined);
 })().catch(error=>{console.error(error);process.exitCode=1;});
-""".replace('ASSISTANT_ROW', '{}' if has_row else 'null'))
+""".replace('ASSISTANT_ROW', '{}' if has_row else 'null').replace('SPACING',str(spacing)).replace('TAIL',repr(tail)))

--- a/tests/test_issue7478_cancel.py
+++ b/tests/test_issue7478_cancel.py
@@ -1,0 +1,59 @@
+"""Payload-less cancellation keeps its async canonical settlement owner."""
+import pytest
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+@pytest.mark.parametrize('has_row', [True, False])
+def test_wire_cancel_awaits_canonical_snapshot(has_row):
+    run_js(r"""
+(async()=>{
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+let _terminalStateReached=false,_streamFinalized=false,_persistTimer=null;
+const activeSid='s',streamId='r',LIVE_STREAMS={};
+const S={session:{session_id:'s'},messages:[],activeStreamId:'r'};
+let assistantText='partial',closed=0,lifecycle=0,rendered=0;
+let segmentStart=0,_semanticProseTimer=null,_semanticProseDirty=false,scans=0,semanticText='';
+const setTimeout=()=>1,clearTimeout=()=>{};
+const assistantRow=ASSISTANT_ROW,_freshSegment=false;
+let inflightScans=0;
+const syncInflightAssistantMessage=()=>{inflightScans++;},_completeAutomaticCompressionOnLiveProgress=()=>{};
+const ensureAssistantRow=()=>{},_scheduleRender=()=>{};
+const _parseStreamState=()=>{scans++;return {displayText:assistantText};};
+const _stripXmlToolCalls=x=>x,_upsertAnchorProcessProse=x=>{semanticText=x;};
+for(const f of ['_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
+let resolveFetch; const api=()=>new Promise(resolve=>{resolveFetch=resolve;});
+const _bailOutOfTerminalEventsFromStaleStream=()=>false;
+const _clearStreamEndRecovery=()=>{},_cancelThrottledSnapshotTimer=()=>{};
+const _clearAnchorProseIncrementalNode=()=>{},_cancelAnimationFramePendingStreamRender=()=>{};
+const _streamFadeCleanupReduceMotionListener=()=>{},_smdEndParser=()=>{};
+const _clearOwnerInflightState=()=>{},_clearStreamHidden=()=>{},_clearStreamNotificationBackground=()=>{};
+const _clearApprovalForOwner=()=>{},_clearClarifyForOwner=()=>{},_flushReasoningToAnchor=()=>{};
+const _applyToAnchor=()=>{},_scheduleAnchorRegistryCleanup=()=>{};
+const _rememberRunJournalCursor=()=>{},_withDeferredAnchorScenePaint=fn=>fn;
+const renderSessionList=()=>{},_setActivePaneIdleIfOwner=()=>{};
+const _attachProjectedAnchorSceneToLastAssistant=()=>{};
+const _carryForwardEphemeralTurnFields=(_,messages)=>messages;
+const clearLiveToolCards=()=>{},_markSessionViewed=()=>{};
+const renderMessages=()=>rendered++;
+const _dispatchExtensionTurnLifecycle=type=>{assert.equal(type,'turn:cancel');lifecycle++;};
+const _completeOwnedTerminal=()=>{};
+const _closeSource=()=>{_anchorPaintGeneration++;_anchorPaintDisposed=true;delete LIVE_STREAMS.s;};
+const callbacks=[];
+const source={readyState:1,close(){closed++;this.readyState=2;},addEventListener(type,fn){callbacks.push({type,fn});}};
+eval(extract(messageSource,'_wireSSE')); _wireSSE(source);
+for(let i=0;i<10000;i++) for(const x of callbacks.filter(x=>x.type==='token')) x.fn({data:'{"text":"x"}'});
+assert.equal(scans,0,'the actual token handler must not scan full history');
+assert.equal(inflightScans,0,'inflight thinking extraction must also be batched');
+for(const x of callbacks.filter(x=>x.type==='cancel')) x.fn({data:'{}'});
+assert.equal(scans,1,'terminal boundary drains the coalesced semantic state');
+assert.equal(semanticText,assistantText);
+for(const x of callbacks.filter(x=>x.type==='stream_end')) x.fn({data:'{}'});
+assert.equal(_anchorPaintDisposed,false,'auxiliary cancel must not dispose pending canonical settlement');
+assert.equal(typeof resolveFetch,'function');
+resolveFetch({session:{session_id:'s',messages:[{role:'assistant',content:'canonical partial',_partial:true}]}});
+await new Promise(resolve=>setImmediate(resolve));
+assert.equal(S.messages[0].content,'canonical partial');
+assert.equal(rendered,1);assert.equal(lifecycle,1);assert.equal(closed,1);
+assert.equal(LIVE_STREAMS.s,undefined);
+})().catch(error=>{console.error(error);process.exitCode=1;});
+""".replace('ASSISTANT_ROW', '{}' if has_row else 'null'))

--- a/tests/test_issue7478_detach.py
+++ b/tests/test_issue7478_detach.py
@@ -1,0 +1,72 @@
+"""Accepted terminal work must survive ordinary owner teardown."""
+import pytest
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+@pytest.mark.parametrize('path', ['page', 'switch'])
+def test_shared_detach_paths_finish_current_owner(path):
+    run_js(r"""
+const order=[],INFLIGHT={};
+const source={readyState:1,close(){order.push('close');this.readyState=2;}};
+const LIVE_STREAMS={session:{streamId:'stream',source,
+ finishScene(){order.push('finish');},flushScene(){order.push('flush');},
+ disposeScene(){order.push('dispose');}}};
+const snapshotLiveTurnHtmlForSession=()=>order.push('snapshot');
+const _resumeSessionStreamAfterLiveChat=()=>{};
+for(const f of ['closeLiveStream','closeOtherLiveStreams','_disposeLiveScenePaints']) eval(extract(messageSource,f));
+if(PATH==='page') _disposeLiveScenePaints(); else closeOtherLiveStreams('other');
+assert.deepEqual(order,['finish','flush','snapshot','dispose','close']);
+""".replace('PATH',repr(path)))
+
+
+@pytest.mark.parametrize('path', ['page', 'switch', 'supersede'])
+def test_pending_fade_terminal_and_cache_share_teardown(path):
+    run_js(r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+let _terminalStateReached=true;
+_pendingTerminalFinish=null;_terminalFadeTimer=1;_terminalFadeFrame=2;
+const activeSid='session',streamId='stream',INFLIGHT={},order=[];
+const source={readyState:1,close(){order.push('close');this.readyState=2;}};
+const LIVE_STREAMS={};
+const clearTimeout=()=>{},cancelAnimationFrame=()=>{};
+const _anchorSceneRenderProjectionCaches=new Map([['old',{sessionId:activeSid,streamId,sourceRows:new Map([['p',{text:'substantial prose'}]])}]]);
+const snapshotLiveTurnHtmlForSession=()=>order.push('snapshot');
+const _resumeSessionStreamAfterLiveChat=()=>{};
+const _drainSemanticProse=()=>{},_rememberRunJournalCursor=()=>{},_withDeferredAnchorScenePaint=fn=>fn;
+const _dropAnchorRegistry=()=>{};
+let _pendingProsePaint=null,_anchorFullPaintRequired=false;
+for(const f of ['closeLiveStream','closeOtherLiveStreams','_disposeLiveScenePaints','_completeOwnedTerminal','_wireSSE']) eval(extract(messageSource,f));
+eval(extract(src,'_releaseAnchorSceneRenderProjections'));
+let persist=0,lifecycle=0;
+_pendingTerminalFinish={generation:0,finish(){order.push('finish');persist++;lifecycle++;closeLiveStream(activeSid,streamId,source);}};
+LIVE_STREAMS[activeSid]={streamId,source,
+ finishScene:_completeOwnedTerminal,flushScene:()=>order.push('flush'),
+ disposeScene(){order.push('dispose');_anchorPaintDisposed=true;_anchorPaintGeneration++;_releaseAnchorSceneRenderProjections(activeSid,streamId);}};
+if(PATH==='page') _disposeLiveScenePaints();
+else if(PATH==='switch') closeOtherLiveStreams('other');
+else _wireSSE({readyState:1,addEventListener(){},close(){}});
+assert.deepEqual(order,['finish','flush','snapshot','dispose','close']);
+assert.equal(persist,1);assert.equal(lifecycle,1);assert.equal(_pendingTerminalFinish,null);
+assert.equal(_anchorSceneRenderProjectionCaches.size,0);
+_completeOwnedTerminal();closeLiveStream(activeSid,streamId,source);
+assert.equal(persist,1);assert.equal(lifecycle,1);
+""".replace('PATH',repr(path)))
+
+
+def test_detach_finishes_before_snapshot_and_handles_terminal_reentry():
+    run_js(r"""
+const order=[];
+const INFLIGHT={};
+const source={readyState:1,close(){order.push('close');this.readyState=2;}};
+const live={streamId:'stream',source,
+ finishScene(){order.push('finish');closeLiveStream('session','stream',source);},
+ flushScene(){order.push('flush');},disposeScene(){order.push('dispose');}};
+const LIVE_STREAMS={session:live};
+const snapshotLiveTurnHtmlForSession=()=>order.push('snapshot');
+const _resumeSessionStreamAfterLiveChat=()=>{};
+eval(extract(messageSource,'closeLiveStream'));
+closeLiveStream('session','stream',source);
+closeLiveStream('session','stream',source);
+assert.deepEqual(order,['finish','flush','snapshot','dispose','close']);
+assert.equal(LIVE_STREAMS.session,undefined);
+""")

--- a/tests/test_issue7478_error.py
+++ b/tests/test_issue7478_error.py
@@ -1,17 +1,23 @@
 """Application-error settlement releases its owner without cutting recovery short."""
 import pytest
 from tests.test_issue6391_live_scene_paint import run_js
+from tests.test_issue7478_spaced_semantic import helpers, runtime
 
 
 @pytest.mark.parametrize('lane', ['background', 'current', 'recovery', 'recovery-replaced'])
 def test_application_error_releases_projection_owner(lane):
-    run_js(r"""
+    run_js(helpers() + r"""
 (async()=>{
+""" + runtime() + r"""
 let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
 let _terminalStateReached=false,_streamFinalized=false,_persistTimer=null;
 const activeSid='s',streamId='r',LIVE_STREAMS={},INFLIGHT={};
 const S={session:{session_id:LANE==='background'?'other':'s'},messages:[],activeStreamId:'r'};
-let assistantText='partial',closed=0,lifecycle=0;
+let assistantText='',liveReasoningText='',segmentStart=0,closed=0,lifecycle=0;
+let _semanticProseTimer=null,_semanticProseDirty=false,semanticText='';
+const assistantRow={},_freshSegment=false,ensureAssistantRow=()=>{},_completeAutomaticCompressionOnLiveProgress=()=>{};
+const syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=text=>{semanticText=text;};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse','_scheduleSemanticProse'])eval(extract(messageSource,f));
 const _anchorRegistry={};
 const _anchorSceneRenderProjectionCaches=new Map([['live',{sessionId:'s',streamId:'r'}]]);
 eval(extract(src,'_releaseAnchorSceneRenderProjections'));
@@ -25,21 +31,24 @@ const _clearAnchorProseIncrementalNode=()=>{},_cancelAnimationFramePendingStream
 const _streamFadeCleanupReduceMotionListener=()=>{},_smdEndParser=()=>{};
 const _clearOwnerInflightState=()=>{},_clearStreamHidden=()=>{},_clearStreamNotificationBackground=()=>{};
 const _clearApprovalForOwner=()=>{},_clearClarifyForOwner=()=>{},_flushReasoningToAnchor=()=>{};
-const _applyToAnchor=()=>{},_scheduleAnchorRegistryCleanup=()=>{},_drainSemanticProse=()=>{};
+const _applyToAnchor=()=>{},_scheduleAnchorRegistryCleanup=()=>{};
 const _rememberRunJournalCursor=()=>{},_withDeferredAnchorScenePaint=fn=>fn;
 const renderSessionList=()=>{},_setActivePaneIdleIfOwner=()=>{},trackBackgroundError=()=>{};
 const _attachProjectedAnchorSceneToLastAssistant=()=>{},clearLiveToolCards=()=>{};
 const _markSessionViewed=()=>{},renderMessages=()=>{},_settledAnchorRetryOwnerKey=()=>'';
 const _filterRecoveryControlMessages=x=>x;
 const _dispatchExtensionTurnLifecycle=()=>lifecycle++,_completeOwnedTerminal=()=>{};
-const setTimeout=()=>1;
+const setTimeout=()=>1,clearTimeout=()=>{};
 let resolveRecovery;
 const _restoreSettledSession=()=>new Promise(resolve=>{resolveRecovery=resolve;});
 const callbacks=[];
 const source={readyState:1,close(){closed++;this.readyState=2;},addEventListener(type,fn){callbacks.push({type,fn});}};
 eval(extract(messageSource,'_wireSSE'));_wireSSE(source);
+for(const text of ['before','<thi'])for(const x of callbacks.filter(x=>x.type==='token'))x.fn({data:JSON.stringify({text})});
 const data=LANE.startsWith('recovery')?{session_id:'s',type:'interrupted',recovery_control:true}:{session_id:'s',type:'rate_limit',message:'synthetic error'};
 for(const x of callbacks.filter(x=>x.type==='apperror')) x.fn({data:JSON.stringify(data)});
+assert.equal(semanticText,'before');assert.equal(_semanticProseTimer,null);
+assert.equal(assistantText,'before<thi','raw partial delimiter is retained for canonical recovery');
 if(LANE.startsWith('recovery')){
  assert.equal(_anchorPaintDisposed,false,'recovery retains generation until settlement');
  assert.equal(_anchorSceneRenderProjectionCaches.size,1);
@@ -58,3 +67,72 @@ assert.equal(LIVE_STREAMS.s,undefined,'application error retires the closed owne
 assert.equal(_anchorPaintDisposed,true);assert.equal(_anchorSceneRenderProjectionCaches.size,0);
 })().catch(error=>{console.error(error);process.exitCode=1;});
 """.replace('LANE', repr(lane)))
+
+
+@pytest.mark.parametrize('prefix', ['', 'before ', '<thi'])
+@pytest.mark.parametrize('replay', [False, True])
+def test_transport_recovery_recreates_semantics_before_first_token(prefix, replay):
+    run_js(helpers() + r"""
+(async()=>{
+""" + runtime() + r"""
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+let _terminalStateReached=false,_streamFinalized=false,_persistTimer=null;
+let _pendingProsePaint=null,_pendingKatexPaint=false;const _pendingMediaPaintRoots=new Set();
+let _pendingStreamEndRecovery=false,_reconnectAttempted=false;
+const activeSid='s',streamId='r',LIVE_STREAMS={},INFLIGHT={s:{messages:[]}};
+const S={session:{session_id:'s'},messages:[]};
+let assistantText='',liveReasoningText='',reasoningText='',segmentStart=0;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},_freshSegment=false,ensureAssistantRow=()=>{};
+const _completeAutomaticCompressionOnLiveProgress=()=>{},_upsertAnchorProcessProse=()=>{};
+const _throttledPersist=()=>{},_rememberRunJournalCursor=()=>{};
+const _cancelAnimationFramePendingStreamRender=()=>{},_cancelThrottledSnapshotTimer=()=>{};
+const _clearStreamEndRecovery=()=>{_pendingStreamEndRecovery=false;};
+const _bailOutOfTerminalEventsFromStaleStream=()=>false,_deferStreamErrorIfOffline=()=>false;
+const _deferStreamErrorIfPageHidden=()=>false,_isSessionCurrentPane=()=>true;
+const snapshotLiveTurnHtmlForSession=()=>{},_resumeSessionStreamAfterLiveChat=()=>{};
+const setComposerStatus=()=>{},_runJournalReplayParams=()=>'';
+const document={baseURI:'http://127.0.0.1/'};
+const timers=new Map();let timerId=0;
+const setTimeout=(fn,ms)=>{timers.set(++timerId,{fn,ms});return timerId;};
+const clearTimeout=id=>timers.delete(id),cancelAnimationFrame=()=>{};
+const api=async()=>REPLAY?{replay_available:true}:{active:true};
+const sources=[];
+class EventSource{
+ constructor(){this.readyState=1;this.callbacks=[];sources.push(this);}
+ addEventListener(type,fn){this.callbacks.push({type,fn});}
+ close(){this.readyState=2;}
+ async emit(type,data){for(const x of this.callbacks.filter(x=>x.type===type))await x.fn({data:JSON.stringify(data)});}
+}
+for(const name of ['_stripXmlToolCalls','_parseStreamState','syncInflightAssistantMessage',
+ '_drainSemanticProse','_scheduleSemanticProse','_withDeferredAnchorScenePaint',
+ '_completeOwnedTerminal','_disposeAnchorScenePaint','_retireSourceForRecovery','closeLiveStream','_wireSSE'])eval(extract(messageSource,name));
+const first=new EventSource();_wireSSE(first);
+assert.equal(_semanticMetrics.fullParses,0,'first empty attach needs no recovery parse');
+if(PREFIX)await first.emit('token',{text:PREFIX});
+await first.emit('error',{});
+assert.equal(_semanticState,null,'retired parser is actually released');
+assert.equal(_semanticFallback,null);assert.equal(_semanticRaw,'');
+const retry=[...timers].find(([,t])=>t.ms===1500);assert.ok(retry);
+timers.delete(retry[0]);retry[1].fn();
+await new Promise(resolve=>setImmediate(resolve));
+assert.equal(sources.length,2,'actual reconnect status handler created successor transport');
+const second=sources[1];
+const tail=PREFIX==='<thi'?'nk>secret</think>answer':'<think>secret</think>answer';
+for(const text of [tail.slice(0,4),tail.slice(4),'<function_calls>hidden</function_calls>end']){
+ await second.emit('token',{text});_drainSemanticProse();
+}
+const expected=(PREFIX==='before '?'before ':'')+'answerend';
+assert.equal(_semanticSnapshot().content,expected,'tokens after empty recovery must reach semantic output');
+assert.equal(_semanticSnapshot().reasoning,'secret');
+assert.equal(INFLIGHT.s.messages.length,1);
+assert.equal(INFLIGHT.s.messages[0].content,expected);
+assert.equal(INFLIGHT.s.messages[0].reasoning,'secret');
+const accepted=assistantText;await first.emit('token',{text:'stale'});
+assert.equal(assistantText,accepted,'old callbacks cannot feed successor parser');
+closeLiveStream(activeSid,streamId,second);
+assert.equal(_semanticState,null);assert.equal(_semanticFallback,null);assert.equal(_semanticRaw,'');
+assert.equal(timers.size,0);assert.equal(LIVE_STREAMS.s,undefined);
+await second.emit('token',{text:'late'});assert.equal(assistantText,accepted);
+})().catch(error=>{console.error(error);process.exitCode=1;});
+""".replace('PREFIX', repr(prefix)).replace('REPLAY', 'true' if replay else 'false'))

--- a/tests/test_issue7478_error.py
+++ b/tests/test_issue7478_error.py
@@ -1,0 +1,60 @@
+"""Application-error settlement releases its owner without cutting recovery short."""
+import pytest
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+@pytest.mark.parametrize('lane', ['background', 'current', 'recovery', 'recovery-replaced'])
+def test_application_error_releases_projection_owner(lane):
+    run_js(r"""
+(async()=>{
+let _anchorPaintGeneration=0,_anchorPaintDisposed=false,_anchorPaintScheduler=null;
+let _terminalStateReached=false,_streamFinalized=false,_persistTimer=null;
+const activeSid='s',streamId='r',LIVE_STREAMS={},INFLIGHT={};
+const S={session:{session_id:LANE==='background'?'other':'s'},messages:[],activeStreamId:'r'};
+let assistantText='partial',closed=0,lifecycle=0;
+const _anchorRegistry={};
+const _anchorSceneRenderProjectionCaches=new Map([['live',{sessionId:'s',streamId:'r'}]]);
+eval(extract(src,'_releaseAnchorSceneRenderProjections'));
+const _disposeAnchorScenePaint=()=>{_anchorPaintGeneration++;_anchorPaintDisposed=true;_releaseAnchorSceneRenderProjections(activeSid,streamId);};
+const snapshotLiveTurnHtmlForSession=()=>{},_resumeSessionStreamAfterLiveChat=()=>{};
+eval(extract(messageSource,'closeLiveStream'));
+const _closeSource=source=>closeLiveStream(activeSid,streamId,source);
+const _bailOutOfTerminalEventsFromStaleStream=()=>false;
+const _clearStreamEndRecovery=()=>{},_cancelThrottledSnapshotTimer=()=>{};
+const _clearAnchorProseIncrementalNode=()=>{},_cancelAnimationFramePendingStreamRender=()=>{};
+const _streamFadeCleanupReduceMotionListener=()=>{},_smdEndParser=()=>{};
+const _clearOwnerInflightState=()=>{},_clearStreamHidden=()=>{},_clearStreamNotificationBackground=()=>{};
+const _clearApprovalForOwner=()=>{},_clearClarifyForOwner=()=>{},_flushReasoningToAnchor=()=>{};
+const _applyToAnchor=()=>{},_scheduleAnchorRegistryCleanup=()=>{},_drainSemanticProse=()=>{};
+const _rememberRunJournalCursor=()=>{},_withDeferredAnchorScenePaint=fn=>fn;
+const renderSessionList=()=>{},_setActivePaneIdleIfOwner=()=>{},trackBackgroundError=()=>{};
+const _attachProjectedAnchorSceneToLastAssistant=()=>{},clearLiveToolCards=()=>{};
+const _markSessionViewed=()=>{},renderMessages=()=>{},_settledAnchorRetryOwnerKey=()=>'';
+const _filterRecoveryControlMessages=x=>x;
+const _dispatchExtensionTurnLifecycle=()=>lifecycle++,_completeOwnedTerminal=()=>{};
+const setTimeout=()=>1;
+let resolveRecovery;
+const _restoreSettledSession=()=>new Promise(resolve=>{resolveRecovery=resolve;});
+const callbacks=[];
+const source={readyState:1,close(){closed++;this.readyState=2;},addEventListener(type,fn){callbacks.push({type,fn});}};
+eval(extract(messageSource,'_wireSSE'));_wireSSE(source);
+const data=LANE.startsWith('recovery')?{session_id:'s',type:'interrupted',recovery_control:true}:{session_id:'s',type:'rate_limit',message:'synthetic error'};
+for(const x of callbacks.filter(x=>x.type==='apperror')) x.fn({data:JSON.stringify(data)});
+if(LANE.startsWith('recovery')){
+ assert.equal(_anchorPaintDisposed,false,'recovery retains generation until settlement');
+ assert.equal(_anchorSceneRenderProjectionCaches.size,1);
+ assert.equal(typeof resolveRecovery,'function');
+ if(LANE==='recovery-replaced') LIVE_STREAMS.s={streamId:'r',source:{readyState:1}};
+ resolveRecovery(true);
+ await new Promise(resolve=>setImmediate(resolve));
+}
+assert.equal(lifecycle,1);assert.equal(closed,1);
+if(LANE==='recovery-replaced'){
+ assert.notEqual(LIVE_STREAMS.s.source,source);
+ assert.equal(_anchorSceneRenderProjectionCaches.size,1,'late recovery must not release successor state');
+ return;
+}
+assert.equal(LIVE_STREAMS.s,undefined,'application error retires the closed owner');
+assert.equal(_anchorPaintDisposed,true);assert.equal(_anchorSceneRenderProjectionCaches.size,0);
+})().catch(error=>{console.error(error);process.exitCode=1;});
+""".replace('LANE', repr(lane)))

--- a/tests/test_issue7478_fade_batch.py
+++ b/tests/test_issue7478_fade_batch.py
@@ -1,0 +1,49 @@
+"""Bound same-frame opacity nodes without changing reveal or rewind semantics."""
+import json
+
+import pytest
+from playwright.sync_api import sync_playwright
+from tests.test_smooth_text_fade import function_block, MESSAGES_JS
+
+
+@pytest.mark.parametrize('writer', ['append', 'renderer'])
+def test_same_frame_fade_batches_preserve_text_and_rewind_tail(writer):
+    names = ['_streamFadeAppendText', '_streamFadeRenderer', '_streamFadeBindCleanup',
+             '_streamFadeSkipNode', '_streamFadeMuteRenderedPrefix']
+    helpers = '\n'.join(function_block(MESSAGES_JS, name) for name in names)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.set_content('<div id="root" class="stream-fade-active"></div>')
+        result = page.evaluate('''() => {
+          let reduce=false,_streamFadeSilentPrefixChars=0,_streamFadeCurrentMs=620;
+          let _streamFadeLatestAnimationEndAt=0;
+          const _STREAM_FADE_MS=620,_SMD_MEDIA_TAIL=null;
+          const _streamFadeReduceMotionEnabled=()=>reduce;
+          const _smdParserKey=()=>null,_smdMediaPrefixTail=()=>'';
+          window.smd={default_renderer:()=>({add_text(){},set_attr(){}})};
+        ''' + helpers + '''
+          const root=document.getElementById('root');
+          _streamFadeBindCleanup(root);
+          const renderer=_streamFadeRenderer(root);
+          const write=text=>WRITER==='append'?_streamFadeAppendText(root,text):renderer.add_text({nodes:[root],index:0},text);
+          const text='word '.repeat(100);
+          write(text);
+          const initial={text:root.textContent,nodes:root.childNodes.length,spans:root.querySelectorAll('.is-new').length};
+          _streamFadeMuteRenderedPrefix(root,text.slice(0,52));
+          const muted={text:root.textContent,prefix:root.firstChild.textContent,tail:root.querySelector('.is-new')?.textContent};
+          root.querySelector('.is-new')?.dispatchEvent(new Event('animationend',{bubbles:true}));
+          const settled={text:root.textContent,active:root.querySelectorAll('.is-new').length};
+          root.replaceChildren();reduce=true;write(text);
+          const reduced={text:root.textContent,active:root.querySelectorAll('.stream-fade-word').length};
+          root.replaceChildren();reduce=false;_streamFadeSilentPrefixChars=10;write(text);
+          return {initial,muted,settled,reduced,silentText:root.textContent,firstAnimated:root.querySelector('.is-new')?.textContent};
+        }'''.replace('WRITER', json.dumps(writer)))
+        browser.close()
+    text = 'word ' * 100
+    assert result['initial'] == {'text': text, 'nodes': 1, 'spans': 1}
+    assert result['muted'] == {'text': text, 'prefix': text[:54], 'tail': text[54:]}
+    assert result['settled'] == {'text': text, 'active': 0}
+    assert result['reduced'] == {'text': text, 'active': 0}
+    assert result['silentText'] == text
+    assert result['firstAnimated'] == 'word'

--- a/tests/test_issue7478_live_prose_ownership.py
+++ b/tests/test_issue7478_live_prose_ownership.py
@@ -1,0 +1,45 @@
+"""Late legacy prose must not acquire a second visible scene owner."""
+import pytest
+
+from tests.test_issue6391_live_scene_paint import run_js
+
+
+@pytest.mark.parametrize("mode", ["compact_worklog", "transparent_stream", "hide_all_activity"])
+@pytest.mark.parametrize("owner", [True, False])
+def test_new_legacy_segment_respects_an_already_painted_scene(mode, owner):
+    run_js(r"""
+const mode=MODE, owns=OWNS;
+const activeSid='a',streamId='s';
+let assistantRow=null,assistantBody=null,_freshSegment=true;
+let _assistantSegmentSeq=0,_currentLiveSegmentSeq=0,_currentActivityBurstId=1;
+const INFLIGHT={a:{}},S={session:{session_id:'a'},activeStreamId:'s'};
+const _isActiveSession=()=>true;
+const chatActivityMode=()=>mode;
+const isLiveAnchorActivitySceneOwner=id=>owns&&id===streamId;
+function node(){return {children:[],attrs:{},style:{},hidden:false,isConnected:true,
+  classList:{values:new Set(),add(x){this.values.add(x);},contains(x){return this.values.has(x);}},
+  setAttribute(k,v){this.attrs[k]=v;},getAttribute(k){return this.attrs[k]||null;},
+  appendChild(x){this.children.push(x);return x;}};}
+const turn=node();turn.dataset={sessionId:activeSid};
+const blocks=node();blocks.appendChild=x=>{
+  // Assert at insertion, not after a later cleanup or an arbitrary sleep.
+  const sceneOwns=owns&&mode!=='hide_all_activity';
+  assert.equal(x.hidden,sceneOwns,'legacy process prose visibility at insertion');
+  assert.equal(x.classList.contains('assistant-segment-worklog-source'),sceneOwns);
+  assert.equal(x.getAttribute('aria-hidden'),sceneOwns?'true':null);
+  blocks.children.push(x);
+};
+const _assistantTurnBlocks=()=>blocks;
+const $=id=>id==='liveAssistantTurn'?turn:id==='emptyState'?node():null;
+const document={createElement:()=>node()};
+const _semanticSnapshot=()=>({displayText:'Lifecycle terminal process check'});
+eval(extract(messageSource,'ensureAssistantRow'));
+ensureAssistantRow();
+assert.equal(blocks.children.length,1);
+assert.equal(assistantRow.getAttribute('data-live-assistant'),'1');
+assert.equal(assistantRow.children[0],assistantBody);
+ensureAssistantRow();assert.equal(blocks.children.length,1,'same segment is reused');
+// A post-tool segment follows the same creation path without scanning history.
+assistantRow=null;assistantBody=null;_freshSegment=true;
+ensureAssistantRow();assert.equal(blocks.children.length,2);
+""".replace("MODE", repr(mode)).replace("OWNS", str(owner).lower()))

--- a/tests/test_issue7478_semantic.py
+++ b/tests/test_issue7478_semantic.py
@@ -1,0 +1,51 @@
+"""Producer semantic parsing batches tokens and drains at boundaries."""
+from tests.test_issue6391_live_scene_paint import run_js
+from tests.test_issue3455_think_block_extraction import _extract_block, MESSAGES_JS
+
+
+def test_batched_prose_preserves_thinking_and_boundary_order():
+    helpers = _extract_block(MESSAGES_JS, 'const _thinkPairs=') + ';\n'
+    for name in ['_thinkingFenceMarkerAt', '_nextThinkingOpener', '_textTailIsPartialOpener', '_lineIsIndentedCode', '_mergeInlineThinkingReasoning', '_extractInlineThinkingFromContent']:
+        helpers += _extract_block(MESSAGES_JS, 'function ' + name + '(') + '\n'
+    run_js(helpers + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const setTimeout=()=>1,clearTimeout=()=>{};
+const syncInflightAssistantMessage=()=>{},assistantRow={};
+const _stripXmlToolCalls=x=>x;
+const rows=[];
+let proseRow=null;
+const _upsertAnchorProcessProse=text=>{if(!proseRow){proseRow={role:'prose'};rows.push(proseRow);}proseRow.text=text;};
+for(const f of ['_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
+assistantText='<thi';_scheduleSemanticProse();_drainSemanticProse();assert.equal(rows.length,0);
+assistantText+='nk>private reasoning';_scheduleSemanticProse();_drainSemanticProse();assert.equal(rows.length,0);
+assistantText+='</think>before';_scheduleSemanticProse();_drainSemanticProse();
+assert.equal(rows[0].text,'before');assert.equal(_parseStreamState().thinkingText,'private reasoning');
+rows.push({role:'tool',text:'work'});segmentStart=assistantText.length;proseRow=null;
+assistantText+='after';_scheduleSemanticProse();_drainSemanticProse();
+assert.deepEqual(rows.map(r=>[r.role,r.text]),[['prose','before'],['tool','work'],['prose','after']]);
+assistantText+=' terminal';_scheduleSemanticProse();_drainSemanticProse();
+assert.equal(rows[2].text,'after terminal');
+assistantText+='<think>post-tool secret</think>visible';_scheduleSemanticProse();_drainSemanticProse();
+assert.equal(rows[2].text,'after terminalvisible');
+assert.equal(_semanticProseDirty,false);assert.equal(_semanticProseTimer,null);
+""")
+
+
+def test_semantic_prose_batches_long_token_burst_and_drains():
+    run_js(r"""
+let assistantText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+let scans=0,prose='';
+const setTimeout=()=>1,clearTimeout=()=>{};
+const syncInflightAssistantMessage=()=>{},assistantRow={};
+const _parseStreamState=()=>{scans++;return {displayText:assistantText};};
+const _stripXmlToolCalls=x=>x;
+const _upsertAnchorProcessProse=x=>{prose=x;};
+for(const f of ['_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
+for(let i=0;i<10000;i++){assistantText+='x';_scheduleSemanticProse();}
+assert.equal(scans,0);
+_drainSemanticProse();
+assert.equal(scans,1);assert.equal(prose.length,10000);
+_drainSemanticProse();assert.equal(scans,1);
+""")

--- a/tests/test_issue7478_semantic.py
+++ b/tests/test_issue7478_semantic.py
@@ -1,51 +1,44 @@
-"""Producer semantic parsing batches tokens and drains at boundaries."""
+"""Producer semantic snapshots coalesce publication, never parsing."""
 from tests.test_issue6391_live_scene_paint import run_js
-from tests.test_issue3455_think_block_extraction import _extract_block, MESSAGES_JS
+from tests.test_issue7478_spaced_semantic import helpers, runtime
 
 
 def test_batched_prose_preserves_thinking_and_boundary_order():
-    helpers = _extract_block(MESSAGES_JS, 'const _thinkPairs=') + ';\n'
-    for name in ['_thinkingFenceMarkerAt', '_nextThinkingOpener', '_textTailIsPartialOpener', '_lineIsIndentedCode', '_mergeInlineThinkingReasoning', '_extractInlineThinkingFromContent']:
-        helpers += _extract_block(MESSAGES_JS, 'function ' + name + '(') + '\n'
-    run_js(helpers + r"""
+    run_js(helpers() + runtime() + r"""
 let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
 let _semanticProseTimer=null,_semanticProseDirty=false;
 const setTimeout=()=>1,clearTimeout=()=>{};
 const syncInflightAssistantMessage=()=>{},assistantRow={};
-const _stripXmlToolCalls=x=>x;
-const rows=[];
-let proseRow=null;
+const rows=[];let proseRow=null;
 const _upsertAnchorProcessProse=text=>{if(!proseRow){proseRow={role:'prose'};rows.push(proseRow);}proseRow.text=text;};
-for(const f of ['_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
-assistantText='<thi';_scheduleSemanticProse();_drainSemanticProse();assert.equal(rows.length,0);
-assistantText+='nk>private reasoning';_scheduleSemanticProse();_drainSemanticProse();assert.equal(rows.length,0);
-assistantText+='</think>before';_scheduleSemanticProse();_drainSemanticProse();
-assert.equal(rows[0].text,'before');assert.equal(_parseStreamState().thinkingText,'private reasoning');
-rows.push({role:'tool',text:'work'});segmentStart=assistantText.length;proseRow=null;
-assistantText+='after';_scheduleSemanticProse();_drainSemanticProse();
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
+function token(text){assistantText+=text;_scheduleSemanticProse(text);_drainSemanticProse();}
+token('<thi');assert.equal(rows.length,0);
+token('nk>private reasoning');assert.equal(rows.length,0);
+token('</think>before');
+assert.equal(rows[0].text,'before');assert.equal(_semanticSnapshot().thinkingText,'private reasoning');
+rows.push({role:'tool',text:'work'});segmentStart=assistantText.length;_semanticSegmentStart=rows[0].text.length;proseRow=null;
+token('after');
 assert.deepEqual(rows.map(r=>[r.role,r.text]),[['prose','before'],['tool','work'],['prose','after']]);
-assistantText+=' terminal';_scheduleSemanticProse();_drainSemanticProse();
-assert.equal(rows[2].text,'after terminal');
-assistantText+='<think>post-tool secret</think>visible';_scheduleSemanticProse();_drainSemanticProse();
+token(' terminal');assert.equal(rows[2].text,'after terminal');
+token('<think>post-tool secret</think>visible');
 assert.equal(rows[2].text,'after terminalvisible');
 assert.equal(_semanticProseDirty,false);assert.equal(_semanticProseTimer,null);
+assert.equal(_semanticMetrics.fullParses,0);
 """)
 
 
 def test_semantic_prose_batches_long_token_burst_and_drains():
-    run_js(r"""
-let assistantText='',segmentStart=0,_anchorPaintDisposed=false;
-let _semanticProseTimer=null,_semanticProseDirty=false;
-let scans=0,prose='';
+    run_js(helpers() + runtime() + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false,prose='';
 const setTimeout=()=>1,clearTimeout=()=>{};
 const syncInflightAssistantMessage=()=>{},assistantRow={};
-const _parseStreamState=()=>{scans++;return {displayText:assistantText};};
-const _stripXmlToolCalls=x=>x;
+const _parseStreamState=()=>{throw Error('normal growth must not rescan');};
 const _upsertAnchorProcessProse=x=>{prose=x;};
 for(const f of ['_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,f));
-for(let i=0;i<10000;i++){assistantText+='x';_scheduleSemanticProse();}
-assert.equal(scans,0);
-_drainSemanticProse();
-assert.equal(scans,1);assert.equal(prose.length,10000);
-_drainSemanticProse();assert.equal(scans,1);
+for(let i=0;i<10000;i++){assistantText+='x';_scheduleSemanticProse('x');}
+assert.equal(prose,'');_drainSemanticProse();
+assert.equal(prose.length,10000);assert.equal(_semanticState.stats.incrementalBytes,10000);
+_drainSemanticProse();assert.equal(prose.length,10000);
 """)

--- a/tests/test_issue7478_spaced_semantic.py
+++ b/tests/test_issue7478_spaced_semantic.py
@@ -1,0 +1,361 @@
+"""Real semantic drain with virtual time: spacing must not multiply scan work."""
+import pytest
+from tests.test_issue6391_live_scene_paint import run_js
+from tests.test_issue3455_think_block_extraction import _extract_block, MESSAGES_JS
+
+
+def helpers():
+    text = _extract_block(MESSAGES_JS, 'const _thinkPairs=') + ';\n'
+    for name in ['_thinkingFenceMarkerAt', '_nextThinkingOpener', '_textTailIsPartialOpener', '_lineIsIndentedCode', '_mergeInlineThinkingReasoning', '_extractInlineThinkingFromContent']:
+        text += _extract_block(MESSAGES_JS, 'function ' + name + '(') + '\n'
+    if 'function _createIncrementalSemanticState(' in MESSAGES_JS:
+        text += _extract_block(MESSAGES_JS, 'function _createIncrementalSemanticState(') + '\n'
+    return text
+
+
+def runtime():
+    if 'function _createIncrementalSemanticState(' not in MESSAGES_JS:
+        return ''
+    return r"""
+let _semanticState=_createIncrementalSemanticState(),_semanticCursor=0,_semanticSegmentStart=0,_semanticFallback=null,_semanticFallbackCursor=-1,_semanticRaw='';
+const _semanticMetrics={fullParses:0,fullBytes:0,resyncReasons:{}};
+function _scheduleRender(){}
+for(const name of ['_consumeSemanticProse','_resyncSemanticProse','_semanticSnapshot'])eval(extract(messageSource,name));
+"""
+
+
+@pytest.mark.parametrize("mode", ["transparent_stream", "compact_worklog"])
+@pytest.mark.parametrize("spacing", ["spaced", "burst", "alternating"])
+def test_spaced_tokens_bound_full_history_scans(mode, spacing):
+    run_js(helpers() + runtime() + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+let now=0,id=0,timers=new Map(),scans=0,bytes=0;
+const setTimeout=(fn,ms)=>{timers.set(++id,{fn,at:now+ms});return id;};
+const clearTimeout=id=>timers.delete(id);
+function advance(ms){now+=ms;for(const [id,t] of [...timers]) if(t.at<=now){timers.delete(id);t.fn();}}
+const assistantRow={},activeSid='s',INFLIGHT={s:{messages:[]}},_throttledPersist=()=>{};
+let reasoningText='';
+eval(extract(messageSource,'_splitThinkFromContent'));
+eval(extract(messageSource,'syncInflightAssistantMessage'));
+const window={_toolViewMode:MODE};let tokenCount=0;
+const rows=[];let row=null;
+const _upsertAnchorProcessProse=text=>{if(!row){row={kind:'prose'};rows.push(row);}row.text=text;};
+for(const name of ['_stripXmlToolCalls','_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse','_scheduleSemanticProse']) eval(extract(messageSource,name));
+const fullParse=_parseStreamState;
+_parseStreamState=()=>{scans++;bytes+=assistantText.length;return fullParse();};
+function token(text){assistantText+=text;tokenCount++;_scheduleSemanticProse(text);advance(SPACING==='spaced'?40:SPACING==='burst'?0:tokenCount%2?40:0);}
+for(let i=0;i<2000;i++)token('x');
+token('<thi');token('nk>secret');token('</thi');token('nk>before');
+token('<fun');token('ction_calls><invoke>hidden tool</invoke>');token('</function_');token('calls>');
+token('<｜DS');token('ML｜function_calls>hidden');token('</｜DSML｜function_');token('calls>');
+_drainSemanticProse();rows.push({kind:'tool',text:'work'});segmentStart=assistantText.length;if(typeof _semanticSegmentStart!=='undefined')_semanticSegmentStart=rows[0].text.length;row=null;
+for(let i=0;i<2000;i++)token('y');
+token('after');_drainSemanticProse(true);
+assert.ok(scans<=4,`full-history calls=${scans}, bytes=${bytes}`);
+let _anchorPaintGeneration=0,finished=0;
+const cancelAnimationFrame=()=>{};
+eval(extract(messageSource,'_completeOwnedTerminal'));
+_pendingTerminalFinish={generation:0,finish(){assert.equal(INFLIGHT.s.messages[0].content,'x'.repeat(2000)+'before'+'y'.repeat(2000)+'after');assert.equal(INFLIGHT.s.messages[0].reasoning,'secret');finished++;}};
+_completeOwnedTerminal();assert.equal(finished,1);
+assert.equal(rows[0].text,'x'.repeat(2000)+'before');
+assert.equal(rows[1].kind,'tool');assert.equal(rows[2].text,'y'.repeat(2000)+'after');
+assert.ok(scans<=4,`full-history calls=${scans}, bytes=${bytes}`);
+assert.ok(bytes<=assistantText.length*4,`full-history bytes=${bytes}`);
+if(typeof _semanticState!=='undefined'){
+assert.equal(_semanticState.stats.incrementalBytes,assistantText.length);
+assert.ok(_semanticState.stats.steps<assistantText.length*10);
+if(process.env.SEMANTIC_EVIDENCE)fs.writeFileSync(process.env.SEMANTIC_EVIDENCE+'/'+MODE+'-'+SPACING+'.json',JSON.stringify({tokenCount,fullParses:scans,fullBytes:bytes,incrementalBytes:_semanticState.stats.incrementalBytes,steps:_semanticState.stats.steps,finished,rows}));
+}
+""".replace('MODE', repr(mode)).replace('SPACING', repr(spacing)))
+
+
+def test_long_prose_coalesces_publication_without_delaying_semantics_or_boundaries():
+    run_js(helpers() + runtime() + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+let now=0,id=0,timers=new Map(),published=0,renderChecks=0;
+const setTimeout=(fn,ms)=>{timers.set(++id,{fn,at:now+ms});return id;};
+const clearTimeout=id=>timers.delete(id);
+function advance(ms){now+=ms;for(const [id,t] of [...timers])if(t.at<=now){timers.delete(id);t.fn();}}
+const assistantRow={},syncInflightAssistantMessage=()=>{published++;},_upsertAnchorProcessProse=()=>{};
+let _anchorPaintGeneration=0,_renderPending=false,_streamFinalized=false;
+let _cachedParsed=null,_cachedParsedText='',_cachedParsedReasoning='';
+const _isActiveSession=()=>{renderChecks++;return false;};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse','_scheduleSemanticProse','_scheduleRender'])eval(extract(messageSource,f));
+assistantText='x'.repeat(20000);_scheduleSemanticProse(assistantText);
+assert.equal(_semanticSnapshot().content,assistantText,'receipt owns semantic state immediately');
+_scheduleRender();assert.equal(renderChecks,0,'do not race receipt publication with a second paint producer');
+advance(16);assert.equal(published,0,'publication is coalesced, not semantic parsing');
+assistantText+='<thi';_scheduleSemanticProse('<thi');
+advance(16);assert.equal(published,1,'publication is non-resetting and bounded to 32ms even for long prose');
+assert.equal(_semanticSnapshot().content,'x'.repeat(20000));
+assistantText+='nk>secret</think>tail';_scheduleSemanticProse('nk>secret</think>tail');
+assert.equal(_semanticSnapshot().reasoning,'secret');
+_drainSemanticProse(true);assert.equal(published,2,'boundary drains synchronously');
+assert.equal(_semanticSnapshot().content,'x'.repeat(20000)+'tail');
+assert.equal(timers.size,0);assert.equal(_semanticMetrics.fullParses,0);
+assert.equal(_semanticState.stats.incrementalBytes,assistantText.length);
+""")
+
+
+def test_reasoning_snapshot_caches_do_not_rescan_on_prose_ticks():
+    run_js(helpers() + r"""
+const original=_mergeInlineThinkingReasoning;let scanned=0;
+_mergeInlineThinkingReasoning=(base,parts)=>{scanned+=base.length+parts.reduce((n,p)=>n+p.length,0);return original(base,parts);};
+const p=_createIncrementalSemanticState(),channel='r'.repeat(10000);
+p.write('<think>inline</think>');
+for(let i=0;i<10000;i++){p.write('x');p.snapshot(channel);p.snapshot('');}
+assert.ok(scanned<50000,`snapshot scans=${scanned}`);
+assert.ok(p.stats.mergeBytes<50000,`merge work=${p.stats.mergeBytes}`);
+""")
+
+
+def test_reconnect_retains_split_thinking_and_bounds_uncertain_rescans():
+    run_js(helpers() + runtime() + r"""
+let assistantText='<thi',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse'])eval(extract(messageSource,f));
+_resyncSemanticProse('reconnect');
+const delta='nk>secret</think>answer';assistantText+=delta;_consumeSemanticProse(delta);
+assert.equal(_semanticSnapshot().content,'answer');assert.equal(_semanticSnapshot().reasoning,'secret');
+const malformed='<｜'+ ' '.repeat(300);assistantText+=malformed;_consumeSemanticProse(malformed);
+for(let i=0;i<10000;i++){assistantText+='x';_consumeSemanticProse('x');_semanticProseDirty=true;_drainSemanticProse();}
+assert.equal(_semanticMetrics.fullParses,1,'uncertainty must not turn timer ticks into rescans');
+_drainSemanticProse(true);_drainSemanticProse(true);
+assert.equal(_semanticMetrics.fullParses,2,'one rescan per changed uncertain boundary');
+assert.equal(_semanticSnapshot().content,_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText),'',{streaming:true}).content);
+""")
+
+
+def test_rewind_and_terminal_partial_fallback():
+    run_js(helpers() + runtime() + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse'])eval(extract(messageSource,f));
+assistantText='first';_consumeSemanticProse('first');
+assistantText='other';_consumeSemanticProse();
+assert.equal(_semanticSnapshot().content,'other','same-length discontinuity must resync');
+assistantText='replacement growth';_consumeSemanticProse();
+assert.equal(_semanticSnapshot().content,'replacement growth','untrusted growth must resync');
+assistantText='short';_consumeSemanticProse();assert.equal(_semanticSnapshot().content,'short');
+assistantText+=' <func';_consumeSemanticProse(' <func');_semanticProseDirty=true;
+_drainSemanticProse(true);
+assert.equal(_semanticSnapshot().content,'short <func','terminal fallback must not lose literal partial delimiter');
+assert.ok(_semanticMetrics.fullParses<=4);
+""")
+
+
+@pytest.mark.parametrize('chunk_size', [1, 2, 7, 65536])
+@pytest.mark.parametrize('raw', [
+    'before<｜DSML<function_calls>hidden</function_calls>after',
+    '\n\t<think>secret</think><function_calls>hidden</function_calls>answer',
+    '\r\n  \n    <think>secret</think><｜DSML｜function_calls>hidden</｜DSML｜function_calls>answer',
+    '\n\t<think>secret</think>mention DSML literally',
+    '    <think>literal</think>\n<function_calls>hidden</function_calls><think>second</think>answer',
+])
+def test_ambiguous_xml_fails_closed_until_bounded_boundary_resync(raw, chunk_size):
+    run_js(helpers() + runtime() + r"""
+let assistantText='',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse'])eval(extract(messageSource,f));
+for(let i=0;i<RAW.length;i+=CHUNK_SIZE){const delta=RAW.slice(i,i+CHUNK_SIZE);assistantText+=delta;_consumeSemanticProse(delta);_semanticProseDirty=true;_drainSemanticProse();}
+assert.equal(_semanticState.uncertain(),true,'uncertain XML must request a safe resync');
+assert.equal(_semanticMetrics.fullParses,0,'token/timer path never rescans');
+_drainSemanticProse(true);_drainSemanticProse(true);
+const expected=_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText),'',{streaming:true});
+assert.equal(_semanticSnapshot().content,expected.content);
+assert.equal(_semanticSnapshot().reasoning,expected.reasoning);
+assert.equal(_semanticMetrics.fullParses,1,'duplicate drains reuse one rescan');
+""".replace('RAW', __import__('json').dumps(raw)).replace('CHUNK_SIZE', str(chunk_size)))
+
+
+def test_pending_boundary_preserves_distinct_durable_and_live_reasoning():
+    run_js(helpers() + runtime() + r"""
+let assistantText='answer<thi',liveReasoningText='',reasoningText='earlier reasoning',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_drainSemanticProse'])eval(extract(messageSource,f));
+_consumeSemanticProse();_drainSemanticProse(true);
+assert.equal(_semanticSnapshot(reasoningText).reasoning,reasoningText,'fallback must preserve durable channel reasoning');
+assert.equal(_semanticSnapshot().reasoning,'','live reset stays distinct from durable state');
+for(let i=0;i<1000;i++){_semanticSnapshot(reasoningText);_semanticSnapshot();}
+assert.ok(_semanticMetrics.fullParses<=2);
+""")
+
+
+def test_pending_fence_is_not_a_reasoning_transition():
+    run_js(helpers() + r"""
+for(const text of ['before\n`','before\n``','before\n~','before\n~~']){
+ const state=_createIncrementalSemanticState();state.write(text);
+ assert.equal(state.hasPending(),true);
+ assert.equal(state.snapshot().inThinking,false,'a partial code fence is not thinking');
+}
+""")
+
+
+def test_xml_prefix_trim_does_not_drop_post_tool_prose():
+    run_js(helpers() + runtime() + r"""
+let assistantText='  before',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse'])eval(extract(messageSource,f));
+_consumeSemanticProse();segmentStart=assistantText.length;_semanticSegmentStart=_semanticSnapshot().content.length;
+for(const ch of '<function_calls>hidden</function_calls>after'){assistantText+=ch;_consumeSemanticProse(ch);}
+assert.equal(_parseCurrentSegmentDisplayText(),'after','global XML prefix trim must adjust the post-tool semantic offset');
+""")
+
+
+def test_split_tool_marker_survives_nonterminal_semantic_boundary():
+    run_js(helpers() + runtime() + r"""
+let assistantText='before<fun',liveReasoningText='',segmentStart=0,_anchorPaintDisposed=false;
+let _semanticProseTimer=null,_semanticProseDirty=false;
+const assistantRow={},syncInflightAssistantMessage=()=>{},_upsertAnchorProcessProse=()=>{};
+const setTimeout=()=>1,clearTimeout=()=>{};
+for(const f of ['_stripXmlToolCalls','_parseStreamState','_parseCurrentSegmentDisplayText','_drainSemanticProse'])eval(extract(messageSource,f));
+_consumeSemanticProse();_drainSemanticProse('semantic');
+assert.equal(_semanticMetrics.fullParses,0,'a trusted split delimiter remains parser-owned at nonterminal boundaries');
+segmentStart=assistantText.length;_semanticSegmentStart=_semanticSnapshot().content.length;
+for(const ch of 'ction_calls>hidden</function_calls>after'){assistantText+=ch;_consumeSemanticProse(ch);}
+assert.equal(_parseCurrentSegmentDisplayText(),'after');
+assert.equal(_semanticSnapshot().content,'beforeafter');
+_drainSemanticProse(true);assert.equal(_semanticMetrics.fullParses,0);
+_resyncSemanticProse('reconnect');
+assert.equal(_parseCurrentSegmentDisplayText(),'after','resume preserves offsets across a split tool marker');
+""")
+
+
+def test_growing_reasoning_does_not_hash_the_full_body_per_token():
+    run_js(helpers() + r"""
+let hashedUnits=0;const NativeSet=globalThis.Set;
+globalThis.Set=class extends NativeSet {
+ has(value){if(typeof value==='string')hashedUnits+=value.length;return super.has(value);}
+};
+const state=_createIncrementalSemanticState();
+state.write('<think>old</think><think>');
+for(let i=0;i<4000;i++){state.write('z');state.snapshot('external');}
+state.write('</think>answer');const value=state.snapshot('external');
+assert.equal(value.reasoning,'external\n\nold\n\n'+'z'.repeat(4000));
+assert.ok(hashedUnits<=8*state.stats.incrementalBytes,JSON.stringify({hashedUnits,input:state.stats.incrementalBytes}));
+""")
+
+
+def test_uncertain_lookahead_stays_bounded():
+    run_js(helpers() + r"""
+const p=_createIncrementalSemanticState();p.write('before<｜'+ ' '.repeat(300));
+assert.equal(p.uncertain(),true);
+for(let i=0;i<10000;i++)p.write('x');
+assert.ok(p.stats.maxPending<=257);assert.ok(p.stats.steps<600);
+assert.equal(p.snapshot().content,'before');
+""")
+
+
+def test_incremental_split_markers_match_batch_semantics():
+    run_js(helpers() + r"""
+eval(extract(messageSource,'_stripXmlToolCalls'));
+const cases=[
+ 'plain prose', '<think>reason</think>answer',
+ '  before<function_calls>hidden</function_calls>after',
+ '</function_calls>literal', '<｜DSML |bad>',
+ '  </function_calls> literal', '  mention DSML and function_calls literally',
+ ' \t<think>reason</think>answer',
+ '<think>a\n\nb</think><think>b</think>end',
+ 'before<think>first</think>middle<think>second</think>after',
+ '<think>same</think><think>same</think>visible',
+ '<think>first</think>    <think>second</think>answer',
+ 'before<function_calls><invoke>x</invoke></function_calls>after',
+ '<function_calls>hidden</function_calls>    <think>reason</think>answer',
+ 'before<｜DSML｜function_calls><｜DSML｜invoke>x</｜DSML｜invoke></｜DSML｜function_calls>after',
+ 'before< ｜ DSML | function_calls>x</ ｜ DSML | function_calls>after',
+ '`<think>literal</think>` prose', '```xml\n<think>literal</think>\n```\n<think>secret</think>answer',
+ '    <think>literal</think>\nnormal<think>secret</think>answer',
+ '  ~~~\n<think>literal</think>\n  ~~~\nanswer',
+ '<|channel>thought\nreason<channel|>answer', '<|turn|>thinking\nreason<turn|>answer',
+ 'before<think>  split reasoning  \n content  </think>after',
+];
+for(const raw of cases){
+ const expected=_extractInlineThinkingFromContent(_stripXmlToolCalls(raw),'',{streaming:true});
+ for(let size=1;size<=raw.length;size++){
+  const p=_createIncrementalSemanticState();
+  for(let i=0;i<raw.length;i+=size)p.write(raw.slice(i,i+size));
+  const got=p.snapshot();
+  assert.equal(got.content,expected.content,JSON.stringify({raw,size,got,expected}));
+  assert.equal(got.reasoning,expected.reasoning,JSON.stringify({raw,size,got,expected}));
+  assert.ok(p.stats.steps<raw.length*12);
+ }
+}
+""")
+
+
+@pytest.mark.parametrize('mode', ['transparent_stream', 'compact_worklog'])
+@pytest.mark.parametrize('pending', [False, True])
+def test_channel_reasoning_delta_work_is_linear(mode, pending):
+    run_js(helpers() + runtime() + r"""
+let assistantText=PENDING?'answer<thi':'<think>inline</think>answer';
+let reasoningText='',liveReasoningText='',segmentStart=0;
+let _terminalStateReached=false,_streamFinalized=false;
+const S={session:null},activeSid='s',streamId='r';
+const _ownsActiveStreamOrBackground=()=>true;
+for(const name of ['_stripXmlToolCalls','_parseStreamState'])eval(extract(messageSource,name));
+_consumeSemanticProse();if(PENDING)_resyncSemanticProse('reconnect');
+const callbacks={};const source={addEventListener(name,fn){callbacks[name]=fn;}};
+const a=messageSource.indexOf("    source.addEventListener('reasoning',e=>{");
+const b=messageSource.indexOf("    source.addEventListener('tool',",a);
+eval(messageSource.slice(a,b));
+let snapshots=0;
+function syncInflightAssistantMessage(){
+ snapshots++;
+ const suffix=PENDING?'':'\n\ninline';
+ assert.equal(_semanticSnapshot(reasoningText).reasoning,reasoningText.trim()+suffix);
+ assert.equal(_semanticSnapshot().reasoning,liveReasoningText.trim()+suffix);
+}
+for(let i=0;i<2000;i++){
+ callbacks.reasoning({data:JSON.stringify({text:'r'})});
+ if(i===999)liveReasoningText=''; // post-tool live reset, durable base retained
+}
+assert.equal(snapshots,2000);
+let work=_semanticState.stats.mergeBytes;
+if(_semanticFallback?.reasoningState)work+=_semanticFallback.reasoningState.stats.mergeBytes;
+assert.ok(work<30000,`channel merge work ${work} for 2000 one-character deltas`);
+assert.ok(_semanticMetrics.fullParses<=1);
+if(process.env.SEMANTIC_EVIDENCE)fs.writeFileSync(process.env.SEMANTIC_EVIDENCE+'/channel-'+MODE+'-'+PENDING+'.json',JSON.stringify({snapshots,work,full:_semanticMetrics,primary:_semanticState.stats,recovery:_semanticFallback?.reasoningState?.stats}));
+""".replace('PENDING', 'true' if pending else 'false').replace('MODE', repr(mode)))
+
+
+def test_channel_reasoning_append_keeps_batch_merge_parity():
+    run_js(helpers()+r"""
+for(const raw of ['<think>a</think><think>b\n\nc</think>', '<think>a</think><think>b</think><think>open']){
+ const state=_createIncrementalSemanticState();state.write(raw);
+ let base='';
+ for(const ch of '  a\n\nb\n\nc  \n\na extra\n\nopen'){
+  const before=base;base+=ch;
+  state.appendReasoning(ch,[[before,base]]);
+  const expected=_extractInlineThinkingFromContent(raw,base,{streaming:true});
+  assert.equal(state.snapshot(base).reasoning,expected.reasoning,JSON.stringify({raw,base}));
+ }
+}
+""")
+
+
+def test_interleaved_channel_and_inline_reasoning_matches_oracle():
+    run_js(helpers()+r"""
+const bases=['','a','b','a\n\nb','  a\n\n b \n\nc  ','\n\n','a\n\n\nb','open'];
+const raws=['<think>a</think><think>b</think>answer','<think>a\n\nb</think><think>c</think>','<think>a</think><think>open','<think>a</think><think>a\n\nb</think>'];
+for(const raw of raws)for(const initial of bases){
+ const p=_createIncrementalSemanticState();let base=initial,rawSoFar='';p.snapshot(base);
+ for(const ch of raw){
+  rawSoFar+=ch;p.write(ch);
+  const before=base;base+='b';p.appendReasoning('b',[[before,base]]);
+  const expected=_extractInlineThinkingFromContent(rawSoFar,base,{streaming:true});
+  if(!p.hasPending())assert.equal(p.snapshot(base).reasoning,expected.reasoning,JSON.stringify({rawSoFar,base}));
+ }
+}
+""")

--- a/tests/test_issue852_thinking_card_mirror.py
+++ b/tests/test_issue852_thinking_card_mirror.py
@@ -44,7 +44,7 @@ class TestStreamDisplayStripsThinkBlocksAlways:
         m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
         assert m
         fn = m.group(0)
-        assert "_extractInlineThinkingFromContent" in fn
+        assert "_semanticSnapshot().content" in fn
         helper = _inline_extractor_body(js)
         assert "_thinkPairs" in helper
         assert "text.startsWith(candidate.open,index)" in helper
@@ -56,6 +56,6 @@ class TestStreamDisplayStripsThinkBlocksAlways:
         m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
         assert m
         fn = m.group(0)
-        assert "_extractInlineThinkingFromContent" in fn
+        assert "_semanticSnapshot().content" in fn
         helper = _inline_extractor_body(js)
         assert "candidate.open.startsWith(rest)" in helper

--- a/tests/test_katex_streaming.py
+++ b/tests/test_katex_streaming.py
@@ -28,14 +28,17 @@ def _extract_function(src: str, name: str) -> str:
 
 
 def test_streaming_katex_scheduler_marks_live_pass_as_streaming():
-    """The live 150ms KaTeX debounce must identify streaming passes.
+    """The shared live owner must identify streaming KaTeX passes.
 
     Without the explicit streaming flag, renderKatexBlocks() cannot distinguish a
     live parser-owned <equation-block> that is still being filled from a settled
     DOM node, so it may mark partial math as data-rendered permanently.
     """
     fn = _extract_function(MESSAGES_JS, "_scheduleStreamingKatex")
-    assert "renderKatexBlocks(assistantBody,{streaming:true})" in fn
+    assert "_pendingKatexPaint=true" in fn
+    assert "_renderAnchorLiveScene()" in fn
+    owner = _extract_function(MESSAGES_JS, "_renderAnchorLiveScene")
+    assert "renderKatexBlocks(assistantBody,{streaming:true})" in owner
 
 
 def test_render_katex_blocks_skips_pending_streaming_equation_before_rendered_flag():

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -281,7 +281,7 @@ def test_tool_event_flushes_pending_text_before_inserting_activity():
     segment above it a frame later, which looks like process text was inserted
     before an already-visible Activity row.
     """
-    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
+    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
     flush_pos = tool_handler.find("_flushPendingSegmentRender({force:true});")
     append_pos = tool_handler.find("appendLiveToolCard(tc")
     assert flush_pos != -1 and append_pos != -1
@@ -324,7 +324,7 @@ def test_tool_event_does_not_create_blank_text_segment_without_pending_text():
     above every Activity group, making Live Stream look unstable during long
     polling turns.
     """
-    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
+    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
     upsert_pos = tool_handler.find("const tc=upsertLiveToolCall(d,'start');")
     guard_pos = tool_handler.find("String(pendingDisplayText||'').trim()")
     force_pos = tool_handler.find("ensureAssistantRow(true);")
@@ -336,7 +336,7 @@ def test_tool_event_does_not_create_blank_text_segment_without_pending_text():
 
 def test_orphan_tool_complete_does_not_create_blank_text_segment_without_pending_text():
     """An orphan tool_complete should not manufacture an empty assistant segment."""
-    complete_handler = MESSAGES_JS.split("source.addEventListener('tool_complete',e=>{", 1)[1].split("source.addEventListener('approval'", 1)[0]
+    complete_handler = MESSAGES_JS.split("source.addEventListener('tool_complete',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('approval'", 1)[0]
     orphan_branch = complete_handler.split("if(tc._createdByComplete){", 1)[1].split("} else {", 1)[0]
     guard_pos = orphan_branch.find("String(pendingDisplayText||'').trim()")
     force_pos = orphan_branch.find("ensureAssistantRow(true);")

--- a/tests/test_live_anchor_progress_echo.py
+++ b/tests/test_live_anchor_progress_echo.py
@@ -44,7 +44,7 @@ def test_interim_anchor_render_runs_after_legacy_segment_flush_without_duplicate
     flush_fn = MESSAGES[flush_fn_start : MESSAGES.index("function _resetAssistantSegment", flush_fn_start)]
 
     assert "const skipAnchorProcessProse=!!(options&&options.skipAnchorProcessProse);" in flush_fn
-    assert "if(!skipAnchorProcessProse) _upsertAnchorProcessProse(displayText,{sealed:force});" in flush_fn
+    assert "_upsertAnchorProcessProse(" not in flush_fn  # producer-owned; never paint-owned
     assert flush_idx < anchor_idx, (
         "Anchor live scene must render after the legacy interim segment is flushed, "
         "so renderLiveAnchorActivityScene can hide that source segment immediately."

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -50,6 +50,9 @@ def _event_listener_body(src, event_name):
     marker = f"source.addEventListener('{event_name}',e=>{{"
     start = src.find(marker)
     if start == -1:
+        marker = f"source.addEventListener('{event_name}',_withDeferredAnchorScenePaint(e=>{{"
+        start = src.find(marker)
+    if start == -1:
         marker = f"es.addEventListener('{event_name}', e => {{"
         start = src.find(marker)
     assert start != -1, f"{event_name} listener not found"
@@ -249,6 +252,7 @@ function _activityStatusNode(){{ throw new Error('status branch should not execu
 function _anchorSceneToolRowLogicalKey(){{ return ''; }}
 function _anchorSceneMergeToolRows(_prev, row){{ return row; }}
 eval(extractFunc('_anchorSceneIsSettledSuccessfulCompression'));
+eval(extractFunc('_anchorSceneSourceRows'));
 eval(extractFunc('_anchorSceneRowsForRendering'));
 eval(extractFunc('_autoCompressionPreviewText'));
 eval(extractFunc('_autoCompressionWorklogNode'));
@@ -303,11 +307,11 @@ def test_process_prose_is_an_anchor_scene_row_not_a_dom_mirror():
     schedule = _function_body(MESSAGES_JS, "_scheduleRender")
     flush = _function_body(MESSAGES_JS, "_flushPendingSegmentRender")
 
-    assert "_upsertAnchorProcessProse(displayText,{sealed:force})" in flush
+    assert "_upsertAnchorProcessProse(" not in flush
     assert "function _upsertAnchorProcessProse" in MESSAGES_JS
     assert "source_event_type:sourceEventType" in _function_body(MESSAGES_JS, "_applyToAnchor")
     assert "let anchorProcessText=displayText" in schedule
-    assert "_upsertAnchorProcessProse(anchorProcessText)" in schedule
+    assert "_upsertAnchorProcessProse(" not in schedule
     assert "function _replaceAnchorActivityEventByLocalId" in MESSAGES_JS
     assert "events[i]=next" in MESSAGES_JS
     assert "_renderAnchorLiveScene();" in _function_body(MESSAGES_JS, "_upsertAnchorProcessProse")
@@ -582,6 +586,7 @@ const src = fs.readFileSync({json.dumps(str(ROOT / "static" / "ui.js"))}, 'utf8'
 function _anchorSceneToolRowLogicalKey(){{ return ''; }}
 function _anchorSceneMergeToolRows(a,b){{ return b; }}
 function _anchorSceneIsSettledSuccessfulCompression(){{ return false; }}
+eval(extractFunc('_anchorSceneSourceRows'));
 eval(extractFunc('_anchorSceneRowsForRendering'));
 const scene = {{
   activity_rows: [
@@ -669,7 +674,8 @@ def test_anchor_tool_result_text_stays_out_of_header_preview():
 
 
 def test_scene_renderer_allows_prose_tool_prose_tool_interleaving():
-    render = _function_body(UI_JS, "_renderAnchorSceneRowsIntoWorklog")
+    assert "_anchorSceneWorklogAppendRow(" in _function_body(UI_JS, "_renderAnchorSceneRowsIntoWorklog")
+    render = _function_body(UI_JS, "_anchorSceneWorklogAppendRow")
 
     assert "currentTools=null;" in render
     assert render.index("if(row.role==='tool')") < render.index("}else{")

--- a/tests/test_live_tool_callback_events.py
+++ b/tests/test_live_tool_callback_events.py
@@ -66,8 +66,8 @@ def test_tool_callback_events_keep_existing_frontend_event_contract():
     messages = _read("static/messages.js")
     ui = _read("static/ui.js")
 
-    assert "source.addEventListener('tool',e=>{" in messages
-    assert "source.addEventListener('tool_complete',e=>{" in messages
+    assert "source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{" in messages
+    assert "source.addEventListener('tool_complete',_withDeferredAnchorScenePaint(e=>{" in messages
     assert "String(d&&d.tid" in messages or "explicitTid=String(d&&d.tid" in messages, (
         "frontend tool handlers must still consume explicit server tid when present"
     )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1065,8 +1065,11 @@ def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_tes
     compact_token_body = token_body.replace(" ", "").replace("\n", "")
     assert "if(assistantRow){ensureAssistantRow();_scheduleRender();}" in compact_token_body, \
         "token handler should skip the per-token full-text parse after the live answer segment exists"
-    assert "constparsed=_parseStreamState();if(String((parsed&&parsed.displayText)||'').trim())ensureAssistantRow();_scheduleRender(parsed);" in compact_token_body, \
-        "token handler must only create the live answer segment once visible answer text starts"
+    assert "_scheduleSemanticProse();" in compact_token_body
+    assert "_parseStreamState()" not in compact_token_body
+    semantic_body = src[src.index("function _drainSemanticProse("):src.index("function _scheduleSemanticProse(")]
+    assert "if(String(parsed.displayText||'').trim()) ensureAssistantRow();" in semantic_body, \
+        "semantic batch must only create the live answer segment once visible answer text starts"
 
 
 def test_messages_js_stream_perf_cleanup_lifecycle(cleanup_test_sessions):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -701,7 +701,7 @@ def test_live_stream_tokens_persist_partial_assistant_for_session_switch(cleanup
     # assistant text is mirrored into INFLIGHT state — is unchanged.
     assert "content:split.content" in messages_src, \
         "messages.js must persist the (think-split) partial assistant text into INFLIGHT state"
-    assert "_splitThinkFromContent(assistantText" in messages_src, \
+    assert "_semanticSnapshot(reasoningText)" in messages_src and "inflight.lastAssistantText=assistantText" in messages_src, \
         "the persisted partial must be derived from the live assistantText"
     assert "_live:true" in messages_src, \
         "messages.js must mark the persisted in-flight assistant row so renderMessages can re-anchor it"
@@ -1065,7 +1065,7 @@ def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_tes
     compact_token_body = token_body.replace(" ", "").replace("\n", "")
     assert "if(assistantRow){ensureAssistantRow();_scheduleRender();}" in compact_token_body, \
         "token handler should skip the per-token full-text parse after the live answer segment exists"
-    assert "_scheduleSemanticProse();" in compact_token_body
+    assert "_scheduleSemanticProse(d.text);" in compact_token_body
     assert "_parseStreamState()" not in compact_token_body
     semantic_body = src[src.index("function _drainSemanticProse("):src.index("function _scheduleSemanticProse(")]
     assert "if(String(parsed.displayText||'').trim()) ensureAssistantRow();" in semantic_body, \

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -492,6 +492,11 @@ def test_run_journal_cursor_tracks_every_long_task_timeline_event():
     ]
 
     for event_name in timeline_events:
+        if event_name == "cancel":
+            assert "'cancel'" not in cursor_loop, "cancel must not register a competing auxiliary terminal listener"
+            assert "type==='cancel'" in MESSAGES_SRC
+            assert "_rememberRunJournalCursor(event);" in MESSAGES_SRC
+            continue
         assert f"'{event_name}'" in cursor_loop, (
             f"{event_name} must advance the replay cursor to avoid duplicate timeline replay"
         )

--- a/tests/test_smd_media_in_stream.py
+++ b/tests/test_smd_media_in_stream.py
@@ -75,6 +75,7 @@ def _run_real_smd_media_cases() -> dict:
             _extract_js_function(MESSAGES_JS, "_smdMediaAwareAddText"),
             _extract_js_function(MESSAGES_JS, "_smdAppendMediaNode"),
             _extract_js_function(MESSAGES_JS, "_smdScheduleMediaPostProcess"),
+            _extract_js_function(MESSAGES_JS, "_flushStreamingMediaPostProcess"),
             _extract_js_function(MESSAGES_JS, "_smdParserKey"),
             _extract_js_function(MESSAGES_JS, "_smdBindParserIdentity"),
             _extract_js_function(MESSAGES_JS, "_smdMediaTailClear"),
@@ -91,6 +92,8 @@ def _run_real_smd_media_cases() -> dict:
         "import * as smd from './static/vendor/smd.min.js';\n"
         "globalThis.window = { smd };\n"
         "globalThis.requestAnimationFrame = cb => cb();\n"
+        "const _anchorPaintDisposed=false;const _pendingMediaPaintRoots=new Set();\n"
+        "function _renderAnchorLiveScene(){_flushStreamingMediaPostProcess();}\n"
         "const _MEDIA_TAIL_MAX = 4096;\n"
         "const _SMD_MEDIA_PREFIX = 'MEDIA:';\n"
         "const _SMD_MEDIA_TAIL = new WeakMap();\n"

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -179,7 +179,8 @@ def test_stream_fade_uses_incremental_renderer_without_changing_default_path():
         [
             "_renderStreamingFadeMarkdown(displayText)",
             "_smdWrite(displayText)",
-            "?33:66",
+            "_pendingProsePaint=_doRender",
+            "_renderAnchorLiveScene()",
         ],
     )
     assert_contains_all(
@@ -501,16 +502,12 @@ def test_transparent_anchor_prose_receives_revealed_fade_text():
             "const caughtUp=_renderStreamingFadeMarkdown(displayText)",
             "if(_shouldUseLiveProseFade())",
             "anchorProcessText=_streamFadeDomText||''",
-            "if(anchorProcessText) _upsertAnchorProcessProse(anchorProcessText)",
+            "// Producer callbacks own semantic prose; fade/paint only project it.",
         ],
     )
     assert render_section.index("let anchorProcessText=displayText") < render_section.index("if(assistantBody){")
-    assert render_section.index("anchorProcessText=_streamFadeDomText||''") < render_section.index(
-        "_upsertAnchorProcessProse(anchorProcessText)"
-    )
-    assert render_section.index("if(assistantBody){") < render_section.rindex(
-        "if(anchorProcessText) _upsertAnchorProcessProse(anchorProcessText)"
-    )
+    assert "_upsertAnchorProcessProse(" not in render_section
+    # Executable read-only paint contracts live in test_issue6391_paint_readonly.py.
 
 
 def test_stream_fade_done_drain_has_hard_cap_for_large_buffered_responses():
@@ -523,15 +520,13 @@ def test_stream_fade_done_drain_has_hard_cap_for_large_buffered_responses():
             "const target=_streamFadeCurrentDisplayText();",
             "const caughtUp=_renderStreamingFadeMarkdown(target);",
             "const anchorProcessText=_streamFadeDomText||target;",
-            "if(anchorProcessText) _upsertAnchorProcessProse(anchorProcessText);",
+            "// Producer callbacks own semantic prose; fade/paint only project it.",
             "performance.now()-drainStartedAt>=_STREAM_FADE_DONE_DRAIN_MAX_MS",
             "if(_smdParser) _smdEndParser();",
             "onDone();",
         ],
     )
-    assert drain_block.index("_renderStreamingFadeMarkdown(target)") < drain_block.index(
-        "_upsertAnchorProcessProse(anchorProcessText)"
-    )
+    assert "_upsertAnchorProcessProse(" not in drain_block
 
 
 def test_live_streaming_assistant_content_opts_out_of_global_theme_transitions():

--- a/tests/test_sprint38.py
+++ b/tests/test_sprint38.py
@@ -117,8 +117,8 @@ def test_stream_display_uses_shared_inline_thinking_extractor():
     assert fn_idx >= 0, "_streamDisplay function not found in messages.js"
     fn_end = MSG_JS.find("\n  }", fn_idx) + 4
     fn_body = MSG_JS[fn_idx:fn_end]
-    assert "_extractInlineThinkingFromContent(_stripXmlToolCalls(assistantText), liveReasoningText, {streaming:true}).content" in fn_body, \
-        "_streamDisplay must route through the shared inline thinking extractor"
+    assert "_semanticSnapshot().content" in fn_body, \
+        "_streamDisplay must read the shared incremental semantic snapshot"
 
 
 def test_shared_extractor_scans_known_open_tags():

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -762,6 +762,7 @@ def test_invisible_anchor_outcome_applies_without_repainting_live_scene():
     assert NODE, "node is required for assistant-turn ownership tests"
     apply_source = _function_source(_read(MESSAGES_JS), "_applyToAnchor")
     script = f"""
+const _anchorPaintDisposed=false;
 const activeSid='sid-owned-outcome';
 const streamId='stream-owned-outcome';
 const _anchorRegistry={{anchor:{{}}}};
@@ -802,6 +803,7 @@ console.log(JSON.stringify({{result,applied,renderCount,renderOutcome}}));
     assert data["applied"][0]["context"] == {
         "session_id": "sid-owned-outcome",
         "stream_id": "stream-owned-outcome",
+        "order_domain": "transport",
     }
 
 
@@ -849,6 +851,7 @@ def test_side_effect_only_scene_is_persisted_without_creating_a_worklog():
         messages_js, "_attachProjectedAnchorSceneToLastAssistant"
     )
     script = f"""
+const _anchorPaintDisposed=false;
 const activeSid='sid-owned-outcome';
 const streamId='stream-owned-outcome';
 const _anchorRegistry={{}};

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -49,14 +49,18 @@ class TestStreamFinalized:
             "_scheduleRender must return early when _streamFinalized is true"
         )
 
-    def test_raf_handle_stored_in_schedule_render(self):
+    def test_schedule_render_uses_shared_cancellable_owner(self):
         src = read('static/messages.js')
-        assert '_pendingRafHandle=_pendingRafFrameHandle' in src or \
-               '_pendingRafHandle = _pendingRafFrameHandle' in src or \
-               '_pendingRafHandle=requestAnimationFrame' in src or \
-               '_pendingRafHandle = requestAnimationFrame' in src, (
-            "rAF handle must be stored in _pendingRafHandle for cancellation"
-        )
+        match = re.search(r'function _scheduleRender\([^)]*\)\{.*?\n  \}', src, re.DOTALL)
+        assert match
+        fn = match.group(0)
+        assert '_pendingProsePaint=_doRender' in fn
+        assert '_renderAnchorLiveScene()' in fn
+        assert 'requestAnimationFrame(' not in fn
+        dispose = re.search(r'function _disposeAnchorScenePaint\([^)]*\)\{.*?\n  \}', src, re.DOTALL)
+        assert dispose
+        assert '.dispose()' in dispose.group(0)
+        assert '_anchorPaintScheduler=null' in dispose.group(0)
 
     def test_done_sets_stream_finalized(self):
         src = read('static/messages.js')

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -662,7 +662,7 @@ class TestToolCallGroupingStatic:
         assert "data-live-activity-current" in timer_fn, (
             "Elapsed timers should clear once an Activity group is no longer current."
         )
-        tool_start_segment = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
+        tool_start_segment = MESSAGES_JS.split("source.addEventListener('tool',_withDeferredAnchorScenePaint(e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
         assert "_resetAssistantSegment();" in tool_start_segment, (
             "Tool starts should reset the next assistant text segment without closing the current Activity burst."
         )


### PR DESCRIPTION
Refs #6391.

Current published head: `1dbe7b737174408a5d64abf46f218791fb8c765f`. Replay-coherence follow-up: `67cd1aa3e0d34b247ff98bdb1b11773716330586`. Ownership follow-up: `6e766f70ca6a42d6b7b75ff9c6a9b107f28e029c` and `a9e8626916c385aeca7cc0f7230de55a6e4a8f56` (two additive commits; no history rewrite).

## Thinking Path

The live scene path repeatedly rebuilt growing activity history during otherwise valid mixed prose/tool streams. Locally synthesized prose sequence values and transport sequence values were compared as one ordering domain, causing false uncertainty and full-render fallback. Transparent Stream also lost its deferred terminal finalizer when `stream_end` disposed its owner before natural anchor-scene persistence.

The original integration baseline is `f4fa4bf77dcfdf1aa4c6c8f7c145524a3c1343f0`; this is not a wholesale replacement with an old frontend. The branch has not been rebased for this follow-up. Semantic overlap was audited first. The required scene scheduler/projector dependencies from the reconstructed parent were included atomically with the reviewed remediation. Upstream parser-owned fade adoption, mute-prefix bridge, escaping, list rendering and edit-submit fixes are retained. The private graph-ignore file is excluded.

The scope is the live frontend scene pipeline. It does not address the separate backend session-loading or Workspace reports described in issue #6391; therefore this is not a closing reference.

## What Changed

- Keep replay recovery coherent with batched semantic publication by draining pending semantic prose before persisting the replay cursor and recoverable current-turn snapshot.
- Frame-coalesced live scene painting, dirty-row incremental projection and private persistent row views; normal public snapshots remain frozen arrays with correct native reflection/serialization semantics.
- Separate local/transport ordering provenance, retained through persistence and hydration. Genuine ambiguity/regression still fails closed.
- Producer-owned semantic prose and exactly-once terminal ownership; presentation/fade callbacks do not ingest prose again.
- Finish the owned terminal/fade path before transport teardown; naturally persist settled scenes in both display modes and clean up stream/registry ownership and timers.
- Execution-time generation/token checks for delayed snapshot, persistence and recovery callbacks.
- Conservative server-compatible serialized-size budgeting before anchor persistence. Known oversized scenes retain semantic state, report a warning and are not blindly posted or silently truncated.
- Genuinely incremental producer semantic state consumes token deltas; the publication timer does not restore growing full-history scans. Prior detach/cancel/cache lifetime fixes remain in the candidate.
- Prevent a newly inserted compatibility assistant segment from becoming a second visible presentation owner when an existing semantic scene already owns process presentation. The compatibility node remains available for parser, Markdown, fade and metadata duties; canonical settlement remains responsible for legitimate final prose. No-owner and Final answer only paths remain visible.
- Add reasoning-first lifecycle coverage and real-browser immediate cancellation after hidden post-tool compatibility-segment insertion in Transparent Stream and Compact Worklog. Await real session creation in the fixture before composer submission; runtime session creation is unchanged.
- Focused regression coverage and architecture documentation in `docs/architecture/live-scene-terminal-ownership.md` and `docs/architecture/incremental-stream-semantics.md`.

No backend execution policy, session JSON schema migration, settings, deployment files or changelog changes.

The earlier two ownership commits changed six files: a nine-line insertion in `static/messages.js`, lifecycle/cancellation tests, the reasoning-first lifecycle workflow step, and the ownership architecture note. The second commit is test-only.

## Why It Matters

Known-order live activity no longer spends steady-state paints on full-history fallback. Terminal completion and persisted history agree in Compact Worklog and Transparent Stream, including the `done → fade → stream_end` race. Safety fallback remains available for genuinely uncertain or terminal-only render states.

## Contract Routing

- Task type: frontend streaming correctness, lifecycle and performance bug fix.
- Touched areas: `static/messages.js`, `static/ui.js`, `static/assistant_turn_anchors.js`, associated regression tests and architecture notes.
- Relevant public docs: `docs/CONTRACTS.md`, stable-assistant-turn-anchors, live-to-final-assistant-replies and webui-run-state-consistency RFCs.
- State layer / invariant: backend transcript/run authority remains unchanged; scene rendering projects producer state, one current terminal owner finalizes, stale callbacks cannot mutate replacement state, persisted ordering provenance survives hydration.
- Evidence before claiming done: focused and full suites, exact-base unrelated-failure reproduction, real-server synthetic Chromium performance/persistence/reload/continuation lanes, adversarial and frozen-candidate independent review.

## Verification

### Replay-fixture stabilization — exact head `1dbe7b737174408a5d64abf46f218791fb8c765f`

- Initialized the synthetic local turn through the same sidebar ownership helper used by normal `send()`.
- The four previously failing replay CI cases were fixture-initialization races; replay assertions are unchanged. The corrected fixture still reproduces the original missing-prefix RED against the parent production revision.
- Local replay validation: **12/12 scenarios passed** and **80/80 repetitions** of the four previously failing matrix combinations passed. Adjacent focused validation: **177 passed**.
- The unrelated lineage-cache assertion reproduced on unchanged candidate and parent controls (2/5 module runs each). Local Python patch versions differ from CI; Playwright 1.63.0 matches. Exact-head GitHub checks: **24/24 passed**, including **36/36 replay executions** across Python 3.11–3.13; the lineage-cache test passed on all three versions.

### Historical replay-coherence follow-up — tested head `67cd1aa3e0d34b247ff98bdb1b11773716330586`

#7640 exposed a replay-recovery overlap. This follow-up fixes the #7478-specific cursor/projection coherence race. Broader stale replay authority remains separate.

- Replay-coherence regression: **12/12 passed** across virtualization on/off, including user-only state, historical assistant rows, partial current-turn publication, reasoning, and tool activity.
- Reattachment reconstructs persisted prefix + replayed suffix exactly once; stale source callbacks cannot mutate the replacement stream.
- Focused validation: **143 tests passed**.
- Supported full suite: **15,174 passed / 2 failed**; both TLS failures reproduce on the exact accepted upstream base `f4fa4bf77dcfdf1aa4c6c8f7c145524a3c1343f0`.
- Performance remains within the accepted **p95 <=100 ms** gates, with zero steady-state full-history parses and zero steady known-order fallback. Measured receipt-to-commit p95 spans **8.7–41.675 ms** across six lanes.
- Reasoning-first normal/error settlement and immediate cancellation pass in both display modes. JS syntax, Ruff and whitespace checks pass.
- Independent review **`deleg_6464dbf6` — PASS / ACCEPT**.
- Explicit uncertain parser boundaries retain their existing fail-closed full-parse path; delimiter-at-persistence timing has no dedicated new regression.

Earlier validation below is retained as historical evidence for the ownership and original-integration changes.

### Historical ownership checks — accepted head `a9e8626916c385aeca7cc0f7230de55a6e4a8f56`

- Ordinary/reasoning-first normal and terminal-error lifecycle matrix: **12/12 passed**.
- Immediate cancel after hidden compatibility-segment insertion: **3/3 Transparent Stream and 3/3 Compact Worklog**. Verified canonical partial transcript, exactly one `turn:cancel`, natural persistence, empty `LIVE_STREAMS`, and no live compatibility segment after reload.
- Causal RED: removing the nine ownership-repair lines from the served response fails the hidden-insertion assertion in both modes. Pre-fix/after-fix DOM assertions bind to the observed reasoning-first duplicate-presentation state; no live provider or real user session is involved.
- Supported focused validation: **320 passed plus 18 subtests**.
- Supported full suite (`./scripts/test.sh tests/ -q --timeout=60`): **15,161 passed / 3 failed**, 204 skipped, 2 xfailed, 1 xpassed, 45 subtests passed; exit **1**. This is **not an all-green full suite**.
- All three failures reproduced against exact upstream `71689c6ce7031f4b6ffc90d68a61a2c1f9afe52a`: two `test_tls_aware_probe.py` probes and `test_lineage_display_cache.py::test_parent_replace_during_load_is_not_published`. The lineage assertion failed **2/5 base and 2/5 candidate** trials with byte-identical tests; it is not the JavaScript projection cache. TLS fixture/connection-EOF behavior is an environment exception. No candidate-only failure was established.
- Ruff, Python compilation, ESLint runtime, undefined-reference scope and whitespace gates passed. Prior semantic/detach/cancel/cache regressions remain covered by the focused suite.
- Local suite used the supported script-selected Python 3.13.13 environment. Earlier close-match GitHub lifecycle controls used Python 3.12.13 versus CI Python 3.12.14; this difference is disclosed.
- The unsupported unscoped invocation with 113 collection errors is excluded from validation. Skips remain uncovered, not passes. Failed development/startup attempts remain retained.
- Tests/evidence were frozen before independent acceptance; final committed blobs match those reviewed bytes. Publication did not modify source/tests or regenerate evidence.

### Ownership follow-up performance

All eight completed acceptance lanes retain **zero full-history semantic parses**, **zero known-order steady-state fallback**, and **control p95 <=100 ms**. Only initial projection fallback occurs in these lanes.

| Workload | Transparent control p95 | Compact control p95 |
|---|---:|---:|
| 70-cycle | 44.0097 ms | 24.3449 ms |
| 240-cycle | 37.0967 ms | 23.3163 ms |
| Long-token | 24.7254 ms | 21.7614 ms |
| Long-reasoning | 32.8423 ms | 22.2915 ms |

Limits: a Transparent run overlapping the full suite failed the latency gate at **160.573 ms p95**; a Compact attempt failed before workload startup. Both are retained and excluded from passing acceptance lanes. These measurements are not an arbitrary-load or hardware-independent latency guarantee.

### Same-adapter performance evidence — historical original integration

The following preserved comparison belongs to the original `7d81a0898a282c74ef9704d17b4a918808dc2e97` integration candidate, not a rerun at the new head. Current ownership-follow-up measurements are above.

Real server, isolated deterministic gateway fixture, headless Chromium. Standard workload: 70 mixed prose/tool cycles at 5 cycles/sec; long candidate workload: 300 cycles. Browser-control latency measures Playwright composer focus; timeout budget 250 ms. The same frozen v6 adapter runs exact upstream and candidate. Baseline unavailable incremental telemetry is **unknown**, not zero. This is synthetic local evidence, not a hardware-independent guarantee.

| Lane | Transparent control p95 | Compact control p95 |
|---|---:|---:|
| Exact upstream | 252.54 ms (36/62 timeouts) | 152.69 ms (0/137 timeouts) |
| Candidate | 28.93 ms (0/203 timeouts) | 20.34 ms (0/217 timeouts) |
| Candidate repeat | 24.43 ms (0/218 timeouts) | 14.89 ms (0/225 timeouts) |
| Candidate long | 61.52 ms (1/839 timeouts) | 25.69 ms (0/945 timeouts) |

Initial candidate paint p50/p95/p99: Transparent **2.00/3.15/37.73 ms**; Compact **1.30/2.20/16.37 ms**. Each candidate lane has two non-steady full-render fallbacks: initial scene and terminal row. **Known-order steady-state fallback is zero**, with zero measured historical rows copied during incremental paints. Full terminal rendering remains a disclosed outlier: long Transparent maximum paint **374.80 ms**; long Compact **78.20 ms**. Long Transparent recorded one control timeout; its p95 remains within the stated gate. The v6 adapter fixes a pre-measurement first-tool-row readiness race; earlier adapter versions are not substituted into this comparison.

### Persistence and lifecycle

The first four bullets below describe retained original-integration fixture evidence, not a guarantee across every session-refresh ordering.

- Both modes naturally persist exactly one HTTP 200 anchor scene per standard turn, then have `busy=false`, no active stream, `LIVE_STREAMS=0`, no retained terminal owner or owned timer/rAF, and empty registry ownership.
- Reload and continue in the same isolated session passes in both modes: four messages, two successful natural persistence requests across two turns, clean completion.
- Oversized long workloads warn deterministically without a blind POST. Client/server numeric serialization differential: **40 cases, zero unsafe sends, 20 blocked**, semantic JSON unchanged.
- Delayed callback, recovery, competition, page lifecycle and ordering tests exercise extracted real production functions.

#### Delayed-terminal persistence qualification

A controlled **500 ms delayed-terminal** persistence anomaly reproduces equivalently on exact upstream `71689c6ce7031f4b6ffc90d68a61a2c1f9afe52a` and the repaired candidate:

| Revision | Normal reconciliation | Reconciliation deferred until after `done` |
|---|---:|---:|
| Exact upstream | 0/3 passed | 3/3 passed |
| Repaired candidate | 0/3 passed | 3/3 passed |

Deferred runs issue natural anchor-scene requests with HTTP 200 and pass reload checks; normal-order runs reproduce missing persistence. Classification: **`SESSION_REFRESH_RECONCILIATION_RACE / UPSTREAM-EXISTING`**. No candidate-specific persistence regression was established. **No production change for that separate upstream behavior is included in this PR.** This attributes the controlled reproduction, not unrecorded frame timing in an earlier spontaneous failure.

#### Independent acceptance and GitHub review state

**`deleg_00a3826c` — PASS / ACCEPT** covers the final frozen local ownership-acceptance candidate published at `a9e8626916c385aeca7cc0f7230de55a6e4a8f56`. All **6 candidate files**, **6 final committed blobs** and **301 retained review-evidence hashes** match. The reviewer accepted the documented upstream/base exceptions and performance limits; this is not maintainer approval or a whole-application heap proof.

New-head GitHub CI/bot checks are separate from local acceptance; old-head successful checks are not evidence for this head. See this PR's exact-head Checks tab for current results. Prior `CHANGES_REQUESTED` reviews remain for maintainer re-review; no review finding has been marked resolved on the maintainer's behalf. Authorized local synthetic test execution does not supersede the maintainer's prior static-only **NO-RUN** threat-policy disposition.

## Risks / Follow-ups

- The upstream-existing session-refresh reconciliation/persistence race is not fixed here; controlled base/candidate equivalence and the exact-base test exceptions above bound the local acceptance.
- The fallback terminal renderer remains proportional to settled scene size; this change targets steady-state work, not zero terminal cost.
- Oversized scenes are not persisted through the capped endpoint; semantic live state is retained and warning behavior is explicit. No server cap increase or silent truncation.
- Automated fixture/DOM evidence does not constitute owner-performed manual testing. No new manual owner, live-runtime, or responsive visual validation is claimed for this follow-up; no new public desktop/narrow before-and-after image set is included.
- This PR does not address all aspects of #6391. No live deployment or promotion was performed.

## Model Used

- Planning input supplied by owner: **gpt-6-astra**
- Implementation/integration and validation: **Hermes primary**, provider **openai-codex**, model **gpt-6-astra**.
- Native delegated investigations and independent review: **gpt-5.6-luna**. Interrupted/invalidated runs do not count as approval.
- Notable tool/mode use: direct local source/Git inspection, Python/Node regression execution, real-server synthetic Playwright/Chromium fixtures, read-only native independent review; Firecrawl for public issue retrieval and `gh` for authenticated GitHub metadata/publication.
