### PR TITLE
fix(onboarding): stop offering zai/glm-4.5-flash in the OpenRouter setup (#7520)

### DIFF
--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -63,6 +63,22 @@ def _to_openrouter_namespace(model_id: str) -> str:
     return model_id
 
 
+# ── OpenRouter setup: drop ids OpenRouter does not serve (#7520) ────────────
+# ``_FALLBACK_MODELS`` doubles as the curated OpenRouter list, but one Z.AI
+# entry has no counterpart there: OpenRouter serves the GLM-4.5 generation as
+# ``z-ai/glm-4.5`` / ``z-ai/glm-4.5-air`` / ``z-ai/glm-4.5v`` and never as
+# ``glm-4.5-flash`` (audited against the live catalog on 2026-09-10: 437 ids,
+# 0 hits).  The wizard used to hand the id out anyway, so the first message
+# failed provider-side.  Filter it at this projection boundary only — the
+# direct ``zai`` setup keeps every provider-native id.
+#
+# Kept in the *pre-translation* namespace on purpose: the set is matched
+# against ``_FALLBACK_MODELS`` entries, which are authored for the direct
+# endpoint, so the filter stays correct — and one line long — regardless of
+# how ``_to_openrouter_namespace`` above evolves.
+_OPENROUTER_UNSERVED_IDS = frozenset({"zai/glm-4.5-flash"})
+
+
 _SUPPORTED_PROVIDER_SETUPS = {
     # ── Easy start ──────────────────────────────────────────────────────
     "openrouter": {
@@ -73,6 +89,7 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "models": [
             {"id": _to_openrouter_namespace(model["id"]), "label": model["label"]}
             for model in _FALLBACK_MODELS
+            if model["id"] not in _OPENROUTER_UNSERVED_IDS
         ],
         "category": "easy_start",
         "quick": True,

--- a/tests/test_issue7514_openrouter_zai_namespace.py
+++ b/tests/test_issue7514_openrouter_zai_namespace.py
@@ -57,6 +57,7 @@ def test_openrouter_setup_exposes_z_ai_models():
         _expected_openrouter_id(model["id"])
         for model in config._FALLBACK_MODELS
         if model["id"].startswith("zai/")
+        and model["id"] not in onboarding._OPENROUTER_UNSERVED_IDS
     }
     assert expected, "expected the fallback catalog to carry Z.AI models"
     assert expected.issubset(set(ids)), (
@@ -66,8 +67,14 @@ def test_openrouter_setup_exposes_z_ai_models():
 
 
 def test_openrouter_projection_is_namespace_only():
-    """The OpenRouter list stays a 1:1, order-preserving projection."""
-    fallback = config._FALLBACK_MODELS
+    """The OpenRouter list stays a 1:1, order-preserving projection of the
+    served models: every fallback entry except the ones OpenRouter does not
+    serve (#7520) is projected with the same label and the translated id."""
+    fallback = [
+        model
+        for model in config._FALLBACK_MODELS
+        if model["id"] not in onboarding._OPENROUTER_UNSERVED_IDS
+    ]
     openrouter = _models("openrouter")
 
     assert len(openrouter) == len(fallback)

--- a/tests/test_issue7520_openrouter_unserved_models.py
+++ b/tests/test_issue7520_openrouter_unserved_models.py
@@ -1,0 +1,116 @@
+"""The OpenRouter setup must not hand out model ids OpenRouter does not serve (#7520).
+
+``_FALLBACK_MODELS`` doubles as the curated OpenRouter list, so every entry
+becomes a selectable option in the onboarding wizard.  ``zai/glm-4.5-flash`` is
+a Z.AI-direct id with no OpenRouter counterpart: the live catalog serves the
+GLM-4.5 generation as ``z-ai/glm-4.5``, ``z-ai/glm-4.5-air`` and
+``z-ai/glm-4.5v`` only (audited 2026-09-10 against the 437 ids returned by
+``https://openrouter.ai/api/v1/models`` -- zero hits for ``glm-4.5-flash``).
+A user who picked it in the wizard got a provider-side failure on the first
+message.
+
+These tests drive the real setup catalog that the wizard serves; they do not
+match on source text.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.config import _FALLBACK_MODELS
+from api.onboarding import (
+    _OPENROUTER_UNSERVED_IDS,
+    _SUPPORTED_PROVIDER_SETUPS,
+    _build_setup_catalog,
+)
+
+
+def _slug(model_id):
+    """Last path segment: namespace-agnostic (``zai/x`` == ``z-ai/x``)."""
+    return str(model_id or "").rsplit("/", 1)[-1]
+
+
+def _openrouter_models():
+    return _SUPPORTED_PROVIDER_SETUPS["openrouter"]["models"]
+
+
+def _setup_catalog_openrouter_models():
+    catalog = _build_setup_catalog({})
+    for provider in catalog["providers"]:
+        if provider["id"] == "openrouter":
+            return provider["models"]
+    raise AssertionError("openrouter missing from the setup catalog payload")
+
+
+# ── The bug ──────────────────────────────────────────────────────────────
+
+
+def test_openrouter_setup_never_offers_the_dead_glm_4_5_flash_id():
+    """``glm-4.5-flash`` has no OpenRouter counterpart -- it must not be offered.
+
+    Namespace-agnostic on purpose: the entry is dead either way, so both the
+    direct-provider spelling (``zai/glm-4.5-flash``) and the OpenRouter one
+    (``z-ai/glm-4.5-flash``) are rejected.
+    """
+    slugs = [_slug(m["id"]) for m in _openrouter_models()]
+    assert "glm-4.5-flash" not in slugs, (
+        f"OpenRouter setup still offers a model OpenRouter does not serve: {slugs}"
+    )
+
+
+def test_setup_catalog_payload_carries_the_filtered_list():
+    """The wizard consumes ``_build_setup_catalog()``, not the raw table."""
+    payload = _setup_catalog_openrouter_models()
+    assert payload == _openrouter_models()
+    assert "glm-4.5-flash" not in [_slug(m["id"]) for m in payload]
+
+
+# ── Non-regression: only the dead id is dropped ──────────────────────────
+
+
+def test_openrouter_setup_keeps_every_other_fallback_model():
+    """Every other fallback entry still reaches the wizard, same order/labels.
+
+    Compared on the trailing slug so the assertion survives a namespace
+    translation at this boundary (``zai/x`` -> ``z-ai/x``): what must hold is
+    that nothing else is dropped or reordered.
+    """
+    expected = [
+        (_slug(m["id"]), m["label"])
+        for m in _FALLBACK_MODELS
+        if m["id"] not in _OPENROUTER_UNSERVED_IDS
+    ]
+    got = [(_slug(m["id"]), m["label"]) for m in _openrouter_models()]
+    assert [i for i, _ in got] == [i for i, _ in expected], (
+        "the OpenRouter list must stay a 1:1 projection of the fallback catalog "
+        "minus the unserved ids -- order included"
+    )
+    assert [lbl for _, lbl in got] == [lbl for _, lbl in expected]
+
+
+def test_every_unserved_id_exists_in_the_fallback_catalog():
+    """The drop list is a filter, not a place to park made-up ids."""
+    fallback_ids = {m["id"] for m in _FALLBACK_MODELS}
+    unknown = _OPENROUTER_UNSERVED_IDS - fallback_ids
+    assert not unknown, f"unserved ids not present in _FALLBACK_MODELS: {sorted(unknown)}"
+    assert _OPENROUTER_UNSERVED_IDS <= fallback_ids
+
+
+def test_direct_zai_setup_keeps_its_provider_native_ids():
+    """The filter is OpenRouter-only: the direct Z.AI setup is untouched.
+
+    ``glm-4.5-flash`` is a real id for the provider's own endpoint, so dropping
+    it from ``_FALLBACK_MODELS`` (instead of from this projection) would have
+    broken the direct setup.
+    """
+    zai_ids = [m["id"] for m in _SUPPORTED_PROVIDER_SETUPS["zai"]["models"]]
+    assert "glm-4.5-flash" in zai_ids, (
+        f"the direct Z.AI setup must keep the provider-native ids: {zai_ids}"
+    )
+
+
+def test_openrouter_catalog_still_offers_the_glm_4_5_generation():
+    """The drop removes one dead id, not the GLM-4.5 family."""
+    slugs = {_slug(m["id"]) for m in _openrouter_models()}
+    assert {"glm-4.5", "glm-4.7", "glm-5.3"} <= slugs, slugs


### PR DESCRIPTION
## Summary

The onboarding wizard's OpenRouter setup is a 1:1 projection of `_FALLBACK_MODELS`, and one of those entries -- `zai/glm-4.5-flash` -- has no counterpart in OpenRouter's catalog. A user who went through the OpenRouter wizard and picked "GLM-4.5 Flash" got an id the provider does not serve, so the first message failed provider-side. Same failure class as #7514, but the id itself rather than the namespace -- the namespace fix can't mask it.

Audited against the live catalog (`https://openrouter.ai/api/v1/models`, 437 ids, checked 2026-09-10): OpenRouter serves the GLM-4.5 generation as `z-ai/glm-4.5`, `z-ai/glm-4.5-air` and `z-ai/glm-4.5v`. There is no `glm-4.5-flash` under any namespace.

## Fix

Filter at the projection boundary in `api/onboarding.py`:

```python
_OPENROUTER_UNSERVED_IDS = frozenset({"zai/glm-4.5-flash"})
...
"models": [
    {"id": model["id"], "label": model["label"]}
    for model in _FALLBACK_MODELS
    if model["id"] not in _OPENROUTER_UNSERVED_IDS
],
```

- `_FALLBACK_MODELS` stays untouched: `glm-4.5-flash` is a valid id for the provider's own endpoint, and the direct `zai` setup still offers it (test-covered).
- Everything else in the projection is unchanged -- same entries, same order, same labels.

## Alternative considered

The other option from #7520 was remapping the entry to `z-ai/glm-4.5-air`, the tier Z.AI actually serves on OpenRouter. I went with the drop because that entry's label is "GLM-4.5 Flash" and `air` is a different slug and tier: renaming it would silently change which model the user believes they picked. Happy to switch to a rename (with a relabelled option) if you'd rather keep a cheap-tier GLM in the list.

## Relationship to #7518

Complementary: #7518 fixes the *namespace* (`zai/*` -> `z-ai/*`) for the entries OpenRouter does serve; this one removes the entry it serves nowhere. The drop set is keyed on the pre-projection id, so it survives the namespace translation whichever PR lands second -- the rebase is the same one-line comprehension.

## Tests

`tests/test_issue7520_openrouter_unserved_models.py` drives the real setup tables (`_SUPPORTED_PROVIDER_SETUPS`, `_build_setup_catalog({})`); no source-string matching:

- the dead id is gone, namespace-agnostically (`zai/` and `z-ai/` spellings both rejected);
- the payload the wizard actually renders carries the filtered list;
- every other fallback entry survives, same order and labels;
- the drop set only holds ids that exist in the fallback catalog (a filter, not a parking spot);
- the direct `zai` setup still offers `glm-4.5-flash`;
- the GLM-4.5 family is still offered for OpenRouter.

Mutation check: removing just the filter (everything else untouched) fails 3 of the 6 tests.

Local run: 6/6 new, plus 178 passed / 1 skipped across the onboarding and catalog suites (603, 604, 1426, 1499, 1500, 2025, 572, glm-5.3 catalog, custom providers panel, minimax, sprint40); `python3 scripts/ruff_lint.py --diff origin/master` clean.

Closes #7520.
