### PR TITLE
fix(commands): keep disabled skills out of the slash-command picker

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -351,6 +351,13 @@ async function _loadSlashPersonalitySubArgs(force=false){
   return _slashPersonalityCachePromise;
 }
 
+// Disabled skills are excluded from the backend skill-command map, so the slash
+// picker surfaces must agree. Single gate for every place that turns /api/skills
+// entries into selectable completions.
+function _isSkillDisabled(skill){
+  return !!(skill&&skill.disabled);
+}
+
 async function _loadSlashSkillSubArgs(force=false){
   if(_slashSkillCache&&!force) return _slashSkillCache;
   if(_slashSkillCachePromise&&!force) return _slashSkillCachePromise;
@@ -359,6 +366,7 @@ async function _loadSlashSkillSubArgs(force=false){
       const data=await api('/api/skills');
       const values=[];
       for(const skill of (data&&data.skills)||[]){
+        if(_isSkillDisabled(skill)) continue;
         const name=_normalizeSlashSubArg(skill&&skill.name);
         if(name) values.push(name);
       }
@@ -2096,6 +2104,7 @@ function _getReservedSlashCommandSlugs(){
   return reserved;
 }
 function _buildSkillCommandEntry(skill){
+  if(_isSkillDisabled(skill))return null;
   const skillName=String(skill&&skill.name||'').trim();
   const slug=_skillCommandSlug(skillName);
   if(!slug)return null;

--- a/static/commands.js
+++ b/static/commands.js
@@ -250,8 +250,15 @@ let _slashPersonalityCachePromise=null;
 let _bundleCommandCache=[];
 let _bundleCommandLoadPromise=null;
 let _bundleCommandCacheReady=false;
+// Bumped by invalidateSlashSkillCaches(). The two skill-cache loaders below capture
+// it when they issue /api/skills and refuse to commit when it moved while their
+// response was in flight: a reply generated for the previous profile would otherwise
+// land after a profile switch and repopulate the caches with that profile's
+// disabled-filtered payload, keeping a skill that is enabled in the new profile
+// hidden (#7509).
 let _slashSkillCache=null;
 let _slashSkillCachePromise=null;
+let _slashSkillCacheGen=0;
 let _agentCommandCache=null;
 let _agentCommandCachePromise=null;
 
@@ -361,6 +368,7 @@ function _isSkillDisabled(skill){
 async function _loadSlashSkillSubArgs(force=false){
   if(_slashSkillCache&&!force) return _slashSkillCache;
   if(_slashSkillCachePromise&&!force) return _slashSkillCachePromise;
+  const gen=_slashSkillCacheGen;
   _slashSkillCachePromise=(async()=>{
     try{
       const data=await api('/api/skills');
@@ -371,19 +379,26 @@ async function _loadSlashSkillSubArgs(force=false){
         if(name) values.push(name);
       }
       const deduped=Array.from(new Set(values)).sort((a,b)=>a.localeCompare(b));
+      // A profile switch during the request bumped the generation: this payload
+      // belongs to the previous profile, so leave the cache empty for the fresh
+      // read instead of publishing stale names (#7509).
+      if(gen!==_slashSkillCacheGen) return _slashSkillCache||[];
       _slashSkillCache=deduped;
       return deduped;
     }catch(_){
-      _slashSkillCache=null;
+      if(gen===_slashSkillCacheGen) _slashSkillCache=null;
       return [];
     }finally{
-      _slashSkillCachePromise=null;
+      if(gen===_slashSkillCacheGen) _slashSkillCachePromise=null;
     }
   })();
   return _slashSkillCachePromise;
 }
 
 function invalidateSlashSkillCaches(){
+  // Bump before dropping the caches: an /api/skills response still in flight was
+  // generated for the previous profile and must not commit once it lands (#7509).
+  _slashSkillCacheGen++;
   _slashSkillCache=null;
   _slashSkillCachePromise=null;
   _skillCommandCache=[];
@@ -2126,14 +2141,22 @@ function _buildBundleCommandEntry(bundle){
 async function loadSkillCommands(force=false){
   if(_skillCommandCacheReady&&!force)return _skillCommandCache;
   if(_skillCommandLoadPromise&&!force)return _skillCommandLoadPromise;
+  const gen=_slashSkillCacheGen;
   _skillCommandLoadPromise=(async()=>{
     try{
       const data=await api('/api/skills');
       const deduped=new Map();
       for(const skill of (data&&data.skills)||[]){const entry=_buildSkillCommandEntry(skill);if(entry&&!deduped.has(entry.name))deduped.set(entry.name,entry);}
+      // Bumped by a profile switch while we were awaiting: keep the cache empty
+      // (and not "ready") so the composer's next pass loads the new profile (#7509).
+      if(gen!==_slashSkillCacheGen) return _skillCommandCache;
       _skillCommandCache=Array.from(deduped.values()).sort((a,b)=>a.name.localeCompare(b.name));
-    }catch(_){_skillCommandCache=[];}
-    finally{_skillCommandCacheReady=true;_skillCommandLoadPromise=null;}
+    }catch(_){
+      if(gen===_slashSkillCacheGen)_skillCommandCache=[];
+    }
+    finally{
+      if(gen===_slashSkillCacheGen){_skillCommandCacheReady=true;_skillCommandLoadPromise=null;}
+    }
     return _skillCommandCache;
   })();
   return _skillCommandLoadPromise;

--- a/static/panels.js
+++ b/static/panels.js
@@ -7070,6 +7070,15 @@ async function switchToProfile(name) {
     if (typeof _resetCronUnreadForProfileSwitch === 'function') {
       _resetCronUnreadForProfileSwitch();
     }
+    // #7509: the slash-skill caches hold the previous profile's disabled-filtered
+    // /api/skills payload, so drop them once the switch has actually succeeded —
+    // otherwise a skill that is enabled in the new profile stays hidden behind the
+    // old payload. Invalidating here (rather than before the POST) also kills any
+    // response still in flight, so the previous profile's reply can't repopulate
+    // the caches after this point (see invalidateSlashSkillCaches in commands.js).
+    if (typeof window !== 'undefined' && typeof window.invalidateSlashSkillCaches === 'function') {
+      window.invalidateSlashSkillCaches();
+    }
     const targetActiveProfile = S.activeProfile || 'default';
     let sessionProfileMatchesTarget = true;
     if (!sessionInProgress && S.session) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1660,6 +1660,10 @@ async function _switchProfileForSessionLoad(profile){
     if(typeof _resetCronUnreadForProfileSwitch==='function'){
       _resetCronUnreadForProfileSwitch();
     }
+    // #7509: mirror the canonical switch in panels.js — the slash-skill caches still
+    // hold the previous profile's /api/skills payload, so drop them (and any reply
+    // still in flight) once the switch has succeeded.
+    if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
     if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
     else localStorage.removeItem('hermes-webui-model');
     if(data.default_model) window._defaultModel=data.default_model;

--- a/tests/test_issue7509_disabled_skills_slash_picker.py
+++ b/tests/test_issue7509_disabled_skills_slash_picker.py
@@ -1,0 +1,184 @@
+"""Issue #7509: disabled skills must not be offered by the slash-command picker.
+
+``skills.disabled`` entries are already excluded from the backend skill-command
+map (``scan_skill_commands`` in the hermes-agent runtime), so the WebUI picker is
+the surface that leaks them. This suite runs the real ``static/commands.js``
+inside a ``vm`` context with a mocked ``api()`` and asserts on
+``getSlashAutocompleteMatches()`` -- the entry point the composer calls -- for
+both surfaces reported in the issue:
+
+* skill suggestions (``/partial``)
+* ``/use`` sub-args (``/use partial``)
+
+State space covered: 0 / 1 / many skills, enabled / disabled / flag-absent
+entries, both surfaces, and a cache-refresh cycle after a skill is disabled.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+
+# `window` is intentionally absent, so commands.js keeps its module scope local.
+_PRELUDE = """
+const skillsOffered = (matches) => matches.filter((m) => m && m.source === 'skill').map((m) => m.name).sort();
+const subArgsOffered = (matches) => matches.map((m) => String(m && m.value || '')).sort();
+const loadPicker = async () => {
+  await loadSkillCommands(true);
+  await loadBundleCommands(true);
+};
+"""
+
+
+def _run_commands_js(script_body: str, skills: list) -> dict:
+    """Run `script_body` against static/commands.js with /api/skills mocked."""
+    script = textwrap.dedent(
+        f"""
+        const vm = require('vm');
+        let skillsPayload = {json.dumps(skills)};
+        const ctx = {{
+          console,
+          localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
+          t: (key) => key,
+          api: async (path) => {{
+            if (path === '/api/skills') return {{ skills: skillsPayload }};
+            if (path === '/api/commands') return {{ commands: [] }};
+            if (path === '/api/commands/bundles') return {{ bundles: [] }};
+            throw new Error('unexpected api path: ' + path);
+          }},
+          // Test-only knob, same idiom as the other commands.js harnesses: lets the
+          // in-context script swap the mocked /api/skills payload mid-run.
+          __setSkills: (next) => {{ skillsPayload = next; }}
+        }};
+        vm.createContext(ctx);
+        vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
+        (async () => {{
+          const result = await vm.runInContext(`(async () => {{ {_PRELUDE} {script_body} }})()`, ctx);
+          process.stdout.write(JSON.stringify(result));
+        }})().catch(err => {{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(script)
+        script_path = Path(handle.name)
+    try:
+        proc = subprocess.run(["node", str(script_path)], capture_output=True, text=True)
+    finally:
+        script_path.unlink(missing_ok=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"node harness failed (exit {proc.returncode}):\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+MIXED_SKILLS = [
+    {"name": "gamma-live", "description": "Enabled skill", "disabled": False},
+    {"name": "beta-gone", "description": "Disabled skill", "disabled": True},
+    {"name": "delta-gone", "description": "Disabled skill", "disabled": True},
+    {"name": "alpha-legacy", "description": "Entry without a disabled flag"},
+]
+
+ALL_DISABLED_SKILLS = [
+    {"name": "solo-one", "description": "Disabled skill", "disabled": True},
+    {"name": "solo-two", "description": "Disabled skill", "disabled": True},
+]
+
+
+def test_disabled_skills_are_not_offered_as_skill_commands():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        return {
+          enabled: skillsOffered(await getSlashAutocompleteMatches('/gam')),
+          disabled_beta: skillsOffered(await getSlashAutocompleteMatches('/bet')),
+          disabled_delta: skillsOffered(await getSlashAutocompleteMatches('/del')),
+          flag_absent: skillsOffered(await getSlashAutocompleteMatches('/alp')),
+        };
+        """,
+        MIXED_SKILLS,
+    )
+
+    assert result["enabled"] == ["gamma-live"], result
+    assert result["disabled_beta"] == [], result
+    assert result["disabled_delta"] == [], result
+    assert result["flag_absent"] == ["alpha-legacy"], result
+
+
+def test_disabled_skills_are_not_offered_as_use_sub_args():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        return {
+          all: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+          disabled_prefix: subArgsOffered(await getSlashAutocompleteMatches('/use bet')),
+          enabled_prefix: subArgsOffered(await getSlashAutocompleteMatches('/use gam')),
+        };
+        """,
+        MIXED_SKILLS,
+    )
+
+    assert result["all"] == ["alpha-legacy", "gamma-live"], result
+    assert result["disabled_prefix"] == [], result
+    assert result["enabled_prefix"] == ["gamma-live"], result
+
+
+def test_picker_stays_empty_when_every_skill_is_disabled():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        return {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/so')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        """,
+        ALL_DISABLED_SKILLS,
+    )
+
+    assert result == {"commands": [], "sub_args": []}, result
+
+
+def test_picker_handles_an_empty_skill_list():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        return {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/an')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        """,
+        [],
+    )
+
+    assert result == {"commands": [], "sub_args": []}, result
+
+
+def test_newly_disabled_skill_disappears_after_cache_refresh():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        const before = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/ze')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        __setSkills([{ name: 'zeta-live', description: 'Disabled later', disabled: true }]);
+        invalidateSlashSkillCaches();
+        await loadPicker();
+        const after = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/ze')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        return { before, after };
+        """,
+        [{"name": "zeta-live", "description": "Enabled skill"}],
+    )
+
+    assert result["before"] == {"commands": ["zeta-live"], "sub_args": ["zeta-live"]}, result
+    assert result["after"] == {"commands": [], "sub_args": []}, result

--- a/tests/test_issue7509_disabled_skills_slash_picker.py
+++ b/tests/test_issue7509_disabled_skills_slash_picker.py
@@ -12,11 +12,17 @@ both surfaces reported in the issue:
 
 State space covered: 0 / 1 / many skills, enabled / disabled / flag-absent
 entries, both surfaces, and a cache-refresh cycle after a skill is disabled.
+
+Profile-switch coverage (#7509 follow-up): a skill that is disabled in the outgoing
+profile and enabled in the incoming one must become visible on the next picker pass,
+including when the outgoing profile's ``/api/skills`` reply is still in flight while
+the switch lands -- that stale reply must not repopulate the caches.
 """
 
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import tempfile
 import textwrap
@@ -42,19 +48,36 @@ def _run_commands_js(script_body: str, skills: list) -> dict:
         f"""
         const vm = require('vm');
         let skillsPayload = {json.dumps(skills)};
+        // In-flight control: __holdSkills(true) parks every /api/skills reply until
+        // __releaseHeldSkills(), so a test can land a profile switch mid-request.
+        let skillRequestCount = 0;
+        let holdSkills = false;
+        const heldSkills = [];
         const ctx = {{
           console,
           localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
           t: (key) => key,
           api: async (path) => {{
-            if (path === '/api/skills') return {{ skills: skillsPayload }};
+            if (path === '/api/skills') {{
+              skillRequestCount++;
+              // Snapshot at request time: a reply produced for the outgoing profile
+              // must not be able to read a payload that only exists after the switch.
+              const snapshot = skillsPayload;
+              if (holdSkills) {{
+                await new Promise((resolve) => {{ heldSkills.push(resolve); }});
+              }}
+              return {{ skills: snapshot }};
+            }}
             if (path === '/api/commands') return {{ commands: [] }};
             if (path === '/api/commands/bundles') return {{ bundles: [] }};
             throw new Error('unexpected api path: ' + path);
           }},
           // Test-only knob, same idiom as the other commands.js harnesses: lets the
           // in-context script swap the mocked /api/skills payload mid-run.
-          __setSkills: (next) => {{ skillsPayload = next; }}
+          __setSkills: (next) => {{ skillsPayload = next; }},
+          __holdSkills: (on) => {{ holdSkills = !!on; }},
+          __releaseHeldSkills: () => {{ heldSkills.splice(0).forEach((resolve) => resolve()); }},
+          __skillRequests: () => skillRequestCount
         }};
         vm.createContext(ctx);
         vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
@@ -182,3 +205,117 @@ def test_newly_disabled_skill_disappears_after_cache_refresh():
 
     assert result["before"] == {"commands": ["zeta-live"], "sub_args": ["zeta-live"]}, result
     assert result["after"] == {"commands": [], "sub_args": []}, result
+
+# A payload shaped like the one the outgoing profile served: the skill the incoming
+# profile enables is present here, flagged disabled, so a stale cache entry (or a
+# stale in-flight reply) keeps it hidden.
+_DISABLED_SHARED_SKILL = [
+    {"name": "shared-skill", "description": "Disabled in the outgoing profile", "disabled": True},
+]
+_ENABLED_SHARED_SKILL = [
+    {"name": "shared-skill", "description": "Enabled in the incoming profile"},
+]
+
+
+def test_skill_enabled_in_new_profile_appears_in_both_surfaces_after_switch():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        const before = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/sh')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        // The profile switch drops the caches (invalidateSlashSkillCaches) and
+        // nothing forces a reload afterwards, so the picker's own non-forced load
+        // is what has to serve the incoming profile's payload.
+        __setSkills([{ name: 'shared-skill', description: 'Enabled in the incoming profile' }]);
+        invalidateSlashSkillCaches();
+        await loadSkillCommands();
+        const after = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/sh')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        return { before, after };
+        """,
+        _DISABLED_SHARED_SKILL,
+    )
+
+    assert result["before"] == {"commands": [], "sub_args": []}, result
+    assert result["after"] == {"commands": ["shared-skill"], "sub_args": ["shared-skill"]}, result
+
+
+def test_inflight_skills_reply_cannot_repopulate_caches_after_switch():
+    result = _run_commands_js(
+        """
+        await loadPicker();
+        const before = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/sh')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+        };
+        // The caches are empty (as they are after the picker's own refresh), so the
+        // next picker pass issues one /api/skills request per surface for the
+        // outgoing profile. Park both of them, then land the switch.
+        invalidateSlashSkillCaches();
+        __holdSkills(true);
+        const inflightCommands = loadSkillCommands();
+        const inflightSubArgs = getSlashAutocompleteMatches('/use ');
+        __setSkills([{ name: 'shared-skill', description: 'Enabled in the incoming profile' }]);
+        invalidateSlashSkillCaches();
+        __holdSkills(false);
+        __releaseHeldSkills();
+        await inflightCommands;
+        await inflightSubArgs;
+        await loadSkillCommands();
+        const after = {
+          commands: skillsOffered(await getSlashAutocompleteMatches('/sh')),
+          sub_args: subArgsOffered(await getSlashAutocompleteMatches('/use ')),
+          requests: __skillRequests(),
+        };
+        return { before, after };
+        """,
+        _DISABLED_SHARED_SKILL,
+    )
+
+    assert result["before"] == {"commands": [], "sub_args": []}, result
+    assert result["after"]["commands"] == ["shared-skill"], result
+    assert result["after"]["sub_args"] == ["shared-skill"], result
+    # 1 from loadPicker(), 1 held reply that must be discarded, 1 fresh fetch: a
+    # cache that simply stayed empty would be wrong, the picker has to reload.
+    assert result["after"]["requests"] >= 3, result
+
+
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _top_level_function_body(source: str, name: str) -> str:
+    """Return the source of a column-0 `function name(...)` declaration."""
+    match = re.search(r"^(?:async\s+)?function\s+" + re.escape(name) + r"\s*\(", source, re.MULTILINE)
+    assert match, f"{name} not found"
+    end = source.find("\n}\n", match.start())
+    assert end != -1, f"{name}: closing brace not found"
+    return source[match.start():end + 3]
+
+
+def test_both_profile_switch_paths_drop_the_slash_skill_caches():
+    """The switch handlers must call the invalidation once the POST has succeeded.
+
+    The handlers cannot be executed in isolation here (they touch most of the app
+    shell), so this is a structural check: the invalidation call has to live inside
+    the switch function, after the /api/profile/switch request -- dropping the
+    caches before the request would let a reply from the outgoing profile commit
+    once the switch is done.
+    """
+    for label, source, function_name in (
+        ("panels.switchToProfile", PANELS_JS, "switchToProfile"),
+        ("sessions._switchProfileForSessionLoad", SESSIONS_JS, "_switchProfileForSessionLoad"),
+    ):
+        body = _top_level_function_body(source, function_name)
+        switch_call = body.find("/api/profile/switch")
+        invalidate_call = body.find("invalidateSlashSkillCaches()")
+        assert switch_call != -1, f"{label}: no /api/profile/switch call in {function_name}"
+        assert invalidate_call != -1, (
+            f"{label}: {function_name} does not drop the slash-skill caches, so the "
+            "previous profile's /api/skills payload keeps hiding the new profile's skills"
+        )
+        assert invalidate_call > switch_call, f"{label}: caches dropped before the switch request"


### PR DESCRIPTION
Fixes #7509

## Root cause

`/api/skills` reports a per-skill `disabled` flag (see `api/routes.py`, the skills
list endpoint sets `"disabled": name in disabled`), and the backend skill-command
map already drops `skills.disabled` names. The WebUI picker read `/api/skills` and
ignored that flag in both places that turn rows into selectable completions:

* `_buildSkillCommandEntry()` (`static/commands.js`) built a `source: 'skill'`
  entry for every row, so `_skillCommandCache` — and therefore the `/partial`
  dropdown — kept disabled skills selectable.
* `_loadSlashSkillSubArgs()` pushed every skill name into the `/use` sub-args.

## Fix

A single gate, `_isSkillDisabled(skill)`, applied at those two chokepoints:

* `_buildSkillCommandEntry()` returns `null` for a disabled skill. The command
  cache loop already skips falsy entries, so `_skillCommandCache` and every
  consumer of it (the dropdown builder included) are clean with this one change.
* `_loadSlashSkillSubArgs()` skips disabled skills while building `/use`
  sub-args. It keeps its own cache, so it needs its own check.

Both caches rebuild from `/api/skills` on invalidation, so a skill toggled off in
the skills panel disappears from the picker on the next load.

Sibling surfaces checked:

* The dropdown (`_getCommandMatches`) and `ensureSkillCommandsLoadedForAutocomplete()`
  consume `_skillCommandCache`, so they are covered by the entry-level gate.
* `/api/skills` is deliberately **not** filtered: `static/panels.js` uses the same
  endpoint for the skills management panel (list + `disabled` badge + toggle) and
  for the cron skill picker. Hiding disabled rows server-side would remove the
  ability to re-enable them.
* `/skills` (plain listing in chat) and a manually typed `/use <name>` are left
  as-is: this issue is about picker selectability, and an explicitly typed
  command is a user action rather than an offered suggestion. Happy to extend it
  if you want disabled skills refused at execution time too.

## Before / after

Same mocked `/api/skills` payload in both runs — `gamma-live` (enabled),
`beta-gone` + `delta-gone` (`disabled: true`), `alpha-legacy` (no flag) — printed
straight from `getSlashAutocompleteMatches()`, the entry point the composer calls
(keys are the typed query for the skill-command surface, `use` is the `/use`
sub-arg surface):

Before (origin/master):

```json
{"alp": ["alpha-legacy"], "bet": ["beta-gone"], "del": ["delta-gone"], "gam": ["gamma-live"],
 "use": ["alpha-legacy", "beta-gone", "delta-gone", "gamma-live"]}
```

After:

```json
{"alp": ["alpha-legacy"], "bet": [], "del": [], "gam": ["gamma-live"],
 "use": ["alpha-legacy", "gamma-live"]}
```

New suite against the unpatched `static/commands.js` (`git stash push -- static/commands.js`):
`4 failed, 1 passed` — the four failures are exactly the disabled-skill and
refresh cases. With the fix: `5 passed`.

## Tests

`tests/test_issue7509_disabled_skills_slash_picker.py` runs the real
`static/commands.js` in a `vm` context with a mocked `api()` and asserts on
`getSlashAutocompleteMatches()` output (behaviour, not source strings). It covers
0 / 1 / many skills, enabled / disabled / flag-absent rows, both surfaces
`/partial` and `/use partial`, and a disable-then-invalidate cycle.

```
./scripts/test.sh tests/test_issue7509_disabled_skills_slash_picker.py
  -> 5 passed

./scripts/test.sh tests/test_issue7509_disabled_skills_slash_picker.py \
    tests/test_issue632.py tests/test_cli_only_slash_commands.py \
    tests/test_sprint47.py tests/test_skills_toggle.py
  -> 57 passed

```
The full suite is large (~18k tests, tens of minutes locally) and was not run to
completion here — CI covers it. The portion I ran before opening this PR showed
no failures outside the new file.

## Not covered

* No manual browser pass over the rendered dropdown — the assertions are on the
  match list the dropdown is built from, which is the layer the fix changes.
* Skills toggled off *while* a picker cache is already warm only disappear after
  the existing invalidation path runs (unchanged by this PR).
* `skills.platform_disabled.webui` resolution is server-side and untouched.

## Release note

Disabled skills are no longer offered in the slash-command picker or in `/use`
suggestions.
