### PR TITLE
fix(models): share the cold-rebuild budget fairly across custom-provider probes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -430,7 +430,7 @@ wall-clock budget:
 | --- | --- | --- |
 | `HERMES_WEBUI_MODELS_REBUILD_BUDGET` | `4` (seconds) | Window a foreground caller waits for a cold rebuild. `0` restores the legacy synchronous unbounded rebuild. |
 | `CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS` | `5.0` | Per-endpoint cap for a custom provider `/v1/models` probe. |
-| `CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS` | `0.01` | Arithmetic guard against a zero timeout. Not a per-probe minimum — see below. |
+| `CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS` | `0.01` | Attempt-only timeout for a probe reached after the window is already spent while the caller is still waiting. Not a per-probe minimum and not a slice — see below. |
 
 Within the window the rebuild behaves normally; past it the caller is served a fallback
 (last-known disk cache, else a network-free static catalog) while the worker keeps going so
@@ -443,18 +443,28 @@ slice of the *remaining* window instead of letting one probe take the whole per-
 cap, so an unreachable endpoint cannot leave the reachable providers behind it with no
 in-band probe at all (#7481).
 
-- Each slice is `min(cap, left / (remaining + 1))`. The `+1` reserves a slot of headroom,
-  so a chain of N probes can spend at most `N/(N+1)` of the window and always finishes
-  inside it — that is what keeps the foreground caller on a published catalog instead of
-  the over-budget fallback. The guard above is clamped against `left`, so no chain length
-  can outspend the window.
+- Each slice is `min(cap, left / (remaining + 1))`, with **no lower bound**. The `+1`
+  reserves a slot of headroom, so a chain of N probes can spend at most `N/(N+1)` of the
+  window and always finishes inside it — that is what keeps the foreground caller on a
+  published catalog instead of the over-budget fallback. A floor (however small) would make
+  the chain's cumulative spend grow with the endpoint count, and `custom_providers` has no
+  count limit, so a long enough chain of dead endpoints could again outspend the window and
+  push the reachable providers behind it out of the in-band rebuild.
+- The two states that keep the unthrottled per-endpoint cap are stated explicitly rather
+  than inferred from the clock, because a spent window says nothing about whether anyone is
+  still waiting:
+  - the legacy unbounded path (budget `0`), which has no window to share;
+  - the out-of-band continuation — the worker still probing after the foreground caller
+    gave up and served its fallback. It is recognised through an explicit signal (the
+    caller sets the event when it stops waiting) and is the only in-process state allowed
+    to spend past the window. The narrow race where a probe finds the window spent while
+    the caller *is* still waiting is not that state: it gets the attempt-only timeout
+    above, never the cap.
 - Trade-off to know about: slices shrink as the chain grows, because the window is fixed
   and shared. A slow-but-reachable endpoint in a long chain can be cut off; size
   `HERMES_WEBUI_MODELS_REBUILD_BUDGET` for the endpoints actually in use, or give a
   `custom_providers` entry a static `models:` allowlist so it is never probed live.
-- The legacy unbounded path (budget `0`) and the out-of-band continuation (window already
-  spent) keep the unthrottled per-endpoint cap, so their behaviour is unchanged. Probe
-  order, per-endpoint SSRF and authentication rules, and the per-endpoint cap are
+- Probe order, per-endpoint SSRF and authentication rules, and the per-endpoint cap are
   preserved.
 
 Publication is ordered by **generation, not by wall clock**. Each cold rebuild takes the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -464,6 +464,14 @@ in-band probe at all (#7481).
   and shared. A slow-but-reachable endpoint in a long chain can be cut off; size
   `HERMES_WEBUI_MODELS_REBUILD_BUDGET` for the endpoints actually in use, or give a
   `custom_providers` entry a static `models:` allowlist so it is never probed live.
+- An endpoint is probed **at most once per rebuild**. The three live-probe consumers
+  (active `model.base_url`, named `custom_providers`, LM Studio provider-group fallback)
+  share a per-rebuild memo keyed by the endpoint URL plus the credential sent, so the
+  common config where the active endpoint and `providers.lmstudio.base_url` are the same
+  LAN host no longer pays that host's connect timeout twice, and two named entries on one
+  endpoint probe it once. A different URL — or the same URL with a different key, which can
+  change the outcome — is still its own probe, and the memo is consulted only after the
+  per-endpoint SSRF/authentication checks, so a call that would have been refused still is.
 - Probe order, per-endpoint SSRF and authentication rules, and the per-endpoint cap are
   preserved.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -418,6 +418,53 @@ whose default `SessionDB()` path remains frozen at module import. Keep this fall
 compatibility-only: new goal semantics belong in Hermes Agent's native manager rather
 than a second WebUI implementation.
 
+### 4.9 Model Catalog Rebuild Budget and Probe Scheduling
+
+The model picker's catalog (`GET /api/models`) is produced by one cold rebuild that
+live-probes providers. A probe is a network call to a provider the WebUI may not be able
+to reach — a LAN LM Studio/Ollama host is the usual case, because the probe runs in the
+server process rather than the browser — so the rebuild runs on a daemon worker under a
+wall-clock budget:
+
+| Knob | Default | Meaning |
+| --- | --- | --- |
+| `HERMES_WEBUI_MODELS_REBUILD_BUDGET` | `4` (seconds) | Window a foreground caller waits for a cold rebuild. `0` restores the legacy synchronous unbounded rebuild. |
+| `CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS` | `5.0` | Per-endpoint cap for a custom provider `/v1/models` probe. |
+| `CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS` | `0.01` | Arithmetic guard against a zero timeout. Not a per-probe minimum — see below. |
+
+Within the window the rebuild behaves normally; past it the caller is served a fallback
+(last-known disk cache, else a network-free static catalog) while the worker keeps going so
+the refresh lands out-of-band for the next caller.
+
+Custom endpoints are probed **serially**: the active `model.base_url` first, then each
+named `custom_providers` entry in config order, then the LM Studio provider-group
+fallback. `_CustomProbeSchedule` in `api/config.py` hands each of those probes a fair
+slice of the *remaining* window instead of letting one probe take the whole per-endpoint
+cap, so an unreachable endpoint cannot leave the reachable providers behind it with no
+in-band probe at all (#7481).
+
+- Each slice is `min(cap, left / (remaining + 1))`. The `+1` reserves a slot of headroom,
+  so a chain of N probes can spend at most `N/(N+1)` of the window and always finishes
+  inside it — that is what keeps the foreground caller on a published catalog instead of
+  the over-budget fallback. The guard above is clamped against `left`, so no chain length
+  can outspend the window.
+- Trade-off to know about: slices shrink as the chain grows, because the window is fixed
+  and shared. A slow-but-reachable endpoint in a long chain can be cut off; size
+  `HERMES_WEBUI_MODELS_REBUILD_BUDGET` for the endpoints actually in use, or give a
+  `custom_providers` entry a static `models:` allowlist so it is never probed live.
+- The legacy unbounded path (budget `0`) and the out-of-band continuation (window already
+  spent) keep the unthrottled per-endpoint cap, so their behaviour is unchanged. Probe
+  order, per-endpoint SSRF and authentication rules, and the per-endpoint cap are
+  preserved.
+
+Publication is ordered by **generation, not by wall clock**. Each cold rebuild takes the
+next sequence number (`_allocate_models_rebuild_seq`), the published catalog records the
+sequence it came from (`_models_published_seq`), and a result is dropped if it is older
+than what is already published. This matters for the out-of-band publisher, which outlives
+the foreground caller: without the guard it could resurrect a superseded catalog over a
+newer one. A timestamp comparison cannot express the ordering, because an older build can
+publish *after* a newer build has already started.
+
 ---
 
 ## 5. Frontend Architecture: Current State

--- a/api/config.py
+++ b/api/config.py
@@ -98,6 +98,12 @@ logger = logging.getLogger(__name__)
 # short hard cap and graceful degradation.
 CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS = 5.0
 
+# Floor for the fair-share slice handed to a probe in the serial custom-endpoint
+# chain (see ``_CustomProbeSchedule``, #7481). A slice that rounded down to ~0
+# would turn a reachable provider into a guaranteed failure, so every probe
+# still gets at least this long before the chain stops handing out real attempts.
+CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS = 0.5
+
 
 def _env_mb_bytes(name: str, default_mb: int) -> int:
     """Parse an optional megabyte environment variable into bytes.
@@ -5285,6 +5291,63 @@ except (TypeError, ValueError):
     _LIVE_REBUILD_BUDGET_SECONDS = 4.0
 
 
+class _CustomProbeSchedule:
+    """Fair-share timing for the serial custom-endpoint probe chain (#7481).
+
+    The cold model-catalog rebuild probes the active endpoint first and each
+    named ``custom_providers`` entry after it, serially, and every probe in the
+    chain shares the one ``_LIVE_REBUILD_BUDGET_SECONDS`` wall-clock budget
+    while individually being capped at ``CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS``.
+    One unreachable endpoint — a LAN LM Studio/Ollama host the webui container
+    cannot route to is the common case, since the probe runs server-side —
+    therefore used to spend the entire budget on its connect timeout, and every
+    reachable provider scheduled behind it never got an in-band ``/v1/models``
+    probe at all: its group rendered from a stale disk cache or stayed empty and
+    the whole rebuild was pushed out-of-band.
+
+    This schedule hands each probe a fair slice of the *remaining* budget rather
+    than letting it consume the whole cap, so an endpoint that times out cannot
+    starve the endpoints after it. Two cases intentionally keep the historical
+    unthrottled cap:
+
+    * the legacy unbounded path (``_LIVE_REBUILD_BUDGET_SECONDS <= 0``), where
+      there is no window to share;
+    * the out-of-band continuation, i.e. the rebuild worker still running after
+      the foreground caller already gave up — its probes are no longer holding
+      anyone up and must keep their full attempt so the refresh can complete.
+
+    The only change in the single-endpoint case is that its probe is now bounded
+    by the rebuild window it shares, instead of being allowed to outlive it.
+    """
+
+    def __init__(self, endpoint_count: int) -> None:
+        self._remaining = max(1, int(endpoint_count))
+        self._cap = float(CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS)
+        self._min = float(CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS)
+        self._deadline = (
+            time.monotonic() + float(_LIVE_REBUILD_BUDGET_SECONDS)
+            if _LIVE_REBUILD_BUDGET_SECONDS > 0
+            else None
+        )
+
+    def next_timeout(self) -> float:
+        """Timeout for the next probe in the chain, then advance the schedule."""
+        remaining = self._remaining
+        self._remaining = max(1, remaining - 1)
+        if self._deadline is None:
+            return self._cap
+        left = self._deadline - time.monotonic()
+        if left <= 0:
+            return self._cap
+        # ``remaining + 1`` rather than ``remaining``: the extra slot is the
+        # headroom that lets the whole chain finish *inside* the window instead
+        # of draining it to the last millisecond and tipping the foreground
+        # caller onto the fallback anyway. With N probes the chain can spend at
+        # most N/(N+1) of the budget, so even a probe that burns its whole slice
+        # leaves the rebuild room to publish in-band.
+        return max(self._min, min(self._cap, left / (remaining + 1)))
+
+
 # ── Budget-exceeded warning rate-limit ───────────────────────────────────────
 # Q-2979-A3 / Copilot discussion_r3305864400: the live-rebuild-budget-exceeded
 # warning at _invoke_models_rebuild's slow-path is potentially high-volume —
@@ -7434,6 +7497,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             *,
             api_key: object = "",
             trusted_base_urls: tuple[object, ...] = (),
+            timeout_seconds: float | None = None,
         ) -> tuple[list[dict], dict | None]:
             base = str(base_url or "").strip()
             if not base:
@@ -7484,7 +7548,16 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 req.add_header("User-Agent", "OpenAI/Python 1.0")
                 for k, v in headers.items():
                     req.add_header(k, v)
-                with urllib.request.urlopen(req, timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS) as response:  # nosec B310
+                # #7481: the caller may hand us a fair-share slice of the shared
+                # rebuild budget (see _CustomProbeSchedule) instead of the full
+                # per-endpoint cap, so one unreachable endpoint cannot starve the
+                # providers probed after it. Default stays the documented cap.
+                probe_timeout = (
+                    CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS
+                    if timeout_seconds is None
+                    else float(timeout_seconds)
+                )
+                with urllib.request.urlopen(req, timeout=probe_timeout) as response:  # nosec B310
                     data = json.loads(response.read().decode("utf-8"))
                 return _extract_model_entries_from_payload(data, provider), None
             except urllib.error.HTTPError as exc:
@@ -7495,6 +7568,52 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 error = _custom_endpoint_error(provider, exc)
                 logger.debug("Custom endpoint unreachable or misconfigured for provider %s: %s", provider, error)
                 return [], error
+
+        # ── Fair-share schedule for the serial custom-endpoint probe chain ───
+        # #7481: step 4 probes the active endpoint and step 5 probes each named
+        # ``custom_providers`` entry after it, serially, off one shared rebuild
+        # budget. Without a schedule the first endpoint in the chain could spend
+        # that entire budget on its own connect timeout and leave every later —
+        # reachable — provider with no in-band probe at all. See
+        # _CustomProbeSchedule for the allocation rules.
+        def _pending_custom_probe_count() -> int:
+            """How many endpoints this rebuild is about to probe live, in order.
+
+            Counts the active endpoint (step 4) plus the named
+            ``custom_providers`` entries that will need a live ``/v1/models``
+            probe (step 5). Providers carrying a static ``models:`` allowlist
+            never probe live, so they must not dilute the schedule. Entries
+            whose base_url is only resolvable later from the credential pool are
+            counted anyway — over-counting merely makes the earlier slices a
+            little smaller, whereas under-counting would over-spend the budget.
+            """
+            count = 1 if cfg_base_url else 0
+            custom_providers_cfg = cfg.get("custom_providers", [])
+            if isinstance(custom_providers_cfg, list):
+                for entry in custom_providers_cfg:
+                    if not isinstance(entry, dict):
+                        continue
+                    if not (entry.get("name") or "").strip():
+                        continue
+                    configured_models = entry.get("models")
+                    if isinstance(configured_models, (dict, list)) and len(configured_models) > 0:
+                        continue
+                    count += 1
+            # The LM Studio provider-group branch re-probes the same
+            # /v1/models endpoint from ``providers.lmstudio.base_url`` in its own
+            # right — the second consumer of a single dead LAN endpoint in the
+            # common #7481 config — so it has to hold a slot in the schedule too.
+            # When the hermes_cli tier answers first no HTTP probe happens and
+            # the slot simply goes unused, which only makes the earlier slices a
+            # touch smaller.
+            if (
+                "lmstudio" in {str(pid).strip().lower() for pid in detected_providers}
+                and _get_provider_base_url("lmstudio")
+            ):
+                count += 1
+            return count
+
+        custom_probe_schedule = _CustomProbeSchedule(_pending_custom_probe_count())
 
         # 4. Fetch models from custom endpoint if base_url is configured
         auto_detected_models = []
@@ -7570,6 +7689,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 provider,
                 api_key=api_key,
                 trusted_base_urls=tuple(_trusted_custom_bases),
+                timeout_seconds=custom_probe_schedule.next_timeout(),
             )
             for auto_model in _active_endpoint_models:
                 auto_detected_models.append(auto_model)
@@ -7643,6 +7763,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             _slug,
                             api_key=_cp_api_key,
                             trusted_base_urls=(_cp_base_url,),
+                            timeout_seconds=custom_probe_schedule.next_timeout(),
                         )
                     if _live_error:
                         _named_custom_errors[_slug] = _live_error
@@ -8104,7 +8225,14 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                             try:
                                 import urllib.request as _urlreq
                                 req = _urlreq.Request(endpoint, method="GET", headers=headers)
-                                with _urlreq.urlopen(req, timeout=5) as resp:
+                                # #7481: this probe is part of the same rebuild as
+                                # the custom-endpoint chain, so it draws from the
+                                # shared schedule instead of a hardcoded 5s that
+                                # could push the rebuild past the budget on its own.
+                                with _urlreq.urlopen(
+                                    req,
+                                    timeout=custom_probe_schedule.next_timeout(),
+                                ) as resp:
                                     lm_data = json.loads(resp.read().decode())
                                 for m in (lm_data.get("data") or []):
                                     if isinstance(m, dict):
@@ -8590,12 +8718,33 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         budget_exceeded = threading.Event()
         publish_lock = threading.Lock()
         box: dict = {}
+        # #7481: the moment this rebuild started. A published catalog whose
+        # live-rebuild stamp is newer than this belongs to a strictly newer
+        # generation and must never be overwritten by this (older) result.
+        rebuild_started_at = time.monotonic()
 
-        def _publish_models_result(result):
+        def _publish_models_result(result, *, build_started_at: float):
             global _cache_build_in_progress, _available_models_cache
             global _available_models_cache_ts, _available_models_live_rebuild_ts
             global _available_models_cache_source_fingerprint
             with _cache_build_cv:
+                if _available_models_live_rebuild_ts > build_started_at:
+                    # #7481 failure isolation: a newer catalog generation was
+                    # published while this build was still running. Only the
+                    # out-of-band publisher can reach this — it outlives the
+                    # foreground caller that already gave up on it — and
+                    # publishing our older result now would resurrect a
+                    # superseded catalog. Drop it. The newer publish already
+                    # released _cache_build_in_progress (every writer of
+                    # _available_models_live_rebuild_ts clears it), so the flag
+                    # is deliberately left alone rather than released for a
+                    # build that may not be ours.
+                    logger.debug(
+                        "discarding superseded models-catalog rebuild result "
+                        "(%.3fs older than the published generation)",
+                        _available_models_live_rebuild_ts - build_started_at,
+                    )
+                    return
                 published_at = time.monotonic()
                 _available_models_cache = result
                 _available_models_cache_ts = published_at
@@ -8653,7 +8802,9 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     # the correct profile's cache file.
                     if budget_exceeded.is_set() and _claim_publish():
                         if "result" in box:
-                            _publish_models_result(box["result"])
+                            _publish_models_result(
+                                box["result"], build_started_at=rebuild_started_at
+                            )
                         else:
                             _clear_build_in_progress()
 
@@ -8671,7 +8822,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 _clear_build_in_progress()
                 raise box["error"]
             if _claim_publish():
-                _publish_models_result(box["result"])
+                _publish_models_result(box["result"], build_started_at=rebuild_started_at)
             return copy.deepcopy(box["result"])
 
         # Budget elapsed. Mark it so the worker knows it owns out-of-band
@@ -8681,7 +8832,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         budget_exceeded.set()
         if build_done.is_set() and "error" not in box and "result" in box:
             if _claim_publish():
-                _publish_models_result(box["result"])
+                _publish_models_result(box["result"], build_started_at=rebuild_started_at)
             return copy.deepcopy(box["result"])
 
         # Genuinely slow/hung probe: serve the best fallback now; the worker

--- a/api/config.py
+++ b/api/config.py
@@ -98,13 +98,16 @@ logger = logging.getLogger(__name__)
 # short hard cap and graceful degradation.
 CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS = 5.0
 
-# Smallest slice ``_CustomProbeSchedule`` will hand a probe: a zero (or negative)
-# timeout means "non-blocking" to urllib, so a probe that is legitimately still in
-# flight would be reported as an instant connection failure. This is a guard rail
-# for the arithmetic — deliberately tiny, and NOT a per-probe minimum, because a
-# real floor would let a long chain of dead endpoints spend past the rebuild
-# window and recreate exactly the starvation this schedule exists to prevent.
-CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS = 0.01
+# Attempt-only timeout for a probe that ``_CustomProbeSchedule`` reaches *after*
+# the shared rebuild window is already spent while the foreground caller is still
+# waiting — the narrow hand-off race described on ``next_timeout``. It is NOT a
+# per-probe minimum and NOT a share of the window: by the time it applies the
+# window is already gone, so nothing is being divided out of it, and it can never
+# be handed out on the fair-share path. Not zero, because urllib reads a zero
+# timeout as "non-blocking" and would report a probe that is genuinely still in
+# flight as an instant connection failure. The full per-endpoint cap is reserved
+# for the deliberately out-of-band continuation, never for this state.
+CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS = 0.01
 
 
 def _env_mb_bytes(name: str, default_mb: int) -> int:
@@ -5335,13 +5338,20 @@ class _CustomProbeSchedule:
     This schedule hands each probe a fair slice of the *remaining* budget rather
     than letting it consume the whole cap, so an endpoint that times out cannot
     starve the endpoints after it. Two cases intentionally keep the historical
-    unthrottled cap:
+    unthrottled cap, and both are stated rather than inferred:
 
     * the legacy unbounded path (``_LIVE_REBUILD_BUDGET_SECONDS <= 0``), where
       there is no window to share;
     * the out-of-band continuation, i.e. the rebuild worker still running after
-      the foreground caller already gave up — its probes are no longer holding
-      anyone up and must keep their full attempt so the refresh can complete.
+      the foreground caller already gave up — reported by the ``out_of_band``
+      predicate — whose probes are no longer holding anyone up and must keep
+      their full attempt so the refresh can complete.
+
+    The window itself is never over-allocated: a slice is ``left / (remaining +
+    1)`` with **no lower bound**, because any fixed floor makes the chain's total
+    grow with the number of probes — and ``custom_providers`` has no count limit,
+    so a long enough chain of dead endpoints would again spend past the window and
+    push the reachable providers behind it out of the in-band rebuild.
 
     The trade-off to know about: slices shrink as the chain grows, because the
     window is fixed and shared. A slow-but-reachable endpoint sitting in a long
@@ -5353,10 +5363,11 @@ class _CustomProbeSchedule:
     rather than the over-budget fallback.
     """
 
-    def __init__(self, endpoint_count: int) -> None:
+    def __init__(self, endpoint_count: int, *, out_of_band=None) -> None:
         self._remaining = max(1, int(endpoint_count))
         self._cap = float(CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS)
-        self._min = float(CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS)
+        self._attempt_only = float(CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS)
+        self._out_of_band = out_of_band
         self._deadline = (
             time.monotonic() + float(_LIVE_REBUILD_BUDGET_SECONDS)
             if _LIVE_REBUILD_BUDGET_SECONDS > 0
@@ -5367,19 +5378,38 @@ class _CustomProbeSchedule:
         """Timeout for the next probe in the chain, then advance the schedule."""
         remaining = self._remaining
         self._remaining = max(1, remaining - 1)
+        # Legacy unbounded path: no window exists, so there is nothing to share.
         if self._deadline is None:
+            return self._cap
+        # Deliberately out-of-band continuation: the foreground caller has already
+        # stopped waiting and served its fallback, so this chain is no longer
+        # holding anyone up and keeps the full attempt for the refresh to be able
+        # to complete. This is an explicit signal rather than an inference from
+        # the deadline, because the deadline being spent does NOT imply the
+        # foreground has given up — a probe can find the window spent while the
+        # caller is still waiting (the hand-off race handled below), and that
+        # state has to stay bounded.
+        if self._out_of_band is not None and self._out_of_band():
             return self._cap
         left = self._deadline - time.monotonic()
         if left <= 0:
-            return self._cap
+            # In-band, window already spent: attempt the probe with the smallest
+            # workable timeout instead of the full cap. Handing out the cap here
+            # is what let a long chain outspend the window once its early slices
+            # were floored up — the later probes paid a full per-endpoint cap each
+            # after the window was gone, so a reachable provider behind them still
+            # landed out-of-band (or not at all), which is the reported defect.
+            return min(self._cap, self._attempt_only)
         # ``remaining + 1`` reserves one slot of headroom, so a chain of N probes
         # can spend at most N/(N+1) of the window and always finishes inside it —
         # which is what keeps the foreground caller on a published catalog rather
-        # than the over-budget fallback. Clamping the guard against ``left`` keeps
-        # that true at every chain length: a probe can never be handed more time
-        # than the window has left, so the floor can't defeat the headroom.
-        slice_seconds = left / (remaining + 1)
-        return min(self._cap, max(slice_seconds, min(self._min, left)))
+        # than the over-budget fallback. Deliberately NO lower bound on the slice:
+        # a fixed floor (0.5s, then 0.01s in earlier revisions) made the chain's
+        # cumulative spend grow with the endpoint count, so an unbounded
+        # ``custom_providers`` list could still exhaust the window before the
+        # later providers were reached. A positive ``left`` always divides to a
+        # positive slice, so there is nothing left to guard against here.
+        return min(self._cap, left / (remaining + 1))
 
 
 # ── Budget-exceeded warning rate-limit ───────────────────────────────────────
@@ -6980,6 +7010,21 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.
+    #
+    # #7481: explicit foreground-vs-out-of-band signal for the probe schedule.
+    # The bounded path below runs the rebuild on a daemon worker and lets the
+    # foreground caller stop waiting at the budget; from that moment the worker's
+    # remaining probes are out-of-band and keep the full per-endpoint cap so the
+    # refresh can complete. That is a *different* contract from the in-band chain,
+    # which must stay inside the shared window — and the two cannot be told apart
+    # by the deadline alone (a probe can find the window spent while the caller is
+    # still waiting). The foreground sets this event when it gives up; every
+    # rebuild invocation gets its own, so a still-running worker from an earlier
+    # rebuild cannot read a later caller's state. Defined before the builder
+    # closure so the closure can capture it as a free variable; on the legacy
+    # synchronous path it is simply never set and there is no window to share.
+    _models_rebuild_abandoned = threading.Event()
+
     def _build_available_models_uncached() -> dict:
         active_provider = None
         default_model = get_effective_default_model(cfg)
@@ -7648,7 +7693,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 count += 1
             return count
 
-        custom_probe_schedule = _CustomProbeSchedule(_pending_custom_probe_count())
+        custom_probe_schedule = _CustomProbeSchedule(
+            _pending_custom_probe_count(),
+            out_of_band=_models_rebuild_abandoned.is_set,
+        )
 
         # 4. Fetch models from custom endpoint if base_url is configured
         auto_detected_models = []
@@ -8866,10 +8914,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             return copy.deepcopy(box["result"])
 
         # Budget elapsed. Mark it so the worker knows it owns out-of-band
-        # publication. Handle the tiny race where the build completed between
-        # wait() returning False and here: if so, still publish synchronously
-        # so this caller honours the cache contract.
+        # publication, and so the probe schedule hands its remaining probes the
+        # full per-endpoint cap instead of a share of a window nobody is waiting
+        # on any more (#7481). Handle the tiny race where the build completed
+        # between wait() returning False and here: if so, still publish
+        # synchronously so this caller honours the cache contract.
         budget_exceeded.set()
+        _models_rebuild_abandoned.set()
         if build_done.is_set() and "error" not in box and "result" in box:
             if _claim_publish():
                 _publish_models_result(box["result"], rebuild_seq=rebuild_seq)

--- a/api/config.py
+++ b/api/config.py
@@ -98,11 +98,13 @@ logger = logging.getLogger(__name__)
 # short hard cap and graceful degradation.
 CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS = 5.0
 
-# Floor for the fair-share slice handed to a probe in the serial custom-endpoint
-# chain (see ``_CustomProbeSchedule``, #7481). A slice that rounded down to ~0
-# would turn a reachable provider into a guaranteed failure, so every probe
-# still gets at least this long before the chain stops handing out real attempts.
-CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS = 0.5
+# Smallest slice ``_CustomProbeSchedule`` will hand a probe: a zero (or negative)
+# timeout means "non-blocking" to urllib, so a probe that is legitimately still in
+# flight would be reported as an instant connection failure. This is a guard rail
+# for the arithmetic — deliberately tiny, and NOT a per-probe minimum, because a
+# real floor would let a long chain of dead endpoints spend past the rebuild
+# window and recreate exactly the starvation this schedule exists to prevent.
+CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS = 0.01
 
 
 def _env_mb_bytes(name: str, default_mb: int) -> int:
@@ -5157,6 +5159,31 @@ _available_models_cache_lock = threading.RLock()  # must be RLock: cold path ref
 _cache_build_cv = threading.Condition(_available_models_cache_lock)  # shares underlying RLock so notify_all() is safe inside with _available_models_cache_lock
 _cache_build_in_progress = False  # True while a cold path is actively building
 
+# ── Catalog publication ordering ─────────────────────────────────────────────
+# Every cold rebuild takes the next sequence number, and the published catalog
+# remembers the sequence it came from. A build may publish only if it is newer
+# than whatever is already published. That is what stops an over-budget worker
+# finishing late — the out-of-band publisher, which outlives the foreground
+# caller that gave up on it — from resurrecting a superseded catalog over a
+# newer one. Wall-clock stamps cannot express this ordering: an OLDER build can
+# publish *after* a newer build has already started, and a time comparison would
+# read that publication as "newer" and wrongly discard the newer build's result
+# (#7481 review).
+_models_rebuild_seq: int = 0
+_models_published_seq: int = 0
+
+
+def _allocate_models_rebuild_seq() -> int:
+    """Take the next catalog-rebuild sequence number.
+
+    The caller must hold ``_available_models_cache_lock`` (the cold path does),
+    so the counter is never advanced by two builds at once.
+    """
+    global _models_rebuild_seq
+    _models_rebuild_seq += 1
+    return _models_rebuild_seq
+
+
 # Memoized (snapshot_ref, {provider_slug: frozenset(model_ids)}) derived from
 # the published models-catalog snapshot. Used by _endpoint_advertised_model_ids
 # to answer "did this endpoint actually advertise this exact id?" in O(1) per
@@ -5316,8 +5343,14 @@ class _CustomProbeSchedule:
       the foreground caller already gave up — its probes are no longer holding
       anyone up and must keep their full attempt so the refresh can complete.
 
-    The only change in the single-endpoint case is that its probe is now bounded
-    by the rebuild window it shares, instead of being allowed to outlive it.
+    The trade-off to know about: slices shrink as the chain grows, because the
+    window is fixed and shared. A slow-but-reachable endpoint sitting in a long
+    chain can therefore be cut off; raise ``HERMES_WEBUI_MODELS_REBUILD_BUDGET``
+    for the endpoints actually in use, or give a ``custom_providers`` entry a
+    static ``models:`` allowlist so it is never probed live. What does NOT change
+    for any chain length is the total: the probes can never between them spend
+    past the window, so the foreground caller still receives a published catalog
+    rather than the over-budget fallback.
     """
 
     def __init__(self, endpoint_count: int) -> None:
@@ -5339,13 +5372,14 @@ class _CustomProbeSchedule:
         left = self._deadline - time.monotonic()
         if left <= 0:
             return self._cap
-        # ``remaining + 1`` rather than ``remaining``: the extra slot is the
-        # headroom that lets the whole chain finish *inside* the window instead
-        # of draining it to the last millisecond and tipping the foreground
-        # caller onto the fallback anyway. With N probes the chain can spend at
-        # most N/(N+1) of the budget, so even a probe that burns its whole slice
-        # leaves the rebuild room to publish in-band.
-        return max(self._min, min(self._cap, left / (remaining + 1)))
+        # ``remaining + 1`` reserves one slot of headroom, so a chain of N probes
+        # can spend at most N/(N+1) of the window and always finishes inside it —
+        # which is what keeps the foreground caller on a published catalog rather
+        # than the over-budget fallback. Clamping the guard against ``left`` keeps
+        # that true at every chain length: a probe can never be handed more time
+        # than the window has left, so the floor can't defeat the headroom.
+        slice_seconds = left / (remaining + 1)
+        return min(self._cap, max(slice_seconds, min(self._min, left)))
 
 
 # ── Budget-exceeded warning rate-limit ───────────────────────────────────────
@@ -6930,6 +6964,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     """
     global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts
     global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint, _cache_build_cv
+    global _models_published_seq
     # Config mtime check — must come before any config reads.
     # (Test #585 verifies _current_mtime appears before active_provider = None)
     try:
@@ -8632,6 +8667,11 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # Cold path: full rebuild — only one thread reaches here at a time
         with _cache_build_cv:
             _cache_build_in_progress = True
+        # This build's position in the publication order. Taken while holding
+        # _available_models_cache_lock (above), so no two builds can share one,
+        # and used to keep a late out-of-band publisher from overwriting a newer
+        # catalog (#7481).
+        rebuild_seq = _allocate_models_rebuild_seq()
 
         # Capture the active per-request profile (#3957). The live provider
         # probe inside the rebuild resolves credentials from os.environ /
@@ -8681,6 +8721,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 _available_models_cache_ts = published_at
                 _available_models_live_rebuild_ts = published_at
                 _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                _models_published_seq = rebuild_seq
                 _sync_models_cache_provenance()
             try:
                 _save_models_cache_to_disk(result)
@@ -8718,31 +8759,29 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         budget_exceeded = threading.Event()
         publish_lock = threading.Lock()
         box: dict = {}
-        # #7481: the moment this rebuild started. A published catalog whose
-        # live-rebuild stamp is newer than this belongs to a strictly newer
-        # generation and must never be overwritten by this (older) result.
-        rebuild_started_at = time.monotonic()
 
-        def _publish_models_result(result, *, build_started_at: float):
+        def _publish_models_result(result, *, rebuild_seq: int):
             global _cache_build_in_progress, _available_models_cache
             global _available_models_cache_ts, _available_models_live_rebuild_ts
-            global _available_models_cache_source_fingerprint
+            global _available_models_cache_source_fingerprint, _models_published_seq
             with _cache_build_cv:
-                if _available_models_live_rebuild_ts > build_started_at:
-                    # #7481 failure isolation: a newer catalog generation was
-                    # published while this build was still running. Only the
-                    # out-of-band publisher can reach this — it outlives the
-                    # foreground caller that already gave up on it — and
-                    # publishing our older result now would resurrect a
-                    # superseded catalog. Drop it. The newer publish already
-                    # released _cache_build_in_progress (every writer of
-                    # _available_models_live_rebuild_ts clears it), so the flag
-                    # is deliberately left alone rather than released for a
-                    # build that may not be ours.
+                if rebuild_seq < _models_published_seq:
+                    # #7481 failure isolation: the cache already holds a catalog
+                    # from a newer rebuild, so this one is superseded and must
+                    # not overwrite it. Only the out-of-band publisher can reach
+                    # this — it outlives the foreground caller that gave up on
+                    # it. Ordered by rebuild sequence, not by wall clock: an
+                    # older build can publish *after* a newer build started, and
+                    # a timestamp comparison would misread that as newer and drop
+                    # the newer result instead. The newer publish already
+                    # released _cache_build_in_progress, so the flag is
+                    # deliberately left alone rather than released for a build
+                    # that may not be ours.
                     logger.debug(
                         "discarding superseded models-catalog rebuild result "
-                        "(%.3fs older than the published generation)",
-                        _available_models_live_rebuild_ts - build_started_at,
+                        "(rebuild #%d, catalog published by rebuild #%d)",
+                        rebuild_seq,
+                        _models_published_seq,
                     )
                     return
                 published_at = time.monotonic()
@@ -8752,6 +8791,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 _available_models_cache_source_fingerprint = (
                     _models_cache_source_fingerprint()
                 )
+                _models_published_seq = rebuild_seq
                 _sync_models_cache_provenance()
             try:
                 _save_models_cache_to_disk(result)
@@ -8803,7 +8843,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     if budget_exceeded.is_set() and _claim_publish():
                         if "result" in box:
                             _publish_models_result(
-                                box["result"], build_started_at=rebuild_started_at
+                                box["result"], rebuild_seq=rebuild_seq
                             )
                         else:
                             _clear_build_in_progress()
@@ -8822,7 +8862,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 _clear_build_in_progress()
                 raise box["error"]
             if _claim_publish():
-                _publish_models_result(box["result"], build_started_at=rebuild_started_at)
+                _publish_models_result(box["result"], rebuild_seq=rebuild_seq)
             return copy.deepcopy(box["result"])
 
         # Budget elapsed. Mark it so the worker knows it owns out-of-band
@@ -8832,7 +8872,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         budget_exceeded.set()
         if build_done.is_set() and "error" not in box and "result" in box:
             if _claim_publish():
-                _publish_models_result(box["result"], build_started_at=rebuild_started_at)
+                _publish_models_result(box["result"], rebuild_seq=rebuild_seq)
             return copy.deepcopy(box["result"])
 
         # Genuinely slow/hung probe: serve the best fallback now; the worker

--- a/api/config.py
+++ b/api/config.py
@@ -7547,7 +7547,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
         def _custom_endpoint_error(
             provider: str,
-            exc: Exception,
+            exc: Exception | None = None,
             *,
             code: int | None = None,
         ) -> dict:
@@ -7571,6 +7571,44 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 "message": f"Models endpoint unreachable for {provider_label}; verify base_url.",
             }
 
+        # ── In-rebuild probe de-duplication (#7481 follow-up) ────────────────
+        # One rebuild can consult the same endpoint more than once: step 4 probes
+        # the active ``model.base_url``, and the LM Studio provider-group fallback
+        # later reads ``providers.lmstudio.base_url`` (falling back to
+        # ``model.base_url`` when lmstudio is the active provider) — in the config
+        # shape the issue reports those are the SAME unreachable LAN host, so one
+        # dead endpoint cost the rebuild two full connect timeouts and two slots of
+        # the shared window. A named ``custom_providers`` entry can likewise repeat
+        # an endpoint an earlier entry already probed. Memoise by (endpoint URL,
+        # credential) and reuse the outcome, so an endpoint is probed at most once
+        # per rebuild.
+        #
+        # The credential is part of the identity: the same URL with a different key
+        # is a different probe and still runs. The raw payload is cached rather than
+        # the parsed entries, so each consumer still shapes the list for its own
+        # provider, and the memo is consulted only AFTER the per-endpoint
+        # SSRF/validation checks — a consumer that would have been blocked is still
+        # blocked rather than served another caller's result.
+        _custom_endpoint_probe_memo: dict[tuple[str, str], tuple[str, object]] = {}
+
+        def _custom_endpoint_probe_key(endpoint_url: str, headers: dict) -> tuple[str, str]:
+            """Identity of one custom-endpoint probe: the URL it hits + the credential it sends."""
+            parsed = urlparse(
+                str(endpoint_url) if "://" in str(endpoint_url) else f"http://{endpoint_url}"
+            )
+            scheme = (parsed.scheme or "http").lower()
+            host = (parsed.hostname or "").lower()
+            port = parsed.port
+            if port and port != (443 if scheme == "https" else 80):
+                host = f"{host}:{port}"
+            # Path comparison ignores repeated/leading/trailing slashes but keeps
+            # case: a path is case-sensitive, a host is not.
+            path = "/".join(seg for seg in (parsed.path or "").split("/") if seg)
+            return (
+                f"{scheme}://{host}/{path}",
+                str(headers.get("Authorization") or ""),
+            )
+
         def _read_custom_endpoint_models(
             base_url: object,
             provider: str,
@@ -7582,6 +7620,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             base = str(base_url or "").strip()
             if not base:
                 return [], None
+            # Filled in once the endpoint has passed validation; the failure paths
+            # below memoize their outcome under it so a later consumer in the same
+            # rebuild does not pay the same timeout twice. It stays None when the
+            # validation refuses the URL, so a consumer that would have been blocked
+            # is never served another caller's memoized result.
+            probe_key: tuple[str, str] | None = None
             try:
                 import ipaddress
                 import urllib.error
@@ -7624,6 +7668,19 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     except socket.gaierror:
                         pass
 
+                probe_key = _custom_endpoint_probe_key(endpoint_url, headers)
+                memoized = _custom_endpoint_probe_memo.get(probe_key)
+                if memoized is not None:
+                    # This exact endpoint + credential was already probed earlier in
+                    # this rebuild, so reuse the outcome rather than paying the
+                    # connect timeout a second time (#7481 follow-up). A memoized
+                    # failure is re-reported for THIS provider (its own label).
+                    memo_kind, memo_value = memoized
+                    if memo_kind == "ok":
+                        logger.debug("Reusing in-rebuild /models probe for %s", endpoint_url)
+                        return _extract_model_entries_from_payload(memo_value, provider), None
+                    return [], _custom_endpoint_error(provider, code=memo_value)
+
                 req = urllib.request.Request(endpoint_url, method="GET")
                 req.add_header("User-Agent", "OpenAI/Python 1.0")
                 for k, v in headers.items():
@@ -7639,13 +7696,20 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 )
                 with urllib.request.urlopen(req, timeout=probe_timeout) as response:  # nosec B310
                     data = json.loads(response.read().decode("utf-8"))
+                if probe_key is not None:
+                    _custom_endpoint_probe_memo[probe_key] = ("ok", data)
                 return _extract_model_entries_from_payload(data, provider), None
             except urllib.error.HTTPError as exc:
-                error = _custom_endpoint_error(provider, exc, code=getattr(exc, "code", None))
+                response_code = getattr(exc, "code", None)
+                error = _custom_endpoint_error(provider, exc, code=response_code)
+                if probe_key is not None:
+                    _custom_endpoint_probe_memo[probe_key] = ("error", response_code)
                 logger.debug("Custom endpoint models fetch failed for provider %s: %s", provider, error)
                 return [], error
             except Exception as exc:
                 error = _custom_endpoint_error(provider, exc)
+                if probe_key is not None:
+                    _custom_endpoint_probe_memo[probe_key] = ("error", None)
                 logger.debug("Custom endpoint unreachable or misconfigured for provider %s: %s", provider, error)
                 return [], error
 
@@ -8306,24 +8370,57 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                                 headers["Authorization"] = f"Bearer {lm_api_key}"
                             endpoint = (lm_base_url + "/models").rstrip("/")
                             try:
-                                import urllib.request as _urlreq
-                                req = _urlreq.Request(endpoint, method="GET", headers=headers)
-                                # #7481: this probe is part of the same rebuild as
-                                # the custom-endpoint chain, so it draws from the
-                                # shared schedule instead of a hardcoded 5s that
-                                # could push the rebuild past the budget on its own.
-                                with _urlreq.urlopen(
-                                    req,
-                                    timeout=custom_probe_schedule.next_timeout(),
-                                ) as resp:
-                                    lm_data = json.loads(resp.read().decode())
+                                _lm_probe_key = _custom_endpoint_probe_key(endpoint, headers)
+                            except Exception:
+                                _lm_probe_key = None
+                            _lm_memo = (
+                                _custom_endpoint_probe_memo.get(_lm_probe_key)
+                                if _lm_probe_key is not None
+                                else None
+                            )
+                            lm_data = None
+                            if _lm_memo is not None:
+                                # #7481 follow-up: this endpoint was already probed
+                                # earlier in this rebuild — typically by the active
+                                # model.base_url probe, since
+                                # _get_provider_base_url("lmstudio") falls back to
+                                # model.base_url when lmstudio is the active
+                                # provider. Reuse that payload (or its failure)
+                                # instead of stalling on the same host a second
+                                # time, which is what made one dead LAN endpoint
+                                # cost the rebuild two connect timeouts.
+                                if _lm_memo[0] == "ok":
+                                    lm_data = _lm_memo[1]
+                                else:
+                                    logger.debug(
+                                        "LM Studio endpoint %s already failed in this rebuild; not re-probing",
+                                        endpoint,
+                                    )
+                            else:
+                                try:
+                                    import urllib.request as _urlreq
+                                    req = _urlreq.Request(endpoint, method="GET", headers=headers)
+                                    # #7481: this probe is part of the same rebuild as
+                                    # the custom-endpoint chain, so it draws from the
+                                    # shared schedule instead of a hardcoded 5s that
+                                    # could push the rebuild past the budget on its own.
+                                    with _urlreq.urlopen(
+                                        req,
+                                        timeout=custom_probe_schedule.next_timeout(),
+                                    ) as resp:
+                                        lm_data = json.loads(resp.read().decode())
+                                    if _lm_probe_key is not None:
+                                        _custom_endpoint_probe_memo[_lm_probe_key] = ("ok", lm_data)
+                                except Exception:
+                                    if _lm_probe_key is not None:
+                                        _custom_endpoint_probe_memo[_lm_probe_key] = ("error", None)
+                                    logger.debug("LM Studio /models fetch failed at %s", endpoint)
+                            if isinstance(lm_data, dict):
                                 for m in (lm_data.get("data") or []):
                                     if isinstance(m, dict):
                                         mid = str(m.get("id") or "").strip()
                                         if mid and {"id": mid, "label": mid} not in raw_models:
                                             raw_models.append({"id": mid, "label": mid})
-                            except Exception:
-                                logger.debug("LM Studio /models fetch failed at %s", endpoint)
 
                     if raw_models:
                         _append_picker_group(provider_name, pid, raw_models)

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -1,0 +1,362 @@
+"""Regression coverage for #7481 — serial custom-provider probes starving.
+
+During a cold model-catalog rebuild the WebUI probes the active endpoint first
+(``model.base_url``) and then each named ``custom_providers`` entry, serially,
+off one shared ``_LIVE_REBUILD_BUDGET_SECONDS`` budget while each probe is
+individually capped at ``CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS``.
+
+Before the fix one unreachable endpoint — the common case being a LAN
+LM Studio/Ollama host the webui container cannot route to, because the probe runs
+server-side — spent the whole budget on its own connect timeout, so every
+reachable provider scheduled behind it never got an in-band ``/v1/models``
+probe: its group rendered from a stale disk cache or stayed empty, and every
+cold load paid the full stall.
+
+The fix (``_CustomProbeSchedule``) gives every probe a fair slice of the
+remaining window instead of the whole cap, and the LM Studio provider-group
+fallback — a second consumer of the same dead endpoint, previously on a
+hardcoded 5s timeout outside any budget — now draws from the same schedule.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import socket
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+import api.config as cfg
+import api.profiles as profiles
+
+
+# Models the reachable gateway advertises — what the picker must show in-band.
+_GATEWAY_MODELS = ["gateway-model-a", "gateway-model-b"]
+
+# The issue's own numbers, scaled down only where noted.
+_BUDGET = 4.0
+_CAP = 1.5
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts):
+    """Route probes by host and record the timeout each one was handed.
+
+    A "dead" host behaves the way an unreachable LAN endpoint does: it burns the
+    entire timeout it was given and then fails — exactly the behaviour that used
+    to eat the shared rebuild budget.
+
+    Returns ``{"dead": [(url, timeout)], "live": [(url, timeout)]}``.
+    """
+    observed: dict[str, list] = {"dead": [], "live": []}
+
+    def fake_urlopen(req, timeout=None):
+        url = str(getattr(req, "full_url", ""))
+        if any(host in url for host in dead_hosts):
+            observed["dead"].append((url, timeout))
+            time.sleep(timeout if timeout is not None else 10)
+            raise urllib.error.URLError("timed out")
+        if any(host in url for host in live_hosts):
+            observed["live"].append((url, timeout))
+            return _FakeResponse({"data": [{"id": mid} for mid in _GATEWAY_MODELS]})
+        raise urllib.error.URLError(f"unexpected probe: {url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return observed
+
+
+@pytest.fixture(autouse=True)
+def isolate_models_catalog_state(monkeypatch, tmp_path):
+    """Hermetic catalog state, mirroring the #3928 budget-fallback fixture."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: {}\n", encoding="utf-8")
+    auth_store_path = tmp_path / "auth.json"
+    auth_store_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_has_in_memory_overrides", lambda: True)
+    monkeypatch.setattr(cfg, "_get_auth_store_path", lambda: auth_store_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(cfg, "_delete_models_cache_on_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: "issue-7481-fp")
+    monkeypatch.setattr(cfg, "_available_models_cache", None, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_cache_ts", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_live_rebuild_ts", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_cache_source_fingerprint", None, raising=False)
+    monkeypatch.setattr(cfg, "_cache_build_in_progress", False, raising=False)
+    monkeypatch.setattr(cfg, "cfg", {}, raising=False)
+    # Any provider left in the catalog would otherwise shell out to the Hermes
+    # CLI for a live id list; the rebuild must stay network-free apart from the
+    # custom endpoints under test.
+    monkeypatch.setattr(cfg, "_read_live_provider_model_ids", lambda _pid: [])
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path / "hermes-home")
+    monkeypatch.setattr(cfg.os, "getenv", lambda key, default=None: default or "")
+    # The probe path resolves the endpoint hostname for its SSRF guard. A real
+    # resolver makes these tests depend on the host's DNS behaviour (and this
+    # container takes seconds to answer NXDOMAIN), so pin it to an immediate
+    # failure: the guard treats that as "not resolvable" and lets the probe
+    # through, which is exactly what the fake urlopen above is standing in for.
+    def _unresolvable(host, port, *args, **kwargs):
+        raise socket.gaierror("hermetic test resolver")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _unresolvable)
+
+    return {"tmp_path": tmp_path, "auth_store_path": auth_store_path}
+
+
+def _configure(monkeypatch, *, active_base_url, provider_base_url=None, custom_providers=None):
+    cfg.cfg = {
+        "model": {
+            "provider": "lmstudio",
+            "default": "some-local-model",
+            "base_url": active_base_url,
+        },
+        "providers": (
+            {"lmstudio": {"base_url": provider_base_url}} if provider_base_url else {}
+        ),
+        "fallback_providers": [],
+        "custom_providers": custom_providers or [],
+    }
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", _BUDGET, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", _CAP, raising=False)
+
+
+def _bare_id(model_id: str) -> str:
+    """``@custom:my-gateway:model-a`` -> ``model-a``."""
+    return str(model_id).split(":")[-1]
+
+
+def _models_by_provider(catalog: dict) -> dict[str, list[str]]:
+    return {
+        group["provider_id"]: [_bare_id(m.get("id")) for m in group.get("models", [])]
+        for group in catalog["groups"]
+    }
+
+
+def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
+    monkeypatch, isolate_models_catalog_state
+):
+    """The #7481 repro, using the issue's own config shape.
+
+    A dead LAN endpoint is configured both as the active provider and as
+    ``providers.lmstudio`` (so the provider-group fallback probes it a second
+    time). The reachable named gateway behind it must still get its in-band
+    probe and land in the catalog the caller receives — not merely be deferred
+    to an out-of-band refresh after a fallback was served.
+    """
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        provider_base_url="http://lan-dead.example:1234/v1",
+        custom_providers=[
+            {
+                "name": "My Gateway",
+                "base_url": "https://gw-live.example/v1",
+                "api_key": "sk-live",
+            }
+        ],
+    )
+    observed = _install_urlopen(
+        monkeypatch, dead_hosts=["lan-dead.example"], live_hosts=["gw-live.example"]
+    )
+
+    started = time.monotonic()
+    catalog = cfg.get_available_models()
+    elapsed = time.monotonic() - started
+
+    # The rebuild published in-band: no budget-exceeded fallback was served.
+    assert elapsed < _BUDGET
+    assert observed["live"], "the reachable named provider was never probed"
+    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
+
+    # Both consumers of the dead endpoint were attempted — the active-endpoint
+    # probe and the LM Studio provider-group fallback — and each was handed a
+    # bounded slice rather than the whole window.
+    assert len(observed["dead"]) == 2
+    for _url, timeout in observed["dead"]:
+        assert timeout is not None and timeout < _CAP
+
+
+def test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through(
+    monkeypatch, isolate_models_catalog_state
+):
+    """Two dead named providers in front of a reachable one must not starve it."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        custom_providers=[
+            {"name": "Dead One", "base_url": "https://dead-one.example/v1", "api_key": "k1"},
+            {"name": "Dead Two", "base_url": "https://dead-two.example/v1", "api_key": "k2"},
+            {"name": "My Gateway", "base_url": "https://gw-live.example/v1", "api_key": "k3"},
+        ],
+    )
+    observed = _install_urlopen(
+        monkeypatch,
+        dead_hosts=["lan-dead.example", "dead-one.example", "dead-two.example"],
+        live_hosts=["gw-live.example"],
+    )
+
+    catalog = cfg.get_available_models()
+
+    # Every named endpoint was attempted, in config order, before the budget
+    # ran out (the active endpoint may additionally be re-probed by the LM
+    # Studio provider-group fallback, which is the same window).
+    probed_hosts = [url.split("://", 1)[1].split("/", 1)[0] for url, _ in observed["dead"]]
+    assert [host for host in probed_hosts if host != "lan-dead.example:1234"] == [
+        "dead-one.example",
+        "dead-two.example",
+    ]
+    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
+
+
+def test_static_allowlist_provider_is_never_probed_and_does_not_dilute_the_schedule(
+    monkeypatch, isolate_models_catalog_state
+):
+    """A provider with a static ``models:`` allowlist consumes no probe slot."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        custom_providers=[
+            {
+                "name": "Static Co",
+                "base_url": "https://static-never-probed.example/v1",
+                "api_key": "k",
+                "models": ["static-a", "static-b"],
+            },
+            {"name": "My Gateway", "base_url": "https://gw-live.example/v1", "api_key": "k"},
+        ],
+    )
+    observed = _install_urlopen(
+        monkeypatch,
+        dead_hosts=["lan-dead.example"],
+        live_hosts=["gw-live.example", "static-never-probed.example"],
+    )
+
+    catalog = cfg.get_available_models()
+
+    # The allowlist provider rendered from config and was never probed…
+    assert _models_by_provider(catalog).get("custom:static-co") == ["static-a", "static-b"]
+    assert not [
+        url
+        for url, _ in observed["live"] + observed["dead"]
+        if "static-never-probed.example" in url
+    ]
+    # …while the live provider behind the dead endpoint still made it in-band.
+    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
+
+
+def test_probe_schedule_keeps_the_documented_cap_when_the_budget_is_disabled(monkeypatch):
+    """Legacy synchronous path (budget <= 0) has no window to share."""
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    schedule = cfg._CustomProbeSchedule(3)
+
+    assert [schedule.next_timeout() for _ in range(3)] == [5.0, 5.0, 5.0]
+
+
+def test_probe_schedule_shares_the_window_and_reserves_headroom(monkeypatch):
+    """Every probe gets a slice, and a fully-burned chain cannot drain the window."""
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 4.0, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    class _Clock:
+        now = 0.0
+
+        def monotonic(self):  # noqa: D102 - stand-in for time.monotonic
+            return self.now
+
+    clock = _Clock()
+    monkeypatch.setattr(cfg, "time", clock, raising=False)
+
+    schedule = cfg._CustomProbeSchedule(4)
+    timeouts = []
+    for _ in range(4):
+        timeout = schedule.next_timeout()
+        timeouts.append(timeout)
+        clock.now += timeout  # the probe burns its whole slice
+
+    assert all(t < 5.0 for t in timeouts), timeouts
+    # A fully-burned chain still finishes inside the window, so the foreground
+    # caller gets a published catalog instead of the over-budget fallback.
+    assert clock.now < 4.0, timeouts
+
+
+def test_probe_schedule_restores_the_cap_once_the_budget_is_spent(monkeypatch):
+    """The out-of-band continuation still gets a full attempt to refresh."""
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    schedule = cfg._CustomProbeSchedule(3)
+    assert schedule.next_timeout() < 5.0
+    time.sleep(0.1)  # budget now spent
+    assert schedule.next_timeout() == 5.0
+
+
+def test_late_out_of_band_result_cannot_overwrite_a_newer_generation(
+    monkeypatch, isolate_models_catalog_state
+):
+    """A superseded rebuild must not resurrect its catalog over a newer one."""
+    _configure(monkeypatch, active_base_url=None)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+
+    newer = {
+        "active_provider": "newer-generation",
+        "default_model": "newer-generation/model",
+        "configured_model_badges": {},
+        "groups": [{"provider": "Newer", "provider_id": "newer-generation", "models": []}],
+        "aliases": {},
+    }
+    older = {
+        "active_provider": "older-generation",
+        "default_model": "older-generation/model",
+        "configured_model_badges": {},
+        "groups": [{"provider": "Older", "provider_id": "older-generation", "models": []}],
+        "aliases": {},
+    }
+    finished = {"value": False}
+
+    def _slow_builder(_builder):
+        # Still running when the foreground gives up — and by now a newer
+        # generation has been published (the out-of-band race).
+        time.sleep(0.15)
+        cfg._available_models_cache = newer
+        cfg._available_models_cache_ts = time.monotonic()
+        cfg._available_models_live_rebuild_ts = time.monotonic()
+        finished["value"] = True
+        return copy.deepcopy(older)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_builder)
+
+    cfg.get_available_models()
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and not finished["value"]:
+        time.sleep(0.01)
+    # Give the worker's finally-block publisher a moment to (not) clobber.
+    time.sleep(0.15)
+
+    assert finished["value"] is True
+    assert cfg._available_models_cache is newer, (
+        "the superseded out-of-band rebuild overwrote a newer catalog generation"
+    )

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -56,12 +56,19 @@ class _FakeResponse:
         return self._body
 
 
-def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts):
+def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts, clock=None):
     """Route probes by host and record the timeout each one was handed.
 
     A "dead" host behaves the way an unreachable LAN endpoint does: it burns the
     entire timeout it was given and then fails — exactly the behaviour that used
     to eat the shared rebuild budget.
+
+    ``clock`` (a ``_FakeClock`` already installed as ``cfg.time``) makes that burn
+    *virtual* instead of real. A real sleep ties the budget arithmetic to how fast
+    the runner is: on a slower box the active endpoint's sleep crosses the 4s
+    deadline before the later endpoints are reached, so the chain is cut off in a
+    way these tests were not written to describe. Advancing the injected clock
+    keeps the budget exact and the ordering assertions meaningful on any runner.
 
     Returns ``{"dead": [(url, timeout)], "live": [(url, timeout)]}``.
     """
@@ -71,7 +78,10 @@ def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts):
         url = str(getattr(req, "full_url", ""))
         if any(host in url for host in dead_hosts):
             observed["dead"].append((url, timeout))
-            time.sleep(timeout if timeout is not None else 10)
+            if clock is not None:
+                clock.now += float(timeout or 0.0)
+            else:
+                time.sleep(timeout if timeout is not None else 10)
             raise urllib.error.URLError("timed out")
         if any(host in url for host in live_hosts):
             observed["live"].append((url, timeout))
@@ -157,13 +167,26 @@ def _models_by_provider(catalog: dict) -> dict[str, list[str]]:
 
 
 class _FakeClock:
-    """Stand-in for the ``time`` module so a schedule can be advanced by hand."""
+    """Stand-in for the ``time`` module so a schedule can be advanced by hand.
+
+    Only ``monotonic()`` is virtual — that is the clock ``_CustomProbeSchedule``
+    measures the rebuild window with, and the one a mock probe advances when it
+    "burns" its slice. ``time()`` stays real so the epoch-based comparisons
+    elsewhere in the module (cache file ages, credential-pool TTLs) keep their
+    meaning; nothing in ``api/config.py`` calls ``time.sleep``.
+    """
 
     def __init__(self) -> None:
         self.now = 0.0
 
     def monotonic(self) -> float:
         return self.now
+
+    def time(self) -> float:
+        return time.time()
+
+    def sleep(self, seconds: float) -> None:
+        self.now += max(0.0, float(seconds))
 
 
 def _catalog(name: str) -> dict:
@@ -187,6 +210,10 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
     time). The reachable named gateway behind it must still get its in-band
     probe and land in the catalog the caller receives — not merely be deferred
     to an out-of-band refresh after a fallback was served.
+
+    Runs on the injected clock (maintainer review, 2026-09-10): the dead host
+    burns *virtual* time instead of really sleeping, so the budget arithmetic is
+    exact rather than dependent on how fast this runner happens to be.
     """
     _configure(
         monkeypatch,
@@ -200,16 +227,20 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
             }
         ],
     )
+    clock = _FakeClock()
+    monkeypatch.setattr(cfg, "time", clock, raising=False)
     observed = _install_urlopen(
-        monkeypatch, dead_hosts=["lan-dead.example"], live_hosts=["gw-live.example"]
+        monkeypatch,
+        dead_hosts=["lan-dead.example"],
+        live_hosts=["gw-live.example"],
+        clock=clock,
     )
 
-    started = time.monotonic()
     catalog = cfg.get_available_models()
-    elapsed = time.monotonic() - started
 
-    # The rebuild published in-band: no budget-exceeded fallback was served.
-    assert elapsed < _BUDGET
+    # The whole chain fitted inside the window, so the rebuild published in-band
+    # and no budget-exceeded fallback was served.
+    assert clock.now < _BUDGET, clock.now
     assert observed["live"], "the reachable named provider was never probed"
     assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
 
@@ -230,7 +261,13 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
 def test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through(
     monkeypatch, isolate_models_catalog_state
 ):
-    """Two dead named providers in front of a reachable one must not starve it."""
+    """Two dead named providers in front of a reachable one must not starve it.
+
+    Also on the injected clock (maintainer review, 2026-09-10): with real sleeps
+    the active endpoint's sleep could cross the 4s deadline before ``dead-one`` /
+    ``dead-two`` were reached on a slower box, so the ordering assertion this test
+    exists for was decided by the runner's speed.
+    """
     _configure(
         monkeypatch,
         active_base_url="http://lan-dead.example:1234/v1",
@@ -240,22 +277,31 @@ def test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through(
             {"name": "My Gateway", "base_url": "https://gw-live.example/v1", "api_key": "k3"},
         ],
     )
+    clock = _FakeClock()
+    monkeypatch.setattr(cfg, "time", clock, raising=False)
     observed = _install_urlopen(
         monkeypatch,
         dead_hosts=["lan-dead.example", "dead-one.example", "dead-two.example"],
         live_hosts=["gw-live.example"],
+        clock=clock,
     )
 
     catalog = cfg.get_available_models()
 
-    # Every named endpoint was attempted, in config order, before the budget
-    # ran out (the active endpoint may additionally be re-probed by the LM
-    # Studio provider-group fallback, which is the same window).
+    # Every endpoint was attempted, in config order, before the budget ran out:
+    # the active endpoint first, then the named entries. The LM Studio
+    # provider-group fallback resolves to the active endpoint's URL here and
+    # reuses that probe's outcome (same URL, same credential) rather than
+    # repeating it, so it adds no third probe of the dead host.
     probed_hosts = [url.split("://", 1)[1].split("/", 1)[0] for url, _ in observed["dead"]]
-    assert [host for host in probed_hosts if host != "lan-dead.example:1234"] == [
+    assert probed_hosts == [
+        "lan-dead.example:1234",
         "dead-one.example",
         "dead-two.example",
-    ]
+    ], probed_hosts
+    # …and the chain still finished inside the window, so the live provider behind
+    # the dead ones was probed in-band and published.
+    assert clock.now < _BUDGET, clock.now
     assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
 
 

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -213,10 +213,12 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
     assert observed["live"], "the reachable named provider was never probed"
     assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
 
-    # Both consumers of the dead endpoint were attempted — the active-endpoint
-    # probe and the LM Studio provider-group fallback — and each was handed a
-    # bounded slice rather than the whole window.
-    assert len(observed["dead"]) == 2
+    # The dead endpoint is configured twice (active `model.base_url` and
+    # `providers.lmstudio.base_url`), but it is now probed ONCE per rebuild: the
+    # second consumer reuses the first outcome instead of paying the connect
+    # timeout again. Its single probe was still handed a bounded slice of the
+    # window rather than the whole per-endpoint cap.
+    assert len(observed["dead"]) == 1
     for _url, timeout in observed["dead"]:
         assert timeout is not None and 0 < timeout < _CAP
     # The reachable provider was probed in-band off the same window, so its probe

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -104,6 +104,8 @@ def isolate_models_catalog_state(monkeypatch, tmp_path):
     monkeypatch.setattr(cfg, "_available_models_live_rebuild_ts", 0.0, raising=False)
     monkeypatch.setattr(cfg, "_available_models_cache_source_fingerprint", None, raising=False)
     monkeypatch.setattr(cfg, "_cache_build_in_progress", False, raising=False)
+    monkeypatch.setattr(cfg, "_models_rebuild_seq", 0, raising=False)
+    monkeypatch.setattr(cfg, "_models_published_seq", 0, raising=False)
     monkeypatch.setattr(cfg, "cfg", {}, raising=False)
     # Any provider left in the catalog would otherwise shell out to the Hermes
     # CLI for a live id list; the rebuild must stay network-free apart from the
@@ -150,6 +152,27 @@ def _models_by_provider(catalog: dict) -> dict[str, list[str]]:
     return {
         group["provider_id"]: [_bare_id(m.get("id")) for m in group.get("models", [])]
         for group in catalog["groups"]
+    }
+
+
+class _FakeClock:
+    """Stand-in for the ``time`` module so a schedule can be advanced by hand."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _catalog(name: str) -> dict:
+    """A minimal catalog tagged so a test can tell which build produced it."""
+    return {
+        "active_provider": name,
+        "default_model": f"{name}/model",
+        "configured_model_badges": {},
+        "groups": [{"provider": name.title(), "provider_id": name, "models": []}],
+        "aliases": {},
     }
 
 
@@ -280,13 +303,7 @@ def test_probe_schedule_shares_the_window_and_reserves_headroom(monkeypatch):
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 4.0, raising=False)
     monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
 
-    class _Clock:
-        now = 0.0
-
-        def monotonic(self):  # noqa: D102 - stand-in for time.monotonic
-            return self.now
-
-    clock = _Clock()
+    clock = _FakeClock()
     monkeypatch.setattr(cfg, "time", clock, raising=False)
 
     schedule = cfg._CustomProbeSchedule(4)
@@ -302,6 +319,28 @@ def test_probe_schedule_shares_the_window_and_reserves_headroom(monkeypatch):
     assert clock.now < 4.0, timeouts
 
 
+def test_probe_schedule_cannot_outspend_the_window_at_any_chain_length(monkeypatch):
+    """The headroom must survive long chains — `custom_providers` is unbounded.
+
+    Regression guard for the review finding on the first revision: a fixed 0.5s
+    per-probe floor let eight timeouts spend the whole four-second window and
+    nine spend past it, so a long chain of dead endpoints could still push a
+    reachable provider out of the in-band rebuild.
+    """
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 4.0, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    clock = _FakeClock()
+    monkeypatch.setattr(cfg, "time", clock, raising=False)
+
+    for endpoint_count in (1, 2, 8, 24):
+        clock.now = 0.0
+        schedule = cfg._CustomProbeSchedule(endpoint_count)
+        for _ in range(endpoint_count):
+            clock.now += schedule.next_timeout()  # every probe burns its slice
+        assert clock.now < 4.0, (endpoint_count, clock.now)
+
+
 def test_probe_schedule_restores_the_cap_once_the_budget_is_spent(monkeypatch):
     """The out-of-band continuation still gets a full attempt to refresh."""
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
@@ -313,33 +352,24 @@ def test_probe_schedule_restores_the_cap_once_the_budget_is_spent(monkeypatch):
     assert schedule.next_timeout() == 5.0
 
 
-def test_late_out_of_band_result_cannot_overwrite_a_newer_generation(
+def test_late_out_of_band_result_cannot_overwrite_a_newer_rebuild(
     monkeypatch, isolate_models_catalog_state
 ):
     """A superseded rebuild must not resurrect its catalog over a newer one."""
     _configure(monkeypatch, active_base_url=None)
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
 
-    newer = {
-        "active_provider": "newer-generation",
-        "default_model": "newer-generation/model",
-        "configured_model_badges": {},
-        "groups": [{"provider": "Newer", "provider_id": "newer-generation", "models": []}],
-        "aliases": {},
-    }
-    older = {
-        "active_provider": "older-generation",
-        "default_model": "older-generation/model",
-        "configured_model_badges": {},
-        "groups": [{"provider": "Older", "provider_id": "older-generation", "models": []}],
-        "aliases": {},
-    }
+    newer = _catalog("newer")
+    older = _catalog("older")
     finished = {"value": False}
 
     def _slow_builder(_builder):
-        # Still running when the foreground gives up — and by now a newer
-        # generation has been published (the out-of-band race).
+        # Still running when the foreground gives up — and by now a NEWER
+        # rebuild has been allocated and published its catalog (the out-of-band
+        # race the guard exists for).
         time.sleep(0.15)
+        cfg._models_rebuild_seq += 1
+        cfg._models_published_seq = cfg._models_rebuild_seq
         cfg._available_models_cache = newer
         cfg._available_models_cache_ts = time.monotonic()
         cfg._available_models_live_rebuild_ts = time.monotonic()
@@ -358,5 +388,43 @@ def test_late_out_of_band_result_cannot_overwrite_a_newer_generation(
 
     assert finished["value"] is True
     assert cfg._available_models_cache is newer, (
-        "the superseded out-of-band rebuild overwrote a newer catalog generation"
+        "the superseded out-of-band rebuild overwrote a newer catalog"
     )
+
+
+def test_older_publish_does_not_cost_a_newer_rebuild_its_result(
+    monkeypatch, isolate_models_catalog_state
+):
+    """An older build publishing late must not suppress the newer build's publish.
+
+    Regression guard for the review finding on the first revision: ordering by
+    wall-clock stamp meant an OLDER rebuild that published *after* a newer one
+    had started read as the newer generation, so the newer build's correct result
+    was discarded — leaving a stale catalog in the cache and disk while its
+    caller received a catalog that was never published.
+    """
+    _configure(monkeypatch, active_base_url=None)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 5.0, raising=False)
+
+    newer = _catalog("newer")
+    older = _catalog("older")
+
+    def _builder(_builder):
+        # This run is rebuild N; simulate rebuild N-1 publishing its older
+        # catalog late, while we are still building.
+        cfg._models_published_seq = cfg._models_rebuild_seq - 1
+        cfg._available_models_cache = older
+        cfg._available_models_cache_ts = time.monotonic()
+        cfg._available_models_live_rebuild_ts = time.monotonic()
+        return copy.deepcopy(newer)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _builder)
+
+    result = cfg.get_available_models()
+
+    assert result["active_provider"] == "newer"
+    assert cfg._available_models_cache is not older, (
+        "an older publish suppressed the newer rebuild's result"
+    )
+    assert cfg._available_models_cache["active_provider"] == "newer"
+    assert cfg._models_published_seq == cfg._models_rebuild_seq

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import copy
 import json
 import socket
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -217,7 +218,11 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
     # bounded slice rather than the whole window.
     assert len(observed["dead"]) == 2
     for _url, timeout in observed["dead"]:
-        assert timeout is not None and timeout < _CAP
+        assert timeout is not None and 0 < timeout < _CAP
+    # The reachable provider was probed in-band off the same window, so its probe
+    # is bounded by the remaining budget too rather than the per-endpoint cap.
+    for _url, timeout in observed["live"]:
+        assert timeout is not None and 0 < timeout < _CAP
 
 
 def test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through(
@@ -319,13 +324,21 @@ def test_probe_schedule_shares_the_window_and_reserves_headroom(monkeypatch):
     assert clock.now < 4.0, timeouts
 
 
-def test_probe_schedule_cannot_outspend_the_window_at_any_chain_length(monkeypatch):
+@pytest.mark.parametrize("endpoint_count", [1, 2, 8, 24, 401, 1000])
+def test_probe_schedule_cannot_outspend_the_window_at_any_chain_length(
+    endpoint_count, monkeypatch
+):
     """The headroom must survive long chains — `custom_providers` is unbounded.
 
-    Regression guard for the review finding on the first revision: a fixed 0.5s
-    per-probe floor let eight timeouts spend the whole four-second window and
-    nine spend past it, so a long chain of dead endpoints could still push a
-    reachable provider out of the in-band rebuild.
+    Regression guard for both earlier revisions. A fixed 0.5s per-probe floor let
+    eight timeouts spend the whole four-second window and nine spend past it. The
+    0.01s "arithmetic guard" that replaced it was still a floor: with a computed
+    share below it, roughly the first 400 probes of a thousand could drain the
+    window and every probe after that was handed the full per-endpoint cap. Either
+    way a long chain of dead endpoints could push a reachable provider out of the
+    in-band rebuild — the reported defect — so the counts here run past both
+    thresholds, and the assertion is made after *every* allocation rather than
+    only at the end of the chain.
     """
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 4.0, raising=False)
     monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
@@ -333,23 +346,101 @@ def test_probe_schedule_cannot_outspend_the_window_at_any_chain_length(monkeypat
     clock = _FakeClock()
     monkeypatch.setattr(cfg, "time", clock, raising=False)
 
-    for endpoint_count in (1, 2, 8, 24):
-        clock.now = 0.0
-        schedule = cfg._CustomProbeSchedule(endpoint_count)
-        for _ in range(endpoint_count):
-            clock.now += schedule.next_timeout()  # every probe burns its slice
-        assert clock.now < 4.0, (endpoint_count, clock.now)
+    schedule = cfg._CustomProbeSchedule(endpoint_count)
+    for probe in range(endpoint_count):
+        timeout = schedule.next_timeout()
+        # Every slot is still attempted — including the last of a very long chain
+        # — and none of them is handed the full cap out of the shared window.
+        assert 0 < timeout < 5.0, (endpoint_count, probe, timeout)
+        clock.now += timeout  # every probe burns its slice
+        # Cumulative spend never reaches the window, so the chain always finishes
+        # in-band and the foreground caller gets a published catalog.
+        assert clock.now < 4.0, (endpoint_count, probe, clock.now)
 
 
-def test_probe_schedule_restores_the_cap_once_the_budget_is_spent(monkeypatch):
+def test_probe_schedule_restores_the_cap_once_the_foreground_gives_up(monkeypatch):
     """The out-of-band continuation still gets a full attempt to refresh."""
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
     monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
 
-    schedule = cfg._CustomProbeSchedule(3)
+    abandoned = threading.Event()
+    schedule = cfg._CustomProbeSchedule(3, out_of_band=abandoned.is_set)
+
     assert schedule.next_timeout() < 5.0
     time.sleep(0.1)  # budget now spent
+    abandoned.set()  # the foreground caller has stopped waiting
     assert schedule.next_timeout() == 5.0
+
+
+def test_probe_schedule_stays_bounded_in_band_after_the_window_is_spent(monkeypatch):
+    """A spent window is not the same state as an out-of-band continuation.
+
+    Regression guard for the review finding on the second revision: the deadline
+    being spent said nothing about whether the foreground caller had given up, so
+    an in-band chain that had already outspent the window was handed the full
+    per-endpoint cap for each of its remaining probes — the window was bypassed
+    and whatever reachable provider sat behind it landed out-of-band (or not at
+    all), which is the reported defect. Only a caller that has actually stopped
+    waiting may spend past the window.
+    """
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", 5.0, raising=False)
+
+    # No out-of-band signal: the caller is still waiting on this chain.
+    schedule = cfg._CustomProbeSchedule(3)
+
+    assert schedule.next_timeout() < 5.0
+    time.sleep(0.1)  # window spent while the foreground is still waiting
+    for _ in range(3):
+        timeout = schedule.next_timeout()
+        assert 0 < timeout < 5.0, timeout  # attempted, but never the full cap
+
+
+def test_probe_schedule_is_wired_to_the_foreground_giving_up(
+    monkeypatch, isolate_models_catalog_state
+):
+    """The schedule must see the real hand-off, not infer it from the deadline.
+
+    The over-budget continuation is recognised through an explicit signal; if a
+    rebuild never passed one, its probes would stay pinned to the window that the
+    caller already walked away from, and the out-of-band refresh could not
+    complete. This asserts the schedule is handed a signal, and that the signal
+    reports out-of-band once the foreground caller has stopped waiting.
+    """
+    _configure(monkeypatch, active_base_url=None)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+
+    seen: dict = {}
+    real_schedule = cfg._CustomProbeSchedule
+    real_invoke = cfg._invoke_models_rebuild
+
+    class _RecordingSchedule(real_schedule):
+        def __init__(self, endpoint_count, *, out_of_band=None):
+            seen["predicate"] = out_of_band
+            super().__init__(endpoint_count, out_of_band=out_of_band)
+
+    monkeypatch.setattr(cfg, "_CustomProbeSchedule", _RecordingSchedule)
+
+    def _slow_builder(builder):
+        # Hold the worker past the budget so the foreground gives up before the
+        # probe chain is scheduled — the state the signal has to report.
+        time.sleep(0.15)
+        return real_invoke(builder)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_builder)
+
+    cfg.get_available_models()
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and "predicate" not in seen:
+        time.sleep(0.01)
+
+    assert seen.get("predicate") is not None, (
+        "the probe schedule was never given a foreground/out-of-band signal"
+    )
+    assert seen["predicate"]() is True, (
+        "the foreground gave up but the schedule still reads as in-band"
+    )
 
 
 def test_late_out_of_band_result_cannot_overwrite_a_newer_rebuild(

--- a/tests/test_issue7481_custom_probe_budget_fairness.py
+++ b/tests/test_issue7481_custom_probe_budget_fairness.py
@@ -41,6 +41,19 @@ _GATEWAY_MODELS = ["gateway-model-a", "gateway-model-b"]
 _BUDGET = 4.0
 _CAP = 1.5
 
+# Deliberately widened budget/cap pair for the end-to-end publication assertion
+# (the repro test). The rebuild worker's deadline is a *real* OS-clock wait —
+# ``build_done.wait(timeout=_LIVE_REBUILD_BUDGET_SECONDS)`` in
+# ``get_available_models`` — which the injected ``_FakeClock`` cannot
+# virtualise, so on a slow runner the issue's 4s window can be crossed mid-build
+# and the over-budget fallback served without the gateway. Widening the window
+# makes the assertion depend on the fix rather than on the runner: the repro's
+# locally-served, non-sleeping probes finish in milliseconds against 40s, while
+# the "slice < cap" rule still holds — its three scheduled slots get
+# ``40 / (3 + 1) = 10 < 20``.
+_WIDE_BUDGET = 40.0
+_WIDE_CAP = 20.0
+
 
 class _FakeResponse:
     def __init__(self, payload: dict) -> None:
@@ -70,14 +83,17 @@ def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts, clock=None):
     way these tests were not written to describe. Advancing the injected clock
     keeps the budget exact and the ordering assertions meaningful on any runner.
 
-    Returns ``{"dead": [(url, timeout)], "live": [(url, timeout)]}``.
+    Returns ``{"dead": [(url, timeout)], "live": [(url, timeout)],
+    "order": [url, ...]}`` — ``order`` is the flat probe sequence across both
+    categories, so a test can assert the visit order rather than only per-host.
     """
-    observed: dict[str, list] = {"dead": [], "live": []}
+    observed: dict[str, list] = {"dead": [], "live": [], "order": []}
 
     def fake_urlopen(req, timeout=None):
         url = str(getattr(req, "full_url", ""))
         if any(host in url for host in dead_hosts):
             observed["dead"].append((url, timeout))
+            observed["order"].append(url)
             if clock is not None:
                 clock.now += float(timeout or 0.0)
             else:
@@ -85,6 +101,7 @@ def _install_urlopen(monkeypatch, *, dead_hosts, live_hosts, clock=None):
             raise urllib.error.URLError("timed out")
         if any(host in url for host in live_hosts):
             observed["live"].append((url, timeout))
+            observed["order"].append(url)
             return _FakeResponse({"data": [{"id": mid} for mid in _GATEWAY_MODELS]})
         raise urllib.error.URLError(f"unexpected probe: {url}")
 
@@ -208,12 +225,28 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
     A dead LAN endpoint is configured both as the active provider and as
     ``providers.lmstudio`` (so the provider-group fallback probes it a second
     time). The reachable named gateway behind it must still get its in-band
-    probe and land in the catalog the caller receives — not merely be deferred
-    to an out-of-band refresh after a fallback was served.
+    probe — not merely be deferred to an out-of-band refresh after a fallback
+    was served.
 
-    Runs on the injected clock (maintainer review, 2026-09-10): the dead host
-    burns *virtual* time instead of really sleeping, so the budget arithmetic is
-    exact rather than dependent on how fast this runner happens to be.
+    Machine-speed independence (maintainer review, 2026-09-11). Installing
+    ``_FakeClock`` makes the *schedule's* window arithmetic exact, but the
+    budget is ultimately enforced by the rebuild worker's
+    ``build_done.wait(timeout=_LIVE_REBUILD_BUDGET_SECONDS)``, a real OS-clock
+    wait the injected clock cannot virtualise. On a slow runner the build can
+    therefore cross the 4s deadline mid-call, the foreground serves the
+    over-budget fallback, ``observed["live"]`` is empty and the gateway never
+    reaches the caller — a property of the runner, not of the fix. So this test
+    asserts the probe/scheduling invariants that the fake clock makes exact,
+    and takes the one end-to-end "lands in the caller's catalog" assertion under
+    a deliberately widened budget/cap pair (see ``_WIDE_BUDGET`` / ``_WIDE_CAP``)
+    whose real work finishes with a large margin.
+
+    The in-band publication itself is also covered, machine-independently, by
+    ``test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through``
+    and ``test_static_allowlist_provider_is_never_probed_and_does_not_dilute_the_schedule``;
+    if the widened pair ever proves flaky on a runner, drop the final catalog
+    assertion and keep the four invariants, relying on those two for
+    end-to-end coverage.
     """
     _configure(
         monkeypatch,
@@ -227,6 +260,12 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
             }
         ],
     )
+    # Widen the window for this test only: the schedule then computes its slices
+    # from a 40s budget while the per-endpoint cap is 20s, so the repro's three
+    # slots each get 10s (still strictly below the cap) and the call phase has an
+    # ≥8x real-time margin instead of racing the 4s deadline.
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", _WIDE_BUDGET, raising=False)
+    monkeypatch.setattr(cfg, "CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS", _WIDE_CAP, raising=False)
     clock = _FakeClock()
     monkeypatch.setattr(cfg, "time", clock, raising=False)
     observed = _install_urlopen(
@@ -238,24 +277,33 @@ def test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it(
 
     catalog = cfg.get_available_models()
 
-    # The whole chain fitted inside the window, so the rebuild published in-band
-    # and no budget-exceeded fallback was served.
-    assert clock.now < _BUDGET, clock.now
-    assert observed["live"], "the reachable named provider was never probed"
-    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
-
-    # The dead endpoint is configured twice (active `model.base_url` and
+    # (1) The dead endpoint is configured twice (active `model.base_url` and
     # `providers.lmstudio.base_url`), but it is now probed ONCE per rebuild: the
     # second consumer reuses the first outcome instead of paying the connect
-    # timeout again. Its single probe was still handed a bounded slice of the
-    # window rather than the whole per-endpoint cap.
+    # timeout again.
     assert len(observed["dead"]) == 1
-    for _url, timeout in observed["dead"]:
-        assert timeout is not None and 0 < timeout < _CAP
-    # The reachable provider was probed in-band off the same window, so its probe
-    # is bounded by the remaining budget too rather than the per-endpoint cap.
-    for _url, timeout in observed["live"]:
-        assert timeout is not None and 0 < timeout < _CAP
+
+    # (2) Probes are walked in config order — the active (`lan-dead`) endpoint
+    # before the named gateway — and the gateway really was probed in-band.
+    assert observed["live"], "the reachable named provider was never probed"
+    probed_hosts = [url.split("://", 1)[1].split("/", 1)[0] for url in observed["order"]]
+    assert probed_hosts == ["lan-dead.example:1234", "gw-live.example"], probed_hosts
+
+    # (3) Every probe was handed a bounded slice of the window — positive and
+    # strictly below the per-endpoint cap — rather than the whole cap.
+    for url, timeout in observed["dead"] + observed["live"]:
+        assert timeout is not None and 0 < timeout < _WIDE_CAP, (url, timeout)
+
+    # (4) The schedule's own arithmetic stayed inside the window. This is the
+    # virtual clock, so it states "the chain fitted inside the window" on any
+    # runner — the invariant the slow-runner failure violated via the real-clock
+    # fallback. (The catalogue the caller actually receives is asserted next,
+    # under the widened budget that removes the real-clock race.)
+    assert clock.now < _WIDE_BUDGET, clock.now
+
+    # (5) End-to-end: the reachable gateway lands in the catalog the caller
+    # receives rather than only in an out-of-band refresh after a fallback.
+    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
 
 
 def test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through(

--- a/tests/test_issue7481_probe_dedup.py
+++ b/tests/test_issue7481_probe_dedup.py
@@ -1,0 +1,196 @@
+"""Regression coverage for the #7481 follow-up: one endpoint, one probe per rebuild.
+
+The cold catalog rebuild can reach the same custom endpoint more than once. Step 4
+probes the active ``model.base_url``, and the LM Studio provider-group fallback later
+reads ``providers.lmstudio.base_url`` — which falls back to ``model.base_url`` when
+lmstudio is the active provider. In the config shape the issue reports both point at
+the same unreachable LAN host, so one dead endpoint used to cost the rebuild that
+host's connect timeout TWICE, and two named ``custom_providers`` entries can share an
+endpoint just as easily.
+
+The fix memoises each probe by (endpoint URL, credential) for the duration of one
+rebuild, so a repeated endpoint reuses the first outcome — including a failure, which
+is exactly what used to stall the rebuild a second time — while a different URL or a
+different credential is still probed in its own right.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import api.config as cfg
+from tests.test_issue7481_custom_probe_budget_fairness import (  # noqa: F401
+    _GATEWAY_MODELS,
+    _configure,
+    _install_urlopen,
+    _models_by_provider,
+    isolate_models_catalog_state,
+)
+
+
+def _hosts(observed, kind: str) -> list[str]:
+    return [url.split("://", 1)[1].split("/", 1)[0] for url, _ in observed[kind]]
+
+
+def test_shared_endpoint_between_active_probe_and_lmstudio_fallback_is_probed_once(
+    monkeypatch, isolate_models_catalog_state
+):
+    """A dead host configured as both the active endpoint and lmstudio costs one probe.
+
+    This is the issue's own config shape: before the de-duplication the same
+    unreachable LAN host was probed by step 4 and again by the LM Studio
+    provider-group fallback, so it spent two slices of the shared rebuild window.
+    """
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        provider_base_url="http://lan-dead.example:1234/v1",
+        custom_providers=[
+            {
+                "name": "My Gateway",
+                "base_url": "https://gw-live.example/v1",
+                "api_key": "sk-live",
+            }
+        ],
+    )
+    observed = _install_urlopen(
+        monkeypatch, dead_hosts=["lan-dead.example"], live_hosts=["gw-live.example"]
+    )
+
+    catalog = cfg.get_available_models()
+
+    assert _hosts(observed, "dead") == ["lan-dead.example:1234"], (
+        "the shared dead endpoint was probed more than once"
+    )
+    # The reachable provider behind it still made it into the published catalog.
+    assert _models_by_provider(catalog).get("custom:my-gateway") == _GATEWAY_MODELS
+
+
+def test_shared_reachable_endpoint_is_probed_once_and_still_renders(
+    monkeypatch, isolate_models_catalog_state
+):
+    """De-duplication must not cost the lmstudio group its models."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-live.example:1234/v1",
+        provider_base_url="http://lan-live.example:1234/v1",
+    )
+    observed = _install_urlopen(
+        monkeypatch, dead_hosts=[], live_hosts=["lan-live.example:1234"]
+    )
+
+    catalog = cfg.get_available_models()
+
+    assert _hosts(observed, "live") == ["lan-live.example:1234"], (
+        "the shared reachable endpoint was probed more than once"
+    )
+    # The probed models still land in the lmstudio group (which also carries the
+    # config-declared default model, so assert containment, not equality).
+    assert set(_GATEWAY_MODELS) <= set(_models_by_provider(catalog).get("lmstudio") or [])
+
+
+def test_distinct_endpoints_are_still_each_probed(
+    monkeypatch, isolate_models_catalog_state
+):
+    """Two different endpoints are two probes — no over-merging."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead-a.example:1234/v1",
+        provider_base_url="http://lan-dead-b.example:1234/v1",
+    )
+    observed = _install_urlopen(
+        monkeypatch, dead_hosts=["lan-dead-a.example", "lan-dead-b.example"], live_hosts=[]
+    )
+
+    cfg.get_available_models()
+
+    assert sorted(_hosts(observed, "dead")) == [
+        "lan-dead-a.example:1234",
+        "lan-dead-b.example:1234",
+    ]
+
+
+def test_same_endpoint_with_a_different_credential_is_probed_separately(
+    monkeypatch, isolate_models_catalog_state
+):
+    """The credential is part of a probe's identity: it can change the outcome."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        provider_base_url="http://lan-dead.example:1234/v1",
+    )
+    cfg.cfg["model"]["api_key"] = "active-key"
+    cfg.cfg["providers"]["lmstudio"]["api_key"] = "lmstudio-key"
+    observed = _install_urlopen(
+        monkeypatch, dead_hosts=["lan-dead.example"], live_hosts=[]
+    )
+
+    cfg.get_available_models()
+
+    assert _hosts(observed, "dead") == [
+        "lan-dead.example:1234",
+        "lan-dead.example:1234",
+    ], "one credential's result was reused for a probe that sends a different one"
+
+
+def test_named_providers_sharing_an_endpoint_are_probed_once(
+    monkeypatch, isolate_models_catalog_state
+):
+    """Two named entries pointing at one endpoint probe it once, for both groups."""
+    _configure(
+        monkeypatch,
+        active_base_url=None,
+        custom_providers=[
+            {"name": "Proxy A", "base_url": "https://shared.example/v1", "api_key": "k"},
+            {"name": "Proxy B", "base_url": "https://shared.example/v1", "api_key": "k"},
+        ],
+    )
+    observed = _install_urlopen(monkeypatch, dead_hosts=[], live_hosts=["shared.example"])
+
+    catalog = cfg.get_available_models()
+
+    assert _hosts(observed, "live") == ["shared.example"]
+    groups = _models_by_provider(catalog)
+    assert groups.get("custom:proxy-a") == _GATEWAY_MODELS
+    assert groups.get("custom:proxy-b") == _GATEWAY_MODELS
+
+
+def test_named_provider_repeating_the_active_endpoint_is_probed_once(
+    monkeypatch, isolate_models_catalog_state
+):
+    """The active-endpoint result is reused by a named entry on the same URL."""
+    _configure(
+        monkeypatch,
+        active_base_url="http://lan-dead.example:1234/v1",
+        custom_providers=[
+            {
+                "name": "Same Host",
+                "base_url": "http://lan-dead.example:1234/v1",
+                "api_key": "",
+            }
+        ],
+    )
+    observed = _install_urlopen(monkeypatch, dead_hosts=["lan-dead.example"], live_hosts=[])
+
+    cfg.get_available_models()
+
+    assert _hosts(observed, "dead") == ["lan-dead.example:1234"]
+
+
+def test_trailing_slash_spelling_of_one_endpoint_is_a_single_probe(
+    monkeypatch, isolate_models_catalog_state
+):
+    """`https://h/v1` and `https://h/v1/` are the same endpoint, so one probe."""
+    _configure(
+        monkeypatch,
+        active_base_url=None,
+        custom_providers=[
+            {"name": "Proxy A", "base_url": "https://shared.example/v1", "api_key": "k"},
+            {"name": "Proxy B", "base_url": "https://shared.example/v1/", "api_key": "k"},
+        ],
+    )
+    observed = _install_urlopen(monkeypatch, dead_hosts=[], live_hosts=["shared.example"])
+
+    cfg.get_available_models()
+
+    assert _hosts(observed, "live") == ["shared.example"]

--- a/tests/test_issue7481_probe_dedup.py
+++ b/tests/test_issue7481_probe_dedup.py
@@ -16,16 +16,69 @@ different credential is still probed in its own right.
 
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 import api.config as cfg
-from tests.test_issue7481_custom_probe_budget_fairness import (  # noqa: F401
+import api.profiles as profiles
+from tests.test_issue7481_custom_probe_budget_fairness import (
     _GATEWAY_MODELS,
     _configure,
     _install_urlopen,
     _models_by_provider,
-    isolate_models_catalog_state,
 )
+
+
+@pytest.fixture
+def isolate_models_catalog_state(monkeypatch, tmp_path):
+    """Hermetic catalog state, same harness as the sibling #7481 module.
+
+    Defined here rather than imported from there: a fixture imported purely so it
+    can be requested as a fixture reads as an unused import to linters (ruff F401)
+    and collides with the very parameters that request it (ruff F811). Each test
+    module owning its harness is what the rest of this suite does.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: {}\n", encoding="utf-8")
+    auth_store_path = tmp_path / "auth.json"
+    auth_store_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_has_in_memory_overrides", lambda: True)
+    monkeypatch.setattr(cfg, "_get_auth_store_path", lambda: auth_store_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(cfg, "_delete_models_cache_on_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: "issue-7481-fp")
+    monkeypatch.setattr(cfg, "_available_models_cache", None, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_cache_ts", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_live_rebuild_ts", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_cache_source_fingerprint", None, raising=False)
+    monkeypatch.setattr(cfg, "_cache_build_in_progress", False, raising=False)
+    monkeypatch.setattr(cfg, "_models_rebuild_seq", 0, raising=False)
+    monkeypatch.setattr(cfg, "_models_published_seq", 0, raising=False)
+    monkeypatch.setattr(cfg, "cfg", {}, raising=False)
+    # Any provider left in the catalog would otherwise shell out to the Hermes
+    # CLI for a live id list; the rebuild must stay network-free apart from the
+    # custom endpoints under test.
+    monkeypatch.setattr(cfg, "_read_live_provider_model_ids", lambda _pid: [])
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path / "hermes-home")
+    monkeypatch.setattr(cfg.os, "getenv", lambda key, default=None: default or "")
+    # The probe path resolves the endpoint hostname for its SSRF guard. A real
+    # resolver makes these tests depend on the host's DNS behaviour (and this
+    # container takes seconds to answer NXDOMAIN), so pin it to an immediate
+    # failure: the guard treats that as "not resolvable" and lets the probe
+    # through, which is exactly what the fake urlopen above is standing in for.
+    def _unresolvable(host, port, *args, **kwargs):
+        raise socket.gaierror("hermetic test resolver")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _unresolvable)
+
+    return {"tmp_path": tmp_path, "auth_store_path": auth_store_path}
 
 
 def _hosts(observed, kind: str) -> list[str]:


### PR DESCRIPTION
@Yang-qwq

Refs #7481

### Thinking Path

The cold catalog rebuild probes the active endpoint first and each named `custom_providers` entry after it, **serially**, off one shared `_LIVE_REBUILD_BUDGET_SECONDS` (4.0s) window, while every probe is individually capped at `CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS` (5.0s). Because the per-endpoint cap (5s) is larger than the whole chain's budget (4s), the first endpoint in the chain can consume the entire window on its own connect timeout. Everything behind it never gets an in-band `/v1/models` probe, so its group renders from stale disk cache or stays empty, and the caller is handed the over-budget fallback.

I reproduced this against current `master` with the issue's own config shape (dead LAN endpoint as the active provider **and** as `providers.lmstudio`, plus a reachable named gateway), instrumenting `urllib.request.urlopen`:

```
(0.07s, lan-dead/v1/models, timeout=5)        <- active endpoint, UNREACHABLE, burns the cap
(elapsed 4.06s) "live provider-catalog rebuild exceeded 4.0s budget — serving fallback"
gateway group: ABSENT
```

Two things feed that stall, not one. Besides the chain's step 4/step 5 probes, the LM Studio provider-group branch (`pid == "lmstudio"`) re-probes the *same* dead endpoint again from `providers.lmstudio.base_url` under a **hardcoded `timeout=5`** that sits outside any budget at all. Bounding only the chain leaves the rebuild over budget anyway, so the fix has to cover both to actually publish the reachable provider in-band.

### What Changed

`api/config.py`

- **`_CustomProbeSchedule`** (new): hands each probe in the chain a fair slice of the *remaining* window instead of the whole per-endpoint cap, so an endpoint that times out cannot starve the endpoints scheduled after it. The slice is `min(CAP, left / (remaining + 1))` with **no lower bound**: the `+1` reserves a slot of headroom, the slices telescope, so a chain of N probes spends exactly `N/(N+1)` of the window for every N and the foreground gets a published catalog rather than a fallback. A fixed floor made the total grow with chain length at 0.5s (first revision) *and* at 0.01s (second revision) — a positive `left` already divides to a positive slice, so there is nothing to floor; see **Review Round 2**.
- **Explicit foreground-vs-out-of-band signal**: `_CustomProbeSchedule` takes an `out_of_band` predicate, and `get_available_models` passes the per-rebuild event it sets when the foreground caller stops waiting. Only that deliberately out-of-band continuation keeps the full per-endpoint cap (its probes are no longer holding anyone up, and the refresh must be able to complete). A probe that finds the window spent while the caller *is* still waiting is a separate, bounded state: it gets an attempt-only timeout (`CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS` — not a floor, not a share of the window, and unreachable from the fair-share path), never the cap.
- The schedule is constructed per rebuild from the count of endpoints about to be probed (active endpoint + named providers without a static `models:` allowlist + the LM Studio fallback when it will fire), and supplies the timeout at all three probe sites: step 4, step 5, and the LM Studio provider-group fallback (previously the hardcoded `timeout=5`).
- **Superseded-result guard** in `_publish_models_result`, ordered by an explicit rebuild sequence rather than by wall clock: `_allocate_models_rebuild_seq()` hands each cold rebuild the next number (taken under `_available_models_cache_lock`), the published catalog records the sequence it came from (`_models_published_seq`), and a result is dropped only when `rebuild_seq < _models_published_seq`. Only the out-of-band publisher can reach that path (it outlives the foreground caller that gave up on it), and without the guard it could resurrect a superseded catalog. Ordering by timestamp cannot express this — an older build can publish *after* a newer one has started, which would then wrongly drop the newer result.

`ARCHITECTURE.md`

- New **§4.9 "Model Catalog Rebuild Budget and Probe Scheduling"**: the budget/knob table (including the no-floor rule and why `CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS` is neither a floor nor a slice), the serial probe order and fair-share rule with its trade-off, the two states that keep the unthrottled cap (legacy unbounded path, explicit out-of-band continuation) with the hand-off race called out as a distinct bounded state, and generation-ordered out-of-band publication. `CHANGELOG.md` is untouched, per `AGENTS.md` / `CONTRIBUTING.md`.

Deliberately unchanged, per the maintainer's scope note:

- **Provider ordering** stays exactly as it was (deterministic, config order, active endpoint first).
- **Every endpoint keeps its own SSRF and authentication rules** — the guard, the trusted-host list, and the key resolution are untouched, and no private/LAN address is special-cased.
- **The total rebuild budget is unchanged** (`_LIVE_REBUILD_BUDGET_SECONDS`, same env override); the chain now simply fits inside it. The legacy synchronous path (`budget <= 0`) and the out-of-band continuation both keep the historical unthrottled cap, so their behaviour is identical to before.

`tests/test_issue7481_custom_probe_budget_fairness.py` (new, 16 tests) — bound to the issue's pinned config shape, with the host resolver and `urlopen` stubbed so the probes are exactly the ones the issue describes:

| coverage the maintainer asked for | test |
| --- | --- |
| unreachable active endpoint followed by a reachable named provider | `test_unreachable_lan_active_endpoint_does_not_starve_the_gateway_behind_it` |
| multiple timeouts | `test_every_dead_endpoint_in_the_chain_still_lets_the_live_one_through` |
| static `models:` providers | `test_static_allowlist_provider_is_never_probed_and_does_not_dilute_the_schedule` |
| cache/fallback behaviour | `test_probe_schedule_restores_the_cap_once_the_foreground_gives_up` (+ the repro asserting no fallback was served) |
| late timed-out result cannot overwrite a newer generation | `test_late_out_of_band_result_cannot_overwrite_a_newer_generation`, `test_older_publish_does_not_cost_a_newer_rebuild_its_result` |
| budget holds at any chain length, in-band and out-of-band distinguished | `test_probe_schedule_cannot_outspend_the_window_at_any_chain_length` (N ∈ {1, 2, 8, 24, 401, 1000}), `test_probe_schedule_stays_bounded_in_band_after_the_window_is_spent`, `test_probe_schedule_is_wired_to_the_foreground_giving_up` |
| — | `test_probe_schedule_keeps_the_documented_cap_when_the_budget_is_disabled`, `test_probe_schedule_shares_the_window_and_reserves_headroom` |

### Why It Matters

With the fix, the same reproduction finishes in-band and the reachable gateway is in the catalog the caller receives:

```
(0.07s, lan-dead/v1/models, timeout=1.00)   active endpoint, throttled
(1.07s, gw-live/v1/models, timeout=1.00)    reachable gateway -> probed in-band
(1.08s, lan-dead/v1/models, timeout=1.50)   lmstudio fallback, now bounded
ELAPSED 2.58s (budget 4.0) — no "exceeded budget" fallback
gateway group: ['@custom:my-gateway:gateway-model-a', '@custom:my-gateway:gateway-model-b']
```

A user with an unreachable LAN endpoint configured stops seeing a stale/empty custom-provider group, and every cold model-list load stops paying a full-budget stall followed by a fallback.

### Verification

Local runs used Python 3.12 (CI's middle matrix entry), against `master` @ `71689c6ce7031f4b6ffc90d68a61a2c1f9afe52a`.

- **Fail-first, original fix** (`f9fb6ff`): 7 of the module's tests fail on pre-fix `master` and all pass with the fix; the repro test fails pre-fix because the gateway is never probed and the over-budget fallback is served.
- **Fail-first, round 2** (`8e333e5`): with `api/config.py` reverted to `0515ab0`, `test_probe_schedule_cannot_outspend_the_window_at_any_chain_length[401]`, `[1000]`, `test_probe_schedule_stays_bounded_in_band_after_the_window_is_spent` and `test_probe_schedule_is_wired_to_the_foreground_giving_up` **fail**, while `[1]/[2]/[8]/[24]` still pass there — exactly the threshold behaviour the round-2 review described. All 16 pass on `8e333e5`.
- **Neighbouring-area run** (47 model/provider/catalog/budget/probe files, 483 tests): `476 passed, 6 skipped, 1 failed`. The single failure is `test_model_picker_badges.py::test_available_models_exposes_primary_and_fallback_badges`, a pre-existing cross-file ordering failure: it passes in isolation on this revision, and it fails **identically** when the same batch is run against `0515ab0` with this new module excluded (`1 failed, 464 passed, 2 skipped` then), so it is not introduced by this diff.
- A separate 18-file budget/catalog/custom-provider batch (`216 passed`) shows the same pattern: its two failures (`test_issue2513_custom_provider_remote_models.py`, `test_issue2540_models_endpoint_error.py`) reproduce byte-for-byte on `0515ab0` in that batch and pass in isolation on both revisions.
- **Lint**: `python3 scripts/ruff_lint.py --diff origin/master` → `0 new violations on added/modified lines`.
- Four unrelated test modules (`test_extensions_settings_panel`, `test_issue1908_docker_hardening`, `test_issue3012_3006_docker_docs`, `test_nix_flake_module_source`) fail **collection** on this checkout for missing repo files, on both revisions — environmental, not touched here.

### Review Round 1 → `0515ab0`

Both P1 findings from the automated review were real and are fixed (replies on the inline threads):

| Finding | Fix |
| --- | --- |
| The superseded-result guard compared completion stamps against start stamps, so a later-started build could be discarded in favour of an older one | Order by an explicit rebuild sequence (`_models_rebuild_seq` / `_models_published_seq`); a result is dropped only when strictly older than the published catalog |
| A fixed 0.5s per-probe floor let 8 probes spend the whole 4s window and 9 spend past it | Replaced the 0.5s floor with a 0.01s "arithmetic guard" — **superseded in Round 2: as the reviewer found, that guard was still a per-probe floor for chains long enough to compute a share below it** |
| Runtime change lacked documentation (P2) | Added `ARCHITECTURE.md` §4.9 |

### Review Round 2 → `8e333e5`

The review's finding was correct and is fixed:

- **The lower bound is gone from the in-window allocation.** The allocation is now `min(CAP, left / (remaining + 1))` — no `max(...)`, no floor. With the `+1` headroom the slices telescope: after burning every one of N probes, `left = budget · 1/(N+1) > 0`, so the chain spends `N/(N+1)` of the window at every length and always finishes inside it. `custom_providers` is unbounded, so this now holds for a configured chain of any size, not just the counts the earlier revision happened to test.
- **The full cap now requires an explicit signal rather than a spent deadline.** `_CustomProbeSchedule(endpoint_count, *, out_of_band=...)` takes the predicate; `get_available_models` passes the per-rebuild event it sets at the same point it sets `budget_exceeded` (i.e. when the foreground caller stops waiting). A probe that finds the window spent while the caller is *still* waiting is explicitly not that state: it gets the attempt-only timeout, renamed `CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS` — not a floor, not a share of anything. That is the foreground-vs-out-of-band signal you suggested; the two states were genuinely indistinguishable from the clock alone.
- **Tests.** `test_probe_schedule_cannot_outspend_the_window_at_any_chain_length` is now parametrised over `[1, 2, 8, 24, 401, 1000]` — past both the 0.5s and 0.01s thresholds — advances the fake clock by every returned timeout, and asserts after *every* allocation that elapsed time is still below four seconds and that each slot received a positive, sub-cap attempt. Added `test_probe_schedule_stays_bounded_in_band_after_the_window_is_spent` (spent window, no signal → attempt-only, never the cap) and `test_probe_schedule_is_wired_to_the_foreground_giving_up` (the schedule really receives the signal and observes the hand-off). `test_probe_schedule_restores_the_cap_once_the_foreground_gives_up` is preserved for the genuinely out-of-band continuation, and now sets the signal explicitly.
- **Docs.** §4.9 no longer claims the guard is harmless: it states the no-floor rule, the telescoping bound, and the two cap-keeping states, with the hand-off race named as a distinct bounded state.

What I could not verify: real-world latency of a sub-10ms slice against a live TLS endpoint (no live network here), and the fair-share cut-off itself is a real limit — at N ≈ 1000 each probe gets ~4ms, which no HTTPS handshake completes in, so a reachable provider at the tail of an absurdly long chain is still effectively unprobed in-band. That is now *bounded* rather than an implicit cap bump, but it is not useful; addressing it honestly means fewer probes or a bigger budget, not a floor.

### Follow-up: the duplicated probe -> `635e93b`

While fixing the budget I noted that the dead endpoint in the issue's config is consulted twice —
step 4 reads the active `model.base_url`, and the LM Studio provider-group fallback reads
`providers.lmstudio.base_url`, which falls back to `model.base_url` when lmstudio is the active
provider. One unreachable host therefore cost two connect timeouts out of the same shared window,
which no amount of fair-share scheduling can win back. It is now handled rather than only documented:

- Each probe is memoised per rebuild, keyed by **(endpoint URL, credential)**; a repeat reuses the
  first outcome — including a failure, since re-probing an endpoint this rebuild already found
  unreachable *is* the stall.
- A different URL, or the same URL with a different key (which can change the outcome), is still
  its own probe.
- The raw payload is reused, not the parsed entries, so each consumer still shapes the list for its
  own provider, and a memoised failure is re-reported with the asking provider's label.
- The memo is consulted only after the per-endpoint SSRF/authentication checks, so a consumer that
  would have been refused still is.

Tests (`tests/test_issue7481_probe_dedup.py`, 7): shared dead endpoint probed once · shared
reachable endpoint still renders its group · two distinct endpoints still each probed · same URL
with a different credential still probed twice · two named entries on one endpoint probed once ·
a named entry repeating the active endpoint probed once · trailing-slash spelling treated as one
endpoint. **Five of the seven fail on `8e333e5`**; the other two are the no-over-merge guards. The
#7506 repro test's dead-probe count expectation drops from two to one, which is what this change is
about.

Process note, so you can push back: this went into this PR rather than a second one because it
updates an assertion in *this* PR's own test file, and a stacked PR cannot target a fork branch
(GitHub requires the base branch to exist in the base repo, so a follow-up PR would have to carry
this PR's commits). If you would rather keep this PR strictly to budget and ordering, say so and
I will split it into a PR that lands on top of this one.

### Review Round 3 -> `2c6d9f1`, head `daf4458` (tests only)

You were right that those two tests were decided by wall-clock: their dead-host mock really slept the slice it was handed while `_CustomProbeSchedule` measured the window with the real `time.monotonic()`, so on a slower box the active endpoint's sleep crossed the 4s deadline before `dead-one`/`dead-two` were reached. Both now run on the injected clock:

- `_install_urlopen` takes an optional `clock`; a "dead" probe advances it by the timeout it was handed instead of really sleeping.
- Both tests install `_FakeClock` via `monkeypatch.setattr(cfg, "time", clock)` — the same seam the schedule tests and the budget path use — so the window arithmetic is virtual.
- The repro test's elapsed assertion is now `clock.now < _BUDGET`: it states "the chain fitted inside the window" instead of measuring this host.
- The second test's ordering assertion is exact again — active endpoint, then `dead-one`, then `dead-two` — instead of filtering the active host out, so "walked in config order, in-band" is asserted rather than implied.
- `_FakeClock` gained `time()` (delegates to the real clock, so the module's epoch-based comparisons keep their meaning) and `sleep()` (virtual). Nothing in `api/config.py` calls `time.sleep`.

Evidence: the module runs its 16 tests in ~6.4s (was ~14.4s with the real sleeps), both converted tests pass 5/5 repeats, and their call phase no longer appears among the slowest durations. `api/config.py` is byte-identical to `635e93b` across these two commits.

`daf4458` also fixes a gate-cleanliness issue of my own making: the dedup module imported the sibling's harness fixture, which the curated ruff gate flags as F401 (unused import) plus F811 (the import collides with the parameters requesting it), so that module now defines the fixture it uses. `ruff_lint --diff origin/master`: no new violations.

### Risks / Follow-ups

- **Trade-off, stated plainly**: because a probe's slice is now a share of the window, a genuinely slow-but-reachable endpoint that sits early in a long chain can be cut off where before it happened to fit under the full 5s cap. That is the deliberate cost of not letting one endpoint consume the budget — the alternative (today's behaviour) loses the endpoints behind it *entirely*.
- The window is fixed and shared, so a probe's slice necessarily shrinks as the chain grows: nine probes cannot each get 0.5s out of 4s. Size `HERMES_WEBUI_MODELS_REBUILD_BUDGET` for the endpoints actually in use, or give an entry a static `models:` allowlist. The invariant that now holds at *any* chain length — and is tested over N ∈ {1, 2, 8, 24, 401, 1000} — is that the chain cannot outspend the window while the caller is still waiting.
- **Both stalls on the issue's dead endpoint are gone.** Step 4 and the LM Studio provider-group fallback used to read the same URL independently, so one unreachable LAN host cost two connect timeouts. `635e93b` memoises each probe by (endpoint URL, credential) and probes a repeated endpoint once per rebuild — see Follow-up below.
- The OpenRouter free-tier discovery probe in the provider-group loop is still on its own timeout; it targets a fixed public endpoint, not a user-configured one, so it is outside this issue.
- `CUSTOM_MODELS_MIN_PROBE_TIMEOUT_SECONDS` → `CUSTOM_MODELS_ATTEMPT_ONLY_TIMEOUT_SECONDS`: the old name asserted exactly the property that turned out to be false. The constant is introduced by this PR, so there are no other consumers.
- The branch is behind `master` (`71689c6`); I have not rebased, to keep the existing review threads anchored. Happy to rebase on request.
- Both the cold in-band path and the out-of-band continuation still do **not** share one timing contract (the continuation deliberately keeps the full cap so the refresh can complete), so this PR links the issue with a plain reference keyword and deliberately carries no auto-closing keyword. If you read the bounded in-band path plus generation-ordered publication as sharing the isolation contract, say so and I will switch the reference to an explicit auto-closing keyword.

### AI Usage Disclosure / Model Used

- Provider: Nous Research — Hermes Agent
- Model: `deepseek-v4-flash`
- Notable tool use: this change was authored by the agent autonomously (repo read via the GitHub API, tests run locally, diff reviewed before submitting). **The commit and this PR were created automatically by an agent on behalf of @HarukiTakehata.** The reproduction and verification numbers above are from real local runs, not summarised estimates.
