### PR TITLE
fix(chat): guide agents to supported workspace file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Directory tree with expand/collapse (single-click toggles, double-click navigates)
 - Breadcrumb navigation with clickable path segments
 - Preview text, code, Markdown (rendered), and images inline
-- Chat links using `workspace://path/to/file` open files in the right-side preview pane
+- Chat links using `[label](workspace://relative/path/to/file.ext)` open files in the right-side preview pane. WebUI guides the agent to percent-encode path segments, including spaces, parentheses, and literal `%`.
+- For file access, the agent can use an existing download URL or `[label](file:///absolute/path/to/file.ext)`. Absolute file links remain subject to media-serving restrictions and may preview supported types instead of downloading. If access is denied or unknown, the agent shows the path in backticks. `MEDIA:` delivery and links inside authored files are unchanged.
 - Edit, create, delete, and rename files; create folders
 - Binary file download (auto-detected from server)
 - File preview auto-closes on directory navigation (with unsaved-edit guard)

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Directory tree with expand/collapse (single-click toggles, double-click navigates)
 - Breadcrumb navigation with clickable path segments
 - Preview text, code, Markdown (rendered), and images inline
-- Chat links using `[label](workspace://relative/path/to/file.ext)` open files in the right-side preview pane. WebUI guides the agent to percent-encode path segments, including spaces, parentheses, and literal `%`.
-- For file access, the agent can use an existing download URL or `[label](file:///absolute/path/to/file.ext)`. Absolute file links remain subject to media-serving restrictions and may preview supported types instead of downloading. If access is denied or unknown, the agent shows the path in backticks. `MEDIA:` delivery and links inside authored files are unchanged.
+- Chat links using `workspace://path/to/file` open files in the right-side preview pane
 - Edit, create, delete, and rename files; create folders
 - Binary file download (auto-detected from server)
 - File preview auto-closes on directory navigation (with unsaved-edit guard)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -915,7 +915,8 @@ WebUI progress guidance:
 WebUI file references:
 Apply these rules to local-file Markdown links in chat replies, including download links. Keep MEDIA: delivery and links inside authored files unchanged.
 - For workspace navigation, use [label](workspace://relative/path/to/file.ext).
-- For downloads or files outside the workspace, use an existing download URL when available; otherwise use [label](file:///absolute/path/to/file.ext). If WebUI access is denied or unknown, show its path in backticks.
+- For download links, use an existing download URL; if none is available, say so.
+- For open/view links to other local files, use [label](file:///absolute/path/to/file.ext). These may preview inline rather than download. If WebUI access is denied or unknown, show its path in backticks.
 - When constructing workspace:// or file:// links from filesystem paths, percent-encode each path segment, including spaces, parentheses, and literal %, while preserving the scheme and / separators.
 """.strip()
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -911,6 +911,12 @@ WebUI progress guidance:
 - Final visible assistant replies must be clear, user-facing, and in the user's language, not private planning notes.
 - Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need script", "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.
+
+WebUI file references:
+Apply these rules to local-file Markdown links in chat replies, including download links. Keep MEDIA: delivery and links inside authored files unchanged.
+- For workspace navigation, use [label](workspace://relative/path/to/file.ext).
+- For downloads or files outside the workspace, use an existing download URL when available; otherwise use [label](file:///absolute/path/to/file.ext). If WebUI cannot serve the file, show its path in backticks.
+- When constructing workspace:// or file:// links from filesystem paths, percent-encode each path segment, including spaces, parentheses, and literal %, while preserving the scheme and / separators.
 """.strip()
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -915,7 +915,7 @@ WebUI progress guidance:
 WebUI file references:
 Apply these rules to local-file Markdown links in chat replies, including download links. Keep MEDIA: delivery and links inside authored files unchanged.
 - For workspace navigation, use [label](workspace://relative/path/to/file.ext).
-- For downloads or files outside the workspace, use an existing download URL when available; otherwise use [label](file:///absolute/path/to/file.ext). If WebUI cannot serve the file, show its path in backticks.
+- For downloads or files outside the workspace, use an existing download URL when available; otherwise use [label](file:///absolute/path/to/file.ext). If WebUI access is denied or unknown, show its path in backticks.
 - When constructing workspace:// or file:// links from filesystem paths, percent-encode each path segment, including spaces, parentheses, and literal %, while preserving the scheme and / separators.
 """.strip()
 


### PR DESCRIPTION
## Thinking Path

- When an agent references a generated local file in WebUI chat, we repeatedly see links such as `[Open report](./reports/report.md)` displayed as literal Markdown instead of clickable links. The file exists, but the handoff leaves the user finding it manually or asking for a corrected reference.
- The settled Markdown renderer recognizes explicit schemes such as `workspace://`, but not bare relative filesystem paths as Markdown link targets. The existing WebUI runtime guidance does not explain this distinction.
- Add the supported file-reference convention to the existing WebUI-only ephemeral prompt. This gives the agent the information needed when composing its response, without relying on users to request a particular syntax.
- Keep the renderer unchanged. Supporting arbitrary relative Markdown links would require separate decisions about path resolution and access. A profile-wide `SOUL.md` rule would also apply this WebUI-specific constraint to unrelated clients.

## What Changed

Addition to `_WEBUI_PROGRESS_PROMPT` in `api/streaming.py`, grouped under its own heading:

```text
WebUI file references:
Apply these rules to local-file Markdown links in chat replies, including download links. Keep MEDIA: delivery and links inside authored files unchanged.
- For workspace navigation, use [label](workspace://relative/path/to/file.ext).
- For download links, use an existing download URL; if none is available, say so.
- For open/view links to other local files, use [label](file:///absolute/path/to/file.ext). These may preview inline rather than download. If WebUI access is denied or unknown, show its path in backticks.
- When constructing workspace:// or file:// links from filesystem paths, percent-encode each path segment, including spaces, parentheses, and literal %, while preserving the scheme and / separators.
```

This uses the existing ephemeral prompt assembly. It requires no new configuration setting, renderer behavior, or change to persisted chat messages.

## Why It Matters

The intended result is a usable file reference on the first response, rather than another correction cycle.

The wording follows Matt Pocock’s [Writing for Agents](https://github.com/mattpocock/skills/blob/3cca18b368ae95cdbdebbff572ccafa662551015/skills/productivity/writing-for-agents/SKILL.md) guidance:

- **State the desired behavior.** The prompt gives the exact supported syntax instead of only banning relative links or asking for an unspecified “supported format.”
- **Keep related rules together.** The format, encoding requirement, and fallback share one heading.
- **Make each instruction earn its place.** Encoding addresses concrete parsing constraints. The scope sentence protects document links and existing artifact delivery. The fallback covers files outside the workspace without suggesting an invented URL.
- **Avoid duplication.** The addition belongs in the shared WebUI prompt, not in each chat entry point or every user’s profile.

## Verification

Workspace-link and runtime prompt regression coverage:

```bash
./scripts/test.sh tests/test_webui_surface_context.py tests/test_issue5871_redaction_awareness_prompt.py tests/test_issue2881_workspace_chat_links.py tests/test_webui_gateway_chat_backend.py tests/test_sprint42.py -q
```

**Result: 99 passed, 11 subtests passed.**

Additional renderer probes confirmed:

- A labeled `workspace://` reference becomes an internal workspace link.
- Percent-encoded spaces, parentheses, and literal `%` survive link conversion.
- A bare `./...` Markdown destination remains literal text.
- Ordinary HTTPS links still render.

## Risks / Follow-ups

- Prompting cannot guarantee compliance or repair existing responses. A rendered link also does not prove that its target exists or is accessible.
- Adds approximately 150 input tokens per WebUI agent model request; the exact count depends on the model’s tokenizer.

## Models Used

- Hermes Agent / `gpt-6-astra` (`Default`) via OpenAI Codex: Investigation, prompt refinement, verification, and PR-description drafting.
- Claude Code / `claude-opus-5` (`medium`) via Anthropic first-party API: Prompt design and wording refinements; independent review and regression-test verification of the pre-publication implementation.
