### PR TITLE
fix(onboarding): use OpenRouter namespace z-ai/ for Z.AI models (#7514)

### DIFF
--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -35,6 +35,34 @@ from api.workspace import get_last_workspace, load_workspaces
 logger = logging.getLogger(__name__)
 
 
+# ── OpenRouter namespace translation (#7514) ────────────────────────────────
+#
+# ``_FALLBACK_MODELS`` (api/config.py) is authored for the *direct* provider
+# endpoints, so its Z.AI entries carry the provider's own ``zai/`` prefix.
+# OpenRouter serves the same models under its canonical ``z-ai/`` slug, so
+# projecting that list into the OpenRouter setup verbatim handed the wizard
+# ids that 404 on openrouter.ai (``zai/glm-5.3`` instead of
+# ``z-ai/glm-5.3``).  Translate at this projection boundary only — the
+# fallback catalog and the direct ``zai`` setup keep their own namespace.
+#
+# Every other namespace in the fallback list is already OpenRouter-canonical:
+# openai/, anthropic/, google/, deepseek/, qwen/, x-ai/, mistralai/, minimax/,
+# openrouter/, tencent/, nvidia/, arcee-ai/ — hence a single mapping entry.
+_OPENROUTER_NAMESPACE_MAP = {"zai/": "z-ai/"}
+
+
+def _to_openrouter_namespace(model_id: str) -> str:
+    """Return *model_id* with direct-provider prefixes mapped to OpenRouter's.
+
+    Ids whose namespace already matches OpenRouter (or that carry no
+    namespace) are returned unchanged.
+    """
+    for direct_prefix, openrouter_prefix in _OPENROUTER_NAMESPACE_MAP.items():
+        if model_id.startswith(direct_prefix):
+            return openrouter_prefix + model_id[len(direct_prefix):]
+    return model_id
+
+
 _SUPPORTED_PROVIDER_SETUPS = {
     # ── Easy start ──────────────────────────────────────────────────────
     "openrouter": {
@@ -43,7 +71,8 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "default_model": "anthropic/claude-sonnet-4.6",
         "requires_base_url": False,
         "models": [
-            {"id": model["id"], "label": model["label"]} for model in _FALLBACK_MODELS
+            {"id": _to_openrouter_namespace(model["id"]), "label": model["label"]}
+            for model in _FALLBACK_MODELS
         ],
         "category": "easy_start",
         "quick": True,

--- a/tests/test_issue7514_openrouter_zai_namespace.py
+++ b/tests/test_issue7514_openrouter_zai_namespace.py
@@ -71,7 +71,7 @@ def test_openrouter_projection_is_namespace_only():
     openrouter = _models("openrouter")
 
     assert len(openrouter) == len(fallback)
-    for source, projected in zip(fallback, openrouter):
+    for source, projected in zip(fallback, openrouter, strict=True):
         assert projected["label"] == source["label"]
         assert projected["id"] == _expected_openrouter_id(source["id"])
 

--- a/tests/test_issue7514_openrouter_zai_namespace.py
+++ b/tests/test_issue7514_openrouter_zai_namespace.py
@@ -1,0 +1,114 @@
+"""Regression tests for #7514: OpenRouter onboarding must serve Z.AI models
+under OpenRouter's canonical ``z-ai/`` namespace, not the direct provider's
+``zai/`` namespace.
+
+``_FALLBACK_MODELS`` (api/config.py) is authored for the *direct* provider
+endpoints, and its Z.AI entries use that provider's own ``zai/`` prefix.
+The OpenRouter onboarding setup reused the list verbatim, so the wizard
+offered ids such as ``zai/glm-5.3`` — which 404 on openrouter.ai, where the
+canonical slug is ``z-ai/glm-5.3``.
+
+These tests pin the boundary:
+
+  1. The ``openrouter`` setup translates ``zai/`` → ``z-ai/`` and never
+     serves a ``zai/`` id.
+  2. The translation is namespace-only: same models, same order, same labels.
+  3. The direct ``zai`` setup keeps ``zai/`` (it talks to the Z.AI endpoint,
+     not to OpenRouter).
+  4. ``_FALLBACK_MODELS`` itself is never rewritten — other consumers still
+     see the direct-provider namespace.
+"""
+
+from __future__ import annotations
+
+import api.config as config
+import api.onboarding as onboarding
+
+
+def _models(provider_id: str) -> list[dict]:
+    return onboarding._SUPPORTED_PROVIDER_SETUPS[provider_id]["models"]
+
+
+def _ids(provider_id: str) -> list[str]:
+    return [model["id"] for model in _models(provider_id)]
+
+
+def _expected_openrouter_id(model_id: str) -> str:
+    """Independent reference implementation of the namespace translation."""
+    if model_id.startswith("zai/"):
+        return "z-ai/" + model_id[len("zai/") :]
+    return model_id
+
+
+def test_openrouter_setup_never_serves_direct_zai_namespace():
+    served = [model_id for model_id in _ids("openrouter") if model_id.startswith("zai/")]
+    assert served == [], (
+        "OpenRouter onboarding served ids from the direct-provider namespace; "
+        f"these 404 on the OpenRouter API: {served}"
+    )
+
+
+def test_openrouter_setup_exposes_z_ai_models():
+    ids = _ids("openrouter")
+    assert "z-ai/glm-5.3" in ids
+    assert "z-ai/glm-5.3-flash" in ids
+
+    expected = {
+        _expected_openrouter_id(model["id"])
+        for model in config._FALLBACK_MODELS
+        if model["id"].startswith("zai/")
+    }
+    assert expected, "expected the fallback catalog to carry Z.AI models"
+    assert expected.issubset(set(ids)), (
+        "every Z.AI model from the fallback catalog must be offered under the "
+        f"OpenRouter namespace; missing: {sorted(expected - set(ids))}"
+    )
+
+
+def test_openrouter_projection_is_namespace_only():
+    """The OpenRouter list stays a 1:1, order-preserving projection."""
+    fallback = config._FALLBACK_MODELS
+    openrouter = _models("openrouter")
+
+    assert len(openrouter) == len(fallback)
+    for source, projected in zip(fallback, openrouter):
+        assert projected["label"] == source["label"]
+        assert projected["id"] == _expected_openrouter_id(source["id"])
+
+
+def test_direct_zai_setup_keeps_direct_provider_ids():
+    """The direct Z.AI setup talks to the Z.AI endpoint (base_url is set on the
+    setup), so it keeps its own bare provider ids and must not inherit the
+    OpenRouter translation."""
+    ids = _ids("zai")
+    assert ids == [model["id"] for model in config._PROVIDER_MODELS["zai"]]
+    assert "glm-5.3" in ids
+    assert [model_id for model_id in ids if model_id.startswith("z-ai/")] == []
+
+
+def test_fallback_models_are_untouched():
+    ids = [model["id"] for model in config._FALLBACK_MODELS]
+    assert "zai/glm-5.3" in ids
+    assert [model_id for model_id in ids if model_id.startswith("z-ai/")] == []
+
+
+def test_namespace_helper_is_a_noop_for_other_namespaces_and_bare_ids():
+    for model_id in (
+        "anthropic/claude-sonnet-4.6",
+        "x-ai/grok-4.20",
+        "minimax/MiniMax-M3",
+        "openrouter/elephant-alpha",
+        "gpt-4o",
+    ):
+        assert onboarding._to_openrouter_namespace(model_id) == model_id
+    assert onboarding._to_openrouter_namespace("zai/glm-5.3") == "z-ai/glm-5.3"
+
+
+def test_setup_catalog_serves_the_translated_namespace():
+    """The payload the wizard consumes carries the OpenRouter namespace."""
+    catalog = onboarding._build_setup_catalog({})
+    entries = {provider["id"]: provider for provider in catalog["providers"]}
+    ids = [model["id"] for model in entries["openrouter"]["models"]]
+
+    assert [model_id for model_id in ids if model_id.startswith("zai/")] == []
+    assert "z-ai/glm-5.3" in ids


### PR DESCRIPTION
## Summary

Fixes #7514 — the OpenRouter onboarding wizard offered Z.AI models under the direct-provider namespace (`zai/glm-5.3`) instead of OpenRouter's canonical slug (`z-ai/glm-5.3`). Picking one of those entries produced a model id that 404s on the OpenRouter API.

## Root cause

`api/onboarding.py` builds `_SUPPORTED_PROVIDER_SETUPS["openrouter"]["models"]` by reusing `_FALLBACK_MODELS` from `api/config.py` verbatim. That catalog is authored for the *direct* provider endpoints, where Z.AI models legitimately live under `zai/`; OpenRouter serves them under `z-ai/`.

Audited every namespace in `_FALLBACK_MODELS` against the live OpenRouter catalog (`GET https://openrouter.ai/api/v1/models`, 437 ids): `openai/`, `anthropic/`, `google/`, `deepseek/`, `qwen/`, `x-ai/`, `mistralai/`, `minimax/`, `openrouter/`, `tencent/`, `nvidia/`, `arcee-ai/` already match OpenRouter. `zai/` was the only mismatch — OpenRouter has no `zai/` entry at all. Downstream is already fine: `api/config.py` treats `z-ai` as an alias of the `zai` provider, so only the onboarding projection needed fixing.

## Fix

`api/onboarding.py` only:

- adds `_OPENROUTER_NAMESPACE_MAP = {"zai/": "z-ai/"}` plus a small `_to_openrouter_namespace()` helper;
- the `openrouter` setup projects the fallback list through that helper, so just the prefix is translated — same models, same order, same labels.

`_FALLBACK_MODELS` is **not** touched and neither is the direct `zai` setup (which keeps its own bare provider ids, since it points at the Z.AI endpoint). No module rewrite: the sibling PR #7515 was **closed** because it replaced `onboarding.py` with a 17-line stub — this PR is the surgical namespace map the issue asked for.

### Out of scope (flagging, not changing)

`z-ai/glm-4.5-flash` has no counterpart in the live OpenRouter catalog (Z.AI's free/flash tier there is served as `z-ai/glm-4.5-air`). Remapping an id to a different model is a semantic decision, so this PR stays namespace-only — happy to send a follow-up if you want that entry swapped.

## Test plan

New `tests/test_issue7514_openrouter_zai_namespace.py` (7 tests): the `openrouter` setup serves no `zai/` id; it offers the Z.AI models under `z-ai/` (incl. `z-ai/glm-5.3`, `z-ai/glm-5.3-flash`); the projection is 1:1, order-preserving and label-preserving; the direct `zai` setup is unchanged; `_FALLBACK_MODELS` still uses `zai/`; the helper is a no-op for other namespaces and bare ids; and the `_build_setup_catalog()` payload the wizard consumes carries the translated ids.

```
$ .venv/bin/python -m pytest tests/test_issue7514_openrouter_zai_namespace.py -v
7 passed in 2.34s

# RED check on the unpatched module (proves the tests bite):
5 failed, 2 passed in 3.19s

# related onboarding + GLM catalog suites:
$ .venv/bin/python -m pytest tests/test_issue7514_openrouter_zai_namespace.py tests/test_glm_5_3_catalog.py tests/test_glm_5_3_flash_catalog.py tests/test_issue603_provider_categories.py tests/test_onboarding_static.py tests/test_onboarding_existing_config.py tests/test_issue1499_keyless_onboarding.py -q
89 passed in 5.94s
```

Closes #7514
