### PR TITLE
fix(approvals): mint actionable ids for raw id-less local pending entries

### DIFF
--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -265,6 +265,23 @@ def reconcile_gateway_pending_mirror_locked(session_key: str) -> tuple[dict | No
             live_local_tokens.add(live_entry_token)
             if not str(live_data.get("approval_id") or "").strip():
                 live_data["approval_id"] = f"gwlocal:{live_entry_token}"
+
+    # A raw id-less LOCAL entry in `_pending` (agent-side _pending_result drops
+    # `{command, pattern_key, pattern_keys, description}` verbatim when no
+    # gateway notifier is registered) is unactionable by contract: the frontend
+    # owner-capture requires an approval_id, so its card can neither be
+    # approved nor dismissed — the poll re-serves it forever. Mint a stable id
+    # on the entry itself (the same contract the producer-tokenization loop
+    # above applies to _gateway_queues producers). Minting on the stored dict
+    # keeps the id stable across polls, so frontend dismiss markers persist.
+    for entry in queue_list:
+        if not isinstance(entry, dict) or _is_gateway_mirror_entry(entry):
+            continue
+        if str(entry.get("approval_id") or "").strip():
+            continue
+        if str(entry.get("run_id") or "").strip():
+            continue
+        entry["approval_id"] = f"gwlocal-mirrorless:{uuid.uuid4().hex}"
     live_token = (
         _gateway_mirror_entry_token(live_head_entry)
         if live_head_entry and live_head_data

--- a/tests/test_issue_raw_pending_approval_id.py
+++ b/tests/test_issue_raw_pending_approval_id.py
@@ -1,0 +1,249 @@
+"""Raw id-less local approval entries in ``_pending`` must be actionable.
+
+Regression for the Sep 2026 live incident. When a guarded tool needs approval
+and no gateway notifier is registered for the session (``unregister_gateway_
+notify`` fires at turn end; a queued wakeup/continuation then hits a guard),
+the agent-side fallback ``tools/approval.py::_pending_result`` writes a raw
+dict — ``{command, description, pattern_key, pattern_keys}`` and NOTHING else,
+no ``approval_id``, no ``request_id`` — directly into the shared
+``tools.approval._pending[session_key]`` dict that the WebUI imports.
+
+Before the fix:
+- ``GET /api/approval/pending`` served that raw dict verbatim (reconcile passes
+  non-mirror entries through untouched) with NO ``approval_id``, so the
+  frontend owner-capture (``_captureApprovalResponseOwner``) bailed and every
+  button on the approval card was a no-op;
+- the frontend dismiss (X) only hid the card locally and the 1.5s poll
+  re-rendered it forever — the card could neither be approved nor dismissed;
+- there is no waiter thread behind this shape (``_pending_result`` returns the
+  STOP message immediately), so draining the entry is purely UI hygiene — but
+  leaving it forever means the session shows a permanent phantom card.
+
+After the fix (mint at the reconcile chokepoint):
+- id-less, run-less, non-mirror ``_pending`` entries get a stable minted
+  ``approval_id`` (persisted in the stored entry dict, so it is stable across
+  polls and dismissals persist);
+- an exact-id response pops the entry and reports ``ok``;
+- a stale/different explicit id still fails closed (#527 guard preserved);
+- Skip-all (yolo release) drains the entry instead of dead-ending.
+
+The sibling shape — an orphaned ``_gateway_queues`` producer entry — is already
+covered upstream (minting ``gwlocal:<token>`` in the producer-tokenization loop,
+commit 5826d76d); the tests in ``test_gateway_approval_legacy_path.py`` and this
+file's history document it. This file covers the raw-``_pending`` shape, which
+no existing test exercised.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from api import models
+from api import route_approvals as ra
+from api import routes
+
+try:
+    import tools.approval as ta
+    APPROVAL_AVAILABLE = True
+except ImportError:
+    ta = None
+    APPROVAL_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not APPROVAL_AVAILABLE,
+    reason="tools.approval not available in this environment",
+)
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self._body = b""
+        self.client_address = ("127.0.0.1", 0)
+        self.headers = {}
+
+        class _W:
+            def __init__(self, outer):
+                self.outer = outer
+
+            def write(self, b):
+                self.outer._body += b
+
+        self.wfile = _W(self)
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, k, v):
+        pass
+
+    def end_headers(self):
+        pass
+
+    def json(self):
+        return json.loads(self._body.decode("utf-8"))
+
+
+def _register_session(sid: str, active_stream_id: str | None = None):
+    s = models.Session(session_id=sid, title="approval-raw-pending-orphan")
+    s.active_stream_id = active_stream_id
+    with models.LOCK:
+        models.SESSIONS[sid] = s
+    return s
+
+
+def _seed_raw_pending(sid: str, command: str = "rm -rf /tmp/qa-probe-home",
+                      key: str = "recursive delete") -> dict:
+    """Seed ``_pending[sid]`` with the exact ``_pending_result`` shape.
+
+    Mirrors agent-side tools/approval.py::_pending_result when no gateway
+    notifier is registered: a raw dict with no approval_id, no request_id,
+    no run_id, written directly into the shared _pending dict.
+    """
+    pending = {
+        "command": command,
+        "pattern_key": key,
+        "pattern_keys": [key],
+        "description": "recursive delete",
+    }
+    with ta._lock:
+        ta._pending[sid] = pending
+        ta._gateway_queues.pop(sid, None)
+    return pending
+
+
+def _cleanup(sid: str):
+    with ta._lock:
+        ta._pending.pop(sid, None)
+        ta._gateway_queues.pop(sid, None)
+    with models.LOCK:
+        models.SESSIONS.pop(sid, None)
+    try:
+        ta.disable_session_yolo(sid)
+    except Exception:
+        pass
+
+
+def _poll_pending(sid: str) -> dict:
+    h = _FakeHandler()
+    routes._handle_approval_pending(h, type("P", (), {"query": f"session_id={sid}"})())
+    assert h.status == 200, f"pending poll failed: {h.status} {h.json()!r}"
+    return h.json()
+
+
+def _respond(sid: str, body: dict):
+    h = _FakeHandler()
+    with patch("api.gateway_chat.webui_gateway_chat_enabled", return_value=True):
+        routes._handle_approval_respond(h, body)
+    return h
+
+
+MINTED_ID_RE = re.compile(r"^gwlocal-mirrorless:[0-9a-f]{32}$")
+
+
+def test_raw_pending_entry_surfaces_with_stable_actionable_id():
+    """The id-less raw entry must be served with a minted id that is stable
+    across polls (dismiss persistence keys on sid+approval_id)."""
+    sid = f"raw-id-{uuid.uuid4().hex[:8]}"
+    entry = _seed_raw_pending(sid)
+    try:
+        data = _poll_pending(sid)
+        assert data["pending_count"] >= 1
+        pending = data["pending"]
+        assert pending is not None
+        approval_id = pending.get("approval_id")
+        assert approval_id, (
+            "pending payload served a raw id-less local entry with no "
+            "approval_id; the frontend cannot act on it (buttons no-op, "
+            "dismiss cannot stick)"
+        )
+        assert MINTED_ID_RE.match(approval_id), approval_id
+
+        # Stability: the second poll must return the SAME id — the mint must
+        # persist in the stored entry, not re-mint per poll.
+        data2 = _poll_pending(sid)
+        assert data2["pending"]["approval_id"] == approval_id
+        assert entry["approval_id"] == approval_id
+    finally:
+        _cleanup(sid)
+
+
+def test_raw_pending_entry_respond_with_minted_id_pops_entry():
+    """An exact-id response must pop the raw entry and report ok (no waiter
+    exists behind this shape — draining is the correct resolution)."""
+    sid = f"raw-resp-{uuid.uuid4().hex[:8]}"
+    entry = _seed_raw_pending(sid)
+    # The incident session had a LIVE run pointer; the stale stream-pointer
+    # guard must not 409 the click before the legacy resolver pops the entry.
+    _register_session(sid, active_stream_id="stream-raw-resp-live")
+    from api.gateway_chat import _STREAM_RUN_IDS
+
+    _STREAM_RUN_IDS["stream-raw-resp-live"] = "run-live-1"
+    try:
+        approval_id = _poll_pending(sid)["pending"]["approval_id"]
+        assert approval_id
+
+        h = _respond(sid, {"session_id": sid, "choice": "deny",
+                           "approval_id": approval_id})
+        body = h.json()
+        assert h.status == 200, f"respond failed: {h.status} {body!r}"
+        assert body.get("ok") is True, f"respond not accepted: {body!r}"
+
+        # The entry must actually be gone — no more phantom card.
+        data = _poll_pending(sid)
+        assert data["pending"] is None
+        assert data["pending_count"] == 0
+    finally:
+        _STREAM_RUN_IDS.pop("stream-raw-resp-live", None)
+        _cleanup(sid)
+
+
+def test_raw_pending_entry_stale_id_fails_closed():
+    """#527 guard preserved: a different explicit id must not pop the live
+    entry and must keep it surfaced with its stable id."""
+    sid = f"raw-stale-{uuid.uuid4().hex[:8]}"
+    entry = _seed_raw_pending(sid)
+    _register_session(sid)
+    try:
+        approval_id = _poll_pending(sid)["pending"]["approval_id"]
+        assert approval_id
+
+        h = _respond(sid, {"session_id": sid, "choice": "once",
+                           "approval_id": "stale-different-id"})
+        body = h.json()
+        assert body.get("ok") is not True, f"stale id must fail closed: {body!r}"
+
+        # The live entry remains pending, unchanged, with its stable id.
+        data = _poll_pending(sid)
+        assert data["pending"] is not None
+        assert data["pending"]["approval_id"] == approval_id
+        assert entry["approval_id"] == approval_id
+    finally:
+        _cleanup(sid)
+
+
+def test_raw_pending_entry_yolo_skip_all_drains():
+    """Skip-all (yolo release) must drain the raw entry instead of leaving the
+    phantom card, and report the yolo state truthfully."""
+    sid = f"raw-yolo-{uuid.uuid4().hex[:8]}"
+    entry = _seed_raw_pending(sid)
+    _register_session(sid)
+    try:
+        approval_id = _poll_pending(sid)["pending"]["approval_id"]
+        assert approval_id
+
+        h = _respond(sid, {"session_id": sid, "choice": "once",
+                           "approval_id": approval_id, "yolo": True})
+        body = h.json()
+        assert h.status == 200, f"yolo respond failed: {h.status} {body!r}"
+        assert body.get("ok") is True, body
+        assert body.get("yolo_enabled") is True
+        assert _poll_pending(sid)["pending"] is None
+    finally:
+        # Restore: the yolo release enables session YOLO as a side effect.
+        _cleanup(sid)


### PR DESCRIPTION
## User story

I use Hermes WebUI daily, and yesterday one of my sessions did this: a long autonomous session hit a command guard (`rm -rf` inside a QA probe), the approval card popped, and I was busy — so I didn't answer within the 60s timeout. Fine, the agent got its "BLOCKED, silence is not consent" error and moved on. But when that turn later ended (`review_input_budget_exhausted`), the **card stayed on screen. Forever.**

I could not approve it (clicking the buttons did nothing), and I could not dismiss it (the X hid it for exactly one polling tick — 1.5s later it was back). Restarting the browser didn't help; the card lives server-side. I had to hand-drain it by POSTing the Skip-all release endpoint with `yolo: true`, because *no ordinary UI interaction could make this card go away*.

The queue handed the UI a pointer it never let anyone dereference: the pending payload had no `approval_id`, so the frontend's owner-capture bailed on every button click, while the poll kept re-serving the same raw entry.

## Root cause

The agent-side fallback `tools/approval.py::_pending_result` — used when **no gateway notifier is registered** for the session (e.g. `unregister_gateway_notify` fired at turn end, and a queued wakeup/continuation then hit a guard) — writes a raw dict into the shared `_pending[session_key]`:

```python
pending = {"command": ..., "pattern_key": ..., "pattern_keys": [...], "description": ...}
submit_pending(session_key, pending)
```

No `approval_id`. The WebUI imports that same dict. `reconcile_gateway_pending_mirror_locked` passes non-mirror entries through verbatim, so `/api/approval/pending` serves the id-less payload forever:

- **Approve/Deny/Skip-all**: dead — `_captureApprovalResponseOwner()` returns null without an `approvalId`.
- **Dismiss (X)**: hides locally, but `_markApprovalDismissed(sid, undefined)` can never match on the next poll, so the card re-renders every 1.5s.

Payload forensics from the live incident confirm the shape: exactly those four keys, no `approval_id`, no `request_id` (every `_ApprovalEntry` in `_gateway_queues` gets a `request_id` stamped — so this card came from the raw-`_pending` path, not the orphaned-producer path).

## The fix

`reconcile_gateway_pending_mirror_locked` already mints `gwlocal:<token>` ids onto id-less `_gateway_queues` producers (5826d76d) — this extends the **same contract to its sibling shape**: raw, non-mirror, run-less `_pending` entries get a stable `gwlocal-mirrorless:<uuid>` id, minted **once onto the stored entry dict** (not per-poll), so:

- the id is stable across polls → frontend dismiss markers (`_isApprovalDismissed` keys on `sid + approval_id`) actually stick;
- the exact-id respond path needs **no further change**: `_resolve_approval_legacy` pops the entry by id — which also happens to clear the stale stream-pointer `_candidate_run_id` 409 guard, because a local `local_match` nulls the candidate run id;
- stale explicit ids against a live entry still fail closed (#527);
- the YOLO/Skip-all release drains the entry.

Note there is **no waiter thread** behind this shape (`_pending_result` returns its STOP message immediately) — draining the entry is purely correct UI hygiene, never a lost signal to a blocked agent.

## Siblings checked (guideline #1)

- `_gateway_queues` orphan producers — already minted upstream (5826d76d); my regression suite for this PR initially targeted that shape and passed on pristine master, which is how I found the sibling.
- Run-backed mirrors, tokened no-run mirrors, retained mirrors — untouched; all identity rules preserved.
- SSE notify paths — the mint happens inside reconcile, before any notify computes its head, so subscribers always see the id-carrying entry.

## Tests

New `tests/test_issue_raw_pending_approval_id.py` (handler-level, real `_pending`/`_gateway_queues` state, the same harness as `test_issue4948_local_stale_approval.py`):

1. **surfaces_with_stable_actionable_id** — the payload carries a minted id, stable across two polls, persisted on the stored entry.
2. **respond_with_minted_id_pops_entry** — with a *live run pointer* seeded (`_STREAM_RUN_IDS`, the exact incident condition), respond returns `ok:true` and the queue drains.
3. **stale_id_fails_closed** — a different explicit id does not pop the live entry (#527), entry stays surfaced with its stable id.
4. **yolo_skip_all_drains** — Skip-all releases the entry and reports yolo state truthfully.

All four **fail on pristine upstream/master** (bite-verified via stash: 4 failed without the fix, 4 pass with it).

Regression: 58 passed (`test_approval_queue`, `test_issue4948_local_stale_approval`, `test_gateway_approval_legacy_path`, `test_route_approvals_extraction`, `test_issue4771_local_approval_regression`, `test_issue4041_approval_poll_busy_dip`) + 177 passed / 27 skipped across the remaining approval suites (`test_approval_sse`, `test_approval_unblock`, `test_gateway_approval_runs_api`, `test_issue4300/4479/4754/5139`, `test_3007_approval_card_collapse`, `test_approval_card_layering`).

## Not verified

- No live-server restart test: the fix is server-side Python and my running instance predates it; verification is handler-level against real module state.
- The frontend side needs no change and has none; the existing dismiss-marking code was verified by reading, not by browser test.
